### PR TITLE
xfce4: rename application xfce4screenshooter to xfce4-screenshooter

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -75,7 +75,7 @@ in
         pkgs.xfce.xfce4settings
         pkgs.xfce.xfce4mixer
         pkgs.xfce.xfce4volumed
-        pkgs.xfce.xfce4screenshooter
+        pkgs.xfce.xfce4-screenshooter
         pkgs.xfce.xfconf
         pkgs.xfce.xfwm4
         # This supplies some "abstract" icons such as


### PR DESCRIPTION
The package itself has been renamed in #15454, but a reference to the old name in `nixos/modules/services/x11/desktop-managers/xfce.nix` is still there.
