### PR TITLE
mdadm: call /var/setuid-wrappers/sendmail instead of /usr/sbin/sendmail

### DIFF
--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -29,7 +29,9 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-std=gnu89";
 
   preConfigure = ''
-    sed -e 's@/lib/udev@''${out}/lib/udev@' -e 's@ -Werror @ @' -i Makefile
+    sed -e 's@/lib/udev@''${out}/lib/udev@' \
+        -e 's@ -Werror @ @' \
+        -e 's@/usr/sbin/sendmail@/var/setuid-wrappers/sendmail@' -i Makefile
   '';
 
   meta = {


### PR DESCRIPTION
I'm running `mdadm` in `--monitor` mode and I would like it to send emails when RAID events occur. Unfortunately `mdadm` hard codes the sendmail command to `/usr/sbin/sendmail` which doesn't exist in NixOS. 

I'm not sure setting the command to `/var/setuid-wrappers/sendmail` is the best fix since that only exists on NixOS. Maybe it's better to just set it to `sendmail` and allow `mdadm` to look it up in the `PATH`. However the current fix works for me.
