### PR TITLE
[WIP] ruby: update 2.3 series to 2.3.1

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -206,15 +206,14 @@ in {
     };
   };
 
-  ruby_2_3_0 = generic {
+  ruby_2_3_1 = generic {
     majorVersion = "2";
     minorVersion = "3";
-    teenyVersion = "0";
+    teenyVersion = "1";
     patchLevel = "0";
     sha256 = {
-      # src = "1ssq3c23ay57ypfis47y2n817hfmb71w0xrdzp57j6bv12jqmgrx";
-      src = "01z5cya4a7y751d4pb3aak5qcwmmvnwkbgz9z171p8hsbw7acnxs";
-      git = "0nl0pp96m0jxi422mqx09jqn9bff90pzz0xxa0ikrx7by0g00npg";
+      src = "1kbxg72las93w0y553cxv3lymy2wvij3i3pg1y9g8aq3na676z5q";
+      git = "0dv1rf5f9lj3icqs51bq7ljdcf17sdclmxm9hilwxps5l69v5q9r";
     };
   };
 }

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -54,9 +54,9 @@ rec {
     "${patchSet}/patches/ruby/2.2.3/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.2.3/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
-  "2.3.0" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.3.0/railsexpress/01-skip-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.3.0/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.3.0/railsexpress/03-display-more-detailed-stack-trace.patch"
+  "2.3.1" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/2.3/head/railsexpress/01-skip-broken-tests.patch"
+    "${patchSet}/patches/ruby/2.3/head/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.3/head/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5593,7 +5593,7 @@ in
     ruby_2_0_0
     ruby_2_1_7
     ruby_2_2_3
-    ruby_2_3_0;
+    ruby_2_3_1;
 
   # Ruby aliases
   ruby = ruby_2_3;
@@ -5601,7 +5601,7 @@ in
   ruby_2_0 = ruby_2_0_0;
   ruby_2_1 = ruby_2_1_7;
   ruby_2_2 = ruby_2_2_3;
-  ruby_2_3 = ruby_2_3_0;
+  ruby_2_3 = ruby_2_3_1;
 
   scsh = callPackage ../development/interpreters/scsh { };
 


### PR DESCRIPTION
Did some preliminary local testing with 2.3.1, and I'm currently going through the enormous `nox-review` build to try to identify any newly broken revdeps.

Pinging @zimbatm and @cstrahan in case you are interested.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on nxon-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
