### PR TITLE
elm: 0.16.0 -> 0.17.0 (#15383), backport 16.03

### DIFF
--- a/pkgs/development/compilers/elm/packages/elm-compiler.nix
+++ b/pkgs/development/compilers/elm/packages/elm-compiler.nix
@@ -7,11 +7,11 @@
 }:
 mkDerivation {
   pname = "elm-compiler";
-  version = "0.16";
+  version = "0.17";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-compiler";
-    sha256 = "b3bcdca469716f3a4195469549a9e9bc53a6030aff132ec620b9c93958a5ffe6";
-    rev = "df86c1c9b3cf06de3ccb78f26b4d2fac0129ce5a";
+    sha256 = "185mh53yyxh9m0z8808fxpds3vqyrbhahf587nnw6qzyzv63m7px";
+    rev = "c9c7e72c424a13255f8ee84c719f7ef48b689c1a";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/packages/elm-make.nix
+++ b/pkgs/development/compilers/elm/packages/elm-make.nix
@@ -1,22 +1,22 @@
 { mkDerivation, aeson, ansi-terminal, ansi-wl-pprint, base, binary
 , blaze-html, blaze-markup, bytestring, containers, directory
 , elm-compiler, elm-package, fetchgit, filepath, mtl
-, optparse-applicative, stdenv, text, time
+, optparse-applicative, stdenv, text, time, raw-strings-qq
 }:
 mkDerivation {
   pname = "elm-make";
-  version = "0.16";
+  version = "0.17";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-make";
-    sha256 = "fc0a6ed08b236dfab43e9af73f8e83a3b88a155695a9671a2b291dc596a75116";
-    rev = "54e0b33fea0cd72400ac6a3dec7643bf1b900741";
+    sha256 = "0y8a67y8jhnhbcqzgjymyf1ffs75vyfpyb8as2bi0mkhb7fvzi6q";
+    rev = "5f7b74567c43eff341048c7caceb247b51cdb8bb";
   };
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [
     aeson ansi-terminal ansi-wl-pprint base binary blaze-html
     blaze-markup bytestring containers directory elm-compiler
-    elm-package filepath mtl optparse-applicative text time
+    elm-package filepath mtl optparse-applicative text time raw-strings-qq
   ];
   jailbreak = true;
   homepage = "http://elm-lang.org";

--- a/pkgs/development/compilers/elm/packages/elm-package.nix
+++ b/pkgs/development/compilers/elm/packages/elm-package.nix
@@ -6,11 +6,11 @@
 }:
 mkDerivation {
   pname = "elm-package";
-  version = "0.16";
+  version = "0.17";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-package";
-    sha256 = "836789a823ab1d97a37907396856d8808c5573e295315c0a55e5bb44915fba4b";
-    rev = "6305a7954a45d1635d6a7185f2dcf136c376074f";
+    sha256 = "1x9jczby38ax3rbjq6hbyr593dhxazm39gy9jv00k6508dzvfg2l";
+    rev = "fc0924210fe5a7c0af543769b1353dbb2ddf2f0c";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/packages/elm-reactor-elm.nix
+++ b/pkgs/development/compilers/elm/packages/elm-reactor-elm.nix
@@ -1,18 +1,22 @@
 {
-  "evancz/virtual-dom" = {
-    version = "2.1.0";
-    sha256 = "0x072vk2x9md5pxwc3f3v7gm738wr996d54avzzadfvj3qcjxpfs";
+  "elm-lang/virtual-dom" = {
+    version = "1.0.0";
+    sha256 = "0pa8k04g9yfixahsb30j0rbhfh6hwdh7xmm2fvk0hkidw7b4xg57";
   };
   "evancz/elm-markdown" = {
-    version = "2.0.0";
-    sha256 = "1x1kvwag7idxif4gsznnx0lp1c49dl9pin3aj0dq21lzradggn3g";
+    version = "3.0.0";
+    sha256 = "1wlr8sgnyq6qgh5rcjy7imfmpqxrxgmmqcfx6p541fs70yiqya12";
   };
-  "evancz/elm-html" = {
-    version = "4.0.2";
-    sha256 = "05hzsnsqp2krd9s4xjwhmvyafpky4dc40bbk9sgsr301450cfgw6";
+  "elm-lang/html" = {
+    version = "1.0.0";
+    sha256 = "16cr01yxkpkmgbgclp2p80nd62a6fjw3qipzjsgksrhwv9vv4gm4";
   };
   "elm-lang/core" = {
-    version = "3.0.0";
-    sha256 = "18pdsnz05pjhdv575l3bqzrjd7780zgpcklg4c6lvwwcanpg42pk";
+    version = "4.0.0";
+    sha256 = "04qgzgv90qyhjk55yw4szy50h2dqdlm0a2padbgn02yf4bb1b4nw";
+  };
+  "elm-lang/svg" = {
+    version = "1.0.0";
+    sha256 = "0c29y6c58x2sq1bl29z1hr5gi2rlza8clk7ssgzmsf4xbvcczbjx";
   };
 }

--- a/pkgs/development/compilers/elm/packages/elm-reactor.nix
+++ b/pkgs/development/compilers/elm/packages/elm-reactor.nix
@@ -1,22 +1,22 @@
 { mkDerivation, base, blaze-html, blaze-markup, bytestring, cmdargs
 , directory, elm-compiler, fetchgit, filepath, fsnotify, mtl
 , snap-core, snap-server, stdenv, text, time, transformers
-, websockets, websockets-snap
+, websockets, websockets-snap, elm-package, file-embed
 }:
 mkDerivation {
   pname = "elm-reactor";
-  version = "0.16";
+  version = "0.17";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-reactor";
-    sha256 = "55605b8443dad20c78e297ce35a603cb107b0c1e57bf1c4710faaebc60396de0";
-    rev = "b03166296d11e240fa04cdb748e1f3c4af7afc83";
+    sha256 = "14hb16qwx1f4bfngh87pwjavgz6njbwdxlsy218rw3xydy3s1cn3";
+    rev = "4781ad2fbb6cbcde0d659dec293bbed9c847ba71";
   };
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [
     base blaze-html blaze-markup bytestring cmdargs directory
     elm-compiler filepath fsnotify mtl snap-core snap-server text time
-    transformers websockets websockets-snap
+    transformers websockets websockets-snap elm-package file-embed
   ];
   jailbreak = true;
   homepage = "http://elm-lang.org";

--- a/pkgs/development/compilers/elm/packages/elm-repl.nix
+++ b/pkgs/development/compilers/elm/packages/elm-repl.nix
@@ -5,11 +5,11 @@
 }:
 mkDerivation {
   pname = "elm-repl";
-  version = "0.16";
+  version = "0.17";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-repl";
-    sha256 = "36d50cf1f86815900afd4b75da6e5cd15008b2652e97ffed0f321a28e6442874";
-    rev = "265de7283488964f44f0257a8b4a055ad8af984d";
+    sha256 = "1mxg99w36b8i43kl1nxp7fd86igi5wyj08m9mraiq58vpcgyqnzq";
+    rev = "95b4555cff6b6e2a55a4ea3dab00bfb39dfebf0d";
   };
   isLibrary = false;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/packages/release.nix
+++ b/pkgs/development/compilers/elm/packages/release.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 {
-  version = "0.16.0";
+  version = "0.17.0";
   packages = {
     elm-compiler = callPackage ./elm-compiler.nix { };
     elm-package = callPackage ./elm-package.nix { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Any reason not to backport to 16.03? Just getting started on elm so I have no opinion either way.
