### PR TITLE
util-linux: 2.27.1 -> 2.28

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, pkgconfig, zlib, ncurses ? null, perl ? null, pam, systemd }:
 
 stdenv.mkDerivation rec {
-  name = "util-linux-2.27.1";
+  name = "util-linux-${version}";
+  version = "2.28";
 
   src = fetchurl {
-    url = "mirror://kernel/linux/utils/util-linux/v2.27/${name}.tar.xz";
-    sha256 = "1452hz5zx56a3mad8yrg5wb0vy5zi19mpjp6zx1yr6p9xp6qz08a";
+    url = "mirror://kernel/linux/utils/util-linux/v${version}/${name}.tar.xz";
+    sha512 = "251zv6lk6b8ip38w2h0w2rpnly38nzh96945mbpssvwjv8fgr5bnhj3207aingyybik79761zngk981wl0rblq5f7l5v655znyi3yd1";
   };
 
   patches = [
@@ -63,7 +64,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.kernel.org/pub/linux/utils/util-linux/;
+    homepage = https://www.kernel.org/pub/linux/utils/util-linux/;
     description = "A set of system utilities for Linux";
     license = licenses.gpl2; # also contains parts under more permissive licenses
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/util-linux/rtcwake-search-PATH-for-shutdown.patch
+++ b/pkgs/os-specific/linux/util-linux/rtcwake-search-PATH-for-shutdown.patch
@@ -3,23 +3,24 @@ which isn't valid on NixOS (and a compatibility link on most other modern
 distros anyway).
 
   -- nckx <tobias.geerinckx.rice@gmail.com>
-
-diff -ru util-linux-2.27-orig/include/pathnames.h util-linux-2.27/include/pathnames.h
---- util-linux-2.27-orig/include/pathnames.h	2015-06-29 13:13:14.669847478 +0200
-+++ util-linux-2.27/include/pathnames.h	2015-10-07 20:09:17.401022602 +0200
-@@ -54,7 +54,7 @@
- #define _PATH_INITTAB		"/etc/inittab"
- #define _PATH_RC		"/etc/rc"
- #define _PATH_REBOOT		"/sbin/reboot"
+diff --git a/include/pathnames.h b/include/pathnames.h
+index de6a13c..0c1aeb9 100644
+--- a/include/pathnames.h
++++ b/include/pathnames.h
+@@ -50,7 +50,7 @@
+ #define	_PATH_VAR_NOLOGIN	"/var/run/nologin"
+ 
+ #define _PATH_LOGIN		"/bin/login"
 -#define _PATH_SHUTDOWN		"/sbin/shutdown"
 +#define _PATH_SHUTDOWN		"shutdown"
- #define _PATH_SINGLE		"/etc/singleboot"
- #define _PATH_SHUTDOWN_CONF	"/etc/shutdown.conf"
  
-diff -ru util-linux-2.27-orig/sys-utils/rtcwake.c util-linux-2.27/sys-utils/rtcwake.c
---- util-linux-2.27-orig/sys-utils/rtcwake.c	2015-08-05 11:32:44.453821232 +0200
-+++ util-linux-2.27/sys-utils/rtcwake.c	2015-10-07 20:09:37.834032536 +0200
-@@ -576,7 +576,7 @@
+ #define _PATH_TERMCOLORS_DIRNAME "terminal-colors.d"
+ #define _PATH_TERMCOLORS_DIR	"/etc/" _PATH_TERMCOLORS_DIRNAME
+diff --git a/sys-utils/rtcwake.c b/sys-utils/rtcwake.c
+index 7c748dc..9a99a7c 100644
+--- a/sys-utils/rtcwake.c
++++ b/sys-utils/rtcwake.c
+@@ -575,7 +575,7 @@ int main(int argc, char **argv)
  		arg[i++] = "now";
  		arg[i]   = NULL;
  		if (!ctl.dryrun) {


### PR DESCRIPTION
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested rename, but none of the other binaries.
