### PR TITLE
pycairo: enable for python35

### DIFF
--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch, python, pkgconfig, cairo, xlibsWrapper, isPyPy, isPy35 }:
 
-if (isPyPy || isPy35) then throw "pycairo not supported for interpreter ${python.executable}" else stdenv.mkDerivation rec {
+if (isPyPy) then throw "pycairo not supported for interpreter ${python.executable}" else stdenv.mkDerivation rec {
   version = "1.10.0";
   name = "${python.libPrefix}-pycairo-${version}";
   src = if python.is_py3k or false
@@ -23,6 +23,8 @@ if (isPyPy || isPy35) then throw "pycairo not supported for interpreter ${python
     sha256 = "0xfl1i9dips2nykyg91f5h5r3xpk2hp1js1gq5z0hwjr0in55id4";
   };
 
+  patch_waf-py3_5 = ./waf-py3_5.patch;
+
   buildInputs = [ python pkgconfig cairo xlibsWrapper ];
 
   configurePhase = ''
@@ -30,6 +32,7 @@ if (isPyPy || isPy35) then throw "pycairo not supported for interpreter ${python
       cd $(${python.executable} waf unpack)
       pwd
       patch -p1 < ${patch_waf}
+      ${stdenv.lib.optionalString isPy35 "patch -p1 < ${patch_waf-py3_5}"}
     )
 
     ${python.executable} waf configure --prefix=$out

--- a/pkgs/development/python-modules/pycairo/waf-py3_5.patch
+++ b/pkgs/development/python-modules/pycairo/waf-py3_5.patch
@@ -1,0 +1,10 @@
+--- a/waflib/Build.py
++++ b/waflib/Build.py
+@@ -151,6 +151,7 @@ class BuildContext(Context.Context):
+ 				f.close()
+ 		self.init_dirs()
+ 	def store(self):
++		return
+ 		data={}
+ 		for x in SAVED_ATTRS:
+ 			data[x]=getattr(self,x)


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The patch was taken from FreeBSD, it is also used on debian.
see:
https://svnweb.freebsd.org/ports/head/graphics/py3-cairo/files/pycairo-1.10.0-waf-py3_5.patch?revision=401900&view=markup
