### PR TITLE
nix-generate-from-cpan: fix core module detection

### DIFF
--- a/maintainers/scripts/nix-generate-from-cpan.nix
+++ b/maintainers/scripts/nix-generate-from-cpan.nix
@@ -1,7 +1,7 @@
 { stdenv, makeWrapper, perl, perlPackages }:
 
 stdenv.mkDerivation {
-  name = "nix-generate-from-cpan-2";
+  name = "nix-generate-from-cpan-3";
 
   buildInputs = with perlPackages; [
     makeWrapper perl CPANMeta GetoptLongDescriptive CPANPLUS Readonly Log4Perl
@@ -20,5 +20,6 @@ stdenv.mkDerivation {
   meta = {
     maintainers = with stdenv.lib.maintainers; [ eelco rycee ];
     description = "Utility to generate a Nix expression for a Perl package from CPAN";
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/maintainers/scripts/nix-generate-from-cpan.pl
+++ b/maintainers/scripts/nix-generate-from-cpan.pl
@@ -278,13 +278,13 @@ sub get_deps {
     foreach my $n ( $deps->required_modules ) {
         next if $n eq "perl";
 
-        # Hacky way to figure out if this module is part of Perl.
-        if ( $n !~ /^JSON/ && $n !~ /^YAML/ && $n !~ /^Module::Pluggable/  && $n !~ /^if$/ ) {
-            eval "use $n;";
-            if ( !$@ ) {
-                DEBUG("skipping Perl-builtin module $n");
-                next;
-            }
+        # Figure out whether the module is a core module by attempting
+        # to `use` the module in a pure Perl interpreter and checking
+        # whether it succeeded. Note, $^X is a magic variable holding
+        # the path to the running Perl interpreter.
+        if ( system("env -i $^X -M$n -e1 >/dev/null 2>&1") == 0 ) {
+            DEBUG("skipping Perl-builtin module $n");
+            next;
         }
 
         my $pkg = module_to_pkg( $cb, $n );


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This makes the detection of core modules a bit more robust by checking the module inclusion in a pure Perl interpreter. This ensures that any extra path in the `nix-generate-from-cpan` script's `PERL5LIB` does not affect the generated package expression.
