### PR TITLE
hexchat: 2.10.2 -> 2.12.1

### DIFF
--- a/pkgs/applications/networking/irc/hexchat/default.nix
+++ b/pkgs/applications/networking/irc/hexchat/default.nix
@@ -1,24 +1,28 @@
-{ stdenv, fetchurl, pkgconfig, gtk, perl, python, gettext
+{ stdenv, fetchurl, pkgconfig, gtk, lua, perl, python
 , libtool, pciutils, dbus_glib, libcanberra, libproxy
 , libsexy, enchant, libnotify, openssl, intltool
 , desktop_file_utils, hicolor_icon_theme
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.10.2";
+  version = "2.12.1";
   name = "hexchat-${version}";
 
   src = fetchurl {
     url = "http://dl.hexchat.net/hexchat/${name}.tar.xz";
-    sha256 = "0b5mw6jxa7c93nbgiwijm7j7klm6nccx6l9zyainyrbnqmjz7sw7";
+    sha256 = "0svwz9ldrry1sn35jywgpacjj1cf3xl3k74ynwn8rjvxs73b00aj";
   };
 
-  buildInputs = [
-    pkgconfig gtk perl python gettext
-    libtool pciutils dbus_glib libcanberra libproxy
-    libsexy libnotify openssl intltool
-    desktop_file_utils hicolor_icon_theme
+  nativeBuildInputs = [
+    pkgconfig libtool intltool
   ];
+
+  buildInputs = [
+    gtk lua perl python pciutils dbus_glib libcanberra libproxy
+    libsexy libnotify openssl desktop_file_utils hicolor_icon_theme
+  ];
+
+  enableParallelBuilding = true;
 
  #hexchat and heachat-text loads enchant spell checking library at run time and so it needs to have route to the path
   patchPhase = ''


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
