### PR TITLE
emacsPackages.keyfreq: init at 1.8

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -1072,6 +1072,17 @@ let
     };
   };
 
+  keyfreq = trivialBuild rec {
+    pname = "keyfreq";
+    version = "1.8";
+    src = fetchFromGitHub {
+      owner = "dacap";
+      repo = "keyfreq";
+      rev = "1.8";
+      sha256 = "0ways4ksb9pk2kkpgclsxgc0ycfwcr8vghlbv5ic4y0c4ycmlb2d";
+    };
+  };
+
   lcs = melpaBuild rec {
     pname   = "lcs";
     version = circe.version;


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

https://github.com/dacap/keyfreq
