### PR TITLE
pharo-vm: add PharoV50.sources

### DIFF
--- a/pkgs/development/pharo/vm/share.nix
+++ b/pkgs/development/pharo/vm/share.nix
@@ -26,6 +26,11 @@ stdenv.mkDerivation rec {
     sha256 = "1xq1721ql19hpgr8ir372h92q7g8zwd6k921b21dap4wf8djqnpd";
   };
 
+  sources50Zip = fetchurl {
+    url = http://files.pharo.org/sources/PharoV50.sources.zip;
+    sha256 = "0ykl1y0a4yy5qn8fwz0wkl8fcn4pqv9q0w0r2llhzdz3jdg1k69g";
+  };
+
   buildInputs = [ unzip ];
 
   installPhase = ''
@@ -37,6 +42,7 @@ stdenv.mkDerivation rec {
     unzip ${sources20Zip} -d $prefix/lib/
     unzip ${sources30Zip} -d $prefix/lib/
     unzip ${sources40Zip} -d $prefix/lib/
+    unzip ${sources50Zip} -d $prefix/lib/
   '';
 
   meta = {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
