### PR TITLE
Make Go packages work with nix-shell

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -155,6 +155,13 @@ go.stdenv.mkDerivation (
     done < <(find $bin/bin -type f 2>/dev/null)
   '';
 
+  shellHook = ''
+    d=$(mktemp -d "--suffix=-$name")
+    mkdir -p "$d/src/$(dirname "$goPackagePath")"
+    ln -s "$src" "$d/src/$goPackagePath"
+    export GOPATH="$d:$GOPATH"
+  '';
+
   disallowedReferences = lib.optional (!allowGoReference) go
     ++ lib.optional (!dontRenameImports) govers;
 


### PR DESCRIPTION
Go projects currently don't work with `nix-shell` because the source for the project never gets added to `$GOPATH`. This adds a shell hook to do that.
