### PR TITLE
KDE: update Plasma and Applications

### DIFF
--- a/pkgs/desktops/kde-5/applications-16.04/fetchsrcs.sh
+++ b/pkgs/desktops/kde-5/applications-16.04/fetchsrcs.sh
@@ -4,7 +4,7 @@
 set -x
 
 # The trailing slash at the end is necessary!
-WGET_ARGS='http://download.kde.org/stable/applications/16.04.0/ -A *.tar.xz'
+WGET_ARGS='http://download.kde.org/stable/applications/16.04.1/ -A *.tar.xz'
 
 mkdir tmp; cd tmp
 

--- a/pkgs/desktops/kde-5/applications-16.04/srcs.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/srcs.nix
@@ -3,2091 +3,2091 @@
 
 {
   akonadi = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/akonadi-16.04.0.tar.xz";
-      sha256 = "01m032iwy3yylxxfmznhn0aly20yc07h8z0ppzgx9gz8smn8351k";
-      name = "akonadi-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/akonadi-16.04.1.tar.xz";
+      sha256 = "1ik65izkcphc2wvb7hf8qw38fdfxd015hba8kv5ksmyydd01c6qf";
+      name = "akonadi-16.04.1.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/akonadi-calendar-16.04.0.tar.xz";
-      sha256 = "1n06d0m2m553agn95b75sgqaijaaxdrdb6gnv4zizwjxr37cgnwm";
-      name = "akonadi-calendar-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/akonadi-calendar-16.04.1.tar.xz";
+      sha256 = "0v7mhv4sdxnv2kcmkln0dnjw33f9y82h65wigfs7dv017jcy0ija";
+      name = "akonadi-calendar-16.04.1.tar.xz";
     };
   };
   akonadi-search = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/akonadi-search-16.04.0.tar.xz";
-      sha256 = "101cbms0mlv86g8ld027ras5bkzfil9avbpvfh2rnlfpm2yp3jgq";
-      name = "akonadi-search-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/akonadi-search-16.04.1.tar.xz";
+      sha256 = "06gzs0844df0v9x8nmd3ssxg7z2zrdpcfzwjpylis55a93689rxs";
+      name = "akonadi-search-16.04.1.tar.xz";
     };
   };
   analitza = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/analitza-16.04.0.tar.xz";
-      sha256 = "0ir7siwxp6fi9gwri9ynp497ppg72vrbqnwaq3fk3rf9i4brib3s";
-      name = "analitza-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/analitza-16.04.1.tar.xz";
+      sha256 = "01kakqh021qk9irf6jl0kk4lph4w8q7xb8y7jxc09abl1cbx8p0w";
+      name = "analitza-16.04.1.tar.xz";
     };
   };
   ark = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ark-16.04.0.tar.xz";
-      sha256 = "07zvnslnxjz0rq90cvba6lh7gcym4z7817fdz56pjdffpcd0j9xa";
-      name = "ark-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ark-16.04.1.tar.xz";
+      sha256 = "0qlyl37crqw8rg1wpak0xcmnlwx1n0s8mhsd8xm1rsi2lq11sf64";
+      name = "ark-16.04.1.tar.xz";
     };
   };
   artikulate = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/artikulate-16.04.0.tar.xz";
-      sha256 = "00y47nzlqlhrv3xx0g0h9is2v7v2vch9vk0hmjb4sgmmri21r47i";
-      name = "artikulate-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/artikulate-16.04.1.tar.xz";
+      sha256 = "0lpqsf11dw2gcvj51j47cpr3aj9shgnmqgkfd1qsy92d7hp83355";
+      name = "artikulate-16.04.1.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/audiocd-kio-16.04.0.tar.xz";
-      sha256 = "1r1x1igihd4bvvjjf8c5xi341y7jn43ba0jh724x82ljhwjjivnh";
-      name = "audiocd-kio-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/audiocd-kio-16.04.1.tar.xz";
+      sha256 = "0s5hx0yzzz1y3a39ibwsspqgdmcw7921bh2fq8k1xpcy4cdkiavx";
+      name = "audiocd-kio-16.04.1.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/baloo-widgets-16.04.0.tar.xz";
-      sha256 = "0j8l34q0nmprw0y7hcsy5rxisv19zjf757dhy7rwlbvs72a8fyn2";
-      name = "baloo-widgets-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/baloo-widgets-16.04.1.tar.xz";
+      sha256 = "1j5c70xi13c7drc2ndlzkz0nznbxlw0rrlgqpp7yxdprlp2x84g4";
+      name = "baloo-widgets-16.04.1.tar.xz";
     };
   };
   blinken = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/blinken-16.04.0.tar.xz";
-      sha256 = "1fi0vnxc31nd2hk7yx4gbxlmwsxsrw7yidblv3ly6j3q65ra4cgp";
-      name = "blinken-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/blinken-16.04.1.tar.xz";
+      sha256 = "0sj3ih0izm9vgy2k40qh5x9navcg2rhh6sn7nxnwwj9gh16g4q0a";
+      name = "blinken-16.04.1.tar.xz";
     };
   };
   bomber = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/bomber-16.04.0.tar.xz";
-      sha256 = "0rv2mfn8l78zfb0apxpgqfw2zp0zvgrjx5fdqn7mhah6w2wr421i";
-      name = "bomber-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/bomber-16.04.1.tar.xz";
+      sha256 = "04flkvlmmsx8l5r4mcsp36b1b4rfbsw1108k7mcfd98bzx8af6r6";
+      name = "bomber-16.04.1.tar.xz";
     };
   };
   bovo = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/bovo-16.04.0.tar.xz";
-      sha256 = "1z0wkmlvx052drdjkc3scmbqd299vq26l15qdykf7k7i69abpa91";
-      name = "bovo-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/bovo-16.04.1.tar.xz";
+      sha256 = "1wynbs4p20awn5ssik36205xswlvpk17x9wmvpf6yhrpwdsyac1l";
+      name = "bovo-16.04.1.tar.xz";
     };
   };
   calendarsupport = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/calendarsupport-16.04.0.tar.xz";
-      sha256 = "1l4hr59r5ns5lhvr4622i8lm99933j72v6fhjv4hmw1yvy0d97kf";
-      name = "calendarsupport-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/calendarsupport-16.04.1.tar.xz";
+      sha256 = "0djmr6anfwcvxq6sqg4zwvvjcpak6x16m1wnbfbr2d8b8b2hbv2h";
+      name = "calendarsupport-16.04.1.tar.xz";
     };
   };
   cantor = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/cantor-16.04.0.tar.xz";
-      sha256 = "195b974swl1aw9g9l2d4si7zvhb6jahrvkkgjyyzqrkgqj10qjgh";
-      name = "cantor-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/cantor-16.04.1.tar.xz";
+      sha256 = "0296jj14mygx5v0q8byyks87q6gx04w6k2k6gqqfbnalimfrxyh2";
+      name = "cantor-16.04.1.tar.xz";
     };
   };
   cervisia = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/cervisia-16.04.0.tar.xz";
-      sha256 = "049df86n0mj0jcxlwi64cf1ijm5bilgq0dn0b1av3ivb53c2k8c1";
-      name = "cervisia-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/cervisia-16.04.1.tar.xz";
+      sha256 = "1w2qdbdgjmm8gavwg5r9law86s3mayqbwa8y22bika2ffgikb6aw";
+      name = "cervisia-16.04.1.tar.xz";
     };
   };
   dolphin = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/dolphin-16.04.0.tar.xz";
-      sha256 = "1cnvlcn5cgy1paxrcv9x8dnjvnivn86pr93gmscwl83p9dg3ly37";
-      name = "dolphin-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/dolphin-16.04.1.tar.xz";
+      sha256 = "19g053y6icazq58zh450qhnxy60j787qgvfaic389czcvbf0rn9i";
+      name = "dolphin-16.04.1.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/dolphin-plugins-16.04.0.tar.xz";
-      sha256 = "0r58i2w7jiznh190jqvdb7rdgyk3rnwb34hxbid02w042hsf06gp";
-      name = "dolphin-plugins-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/dolphin-plugins-16.04.1.tar.xz";
+      sha256 = "0kbypywyk7v13bnvsdaa6g7ln3q19v3hsymakxm3gylghn6ii0ac";
+      name = "dolphin-plugins-16.04.1.tar.xz";
     };
   };
   dragon = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/dragon-16.04.0.tar.xz";
-      sha256 = "0b81wfpxzx4wnawvkhsj16ijvdajq528m24iswxdss1ya7hcszm2";
-      name = "dragon-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/dragon-16.04.1.tar.xz";
+      sha256 = "063ylb10y1v9ml6lgycn5f1qrdda00147s35b3d3vslw8l1xcwj8";
+      name = "dragon-16.04.1.tar.xz";
     };
   };
   eventviews = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/eventviews-16.04.0.tar.xz";
-      sha256 = "1gyslz02y0i9fcrxg7xxcag7h7qd1g9amn2ry2rygpxcl98bzcz7";
-      name = "eventviews-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/eventviews-16.04.1.tar.xz";
+      sha256 = "1yrlr5xa21vsbl0by706plknzi2mkg9zi9w0702lyvj1y2bm3yw3";
+      name = "eventviews-16.04.1.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ffmpegthumbs-16.04.0.tar.xz";
-      sha256 = "0jjq5gm4avi2lli3r6zd1m4v6nzc4dxd2msm6lr35nkhadamihjj";
-      name = "ffmpegthumbs-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ffmpegthumbs-16.04.1.tar.xz";
+      sha256 = "1694bxkmgzb5qsibl3dcc510xz96gjb8mrzdsmi84gbwhrnhaahw";
+      name = "ffmpegthumbs-16.04.1.tar.xz";
     };
   };
   filelight = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/filelight-16.04.0.tar.xz";
-      sha256 = "07k1fkb5nangzzxl00jkz9jqrlzi8g9dvp1qm8s5vbpfww6gaq4a";
-      name = "filelight-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/filelight-16.04.1.tar.xz";
+      sha256 = "1gvk9y2iy48c63bgq1d38iix70jz429d0fsgqk9k1h6c5lmywf3w";
+      name = "filelight-16.04.1.tar.xz";
     };
   };
   gpgmepp = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/gpgmepp-16.04.0.tar.xz";
-      sha256 = "0k5wawmqmpsjg3q4wcg54xvs0rlkv26398gkvfhvw5kixcd71kys";
-      name = "gpgmepp-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/gpgmepp-16.04.1.tar.xz";
+      sha256 = "09cqnqqwh0lzfcip09pdwa6k0pf4hhl978jiry4dsvjmiymlzhac";
+      name = "gpgmepp-16.04.1.tar.xz";
     };
   };
   granatier = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/granatier-16.04.0.tar.xz";
-      sha256 = "1j5jzhyfp7jy3nzj6y2s8gy4hm1q8z3vwlx7cd7j936vk27r4vw2";
-      name = "granatier-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/granatier-16.04.1.tar.xz";
+      sha256 = "0350v1jkizybicl9qqkjks0sjvnpxc09jzjbz916ya1zakw48m7i";
+      name = "granatier-16.04.1.tar.xz";
     };
   };
   grantleetheme = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/grantleetheme-16.04.0.tar.xz";
-      sha256 = "0dccrqa8nsjjljwi9z9yfx71cr6ds74k8kzkyc2bgw4zdcmw62kg";
-      name = "grantleetheme-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/grantleetheme-16.04.1.tar.xz";
+      sha256 = "1205fzj49yi5nw4k28njn52jxzq12lpgdb9dz5f6g3c0zgzxdfbf";
+      name = "grantleetheme-16.04.1.tar.xz";
     };
   };
   gwenview = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/gwenview-16.04.0.tar.xz";
-      sha256 = "16viz9z4r3mllc4yfw7rirq9hjaxsbfv0vgckrc4mvwbpjhhbl88";
-      name = "gwenview-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/gwenview-16.04.1.tar.xz";
+      sha256 = "1piw2crfhxig5smscz1ch6ifbadma7fylwxa98kp9p0srslmagx7";
+      name = "gwenview-16.04.1.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/incidenceeditor-16.04.0.tar.xz";
-      sha256 = "08fvqpr12295dinarcfrh2m95591h1hiqyllc36asc8pwzisfb9f";
-      name = "incidenceeditor-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/incidenceeditor-16.04.1.tar.xz";
+      sha256 = "16bzxsw09spk75zpgj9q49yvl4302zi78syi0g521gln4jjc730q";
+      name = "incidenceeditor-16.04.1.tar.xz";
     };
   };
   jovie = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/jovie-16.04.0.tar.xz";
-      sha256 = "0xvwgpqzh7h2vl2dpzninz4r93z18giwwij4yffl8740k4fk5id5";
-      name = "jovie-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/jovie-16.04.1.tar.xz";
+      sha256 = "10d5w5z2fgbfr263m6jvq6li7q3fxr03h4s51j2vspniyy8rq6v8";
+      name = "jovie-16.04.1.tar.xz";
     };
   };
   juk = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/juk-16.04.0.tar.xz";
-      sha256 = "0y4bfq6qza84s0nk6fajwg1bmn0kzjnjj2zjglas322fh8vbdz4n";
-      name = "juk-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/juk-16.04.1.tar.xz";
+      sha256 = "1amxykyc97iw5ldflk9h97jnkm6zm1v48il0sm5xknlhiv7qma0v";
+      name = "juk-16.04.1.tar.xz";
     };
   };
   kaccessible = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kaccessible-16.04.0.tar.xz";
-      sha256 = "1glwmqaafvcm6gjvs2m0d2iaglqz3y1mj3g0jqips4sx32zbsgxf";
-      name = "kaccessible-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kaccessible-16.04.1.tar.xz";
+      sha256 = "0l3xrkgmfnd5pfa9jfx65f1iy4ynrx266ga6if24nkk8mp1l6hqk";
+      name = "kaccessible-16.04.1.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kaccounts-integration-16.04.0.tar.xz";
-      sha256 = "0h84nbibzzlxs0vpklij0yczs2c53gqwdx5yvfhnipbi285wy7km";
-      name = "kaccounts-integration-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kaccounts-integration-16.04.1.tar.xz";
+      sha256 = "02is41d5zchqri8v767rzb6bp2apq8z1wwgqs2v4iaylh49fbnrf";
+      name = "kaccounts-integration-16.04.1.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kaccounts-providers-16.04.0.tar.xz";
-      sha256 = "1bmc5kycmw7r84jy7si0dap6lq011lbq050ldhba6ix5dnx0nsws";
-      name = "kaccounts-providers-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kaccounts-providers-16.04.1.tar.xz";
+      sha256 = "1f3r48kzhnrs6af6zql1gcj5vhzs4kcmp5zj97bkh0kp5d9sqrqk";
+      name = "kaccounts-providers-16.04.1.tar.xz";
     };
   };
   kajongg = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kajongg-16.04.0.tar.xz";
-      sha256 = "0fasvm8x3cgw0gv1ac38xp12ncms2nf9b5r8hprjxmb5485p7mh6";
-      name = "kajongg-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kajongg-16.04.1.tar.xz";
+      sha256 = "0sakgaaq99s1rfrrlpi81rpxrcdyhqpigczsxjw79amm368yw2va";
+      name = "kajongg-16.04.1.tar.xz";
     };
   };
   kalarmcal = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kalarmcal-16.04.0.tar.xz";
-      sha256 = "03ylk2kaidqi54zmz84alqhzkiq87kw5a0f7qfj76r8mf7lmnlki";
-      name = "kalarmcal-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kalarmcal-16.04.1.tar.xz";
+      sha256 = "1qg2hdybcss86l92xnzcgc60rdzgg8cp07rk59lrskipj12fzpp5";
+      name = "kalarmcal-16.04.1.tar.xz";
     };
   };
   kalgebra = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kalgebra-16.04.0.tar.xz";
-      sha256 = "0clcgq89wh451dj7nib7pbbppncslnzkn3532hyw347ckisphyvc";
-      name = "kalgebra-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kalgebra-16.04.1.tar.xz";
+      sha256 = "1mbbsi193vwig65xbk4c865xqbs3mxm16x7d8fxdq1j6glwa6l2j";
+      name = "kalgebra-16.04.1.tar.xz";
     };
   };
   kalzium = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kalzium-16.04.0.tar.xz";
-      sha256 = "1cqkgkc5m8fz7l18x0ybh85ldif15mc9gzdak8g2mdjcacxsm9nz";
-      name = "kalzium-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kalzium-16.04.1.tar.xz";
+      sha256 = "1rx57fsyc66gpsvzcig6mymhlxc4nf3cjg8bkmq89avhbpkzhzri";
+      name = "kalzium-16.04.1.tar.xz";
     };
   };
   kamera = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kamera-16.04.0.tar.xz";
-      sha256 = "0n6h7z9dzv2fhwmk41smzv6l1db61334drcgivjmkblmglbdi473";
-      name = "kamera-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kamera-16.04.1.tar.xz";
+      sha256 = "1s6fpzna6pvbqzcvd799r87d92l460b4zws84yik811dfqrcpf3s";
+      name = "kamera-16.04.1.tar.xz";
     };
   };
   kanagram = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kanagram-16.04.0.tar.xz";
-      sha256 = "0g2d7zcb76a01hgbk0aid64xp8qym64a76k3vixwqzjdwf3jbcfr";
-      name = "kanagram-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kanagram-16.04.1.tar.xz";
+      sha256 = "0y80gpdq17cbiwih3gndhb8qyfa84f305hisgslrdqx39nai0fmf";
+      name = "kanagram-16.04.1.tar.xz";
     };
   };
   kapman = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kapman-16.04.0.tar.xz";
-      sha256 = "1arb6jiy1ikn96rsvmd87fj35kxnpdq7s0nxn747psc3wvms43wr";
-      name = "kapman-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kapman-16.04.1.tar.xz";
+      sha256 = "0im0gszmsvxfcjmlcpqxc5ik8kr890b7kd83lnydkm50xxmyk9x0";
+      name = "kapman-16.04.1.tar.xz";
     };
   };
   kapptemplate = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kapptemplate-16.04.0.tar.xz";
-      sha256 = "0bqrhzl0w499m8370idv76yz1f8n5wv418y82abd2f9qip0xk1sc";
-      name = "kapptemplate-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kapptemplate-16.04.1.tar.xz";
+      sha256 = "14jq6q1bsmqp7vz7lwi4h7hqc8zyghl2mbyl1yyhv5hbvr00b2w3";
+      name = "kapptemplate-16.04.1.tar.xz";
     };
   };
   kate = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kate-16.04.0.tar.xz";
