### PR TITLE
Manual: rephrase definition for indented strings

### DIFF
--- a/nixos/doc/manual/configuration/config-file.xml
+++ b/nixos/doc/manual/configuration/config-file.xml
@@ -106,11 +106,15 @@ networking.extraHosts =
   '';
 </programlisting>
 
-      The main difference is that preceding whitespace is
-      automatically stripped from each line, and that characters like
+      The main difference is that it strips from each line
+      a number of spaces equal to the minimal indentation of
+      the string as a whole (disregarding the indentation of
+      empty lines), and that characters like
       <literal>"</literal> and <literal>\</literal> are not special
       (making it more convenient for including things like shell
       code).</para>
+      See more info about this in the Nix manual <link
+xlink:href="https://nixos.org/nix/manual/#ssec-values">here</link>.
     </listitem>
   </varlistentry>
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Did not test this in any way... please suggest a way to test(the manual?), if needed and/or for the future.

Text stolen from: https://nixos.org/nix/manual/#ssec-values

Closes #15076 
