### PR TITLE
pypy: 4.0.1 -> 5.1.1

### DIFF
--- a/pkgs/development/interpreters/pypy/default.nix
+++ b/pkgs/development/interpreters/pypy/default.nix
@@ -71,16 +71,10 @@ let
        export HOME="$TMPDIR";
        # disable shutils because it assumes gid 0 exists
        # disable socket because it has two actual network tests that fail
-       # disable test_mhlib because it fails for unknown reason
-       # disable sqlite3 due to https://bugs.pypy.org/issue1740
-       # disable test_multiprocessing due to transient errors
-       # disable test_os because test_urandom_failure fails
        # disable test_urllib2net, test_urllib2_localnet, and test_urllibnet because they require networking (example.com)
-       # disable test_zipfile64 because it randomly timeouts
-       # disable test_cpickle because timeouts
        # disable test_ssl because no shared cipher' not found in '[Errno 1] error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
        # disable test_epoll because of invalid arg, should be fixed in as of version 5.1.2
-      ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not (test_ssl or test_cpickle or test_sqlite or test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_os or test_shutil or test_mhlib or test_multiprocessing or test_zipfile64 or test_epoll)' lib-python
+      ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not ( test_ssl or test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_shutil or test_epoll )' lib-python
     '';
 
     installPhase = ''

--- a/pkgs/development/interpreters/pypy/default.nix
+++ b/pkgs/development/interpreters/pypy/default.nix
@@ -6,8 +6,8 @@ assert zlibSupport -> zlib != null;
 
 let
 
-  majorVersion = "4.0";
-  version = "${majorVersion}.1";
+  majorVersion = "5.1.1";
+  version = "${majorVersion}";
   libPrefix = "pypy${majorVersion}";
 
   pypy = stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ let
 
     src = fetchurl {
       url = "https://bitbucket.org/pypy/pypy/get/release-${version}.tar.bz2";
-      sha256 = "1g7iipllgdfjgdkypsa1g2pzxgjw9agp40rh82hk31rsbak2hfbl";
+      sha256 = "1dmckvffanmh0b50pq34shnw05r55gjxn43kgvnkz5kkvvsbxdg1";
     };
 
     buildInputs = [ bzip2 openssl pkgconfig pythonFull libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 makeWrapper gdbm db ]
@@ -79,7 +79,8 @@ let
        # disable test_zipfile64 because it randomly timeouts
        # disable test_cpickle because timeouts
        # disable test_ssl because no shared cipher' not found in '[Errno 1] error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
-      ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not (test_ssl or test_cpickle or test_sqlite or test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_os or test_shutil or test_mhlib or test_multiprocessing or test_zipfile64)' lib-python
+       # disable test_epoll because of invalid arg, should be fixed in as of version 5.1.2
+      ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not (test_ssl or test_cpickle or test_sqlite or test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_os or test_shutil or test_mhlib or test_multiprocessing or test_zipfile64 or test_epoll)' lib-python
     '';
 
     installPhase = ''

--- a/pkgs/development/interpreters/pypy/default.nix
+++ b/pkgs/development/interpreters/pypy/default.nix
@@ -73,8 +73,9 @@ let
        # disable socket because it has two actual network tests that fail
        # disable test_urllib2net, test_urllib2_localnet, and test_urllibnet because they require networking (example.com)
        # disable test_ssl because no shared cipher' not found in '[Errno 1] error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
+       # disable test_zipfile64 because it causes ENOSPACE
        # disable test_epoll because of invalid arg, should be fixed in as of version 5.1.2
-      ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not ( test_ssl or test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_shutil or test_epoll )' lib-python
+      ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not ( test_ssl or test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_shutil or test_zipfile64 or test_epoll )' lib-python
     '';
 
     installPhase = ''


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The update commit also disables a test, for which the fix is already in upstream, after I pinged #pypy on IRC.
The revised - test commit enables a couple of non-network related tests, that I have observed passing, but that has to be verified on hydra ...

cc @domenkozar 
