### PR TITLE
emacs: hide wrapper dependencies

### DIFF
--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -32,7 +32,7 @@ in customEmacsPackages.emacsWithPackages (epkgs: [ epkgs.evil epkgs.magit ])
 
 */
 
-{ lib, lndir, makeWrapper, stdenv }: self:
+{ lib, lndir, makeWrapper, runCommand, stdenv }: self:
 
 with lib; let inherit (self) emacs; in
 
@@ -49,67 +49,69 @@ stdenv.mkDerivation {
   name = (appendToName "with-packages" emacs).name;
   nativeBuildInputs = [ emacs lndir makeWrapper ];
   inherit emacs explicitRequires;
-  phases = [ "installPhase" ];
-  installPhase = ''
-    readonly SHARE="share/emacs-with-packages"
 
-    mkdir -p "$out/bin"
-    mkdir -p "$out/$SHARE/bin"
-    mkdir -p "$out/$SHARE/site-lisp"
+  # Store all paths we want to add to emacs here, so that we only need to add
+  # one path to the load lists
+  deps = runCommand "emacs-packages-deps"
+   { inherit explicitRequires lndir emacs; }
+   ''
+     mkdir -p $out/bin
+     mkdir -p $out/share/emacs/site-lisp
 
-    local requires
-    for pkg in $explicitRequires; do
-      findInputs $pkg requires propagated-user-env-packages
-    done
-    # requires now holds all requested packages and their transitive dependencies
+     local requires
+     for pkg in $explicitRequires; do
+       findInputs $pkg requires propagated-user-env-packages
+     done
+     # requires now holds all requested packages and their transitive dependencies
 
-    siteStart="$out/$SHARE/site-lisp/site-start.el"
+     linkPath() {
+       local pkg=$1
+       local origin_path=$2
+       local dest_path=$3
 
-    # Begin the new site-start.el by loading the original, which sets some
-    # NixOS-specific paths. Paths are searched in the reverse of the order
-    # they are specified in, so user and system profile paths are searched last.
-    cat >"$siteStart" <<EOF
+       # Add the path to the search path list, but only if it exists
+       if [[ -d "$pkg/$origin_path" ]]; then
+         $lndir/bin/lndir -silent "$pkg/$origin_path" "$out/$dest_path"
+       fi
+     }
+
+     linkEmacsPackage() {
+       linkPath "$1" "bin" "bin"
+       linkPath "$1" "share/emacs/site-lisp" "share/emacs/site-lisp"
+     }
+
+     for pkg in $requires; do
+       linkEmacsPackage $pkg
+     done
+
+     siteStart="$out/share/emacs/site-lisp/site-start.el"
+
+     # A dependency may have brought the original siteStart, delete it and
+     # create our own
+     # Begin the new site-start.el by loading the original, which sets some
+     # NixOS-specific paths. Paths are searched in the reverse of the order
+     # they are specified in, so user and system profile paths are searched last.
+     rm -f $siteStart
+     cat >"$siteStart" <<EOF
 (load-file "$emacs/share/emacs/site-lisp/site-start.el")
-(add-to-list 'load-path "$out/$SHARE/site-lisp")
-(add-to-list 'exec-path "$out/$SHARE/bin")
+(add-to-list 'load-path "$out/share/emacs/site-lisp")
+(add-to-list 'exec-path "$out/bin")
 EOF
 
-    linkPath() {
-      local pkg=$1
-      local origin_path=$2
-      local dest_path=$3
+     # Byte-compiling improves start-up time only slightly, but costs nothing.
+     $emacs/bin/emacs --batch -f batch-byte-compile "$siteStart"
+  '';
 
-      # Add the path to the search path list, but only if it exists
-      if [[ -d "$pkg/$origin_path" ]]; then
-        lndir -silent "$pkg/$origin_path" "$out/$dest_path"
-      fi
-    }
-
-    # Add a package's paths to site-start.el
-    linkEmacsPackage() {
-      linkPath "$1" "bin" "$SHARE/bin"
-      linkPath "$1" "share/emacs/site-lisp" "$SHARE/site-lisp"
-    }
-
-    # First, link all the explicitly-required packages.
-    for pkg in $explicitRequires; do
-      linkEmacsPackage $pkg
-    done
-
-    # Next, link all the dependencies.
-    for pkg in $requires; do
-      linkEmacsPackage $pkg
-    done
-
-    # Byte-compiling improves start-up time only slightly, but costs nothing.
-    emacs --batch -f batch-byte-compile "$siteStart"
+  phases = [ "installPhase" ];
+  installPhase = ''
+    mkdir -p "$out/bin"
 
     # Wrap emacs and friends so they find our site-start.el before the original.
     for prog in $emacs/bin/*; do # */
       local progname=$(basename "$prog")
       rm -f "$out/bin/$progname"
       makeWrapper "$prog" "$out/bin/$progname" \
-        --suffix EMACSLOADPATH ":" "$out/$SHARE/site-lisp:"
+        --suffix EMACSLOADPATH ":" "$deps/share/emacs/site-lisp:"
     done
 
     mkdir -p $out/share

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12388,7 +12388,7 @@ in
 
     inherit lib newScope stdenv;
     inherit fetchFromGitHub fetchgit fetchhg fetchurl;
-    inherit emacs texinfo makeWrapper;
+    inherit emacs texinfo makeWrapper runCommand;
     inherit (xorg) lndir;
 
     trivialBuild = callPackage ../build-support/emacs/trivial.nix {

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -34,7 +34,7 @@
 
 { overrides
 
-, lib, newScope, stdenv, fetchurl, fetchgit, fetchFromGitHub, fetchhg
+, lib, newScope, stdenv, fetchurl, fetchgit, fetchFromGitHub, fetchhg, runCommand
 
 , emacs, texinfo, lndir, makeWrapper
 , trivialBuild
@@ -64,7 +64,7 @@ let
   };
 
   emacsWithPackages = import ../build-support/emacs/wrapper.nix {
-    inherit lib lndir makeWrapper stdenv;
+    inherit lib lndir makeWrapper stdenv runCommand;
   };
 
   packagesFun = self: with self; {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Move all the dependencies to their own derivation, so that we don't publish all
of them if the wrapper is installed in a profile.

The previous solution just moved them to a custom directory to avoid conflicts,
this refactors that and completely hides them, while preserving the desired
improvement of adding only one directory to each of the emacs search paths
