### PR TITLE
squid: 3.5.17 -> 3.5.19

### DIFF
--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -1,10 +1,10 @@
 { fetchurl, stdenv, perl, lib, openldap, pam, db, cyrus_sasl, libcap,
 expat, libxml2, libtool, openssl}:
 stdenv.mkDerivation rec {
-  name = "squid-3.5.17";
+  name = "squid-3.5.19";
   src = fetchurl {
     url = "http://www.squid-cache.org/Versions/v3/3.5/${name}.tar.bz2";
-    sha256 = "1kdq778cm18ak4624gchmbi8avnzyvwgyzjplkd0fkcrgfs44bsf";
+    sha256 = "1iy2r7r12xv0q9414rczbqbbggyyxgdmg21bynpygwkgalaz1dxx";
   };
   buildInputs = [perl openldap pam db cyrus_sasl libcap expat libxml2
     libtool openssl];


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Just a minor update. 
