### PR TITLE
gtk-xfce-engine: 2.10.1 -> 3.2.0

### DIFF
--- a/pkgs/desktops/xfce/core/gtk-xfce-engine.nix
+++ b/pkgs/desktops/xfce/core/gtk-xfce-engine.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk, withGtk3 ? false, gtk3 }:
 
 stdenv.mkDerivation rec {
   p_name  = "gtk-xfce-engine";
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 
-  buildInputs = [ pkgconfig intltool gtk ];
+  buildInputs = [ pkgconfig intltool gtk ] ++ stdenv.lib.optional withGtk3 gtk3;
+  
+  configureFlags = stdenv.lib.optional withGtk3 "--enable-gtk3";
 
   meta = {
     homepage = http://www.xfce.org/;

--- a/pkgs/desktops/xfce/core/gtk-xfce-engine.nix
+++ b/pkgs/desktops/xfce/core/gtk-xfce-engine.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   p_name  = "gtk-xfce-engine";
-  ver_maj = "2.10";
-  ver_min = "1";
+  ver_maj = "3.2";
+  ver_min = "0";
 
   src = fetchurl {
     url = "mirror://xfce/src/xfce/${p_name}/${ver_maj}/${name}.tar.bz2";
-    sha256 = "4a92910205881f707f2cc8d3c9b00a95feb58eb9084d932c841f3ed027f7063d";
+    sha256 = "1va71f3gpl8gikfkmqsd5ikgp7qj8b64jii2l98g1ylnv8xrqp47";
   };
   name = "${p_name}-${ver_maj}.${ver_min}";
 

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -21,7 +21,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
 
   exo             = callPackage ./core/exo.nix { };
   garcon          = callPackage ./core/garcon.nix { };
-  gtk_xfce_engine = callPackage ./core/gtk-xfce-engine.nix { }; # ToDo: when should be used?
+  gtk_xfce_engine = callPackage ./core/gtk-xfce-engine.nix { withGtk3 = true; }; # ToDo: when should be used?
   libxfce4ui      = callPackage ./core/libxfce4ui.nix { };
   libxfce4ui_gtk3 = libxfce4ui.override { withGtk3 = true; };
   libxfce4util    = callPackage ./core/libxfce4util.nix { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Update to the latest version of the package and add support for Gtk+.
