### PR TITLE
libinput: 1.2.3 -> 1.3.0

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -15,11 +15,11 @@ in
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "libinput-1.2.3";
+  name = "libinput-1.3.0";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/libinput/${name}.tar.xz";
-    sha256 = "1wp937sn2dzqhrbl2bhapqb0pvybc80z8ynw7yfkm5ycl39skch9";
+    sha256 = "1sn1s1bz06fa49izqkqf519sjclsvhf42i6slzx1w5hx4vxpb2lr";
   };
 
   configureFlags = [


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

> libinput 1.3 is now available.
> 
> The main addition over 1.2 is support for so-called tablet pads, i.e.
> the actual tablet part of a graphics tablet. This concludes the graphics
> tablet work in libinput, we are now feature-complete.
> Since the rc2 we only had a documentation change, so below is the
> announcement for 1.3rc1.
> 
> Tablet pads feature three input sources - buttons, rings and strips. Rings
> and strips provide data in degrees and normalized, respectively, with a
> similar "source" system as we already offer for pointer axis sources.
> Buttons are just that, a sequential list of buttons starting at index 0 -
> this is a notable departure from the linux/input.h event codes we use in the
> pointer and the tablet tool interface.
> 
> The second notable addition are middle buttons for touchpads with a software
> button area. Previously, a middle button could be triggered by pressing with
> a finger in the left and right button area simultanously. Unfortunately, too
> many touchpads are unable to reliably detect both fingers. The middle button
> area is always available when software buttons are enabled and encompasses
> the center 15-20mm on the touchpad.
> 
> We already had middle button scrolling available on trackpoints, with this
> release middle button emulation now works as well. Thus, scrolling is
> available on trackpoints that don't have a physical middle button.
> 
> Finally, touchscreens that have a fuzz value set on the kernel device are
> now defuzzed in libinput, thus stopping pointer wobbles previously seen when
> holding the finger still. Note that libinput does not _set_ the fuzz value,
> it merely uses it. Employ a udev rule or hwdb entry to set this on your
> device if needed.
