### PR TITLE
diffoscope: 49 -> 52

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -6,22 +6,19 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "diffoscope-${version}";
-  version = "49";
+  version = "52";
 
   namePrefix = "";
 
   src = fetchgit {
     url = "git://anonscm.debian.org/reproducible/diffoscope.git";
     rev = "refs/tags/${version}";
-    sha256 = "0kh96h95rp7bk8rgc1z18jwv89dyp1n36bawqyqxhwwklmrgxr66";
+    sha256 = "1a22abvjs8f8c4anrcfhn02xw7m2gl701b9csxy06c5ymib0npxd";
   };
 
   patches =
-    [ # Ignore different link counts and inode change times.
-      (fetchpatch {
-        url = https://github.com/edolstra/diffoscope/commit/367f77bba8df0dbc89e63c9f66f05736adf5ec59.patch;
-        sha256 = "0mnp7icdrjn02dr6f5dwqvvr848jzgkv3cg69a24234y9gxd30ww";
-      })
+    [ # Ignore different link counts.
+      ./ignore_links.patch
     ];
 
   postPatch = ''

--- a/pkgs/tools/misc/diffoscope/ignore_links.patch
+++ b/pkgs/tools/misc/diffoscope/ignore_links.patch
@@ -1,0 +1,25 @@
+From: Eelco Dolstra <eelco.dolstra@logicblox.com>
+
+Nix deduplicates by hard-linking identical files, so it's normal for
+the the number of links to a file to differ.
+---
+diff --git a/diffoscope/comparators/directory.py b/diffoscope/comparators/directory.py
+index 7d1cd75..bd91eb0 100644
+--- a/diffoscope/comparators/directory.py
++++ b/diffoscope/comparators/directory.py
+@@ -47,6 +47,7 @@ class Stat(Command):
+     FILE_RE = re.compile(r'^\s*File:.*$')
+     DEVICE_RE = re.compile(r'Device: [0-9a-f]+h/[0-9]+d')
+     INODE_RE = re.compile(r'Inode: [0-9]+')
++    LINKS_RE = re.compile(r'Links: [0-9]+')
+     ACCESS_TIME_RE = re.compile(r'^Access: [0-9]{4}-[0-9]{2}-[0-9]{2}.*$')
+     CHANGE_TIME_RE = re.compile(r'^Change: [0-9]{4}-[0-9]{2}-[0-9]{2}.*$')
+
+@@ -55,6 +56,7 @@ class Stat(Command):
+         line = Stat.FILE_RE.sub('', line)
+         line = Stat.DEVICE_RE.sub('', line)
+         line = Stat.INODE_RE.sub('', line)
++        line = Stat.LINKS_RE.sub('', line)
+         line = Stat.ACCESS_TIME_RE.sub('', line)
+         line = Stat.CHANGE_TIME_RE.sub('', line)
+         return line.encode('utf-8')


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
