### PR TITLE
qmidinet: 0.2.1 -> 0.4.1

### DIFF
--- a/pkgs/applications/audio/qmidinet/default.nix
+++ b/pkgs/applications/audio/qmidinet/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, qt4, alsaLib, libjack2 }:
+{ stdenv, fetchurl, qt5, alsaLib, libjack2 }:
 
 stdenv.mkDerivation rec {
-  version = "0.2.1";
+  version = "0.4.1";
   name = "qmidinet-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/qmidinet/${name}.tar.gz";
-    sha256 = "1a1pj4w74wj1gcfv4a0vzcglmr5sw0xp0y56w8rk3ig4k11xi8sa";
+    sha256 = "1hh06g19lfh6r673avfvy0l2mq999mxk2jnv396226swj97lv7yz";
   };
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ qt4 alsaLib libjack2 ];
+  buildInputs = [  qt5.qtbase qt5.qttools alsaLib libjack2 ];
 
   meta = with stdenv.lib; {
     description = "A MIDI network gateway application that sends and receives MIDI data (ALSA Sequencer and/or JACK MIDI) over the network";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
