### PR TITLE
npm2nix: 6.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -143,6 +143,7 @@
   garrison = "Jim Garrison <jim@garrison.cc>";
   gavin = "Gavin Rogers <gavin@praxeology.co.uk>";
   gebner = "Gabriel Ebner <gebner@gebner.org>";
+  gilligan = "Tobias Pflug <tobias.pflug@gmail.com>";
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";
   gleber = "Gleb Peregud <gleber.p@gmail.com>";
   globin = "Robin Gloster <mail@glob.in>";

--- a/pkgs/development/tools/npm2nix/default.nix
+++ b/pkgs/development/tools/npm2nix/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchFromGitHub, nodejs }:
+
+stdenv.mkDerivation rec {
+  version = "6.0.0";
+  name = "npm2nix-${version}";
+
+  src = fetchFromGitHub {
+    owner = "svanderburg";
+    repo = "npm2nix";
+
+    rev = "758b286acfb077051a17aa9579adc558deeebbd4";
+    sha256 = "0gmvpxvp75fqw7w7x0c1ywc1zghd1hl6iimbv4xnjwlxgh704yg6";
+  };
+
+  meta = with lib; {
+    description = "Generate nix expressions to build npm packages";
+    homepage = http://github.com/svanderburg/npm2nix/tree/reengineering2;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = [ maintainers.gilligan ];
+  };
+
+  buildInputs = [ nodejs ];
+
+  buildPhase = ''
+    mkdir ./npm-home
+    export HOME=$(readlink -f ./npm-home)
+    npm install
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp -R node_modules $out
+    cp bin/npm2nix.js $out/bin/npm2nix
+    cp -R lib $out/
+    cp -R nix $out/
+
+    chmod +x $out/bin/npm2nix
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2195,7 +2195,9 @@ in
   else
     nodePackages_4_x;
 
-  npm2nix = nodePackages.npm2nix;
+  npm2nix = callPackage ../development/tools/npm2nix {
+    inherit fetchFromGitHub;
+  };
 
   ldapvi = callPackage ../tools/misc/ldapvi { };
 


### PR DESCRIPTION
This is a first PR to work towards what was discussed in  #14532 
- Add npm2nix package (using https://github.com/svanderburg/npm2nix/tree/reengineering2):

The reengineering branch by @svanderburg is a big improvement on `NixOS/npm2nix` version. I hope you are fine with me packaging it.

/cc @zimbatm 

**Edit**: I first tried to actually remove npm2nix from node-packages.json / node-packages-generated not realizing that the new npm2nix version generates output that is not compatible with the previous one. I amended it to only add the package for now.
