### PR TITLE
nodejs: 6.1.0 -> 6.2.0

### DIFF
--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -4,9 +4,9 @@
 }@args:
 
 import ./nodejs.nix (args // rec {
-  version = "6.1.0";
+  version = "6.2.0";
   src = fetchurl {
     url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.gz";
-    sha256 = "1hsbmr3yc6zmyhz058zfxg77dzjhk94g1k0y65p6xq8ihq5yyrwy";
+    sha256 = "1fcldsnkk6px5fms405j9z2yv6mmscin5x7sma8bdavqgn283zgw";
   };
 })


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] OS X
  - [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

[Release Notes](https://nodejs.org/en/blog/release/v6.2.0/)
