### PR TITLE
scorched3d update and SDL1.2 opengl fix

### DIFF
--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, audiofile, libcap
-, openglSupport ? false, mesa_noglu ? null
+, openglSupport ? false, mesa ? null
 , alsaSupport ? true, alsaLib ? null
 , x11Support ? true, xlibsWrapper ? null, libXrandr ? null
 , pulseaudioSupport ? true, libpulseaudio ? null
@@ -10,7 +10,7 @@
 # PulseAudio.
 assert (stdenv.isLinux && !(stdenv ? cross)) -> alsaSupport || pulseaudioSupport;
 
-assert openglSupport -> (mesa_noglu != null && x11Support);
+assert openglSupport -> (mesa != null && x11Support);
 assert x11Support -> (xlibsWrapper != null && libXrandr != null);
 assert alsaSupport -> alsaLib != null;
 assert pulseaudioSupport -> libpulseaudio != null;
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     optionals x11Support [ xlibsWrapper libXrandr ] ++
     optional alsaSupport alsaLib ++
     optional stdenv.isLinux libcap ++
-    optional openglSupport mesa_noglu ++
+    optional openglSupport mesa ++
     optional pulseaudioSupport libpulseaudio ++
     optional stdenv.isDarwin Cocoa;
 

--- a/pkgs/games/scorched3d/default.nix
+++ b/pkgs/games/scorched3d/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ mesa glew openalSoft freealut wxGTK libogg freetype libvorbis
-      SDL SDL_net expat libjpeg libpng
+      SDL SDL_net expat libjpeg libpng fftwSinglePrec
     ];
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@a9a94df reverted because it removes OpenGL (GLX) support (it shows up during configure phase as "checking for OpenGL (GLX) support... yes/no"). I actually think this broke other stuff too, if anyone wants to check open issues.

As for scorched3d itself, it seems it was just missing fftw from the build inputs.

maintainers @lovek323 @abbradar 
