### PR TITLE
Pweave: init at 0.25

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20919,6 +20919,27 @@ in modules // {
     };
   });
 
+  Pweave = buildPythonPackage (rec {
+    name = "Pweave-0.25";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/f6/2f/e9735b04747ae5ef29d64e0b215fb0e11f1c89826097ac17342efebbbb84/Pweave-0.25.tar.gz";
+      sha256 = "1isqjz66c7vxdaqfwpkspki9p4054dsfx7pznwz28ik634hnj3qw";
+    };
+
+    buildInputs = with self; [ mock pkgs.glibcLocales ];
+
+    propagatedBuildInputs = with self; [
+      matplotlib
+    ];
+
+    meta = {
+      description = "Scientific reports with embedded python computations with reST, LaTeX or markdown";
+      homepage = http://mpastell.com/pweave/ ;
+      license = licenses.bsd3;
+    };
+  });
+
   spyder = callPackage ../applications/science/spyder {
     rope = if isPy3k then null else self.rope;
   };


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
