### PR TITLE
qjackctl: 4.0 -> 4.2, qt4 -> qt5

### DIFF
--- a/pkgs/applications/audio/qjackctl/default.nix
+++ b/pkgs/applications/audio/qjackctl/default.nix
@@ -1,17 +1,23 @@
-{ stdenv, fetchurl, qt4, alsaLib, libjack2, dbus }:
+{ stdenv, fetchurl, alsaLib, libjack2, dbus, qt5 }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.0";
+  version = "0.4.2";
   name = "qjackctl-${version}";
 
   # some dependencies such as killall have to be installed additionally
 
   src = fetchurl {
     url = "mirror://sourceforge/qjackctl/${name}.tar.gz";
-    sha256 = "0nj8c8vy00524hbjqwsqkliblcf9j7h46adk6v5np645pp2iqrav";
+    sha256 = "0pmgkqgkapbma42zqb5if4ngmj183rxl8bhjm7mhyhgq4bzll76g";
   };
 
-  buildInputs = [ qt4 alsaLib libjack2 dbus ];
+  buildInputs = [ 
+    qt5.full
+    qt5.qtx11extras
+    alsaLib 
+    libjack2
+    dbus 
+  ];
 
   configureFlags = "--enable-jack-version";
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
