### PR TITLE
calibre: Fix file already exists building problem

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
   # hack around a build problem
   preBuild = ''
     mkdir -p ../tmp.*/lib
-    ln -s '${qtbase.out}/lib/libQt5PlatformSupport.a' ../tmp.*/lib/
   '';
 
   nativeBuildInputs = [ makeWrapper pkgconfig qmakeHook ];


### PR DESCRIPTION
Because of the new Qt upgrade in `staging`, this line of build fix does not apply any more. It results in "file already exists` building problem.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
