### PR TITLE
epson-escpr: 1.6.4 -> 1.6.5

### DIFF
--- a/pkgs/misc/drivers/epson-escpr/default.nix
+++ b/pkgs/misc/drivers/epson-escpr/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, cups }:
 
 let
-  version = "1.6.4";
+  version = "1.6.5";
 in
   stdenv.mkDerivation {
 
     name = "epson-escpr-${version}";
   
     src = fetchurl {
-      url = "https://download3.ebz.epson.net/dsc/f/03/00/04/37/97/88177bc0dc7025905eae4a0da1e841408f82e33c/epson-inkjet-printer-escpr-1.6.4-1lsb3.2.tar.gz"; 
-      sha256 = "76c66461a30be82b9cc37d663147a72f488fe060ef54578120602bb87a3f7754"; 
+      url = "https://download3.ebz.epson.net/dsc/f/03/00/04/54/27/b73564748bfde7b7ce625e20d4a3257d447bec79/epson-inkjet-printer-escpr-1.6.5-1lsb3.2.tar.gz"; 
+      sha256 = "1cd9e0506bf181e1476bd8305f1c6b8dbc4354eab9415d0d5529850856129e4c"; 
     }; 
 
     patches = [ ./cups-filter-ppd-dirs.patch ]; 
@@ -17,7 +17,7 @@ in
     buildInputs = [ cups ];
 
     meta = with stdenv.lib; {
-      homepage = https://github.com/artuuge/NixOS-files/;
+      homepage = "http://download.ebz.epson.net/dsc/search/01/search/";
       description = "ESC/P-R Driver (generic driver)";
       longDescription = ''
         Epson Inkjet Printer Driver (ESC/P-R) for Linux and the


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
