### PR TITLE
Init CKAN: The Comprehensive Kerbal Archive Network

### DIFF
--- a/pkgs/development/compilers/mono/default.nix
+++ b/pkgs/development/compilers/mono/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   # In fact I think this line does not help at all to what I
   # wanted to achieve: have mono to find libgdiplus automatically
-  configureFlags = "--x-includes=${libX11}/include --x-libraries=${libX11}/lib --with-libgdiplus=${libgdiplus}/lib/libgdiplus.so ${llvmOpts}";
+  configureFlags = "--x-includes=${libX11.dev}/include --x-libraries=${libX11.out}/lib --with-libgdiplus=${libgdiplus}/lib/libgdiplus.so ${llvmOpts}";
 
   # Attempt to fix this error when running "mcs --version":
   # The file /nix/store/xxx-mono-2.4.2.1/lib/mscorlib.dll is an invalid CIL image
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   # http://www.mono-project.com/Config_DllMap
   postBuild = ''
     find . -name 'config' -type f | while read i; do
-        sed -i "s@libX11.so.6@${libX11}/lib/libX11.so.6@g" $i
+        sed -i "s@libX11.so.6@${libX11.out}/lib/libX11.so.6@g" $i
         sed -i "s@/.*libgdiplus.so@${libgdiplus}/lib/libgdiplus.so@g" $i
     done
   '';

--- a/pkgs/games/ckan/default.nix
+++ b/pkgs/games/ckan/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, makeWrapper, perl, mono, gtk }:
+
+stdenv.mkDerivation rec {
+  name = "ckan-${version}";
+  version = "1.16.1";
+
+  src = fetchFromGitHub {
+    owner = "KSP-CKAN";
+    repo = "CKAN";
+    rev = "v${version}";
+    sha256 = "0lfvl8w09lakz35szp5grfvhq8xx486f5igvj1m6azsql4n929lg";
+  };
+
+  buildInputs = [ makeWrapper perl mono gtk ];
+
+  postPatch = ''
+    substituteInPlace bin/build \
+      --replace /usr/bin/perl ${perl}/bin/perl
+  '';
+
+  # Tests don't currently work, as they try to write into /var/empty.
+  doCheck = false;
+  checkTarget = "test";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    for exe in *.exe; do
+      install -m 0644 $exe $out/bin
+      makeWrapper ${mono}/bin/mono $out/bin/$(basename $exe .exe) \
+        --add-flags $out/bin/$exe \
+        --set LD_LIBRARY_PATH ${gtk.out}/lib
+    done
+  '';
+
+  meta = {
+    description = "Mod manager for Kerbal Space Program";
+    homepage = https://github.com/KSP-CKAN/CKAN;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.Baughn ];
+    platforms = stdenv.lib.platforms.all;
+  };    
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14762,6 +14762,8 @@ in
 
   chocolateDoom = callPackage ../games/chocolate-doom { };
 
+  ckan = callPackage ../games/ckan { };
+
   cockatrice = qt5.callPackage ../games/cockatrice {  };
 
   confd = goPackages.confd.bin // { outputs = [ "bin" ]; };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

At this version, it automatically discovers the Steam version of KSP. Works great!
