### PR TITLE
racerd: init at 0.1.1

### DIFF
--- a/pkgs/development/tools/rust/racerd/default.nix
+++ b/pkgs/development/tools/rust/racerd/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchgit, rustPlatform, makeWrapper }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "racerd-${version}";
+  version = "0.1.1";
+  src = fetchgit {
+    url = "git://github.com/jwilm/racerd.git";
+    rev = "dcbb7885e84eb5e2fbb2072e185701ad1abbd93a";
+    sha256 = "18c6a1x0li5yxif9qqnsnyas6if0m6srbqh0h0nywgx0lm8bpgly";
+  };
+
+  doCheck = false;
+
+  depsSha256 = "0ca0lc8mm8kczll5m03n5fwsr0540c2xbfi4nn9ksn0s4sap50yn";
+
+  buildInputs = [ makeWrapper ];
+
+  RUST_SRC_PATH = ''${rustc.src}/src'';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -p target/release/racerd $out/bin/
+    wrapProgram $out/bin/racerd --set RUST_SRC_PATH "$RUST_SRC_PATH"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "JSON/HTTP Server based on racer for adding Rust support to editors and IDEs";
+    homepage = "https://github.com/jwilm/racerd";
+    license = licenses.asl20;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1,7 +1,7 @@
 # TODO check that no license information gets lost
 { fetchurl, bash, stdenv, python, go, cmake, vim, vimUtils, perl, ruby, unzip
 , which, fetchgit, fetchFromGitHub, fetchhg, fetchzip, llvmPackages_38, zip
-, vim_configurable, vimPlugins, xkb_switch, git
+, vim_configurable, vimPlugins, xkb_switch, git, racerdRust
 , Cocoa ? null
 }:
 
@@ -952,6 +952,10 @@ rec {
       (if stdenv.isDarwin then llvmPackages_38.clang else llvmPackages_38.clang-unwrapped)
       llvmPackages_38.llvm
     ] ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
+
+    propogatedBuildInputs = [
+      racerdRust
+    ];
 
     buildPhase = ''
       patchShebangs .

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/youcompleteme
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/youcompleteme
@@ -4,6 +4,10 @@
       llvmPackages.llvm
     ] ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
 
+    propogatedBuildInputs = [
+      racerdRust
+    ];
+
     buildPhase = ''
       patchShebangs .
       substituteInPlace plugin/youcompleteme.vim \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6309,6 +6309,8 @@ in
 
   racerRust = callPackage ../development/tools/rust/racer { };
 
+  racerdRust = callPackage ../development/tools/rust/racerd { };
+
   radare = callPackage ../development/tools/analysis/radare {
     inherit (gnome) vte;
     lua = lua5;


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Needed for YouCompleteMe Rust support. See #12330 

You also have to tell YouCompleteMe where rust's source is located if you want standard-lib support. See this snippet from my vimrc:

```
" YouCompleteMe's rust completion needs src path
" TODO: It would be better if YouCompleteMe or racerd did this automatically
let g:ycm_rust_src_path = '${rustPlatform.rustc.src}/src'
```

any advice on how to include this information in the `nix` derivation for this package would be appreciated

cc @jagajaga 
