### PR TITLE
certbot: 0.5.0 -> 0.6.0; rename from letsencrypt

### DIFF
--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "utox-${version}";
-  version = "0.7.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "GrayHatter";
     repo = "uTox";
     rev = "v${version}";
-    sha256 = "1md8fw6zqd3giskd89i56dgrsl83vn27xwr8k22263wkj1fxxw4c";
+    sha256 = "12l2821m4r8p3vmsqhqhfj60yhkl4w4xfy73cvy73qqw6xf2yam1";
   };
 
   buildInputs = [ pkgconfig libtoxcore-dev dbus libvpx libX11 openal freetype

--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -1,14 +1,14 @@
 { stdenv, pythonPackages, fetchFromGitHub, dialog }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "letsencrypt-${version}";
-  version = "0.5.0";
+  name = "certbot-${version}";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "certbot";
     repo = "certbot";
     rev = "v${version}";
-    sha256 = "0x098cdyfgqvh7x5d3sz56qjpjyg5b4fl82086sm43d8mbz0h5rm";
+    sha256 = "1x0prlldkgg0hxmya4m5h3k3c872wr0jylmzpr3m04mk339yiw0c";
   };
 
   propagatedBuildInputs = with pythonPackages; [
@@ -29,8 +29,8 @@ pythonPackages.buildPythonApplication rec {
   buildInputs = [ dialog ] ++ (with pythonPackages; [ nose mock gnureadline ]);
 
   patchPhase = ''
-    substituteInPlace letsencrypt/notify.py --replace "/usr/sbin/sendmail" "/var/setuid-wrappers/sendmail"
-    substituteInPlace letsencrypt/le_util.py --replace "sw_vers" "/usr/bin/sw_vers"
+    substituteInPlace certbot/notify.py --replace "/usr/sbin/sendmail" "/var/setuid-wrappers/sendmail"
+    substituteInPlace certbot/le_util.py --replace "sw_vers" "/usr/bin/sw_vers"
   '';
 
   postInstall = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -54,6 +54,7 @@ doNotDisplayTwice rec {
   inotifyTools = inotify-tools;
   joseki = apache-jena-fuseki; # added 2016-02-28
   jquery_ui = jquery-ui;  # added 2014-09-07
+  letsencrypt = certbot; # added 2016-05-16
   libdbusmenu_qt5 = qt5.libdbusmenu;  # added 2015-12-19
   libcap_manpages = libcap.doc; # added 2016-04-29
   libcap_pam = if stdenv.isLinux then libcap.pam else null; # added 2016-04-29

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6652,6 +6652,8 @@ in
 
   cegui = callPackage ../development/libraries/cegui {};
 
+  certbot = callPackage ../tools/admin/certbot { };
+
   cgal = callPackage ../development/libraries/CGAL {};
 
   cgui = callPackage ../development/libraries/cgui {};
@@ -7451,8 +7453,6 @@ in
   leptonica = callPackage ../development/libraries/leptonica {
     libpng = libpng12;
   };
-
-  letsencrypt = callPackage ../tools/admin/letsencrypt { };
 
   lib3ds = callPackage ../development/libraries/lib3ds { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -371,7 +371,7 @@ in modules // {
   };
 
   acme = buildPythonPackage rec {
-    inherit (pkgs.letsencrypt) src version;
+    inherit (pkgs.certbot) src version;
 
     name = "acme-${version}";
 


### PR DESCRIPTION
It's not just the binary; this package has in fact changed its name. We should follow suit. I've added an alias to ease the transition.

CC maintainer @domenkozar.
