### PR TITLE
garcosim: Added tracefilegen and tracefilesim

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -76,6 +76,7 @@
   choochootrain = "Hurshal Patel <hurshal@imap.cc>";
   christopherpoole = "Christopher Mark Poole <mail@christopherpoole.net>";
   cleverca22 = "Michael Bishop <cleverca22@gmail.com>";
+  cmcdragonkai = "Roger Qiu <roger.qiu@matrix.ai>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";
   codsl = "codsl <codsl@riseup.net>";
   codyopel = "Cody Opel <codyopel@gmail.com>";

--- a/pkgs/development/tools/analysis/garcosim/tracefilegen/builder.sh
+++ b/pkgs/development/tools/analysis/garcosim/tracefilegen/builder.sh
@@ -1,0 +1,17 @@
+source "$stdenv"/setup
+
+cp --recursive "$src" ./
+
+chmod --recursive u=rwx ./"$(basename "$src")"
+
+cd ./"$(basename "$src")"
+
+cmake ./ 
+
+make
+
+mkdir --parents "$out"/bin
+cp ./TraceFileGen "$out"/bin
+
+mkdir --parents "$out"/share/doc/"$name"/html
+cp --recursive ./Documentation/html/* "$out/share/doc/$name/html/"

--- a/pkgs/development/tools/analysis/garcosim/tracefilegen/default.nix
+++ b/pkgs/development/tools/analysis/garcosim/tracefilegen/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchgit, cmake }:
+
+stdenv.mkDerivation rec {
+
+  name = "tracefilegen-2015-11-14";
+
+  src = fetchgit {
+    url = "https://github.com/GarCoSim/TraceFileGen.git";
+    rev = "4acf75b142683cc475c6b1c841a221db0753b404";
+    sha256 = "69b056298cf570debd3718b2e2cb7e63ad9465919c8190cf38043791ce61d0d6";
+  };
+
+  buildInputs = [ cmake ];
+
+  builder = ./builder.sh;
+  
+  meta = with stdenv.lib; {
+    description = "Automatically generate all types of basic memory management operations and write into trace files";
+    homepage = "https://github.com/GarCoSim"; 
+    maintainers = [ maintainers.cmcdragonkai ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/development/tools/analysis/garcosim/tracefilesim/default.nix
+++ b/pkgs/development/tools/analysis/garcosim/tracefilesim/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+
+  name = "tracefilesim-2015-11-07";
+  
+  src = fetchgit {
+    url = "https://github.com/GarCoSim/TraceFileSim.git";
+    rev = "368aa6b1d6560e7ecbd16fca47000c8f528f3da2";
+    sha256 = "22dfb60d1680ce6c98d60d12c0d0950073f02359605fcdef625e3049bca07809";
+  };
+  
+  installPhase = ''
+    mkdir --parents "$out/bin"
+    cp ./traceFileSim "$out/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Ease the analysis of existing memory management techniques, as well as the prototyping of new memory management techniques.";
+    homepage = "https://github.com/GarCoSim";
+    maintainers = [ maintainers.cmcdragonkai ];
+    licenses = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3521,6 +3521,10 @@ in
 
   tracebox = callPackage ../tools/networking/tracebox { };
 
+  tracefilegen = callPackage ../development/tools/analysis/garcosim/tracefilegen { };
+
+  tracefilesim = callPackage ../development/tools/analysis/garcosim/tracefilesim { };
+
   trash-cli = callPackage ../tools/misc/trash-cli { };
 
   trickle = callPackage ../tools/networking/trickle {};


### PR DESCRIPTION
2 very simple C/C++ packages, that unfortunately don't use versioning, so I'm just using the git ref as content addressed dependencies.

These 2 allow one to create memory mutator trace files and then simulate the trace files.

It should work on all platforms, as it's really simple and self contained.

Tested on 15.09.
- Tested using sandboxing (nix.useSandbox on NixOS, or option build-use-sandbox in nix.conf on non-NixOS): nope
- Built on platform(s): NixOS
- Tested compilation of all pkgs that depend on this change using nix-shell -p nox --run "nox-review wip": nope
-  Tested execution of all binary files (usually in ./result/bin/): yes
- Fits CONTRIBUTING.md: I think so.
