### PR TITLE
arduino: 1.0.6 -> 1.6.6

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -1,45 +1,51 @@
 { stdenv, fetchFromGitHub, jdk, jre, ant, coreutils, gnugrep, file, libusb
-, withGui ? false, gtk2 ? null
-}:
+, unzip, zlib, readline, ncurses, withGui ? false, gtk2 ? null }:
 
 assert withGui -> gtk2 != null;
 
 stdenv.mkDerivation rec {
 
-  version = "1.0.6";
+  version = "1.6.6";
   name = "arduino${stdenv.lib.optionalString (withGui == false) "-core"}-${version}";
 
   src = fetchFromGitHub {
     owner = "arduino";
     repo = "Arduino";
     rev = "${version}";
-    sha256 = "0nr5b719qi03rcmx6swbhccv6kihxz3b8b6y46bc2j348rja5332";
+    sha256 = "1gm3sjjs149r2d82ynx25qlg31bbird1zr4x01qi4ybk3gp0268v";
   };
 
-  buildInputs = [ jdk ant file ];
+  buildInputs = [ jdk ant file unzip ];
 
   buildPhase = ''
-    cd ./core && ant 
+    cd ./arduino-core && ant 
     cd ../build && ant 
     cd ..
   '';
+
+  libPath = stdenv.lib.makeLibraryPath (builtins.filter (l: l != null) [
+    gtk2 stdenv.cc.cc zlib readline libusb ncurses]) + ":$out/lib";
 
   installPhase = ''
     mkdir -p $out/share/arduino
     cp -r ./build/linux/work/* "$out/share/arduino/"
     echo ${version} > $out/share/arduino/lib/version.txt
 
+    # Hack around lack of libtinfo in NixOS
+    mkdir -p $out/lib
+    ln -s ${ncurses.out}/lib/libncursesw.so.5 $out/lib/libtinfo.so.5
+
     ${stdenv.lib.optionalString withGui ''
       mkdir -p "$out/bin"
-      sed -i -e "s|^java|${jdk}/bin/java|" "$out/share/arduino/arduino"
-      sed -i -e "s|^LD_LIBRARY_PATH=|LD_LIBRARY_PATH=${gtk2}/lib:|" "$out/share/arduino/arduino"
+      sed -i -e "s|^JAVA=.*|JAVA=${jdk}/bin/java|" "$out/share/arduino/arduino"
+      sed -i -e "s|^LD_LIBRARY_PATH=|LD_LIBRARY_PATH=${libPath}:|" "$out/share/arduino/arduino"
       ln -sr "$out/share/arduino/arduino" "$out/bin/arduino"
     ''}
 
     # Fixup "/lib64/ld-linux-x86-64.so.2" like references in ELF executables.
     echo "running patchelf on prebuilt binaries:"
     find "$out" | while read filepath; do
-        if file "$filepath" | grep -q "ELF.*executable"; then
+        if file "$filepath" | grep -q "ELF.*executable.*dynamic"; then
             # skip target firmware files
             if echo "$filepath" | grep -q "\.elf$"; then
                 continue
@@ -50,8 +56,8 @@ stdenv.mkDerivation rec {
         fi
     done
 
-    patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ libusb ]} \
-        "$out/share/arduino/hardware/tools/avrdude"
+    patchelf --set-rpath ${libPath} \
+        "$out/share/arduino/hardware/tools/avr/bin/avrdude_bin"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)

I couldn't find this option. Has it been renamed?
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)

Tested compiling and uploading programs to Arduinos.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
