### PR TITLE
menu-cache: 0.7.0 -> 1.0.1

### DIFF
--- a/pkgs/development/libraries/menu-cache/default.nix
+++ b/pkgs/development/libraries/menu-cache/default.nix
@@ -1,15 +1,17 @@
 { stdenv, fetchurl, glib, pkgconfig, libfm-extra }:
 
-let name = "menu-cache-0.7.0";
+let name = "menu-cache-1.0.1";
 in
 stdenv.mkDerivation {
   inherit name;
   src = fetchurl {
     url = "mirror://sourceforge/lxde/${name}.tar.xz";
-    sha256 = "0wwkk4jrcl2sp11bspabplchh4ipi1zyn39j3skyzgbm8k40gkhk";
+    sha256 = "0ngxvwfj9drabqi3lyzgpi0d0za6431sy2ijb010filrj54jdiqa";
   };
 
-  buildInputs = [ glib pkgconfig libfm-extra ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ glib libfm-extra ];
 
   meta = with stdenv.lib; {
     homepage = "http://blog.lxde.org/?tag=menu-cache";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
