### PR TITLE
redis-desktop-manager: init at 0.8.3

### DIFF
--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -1,0 +1,81 @@
+{ stdenv, lib, fetchgit, pkgconfig , libssh2
+, qtbase, qtdeclarative, qtgraphicaleffects, qtimageformats, qtquickcontrols
+, qtsvg, qttools, qtquick1
+, makeQtWrapper, qmakeHook
+}:
+
+let
+  breakpad_lss = fetchgit {
+    url = "https://chromium.googlesource.com/linux-syscall-support";
+    rev = "08056836f2b4a5747daff75435d10d649bed22f6";
+    sha256 = "1ryshs2nyxwa0kn3rlbnd5b3fhna9vqm560yviddcfgdm2jyg0hz";
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  name = "redis-desktop-manager-${version}";
+  version = "0.8.3";
+
+  src = fetchgit {
+    url = "https://github.com/uglide/RedisDesktopManager.git";
+    fetchSubmodules = true;
+    rev = "refs/tags/${version}";
+    sha256 = "08969xwqpjgvfa195dxskpr54p4mnapgfykcffpqpczp990ak1l6";
+  };
+
+  nativeBuildInputs = [ makeQtWrapper qmakeHook ];
+
+  buildInputs = [
+    pkgconfig libssh2 qtbase qtdeclarative qtgraphicaleffects qtimageformats
+    qtquick1 qtquickcontrols qtsvg qttools
+  ];
+
+  configurePhase = "true";
+
+  buildPhase = ''
+    srcdir=$PWD
+
+    substituteInPlace src/resources/qml/ValueTabs.qml \
+      --replace "import QtQuick.Controls 1.4" \
+                "import QtQuick.Controls 1.2"
+
+    cat <<EOF > src/version.h
+#ifndef RDM_VERSION
+    #define RDM_VERSION "${version}-120"
+#endif // !RDM_VERSION
+EOF
+
+    cd $srcdir/3rdparty/gbreakpad
+    cp -r ${breakpad_lss} src/third_party/lss
+    chmod +w -R src/third_party/lss
+    touch README
+
+    cd $srcdir/3rdparty/crashreporter
+    qmake CONFIG+=release DESTDIR="$srcdir/rdm/bin/linux/release" QMAKE_LFLAGS_RPATH=""
+    make
+
+    cd $srcdir/3rdparty/gbreakpad
+    ./configure
+    make
+
+    cd $srcdir/src
+    qmake
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    instdir="$srcdir/bin/linux/release"
+    cp $instdir/rdm $out/bin
+    wrapQtProgram $out/bin/rdm
+  '';
+
+  meta = with lib; {
+    description = "Cross-platform open source Redis DB management tool";
+    homepage = "http://redisdesktop.com/";
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cstrahan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16358,6 +16358,8 @@ in
     inherit (pythonPackages) pexpect paramiko;
   };
 
+  redis-desktop-manager = qt5.callPackage ../applications/misc/redis-desktop-manager { };
+
   robomongo = qt5.callPackage ../applications/misc/robomongo { };
 
   rucksack = callPackage ../development/tools/rucksack { };


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
