### PR TITLE
i-score: init at v1.0.0-a67

### DIFF
--- a/pkgs/applications/audio/i-score/default.nix
+++ b/pkgs/applications/audio/i-score/default.nix
@@ -1,0 +1,85 @@
+{
+  boost,
+  cln,
+  cmake,
+  fetchgit,
+  gcc5,
+  ginac,
+  jamomacore,
+  kde5,
+  libsndfile,
+  ninja,
+  portaudio,
+  qtbase,
+  qtdeclarative,
+  qtimageformats,
+  qtsvg,
+  qttools,
+  qtwebsockets,
+  rtaudio,
+  stdenv
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.0.0-a67";
+  name = "i-score-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/OSSIA/i-score.git";
+    rev = "ede2453b139346ae46702b5e2643c5488f8c89fb";
+    sha256 = "04li771nj0k8gym7vg6rnawjkp2f6d5m5mby26h0k6ksf7hg7h70";
+    leaveDotGit = true;
+    deepClone = true;
+  };
+
+  buildInputs = [
+    boost
+    cln
+    cmake
+    ginac
+    gcc5
+    jamomacore
+    kde5.kdnssd
+    libsndfile
+    ninja
+    portaudio
+    qtbase
+    qtdeclarative
+    qtimageformats
+    qtsvg
+    qttools
+    qtwebsockets
+    rtaudio
+  ];
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DISCORE_CONFIGURATION=static-release"
+    "-DISCORE_ENABLE_LTO=OFF"
+    "-DISCORE_BUILD_FOR_PACKAGE_MANAGER=True"
+  ];
+
+  patchPhase = ''
+    sed -e '77d' -i CMake/modules/GetGitRevisionDescription.cmake
+  '';
+
+  preConfigure = ''
+    export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:$(echo "${jamomacore}/jamoma/share/cmake/Jamoma")"
+  '';
+
+  preBuild = ''
+    ninja
+  '';
+
+  installPhase = ''
+    cmake --build . --target install
+  '';
+
+  meta = {
+    description = "An interactive sequencer for the intermedia arts";
+    homepage = http://i-score.org/;
+    license = stdenv.lib.licenses.cecill20;
+    maintainers = [ stdenv.lib.maintainers.magnetophon ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/audio/jamomacore/default.nix
+++ b/pkgs/development/libraries/audio/jamomacore/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, pkgconfig, alsaLib, portaudio, portmidi, libsndfile, cmake, libxml2,  ninja }:
+
+stdenv.mkDerivation rec {
+  version = "1.0-beta.1";
+  name = "JamomaCore-v${version}";
+
+  src = fetchFromGitHub {
+    owner = "jamoma";
+    repo = "JamomaCore";
+    rev = "v${version}";
+    sha256 = "1hb9b6qc18rsvzvixgllknn756m6zwcn22c79rdibbyz1bhrcnln";
+  };
+
+  buildInputs = [ pkgconfig alsaLib portaudio portmidi libsndfile cmake libxml2  ninja ];
+
+  meta = {
+    description = "A C++ platform for building dynamic and reflexive systems with an emphasis on audio and media";
+    homepage = https://jamoma.org;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.magnetophon ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/audio/rtaudio/default.nix
+++ b/pkgs/development/libraries/audio/rtaudio/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, libjack2,  alsaLib, rtmidi }:
+
+stdenv.mkDerivation rec {
+  version = "4.1.2";
+  name = "rtaudio-${version}";
+
+  src = fetchFromGitHub {
+    owner = "thestk";
+    repo = "rtaudio";
+    rev = "${version}";
+    sha256 = "09j84l9l3q0g238z5k89rm8hgk0i1ir8917an7amq474nwjp80pq";
+  };
+
+  buildInputs = [ autoconf automake libtool libjack2 alsaLib rtmidi ];
+
+  preConfigure = ''
+    ./autogen.sh --no-configure
+    ./configure
+  '';
+
+  meta = {
+    description = "A set of C++ classes that provide a cross platform API for realtime audio input/output";
+    homepage =  http://www.music.mcgill.ca/~gary/rtaudio/;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.magnetophon ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/development/libraries/audio/rtmidi/default.nix
+++ b/pkgs/development/libraries/audio/rtmidi/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, libjack2, alsaLib, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  version = "2.1.1";
+  name = "rtmidi-${version}";
+
+  src = fetchFromGitHub {
+    owner = "thestk";
+    repo = "rtmidi";
+    rev = "${version}";
+    sha256 = "11pl45lp8sq5xkpipwk622w508nw0qcxr03ibicqn1lsws0hva96";
+  };
+
+  buildInputs = [ autoconf automake libtool libjack2 alsaLib pkgconfig ];
+
+  preConfigure = ''
+    ./autogen.sh --no-configure
+    ./configure
+  '';
+
+  meta = {
+    description = "A set of C++ classes that provide a cross platform API for realtime MIDI input/output";
+    homepage =  http://www.music.mcgill.ca/~gary/rtmidi/;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.magnetophon ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1949,6 +1949,8 @@ in
 
   i2pd = callPackage ../tools/networking/i2pd {};
 
+  i-score = qt5.callPackage ../applications/audio/i-score { };
+
   iasl = callPackage ../development/compilers/iasl { };
 
   iannix = qt5.callPackage ../applications/audio/iannix { };
@@ -2983,6 +2985,10 @@ in
   pytrainer = callPackage ../applications/misc/pytrainer { };
 
   remarshal = (callPackage ../development/tools/remarshal { }).bin // { outputs = [ "bin" ]; };
+
+  rtaudio = callPackage ../development/libraries/audio/rtaudio { };
+
+  rtmidi = callPackage ../development/libraries/audio/rtmidi { };
 
   openmpi = callPackage ../development/libraries/openmpi { };
 
@@ -6092,6 +6098,8 @@ in
 
   jam = callPackage ../development/tools/build-managers/jam { };
 
+  jamomacore = callPackage ../development/libraries/audio/jamomacore { };
+
   jikespg = callPackage ../development/tools/parsing/jikespg { };
 
   jenkins = callPackage ../development/tools/continuous-integration/jenkins { };
@@ -6470,13 +6478,13 @@ in
   beecrypt = callPackage ../development/libraries/beecrypt { };
 
   beignet = callPackage ../development/libraries/beignet {
-    inherit (llvmPackages) clang-unwrapped; 
-    inherit (xlibs) libX11; 
-    inherit (xorg) libXfixes libpthreadstubs libXdmcp libXdamage libXxf86vm; 
-    inherit (python3Packages) python; 
-    inherit (purePackages) gl; 
-  }; 
-  
+    inherit (llvmPackages) clang-unwrapped;
+    inherit (xlibs) libX11;
+    inherit (xorg) libXfixes libpthreadstubs libXdmcp libXdamage libXxf86vm;
+    inherit (python3Packages) python;
+    inherit (purePackages) gl;
+  };
+
   belle-sip = callPackage ../development/libraries/belle-sip { };
 
   bobcat = callPackage ../development/libraries/bobcat { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
