### PR TITLE
zookeeper: include ZooInspector app

### DIFF
--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -23,14 +23,28 @@ stdenv.mkDerivation rec {
         --prefix PATH : "${bash}/bin"
     done
     chmod -x $out/bin/zkEnv.sh
+
+    mkdir -p $out/share/zooinspector
+    cp -r contrib/ZooInspector/{${name}-ZooInspector.jar,icons,lib,config} $out/share/zooinspector
+
+    classpath="$out/${name}.jar:$out/share/zooinspector/${name}-ZooInspector.jar"
+    for jar in $out/lib/*.jar $out/share/zooinspector/lib/*.jar; do
+      classpath="$classpath:$jar"
+    done
+
+    cat << EOF > $out/bin/zooInspector.sh
+    #!${stdenv.shell}
+    cd $out/share/zooinspector
+    exec ${jre}/bin/java -cp $classpath org.apache.zookeeper.inspector.ZooInspector
+    EOF
+    chmod +x $out/bin/zooInspector.sh
   '';
 
   meta = with stdenv.lib; {
     homepage = "http://zookeeper.apache.org";
     description = "Apache Zookeeper";
     license = licenses.asl20;
-    maintainers = [ maintainers.nathan-gs ];
+    maintainers = with maintainers; [ nathan-gs cstrahan ];
     platforms = platforms.unix;
   };
-
 }

--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -1,36 +1,36 @@
 { stdenv, fetchurl, jre, makeWrapper, bash }:
 
 stdenv.mkDerivation rec {
-	name = "zookeeper-3.4.6";
+  name = "zookeeper-3.4.6";
 
-	src = fetchurl {
-		url = "mirror://apache/zookeeper/${name}/${name}.tar.gz";
-		sha256 = "01b3938547cd620dc4c93efe07c0360411f4a66962a70500b163b59014046994";
-	};
+  src = fetchurl {
+    url = "mirror://apache/zookeeper/${name}/${name}.tar.gz";
+    sha256 = "01b3938547cd620dc4c93efe07c0360411f4a66962a70500b163b59014046994";
+  };
 
-	buildInputs = [ makeWrapper jre ];
+  buildInputs = [ makeWrapper jre ];
 
-	phases = ["unpackPhase" "installPhase"];
+  phases = ["unpackPhase" "installPhase"];
 
-	installPhase = ''
-		mkdir -p $out
-		cp -R conf docs lib ${name}.jar $out
-		mkdir -p $out/bin
-		cp -R bin/{zkCli,zkCleanup,zkEnv}.sh $out/bin
-		for i in $out/bin/{zkCli,zkCleanup}.sh; do
-			wrapProgram $i \
-				--set JAVA_HOME "${jre}" \
-				--prefix PATH : "${bash}/bin"
-		done
-                chmod -x $out/bin/zkEnv.sh
-	'';
+  installPhase = ''
+    mkdir -p $out
+    cp -R conf docs lib ${name}.jar $out
+    mkdir -p $out/bin
+    cp -R bin/{zkCli,zkCleanup,zkEnv}.sh $out/bin
+    for i in $out/bin/{zkCli,zkCleanup}.sh; do
+      wrapProgram $i \
+        --set JAVA_HOME "${jre}" \
+        --prefix PATH : "${bash}/bin"
+    done
+    chmod -x $out/bin/zkEnv.sh
+  '';
 
-	meta = with stdenv.lib; {
-		homepage = "http://zookeeper.apache.org";
-		description = "Apache Zookeeper";
-		license = licenses.asl20;
-		maintainers = [ maintainers.nathan-gs ];	
-		platforms = platforms.unix;	
-	};		
+  meta = with stdenv.lib; {
+    homepage = "http://zookeeper.apache.org";
+    description = "Apache Zookeeper";
+    license = licenses.asl20;
+    maintainers = [ maintainers.nathan-gs ];
+    platforms = platforms.unix;
+  };
 
 }


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

ZooInspector is a Swing based GUI for interacting with Zookeeper.