-      sha256 = "13v8a4p3fnymgi682kfhfvd2h71xmhb5i1739cbf9baixsggcbnh";
-      name = "kate-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kate-16.04.1.tar.xz";
+      sha256 = "0192dqf22rkr3v5ywxadjx7nmwrih336dxlma3nxprw8ng3ppacm";
+      name = "kate-16.04.1.tar.xz";
     };
   };
   katomic = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/katomic-16.04.0.tar.xz";
-      sha256 = "1g47gxxxy52mdf3lra98fibg93s302vavp0fi73gdy09wvm4nfk1";
-      name = "katomic-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/katomic-16.04.1.tar.xz";
+      sha256 = "1flg9kkrv8z49amiay88010aj76s0x6f14w8701zlinl238jrp08";
+      name = "katomic-16.04.1.tar.xz";
     };
   };
   kblackbox = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kblackbox-16.04.0.tar.xz";
-      sha256 = "0jjyffs1aijvqan9cva6d9cfnskqp4ynvpqkx1rw2mqnvadm59g3";
-      name = "kblackbox-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kblackbox-16.04.1.tar.xz";
+      sha256 = "0a6bdyqla3ip981lpmj81q3wbr6ca2slpwzfs599hadzmrwxmlxw";
+      name = "kblackbox-16.04.1.tar.xz";
     };
   };
   kblocks = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kblocks-16.04.0.tar.xz";
-      sha256 = "1c16s7lq4j6ixq8rvqf5cadag8cabzjgyw9hiwqix9k3csbnh5br";
-      name = "kblocks-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kblocks-16.04.1.tar.xz";
+      sha256 = "00q70ja45g38n3l62iivyi9pzb124cvsiyszsb4b2qcvi3akzabz";
+      name = "kblocks-16.04.1.tar.xz";
     };
   };
   kblog = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kblog-16.04.0.tar.xz";
-      sha256 = "1hhh2f8rj0nfzm1imckhk3iczzda6q1nxnd3v6bp0dnxh14yanwk";
-      name = "kblog-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kblog-16.04.1.tar.xz";
+      sha256 = "0yib39p27xxbsdwazq5jwb2jaqsnf7c456y4js61hm2qh415nlkk";
+      name = "kblog-16.04.1.tar.xz";
     };
   };
   kbounce = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kbounce-16.04.0.tar.xz";
-      sha256 = "0sfrlyqkig089kn1d8fvfhl18hwrc3jygbl9sx0r87wg25w8niv7";
-      name = "kbounce-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kbounce-16.04.1.tar.xz";
+      sha256 = "0h615ijxm7rj1m89aaz8g7ikcysv10mm2w4r1x5qdf7ihq1nxn4a";
+      name = "kbounce-16.04.1.tar.xz";
     };
   };
   kbreakout = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kbreakout-16.04.0.tar.xz";
-      sha256 = "05rbxhifx8nwma1nm0ji28d3jyg6kadgb90ma573xj9i4b97ak74";
-      name = "kbreakout-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kbreakout-16.04.1.tar.xz";
+      sha256 = "18yb93jfy74ybmwd6fp2xca15zgzk0hiqzaan89a0fd02ldd4aw9";
+      name = "kbreakout-16.04.1.tar.xz";
     };
   };
   kbruch = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kbruch-16.04.0.tar.xz";
-      sha256 = "1ncfcdcdvxd992q1brqqfq107x8q2y0235dx7z2hxvclf94npigj";
-      name = "kbruch-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kbruch-16.04.1.tar.xz";
+      sha256 = "03dm0q0wifz0psj51r3dxgg2qrcpvj207mw036kvqzsxgn6fcdx5";
+      name = "kbruch-16.04.1.tar.xz";
     };
   };
   kcachegrind = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kcachegrind-16.04.0.tar.xz";
-      sha256 = "0jks1gc03s2qc6x9klc6x2j8jcx05n13qn0l5qp4sny93mxxyxlv";
-      name = "kcachegrind-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kcachegrind-16.04.1.tar.xz";
+      sha256 = "11f6l8189vnw3brpzgd0vsv3hrra9ha1vdmzfk5haq092rxyw26s";
+      name = "kcachegrind-16.04.1.tar.xz";
     };
   };
   kcalc = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kcalc-16.04.0.tar.xz";
-      sha256 = "15w0856jqh7vrg3a88b1mcqw63gmady3sdl1zish719jg5hjgw9i";
-      name = "kcalc-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kcalc-16.04.1.tar.xz";
+      sha256 = "1wldinbl4fkgw9idvbdr4gcmnsbjfgfakg2mn9axjs98iis1igyx";
+      name = "kcalc-16.04.1.tar.xz";
     };
   };
   kcalcore = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kcalcore-16.04.0.tar.xz";
-      sha256 = "1cnp93sgh13aiycwfw9zayzhk6wcxawa8cnvliyfn05809cjffwq";
-      name = "kcalcore-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kcalcore-16.04.1.tar.xz";
+      sha256 = "0cp2pjfg34zg6s83dl5dkgn4ssdj1295vrzkidkcdxj5br1z767s";
+      name = "kcalcore-16.04.1.tar.xz";
     };
   };
   kcalutils = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kcalutils-16.04.0.tar.xz";
-      sha256 = "0gz83k11idib66n9m02kql6blfv6h39slmqsx6fkbd6vlajz9wn7";
-      name = "kcalutils-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kcalutils-16.04.1.tar.xz";
+      sha256 = "1hlqpklni83b0vg53b8gpsirnn04q8hvk364kgq532czvkf50lyw";
+      name = "kcalutils-16.04.1.tar.xz";
     };
   };
   kcharselect = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kcharselect-16.04.0.tar.xz";
-      sha256 = "07gnsdnxm84whi2syyj2h2n6sq99mhjx53dndcm3y8c1ry4d2qp5";
-      name = "kcharselect-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kcharselect-16.04.1.tar.xz";
+      sha256 = "05wb5is2srwy01v88nxbdvkkqw798wr8s1k8s9mwa7l5jsa97rvp";
+      name = "kcharselect-16.04.1.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kcolorchooser-16.04.0.tar.xz";
-      sha256 = "0l2ahmqzrl1s3vsiwbgb05rsazqcg5zk8h5n2lg00q30glly24x3";
-      name = "kcolorchooser-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kcolorchooser-16.04.1.tar.xz";
+      sha256 = "0d9f8s5lg7j2l6sl4pivl01fmgal42frmx49cp5hhshqfxqc30kv";
+      name = "kcolorchooser-16.04.1.tar.xz";
     };
   };
   kcontacts = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kcontacts-16.04.0.tar.xz";
-      sha256 = "1ysism44p2ql95q0fkypa3w1r0fps720yj539a61g60fvdij2nsn";
-      name = "kcontacts-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kcontacts-16.04.1.tar.xz";
+      sha256 = "007a02dwj71id5n3jmbj11hwqyfcy6zpygqh061s5symaqpswrw6";
+      name = "kcontacts-16.04.1.tar.xz";
     };
   };
   kcron = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kcron-16.04.0.tar.xz";
-      sha256 = "0dkrb4h5fnzh81c1i38j62ik5lqfai0hhyjs3zrh9av6ylzmb9yc";
-      name = "kcron-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kcron-16.04.1.tar.xz";
+      sha256 = "0rfwg5ywgn242jfm85lvqirdxrazc4yw2nhkhvdylph9ngwqc2bn";
+      name = "kcron-16.04.1.tar.xz";
     };
   };
   kde-baseapps = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-baseapps-16.04.0.tar.xz";
-      sha256 = "1py7j2j2nnxih0cyyyv27g6svrga80v4hqsi5gafk843zln5v836";
-      name = "kde-baseapps-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-baseapps-16.04.1.tar.xz";
+      sha256 = "10rfn5kc6kdsp9dw0n191h87p7z60vyfq0cal233x722lmzflsjj";
+      name = "kde-baseapps-16.04.1.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdebugsettings-16.04.0.tar.xz";
-      sha256 = "0madfi735qas20dpfx92jfcl6mcl2sfr0z5wxby5k1p1xc0rmm32";
-      name = "kdebugsettings-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdebugsettings-16.04.1.tar.xz";
+      sha256 = "158p1mnb0mi8ka2nc5bkmz5cw6ki4mh67ry75dxxdgnnnfcqagrc";
+      name = "kdebugsettings-16.04.1.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-dev-scripts-16.04.0.tar.xz";
-      sha256 = "1p4aklykn463f0h6kn0brhm81lli5rl5sh4d5fgaj6r3b5s0l2gf";
-      name = "kde-dev-scripts-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-dev-scripts-16.04.1.tar.xz";
+      sha256 = "10vxiz1h9lcd133sffrdillq9ssn2b49phmx66ll9c7iawsvgs4q";
+      name = "kde-dev-scripts-16.04.1.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-dev-utils-16.04.0.tar.xz";
-      sha256 = "0ldmmww497q2lmlj16jm6k2p89931bgn841rvaj7rb6pclms1l49";
-      name = "kde-dev-utils-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-dev-utils-16.04.1.tar.xz";
+      sha256 = "0ybd7kckxyc5an9kn6r31his87mvgc9cbadwd5jm9fh2v4vy8da3";
+      name = "kde-dev-utils-16.04.1.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdeedu-data-16.04.0.tar.xz";
-      sha256 = "01ps6iqdc685q3xpyjfcjy98hz29max0gl9kfppzq4nzx3hiykj9";
-      name = "kdeedu-data-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdeedu-data-16.04.1.tar.xz";
+      sha256 = "0ns362vz424s4klrk9qllg0qmb41whrhv25xrb27il73nla27cn2";
+      name = "kdeedu-data-16.04.1.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdegraphics-mobipocket-16.04.0.tar.xz";
-      sha256 = "0lzj4xyjs91404k7h0mcbg8vc2jd5h2r83w83iq76b4cy2gmqhhd";
-      name = "kdegraphics-mobipocket-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdegraphics-mobipocket-16.04.1.tar.xz";
+      sha256 = "0d4yd4zfkbpm7qixkiiz7lpg66afvdfsz621fby59n9i3nla5b8d";
+      name = "kdegraphics-mobipocket-16.04.1.tar.xz";
     };
   };
   kdegraphics-strigi-analyzer = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdegraphics-strigi-analyzer-16.04.0.tar.xz";
-      sha256 = "0ibkbr7z5lz42cz65hwx0j4sjqy7k8rzj304d8ra2732mazamapj";
-      name = "kdegraphics-strigi-analyzer-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdegraphics-strigi-analyzer-16.04.1.tar.xz";
+      sha256 = "01j4ymrvd82xzfpsdl76nr7xjiaji9ki8iv41qkp32frvxj0g48z";
+      name = "kdegraphics-strigi-analyzer-16.04.1.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdegraphics-thumbnailers-16.04.0.tar.xz";
-      sha256 = "0qw0bq9gkasrkd4mxh30k15k50d28jkl7sc88akys91id1wn8mcb";
-      name = "kdegraphics-thumbnailers-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdegraphics-thumbnailers-16.04.1.tar.xz";
+      sha256 = "1fqj0kgq9cpq8bv4riwqfbczc6cjfv4s2han7jy267n2lgzi7kpa";
+      name = "kdegraphics-thumbnailers-16.04.1.tar.xz";
     };
   };
   kde-l10n-ar = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ar-16.04.0.tar.xz";
-      sha256 = "1rb8vqq06f83w5q81d1r5qf76yzr85kf826a0a47hfly2plaw3lc";
-      name = "kde-l10n-ar-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ar-16.04.1.tar.xz";
+      sha256 = "0in3bzbhdalpyc366sngz2al5ycv5r3a3n1dmxzn5jw4gzr32rbg";
+      name = "kde-l10n-ar-16.04.1.tar.xz";
     };
   };
   kde-l10n-ast = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ast-16.04.0.tar.xz";
-      sha256 = "1lzlwyxyi9dgds8sgghzjlhkbd18w9plbli4yqrglfbxl8yc60xl";
-      name = "kde-l10n-ast-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ast-16.04.1.tar.xz";
+      sha256 = "0xn1759ccm9kvvynjf9ndav0q7fg3k20hawdmfisyan6zdsnih7i";
+      name = "kde-l10n-ast-16.04.1.tar.xz";
     };
   };
   kde-l10n-bg = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-bg-16.04.0.tar.xz";
-      sha256 = "026apn9qz3k29dvk1pvylh9ha1m637gjhnpjmj6i03frh2ai7fqs";
-      name = "kde-l10n-bg-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-bg-16.04.1.tar.xz";
+      sha256 = "1fvnlqljp0swx1k1lasy0k8bz4cpj8z0kwrnj5zagpys6bg5dlxh";
+      name = "kde-l10n-bg-16.04.1.tar.xz";
     };
   };
   kde-l10n-bs = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-bs-16.04.0.tar.xz";
-      sha256 = "0j1i6794rvdpzzqmjqcig6wh1ljrnvygwm6zr0yin4didadm78xm";
-      name = "kde-l10n-bs-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-bs-16.04.1.tar.xz";
+      sha256 = "0cvqmh275j92mdc4wwrfpgds4lnzqdd8mzv2w317n7p351nklwfd";
+      name = "kde-l10n-bs-16.04.1.tar.xz";
     };
   };
   kde-l10n-ca = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ca-16.04.0.tar.xz";
-      sha256 = "08wrdlrdqp0w7dg2ygk9pi78ynj6ipzlyxx2mqyplnj1hx2jgrw4";
-      name = "kde-l10n-ca-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ca-16.04.1.tar.xz";
+      sha256 = "1yzqvd3nvgvxlr49y143hs77pjrr2rb91mc3xyinrqls0awq4j4b";
+      name = "kde-l10n-ca-16.04.1.tar.xz";
     };
   };
   kde-l10n-ca_valencia = {
-    version = "ca_valencia-16.04.0";
+    version = "ca_valencia-16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ca@valencia-16.04.0.tar.xz";
-      sha256 = "0a9dyvqng3gbn5kljq0av93b6wd7l04i57gmac0vz3qja9fyw7px";
-      name = "kde-l10n-ca_valencia-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ca@valencia-16.04.1.tar.xz";
+      sha256 = "0xv9akrnvlf983qjj9l63h9f0ppk61yi1lrhpp8ba9i57b2z0apy";
+      name = "kde-l10n-ca_valencia-16.04.1.tar.xz";
     };
   };
   kde-l10n-cs = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-cs-16.04.0.tar.xz";
-      sha256 = "1ai2p9hg7l7s77k45gmxdn3lqnv4mh8gdsxhbjdpqcmwxyc2zgwf";
-      name = "kde-l10n-cs-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-cs-16.04.1.tar.xz";
+      sha256 = "0ig21rl11m9c73v3vkn3q13zw2xv39ymxdq4hnm96d323pp3lrhp";
+      name = "kde-l10n-cs-16.04.1.tar.xz";
     };
   };
   kde-l10n-da = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-da-16.04.0.tar.xz";
-      sha256 = "05ncpim4fpyiv2cca4dvn7d8sd031xjc4f85p1yf9inwbsj4nf5x";
-      name = "kde-l10n-da-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-da-16.04.1.tar.xz";
+      sha256 = "0m6pgyib8nbmrvqm7asb9dj64552mkadh6wfxqz7k5ylahar82l5";
+      name = "kde-l10n-da-16.04.1.tar.xz";
     };
   };
   kde-l10n-de = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-de-16.04.0.tar.xz";
-      sha256 = "17cbibk6lqiabyyinnj9by0jjhqzlkn09zr8m0h967704fkhnzjc";
-      name = "kde-l10n-de-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-de-16.04.1.tar.xz";
+      sha256 = "1jp6iqlrxpxr3xqibph505p9qn84m3s4sq2bbfk3sb256w1qzh88";
+      name = "kde-l10n-de-16.04.1.tar.xz";
     };
   };
   kde-l10n-el = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-el-16.04.0.tar.xz";
-      sha256 = "15raxjj0cnnrqwr8cfdww5a93k7c17lakb88z65lpafvhnyf6mry";
-      name = "kde-l10n-el-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-el-16.04.1.tar.xz";
+      sha256 = "07m80cyi8nfk1ih05dhj22gg03wjb4zv12ywqamym4pl5k08wgls";
+      name = "kde-l10n-el-16.04.1.tar.xz";
     };
   };
   kde-l10n-en_GB = {
-    version = "en_GB-16.04.0";
+    version = "en_GB-16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-en_GB-16.04.0.tar.xz";
-      sha256 = "17dbbwmwm5mqxc0wbc27ys9izfh8jkjbvc2vnw8gd1kxqgfqy49l";
-      name = "kde-l10n-en_GB-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-en_GB-16.04.1.tar.xz";
+      sha256 = "0936bai72v2fj84rnd7vr2ljwdy6x33m7iiall69cgkam4c26vyz";
+      name = "kde-l10n-en_GB-16.04.1.tar.xz";
     };
   };
   kde-l10n-eo = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-eo-16.04.0.tar.xz";
-      sha256 = "03bz9hpm36lmh1g2560r2xy8fais0f7wdqj58z82kvxb2lqwr2jg";
-      name = "kde-l10n-eo-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-eo-16.04.1.tar.xz";
+      sha256 = "1rrhpfq24cgq0mgawmk5vz0v033gnfa68phlgsa1ynmm42cg6vn9";
+      name = "kde-l10n-eo-16.04.1.tar.xz";
     };
   };
   kde-l10n-es = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-es-16.04.0.tar.xz";
-      sha256 = "0kqvw2a7lgp9qy3ph6f6kxl3mvqlq19r99821w0hbv7qk2p9frbs";
-      name = "kde-l10n-es-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-es-16.04.1.tar.xz";
+      sha256 = "07rzyhr4hha38vdl30fhb4slan7w4fwryg59vf9fj4pb8x97qisq";
+      name = "kde-l10n-es-16.04.1.tar.xz";
     };
   };
   kde-l10n-et = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-et-16.04.0.tar.xz";
-      sha256 = "1x483l2a39da9kbhh8k20s84x6zjy27f760i7y9mmkah5ryxbn68";
-      name = "kde-l10n-et-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-et-16.04.1.tar.xz";
+      sha256 = "1nlnsw2z0iq9vxkclkrhkq6k3qzqq7xrg4yl4159fsdfvby11m1d";
+      name = "kde-l10n-et-16.04.1.tar.xz";
     };
   };
   kde-l10n-eu = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-eu-16.04.0.tar.xz";
-      sha256 = "0z0bqnywx9crk829vdixg5kswf208qmcicvi72fiz2cwjwcqhbyg";
-      name = "kde-l10n-eu-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-eu-16.04.1.tar.xz";
+      sha256 = "0wjjq7gkmlnmwwbkqxpn3ddx335cn0g4443h1m7ddm823mqf5prv";
+      name = "kde-l10n-eu-16.04.1.tar.xz";
     };
   };
   kde-l10n-fa = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-fa-16.04.0.tar.xz";
