### PR TITLE
squid: 3.5.15 -> 3.5.17 (resolving CVE-2016-3947, CVE-2016-3948, CVE-2016-4051, CVE-2016-4052, CVE-2016-4053, CVE-2016-4054)

### DIFF
--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -1,10 +1,10 @@
 { fetchurl, stdenv, perl, lib, openldap, pam, db, cyrus_sasl, libcap,
 expat, libxml2, libtool, openssl}:
 stdenv.mkDerivation rec {
-  name = "squid-3.5.15";
+  name = "squid-3.5.17";
   src = fetchurl {
     url = "http://www.squid-cache.org/Versions/v3/3.5/${name}.tar.bz2";
-    sha256 = "1cgy6ffyarqd35plqmqi3mrsp0941c6n55pr3zavp07ksj46wgzm";
+    sha256 = "1kdq778cm18ak4624gchmbi8avnzyvwgyzjplkd0fkcrgfs44bsf";
   };
   buildInputs = [perl openldap pam db cyrus_sasl libcap expat libxml2
     libtool openssl];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
