### PR TITLE
hunspell-dict-de-any-igerman98: init at 20160407

### DIFF
--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -1,6 +1,6 @@
 /* hunspell dictionaries */
 
-{ stdenv, fetchurl, unzip }:
+{ stdenv, fetchurl, gnused, hunspell, ispell, perl, unzip }:
 
 with stdenv.lib;
 
@@ -9,10 +9,11 @@ let
   mkDict =
   { name, src, meta, readmeFile, dictFileName, ... }:
   let
+    isEnglish = hasSuffix "en_" dictFileName;
     isFrench = hasSuffix "fr_" dictFileName;
+    isGerman = hasSuffix "de_" dictFileName;
     isItaly = hasSuffix "it_" dictFileName;
     isSpanish = hasSuffix "es_" dictFileName;
-    isEnglish = hasSuffix "en_" dictFileName;
   in
   stdenv.mkDerivation rec {
     inherit name src meta;
@@ -406,6 +407,48 @@ in {
       Ce dictionnaire ne connaît que les graphies nouvelles des mots concernés
       par la réforme de 1990.
     '';
+  };
+
+  /* GERMAN */
+
+  de-any = stdenv.mkDerivation rec {
+    name = "hunspell-dict-de-any-igerman98-${version}";
+    version = "20160407";
+
+    src = fetchurl {
+      url = "https://www.j3e.de/ispell/igerman98/dict/igerman98-${version}.tar.bz2";
+      sha256 = "18vn2n2dxc3sga79ha1a5swhhhyb6vgaazx4xa1kiml123d5hq3p";
+    };
+
+    buildInputs = [ gnused hunspell ispell perl ];
+
+    patchPhase = ''
+      find bin -type f | while IFS= read -r file
+      do
+        substituteInPlace "$file" \
+          --replace /usr/bin/perl "${perl}/bin/perl" \
+          --replace /bin/sed "${gnused}/bin/sed"
+      done
+    '';
+
+    buildFlags = [ "hunspell-all" ];
+
+    installPhase = ''
+      install -dm755 -- "$out/share/myspell/dicts"
+      for file in de_{AT,CH,DE}.{aff,dic}
+      do
+        install -Dm644 -- "hunspell/$file" "$out/share/hunspell/$file"
+        ln -s -- "$out/share/hunspell/$file" "$out/share/myspell/dicts"
+      done
+      install -Dm644 Documentation/README $out/share/doc/${name}.txt
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Hunspell dictionary for German (Austria, Germany, Switzerland) from igerman98";
+      license = with licenses; [ gpl2 gpl3 ];
+      homepage = https://www.j3e.de/ispell/igerman98/;
+      platforms = platforms.all;
+    };
   };
 
   /* ITALIAN */

--- a/pkgs/tools/text/ispell/default.nix
+++ b/pkgs/tools/text/ispell/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchurl, bison, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "ispell-3.3.02";
+  src = fetchurl {
+    url = "http://fmg-www.cs.ucla.edu/geoff/tars/${name}.tar.gz";
+    sha256 = "1d7c2fqrdjckp91ajpkn5nnmpci2qrxqn8b6cyl0zn1afb9amxbz";
+  };
+  buildInputs = [ bison ncurses ];
+  patches = [
+    ./patches/0005-Do-not-reorder-words.patch
+    ./patches/0007-Use-termios.patch
+    ./patches/0008-Tex-backslash.patch
+    ./patches/0009-Fix-FTBFS-on-glibc.patch
+    ./patches/0011-Missing-prototypes.patch
+    ./patches/0012-Fix-getline.patch
+    ./patches/0013-Fix-man-pages.patch
+    ./patches/0021-Fix-gcc-warnings.patch
+    ./patches/0023-Exclusive-options.patch
+    ./patches/0024-Check-tempdir-creation.patch
+    ./patches/0025-Languages.patch
+    ./patches/0030-Display-whole-multibyte-character.patch
+  ];
+  postPatch = ''
+    cat >> local.h <<EOF
+    #define USG
+    #define TERMLIB "-lncurses"
+    #define LANGUAGES "{american,MASTERDICTS=american.med,HASHFILES=americanmed.hash}"
+    #define MASTERHASH "americanmed.hash"
+    #define BINDIR "$out/bin"
+    #define LIBDIR "$out/lib"
+    #define ELISPDIR "{$out}/share/emacs/site-lisp"
+    #define TEXINFODIR "$out/share/info"
+    #define MAN1DIR "$out/share/man/man1"
+    #define MAN4DIR "$out/share/man/man4"
+    #define MAN45DIR "$out/share/man/man5"
+    #define MINIMENU
+    #define HAS_RENAME
+    EOF
+
+    #XXX: We need USG for term.c, but we don't need bcopy/bzero
+    #sed -i -e "s|#define bzero.*||" -e "s|#define bcopy.*||" config.X
+
+    #XXX: getline is already defined (name clash), so rename it
+    #sed -i -e "s|getline|getlineXXX|g" correct.c
+
+    #XXX: strcmp is a macro, so importing it as function won't work
+    #sed -i -e 's| *extern int\s*strcmp.*||' ijoin.c
+
+    #XXX: buildhash uses int to store pointers, which doesn't work on 64bit
+    #sed -i -e 's|\s*int\s*strptr|intptr_t strptr|' -e 's|\s*int\s*x|intptr_t x|' buildhash.c
+  '';
+  preBuild = ''
+    for dir in $out/share/emacs/site-lisp $out/share/info $out/share/man/man1 $out/share/man/man4 $out/bin $out/lib; do
+    mkdir -p $dir
+    done
+  '';
+}

