### PR TITLE
poppler: 0.36.0 -> 0.43.0

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -5,8 +5,8 @@
 }:
 
 let # beware: updates often break cups_filters build
-  version = "0.36.0"; # even major numbers are stable
-  sha256 = "13i440kv873wgmw50rs4d1v05cj0r7bqnghd70hp9vy44dxhdk4k";
+  version = "0.43.0"; # even major numbers are stable
+  sha256 = "0mi4zf0pz3x3fx3ir7szz1n57nywgbpd4mp2r7mvf47f4rmf4867";
 in
 stdenv.mkDerivation rec {
   name = "poppler-${suffix}-${version}";


### PR DESCRIPTION
A.k.a let's build libreoffice.
