### PR TITLE
blackbird: init at 2016-04-10

### DIFF
--- a/pkgs/misc/themes/blackbird/default.nix
+++ b/pkgs/misc/themes/blackbird/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "Blackbird";
+  version = "2016-04-10";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    repo = "${pname}";
+    owner = "shimmerproject";
+    rev = "e9f780993c957e3349f97b0e2e6fabdc36ccefb0";
+    sha256 = "00fdd63lnb2gmsn6cbdkanvh3rvz48jg08gmzg372byhj70m63hi";
+  };
+
+  buildInputs = [ gtk-engine-murrine ];
+  
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/themes/${pname}
+    cp -a * $out/share/themes/${pname}/
+  '';
+
+  meta = {
+    description = "Dark Desktop Suite for Gtk, Xfce and Metacity";
+    homepage = http://github.com/shimmerproject/Blackbird;
+    license = with stdenv.lib.licenses; [ gpl2Plus cc-by-nc-sa-30 ];
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16257,6 +16257,8 @@ in
 
   beep = callPackage ../misc/beep { };
 
+  blackbird = callPackage ../misc/themes/blackbird { };
+
   brgenml1lpr = callPackage_i686 ../misc/cups/drivers/brgenml1lpr {};
 
   brgenml1cupswrapper = callPackage ../misc/cups/drivers/brgenml1cupswrapper {};


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
