### PR TITLE
Allow plugins to work for Finch (CLI Pidgin)

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks/default.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = "cd steam-mobile";
   postInstall = ''
-    mkdir -p $out/lib/pidgin/
+    mkdir -p $out/lib/purple-2
     mkdir -p $out/share/pixmaps/pidgin/protocols/
-    cp libsteam.so $out/lib/pidgin/
+    cp libsteam.so $out/lib/purple-2/
     unzip releases/icons.zip -d $out/share/pixmaps/pidgin/protocols/
   '';
 

--- a/pkgs/applications/networking/instant-messengers/pidgin/wrapper.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/wrapper.nix
@@ -13,5 +13,8 @@ in symlinkJoin {
     wrapProgram $out/bin/pidgin \
       --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${pidgin.majorVersion} $out/lib/pidgin" \
       ${toString extraArgs}
+    wrapProgram $out/bin/finch \
+      --suffix-each PURPLE_PLUGIN_PATH ':' "$out/lib/purple-${pidgin.majorVersion}" \
+      ${toString extraArgs}
   '';
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

First commit wraps the `finch` binary the same way the `pidgin` one is so it can find the libpurple plugin directory, allowing it to use libpurple plugins. 

Second commit changes pidgin-opensteamworks to output its plugin to the general libpurple directory instead of the pidgin one, as pidgin-opensteamworks is actually a general libpurple plugin.
