### PR TITLE
lesspipe: init at Debian version

### DIFF
--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, substituteAll, coreutils, which }:
+
+stdenv.mkDerivation rec {
+  name = "lesspipe";
+
+  buildCommand = ''
+    install -Dm755 $script $out/bin/lesspipe
+    ln -s $out/bin/lesspipe $out/bin/lessfile
+    mkdir -p $out/share/man/man1
+    gzip -c $manual > $out/share/man/man1/lesspipe.1.gz
+  '';
+
+  script = substituteAll {
+    src = ./lesspipe;
+    inherit coreutils which;
+  };
+
+  manual = ./lesspipe.1;
+
+  meta = with stdenv.lib; {
+    description = "Input preprocessor for less";
+    longDescription = ''
+      lessfile and lesspipe are programs that can be used to modify the way
+      the contents of a file are displayed in less. What this means is that
+      less can automatically open up tar files, uncompress gzipped files,
+      and even display something reasonable for graphics files.
+    '';
+    platforms = platforms.all;
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/tools/misc/lesspipe/lesspipe
+++ b/pkgs/tools/misc/lesspipe/lesspipe
@@ -1,0 +1,313 @@
+#!/bin/sh
+#
+# lessfile/lesspipe
+# $Id: lessopen,v 1.4 1998/05/12 09:37:46 torin Exp $
+# Plus POSIX sh changes by Y.Dirson
+#
+# Less filter for viewing non text files.
+#
+# Written by: Behan Webster <behanw@pobox.com>
+# Many Modifications by Darren Stalder
+# Further Modifications by Thomas Schoepf <schoepf@debian.org>
+#
+# combined lessfile and lesspipe to avoid duplication of decode stage
+# shell is sure icky.  I'm real tempted to rewrite the whole thing in Perl
+#
+# Unfortunately, this means that I have filename dependencies sprinkled
+# throughout the code.  If you don't want lessfile to be called that,
+# you'll need to change the LESSFILE envar below.
+#
+# Usage: eval `lessfile`  or eval `lesspipe`
+#
+# less passes in:
+#    $1  filename to be viewed with less  (used by LESSOPEN)
+# and possibly (if used by lessfile)
+#    $2  filename that was created during LESSOPEN
+
+TMPDIR=${TMPDIR:-/tmp}
+BASENAME=`basename $0`
+LESSFILE=lessfile
+
+# Helper function to list contents of ISO files (CD images)
+iso_list() {
+	isoinfo -d -i "$1"
+	isoinfo -d -i "$1" | grep -q ^Rock\.Ridge && iiopts="$iiopts -R"
+	isoinfo -d -i "$1" | grep -q ^Joliet && iiopts="$iiopts -J"
+	echo
+	isoinfo -f $iiopts -i "$1"
+}
+
+if [ $# -eq 1 ] ; then
+	# we were called as LESSOPEN
+
+	# if the file doesn't exist, we don't do anything
+	if [ ! -r "$1" ]; then
+		exit 0
+	fi
+
+	# generate filename for possible use by lesspipe
+	umask 077
+	if [ $BASENAME = $LESSFILE ]; then
+		TMPFILE=`@coreutils@/bin/mktemp -p $TMPDIR -suffix .lessf`
+		if [ -z "$TMPFILE" ]; then
+			echo >&2 "Could not find essential program 'tempfile'. Exiting"
+      exit 1
+		fi
+	fi
+
+	(
+		# possibly redirect stdout to a file for lessfile
+		if [ $BASENAME = $LESSFILE ]; then exec > $TMPFILE; fi
+
+		# Allow for user defined filters
+		#if [ -x ~/.lessfilter -a -O ~/.lessfilter ]; then
+		if [ -x ~/.lessfilter ]; then
+			~/.lessfilter "$1"
+			if [ $? -eq 0 ]; then
+				if [ $BASENAME = $LESSFILE ]; then
+					if [ -s $TMPFILE ]; then
+						echo $TMPFILE
+					else
+						rm -f $TMPFILE
+					fi
+				fi
+				exit 0
+			fi
+		fi
+
+		# Decode file for less
+		case `echo "$1" | tr '[:upper:]' '[:lower:]'` in
+			*.a)
+				if [ -x "`@which@/bin/which ar`" ]; then ar tv "$1"
+				else echo "No ar available"; fi ;;
+
+			*.arj)
+				if [ -x "`@which@/bin/which unarj`" ]; then unarj l "$1"
+				else echo "No unarj available"; fi ;;
+
+			*.tar.bz2)
+				if [ -x "`@coreutils@/bin/which bunzip2`" ]; then
+					bunzip2 -dc "$1" | tar tvvf -
+				else echo "No bunzip2 available"; fi ;;
+
+			*.bz)
+				if [ -x "`@coreutils@/bin/which bunzip`" ]; then bunzip -c "$1"
+				else echo "No bunzip available"; fi ;;
+
+			*.bz2)
+				if [ -x "`@coreutils@/bin/which bunzip2`" ]; then bunzip2 -dc "$1"
+				else echo "No bunzip2 available"; fi ;;
+
+			*.deb|*.udeb|*.ddeb)
+				echo "$1:"; dpkg --info "$1"
+				echo
+				echo '*** Contents:'; dpkg-deb --contents "$1"
+				;;
+
+			*.doc)
+				if [ -x "`@coreutils@/bin/which catdoc`" ]; then
+					catdoc "$1"
+				else
+					# no catdoc, read normally if file is text.
+					if ( file "$1" | grep ASCII 2>/dev/null >/dev/null); then
+						cat "$1"
+					else
+						echo "No catdoc available";
+					fi
+				fi
+				;;
+
+			*.gif|*.jpeg|*.jpg|*.pcd|*.png|*.tga|*.tiff|*.tif)
+				if [ -x "`@coreutils@/bin/which identify`" ]; then
+					identify "$1"
+				else
+					echo "No identify available"
+					echo "Install ImageMagick to browse images"
+				fi
+				;;
+
+			*.iso)
+				if [ -x "`@coreutils@/bin/which isoinfo`" ]; then iso_list "$1"
+				else
+					echo "No isoinfo available"
+					echo "Install mkisofs to view ISO images"
+				fi
+				;;
+
+			*.bin|*.raw)
+				if [ -x "`@coreutils@/bin/which isoinfo`" ]; then
+					file "$1" | grep -q ISO\.9660 && iso_list "$1"
+				else
+					echo "No isoinfo available"
+					echo "Install mkisofs to view ISO images"
+				fi
+				;;
+
+			*.lha|*.lzh)
+				if [ -x "`@coreutils@/bin/which lha`" ]; then lha v "$1"
+				else echo "No lha available"; fi ;;
+
+			*.tar.lz|*.tlz)
+				if [ -x "`@coreutils@/bin/which lzip`" ]; then
+					lzip -dc "$1" | tar tvvf -
+				elif [ -x "`@coreutils@/bin/which lunzip`" ]; then
+					lunzip -dc "$1" | tar tvvf -
+				else echo "No lzip or lunzip available"; fi ;;
+
+			*.lz)
+				if [ -x "`@coreutils@/bin/which lzip`" ]; then lzip -dc "$1"
+				elif [ -x "`@coreutils@/bin/which lunzip`" ]; then lunzip -dc "$1"
+				else echo "No lzip or lunzip available"; fi ;;
+
+			*.tar.lzma)
+				if [ -x "`@coreutils@/bin/which lzma`" ]; then
+					lzma -dc "$1" | tar tfvv -
+				else
+					echo "No lzma available"
+				fi
+				;;
+
+			*.lzma)
+				if [ -x "`@coreutils@/bin/which lzma`" ]; then
+					lzma -dc "$1"
+				else
+					echo "No lzma available"
+				fi
+				;;
+
+			*.pdf)
+				if [ -x "`@coreutils@/bin/which pdftotext`" ]; then pdftotext -layout "$1" -
+				else echo "No pdftotext available"; fi ;;
+
+			*.rar|*.r[0-9][0-9])
+				if [ -x "`@coreutils@/bin/which rar`" ]; then rar v "$1"
+				elif [ -x "`@coreutils@/bin/which unrar`" ]; then unrar v "$1"
+				else echo "No rar or unrar available"; fi ;;
+
+			*.rpm)
+				if [ -x "`@coreutils@/bin/which rpm`" ]; then
+					echo "$1:"; rpm -q -i -p "$1"
+					echo
+					echo '*** Contents:'
+					rpm -q -l -p "$1"
+				else echo "rpm isn't available, no query on rpm package possible"; fi ;;
+
+			*.tar.gz|*.tgz|*.tar.z|*.tar.dz)
+				tar tzvf "$1" --force-local
+				;;
+
+			*.tar.xz|*.txz)
+				if [ -x "`@coreutils@/bin/which xz`" ]; then
+					xz -dc "$1" | tar tfvv -
+				else
+					echo "No xz available"
+				fi
+				;;
+
+			*.xz)
+				if [ -x "`@coreutils@/bin/which xz`" ]; then
+					xz -dc "$1"
+				else
+					echo "No xz available"
+				fi
+				;;
+
+			# Note that this is out of alpha order so that we don't catch
+			# the gzipped tar files.
+			*.gz|*.z|*.dz)
+				gzip -dc "$1" ;;
+
+			*.tar)
+				tar tvf "$1" --force-local
+				;;
+
+			*.jar|*.war|*.ear|*.xpi|*.zip)
+				if [ -x "`@coreutils@/bin/which unzip`" ]; then unzip -v "$1";
+				elif [ -x "`@coreutils@/bin/which miniunzip`" ]; then miniunzip -l "$1";
+				elif [ -x "`@coreutils@/bin/which miniunz`" ]; then miniunz -l "$1";
+				else echo "No unzip, miniunzip or miniunz available"; fi ;;
+
+			*.7z)
+				if [ -x "`@coreutils@/bin/which 7za`" ]; then 7za l "$1";
+                                elif [ -x "`@coreutils@/bin/which 7zr`" ]; then 7zr l "$1";
+				else echo "No 7za or 7zr available"; fi ;;
+
+			*.zoo)
+				if [ -x "`@coreutils@/bin/which zoo`" ]; then zoo v "$1";
+				elif [ -x "`@coreutils@/bin/which unzoo`" ]; then unzoo -l "$1";
+				else echo "No unzoo or zoo available"; fi ;;
+
+		esac
+	) 2>/dev/null
+
+	if [ $BASENAME = $LESSFILE ]; then
+		if [ -s $TMPFILE ]; then
+			echo $TMPFILE
+		else
+			rm -f $TMPFILE
+		fi
+	fi
+
+elif [ $# -eq 2 ] ; then
+	#
+	# we were called as LESSCLOSE
+	# delete the file created if we were lessfile
+	#
+	if [ $BASENAME = $LESSFILE ]; then
+		if [ -n "$BASH" ]; then
+			if [ ! -O "$2" ]; then
+				echo "Error in deleting $2" > /dev/tty
+			fi
+		fi
+
+		if [ -f "$2" ]; then
+			rm -f "$2"
+		else
+			echo "Error in deleting $2" > /dev/tty
+		fi
+	fi
+
+elif [ $# -eq 0 ] ; then
+	#
+	# must setup shell to use LESSOPEN/LESSCLOSE
+	#
+	# I have no idea how some of the more esoteric shells (es, rc) do
+	# things. If they don't do things in a Bourne manner, send me a patch
+	# and I'll incorporate it.
+	#
+
+	# first determine the full path of lessfile/lesspipe
+	# if you can determine a better way to do this, send me a patch, I've
+	# not shell-scripted for many a year.
+	FULLPATH=`cd \`@coreutils@/bin/dirname $0\`;pwd`/$BASENAME
+
+	case "$SHELL" in
+		*csh)
+			if [ $BASENAME = $LESSFILE ]; then
+				echo "setenv LESSOPEN \"$FULLPATH %s\";"
+				echo "setenv LESSCLOSE \"$FULLPATH %s %s\";"
+			else
+				echo "setenv LESSOPEN \"| $FULLPATH %s\";"
+				echo "setenv LESSCLOSE \"$FULLPATH %s %s\";"
+			fi
+			;;
+		*)
+			if [ $BASENAME = $LESSFILE ]; then
+				echo "export LESSOPEN=\"$FULLPATH %s\";"
+				echo "export LESSCLOSE=\"$FULLPATH %s %s\";"
+			else
+				echo "export LESSOPEN=\"| $FULLPATH %s\";"
+				echo "export LESSCLOSE=\"$FULLPATH %s %s\";"
+			fi
+			;;
+	esac
+
+	#echo "# If you tried to view a file with a name that starts with '#', you"
+	#echo "# might see this message instead of the file's contents."
+	#echo "# To view the contents, try to put './' ahead of the filename when"
+	#echo "# calling less."
+
+else
+	echo "Usage: eval \`$BASENAME\`"
+	exit
+fi

