### PR TITLE
Python: be explicit about buildInputs

### DIFF
--- a/pkgs/development/interpreters/python/3.3/default.nix
+++ b/pkgs/development/interpreters/python/3.3/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation {
   pythonVersion = majorVersion;
   inherit majorVersion version;
 
+  inherit buildInputs;
+
   src = fetchurl {
     url = "http://www.python.org/ftp/python/${version}/Python-${version}.tar.xz";
     sha256 = "0gsxpgd5p4mwd01gw501vsyahncyw3h9836ypkr3y32kgazy89jj";

--- a/pkgs/development/interpreters/python/3.4/default.nix
+++ b/pkgs/development/interpreters/python/3.4/default.nix
@@ -27,15 +27,27 @@ let
   fullVersion = "${version}";
 
   buildInputs = filter (p: p != null) [
-    zlib bzip2 lzma gdbm sqlite db readline ncurses openssl tcl tk libX11 xproto
-  ];
+    zlib
+    bzip2
+    lzma
+    gdbm
+    sqlite
+    db
+    readline
+    ncurses
+    openssl
+    tcl
+    tk
+    libX11
+    xproto
+  ] ++ optionals stdenv.isDarwin [ CF configd ];
 in
 stdenv.mkDerivation {
   name = "python3-${fullVersion}";
   pythonVersion = majorVersion;
   inherit majorVersion version;
 
-  buildInputs = optionals stdenv.isDarwin [ CF configd ];
+  inherit buildInputs;
 
   src = fetchurl {
     url = "http://www.python.org/ftp/python/${version}/Python-${fullVersion}.tar.xz";

--- a/pkgs/development/interpreters/python/3.5/default.nix
+++ b/pkgs/development/interpreters/python/3.5/default.nix
@@ -27,15 +27,27 @@ let
   fullVersion = "${version}";
 
   buildInputs = filter (p: p != null) [
-    zlib bzip2 lzma gdbm sqlite db readline ncurses openssl tcl tk libX11 xproto
-  ];
+    zlib
+    bzip2
+    lzma
+    gdbm
+    sqlite
+    db
+    readline
+    ncurses
+    openssl
+    tcl
+    tk
+    libX11
+    xproto
+  ] ++ optionals stdenv.isDarwin [ CF configd ];
 in
 stdenv.mkDerivation {
   name = "python3-${fullVersion}";
   pythonVersion = majorVersion;
   inherit majorVersion version;
 
-  buildInputs = optionals stdenv.isDarwin [ CF configd ];
+  inherit buildInputs;
 
   src = fetchurl {
     url = "http://www.python.org/ftp/python/${version}/Python-${fullVersion}.tar.xz";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The `buildInputs` were not explicitly passed to `mkDerivation`, see also #12300.
While I don't think it makes any real difference it doesn't hurt to be explicit.
cc @codyopel @garbas @copumpkin @domenkozar 
