### PR TITLE
Manual: rephrase definition for indented strings

### DIFF
--- a/nixos/doc/manual/configuration/config-file.xml
+++ b/nixos/doc/manual/configuration/config-file.xml
@@ -106,11 +106,15 @@ networking.extraHosts =
   '';
 </programlisting>
 
-      The main difference is that preceding whitespace is
-      automatically stripped from each line, and that characters like
+      The main difference is that it strips from each line
+      a number of spaces equal to the minimal indentation of
+      the string as a whole (disregarding the indentation of
+      empty lines), and that characters like
       <literal>"</literal> and <literal>\</literal> are not special
       (making it more convenient for including things like shell
-      code).</para>
+      code).
+      See more info about this in the Nix manual <link
+      xlink:href="https://nixos.org/nix/manual/#ssec-values">here</link>.</para>
     </listitem>
   </varlistentry>
 


### PR DESCRIPTION
Attempt to fix #15086 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- [x] Tested with: `time nix-build /etc/nixos/nixpkgs/nixos/release.nix -A manual.x86_64-linux`
- [x] Tested in firefox to look as expected.

**EDIT:** Unrelated issue: https://github.com/NixOS/nixpkgs/issues/15108 therefore ignore the below:

I get these whether I leave or remove the `<link ... </link>` part:

```
$ time nix-build /etc/nixos/nixpkgs/nixos/release.nix -A manual.x86_64-linux
these derivations will be built:
  /nix/store/j1m5l6jaf3893l5azmd60bnd08i7z6mj-nixos-manual.drv
building path(s) ‘/nix/store/aswvb9imh7928inyp459l2qrppn8w2lq-nixos-manual’
manual.xml validates
warning: failed to load external entity "olinkdb.xml"
Olink error: could not open target database 'olinkdb.xml'.
Error: unresolved olink: targetdoc/targetptr = 'manual/module-taskserver'.
Writing options.html for appendix(ch-options)
Writing release-notes.html for appendix(ch-release-notes)
Writing index.html for book(book-nixos-manual)
/nix/store/aswvb9imh7928inyp459l2qrppn8w2lq-nixos-manual

real    0m26.107s
user    0m1.857s
sys 0m0.373s

z@vbox1 ~
$ time nix-build /etc/nixos/nixpkgs/nixos/release.nix -A manual.x86_64-linux
these derivations will be built:
  /nix/store/60fq62vnl30h0108vqwdz36k15njbkib-nixos-manual.drv
building path(s) ‘/nix/store/5zv5bbqjfr67gln909lb21rgdb0jahdc-nixos-manual’
manual.xml validates
warning: failed to load external entity "olinkdb.xml"
Olink error: could not open target database 'olinkdb.xml'.
Error: unresolved olink: targetdoc/targetptr = 'manual/module-taskserver'.
Writing options.html for appendix(ch-options)
Writing release-notes.html for appendix(ch-release-notes)
Writing index.html for book(book-nixos-manual)
/nix/store/5zv5bbqjfr67gln909lb21rgdb0jahdc-nixos-manual

real    0m28.712s
user    0m1.705s
sys 0m0.398s
```

**EDIT:**

``` grep
nixos/modules/services/misc/taskserver/default.nix:197:          <olink targetdoc="manual" targetptr="module-taskserver"/>.
nixos/modules/services/misc/taskserver/doc.xml:4:    xml:id="module-taskserver">
```

Closes #15102 
