### PR TITLE
sniproxy: init at 0.4.0 with dependency udns: init at 0.4

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -265,6 +265,7 @@
       factorio = 241;
       emby = 242;
       graylog = 243;
+      sniproxy = 244;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -500,6 +501,7 @@
       taskd = 240;
       factorio = 241;
       emby = 242;
+      sniproxy = 244;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -379,6 +379,7 @@
   ./services/networking/skydns.nix
   ./services/networking/shairport-sync.nix
   ./services/networking/shout.nix
+  ./services/networking/sniproxy.nix
   ./services/networking/softether.nix
   ./services/networking/spiped.nix
   ./services/networking/sslh.nix

--- a/nixos/modules/services/networking/sniproxy.nix
+++ b/nixos/modules/services/networking/sniproxy.nix
@@ -1,0 +1,99 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.sniproxy;
+
+  configFile = pkgs.writeText "sniproxy.conf" ''
+    user ${cfg.user}
+    pidfile /run/sniproxy.pid
+    ${cfg.config}
+  '';
+
+in
+{
+  options = {
+    services.sniproxy = {
+      enable = mkEnableOption "sniproxy server";
+
+      user = mkOption {
+        type = types.str;
+        default = "sniproxy";
+        description = "User account under which sniproxy runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "sniproxy";
+        description = "Group under which sniproxy runs.";
+      };
+
+      config = mkOption {
+        type = types.lines;
+        default = "";
+        description = "sniproxy.conf configuration excluding the daemon username and pid file.";
+        example = literalExample ''
+          error_log {
+            filename /var/log/sniproxy/error.log
+          }
+          access_log {
+            filename /var/log/sniproxy/access.log
+          }
+          listen 443 {
+            proto tls
+          }
+          table {
+            example.com 192.0.2.10
+            example.net 192.0.2.20
+        }
+        '';
+      };
+
+      logDir = mkOption {
+        type = types.str;
+        default = "/var/log/sniproxy/";
+        description = "Location of the log directory for sniproxy.";
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.sniproxy = {
+      description = "sniproxy server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      preStart = ''
+        test -d ${cfg.logDir} || {
+          echo "Creating initial log directory for sniproxy in ${cfg.logDir}"
+          mkdir -p ${cfg.logDir}
+          chmod 640 ${cfg.logDir}
+          }
+        chown -R ${cfg.user}:${cfg.group} ${cfg.logDir}
+      '';
+
+      serviceConfig = {
+        Type = "forking";
+        ExecStart = "${pkgs.sniproxy}/bin/sniproxy -c ${configFile}";
+        Restart = "always";
+      };
+    };
+
+    users.extraUsers = mkIf (cfg.user == "sniproxy") {
+      sniproxy = {
+        group = cfg.group;
+        uid = config.ids.uids.sniproxy;
+      };
+    };
+
+    users.extraGroups = mkIf (cfg.group == "sniproxy") {
+      sniproxy = {
+        gid = config.ids.gids.sniproxy;
+      };
+    };
+
+  };
+}

--- a/pkgs/applications/networking/sniproxy/default.nix
+++ b/pkgs/applications/networking/sniproxy/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, autoreconfHook, gettext, libev, pcre, pkgconfig, udns }:
+
+stdenv.mkDerivation rec {
+  name = "sniproxy-${version}";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "dlundquist";
+    repo = "sniproxy";
+    rev = version;
+    sha256 = "1r6hv55k2z8l5q57l2q2x3nsspc2yjvi56l760yrz2c1hgh6r0a2";
+  };
+
+  buildInputs = [ autoconf automake autoreconfHook gettext libev pcre pkgconfig udns ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Transparent TLS and HTTP layer 4 proxy with SNI support";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.womfoo ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/development/libraries/udns/default.nix
+++ b/pkgs/development/libraries/udns/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl }:
+
+# this expression is mostly based on debian's packaging
+# https://tracker.debian.org/media/packages/u/udns/rules-0.4-1
+
+stdenv.mkDerivation rec {
+  name = "udns-${version}";
+  version = "0.4";
+
+  configurePhase = "./configure --enable-ipv6";
+
+  buildPhase = "make staticlib sharedlib rblcheck_s dnsget_s";
+
+  src = fetchurl {
+    url = "http://www.corpit.ru/mjt/udns/${name}.tar.gz";
+    sha256 = "0447fv1hmb44nnchdn6p5pd9b44x8p5jn0ahw6crwbqsg7f0hl8i";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/include
+    mkdir -p $out/lib
+    mkdir -p $out/share/man/man1
+    mkdir -p $out/share/man/man3
+    cp dnsget_s $out/bin/dnsget
+    cp rblcheck_s $out/bin/rblcheck
+    cp udns.h $out/include/
+    cp libudns.a $out/lib/
+    cp libudns.so.0 $out/lib/
+    ln -rs $out/lib/libudns.so.0 $out/lib/libudns.so
+    cp dnsget.1 rblcheck.1 $out/share/man/man1
+    cp udns.3 $out/share/man/man3
+  '';
+
+  # keep man3
+  outputDocdev = "out";
+
+  meta = with stdenv.lib; {
+    homepage = http://www.corpit.ru/mjt/udns.html;
+    description = "Async-capable DNS stub resolver library";
+    license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.womfoo ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13843,6 +13843,8 @@ in
 
   slrn = callPackage ../applications/networking/newsreaders/slrn { };
 
+  sniproxy = callPackage ../applications/networking/sniproxy { };
+
   sooperlooper = callPackage ../applications/audio/sooperlooper { };
 
   sorcer = callPackage ../applications/audio/sorcer { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8998,6 +8998,8 @@ in
 
   tremor = callPackage ../development/libraries/tremor { };
 
+  udns = callPackage ../development/libraries/udns { };
+
   uid_wrapper = callPackage ../development/libraries/uid_wrapper { };
 
   unibilium = callPackage ../development/libraries/unibilium { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
