### PR TITLE
nixos: ensure TERMINFO is set before user shells are run

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -150,6 +150,10 @@ in
 
     system.build.binsh = pkgs.bashInteractive;
 
+    # Ensure TERMINFO is set appropriately *before* user shells are run,
+    # as they may depend on it
+    environment.sessionVariables.TERMINFO = "/run/current-system/sw/share/terminfo";
+
     # Set session variables in the shell as well. This is usually
     # unnecessary, but it allows changes to session variables to take
     # effect without restarting the session (e.g. by opening a new


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md) (wasn't sure if there was a more specific service name appropriate here)

---

The specific motivation for implementing this: I'm currently using `rxvt_unicode-with-plugins` as my terminal, and `fish` as my shell. This works fine when starting a local `urxvt` instance, but only because `urxvt` explicitly sets `$TERMINFO` to the copy it compiled. 

However, if you attempt to `ssh` to a server, `fish` will fail to find the `rxvt-unicode-256color` terminfo file, because it uses `ncurses`, which defaults `$TERMINFO`  to `${pkgs.ncurses}/share/terminfo`, essentially. You can't solve this by setting `$TERMINFO` inside the shell, obviously, because it initializes `ncurses` long before it processes profile scripts.

Modifying the PAM environment appears to be the only sane way of affecting the pre-shell environment, which is what is required to solve this problem.
