### PR TITLE
Just strip everything by default, fully tested version :-)

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -846,8 +846,9 @@ following:
   subdirectories of <envar>$out</envar> to
   <filename>share/</filename>.</para></listitem>
       
-  <listitem><para>It strips libraries and executables of debug
-  information.</para></listitem>
+  <listitem><para>It strips libraries and executables of debug information.
+  This step is crucial to remove references to build inputs.  It also reduces
+  the size of binaries.</para></listitem>
 
   <listitem><para>On Linux, it applies the <command>patchelf</command>
   command to ELF executables and libraries to remove unused
@@ -869,8 +870,27 @@ following:
 
   <varlistentry>
     <term><varname>dontStrip</varname></term>
-    <listitem><para>If set, libraries and executables are not
-    stripped.  By default, they are.</para></listitem>
+    <listitem><warning><para>Stripping is required to avoid propagating build
+    inputs as run-time dependencies.  Please ensure you understand the
+    implications before disabling stripping.  To disable stripping on selected
+    files of folders, see <varname>dontStripList</varname> or
+    <varname>strip{Debug,All}List</varname>.</para></warning><para>If set,
+    libraries and executables are not stripped.  By default, they are.
+    </para></listitem>
+  </varlistentry>
+
+  <varlistentry>
+    <term><varname>dontStripList</varname></term>
+    <listitem><para>List of paths that should not be stripped.  Bash patterns
+    are accepted, and are relative to the package's prefix.  For example,
+    <literal>["share" "modules/*.i" "bin/libannoying.so"]</literal> is an
+    acceptable value. By default it's empty.  Avoid trailing slashes as the
+    underlying <command>find</command> ignores such paths.</para>
+    <para>Two good reasons to add paths to this list are when
+    <command>strip</command> fails on the file, breaking the build, and when
+    the package requires the debug info. In the latter case, you should ensure
+    that the unstripped executable does not maintain reference to build inputs.
+    </para></listitem>
   </varlistentry>
 
   <varlistentry>
@@ -881,11 +901,12 @@ following:
 
   <varlistentry>
     <term><varname>stripAllList</varname></term>
-    <listitem><para>List of directories to search for libraries and
-    executables from which <emphasis>all</emphasis> symbols should be
-    stripped.  By default, it’s empty.  Stripping all symbols is
-    risky, since it may remove not just debug symbols but also ELF
-    information necessary for normal execution.</para></listitem>
+    <listitem><para>List of paths to search for libraries and executables from
+    which <emphasis>all</emphasis> symbols should be stripped.  See
+    <varname>dontStripList</varname> for detailed information about accepted
+    values.  By default, it’s empty.  Stripping all symbols is risky, since it
+    may remove not just debug symbols but also ELF information necessary for
+    normal execution.</para></listitem>
   </varlistentry>
 
   <varlistentry>
@@ -898,10 +919,13 @@ following:
 
   <varlistentry>
     <term><varname>stripDebugList</varname></term>
-    <listitem><para>List of directories to search for libraries and
-    executables from which only debugging-related symbols should be
-    stripped.  It defaults to <literal>lib bin
-    sbin</literal>.</para></listitem>
+    <listitem><para>List of paths to search for libraries and executables from
+    which only debugging-related symbols should be stripped. See
+    <varname>dontStripList</varname> for detailed information about accepted
+    values. By default, everything is stripped.  The same warning as for
+    <varname>dontStrip</varname> applies here.  For most purposes,
+    <varname>dontStripList</varname> should be used in place of this option.
+    </para></listitem>
   </varlistentry>
 
   <varlistentry>

