### PR TITLE
zsh-navigation-tools: 1.4 -> 2.0.7, install all files

### DIFF
--- a/pkgs/tools/misc/zsh-navigation-tools/default.nix
+++ b/pkgs/tools/misc/zsh-navigation-tools/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "zsh-navigation-tools-${version}";
-  version = "1.4";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = "psprint";
     repo = "zsh-navigation-tools";
     rev = "v${version}";
-    sha256 = "1r24mpx57jyn201mdhd793rlhlr5r83n9137aafkgf86282ghr7y";
+    sha256 = "0rfab3maha366dgvcmiqj6049wk5fynns1ygbgy4gnvavx2acvg2";
   };
 
   dontBuild = true;

--- a/pkgs/tools/misc/zsh-navigation-tools/default.nix
+++ b/pkgs/tools/misc/zsh-navigation-tools/default.nix
@@ -15,8 +15,11 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/share/zsh/site-functions/
+    cp zsh-navigation-tools.plugin.zsh $out/share/zsh/site-functions/
     cp n-* $out/share/zsh/site-functions/
     cp znt-* $out/share/zsh/site-functions/
+    mkdir -p $out/share/zsh/site-functions/.config/znt
+    cp .config/znt/n-* $out/share/zsh/site-functions/.config/znt
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Basic update, all files are installed (this allows to comfortably run ZNT with *plugin.zsh file) and version bump
