### PR TITLE
freerdpUnstable: 1.2.0-beta1 -> 1.2.0-20160107

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/unstable.nix
+++ b/pkgs/applications/networking/remote/freerdp/unstable.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, openssl, zlib, libX11, libXcursor
-, libXdamage, libXext, glib, alsaLib, ffmpeg, libxkbfile, libXinerama, libXv
-, substituteAll
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, openssl, zlib
+, libX11, libXcursor, libXdamage, libXext, libXrender, libxkbfile, libXinerama, libXv
+, glib, alsaLib, ffmpeg, substituteAll, wayland
 , libpulseaudio ? null, cups ? null, pcsclite ? null
 , buildServer ? true, optimize ? true
 }:
 
 stdenv.mkDerivation rec {
-  name = "freerdp-1.2.0-beta1";
+  name = "freerdp-1.2.0-20160107";
 
   src = fetchFromGitHub {
     owner = "FreeRDP";
     repo = "FreeRDP";
-    rev = "1.2.0-beta1+android7";
-    sha256 = "08nn18jydblrif1qs92pakzd3ww7inr0i378ssn1bjp09lm1bkk0";
+    rev = "c3ce0c3b09bf10f388011e01bb4091e351af39e9";
+    sha256 = "0m8yqs4acj8jga1zxifba8zwmasgff5l0fmgb0iwzczp8wwj36rw";
   };
 
   patches = [
@@ -23,8 +23,9 @@ stdenv.mkDerivation rec {
       });
 
   buildInputs = [
-    cmake pkgconfig openssl zlib libX11 libXcursor libXdamage libXext glib
+    cmake pkgconfig openssl zlib libX11 libXcursor libXdamage libXext libXrender glib
     alsaLib ffmpeg libxkbfile libXinerama libXv cups libpulseaudio pcsclite
+    wayland
   ];
 
   doCheck = false;
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DWITH_CUNIT=OFF"
+    "-DWITH_WAYLAND=ON"
   ] ++ stdenv.lib.optional (libpulseaudio != null) "-DWITH_PULSE=ON"
     ++ stdenv.lib.optional (cups != null) "-DWITH_CUPS=ON"
     ++ stdenv.lib.optional (pcsclite != null) "-DWITH_PCSC=ON"
@@ -47,8 +49,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.freerdp.com/;
     license = licenses.asl20;
-    maintainers = with maintainers; [ wkennington ];
+    maintainers = with maintainers; [ wkennington peterhoeg ];
     platforms = platforms.unix;
   };
 }
-


### PR DESCRIPTION
This release fixes a number of issues with especially keyboard handling compared to the previous version.

I have been using it as the daily driver for a month or so. FAR better than the previous version.

It isn't a release per se, but this commit was chosen as it is the one used by Arch Linux.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
