### PR TITLE
perl-maatkit: fix build

### DIFF
--- a/pkgs/development/perl-modules/maatkit/default.nix
+++ b/pkgs/development/perl-modules/maatkit/default.nix
@@ -8,6 +8,8 @@ buildPerlPackage rec {
     sha256 = "1a7rxrddkrsfxb2wj01ha91ld0vapfkqcy8j9p08l76zz2l8p2v1";
   };
 
+  outputs = [ "out" ];
+
   buildInputs = [ DBDmysql ] ;
 
   preConfigure = ''


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This fixes the maatkit build (it wasn't very happy with the docdev output) but I cannot confirm whether it actually works. The expression is quite old, is anybody needing and maintaining it?
