### PR TITLE
Make using separate debugging info easier.

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -153,6 +153,7 @@ stdenv.mkDerivation {
      '');
 
   enableParallelBuilding = true;
+  separateDebugInfo = true;
 
   meta = {
     homepage = http://git-scm.com/;

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation ({
   inherit (stdenv) is64bit;
 
   enableParallelBuilding = true;
+  separateDebugInfo = true;
 
   patches =
     [ /* Have rpcgen(1) look for cpp(1) in $PATH.  */

--- a/pkgs/development/tools/misc/gdb/nix.py
+++ b/pkgs/development/tools/misc/gdb/nix.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+
+import gdb
+
+_objects_without_symbols_loaded = set()
+
+def _new_objfile(event):
+	_load(event.new_objfile)
+
+gdb.events.new_objfile.connect(_new_objfile)
+
+def _clear_objfiles(event):
+	_objects_without_symbols_loaded.clear()
+
+gdb.events.clear_objfiles.connect(_clear_objfiles)
+
+def _get_debug_file_path(obj):
+	try:
+		out = subprocess.check_output([
+			"objcopy",
+			"--dump-section=.nix_debug=/dev/stdout",
+			obj.filename,
+			"/dev/null",
+		], stderr=subprocess.STDOUT)
+		if b"File in wrong format" in out:
+			# objdump isn't exiting with failure in this case.
+			return None
+		return str(out).replace(" ", "", 1).rstrip()
+	except:
+		return None
+
+def _load(obj):
+	debugfile = _get_debug_file_path(obj)
+	if not debugfile:
+		return
+	
+	try:
+		obj.add_separate_debug_file(debugfile)
+		gdb.write("Loaded symbols for {}.\n".format(obj.username))
+		_objects_without_symbols_loaded.discard(obj)
+	except Exception as e:
+		_objects_without_symbols_loaded.add(obj)
+		gdb.write("Error loading debug symbols: {}\n".format(e))
+		gdb.write("From: {}\n".format(debugfile, e))
+		gdb.write("For:  {}\n".format(obj.username))
+		if not os.path.exists(debugfile):
+			gdb.write("The debug file doesn't exists.\n")
+			gdb.write("You can download missing debug files with 'nix-download-debug'.\n")
+
+def _download(objs):
+	debugfiles = [_get_debug_file_path(obj) for obj in objs]
+	subprocess.check_call(["nix-store", "-rk"] + debugfiles)
+
+class CommandNixDownloadDebug(gdb.Command):
+	def __init__(self):
+		super(CommandNixDownloadDebug, self).__init__("nix-download-debug", gdb.COMMAND_USER)
+	
+	def invoke(self, arg, from_tty):
+		assert not arg
+		try:
+			_download(_objects_without_symbols_loaded)
+		finally:
+			for obj in list(_objects_without_symbols_loaded):
+				_load(obj)
+
+CommandNixDownloadDebug()

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "dev" "out" "bin" "man" "doc" ];
 
+  enableParallelBuilding = true;
+  separateDebugInfo = true;
   doCheck = true;
 
   # In stdenv-linux, prevent a dependency on bootstrap-tools.


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The previous iteration of debug info required that all of the packages
were "installed". This is suboptimal because "installing" all of the
programs you want to debug as well as the libraries that they use.

This method enables debug symbols for all loaded files as long as those
symbols are present in the nix store, as well as a command to download
those symbols from binary caches for all loaded object files.

This is implemented by adding a new section to the executable witch
contains the path to the debug symbols. An extension that is auto-loaded
by GDB then uses this information to automatically load these symbols
whenever the object file is loaded.

Future work:
- [ ] Find a way to make all packages build with debug symbols by default.
- [ ] Find a better way to "attach" debug symbols to packages (weak references?)
