### PR TITLE
nixos: reintroduce sshd uid (fixes #10088)

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -205,6 +205,7 @@
       ntp = 179;
       zabbix = 180;
       redis = 181;
+      sshd = 182;
       unifi = 183;
       uptimed = 184;
       zope2 = 185;
@@ -448,6 +449,7 @@
       #ntp = 179; # unused
       #zabbix = 180; # unused
       #redis = 181; # unused
+      #sshd = 182; # unused
       #unifi = 183; # unused
       #uptimed = 184; # unused
       #zope2 = 185; # unused

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -230,6 +230,7 @@ in
     users.extraUsers.sshd =
       { isSystemUser = true;
         description = "SSH privilege separation user";
+        uid = config.ids.uids.sshd;
       };
 
     services.openssh.moduliFile = mkDefault "${cfgc.package}/etc/ssh/moduli";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
