### PR TITLE
libvpx: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -13,12 +13,10 @@
 , runtimeCpuDetectSupport ? true # detect cpu capabilities at runtime
 , thumbSupport ? false # build arm assembly in thumb mode
 , examplesSupport ? true # build examples (vpxdec & vpxenc are part of examples)
-, fastUnalignedSupport ? true # use unaligned accesses if supported by hardware
 , debugLibsSupport ? false # include debug version of each library
 , postprocSupport ? true # postprocessing
 , multithreadSupport ? true # multithreaded decoding & encoding
 , internalStatsSupport ? false # output of encoder internal stats for debug, if supported (encoders)
-, memTrackerSupport ? false # track memory usage
 , spatialResamplingSupport ? true # spatial sampling (scaling)
 , realtimeOnlySupport ? false # build for real-time encoding
 , ontheflyBitpackingSupport ? false # on-the-fly bitpacking in real-time encoding
@@ -61,13 +59,13 @@ assert isCygwin -> unitTestsSupport && webmIOSupport && libyuvSupport;
 
 stdenv.mkDerivation rec {
   name = "libvpx-${version}";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "webmproject";
     repo = "libvpx";
     rev = "v${version}";
-    sha256 = "1y8cf2q5ij8z8ab5j36m18rbs62aah6sw6shzbs3jr70ja0z6n8s";
+    sha256 = "19ill4c7dak5f8m4pdbas87zknw3a34sca8a4i952q0l0jnif0np";
   };
 
   patchPhase = ''patchShebangs .'';
@@ -103,7 +101,6 @@ stdenv.mkDerivation rec {
     "--as=yasm"
     # Limit default decoder max to WHXGA
     (if sizeLimitSupport then "--size-limit=5120x3200" else null)
-    (enableFeature fastUnalignedSupport "fast-unaligned")
     "--disable-codec-srcs"
     (enableFeature debugLibsSupport "debug-libs")
     (enableFeature isMips "dequant-tokens")
@@ -112,7 +109,6 @@ stdenv.mkDerivation rec {
     (enableFeature (postprocSupport && (vp9DecoderSupport || vp9EncoderSupport)) "vp9-postproc")
     (enableFeature multithreadSupport "multithread")
     (enableFeature internalStatsSupport "internal-stats")
-    (enableFeature memTrackerSupport "mem-tracker")
     (enableFeature spatialResamplingSupport "spatial-resampling")
     (enableFeature realtimeOnlySupport "realtime-only")
     (enableFeature ontheflyBitpackingSupport "onthefly-bitpacking")
@@ -158,6 +154,7 @@ stdenv.mkDerivation rec {
     dontSetConfigureCross = true;
     configureFlags = configureFlags ++ [
       #"--extra-cflags="
+      #"--extra-cxxflags="
       #"--prefix="
       #"--libc="
       #"--libdir="


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Here are the [CHANGELOG](https://github.com/webmproject/libvpx/blob/v1.5.0/CHANGELOG) and the [diff of `configure --help` between 1.4.0 and 1.5.0](https://gist.github.com/taku0/daf345870bbf569dbc0cc75e4bdd05f1).

VP10 doesn't seems to be enabled yet. There is `--enable-vp10` flag in the configure script but vp10 directory does not exist for v1.5.0 tag (it exists in the master branch).

Firefox 46.0 requires `libvpx` 1.5.0, so that it is disabled temporarily: https://github.com/NixOS/nixpkgs/commit/930d243ea490c1cbb5d70b514a70f2d9c989b25f.
