### PR TITLE
fetchurl: better support multiple hash types

### DIFF
--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -87,13 +87,14 @@ in
 
 assert builtins.isList urls;
 assert (urls == []) != (url == "");
-assert sha512 != "" -> builtins.compareVersions "1.11" builtins.nixVersion <= 0;
 
 
 let
 
+  sha512Supported = builtins.compareVersions "1.11" builtins.nixVersion <= 0;
+
   hasHash = showURLs || (outputHash != "" && outputHashAlgo != "")
-    || md5 != "" || sha1 != "" || sha256 != "" || sha512 != "";
+    || md5 != "" || sha1 != "" || sha256 != "" || (sha512Supported && sha512 != "");
   urls_ = if urls != [] then urls else [url];
 
 in
@@ -116,9 +117,9 @@ if (!hasHash) then throw "Specify hash for fetchurl fixed-output derivation: ${s
 
   # New-style output content requirements.
   outputHashAlgo = if outputHashAlgo != "" then outputHashAlgo else
-      if sha512 != "" then "sha512" else if sha256 != "" then "sha256" else if sha1 != "" then "sha1" else "md5";
+      if (sha512Supported && sha512 != "") then "sha512" else if sha256 != "" then "sha256" else if sha1 != "" then "sha1" else "md5";
   outputHash = if outputHash != "" then outputHash else
-      if sha512 != "" then sha512 else if sha256 != "" then sha256 else if sha1 != "" then sha1 else md5;
+      if (sha512Supported && sha512 != "") then sha512 else if sha256 != "" then sha256 else if sha1 != "" then sha1 else md5;
 
   outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
 

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -7,6 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "mirror://kernel/linux/utils/util-linux/v${version}/${name}.tar.xz";
     sha512 = "251zv6lk6b8ip38w2h0w2rpnly38nzh96945mbpssvwjv8fgr5bnhj3207aingyybik79761zngk981wl0rblq5f7l5v655znyi3yd1";
+    sha256 = "1fql204qn3098j34yd358l85ffp7a4kqjf7jf1qk2b4al7i4fn1r";
   };
 
   patches = [


### PR DESCRIPTION
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Instead of requiring that Nix be new enough to handle the sha512 hash
type if it is passed to fetchurl with an assert, instead fallback to
other hash types if Nix is not new enough. This enables passing
multiple hash types (e.g. sha256 and sha512) to fetchurl in a way that
can be evaluated on both new and old Nixes that do/do not support the
newer hash (sha512).

See conversation at https://github.com/NixOS/nixpkgs/pull/15048.

This did not cause any rebuilds for me (with Nix version 1.11.2); I did not test with an older Nix but I will try to do that soon. If this change is accepted, I would like to have future changes require both sha256 and sha512 hashes so they can evaluate on both old and new Nix versions.

cc @vcunat 
