### PR TITLE
iscsiadm can't load modules, so let's update open-iscsi and patch it.

### DIFF
--- a/pkgs/os-specific/linux/open-iscsi/default.nix
+++ b/pkgs/os-specific/linux/open-iscsi/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchFromGitHub, nukeReferences, automake, autoconf, libtool, gettext, utillinux, openisns, openssl }:
+{ stdenv, fetchFromGitHub, nukeReferences, automake, autoconf, libtool, gettext, utillinux, openisns, openssl, kmod }:
 stdenv.mkDerivation rec {
   name = "open-iscsi-${version}";
   version = "2.0-873-${stdenv.lib.substring 0 7 src.rev}";
   outputs = [ "out" "iscsistart" ];
 
-  buildInputs = [ nukeReferences automake autoconf libtool gettext utillinux openisns.lib openssl ];
+  buildInputs = [ nukeReferences automake autoconf libtool gettext utillinux openisns.lib openssl kmod ];
   
   src = fetchFromGitHub {
     owner = "open-iscsi";
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
   
   DESTDIR = "$(out)";
   
+  NIX_LDFLAGS = "-lkmod";
+  NIX_CFLAGS_COMPILE = "-DUSE_KMOD";
+
   preConfigure = ''
     sed -i 's|/usr/|/|' Makefile
   '';

--- a/pkgs/os-specific/linux/open-iscsi/default.nix
+++ b/pkgs/os-specific/linux/open-iscsi/default.nix
@@ -1,18 +1,16 @@
-{ stdenv, fetchurl, nukeReferences }:
-let
-  pname = "open-iscsi-2.0-873";
-in stdenv.mkDerivation {
-  name = pname;
+{ stdenv, fetchFromGitHub, nukeReferences, automake, autoconf, libtool, gettext, utillinux, openisns, openssl }:
+stdenv.mkDerivation rec {
+  name = "open-iscsi-${version}";
+  version = "2.0-873-${stdenv.lib.substring 0 7 src.rev}";
   outputs = [ "out" "iscsistart" ];
 
-  buildInputs = [ nukeReferences ];
+  buildInputs = [ nukeReferences automake autoconf libtool gettext utillinux openisns.lib openssl ];
   
-  src = fetchurl {
-    urls = [
-      "http://www.open-iscsi.org/bits/${pname}.tar.gz"
-      "http://pkgs.fedoraproject.org/repo/pkgs/iscsi-initiator-utils/${pname}.tar.gz/8b8316d7c9469149a6cc6234478347f7/${pname}.tar.gz"
-    ];
-    sha256 = "1nbwmj48xzy45h52917jbvyqpsfg9zm49nm8941mc5x4gpwz5nbx";
+  src = fetchFromGitHub {
+    owner = "open-iscsi";
+    repo = "open-iscsi";
+    rev = "4c1f2d90ef1c73e33d9f1e4ae9c206ffe015a8f9";
+    sha256 = "0h030zk4zih3l8z5662b3kcifdxlakbwwkz1afb7yf0cicds7va8";
   };
   
   DESTDIR = "$(out)";
@@ -30,7 +28,7 @@ in stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "A high performance, transport independent, multi-platform implementation of RFC3720";
     license = licenses.gpl2Plus;
-    homepage = http://www.open-iscsi.org;
+    homepage = http://www.open-iscsi.com;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/open-isns/default.nix
+++ b/pkgs/os-specific/linux/open-isns/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, openssl, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "open-isns-${version}";
+  version = "0.95";
+
+  src = fetchFromGitHub {
+    owner = "gonzoleeman";
+    repo = "open-isns";
+    rev = "v${version}";
+    sha256 = "1c2x3yf9806gbjsw4xi805rfhyxk353a3whqvpccz8dwas6jajwh";
+  };
+
+  propagatedBuildInputs = [ openssl ];
+  outputs = ["out" "lib" ];
+  outputInclude = "lib";
+
+  installFlags = "etcdir=$(out)/etc vardir=$(out)/var/lib/isns";
+  installTargets = "install install_hdrs install_lib";
+
+  meta = {
+    description = "iSNS server and client for Linux";
+    license = stdenv.lib.licenses.lgpl21;
+    homepage = https://github.com/gonzoleeman/open-isns;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10420,6 +10420,8 @@ in
 
   openiscsi = callPackage ../os-specific/linux/open-iscsi { };
 
+  openisns = callPackage ../os-specific/linux/open-isns { };
+
   tgt = callPackage ../tools/networking/tgt { };
 
   # -- Linux kernel expressions ------------------------------------------------


### PR DESCRIPTION
iscsiadm tries to load iscsi transport tcp modules when needed. Luckily open-iscsi has kmod support that just needs to be enabled. That's more easy when open-iscsi is updated. This introduces an open-isns dependency. The patch set deals with these points in reverse order.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
