### PR TITLE
factoryboy: init at 2.6.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5916,6 +5916,35 @@ in modules // {
     };
   };
 
+  fake_factory_0_5 = self.fake_factory.override rec {
+    name = "fake-factory-${version}";
+    version = "0.5.7";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/f/fake-factory/${name}.tar.gz";
+      sha256 = "1chmarnrdzn4r017n8qlic0m0bbnhw04s3hkwribjvm3mqpb6pa0";
+    };
+    propagatedBuildInputs = with self; [ six dateutil ipaddress ];
+
+    # AttributeError: 'module' object has no attribute 'tests'
+    doCheck = false;
+  };
+
+  factory_boy = buildPythonPackage rec {
+    name = "factory_boy-${version}";
+    version = "2.6.1";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/f/factory_boy/${name}.tar.gz";
+      sha256 = "0a21f8kq917fj8xgmyp6gy8vcrlzzgwn80qas0d76h3vjbdy0bdq";
+    };
+    propagatedBuildInputs = with self; [ six fake_factory_0_5 mock ];
+
+    meta = {
+      description = "A Python package to create factories for complex object";
+      homepage    = https://github.com/rbarrois/factory_boy;
+      license     = licenses.mit;
+    };
+  };
+
   Fabric = buildPythonPackage rec {
     name = "Fabric-${version}";
     version = "1.10.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5902,11 +5902,19 @@ in modules // {
   };
 
   fake_factory = buildPythonPackage rec {
-    name = "fake-factory-0.2";
+    name = "fake-factory-${version}";
+    version = "0.5.7";
+
     src = pkgs.fetchurl {
-      url = mirror://pypi/f/fake-factory/fake-factory-0.2.tar.gz;
-      sha256 = "0qdmk8p4anrj9mf95dh9v7bkhv1pz69hvhlw380kj4iz7b44b6zn";
+      url = "mirror://pypi/f/fake-factory/${name}.tar.gz";
+      sha256 = "1chmarnrdzn4r017n8qlic0m0bbnhw04s3hkwribjvm3mqpb6pa0";
     };
+
+    propagatedBuildInputs = with self; [ six dateutil ipaddress mock ];
+    checkPhase = ''
+      ${python.interpreter} -m unittest faker.tests
+    '';
+
     meta = {
       description = "A Python package that generates fake data for you";
       homepage    = https://pypi.python.org/pypi/fake-factory;
@@ -5916,30 +5924,19 @@ in modules // {
     };
   };
 
-  fake_factory_0_5 = self.fake_factory.override rec {
-    name = "fake-factory-${version}";
-    version = "0.5.7";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/f/fake-factory/${name}.tar.gz";
-      sha256 = "1chmarnrdzn4r017n8qlic0m0bbnhw04s3hkwribjvm3mqpb6pa0";
-    };
-    propagatedBuildInputs = with self; [ six dateutil ipaddress ];
-
-    # AttributeError: 'module' object has no attribute 'tests'
-    doCheck = false;
-  };
-
   factory_boy = buildPythonPackage rec {
     name = "factory_boy-${version}";
     version = "2.6.1";
+
     src = pkgs.fetchurl {
       url = "mirror://pypi/f/factory_boy/${name}.tar.gz";
       sha256 = "0a21f8kq917fj8xgmyp6gy8vcrlzzgwn80qas0d76h3vjbdy0bdq";
     };
-    propagatedBuildInputs = with self; [ six fake_factory_0_5 mock ];
+
+    propagatedBuildInputs = with self; [ fake_factory ];
 
     meta = {
-      description = "A Python package to create factories for complex object";
+      description = "A Python package to create factories for complex objects";
       homepage    = https://github.com/rbarrois/factory_boy;
       license     = licenses.mit;
     };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
