### PR TITLE
[WIP/Pretty big rebuild] openjdk: 8u76 -> 8u92

### DIFF
--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -18,42 +18,42 @@ let
     else
       throw "openjdk requires i686-linux or x86_64 linux";
 
-  update = "76";
-  build = "00";
+  update = "92";
+  build = "14";
   baseurl = "http://hg.openjdk.java.net/jdk8u/jdk8u";
   repover = "jdk8u${update}-b${build}";
   paxflags = if stdenv.isi686 then "msp" else "m";
   jdk8 = fetchurl {
              url = "${baseurl}/archive/${repover}.tar.gz";
-             sha256 = "1bzwrm18vdd531xxin7pzsc5dx2ybkdgdxz6jp2ki19ka6pmk1l7";
+             sha256 = "05ly2v3b6vr3sxa27m7ahlp8w4w1q68rki2dfczrklcdq4l61g0r";
           };
   langtools = fetchurl {
              url = "${baseurl}/langtools/archive/${repover}.tar.gz";
-             sha256 = "044gyb7hgrahlr78vah9r3wfv6w569ihqzwqplwzr6m0l1s52994";
+             sha256 = "1zb7gvj1b1q3pvq5x7ac98k5dk83m7849ngcy1swfwj18g8i4k9p";
           };
   hotspot = fetchurl {
              url = "${baseurl}/hotspot/archive/${repover}.tar.gz";
-             sha256 = "1if70s9wjsvmrdj92ky88ngpmigi9c5gfpkilpydzdibs38f05f8";
+             sha256 = "057qrhm9gbz672qgb85al9p3qvgvbviadppf5a9b8hp5sg322f35";
           };
   corba = fetchurl {
              url = "${baseurl}/corba/archive/${repover}.tar.gz";
-             sha256 = "0fl852x25cjzz3lrhjnhj59qbb4m3ywwc2f9vbj6mqdnpzl7cg83";
+             sha256 = "0s9h61jw42nbvrw24qaizp7pp063ala37sjgl547zfglhk1dlzi8";
           };
   jdk = fetchurl {
              url = "${baseurl}/jdk/archive/${repover}.tar.gz";
-             sha256 = "11ql3p5fsizrn1fiylfkgrw0lgf6snwyich18hggsmd00bhvv3ah";
+             sha256 = "0sgyjdmxsrdj8b8y2ri3c70x9l9m777v559cq8rmaz1jpc9lld4s";
           };
   jaxws = fetchurl {
              url = "${baseurl}/jaxws/archive/${repover}.tar.gz";
-             sha256 = "1d2q4bbvlz557caqciwpd5ms9f14bjk8jl5zlfflqnww9b097qy4";
+             sha256 = "12aajlswn5nkm4nbrdh3jff2sz81wdczrgliwd5lnqfnh73sbbkp";
           };
   jaxp = fetchurl {
              url = "${baseurl}/jaxp/archive/${repover}.tar.gz";
-             sha256 = "0nrd4c77ggxkyv2271k30afbjjcp0kybc8gcypmhy8by54w4ap0j";
+             sha256 = "133r5wicgva6mklrlnvb09p9izyw0fj281s51kndf3ba3zzggvv3";
           };
   nashorn = fetchurl {
              url = "${baseurl}/nashorn/archive/${repover}.tar.gz";
-             sha256 = "11idvkzk4nqhhw4xq5pl03g4gwnaiq021xxj2yx54rixr59zl0q6";
+             sha256 = "1rmk868qg7kgv7f5lhj1b7wdnql0bj2bfqd2lg9ci64418j8x8bn";
           };
   openjdk8 = stdenv.mkDerivation {
     name = "openjdk-8u${update}b${build}";


### PR DESCRIPTION
**WIP**: The nox review is running right now, will report back when I have the result :)

