### PR TITLE
input-method module: use xim for GTK Fcitx

### DIFF
--- a/nixos/modules/i18n/input-method/fcitx.nix
+++ b/nixos/modules/i18n/input-method/fcitx.nix
@@ -35,7 +35,7 @@ in
     environment.systemPackages = [ fcitxPackage ];
 
     environment.variables = {
-      GTK_IM_MODULE = "fcitx";
+      GTK_IM_MODULE = "xim";
       QT_IM_MODULE  = "fcitx";
       XMODIFIERS    = "@im=fcitx";
     };


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fcitx has a `xim` interface, which works better for GTK applications. On my KDE desktop, the `fcitx` IM module doesn't work for GTK applications. Only `xim` works.
