### PR TITLE
spring, springlobby update

### DIFF
--- a/pkgs/development/libraries/alure/default.nix
+++ b/pkgs/development/libraries/alure/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, cmake, openal }:
+
+stdenv.mkDerivation rec {
+  name = "alure-${version}";
+  version = "1.2";
+
+  src = fetchurl {
+    url = "http://kcat.strangesoft.net/alure-releases/alure-${version}.tar.bz2";
+    sha256 = "0w8gsyqki21s1qb2s5ac1kj08i6nc937c0rr08xbw9w9wvd6lpj6";
+  };
+
+  buildInputs = [ cmake openal ];
+
+  meta = with stdenv.lib; {
+    description = "A utility library to help manage common tasks with OpenAL applications";
+    homepage = http://kcat.strangesoft.net/alure.html;
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -1,32 +1,41 @@
 { stdenv, fetchurl, cmake, lzma, boost, libdevil, zlib, p7zip
-, openal, libvorbis, glew, freetype, xorg, SDL, mesa, binutils
+, openal, libvorbis, glew, freetype, xorg, SDL2, mesa, binutils
 , asciidoc, libxslt, docbook_xsl, docbook_xsl_ns, curl, makeWrapper
-, jdk ? null, python ? null, systemd
+, jdk ? null, python ? null, systemd, libunwind, glibc, which, minizip
 , withAI ? true # support for AI Interfaces and Skirmish AIs
 }:
 
 stdenv.mkDerivation rec {
 
   name = "spring-${version}";
-  version = "96.0";
+  version = "101.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/springrts/spring_${version}_src.tar.lzma";
-    sha256 = "1axyqkxgv3a0zg0afzlc7j3lyi412zd551j317ci41yqz2qzf0px";
+    sha256 = "0nr65zhw92k36zgwqgi31vcp129vk7r3v7xzd6l9w7mp1ljvypgi";
   };
+
+  # The cmake included module correcly finds nix's glew, however
+  # it has to be the bundled FindGLEW for headless or dedicated builds
+  prePatch = ''
+    substituteInPlace ./rts/build/cmake/FindAsciiDoc.cmake \
+      --replace "PATHS /usr /usr/share /usr/local /usr/local/share" "PATHS ${docbook_xsl}"\
+      --replace "xsl/docbook/manpages" "share/xml/docbook-xsl/manpages"
+    patchShebangs .
+    rm rts/build/cmake/FindGLEW.cmake
+  '';
 
   cmakeFlags = ["-DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON"
                 "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON"
                 "-DPREFER_STATIC_LIBS:BOOL=OFF"];
 
-  buildInputs = [ cmake lzma boost libdevil zlib p7zip openal libvorbis freetype SDL
+  buildInputs = [ cmake lzma boost libdevil zlib p7zip openal libvorbis freetype SDL2
     xorg.libX11 xorg.libXcursor mesa glew asciidoc libxslt docbook_xsl curl makeWrapper
-    docbook_xsl_ns systemd ]
+    docbook_xsl_ns systemd libunwind glibc.dev glibc.static which minizip ]
     ++ stdenv.lib.optional withAI jdk
     ++ stdenv.lib.optional withAI python;
 
-  # reported upstream http://springrts.com/mantis/view.php?id=4305
-  #enableParallelBuilding = true; # occasionally missing generated files on Hydra
+  enableParallelBuilding = true;
 
   NIX_CFLAGS_COMPILE = "-fpermissive"; # GL header minor incompatibility
 

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -1,18 +1,19 @@
-{ stdenv, fetchurl, cmake, wxGTK, openal, pkgconfig, curl, libtorrentRasterbar, libpng, libX11
-, gettext, bash, gawk, boost, libnotify, gtk, doxygen, spring, makeWrapper }:
+{ stdenv, fetchurl, cmake, wxGTK30, openal, pkgconfig, curl, libtorrentRasterbar
+, libpng, libX11, gettext, bash, gawk, boost, libnotify, gtk, doxygen, spring
+, makeWrapper, glib, minizip, alure, pcre, jsoncpp }:
 stdenv.mkDerivation rec {
 
   name = "springlobby-${version}";
-  version = "0.195";
+  version = "0.247";
 
   src = fetchurl {
     url = "http://www.springlobby.info/tarballs/springlobby-${version}.tar.bz2";
-    sha256 = "0hxxm97c74rvm78vlfn2byn0zjlrhankxdrs2hz73rdq6451h10b";
+    sha256 = "0sx14k4xsyjkmphhxfn9q341lv32c53g6wl1cbdx2sknzs3qasxs";
   };
 
   buildInputs = [
-    cmake wxGTK openal pkgconfig curl gettext libtorrentRasterbar
-    boost libpng libX11 libnotify gtk doxygen makeWrapper
+    cmake wxGTK30 openal pkgconfig curl gettext libtorrentRasterbar pcre jsoncpp
+    boost libpng libX11 libnotify gtk doxygen makeWrapper glib minizip alure
   ];
 
   prePatch = ''
@@ -20,9 +21,6 @@ stdenv.mkDerivation rec {
     substituteInPlace tools/test-susynclib.awk --replace "#!/usr/bin/awk" "#!${gawk}/bin/awk"
     substituteInPlace CMakeLists.txt --replace "boost_system-mt" "boost_system"
   '';
-
-  # for now sound is disabled as it causes a linker error with alure i can't resolve (qknight)
-  cmakeFlags = "-DOPTION_SOUND:BOOL=OFF"; 
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6387,6 +6387,8 @@ in
 
   afflib = callPackage ../development/libraries/afflib { };
 
+  alure = callPackage ../development/libraries/alure { };
+
   agg = callPackage ../development/libraries/agg { };
 
   allegro = callPackage ../development/libraries/allegro {};


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Alure is built without some of it's optional supports, hopefully it's not needed.
- The glibc.static dependency is added so -mieee-fp works
- upstream says parallel building is fixed https://springrts.com/mantis/view.php?id=4305

maintainers @qknight @Phreedom @domenkozar 