-      sha256 = "1m4vdmzy94jg3rky8d8rbqrkyja6rv6jybfh1q0ydpihz9k5p5hk";
-      name = "kde-l10n-fa-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-fa-16.04.1.tar.xz";
+      sha256 = "1ikjkn8ikp959bzq32r05irxzb37mswhjps4244cgv2wzr79jinh";
+      name = "kde-l10n-fa-16.04.1.tar.xz";
     };
   };
   kde-l10n-fi = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-fi-16.04.0.tar.xz";
-      sha256 = "1bcblmd3dsx6slvia5x9ammw4054wsyjk6mdzgcabyi86xmm1xj8";
-      name = "kde-l10n-fi-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-fi-16.04.1.tar.xz";
+      sha256 = "039v26478iqk6z2j9z2mblvl9ypmnl69xp8fybyp8nhlmakmxffp";
+      name = "kde-l10n-fi-16.04.1.tar.xz";
     };
   };
   kde-l10n-fr = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-fr-16.04.0.tar.xz";
-      sha256 = "1311ymksp37l1yfz8921zvbrcd4g2pygfhilmmjrww0chizxjdjf";
-      name = "kde-l10n-fr-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-fr-16.04.1.tar.xz";
+      sha256 = "0cmw70kvzi365sj5rlkxjj69h5si8bygyl6c6nia1v9ykdi9yw1q";
+      name = "kde-l10n-fr-16.04.1.tar.xz";
     };
   };
   kde-l10n-ga = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ga-16.04.0.tar.xz";
-      sha256 = "0iml1y2xdwchn2gqgbvcvs2fbq78drh2r6068jlrc3hixbf76wsy";
-      name = "kde-l10n-ga-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ga-16.04.1.tar.xz";
+      sha256 = "0wndnikw0pi4jib6y571zgf38ggk16d66izjwcwxrvminjc6wni1";
+      name = "kde-l10n-ga-16.04.1.tar.xz";
     };
   };
   kde-l10n-gl = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-gl-16.04.0.tar.xz";
-      sha256 = "1v1hq61fwj2x8iiqjm9fwabzgc7m044narb1108cijl7d76lsn4m";
-      name = "kde-l10n-gl-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-gl-16.04.1.tar.xz";
+      sha256 = "1mmwhb75cpkfz9hp5y0ncv5vga7pv34ybdav30g1m99mjih9ld2j";
+      name = "kde-l10n-gl-16.04.1.tar.xz";
     };
   };
   kde-l10n-he = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-he-16.04.0.tar.xz";
-      sha256 = "0q1gj3gffin7l0r7xlp395zj5kdil8bnrl6apk2jslg7pz929dhb";
-      name = "kde-l10n-he-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-he-16.04.1.tar.xz";
+      sha256 = "0jwi0z3mvz8r6cg9b6665qh327yyj7mb22627xavfbp0rb1a2c21";
+      name = "kde-l10n-he-16.04.1.tar.xz";
     };
   };
   kde-l10n-hi = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-hi-16.04.0.tar.xz";
-      sha256 = "19czqc6l4jn321zwygk7b46wgsimcbf8zvl30a0rkdvspwyvaqc5";
-      name = "kde-l10n-hi-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-hi-16.04.1.tar.xz";
+      sha256 = "1rv08lc6804ip81nvwy65zgxdb7q68sfx0v66xyckds9f2q2g9jv";
+      name = "kde-l10n-hi-16.04.1.tar.xz";
     };
   };
   kde-l10n-hr = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-hr-16.04.0.tar.xz";
-      sha256 = "0bbcjrxgm5yqjz1y4ngm133hcvrp3c2z8lrycpg76g7j50w3fsi5";
-      name = "kde-l10n-hr-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-hr-16.04.1.tar.xz";
+      sha256 = "1p7qa99x3bmbc41fmnsjbaimkjg89m44yxak7ka516w4r87aai5y";
+      name = "kde-l10n-hr-16.04.1.tar.xz";
     };
   };
   kde-l10n-hu = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-hu-16.04.0.tar.xz";
-      sha256 = "0iww0m45gdlmf0j1jw8qljqar0dsmax4sxkr6yd3kswwr6m75v2i";
-      name = "kde-l10n-hu-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-hu-16.04.1.tar.xz";
+      sha256 = "0a7pi8w2phn8523vv6zsvgzv6yk7iy4jixc9glxvqn4sy6cy8j1n";
+      name = "kde-l10n-hu-16.04.1.tar.xz";
     };
   };
   kde-l10n-ia = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ia-16.04.0.tar.xz";
-      sha256 = "0ivgp1gjxshxq1fvn254k4gni30svyqfnlfz7d8niqp3msnfmc2b";
-      name = "kde-l10n-ia-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ia-16.04.1.tar.xz";
+      sha256 = "1cxqjrpj2pplwvdc9zg97w3nhhamzpi7a3h504r9i2wvlb76y0s2";
+      name = "kde-l10n-ia-16.04.1.tar.xz";
     };
   };
   kde-l10n-id = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-id-16.04.0.tar.xz";
-      sha256 = "15fnm4isigmgpxsgpqhj6gbvcrlhi51491a6fnxiwa3xmrc2pva8";
-      name = "kde-l10n-id-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-id-16.04.1.tar.xz";
+      sha256 = "17dncrhwxp8glxcgphwfaqhnr8a8s9ad6g6gw6kd3pbd9a4jpi2v";
+      name = "kde-l10n-id-16.04.1.tar.xz";
     };
   };
   kde-l10n-is = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-is-16.04.0.tar.xz";
-      sha256 = "14bl3j2kqwg6cln84k5kpm400mnm4r81xhgmjpfb3xy92ms3sycr";
-      name = "kde-l10n-is-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-is-16.04.1.tar.xz";
+      sha256 = "0xif4igmrcrngy0r1pbvhwhbj7pax2v7rzrh29j4rhnx3ilsk1gv";
+      name = "kde-l10n-is-16.04.1.tar.xz";
     };
   };
   kde-l10n-it = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-it-16.04.0.tar.xz";
-      sha256 = "06akl5x2x0j50gyzw3m1yavxxw3jszyfyychsihn74fk8hslzp6m";
-      name = "kde-l10n-it-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-it-16.04.1.tar.xz";
+      sha256 = "0frylngivi26x9l9db010knmqpb1w9qixg08w7hkbqwrhic1asif";
+      name = "kde-l10n-it-16.04.1.tar.xz";
     };
   };
   kde-l10n-ja = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ja-16.04.0.tar.xz";
-      sha256 = "1kcmryifsjripsxwa7qa7m3ky0wxaipz9smrfhhrnw41i62sfp9a";
-      name = "kde-l10n-ja-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ja-16.04.1.tar.xz";
+      sha256 = "1hgfismzp69br4g0kdjmb70v6a99yjnv5y2r25d2yfkik0layglf";
+      name = "kde-l10n-ja-16.04.1.tar.xz";
     };
   };
   kde-l10n-kk = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-kk-16.04.0.tar.xz";
-      sha256 = "05c100727ydimn55jlvyynlgxzxncig2y4i4b53aslfi6h17fn0i";
-      name = "kde-l10n-kk-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-kk-16.04.1.tar.xz";
+      sha256 = "0iqf8sad1fcs8vffvk0h8ch5qs52djfy1lgzzqlhp2n24rmgh478";
+      name = "kde-l10n-kk-16.04.1.tar.xz";
     };
   };
   kde-l10n-km = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-km-16.04.0.tar.xz";
-      sha256 = "1shbg5vbzbgx07lbgi6ddhphh5b2bm9qd1gavls8alcgpbqj221c";
-      name = "kde-l10n-km-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-km-16.04.1.tar.xz";
+      sha256 = "0c00k11nqsrvw0sy7n2zc0jdrjxd43ajbqpam7153cs00k2ff1im";
+      name = "kde-l10n-km-16.04.1.tar.xz";
     };
   };
   kde-l10n-ko = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ko-16.04.0.tar.xz";
-      sha256 = "1fjavkaivv6zspagqcbdhy7gdkmv38z20bv7fs45qf4470ffmwz5";
-      name = "kde-l10n-ko-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ko-16.04.1.tar.xz";
+      sha256 = "0z99i1426fd4vxr64m4lssbrpp6gxdqbh7107vbpcscvn5zzjika";
+      name = "kde-l10n-ko-16.04.1.tar.xz";
     };
   };
   kde-l10n-lt = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-lt-16.04.0.tar.xz";
-      sha256 = "09n4yc9grd7g3yqkgxj9x6hkygcqbx6dxi0jj6v98a5p50b78a5d";
-      name = "kde-l10n-lt-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-lt-16.04.1.tar.xz";
+      sha256 = "1qkx6ca7i5d4qlp91j0sspd89jhxw2q468yf4pvkmlv5ry4ahfnd";
+      name = "kde-l10n-lt-16.04.1.tar.xz";
     };
   };
   kde-l10n-lv = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-lv-16.04.0.tar.xz";
-      sha256 = "1c86bhsq0j0r2bmc6524g4sxc0bsw5sx6d4fxs6sxzx3bpdml5bq";
-      name = "kde-l10n-lv-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-lv-16.04.1.tar.xz";
+      sha256 = "068ka9agb4iwayrm1j4rbs83zznx3cil2ja47id20hwf2diqcjjx";
+      name = "kde-l10n-lv-16.04.1.tar.xz";
     };
   };
   kde-l10n-mr = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-mr-16.04.0.tar.xz";
-      sha256 = "1xp3fb99crsvf1xl45iy9q31nbs2735hxai1wlfn5h0q9scz2nin";
-      name = "kde-l10n-mr-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-mr-16.04.1.tar.xz";
+      sha256 = "0vh6pawbpmnfc7kvrqi9rm4b16zndfwvsy8xny1jjj443i58fyfh";
+      name = "kde-l10n-mr-16.04.1.tar.xz";
     };
   };
   kde-l10n-nb = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-nb-16.04.0.tar.xz";
-      sha256 = "1dkfwqvbh6dxfxg4gznchpkwscc4g6rgwndxzjj53lvfz69611dj";
-      name = "kde-l10n-nb-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-nb-16.04.1.tar.xz";
+      sha256 = "0xn35j38fcnb6q1p6wimvr96s3rf4fs8s3jw92qcqa7n7zy866k0";
+      name = "kde-l10n-nb-16.04.1.tar.xz";
     };
   };
   kde-l10n-nds = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-nds-16.04.0.tar.xz";
-      sha256 = "1pma4pn7h1r9y6dxs86xqh0ahvl04rhw8qad3cbyil2r1s7j80ac";
-      name = "kde-l10n-nds-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-nds-16.04.1.tar.xz";
+      sha256 = "0a3wsarls6g12aa2av444rkg7r8x78j7zdy9q46qh3rvsp3habh9";
+      name = "kde-l10n-nds-16.04.1.tar.xz";
     };
   };
   kde-l10n-nl = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-nl-16.04.0.tar.xz";
-      sha256 = "0bd49aylsklgp9rqs6nk72n0za9kcp7fjzr5myfavcxliwv8lhqp";
-      name = "kde-l10n-nl-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-nl-16.04.1.tar.xz";
+      sha256 = "161y9417bynvhl6rsl6x1ncrwcgdxrzgivlf9gs9q7bii81ywcli";
+      name = "kde-l10n-nl-16.04.1.tar.xz";
     };
   };
   kde-l10n-nn = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-nn-16.04.0.tar.xz";
-      sha256 = "14acr8pchds4ib246fz6ml65qjkiifcxfs6r5hqh99l72im30hx1";
-      name = "kde-l10n-nn-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-nn-16.04.1.tar.xz";
+      sha256 = "11kh5ld024b7ls1jgm26r7jwacbgddn78cgfg6s5rn8m1v71z3j0";
+      name = "kde-l10n-nn-16.04.1.tar.xz";
     };
   };
   kde-l10n-pa = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-pa-16.04.0.tar.xz";
-      sha256 = "116dssrchp0yf173m3n8hkcfyr0k02bjlda24ikknjbh50y5kqfk";
-      name = "kde-l10n-pa-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-pa-16.04.1.tar.xz";
+      sha256 = "052rxwah1q8zpz1ga8lw46hzmj311bqwghrlsy01qx1w1gf0b374";
+      name = "kde-l10n-pa-16.04.1.tar.xz";
     };
   };
   kde-l10n-pl = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-pl-16.04.0.tar.xz";
-      sha256 = "1gibqcmgqvq9f1573jfchh7nhkd8czdi183n2smld4irsd750la8";
-      name = "kde-l10n-pl-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-pl-16.04.1.tar.xz";
+      sha256 = "1j5claq1dwss2ffmdgxzsf7lnswrkvb6nzzwzs8ffa4kfl35jwks";
+      name = "kde-l10n-pl-16.04.1.tar.xz";
     };
   };
   kde-l10n-pt = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-pt-16.04.0.tar.xz";
-      sha256 = "1yrjhqcl93fdch9nvzc2yk30rbzxsrya3xsj54xgxv2anggbr3wr";
-      name = "kde-l10n-pt-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-pt-16.04.1.tar.xz";
+      sha256 = "0qjc04kkj3lp5ds0d2p1g6hsq09b4wsf2ppks0kcrv5clgj5vyg5";
+      name = "kde-l10n-pt-16.04.1.tar.xz";
     };
   };
   kde-l10n-pt_BR = {
-    version = "pt_BR-16.04.0";
+    version = "pt_BR-16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-pt_BR-16.04.0.tar.xz";
-      sha256 = "0sbg767ddcknzs4k4v76ys00jxgqlxlggf5i9fw3dvaggs78azj7";
-      name = "kde-l10n-pt_BR-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-pt_BR-16.04.1.tar.xz";
+      sha256 = "1jp0srhqj2yziasbibij6ks11hgi994cvpc9yyn8dadjmpv091r7";
+      name = "kde-l10n-pt_BR-16.04.1.tar.xz";
     };
   };
   kde-l10n-ro = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ro-16.04.0.tar.xz";
-      sha256 = "0bz25pg9xj2n4vl2aadaj02p0jx37j3i37p7bvafsb499qpgprk2";
-      name = "kde-l10n-ro-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ro-16.04.1.tar.xz";
+      sha256 = "09yixhqh41591kri0c6j79ikn2flcs1hvm0lcil3jfkhsas0j9mg";
+      name = "kde-l10n-ro-16.04.1.tar.xz";
     };
   };
   kde-l10n-ru = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ru-16.04.0.tar.xz";
-      sha256 = "0jkljdc5i3hq7kkkq4gl7rh92ia4vv6m2vd74bsilibgxgb1kmah";
-      name = "kde-l10n-ru-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ru-16.04.1.tar.xz";
+      sha256 = "1x3rc8hcz8bhfyir02rq92wll0qx4rb5rgjhqwfshrq5x1qmx8g0";
+      name = "kde-l10n-ru-16.04.1.tar.xz";
     };
   };
   kde-l10n-sk = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-sk-16.04.0.tar.xz";
-      sha256 = "06lnlky47xq6fcjj70msc28q97cymsh0g4z06pbc0cyyby85521m";
-      name = "kde-l10n-sk-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-sk-16.04.1.tar.xz";
+      sha256 = "0qcylh5zj3258pfi0gvxsrvycc1f1b521nn00r664xhlm8akgs5g";
+      name = "kde-l10n-sk-16.04.1.tar.xz";
     };
   };
   kde-l10n-sl = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-sl-16.04.0.tar.xz";
-      sha256 = "0z2d8jx117prr35malcp0ca93ipbjj55s4dm3iad2iy2q728hkmv";
-      name = "kde-l10n-sl-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-sl-16.04.1.tar.xz";
+      sha256 = "0m0r4m8anxpmkn76rq3xkxk99xla978qd1106gi5rpadsk6id2ql";
+      name = "kde-l10n-sl-16.04.1.tar.xz";
     };
   };
   kde-l10n-sr = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-sr-16.04.0.tar.xz";
-      sha256 = "0w24mrb48qyc7diw40hwzplxb2rqlrrymvwnxbdy2d6x35hha0j4";
-      name = "kde-l10n-sr-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-sr-16.04.1.tar.xz";
+      sha256 = "0k5s1hzdzq7k0fjmslk63bkhz87qj0dkk0i82yyfizinshyb8wiw";
+      name = "kde-l10n-sr-16.04.1.tar.xz";
     };
   };
   kde-l10n-sv = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-sv-16.04.0.tar.xz";
-      sha256 = "039q4d2y3vwxnpz6rwgf9s1ivhrlz26gp5kx3y9cz8fhcsa4jk8j";
-      name = "kde-l10n-sv-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-sv-16.04.1.tar.xz";
+      sha256 = "0i0p610a1vg6l2qh15abbvr1dgiadff0yf6j0xa51iljvjijl44i";
+      name = "kde-l10n-sv-16.04.1.tar.xz";
     };
   };
   kde-l10n-tr = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-tr-16.04.0.tar.xz";
-      sha256 = "1sr5xxxzs29sah0azfc71w01nbm5njhgygpzll3lfx3padsvfz49";
-      name = "kde-l10n-tr-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-tr-16.04.1.tar.xz";
+      sha256 = "1py52clbklvkrrydm5jc4sdcf9xqwnfw3b0cn3dj34qs2zfi4d93";
+      name = "kde-l10n-tr-16.04.1.tar.xz";
     };
   };
   kde-l10n-ug = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-ug-16.04.0.tar.xz";
-      sha256 = "16jpax5k3z8anhsf61wsi93n8ail8ybjpi31dnk859g0y50a4nr5";
-      name = "kde-l10n-ug-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-ug-16.04.1.tar.xz";
+      sha256 = "1k57q3zww146sh5rbab48dj4lpkipld2xl2zicspammq21bjy1yy";
+      name = "kde-l10n-ug-16.04.1.tar.xz";
     };
   };
   kde-l10n-uk = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-uk-16.04.0.tar.xz";
-      sha256 = "1275347grzcdm0jd9mzm1ww8dsh3g2ws5ppfxs3ip7jdsxgmcqh0";
-      name = "kde-l10n-uk-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-uk-16.04.1.tar.xz";
+      sha256 = "1y6n97287vs2dhavdql50i8nby766b9ragrxbdlxdfmz2m7b0azp";
+      name = "kde-l10n-uk-16.04.1.tar.xz";
     };
   };
   kde-l10n-wa = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-wa-16.04.0.tar.xz";
