### PR TITLE
faustCompressors: init at 0.1.1, update other magnetophon-dsp to use lv2 gui

### DIFF
--- a/pkgs/applications/audio/CharacterCompressor/default.nix
+++ b/pkgs/applications/audio/CharacterCompressor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jack, faust2lv2 }:
+{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2gui }:
 stdenv.mkDerivation rec {
   name = "CharacterCompressor-${version}";
   version = "0.2";
@@ -10,11 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "0fvi8m4nshcxypn4jgxhnh7pxp68wshhav3k8wn3il7qpw71pdxi";
   };
 
-  buildInputs = [ faust2jack faust2lv2 ];
+  buildInputs = [ faust2jaqt faust2lv2gui ];
 
   buildPhase = ''
-    faust2jack -t 99999 CharacterCompressor.dsp
-    faust2lv2 -t 99999 CharacterCompressor.dsp
+    faust2jaqt -t 99999 CharacterCompressor.dsp
+    faust2lv2 -gui -t 99999 CharacterCompressor.dsp
   '';
 
   installPhase = ''

--- a/pkgs/applications/audio/LazyLimiter/default.nix
+++ b/pkgs/applications/audio/LazyLimiter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jack, faust2lv2 }:
+{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2gui }:
 stdenv.mkDerivation rec {
   name = "LazyLimiter-${version}";
   version = "0.3.01";
@@ -10,11 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "1yx9d5cakmqbiwb1j9v2af9h5lqzahl3kaamnyk71cf4i8g7zp3l";
   };
 
-  buildInputs = [ faust2jack faust2lv2 ];
+  buildInputs = [ faust2jaqt faust2lv2gui ];
 
   buildPhase = ''
-    faust2jack -t 99999 LazyLimiter.dsp
-    faust2lv2 -t 99999 LazyLimiter.dsp
+    faust2jaqt -t 99999 LazyLimiter.dsp
+    faust2lv2 -gui -t 99999 LazyLimiter.dsp
   '';
 
   installPhase = ''

--- a/pkgs/applications/audio/MBdistortion/default.nix
+++ b/pkgs/applications/audio/MBdistortion/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jack, faust2lv2 }:
+{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2gui }:
 stdenv.mkDerivation rec {
   name = "MBdistortion-${version}";
   version = "1.1";
@@ -10,11 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "1rmvfi48hg8ybfw517zgj3fjj2xzckrmv8x131i26vj0fv7svjsp";
   };
 
-  buildInputs = [ faust2jack faust2lv2 ];
+  buildInputs = [ faust2jaqt faust2lv2gui ];
 
   buildPhase = ''
-    faust2jack -t 99999 MBdistortion.dsp
-    faust2lv2 -t 99999 MBdistortion.dsp
+    faust2jaqt -t 99999 MBdistortion.dsp
+    faust2lv2 -gui -t 99999 MBdistortion.dsp
   '';
 
   installPhase = ''

--- a/pkgs/applications/audio/RhythmDelay/default.nix
+++ b/pkgs/applications/audio/RhythmDelay/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, faust2jack, faust2lv2 }:
+{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2gui }:
 stdenv.mkDerivation rec {
   name = "RhythmDelay-${version}";
   version = "2.0";
@@ -10,11 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "0n938nm08mf3lz92k6v07k1469xxzmfkgclw40jgdssfcfa16bn7";
   };
 
-  buildInputs = [ faust2jack faust2lv2 ];
+  buildInputs = [ faust2jaqt faust2lv2gui ];
 
   buildPhase = ''
-    faust2jack -t 99999 RhythmDelay.dsp
-    faust2lv2 -t 99999 RhythmDelay.dsp
+    faust2jaqt -t 99999 RhythmDelay.dsp
+    faust2lv2 -gui -t 99999 RhythmDelay.dsp
   '';
 
   installPhase = ''

--- a/pkgs/applications/audio/constant-detune-chorus/default.nix
+++ b/pkgs/applications/audio/constant-detune-chorus/default.nix
@@ -1,27 +1,27 @@
-{ stdenv, fetchFromGitHub, faust2jack, faust2lv2 }:
+{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2gui }:
 stdenv.mkDerivation rec {
   name = "constant-detune-chorus-${version}";
-  version = "0.1.01";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "constant-detune-chorus";
     rev = "v${version}";
-    sha256 = "1z8aj1a36ix9jizk9wl06b3i98hrkg47qxqp8vx930r624pc5z86";
+    sha256 = "1ks2k6pflqyi2cs26bnbypphyrrgn0xf31l31kgx1qlilyc57vln";
   };
 
-  buildInputs = [ faust2jack faust2lv2 ];
+  buildInputs = [ faust2jaqt faust2lv2gui ];
 
   buildPhase = ''
-    faust2jack -t 99999 constant-detune-chorus.dsp
-    faust2lv2 -t 99999 constant-detune-chorus.dsp
+    faust2jaqt -t 99999 ConstantDetuneChorus.dsp
+    faust2lv2 -gui -t 99999 ConstantDetuneChorus.dsp
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    cp constant-detune-chorus $out/bin/
+    cp ConstantDetuneChorus $out/bin/
     mkdir -p $out/lib/lv2
-    cp -r constant-detune-chorus.lv2/ $out/lib/lv2
+    cp -r ConstantDetuneChorus.lv2/ $out/lib/lv2
   '';
 
   meta = {

--- a/pkgs/applications/audio/faustCompressors/default.nix
+++ b/pkgs/applications/audio/faustCompressors/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2gui }:
 stdenv.mkDerivation rec {
-  name = "CompBus-${version}";
-  version = "1.1.02";
+  name = "faustCompressors-${version}";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
-    repo = "CompBus";
+    repo = "faustCompressors";
     rev = "v${version}";
-    sha256 = "025vi60caxk3j2vxxrgbc59xlyr88vgn7k3127s271zvpyy7apwh";
+    sha256 = "0x5nd2cjhknb4aclhkkjaywx75bi2wj22prgv8n47czi09jcj0jb";
   };
 
   buildInputs = [ faust2jaqt faust2lv2gui ];
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     for f in *.dsp;
     do
-      faust2jaqt -t 99999 $f
-      faust2lv2 -gui -t 99999 $f
+      faust2jaqt -double -t 99999 $f
+      faust2lv2 -double -gui -t 99999 $f
     done
   '';
 
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A group of compressors mixed into a bus, sidechained from that mix bus. For jack and lv2";
-    homepage = https://github.com/magnetophon/CompBus;
+    description = "A collection of bread and butter compressors";
+    homepage = https://github.com/magnetophon/faustCompressors;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -891,7 +891,7 @@ in
     enableStandardFeatures = true;
     enableExtraPlugins = true;
   });
-  
+
   asciidoctor = callPackage ../tools/typesetting/asciidoctor { };
 
   autossh = callPackage ../tools/networking/autossh { };
@@ -16291,6 +16291,8 @@ in
   faust2lv2 = callPackage ../applications/audio/faust/faust2lv2.nix { };
 
   faust2lv2gui = callPackage ../applications/audio/faust/faust2lv2gui.nix { };
+
+  faustCompressors =  callPackage ../applications/audio/faustCompressors { };
 
   fceux = callPackage ../misc/emulators/fceux { };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
