### PR TITLE
debian-build: fix checkinstall invocation

### DIFF
--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -54,11 +54,15 @@ vmTools.runInLinuxImage (stdenv.mkDerivation (
       eval "$preInstall"
       export LOGNAME=root
 
+      # otherwise build hangs when it wants to display
+      # the log file
+      export PAGER=cat
       ${checkinstall}/sbin/checkinstall --nodoc -y -D \
         --fstrans=${if fsTranslation then "yes" else "no"} \
         --requires="${concatStringsSep "," debRequires}" \
         --provides="${concatStringsSep "," debProvides}" \
-        ${optionalString (src ? version) "--pkgversion=$(echo ${src.version} | tr _ -)"} \
+        ${if (src ? version) then "--pkgversion=$(echo ${src.version} | tr _ -)"
+                             else "--pkgversion=0.0.0"} \
         ''${debMaintainer:+--maintainer="'$debMaintainer'"} \
         ''${debName:+--pkgname="'$debName'"} \
         $checkInstallFlags \


### PR DESCRIPTION
Checkinstall had two problems:
1. when it was called without a version (e.g. with a derivation created
by fetchFromGitHub) it would use `src` as debian version, which caused
dpkg to fail
2. when dpkg failed, it would invoke the pager with the log, which hangs
the build

So now
1. the default version is the dummy `0.0.0`
2. the used pager is `cat`
