### PR TITLE
elixir: 1.2.4 -> 1.2.5

### DIFF
--- a/pkgs/development/interpreters/elixir/default.nix
+++ b/pkgs/development/interpreters/elixir/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, fetchurl, erlang, rebar, makeWrapper, coreutils, curl, bash,
+{ stdenv, fetchFromGitHub, erlang, rebar, makeWrapper, coreutils, curl, bash,
   debugInfo ? false }:
 
 stdenv.mkDerivation rec {
   name = "elixir-${version}";
-  version = "1.2.4";
+  version = "1.2.5";
 
-  src = fetchurl {
-    url = "https://github.com/elixir-lang/elixir/archive/v${version}.tar.gz";
-    sha256 = "16759ff84d08b480b7e5499716e663b2fffd26e20cf2863de5613bc7bb05c817";
+  src = fetchFromGitHub {
+    owner = "elixir-lang";
+    repo = "elixir";
+    rev = "v${version}";
+    sha256 = "0qnmsmzmr431y1chkzk2aq501fk734mncdbn7nsiq98bnqgb6php";
   };
 
   buildInputs = [ erlang rebar makeWrapper ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
