### PR TITLE
factorio: 0.12.29 -> 0.12.33

### DIFF
--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -75,9 +75,10 @@ in
       after         = [ "network.target" ];
 
       preStart = ''
-          test -e ${stateDir}/saves/${cfg.saveName}.zip || ${pkgs.factorio-headless}/bin/factorio \
-            --config=${cfg.configFile} \
-            --create=${cfg.saveName}
+          test -e ${stateDir}/saves/${cfg.saveName}.zip || \
+            ${pkgs.factorio-headless}/bin/factorio         \
+              --config=${cfg.configFile}                   \
+              --create=${cfg.saveName}
       '';
 
       serviceConfig = {

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -8,7 +8,7 @@ assert releaseType == "alpha" || releaseType == "headless";
 
 with stdenv.lib;
 let
-  version = "0.12.29";
+  version = "0.12.33";
   isHeadless = releaseType == "headless";
 
   arch = if stdenv.system == "x86_64-linux" then {
@@ -25,12 +25,12 @@ let
     url = "https://www.factorio.com/get-download/${version}/${releaseType}/${arch.inUrl}";
     name = "factorio_${releaseType}_${arch.inTar}-${version}.tar.gz"; # TODO take this from 302 redirection somehow? fetchurl doesn't help.
     x64 = {
-      headless = fetchurl        { inherit name url; sha256 = "1hr5dhpfagknjjd47qw3fa3ap8ikjc9hvxavrg4mpslbr0iqww8v"; };
-      alpha = authenticatedFetch { inherit      url; sha256 = "0vngfrjjib99k6czhg32rikfi36i3p3adx4mxc1z8bi5n70dbwqb"; };
+      headless = fetchurl        { inherit name url; sha256 = "073bwkpw2bwhbr3m8k3imlns89x5035xl4b7yq1c6npm4m7qcdnp"; };
+      alpha = authenticatedFetch { inherit      url; sha256 = "0dmq0kvzz885gcvj57h22icqhx0nvyfav4dvwsvpi15833208ca3"; };
     };
     i386 = {
       headless = abort "Factorio 32-bit headless binaries are not available for download.";
-      alpha = authenticatedFetch { inherit      url; sha256 = "10135rd9103x79i89p6fh5ssmw612012yyx3yyhb3nzl554zqzbm"; };
+      alpha = authenticatedFetch { inherit      url; sha256 = "1yxv6kr89iavpfsg21fx3q12m97ls0m9h3x33m4xnqp8px55851v"; };
     };
   };
 


### PR DESCRIPTION
No functional changes; just tried to make the derivation-split more readable.

Then I bumped the hashes and version to actual release's.
