### PR TITLE
flashplayer: 11.2.202.616 -> 11.2.202.621

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
@@ -70,11 +70,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "11.2.202.616";
+  version = "11.2.202.621";
 
   src = fetchurl {
     url = "https://fpdownload.macromedia.com/pub/flashplayer/installers/archive/fp_${version}_archive.zip";
-    sha256 = "0y4bjkla6ils4crmx61pi31s4gscy8rgiv7xccx1z0g6hba9j73l";
+    sha256 = "0xv7pzna4pfmi9bjwfbr0kf92xvdgpirm97kks4kphwngf3bzrm0";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
[CRITICAL SECURITY FIX]
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Critical security fix.

https://helpx.adobe.com/security/products/flash-player/apsa16-02.html
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4117
