### PR TITLE
haskell-twilio: disable test suite

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -43,6 +43,7 @@ self: super: {
   options = dontCheck super.options;
   statistics = dontCheck super.statistics;
   c2hs = if pkgs.stdenv.isDarwin then dontCheck super.c2hs else super.c2hs;
+  twilio = dontCheck super.twilio;
 
   # Use the default version of mysql to build this package (which is actually mariadb).
   mysql = super.mysql.override { mysql = pkgs.mysql.lib; };


### PR DESCRIPTION
It requires some environment variables to be set in order to run against
a Twilio account. Not something we want to do I don't think.

@peti not sure if the correct place for this kind of thing is here or in cabal2nix.
