### PR TITLE
libiconv: Correct cross-building

### DIFF
--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -1,6 +1,5 @@
 { fetchurl, stdenv, lib }:
 
-assert (!stdenv.isLinux);
 
 stdenv.mkDerivation rec {
   name = "libiconv-1.14";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7725,7 +7725,7 @@ in
   libiconv = (if stdenv.isGlibc then stdenv.cc.libc
         else if stdenv.isDarwin then darwin.libiconv
         else libiconvReal ) // {
-	crossDrv = (if crossSystem.libc == "glibc" then libcCross.crossDrv
+	crossDrv = (if crossSystem.libc == "glibc" then libcCross
       else libiconvReal.crossDrv); };
 
   libiconvReal = callPackage ../development/libraries/libiconv {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7722,13 +7722,12 @@ in
   # glibc provides libiconv so systems with glibc don't need to build libiconv
   # separately, but we also provide libiconvReal, which will always be a
   # standalone libiconv, just in case you want it
-  libiconv = if crossSystem != null then
-    (if crossSystem.libc == "glibc" then libcCross
-      else if crossSystem.libc == "libSystem" then darwin.libiconv
-      else libiconvReal)
-    else if stdenv.isGlibc then stdenv.cc.libc
-    else if stdenv.isDarwin then darwin.libiconv
-    else libiconvReal;
+  libiconv = (if stdenv.isGlibc then stdenv.cc.libc
+        else if stdenv.isDarwin then darwin.libiconv
+        else libiconvReal ) // {
+	crossDrv = (if crossSystem.libc == "glibc" then libcCross.crossDrv
+      else if crossSystem.libc == "libSystem" then darwin.libiconv.crossDrv
+      else libiconvReal.crossDrv); };
 
   libiconvReal = callPackage ../development/libraries/libiconv {
     fetchurl = fetchurlBoot;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7726,7 +7726,6 @@ in
         else if stdenv.isDarwin then darwin.libiconv
         else libiconvReal ) // {
 	crossDrv = (if crossSystem.libc == "glibc" then libcCross.crossDrv
-      else if crossSystem.libc == "libSystem" then darwin.libiconv.crossDrv
       else libiconvReal.crossDrv); };
 
   libiconvReal = callPackage ../development/libraries/libiconv {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7724,9 +7724,12 @@ in
   # standalone libiconv, just in case you want it
   libiconv = (if stdenv.isGlibc then stdenv.cc.libc
         else if stdenv.isDarwin then darwin.libiconv
-        else libiconvReal ) // {
-	crossDrv = (if crossSystem.libc == "glibc" then libcCross
-      else libiconvReal.crossDrv); };
+        else libiconvReal ) //
+	stdenv.lib.optionalAttrs (crossSystem != null)
+	{
+        crossDrv = (if crossSystem.libc == "glibc" then libcCross
+	            else libiconvReal.crossDrv);
+        };
 
   libiconvReal = callPackage ../development/libraries/libiconv {
     fetchurl = fetchurlBoot;


### PR DESCRIPTION
###### Things done
- [ X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Select the crossDrv based on the target platform in all-packages.nix,
remove superfluous assert in libiconv

nix-shell -p nox --run "nox-review wip" fails because it tries to build libiconvReal on Linux which fails on master already