-      sha256 = "1gz918hj908308fd49pdbw1z8252shjbng5qgfzmdgfp9nvfhc14";
-      name = "kde-l10n-wa-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-wa-16.04.1.tar.xz";
+      sha256 = "097jnd3qrs7p1bym1b2h5672pfm39y4wk5dga18l9gf8vkh6vxx4";
+      name = "kde-l10n-wa-16.04.1.tar.xz";
     };
   };
   kde-l10n-zh_CN = {
-    version = "zh_CN-16.04.0";
+    version = "zh_CN-16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-zh_CN-16.04.0.tar.xz";
-      sha256 = "1kyakzig301vylmib9wjb46llllw0jjiq18wys017hzjxykx170f";
-      name = "kde-l10n-zh_CN-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-zh_CN-16.04.1.tar.xz";
+      sha256 = "17askly6wn8wm9piskhvr5q7q9cg30bbnn0r4n56rbfpzhjhwwdj";
+      name = "kde-l10n-zh_CN-16.04.1.tar.xz";
     };
   };
   kde-l10n-zh_TW = {
-    version = "zh_TW-16.04.0";
+    version = "zh_TW-16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-l10n/kde-l10n-zh_TW-16.04.0.tar.xz";
-      sha256 = "0s2m1f4ylm6l3vp67h6v41n06pmk6762lk32wqy0l2fgg4zxrrzl";
-      name = "kde-l10n-zh_TW-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-l10n/kde-l10n-zh_TW-16.04.1.tar.xz";
+      sha256 = "11cqq7nba322mgqplll4l7rkpmhxj8n1aswhdib10zifqm9ni121";
+      name = "kde-l10n-zh_TW-16.04.1.tar.xz";
     };
   };
   kdelibs = {
-    version = "4.14.19";
+    version = "4.14.20";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdelibs-4.14.19.tar.xz";
-      sha256 = "0dfmhivd41y8c9pnag496rc8qlj78dg62liap5zdphgvi2baf8p6";
-      name = "kdelibs-4.14.19.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdelibs-4.14.20.tar.xz";
+      sha256 = "1d1wijg8nn5jvprc48pfk9h4i0a39xwidn1g1sq3smk3a0y9nzmp";
+      name = "kdelibs-4.14.20.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdenetwork-filesharing-16.04.0.tar.xz";
-      sha256 = "08rlg7ppqbi2xvq6ixjjw1xdr17n7bhzi2ymssxv8q1fmznfqhvp";
-      name = "kdenetwork-filesharing-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdenetwork-filesharing-16.04.1.tar.xz";
+      sha256 = "17m9bl01xdxsfhchw1fzmxxnc08pj3062cnzri1d2alg9iwngn63";
+      name = "kdenetwork-filesharing-16.04.1.tar.xz";
     };
   };
   kdenetwork-strigi-analyzers = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdenetwork-strigi-analyzers-16.04.0.tar.xz";
-      sha256 = "0i08niv87jn6bh6c1fknpqr7mkbg5csd8lgm39bwq551zgn7n6sw";
-      name = "kdenetwork-strigi-analyzers-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdenetwork-strigi-analyzers-16.04.1.tar.xz";
+      sha256 = "0vy3dvrzwzf60smjsp85jyi36j3lkgni2qv5vlpn611bk59wy0kl";
+      name = "kdenetwork-strigi-analyzers-16.04.1.tar.xz";
     };
   };
   kdenlive = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdenlive-16.04.0.tar.xz";
-      sha256 = "0ks30as7cnr9jcacj97c720pf2dn1wv8xg9mgxsin7c2lhbz8i5f";
-      name = "kdenlive-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdenlive-16.04.1.tar.xz";
+      sha256 = "1b1sr4pvvcpfp4lgg3y34gnw5ljf4d12np4r7mp7ybzh6nvk3pbj";
+      name = "kdenlive-16.04.1.tar.xz";
     };
   };
   kdepim = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdepim-16.04.0.tar.xz";
-      sha256 = "0cd39hgr7gvv78mf5rypj7yjpfrnapd1pxad1aanlsr6ms5qdzyg";
-      name = "kdepim-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdepim-16.04.1.tar.xz";
+      sha256 = "15p12288yksmr1i3779bz20v499yyqb3srpadbk7nrkywnj9py52";
+      name = "kdepim-16.04.1.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdepim-addons-16.04.0.tar.xz";
-      sha256 = "1dfvl0pd9269ghpjwydyws40flvw7clq2hq830m4jk6myqjccd4i";
-      name = "kdepim-addons-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdepim-addons-16.04.1.tar.xz";
+      sha256 = "09h7pvhw4hknd62cvqk2n7zggixdzaighdy3v4fp7mfb3gkfkccj";
+      name = "kdepim-addons-16.04.1.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdepim-apps-libs-16.04.0.tar.xz";
-      sha256 = "1slnsssd242wzk0pga4l6i8q83gdca1vgmqixz82x4pvfj62bw7w";
-      name = "kdepim-apps-libs-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdepim-apps-libs-16.04.1.tar.xz";
+      sha256 = "0yf1gr8zq5cjijmpp82ddi7q8f0lcawmz4kqlc7dri0rjc4y8x3w";
+      name = "kdepim-apps-libs-16.04.1.tar.xz";
     };
   };
   kdepimlibs = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdepimlibs-16.04.0.tar.xz";
-      sha256 = "1mk8rjf918c5dfglv1sdrs6wjyf31dry4070ip3fx6kdph2x5akr";
-      name = "kdepimlibs-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdepimlibs-16.04.1.tar.xz";
+      sha256 = "0ych4xkzx6d1kb6fw3br82h4a3hv2anh0qfd2aawm0fzs9m52afp";
+      name = "kdepimlibs-16.04.1.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdepim-runtime-16.04.0.tar.xz";
-      sha256 = "0siwplwdbrsaikzfxbz9w00wk3xfg4a6y124nlwqx7588ni8brs3";
-      name = "kdepim-runtime-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdepim-runtime-16.04.1.tar.xz";
+      sha256 = "1l4iqhyvvcz3f8zy5gvv5gd6ir39iini2b8zczw70j1frdqiah9p";
+      name = "kdepim-runtime-16.04.1.tar.xz";
     };
   };
   kde-runtime = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kde-runtime-16.04.0.tar.xz";
-      sha256 = "0sr06v4z6lbkacqgk8a35m3ldal1fcpvp6n2s8bfa226yck8sdq6";
-      name = "kde-runtime-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kde-runtime-16.04.1.tar.xz";
+      sha256 = "1197w24v37ghhmh36n2g2lzs7k9nvp9y13098c82dbck58xyja1m";
+      name = "kde-runtime-16.04.1.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdesdk-kioslaves-16.04.0.tar.xz";
-      sha256 = "0lwdy4l48id0p3vkpk92n3ja6ymzxx9zl7iwwszb1rxbr48q4v7l";
-      name = "kdesdk-kioslaves-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdesdk-kioslaves-16.04.1.tar.xz";
+      sha256 = "11dvh0rk20qx0ckfb1aw2s01h41a3zwgi1n9wsc09qzdyix5f422";
+      name = "kdesdk-kioslaves-16.04.1.tar.xz";
     };
   };
   kdesdk-strigi-analyzers = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdesdk-strigi-analyzers-16.04.0.tar.xz";
-      sha256 = "1bn12pqqq9bgr6y916wd54i0dsw30ab9xhz99mqyjw2fcxpz4mf8";
-      name = "kdesdk-strigi-analyzers-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdesdk-strigi-analyzers-16.04.1.tar.xz";
+      sha256 = "1vylfy4nsavfxxf36yfmlad02igdqix2jns24fc0nd3z8r8la4k3";
+      name = "kdesdk-strigi-analyzers-16.04.1.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdesdk-thumbnailers-16.04.0.tar.xz";
-      sha256 = "1wqlrkgix2nnpvlqqqdja4j5iws4vjglds94ra5s0wmyfk0y9yc2";
-      name = "kdesdk-thumbnailers-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdesdk-thumbnailers-16.04.1.tar.xz";
+      sha256 = "1r6c2almxa92917vi3pdzcqfb93gw4l16k4xbasn10qmn3wmyrvh";
+      name = "kdesdk-thumbnailers-16.04.1.tar.xz";
     };
   };
   kdewebdev = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdewebdev-16.04.0.tar.xz";
-      sha256 = "1xmibm0hi0mdwsvp8h48qph4mjwb1k3q58i9y8s1c7vqczl1q09n";
-      name = "kdewebdev-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdewebdev-16.04.1.tar.xz";
+      sha256 = "12jjhbifigvq8r6bn4940wmc50kfbn3v2wzvi2h2nrfpvkq7j4kf";
+      name = "kdewebdev-16.04.1.tar.xz";
     };
   };
   kdf = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdf-16.04.0.tar.xz";
-      sha256 = "12bcvy6x8wkizjykrc3wmd3lbsj2zmiizxknic5jiwin6zqjrzh4";
-      name = "kdf-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdf-16.04.1.tar.xz";
+      sha256 = "0f8vqsn5cjg6hf2djhpdwm7prz36gkr1qlk1s15fnnk850dyq610";
+      name = "kdf-16.04.1.tar.xz";
     };
   };
   kdgantt2 = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdgantt2-16.04.0.tar.xz";
-      sha256 = "0j9b2f5zkvasv5w4paazyc47iph27nqd4l4nrwr3plvdirivdidf";
-      name = "kdgantt2-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdgantt2-16.04.1.tar.xz";
+      sha256 = "0xfgdrycldijyhg9q400s6ajzm3apbyam3g5n2fivsaa6s68hgdh";
+      name = "kdgantt2-16.04.1.tar.xz";
     };
   };
   kdiamond = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kdiamond-16.04.0.tar.xz";
-      sha256 = "1alb6hv95whdy15kmc0kzx4758wjni6q2k3dxxpdhw0hq657v508";
-      name = "kdiamond-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kdiamond-16.04.1.tar.xz";
+      sha256 = "1yxy2412xl5gq59s1kpd213vsrhbf20ci528qvz6y9yz3b3safxq";
+      name = "kdiamond-16.04.1.tar.xz";
     };
   };
   kfloppy = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kfloppy-16.04.0.tar.xz";
-      sha256 = "09jwqbfs0ayswlzih90bq439c8ljhay12jfv73gdnkvf23qiq5vw";
-      name = "kfloppy-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kfloppy-16.04.1.tar.xz";
+      sha256 = "1pgr3kng88cprkp4prhg351k6pnbzqrpw4ihjfcdfa5mqirq64im";
+      name = "kfloppy-16.04.1.tar.xz";
     };
   };
   kfourinline = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kfourinline-16.04.0.tar.xz";
-      sha256 = "13hgwn3gzyhvh4xw7ym80vsbnqbvhlvn3jwzjrxlj377q9q1h6i6";
-      name = "kfourinline-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kfourinline-16.04.1.tar.xz";
+      sha256 = "0712fcg20jm1dq2slrk3nlgz3rqaw22fzvv2vzk4b763b6ha5xh0";
+      name = "kfourinline-16.04.1.tar.xz";
     };
   };
   kgeography = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kgeography-16.04.0.tar.xz";
-      sha256 = "1pk76akkd5ykh9p1l757cqj8niwwavxdxwinkz51w0dz0n62zb4x";
-      name = "kgeography-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kgeography-16.04.1.tar.xz";
+      sha256 = "1cf6jaw25d1z1k7abm268qn86cvwlzvx7m7xkg8a1ipynr0zhgzi";
+      name = "kgeography-16.04.1.tar.xz";
     };
   };
   kget = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kget-16.04.0.tar.xz";
-      sha256 = "17z2n0bgj1dm4d4abprnx8crw30flxxk95w8sv3483zqbk0k3p4i";
-      name = "kget-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kget-16.04.1.tar.xz";
+      sha256 = "1h0fc3w9s8lvcij7agin6gpbgq4i825b8jw9lvra6r4hpmsg4s8g";
+      name = "kget-16.04.1.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kgoldrunner-16.04.0.tar.xz";
-      sha256 = "019dk1nq1jmk7w3lklxlsy667m7vahspjd0w5rrpas54czl975w8";
-      name = "kgoldrunner-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kgoldrunner-16.04.1.tar.xz";
+      sha256 = "18vbyjxli5r2c9lgpvr92aqqprmybk197nff7wd5bk9qaxf0zxgr";
+      name = "kgoldrunner-16.04.1.tar.xz";
     };
   };
   kgpg = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kgpg-16.04.0.tar.xz";
-      sha256 = "0qrijbwnrg61kwmv7l5k6796lbr9ry4grmk9jc38cq2g7bi64wz2";
-      name = "kgpg-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kgpg-16.04.1.tar.xz";
+      sha256 = "0w8ac7352vy2p2n0aribrc93la5hcmcvr4m53x13q29di7czf5qp";
+      name = "kgpg-16.04.1.tar.xz";
     };
   };
   khangman = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/khangman-16.04.0.tar.xz";
-      sha256 = "0ljrap9ybccmwymkay7760rgmpp51cssnvn4lwmd3mig5cfqlavs";
-      name = "khangman-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/khangman-16.04.1.tar.xz";
+      sha256 = "08hwiprzr12i7dlrza5rfbgpfzx8rpbx62rl6w09fcmr5sv1mbmh";
+      name = "khangman-16.04.1.tar.xz";
     };
   };
   khelpcenter = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/khelpcenter-16.04.0.tar.xz";
-      sha256 = "1r6aysdnc0qdg9lbzy1zb6pirfyfah3sbjsqkmrnf63kqsyjvapy";
-      name = "khelpcenter-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/khelpcenter-16.04.1.tar.xz";
+      sha256 = "0h1fg09y95v3q8fx6z3bnjcx99vwc706pm15qkbn80wcyif3hv5n";
+      name = "khelpcenter-16.04.1.tar.xz";
     };
   };
   kholidays = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kholidays-16.04.0.tar.xz";
-      sha256 = "04gfy3f5fip79ra08m3f098cbgp0k7v76lam3513r0zvl0h53gad";
-      name = "kholidays-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kholidays-16.04.1.tar.xz";
+      sha256 = "0x7plfjmaa6ca6w35ibrparwrz3q5sydi0ci7cfsra2cizcyh5l8";
+      name = "kholidays-16.04.1.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kidentitymanagement-16.04.0.tar.xz";
-      sha256 = "0dhpjgmz7ndbk77syp1zvk5g7sn991wjx5cllk6dx0q9ylfl1895";
-      name = "kidentitymanagement-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kidentitymanagement-16.04.1.tar.xz";
+      sha256 = "1dbchsr6j0ll7b4mvbv5yw1jyzvs9y68gaylybsqfzdzj9yiq3np";
+      name = "kidentitymanagement-16.04.1.tar.xz";
     };
   };
   kig = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kig-16.04.0.tar.xz";
-      sha256 = "0rlx7cm41z8zm4v4rdwmwicam2g2ibd0gmzlsnh77s4cv8xhmd7y";
-      name = "kig-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kig-16.04.1.tar.xz";
+      sha256 = "1jwd66accr4xi771chv8a0lm6g6mrcksad3c28b8l0sv39l1jr3n";
+      name = "kig-16.04.1.tar.xz";
     };
   };
   kigo = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kigo-16.04.0.tar.xz";
-      sha256 = "1cw8hyhayn650j73kqr8aqzj6wd6bq21l5c4ibl2qm90p1byj6zz";
-      name = "kigo-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kigo-16.04.1.tar.xz";
+      sha256 = "0660qd9h2ifmy13xccy7najna6zag2rziw7xf91hrgmkszzyn8l1";
+      name = "kigo-16.04.1.tar.xz";
     };
   };
   killbots = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/killbots-16.04.0.tar.xz";
-      sha256 = "1qnrwj1shy7ah2x0nh03r0zf3h8535qxxg62wgyg675n80ndl6wh";
-      name = "killbots-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/killbots-16.04.1.tar.xz";
+      sha256 = "1gdbk2403jvn2grx42vixlf3bj50a556inicg06qkgg3cf17xypr";
+      name = "killbots-16.04.1.tar.xz";
     };
   };
   kimap = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kimap-16.04.0.tar.xz";
-      sha256 = "028xpqdxgylab6sznzxdd7pyfm7l27mzj13zzxhd7lc7fqd3xgx9";
-      name = "kimap-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kimap-16.04.1.tar.xz";
+      sha256 = "1x4s88dk62sdnlidgk3vb706ppn0acfc4iiis4srvjn1sr0xl5yb";
+      name = "kimap-16.04.1.tar.xz";
     };
   };
   kio-extras = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kio-extras-16.04.0.tar.xz";
-      sha256 = "0iims3vk5mqz8lnpimwc3kjlvkmfh10287zy4sm5p8kxxfgz88fj";
-      name = "kio-extras-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kio-extras-16.04.1.tar.xz";
+      sha256 = "1187p0jzwhr7lixlswjjjlf367rp04pdzjyw7qw1brwj60jqz09m";
+      name = "kio-extras-16.04.1.tar.xz";
     };
   };
   kiriki = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kiriki-16.04.0.tar.xz";
-      sha256 = "0bywgx8j1kx5x5j4h5bv8zrf73pkdzd96wharrgia0x55kmnzgn2";
-      name = "kiriki-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kiriki-16.04.1.tar.xz";
+      sha256 = "028r7hxqyfd029z4cbx3vdzrn9d0s8d06f4p5clx97vr2lrii26v";
+      name = "kiriki-16.04.1.tar.xz";
     };
   };
   kiten = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kiten-16.04.0.tar.xz";
-      sha256 = "12d0p468439llj5jyxyd7qhr2zavdkbl8s87qcfhw7lngsnssq34";
-      name = "kiten-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kiten-16.04.1.tar.xz";
+      sha256 = "18c41dxn2sx64xih37n5v6vjmmw0kwv26na9cd6y5jd70yczcjzj";
+      name = "kiten-16.04.1.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kjumpingcube-16.04.0.tar.xz";
-      sha256 = "1grrcfblnfr2p6a72n38r6awkfm662brnv1r2k4kqbiz0qmwmvyd";
-      name = "kjumpingcube-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kjumpingcube-16.04.1.tar.xz";
+      sha256 = "001nvs1cppppsgr6x8vd16fzkgi6axac4k42xw7rpibcbwxvws27";
+      name = "kjumpingcube-16.04.1.tar.xz";
     };
   };
   kldap = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kldap-16.04.0.tar.xz";
-      sha256 = "1gbm7rgf2llxdnckzlnsjii9jd8s59hym96hf9v87svbphbm1738";
-      name = "kldap-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kldap-16.04.1.tar.xz";
+      sha256 = "0r150fg9zhl2gkl9w5dlxlzz3lrg1an690if0l1rpl2kzhrpdpyp";
+      name = "kldap-16.04.1.tar.xz";
     };
   };
   kleopatra = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kleopatra-16.04.0.tar.xz";
