### PR TITLE
Python: re-enable default testing

### DIFF
--- a/pkgs/development/python-modules/generic/default.nix
+++ b/pkgs/development/python-modules/generic/default.nix
@@ -93,11 +93,13 @@ let
           runHook postCheck
         '';
 
-        # We run all tests after software has been installed since that is
-        # a common idiom in Python
-        #
+        # Python packages that are installed with setuptools
+        # are typically distributed with tests.
+        # With Python it's a common idiom to run the tests
+        # after the software has been installed.
+
         # For backwards compatibility, let's use an alias
-        doInstallCheck = attrs.doCheck or false;
+        doInstallCheck = attrs.doCheck or true;
       }
     else
       throw "Unsupported format ${format}";
@@ -121,7 +123,7 @@ python.stdenv.mkDerivation (builtins.removeAttrs attrs ["disabled" "doCheck"] //
     runHook postConfigure
   '';
 
-  # Python packages don't have a checkPhase, only a installCheckPhase
+  # Python packages don't have a checkPhase, only an installCheckPhase
   doCheck = false;
 
   installPhase = attrs.installPhase or ''


### PR DESCRIPTION
###### Things done
- [ x ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

In 303e976 default testing of setuptools packages was accidentally
disabled.

cc @zimbatm @domenkozar 
