### PR TITLE
pythonPackages.mitmproxy: fetchurl -> fetchFromGitHub

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12201,9 +12201,11 @@ in modules // {
     name = "${baseName}-${version}";
     version = "0.14";
 
-    src = pkgs.fetchurl {
-      url ="https://github.com/mitmproxy/mitmproxy/archive/v${version}.tar.gz";
-      sha256 = "072yihnrv78lffk2r12jk7phs4c8mc1gs4y96cp9rg63vw6w1fry";
+    src = pkgs.fetchFromGitHub {
+      owner = "mitmproxy";
+      repo = "mitmproxy";
+      rev = "v${version}";
+      sha256 = "1zxw4yviryy0v53vhccgqb7f5d3fga16dy9kp1xwp6b59w0fcc2g";
     };
 
     propagatedBuildInputs = with self; [


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @copumpkin 
