### PR TITLE
Install jekyll-paginate along with jekyll.

### DIFF
--- a/pkgs/applications/misc/jekyll/Gemfile
+++ b/pkgs/applications/misc/jekyll/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 gem 'jekyll'
+gem 'jekyll-paginate'
 gem 'rdiscount'
 gem 'RedCloth'

--- a/pkgs/applications/misc/jekyll/Gemfile.lock
+++ b/pkgs/applications/misc/jekyll/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
       sass (~> 3.4)
     jekyll-watch (1.3.0)
       listen (~> 3.0)
+    jekyll-paginate (1.1.0)
     kramdown (1.9.0)
     liquid (3.0.6)
     listen (3.0.5)

--- a/pkgs/applications/misc/jekyll/gemset.nix
+++ b/pkgs/applications/misc/jekyll/gemset.nix
@@ -30,6 +30,7 @@
       "colorator"
       "jekyll-sass-converter"
       "jekyll-watch"
+      "jekyll-paginate"
       "kramdown"
       "liquid"
       "mercenary"
@@ -56,6 +57,13 @@
     dependencies = [
       "listen"
     ];
+  };
+  "jekyll-paginate" = {
+    version = "1.1.0";
+    source = {
+      type = "gem";
+      sha256 = "0r7bcs8fq98zldih4787zk5i9w24nz5wa26m84ssja95n3sas2l8";
+    };
   };
   "kramdown" = {
     version = "1.9.0";


### PR DESCRIPTION
A lof of Jekyll users will need jekyll-paginate, so add it to the dependencies.