--- a/pkgs/tools/text/ispell/patches/0005-Do-not-reorder-words.patch
+++ b/pkgs/tools/text/ispell/patches/0005-Do-not-reorder-words.patch
@@ -1,0 +1,52 @@
+From: Geoff Kuenning <geoff@cs.hmc.edu>
+Date: Thu, 3 Nov 2005 14:14:15 -0800
+Subject: 0005 Do not reorder words
+
+ispell reorders words in personal dictionary without good reason.
+
+The correct approach is to build the internal data structure with variant
+spellings stored in the same order as they appear in the personal dictionary.
+Fortunately, this is easy, though the patch is to a different file. This one
+has been tested (That's what I get for trying to rush out a fix before a
+meeting!).
+---
+ makedent.c |   18 +++++++++++-------
+ 1 files changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/makedent.c b/makedent.c
+index 0453d11..d121345 100644
+--- a/makedent.c
++++ b/makedent.c
+@@ -447,9 +447,10 @@ int combinecaps (hdrp, newp)
+     if (retval == 0)
+ 	{
+ 	/*
+-	** Couldn't combine the two entries.  Add a new variant.  For
+-	** ease, we'll stick it right behind the header, rather than
+-	** at the end of the list.
++	** Couldn't combine the two entries.  Add a new variant.  We
++	** stick it at the end of the variant list because it's
++	** important to maintain order; this causes the personal
++	** dictionary to have a stable ordering.
+ 	*/
+ 	forcevheader (hdrp, oldp, newp);
+ 	tdent = (struct dent *) mymalloc (sizeof (struct dent));
+@@ -460,10 +461,13 @@ int combinecaps (hdrp, newp)
+ 	    return -1;
+ 	    }
+ 	*tdent = *newp;
+-	tdent->next = hdrp->next;
+-	hdrp->next = tdent;
+-	tdent->flagfield |= (hdrp->flagfield & MOREVARIANTS);
+-	hdrp->flagfield |= MOREVARIANTS;
++	for (oldp = hdrp;
++	  oldp->next != NULL  &&  oldp->flagfield & MOREVARIANTS;
++	  oldp = oldp->next)
++	    ;
++	tdent->next = oldp->next;
++	oldp->next = tdent;
++	oldp->flagfield |= MOREVARIANTS;
+ 	combineaffixes (hdrp, newp);
+ 	hdrp->flagfield |= (newp->flagfield & KEEP);
+ 	if (captype (newp->flagfield) == FOLLOWCASE)
+-- 

