### PR TITLE
pharo-vm5: 2016.04.04 -> 2016.05.04

### DIFF
--- a/pkgs/development/pharo/vm/default.nix
+++ b/pkgs/development/pharo/vm/default.nix
@@ -16,12 +16,12 @@ rec {
   };
 
   pharo-spur = pharo-vm-build rec {
-    version = "2016.04.04";
+    version = "2016.05.04";
     name = "pharo-vm-spur-i386-${version}";
     binary-basename = "pharo-spur-vm";
     src = fetchurl {
       url = "${base-url}/pharo-vm-spur-${version}.tar.bz2";
-      sha256 = "1kmf782vdk9xbzi2yn1vpzksv8m04ry8n2ih16jhcihibxzcmz23";
+      sha256 = "01xvpcp9mslxmfjpi43jhgf8jnx20dqngwrfyi838il61128hwq2";
     };
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
