### PR TITLE
chromium stable: 49.0.2623.110 -> 50.0.2661.102

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -11,8 +11,8 @@
     version = "51.0.2693.2";
   };
   stable = {
-    sha256 = "1lmv6nmbqhxmr4340s5i4ypgz2b7vkh0wy5x9v75b5bnscjhk121";
-    sha256bin64 = "1djd2i9phym1d8afv4vfajb7l1bz0ny2wmihwi6jaz712vil4a13";
-    version = "49.0.2623.110";
+    sha256 = "1ijpbmn38znjjb3h8579x5gsclgjx122lvm0afv17gf2j3w5w4qj";
+    sha256bin64 = "17vqvxmy6llg7dpc3pxi0qhwpm9qc9rsq8lgknhwwygvkl8g14sb";
+    version = "50.0.2661.102";
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This addresses the following security fixes:
- High   CVE-2016-1667: Same origin bypass in DOM. Credit to
                       Mariusz Mlynski.
- High   CVE-2016-1668: Same origin bypass in Blink V8 bindings. Credit
                       to Mariusz Mlynski.
- High   CVE-2016-1669: Buffer overflow in V8. Credit to Choongwoo Han.
- Medium CVE-2016-1670: Race condition in loader. Credit to anonymous.
- Medium CVE-2016-1671: Directory traversal using the file scheme on
                       Android. Credit to Jann Horn.

See: http://googlechromereleases.blogspot.com/2016/05/stable-channel-update.html
