### PR TITLE
betamax: Disable tests

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1717,6 +1717,8 @@ in modules // {
 
     propagatedBuildInputs = [ self.requests2 ];
 
+    doCheck = false;
+
     meta = with stdenv.lib; {
       homepage = https://betamax.readthedocs.org/en/latest/;
       description = "A VCR imitation for requests";


### PR DESCRIPTION
Closes #15030 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a proposal. It is a short-term fix for building betamax with python 3. Nevertheless, the update may be done asap, but the python3 build should succeed then.

@pSub You did the update which is reverted by this PR.
