### PR TITLE
glide: 0.6.1 -> 0.10.2 (using go 1.6)

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -799,6 +799,8 @@ in
 
   gist = callPackage ../tools/text/gist { };
 
+  glide = go16Packages.glide.bin // { outputs = [ "bin" ]; };
+
   gmic = callPackage ../tools/graphics/gmic { };
 
   gti = callPackage ../tools/misc/gti { };

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -1052,10 +1052,10 @@ let
   };
 
   glide = buildFromGitHub {
-    rev    = "0.6.1";
+    rev    = "0.10.2";
     owner  = "Masterminds";
     repo   = "glide";
-    sha256 = "1v66c2igm8lmljqrrsyq3cl416162yc5l597582bqsnhshj2kk4m";
+    sha256 = "1qb2n5i04gabb2snnwfr8wv4ypcp1pdzvgga62m9xkhk4p2w6pwl";
     buildInputs = [ cookoo cli-go go-gypsy vcs ];
   };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`   (Nahum: I couldn't find any)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Simple update to glide and add it to all-packages (go 1.6 used explicitly because the build failed with go 1.5 and go 1.5 is currently still the default.)