--- a/pkgs/build-support/setup-hooks/strip.sh
+++ b/pkgs/build-support/setup-hooks/strip.sh
@@ -4,33 +4,78 @@ fixupOutputHooks+=(_doStrip)
 
 _doStrip() {
     if [ -z "$dontStrip" ]; then
-        stripDebugList=${stripDebugList:-lib lib32 lib64 libexec bin sbin}
-        if [ -n "$stripDebugList" ]; then
-            stripDirs "$stripDebugList" "${stripDebugFlags:--S}"
-        fi
 
-        stripAllList=${stripAllList:-}
-        if [ -n "$stripAllList" ]; then
-            stripDirs "$stripAllList" "${stripAllFlags:--s}"
+        stripDirs "${stripDebugList:-*}" "${stripDebugFlags:--S}"
+
+        if [ -n "${stripAllList:-}" ]; then
+            stripDirs "${stripAllList:-}" "${stripAllFlags:--s}"
         fi
     fi
 }
 
 stripDirs() {
-    local dirs="$1"
     local stripFlags="$2"
-    local dirsNew=
 
-    for d in ${dirs}; do
-        if [ -d "$prefix/$d" ]; then
-            dirsNew="${dirsNew} $prefix/$d "
-        fi
-    done
-    dirs=${dirsNew}
-
-    if [ -n "${dirs}" ]; then
-        header "stripping (with flags $stripFlags) in$dirs"
-        find $dirs -type f -print0 | xargs -0 ${xargsFlags:--r} strip $commonStripFlags $stripFlags || true
+    # Ensure $prefix is a directory
+    if [ -f "$prefix" ]; then
+        header "Stripping (with flags $stripFlags) the file ${prefix}."
+        echo -ne $prefix'\0' | stripAll "$stripFlags"
         stopNest
     fi
+    [ -d "$prefix" ] || return 0
+
+    # Ensure expansion occurs within $prefix/.
+    pushd "$prefix" >/dev/null
+        shopt -s dotglob
+        local stripDirs=( $1 )
+        local ignoreDirs=( $dontStripList )
+        shopt -u dotglob
+    popd >/dev/null
+    local debugIncluded= debugExcluded= p=
+
+    # `find` fails on missing paths. Remove them.
+    local roots=()
+    for p in "${stripDirs[@]}"; do
+        if [ -e "$prefix/$p" ]; then
+            roots+=( "$prefix/$p" )
+            debugIncluded="$debugIncluded${debugIncluded:+,}$p"
+        fi
+    done
+    [ "${#roots[@]}" -eq 0 ] && return 0
+
+    # Add ignored paths to find command.
+    local findArgs=( "${roots[@]}" )
+    for p in "${ignoreDirs[@]}"; do
+        if [ -e "$prefix/$p" ]; then
+            findArgs+=( "-path" "$prefix/$p" "-prune" "-o" )
+            debugExcluded="$debugExcluded $p"
+        fi
+    done
+
+    header "Stripping (with flags $stripFlags) in $prefix${debugIncluded:+"/{$debugIncluded}"}${debugExcluded:+", skipping$debugExcluded"}."
+    find "${findArgs[@]}" -type f -print0 | stripAll "$stripFlags"
+    stopNest
+}
+
+stripAll() {
+    local stripFlags="$1"
+
+    local _ls f stripOutput
+    while IFS= read -r -d $'\0' f; do
+        # Skip very small files, they make strip choke.
+        _ls=( $(ls -Ln "$f") )
+        [ "${_ls[4]}" -lt 4 ] && continue;
+
+        if stripOutput=$(strip $commonStripFlags $stripFlags "$f" 2>&1); then
+            echo "Stripped $f"
+        else
+            # Ignore failures on files that cannot be stripped.
+            [ "$stripOutput" = "strip:$f: File format not recognized" ] && continue
+            [ "$stripOutput" = "strip:$f: File truncated" ] && continue
+
+            [ -n "$stripOutput" ] && echo "$stripOutput"
+            echo "Strip failed on file $f"
+            false # fail !
+        fi
+    done
 }

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -118,6 +118,8 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
+  dontStripList = [ "share/go/src/debug/elf/testdata" ];
+
   meta = with stdenv.lib; {
     branch = "1.4";
     homepage = http://golang.org/;

--- a/pkgs/development/compilers/go/1.6.nix
+++ b/pkgs/development/compilers/go/1.6.nix
@@ -146,6 +146,8 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
+  dontStripList = [ "share/go/src/debug/elf/testdata" ];
+
   disallowedReferences = [ go_bootstrap ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/go/1.7.nix
+++ b/pkgs/development/compilers/go/1.7.nix
@@ -149,6 +149,8 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
+  dontStripList = [ "share/go/src/debug/elf/testdata" ];
+
   disallowedReferences = [ go_bootstrap ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/misc/avr-gcc-with-avr-libc/default.nix
+++ b/pkgs/development/misc/avr-gcc-with-avr-libc/default.nix
@@ -28,8 +28,10 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  # Make sure we don't strip the libraries in lib/gcc/avr.
-  stripDebugList= [ "bin" "avr/bin" "libexec" ];
+  dontStripList = [
+    "lib/gcc/avr"   # Stripping here makes the whole toolchain unstable
+    "avr/lib"       # Avr binaries need to be stripped with avr-strip; see below.
+  ];
 
   installPhase = ''
     # important, without this gcc won't find the binutils executables
@@ -65,6 +67,12 @@ stdenv.mkDerivation {
     make $MAKE_FLAGS
     make install
     popd
+  '';
+
+  postFixup = ''
+    # Strip avr/lib with avr-strip
+    alias strip=$out/bin/avr-strip
+    dontStripList= stripDirs "avr/strip" "''${stripDebugFlags:--S}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/swig/2.x.nix
+++ b/pkgs/development/tools/misc/swig/2.x.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
+  # Some files in share look like malformed executables.
+  dontStripList = [ "share/swig" ];
+
   meta = {
     description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
 

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
+  # Some files in share look like malformed executables.
+  dontStripList = [ "share/swig" ];
+
   meta = with stdenv.lib; {
     description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
     homepage = http://swig.org/;

--- a/pkgs/development/tools/misc/swig/default.nix
+++ b/pkgs/development/tools/misc/swig/default.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--disable-ccache";
 
+  # Some files in share look like malformed executables.
+  dontStripList = [ "share/swig" ];
+
   meta = {
     description = "Interface compiler that connects C/C++ code to higher-level languages";
 

--- a/pkgs/os-specific/linux/syslinux/default.nix
+++ b/pkgs/os-specific/linux/syslinux/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
     substituteInPlace utils/ppmtolss16 gpxe/src/Makefile --replace /usr/bin/perl $(type -P perl)
   '';
 
-  stripDebugList = "bin sbin share/syslinux/com32";
-
   makeFlags = [
     "BINDIR=$(out)/bin"
     "SBINDIR=$(out)/sbin"

--- a/pkgs/servers/http/apache-httpd/2.2.nix
+++ b/pkgs/servers/http/apache-httpd/2.2.nix
@@ -56,8 +56,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  stripDebugList = "lib modules bin";
-
   postInstall = ''
     mkdir -p $doc/share/doc/httpd
     mv $out/manual $doc/share/doc/httpd


### PR DESCRIPTION
This is the same PR as #15087, but fully tested and modified to take into account the discovered bugs.

Stdenv now supports the `dontStripPath` attribute which is the black-list version of the former `stripDebugList` and `stripAllList` (maintained for compatibility).

These three variables now support bash globbing, as explained in the updated manual.
`stripDebugList = [ "bin" "lib/libpretty.so" "modules/*.so" ]` are three valid expressions, expanded under `$prefix/`.

It appears that this PR _can_ break stuff. Sometimes strip will fail with slightly different error messages than the expected ones. It seems to come from its structure, where the file type is recognised and handled by a custom handler, which in turn may fail with custom errors that we cannot (and dont want to) catch. For these cases, we will need to update the derivation wit a `dontStripList` argument. The only example of this I have encountered is swig. Some template text file presumably looks like one of the supported binary formats, but truncated. The error message is quite different from the basic truncation error.

A similar issue occurred with go which ships sample binaries for testing purposes. These are allegedly ELF's, but not to `strip`'s liking.

Finally, I could not resist the pleasure of removing some superfluous stripDebugList's :-).

The build is successful for `nix-build -A samba -A go -A flashplayer -A mesa_noglu -A apacheHttpd -A syslinux -A avrgcclibc`, which is already a good panel of derivations. (Well, at least it takes a few hours on my quad-core, and at least one hour for gcc alone.) (BTW, the build is not successful for nss, but it's not my fault, it comes from https://github.com/NixOS/nixpkgs/commit/d71a4851e8a2ef52f6d806d65822290cdbae8804#commitcomment-17408979, which in turn calls for a refactoring of my `stripDirs` function into a generic wrapper for find, but let's leave this for later.)

Closes #14821, #14822, #14823, #14824.
