### PR TITLE
update libmemcached osx sha256 hash

### DIFF
--- a/pkgs/development/libraries/libmemcached/default.nix
+++ b/pkgs/development/libraries/libmemcached/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   patches = stdenv.lib.optional stdenv.isLinux ./libmemcached-fix-linking-with-libpthread.patch
     ++ stdenv.lib.optional stdenv.isDarwin (fetchpatch {
       url = "https://raw.githubusercontent.com/Homebrew/homebrew/bfd4a0a4626b61c2511fdf573bcbbc6bbe86340e/Library/Formula/libmemcached.rb";
-      sha256 = "1nvxwdkxj2a2g39z0g8byxjwnw4pa5xlvsmdk081q63vmfywh7zb";
+      sha256 = "1gjf3vd7hiyzxjvlg2zfc3y2j0lyr6nhbws4xb5dmin3csyp8qb8";
     });
 
   buildInputs = [ libevent ];


### PR DESCRIPTION
I'm not a nix guru so not sure if there is something else I'm misssing, but nix was complaining about this hash when building libmemcached on Mac OSX:

`output path ‘/nix/store/851i9vscxj478yl6vv93hv8r6k3pyk5c-libmemcached.rb’ has sha256 hash ‘1gjf3vd7hiyzxjvlg2zfc3y2j0lyr6nhbws4xb5dmin3csyp8qb8’ when ‘1nvxwdkxj2a2g39z0g8byxjwnw4pa5xlvsmdk081q63vmfywh7zb’ was expected
cannot build derivation ‘/nix/store/4ml0r3gr96dkfh6sl2365l5x5ils1s39-libmemcached-1.0.18.drv’: 1 dependencies couldn't be built
`
- changing it seemed to fix the build, could someone more knowledgable see if this is correct
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
