### PR TITLE
owncloud-client: Fix "libocsync.so.0 not found" error

### DIFF
--- a/pkgs/applications/networking/owncloud-client/default.nix
+++ b/pkgs/applications/networking/owncloud-client/default.nix
@@ -13,14 +13,9 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ cmake qt4 pkgconfig qtkeychain sqlite];
 
-  #configurePhase = ''
-  #  mkdir build
-  #  cd build
-  #  cmake -DBUILD_WITH_QT4=on \
-  #        -DCMAKE_INSTALL_PREFIX=$out \
-  #        -DCMAKE_BUILD_TYPE=Release \
-  #        ..
-  #'';
+  cmakeFlags = [
+  "-UCMAKE_INSTALL_LIBDIR"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Things done
- [x] Tested using my `config.nix`:

``` nix
    myowncloudclient = pkgs.stdenv.lib.overrideDerivation pkgs.owncloudclient (oldAttrs: {
      name = "owncloud-client-2.1.1";

      configurePhase = ''
      mkdir build
      cd build
      cmake -DBUILD_WITH_QT4=on \
      -DCMAKE_INSTALL_PREFIX=$out \
      -DCMAKE_BUILD_TYPE=Release \
      ..
      '';
    });
```
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Close #15130
