### PR TITLE
letsencrypt: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -1,7 +1,8 @@
 { stdenv, pythonPackages, fetchFromGitHub, dialog }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "letsencrypt-${version}";
+  name = "certbot-${version}";
+  # when the renamed version is released update patchPhase
   version = "0.5.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/admin/letsencrypt/default.nix
+++ b/pkgs/tools/admin/letsencrypt/default.nix
@@ -2,13 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "letsencrypt-${version}";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
-    owner = "letsencrypt";
-    repo = "letsencrypt";
+    owner = "certbot";
+    repo = "certbot";
     rev = "v${version}";
-    sha256 = "0r2wis48w5nailzp2d5brkh2f40al6sbz816xx0akh3ll0rl1hbv";
+    sha256 = "0x098cdyfgqvh7x5d3sz56qjpjyg5b4fl82086sm43d8mbz0h5rm";
   };
 
   propagatedBuildInputs = with pythonPackages; [
@@ -26,7 +26,7 @@ pythonPackages.buildPythonApplication rec {
     zope_component
     zope_interface
   ];
-  buildInputs = with pythonPackages; [ nose dialog ];
+  buildInputs = [ dialog ] ++ (with pythonPackages; [ nose mock gnureadline ]);
 
   patchPhase = ''
     substituteInPlace letsencrypt/notify.py --replace "/usr/sbin/sendmail" "/var/setuid-wrappers/sendmail"
@@ -41,7 +41,7 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/letsencrypt/letsencrypt;
+    homepage = src.meta.homepage;
     description = "ACME client that can obtain certs and extensibly update server configurations";
     platforms = platforms.unix;
     maintainers = [ maintainers.iElectric ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -53,6 +53,7 @@ doNotDisplayTwice rec {
   inotifyTools = inotify-tools;
   joseki = apache-jena-fuseki; # added 2016-02-28
   jquery_ui = jquery-ui;  # added 2014-09-07
+  letsencrypt = certbot; # added 2016-05-10
   libdbusmenu_qt5 = qt5.libdbusmenu;  # added 2015-12-19
   libcap_manpages = libcap.doc; # added 2016-04-29
   libcap_pam = if stdenv.isLinux then libcap.pam else null; # added 2016-04-29

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7411,7 +7411,7 @@ in
     libpng = libpng12;
   };
 
-  letsencrypt = callPackage ../tools/admin/letsencrypt { };
+  certbot = callPackage ../tools/admin/certbot { };
 
   lib3ds = callPackage ../development/libraries/lib3ds { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -267,8 +267,7 @@ in modules // {
     ];
 
     buildInputs = with self; [ nose ];
-
-    sourceRoot = "letsencrypt-v${version}-src/acme";
+    postUnpack = "sourceRoot=\${sourceRoot}/acme";
   };
 
   # Maintained for simp_le compatibility


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Seems like the dependency on gnureadline is more or less optional for letsencrypt itself but the tests will not pass without it.
