### PR TITLE
ntopng: prefer nixpkgs over in-tree deps

### DIFF
--- a/pkgs/tools/networking/ntopng/default.nix
+++ b/pkgs/tools/networking/ntopng/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, libpcap,/* gnutls, libgcrypt,*/ libxml2, glib
 , geoip, geolite-legacy, sqlite, which, autoreconfHook, git
-, pkgconfig, groff, curl, json_c
+, pkgconfig, groff, curl, json_c, luajit, zeromq, rrdtool
 }:
 
 # ntopng includes LuaJIT, mongoose, rrdtool and zeromq in its third-party/
-# directory.
+# directory, but we use luajit, zeromq, and rrdtool from nixpkgs
 
 stdenv.mkDerivation rec {
   name = "ntopng-2.0";
@@ -23,7 +23,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ libpcap/* gnutls libgcrypt*/ libxml2 glib geoip geolite-legacy
-    sqlite which autoreconfHook git pkgconfig groff curl json_c ];
+    sqlite which autoreconfHook git pkgconfig groff curl json_c luajit zeromq
+    rrdtool ];
 
 
   autoreconfPhase = ''
@@ -48,13 +49,15 @@ stdenv.mkDerivation rec {
 
     rm -rf httpdocs/geoip
     ln -s ${geolite-legacy}/share/GeoIP httpdocs/geoip
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    sed 's|LIBS += -lstdc++.6||' -i Makefile
   '';
 
   meta = with stdenv.lib; {
     description = "High-speed web-based traffic analysis and flow collection tool";
     homepage = http://www.ntop.org/products/ntop/;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've also added darwin compatibility. Using the third-party sources that come with `ntopng` is problematic as they do not build as-is on darwin. It seems better to use the `nixpkgs` versions in any case, so I hope nobody objects.
