### PR TITLE
xfce4-cpufreq-plugin: 1.1.1 -> 1.1.3

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-cpufreq-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-cpufreq-plugin.nix
@@ -4,20 +4,27 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
   p_name  = "xfce4-cpufreq-plugin";
   ver_maj = "1.1";
-  ver_min = "1";
+  ver_min = "3";
 
   src = fetchurl {
     url = "mirror://xfce/src/panel-plugins/${p_name}/${ver_maj}/${name}.tar.bz2";
-    sha256 = "1ryaynkxpqpp92pj18bdds869sf560ir1k3bgl8gqnz60z04ak27";
+    sha256 = "0crd21l5cw0xgm6w7s049xa36k203yx7l56ssnah9nq1w73n58bl";
   };
+
   name = "${p_name}-${ver_maj}.${ver_min}";
 
-  buildInputs = [ pkgconfig intltool libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  buildInputs = [ libxfce4util libxfce4ui xfce4panel libxfcegui4 xfconf gtk ];
+
+  enableParallelBuilding = true;
+
   preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "CPU Freq load plugin for Xfce panel";
+    license = [ licenses.gpl2Plus ];
     platforms = platforms.linux;
     maintainers = [ maintainers.AndersonTorres ];
   };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
