### PR TITLE
bins: init at 1.1.29 (plus perl dependencies)

### DIFF
--- a/pkgs/development/perl-modules/xml-grove-utf8.patch
+++ b/pkgs/development/perl-modules/xml-grove-utf8.patch
@@ -1,0 +1,10 @@
+--- XML-Grove-0.46alpha/t/grove.t	2008-07-22 14:47:27.000000000 +0200
++++ XML-Grove-0.46alpha/t/grove.t	2008-07-22 14:46:42.000000000 +0200
+@@ -13,6 +13,7 @@ use XML::Parser::PerlSAX;
+ use XML::Grove::Builder;
+ use XML::Grove::AsString;
+ use XML::Grove::AsCanonXML;
++use utf8;
+ 
+ $loaded = 1;
+ print "ok 1\n";

--- a/pkgs/tools/graphics/bins/bins_edit-isa.patch
+++ b/pkgs/tools/graphics/bins/bins_edit-isa.patch
@@ -1,0 +1,20 @@
+--- a/bins_edit	2005-08-25 14:34:39.000000000 -0400
++++ b/bins_edit	2016-05-18 20:25:40.913460314 -0400
+@@ -26,7 +26,7 @@
+ 
+ use Getopt::Long;
+ use IO::File;
+-use UNIVERSAL qw(isa);
++use Scalar::Util 'reftype';
+ 
+ # XML parsing & writing
+ use XML::Grove;
+@@ -198,7 +198,7 @@
+   my $fieldValue;
+   foreach my $element
+     (@{$document->at_path('/'.$fileType.'/description')->{Contents}}) {
+-      if (isa($element, 'XML::Grove::Element') && $element->{Name} eq "field") {
++      if (reftype($element) eq 'XML::Grove::Element' && $element->{Name} eq "field") {
+ 	$fieldName = $element->{Attributes}{'name'};
+ 	$fieldValue = "";
+ 	if ($fieldName eq $field) {

--- a/pkgs/tools/graphics/bins/default.nix
+++ b/pkgs/tools/graphics/bins/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, makeWrapper, perl, perlPackages }:
+
+let
+  version = "1.1.29";
+
+in
+
+#note: bins-edit-gui does not work
+
+stdenv.mkDerivation {
+  name = "bins-${version}";
+
+  src = fetchurl {
+    url = "http://download.gna.org/bins/bins-${version}.tar.gz";
+    sha256 = "0n4pcssyaic4xbk25aal0b3g0ibmi2f3gpv0gsnaq61sqipyjl94";
+  };
+
+  buildInputs = with perlPackages; [ makeWrapper perl
+                                     ImageSize ImageInfo PerlMagick
+                                     URI HTMLParser HTMLTemplate HTMLClean
+                                     XMLGrove XMLHandlerYAWriter
+                                     TextIconv TextUnaccent
+                                     DateTimeFormatDateParse ]; #TODO need Gtk (not Gtk2?) for bins-edit-gui
+
+  patches = [ ./bins_edit-isa.patch
+              ./hashref.patch ];
+
+  installPhase = ''
+    export DESTDIR=$out;
+    export PREFIX=.;
+
+    echo | ./install.sh
+
+    for f in bins bins_edit bins-edit-gui; do
+      substituteInPlace $out/bin/$f \
+        --replace /usr/bin/perl ${perl}/bin/perl \
+        --replace /etc/bins $out/etc/bins \
+        --replace /usr/local/share $out/share;
+      wrapProgram $out/bin/$f --set PERL5LIB "$PERL5LIB";
+    done
+  '';
+
+  meta = {
+    description = "generates static HTML photo albums";
+    homepage = http://bins.sautret.org;
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/tools/graphics/bins/hashref.patch
+++ b/pkgs/tools/graphics/bins/hashref.patch
@@ -1,0 +1,13 @@
+--- a/bins	2016-05-18 20:45:49.513330005 -0400
++++ b/bins	2016-05-18 20:58:58.957830874 -0400
+@@ -3643,8 +3643,8 @@
+ 
+     my @descTable;
+     foreach my $tagName (@mainFields) {
+-        if (${%$hashref}{$tagName}) {
+-            my $value=${%$hashref}{$tagName};
++        if (${$hashref}{$tagName}) {
++            my $value=${$hashref}{$tagName};
+             $value =~ s/'/&#39;/g  ; # in case it's used in javascript code
+             push @descTable, {DESC_FIELD_NAME => getFields($configHash)->{$tagName}->{'Name'},
+                               DESC_FIELD_VALUE => $value,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -569,6 +569,8 @@ in
 
   bindfs = callPackage ../tools/filesystems/bindfs { };
 
+  bins = callPackage ../tools/graphics/bins { };
+
   binwalk = callPackage ../tools/misc/binwalk {
     python = pythonFull;
     wrapPython = pythonPackages.wrapPython;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5694,6 +5694,18 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  HTMLClean = buildPerlPackage rec {
+    name = "HTML-Clean-0.8";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/L/LI/LINDNER/${name}.tar.gz";
+      sha256 = "1h0dzxx034hpshxlpsxhxh051d1p79cjgp4q5kg68kgx7aian85c";
+    };
+    meta = {
+      description = "Cleans up HTML code for web browsers, not humans";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   HTMLElementExtended = buildPerlPackage {
     name = "HTML-Element-Extended-1.18";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13807,6 +13807,22 @@ let self = _self // overrides; _self = with self; {
     doCheck = false;
   };
 
+  XMLGrove = buildPerlPackage rec {
+    name = "XML-Grove-0.46alpha";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/K/KM/KMACLEOD/${name}.tar.gz";
+      sha256 = "05yis1ms7cgwjh57k57whrmalb3ha0bjr9hyvh7cnadcyiynvdpw";
+    };
+    buildInputs = [ pkgs.libxml2 ];
+    propagatedBuildInputs = [ libxml_perl ];
+
+    #patch from https://bugzilla.redhat.com/show_bug.cgi?id=226285
+    patches = [ ../development/perl-modules/xml-grove-utf8.patch ];
+    meta = {
+      description = "Perl-style XML objects";
+    };
+  };
+
   XMLLibXML = buildPerlPackage rec {
     name = "XML-LibXML-2.0122";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13823,6 +13823,18 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  XMLHandlerYAWriter = buildPerlPackage rec {
+    name = "XML-Handler-YAWriter-0.23";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/K/KR/KRAEHE/${name}.tar.gz";
+      sha256 = "11d45a1sz862va9rry3p2m77pwvq3kpsvgwhc5ramh9mbszbnk77";
+    };
+    propagatedBuildInputs = [ libxml_perl ];
+    meta = {
+      description = "Yet another Perl SAX XML Writer";
+    };
+  };
+
   XMLLibXML = buildPerlPackage rec {
     name = "XML-LibXML-2.0122";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6166,6 +6166,19 @@ let self = _self // overrides; _self = with self; {
   # For backwards compatibility.
   if_ = self."if";
 
+  ImageInfo = buildPerlPackage rec {
+    name = "Image-Info-1.38";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SR/SREZIC/${name}.tar.gz";
+      sha256 = "b8a68b5661555feaf767956fe9ff14c917a63bedb3e30454d5598d992eb7e919";
+    };
+    propagatedBuildInputs = [ IOstringy ];
+    meta = {
+      description = "Extract meta information from image files";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   ImageSize = buildPerlPackage rec {
     name = "Image-Size-3.232";
     src = fetchurl {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

`bins-edit-gui` does not work, but I don't use it so didn't spend the time hunting down its perl dependencies.  :-/
