### PR TITLE
mpop: init at 1.2.4

### DIFF
--- a/pkgs/applications/networking/mpop/default.nix
+++ b/pkgs/applications/networking/mpop/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, openssl, pkgconfig, gnutls, gsasl, libidn, Security }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.4";
+  name = "mpop-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/mpop/${name}.tar.xz";
+    sha256 = "158zl6clxrl2id4kvdig2lvdvm0vg2byqcgn1dnxfjg5mw16ngwk";
+  };
+
+  buildInputs = [ openssl pkgconfig gnutls gsasl libidn ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
+
+  configureFlags =
+    stdenv.lib.optional stdenv.isDarwin [ "--with-macosx-keyring" ];
+
+  meta = {
+      description = "POP3 mail retrieval agent";
+      homepage = "http://mpop.sourceforge.net/";
+      license = stdenv.lib.licenses.gpl3Plus;
+      platforms = stdenv.lib.platforms.unix;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13486,6 +13486,10 @@ in
 
   sxhkd = callPackage ../applications/window-managers/sxhkd { };
 
+  mpop = callPackage ../applications/networking/mpop {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   msmtp = callPackage ../applications/networking/msmtp {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
