### PR TITLE
Minetest 0.4.13 -> 0.4.14

### DIFF
--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, irrlicht, libpng, bzip2, curl, libogg, jsoncpp
 , libjpeg, libXxf86vm, mesa, openal, libvorbis, xlibsWrapper, sqlite, luajit
-, freetype, gettext, doxygen, ncurses
+, freetype, gettext, doxygen, ncurses, leveldb
 }:
 
 let
@@ -35,6 +35,7 @@ in stdenv.mkDerivation {
   buildInputs = [
     cmake irrlicht libpng bzip2 libjpeg curl libogg jsoncpp libXxf86vm mesa
     openal libvorbis xlibsWrapper sqlite luajit freetype gettext doxygen ncurses
+    leveldb
   ];
 
   postInstall = ''

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -1,20 +1,22 @@
-{ stdenv, fetchgit, cmake, irrlicht, libpng, bzip2, curl, libogg, jsoncpp
+{ stdenv, fetchFromGitHub, cmake, irrlicht, libpng, bzip2, curl, libogg, jsoncpp
 , libjpeg, libXxf86vm, mesa, openal, libvorbis, xlibsWrapper, sqlite, luajit, freetype
 , gettext, doxygen
 }:
 
 let
-  version = "0.4.13";
+  version = "0.4.14";
   sources = {
-    src = fetchgit {
-      url = "https://github.com/minetest/minetest.git";
-      rev = "d44fceac7e1237b00c6431ee1bb5805b602d0dcd";
-      sha256 = "034w9nv23ncdwbs4arzxfph60cfgvalh27hxprjassmz8p7ixnra";
+    src = fetchFromGitHub {
+      owner = "minetest";
+      repo = "minetest";
+      rev = "${version}";
+      sha256 = "1f74wsiqj8x1m8wqmxijb00df5ljlvy4ac0ahbh325vfzi0bjla3";
     };
-    data = fetchgit {
-      url = "https://github.com/minetest/minetest_game.git";
-      rev = "2392842948b114670334eabbb593b66e1427747c";
-      sha256 = "0wb8rdqc2ghi66k8bm8w2db0w7k5rsbdld0dyj1wdr3d6x0bpkcr";
+    data = fetchFromGitHub {
+      owner = "minetest";
+      repo = "minetest_game";
+      rev = "${version}";
+      sha256 = "1dc9zfbp603h2nlk39bw37kjbswrfmpd9yg3v72z1jb89pcxzsqs";
     };
   };
 in stdenv.mkDerivation {

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, irrlicht, libpng, bzip2, curl, libogg, jsoncpp
-, libjpeg, libXxf86vm, mesa, openal, libvorbis, xlibsWrapper, sqlite, luajit, freetype
-, gettext, doxygen
+, libjpeg, libXxf86vm, mesa, openal, libvorbis, xlibsWrapper, sqlite, luajit
+, freetype, gettext, doxygen, ncurses
 }:
 
 let
@@ -34,7 +34,7 @@ in stdenv.mkDerivation {
 
   buildInputs = [
     cmake irrlicht libpng bzip2 libjpeg curl libogg jsoncpp libXxf86vm mesa
-    openal libvorbis xlibsWrapper sqlite luajit freetype gettext doxygen
+    openal libvorbis xlibsWrapper sqlite luajit freetype gettext doxygen ncurses
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

http://dev.minetest.net/Changelog#0.4.13_.E2.86.92_0.4.14

Added ncurses because there's now support for a ncurses interface for server admin.

Added leveldb (but not redis) support because #minetest said I should. Apparently it's faster than the default sqlite3.

maintainers @jgeerds @c0dehero
