### PR TITLE
man-db: fix sysconfdir prefix

### DIFF
--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pkgconfig, libpipeline, db, groff }:
- 
+
 stdenv.mkDerivation rec {
   name = "man-db-2.7.5";
-  
+
   src = fetchurl {
     url = "mirror://savannah/man-db/${name}.tar.xz";
     sha256 = "056a3il7agfazac12yggcg4gf412yq34k065im0cpfxbcw6xskaw";
   };
-  
+
   buildInputs = [ pkgconfig libpipeline db groff ];
 
   configureFlags = [

--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-setuid"
-    "--sysconfdir=/etc"
+    "--sysconfdir=\${out}/etc"
     "--localstatedir=/var"
     "--with-systemdtmpfilesdir=\${out}/lib/tmpfiles.d"
     "--with-eqn=${groff}/bin/eqn"


### PR DESCRIPTION
Fixes the sysconfdir prefix  which resolves this problem:

```
man man
man: can't open the manpath configuration file /etc/man_db.conf`
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
