### PR TITLE
matchbox: FIX updated source urls + libmatchbox: 1.9 -> 1.11

### DIFF
--- a/pkgs/applications/window-managers/matchbox/default.nix
+++ b/pkgs/applications/window-managers/matchbox/default.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchurl, libmatchbox, pkgconfig}:
 
 stdenv.mkDerivation rec {
-  name = "matchbox-1.2";
+  name = "matchbox-${version}";
+  version = "1.2";
 
   buildInputs = [ libmatchbox pkgconfig ];
 
   src = fetchurl {
-    url = http://matchbox-project.org/sources/matchbox-window-manager/1.2/matchbox-window-manager-1.2.tar.bz2;
+    url = "http://downloads.yoctoproject.org/releases/matchbox/matchbox-window-manager/${version}/matchbox-window-manager-${version}.tar.bz2";
     sha256 = "1zyfq438b466ygcz78nvsmnsc5bhg4wcfnpxb43kbkwpyx53m8l1";
   };
 

--- a/pkgs/development/libraries/libmatchbox/default.nix
+++ b/pkgs/development/libraries/libmatchbox/default.nix
@@ -1,14 +1,15 @@
 { stdenv, fetchurl, libX11, libXext, libpng, libXft, libICE, pango, libjpeg}:
 
 stdenv.mkDerivation rec {
-  name = "libmatchbox-1.9";
+  name = "libmatchbox-${version}";
+  version = "1.11";
 
   buildInputs = [ libXft libICE pango libjpeg ];
   propagatedBuildInputs = [ libX11 libXext libpng ];
 
   src = fetchurl {
-    url = http://matchbox-project.org/sources/libmatchbox/1.9/libmatchbox-1.9.tar.bz2;
-    sha256 = "006zdrgs7rgh7dvakjmqsp1q9karq6c5cz4gki2l15fhx0cf40fv";
+    url = "http://downloads.yoctoproject.org/releases/matchbox/libmatchbox/${version}/libmatchbox-${version}.tar.bz2";
+    sha256 = "0lvv44s3bf96zvkysa4ansxj2ffgj3b5kgpliln538q4wd9ank15";
   };
 
   meta = {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
