### PR TITLE
gazeboSimulator.sdformat3: fixed cmake output (fixes gazebo6 #14921)

### DIFF
--- a/pkgs/development/libraries/sdformat/default.nix
+++ b/pkgs/development/libraries/sdformat/default.nix
@@ -20,4 +20,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     cmake boost ruby ignition.math2 tinyxml
   ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
 }


### PR DESCRIPTION
@therealpxc fixes #14921
