### PR TITLE
subversion: fix apr-1 linking related to #14495

### DIFF
--- a/pkgs/applications/version-management/subversion/apr-1.patch
+++ b/pkgs/applications/version-management/subversion/apr-1.patch
@@ -1,0 +1,11 @@
+--- a/subversion/bindings/swig/perl/native/Makefile.PL.in
++++ b/subversion/bindings/swig/perl/native/Makefile.PL.in
+@@ -72,7 +72,7 @@
+ # According to the log of r7937, the flags guarded by the conditional break
+ # the build on FreeBSD if not conditionalized.
+ my $apr_ldflags = '@SVN_APR_LIBS@'
+-   if $^O eq 'darwin' or $^O eq 'cygwin';
++   if $^O eq 'darwin' or $^O eq 'cygwin' or $^O eq 'linux';
+ 
+ chomp $apr_shlib_path_var;
+ 

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -35,6 +35,8 @@ let
       ++ stdenv.lib.optional perlBindings perl
       ++ stdenv.lib.optional saslSupport sasl;
 
+    patches = [ ./apr-1.patch ];
+
     configureFlags = ''
       ${if bdbSupport then "--with-berkeley-db" else "--without-berkeley-db"}
       ${if httpServer then "--with-apxs=${apacheHttpd}/bin/apxs" else "--without-apxs"}


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm not sure yet what exactly is the source of the problem and why the update to binutils-2.26 broke the perl bindings, but this partly fixes #14495 (I think the remaining issue is multiple outputs related, will fix later). 

For reference, the problem seems to be a missing -lapr-1 flag on the LIBS part of the config in subversion/bindings/swig/perl/native/Makefile.PL(.in). If anyone more familiar with perl, makemaker or the subversion build can contribute a better fix, please do.

maintainers @edolstra @lovek323 
