### PR TITLE
numix-gtk-theme: 2.2.3 -> 2.5.1

### DIFF
--- a/pkgs/misc/themes/gtk3/numix-gtk-theme/default.nix
+++ b/pkgs/misc/themes/gtk3/numix-gtk-theme/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.2.3";
+  version = "2.5.1";
   name = "numix-gtk-theme-${version}";
   
   src = fetchurl {
-    url = "https://github.com/shimmerproject/Numix/archive/v${version}.tar.gz";
-    sha256 = "b0acc2d81300b898403766456d3406304553cc7016677381f3179dbeb1192a2d";
+    url = "https://github.com/numixproject/Numix/archive/v${version}.tar.gz";
+    sha256 = "0y6c4xr2n9sygxhgviwd97l02n17n53bkpfp62srkm05cq0jy87k";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not compatible with gtk-3.18 yet, but should provide improvements for other versions. The project seems fairly active, so another release should be on the way.
