### PR TITLE
pixie: 1333 -> 1352

### DIFF
--- a/pkgs/development/interpreters/pixie/default.nix
+++ b/pkgs/development/interpreters/pixie/default.nix
@@ -3,7 +3,7 @@
   variant ? "jit", buildWithPypy ? false }:
 
 let
-  commit-count = "1333";
+  commit-count = "1352";
   common-flags = "--thread --gcrootfinder=shadowstack --continuation";
   variants = {
     jit = { flags = "--opt=jit"; target = "target.py"; };
@@ -13,8 +13,8 @@ let
   };
   pixie-src = fetchgit {
     url = "https://github.com/pixie-lang/pixie.git";
-    rev = "36ce07e1cd85ca82eedadf366bef3bb57a627a2a";
-    sha256 = "1b3v99c0is33w029r15qvd0mkrc5n1mrvjjmfpcd9yvhvqb2vcjs";
+    rev = "dd754fe9f329e9e176eeaedae1095c85cde65028";
+    sha256 = "1jf3nkd1jzvxrw9ql2r74drsirrxfihc125x0wmk45jyl5q24vdd";
   };
   pypy-tag = "81254";
   pypy-src = fetchurl {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
