### PR TITLE
openra: 20141029 -> 20151224

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -291,6 +291,7 @@
   pxc = "Patrick Callahan <patrick.callahan@latitudeengineering.com>";
   qknight = "Joachim Schiele <js@lastlog.de>";
   ragge = "Ragnar Dahlen <r.dahlen@gmail.com>";
+  rardiol = "Ricardo Ardissone <ricardo.ardissone@gmail.com>";
   rasendubi = "Alexey Shmalko <rasen.dubi@gmail.com>";
   raskin = "Michael Raskin <7c6f434c@mail.ru>";
   redbaron = "Maxim Ivanov <ivanov.maxim@gmail.com>";

--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -1,9 +1,10 @@
 { stdenv, fetchurl, mono, makeWrapper, lua
-, SDL2, freetype, openal, systemd, pkgconfig
+, SDL2, freetype, openal, systemd, pkgconfig,
+  dotnetPackages, gnome3
 }:
 
 let
-  version = "20141029";
+  version = "20151224";
 in stdenv.mkDerivation rec {
   name = "openra-${version}";
 
@@ -17,23 +18,71 @@ in stdenv.mkDerivation rec {
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "https://github.com/OpenRA/OpenRA/archive/release-${version}.tar.gz";
-    sha256 = "082rwcy866k636s4qhbry3ja2p81mdz58bh1dw2mic5mv2q6p67r";
+    sha256 = "0dgaxy1my5r3sr3l3gw79v89dsc7179pasj2bibswlv03wsjgqbi";
   };
 
   dontStrip = true;
 
-  buildInputs = [ lua ];
+  buildInputs = with dotnetPackages;
+     [ NUnit NewtonsoftJson MonoNat FuzzyLogicLibrary SmartIrc4net SharpZipLib MaxMindGeoIP2 MaxMindDb SharpFont StyleCopMSBuild StyleCopPlusMSBuild RestSharp ]
+     ++ [ lua gnome3.zenity ];
   nativeBuildInputs = [ mono makeWrapper lua pkgconfig ];
 
   patchPhase = ''
     sed -i 's/^VERSION.*/VERSION = release-${version}/g' Makefile
-    substituteInPlace configure --replace /bin/bash "$shell" --replace /usr/local/lib "${lua}/lib"
+    substituteInPlace thirdparty/configure-native-deps.sh --replace "locations=\"" "locations=\"${lua}/lib "
+    substituteInPlace Makefile --replace "@./thirdparty/fetch-geoip-db.sh" ""
   '';
 
   preConfigure = ''
     makeFlags="prefix=$out"
     make version
   '';
+
+  preBuild = let dotnetPackagesDlls = with dotnetPackages; [
+    "${MonoNat}/lib/dotnet/Mono.Nat/net40/Mono.Nat.dll"
+    "${FuzzyLogicLibrary}/lib/dotnet/FuzzyLogicLibrary/Release/FuzzyLogicLibrary.dll"
+    "${SmartIrc4net}/lib/dotnet/SmartIrc4net/net40/SmarIrc4net*"
+    "${SharpZipLib}/lib/dotnet/SharpZipLib/20/ICSharpCode.SharpZipLib.dll"
+    "${MaxMindGeoIP2}/lib/dotnet/MaxMind.GeoIP2/net40/MaxMind.GeoIP2*"
+    "${MaxMindDb}/lib/dotnet/MaxMind.Db/net40/MaxMind.Db.*"
+    "${SharpFont}/lib/dotnet/SharpFont/net20/SharpFont.dll"
+    "${SharpFont}/lib/dotnet/SharpFont/SharpFont.dll.config"
+    "${StyleCopMSBuild}/lib/dotnet/StyleCop.MSBuild/StyleCop*.dll"
+    "${StyleCopPlusMSBuild}/lib/dotnet/StyleCopPlus.MSBuild/StyleCopPlus.dll"
+    "${RestSharp}/lib/dotnet/RestSharp/net4-client/RestSharp.dll"
+    "${NUnit}/lib/dotnet/NUnit/nunit.framework.*"
+    "${NewtonsoftJson}/lib/dotnet/Newtonsoft.Json/Newtonsoft.Json.dll"
+    ];
+    movePackages = [
+      ( let filename = "Eluant.dll"; in { origin = fetchurl {
+          url = "https://github.com/OpenRA/Eluant/releases/download/20140425/${filename}";
+          sha256 = "1c20whz7dzfhg3szd62rvb79745x5iwrd5pp62j3bbj1q9wpddmb";
+        }; target = filename; })
+
+      ( let filename = "SDL2-CS.dll"; in { origin = fetchurl {
+          url = "https://github.com/OpenRA/SDL2-CS/releases/download/20150709/${filename}";
+          sha256 = "0ms75w9w0x3dzpg5g1ym5nb1id7pmagbzqx0am7h8fq4m0cqddmc";
+        }; target = filename; })
+
+      ( let filename = "GeoLite2-Country.mmdb.gz"; in { origin = fetchurl {
+          url = "http://geolite.maxmind.com/download/geoip/database/${filename}";
+          sha256 = "0lr978pipk5q2z3x011ps4fx5nfc3hsal7jb77fc60aa6iscr05m";
+        }; target = filename; })
+    ];
+  in ''
+    mkdir thirdparty/download/
+
+    ${stdenv.lib.concatMapStringsSep "\n" (from: "cp ${from} thirdparty/download") dotnetPackagesDlls}
+    ${stdenv.lib.concatMapStringsSep "\n" ({origin, target}: "cp ${origin} thirdparty/download/${target}") movePackages}
+
+    make dependencies
+  '';
+
+  #todo: man-page
+  buildFlags = [ "DEBUG=false" "default" ];
+
+  installTargets = [ "install" "install-linux-icons" "install-linux-desktop" "install-linux-appdata" "install-linux-mime" ];
 
   postInstall = with stdenv.lib; let
     runtime = makeLibraryPath [ SDL2 freetype openal systemd lua ];
@@ -42,9 +91,9 @@ in stdenv.mkDerivation rec {
       --prefix PATH : "${mono}/bin" \
       --set PWD $out/lib/openra/ \
       --prefix LD_LIBRARY_PATH : "${runtime}"
-      
+
     mkdir -p $out/bin
-    echo "cd $out/lib/openra && $out/lib/openra/launch-game.sh" > $out/bin/openra
+    echo -e "#!${stdenv.shell}\ncd $out/lib/openra && $out/lib/openra/launch-game.sh" > $out/bin/openra
     chmod +x $out/bin/openra
   '';
 }

--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -11,6 +11,7 @@ in stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Real Time Strategy game engine recreates the C&C titles";
     homepage    = "http://www.open-ra.org/";
+    maintainers = [ maintainers.rardiol ];
     license     = licenses.gpl3;
     platforms   = platforms.linux;
   };

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -109,6 +109,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/*" ];
   };
 
+  MaxMindGeoIP2 = fetchNuGet {
+    baseName = "MaxMind.GeoIP2";
+    version = "2.3.1";
+    sha256 = "1s44dvjnmj1aimbrgkmpj6h5dn1w6acgqjch1axc76yz6hwknqgf";
+    outputFiles = [ "lib/*" ];
+  };
+
   NUnitRunners = fetchNuGet {
     baseName = "NUnit.Runners";
     version = "2.6.4";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -137,6 +137,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "bin/*" ];
   };
 
+  MonoNat = fetchNuGet {
+    baseName = "Mono.Nat";
+    version = "1.2.21";
+    sha256 = "011xhmjrx6w5h110fcp40l95k3qj1gkzz3axgbfy0s8haf5hsf7s";
+    outputFiles = [ "lib/*" ];
+  };
+
   NUnitRunners = fetchNuGet {
     baseName = "NUnit.Runners";
     version = "2.6.4";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -116,6 +116,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/*" ];
   };
 
+  SharpZipLib = fetchNuGet {
+    baseName = "SharpZipLib";
+    version = "0.86.0";
+    sha256 = "01w2038gckfnq31pncrlgm7d0c939pwr1x4jj5450vcqpd4c41jr";
+    outputFiles = [ "lib/*" ];
+  };
+
   NUnitRunners = fetchNuGet {
     baseName = "NUnit.Runners";
     version = "2.6.4";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -130,6 +130,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/*" ];
   };
 
+  FuzzyLogicLibrary = fetchNuGet {
+    baseName = "FuzzyLogicLibrary";
+    version = "1.2.0";
+    sha256 = "0x518i8d3rw9n51xwawa4sywvqd722adj7kpcgcm63r66s950r5l";
+    outputFiles = [ "bin/*" ];
+  };
+
   NUnitRunners = fetchNuGet {
     baseName = "NUnit.Runners";
     version = "2.6.4";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -123,6 +123,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/*" ];
   };
 
+  StyleCopMSBuild = fetchNuGet {
+    baseName = "StyleCop.MSBuild";
+    version = "4.7.49.0";
+    sha256 = "0rpfyvcggm881ynvgr17kbx5hvj7ivlms0bmskmb2zyjlpddx036";
+    outputFiles = [ "tools/*" ];
+  };
+
   SharpFont = fetchNuGet {
     baseName = "SharpFont";
     version = "3.0.1";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -102,6 +102,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/*" ];
   };
 
+  MaxMindDb = fetchNuGet {
+    baseName = "MaxMind.Db";
+    version = "1.1.0.0";
+    sha256 = "0lixl76f7k3ldiqzg94zh13gn82w5mm5dx72y97fcqvp8g6nj3ds";
+    outputFiles = [ "lib/*" ];
+  };
+
   NUnitRunners = fetchNuGet {
     baseName = "NUnit.Runners";
     version = "2.6.4";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -130,6 +130,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "tools/*" ];
   };
 
+  StyleCopPlusMSBuild = fetchNuGet {
+    baseName = "StyleCopPlus.MSBuild";
+    version = "4.7.49.5";
+    sha256 = "1hv4lfxw72aql8siyqc4n954vzdz8p6jx9f2wrgzz0jy1k98x2mr";
+    outputFiles = [ "tools/*" ];
+  };
+
   SharpFont = fetchNuGet {
     baseName = "SharpFont";
     version = "3.0.1";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -123,6 +123,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/*" ];
   };
 
+  SharpFont = fetchNuGet {
+    baseName = "SharpFont";
+    version = "3.0.1";
+    sha256 = "1g639i8mbxc6qm0xqsf4mc0shv8nwdaidllka2xxwyksbq54skhs";
+    outputFiles = [ "lib/*" "config/*" ];
+  };
+
   SmartIrc4net = fetchNuGet {
     baseName = "SmartIrc4net";
     version = "0.4.5.1";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -137,6 +137,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "tools/*" ];
   };
 
+  RestSharp = fetchNuGet {
+    baseName = "RestSharp";
+    version = "105.2.3";
+    sha256 = "1br48124ppz80x92m84sfyil1gn23hxg2ml9i9hsd0lp86vlaa1m";
+    outputFiles = [ "lib/*" ];
+  };
+
   SharpFont = fetchNuGet {
     baseName = "SharpFont";
     version = "3.0.1";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -123,6 +123,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/*" ];
   };
 
+  SmartIrc4net = fetchNuGet {
+    baseName = "SmartIrc4net";
+    version = "0.4.5.1";
+    sha256 = "1k6zc6xsqfzj7nc9479d32akj6d37jq6i1qirmz1i66p52zb5hm1";
+    outputFiles = [ "lib/*" ];
+  };
+
   NUnitRunners = fetchNuGet {
     baseName = "NUnit.Runners";
     version = "2.6.4";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- I can't run this in in fullscreen or pseudofullscreen, but from searching the problem and running the previous version it doesn't seem related to the update. Would be nice if someone build it and checked if it's specific to my setup or not.
- The geolite database this requires will be updated at some point, breaking the hash. I can't think of a proper fix, except maybe making a mirror with dates.
- Technically, upstream asks for NewtonsoftJson 7.0.1 and not 6.0.8
- This follows #15091 
- If anyone knows of a cleaner way to do the preBuild part I'm interested.
