### PR TITLE
go-ethereum: init at 1.4.1

### DIFF
--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -745,6 +745,22 @@ let
     sha256 = "1rmm1ky7irqypqjkk6qcd2n0xkzpaggdxql9dp9i9qci5rvvwwd4";
   };
 
+  ethereum = buildFromGitHub rec {
+    name = "ethereum";
+    rev = "v1.4.1";
+    goPackagePath = "github.com/ethereum/go-ethereum";
+    owner = "ethereum";
+    repo = "go-ethereum";
+    sha256 = "0z6yzkk72g41dzqa52fizxqxqh349y1m9s3byfh9ixq5xy5fnjn3";
+    preBuild = "export GOPATH=$GOPATH:$NIX_BUILD_TOP/go/src/${goPackagePath}/Godeps/_workspace";
+    postBuild = "rm $NIX_BUILD_TOP/go/bin/*test";
+    meta = with stdenv.lib; {
+      homepage = "https://ethereum.github.io/go-ethereum/";
+      description = "Official golang implementation of the Ethereum protocol";
+      license = with licenses; [ lgpl3 gpl3 ];
+    };
+  };
+
   exercism = buildFromGitHub {
     rev = "v2.2.1";
     name = "exercism";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This replaces #10146
