### PR TITLE
xscreensaver: Fix `xscreensaver-text` command

### DIFF
--- a/pkgs/misc/screensavers/xscreensaver/default.nix
+++ b/pkgs/misc/screensavers/xscreensaver/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, bc, perl, pam, libXext, libXScrnSaver, libX11
 , libXrandr, libXmu, libXxf86vm, libXrender, libXxf86misc, libjpeg, mesa, gtk
-, libxml2, libglade, intltool
+, libxml2, libglade, intltool, xorg, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ pkgconfig bc perl libjpeg mesa gtk libxml2 libglade pam
       libXext libXScrnSaver libX11 libXrandr libXmu libXxf86vm libXrender
-      libXxf86misc intltool
+      libXxf86misc intltool xorg.appres makeWrapper
     ];
 
   preConfigure =
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
       "--with-xshm-ext" "--with-xdbe-ext" "--without-readdisplay"
       "--with-x-app-defaults=\${out}/share/xscreensaver/app-defaults"
     ];
+
+  postInstall = ''
+      wrapProgram $out/bin/xscreensaver-text \
+        --prefix PATH : ${stdenv.lib.makeBinPath [xorg.appres]}
+  '';
 
   meta = {
     homepage = "http://www.jwz.org/xscreensaver/";

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -28,6 +28,17 @@ let
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit ;};
 
+  appres = (mkDerivation "appres" {
+    name = "appres-1.0.4";
+    builder = ./builder.sh;
+    src = fetchurl {
+      url = mirror://xorg/individual/app/appres-1.0.4.tar.bz2;
+      sha256 = "139yp08qy1w6dccamdy0fh343yhaf1am1v81m2j435nd4ya4wqcz";
+    };
+    buildInputs = [pkgconfig libX11 xproto libXt ];
+    meta.platforms = stdenv.lib.platforms.unix;
+  }) // {inherit libX11 xproto libXt ;};
+
   bdftopcf = (mkDerivation "bdftopcf" {
     name = "bdftopcf-1.0.5";
     builder = ./builder.sh;

--- a/pkgs/servers/x11/xorg/extra.list
+++ b/pkgs/servers/x11/xorg/extra.list
@@ -8,3 +8,4 @@ http://xcb.freedesktop.org/dist/xcb-util-keysyms-0.4.0.tar.bz2
 http://xcb.freedesktop.org/dist/xcb-util-renderutil-0.3.9.tar.bz2
 http://xcb.freedesktop.org/dist/xcb-util-wm-0.4.1.tar.bz2
 http://xcb.freedesktop.org/dist/xcb-util-errors-1.0.tar.bz2
+mirror://xorg/individual/app/appres-1.0.4.tar.bz2


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Without `appres` some screensavers show perl stacktraces instead of more friendly texts.
