### PR TITLE
pythonPackages.neovim: 0.0.38 -> 0.1.7

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25786,12 +25786,12 @@ in modules // {
   };
 
   neovim = buildPythonPackage rec {
-    version = "0.0.38";
+    version = "0.1.7";
     name = "neovim-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/n/neovim/${name}.tar.gz";
-      sha256 = "93f475d5583a053af919ba0729b32b3fefef1dbde4717b5657d806bdc69b76b3";
+      sha256 = "0il6h9qpy9rkgz16yn2bhhg5f23w41wvm9ivlscx5l55llq9sd9q";
     };
 
     propagatedBuildInputs = with self; [ msgpack ]


### PR DESCRIPTION
Fixes #15161 .
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (see below)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
### Test

I tested this by building my system on https://github.com/matthiasbeyer/nixpkgs/commit/4aa25e8ac403cf8618a426ec770e5fa96f4463a2 which is essentially the same as the commit from this PR and then I started neovim, which didn't yield the issue described in #15161 .

I wonder why this package was outdated so much. There were almost 10 versions between the last version in nixpkgs and this version. Anyways, ... I managed to solve this, I guess.
