### PR TITLE
bittorrentSync20: 2.3.3 -> 2.3.6

### DIFF
--- a/pkgs/applications/networking/bittorrentsync/2.0.x.nix
+++ b/pkgs/applications/networking/bittorrentsync/2.0.x.nix
@@ -1,28 +1,27 @@
-{ stdenv, fetchurl, patchelf }:
+{ stdenv, fetchurl }:
 
 let
   arch = if stdenv.system == "x86_64-linux" then "x64"
     else if stdenv.system == "i686-linux" then "i386"
     else throw "Bittorrent Sync for: ${stdenv.system} not supported!";
 
-  sha256 = if stdenv.system == "x86_64-linux" then "0l6z2fyd7i3i3cr95gkihbf6fwa7mk1b2m1jpf2nq5ispg0qf74n"
-    else if stdenv.system == "i686-linux" then "06x8f75dh58saqrz2k2xgcilh27v0jmql4k4rs7g361aad9v3pnr"
+  sha256 = if stdenv.system == "x86_64-linux" then "01yrligi61gxcixh7z6gi427ga0sx97wnmkv08p9ykd4b90hvj7s"
+    else if stdenv.system == "i686-linux" then     "119dll7f4w7h8nrrafmrj1d0lddjzwg5l8hnf74xdjg6g7rhrmd7"
     else throw "Bittorrent Sync for: ${stdenv.system} not supported!";
 
   libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.libc ];
 in
 stdenv.mkDerivation rec {
   name = "btsync-${version}";
-  version = "2.3.3";
+  version = "2.3.6";
 
   src  = fetchurl {
-    url  = "https://download-cdn.getsyncapp.com/${version}/linux-${arch}/BitTorrent-Sync_${arch}.tar.gz";
+    url  = "https://download-cdn.getsync.com/${version}/linux-${arch}/BitTorrent-Sync_${arch}.tar.gz";
     inherit sha256;
   };
 
   dontStrip   = true; # Don't strip, otherwise patching the rpaths breaks
   sourceRoot  = ".";
-  buildInputs = [ patchelf ];
 
   installPhase = ''
     mkdir -p "$out/bin/"
@@ -34,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Automatically sync files via secure, distributed technology";
-    homepage    = "http://www.bittorrent.com/sync";
+    homepage    = https://www.getsync.com/;
     license     = stdenv.lib.licenses.unfreeRedistributable;
     platforms   = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ iElectric thoughtpolice cwoac ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note that this changes the domain from getsyncapp.com (no longer valid)
to getsync.com.
