### PR TITLE
lesspipe: init at 1.82

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -221,6 +221,7 @@
   marcweber = "Marc Weber <marco-oweber@gmx.de>";
   markus1189 = "Markus Hauck <markus1189@gmail.com>";
   markWot = "Markus Wotringer <markus@wotringer.de>";
+  martijnvermaat = "Martijn Vermaat <martijn@vermaat.name>";
   matejc = "Matej Cotman <cotman.matej@gmail.com>";
   mathnerd314 = "Mathnerd314 <mathnerd314.gph+hs@gmail.com>";
   matthiasbeyer = "Matthias Beyer <mail@beyermatthias.de>";

--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, perl }:
+
+stdenv.mkDerivation rec {
+  name = "lesspipe-${version}";
+  version = "1.82";
+
+  buildInputs = [ perl ];
+  preConfigure = "patchShebangs .";
+
+  src = fetchFromGitHub {
+    owner = "wofr06";
+    repo = "lesspipe";
+    rev = version;
+    sha256 = "0vb7bpap8vy003ha10hc7hxl17y47sgdnrjpihgqxkn8k0bfqbbq";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A preprocessor for less";
+    longDescription = ''
+      Usually lesspipe.sh is called as an input filter to less. With the help
+      of that filter less will display the uncompressed contents of compressed
+      (gzip, bzip2, compress, rar, 7-zip, lzip, xz or lzma) files. For files
+      containing archives and directories, a table of contents will be
+      displayed (e.g tar, ar, rar, jar, rpm and deb formats). Other supported
+      formats include nroff, pdf, ps, dvi, shared library, MS word, OASIS
+      (e.g. Openoffice), NetCDF, html, mp3, jpg, png, iso images, MacOSX bom,
+      plist and archive formats, perl storable data and gpg encrypted files.
+      This does require additional helper programs being installed.
+    '';
+    homepage = https://github.com/wofr06/lesspipe;
+    platforms = platforms.all;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.martijnvermaat ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2141,6 +2141,8 @@ in
 
   less = callPackage ../tools/misc/less { };
 
+  lesspipe = callPackage ../tools/misc/lesspipe { };
+
   liquidsoap = callPackage ../tools/audio/liquidsoap/full.nix { };
 
   lnav = callPackage ../tools/misc/lnav { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Please see and compare with #15337. That one uses `lesspipe` from the Debian stable `less` package, this one uses [this lesspipe.sh](https://github.com/wofr06/lesspipe).
- This has a lot of soft runtime dependencies, which I ignored.
- I discovered `nix.useChroot` only after having built this version of the expression. Enabling it now doesn't trigger a rebuild with `nix-build` so I don't think I actually tested using sandboxing.
