### PR TITLE
siege: 3.0.8 -> 4.0.1

### DIFF
--- a/pkgs/tools/networking/siege/default.nix
+++ b/pkgs/tools/networking/siege/default.nix
@@ -1,18 +1,21 @@
-{ stdenv, fetchurl, openssl }:
+{ stdenv, fetchurl, openssl, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "siege-3.0.8";
+  name = "siege-4.0.1";
 
   src = fetchurl {
     url = "http://download.joedog.org/siege/${name}.tar.gz";
-    sha256 = "15xj0cl64mzf89i0jknqg37rkrcaqmgs4755l74b4nmp4bky7ddq";
+    sha256 = "0dr8k64s7zlhy3w8n1br0h6xd06p09p9809l9rp13isf10jp5pgx";
   };
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
 
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl zlib ];
 
-  configureFlags = [ "--with-ssl=${openssl.dev}" ];
+  configureFlags = [
+    "--with-ssl=${openssl.dev}"
+    "--with-zlib=${zlib.dev}"
+  ];
 
   meta = with stdenv.lib; {
     description = "HTTP load tester";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Bump `siege` version after build was fixed (#15038).
