### PR TITLE
wmii needs which

### DIFF
--- a/pkgs/applications/window-managers/wmii-hg/default.nix
+++ b/pkgs/applications/window-managers/wmii-hg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchhg, pkgconfig, libixp_hg, txt2tags, dash, python
+{ stdenv, fetchhg, pkgconfig, libixp_hg, txt2tags, dash, python, which
 , libX11 , libXrender, libXext, libXinerama, libXrandr, libXft }:
 
 stdenv.mkDerivation rec {
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
   # for dlopen-ing
   patchPhase = ''
     substituteInPlace lib/libstuff/x11/xft.c --replace "libXft.so" "${libXft}/lib/libXft.so"
+    substituteInPlace cmd/wmii.sh.sh --replace "\$(which which)" "${which}/bin/which"
   '';
 
   configurePhase = ''
@@ -29,7 +30,7 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
-  buildInputs = [ pkgconfig libixp_hg txt2tags dash python
+  buildInputs = [ pkgconfig libixp_hg txt2tags dash python which
                   libX11 libXrender libXext libXinerama libXrandr libXft ];
 
   # For some reason including mercurial in buildInputs did not help


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

While wmii will sort of work without it, it breaks before it
runs any user configuration which requires me to using the windows
key as my modifier.
