### PR TITLE
bspwm: add _JAVA_AWT_WM_NONREPARENTING=1

### DIFF
--- a/nixos/modules/services/x11/window-managers/bspwm.nix
+++ b/nixos/modules/services/x11/window-managers/bspwm.nix
@@ -38,6 +38,7 @@ in
       start = if cfg.startThroughSession
         then cfg.sessionScript
         else ''
+            export _JAVA_AWT_WM_NONREPARENTING=1
             SXHKD_SHELL=/bin/sh ${pkgs.sxhkd}/bin/sxhkd -f 100 &
             ${pkgs.bspwm}/bin/bspwm
         '';


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux

bspwm is not in java's internal list of non-reparrenting
window managers. See https://awesomewm.org/wiki/Problems_with_Java
