### PR TITLE
chefdk: fix build of hitimes on OS X

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -57,6 +57,12 @@ in
     buildInputs = [ gpgme ];
   };
 
+  hitimes = attrs: {
+    buildInputs =
+      stdenv.lib.optionals stdenv.isDarwin
+        [ darwin.apple_sdk.frameworks.CoreServices ];
+  };
+
   # note that you need version >= v3.16.14.8,
   # otherwise the gem will fail to link to the libv8 binary.
   # see: https://github.com/cowboyd/libv8/pull/161


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes build of `chefdk` on Darwin (OS X) by adding `CoreServices` to the `hitimes` gem as an optional `buildInput` in the `defaultGemConfig`. [Build has been broken on Hydra since 2016-03-11](https://hydra.nixos.org/job/nixpkgs/trunk/chefdk.x86_64-darwin). This build issue was reproduced locally and fixed.
