### PR TITLE
BittorrentSync 1.4: changed mirror

### DIFF
--- a/pkgs/applications/networking/bittorrentsync/1.4.x.nix
+++ b/pkgs/applications/networking/bittorrentsync/1.4.x.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation rec {
   version = "1.4.110";
 
   src  = fetchurl {
-    url  = "http://syncapp.bittorrent.com/${version}/btsync_${arch}-${version}.tar.gz";
+    #url  = "http://syncapp.bittorrent.com/${version}/btsync_${arch}-${version}.tar.gz";
+    url  = "http://archive.yeasoft.net/btsync/${version}/btsync_${arch}-${version}.tar.gz";
     inherit sha256;
   };
 

--- a/pkgs/applications/networking/bittorrentsync/1.4.x.nix
+++ b/pkgs/applications/networking/bittorrentsync/1.4.x.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
   version = "1.4.110";
 
   src  = fetchurl {
-    #url  = "http://syncapp.bittorrent.com/${version}/btsync_${arch}-${version}.tar.gz";
     url  = "http://archive.yeasoft.net/btsync/${version}/btsync_${arch}-${version}.tar.gz";
     inherit sha256;
   };


### PR DESCRIPTION
Changed the location of the mirror, because bittorrent.com doesn't host these versions anymore.
