### PR TITLE
firefox: Use refactored makeSearchPathOutput

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -129,7 +129,7 @@ stdenv.mkDerivation {
   # Let each plugin tell us (through its `mozillaPlugin') attribute
   # where to find the plugin in its tree.
   plugins = map (x: x + x.mozillaPlugin) plugins;
-  libs = lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutputs "lib64" ["lib"] libs;
+  libs = lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
   gtk_modules = map (x: x + x.gtkModule) gtk_modules;
 
   passthru = { unwrapped = browser; };


### PR DESCRIPTION
`makeSearchPathOutputs` was refactored to `makeSearchPathOutput` in commit #c779e30d531032a7744685e80c2143b358efe1b0.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
