### PR TITLE
phwmon: init at 2016-03-13

### DIFF
--- a/pkgs/applications/misc/phwmon/default.nix
+++ b/pkgs/applications/misc/phwmon/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitLab, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  name = "phwmon-${version}";
+  version = "2016-03-13";
+
+  src = fetchFromGitLab {
+    owner = "o9000";
+    repo = "phwmon";
+    rev = "90247ceaff915ad1040352c5cc9195e4153472d4";
+    sha256 = "1gkjfmd8rai7bl1j7jz9drmzlw72n7mczl0akv39ya4l6k8plzvv";
+  };
+
+  nativeBuildInputs = [ pythonPackages.wrapPython ];
+
+  buildInputs = [ pythonPackages.pygtk pythonPackages.psutil ];
+
+  pythonPath = [ pythonPackages.pygtk pythonPackages.psutil ];
+  
+  patchPhase = ''
+    substituteInPlace install.sh --replace "/usr/local" "$out"
+  '';
+    
+  installPhase = ''
+    mkdir -p $out/bin $out/share/applications
+    ./install.sh
+  '';
+
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  meta = {
+    homepage = https://gitlab.com/o9000/phwmon;
+    description = "Hardware monitor (CPU, memory, network and disk I/O) for the system tray";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13674,6 +13674,8 @@ in
 
   phototonic = qt5.callPackage ../applications/graphics/phototonic { };
 
+  phwmon = callPackage ../applications/misc/phwmon { };
+
   pianobar = callPackage ../applications/audio/pianobar { };
 
   pianobooster = callPackage ../applications/audio/pianobooster { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
