### PR TITLE
pulseaudio: wrong path fallout from multiple outputs

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/kde4.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde4.nix
@@ -111,7 +111,7 @@ in
             # Load PulseAudio module for routing support.
             # See http://colin.guthr.ie/2009/10/so-how-does-the-kde-pulseaudio-support-work-anyway/
             ${optionalString config.hardware.pulseaudio.enable ''
-              ${config.hardware.pulseaudio.package}/bin/pactl load-module module-device-manager "do_routing=1"
+              ${config.hardware.pulseaudio.package.out}/bin/pactl load-module module-device-manager "do_routing=1"
             ''}
 
             # Start KDE.

--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -59,7 +59,7 @@ in
         # Load PulseAudio module for routing support.
         # See http://colin.guthr.ie/2009/10/so-how-does-the-kde-pulseaudio-support-work-anyway/
         ${optionalString config.hardware.pulseaudio.enable ''
-          ${config.hardware.pulseaudio.package}/bin/pactl load-module module-device-manager "do_routing=1"
+          ${config.hardware.pulseaudio.package.out}/bin/pactl load-module module-device-manager "do_routing=1"
         ''}
 
         exec "${kde5.startkde}"


### PR DESCRIPTION
This isn't tested admittedly, but ShouldJustWork(tm).

needs .out appended to package
