### PR TITLE
idea.idea14-ultimate: init at 14.1.7

### DIFF
--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -195,6 +195,18 @@ in
     };
   };
 
+  idea14-ultimate = buildIdea rec {
+    name = "idea-ultimate-${version}";
+    version = "14.1.7";
+    build = "IU-141.3058.30";
+    description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
+    license = stdenv.lib.licenses.unfree;
+    src = fetchurl {
+      url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
+      sha256 = "a2259249f6e7bf14ba17b0af90a18d24d9b4670af60d24f0bb51af2f62500fc2";
+    };
+  };
+
   idea15-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
     version = "15.0.5";


### PR DESCRIPTION
I'm using the stable release. Upon upgrading to release-16.03, I found that IDEA 14 had been removed. Since I don't have an IDEA 15 license, I need to add IDEA 14 back.

This PR is against stable release branch since that's what I'm using (and don't have the time to switch to unstable), but I think it should be cherry-picked to master as well.
