### PR TITLE
cacert: remove dependency on LWP

### DIFF
--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, nss, curl, perl, perlPackages }:
+{ stdenv, nss, curl, perl }:
 
 stdenv.mkDerivation rec {
   name = "nss-cacert-${nss.version}";
@@ -7,9 +7,16 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     unpackFile ${curl.src};
+
+    # Remove dependency on LWP, curl is enough. Also, since curl here
+    # is working on a local file it will not actually get a 200 OK, so
+    # remove that expectation.
+    substituteInPlace curl-*/lib/mk-ca-bundle.pl \
+      --replace 'use LWP::UserAgent;' "" \
+      --replace ' && $out[0] == 200' ""
   '';
 
-  nativeBuildInputs = [ perl perlPackages.LWP ];
+  nativeBuildInputs = [ curl perl ];
 
   buildPhase = ''
     perl curl-*/lib/mk-ca-bundle.pl -d "file://$(pwd)/nss/lib/ckfw/builtins/certdata.txt" ca-bundle.crt


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The `mk-ca-bundle.pl` script manages quite well using only curl but fails without LWP being present due to a `use` statement. This removes the Perl import of the LWP library and adds curl as a build input. This should reduce large rebuilds of unrelated packages when things like, for example, `perlPackages.HTTPDate` are touched.

I have not done a full nox-review wip on this but I have verified that it produces the same `ca-bundle.crt` file as before the change.

CC maintainer @wkennington 
