### PR TITLE
tint2: 0.12.9 -> 0.12.10

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchFromGitLab, pkgconfig, cmake, gettext, pango, cairo, glib
 , pcre , imlib2, libXinerama , libXrender, libXcomposite, libXdamage, libX11
 , libXrandr, gtk, libpthreadstubs , libXdmcp, librsvg
-, libstartup_notification, wrapGAppsHook
+, libstartup_notification, hicolor_icon_theme, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
   name = "tint2-${version}";
-  version = "0.12.9";
+  version = "0.12.10";
 
   src = fetchFromGitLab {
     owner = "o9000";
     repo = "tint2";
     rev = version;
-    sha256 = "17n3yssqiwxqrwsxypzw8skwzxm2540ikbyx7kfxv2gqlbjx5y6q";
+    sha256 = "0da28ykid84i4pw0cvgaxw0wq2yn03i68g54dzmajgsl1wvkqb0z";
   };
 
   enableParallelBuilding = true;
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pango cairo glib pcre imlib2 libXinerama libXrender
     libXcomposite libXdamage libX11 libXrandr gtk libpthreadstubs libXdmcp
-    librsvg libstartup_notification ];
+    librsvg libstartup_notification hicolor_icon_theme ];
 
   preConfigure = ''
     substituteInPlace CMakeLists.txt --replace /etc $out/etc
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = https://gitlab.com/o9000/tint2;
     license = stdenv.lib.licenses.gpl2;
-    description = "A simple panel/taskbar unintrusive and light (memory / cpu / aestetic)";
+    description = "Simple panel/taskbar unintrusive and light (memory / cpu / aestetic)";
     platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
