### PR TITLE
gnome-keyring: add gcr dependency to service

### DIFF
--- a/nixos/modules/services/desktops/gnome3/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-keyring.nix
@@ -36,7 +36,7 @@ in
 
     environment.systemPackages = [ gnome3.gnome_keyring ];
 
-    services.dbus.packages = [ gnome3.gnome_keyring ];
+    services.dbus.packages = [ gnome3.gnome_keyring gnome3.gcr ];
 
   };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

gcr is used to provide the popup dialog, this fixes gnome-keyring for
non-gnome sessions
