### PR TITLE
stumpwm-contrib: e13988 -> 9bebe3

### DIFF
--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -6,8 +6,8 @@ let
   version = "0.9.9";
   contrib = (fetchgit {
     url = "https://github.com/stumpwm/stumpwm-contrib.git";
-    rev = "e139885fffcedaeba4b263e4575daae4364cad52";
-    sha256 = "fe75bb27538a56f2d213fb21e06a8983699e129a10da7014ddcf6eed5cd965f8";
+    rev = "9bebe3622b2b6c31a6bada9055ef3862fa79b86f";
+    sha256 = "1ml6mjk2fsfv4sf65fdbji3q5x0qiq99g1k8w7a99gsl2i8h60gc";
   });
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

this contains a fix for controlling volume with hardware keys
