### PR TITLE
ocaml-oasis: 0.4.5 -> 0.4.6

### DIFF
--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -2,11 +2,11 @@
  ocamlmod, ocamlify, ounit, expect}:
 
 stdenv.mkDerivation {
-  name = "ocaml-oasis-0.4.5";
+  name = "ocaml-oasis-0.4.6";
 
   src = fetchurl {
-    url = http://forge.ocamlcore.org/frs/download.php/1475/oasis-0.4.5.tar.gz;
-    sha256 = "0i1fifzig2slhb07d1djx6i690b8ys0avsx6ssnihisw841sc8v6";
+    url = http://forge.ocamlcore.org/frs/download.php/1604/oasis-0.4.6.tar.gz;
+    sha256 = "1yxv3ckkf87nz0cyll0yy1kd295j5pv3jqwkfrr1y65wkz5vw90k";
   };
 
   createFindlibDestdir = true;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
