### PR TITLE
ghc8 | config:  th-reify-many:  drop the pin obviated by  hackage import

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -146,15 +146,6 @@ self: super: {
     };
   }));
 
-  # The essential part is released in 0.1.4.1 upstream (needs hackage import)
-  th-reify-many          = doJailbreak (pkgs.haskell.lib.overrideCabal super.th-reify-many (oldAttrs: {
-    src = pkgs.fetchgit {
-            url    = https://github.com/mgsloan/th-reify-many.git;
-            rev    = "699eed232c2ccaf9fb109f131e80ed8d654d6f08";
-            sha256 = "001fvpq039l9wj9v8id7kfjwmp4acf53zr4z6sppdvrv6npzz5yb";
-    };
-  }));
-
   trifecta       = doJailbreak super.trifecta;
 
   turtle         = doJailbreak super.turtle;


### PR DESCRIPTION
@peti, unpinning th-reify-many for GHC 8.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
