### PR TITLE
Greybird: init at 2016-03-11

### DIFF
--- a/pkgs/misc/themes/greybird/default.nix
+++ b/pkgs/misc/themes/greybird/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "Greybird";
+  version = "2016-03-11";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    repo = "${pname}";
+    owner = "shimmerproject";
+    rev = "77f3cbd94b0c87f502aaeeaa7fd6347283c876cf";
+    sha256 = "1gqq9j61izdw8arly8kzr629wa904rn6mq48cvlaksknimw0hf2h";
+  };
+
+  buildInputs = [ gtk-engine-murrine ];
+  
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/themes/${pname}{," Bright"," Compact"," a11y"}
+    cp -a * $out/share/themes/${pname}/
+    mv $out/share/themes/${pname}/xfce-notify-4.0_bright $out/share/themes/${pname}" Bright"/xfce-notify-4.0
+    mv $out/share/themes/${pname}/xfwm4-compact $out/share/themes/${pname}" Compact"/xfwm4
+    mv $out/share/themes/${pname}/xfwm4-a11y $out/share/themes/${pname}" a11y"/xfwm4
+  '';
+
+  meta = {
+    description = "Grey and blue theme (Gtk, Xfce, Emerald, Metacity, Mutter, Unity)";
+    homepage = http://shimmerproject.org/our-projects/greybird/;
+    license = with stdenv.lib.licenses; [ gpl2Plus cc-by-nc-sa-30 ];
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16266,6 +16266,8 @@ in
   gnuk-unstable = callPackage ../misc/gnuk/unstable.nix { };
   gnuk-git = callPackage ../misc/gnuk/git.nix { };
 
+  greybird = callPackage ../misc/themes/greybird { };
+
   gxemul = callPackage ../misc/emulators/gxemul { };
 
   hatari = callPackage ../misc/emulators/hatari { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
