### PR TITLE
nzbget: 16.4 -> 17.0-r1686 and nzbget service

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -266,6 +266,7 @@
       emby = 242;
       graylog = 243;
       sniproxy = 244;
+      nzbget = 245;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -502,6 +503,7 @@
       factorio = 241;
       emby = 242;
       sniproxy = 244;
+      nzbget = 245;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -239,6 +239,7 @@
   ./services/misc/nix-gc.nix
   ./services/misc/nixos-manual.nix
   ./services/misc/nix-ssh-serve.nix
+  ./services/misc/nzbget.nix
   ./services/misc/octoprint.nix
   ./services/misc/parsoid.nix
   ./services/misc/phd.nix

--- a/nixos/modules/services/misc/nzbget.nix
+++ b/nixos/modules/services/misc/nzbget.nix
@@ -1,0 +1,85 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.nzbget;
+  nzbget = pkgs.nzbget;
+in
+{
+  options = {
+    services.nzbget = {
+      enable = mkEnableOption "NZBGet";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.nzbget;
+        defaultText = "pkgs.nzbget";
+        description = "The NZBGet package to use";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "nzbget";
+        description = "User account under which NZBGet runs";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nzbget";
+        description = "Group under which NZBGet runs";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.nzbget = {
+      description = "NZBGet Daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [
+        unrar
+        p7zip
+      ];
+      preStart = ''
+        test -d /var/lib/nzbget || {
+          echo "Creating nzbget state directoy in /var/lib/"
+          mkdir -p /var/lib/nzbget
+        }
+        test -f /var/lib/nzbget/nzbget.conf || {
+          echo "nzbget.conf not found. Copying default config to /var/lib/nzbget/nzbget.conf"
+          cp ${cfg.package}/share/nzbget/nzbget.conf /var/lib/nzbget/nzbget.conf
+          echo "Setting file mode of nzbget.conf to 0700 (needs to be written and contains plaintext credentials)"
+          chmod 0700 /var/lib/nzbget/nzbget.conf
+          echo "Setting temporary \$MAINDIR variable in default config required in order to allow nzbget to complete initial start"
+          echo "Remember to change this to a proper value once NZBGet startup has been completed"
+          sed -i -e 's/MainDir=.*/MainDir=\/tmp/g' /var/lib/nzbget/nzbget.conf
+        }
+        echo "Ensuring proper ownership of /var/lib/nzbget (${cfg.user}:${cfg.group})."
+        chown -R ${cfg.user}:${cfg.group} /var/lib/nzbget
+      '';
+
+      serviceConfig = {
+        Type = "forking";
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = "true";
+        ExecStart = "${cfg.package}/bin/nzbget --daemon --configfile /var/lib/nzbget/nzbget.conf";
+        Restart = "on-failure";
+      };
+    };
+
+    users.extraUsers = mkIf (cfg.user == "nzbget") {
+      nzbget = {
+        group = cfg.group;
+        uid = config.ids.uids.nzbget;
+      };
+    };
+
+    users.extraGroups = mkIf (cfg.group == "nzbget") {
+      nzbget = {
+        gid = config.ids.gids.nzbget;
+      };
+    };
+  };
+}

--- a/pkgs/tools/networking/nzbget/default.nix
+++ b/pkgs/tools/networking/nzbget/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchurl, pkgconfig, libxml2, ncurses, libsigcxx, libpar2
-, gnutls, libgcrypt, zlib }:
+, gnutls, libgcrypt, zlib, openssl }:
 
 stdenv.mkDerivation rec {
   name = "nzbget-${version}";
-  version = "16.4";
+  version = "17.0-r1686";
+  filename = "nzbget-17.0-testing-r1686";
 
   src = fetchurl {
-    url = "http://github.com/nzbget/nzbget/releases/download/v${version}/${name}-src.tar.gz";
-    sha256 = "03sdzxxsjpxp82jpk593xls96yk29989z05j73jah21dbpkkx7lf";
+    url = "http://github.com/nzbget/nzbget/releases/download/v${version}/${filename}-src.tar.gz";
+    sha256 = "0hk0hiccdk3bivdnc2635kqqdwgwf73wvis1wl9k0snds25dwfiw";
   };
 
   buildInputs = [ pkgconfig libxml2 ncurses libsigcxx libpar2 gnutls
-                  libgcrypt zlib ];
+                  libgcrypt zlib openssl ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Things done
- [x] Using this code for >1 week on multiple hosts
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Using 17.0-r1686 testing release as current nzbget 16.4 in nixpkgs is broken. This resolves #15169.
