### PR TITLE
flamerobin: init at 0.9.3.1

### DIFF
--- a/pkgs/applications/misc/flamerobin/default.nix
+++ b/pkgs/applications/misc/flamerobin/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, wxGTK30, boost, firebird }:
+
+stdenv.mkDerivation rec {
+  version = "0.9.3.1";
+  name = "flamerobin-${version}";
+
+  src = fetchFromGitHub {
+    owner = "mariuz";
+    repo = "flamerobin";
+    rev = version;
+    sha256 = "1wwcsca01hpgi9z5flvbdhs9zv7jvahnbn97j6ymy0hdyb8lv6si";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ wxGTK30 boost firebird ];
+
+  preBuild = ''
+    sed -i 's/CXXFLAGS = -g -O2/CXXFLAGS = -g -O2 -nostartfiles/' Makefile
+  '';
+
+  configureFlags = [
+    "--disable-debug"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Database administration tool for Firebird RDBMS";
+    homepage = "https://github.com/mariuz/flamerobin";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ uralbash ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1514,6 +1514,8 @@ in
 
   fio = callPackage ../tools/system/fio { };
 
+  flamerobin = callPackage ../applications/misc/flamerobin { };
+
   flashtool = callPackage_i686 ../development/mobile/flashtool {
     platformTools = androidenv.platformTools;
   };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