-      sha256 = "0rmzsqvp0xwyjr25d2vnslgg6cvni9km8hkijyhz8zrmnmpdm97z";
-      name = "kleopatra-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kleopatra-16.04.1.tar.xz";
+      sha256 = "0p13ff91q6033v16rh114viqhcl383s9fzdxi69wk657kqsn5fsi";
+      name = "kleopatra-16.04.1.tar.xz";
     };
   };
   klettres = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/klettres-16.04.0.tar.xz";
-      sha256 = "17m30hkjjrk5h4a5z1c96sgl8i0729537q11v9ndj8kh1699sfxs";
-      name = "klettres-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/klettres-16.04.1.tar.xz";
+      sha256 = "0mqplal91q2k9jkr5ksn9lmwncdi4rvrsz1sy3lfpjrwmm74rp24";
+      name = "klettres-16.04.1.tar.xz";
     };
   };
   klickety = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/klickety-16.04.0.tar.xz";
-      sha256 = "0ggj585vki81ds94k9i7b1sawzxz24k582zm5d3lngipcb1x808l";
-      name = "klickety-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/klickety-16.04.1.tar.xz";
+      sha256 = "1ykrsqwvyw73s6hnkn2k0xw8gs9v7znhzp0fykqcdprix2wb7qzm";
+      name = "klickety-16.04.1.tar.xz";
     };
   };
   klines = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/klines-16.04.0.tar.xz";
-      sha256 = "1000j5n9hzr3ffpi7mj5aicflr5gvbbd02s4l2qy9ghgxf5ghfzw";
-      name = "klines-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/klines-16.04.1.tar.xz";
+      sha256 = "07dmfnfpp8bg907kyj3jidgyicxgsbs8jmiximdky1n8hmqa6sm3";
+      name = "klines-16.04.1.tar.xz";
     };
   };
   kmag = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmag-16.04.0.tar.xz";
-      sha256 = "0z9jrd9a9xmxsbk6xckiqvidd6f9dcj1lfav818fm1wf5jr04v40";
-      name = "kmag-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmag-16.04.1.tar.xz";
+      sha256 = "0a89mhr048p7xpl8ah9p236yxx1k1jnbw8ybcgjfw6n0s7xzaf59";
+      name = "kmag-16.04.1.tar.xz";
     };
   };
   kmahjongg = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmahjongg-16.04.0.tar.xz";
-      sha256 = "0wl7mv20zal3nx3y1cdc8xq0vhkvb8rb8sag8kb66a1ch8zdzw9s";
-      name = "kmahjongg-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmahjongg-16.04.1.tar.xz";
+      sha256 = "10z6rfdhnv19x3sqspgz2wz7dr6yd000vlkg6wr0hsy6kqg7si8b";
+      name = "kmahjongg-16.04.1.tar.xz";
     };
   };
   kmailtransport = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmailtransport-16.04.0.tar.xz";
-      sha256 = "0imw47nlfnd1qq2c91ig7cmwrcm1c9jcqfxvi1svllbwy9bgab3i";
-      name = "kmailtransport-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmailtransport-16.04.1.tar.xz";
+      sha256 = "0h57s0wxc0xfym60i69y6lbh7cchf4clpar9f1b9x461vfcnd432";
+      name = "kmailtransport-16.04.1.tar.xz";
     };
   };
   kmbox = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmbox-16.04.0.tar.xz";
-      sha256 = "1w2y6nda7p5wfl76rmirpglgar8qxhyynx66k5qnvfpvk8xa02wk";
-      name = "kmbox-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmbox-16.04.1.tar.xz";
+      sha256 = "1sm5k1qsn2maa08hyxidrcapfzqwrs5i63wwlpnj8xbgfy61nr5p";
+      name = "kmbox-16.04.1.tar.xz";
     };
   };
   kmime = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmime-16.04.0.tar.xz";
-      sha256 = "04hqdl1kbqv3xm0qvdsrvjs1fnsymqfw2yn286rh7ynlix4p09zz";
-      name = "kmime-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmime-16.04.1.tar.xz";
+      sha256 = "01r267bf6ps5x8q1ia3jv2zi07dbcv120nq9pq3wqixk64gr7gh5";
+      name = "kmime-16.04.1.tar.xz";
     };
   };
   kmines = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmines-16.04.0.tar.xz";
-      sha256 = "0q8jqycwsjadi10a1ycxn09507j85lh0zwxq1b374cdb01m7ajzw";
-      name = "kmines-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmines-16.04.1.tar.xz";
+      sha256 = "12mfsrx32g46kg3s98xali2lhq1gcydmyn7j0ldgi9ksj4zhvc9p";
+      name = "kmines-16.04.1.tar.xz";
     };
   };
   kmix = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmix-16.04.0.tar.xz";
-      sha256 = "0nmfjrxdxpkvxrsp06w6ddcyhfasmzvn8hk44n4wd9v86vgi29cz";
-      name = "kmix-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmix-16.04.1.tar.xz";
+      sha256 = "1k51s1r16zk5qgzyg6y4z24qlabgnnf6s4a5rc4pjwm734yh28g6";
+      name = "kmix-16.04.1.tar.xz";
     };
   };
   kmousetool = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmousetool-16.04.0.tar.xz";
-      sha256 = "1g2lgmimkq9yb8s1lypwh4cz5zxih4fppcqcjlgwcpg0n4ia2hh7";
-      name = "kmousetool-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmousetool-16.04.1.tar.xz";
+      sha256 = "0zn3hxy5p7fq6v617pbxcbbi3zvk3k07dx98d5pjlgzns7jjsmmf";
+      name = "kmousetool-16.04.1.tar.xz";
     };
   };
   kmouth = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmouth-16.04.0.tar.xz";
-      sha256 = "0bqqjs2khdhqgd3apk7bd8sayb9dg6mwc8f211z7zb03xvgb95nd";
-      name = "kmouth-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmouth-16.04.1.tar.xz";
+      sha256 = "1pgyc3x2gixlw2zlh293mpisb2asblbamsbv8565pbf0rz0p84xg";
+      name = "kmouth-16.04.1.tar.xz";
     };
   };
   kmplot = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kmplot-16.04.0.tar.xz";
-      sha256 = "1q76bl3604qcp67w754qsncsg0mw5vm9c5jp8hj6i9vksdl8i3n8";
-      name = "kmplot-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kmplot-16.04.1.tar.xz";
+      sha256 = "1a4i0lj6k8fw8s34vnbiphd1xrfjlk12dbv359gnxjdqalvir9ib";
+      name = "kmplot-16.04.1.tar.xz";
     };
   };
   knavalbattle = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/knavalbattle-16.04.0.tar.xz";
-      sha256 = "0q0k37dvw8pajxcmsv25if726ml9mzdm6am2q22x64hblsgmva0h";
-      name = "knavalbattle-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/knavalbattle-16.04.1.tar.xz";
+      sha256 = "1l7x76b0jn1vssxaxvskp62h33sk2b35n60zih36lscgpv0ldq8w";
+      name = "knavalbattle-16.04.1.tar.xz";
     };
   };
   knetwalk = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/knetwalk-16.04.0.tar.xz";
-      sha256 = "0i00lnw31jb7lb18r6r8k4k61syjak7pglwxwbah96wxrrmdnvpk";
-      name = "knetwalk-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/knetwalk-16.04.1.tar.xz";
+      sha256 = "1rkarsvmmfi0cax7cy71g0mzcwhjcfpiq8xxdnmsn7gwdwf9mlyd";
+      name = "knetwalk-16.04.1.tar.xz";
     };
   };
   kolf = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kolf-16.04.0.tar.xz";
-      sha256 = "1b0247wpnzm9lz82d5v3wv28cacj3b7r5rirdg8plri5y2gks8ql";
-      name = "kolf-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kolf-16.04.1.tar.xz";
+      sha256 = "0azkm74br2xpxg3mvnmi61d5a438igw98a5vk0jycc1y0xfbsfzf";
+      name = "kolf-16.04.1.tar.xz";
     };
   };
   kollision = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kollision-16.04.0.tar.xz";
-      sha256 = "1hmgw5410xznjddv1x2jg6v1rv6hkksr281ylhdb2ca8zh2wdwqi";
-      name = "kollision-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kollision-16.04.1.tar.xz";
+      sha256 = "0kb5ykaayh26f2nwghdwc5vxnr2ik5b4s9k5x0sbz9p933l1wy9z";
+      name = "kollision-16.04.1.tar.xz";
     };
   };
   kolourpaint = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kolourpaint-16.04.0.tar.xz";
-      sha256 = "13x7r8k60q0nnip37xadqdypm88c2zrfk2nhlllhqb41d23hbbsw";
-      name = "kolourpaint-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kolourpaint-16.04.1.tar.xz";
+      sha256 = "1d07yjkxx82czpg57bnzkn5887lhn6rilgyy08zn1739avk589n7";
+      name = "kolourpaint-16.04.1.tar.xz";
     };
   };
   kompare = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kompare-16.04.0.tar.xz";
-      sha256 = "1yd06ykjbi5kvas9vrnhy9svpsvlk4y8xvs963vvi0jdw7x5ylzj";
-      name = "kompare-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kompare-16.04.1.tar.xz";
+      sha256 = "1cysz9qg93jddb20hxgi29c6rm6x3nmi70ji32r8mzpv3r27217n";
+      name = "kompare-16.04.1.tar.xz";
     };
   };
   konquest = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/konquest-16.04.0.tar.xz";
-      sha256 = "198s495slqi7fffmsnn6pj90mi51bjw3grkr033l4z0lmxhqljmb";
-      name = "konquest-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/konquest-16.04.1.tar.xz";
+      sha256 = "1w8axkl0gsvbs7xhmy188xl1h2xkd80w0gdvskykdmcri4mrhldl";
+      name = "konquest-16.04.1.tar.xz";
     };
   };
   konsole = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/konsole-16.04.0.tar.xz";
-      sha256 = "06c3d01h658g00yi4vhc8rk6ndxs4ha0pj6y0w4d10g78zcnjmd4";
-      name = "konsole-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/konsole-16.04.1.tar.xz";
+      sha256 = "15h38zydnlkchsdjhax15gv6507nqqgql5ykw81fqp2byibxl25s";
+      name = "konsole-16.04.1.tar.xz";
     };
   };
   kontactinterface = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kontactinterface-16.04.0.tar.xz";
-      sha256 = "1plhya2xpvvsx2japbiq8v5a2c1rbw77jf3q278kqwracrkgsiax";
-      name = "kontactinterface-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kontactinterface-16.04.1.tar.xz";
+      sha256 = "0qvkrpx9p3hmwqja3iv6n80j1j0b46jvbimfgjs183xlwhqy90l2";
+      name = "kontactinterface-16.04.1.tar.xz";
     };
   };
   kopete = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kopete-16.04.0.tar.xz";
-      sha256 = "1xcaz0f6cmjxy7sifxhlm7jvndj238azx59xg4glrk4mhrnac5m7";
-      name = "kopete-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kopete-16.04.1.tar.xz";
+      sha256 = "1i406hr0r1lfv9awy0fvlg4kh8lljc14hrg9da83nnf07njxb0gh";
+      name = "kopete-16.04.1.tar.xz";
     };
   };
   kpat = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kpat-16.04.0.tar.xz";
-      sha256 = "06xsisy0sv8rldpc2fw3hc4dr66wmxbw006x3p9gi1xxwqlp8j3w";
-      name = "kpat-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kpat-16.04.1.tar.xz";
+      sha256 = "0axm2390bjj57mkykaw196gycjvcx303l0aq3capv971ailx8mxs";
+      name = "kpat-16.04.1.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kpimtextedit-16.04.0.tar.xz";
-      sha256 = "0wkxqqyifvgd1h2i2q3958diwybff8m2wc7g9grl6wagj0rbr6y8";
-      name = "kpimtextedit-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kpimtextedit-16.04.1.tar.xz";
+      sha256 = "0bsviwk4nfy0b632xz29mdl5x9p9c3774l0ghi292rr6891ysz56";
+      name = "kpimtextedit-16.04.1.tar.xz";
     };
   };
   kppp = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kppp-16.04.0.tar.xz";
-      sha256 = "0z53n7cppr79z7k8siaadrspl1134gw5a7wx02jigl0kihm9sykf";
-      name = "kppp-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kppp-16.04.1.tar.xz";
+      sha256 = "1j86kcxx5wrqv72wqbcn50gysp5ddh2i0b6dbaw2qydhv56h1c50";
+      name = "kppp-16.04.1.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kqtquickcharts-16.04.0.tar.xz";
-      sha256 = "12x3mgxba4bfi7imli22a8m3af3hkq3fkx192ij3wx8ils7b6in7";
-      name = "kqtquickcharts-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kqtquickcharts-16.04.1.tar.xz";
+      sha256 = "0yqw8l6l7k2a50djm64lrcvl8rwkkvjiaa51mwcvj34cqfg8i55k";
+      name = "kqtquickcharts-16.04.1.tar.xz";
     };
   };
   krdc = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/krdc-16.04.0.tar.xz";
-      sha256 = "0azlvqai97ki33dc448zw76hqbsqzd6a5k7gj9fsj8pg11m06kn4";
-      name = "krdc-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/krdc-16.04.1.tar.xz";
+      sha256 = "1zij88q4x48kpww22g4p9dbz9f78s2s50m0bpxcrz5aqdvsijgfq";
+      name = "krdc-16.04.1.tar.xz";
     };
   };
   kremotecontrol = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kremotecontrol-16.04.0.tar.xz";
-      sha256 = "027ljqfxl9gsn6q5rld0azqzg3a1ky96045i809dzhdwknrz014a";
-      name = "kremotecontrol-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kremotecontrol-16.04.1.tar.xz";
+      sha256 = "1xxfggy6nx3ncq5h72x1mlnyw7hhi7m15kwfnsg2nhzc86mxg5k5";
+      name = "kremotecontrol-16.04.1.tar.xz";
     };
   };
   kreversi = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kreversi-16.04.0.tar.xz";
-      sha256 = "193vj6qdshh0k7jn7ca63yfkb99sbb0xn3fhyd65iimwcyziz6yj";
-      name = "kreversi-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kreversi-16.04.1.tar.xz";
+      sha256 = "091m8p6z3xw86pn71zz691s4g11jx83ja06bdcpyjwmmwdz4asmb";
+      name = "kreversi-16.04.1.tar.xz";
     };
   };
   krfb = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/krfb-16.04.0.tar.xz";
-      sha256 = "1xcnvs9l2w5awfkxzq2yi0chpljip8nkc3zqlzlqnchkzpxy568j";
-      name = "krfb-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/krfb-16.04.1.tar.xz";
+      sha256 = "16xdzczf9jg22crbymsmij4gjzgbijx9sk7vblprhaqls4gnh55q";
+      name = "krfb-16.04.1.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kross-interpreters-16.04.0.tar.xz";
-      sha256 = "18sc600x5yki1rngxa9ng6zrw5yam824sf05filwa6m22kxi91y8";
-      name = "kross-interpreters-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kross-interpreters-16.04.1.tar.xz";
+      sha256 = "1hz31lkdmkilc2rbfffjx57dwfscr5f4h406346a9qryjk4n466s";
+      name = "kross-interpreters-16.04.1.tar.xz";
     };
   };
   kruler = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kruler-16.04.0.tar.xz";
-      sha256 = "07p85apr7rvgwphnd7vwpmyn8i26m1px4ssq54wk9kindxcs2awg";
-      name = "kruler-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kruler-16.04.1.tar.xz";
+      sha256 = "1xjc1k82xvfk3ad4937v663dhn6b4d3r8gp2aqgzbjnms88sqxsm";
+      name = "kruler-16.04.1.tar.xz";
     };
   };
   ksaneplugin = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ksaneplugin-16.04.0.tar.xz";
-      sha256 = "0ldgj3pna0y7ayyw8nz2ybj8g6i1i7axd96sgpgx11708jqphy91";
-      name = "ksaneplugin-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ksaneplugin-16.04.1.tar.xz";
+      sha256 = "162s931ygfzdiq4l0zcfz75mhm5r4j1mz0730jchfzcpahan3cgl";
+      name = "ksaneplugin-16.04.1.tar.xz";
     };
   };
   kscd = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kscd-16.04.0.tar.xz";
-      sha256 = "0k1dxi6gimy41d8mjcb371fkv8z64cdjhyisdgsyfqq6klhy93ss";
-      name = "kscd-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kscd-16.04.1.tar.xz";
+      sha256 = "1nb5y4q17vg8zy7kzhadhbd0pp1n3z1kgix898is2fhain2har85";
+      name = "kscd-16.04.1.tar.xz";
     };
   };
   kshisen = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kshisen-16.04.0.tar.xz";
-      sha256 = "1k75l3y89hv0gs08kfczb1avy5i5h964xf4b976hslzhpvwi8w1q";
-      name = "kshisen-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kshisen-16.04.1.tar.xz";
+      sha256 = "1cdmawq2z2avl4fkwc9pb7s7m4pqcrm8zhhwkp2gqz8b0vsgz40f";
+      name = "kshisen-16.04.1.tar.xz";
     };
   };
   ksirk = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ksirk-16.04.0.tar.xz";
-      sha256 = "0hswi5f0r10yjm9rdiffaw96d5wwjwcnv2g07hh7lc1w6irmq7v7";
-      name = "ksirk-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ksirk-16.04.1.tar.xz";
+      sha256 = "1jmrbmdbpy0cpakzyh3nqaf8alv05v0i70m1a2b5yw7iiy1jjh0l";
+      name = "ksirk-16.04.1.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ksnakeduel-16.04.0.tar.xz";
-      sha256 = "1666k9q065xrij07fbwv1b1xa23p02qk3b366cfhd38kf1shp9fg";
-      name = "ksnakeduel-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ksnakeduel-16.04.1.tar.xz";
+      sha256 = "1l01rwg8lis624jncj07x9cdvp7g6sb4v75yp3bz8a12s14ayl6h";
+      name = "ksnakeduel-16.04.1.tar.xz";
     };
   };
   kspaceduel = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kspaceduel-16.04.0.tar.xz";
-      sha256 = "03jqb8yn5jgdc9pd92bpbkvr8vwr91cpvmzgmmrqi4llj3cjpp9x";
-      name = "kspaceduel-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kspaceduel-16.04.1.tar.xz";
+      sha256 = "0bzaq2alfkclk5496g9zf53lih52hray14nfnif49acnccs7g1a3";
+      name = "kspaceduel-16.04.1.tar.xz";
     };
   };
   ksquares = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ksquares-16.04.0.tar.xz";
