### PR TITLE
nix-cmd: init at 2016-01-10

### DIFF
--- a/pkgs/tools/package-management/nix-cmd/default.nix
+++ b/pkgs/tools/package-management/nix-cmd/default.nix
@@ -1,0 +1,19 @@
+{pythonPackages, fetchgit}:
+
+pythonPackages.buildPythonApplication {
+
+  name = "nix-cmd";
+  version = "2016-01-10";
+
+  src = fetchgit {
+    url = https://github.com/FRidh/nix-cmd;
+    rev = "c8be0cd8b30fd8edcbb01f3712701c6cd9352b15";
+    sha256 = "131rvqqqnnx1c8xy5v322wby43zy70bwiac0knhs3jhj5qdn1wgh";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ click ];
+
+  meta = {
+    description = "The nix command provides a user-friendly way to use the Nix package manager";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16468,6 +16468,8 @@ in
     nixStable
     nixUnstable;
 
+  nix-cmd = callPackage ../tools/package-management/nix-cmd { };
+
   nixops = callPackage ../tools/package-management/nixops { };
 
   nixopsUnstable = nixops;# callPackage ../tools/package-management/nixops/unstable.nix { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@garbas made a [demo of a new UI](https://gist.github.com/garbas/991aef248091f0692d3b). I've packaged this into a [Python package](https://github.com/FRidh/nix-cmd). This PR adds `nix-cmd` to Nixpkgs.
