### PR TITLE
subsonic: 5.3 -> 6.0

### DIFF
--- a/pkgs/servers/misc/subsonic/default.nix
+++ b/pkgs/servers/misc/subsonic/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, jre }:
 
-let version = "5.3"; in
+let version = "6.0"; in
 
 stdenv.mkDerivation rec {
   name = "subsonic-${version}";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/subsonic/subsonic-${version}-standalone.tar.gz";
-    sha256 = "11ylg89r9dbxyas7jcyij6fpm84dixskdkahb3hdi4ig0wqwswfw";
+    sha256 = "0aw7lz7bkhqvjj3lkk68n2aqr5l84s91cgifg2379w2j7dgd056z";
   };
 
   inherit jre;


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
  - nix.useSandbox doesn't seem to exist.
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
