### PR TITLE
you-get: init at 0.4.390

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -316,6 +316,7 @@
   ryanartecona = "Ryan Artecona <ryanartecona@gmail.com>";
   ryantm = "Ryan Mulligan <ryan@ryantm.com>";
   rycee = "Robert Helgesson <robert@rycee.net>";
+  ryneeverett = "Ryne Everett <ryneeverett@gmail.com>";
   samuelrivas = "Samuel Rivas <samuelrivas@gmail.com>";
   sander = "Sander van der Burg <s.vanderburg@tudelft.nl>";
   schmitthenner = "Fabian Schmitthenner <development@schmitthenner.eu>";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14656,6 +14656,8 @@ in
 
   inherit (gnome3) yelp;
 
+  inherit (python3Packages) you-get;
+
   inherit (pythonPackages) youtube-dl;
 
   qgis = callPackage ../applications/gis/qgis {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23203,6 +23203,29 @@ in modules // {
     };
   };
 
+  you-get = buildPythonApplication rec {
+    version = "0.4.390";
+    name = "you-get-${version}";
+    disabled = !isPy3k;
+
+    # Tests aren't packaged, but they all hit the real network so
+    # probably aren't suitable for a build environment anyway.
+    doCheck = false;
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/y/you-get/${name}.tar.gz";
+      sha256 = "17hs0g9yvgvkmr7p1cz39mbbvb40q65qkc31j3ixc2f873gahagw";
+    };
+
+    meta = {
+      description = "A tiny command line utility to download media contents from the web";
+      homepage = https://you-get.org;
+      license = licenses.mit;
+      maintainers = with maintainers; [ ryneeverett ];
+      platforms = platforms.all;
+    };
+  };
+
   zope_broken = buildPythonPackage rec {
     name = "zope.broken-3.6.0";
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
