### PR TITLE
NUnit3, openra and dependencies update

### DIFF
--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -30,6 +30,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ mono makeWrapper lua pkgconfig ];
 
   patchPhase = ''
+    mkdir Support
     sed -i 's/^VERSION.*/VERSION = release-${version}/g' Makefile
     substituteInPlace thirdparty/configure-native-deps.sh --replace "locations=\"" "locations=\"${lua}/lib "
     substituteInPlace Makefile --replace "@./thirdparty/fetch-geoip-db.sh" ""
@@ -96,10 +97,9 @@ in stdenv.mkDerivation rec {
     make dependencies
   '';
 
-  #todo: man-page
-  buildFlags = [ "DEBUG=false" "default" ];
+  buildFlags = [ "DEBUG=false" "default" "man-page" ];
 
-  installTargets = [ "install" "install-linux-icons" "install-linux-desktop" "install-linux-appdata" "install-linux-mime" ];
+  installTargets = [ "install" "install-linux-icons" "install-linux-desktop" "install-linux-appdata" "install-linux-mime" "install-man-page" ];
 
   postInstall = with stdenv.lib; let
     runtime = makeLibraryPath [ SDL2 freetype openal systemd lua ];

--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "20151224";
+  version = "20160508";
 in stdenv.mkDerivation rec {
   name = "openra-${version}";
 
@@ -19,13 +19,13 @@ in stdenv.mkDerivation rec {
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "https://github.com/OpenRA/OpenRA/archive/release-${version}.tar.gz";
-    sha256 = "0dgaxy1my5r3sr3l3gw79v89dsc7179pasj2bibswlv03wsjgqbi";
+    sha256 = "1vr5bvdkh0n5569ga2h7ggj43vnzr37hfqkfnsis1sg4vgwrnzr7";
   };
 
   dontStrip = true;
 
   buildInputs = with dotnetPackages;
-     [ NUnit NewtonsoftJson MonoNat FuzzyLogicLibrary SmartIrc4net SharpZipLib MaxMindGeoIP2 MaxMindDb SharpFont StyleCopMSBuild StyleCopPlusMSBuild RestSharp ]
+     [ NUnit3 NewtonsoftJson MonoNat FuzzyLogicLibrary SmartIrc4net SharpZipLib MaxMindGeoIP2 MaxMindDb SharpFont StyleCopMSBuild StyleCopPlusMSBuild RestSharp NUnitConsole ]
      ++ [ lua gnome3.zenity ];
   nativeBuildInputs = [ mono makeWrapper lua pkgconfig ];
 
@@ -53,28 +53,44 @@ in stdenv.mkDerivation rec {
     "${StyleCopPlusMSBuild}/lib/dotnet/StyleCopPlus.MSBuild/StyleCopPlus.dll"
     "${RestSharp}/lib/dotnet/RestSharp/net4-client/RestSharp.dll"
     "${NUnit}/lib/dotnet/NUnit/nunit.framework.*"
+    "${NUnitConsole}/lib/dotnet/NUnit.Console/*"
     "${NewtonsoftJson}/lib/dotnet/Newtonsoft.Json/Newtonsoft.Json.dll"
     ];
     movePackages = [
       ( let filename = "Eluant.dll"; in { origin = fetchurl {
-          url = "https://github.com/OpenRA/Eluant/releases/download/20140425/${filename}";
+          url = "https://github.com/OpenRA/Eluant/releases/download/20160124/${filename}";
           sha256 = "1c20whz7dzfhg3szd62rvb79745x5iwrd5pp62j3bbj1q9wpddmb";
         }; target = filename; })
 
       ( let filename = "SDL2-CS.dll"; in { origin = fetchurl {
-          url = "https://github.com/OpenRA/SDL2-CS/releases/download/20150709/${filename}";
-          sha256 = "0ms75w9w0x3dzpg5g1ym5nb1id7pmagbzqx0am7h8fq4m0cqddmc";
+          url = "https://github.com/OpenRA/SDL2-CS/releases/download/20151227/${filename}";
+          sha256 = "0gqw2wg37cqhhlc2a9lfc4ndkyfi4m8bkv7ckxbawgydjlknq83n";
+        }; target = filename; })
+
+      ( let filename = "SDL2-CS.dll.config"; in { origin = fetchurl {
+          url = "https://github.com/OpenRA/SDL2-CS/releases/download/20151227/${filename}";
+          sha256 = "15709iscdg44wd33szw5y0fdxwvqfjw8v3xjq6a0mm46gr7mkw7g";
+        }; target = filename; })
+
+      ( let filename = "OpenAL-CS.dll"; in { origin = fetchurl {
+          url = "https://github.com/OpenRA/OpenAL-CS/releases/download/20151227/${filename}";
+          sha256 = "0lvyjkn7fqys97wym8rwlcp6ay2z059iabfvlcxhlrscjpyr2cyk";
+        }; target = filename; })
+
+      ( let filename = "OpenAL-CS.dll.config"; in { origin = fetchurl {
+          url = "https://github.com/OpenRA/OpenAL-CS/releases/download/20151227/${filename}";
+          sha256 = "0wcmk3dw26s93598ck5jism5609v0y233i0f1b76yilyfimg9sjq";
         }; target = filename; })
 
       ( let filename = "GeoLite2-Country.mmdb.gz"; in { origin = fetchurl {
           url = "http://geolite.maxmind.com/download/geoip/database/${filename}";
-          sha256 = "0lr978pipk5q2z3x011ps4fx5nfc3hsal7jb77fc60aa6iscr05m";
+          sha256 = "0a82v0sj4zf5vigrn1pd6mnbqz6zl3rgk9nidqqzy836as2kxk9v";
         }; target = filename; })
     ];
   in ''
     mkdir thirdparty/download/
 
-    ${stdenv.lib.concatMapStringsSep "\n" (from: "cp ${from} thirdparty/download") dotnetPackagesDlls}
+    ${stdenv.lib.concatMapStringsSep "\n" (from: "cp -r ${from} thirdparty/download") dotnetPackagesDlls}
     ${stdenv.lib.concatMapStringsSep "\n" ({origin, target}: "cp ${origin} thirdparty/download/${target}") movePackages}
 
     make dependencies

--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -99,6 +99,11 @@ in stdenv.mkDerivation rec {
 
   buildFlags = [ "DEBUG=false" "default" "man-page" ];
 
+  doCheck = true;
+
+  #TODO: check
+  checkTarget = "nunit test";
+
   installTargets = [ "install" "install-linux-icons" "install-linux-desktop" "install-linux-appdata" "install-linux-mime" "install-man-page" ];
 
   postInstall = with stdenv.lib; let

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -111,6 +111,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
   NUnit = NUnit2;
 
+  NUnitConsole = fetchNuGet {
+    baseName = "NUnit.Console";
+    version = "3.0.1";
+    sha256 = "154bqwm2n95syv8nwd67qh8qsv0b0h5zap60sk64z3kd3a9ffi5p";
+    outputFiles = [ "tools/*" ];
+  };
+
   MaxMindDb = fetchNuGet {
     baseName = "MaxMind.Db";
     version = "1.1.0.0";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -95,12 +95,21 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "lib/net40/*" ];
   };
 
-  NUnit = fetchNuGet {
+  NUnit3 = fetchNuGet {
+    baseName = "NUnit";
+    version = "3.0.1";
+    sha256 = "1g3j3kvg9vrapb1vjgq65nvn1vg7bzm66w7yjnaip1iww1yn1b0p";
+    outputFiles = [ "lib/*" ];
+  };
+
+  NUnit2 = fetchNuGet {
     baseName = "NUnit";
     version = "2.6.4";
     sha256 = "1acwsm7p93b1hzfb83ia33145x0w6fvdsfjm9xflsisljxpdx35y";
     outputFiles = [ "lib/*" ];
   };
+
+  NUnit = NUnit2;
 
   MaxMindDb = fetchNuGet {
     baseName = "MaxMind.Db";

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -183,8 +183,8 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
   MonoNat = fetchNuGet {
     baseName = "Mono.Nat";
-    version = "1.2.21";
-    sha256 = "011xhmjrx6w5h110fcp40l95k3qj1gkzz3axgbfy0s8haf5hsf7s";
+    version = "1.2.24";
+    sha256 = "0vfkach11kkcd9rcqz3s38m70d5spyb21gl99iqnkljxj5555wjs";
     outputFiles = [ "lib/*" ];
   };
 

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -162,8 +162,8 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
 
   SharpFont = fetchNuGet {
     baseName = "SharpFont";
-    version = "3.0.1";
-    sha256 = "1g639i8mbxc6qm0xqsf4mc0shv8nwdaidllka2xxwyksbq54skhs";
+    version = "3.1.0";
+    sha256 = "137y514i4zi0i0qsx7nv4ibl4kifbr8xr23rqdkwf7yxf88jjmh2";
     outputFiles = [ "lib/*" "config/*" ];
   };
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

[NUnit 3 is incompatible with NUnit 2 ](https://www.nuget.org/packages/NUnit/3.0.1), but openra wants 3, so I added a separated NUnit 2 and NUnit3. NUnit = NUnit2, but I don't know if that's the right place to leave the link.

Technically, the tests don't even run right now (they fail, will try to work on it later), so it's probably ok to remove it.

Edit: now there are tests, so having the correct nunit is probably better.
