### PR TITLE
siege: fix build after multiple-outputs

### DIFF
--- a/pkgs/tools/networking/siege/default.nix
+++ b/pkgs/tools/networking/siege/default.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
 
-  configureFlags = [ "--with-ssl=${openssl}" ];
+  buildInputs = [ openssl ];
+
+  configureFlags = [ "--with-ssl=${openssl.dev}" ];
 
   meta = with stdenv.lib; {
     description = "HTTP load tester";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
