### PR TITLE
uim: enable fep

### DIFF
--- a/pkgs/tools/inputmethods/uim/default.nix
+++ b/pkgs/tools/inputmethods/uim/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, intltool, pkgconfig, qt4, gtk2, gtk3, kdelibs,
+{stdenv, fetchurl, intltool, pkgconfig, qt4, gtk2, gtk3, kdelibs, ncurses,
  cmake, anthy, automoc4, m17n_lib, m17n_db}:
 
 stdenv.mkDerivation rec {
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
     gtk2
     gtk3
     kdelibs
+    ncurses
     cmake
     anthy
     automoc4


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
