### PR TITLE
ripple-rest: mark as broken

### DIFF
--- a/pkgs/servers/rippled/ripple-rest.nix
+++ b/pkgs/servers/rippled/ripple-rest.nix
@@ -22,5 +22,6 @@ in nodePackages.buildNodePackage rec {
     homepage = https://github.com/ripple/ripple-rest;
     maintainers = with maintainers; [ offline ];
     license = [ licenses.mit ];
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

development is frozen as of Nov 2015
author recommends migrating to RippleAPI

We should probably investigate this further (perhaps only needs node 0.10?) or deprecate the ripple-rest service aswell.
Ping @offlinehacker 