-      sha256 = "11fqvpkghvy54zrvyvwk9kasx3i1clw8rj4bjphif2nr6sc5wdi7";
-      name = "ksquares-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ksquares-16.04.1.tar.xz";
+      sha256 = "1law2s9wdhpzp1zd1q476afscbaxcdi023n0q9j73w1l8jais2p9";
+      name = "ksquares-16.04.1.tar.xz";
     };
   };
   kstars = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kstars-16.04.0.tar.xz";
-      sha256 = "0h648mnp6l5msv56pmwrm5197hdx20jmw2wzdflx09lj3iir6d1y";
-      name = "kstars-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kstars-16.04.1.tar.xz";
+      sha256 = "0sss1d6k89wsjqnywmklnb3ywyws50d1vfz1lfcsmhcgc37w6cm7";
+      name = "kstars-16.04.1.tar.xz";
     };
   };
   ksudoku = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ksudoku-16.04.0.tar.xz";
-      sha256 = "1d6mwhcsa09yrrd43a842xzyf87hpqwlhp1x82f9kx31hkq1hs6m";
-      name = "ksudoku-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ksudoku-16.04.1.tar.xz";
+      sha256 = "0bb7hv8m68qhjh7z3g7qkcnyn41wacby6kaq0qhrr4x37dx96r3i";
+      name = "ksudoku-16.04.1.tar.xz";
     };
   };
   ksystemlog = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ksystemlog-16.04.0.tar.xz";
-      sha256 = "0qcycfyj1wk730hcnzjn75wf6vcxd6svmvqz6q3q85rrjjs3am6s";
-      name = "ksystemlog-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ksystemlog-16.04.1.tar.xz";
+      sha256 = "0ws9vln9gz8r3m1pk1x3fk6b05h1fx070d5ln3g9vxwbkfh3g73d";
+      name = "ksystemlog-16.04.1.tar.xz";
     };
   };
   kteatime = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kteatime-16.04.0.tar.xz";
-      sha256 = "0yhldn2d2kz0kf5s1s8wkmmg73v620mf2h5prf59hqygkdzmxq1n";
-      name = "kteatime-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kteatime-16.04.1.tar.xz";
+      sha256 = "0ap8nc265kylb7idgdbymln6pz4xw3pmgqp1dpqix6pskz64wn7p";
+      name = "kteatime-16.04.1.tar.xz";
     };
   };
   ktimer = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktimer-16.04.0.tar.xz";
-      sha256 = "0p925v4h944vsp8br581wdlnfvp51yq92kf8xfsgc8d7r85h28w4";
-      name = "ktimer-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktimer-16.04.1.tar.xz";
+      sha256 = "1kkga4mcgn2zzsardcvk0r4y75ip1kbdiyp9qhpsdsf1r68m7h6i";
+      name = "ktimer-16.04.1.tar.xz";
     };
   };
   ktnef = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktnef-16.04.0.tar.xz";
-      sha256 = "1n1hi22l1cgjq989dhglm1m47f8bg3zdpsyh506qa3j7fg2y3rs6";
-      name = "ktnef-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktnef-16.04.1.tar.xz";
+      sha256 = "1f0m75n4wxqyjiwr13znk4yhr6852mfns5n5v40yxnjhlvi1zq88";
+      name = "ktnef-16.04.1.tar.xz";
     };
   };
   ktouch = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktouch-16.04.0.tar.xz";
-      sha256 = "19n33p2yirxh21i7ij2bncqksz1i2k57c2cwrzzq40a3b9dndimc";
-      name = "ktouch-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktouch-16.04.1.tar.xz";
+      sha256 = "1hzri668q3d8q0s8n9362hm53jmrmzbil2am0naa3gkr16nj4rjd";
+      name = "ktouch-16.04.1.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-accounts-kcm-16.04.0.tar.xz";
-      sha256 = "1mr7f481dcgg3gyyzycs92n7s2ap5kyv7xy2dmf7rypz1xkp2sya";
-      name = "ktp-accounts-kcm-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-accounts-kcm-16.04.1.tar.xz";
+      sha256 = "0q06lk8agqqgs5hlmyl8pmwdcp95zys2psnzm3s6pvs3lyq9zkkd";
+      name = "ktp-accounts-kcm-16.04.1.tar.xz";
     };
   };
   ktp-approver = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-approver-16.04.0.tar.xz";
-      sha256 = "1mqbvb797mms4mwk5v5xkh2z67fkh1ayhkjq0hgj0wi3a2x65zx8";
-      name = "ktp-approver-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-approver-16.04.1.tar.xz";
+      sha256 = "0wf24dvvxx9cvhihjgfpp78yymnll1bn1zbwi5lg2by75hqzvvi7";
+      name = "ktp-approver-16.04.1.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-auth-handler-16.04.0.tar.xz";
-      sha256 = "1l7rlqiaaffcdpplznkbhhrn41q7f1vx4ripjizj0q8a62fivbr6";
-      name = "ktp-auth-handler-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-auth-handler-16.04.1.tar.xz";
+      sha256 = "1p4jsnvhc6g6r1pdhhbq0b38vhi93v1715naxl5vbdfgk11q72bq";
+      name = "ktp-auth-handler-16.04.1.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-call-ui-16.04.0.tar.xz";
-      sha256 = "0ndknp2c3qyd894cavxbp7kfc8rxgz7pcd3gvsrwdgk31k4jajyx";
-      name = "ktp-call-ui-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-call-ui-16.04.1.tar.xz";
+      sha256 = "01bly8lbk1mg86vjqfq8vz9ym36w4hz2gsizqs616prpxyrfgk0s";
+      name = "ktp-call-ui-16.04.1.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-common-internals-16.04.0.tar.xz";
-      sha256 = "1q0bwnsna9h7lj8pva1kzmn8qnlgyynbvldgcr85g713jr2lnmr8";
-      name = "ktp-common-internals-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-common-internals-16.04.1.tar.xz";
+      sha256 = "0jdmsg1vdvkvx9fb10l0qpwrp5i5w64qfx94231kz4gv1xci0zcb";
+      name = "ktp-common-internals-16.04.1.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-contact-list-16.04.0.tar.xz";
-      sha256 = "07ffzrzm5y8kgz6cxjsj8kkgsnvprrjkl4ck8y0san47gk2p5rb7";
-      name = "ktp-contact-list-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-contact-list-16.04.1.tar.xz";
+      sha256 = "1mjn4if6r7z5smnxac4mr7smh616pd7hm5jmnfgxic9dlvqbxy2x";
+      name = "ktp-contact-list-16.04.1.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-contact-runner-16.04.0.tar.xz";
-      sha256 = "0rcpci13hz9xdc51p364rvyi50vkjjgmf74wkwmaxc57sclf5bwi";
-      name = "ktp-contact-runner-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-contact-runner-16.04.1.tar.xz";
+      sha256 = "08ch3b7pq17ah1xahvbcb8zcizj81vpbqxv0zwmnd55byx3i3nsz";
+      name = "ktp-contact-runner-16.04.1.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-desktop-applets-16.04.0.tar.xz";
-      sha256 = "01w3cdbrii14211wgn9vl3l108za5bw22f39pyznf1bqjimdz4nh";
-      name = "ktp-desktop-applets-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-desktop-applets-16.04.1.tar.xz";
+      sha256 = "0n0v3q1x33z1ck1rlj5jhbsywvjlv8hr878bkv0ppgyndcjv4hwx";
+      name = "ktp-desktop-applets-16.04.1.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-filetransfer-handler-16.04.0.tar.xz";
-      sha256 = "1sf7xg317dgcdvnj2j9hq63633d6iyl7rgn22xryawpq2iw3wz9n";
-      name = "ktp-filetransfer-handler-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-filetransfer-handler-16.04.1.tar.xz";
+      sha256 = "0d34blakmqp3qc80dpakpsk3xdzncy4q8nfg0jjjw9s5qldw0gjx";
+      name = "ktp-filetransfer-handler-16.04.1.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-kded-module-16.04.0.tar.xz";
-      sha256 = "13zsgzipmkn15h83ziwa3wg1dcin4lqawmhapkhlf4xxs8wm1mb6";
-      name = "ktp-kded-module-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-kded-module-16.04.1.tar.xz";
+      sha256 = "19fcc53bwlgdm3gvyiyzp9hdfk9hps5ng9cdqlx1agdx9ap9sbi8";
+      name = "ktp-kded-module-16.04.1.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-send-file-16.04.0.tar.xz";
-      sha256 = "0sdwrj644n80xnx8syycpiwwn432ww2i3vvx1v6sj696gcrkv7i4";
-      name = "ktp-send-file-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-send-file-16.04.1.tar.xz";
+      sha256 = "0svm1ij82zgnkczhrhkmzpy2w1p2khv8wzkj4584zwfjafy3y8yj";
+      name = "ktp-send-file-16.04.1.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktp-text-ui-16.04.0.tar.xz";
-      sha256 = "1pgz1hzrkmx6k88cghgacgjykmkbjvvm1hhyr377hgvdhrfc6scy";
-      name = "ktp-text-ui-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktp-text-ui-16.04.1.tar.xz";
+      sha256 = "1s5kw9yk9m2rj48l5c54m8zsa247hv9ajq9zp2gqrvv3sz7y1bsf";
+      name = "ktp-text-ui-16.04.1.tar.xz";
     };
   };
   ktuberling = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/ktuberling-16.04.0.tar.xz";
-      sha256 = "1w7qv0iacjhr9yphm3kxxiwh2c17x6ky4i2yzb178nb5sh6dgdig";
-      name = "ktuberling-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/ktuberling-16.04.1.tar.xz";
+      sha256 = "05p3jiy7cykpxrjlvhnz5jc3x1mqbdyq6i2h15h315sd39wra5bx";
+      name = "ktuberling-16.04.1.tar.xz";
     };
   };
   kturtle = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kturtle-16.04.0.tar.xz";
-      sha256 = "1as62h92dx4f1n1fb1lhsyvx90msl2392b595hfsgkhgqb4spn3y";
-      name = "kturtle-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kturtle-16.04.1.tar.xz";
+      sha256 = "0cs7k2jv9s89sbh0ig2zvm31v906jvwjrjfdw223zl105c99xshr";
+      name = "kturtle-16.04.1.tar.xz";
     };
   };
   kubrick = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kubrick-16.04.0.tar.xz";
-      sha256 = "1vvh3yzpcri1yyc3z4djkr8sjs03pbrwinrz0f4iwah8diyrdpy0";
-      name = "kubrick-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kubrick-16.04.1.tar.xz";
+      sha256 = "1pxb357bmh4r4g92zxr3x6w65z9lsd34vkvbg7s250q3a7358y4n";
+      name = "kubrick-16.04.1.tar.xz";
     };
   };
   kuser = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kuser-16.04.0.tar.xz";
-      sha256 = "11fradjslci2znglh24wcljhpld4zp206r0wrp392hjc4i6ck069";
-      name = "kuser-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kuser-16.04.1.tar.xz";
+      sha256 = "0b0wjsbj4hin3g4dgijxvm99idzl57i65f1k6hq4mjypnd19ccwv";
+      name = "kuser-16.04.1.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kwalletmanager-16.04.0.tar.xz";
-      sha256 = "1wqdhwvkxky0c4lnm9b3akjvb2ydx3qx3hr08959za7kkk976nmb";
-      name = "kwalletmanager-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kwalletmanager-16.04.1.tar.xz";
+      sha256 = "1w6y55zk7gs7fp0qz5zgmmh3mz8d6ii5g948pwg18415x4ydbrx1";
+      name = "kwalletmanager-16.04.1.tar.xz";
     };
   };
   kwordquiz = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/kwordquiz-16.04.0.tar.xz";
-      sha256 = "0yk95l6gl57hs62l8xvi9xfrzmkcch0v3ijasqhg20i4w33309z0";
-      name = "kwordquiz-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/kwordquiz-16.04.1.tar.xz";
+      sha256 = "0v3snpljvc8zf34jpwbchrqsdajd14k3g4jd3xaz9waa62kbc2m7";
+      name = "kwordquiz-16.04.1.tar.xz";
     };
   };
   libgravatar = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libgravatar-16.04.0.tar.xz";
-      sha256 = "0kbvy90r5x1s1s3h680cqiqj221gicvy8j0pwid5vr2pxjkdih0l";
-      name = "libgravatar-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libgravatar-16.04.1.tar.xz";
+      sha256 = "0wqp5p16jn2qnsndill5ccfk8nirx5j4iyhjny0ri19lkdkcz010";
+      name = "libgravatar-16.04.1.tar.xz";
     };
   };
   libkcddb = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkcddb-16.04.0.tar.xz";
-      sha256 = "1wylsqij5l3w4pvw3g2jkypqpn3a8fg72x7q5dp22l0n9ihrhn8j";
-      name = "libkcddb-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkcddb-16.04.1.tar.xz";
+      sha256 = "1dpmynbb1cyin8f0hd9r1gn432pzj7lck86nbhz38w0w8x2m6b81";
+      name = "libkcddb-16.04.1.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkcompactdisc-16.04.0.tar.xz";
-      sha256 = "0zf3bry65jak3z4kjhnszjy05h4pvnzzz7nh954cmigv369iwsz8";
-      name = "libkcompactdisc-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkcompactdisc-16.04.1.tar.xz";
+      sha256 = "15zm5jmybvh8q2sbwx4203yq6lgj6nm9jgqk3yh8ikbh5ml24bfr";
+      name = "libkcompactdisc-16.04.1.tar.xz";
     };
   };
   libkdcraw = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkdcraw-16.04.0.tar.xz";
-      sha256 = "0l6aa2458apxbz1hm300w3s32ywxjhy80vnm3sxnk3313ba38cml";
-      name = "libkdcraw-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkdcraw-16.04.1.tar.xz";
+      sha256 = "13agxmqqfz38sz0vmqy2rk7xj4bmcffpn84i9a5s1191l13kj0ks";
+      name = "libkdcraw-16.04.1.tar.xz";
     };
   };
   libkdeedu = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkdeedu-16.04.0.tar.xz";
-      sha256 = "16aabzc57qjjzmfmsnb4rjw28w4014l66dsy528rfj5i0wyw40vy";
-      name = "libkdeedu-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkdeedu-16.04.1.tar.xz";
+      sha256 = "1i20ib710cn77y8q9aqwlh4rvyfv8r8w03mwnl45jn27c0rmxmrz";
+      name = "libkdeedu-16.04.1.tar.xz";
     };
   };
   libkdegames = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkdegames-16.04.0.tar.xz";
-      sha256 = "0nr3z1plcinx0hw9q1gac32czgy6079q36v57qk76l6531cssk73";
-      name = "libkdegames-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkdegames-16.04.1.tar.xz";
+      sha256 = "0sx09sm19s8n2imf267sazymwpx1ry68n7ahwj4mczhi3wgvs72w";
+      name = "libkdegames-16.04.1.tar.xz";
     };
   };
   libkdepim = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkdepim-16.04.0.tar.xz";
-      sha256 = "0197r1hdx6cpakmvcp1195bm1vn71y8sprbx23n4m9ak92ak9z6x";
-      name = "libkdepim-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkdepim-16.04.1.tar.xz";
+      sha256 = "03wks48jzj0p6vvqbf5nq14ipln6lcahsi88d7q082yckgkgbjqr";
+      name = "libkdepim-16.04.1.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkeduvocdocument-16.04.0.tar.xz";
-      sha256 = "0j92kjhj143z4g9702ir4xs0hdpkk74ydi9347cvb1vh8mq7wqn0";
-      name = "libkeduvocdocument-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkeduvocdocument-16.04.1.tar.xz";
+      sha256 = "0gw0m31aa4px8ag2nh1ysm1bqlhr2b6gzlqxgjipgi4hlaw72nzs";
+      name = "libkeduvocdocument-16.04.1.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkexiv2-16.04.0.tar.xz";
-      sha256 = "1n3bhzlw729vka1lc00sw75m7cfg5ibqh2lliv6lv9g9aqb7xk0z";
-      name = "libkexiv2-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkexiv2-16.04.1.tar.xz";
+      sha256 = "0h0iw9sgmaascv60yzxyap6mrj7jrr2fh1dcbnfvw7162qq2ldyq";
+      name = "libkexiv2-16.04.1.tar.xz";
     };
   };
   libkface = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkface-16.04.0.tar.xz";
-      sha256 = "1vykpj8yws1sd4x3zcpjlrlq9ygybia4wi34qcakx5016fym2qxb";
-      name = "libkface-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkface-16.04.1.tar.xz";
+      sha256 = "16bb1mpls2wxmpr5vkaapj140c2dxk4rl6cijw2gym7sm1njy98n";
+      name = "libkface-16.04.1.tar.xz";
     };
   };
   libkgeomap = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkgeomap-16.04.0.tar.xz";
-      sha256 = "0kl2wzxmy25398amk3631vql0vh66vd2j9qdxzjb9lvlw7gvn55s";
-      name = "libkgeomap-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkgeomap-16.04.1.tar.xz";
+      sha256 = "0m5cg1pdzldxbv62g2vv048g5dfbkhsjj8zsli1l6arcy38anpwv";
+      name = "libkgeomap-16.04.1.tar.xz";
     };
   };
   libkipi = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkipi-16.04.0.tar.xz";
-      sha256 = "0ffa57f1p86sdqq1spf5bvzh2vfa9wfhm8lrhs6mfrr0nr65v85x";
-      name = "libkipi-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkipi-16.04.1.tar.xz";
+      sha256 = "100hrb52ab2b2rgqsbk9d1hz77ch33cn60sy3zc473p8pfgsp1is";
+      name = "libkipi-16.04.1.tar.xz";
     };
   };
   libkleo = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkleo-16.04.0.tar.xz";
-      sha256 = "0yw36vxscwh10bnn20lbas06j1pcwdgd08qhd8hfdl9yajg9jg0w";
-      name = "libkleo-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkleo-16.04.1.tar.xz";
+      sha256 = "1s16vhv8p7ir532q122zfwibjzv08dbhbxvg0xz83hz87lyr27mj";
+      name = "libkleo-16.04.1.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkmahjongg-16.04.0.tar.xz";
-      sha256 = "08vh9mpxy4i9lnd8a57i443lr77b5am50w4xnpssi0jfy0jjsxkr";
-      name = "libkmahjongg-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkmahjongg-16.04.1.tar.xz";
+      sha256 = "1zrbbfrzbwlgja8n093g797aiws4nc0icp5fsxv6ryfpxxzzawsv";
+      name = "libkmahjongg-16.04.1.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libkomparediff2-16.04.0.tar.xz";
-      sha256 = "137p3c07f7ni5khwbnb9fm9i8vprn0y0wzqmlfa2rhc78bn0czsl";
-      name = "libkomparediff2-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libkomparediff2-16.04.1.tar.xz";
+      sha256 = "0zhx3bsklbj3mwj22x8svqza0z4m4wvj0dysj731kjkmg9i75g8m";
+      name = "libkomparediff2-16.04.1.tar.xz";
     };
   };
   libksane = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libksane-16.04.0.tar.xz";
