### PR TITLE
i3pystatus: fix libpulseaudio

### DIFF
--- a/pkgs/applications/window-managers/i3/pystatus.nix
+++ b/pkgs/applications/window-managers/i3/pystatus.nix
@@ -14,7 +14,8 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = with python3Packages; [ keyring colour netifaces praw psutil basiciw ] ++
     [ libpulseaudio ] ++ extraLibs;
 
-  ldWrapperSuffix = "--suffix LD_LIBRARY_PATH : \"${libpulseaudio}/lib\"";
+  libpulseaudioPath = stdenv.lib.makeLibraryPath [ libpulseaudio ];
+  ldWrapperSuffix = "--suffix LD_LIBRARY_PATH : \"${libpulseaudioPath}\"";
   makeWrapperArgs = [ ldWrapperSuffix ]; # libpulseaudio.so is loaded manually
 
   postInstall = ''


### PR DESCRIPTION
Fix problem with wrong library path to libpulseaudio. Now `i3pystatus` can start without errors about pulseaudio.
Tested locally:

``` bash
[19:58] igor@igor-pc nixpkgs (i3pystatus-fix *) $ /run/user/1000/nox-review-nzacujtx/result/bin/i3pystatus-python-interpreter ~/.config/i3/status-config.py 
{"click_events": true, "version": 1}
[
[{"name": "i3pystatus.keyboard_locks.Keyboard_locks", "instance": "140229341230136", "markup": "none", "full_text": " NUM "}, {"name": "i3pystatus.shell.Shell", "instance": "140229280843368", "markup": "none", "full_text": "US"}, {"name": "i3pystatus.pulseaudio.PulseAudio", "instance": "140229280845104", "markup": "none", "full_text": "\u266a: 20"}, {"markup": "none", "name": "i3pystatus.disk.Disk", "instance": "140229306259552", "urgent": false, "full_text": "41.14% (23.68 GiB)"}, {"markup": "none", "name": "i3pystatus.load.Load", "instance": "140229280593400", "urgent": false, "full_text": "0.41 0.59 0.81"}, {"name": "i3pystatus.weather.Weather", "instance": "140229329923096", "color": "#FFCC00", "markup": "none", "full_text": "16\u00b0C \u2600"}, {"markup": "none", "name": "i3pystatus.clock.Clock", "instance": "140229328124616", "urgent": false, "full_text": "Sat May 14 19:58"}]
,[{"name": "i3pystatus.keyboard_locks.Keyboard_locks", "instance": "140229341230136", "markup": "none", "full_text": " NUM "}, {"name": "i3pystatus.shell.Shell", "instance": "140229280843368", "markup": "none", "full_text": "US"}, {"name": "i3pystatus.pulseaudio.PulseAudio", "instance": "140229280845104", "markup": "none", "full_text": "\u266a: 20"}, {"markup": "none", "name": "i3pystatus.disk.Disk", "instance": "140229306259552", "urgent": false, "full_text": "41.14% (23.68 GiB)"}, {"markup": "none", "name": "i3pystatus.load.Load", "instance": "140229280593400", "urgent": false, "full_text": "0.41 0.59 0.81"}, {"name": "i3pystatus.weather.Weather", "instance": "140229329923096", "color": "#FFCC00", "markup": "none", "full_text": "16\u00b0C \u2600"}, {"markup": "none", "name": "i3pystatus.clock.Clock", "instance": "140229328124616", "urgent": false, "full_text": "Sat May 14 19:58"}]
,[{"name": "i3pystatus.keyboard_locks.Keyboard_locks", "instance": "140229341230136", "markup": "none", "full_text": " NUM "}, {"name": "i3pystatus.shell.Shell", "instance": "140229280843368", "markup": "none", "full_text": "US"}, {"name": "i3pystatus.pulseaudio.PulseAudio", "instance": "140229280845104", "markup": "none", "full_text": "\u266a: 20"}, {"markup": "none", "name": "i3pystatus.disk.Disk", "instance": "140229306259552", "urgent": false, "full_text": "41.14% (23.68 GiB)"}, {"markup": "none", "name": "i3pystatus.load.Load", "instance": "140229280593400", "urgent": false, "full_text": "0.41 0.59 0.81"}, {"name": "i3pystatus.weather.Weather", "instance": "140229329923096", "color": "#FFCC00", "markup": "none", "full_text": "16\u00b0C \u2600"}, {"markup": "none", "name": "i3pystatus.clock.Clock", "instance": "140229328124616", "urgent": false, "full_text": "Sat May 14 19:58"}]
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
