### PR TITLE
Add guile-sdl2 package to nixpkgs

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -328,6 +328,7 @@
   schmitthenner = "Fabian Schmitthenner <development@schmitthenner.eu>";
   schristo = "Scott Christopher <schristopher@konputa.com>";
   scolobb = "Sergiu Ivanov <sivanov@colimite.fr>";
+  seppeljordan = "Sebastian Jordan <sebastian.jordan.mail@googlemail.com>";
   sepi = "Raffael Mancini <raffael@mancini.lu>";
   sheenobu = "Sheena Artrip <sheena.artrip@gmail.com>";
   sheganinans = "Aistis Raulinaitis <sheganinans@gmail.com>";

--- a/pkgs/development/guile-modules/guile-sdl2/default.nix
+++ b/pkgs/development/guile-modules/guile-sdl2/default.nix
@@ -1,0 +1,47 @@
+{ stdenv,
+  SDL2,
+  SDL2_image,
+  SDL2_ttf,
+  SDL2_mixer,
+  autoconf,
+  automake,
+  fetchgit,
+  guile,
+  libtool,
+  pkgconfig,
+  buildEnv
+  }:
+stdenv.mkDerivation rec {
+  name = "guile-sdl2-${version}";
+  version = "0.1.0";
+  buildInputs = [ autoconf
+                  automake
+                  SDL2
+                  SDL2_image
+                  SDL2_ttf
+                  SDL2_mixer
+                  libtool
+                  guile
+                  pkgconfig ];
+  src = fetchgit {
+    url = "git://dthompson.us/guile-sdl2.git";
+    rev = "048f80ddb5c6b03b87bba199a99a6f22d911bfff";
+    sha256 = "1wbx157xd8lsv4vs8igqy3qw8yym5r5s7z94an18kwbf89npmf5d";
+  };
+  preConfigurePhases = [ "bootstrapPhase" ];
+  bootstrapPhase = ''
+    ./bootstrap
+  '';
+  configureFlags = [ "--with-libsdl2-prefix=${SDL2}"
+                     "--with-libsdl2-image-prefix=${SDL2_image}"
+                     "--with-libsdl2-ttf-prefix=${SDL2_ttf}"
+                     "--with-libsdl2-mixer-prefix=${SDL2_mixer}"];
+  makeFlags = ["GUILE_AUTO_COMPILE=0"];
+  meta = {
+    description = "Bindings to SDL2 for GNU Guile";
+    homepage = "https://git.dthompson.us/guile-sdl2.git";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.seppeljordan ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5770,6 +5770,8 @@ in
 
   guile-sdl = callPackage ../development/guile-modules/guile-sdl { };
 
+  guile-sdl2 = callPackage ../development/guile-modules/guile-sdl2 { };
+
   guile-xcb = callPackage ../development/guile-modules/guile-xcb { };
 
   pharo-vms = callPackage_i686 ../development/pharo/vm { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Reguarding sandboxing: I cannot find it in the manual link you provided, sorry.
