### PR TITLE
keepass: fix warning about missing GTK

### DIFF
--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildDotnetPackage, makeWrapper, unzip, makeDesktopItem, icoutils, plugins ? [] }:
+{ stdenv, lib, fetchurl, buildDotnetPackage, makeWrapper, unzip, makeDesktopItem, icoutils, gtk2, plugins ? [] }:
 
 # KeePass looks for plugins in under directory in which KeePass.exe is
 # located. It follows symlinks where looking for that directory, so
@@ -72,6 +72,8 @@ with builtins; buildDotnetPackage rec {
   # is found and does not pollute output path.
   binPaths = lib.concatStrings (lib.intersperse ":" (map (x: x + "/bin") plugins));
 
+  dynlibPath = stdenv.lib.makeLibraryPath [ gtk2 ];
+
   postInstall = 
   let
     extractFDeskIcons = ./extractWinRscIconsToStdFreeDesktopDir.sh;
@@ -79,7 +81,9 @@ with builtins; buildDotnetPackage rec {
   ''
     mkdir -p "$out/share/applications"
     cp ${desktopItem}/share/applications/* $out/share/applications
-    wrapProgram $out/bin/keepass --prefix PATH : "$binPaths"
+    wrapProgram $out/bin/keepass \
+      --prefix PATH : "$binPaths" \
+      --prefix LD_LIBRARY_PATH : "$dynlibPath"
 
     ${extractFDeskIcons} \
       "./Translation/TrlUtil/Resources/KeePass.ico" \


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (there is no dependent packages)
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Some part of Mono is trying to dynamically load GTK - starting `keepass`
always shows warning:

```
Gtk not found (missing LD_LIBRARY_PATH to libgtk-x11-2.0.so.0?), using built-in colorscheme
```
