### PR TITLE
nixos/xserver: Changed xrandrHeads to support corresponding monitor section configuration in Xorg

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -17,7 +17,16 @@ has the following highlights: </para>
       A consequence is that UIDs and GIDs are no longer reused.
     </para>
   </listitem>
-
+  <listitem>
+    <para>
+      Xserver services module now allows one to specify configuration for each monitor.
+      This is done via the xrandrHeads property. It is backwards compatible, so your
+      existing configuration still works. You can replace each monitor designation with
+      an attribute set containing the monitor designation, whether the monitor is the
+      primary monitor, and extra configuration for that specific monitor. Only one
+      monitor can be the primary monitor.
+    </para>
+  </listitem>
 </itemizedlist>
 
 <para>The following new services were added since the last release:</para>

--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -19,12 +19,25 @@ has the following highlights: </para>
   </listitem>
   <listitem>
     <para>
-      Xserver services module now allows one to specify configuration for each monitor.
-      This is done via the xrandrHeads property. It is backwards compatible, so your
-      existing configuration still works. You can replace each monitor designation with
-      an attribute set containing the monitor designation, whether the monitor is the
-      primary monitor, and extra configuration for that specific monitor. Only one
-      monitor can be the primary monitor.
+      The module option <option>services.xserver.xrandrHeads</option> now
+      causes the first head specified in this list to be set as the primary
+      head. Apart from that, it's now possible to also set additional options
+      by using an attribute set, for example:
+<programlisting>
+{ services.xserver.xrandrHeads = [
+    "HDMI-0"
+    {
+      output = &quot;DVI-0&quot;;
+      primary = true;
+      monitorConfig = ''
+        Option &quot;Rotate&quot; &quot;right&quot;
+      '';
+    }
+  ];
+}
+</programlisting>
+      This will set the <literal>DVI-0</literal> output to be the primary head,
+      even though <literal>HDMI-0</literal> is the first head in the list.
     </para>
   </listitem>
 </itemizedlist>

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -31,36 +31,51 @@ let
       pkgs.xorg.fontadobe75dpi
     ];
 
+  xrandrOptions = {
+    output = mkOption {
+      type = types.str;
+      example = "DVI-0";
+      description = ''
+        The output name of the monitor, as shown by <citerefentry>
+          <refentrytitle>xrandr</refentrytitle>
+          <manvolnum>1</manvolnum>
+        </citerefentry> invoked without arguments.
+      '';
+    };
+
+    primary = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether this head is treated as the primary monitor,
+      '';
+    };
+
+    monitorConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        DisplaySize 408 306
+        Option "DPMS" "false"
+      '';
+      description = ''
+        Extra lines to append to the <literal>Monitor</literal> section
+        verbatim.
+      '';
+    };
+  };
 
   # Just enumerate all heads without discarding XRandR output information.
-  xrandrHeads = (
-    fold
-      (nextHead: { index, alreadyPrimary, processedHeads }:
-        let
-          processedHead = { name = "multihead${toString index}"; } // 
-            (if isAttrs nextHead then
-              {
-                output = nextHead.output;
-                primary = if alreadyPrimary then false else nextHead.primary || index == 0;
-                monitorConfig = nextHead.monitorConfig;
-              }
-            else
-              {
-                output = nextHead;
-                primary = if alreadyPrimary then false else index == 0;
-                monitorConfig = "";
-              }
-            );
-          primariness = if alreadyPrimary then true else processedHead.primary;
-        in
-          { index = index - 1; alreadyPrimary = primariness; processedHeads = ([ processedHead ] ++ processedHeads); })
-      { index = (length cfg.xrandrHeads) - 1; alreadyPrimary = false; processedHeads = []; }
-      cfg.xrandrHeads
-  ).processedHeads;
+  xrandrHeads = let
+    mkHead = num: config: {
+      name = "multihead${toString num}";
+      inherit config;
+    };
+  in imap mkHead cfg.xrandrHeads;
 
   xrandrDeviceSection = let
     monitors = flip map xrandrHeads (h: ''
-      Option "monitor-${h.output}" "${h.name}"
+      Option "monitor-${h.config.output}" "${h.name}"
     '');
     # First option is indented through the space in the config but any
     # subsequent options aren't so we need to apply indentation to
@@ -80,13 +95,13 @@ let
       value = ''
         Section "Monitor"
           Identifier "${current.name}"
-          ${optionalString (current.primary) ''
+          ${optionalString (current.config.primary) ''
           Option "Primary" "true"
           ''}
           ${optionalString (previous != []) ''
           Option "RightOf" "${(head previous).name}"
           ''}
-          ${current.monitorConfig}
+          ${current.config.monitorConfig}
         EndSection
       '';
     } ++ previous;
