### PR TITLE
rpm: fix build error with chroot

### DIFF
--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_LINK = "-L${elfutils}/lib";
 
+  patches = [ ./no_mkdir_in_chroot.patch ];
+
   postPatch = ''
     # For Python3, the original expression evaluates as 'python3.4' but we want 'python3.4m' here
     substituteInPlace configure --replace 'python''${PYTHON_VERSION}' ${python.executable}

--- a/pkgs/tools/package-management/rpm/no_mkdir_in_chroot.patch
+++ b/pkgs/tools/package-management/rpm/no_mkdir_in_chroot.patch
@@ -1,0 +1,11 @@
+diff -u a/Makefile.in b/Makefile.in
+--- a/Makefile.in	2016-05-04 17:46:52.453406808 +0900
++++ b/Makefile.in	2016-05-04 17:49:25.406651217 +0900
+@@ -1809,7 +1809,6 @@
+ 		$(SHELL) $(top_srcdir)/installplatform \
+ 			rpmrc platform macros \
+ 			$(RPMCANONVENDOR) $(RPMCANONOS) $(RPMCANONGNU)
+-	@$(MKDIR_P) $(DESTDIR)$(localstatedir)/tmp
+ 
+ # XXX to appease distcheck we need to remove "stuff" here...
+ uninstall-local:


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

If `nix.useChroot` is `true`, I get the following error:

```
DESTDIR="" pkglibdir="/nix/store/21ikz5fvnsj89r2lpbqs3k49falds004-rpm-4.12.0/lib/rpm" \
        /nix/store/d20f169ryps7ds2qak0r5n1f4hhxr80h-bash-4.3-p42/bin/bash ./installplatform \
                rpmrc platform macros \
                unknown linux -gnu
/nix/store/7b38vz4w4rjwwww3k53h4s4ysf1ff4gx-coreutils-8.25/bin/mkdir: cannot create directory '/var': Permission denied
Makefile:1808: recipe for target 'install-data-local' failed
```
