### PR TITLE
connman: 1.31 -> 1.32

### DIFF
--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,26 +1,25 @@
-{ stdenv, fetchgit, autoconf, automake, libtool, pkgconfig, openconnect, file,
+{ stdenv, fetchurl, pkgconfig, openconnect, file,
   openvpn, vpnc, glib, dbus, iptables, gnutls, polkit,
-  wpa_supplicant, readline6, pptp, ppp, tree }:
+  wpa_supplicant, readline6, pptp, ppp }:
 
 stdenv.mkDerivation rec {
   name = "connman-${version}";
-  version = "1.31";
-  src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/network/connman/connman.git";
-    rev = "refs/tags/${version}";
-    sha256 = "90dab6b11841cb4b6400711d234b59fb4fad4e8778bed6e7ad3ac7ac135d6893";
+  version = "1.32";
+  src = fetchurl {
+    url = "mirror://kernel/linux/network/connman/${name}.tar.xz";
+    sha256 = "0k4kw2j78gwxf0rq79a099qkzl6wi4v5i7rfs4rn0si0fd68d19i";
   };
 
-  buildInputs = [ autoconf automake libtool pkgconfig openconnect polkit
-                  file openvpn vpnc glib dbus iptables gnutls
-                  wpa_supplicant readline6 pptp ppp tree ];
+  buildInputs = [ openconnect polkit
+                  openvpn vpnc glib dbus iptables gnutls
+                  wpa_supplicant readline6 pptp ppp ];
+
+  nativeBuildInputs = [ pkgconfig file ];
 
   preConfigure = ''
     export WPASUPPLICANT=${wpa_supplicant}/sbin/wpa_supplicant
-    ./bootstrap
+    export PPPD=${ppp}/sbin/pppd
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
-    substituteInPlace configure --replace /usr/sbin/pptp ${pptp}/sbin/pptp
-    substituteInPlace configure --replace /usr/sbin/pppd ${ppp}/sbin/pppd
   '';
 
   configureFlags = [
@@ -43,6 +42,7 @@ stdenv.mkDerivation rec {
     "--enable-tools"
     "--enable-datafiles"
     "--enable-pptp"
+    "--with-pptp=${pptp}/sbin/pptp"
   ];
 
   postInstall = ''

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, openconnect, file,
+{ stdenv, fetchurl, pkgconfig, openconnect, file, gawk,
   openvpn, vpnc, glib, dbus, iptables, gnutls, polkit,
   wpa_supplicant, readline6, pptp, ppp }:
 
@@ -14,11 +14,12 @@ stdenv.mkDerivation rec {
                   openvpn vpnc glib dbus iptables gnutls
                   wpa_supplicant readline6 pptp ppp ];
 
-  nativeBuildInputs = [ pkgconfig file ];
+  nativeBuildInputs = [ pkgconfig file gawk ];
 
   preConfigure = ''
     export WPASUPPLICANT=${wpa_supplicant}/sbin/wpa_supplicant
     export PPPD=${ppp}/sbin/pppd
+    export AWK=${gawk}/bin/gawk
     sed -i "s/\/usr\/bin\/file/file/g" ./configure
   '';
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

needed to update iptables
I'm not sure about the second commit (awk dependency):
- should the dependency be made explicit
- should the path be provided to configure
- is it needed to add it to nativeBuildInputs or is this automatically done if it's used in the preConfigure phase
