### PR TITLE
ccacheStdenv: inherit lib output from wrapped gcc

### DIFF
--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -20,9 +20,14 @@ let ccache = stdenv.mkDerivation rec {
   passthru = {
     # A derivation that provides gcc and g++ commands, but that
     # will end up calling ccache for the given cacheDir
-    links = extraConfig: (runCommand "ccache-links"
-      { passthru.gcc = gcc; passthru.isGNU = true; }
-      ''
+    links = extraConfig: stdenv.mkDerivation rec {
+      name = "ccache-links";
+      passthru = {
+        inherit gcc;
+        isGNU = true;
+      };
+      inherit (gcc.cc) lib;
+      buildCommand = ''
         mkdir -p $out/bin
         if [ -x "${gcc.cc}/bin/gcc" ]; then
           cat > $out/bin/gcc << EOF
@@ -48,7 +53,8 @@ let ccache = stdenv.mkDerivation rec {
         for file in $(ls ${gcc.cc} | grep -vw bin); do
           ln -s ${gcc.cc}/$file $out/$file
         done
-      '');
+      '';
+    };
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Fixes #15092; I'm able to succesfully evaluate the `rustUnstable` derivation now (although it fails building while running the tests, but that's another matter).

Huge shoutout to nix-repl for making it possible to cut through all of the stdenv.cc.cc etc. nesting and quickly find where I needed to make a change without learning how all the layers of the stdenv (and ccache) wrapping infrastructure works.
