### PR TITLE
xfce4-weather-plugin: init at 0.8.7

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -88,6 +88,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   xfce4_systemload_plugin  = callPackage ./panel-plugins/xfce4-systemload-plugin.nix  { };
   xfce4_verve_plugin       = callPackage ./panel-plugins/xfce4-verve-plugin.nix       { };
   xfce4_xkb_plugin         = callPackage ./panel-plugins/xfce4-xkb-plugin.nix         { };
+  xfce4_weather_plugin     = callPackage ./panel-plugins/xfce4-weather-plugin.nix     { };
   xfce4_whiskermenu_plugin = callPackage ./panel-plugins/xfce4-whiskermenu-plugin.nix { };
   xfce4_pulseaudio_plugin  = callPackage ./panel-plugins/xfce4-pulseaudio-plugin.nix  { };
 

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, pkgconfig, intltool, gtk, libxml2, libsoup, upower,
+libxfce4ui, libxfce4util, xfce4panel }:
+
+stdenv.mkDerivation rec {
+  name = "${p_name}-${ver_maj}.${ver_min}";
+  p_name  = "xfce4-weather-plugin";
+  ver_maj = "0.8";
+  ver_min = "7";
+
+  src = fetchurl {
+    url = "mirror://xfce/src/panel-plugins/${p_name}/${ver_maj}/${name}.tar.bz2";
+    sha256 = "1c35iqqiphazkfdabbjdynk0qkc3r8vxhmk2jc6dkiv8d08727h7";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  buildInputs = [ gtk libxml2 libsoup upower libxfce4ui libxfce4util
+   xfce4panel ];
+
+  enableParallelBuilding = true;
+
+  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+
+  meta = {
+    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    description = "Weather plugin for the Xfce desktop environment";
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
