### PR TITLE
nsd: 4.1.7 -> 4.1.9

### DIFF
--- a/pkgs/servers/dns/nsd/default.nix
+++ b/pkgs/servers/dns/nsd/default.nix
@@ -13,11 +13,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "nsd-4.1.7";
+  name = "nsd-4.1.9";
 
   src = fetchurl {
     url = "http://www.nlnetlabs.nl/downloads/nsd/${name}.tar.gz";
-    sha256 = "12hskfgfbkvcgpa1xxkqd8lnc6xvln1amn97x6avfnj9kfrbxa3v";
+    sha256 = "1wn8jm5kpp81m88c77j97850mnmd87yaw8qp3xsdwcakcd6j44dq";
   };
 
   buildInputs = [ libevent openssl ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
# Features
- Fix #732: tcp-mss, outgoing-tcp-mss options for nsd.conf, patch from Daisuke Higashi.
- Fix #739: zonefile changes when mtime is small are detected on reload, if filesystem supports precision mtime values.
- RR type CSYNC (RFC7477) syntax is supported.
# Bugfixes
- Change the nsd.db file version because of nanosecond precision fix.
- take advantage of arc4random_uniform if available, patch from Loganaden Velvindron.
- Fix flto check for OSX clang.
- Define _DEFAULT_SOURCE with _BSD_SOURCE for glibc 2.20 on Linux.
- Fix #736: segfault during zone transfer.
- Fix #744: Fix that NSD replies for configured but unloaded zone with SERVFAIL, not REFUSED.
