### PR TITLE
asciidoctor: Bumped yanked dependency

### DIFF
--- a/pkgs/tools/typesetting/asciidoctor/Gemfile.lock
+++ b/pkgs/tools/typesetting/asciidoctor/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
       thread_safe (~> 0.3.5)
     asciidoctor-diagram (1.4.0)
       asciidoctor (~> 1.5.0)
-    asciidoctor-latex (1.5.0.6.dev)
+    asciidoctor-latex (1.5.0.8.dev)
       asciidoctor (~> 1.5, >= 1.5.2)
       htmlentities (~> 4.3)
       opal (~> 0.6.3)
@@ -25,7 +25,7 @@ GEM
       safe_yaml (~> 1.0.4)
       thread_safe (~> 0.3.5)
       treetop (= 1.5.3)
-    concurrent-ruby (1.0.1)
+    concurrent-ruby (1.0.2)
     css_parser (1.4.1)
       addressable
     hashery (2.1.2)

--- a/pkgs/tools/typesetting/asciidoctor/gemset.nix
+++ b/pkgs/tools/typesetting/asciidoctor/gemset.nix
@@ -40,7 +40,6 @@
     version = "1.0.0.alpha.1";
   };
   asciidoctor-diagram = {
-    dependencies = ["asciidoctor"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0yb2gqzzbvgf5im0bhv26s3h09m9m6a0pjlq3swqcvwi1szc64k5";
@@ -51,10 +50,10 @@
   asciidoctor-latex = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0kzql61w4phr45w771lvmlmvg22h2wd11n9frrzk3k7psqqd7k61";
+      sha256 = "0wdrhcxz0sz9kx2zxn3qbqm5p664n9gzvv3lmg3214pj3si5wxnn";
       type = "gem";
     };
-    version = "1.5.0.6.dev";
+    version = "1.5.0.8.dev";
   };
   asciidoctor-pdf = {
     source = {
@@ -67,10 +66,10 @@
   concurrent-ruby = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "13igpwgbsq701vzh1lrxs9dlqdgs58kflw8vw35644amwnj1cmjn";
+      sha256 = "1kb4sav7yli12pjr8lscv8z49g52a5xzpfg3z9h8clzw6z74qjsw";
       type = "gem";
     };
-    version = "1.0.1";
+    version = "1.0.2";
   };
   css_parser = {
     source = {


### PR DESCRIPTION
The previously used asciidoctor-latex version was removed upstream, causing a 404 error.
See https://github.com/NixOS/nixpkgs/pull/15135#issuecomment-216984749

As it is a development version, things can get unstable. If this happens again, it might be
worth to downgrade or remove the dependency.

concurrent-ruby also updated.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

asciidoctor-latex: 1.5.0.6.dev -> 1.5.0.8.dev
See NixOS/nixpkgs/pull/15135#issuecomment-216984749
This optional dependency may be removed if this happens too often
