### PR TITLE
rrdtool: darwin compatibility

### DIFF
--- a/pkgs/tools/misc/rrdtool/default.nix
+++ b/pkgs/tools/misc/rrdtool/default.nix
@@ -1,4 +1,5 @@
-{ fetchurl, stdenv, gettext, perl, pkgconfig, libxml2, pango, cairo, groff }:
+{ fetchurl, stdenv, gettext, perl, pkgconfig, libxml2, pango, cairo, groff
+, tcl-8_5 }:
 
 stdenv.mkDerivation rec {
   name = "rrdtool-1.5.5";
@@ -6,7 +7,8 @@ stdenv.mkDerivation rec {
     url = "http://oss.oetiker.ch/rrdtool/pub/${name}.tar.gz";
     sha256 = "1xm6ikzx8iaa6r7v292k8s7srkzhnifamp1szkimgmh5ki26sa1s";
   };
-  buildInputs = [ gettext perl pkgconfig libxml2 pango cairo groff ];
+  buildInputs = [ gettext perl pkgconfig libxml2 pango cairo groff ]
+    ++ stdenv.lib.optional stdenv.isDarwin tcl-8_5;
   
   postInstall = ''
     # for munin and rrdtool support
@@ -18,7 +20,7 @@ stdenv.mkDerivation rec {
     homepage = http://oss.oetiker.ch/rrdtool/;
     description = "High performance logging in Round Robin Databases";
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ pSub ];
   };
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I needed Tcl-8.5 to build on darwin. Not sure where it comes from on
Linux.