Release notes:
https://bugs.openjdk.java.net/projects/JDK/versions/18505
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
~> nix-shell -p nox --run "nox-review wip"
Building in /run/user/1000/nox-review-99aar35t: alloy sweethome3d.textures-editor odpdown androidsdk_4_4 eclipses.eclipse-cpp-37 icedtea8_web isabelle idea.clion swt storm R alchemy tomcat_connectors sqldeveloper freenet seyren faust2alsa linphone eclipses.eclipse-sdk-431 faust2jaqt kodi eclipses.eclipse-sdk-44 eclipses.eclipse-sdk-45 pig springLobby jabref libmatthew_java faust2csound elasticsearchPlugins.elasticsearch_kopf twitterBootstrap jython eclipses.eclipse-sdk-422 weka sharedobjects smartgithg yed zdfmediathk bazel cassandra_1_2 eclipses.eclipse-platform trang erlangR17_javac kde4.cantor nco libreoffice python35Packages.udiskie python35Packages.rpy2 cassandra_2_0 davmail RhythmDelay plm idea.idea14-community cassandra idea.idea-ultimate azureus netbeans python27Packages.udiskie apache-jena-fuseki saxonb fop awstats libcollectdclient faust2jack collectd jing vue eclipses.eclipse-sdk-451 kodiPlain eclipses.eclipse-sdk-36 rascal perlPackages.InlineJava munin python27Packages.kazoo apache-jena ssvnc androidsdk pystringtemplate perlPackages.Autodia hadoop geoipjava minecraft classpath openjdk jclasslib areca atermjava vassal seleniumRCBin galen jedit ums opa elasticsearchPlugins.elasticsearch_analisys_lemmagen eclipses.eclipse-cpp-44 rWrapper idea.android-studio kde4.poxml frostwire selenium-server-standalone purePackages.faust idea.ruby-mine constant-detune-chorus idea.webstorm zgrviewer welkin zxing cfr jboss faust2firefox idea.phpstorm jbidwatcher jsonnet eclipses.eclipse-cpp-36 erlangR18_javac androidndk xtreemfs activator javaCup zookeeper python27Packages.taskflow aldor arduino-core foo-yc20 eclipses.eclipse-sdk-442 disorderfs python27Packages.rpy2 elasticsearchPlugins.search_guard abc boot python27Packages.neurotools VoiceOfFaust jdiskreport jruby groovy antlr gitAndTools.subgit zookeeper_mt marathon erlangR18_odbc_javac jzmq zap spring tomcat5 apktool plantuml belle-sip eclipses.eclipse-cpp-43 aspectj dbus_java selendroid elasticsearchPlugins.elasticsearch_river_jdbc asciidoc-full-with-plugins kodiPlugins.pvr-hts eclipses.eclipse-platform-45 openfire eid-viewer eclipses.eclipse-cpp-42 idea.idea-community crashplan freemind python35Packages.plantuml kotlin subsonic axis2 elasticsearch2 ino DisnixWebService josm idea.idea15-ultimate eclipses.eclipse-platform-451 rstudio LazyLimiter clooj faust2lv2 gpsprune hydraAntLogger clojure emscripten basex sbt zkfuse eclipses.eclipse-sdk-35 postgresql_jdbc idea.pycharm-community mesos opengrok elasticmq picolisp mediathekview elasticsearch gradle python27Packages.sphinxcontrib_plantuml faust scala_2_10 i2p leiningen CompBus briss kde4.kdesdk opentsdb aws_mturk_clt eclipses.eclipse-modeling-36 glance eclipses.eclipse-scala-sdk-40 octaveFull jitsi ditaa sweethome3d.furniture-editor maven elasticsearchPlugins.elasticsearch_river_twitter jjtraveler tuxguitar eclipses.eclipse-sdk-37 faust2alqt umlet smc logisim aacskeys eclipses.eclipse-sdk-421 CharacterCompressor python27Packages.zake jdk arduino spark erlangR17_odbc_javac antlr3 minecraft-server emem flashtool scala liquibase jre MBdistortion eclipses.eclipse-cpp-45 asciidoc-full closurecompiler rabbitmq-java-client swingsane dbvisualizer gradle25 unoconv mercury python35Packages.sphinxcontrib_plantuml neo4j sweethome3d.application libreoffice-still apacheKafka idea.pycharm-professional ec2_api_tools python27Packages.plantuml
```
