### PR TITLE
hashcat: 0.49 -> 2.00

### DIFF
--- a/pkgs/tools/security/hashcat/default.nix
+++ b/pkgs/tools/security/hashcat/default.nix
@@ -1,49 +1,39 @@
-{ stdenv, fetchurl, p7zip, patchelf, gmp }:
+{ stdenv, fetchurl, gmp }:
 
 assert stdenv.isLinux;
 
 let
-  bits    = if stdenv.system == "x86_64-linux" then "64" else "32";
-  libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.libc gmp ];
-
-  fixBin = x: ''
-    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath ${libPath} ${x}
-  '';
+  bits = if stdenv.system == "x86_64-linux" then "64" else "32";
 in
 stdenv.mkDerivation rec {
   name    = "hashcat-${version}";
-  version = "0.49";
+  version = "2.00";
 
   src = fetchurl {
-    url    = "http://hashcat.net/files/${name}.7z";
-    sha256 = "0va07flncihgmnri5wj0jn636w86x5qwm4jmj2halcyg7qwqijh2";
+    name = "${name}.tar.gz";
+    url = "https://codeload.github.com/hashcat/hashcat/tar.gz/${version}";
+    sha256 = "0i2l4i1jkdhj9bkvycgd2nf809kki3jp83y0vrd4iwsdbbbyc9b3";
   };
 
-  buildInputs = [ p7zip patchelf ];
+  buildInputs = [ gmp ];
 
-  unpackPhase = "7z x $src > /dev/null && cd ${name}";
+  buildFlags = [ "posix${bits}" ]
+    ++ stdenv.lib.optionals (bits == "64") [ "posixXOP" "posixAVX" ];
 
+  # Upstream Makefile doesn't have 'install' target
   installPhase = ''
     mkdir -p $out/bin $out/libexec
     cp -R * $out/libexec
 
-    echo -n "/" > $out/bin/eula.accepted
     ln -s $out/libexec/hashcat-cli${bits}.bin $out/bin/hashcat
     ln -s $out/libexec/hashcat-cliXOP.bin $out/bin/hashcat-xop
     ln -s $out/libexec/hashcat-cliAVX.bin $out/bin/hashcat-avx
   '';
 
-  fixupPhase = ''
-    ${fixBin "$out/libexec/hashcat-cli${bits}.bin"}
-    ${fixBin "$out/libexec/hashcat-cliXOP.bin"}
-    ${fixBin "$out/libexec/hashcat-cliAVX.bin"}
-  '';
-
   meta = {
     description = "Fast password cracker";
     homepage    = "http://hashcat.net/hashcat/";
-    license     = stdenv.lib.licenses.unfreeRedistributable;
+    license     = stdenv.lib.licenses.mit;
     platforms   = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
   };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The current URL is broken, upstream has moved the download from .../files/ to
.../files_legacy/. But after fixing that, starting hashcat results in:

  $ ./result/bin/hashcat
  ERROR: this copy of hashcat is outdated. Get a more recent version.

So just update to latest.

New releases are on github, the license is now MIT and there are build
system changes.

CC @thoughtpolice (maintainer).
