### PR TITLE
nwjs: use correct nwEnv and rpath

### DIFF
--- a/pkgs/development/tools/node-webkit/nw12.nix
+++ b/pkgs/development/tools/node-webkit/nw12.nix
@@ -11,10 +11,12 @@ let
     paths = [
       xorg.libX11 xorg.libXrender glib gtk atk pango cairo gdk_pixbuf
       freetype fontconfig xorg.libXcomposite alsaLib xorg.libXdamage
-      xorg.libXext xorg.libXfixes nss nspr gconf expat dbus stdenv.cc
+      xorg.libXext xorg.libXfixes nss nspr gconf expat dbus
       xorg.libXtst xorg.libXi xorg.libXcursor xorg.libXrandr libcap
       libnotify
     ];
+
+    extraOutputsToInstall = [ "lib" "out" ];
   };
 
 in stdenv.mkDerivation rec {
@@ -39,7 +41,7 @@ in stdenv.mkDerivation rec {
 
     ln -s ${libudev.out}/lib/libudev.so $out/share/nwjs/libudev.so.0
 
-    patchelf --set-rpath "${nwEnv}/lib:${nwEnv}/lib64:$out/share/nwjs" $out/share/nwjs/nw
+    patchelf --set-rpath "${nwEnv}/lib:${nwEnv}/lib64:${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}:$out/share/nwjs" $out/share/nwjs/nw
     patchelf --set-rpath "${nwEnv}/lib:${nwEnv}/lib64:$out/share/nwjs" $out/share/nwjs/nwjc
 
     mkdir -p $out/bin


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is related to changes in fontconfig, pango, dbus and udev. They needed `fontconfig.lib` instead of `fontconfig` for instance. This also adds the correct libstdc++ path to rpath. Previously libstdc++ was in `stdenv.cc`, but apparently not anymore.

This should fix issues with popcorntime.
