### PR TITLE
setup-hooks: do not pass missing dirs to find

### DIFF
--- a/pkgs/build-support/setup-hooks/separate-debug-info.sh
+++ b/pkgs/build-support/setup-hooks/separate-debug-info.sh
@@ -6,6 +6,8 @@ dontStrip=1
 fixupOutputHooks+=(_separateDebugInfo)
 
 _separateDebugInfo() {
+    [ -e "$prefix" ] || return 0
+
     local dst="${debug:-$out}"
     if [ "$prefix" = "$dst" ]; then return; fi
 

--- a/pkgs/development/tools/misc/patchelf/setup-hook.sh
+++ b/pkgs/development/tools/misc/patchelf/setup-hook.sh
@@ -6,6 +6,8 @@ fixupOutputHooks+=('if [ -z "$dontPatchELF" ]; then patchELF "$prefix"; fi')
 
 patchELF() {
     local dir="$1"
+    [ -e "$dir" ] || return 0
+
     header "shrinking RPATHs of ELF executables and libraries in $dir"
 
     local i


### PR DESCRIPTION
`find` fails when called with an inexistent search path.
That situation may arise when the output is created after by a postFixup hook.

I discovered the bug while building the nss package for #15339. 
In that case, the "tools" output is only creted in the postFixup hook by the `moveToOutput bin "$tools"` [here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/nss/default.nix#L82).

More generally, the multiple output features increases the risk to encounter empty or missing prefixes during the build.

The issue was introduced by a refactoring in d71a4851e8a2ef52f6d806d65822290cdbae8804.
This PR fixes my comment on that commit. ([here](https://github.com/NixOS/nixpkgs/commit/d71a4851e8a2ef52f6d806d65822290cdbae8804#commitcomment-17408979))
