### PR TITLE
Just strip everything by default

### DIFF
--- a/pkgs/build-support/setup-hooks/strip.sh
+++ b/pkgs/build-support/setup-hooks/strip.sh
@@ -4,7 +4,7 @@ fixupOutputHooks+=(_doStrip)
 
 _doStrip() {
     if [ -z "$dontStrip" ]; then
-        stripDebugList=${stripDebugList:-lib lib32 lib64 libexec bin sbin}
+        stripDebugList=${stripDebugList:-.}
         if [ -n "$stripDebugList" ]; then
             stripDirs "$stripDebugList" "${stripDebugFlags:--S}"
         fi
@@ -29,8 +29,20 @@ stripDirs() {
     dirs=${dirsNew}
 
     if [ -n "${dirs}" ]; then
-        header "stripping (with flags $stripFlags) in$dirs"
-        find $dirs -type f -print0 | xargs -0 ${xargsFlags:--r} strip $commonStripFlags $stripFlags || true
+        header "Stripping (with flags $stripFlags) in$dirs"
+        while IFS= read -r -d $'\0' f; do
+            if out=$(strip $commonStripFlags $stripFlags "$f" 2>&1); then
+                echo "Stripped $f"
+            else
+                # Ignore failures on files that cannot be stripped.
+                if [ "$out" = "strip:$f: File format not recognized" ]; then
+                    continue
+                fi
+
+                echo "Strip failed on file $f: $out"
+                false # fail !
+            fi
+        done < <(find $dirs -type f -print0)
         stopNest
     fi
 }


### PR DESCRIPTION
Stripping binaries is of utmost importance to benefit from the closure-size changes.
To avoid missing custom paths (like /modules for php-like packages), strip the whole output.

This PR has the following advantages
1. It does not produce pointless warning about unrecognized filetypes;
2. It does strip _everything_ that strip can strip;
3. It does not ignore failures of strip (other than unrecognized filetypes).

I have tested it on some derivations (ldb, php) by fiddling around with makeSetupHook, but not on stdenv. That being said, the only way this patch could break stuff is by stripping something that should not be stripped and that resides outside of `lib lib32 lib64 libexec bin sbin`.

NB: This triggers a mass-rebuild.
Fixes #14821, #14822, #14823, #14824.
