### PR TITLE
postgresql service: remove redundant services.postgresql.package option

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -123,6 +123,7 @@ with lib;
     (mkRemovedOptionModule [ "services" "printing" "cupsFilesConf" ])
     (mkRemovedOptionModule [ "services" "printing" "cupsdConf" ])
     (mkRemovedOptionModule [ "services" "xserver" "startGnuPGAgent" ])
+    (mkRemovedOptionModule [ "services" "postgresql" "package" ])
 
   ];
 }

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -20,7 +20,12 @@ let
         '';
     };
 
-  postgresql = postgresqlAndPlugins cfg.package;
+  # Note: when changing the default, make it conditional on
+  # ‘system.stateVersion’ to maintain compatibility with existing
+  # systems!
+  package = if versionAtLeast config.system.stateVersion "16.03" then pkgs.postgresql95 else pkgs.postgresql94;
+
+  postgresql = postgresqlAndPlugins package;
 
   flags = optional cfg.enableTCPIP "-i";
 
@@ -51,14 +56,6 @@ in
         default = false;
         description = ''
           Whether to run PostgreSQL.
-        '';
-      };
-
-      package = mkOption {
-        type = types.package;
-        example = literalExample "pkgs.postgresql92";
-        description = ''
-          PostgreSQL package to use.
         '';
       };
 
@@ -153,12 +150,6 @@ in
   ###### implementation
 
   config = mkIf config.services.postgresql.enable {
-
-    services.postgresql.package =
-      # Note: when changing the default, make it conditional on
-      # ‘system.stateVersion’ to maintain compatibility with existing
-      # systems!
-      mkDefault (if versionAtLeast config.system.stateVersion "16.03" then pkgs.postgresql95 else pkgs.postgresql94);
 
     services.postgresql.authentication = mkAfter
       ''


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] NixOS
- [x] Tested execution of service
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is no longer needed now that `system.stateVersion` is available.

If a customized version of postgresql is needed, then it can be
specified with the usual packageOverrides mechanism:

```
  nixpkgs.config.packageOverrides = super: {
    postgresqlXX = super.postgresqlXX.override { ... };
  };
```

where XX is the postgresql version corresponding to the value of
`system.stateVersion` in use.

Similarly, old versions of postgresql can be specified with `postgresqlXX = super.postgresqlYY`.
