### PR TITLE
libuv: 1.9.0 -> 1.9.1, nodejs-4.3.1 -> 4.4.4, nodejs-5.11.0 -> 5.11.1

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -3,14 +3,14 @@
 , ApplicationServices, CoreServices }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.0";
+  version = "1.9.1";
   name = "libuv-${version}";
 
   src = fetchFromGitHub {
     owner = "libuv";
     repo = "libuv";
     rev = "v${version}";
-    sha256 = "0sq8c8n7xixn2xxp35crprvh35ry18i5mcxgwh12lydwv9ks0d4k";
+    sha256 = "1kc386gkkkymgz9diz1z4r8impcsmki5k88dsiasd6v9bfvq04cc";
   };
 
   buildInputs = [ automake autoconf libtool pkgconfig ]

--- a/pkgs/development/web/nodejs/v4.nix
+++ b/pkgs/development/web/nodejs/v4.nix
@@ -4,9 +4,9 @@
 }@args:
 
 import ./nodejs.nix (args // rec {
-  version = "4.3.1";
+  version = "4.4.4";
   src = fetchurl {
-    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-    sha256 = "0wzf5sirbph5kaik3pm9i2dxbjwqh5qlnqn71azrsv0vhs7dbqk1";
+    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
+    sha256 = "055i4wcc5sfqv7ksdxwbxpy4v1qc16lkzgbyhx46cnhl072fv71c";
   };
 })

--- a/pkgs/development/web/nodejs/v5.nix
+++ b/pkgs/development/web/nodejs/v5.nix
@@ -4,9 +4,9 @@
 }@args:
 
 import ./nodejs.nix (args // rec {
-  version = "5.11.0";
+  version = "5.11.1";
   src = fetchurl {
-    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.gz";
-    sha256 = "14ayv5rgagc6lj7fil0bdbzwj2qxj5picw802rfmmpj9kqdb0hgg";
+    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
+    sha256 = "07v60mhswj77m7516zakj3p1py7ixa5jbgj0m7zlr9vygrrc66zi";
   };
 })

--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -6,7 +6,7 @@
 import ./nodejs.nix (args // rec {
   version = "6.2.0";
   src = fetchurl {
-    url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.gz";
-    sha256 = "1fcldsnkk6px5fms405j9z2yv6mmscin5x7sma8bdavqgn283zgw";
+    url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
+    sha256 = "14p4ah9gsgifj25g2akp7kyqhnqvq726n74h4rfj7wnidxhgwcw6";
   };
 })


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

nodejs 6.2.0 upstream already uses the new libuv
Since the three node packages all depend on libuv and thus will be rebuilt, I figured it may be a good time to bump them aswell.

Tested execution of the respective binaries of all node versions and neovim.

Packages that fail to build for me: airfield (marked broken), groovebasin (needs pinning to node_0.10, I'll open a separate PR), ripple-rest (development frozen probably also needs older node) - I think all of these are unrelated to my changes.
