### PR TITLE
cpputest: init at 3.7.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -179,6 +179,7 @@
   joelteon = "Joel Taylor <me@joelt.io>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
   jraygauthier = "Raymond Gauthier <jraygauthier@gmail.com>";
+  juliendehos = "Julien Dehos <dehos@lisic.univ-littoral.fr>";
   jwiegley = "John Wiegley <johnw@newartisans.com>";
   jwilberding = "Jordan Wilberding <jwilberding@afiniate.com>";
   jzellner = "Jeff Zellner <jeffz@eml.cc>";

--- a/pkgs/development/libraries/cpputest/default.nix
+++ b/pkgs/development/libraries/cpputest/default.nix
@@ -1,0 +1,19 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  version = "3.7.2";
+  name = "cpputest-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/cpputest/cpputest/releases/download/${version}/${name}.tar.gz";
+    sha256 = "0lwn226d8mrppdyzcvr08vsnnp6h0mpy5kz5a475ish87az00pcc";
+  };
+
+  meta = {
+    homepage = "http://cpputest.github.io/";
+    description = "Unit testing and mocking framework for C/C++";
+    platforms = stdenv.lib.platforms.linux ;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.juliendehos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6723,6 +6723,8 @@ in
 
   cppunit = callPackage ../development/libraries/cppunit { };
 
+  cpputest = callPackage ../development/libraries/cpputest { };
+
   cracklib = callPackage ../development/libraries/cracklib { };
 
   cryptopp = callPackage ../development/libraries/crypto++ { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
