### PR TITLE
thunderbird: 38.7.1 -> 45.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -6,25 +6,26 @@
 , cairo, gstreamer, gst_plugins_base, icu
 , debugBuild ? false
 , # If you want the resulting program to call itself "Thunderbird"
-  # instead of "Shredder", enable this option.  However, those
+  # instead of "Earlybird", enable this option.  However, those
   # binaries may not be distributed without permission from the
   # Mozilla Foundation, see
   # http://www.mozilla.org/foundation/trademarks/.
   enableOfficialBranding ? false
 }:
 
-let version = "38.7.1"; in
+let version = "45.0"; in
 let verName = "${version}"; in
 
 stdenv.mkDerivation rec {
   name = "thunderbird-${verName}";
 
   src = fetchurl {
-    url = "http://archive.mozilla.org/pub/thunderbird/releases/${verName}/source/thunderbird-${verName}.source.tar.bz2";
-    sha256 = "0a4kbmas0a6wavp8dxkva0fl1y1qrx6b7l3xdjdan7qx7ysmm626";
+    url = "http://archive.mozilla.org/pub/thunderbird/releases/"
+      + "${verName}/source/thunderbird-${verName}.source.tar.xz";
+    sha256 = "0rynfyxgpvfla17zniaq84slc02kg848qawkjmdbnv74y6bkhs8m";
   };
 
-  buildInputs = # from firefox30Pkgs.xulrunner, but without gstreamer and libvpx
+  buildInputs = # from firefox30Pkgs.xulrunner, without gstreamer and libvpx
     [ pkgconfig which libpng gtk perl zip libIDL libjpeg zlib bzip2
       python dbus dbus_glib pango freetype fontconfig xorg.libXi
       xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
@@ -51,6 +52,7 @@ stdenv.mkDerivation rec {
       "--enable-system-pixman"
       "--enable-system-sqlite"
       "--enable-system-cairo"
+      "--disable-gconf"
       "--disable-gstreamer"
       "--enable-startup-notification"
       # "--enable-content-sandbox"            # available since 26.0, but not much info available


### PR DESCRIPTION
CC maintainers @nbp @edolstra:

I'm not expecting this to be merged as-is (the file's history suggests a preference for ESR releases), but would like to provide something more recent for those who [want it](https://www.mozilla.org/en-US/thunderbird/45.0/releasenotes/). Me, for one. I've been running this for about two weeks without problems.

Perhaps renamed to `thunderbird-latest`, or with the current version kept as `thunderbird-esr`?
