### PR TITLE
subsonic: change NixOS home directory config

### DIFF
--- a/nixos/modules/services/misc/subsonic.nix
+++ b/nixos/modules/services/misc/subsonic.nix
@@ -2,19 +2,14 @@
 
 with lib;
 
-let
-  cfg = config.services.subsonic;
-  homeDir = "/var/subsonic";
-
-in
-{
+let cfg = config.services.subsonic; in {
   options = {
     services.subsonic = {
       enable = mkEnableOption "Subsonic daemon";
 
       home = mkOption {
         type = types.path;
-        default = "${homeDir}";
+        default = "/var/lib/subsonic";
         description = ''
           The directory where Subsonic will create files.
           Make sure it is writable.
@@ -146,7 +141,7 @@ in
 
     users.extraUsers.subsonic = {
       description = "Subsonic daemon user";
-      home = homeDir;
+      home = cfg.home;
       createHome = true;
       group = "subsonic";
       uid = config.ids.uids.subsonic;

--- a/nixos/modules/services/misc/subsonic.nix
+++ b/nixos/modules/services/misc/subsonic.nix
@@ -123,6 +123,18 @@ let cfg = config.services.subsonic; in {
       '';
 
       preStart = ''
+        # Formerly this module set cfg.home to /var/subsonic. Try to move
+        # /var/subsonic to cfg.home.
+        oldHome="/var/subsonic"
+        if [ "${cfg.home}" != "$oldHome" ] &&
+                ! [ -e "${cfg.home}" ] &&
+                [ -d "$oldHome" ] &&
+                [ $(${pkgs.coreutils}/bin/stat -c %u "$oldHome") -eq \
+                    ${toString config.users.extraUsers.subsonic.uid} ]; then
+            logger Moving "$oldHome" to "${cfg.home}"
+            ${pkgs.coreutils}/bin/mv -T "$oldHome" "${cfg.home}"
+        fi
+
         # Install transcoders.
         ${pkgs.coreutils}/bin/rm -rf ${cfg.home}/transcode ; \
         ${pkgs.coreutils}/bin/mkdir -p ${cfg.home}/transcode ; \

--- a/nixos/modules/services/misc/subsonic.nix
+++ b/nixos/modules/services/misc/subsonic.nix
@@ -107,30 +107,31 @@ let cfg = config.services.subsonic; in {
       description = "Personal media streamer";
       after = [ "local-fs.target" "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        ExecStart = ''
-          ${pkgs.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
-            -Dsubsonic.home=${cfg.home} \
-            -Dsubsonic.host=${cfg.listenAddress} \
-            -Dsubsonic.port=${toString cfg.port} \
-            -Dsubsonic.httpsPort=${toString cfg.httpsPort} \
-            -Dsubsonic.contextPath=${cfg.contextPath} \
-            -Dsubsonic.defaultMusicFolder=${cfg.defaultMusicFolder} \
-            -Dsubsonic.defaultPodcastFolder=${cfg.defaultPodcastFolder} \
-            -Dsubsonic.defaultPlaylistFolder=${cfg.defaultPlaylistFolder} \
-            -Djava.awt.headless=true \
-            -verbose:gc \
-            -jar ${pkgs.subsonic}/subsonic-booter-jar-with-dependencies.jar
-        '';
+      script = ''
+        ${pkgs.jre}/bin/java -Xmx${toString cfg.maxMemory}m \
+          -Dsubsonic.home=${cfg.home} \
+          -Dsubsonic.host=${cfg.listenAddress} \
+          -Dsubsonic.port=${toString cfg.port} \
+          -Dsubsonic.httpsPort=${toString cfg.httpsPort} \
+          -Dsubsonic.contextPath=${cfg.contextPath} \
+          -Dsubsonic.defaultMusicFolder=${cfg.defaultMusicFolder} \
+          -Dsubsonic.defaultPodcastFolder=${cfg.defaultPodcastFolder} \
+          -Dsubsonic.defaultPlaylistFolder=${cfg.defaultPlaylistFolder} \
+          -Djava.awt.headless=true \
+          -verbose:gc \
+          -jar ${pkgs.subsonic}/subsonic-booter-jar-with-dependencies.jar
+      '';
+
+      preStart = ''
         # Install transcoders.
-        ExecStartPre = ''
-          ${pkgs.coreutils}/bin/rm -rf ${cfg.home}/transcode ; \
-          ${pkgs.coreutils}/bin/mkdir -p ${cfg.home}/transcode ; \
-          ${pkgs.bash}/bin/bash -c ' \
-            for exe in "$@"; do \
-              ${pkgs.coreutils}/bin/ln -sf "$exe" ${cfg.home}/transcode; \
-            done' IGNORED_FIRST_ARG ${toString cfg.transcoders}
-        '';
+        ${pkgs.coreutils}/bin/rm -rf ${cfg.home}/transcode ; \
+        ${pkgs.coreutils}/bin/mkdir -p ${cfg.home}/transcode ; \
+        ${pkgs.bash}/bin/bash -c ' \
+          for exe in "$@"; do \
+            ${pkgs.coreutils}/bin/ln -sf "$exe" ${cfg.home}/transcode; \
+          done' IGNORED_FIRST_ARG ${toString cfg.transcoders}
+      '';
+      serviceConfig = {
         # Needed for Subsonic to find subsonic.war.
         WorkingDirectory = "${pkgs.subsonic}";
         Restart = "always";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Move Subsonic state directory from `/var/subsonic` to
`/var/lib/subsonic`, since the general convention is for each
application to put its state directory there.

Also, automatically set the home directory of the `subsonic` user to the
value of `config.services.subsonic.home`, rather than setting it to a
value hardcoded in the module. This keeps the home directory of the
`subsonic` user and the state directory for the Subsonic application in
sync.
