### PR TITLE
vivaldi: 1.0 -> 1.1

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -10,23 +10,23 @@
 }:
 
 let
-  archUrl = name: arch: "https://vivaldi.com/download/stable/${name}_${arch}.deb";
+  archUrl = name: arch: "https://downloads.vivaldi.com/stable/${name}_${arch}.deb";
 in
 stdenv.mkDerivation rec {
-  version    = "1.0";
-  debversion = "stable_1.0.435.40-1";
+  version    = "1.1";
+  debversion = "stable_1.1.453.47-1";
   product    = "vivaldi";
   name       = "${product}-${version}";
 
   src = if stdenv.system == "x86_64-linux"
     then fetchurl {
       url    = archUrl "vivaldi-${debversion}" "amd64";
-      sha256 = "12c051a40258a95f9594eed2f73fa5f591482ac2a41d5cf643811b1ea2a1efbf";
+      sha256 = "09kadsi4ydjciq092i6linapqzjdzx915zqmz7vfq6w1yp9mqbwq";
     }
     else if stdenv.system == "i686-linux"
     then fetchurl {
       url    = archUrl "vivaldi-${debversion}" "i386";
-      sha256 = "6e0b84fba38211bab9a71bc10e97398fca77c0acd82791923c1d432b20846f0f";
+      sha256 = "0b5410phnkpg6sz0j345vdn0r6n89rm865bchqw8p4kx7pmy78z3";
     }
     else throw "Vivaldi is not supported on ${stdenv.system} (only i686-linux and x86_64 linux are supported)";
 
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       libXi libXft libXcursor libXfixes libXScrnSaver libXcomposite libXdamage libXtst libXrandr
       atk alsaLib dbus_libs cups gtk gdk_pixbuf libexif ffmpeg libudev
       freetype fontconfig libXrender libuuid expat glib nss nspr
-      gstreamer libxml2 gst_plugins_base pango cairo gnome3.gconf 
+      gstreamer libxml2 gst_plugins_base pango cairo gnome3.gconf
       patchelf
     ];
 


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
