### PR TITLE
xfce service: add noDesktop option

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -12,20 +12,29 @@ in
 {
   options = {
 
-    services.xserver.desktopManager.xfce.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable the Xfce desktop environment.";
+    services.xserver.desktopManager.xfce = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable the Xfce desktop environment.";
+      };
+
+      thunarPlugins = mkOption {
+        default = [];
+        type = types.listOf types.package;
+        example = literalExample "[ pkgs.xfce.thunar-archive-plugin ]";
+        description = ''
+          A list of plugin that should be installed with Thunar.
+        '';
+      };
+
+      noDesktop = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Don't install XFCE desktop components (xfdesktop, panel and notification daemon).";
+      };
     };
 
-    services.xserver.desktopManager.xfce.thunarPlugins = mkOption {
-      default = [];
-      type = types.listOf types.package;
-      example = literalExample "[ pkgs.xfce.thunar-archive-plugin ]";
-      description = ''
-        A list of plugin that should be installed with Thunar.
-      '';
-    };
   };
 
 
@@ -59,14 +68,12 @@ in
         pkgs.xfce.terminal
        (pkgs.xfce.thunar.override { thunarPlugins = cfg.thunarPlugins; })
         pkgs.xfce.xfce4icontheme
-        pkgs.xfce.xfce4panel
         pkgs.xfce.xfce4session
         pkgs.xfce.xfce4settings
         pkgs.xfce.xfce4mixer
         pkgs.xfce.xfce4volumed
         pkgs.xfce.xfce4screenshooter
         pkgs.xfce.xfconf
-        pkgs.xfce.xfdesktop
         pkgs.xfce.xfwm4
         # This supplies some "abstract" icons such as
         # "utilities-terminal" and "accessories-text-editor".
@@ -78,9 +85,13 @@ in
         pkgs.xfce.gvfs
         pkgs.xfce.xfce4_appfinder
         pkgs.xfce.tumbler       # found via dbus
-        pkgs.xfce.xfce4notifyd  # found via dbus
       ]
-      ++ optional config.powerManagement.enable pkgs.xfce.xfce4_power_manager;
+      ++ optional config.powerManagement.enable pkgs.xfce.xfce4_power_manager
+      ++ optionals (!cfg.noDesktop)
+         [ pkgs.xfce.xfce4panel
+           pkgs.xfce.xfdesktop
+	   pkgs.xfce.xfce4notifyd  # found via dbus
+         ];
 
     environment.pathsToLink =
       [ "/share/xfce4" "/share/themes" "/share/mime" "/share/desktop-directories" "/share/gtksourceview-2.0" ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Several services in Xfce are particularly hard to disable when you want to use something else. Notably:

1) `xfce4-notifyd` is started unconditionally and needs to be killed if you want your own notification manager to work;
2) `xfdesktop` can be disabled via saving session settings, but sometimes is started in the middle of session and if killed then, restarted (presumably by the session daemon); you need to open `xfce4-session-settings`, kill it from there, save session and hope it won't repeat soon. Unfortunately, it's incompatible with XMonad (shows in foreground, with all apps and panel hidden underneath);
3) `xfce4-panel` can be disabled via saving session without it but _sometimes_ runs at startup anyway and it's annoying to kill it from time to time.

This option removes those three packages from environment if enabled. While this also has a benefit of saving space, I would be interested in less sledge-hammery fix for those problems from other Xfce+some WM users. FWIW I use XMonad + taffybar.

cc @vcunat (Xfce maintainer)
