### PR TITLE
textql: Init textql at 2.0.3

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3669,6 +3669,8 @@ in
 
   testdisk = callPackage ../tools/misc/testdisk { };
 
+  textql = goPackages.textql.bin // { outputs = [ "bin" ]; };
+
   html2text = callPackage ../tools/text/html2text { };
 
   html-tidy = callPackage ../tools/text/html-tidy { };

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -4159,4 +4159,22 @@ let
     sha256  = "14p3hvv82bsxqnbnzz8hjv75i39kzg154a132n6cdxx3vgw76gck";
     propagatedBuildInputs = [ go-colorable mattn.go-runewidth ingo ];
   };
+
+  textql = buildFromGitHub rec {
+    rev     = "1785cd353c68aa34f97627143b9c2908dfd4ea04";
+    version = "2.0.3";
+    owner   = "dinedal";
+    repo    = "textql";
+    sha256 = "1b61w4pc5gl7m12mphricihzq7ifnzwn0yyw3ypv0d0fj26h5hc3";
+    propagatedBuildInputs = [ go-sqlite3 ];
+
+    meta = with stdenv.lib; {
+      description = "Execute SQL against structured text like CSV or TSV";
+      homepage = https://github.com/dinedal/textql;
+      license = licenses.mit;
+      maintainers = with maintainers; [ vrthra ];
+    };
+
+  };
+
 }; in self


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

textql allows one to execute SQL against structured text like CSV or TSV
This commit provides initial package for textql 2.0.3
