### PR TITLE
bluejeans: 2.125.24.5 -> 2.155.17.5

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
@@ -17,11 +17,11 @@ in
 stdenv.mkDerivation rec {
   name = "bluejeans-${version}";
 
-  version = "2.125.24.5";
+  version = "2.155.17.5";
 
   src = fetchurl {
     url = "https://swdl.bluejeans.com/skinny/bjnplugin_${version}-1_amd64.deb";
-    sha256 = "0lxxd7icfqcpg5rb4njkk4ybxmisv4c509yisznxspi49qfxirwq";
+    sha256 = "1vszk0nrnpji4lm2pndq11kfcrcq1xccjbif9nkm15s3hcb1b66m";
   };
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
