### PR TITLE
burp: Add services for client and server

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -110,6 +110,8 @@
   ./services/audio/mopidy.nix
   ./services/backup/almir.nix
   ./services/backup/bacula.nix
+  ./services/backup/burp-client.nix
+  ./services/backup/burp-server.nix
   ./services/backup/crashplan.nix
   ./services/backup/mysql-backup.nix
   ./services/backup/postgresql-backup.nix

--- a/nixos/modules/services/backup/burp-client.nix
+++ b/nixos/modules/services/backup/burp-client.nix
@@ -1,0 +1,60 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.burpClient;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.burpClient = {
+
+      enable = mkEnableOption "Enable burp client";
+
+      configFile = mkOption {
+        type = types.path;
+        default = "/etc/burp/burp.conf";
+        description = "Path to the burp config file. You need to provide a fully working configuration file yourself.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.burp;
+        example = literalExample "pkgs.burp";
+        description = ''burp package to use.'';
+      };
+
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf config.services.burpClient.enable {
+
+    systemd.timers.burpClient = {
+      description = "burp client timer";
+
+      wantedBy = [ "timers.target" ];
+      after = [ "network.target" ];
+
+      timerConfig.OnBootSec = "10m";
+      timerConfig.OnUnitInactiveSec = "20m";
+      timerConfig.Unit = "burpClient.service";
+
+    };
+    systemd.services.burpClient = {
+      description = "burp client";
+      serviceConfig.ExecStart = "${cfg.package}/bin/burp -a t -c ${toString cfg.configFile}";
+    };
+  
+  };
+
+}

--- a/nixos/modules/services/backup/burp-server.nix
+++ b/nixos/modules/services/backup/burp-server.nix
@@ -1,0 +1,78 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.burpServer;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.burpServer = {
+
+      enable = mkEnableOption "Enable burp server and open port 4971 in firewall";
+
+      configFile = mkOption {
+        default = "/etc/burp/burp-server.conf";
+        type = types.path;
+        description = "Path to the burp server config file. You need to provide a fully working configuration file and setup all paths yourself. burp will be start as user burp with group burp and tcp port 4971 will be opened in the firewall. Ensure that you have setup the configuration accordingly.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.burp;
+        example = literalExample "pkgs.burp";
+        description = ''burp package to use.'';
+      };
+
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf config.services.burpServer.enable {
+
+    users.extraUsers.burp = {
+      group = "burp";
+      isSystemUser = true;
+      description = "burp server user";
+    };
+
+    users.extraGroups.burp = {
+      name = "burp";
+    };
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.burp = {
+      description = "burp server";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/burp -F -c ${toString cfg.configFile}";
+        User = "burp";
+        Group = "burp";
+	# Hardening
+	PrivateTmp = "yes";
+	DevicePolicy = "closed";
+	NoNewPrivileges = "yes";
+	ProtectSystem = "yes";
+	# To be added when there's also a config generator included and the paths are known...
+	#ReadWriteDirectories = "/var/spool/burp /etc/burp/CA";
+      };
+
+    };
+  
+    networking.firewall.allowedTCPPorts = [ 4971 ];
+  };
+
+}


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
