### PR TITLE
asciidoctor: Init at 1.5.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -146,6 +146,7 @@
   giogadi = "Luis G. Torres <lgtorres42@gmail.com>";
   gleber = "Gleb Peregud <gleber.p@gmail.com>";
   globin = "Robin Gloster <mail@glob.in>";
+  gpyh = "Yacine Hmito <yacine.hmito@gmail.com>";
   goibhniu = "Cillian de Róiste <cillian.deroiste@gmail.com>";
   Gonzih = "Max Gonzih <gonzih@gmail.com>";
   gridaphobe = "Eric Seidel <eric@seidel.io>";

--- a/pkgs/tools/typesetting/asciidoctor/Gemfile
+++ b/pkgs/tools/typesetting/asciidoctor/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+gem 'asciidoctor'
+gem 'asciidoctor-diagram'
+gem 'asciidoctor-bespoke'
+gem 'asciidoctor-pdf'
+gem 'asciidoctor-latex'

--- a/pkgs/tools/typesetting/asciidoctor/Gemfile.lock
+++ b/pkgs/tools/typesetting/asciidoctor/Gemfile.lock
@@ -1,0 +1,87 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    Ascii85 (1.0.2)
+    addressable (2.4.0)
+    afm (0.2.2)
+    asciidoctor (1.5.4)
+    asciidoctor-bespoke (1.0.0.alpha.1)
+      asciidoctor (>= 1.5.0)
+      slim (~> 3.0.6)
+      thread_safe (~> 0.3.5)
+    asciidoctor-diagram (1.4.0)
+      asciidoctor (~> 1.5.0)
+    asciidoctor-latex (1.5.0.6.dev)
+      asciidoctor (~> 1.5, >= 1.5.2)
+      htmlentities (~> 4.3)
+      opal (~> 0.6.3)
+    asciidoctor-pdf (1.5.0.alpha.11)
+      asciidoctor (~> 1.5.0)
+      prawn (>= 1.3.0, < 3.0.0)
+      prawn-icon (= 1.0.0)
+      prawn-svg (= 0.21.0)
+      prawn-table (= 0.2.2)
+      prawn-templates (= 0.0.3)
+      safe_yaml (~> 1.0.4)
+      thread_safe (~> 0.3.5)
+      treetop (= 1.5.3)
+    concurrent-ruby (1.0.1)
+    css_parser (1.4.1)
+      addressable
+    hashery (2.1.2)
+    htmlentities (4.3.4)
+    json (1.8.3)
+    opal (0.6.3)
+      source_map
+      sprockets
+    pdf-core (0.6.1)
+    pdf-reader (1.4.0)
+      Ascii85 (~> 1.0.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
+    polyglot (0.3.5)
+    prawn (2.1.0)
+      pdf-core (~> 0.6.1)
+      ttfunk (~> 1.4.0)
+    prawn-icon (1.0.0)
+      prawn (>= 1.1.0, < 3.0.0)
+    prawn-svg (0.21.0)
+      css_parser (~> 1.3)
+      prawn (>= 0.8.4, < 3)
+    prawn-table (0.2.2)
+      prawn (>= 1.3.0, < 3.0.0)
+    prawn-templates (0.0.3)
+      pdf-reader (~> 1.3)
+      prawn (>= 0.15.0)
+    rack (1.6.4)
+    ruby-rc4 (0.1.5)
+    safe_yaml (1.0.4)
+    slim (3.0.6)
+      temple (~> 0.7.3)
+      tilt (>= 1.3.3, < 2.1)
+    source_map (3.0.1)
+      json
+    sprockets (3.6.0)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    temple (0.7.6)
+    thread_safe (0.3.5)
+    tilt (2.0.2)
+    treetop (1.5.3)
+      polyglot (~> 0.3)
+    ttfunk (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  asciidoctor
+  asciidoctor-bespoke
+  asciidoctor-diagram
+  asciidoctor-latex
+  asciidoctor-pdf
+
+BUNDLED WITH
+   1.11.2

--- a/pkgs/tools/typesetting/asciidoctor/default.nix
+++ b/pkgs/tools/typesetting/asciidoctor/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, bundlerEnv, ruby_2_2, curl }:
+
+bundlerEnv rec {
+  name = "asciidoctor-${version}";
+  version = "1.5.4";
+
+  ruby = ruby_2_2;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  # Delete dependencies' executables
+  postBuild = ''
+    find $out/bin -type f -not -wholename '*bin/asciidoctor*' -print0 \
+    | xargs -0 rm
+  '';
+
+  meta = with lib; {
+    description = "A faster Asciidoc processor written in Ruby";
+    homepage = http://asciidoctor.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ gpyh ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/typesetting/asciidoctor/gemset.nix
+++ b/pkgs/tools/typesetting/asciidoctor/gemset.nix
@@ -1,0 +1,267 @@
+{
+  addressable = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mpn7sbjl477h56gmxsjqb89r5s3w7vx5af994ssgc3iamvgzgvs";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  afm = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06kj9hgd0z8pj27bxp2diwqh6fv7qhwwm17z64rhdc4sfn76jgn8";
+      type = "gem";
+    };
+    version = "0.2.2";
+  };
+  Ascii85 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0j95sbxd18kc8rhcnvl1w37kflqpax1r12h1x47gh4xxn3mz4m7q";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
+  asciidoctor = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xrli1fjsf1f0h6d9g55vzivxbqac2ygawcacx5ijnqn522wg9qc";
+      type = "gem";
+    };
+    version = "1.5.4";
+  };
+  asciidoctor-bespoke = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1awy933sswxvi2hxpll3rh9phxcvmqhrbb91m6ibjchnf7qsl3zk";
+      type = "gem";
+    };
+    version = "1.0.0.alpha.1";
+  };
+  asciidoctor-diagram = {
+    dependencies = ["asciidoctor"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yb2gqzzbvgf5im0bhv26s3h09m9m6a0pjlq3swqcvwi1szc64k5";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  asciidoctor-latex = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0kzql61w4phr45w771lvmlmvg22h2wd11n9frrzk3k7psqqd7k61";
+      type = "gem";
+    };
+    version = "1.5.0.6.dev";
+  };
+  asciidoctor-pdf = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06jsbn1yiavg6r07k93rmjxj6ah8csqla5mpymqjzslrkgjg5brs";
+      type = "gem";
+    };
+    version = "1.5.0.alpha.11";
+  };
+  concurrent-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13igpwgbsq701vzh1lrxs9dlqdgs58kflw8vw35644amwnj1cmjn";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+  css_parser = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1ql5q4n39278prbdjdsxx9wkxkxblgzzn0qcdqnwibgd1dkvb5av";
+      type = "gem";
+    };
+    version = "1.4.1";
+  };
+  hashery = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qj8815bf7q6q7llm5rzdz279gzmpqmqqicxnzv066a020iwqffj";
+      type = "gem";
+    };
+    version = "2.1.2";
+  };
+  htmlentities = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nkklqsn8ir8wizzlakncfv42i32wc0w9hxp00hvdlgjr7376nhj";
+      type = "gem";
+    };
+    version = "4.3.4";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nsby6ry8l9xg3yw4adlhk2pnc7i0h0rznvcss4vk3v74qg0k8lc";
+      type = "gem";
+    };
+    version = "1.8.3";
+  };
+  opal = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dmdxhmg43ibd4bsldssslsz8870hzknwcxiv9l1838lh6hd390k";
+      type = "gem";
+    };
+    version = "0.6.3";
+  };
+  pdf-core = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1s0h0kkddkivgpf7k1jni9nzqxw09d9bgcsvyga407ixbiipkgfy";
+      type = "gem";
+    };
+    version = "0.6.1";
+  };
+  pdf-reader = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0j9cimzw2waic800108qmnds7w33xd9y3bdvf9qzijwv9wjv0iq1";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  polyglot = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bqnxwyip623d8pr29rg6m8r0hdg08fpr2yb74f46rn1wgsnxmjr";
+      type = "gem";
+    };
+    version = "0.3.5";
+  };
+  prawn = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18f99v3r0jzym38s68hr0y8anrilv98shmsdf763ascd0gc5dj2n";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  prawn-icon = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07dcsvxg52zdywhg28p6zsbj7ybz3xzbklawc1n7jwym2mli3916";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  prawn-svg = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1p5fsamh33xqp2gld0j4ii80awsxmm4ffp5pq13m0s1gavzaapc3";
+      type = "gem";
+    };
+    version = "0.21.0";
+  };
+  prawn-table = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nxd6qmxqwl850icp18wjh5k0s3amxcajdrkjyzpfgq0kvilcv9k";
+      type = "gem";
+    };
+    version = "0.2.2";
+  };
+  prawn-templates = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0d14sq01c5zn0ywzazwcz6lkk235za36km53wqbf1bqabdb1ls10";
+      type = "gem";
+    };
+    version = "0.0.3";
+  };
+  rack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09bs295yq6csjnkzj7ncj50i6chfxrhmzg1pk6p0vd2lb9ac8pj5";
+      type = "gem";
+    };
+    version = "1.6.4";
+  };
+  ruby-rc4 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00vci475258mmbvsdqkmqadlwn6gj9m01sp7b5a3zd90knil1k00";
+      type = "gem";
+    };
+    version = "0.1.5";
+  };
+  safe_yaml = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hly915584hyi9q9vgd968x2nsi5yag9jyf5kq60lwzi5scr7094";
+      type = "gem";
+    };
+    version = "1.0.4";
+  };
+  slim = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1szs71hh0msm5gj6qbcxw44m3hqnwybx4yh02scwixnwg576058k";
+      type = "gem";
+    };
+    version = "3.0.6";
+  };
+  source_map = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fviv92glr51v2zqy4i5jzi3hzpvjrcwyrxddcfr84ki65zb7pkv";
+      type = "gem";
+    };
+    version = "3.0.1";
+  };
+  sprockets = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16fnlp4fqzrdxlbalbx3r0bir7dwyr1asg7s9lsmmczngl0x7fw7";
+      type = "gem";
+    };
+    version = "3.6.0";
+  };
+  temple = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ysraljv7lkb04z5vdyrkijab7j1jzj1mgz4bj82744dp7d0rhb0";
+      type = "gem";
+    };
+    version = "0.7.6";
+  };
+  thread_safe = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hq46wqsyylx5afkp6jmcihdpv4ynzzq9ygb6z2pb1cbz5js0gcr";
+      type = "gem";
+    };
+    version = "0.3.5";
+  };
+  tilt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lkd40xfdqkp333vdfhrfjmi2y7k2hjs4azawfb62mrkfp7ivj84";
+      type = "gem";
+    };
+    version = "2.0.2";
+  };
+  treetop = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wpl5z33796nz2ah44waflrd1girbra281d9i3m9nz4ylg1ljg5b";
+      type = "gem";
+    };
+    version = "1.5.3";
+  };
+  ttfunk = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k725rji58i0qx5xwf7p9d07cmhmjixqkdvhg1wk3rpp1753cf1j";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -878,6 +878,8 @@ in
     enableStandardFeatures = true;
     enableExtraPlugins = true;
   });
+  
+  asciidoctor = callPackage ../tools/typesetting/asciidoctor { };
 
   autossh = callPackage ../tools/networking/autossh { };
 


### PR DESCRIPTION
This was sitting in my personal repo until @aneeshusa suggested that I share it.

Asciidoctor is packaged with some of its optional dependencies, this is why there are both `asciidoctor` and `asciidoctor-full` as pkgs attributes names. I would very much like the help of someone versed in packaging gems to make this configurable.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