--- a/pkgs/tools/misc/lesspipe/lesspipe.1
+++ b/pkgs/tools/misc/lesspipe/lesspipe.1
@@ -1,0 +1,166 @@
+.TH LESSOPEN 1
+.\" NAME should be all caps, SECTION should be 1-8, maybe w/ subsection
+.\" other parms are allowed: see man(7), man(1)
+.SH NAME
+lessfile, lesspipe \- "input preprocessor" for  less.
+.SH SYNOPSIS
+.B lessfile, lesspipe
+.SH "DESCRIPTION"
+This manual page documents briefly the
+.IR lessfile ,
+and
+.I lesspipe
+commands.
+This manual page was written for the Debian GNU/Linux distribution
+because the input preprocessor scripts are provided by Debian GNU/Linux and
+are not part of the original program.
+.PP
+.I lessfile
+and
+.I lesspipe
+are programs that can be used to modify the way the contents of a file are
+displayed in
+.I less.
+What this means is that
+.I less
+can automatically open
+up tar files, uncompress gzipped files, and even display something reasonable
+for graphics files.
+.PP
+.I lesspipe
+will toss the contents/info on STDOUT and
+.I less
+will read them
+as they come across.  This means that you do not have to wait for the
+decoding to finish before less shows you the file.  This also means that
+you will get a 'byte N' instead of an N% as your file position.  You can
+seek to the end and back to get the N% but that means you have to wait
+for the pipe to finish.
+.PP
+.I lessfile
+will toss the contents/info on a file which
+.I less
+will then
+read.  After you are done,
+.I lessfile
+will then delete the file.  This means that the process has to finish before
+you see it, but you get nice percentages (N%) up front.
+.
+.SH USAGE
+Just put one of the following two commands in your login script (e.g.
+~/.bash_profile):
+.PP
+  eval "$(lessfile)"
+.PP
+or
+.PP
+  eval "$(lesspipe)"
+.SH FILE TYPE RECOGNITION
+File types are recognized by their extensions.
+This is a list of currently supported extensions
+(grouped by the programs that handle them):
+
+.DS
+  *.a
+  *.arj
+  *.tar.bz2
+  *.bz
+  *.bz2
+  *.deb, *.udeb, *.ddeb
+  *.doc
+  *.gif, *.jpeg, *.jpg, *.pcd, *.png, *.tga, *.tiff, *.tif
+  *.iso, *.raw, *.bin
+  *.lha, *.lzh
+  *.tar.lz, *.tlz
+  *.lz
+  *.7z
+  *.pdf
+  *.rar, *.r[0-9][0-9]
+  *.rpm
+  *.tar.gz, *.tgz, *.tar.z, *.tar.dz
+  *.gz, *.z, *.dz
+  *.tar
+  *.tar.xz, *.xz
+  *.jar, *.war, *.xpi, *.zip
+  *.zoo
+.DE
+.SH USER DEFINED FILTERS
+It is possible to extend and overwrite the default
+.I lesspipe
+and
+.I lessfile
+input processor if you have specialized requirements. Create an executable
+program with the name
+.I .lessfilter
+and put it into your home directory. This can be a shell script or a binary
+program.
+
+.PP
+It is important that this program returns the correct exit code: return 0 if
+your filter handles the input, return 1 if the standard
+.I lesspipe/lessfile
+filter should handle the input.
+
+.PP
+Here is an example script:
+
+.DS
+  #!/bin/sh
+
+  case "$1" in
+      *.extension)
+          extension-handler "$1"
+          ;;
+      *)
+          # We don't handle this format.
+          exit 1
+  esac
+
+  # No further processing by lesspipe necessary
+  exit 0
+.DE
+
+.SH FILES
+.TP
+.I ~/.lessfilter
+Executable file that can do user defined processing. See section USER DEFINED
+FILTERS for more information.
+.SH BUGS
+When trying to open compressed 0 byte files,
+.I less
+displays the actual binary file contents. This is not a bug.
+.I less
+is designed to do that (see manual page less(1), section INPUT PREPROCESSOR).
+This is the answer of Mark Nudelman <markn@greenwoodsoftware.com>:
+.IP
+"I recognized when I designed it that a
+lesspipe filter cannot output an empty file and have less display
+nothing in that case; it's a side effect of using the "no output" case
+to mean "the filter has nothing to do".  It could have been designed to
+have some other mechanism to indicate "nothing to do", but "no output"
+seemed the simplest and most intuitive for lesspipe writers."
+
+.PP
+Sometimes, less does not display the contents file you want to view but output
+that is produced by your login scripts (~/.bashrc or ~/.bash_profile). This
+happens because less uses your current shell to run the lesspipe filter. Bash
+first looks for the variable $BASH_ENV in the environment expands its value
+and  uses the expanded value as the name of a file to read and execute. If
+this file produces any output less will display this. A way to solve this
+problem is to put the following lines on the top of your login script that
+produces output:
+
+.DS
+  if [ -z "$PS1" ]; then
+      exit
+  fi
+.DE
+
+This tests whether the prompt variable $PS1 is set and if it isn't (which is
+the case for non-interactive shells) it will exit the script.
+.SH "SEE ALSO"
+less(1)
+.SH AUTHOR
+This manual page was written by Thomas Schoepf <schoepf@debian.org>,
+for the Debian GNU/Linux system (but may be used by others). Most of the
+text was copied from a description written by Darren Stalder <torin@daft.com>.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2139,6 +2139,8 @@ in
 
   less = callPackage ../tools/misc/less { };
 
+  lesspipe = callPackage ../tools/misc/lesspipe { };
+
   liquidsoap = callPackage ../tools/audio/liquidsoap/full.nix { };
 
   lnav = callPackage ../tools/misc/lnav { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I just switched to NixOS and missed this convenience script from Debian. Most distributions seem to have something similar to this. Here I copied the script and manual verbatim from the Debian stable `less` package (it is not packaged separately), which can be found here: https://packages.debian.org/jessie/less

This is my first Nix espression (so please educate me).
- I patched this in-place (after copying from Debian) to use `mktemp` instead of the deprecated `tempfile` and to use the `moreutils` and `which` dependencies.
- This has a lot of soft runtime dependencies, which I ignored (they are checked at runtime using `which`).
- I discovered `nix.useChroot` only after having built this version of the expression. Enabling it now doesn't trigger a rebuild with `nix-build` so I don't think I actually tested using sandboxing.
- As an alternative, I also wrote an expression for [this lesspipe.sh](https://github.com/wofr06/lesspipe), which seems similar but unrelated (but is packaged separately). I'm not sure which one is more appropriate for nixpkgs. See #15338
