### PR TITLE
scalafmt: init at 0.2.3

### DIFF
--- a/pkgs/development/tools/scalafmt/default.nix
+++ b/pkgs/development/tools/scalafmt/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, unzip, jre }:
+
+stdenv.mkDerivation rec {
+  version = "0.2.3";
+  baseName = "scalafmt";
+  name = "${baseName}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/olafurpg/scalafmt/releases/download/v${version}/${baseName}.tar.gz";
+    sha256 = "0klzm86771wl6d8cq5cf4a4mfz8idcis6wrg0x2ix5rcc5zi0d4d";
+  };
+
+  unpackPhase = "tar xvzf $src";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mkdir -p "$out/lib"
+
+    cp cli/target/scala-2.11/scalafmt.jar "$out/lib/${name}.jar"
+
+    cat > "$out/bin/${baseName}" << EOF
+    #!${stdenv.shell}
+    exec ${jre}/bin/java -jar "$out/lib/${name}.jar" "\$@"
+    EOF
+
+    chmod a+x "$out/bin/${baseName}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Opinionated code formatter for Scala";
+    homepage = http://scalafmt.org;
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.markus1189 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5231,6 +5231,8 @@ in
   scala_2_11 = callPackage ../development/compilers/scala { };
   scala = scala_2_11;
 
+  scalafmt = callPackage ../development/tools/scalafmt { };
+
   sdcc = callPackage ../development/compilers/sdcc { boost = boost159; };
 
   smlnjBootstrap = callPackage ../development/compilers/smlnj/bootstrap.nix { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add `scalafmt` Scala code formatter (http://scalafmt.org)
