### PR TITLE
freerdpUnstable: 1.2.0-beta1+andoid7 -> git master

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/unstable.nix
+++ b/pkgs/applications/networking/remote/freerdp/unstable.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "FreeRDP";
     repo = "FreeRDP";
-    rev = "1.2.0-beta1+android7";
-    sha256 = "08nn18jydblrif1qs92pakzd3ww7inr0i378ssn1bjp09lm1bkk0";
+    rev = "f8285956097451f829d7da3455c45e3de39092e6";
+    sha256 = "0iz3a2y6sj4w433259widchrc1bld5wkkpb040gpiz0avdm4nw89";
   };
 
   patches = [


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

FreeRDP's git master branch has seen many improvements, specifically in
respects to terminal server gateway support which has been very limited
in previous versions. Also, the release cycle seems to be very slow
which makes it difficult to get the newest features and fixes.

Built and tested locally (tested gateway support too which finally works)
