### PR TITLE
groovebasin: pin nodejs version

### DIFF
--- a/pkgs/applications/audio/groovebasin/default.nix
+++ b/pkgs/applications/audio/groovebasin/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, fetchFromGitHub, makeWrapper, callPackage, libgroove, python, utillinux }:
+{ stdenv, fetchFromGitHub, makeWrapper, callPackage, libgroove, python, utillinux, nodejs }:
 
 with stdenv.lib;
 
 let
   nodePackages = callPackage (import ../../../top-level/node-packages.nix) {
+    inherit nodejs;
     neededNatives = [ libgroove python utillinux ];
     self = nodePackages;
     generated = ./package.nix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9847,7 +9847,7 @@ in
 
   grafana = (callPackage ../servers/monitoring/grafana { }).bin // { outputs = ["bin"]; };
 
-  groovebasin = callPackage ../applications/audio/groovebasin { };
+  groovebasin = callPackage ../applications/audio/groovebasin { nodejs = nodejs-0_10; };
 
   haka = callPackage ../tools/security/haka { };
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Build was broken - the packages readme suggests it's only compatible with nodejs 0.10 and 0.12, so I made the nodejs version explicit for this package. I hope I've done it the right way :wink: 
