### PR TITLE
nodejs-6_x : init at 6.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -143,6 +143,7 @@
   garrison = "Jim Garrison <jim@garrison.cc>";
   gavin = "Gavin Rogers <gavin@praxeology.co.uk>";
   gebner = "Gabriel Ebner <gebner@gebner.org>";
+  gilligan = "Tobias Pflug <tobias.pflug@gmail.com>";
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";
   gleber = "Gleb Peregud <gleber.p@gmail.com>";
   globin = "Robin Gloster <mail@glob.in>";

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -1,0 +1,59 @@
+{ stdenv, fetchurl, openssl, python, zlib, libuv, v8, utillinux, http-parser
+, pkgconfig, runCommand, which, libtool
+, version
+, src
+, ...
+}:
+
+assert stdenv.system != "armv5tel-linux";
+
+let
+
+  deps = { 
+    inherit openssl zlib libuv; 
+  } // (stdenv.lib.optionalAttrs (!stdenv.isDarwin) {
+    inherit http-parser;
+  });
+
+  sharedConfigureFlags = name: [
+    "--shared-${name}"
+    "--shared-${name}-includes=${builtins.getAttr name deps}/include"
+    "--shared-${name}-libpath=${builtins.getAttr name deps}/lib"
+  ];
+
+  inherit (stdenv.lib) concatMap optional optionals maintainers licenses platforms;
+
+in stdenv.mkDerivation {
+
+  inherit version;
+
+  inherit src;
+
+  name = "nodejs-${version}";
+
+  configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps) ++ [ "--without-dtrace" ];
+  dontDisableStatic = true;
+  prePatch = ''
+    patchShebangs .
+    sed -i 's/raise.*No Xcode or CLT version detected.*/version = "7.0.0"/' tools/gyp/pylib/gyp/xcode_emulation.py
+  '';
+
+  patches = stdenv.lib.optionals stdenv.isDarwin [ ./no-xcode.patch ];
+
+  buildInputs = [ python which zlib libuv openssl python ]
+    ++ optionals stdenv.isLinux [ utillinux http-parser ]
+    ++ optionals stdenv.isDarwin [ pkgconfig openssl libtool ];
+  setupHook = ./setup-hook.sh;
+
+  enableParallelBuilding = true;
+
+  passthru.interpreterName = "nodejs";
+
+  meta = {
+    description = "Event-driven I/O framework for the V8 JavaScript engine";
+    homepage = http://nodejs.org;
+    license = licenses.mit;
+    maintainers = [ maintainers.goibhniu maintainers.havvy maintainers.gilligan ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/web/nodejs/v4.nix
+++ b/pkgs/development/web/nodejs/v4.nix
@@ -1,67 +1,12 @@
 { stdenv, fetchurl, openssl, python, zlib, libuv, v8, utillinux, http-parser
 , pkgconfig, runCommand, which, libtool
-}:
+, callPackage
+}@args:
 
-# nodejs 0.12 can't be built on armv5tel. Armv6 with FPU, minimum I think.
-# Related post: http://zo0ok.com/techfindings/archives/1820
-assert stdenv.system != "armv5tel-linux";
-
-let
+import ./nodejs.nix (args // rec {
   version = "4.3.1";
-
-  deps = {
-    inherit openssl zlib libuv;
-
-    # disabled system v8 because v8 3.14 no longer receives security fixes
-    # we fall back to nodejs' internal v8 copy which receives backports for now
-    # inherit v8
-  } // (stdenv.lib.optionalAttrs (!stdenv.isDarwin) {
-    inherit http-parser;
-  });
-
-  sharedConfigureFlags = name: [
-    "--shared-${name}"
-    "--shared-${name}-includes=${builtins.getAttr name deps}/include"
-    "--shared-${name}-libpath=${builtins.getAttr name deps}/lib"
-  ];
-
-  inherit (stdenv.lib) concatMap optional optionals maintainers licenses platforms;
-in stdenv.mkDerivation {
-  name = "nodejs-${version}";
-
   src = fetchurl {
     url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
     sha256 = "0wzf5sirbph5kaik3pm9i2dxbjwqh5qlnqn71azrsv0vhs7dbqk1";
   };
-
-  configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps) ++ [ "--without-dtrace" ];
-  dontDisableStatic = true;
-  prePatch = ''
-    patchShebangs .
-    sed -i 's/raise.*No Xcode or CLT version detected.*/version = "7.0.0"/' tools/gyp/pylib/gyp/xcode_emulation.py
-  '';
-
-  patches = stdenv.lib.optionals stdenv.isDarwin [ ./no-xcode.patch ];
-
-  buildInputs = [ python zlib libuv openssl python ]
-    ++ optionals stdenv.isLinux [ utillinux http-parser ];
-  nativeBuildInputs = [ pkgconfig ]
-    ++ optional stdenv.isDarwin libtool;
-
-  postFixup = ''
-    sed -i 's/raise.*No Xcode or CLT version detected.*/version = "7.0.0"/' $out/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
-  '';
-  setupHook = ./setup-hook.sh;
-
-  enableParallelBuilding = true;
-
-  passthru.interpreterName = "nodejs";
-
-  meta = {
-    description = "Event-driven I/O framework for the V8 JavaScript engine";
-    homepage = http://nodejs.org;
-    license = licenses.mit;
-    maintainers = [ maintainers.havvy ];
-    platforms = platforms.linux ++ platforms.darwin;
-  };
-}
+})

--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -4,9 +4,9 @@
 }@args:
 
 import ./nodejs.nix (args // rec {
-  version = "5.11.0";
+  version = "6.0.0";
   src = fetchurl {
-    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-    sha256 = "14ayv5rgagc6lj7fil0bdbzwj2qxj5picw802rfmmpj9kqdb0hgg";
+    url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.gz";
+    sha256 = "0cpw7ng193jgfbw2g1fd0kcglmjjkbj4xb89g00z8zz0lj0nvdbd";
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2170,17 +2170,21 @@ in
 
   ninka = callPackage ../development/tools/misc/ninka { };
 
-  nodejs-5_x = callPackage ../development/web/nodejs/v5.nix {
+  nodejs-0_10 = callPackage ../development/web/nodejs/v0_10.nix {
     libtool = darwin.cctools;
+    inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices Carbon Foundation;
   };
 
   nodejs-4_x = callPackage ../development/web/nodejs/v4.nix {
     libtool = darwin.cctools;
   };
 
-  nodejs-0_10 = callPackage ../development/web/nodejs/v0_10.nix {
+  nodejs-5_x = callPackage ../development/web/nodejs/v5.nix {
     libtool = darwin.cctools;
-    inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices Carbon Foundation;
+  };
+
+  nodejs-6_x = callPackage ../development/web/nodejs/v6.nix {
+    libtool = darwin.cctools;
   };
 
   nodejs = if stdenv.system == "armv5tel-linux" then


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [X] NixOS
  - [X] OS X

---

In the process of adding node 6.0.0 I also did some refactoring since v4.nix, v5.nix and v6.nix were pretty much identical apart from `name`, `version` and `src`. Please let me know if there is a more idiomatic way in which I should be doing the composition between v4.nix, v5.nix, v6.nix and nodejs.nix.

Also note that nox-review will again fail for the same reason it failed in #14973 - which as I stated is related to the fact that we have very outdated nodejs libraries packaged that we need to get rid of (see #14532 and #15045)

/cc @svanderburg  
