### PR TITLE
catch: 1.2.1 -> 1.5.0

### DIFF
--- a/pkgs/development/libraries/catch/default.nix
+++ b/pkgs/development/libraries/catch/default.nix
@@ -3,20 +3,20 @@
 stdenv.mkDerivation rec {
 
   name = "catch-${version}";
-  version = "1.2.1";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "philsquared";
     repo = "Catch";
     rev = "v" + version;
-    sha256 = "0rz2nmvvh66x6w2nb7l08vc5x9aqg1qfz2qfiykaz1ybc19fwck2";
+    sha256 = "1ag8siafg7fmb50qdqznryrg3lvv56f09nvqwqqn2rlk83zjnaw0";
   };
 
   buildInputs = [ cmake ];
   dontUseCmakeConfigure = true;
 
   buildPhase = ''
-    cmake -Hprojects/CMake -BBuild -DCMAKE_BUILD_TYPE=Release
+    cmake -Hprojects/CMake -BBuild -DCMAKE_BUILD_TYPE=Release -DUSE_CPP11=ON
     cd Build
     make
     cd ..


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (no dependencies)
- [x] Tested execution of all binary files (usually in `./result/bin/`): 
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
