### PR TITLE
libsndfile: pass AudioToolbox framework on darwin

### DIFF
--- a/pkgs/development/libraries/libsndfile/default.nix
+++ b/pkgs/development/libraries/libsndfile/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, flac, libogg, libvorbis, pkgconfig
-, Carbon
+, Carbon, AudioToolbox
 }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ pkgconfig flac libogg libvorbis ]
-    ++ stdenv.lib.optional stdenv.isDarwin Carbon;
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon AudioToolbox ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7980,7 +7980,7 @@ in
   libsigsegv_25 = callPackage ../development/libraries/libsigsegv/2.5.nix { };
 
   libsndfile = callPackage ../development/libraries/libsndfile {
-    inherit (darwin.apple_sdk.frameworks) Carbon;
+    inherit (darwin.apple_sdk.frameworks) Carbon AudioToolbox;
   };
 
   libsodium = callPackage ../development/libraries/libsodium { };


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  ## \- [ ] Linux

The libsndfile build system wants this framework when building on
darwin.
