### PR TITLE
hugin: 2015.0.0 -> 2016.0.0

### DIFF
--- a/pkgs/applications/graphics/hugin/default.nix
+++ b/pkgs/applications/graphics/hugin/default.nix
@@ -1,33 +1,31 @@
-{ stdenv, cmake, fetchurl, gnumake, pkgconfig, makeWrapper
-, boost, gettext, tclap, wxGTK
-, freeglut, glew, libX11, libXi, libXmu, mesa, cairo
-, autopanosiftc, enblend-enfuse, exiv2, fftw, ilmbase, lensfun, libpng, libtiff
-, openexr, panotools, perlPackages, sqlite, vigra
+{ stdenv, cmake, fetchurl, gnumake, makeWrapper, pkgconfig
+, autopanosiftc, boost, cairo, enblend-enfuse, exiv2, fftw, flann, gettext
+, glew, ilmbase, lcms2, lensfun, libjpeg, libpng, libtiff, libX11, libXi
+, libXmu, mesa, openexr, panotools, perlPackages, sqlite, vigra, wxGTK, zlib
 }:
 
 stdenv.mkDerivation rec {
-  name = "hugin-2015.0.0";
+  name = "hugin-2016.0.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/hugin/${name}.tar.bz2";
-    sha256 = "1gfblax9rxay8xskz5r8bips4nfh70vkyrb8ksgl6pg91c8krn9c";
+    sha256 = "1rk5bgsvszv9bza46jxwr3i3qgiha2rza5v8lbwkqn4b4idv0c5h";
   };
 
-  NIX_CFLAGS_COMPILE = "-I${ilmbase}/include/OpenEXR";
+  buildInputs = [
+    boost cairo exiv2 fftw flann gettext glew ilmbase lcms2 lensfun libjpeg
+    libpng libtiff libX11 libXi libXmu mesa openexr panotools sqlite vigra
+    wxGTK zlib
+  ];
 
-  buildInputs = [ boost gettext tclap wxGTK
-                  freeglut glew libX11 libXi libXmu mesa cairo
-                  exiv2 fftw ilmbase lensfun libtiff libpng openexr panotools
-                  sqlite vigra
-                  perlPackages.ImageExifTool makeWrapper
-                ];
+  nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
 
   # disable installation of the python scripting interface
   cmakeFlags = [ "-DBUILD_HSI:BOOl=OFF" ];
 
-  nativeBuildInputs = [ cmake pkgconfig ];
-
   enableParallelBuilding = true;
+
+  NIX_CFLAGS_COMPILE = "-I${ilmbase}/include/OpenEXR";
 
   postInstall = ''
     for p in $out/bin/*; do
@@ -39,11 +37,11 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://hugin.sourceforge.net/;
     description = "Toolkit for stitching photographs and assembling panoramas, together with an easy to use graphical front end";
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [ viric hrdinka ];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ viric hrdinka ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12831,9 +12831,7 @@ in
     fltk = fltk13;
   };
 
-  hugin = callPackage ../applications/graphics/hugin {
-    boost = boost155;
-  };
+  hugin = callPackage ../applications/graphics/hugin { };
 
   hydrogen = callPackage ../applications/audio/hydrogen { };
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This updates hugin to its latest version and cleanes the derivation.

Release notes:

http://hugin.sourceforge.net/releases/2016.0.0/en.shtml

CC @viric
