### PR TITLE
aria2: enable building for darwin

### DIFF
--- a/pkgs/tools/networking/aria2/default.nix
+++ b/pkgs/tools/networking/aria2/default.nix
@@ -1,6 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, cacert
 , openssl, c-ares, libxml2, sqlite, zlib, libssh2
-, Security
 }:
 
 stdenv.mkDerivation rec {
@@ -13,10 +12,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl c-ares libxml2 sqlite zlib libssh2 ] ++
-    stdenv.lib.optional stdenv.isDarwin Security;
+  buildInputs = [ openssl c-ares libxml2 sqlite zlib libssh2 ];
 
-  configureFlags = [ "--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt" ];
+  configureFlags = [ "--with-ca-bundle=${cacert}/etc/ssl/certs/ca-bundle.crt" ] ++
+    stdenv.lib.optional stdenv.isDarwin [ "--with-openssl" "--without-appletls" ];
 
   enableParallelBuilding = true;
 
@@ -25,6 +24,6 @@ stdenv.mkDerivation rec {
     description = "A lightweight, multi-protocol, multi-source, command-line download utility";
     maintainers = with maintainers; [ koral jgeerds ];
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -504,9 +504,7 @@ in
 
   arc-gtk-theme = callPackage ../misc/themes/arc { };
 
-  aria2 = callPackage ../tools/networking/aria2 {
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
+  aria2 = callPackage ../tools/networking/aria2 { };
   aria = self.aria2;
 
   at = callPackage ../tools/system/at { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Enable building of `aria2` package on Darwin. I first tried building with Security.framework (`--with-appletls`), which could be successfully built, but requesting HTTPS will always fail with "Invalid certificate format" error, thus I changed the configure to always use openssl for Darwin.
