### PR TITLE
postgis: fix build after output splits

### DIFF
--- a/pkgs/development/libraries/postgis/default.nix
+++ b/pkgs/development/libraries/postgis/default.nix
@@ -89,6 +89,10 @@ in rec {
     sha256 = "02gsi1cm63kf0r7881444lrkzdjqhhpz9a5zav3al0q24nq01r8g";
     sql_srcs = ["postgis.sql" "spatial_ref_sys.sql"];
     builtInputs = [gdal json_c pkgconfig];
+
+    # postgis config directory assumes /include /lib from the same root for json-c library
+    NIX_LDFLAGS="-L${json_c.out}/lib";
+
     dontDisableStatic = true;
     preConfigure = ''
       sed -i 's@/usr/bin/file@${file}/bin/file@' configure

--- a/pkgs/development/libraries/postgis/default.nix
+++ b/pkgs/development/libraries/postgis/default.nix
@@ -91,7 +91,7 @@ in rec {
     builtInputs = [gdal json_c pkgconfig];
 
     # postgis config directory assumes /include /lib from the same root for json-c library
-    NIX_LDFLAGS="-L${json_c.out}/lib";
+    NIX_LDFLAGS = "-L${stdenv.lib.makeLibraryPath [json_c]}";
 
     dontDisableStatic = true;
     preConfigure = ''

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -32,11 +32,18 @@ let
     patches =
       [ (if lib.versionAtLeast version "9.4" then ./disable-resolve_symlinks-94.patch else ./disable-resolve_symlinks.patch)
         ./less-is-more.patch
+        ./hardcode-pgxs-path.patch
       ];
 
     installTargets = [ "install-world" ];
 
     LC_ALL = "C";
+
+    postConfigure =
+      ''
+        # Hardcode the path to pgxs so pg_config returns the path in $out
+        substituteInPlace "src/bin/pg_config/pg_config.c" --replace HARDCODED_PGXS_PATH $out/lib
+      '';
 
     postInstall =
       ''

--- a/pkgs/servers/sql/postgresql/hardcode-pgxs-path.patch
+++ b/pkgs/servers/sql/postgresql/hardcode-pgxs-path.patch
@@ -1,0 +1,17 @@
+--- a/src/bin/pg_config/pg_config.c
++++ b/src/bin/pg_config/pg_config.c
+@@ -220,11 +220,13 @@ show_sysconfdir(bool all)
+ static void
+ show_pgxs(bool all)
+ {
+-	char		path[MAXPGPATH];
++	char		path[MAXPGPATH] = "HARDCODED_PGXS_PATH";
+ 
+ 	if (all)
+ 		printf("PGXS = ");
++  /* commented out to be able to point to nix $out path
+ 	get_pkglib_path(mypath, path);
++  */
+ 	strlcat(path, "/pgxs/src/makefiles/pgxs.mk", sizeof(path));
+ 	cleanup_path(path);
+ 	printf("%s\n", path);


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ x] NixOS
  - [ ] OS X
  - [ x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes issue #15236

Two changes were needed:
- pg_config from postgresql package wasn't reporting the correct location for
  the pgxs extension system, after the output split
- json_c is now split in dev and out outputs, postgis configure doesn't find the
  library location properly
