### PR TITLE
transmission_remote_cli: init at 1.7.1

### DIFF
--- a/pkgs/applications/networking/p2p/transmission-remote-cli/default.nix
+++ b/pkgs/applications/networking/p2p/transmission-remote-cli/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  name = "transmission-remote-cli-${version}";
+  version = "1.7.1";
+
+  src = fetchurl {
+    url = "https://github.com/fagga/transmission-remote-cli/archive/v${version}.tar.gz";
+    sha256 = "1y0hkpcjf6jw9xig8yf484hbhy63nip0pkchx401yxj81m25l4z9";
+  };
+
+  buildInputs = with pythonPackages; [ python wrapPython ];
+  pythonPath = [ pythonPackages.curses ];
+
+  installPhase = ''
+    install -D transmission-remote-cli $out/bin/transmission-remote-cli
+    install -D transmission-remote-cli.1 $out/share/man/man1/transmission-remote-cli.1
+    wrapPythonPrograms
+  '';
+
+  meta = {
+    description = "Curses interface for the Transmission BitTorrent daemon";
+    homepage = https://github.com/fagga/transmission-remote-cli;
+    license = stdenv.lib.licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14250,6 +14250,7 @@ in
   transmission = callPackage ../applications/networking/p2p/transmission { };
   transmission_gtk = transmission.override { enableGTK3 = true; };
 
+  transmission-remote-cli = callPackage ../applications/networking/p2p/transmission-remote-cli {};
   transmission_remote_gtk = callPackage ../applications/networking/p2p/transmission-remote-gtk {};
 
   trayer = callPackage ../applications/window-managers/trayer { };


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
