### PR TITLE
graylog: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.0.0";
+  version = "2.0.1";
   name = "graylog-${version}";
 
   src = fetchurl {
     url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
-    sha256 = "0qn2rf2aarfr34387fiv34rmav20c66b4zs9bkm8gpvj0laxrqh2";
+    sha256 = "0i9nng361qnnws7jnk5m91nj5ifg4h78yayahsfjn37665rsrdga";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Minor update: http://docs.graylog.org/en/2.0/pages/changelog.html#graylog-2-0-1
