### PR TITLE
bspwm: backport of socket unlink fix to 0.9

### DIFF
--- a/pkgs/applications/window-managers/bspwm/default.nix
+++ b/pkgs/applications/window-managers/bspwm/default.nix
@@ -9,12 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "1efb2db7b8a251bcc006d66a050cf66e9d311761c94890bebf91a32905042fde";
   };
 
+  patches = [ ./unlink-socket.patch ];
+
   buildInputs = [ libxcb libXinerama xcbutil xcbutilkeysyms xcbutilwm ];
 
   buildPhase = ''
     make PREFIX=$out
   '';
- 
+
   installPhase = ''
     make PREFIX=$out install
   '';

--- a/pkgs/applications/window-managers/bspwm/unlink-socket.patch
+++ b/pkgs/applications/window-managers/bspwm/unlink-socket.patch
@@ -1,0 +1,61 @@
+diff --git a/bspwm.c b/bspwm.c
+index 344e1f4..425000c 100644
+--- a/bspwm.c
++++ b/bspwm.c
+@@ -77,24 +77,6 @@ int main(int argc, char *argv[])
+ 		}
+ 	}
+ 
+-	if (config_path[0] == '\0') {
+-		char *config_home = getenv(CONFIG_HOME_ENV);
+-		if (config_home != NULL)
+-			snprintf(config_path, sizeof(config_path), "%s/%s/%s", config_home, WM_NAME, CONFIG_NAME);
+-		else
+-			snprintf(config_path, sizeof(config_path), "%s/%s/%s/%s", getenv("HOME"), ".config", WM_NAME, CONFIG_NAME);
+-	}
+-
+-	dpy = xcb_connect(NULL, &default_screen);
+-
+-	if (!check_connection(dpy))
+-		exit(EXIT_FAILURE);
+-
+-	load_settings();
+-	setup();
+-
+-	dpy_fd = xcb_get_file_descriptor(dpy);
+-
+ 	char *sp = getenv(SOCKET_ENV_VAR);
+ 	if (sp != NULL) {
+ 		snprintf(socket_path, sizeof(socket_path), "%s", sp);
+@@ -114,12 +96,31 @@ int main(int argc, char *argv[])
+ 	if (sock_fd == -1)
+ 		err("Couldn't create the socket.\n");
+ 
++	unlink(socket_path);
+ 	if (bind(sock_fd, (struct sockaddr *) &sock_address, sizeof(sock_address)) == -1)
+ 		err("Couldn't bind a name to the socket.\n");
+ 
+ 	if (listen(sock_fd, SOMAXCONN) == -1)
+ 		err("Couldn't listen to the socket.\n");
+ 
++	if (config_path[0] == '\0') {
++		char *config_home = getenv(CONFIG_HOME_ENV);
++		if (config_home != NULL)
++			snprintf(config_path, sizeof(config_path), "%s/%s/%s", config_home, WM_NAME, CONFIG_NAME);
++		else
++			snprintf(config_path, sizeof(config_path), "%s/%s/%s/%s", getenv("HOME"), ".config", WM_NAME, CONFIG_NAME);
++	}
++
++	dpy = xcb_connect(NULL, &default_screen);
++
++	if (!check_connection(dpy))
++		exit(EXIT_FAILURE);
++
++	load_settings();
++	setup();
++
++	dpy_fd = xcb_get_file_descriptor(dpy);
++
+ 	signal(SIGINT, sig_handler);
+ 	signal(SIGHUP, sig_handler);
+ 	signal(SIGTERM, sig_handler);


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Backport of https://github.com/baskerville/bspwm/commit/645ad38885bb19a33daa7bd2ec69adc1e51963d4 to bspwm 0.9.0, to fix issues with bspwm not cleaning up its socket.

Issue can be replicated on stock bspwm 0.9 via `kill -9 bspwm` and then trying to launch bspwm again.

Unnecessary in nixos master as bspwm is on 0.9.1 already.
