### PR TITLE
tivodecode: init at 0.2pre4

### DIFF
--- a/pkgs/applications/video/tivodecode/default.nix
+++ b/pkgs/applications/video/tivodecode/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl }:
+
+let
+  version = "0.2pre4";
+
+in
+
+stdenv.mkDerivation {
+  name = "tivodecode-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/tivodecode/tivodecode/${version}/tivodecode-${version}.tar.gz";
+    sha256 = "1pww5r2iygscqn20a1cz9xbfh18p84a6a5ifg4h5nvyn9b63k23q";
+  };
+
+  meta = {
+    description = "Converts a .TiVo file (produced by TiVoToGo) to a normal MPEG file";
+    homepage = http://tivodecode.sourceforge.net;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8960,6 +8960,8 @@ in
 
   tinyxml-2 = callPackage ../development/libraries/tinyxml-2 { };
 
+  tivodecode = callPackage ../applications/video/tivodecode { };
+
   tk = tk-8_6;
 
   tk-8_6 = callPackage ../development/libraries/tk/8.6.nix { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
