### PR TITLE
audacious: Add default icon theme

### DIFF
--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, glib, gtk3, libmowgli, libmcs
 , gettext, dbus_glib, libxml2, libmad, xorg, alsaLib, libogg
 , libvorbis, libcdio, libcddb, flac, ffmpeg, makeWrapper
-, mpg123, neon, faad2
+, mpg123, neon, faad2, gnome3
 }:
 
 let version = "3.5.2"; in
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   buildInputs =
     [ gettext pkgconfig glib gtk3 libmowgli libmcs libxml2 dbus_glib
       libmad xorg.libXcomposite libogg libvorbis flac alsaLib libcdio
-      libcddb ffmpeg makeWrapper mpg123 neon faad2
+      libcddb ffmpeg makeWrapper mpg123 neon faad2 gnome3.defaultIconTheme
     ];
 
   # Here we build bouth audacious and audacious-plugins in one
@@ -48,8 +48,11 @@ stdenv.mkDerivation {
       (
         source $stdenv/setup
         # gsettings schemas for file dialogues
+        # XDG_ICON_DIRS is set by hook for gnome3.defaultIconTheme
         for file in "$out/bin/"*; do
-          wrapProgram "$file" --prefix XDG_DATA_DIRS : "$XDG_ADD:$GSETTINGS_SCHEMAS_PATH"
+          wrapProgram "$file" \
+            --prefix XDG_DATA_DIRS : "$XDG_ADD:$GSETTINGS_SCHEMAS_PATH" \
+            --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
         done
       )
     '';


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Without this audacious shows the same empty icon for every toolbar
button. Installing icon theme to a user profile helps, but this patch
provides the default value. '--suffix' for makeWrapper is use
intentionally - just to be sure that this is only default value, and
anything else can override it.
