### PR TITLE
texlive.combine: fix build

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive-new/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive-new/combine.nix
@@ -66,6 +66,25 @@ in buildEnv {
     # TODO: perhaps do lua actions?
     # tried inspiration from install-tl, sub do_texmf_cnf
   ''
+    patchCnfLua() {
+      local cnfLua="$1"
+
+      if [ -e "$cnfLua" ]; then
+        local cnfLuaOrig="$(realpath "$cnfLua")"
+        rm ./texmfcnf.lua
+        sed \
+          -e 's,texmf-dist,texmf,g' \
+          -e 's,texmf-local,texmf,g' \
+          -e "s,\(TEXMFLOCAL[ ]*=[ ]*\)[^\,]*,\1\"$out/share/texmf\",g" \
+          -e "s,\$SELFAUTOLOC,$out,g" \
+          -e "s,selfautodir:/,$out/share/,g" \
+          -e "s,selfautodir:,$out/share/,g" \
+          -e "s,selfautoparent:/,$out/share/,g" \
+          -e "s,selfautoparent:,$out/share/,g" \
+          "$cnfLuaOrig" > "$cnfLua"
+      fi
+    }
+
     (
       cd ./share/texmf/web2c/
       local cnfOrig="$(realpath ./texmf.cnf)"
@@ -79,18 +98,7 @@ in buildEnv {
         -e "s,\$SELFAUTOGRANDPARENT,$out/share,g" \
         "$cnfOrig" > ./texmf.cnf
 
-      local cnfLuaOrig="$(realpath ./texmfcnf.lua)"
-      rm ./texmfcnf.lua
-      sed \
-        -e 's,texmf-dist,texmf,g' \
-        -e 's,texmf-local,texmf,g' \
-        -e "s,\(TEXMFLOCAL[ ]*=[ ]*\)[^\,]*,\1\"$out/share/texmf\",g" \
-        -e "s,\$SELFAUTOLOC,$out,g" \
-        -e "s,selfautodir:/,$out/share/,g" \
-        -e "s,selfautodir:,$out/share/,g" \
-        -e "s,selfautoparent:/,$out/share/,g" \
-        -e "s,selfautoparent:,$out/share/,g" \
-        "$cnfLuaOrig" > ./texmfcnf.lua
+      patchCnfLua "./texmfcnf.lua"
 
       rm updmap.cfg
     )


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Recent merge of pull request #14681 broke
the build of some texlive components (e.g.: `xetex`)
that do not include the `./share/texmf/web2c/texmf.cnf`.
This fix should allow these component to build
as before by operating on this file only when
it exits.

Tested with:

```
nix-shell --pure -E 'with import <nixpkgs> { }; stdenv.mkDerivation {name = "otf"; buildInputs = [pandoc (texlive.combine { inherit (texlive) scheme-context; })];}'
```

context still able to build my resume.

```
nix-shell --pure -E 'with import <nixpkgs> { }; stdenv.mkDerivation {name = "testXeLatex"; buildInputs = [(texlive.combine { inherit (texlive) scheme-small; })];}'
```

`xetex --help` -> prints help.
