### PR TITLE
pxattr: Init at 2.1.0

### DIFF
--- a/pkgs/tools/archivers/pxattr/default.nix
+++ b/pkgs/tools/archivers/pxattr/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, gcc }:
+
+stdenv.mkDerivation rec {
+  name = "pxattr-2.1.0";
+
+  src = fetchurl {
+    url = "http://www.lesbonscomptes.com/pxattr/pxattr-2.1.0.tar.gz";
+    sha256 = "1dwcqc5z7gzma1zhis2md49bj2nq7m6jimh4zlx9szw6svisz56z";
+  };
+
+  buildInputs = [ gcc ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp pxattr $out/bin
+  '';
+
+  meta = {
+    homepage = http://www.lesbonscomptes.com/pxattr/index.html;
+    description = "Provides a single interface to extended file attributes";
+    maintainers = [ stdenv.lib.maintainers.vrthra ];
+    license = [ stdenv.lib.licenses.mit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1891,6 +1891,8 @@ in
 
   pixz = callPackage ../tools/compression/pixz { };
 
+  pxattr = callPackage ../tools/archivers/pxattr { };
+
   pxz = callPackage ../tools/compression/pxz { };
 
   hans = callPackage ../tools/networking/hans { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

pxattr provides a single interface to extended file system attributes. It can
be used to save and restore extended file system attributes before using
a utility such as tar for backup which does not understand extended fsattr.
