### PR TITLE
oh-my-zsh: 2016-04-06 -> 2016-04-20

### DIFF
--- a/pkgs/shells/oh-my-zsh/default.nix
+++ b/pkgs/shells/oh-my-zsh/default.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation rec {
   name = "oh-my-zsh-git-${version}";
-  version = "2016-04-06";
+  version = "2016-04-20";
 
   src = fetchgit {
     url = "https://github.com/robbyrussell/oh-my-zsh";
-    rev = "d310fac7f65d31f7494532201e02ebf67c9d9555";
-    sha256 = "0kx552b0jf5j8qkk1kixdr1z49ly79cvzhdh27848rj3kwb0z8vq";
+    rev = "1b1315a777328095cd8b5f364fd4345eeae7c4bf";
+    sha256 = "0q3w96a9rjxmqknycxjqjs5mi0q2mark8yrfim7snxrf9ajv0ypk";
   };
 
   phases = "installPhase";


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