-      sha256 = "07944vywdm13swqh5psw6jv36f6hdxqhrb718wicjlr57lbg65mb";
-      name = "libksane-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libksane-16.04.1.tar.xz";
+      sha256 = "16jpq7ip8pjl9vglm1m5c9gpfy4p50fa2d5dmlxlr67fbjs35831";
+      name = "libksane-16.04.1.tar.xz";
     };
   };
   libksieve = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/libksieve-16.04.0.tar.xz";
-      sha256 = "15gwg02sand97khvdl22zhqq734n4xdbndldzla0jh2jxixa2ihn";
-      name = "libksieve-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/libksieve-16.04.1.tar.xz";
+      sha256 = "0hdm4z30czxzdf19gwva03q3zgc3qapb4fawakcrgdr1z9k24jg6";
+      name = "libksieve-16.04.1.tar.xz";
     };
   };
   lokalize = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/lokalize-16.04.0.tar.xz";
-      sha256 = "1r77pmy2dxnbxh1dgcmrpz2d6kpnj6z31yan1lkr8wf0fgh7355i";
-      name = "lokalize-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/lokalize-16.04.1.tar.xz";
+      sha256 = "1h2harrdpx1zdvgw21g9y2q93c9n9g3dansb63j6s8g4kv9skgs0";
+      name = "lokalize-16.04.1.tar.xz";
     };
   };
   lskat = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/lskat-16.04.0.tar.xz";
-      sha256 = "1px4wv9kxqqvrdmk9v4bw212mdjwl0v7qbh8mmyq8j06axf3a6jm";
-      name = "lskat-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/lskat-16.04.1.tar.xz";
+      sha256 = "1a6n954sy4yq4f289y2ziv649fbcfbyiinx9w3rffa3mi9lxw690";
+      name = "lskat-16.04.1.tar.xz";
     };
   };
   mailcommon = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/mailcommon-16.04.0.tar.xz";
-      sha256 = "0s62kzjas1zs9cm06lfk37d3nx4h0h0m75i3wlj87spd7hg8p2i1";
-      name = "mailcommon-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/mailcommon-16.04.1.tar.xz";
+      sha256 = "0n3vzgk3iaqja43aidg08yf1g1k78xf5fp02wrsvndi4spad5hv2";
+      name = "mailcommon-16.04.1.tar.xz";
     };
   };
   mailimporter = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/mailimporter-16.04.0.tar.xz";
-      sha256 = "0ij07frw0bf3h8hlkdacdv8a2czsaipkjqwlscbsl5vcplfxpsxv";
-      name = "mailimporter-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/mailimporter-16.04.1.tar.xz";
+      sha256 = "00jgiplwmwdhaq0s4chan21hk6hqkgnfjhvjcn5hv8lsfmdigkkh";
+      name = "mailimporter-16.04.1.tar.xz";
     };
   };
   marble = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/marble-16.04.0.tar.xz";
-      sha256 = "05idh1011njasxr24r2cd16i07720af1qqvba3anfx20nav1sxgr";
-      name = "marble-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/marble-16.04.1.tar.xz";
+      sha256 = "185hcl6fg90blmik72pd32pzkfcaxhv42mmlnwbpwbb4wfxajys7";
+      name = "marble-16.04.1.tar.xz";
     };
   };
   messagelib = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/messagelib-16.04.0.tar.xz";
-      sha256 = "0zh4fxs33yvvn9wgfs47d016bhzss1mr7qjyq023mrlmsl7jnpr8";
-      name = "messagelib-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/messagelib-16.04.1.tar.xz";
+      sha256 = "0flphkm18fbma2sb490lhnk4p01cmc4ri90gqb2ys4mfc22x1yy0";
+      name = "messagelib-16.04.1.tar.xz";
     };
   };
   minuet = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/minuet-16.04.0.tar.xz";
-      sha256 = "0jyrl2rxl1dllv2d99vrga7jn3dqqkrkvhg3bv7a80w766j9hq8g";
-      name = "minuet-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/minuet-16.04.1.tar.xz";
+      sha256 = "10s5fqkk98nzd0w22pcwxqqlyy49is72wbhcqsy0hf90j8qyzah5";
+      name = "minuet-16.04.1.tar.xz";
     };
   };
   mplayerthumbs = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/mplayerthumbs-16.04.0.tar.xz";
-      sha256 = "0mkgnxli1pysrzqbcxky6hsmcvjww7zly82ya2p4nsjr71g8laid";
-      name = "mplayerthumbs-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/mplayerthumbs-16.04.1.tar.xz";
+      sha256 = "1r7iqlb1ik3k21frwn62552fkdxgl29sf44qc9gxi9q254cnw7nq";
+      name = "mplayerthumbs-16.04.1.tar.xz";
     };
   };
   okteta = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/okteta-16.04.0.tar.xz";
-      sha256 = "01p4sqd1j75nyg3aax15b5z3dnppnzc27ci61yzsa3jhd0470n3c";
-      name = "okteta-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/okteta-16.04.1.tar.xz";
+      sha256 = "066p6iw5ci909pvklx900lawcyjiazl6ch3y8yrys97x498qn7pl";
+      name = "okteta-16.04.1.tar.xz";
     };
   };
   okular = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/okular-16.04.0.tar.xz";
-      sha256 = "0dn9vm22hc30v1fhly52fmbvjd6my2zxvl08f44jwimbh7wh9rw0";
-      name = "okular-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/okular-16.04.1.tar.xz";
+      sha256 = "11fx4a4bcrl89zi2z2wvfcinmlmq7cfnxga1x35hkk5rc6vyl3vl";
+      name = "okular-16.04.1.tar.xz";
     };
   };
   palapeli = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/palapeli-16.04.0.tar.xz";
-      sha256 = "1yrph8a07jm69cg5gj0rgc4mgqfvqg024wald724yyydbcx5i8br";
-      name = "palapeli-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/palapeli-16.04.1.tar.xz";
+      sha256 = "1iixmx4nrjdbkhwd0wl5zv4bgvss9zkcz2a85790q3x0hcd9fshb";
+      name = "palapeli-16.04.1.tar.xz";
     };
   };
   parley = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/parley-16.04.0.tar.xz";
-      sha256 = "17lwb2vy36hrpgz3f9hrfikp7kz36xq013ym4cijh26xysha2gsx";
-      name = "parley-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/parley-16.04.1.tar.xz";
+      sha256 = "0ynvbfilfh6rw4fw7ajl4nz4j1n5ip1pcf39r4ql1qghdgz3hr9c";
+      name = "parley-16.04.1.tar.xz";
     };
   };
   picmi = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/picmi-16.04.0.tar.xz";
-      sha256 = "0w2x9c0bd26b34ckmyzcfn980kbsq0y5zw3kfw3dsh5q8n0c627f";
-      name = "picmi-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/picmi-16.04.1.tar.xz";
+      sha256 = "18048amjd4l9agnj0d7q4109ik76568065q6dn6p8xbnczvlanqq";
+      name = "picmi-16.04.1.tar.xz";
     };
   };
   pimcommon = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/pimcommon-16.04.0.tar.xz";
-      sha256 = "0c0xkg2vd5jps0nfy661z2np17gygpyvkdc6cp5ir41b5sk2fz4h";
-      name = "pimcommon-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/pimcommon-16.04.1.tar.xz";
+      sha256 = "19lxgzy8a9ixljpjbxgj8gp0l88cs0rgvgyhzdw9b6nm8m0lr79a";
+      name = "pimcommon-16.04.1.tar.xz";
     };
   };
   poxml = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/poxml-16.04.0.tar.xz";
-      sha256 = "1zwg7b4j5ijs9sry8hl7fnnli8hsw3gy685cdgpairgj46yyryx8";
-      name = "poxml-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/poxml-16.04.1.tar.xz";
+      sha256 = "14ar7hr35sgfqk8scdbrmnkdfzns1a8pwldn1pz46yssshm0yx6b";
+      name = "poxml-16.04.1.tar.xz";
     };
   };
   print-manager = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/print-manager-16.04.0.tar.xz";
-      sha256 = "1kl68fz52zjwfs9kprihar0i6n6sg6s40slblfhvi60s1g5krf4m";
-      name = "print-manager-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/print-manager-16.04.1.tar.xz";
+      sha256 = "0mfafxnvak8svksld0ddrbsrajn7d959dr7arw0j7djj5fbwrind";
+      name = "print-manager-16.04.1.tar.xz";
     };
   };
   rocs = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/rocs-16.04.0.tar.xz";
-      sha256 = "05wc9b93csf7bsbmy99jcnml7n0mgfql1rvrs3z8jcz17jnfcx9s";
-      name = "rocs-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/rocs-16.04.1.tar.xz";
+      sha256 = "0hb8bahr3gfkc41bqnk4dzw91smk4gi97vvlacirdj3wqps3phjk";
+      name = "rocs-16.04.1.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/signon-kwallet-extension-16.04.0.tar.xz";
-      sha256 = "0a36gklixkkwgnhs3w3z3l14p6x6r0xgzcqw344g36v1x3imvspf";
-      name = "signon-kwallet-extension-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/signon-kwallet-extension-16.04.1.tar.xz";
+      sha256 = "0qzgsifx6zscn8wc06wy2gi7xz0hlnvwcpgac85nf1zz7fngjq7i";
+      name = "signon-kwallet-extension-16.04.1.tar.xz";
     };
   };
   spectacle = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/spectacle-16.04.0.tar.xz";
-      sha256 = "0c0qmgjd32iam0zd4n08kmajfqpfsa0zphxvgq2rh7plxw3npfga";
-      name = "spectacle-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/spectacle-16.04.1.tar.xz";
+      sha256 = "1df3hp9swcy00dvfjx34a7z9naz8mpaprxigv87f3jzg9jwbppg6";
+      name = "spectacle-16.04.1.tar.xz";
     };
   };
   step = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/step-16.04.0.tar.xz";
-      sha256 = "18imzm9v2gbf64f3p08a3l7r7axyjsmi2xvbqvg0ir2ly3pabrx0";
-      name = "step-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/step-16.04.1.tar.xz";
+      sha256 = "0nr4maqy067d4jb25h4akljn2vqg33rdxyb619lzr9sksw04ii5k";
+      name = "step-16.04.1.tar.xz";
     };
   };
   svgpart = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/svgpart-16.04.0.tar.xz";
-      sha256 = "11793djb9v499b11kwr1312p9j9hhrjk7i67035s64lblrnbb9yw";
-      name = "svgpart-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/svgpart-16.04.1.tar.xz";
+      sha256 = "0kklmb4vq6pnf9i088n14zbzg9iz80arl8igb815zdl2bx7yqjjj";
+      name = "svgpart-16.04.1.tar.xz";
     };
   };
   sweeper = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/sweeper-16.04.0.tar.xz";
-      sha256 = "0hahwmiziiwraahssxzsxfzvyli4lmj7fdskqnv9q7b39hai88j7";
-      name = "sweeper-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/sweeper-16.04.1.tar.xz";
+      sha256 = "1lhspwgajja6fnd1nm4gnhvyi3ynnx0dicwd8ks81imvkz3kz7yc";
+      name = "sweeper-16.04.1.tar.xz";
     };
   };
   syndication = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/syndication-16.04.0.tar.xz";
-      sha256 = "0m8dacbqdg9vya2c8gknckx8xjp6m9s93vxd4j6a78jz28j6yvcc";
-      name = "syndication-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/syndication-16.04.1.tar.xz";
+      sha256 = "19pqz7q02axr129wcrwr27lkr4qiv542gck4h2rlj21p9amw46kq";
+      name = "syndication-16.04.1.tar.xz";
     };
   };
   umbrello = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/umbrello-16.04.0.tar.xz";
-      sha256 = "11b7a7bg9v2gdl4hjpfz06k5ks2v36ai70iri6rcp0lw9bcspig2";
-      name = "umbrello-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/umbrello-16.04.1.tar.xz";
+      sha256 = "04ql21kl633nxbhjbv2j9wsi7l8pqpp49x737014mz037a58ppvw";
+      name = "umbrello-16.04.1.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "16.04.0";
+    version = "16.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.04.0/src/zeroconf-ioslave-16.04.0.tar.xz";
-      sha256 = "0ablccfi3kq18rcx79jwn9z317qyflb05ck9kalqpr7f8xnmhzn3";
-      name = "zeroconf-ioslave-16.04.0.tar.xz";
+      url = "${mirror}/stable/applications/16.04.1/src/zeroconf-ioslave-16.04.1.tar.xz";
+      sha256 = "0pg7q6lh5i0yhjw9qbralzjxg6f38if57s1lk57bvh0gnmj5zj9b";
+      name = "zeroconf-ioslave-16.04.1.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/kde-5/plasma-5.6/fetchsrcs.sh
+++ b/pkgs/desktops/kde-5/plasma-5.6/fetchsrcs.sh
@@ -4,7 +4,7 @@
 set -x
 
 # The trailing slash at the end is necessary!
-RELEASE_URL="http://download.kde.org/stable/plasma/5.6.3/"
+RELEASE_URL="http://download.kde.org/stable/plasma/5.6.4/"
 EXTRA_WGET_ARGS='-A *.tar.xz'
 
 mkdir tmp; cd tmp

--- a/pkgs/desktops/kde-5/plasma-5.6/plasma-desktop/0001-qt-5.5-QML-import-paths.patch
+++ b/pkgs/desktops/kde-5/plasma-5.6/plasma-desktop/0001-qt-5.5-QML-import-paths.patch
@@ -1,17 +1,17 @@
-From 7c379686def9f15be1aa8fa4b5358124f7ed57c6 Mon Sep 17 00:00:00 2001
-From: Thomas Tuegel <ttuegel@gmail.com>
-Date: Mon, 19 Oct 2015 18:45:36 -0500
-Subject: [PATCH 1/3] qt-5.5 QML import paths
+From a91568d7c6635f4d66bb4e8ebaf2666c24980312 Mon Sep 17 00:00:00 2001
+From: Frederik Rietdijk <fridh@fridh.nl>
+Date: Sat, 14 May 2016 12:54:27 +0200
+Subject: [PATCH] qml import paths
 
 ---
  applets/pager/package/contents/ui/main.qml              | 2 +-
  containments/desktop/package/contents/ui/FolderView.qml | 2 +-
- containments/desktop/package/contents/ui/main.qml       | 2 +-
+ containments/desktop/package/contents/ui/main.qml       | 4 ++--
  containments/panel/contents/ui/main.qml                 | 2 +-
- 4 files changed, 4 insertions(+), 4 deletions(-)
+ 4 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/applets/pager/package/contents/ui/main.qml b/applets/pager/package/contents/ui/main.qml
-index 0c367c6..c9a82be 100644
+index b8eb8a6..fad3f69 100644
 --- a/applets/pager/package/contents/ui/main.qml
 +++ b/applets/pager/package/contents/ui/main.qml
 @@ -23,7 +23,7 @@ import org.kde.plasma.components 2.0 as PlasmaComponents
