### PR TITLE
pmenu: init at 2016-05-13

### DIFF
--- a/pkgs/applications/misc/pmenu/default.nix
+++ b/pkgs/applications/misc/pmenu/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitLab, pythonPackages, gnome }:
+
+stdenv.mkDerivation rec {
+  name = "pmenu-${version}";
+  version = "2016-05-13";
+
+  src = fetchFromGitLab {
+    owner = "o9000";
+    repo = "pmenu";
+    rev = "90b722de345cff56f8ec0908a0e8a7d733c0c671";
+    sha256 = "15bkvadr7ab44mc8gkdqs3w14cm498mwf72w5rjm2rdh55357jjh";
+  };
+
+  nativeBuildInputs = [ pythonPackages.wrapPython ];
+
+  buildInputs = [ pythonPackages.pygtk gnome.gnome_menus ];
+
+  pythonPath = [ pythonPackages.pygtk ];
+  
+  patchPhase = ''
+    substituteInPlace install.sh --replace "/usr/local" "$out"
+  '';
+    
+  installPhase = ''
+    mkdir -p $out/bin $out/share/applications
+    ./install.sh
+  '';
+
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  meta = {
+    homepage = https://gitlab.com/o9000/pmenu;
+    description = "Start menu for Linux/BSD";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13739,6 +13739,8 @@ in
 
   plugin-torture = callPackage ../applications/audio/plugin-torture { };
 
+  pmenu = callPackage ../applications/misc/pmenu { };
+
   poezio = python3Packages.poezio;
 
   pommed = callPackage ../os-specific/linux/pommed {};


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
