### PR TITLE
autojump: include a way to find the share dir

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -366,4 +366,20 @@ it. Place the resulting <filename>package.nix</filename> file into
 
 </section>
 
+<section xml:id="sec-autojump">
+
+<title>Autojump</title>
+
+<para>
+  autojump needs the shell integration to be useful but unlike other systems,
+  nix doesn't have a standard share directory location. This is why a
+  <command>autojump-share</command> script is shipped that prints the location
+  of the shared folder. This can then be used in the .bashrc like this:
+<screen>
+  source "$(autojump-share)/autojump.bash"
+</screen>
+</para>
+
+</section>
+
 </chapter>

--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -22,9 +22,13 @@ in
       mkdir -p "$out/etc/bash_completion.d"
       cp -v $out/share/autojump/autojump.bash "$out/etc/bash_completion.d"
 
-      # FIXME: What's the right place for `autojump.zsh'?
-      # This can be used as a workaround in .zshrc:
-      # . $HOME/.nix-profile/share/autojump/autojump.zsh
+      cat <<SCRIPT > $out/bin/autojump-share
+      #!/bin/sh
+      # Run this script to find the autojump shared folder where all the shell
+      # integration scripts are living.
+      echo $out/share/autojump
+      SCRIPT
+      chmod +x $out/bin/autojump-share
     '';
 
     meta = {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

autojump-share is a new script that gives you the path to autojump's
shared directory. It can then be used in the various shell's rc files to
find and source the autojump integration. Eg:

```
source "$(autojump-share)/autojump.bash"
```

Fixes #3239
