### PR TITLE
libass: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/libass/default.nix
+++ b/pkgs/development/libraries/libass/default.nix
@@ -5,6 +5,7 @@
 , harfbuzzSupport ? true, harfbuzz ? null # harfbuzz support
 , rasterizerSupport ? false # Internal rasterizer
 , largeTilesSupport ? false # Use larger tiles in the rasterizer
+, libiconv
 }:
 
 assert encaSupport -> enca != null;
@@ -38,7 +39,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ freetype fribidi ]
     ++ optional encaSupport enca
     ++ optional fontconfigSupport fontconfig
-    ++ optional harfbuzzSupport harfbuzz;
+    ++ optional harfbuzzSupport harfbuzz
+    ++ optional stdenv.isDarwin libiconv;
 
   meta = {
     description = "Portable ASS/SSA subtitle renderer";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Need to supply `libiconv`.
