### PR TITLE
milu: Fix hydra failure on darwin

### DIFF
--- a/pkgs/applications/misc/milu/default.nix
+++ b/pkgs/applications/misc/milu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, unzip, pkgconfig, glib, clang }:
+{ stdenv, fetchFromGitHub, unzip, pkgconfig, glib, clang, gcc }:
 
 stdenv.mkDerivation rec {
   name = "milu-nightly-${version}";
@@ -27,13 +27,14 @@ stdenv.mkDerivation rec {
      glib
      unzip
      clang
+     gcc
   ];
 
   meta = {
     description = "Higher Order Mutation Testing Tool for C and C++ programs";
     homepage = http://github.com/yuejia/Milu;
     license = stdenv.lib.licenses.bsd2;
-    platforms = stdenv.lib.platforms.unix;
+    platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.vrthra ];
   };
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The hydra build failed on darwin on compiling, complaining about gcc.
This commit disables the darwin build. (Because I don't have a darwin machine, I have no way to
debug).
