### PR TITLE
nixpart-0.4: fix build of multipath-tools dependency

### DIFF
--- a/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
@@ -10,11 +10,11 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
-  buildInputs = [ lvm2 libaio readline ];
+  buildInputs = [ lvm2 libaio readline gzip ];
 
   preBuild =
     ''
-      makeFlagsArray=(GZIP="${gzip}/bin/gzip -9 -c" prefix=$out mandir=$out/share/man/man8 man5dir=$out/share/man/man5 LIB=lib)
+      makeFlagsArray=(GZIP="-9" prefix=$out mandir=$out/share/man/man8 man5dir=$out/share/man/man5 LIB=lib)
       
       substituteInPlace multipath/Makefile --replace /etc $out/etc
       substituteInPlace kpartx/Makefile --replace /etc $out/etc


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm using Nixops to deploy to Hetzner. I cannot correctly name devices in Kickstart script, so I decided to log into rescue system and find out, why it doesn't detect devices. I tried to build `nixpart` dependencies with this shell script:

```
let pkgs = import <nixpkgs> {};
    nixpart = pkgs.pythonPackages.nixpart0.override {
      useNixUdev = false;
      udevSoMajor = 0;
    };
in pkgs.stdenv.mkDerivation {
  name = "nixpart";
  buildInputs = [ nixpart pkgs.rlwrap ];
}
```

(rlwrap for interactive python).

But here is what I get:

```
gcc -pipe -g -Wall -Wunused -Wstrict-prototypes -fPIC -DLIB_STRING=\"lib\" -I.. -c -o hp_sw.o hp_sw.c
gcc -shared -o libcheckhp_sw.so libsg.o hp_sw.o
gcc -pipe -g -Wall -Wunused -Wstrict-prototypes -fPIC -DLIB_STRING=\"lib\" -I.. -c -o rdac.o rdac.c
gcc -shared -o libcheckrdac.so libsg.o rdac.o
rm tur.o hp_sw.o rdac.o readsector0.o cciss_tur.o emc_clariion.o
make[1]: Leaving directory '/tmp/nix-build-multipath-tools-0.4.9.drv-0/libmultipath/checkers'
make[1]: Entering directory '/tmp/nix-build-multipath-tools-0.4.9.drv-0/multipath'
gcc -pipe -g -Wall -Wunused -Wstrict-prototypes -fPIC -DLIB_STRING=\"lib\" -I../libmultipath -c -o main.o main.c
gcc -pipe -g -Wall -Wunused -Wstrict-prototypes -fPIC -DLIB_STRING=\"lib\" -I../libmultipath main.o -o multipath -lpthread -ldevmapper -ldl -lmultipath -L../libmultipath
/nix/store/8fngdkhqixp4vjypa74vc5h88chyz0ml-gzip-1.7/bin/gzip -9 -c multipath.8 > multipath.8.gz
gzip: -c: option not valid in GZIP environment variable
Try `gzip --help' for more information.
Makefile:17: recipe for target 'multipath' failed
make[1]: *** [multipath] Error 1
make[1]: Leaving directory '/tmp/nix-build-multipath-tools-0.4.9.drv-0/multipath'
Makefile:39: recipe for target 'recurse' failed
make: *** [recurse] Error 2
builder for ‘/nix/store/2lacqh7z908phcp1hdl2jxa2h0hky2kq-multipath-tools-0.4.9.drv’ failed with exit code 2
cannot build derivation ‘/nix/store/xdlik0qay1hf000sfjgcr524n0ya07m0-blivet-0.17-1.drv’: 1 dependencies couldn't be built
cannot build derivation ‘/nix/store/hmc52hhdf9pqw27plqazrhysvzwzzg11-nixpart-0.4.1.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/hmc52hhdf9pqw27plqazrhysvzwzzg11-nixpart-0.4.1.drv’ failed
/home/danbst/.nix-profile/bin/nix-shell: failed to build all dependencies
```

So here is the fix. Error gone. Ping @aszlig
