### PR TITLE
p11-kit: 0.23.1 -> 0.23.2

### DIFF
--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libiconv, pkgconfig, libffi, libtasn1 }:
 
 stdenv.mkDerivation rec {
-  name = "p11-kit-0.23.1";
+  name = "p11-kit-0.23.2";
 
   src = fetchurl {
     url = "${meta.homepage}releases/${name}.tar.gz";
-    sha256 = "1i3a1wdpagm0p3y1bwaz5x5rjhcpqbcrnhkcp10p259vkxk72wz5";
+    sha256 = "1w7szm190phlkg7qx05ychlj2dbvkgkhx9gw6dx4d5rw62l6wwms";
   };
 
   outputs = [ "dev" "out" "docdev" ];
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "exampledir=\${out}/etc/pkcs11" ];
 
   meta = with stdenv.lib; {
-    homepage = http://p11-glue.freedesktop.org/;
+    homepage = https://p11-glue.freedesktop.org/;
     platforms = platforms.all;
     maintainers = with maintainers; [ urkud wkennington ];
     license = licenses.mit;


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