--- a/pkgs/tools/text/ispell/patches/0007-Use-termios.patch
+++ b/pkgs/tools/text/ispell/patches/0007-Use-termios.patch
@@ -1,0 +1,188 @@
+From: Torsten Landschoff <t.landschoff@gmx.net>
+Date: Tue, 30 Mar 1999 21:05:09 +0100
+Subject: 0007 Use termios
+
+Use termios instead of termio (Closes: #35288).
+
+Patch updated on Mon, 07 Mar 2011 20:40:53 +0100 based on
+ispell-3.3.02-terminal.patch from ispell-3.3.02-102.1.src.rpm
+---
+ term.c |   58 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 files changed, 58 insertions(+), 0 deletions(-)
+
+diff --git a/term.c b/term.c
+index 4923844..47c1aa0 100644
+--- a/term.c
++++ b/term.c
+@@ -87,13 +87,22 @@ static char Rcs_Id[] =
+ #include "proto.h"
+ #include "msgs.h"
+ #ifdef USG
++#if defined(__GLIBC__) && __GLIBC__ >= 2
++/* Use termios under at least glibc */
++  #include <termios.h>
++  #define USE_TERMIOS
++#else
+ #include <termio.h>
++#endif
+ #else
+ #ifndef __DJGPP__
+ #include <sgtty.h>
+ #endif
+ #endif
+ #include <signal.h>
++#include <unistd.h>
++#include <sys/types.h>
++#include <sys/wait.h>
+ 
+ void		ierase P ((void));
+ void		imove P ((int row, int col));
+@@ -166,8 +175,13 @@ static int iputch (c)
+     }
+ 
+ #ifdef USG
++#ifdef USE_TERMIOS
++static struct termios	sbuf;
++static struct termios	osbuf;
++#else
+ static struct termio	sbuf;
+ static struct termio	osbuf;
++#endif
+ #else
+ static struct sgttyb	sbuf;
+ static struct sgttyb	osbuf;
+@@ -190,9 +204,13 @@ void terminit ()
+     int			tpgrp;
+ #else
+ #ifdef TIOCGPGRP
++#ifdef USE_TERMIOS
++    pid_t		tpgrp;
++#else
+     int			tpgrp;
+ #endif
+ #endif
++#endif
+ #ifdef TIOCGWINSZ
+     struct winsize	wsize;
+ #endif /* TIOCGWINSZ */
+@@ -276,7 +294,11 @@ retry:
+ 	(void) fprintf (stderr, TERM_C_NO_BATCH);
+ 	exit (1);
+ 	}
++#ifdef USE_TERMIOS
++    (void) tcgetattr (0, &osbuf);
++#else
+     (void) ioctl (0, TCGETA, (char *) &osbuf);
++#endif
+     termchanged = 1;
+ 
+     sbuf = osbuf;
+@@ -285,7 +307,11 @@ retry:
+     sbuf.c_iflag &= ~(INLCR | IGNCR | ICRNL);
+     sbuf.c_cc[VMIN] = 1;
+     sbuf.c_cc[VTIME] = 1;
++#ifdef USE_TERMIOS
++    (void) tcsetattr (0, TCSADRAIN, &sbuf);
++#else
+     (void) ioctl (0, TCSETAW, (char *) &sbuf);
++#endif
+ 
+     uerasechar = osbuf.c_cc[VERASE];
+     ukillchar = osbuf.c_cc[VKILL];
+@@ -298,7 +324,11 @@ retry:
+ #endif
+ #endif
+ #ifdef TIOCGPGRP
++#ifdef USE_TERMIOS
++    if ((tpgrp = tcgetpgrp (0)) == -1)
++#else
+     if (ioctl (0, TIOCGPGRP, (char *) &tpgrp) != 0)
++#endif
+ 	{
+ 	(void) fprintf (stderr, TERM_C_NO_BATCH);
+ 	exit (1);
+@@ -373,7 +403,11 @@ SIGNAL_TYPE done (signo)
+ 	if (te)
+ 	    tputs (te, 1, iputch);
+ #ifdef USG
++#ifdef USE_TERMIOS
++	(void) tcsetattr (0, TCSADRAIN, &osbuf);
++#else
+ 	(void) ioctl (0, TCSETAW, (char *) &osbuf);
++#endif
+ #else
+ 	(void) ioctl (0, TIOCSETP, (char *) &osbuf);
+ #ifdef TIOCSLTC
+@@ -394,7 +428,11 @@ static SIGNAL_TYPE onstop (signo)
+ 	if (te)
+ 	    tputs (te, 1, iputch);
+ #ifdef USG
++#ifdef USE_TERMIOS
++    (void) tcsetattr (0, TCSANOW, &osbuf); /* OpenSuse: TCSADRAIN */
++#else
+ 	(void) ioctl (0, TCSETAW, (char *) &osbuf);
++#endif
+ #else
+ 	(void) ioctl (0, TIOCSETP, (char *) &osbuf);
+ #ifdef TIOCSLTC
+@@ -413,7 +451,11 @@ static SIGNAL_TYPE onstop (signo)
+     if (termchanged)
+ 	{
+ #ifdef USG
++#ifdef USE_TERMIOS
++    (void) tcsetattr (0, TCSANOW, &sbuf);
++#else
+ 	(void) ioctl (0, TCSETAW, (char *) &sbuf);
++#endif
+ #else
+ 	(void) ioctl (0, TIOCSETP, (char *) &sbuf);
+ #ifdef TIOCSLTC
+@@ -481,7 +523,11 @@ int shellescape	(buf)
+     argv[i] = NULL;
+ 
+ #ifdef USG
++#ifdef USE_TERMIOS
++    (void) tcsetattr (0, TCSADRAIN, &osbuf);
++#else
+     (void) ioctl (0, TCSETAW, (char *) &osbuf);
++#endif
+ #else
+     (void) ioctl (0, TIOCSETP, (char *) &osbuf);
+ #ifdef TIOCSLTC
+@@ -527,7 +573,11 @@ int shellescape	(buf)
+ #endif
+ 
+ #ifdef USG
++#ifdef USE_TERMIOS
++    (void) tcsetattr (0, TCSADRAIN, &sbuf);
++#else
+     (void) ioctl (0, TCSETAW, (char *) &sbuf);
++#endif
+ #else
+     (void) ioctl (0, TIOCSETP, (char *) &sbuf);
+ #ifdef TIOCSLTC
+@@ -563,7 +613,11 @@ void shescape (buf)
+ #endif
+ 
+ #ifdef USG
++#ifdef USE_TERMIOS
++    (void) tcsetattr (0, TCSADRAIN, &osbuf);
++#else
+     (void) ioctl (0, TCSETAW, (char *) &osbuf);
++#endif
+ #else
+     (void) ioctl (0, TIOCSETP, (char *) &osbuf);
+ #ifdef TIOCSLTC
+@@ -611,7 +665,11 @@ void shescape (buf)
+ #endif
+ 
+ #ifdef USG
++#ifdef USE_TERMIOS
++    (void) tcsetattr (0, TCSADRAIN, &sbuf);
++#else
+     (void) ioctl (0, TCSETAW, (char *) &sbuf);
++#endif
+ #else
+     (void) ioctl (0, TIOCSETP, (char *) &sbuf);
+ #ifdef TIOCSLTC
+-- 

--- a/pkgs/tools/text/ispell/patches/0008-Tex-backslash.patch
+++ b/pkgs/tools/text/ispell/patches/0008-Tex-backslash.patch
@@ -1,0 +1,48 @@
+From: Ken Stevens <kstevens@ece.utah.edu>
+Date: Sat, 15 Jul 2000 22:10:53 -0400
+Subject: 0008 Tex backslash
+
+Version 3.1.20 contains an irritating bug when using latex that causes all
+sorts of problems when the backslash is used. (The backslash is a common
+character in latex that is used, among other things, to create a forced space
+similar to the tilde character.) In the current version, 3.1.20, the next TWO
+characters are skipped after a backslash. This can results in misspellings and
+the file being incorrectly parsed. (For example, if the text contains the
+sequence `\ $' math mode will not be entered until the matching $ which should
+end it, resulting in the body of the text not being spell checked and the math
+region being checked.)
+
+Make sure to undefine NO8BIT and use a larger number for MASKBITS if you are
+using iso character sets.
+
+http://www.kdstevens.com/~stevens/ispell-faq.html#bslash
+---
+ defmt.c |    7 +++----
+ 1 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/defmt.c b/defmt.c
+index 35f93e4..7499752 100644
+--- a/defmt.c
++++ b/defmt.c
+@@ -884,6 +884,8 @@ static int TeX_math_end (bufp)
+ 	return 0;
+     }
+ 
++/* Updates bufp to point to the next character to skip. */
++/*  Should only be called on non-word characters. */
+ static int TeX_math_begin (bufp)
+     unsigned char **	bufp;
+     {
+@@ -902,10 +904,7 @@ static int TeX_math_begin (bufp)
+ 	if (**bufp == TEXLEFTPAREN  ||  **bufp == TEXLEFTSQUARE)
+ 	    return 1;
+ 	else if (!isalpha(**bufp)  &&  **bufp != '@')
+-	    {
+-	    (*bufp)++;
+-	    continue;
+-	    }
++	    return 0;
+ 	else if (TeX_strncmp (*bufp, "begin", 5) == 0)
+ 	    {
+ 	    if (TeX_math_check ('b', bufp))
+-- 

--- a/pkgs/tools/text/ispell/patches/0009-Fix-FTBFS-on-glibc.patch
+++ b/pkgs/tools/text/ispell/patches/0009-Fix-FTBFS-on-glibc.patch
@@ -1,0 +1,23 @@
+From: Richard Braakman <dark@dark.wapit.fi>
+Date: Fri, 2 Feb 2001 17:22:53 +0200
+Subject: 0009 Fix FTBFS on glibc
+
+Fix FTBFS on glibc (Closes: #75377)
+---
+ config.X |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/config.X b/config.X
+index 18bf621..0a47cb2 100644
+--- a/config.X
++++ b/config.X
+@@ -531,7 +531,7 @@
+ #endif /* NO_MKSTEMP */
+ 
+ /* Aliases for some routines */
+-#ifdef USG
++#if defined (USG) && !defined(__GLIBC__)
+ #define BCOPY(s, d, n)	memcpy (d, s, n)
+ #define BZERO(d, n)	memset (d, 0, n)
+ #define index strchr
+-- 

--- a/pkgs/tools/text/ispell/patches/0011-Missing-prototypes.patch
+++ b/pkgs/tools/text/ispell/patches/0011-Missing-prototypes.patch
@@ -1,0 +1,84 @@
+From: Doug Porter <dsp@debian.org>
+Date: Tue, 22 Jan 2002 10:28:44 -0500
+Subject: 0011 Missing prototypes
+
+Fixing implicit declarations (Closes: #130405).
+---
+ correct.c |    1 +
+ ijoin.c   |    2 +-
+ ispell.c  |    2 ++
+ lookup.c  |    2 ++
+ tree.c    |    1 +
+ 5 files changed, 7 insertions(+), 1 deletions(-)
+
+diff --git a/correct.c b/correct.c
+index e2b63c8..661bf57 100644
+--- a/correct.c
++++ b/correct.c
+@@ -201,6 +201,7 @@ static char Rcs_Id[] =
+  */
+ 
+ #include <ctype.h>
++#include <unistd.h>
+ #include "config.h"
+ #include "ispell.h"
+ #include "proto.h"
+diff --git a/ijoin.c b/ijoin.c
+index edb18d1..5da039a 100644
+--- a/ijoin.c
++++ b/ijoin.c
+@@ -115,6 +115,7 @@ static char Rcs_Id[] =
+  */
+ 
+ #include <stdio.h>
++#include <string.h>
+ #include "config.h"
+ #include "ispell.h"
+ #include "proto.h"
+@@ -169,7 +170,6 @@ static char *		tabchar = " \t"; /* Field separator character(s) */
+ static int		unpairable1 = 0; /* NZ if -a1 */
+ static int		unpairable2 = 0; /* NZ if -a2 */
+ 
+-extern int	strcmp ();
+ 
+ int main (argc, argv)			/* Join files */
+     int			argc;		/* Argument count */
+diff --git a/ispell.c b/ispell.c
+index 9b509d0..59fe358 100644
+--- a/ispell.c
++++ b/ispell.c
+@@ -235,6 +235,8 @@ static char Rcs_Id[] =
+ #include <fcntl.h>
+ #endif /* NO_FCNTL_H */
+ #include <sys/stat.h>
++#include <ctype.h>
++#include <unistd.h>
+ 
+ static void	usage P ((void));
+ int		main P ((int argc, char * argv[]));
+diff --git a/lookup.c b/lookup.c
+index 648f9c8..8bf1f6c 100644
+--- a/lookup.c
++++ b/lookup.c
+@@ -87,6 +87,8 @@ static char Rcs_Id[] =
+ 
+ #include <fcntl.h>
+ 
++#include <sys/types.h>
++#include <unistd.h>
+ #include "config.h"
+ #include "ispell.h"
+ #include "proto.h"
+diff --git a/tree.c b/tree.c
+index 073a6a6..c26f635 100644
+--- a/tree.c
++++ b/tree.c
+@@ -94,6 +94,7 @@ static char Rcs_Id[] =
+ 
+ #include <ctype.h>
+ #include <errno.h>
++#include <unistd.h>
+ #include "config.h"
+ #include "ispell.h"
+ #include "proto.h"
+-- 

--- a/pkgs/tools/text/ispell/patches/0012-Fix-getline.patch
+++ b/pkgs/tools/text/ispell/patches/0012-Fix-getline.patch
@@ -1,0 +1,62 @@
+From: Stefan Potyra <sistpoty@ubuntu.com>
+Date: Sat, 3 Oct 2009 04:00:34 +0200
+Subject: 0012 Fix getline
+
+getline is not provided by eglibc, avoid conflict
+
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=549401
+Forwarded: no
+---
+ correct.c |   10 +++++-----
+ 1 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/correct.c b/correct.c
+index 661bf57..ff7cb99 100644
+--- a/correct.c
++++ b/correct.c
+@@ -246,7 +246,7 @@ static void	save_root_cap P ((ichar_t * word, ichar_t * pattern,
+ 		  struct flagent * sufent,
+ 		  ichar_t savearea[MAX_CAPS][INPUTWORDLEN + MAXAFFIXLEN],
+ 		  int * nsaved));
+-static char *	getline P ((char * buf, int bufsize));
++static char *	getline_ispell P ((char * buf, int bufsize));
+ void		askmode P ((void));
+ void		copyout P ((unsigned char ** cc, int cnt));
+ static void	lookharder P ((unsigned char * string));
+@@ -572,7 +572,7 @@ checkagain:
+ 
+ 		imove (li - 1, 0);
+ 		(void) putchar ('!');
+-		if (getline ((char *) buf, sizeof buf) == NULL)
++		if (getline_ispell ((char *) buf, sizeof buf) == NULL)
+ 		    {
+ 		    (void) putchar (7);
+ 		    ierase ();
+@@ -597,7 +597,7 @@ checkagain:
+ 		    (void) printf ("%s ", CORR_C_READONLY);
+ 		    }
+ 		(void) printf (CORR_C_REPLACE_WITH);
+-		if (getline ((char *) ctok, ctokl) == NULL)
++		if (getline_ispell ((char *) ctok, ctokl) == NULL)
+ 		    {
+ 		    (void) putchar (7);
+ 		    /* Put it back */
+@@ -665,7 +665,7 @@ checkagain:
+ 		unsigned char	buf[100];
+ 		imove (li - 1, 0);
+ 		(void) printf (CORR_C_LOOKUP_PROMPT);
+-		if (getline ((char *) buf, sizeof buf) == NULL)
++		if (getline_ispell ((char *) buf, sizeof buf) == NULL)
+ 		    {
+ 		    (void) putchar (7);
+ 		    ierase ();
+@@ -1584,7 +1584,7 @@ static void save_root_cap (word, pattern, prestrip, preadd, sufstrip, sufadd,
+     return;
+     }
+ 
+-static char * getline (s, len)
++static char * getline_ispell(s, len)
+     register char *	s;
+     register int	len;
+     {
+-- 

--- a/pkgs/tools/text/ispell/patches/0013-Fix-man-pages.patch
+++ b/pkgs/tools/text/ispell/patches/0013-Fix-man-pages.patch
@@ -1,0 +1,227 @@
+From: David Paleino <d.paleino@gmail.com>
+Date: Mon, 9 Nov 2009 09:22:12 +0000
+Subject: 0013 Fix man pages
+
+Fix man pages, manpage-has-errors-from-man and hyphen-used-as-minus-sign
+
+Forwarded: no
+---
+ ispell.1X |   26 +++++++++++++-------------
+ ispell.5X |   26 +++++++++++++-------------
+ 2 files changed, 26 insertions(+), 26 deletions(-)
+
+diff --git a/ispell.1X b/ispell.1X
+index b27b120..79894d4 100644
+--- a/ispell.1X
++++ b/ispell.1X
+@@ -236,8 +236,8 @@ count affix-file
+ .RB [ \-p | \-s]
+ .RB [ \-c ]
+ .I expanded-file
+-.IR affix [ +addition ]
+-...
++.IR affix
++.RI [ +addition ]
+ .PP
+ .B icombine
+ .RB [ \-T
+@@ -336,7 +336,7 @@ The amount of context is subject to a system-imposed limit.
+ If the
+ .B \-V
+ flag is given, characters that are not in the 7-bit ANSI printable
+-character set will always be displayed in the style of "cat -v", even if
++character set will always be displayed in the style of "cat \-v", even if
+ .I ispell
+ thinks that these characters are legal ISO Latin-1 on your system.
+ This is useful when working with older terminals.
+@@ -542,7 +542,7 @@ option is used to specify an alternate hashed dictionary file,
+ other than the default.
+ If the filename does not contain a "/",
+ the library directory for the default dictionary file is prefixed;
+-thus, to use a dictionary in the local directory "-d ./xxx.hash" must
++thus, to use a dictionary in the local directory "\-d ./xxx.hash" must
+ be used.
+ This is useful to allow dictionaries for alternate languages.
+ Unlike previous versions of
+@@ -615,7 +615,7 @@ alphabetics have no meaning - alphabetics are already accepted.
+ .I Ispell
+ will typically be used with input from a file, meaning that preserving
+ parity for possible 8 bit characters from the input text is OK.  If you
+-specify the -l option, and actually type text from the terminal, this may
++specify the \-l option, and actually type text from the terminal, this may
+ create problems if your stty settings preserve parity.
+ .PP
+ It is not possible to use
+@@ -799,7 +799,7 @@ that the '&' is replaced by '?' (and the near-miss count is always zero).
+ The suggested derivations following the near misses are in the form:
+ .PP
+ .RS
+-[prefix+] root [-prefix] [-suffix] [+suffix]
++[prefix+] root [\-prefix] [\-suffix] [+suffix]
+ .RE
+ .PP
+ (e.g., "re+fry-y+ies" to get "refries")
+@@ -841,7 +841,7 @@ These output lines can be summarized as follows:
+ .PP
+ For example, a dummy dictionary containing the words "fray", "Frey",
+ "fry", and "refried" might produce the following response to the
+-command "echo 'frqy refries | ispell -a -m -d ./test.hash":
++command "echo 'frqy refries | ispell \-a \-m \-d ./test.hash":
+ .RS
+ .nf
+ (#) International Ispell Version 3.0.05 (beta), 08/10/91
+@@ -1036,7 +1036,7 @@ script does this.
+ As an example, the command:
+ .PP
+ .RS
+-echo BOTHER | ispell -c
++echo BOTHER | ispell \-c
+ .RE
+ .PP
+ produces:
+@@ -1055,7 +1055,7 @@ it expands affix flags to produce a list of words.
+ For example, the command:
+ .PP
+ .RS
+-echo BOTH/R | ispell -e
++echo BOTH/R | ispell \-e
+ .RE
+ .PP
+ produces:
+@@ -1268,7 +1268,7 @@ hash file if it were added to the language table.
+ Only affixes that generate legal roots (found in the original input)
+ are listed.
+ .PP
+-If the "-c" option is not given, the output lines are in the
++If the "\-c" option is not given, the output lines are in the
+ following format:
+ .IP
+ strip/add/count/bytes
+@@ -1298,7 +1298,7 @@ If the
+ the output is made visually cleaner (but harder to post-process)
+ by changing it to:
+ .IP
+--strip+add<tab>count<tab>bytes
++\-strip+add<tab>count<tab>bytes
+ .PP
+ where
+ .IR strip ,
+@@ -1313,7 +1313,7 @@ represents the ASCII tab character.
+ The method used to generate possible affixes will also generate
+ longer affixes which have common headers or trailers.  For example,
+ the two words "moth" and "mother" will generate not only the obvious
+-substitution "+er" but also "-h+her" and "-th+ther" (and possibly
++substitution "+er" but also "\-h+her" and "\-th+ther" (and possibly
+ even longer ones, depending on the value of
+ .IR min ).
+ To prevent
+@@ -1621,7 +1621,7 @@ redirected.
+ However, a lot of the temporary space needed is for sorting, so TMPDIR
+ is only a partial help on systems with an uncooperative
+ .IR sort (1).
+-("Cooperative" is defined as accepting the undocumented -T switch).
++("Cooperative" is defined as accepting the undocumented \-T switch).
+ At its peak usage,
+ .I munchlist
+ takes 10 to 40 times the original
+diff --git a/ispell.5X b/ispell.5X
+index ab526ed..7a1c2e5 100644
+--- a/ispell.5X
++++ b/ispell.5X
+@@ -137,8 +137,8 @@ This feature can be used to convert an entire dictionary if necessary:)
+ 	echo qqqqq > dummy.dict
+ 	buildhash dummy.dict \fIaffix-file\fP dummy.hash
+ 	awk '{print "*"}END{print "#"}' \fIold-dict-file\fP \e
+-	| ispell -a -T \fIold-dict-string-type\fP \e
+-	  -d ./dummy.hash -p ./\fInew-dict-file\fP \e
++	| ispell \-a \-T \fIold-dict-string-type\fP \e
++	  \-d ./dummy.hash \-p ./\fInew-dict-file\fP \e
+ 	  > /dev/null
+ 	rm dummy.*
+ .fi
+@@ -622,7 +622,7 @@ or
+ .B stringchar
+ statements.
+ For example, if the hyphen is a boundary character (useful in French),
+-the string "foo-bar" would be a single word, but "-foo" would be the
++the string "foo-bar" would be a single word, but "\-foo" would be the
+ same as "foo", and "foo--bar" would be two words separated by non-word
+ characters.
+ .PP
+@@ -916,7 +916,7 @@ The following (suffix) replacements:
+ .RS
+ .nf
+ \&.	>	MENT
+-Y	>	-Y,IES
++Y	>	\-Y,IES
+ .fi
+ .RE
+ .PP
+@@ -956,8 +956,8 @@ Instead, you must use two separate rules:
+ .PP
+ .RS
+ .nf
+-E	>	-E,IES
+-Y	>	-Y,IES
++E	>	\-E,IES
++Y	>	\-Y,IES
+ .fi
+ .RE
+ .PP
+@@ -1005,7 +1005,7 @@ For example, to specify words ending in "ED", write:
+ .PP
+ .RS
+ .nf
+-E D	>	-ED,ING		# As in covered > covering
++E D	>	\-ED,ING		# As in covered > covering
+ .fi
+ .RE
+ .PP
+@@ -1013,7 +1013,7 @@ If you write:
+ .PP
+ .RS
+ .nf
+-ED	>	-ED,ING
++ED	>	\-ED,ING
+ .fi
+ .RE
+ .PP
+@@ -1021,7 +1021,7 @@ the effect will be the same as:
+ .PP
+ .RS
+ .nf
+-[ED]	>	-ED,ING
++[ED]	>	\-ED,ING
+ .fi
+ .RE
+ .PP
+@@ -1047,7 +1047,7 @@ is useful, as in the following example:
+ .PP
+ .RS
+ .nf
+-$ munchlist -c oldaffixes -l newaffixes olddict > newdict
++$ munchlist \-c oldaffixes \-l newaffixes olddict > newdict
+ .fi
+ .RE
+ .PP
+@@ -1070,7 +1070,7 @@ flag from the English affix file:
+ .RS
+ .nf
+ flag *S:
+-    [^AEIOU]Y	>	-Y,IES	# As in imply > implies
++    [^AEIOU]Y	>	\-Y,IES	# As in imply > implies
+     [AEIOU]Y	>	S		# As in convey > conveys
+     [SXZH]	>	ES		# As in fix > fixes
+     [^SXZHY]	>	S		# As in bat > bats
+@@ -1099,8 +1099,8 @@ For example, we could extend the English "R" flag as follows:
+ flag *R:
+    E			>	R		# As in skate > skater
+    E			>	RS		# As in skate > skaters
+-   [^AEIOU]Y	>	-Y,IER	# As in multiply > multiplier
+-   [^AEIOU]Y	>	-Y,IERS	# As in multiply > multipliers
++   [^AEIOU]Y	>	\-Y,IER	# As in multiply > multiplier
++   [^AEIOU]Y	>	\-Y,IERS	# As in multiply > multipliers
+    [AEIOU]Y	>	ER		# As in convey > conveyer
+    [AEIOU]Y	>	ERS		# As in convey > conveyers
+    [^EY]		>	ER		# As in build > builder
+-- 

--- a/pkgs/tools/text/ispell/patches/0021-Fix-gcc-warnings.patch
+++ b/pkgs/tools/text/ispell/patches/0021-Fix-gcc-warnings.patch
@@ -1,0 +1,57 @@
+From: Robert Luberda <robert@debian.org>
+Date: Mon, 7 Mar 2011 22:23:56 +0100
+Subject: 0021 Fix gcc warnings
+
+Fix some gcc warnings.
+---
+ correct.c                |    2 +-
+ languages/english/msgs.h |    8 ++++----
+ tree.c                   |    2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/correct.c b/correct.c
+index 79b259f..982b7c6 100644
+--- a/correct.c
++++ b/correct.c
+@@ -825,7 +825,7 @@ static void inserttoken (buf, start, tok, curchar, oktochange)
+ 	for (p = start;  p != *curchar;  p++)
+ 	    (void) putc (*p, logfile);
+ 	(void) putc (' ', logfile);
+-	(void) fputs (tok, logfile);
++	(void) fputs ((char*) tok, logfile);
+ 	(void) putc ('\n', logfile);
+ 	(void) fflush (logfile);
+ 	}
+diff --git a/languages/english/msgs.h b/languages/english/msgs.h
+index d33b42b..f9c87ca 100644
+--- a/languages/english/msgs.h
++++ b/languages/english/msgs.h
+@@ -182,10 +182,10 @@
+ #define CORR_C_HELP_4		"next to each one.  You have the option of replacing the word%s\n"
+ #define CORR_C_HELP_5		"completely, or choosing one of the suggested words.%s\n"
+     /* You may add HELP_6 through HELP_9 if your language needs more lines */
+-#define CORR_C_HELP_6		""
+-#define CORR_C_HELP_7		""
+-#define CORR_C_HELP_8		""
+-#define CORR_C_HELP_9		""
++#define CORR_C_HELP_6		"%s"
++#define CORR_C_HELP_7		"%s"
++#define CORR_C_HELP_8		"%s"
++#define CORR_C_HELP_9		"%s"
+ #define CORR_C_HELP_COMMANDS	"%s\nCommands are:%s\n%s\n"
+ #define CORR_C_HELP_R_CMD	"R       Replace the misspelled word completely.%s\n"
+ #define CORR_C_HELP_BLANK	"Space   Accept the word this time only.%s\n"
+diff --git a/tree.c b/tree.c
+index 05a6918..229ae16 100644
+--- a/tree.c
++++ b/tree.c
+@@ -351,7 +351,7 @@ void treeinsert (word, wordlen, keep)
+     struct dent *	oldhtab;
+     unsigned int	oldhsize;
+     ichar_t		nword[INPUTWORDLEN + MAXAFFIXLEN];
+-    int			isvariant;
++    MASKTYPE		isvariant;
+ 
+     /*
+      * Expand hash table when it is MAXPCT % full.
+-- 

--- a/pkgs/tools/text/ispell/patches/0023-Exclusive-options.patch
+++ b/pkgs/tools/text/ispell/patches/0023-Exclusive-options.patch
@@ -1,0 +1,38 @@
+From: Robert Luberda <robert@debian.org>
+Date: Tue, 8 Mar 2011 21:12:23 +0100
+Subject: 0023 Exclusive options
+
+Make options -x and -b mutually exclusive
+---
+ ispell.c |    6 ++++--
+ 1 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/ispell.c b/ispell.c
+index d130a0e..cd5802a 100644
+--- a/ispell.c
++++ b/ispell.c
+@@ -279,6 +279,7 @@ int main (argc, argv)
+     static char	outbuf[BUFSIZ];
+     int		argno;
+     int		arglen;
++    int		bflag = 0;
+ 
+     Cmd = *argv;
+ 
+@@ -728,12 +729,13 @@ int main (argc, argv)
+ 		nodictflag++;
+ 		break;
+ 	    case 'b':
+-		if (arglen > 2)
++		if (arglen > 2 || xflag == 1)
+ 		    usage ();
+ 		xflag = 0;		/* Keep a backup file */
++		bflag = 1;
+ 		break;
+ 	    case 'x':
+-		if (arglen > 2)
++		if (arglen > 2 || bflag == 1)
+ 		    usage ();
+ 		xflag = 1;		/* Don't keep a backup file */
+ 		break;
+-- 

--- a/pkgs/tools/text/ispell/patches/0024-Check-tempdir-creation.patch
+++ b/pkgs/tools/text/ispell/patches/0024-Check-tempdir-creation.patch
@@ -1,0 +1,69 @@
+From: Robert Luberda <robert@debian.org>
+Date: Tue, 8 Mar 2011 21:00:31 +0100
+Subject: 0024 Check tempdir creation
+
+Fail if temporary directory cannot be created.
+---
+ findaffix.X |    3 ++-
+ munchlist.X |    3 ++-
+ subset.X    |    3 ++-
+ zapdups.X   |    3 ++-
+ 4 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/findaffix.X b/findaffix.X
+index 2c253e2..58cabab 100755
+--- a/findaffix.X
++++ b/findaffix.X
+@@ -179,7 +179,8 @@ TEMPDIR=`mktemp -d ${TDIR}/faffXXXXXXXXXX 2>/dev/null`  ||  TEMPDIR="$TDIR"
+ TMP=${TEMPDIR}/faff$$
+ if [ "$TEMPDIR" = "$TDIR" ]
+ then
+-    TOREMOVE="${TMP}*"
++    echo "Failed to create temporary directory; exiting"
++    exit 1
+ else
+     TOREMOVE="$TEMPDIR"
+ fi
+diff --git a/munchlist.X b/munchlist.X
+index ada3f1d..47bb908 100755
+--- a/munchlist.X
++++ b/munchlist.X
+@@ -180,7 +180,8 @@ MUNCHDIR=`mktemp -d ${TDIR}/munchXXXXXXXXXX 2>/dev/null`  ||  MUNCHDIR="$TDIR"
+ TMP=${MUNCHDIR}/munch$$
+ if [ "$MUNCHDIR" = "$TDIR" ]
+ then
+-    TOREMOVE="${TMP}*"
++    echo "$0: Failed to create temporary directory, exiting..."
++	exit 1
+ else
+     TOREMOVE="$MUNCHDIR"
+ fi
+diff --git a/subset.X b/subset.X
+index cc748ec..9c904cc 100755
+--- a/subset.X
++++ b/subset.X
+@@ -125,7 +125,8 @@ TEMPDIR=`mktemp -d ${TDIR}/ssetXXXXXXXXXX 2>/dev/null`  ||  TEMPDIR="$TDIR"
+ TMP=${TEMPDIR}/sset$$
+ if [ "$TEMPDIR" = "$TDIR" ]
+ then
+-    TOREMOVE="${TMP}*"
++    echo "$0: Failed to create temporary directory, exiting..."
++    exit 1
+ else
+     TOREMOVE="$TEMPDIR"
+ fi
+diff --git a/zapdups.X b/zapdups.X
+index a68852a..1c610d4 100755
+--- a/zapdups.X
++++ b/zapdups.X
+@@ -111,7 +111,8 @@ TEMPDIR=`mktemp -d ${TDIR}/zapdXXXXXXXXXX 2>/dev/null`  ||  TEMPDIR="$TDIR"
+ TMP=${TEMPDIR}/zapd$$
+ if [ "$TEMPDIR" = "$TDIR" ]
+ then
+-    TOREMOVE="${TMP}*"
++    echo "$0: Failed to create temporary directory, exiting..."
++    exit 1
+ else
+     TOREMOVE="$TEMPDIR"
+ fi
+-- 

--- a/pkgs/tools/text/ispell/patches/0025-Languages.patch
+++ b/pkgs/tools/text/ispell/patches/0025-Languages.patch
@@ -1,0 +1,81 @@
+From: Robert Luberda <robert@debian.org>
+Date: Tue, 8 Mar 2011 21:02:47 +0100
+Subject: 0025 Languages
+
+Fix a few words.
+---
+ languages/english/british.0 |    1 +
+ languages/english/english.0 |    8 ++++++--
+ languages/english/english.1 |    3 ++-
+ 3 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/languages/english/british.0 b/languages/english/british.0
+index dc4caa7..04d9177 100644
+--- a/languages/english/british.0
++++ b/languages/english/british.0
+@@ -46,6 +46,7 @@ armour/DGMRSZ
+ armoured/U
+ armourer/MS
+ armoury/DMS
++artefact/MS
+ atomisation/MS
+ atomise/DGRSZ
+ authorisation/AMS
+diff --git a/languages/english/english.0 b/languages/english/english.0
+index fc13212..f85e15a 100644
+--- a/languages/english/english.0
++++ b/languages/english/english.0
+@@ -3502,6 +3502,7 @@ closure/DGMS
+ cloth/DGS
+ clothe/DGS
+ clothed/U
++cloths
+ cloud/DGS
+ clouded/U
+ cloudless/PY
+@@ -10019,9 +10020,10 @@ mystery/MS
+ mystic/MS
+ mystical/Y
+ mysticism/S
+-myth/MS
++myth/M
+ mythical/Y
+ mythology/MS
++myths
+ nag/MS
+ nail/DGRS
+ naive/PRY
+@@ -14818,6 +14820,7 @@ tent/DGRS
+ tentacle/DS
+ tentative/PY
+ tented/U
++tenth
+ tenths
+ tenure/DS
+ tenured/U
+@@ -16511,8 +16514,9 @@ youngster/MS
+ your/MS
+ yourself
+ yourselves
+-youth/MS
++youth/M
+ youthful/PY
++youths
+ yuck
+ Yugoslavian/MS
+ yummy/R
+diff --git a/languages/english/english.1 b/languages/english/english.1
+index 2bfac86..78a7edf 100644
+--- a/languages/english/english.1
++++ b/languages/english/english.1
+@@ -7449,7 +7449,8 @@ metalloid
+ metallurgic
+ metallurgical/Y
+ metallurgists
+-metalsmith/S
++metalsmith
++metalsmiths
+ metalwork/GJR
+ metamorphic
+ metamorphism
+-- 

--- a/pkgs/tools/text/ispell/patches/0030-Display-whole-multibyte-character.patch
+++ b/pkgs/tools/text/ispell/patches/0030-Display-whole-multibyte-character.patch
@@ -1,0 +1,35 @@
+From: Robert Luberda <robert@debian.org>
+Date: Mon, 21 Mar 2011 10:36:15 +0100
+Subject: 0030 Display whole multibyte character
+
+Display all bytes from multibyte characters instead of converting them
+into `cat -v' format. This fixes an ugly screen content shown while
+checking UTF-8 files.
+---
+ correct.c |   11 +++++++----
+ 1 files changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/correct.c b/correct.c
+index 982b7c6..c91b41b 100644
+--- a/correct.c
++++ b/correct.c
+@@ -733,11 +733,14 @@ static int show_char (cp, linew, output, maxw)
+ 	ichar = SET_SIZE + laststringch;
+     else
+ 	ichar = chartoichar (ch);
+-    if (!vflag  &&  iswordch (ichar)  &&  len == 1)
++    if (!vflag  &&  iswordch (ichar)  &&  len >= 1)
+ 	{
+-	if (output)
+-	    (void) putchar (ch);
+-	(*cp)++;
++	for (i = 0; i < len; ++i)
++	    {
++		if (output)
++			(void) putchar (**cp);
++		(*cp)++;
++	    }
+ 	return 1;
+ 	}
+     if (ch == '\t')
+-- 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2080,6 +2080,8 @@ in
 
   ispike = callPackage ../development/libraries/science/robotics/ispike { };
 
+  ispell = callPackage ../tools/text/ispell {};
+
   isync = callPackage ../tools/networking/isync { };
   isyncUnstable = callPackage ../tools/networking/isync/unstable.nix { };
 


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The derivation's buildPhase requires `ispell` for which we reuse pull request #3320 by @bennofs.
