### PR TITLE
[WIP] mathpartir: init at 1.3.2

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive-new/pkgs.nix
+++ b/pkgs/tools/typesetting/tex/texlive-new/pkgs.nix
@@ -14558,6 +14558,14 @@ tl: { # no indentation
   hasRunfiles = true;
   version = "1.00";
 };
+"mathpartir" = {
+  stripPrefix = 0;
+  md5.run = "5a3d37f8f396818f546a6cacd74a9786";
+  md5.doc = "838dabc769b9609af5948f3a7207f44d";
+  md5.source = "1f7473004a4367f5acf57b2820c89f2f";
+  hasRunfiles = true;
+  version = "1.3.2";
+};
 "mathpazo" = {
   stripPrefix = 0;
   md5.run = "c6f4e8ae7ffda23ce9360f533d12a2ba";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't know the process for adding texlive-new packages, so I may be doing this completely wrong. `md5.run` is correct, and I can successfully build a PDF using mathpartir. `md5.doc` and `md5.source` are wrong (random numbers which look like hashes), but I don't know how to find the right values.
