### PR TITLE
tcpflow: 1.4.5 -> 1.4.6

### DIFF
--- a/pkgs/tools/networking/tcpflow/default.nix
+++ b/pkgs/tools/networking/tcpflow/default.nix
@@ -1,29 +1,61 @@
-{stdenv, fetchurl, openssl, zlib, libpcap, boost, cairo}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="tcpflow";
-    version="1.4.5";
-    name="${baseName}-${version}";
-    hash="0whcyykq710s84jyiaqp6rsr19prd0pr1g1pg74mif0ig51yv7zk";
-    url="http://www.digitalcorpora.org/downloads/tcpflow/tcpflow-1.4.5.tar.gz";
-    sha256="0whcyykq710s84jyiaqp6rsr19prd0pr1g1pg74mif0ig51yv7zk";
+{ stdenv, lib, fetchFromGitHub, openssl, zlib, libpcap, boost, cairo, automake, autoconf, useCairo ? false }:
+
+stdenv.mkDerivation rec {
+  baseName = "tcpflow";
+  version  = "1.4.6";
+  name     = "${baseName}-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "simsong";
+    repo   = "tcpflow";
+    rev    = "017687365b8233d16260f4afd7572c8ad8873cf6";
+    sha256 = "002cqmn786sjysf59xnbb7lgr23nqqslb2gvy29q2xpnq6my9w38";
   };
-  buildInputs = [
-    openssl zlib libpcap boost cairo
-  ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
-  src = fetchurl {
-    inherit (s) url sha256;
+
+  be13_api = fetchFromGitHub {
+    owner  = "simsong";
+    repo   = "be13_api";
+    rev    = "8f4f4b3fe0b4815babb3a6fb595eb9a6d07e8a2e";
+    sha256 = "1dlys702x3m8cr9kf4b9j8n28yh6knhwgqkm6a5yhh1grd8r3ksm";
   };
-  meta = {
-    inherit (s) version;
+
+  dfxml = fetchFromGitHub {
+    owner  = "simsong";
+    repo   = "dfxml";
+    rev    = "13a8cc22189a8336d16777f2897ada6ae2ee59de";
+    sha256 = "0wzhbkp4c8sp6wrk4ilz3skxp14scdnm3mw2xmxxrsifymzs2f5n";
+  };
+
+  httpparser = fetchFromGitHub {
+    owner  = "nodejs";
+    repo   = "http-parser";
+    rev    = "8d9e5db981b623fffc93657abacdc80270cbee58";
+    sha256 = "0x17wwhrc7b2ngiqy0clnzn1zz2gbcz5n9m29pcyrcplly782k52";
+  };
+
+  buildInputs = [ openssl zlib libpcap boost automake autoconf ] ++ lib.optional useCairo cairo;
+
+  postUnpack = ''
+    pushd tcpflow-*-src/src
+    cp -rv ${be13_api}/* be13_api/
+    cp -rv ${dfxml}/* dfxml/
+    cp -rv ${httpparser}/* http-parser/
+    chmod -R u+w dfxml
+    popd
+  '';
+
+  prePatch = ''
+    substituteInPlace ./bootstrap.sh \
+      --replace \ git 'echo git' \
+      --replace /bin/rm rm
+  '';
+
+  preConfigure = "bash ./bootstrap.sh";
+
+  meta = with stdenv.lib; {
     description = ''TCP stream extractor'';
-    license = stdenv.lib.licenses.gpl3 ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    license     = licenses.gpl3 ;
+    maintainers = with maintainers; [ raskin obadz ];
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
cc @7c6f434c
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Switch to fetchFromGitHub as website does not have latest version.
Default to not building against cairo to avoid dependencies on lots
of graphic libraries for a predominently command-line application.
