### PR TITLE
teamspeak-server package & module maintenance

### DIFF
--- a/nixos/modules/services/networking/teamspeak3.nix
+++ b/nixos/modules/services/networking/teamspeak3.nix
@@ -10,13 +10,12 @@ let
 in
 
 {
-  
+
   ###### interface
 
   options = {
 
     services.teamspeak3 = {
-
       enable = mkOption {
         type = types.bool;
         default = false;
@@ -96,34 +95,32 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
-
-    users.extraUsers.teamspeak =
-      { name = "teamspeak";
+  config = mkMerge [
+    (mkIf cfg.enable {
+      users.users.teamspeak = {
         description = "Teamspeak3 voice communication server daemon";
         group = group;
         uid = config.ids.uids.teamspeak;
+        home = cfg.dataDir;
+        createHome = true;
       };
 
-    users.extraGroups.teamspeak =
-      { name = "teamspeak";
+      users.groups.teamspeak = {
         gid = config.ids.gids.teamspeak;
       };
 
-    systemd.services.teamspeak3-server = { 
-      description = "Teamspeak3 voice communication server daemon";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
+      systemd.services.teamspeak3-server = {
+        description = "Teamspeak3 voice communication server daemon";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        mkdir -p ${cfg.dataDir}
-        mkdir -p ${cfg.logPath}
-        chown ${user}:${group} ${cfg.dataDir}
-        chown ${user}:${group} ${cfg.logPath}
-      '';
+        preStart = ''
+          mkdir -p ${cfg.logPath}
+          chown ${user}:${group} ${cfg.logPath}
+        '';
 
-      serviceConfig =
-        { ExecStart = ''
+        serviceConfig = {
+          ExecStart = ''
             ${ts3}/bin/ts3server \
               dbsqlpath=${ts3}/lib/teamspeak/sql/ logpath=${cfg.logPath} \
               voice_ip=${cfg.voiceIP} default_voice_port=${toString cfg.defaultVoicePort} \
@@ -133,10 +130,12 @@ in
           WorkingDirectory = cfg.dataDir;
           User = user;
           Group = group;
-          PermissionsStartOnly = true; # preStart needs to run with root permissions
+          PermissionsStartOnly = true;
         };
       };
-
-  };
-
+    })
+    {
+      meta.maintainers = with lib.maintainers; [ arobyn ];
+    }
+  ];
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- First commit updates the `teamspeak-server` package and makes the `tsdnsserver` binary available in its output. I might later submit a NixOS module for TSDNS, as it looks like I'd have to use it to avoid a long-standing race condition in the client's DNS SRV resolution algorithm.
- Second commit is some housekeeping on the NixOS module, should be essentially transparent to any users.
