### PR TITLE
tortoisehg: 3.7.3 -> 3.8.1

### DIFF
--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonApplication rec {
     name = "tortoisehg-${version}";
-    version = "3.7.3";
+    version = "3.8.1";
 
     src = fetchurl {
       url = "https://bitbucket.org/tortoisehg/targz/downloads/${name}.tar.gz";
-      sha256 = "1vahiavpkf9ib2mx8z5i6f0kh072zycazmbrc4sl94p5pvv5w1dh";
+      sha256 = "1v5h5yz9b360ris9p8zsdjxqvaflp9z2b6b7dfb4abn2irv3jip6";
     };
 
     pythonPath = with pythonPackages; [ pyqt4 mercurial qscintilla iniparse ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

mercurial was updated to 3.8.1 and breaked TortoiseHg. This is fix. Tested against nixpkgs-unstable
