### PR TITLE
dust: fix hash, use fetchFromGitHub, add meta

### DIFF
--- a/pkgs/development/interpreters/pixie/dust.nix
+++ b/pkgs/development/interpreters/pixie/dust.nix
@@ -1,11 +1,12 @@
-{ stdenv, pixie, fetchgit }:
+{ stdenv, pixie, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "dust-0-91";
-  src = fetchgit {
-    url = "https://github.com/pixie-lang/dust.git";
+  src = fetchFromGitHub {
+    owner = "pixie-lang";
+    repo = "dust";
     rev = "efe469661e749a71e86858fd006f61464810575a";
-    sha256 = "0krh7ynald3gqv9f17a4kfx7sx8i31l6j1fhd5k8b6m8cid7f9c1";
+    sha256 = "09n57b6haxwask9m8vimv42ikczf7lgfc7m9izjrcqgs0padvfzc";
   };
   buildInputs = [ pixie ];
   patches = [ ./make-paths-configurable.patch ];

--- a/pkgs/development/interpreters/pixie/dust.nix
+++ b/pkgs/development/interpreters/pixie/dust.nix
@@ -25,4 +25,10 @@ stdenv.mkDerivation rec {
     cp -a src/ run.pxi $out/share/dust
     mv dust $out/bin/dust
   '';
+
+  meta = {
+    description = "Provides tooling around pixie, e.g. a nicer repl, running tests and fetching dependencies";
+    homepage = src.meta.homepage;
+    license = stdenv.lib.licenses.lgpl3;
+  };
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Somehow the hash was wrong.
I switched to fetchFromGitHub and added the meta attribute while I was at it.
