### PR TITLE
albert: 0.8.7.2 -> 0.8.8

### DIFF
--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -2,16 +2,20 @@
 
 stdenv.mkDerivation rec {
   name    = "albert-${version}";
-  version = "0.8.7.2";
+  version = "0.8.8";
 
   src = fetchFromGitHub {
     owner  = "manuelschneid3r";
     repo   = "albert";
     rev    = "v${version}";
-    sha256 = "04k6cawil6kqkmsilq5mpjy8lwgk0g08s0v23d5a83calpq3ljpc";
+    sha256 = "1mqxy5xbvgzykg2vvr2d1p9kr2viga1pqxslkg9y1x05kdhr2zal";
   };
 
-  buildInputs = [ cmake qtbase qtsvg qtx11extras muparser makeQtWrapper ];
+  nativeBuildInputs = [ cmake makeQtWrapper ];
+
+  buildInputs = [ qtbase qtsvg qtx11extras muparser ];
+
+  enableParallelBuilding = true;
 
   fixupPhase = ''
     wrapQtProgram $out/bin/albert


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