@@ -24,7 +24,7 @@ index 0c367c6..c9a82be 100644
  MouseArea {
      id: root
 diff --git a/containments/desktop/package/contents/ui/FolderView.qml b/containments/desktop/package/contents/ui/FolderView.qml
-index 578ec87..04e088c 100644
+index ced3507..6073545 100644
 --- a/containments/desktop/package/contents/ui/FolderView.qml
 +++ b/containments/desktop/package/contents/ui/FolderView.qml
 @@ -27,7 +27,7 @@ import org.kde.plasma.extras 2.0 as PlasmaExtras
@@ -37,20 +37,22 @@ index 578ec87..04e088c 100644
  Item {
      id: main
 diff --git a/containments/desktop/package/contents/ui/main.qml b/containments/desktop/package/contents/ui/main.qml
-index 422e8f7..3c8906e 100644
+index a438b74..b907a36 100644
 --- a/containments/desktop/package/contents/ui/main.qml
 +++ b/containments/desktop/package/contents/ui/main.qml
-@@ -29,7 +29,7 @@ import org.kde.kquickcontrolsaddons 2.0 as KQuickControlsAddons
+@@ -30,8 +30,8 @@ import org.kde.kquickcontrolsaddons 2.0 as KQuickControlsAddons
  
  import org.kde.private.desktopcontainment.desktop 0.1 as Desktop
  
 -import "LayoutManager.js" as LayoutManager
+-import "FolderTools.js" as FolderTools
 +import "../code/LayoutManager.js" as LayoutManager
++import "../code/FolderTools.js" as FolderTools
  
  DragDrop.DropArea {
      id: root
 diff --git a/containments/panel/contents/ui/main.qml b/containments/panel/contents/ui/main.qml
-index bad6ba0..b1fc331 100644
+index 4d71c6e..337c356 100644
 --- a/containments/panel/contents/ui/main.qml
 +++ b/containments/panel/contents/ui/main.qml
 @@ -25,7 +25,7 @@ import org.kde.plasma.components 2.0 as PlasmaComponents
@@ -63,5 +65,5 @@ index bad6ba0..b1fc331 100644
  DragDrop.DropArea {
      id: root
 -- 
-2.6.3
+2.8.0
 

--- a/pkgs/desktops/kde-5/plasma-5.6/srcs.nix
+++ b/pkgs/desktops/kde-5/plasma-5.6/srcs.nix
@@ -3,339 +3,339 @@
 
 {
   bluedevil = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/bluedevil-5.6.3.tar.xz";
-      sha256 = "1x8rdsk2jhx01pfw5d74ks2240w9pky7c38rwb84w18l3w1mrq6q";
-      name = "bluedevil-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/bluedevil-5.6.4.tar.xz";
+      sha256 = "043damq5pgalrv77rggcwkvhvxkdpmzhq022zga7nvbzv58hygk0";
+      name = "bluedevil-5.6.4.tar.xz";
     };
   };
   breeze = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/breeze-5.6.3.tar.xz";
-      sha256 = "191pkbkn1hb1c2k7f5y8x2wm99p4v2rm74jk1ygqk72bh8wpc9zx";
-      name = "breeze-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/breeze-5.6.4.tar.xz";
+      sha256 = "184fkv6wda3g0fcmvnzck1vz7vmiin9zsgi3lycrnhf8bwmdp88x";
+      name = "breeze-5.6.4.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/breeze-grub-5.6.3.tar.xz";
-      sha256 = "0i4kxjw8rmp3y40z10yyc792kbvyai9pxd4lva24bilzsh3x2g5c";
-      name = "breeze-grub-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/breeze-grub-5.6.4.tar.xz";
+      sha256 = "0ccc1r7gmfgv5hbd2lvy8qmkmnfsxywax136i0813bjnc3nmvmpy";
+      name = "breeze-grub-5.6.4.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/breeze-gtk-5.6.3.tar.xz";
-      sha256 = "0yr20v5b0hq4jicfx8lxmy23znqwf3d87hz88qiizjiad4fyy4ca";
-      name = "breeze-gtk-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/breeze-gtk-5.6.4.tar.xz";
+      sha256 = "07y5vpikp2q0knmf86m5hzg8dl7a05zlcmd56mg655b9vijkn7sp";
+      name = "breeze-gtk-5.6.4.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/breeze-plymouth-5.6.3.tar.xz";
-      sha256 = "0gkiwravkpxwk9r6l0mzjyr5hc9fpj1d6l5a0i755q7m80h1dahk";
-      name = "breeze-plymouth-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/breeze-plymouth-5.6.4.tar.xz";
+      sha256 = "1vdxbl4mkdmac9i1wnnlsfpx35n6qzymjkjm3zmxa5saxdwv6w0f";
+      name = "breeze-plymouth-5.6.4.tar.xz";
     };
   };
   discover = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/discover-5.6.3.tar.xz";
-      sha256 = "1rpn22xjabsaakqgdsx0vz4h0v40l8ssfrjqahpj95axs14zi2gg";
-      name = "discover-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/discover-5.6.4.tar.xz";
+      sha256 = "0l9rp77hm8gbih7qkr8j1nf37mymysbyjj9nxx3ilgv3dac1x6lb";
+      name = "discover-5.6.4.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kactivitymanagerd-5.6.3.tar.xz";
-      sha256 = "0zs3z4r27iiqz3wjsv09ik3h45g2f08y1p3mr1ihiss07qgknbz6";
-      name = "kactivitymanagerd-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kactivitymanagerd-5.6.4.tar.xz";
+      sha256 = "0xpy392w0xcssabblkw3q7gv9ajn1725i0q5lm3xzrl0x0iq3h2z";
+      name = "kactivitymanagerd-5.6.4.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kde-cli-tools-5.6.3.tar.xz";
-      sha256 = "1cxbvgc3nhrr98ygm3i7srr26ds2rmbg6fzjqvdz2z4bz80ai892";
-      name = "kde-cli-tools-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kde-cli-tools-5.6.4.tar.xz";
+      sha256 = "1kmhi9jx40s8i8zvim0v9dx66gpg6nvjl88ir0w7r903c4c58kpm";
+      name = "kde-cli-tools-5.6.4.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kdecoration-5.6.3.tar.xz";
-      sha256 = "03iryqrkrpphvc8xpqmmpbdgg7rim9yvvyx3kxrjgpbh2xy6rwsr";
-      name = "kdecoration-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kdecoration-5.6.4.tar.xz";
+      sha256 = "0i84nii940xnd94cch4z7zax3y157mjfngcil34ar0n2lpgya2ap";
+      name = "kdecoration-5.6.4.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kde-gtk-config-5.6.3.tar.xz";
-      sha256 = "0jiraahajpfn5k81j077l4ipfadq9aqnnca0kfyag488mhkgmil1";
-      name = "kde-gtk-config-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kde-gtk-config-5.6.4.tar.xz";
+      sha256 = "11798j2024zjpjmpiwj8a9kp3r9lpkahpvkpyxq2pqsvj4rfi55r";
+      name = "kde-gtk-config-5.6.4.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kdeplasma-addons-5.6.3.tar.xz";
-      sha256 = "1p70ms91hd9lhg9fabnrpz1wkc2la9315ffk2wxi334sx4k70gcs";
-      name = "kdeplasma-addons-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kdeplasma-addons-5.6.4.tar.xz";
+      sha256 = "0h20nq5kkd8gn4x2fysfmzwina6cb98d41c8m7c2vxiw6ycsl5id";
+      name = "kdeplasma-addons-5.6.4.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kgamma5-5.6.3.tar.xz";
-      sha256 = "1wv32s6yc4b8qaskdb444r7j918pz0x8mkal5affbr12vzfz8m6r";
-      name = "kgamma5-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kgamma5-5.6.4.tar.xz";
+      sha256 = "0zc7rdw52awrasiynd3b6lhizpzh8yj097fplvnni7nq6mxsc3x3";
+      name = "kgamma5-5.6.4.tar.xz";
     };
   };
   khelpcenter = {
-    version = "5.6.3";
+    version = "5.6.4.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/khelpcenter-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/khelpcenter-5.6.4.1.tar.xz";
       sha256 = "14mwy1rv04mp92dfci6ak6dvmaqx2vc0yk0zyp1v6s64jiry658g";
-      name = "khelpcenter-5.6.3.tar.xz";
+      name = "khelpcenter-5.6.4.1.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/khotkeys-5.6.3.tar.xz";
-      sha256 = "05235ckdr81cl46iyalapjxxmybqd8b2zy1yqclv7fwld2c347pc";
-      name = "khotkeys-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/khotkeys-5.6.4.tar.xz";
+      sha256 = "1xkxzganifvcrinj2hwp9927yqzsqp0mawnfbxnpyhas2jj813c5";
+      name = "khotkeys-5.6.4.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kinfocenter-5.6.3.tar.xz";
-      sha256 = "1rvixj9sr98abna8ss6bmvf7g7i4nm5xa49dv4d42874kskqjci5";
-      name = "kinfocenter-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kinfocenter-5.6.4.tar.xz";
+      sha256 = "19rkb2rprfyh9i4dn7kz2gf4yxmigq3qdhksffn56g2r77wfp56c";
+      name = "kinfocenter-5.6.4.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kmenuedit-5.6.3.tar.xz";
-      sha256 = "169ybp4vvay5isfwk2kv73npspiww2abb4vaa7af8rbiv82cwr0g";
-      name = "kmenuedit-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kmenuedit-5.6.4.tar.xz";
+      sha256 = "1si5gxlcvdywbzwgw6xnwkx509gbc9jpbw5n1kgzxrya0s0baf0z";
+      name = "kmenuedit-5.6.4.tar.xz";
     };
   };
   kscreen = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kscreen-5.6.3.tar.xz";
-      sha256 = "1cvgxwdh742r7dk59qqa4w28sd7k62gjy7w5hmq3dnhka0nlxr74";
-      name = "kscreen-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kscreen-5.6.4.tar.xz";
+      sha256 = "0h722khwnd41537daz5v1303jz7h2b72x9gdfxbihvb7gxaxq9yj";
+      name = "kscreen-5.6.4.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kscreenlocker-5.6.3.tar.xz";
-      sha256 = "13fqmazqrhcdg32iwdym9rci9fj2jn02mkc01rz8fw9a8fwxzdcn";
-      name = "kscreenlocker-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kscreenlocker-5.6.4.tar.xz";
+      sha256 = "0anhcpl5r0x17i412imn8q0078dqpxgn1wmjz8xjfn33i2y32k0h";
+      name = "kscreenlocker-5.6.4.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/ksshaskpass-5.6.3.tar.xz";
-      sha256 = "0bxpwlylfnicipwkf5fq3s62w9gq8gcxl6iby1lmw8m55fm1xd7y";
-      name = "ksshaskpass-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/ksshaskpass-5.6.4.tar.xz";
+      sha256 = "1qzxj152pq53ach0ddc7adg6dvz250pzd5vaz7w79jbjn9pgkaky";
+      name = "ksshaskpass-5.6.4.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/ksysguard-5.6.3.tar.xz";
-      sha256 = "0vh0wpsv0jlj6lq6fl45k7aivbj2nwq5ksfnyad74v20qhy2069b";
-      name = "ksysguard-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/ksysguard-5.6.4.tar.xz";
+      sha256 = "0003w4kad8lvs0hi49qq49sxg8hsqa1b82miw0cmb3r08ivr1pc1";
+      name = "ksysguard-5.6.4.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kwallet-pam-5.6.3.tar.xz";
-      sha256 = "1zy5s3pv7qlyckzaz7yvqzb0w478q6zldmm5w7m4ax90j16ihg7n";
-      name = "kwallet-pam-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kwallet-pam-5.6.4.tar.xz";
+      sha256 = "1yr5nhxrrkz49qn1nd7ql6k1wvilzy1vg40m3x65wk3gbgajq2xj";
+      name = "kwallet-pam-5.6.4.tar.xz";
     };
   };
   kwayland = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kwayland-5.6.3.tar.xz";
-      sha256 = "04rpvgs25dqrac8bg46w1dpxpwavrlrjyc71bxqiddrya798485v";
-      name = "kwayland-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kwayland-5.6.4.tar.xz";
+      sha256 = "0limprv5sniscnar6l0q2805nvfiv375r4kdwwlq8r0g7cj1bb6q";
+      name = "kwayland-5.6.4.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kwayland-integration-5.6.3.tar.xz";
-      sha256 = "19p224n7knih7gikcxkx6n4v49ysgkxd6ghpqwnw5y6jx147qyg4";
-      name = "kwayland-integration-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kwayland-integration-5.6.4.tar.xz";
+      sha256 = "1jxl6pmbq33sv09lrs558hpy7n7liz3c0l9mmnsnvam43lmj2mzi";
+      name = "kwayland-integration-5.6.4.tar.xz";
     };
   };
   kwin = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kwin-5.6.3.tar.xz";
-      sha256 = "0dxscqk5kqkqfq5cs8qpfwi38i20q3w7r8wvq5l8r9q0q56bsnrk";
-      name = "kwin-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kwin-5.6.4.tar.xz";
+      sha256 = "09869hnck8fas5hkpnn7przdn2hzj8cljpasnzy30nc3h5823rdc";
+      name = "kwin-5.6.4.tar.xz";
     };
   };
   kwrited = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/kwrited-5.6.3.tar.xz";
-      sha256 = "18lqr7an6zzlqs2s50arw5zwfdzxl644c7i00j332nlv23yxc1g3";
-      name = "kwrited-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/kwrited-5.6.4.tar.xz";
+      sha256 = "0cgi9ad0kns5z926hbdpg1hrp3pcpjcfpxna248qq7xf9il8cg2q";
+      name = "kwrited-5.6.4.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/libkscreen-5.6.3.tar.xz";
-      sha256 = "0w1v432i8xjk0xgs6vbz68myfqfa93kzhhya4mqri7jzjc6nyc1y";
-      name = "libkscreen-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/libkscreen-5.6.4.tar.xz";
+      sha256 = "1rrargaaz39xxn9rgvlgm15c9y4zyvz35h4dv6fz7vrix2cjpqkx";
+      name = "libkscreen-5.6.4.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/libksysguard-5.6.3.tar.xz";
-      sha256 = "16pf9p9dbq08mlqrcqrxsmwxgi1dp1rzbm4icksr99cjm30zss0g";
-      name = "libksysguard-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/libksysguard-5.6.4.tar.xz";
+      sha256 = "0acwb9qnrygggywyf5vj7768mp269hmnxz2q0vgn3pwpc68l4xj6";
+      name = "libksysguard-5.6.4.tar.xz";
     };
   };
   milou = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/milou-5.6.3.tar.xz";
-      sha256 = "18d3knb1ndj39pffy5xsqdyncsym0izv73r0cmmc3mw8x7xshcfc";
-      name = "milou-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/milou-5.6.4.tar.xz";
+      sha256 = "1j22i98qwc14xbhc2yy0qq100rnddkmkr6q432pfd2cz31l5pvyk";
+      name = "milou-5.6.4.tar.xz";
     };
   };
   oxygen = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/oxygen-5.6.3.tar.xz";
-      sha256 = "1pnal63by1hnjal356lmadk7sxq2pndi1gfhf8lmqpw0n5dwd9ng";
-      name = "oxygen-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/oxygen-5.6.4.tar.xz";
+      sha256 = "0h8ib1b7l1i92vnwhzdxsw8vspx420dk1pw3dg0p550vw411nfm9";
+      name = "oxygen-5.6.4.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/plasma-desktop-5.6.3.tar.xz";
-      sha256 = "0dk4ya5srb4czslakbi1f7gyrriv1lb6cdkfirqznax561bk6dk7";
-      name = "plasma-desktop-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/plasma-desktop-5.6.4.tar.xz";
+      sha256 = "0xj8y2w8qzxih47qmyg31h588i8g2nlyx7rr3qkj8zvllq1fqspw";
+      name = "plasma-desktop-5.6.4.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/plasma-integration-5.6.3.tar.xz";
-      sha256 = "0wx62s6l8kqhsrc88zji9ydaqgplc9y7l2s52qfwm2g464k4i1qw";
-      name = "plasma-integration-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/plasma-integration-5.6.4.tar.xz";
+      sha256 = "1aqv3agcba6w789mmg0r56afywqkxwcwnvfznaxzzwi33y039x4m";
+      name = "plasma-integration-5.6.4.tar.xz";
     };
   };
   plasma-mediacenter = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/plasma-mediacenter-5.6.3.tar.xz";
-      sha256 = "17g5hkpjqsifb413f4p9y10hnbk74k3vbk5srcx46byrsjbkasgq";
-      name = "plasma-mediacenter-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/plasma-mediacenter-5.6.4.tar.xz";
+      sha256 = "0w2s6s4azdh3if2w88p5h2p8kw14l7z6h6pddj3m4hyq2nyk5izc";
+      name = "plasma-mediacenter-5.6.4.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/plasma-nm-5.6.3.tar.xz";
-      sha256 = "0axsv7nxfwqhjq3j5yn30b76wvr8p21p5jlqspq7yxhmxhk88x4j";
-      name = "plasma-nm-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/plasma-nm-5.6.4.tar.xz";
+      sha256 = "1g0flz5f8ydbi1an55anw4zz1h2wmf6xq500qs7ww038gk24113v";
+      name = "plasma-nm-5.6.4.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/plasma-pa-5.6.3.tar.xz";
-      sha256 = "1d623xav0ckabckr9v51sg6a6695fi7pkcy86q2lrpg1m6f2m2l3";
-      name = "plasma-pa-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/plasma-pa-5.6.4.tar.xz";
+      sha256 = "0whlqhlnadk20qjmiyhxxsh0g1djmn6hjiqlpya224gjdpg9205s";
+      name = "plasma-pa-5.6.4.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/plasma-sdk-5.6.3.tar.xz";
-      sha256 = "0w8gcm0hgqk3yqr981zf1xzd024b06y7zxqmzsbzcr3sfh85f0b2";
-      name = "plasma-sdk-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/plasma-sdk-5.6.4.tar.xz";
+      sha256 = "1x2g1kf40g249n7hcq15k4nxv269lw2v4y49j448gzp4hglfkq4i";
+      name = "plasma-sdk-5.6.4.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/plasma-workspace-5.6.3.tar.xz";
-      sha256 = "0p4g15x1ifcc4kn224h66a6fyv3iki1qqpfnihvmkdxmifmbzy2c";
-      name = "plasma-workspace-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/plasma-workspace-5.6.4.tar.xz";
+      sha256 = "1rrhw13hr8b3088lxjzaks439yi1kx53qxm8iwspnnkx9b88n18v";
+      name = "plasma-workspace-5.6.4.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/plasma-workspace-wallpapers-5.6.3.tar.xz";
-      sha256 = "0jdwm01q7h47qrx832kqshrh17dz4dhjbqmy1x17barxd759kd09";
-      name = "plasma-workspace-wallpapers-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/plasma-workspace-wallpapers-5.6.4.tar.xz";
+      sha256 = "1nzzi19jgfprlhiq7kfarv1z4c4p2vcdds75hk304sb2bj0a1fq3";
+      name = "plasma-workspace-wallpapers-5.6.4.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.6.3";
+    version = "1-5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/polkit-kde-agent-1-5.6.3.tar.xz";
-      sha256 = "1d28v8fb5w5snfn5nwghz8mwvk8p1ahs3kxjkhqkwb6sb6l0kkq1";
-      name = "polkit-kde-agent-1-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/polkit-kde-agent-1-5.6.4.tar.xz";
+      sha256 = "07lkhsb9yr4223qxlfkzl54jsl3amdlf9f86cqh1mryk9hqx4p6z";
+      name = "polkit-kde-agent-1-5.6.4.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/powerdevil-5.6.3.tar.xz";
-      sha256 = "1gq04f2pgr3y7wi3jg6xrk8b3fhf1fqn82knv7cix0d5b2khy2lp";
-      name = "powerdevil-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/powerdevil-5.6.4.tar.xz";
+      sha256 = "0yv0wcfs678z1h0lglsky439c8qqiz0m6630sv254xydsdwld1m5";
+      name = "powerdevil-5.6.4.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/sddm-kcm-5.6.3.tar.xz";
-      sha256 = "1kqkl4p65vl2mvgigw24w3p9p4f0j2fz4d2rv1iy2w93kznl9b4s";
-      name = "sddm-kcm-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/sddm-kcm-5.6.4.tar.xz";
+      sha256 = "05f7xx0ayyq5l15j7cq6rpb9l473lkizcf41yrr0aszrzj45i94v";
+      name = "sddm-kcm-5.6.4.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/systemsettings-5.6.3.tar.xz";
-      sha256 = "16fgr1qwfbmzriajisq4sj978lni11d4ig80z7k1h7g5xxhahk9k";
-      name = "systemsettings-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/systemsettings-5.6.4.tar.xz";
+      sha256 = "1i4pqz4whikcvnpprkv9hd435h4akrnmqrjcvq55v3nr8fxd0dlv";
+      name = "systemsettings-5.6.4.tar.xz";
     };
   };
   user-manager = {
-    version = "5.6.3";
+    version = "5.6.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.6.3/user-manager-5.6.3.tar.xz";
-      sha256 = "1slvz0nxhafpprbdzf87dpiw62yar62ia78rcr9xabgz2rfl0bhl";
-      name = "user-manager-5.6.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.6.4/user-manager-5.6.4.tar.xz";
+      sha256 = "1p1xxs4hjacdn2kr2v2rx1c7kipkgsf8wp3bvpf9vpg4g384p2rm";
+      name = "user-manager-5.6.4.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This PR updates Plasma to 5.6.4 and Applications to 16.04.1. I've tested the desktop and several applications.

cc @ttuegel 
