### PR TITLE
owncloud: 9.0.0 -> 9.0.2

### DIFF
--- a/pkgs/servers/owncloud/default.nix
+++ b/pkgs/servers/owncloud/default.nix
@@ -57,8 +57,8 @@ in {
   };
 
   owncloud90 = common {
-    versiona = "9.0.0";
-    sha256 = "0z57lc6z1h7yn1sa26q8qnhjxyjn0ydy3mf4yy4i9a3p198kfryi";
+    versiona = "9.0.2";
+    sha256 = "845c43fe981fa0fd07fc3708f41f1ea15ecb11c2a15c65a4de191fc85b237c74";
   };
 
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
