### PR TITLE
amarok: add pcre as a dependency to fix failing build

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -2,7 +2,7 @@
 , qtscriptgenerator, gettext, curl , libxml2, mysql, taglib
 , taglib_extras, loudmouth , kdelibs , qca2, libmtp, liblastfm, libgpod
 , phonon , strigi, soprano, qjson, ffmpeg, libofa, nepomuk_core ? null
-, lz4, lzo, snappy, libaio
+, lz4, lzo, snappy, libaio, pcre
 }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     qtscriptgenerator stdenv.cc.libc gettext curl libxml2 mysql.lib
     taglib taglib_extras loudmouth kdelibs phonon strigi soprano qca2
     libmtp liblastfm libgpod qjson ffmpeg libofa nepomuk_core
-    lz4 lzo snappy libaio
+    lz4 lzo snappy libaio pcre
   ];
 
   # This is already fixed upstream, will be release in 2.9


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
## 

```
[ 61%] Linking CXX shared module ../../../../../../lib/amarok_collection-mysqlecollection.so
/nix/store/s0kpgl8a101lkymj599f5a04s4wflf5s-binutils-2.26-dev/bin/ld: cannot find -lpcre
collect2: error: ld returned 1 exit status
```
