### PR TITLE
llvm_38: update hashes and fix on darwin

### DIFF
--- a/pkgs/development/compilers/llvm/3.8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "0i7iyzk024krda5spfpfi8jksh83yp3bxqkal0xp76ffi11bszrm";
+  src = fetch "libcxx" "0yr3fh8vj38289b9cwk37zsy7x98dcd3kjy7xxy8mg20p48lb01n";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/3.8/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "0ambfcmr2nh88hx000xb7yjm9lsqjjz49w5mlf6dlxzmj3nslzx4";
+  src = fetch "libcxxabi" "0175rv2ynkklbg96kpw13iwhnzyrlw3r12f4h09p9v7nmxqhivn5";
 
   buildInputs = [ cmake ] ++ stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
 

--- a/pkgs/development/compilers/llvm/3.8/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.8/llvm.nix
@@ -35,6 +35,13 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ ncurses zlib ];
 
+  # hacky fix: New LLVM releases require a newer OS X SDK than
+  # 10.9. This is a temporary measure until nixpkgs darwin support is
+  # updated.
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+        sed -i 's/os_trace(\(.*\)");$/printf(\1\\n");/g' ./projects/compiler-rt/lib/sanitizer_common/sanitizer_mac.cc
+  '';
+
   # hacky fix: created binaries need to be run before installation
   preBuild = ''
     mkdir -p $out/


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux

---

The hashes for libc++ and libc++abi were wrong.

There was also an incompatibility with nixpkgs on darwin which is now
weakly worked around: the "os_trace" macro changed definition in the OS
X development SDK since version 10.9 as used by nixpkgs. LLVM 3.8 uses
the new version, which I am temporarily replacing with a printf on
darwin as it is only used in one minor location.

Closes #14542 
