### PR TITLE
lp_solve: fixed build error due to defining isnan

### DIFF
--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -10,9 +10,15 @@ stdenv.mkDerivation rec {
     sha256 = "176c7f023mb6b8bfmv4rfqnrlw88lsg422ca74zjh19i2h5s69sq";
   };
 
+  patches = [ ./isnan.patch ];
+
   buildCommand = ''
     . $stdenv/setup
     tar xvfz $src
+    (
+    cd lp_solve*
+    eval patchPhase
+    )
     (
     cd lp_solve*/lpsolve55
     bash ccc
@@ -37,7 +43,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ smironov ];
     platforms   = platforms.unix;
-    broken      = true;
   };
 
 }

--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "lp_solve is a Mixed Integer Linear Programming (MILP) solver";
+    description = "A Mixed Integer Linear Programming (MILP) solver";
     homepage    = "http://lpsolve.sourceforge.net";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ smironov ];

--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "5.5.2.0";
 
   src = fetchurl {
-    url = "http://sourceforge.net/projects/lpsolve/files/lpsolve/${version}/lp_solve_${version}_source.tar.gz";
+    url = "mirror://sourceforge/project/lpsolve/lpsolve/${version}/lp_solve_${version}_source.tar.gz";
     sha256 = "176c7f023mb6b8bfmv4rfqnrlw88lsg422ca74zjh19i2h5s69sq";
   };
 

--- a/pkgs/applications/science/math/lp_solve/isnan.patch
+++ b/pkgs/applications/science/math/lp_solve/isnan.patch
@@ -1,0 +1,13 @@
+diff -u a/lp_lib.h b/lp_lib.h
+--- a/lp_lib.h	2016-05-04 19:45:15.753143720 +0900
++++ b/lp_lib.h	2016-05-04 19:53:59.536920722 +0900
+@@ -59,9 +59,6 @@
+ # if defined _WIN32 && !defined __GNUC__
+ #  define isnan _isnan
+ # endif
+-#if defined NOISNAN
+-# define isnan(x) FALSE
+-#endif
+ 
+ #define SETMASK(variable, mask)     variable |= mask
+ #define CLEARMASK(variable, mask)   variable &= ~(mask)


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #14037.

cc: @joachifm @vcunat @zimbatm