@@ -351,27 +366,36 @@ in
 
       xrandrHeads = mkOption {
         default = [];
-        example = [ "HDMI-0" { output = "DVI-0"; primary = true; monitorConfig = ""; } ];
-        type = with types; listOf (either
-          str
-          (submodule {
-            options.output = str;
-            options.primary = bool;
-            options.monitorConfig = lines;
-          })
-        );
+        example = [
+          "HDMI-0"
+          { output = "DVI-0"; primary = true; }
+          { output = "DVI-1"; monitorConfig = "Option \"Rotate\" \"left\""; }
+        ];
+        type = with types; listOf (coercedTo str (output: {
+          inherit output;
+        }) (submodule { options = xrandrOptions; }));
+        apply = heads: let
+          hasPrimary = any (x: x.primary) heads;
+          firstPrimary = head heads // { primary = true; };
+          newHeads = singleton firstPrimary ++ tail heads;
+        in if heads != [] && !hasPrimary then newHeads else heads;
         description = ''
-          Simple multiple monitor configuration, just specify a list of XRandR
-          outputs as the values of the list. The monitors will be mapped from
-          left to right in the order of the list.
+          Multiple monitor configuration, just specify a list of XRandR
+          outputs. The individual elements should be either simple strings or
+          an attribute set of output options.
 
-          By default, the first monitor will be set as the primary monitor.
-          However instead of a list, you can give an attribute set. That set
-          can contain a primary monitor specification and a custom monitor
-          configuration section.
+          If the element is a string, it is denoting the physical output for a
+          monitor, if it's an attribute set, you must at least provide the
+          <option>output</option> option.
 
-          Only one monitor is allowed to be primary. If multiple monitors are
-          specified as primary, only the last monitor will be primary.
+          The monitors will be mapped from left to right in the order of the
+          list.
+
+          By default, the first monitor will be set as the primary monitor if
+          none of the elements contain an option that has set
+          <option>primary</option> to <literal>true</literal>.
+
+          <note><para>Only one monitor is allowed to be primary.</para></note>
 
           Be careful using this option with multiple graphic adapters or with
           drivers that have poor support for XRandR, unexpected things might
@@ -506,11 +530,18 @@ in
 
     nixpkgs.config.xorg = optionalAttrs (elem "vboxvideo" cfg.videoDrivers) { abiCompat = "1.18"; };
 
-    assertions =
-      [ { assertion = config.security.polkit.enable;
-          message = "X11 requires Polkit to be enabled (‘security.polkit.enable = true’).";
-        }
-      ];
+    assertions = [
+      { assertion = config.security.polkit.enable;
+        message = "X11 requires Polkit to be enabled (‘security.polkit.enable = true’).";
+      }
+      (let primaryHeads = filter (x: x.primary) cfg.xrandrHeads; in {
+        assertion = length primaryHeads < 2;
+        message = "Only one head is allowed to be primary in "
+                + "‘services.xserver.xrandrHeads’, but there are "
+                + "${toString (length primaryHeads)} heads set to primary: "
+                + concatMapStringsSep ", " (x: x.output) primaryHeads;
+      })
+    ];
 
     environment.etc =
       (optionals cfg.exportConfiguration

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -374,6 +374,8 @@ in
         type = with types; listOf (coercedTo str (output: {
           inherit output;
         }) (submodule { options = xrandrOptions; }));
+        # Set primary to true for the first head if no other has been set
+        # primary already.
         apply = heads: let
           hasPrimary = any (x: x.primary) heads;
           firstPrimary = head heads // { primary = true; };


### PR DESCRIPTION
See previous PR: https://github.com/NixOS/nixpkgs/pull/13916

> This is a breaking change (actually it is no longer breaking) to `services.xserver.xrandrHeads`, however it is a necessary change. This allows xrandrHeads to support per-monitor section configuation in Xorg.conf. There's currently no other way to set the primary monitor or per monitor section configuration when using the `xrandrHeads` option.
> 
> Requested by: https://github.com/NixOS/nixpkgs/issues/7463
> 
> What it fixes:
> 
> When you multiple monitors setup. By default, the first monitor detected by `xrandr` is set to the primary monitor. However this may not be the monitor you need to be set as primary. In fact this monitor set to primary may in fact be disconnected. Which is exactly what happened to me. This has affected 3 programs for me:
> 1. XMonad  - gets confused with `Super + {w,e,r}`
> 2. SDDM - puts the login screen on the wrong monitor, and does not currently duplicate the login screen on all monitors
> 3. XMobar - puts the xmobar on the wrong monitor, as it only puts the taskbar on the primary monitor
> 
> This PR fixes all of the above 3 problems (Xmonad is no longer confused, SDDM puts the login screen on my primary monitor (laptop), Xmobar is working. It is simple to use. And simple to change. Previously you would do something like:
> 
> ```
> services.xserver.xrandrHeads = [ "DP-0" "HDMI-0" ];
> ```
> 
> Now you can do:
> 
> ```
> services.xserver.xrandrHeads = {
>     DP-0 =  ''
>         Option "Primary" "true"
>     '';
>     HDMI-0 = "";
> };
> ```
> 
> The reason why I did this, is to allow other per-monitor configuration options when using xrandrHeads (such as per-monitor DPI in the future). Note that the `services.xserver.monitorSection` setting does not work in conjunction with `xrandrHeads`.
> 
> I have tested this in current 15.09-small and it works.

Current usage is actually compatible with existing configuration. Here's the example:

```
services.xserver.xrandrHeads = [ "HDMI-0" { output = "DVI-0"; primary = true; monitorConfig = ""; } ];
```
