### PR TITLE
Ghostscript: Update URL and hash for ghostscript-9.18.tar.bz2 after upstream URL change

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -9,7 +9,7 @@ assert x11Support -> xlibsWrapper != null;
 assert cupsSupport -> cups != null;
 let
   version = "9.18";
-  sha256 = "18ad90za28dxybajqwf3y3dld87cgkx1ljllmcnc7ysspfxzbnl3";
+  sha256 = "83daf5bbbb5afbc32cab944a1afa7ceca046dbf0c3712cd5f2bd21a13e484da1";
 
   fonts = stdenv.mkDerivation {
     name = "ghostscript-fonts";
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   name = "ghostscript-${version}";
 
   src = fetchurl {
-    url = "http://downloads.ghostscript.com/public/${name}.tar.bz2";
+    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs918/${name}.tar.bz2";
     inherit sha256;
   };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Upstream changed their package filing; in particular, http://downloads.ghostscript.com/public/ghostscript-9.18.tar.bz2 does not exist anymore, which breaks this build for me.

They have a replacement (hosted both on github and their own site in a different directory) but it hashes differently. I have not been able to find a copy of the file with the original hash, so I'm also changing the hash to match. I have spot a few copies on third-party mirrors, and they were consistent with the new version despite allegedly dating back to 2015.
