### PR TITLE
hakuneko: init at 1.3.12

### DIFF
--- a/pkgs/tools/misc/hakuneko/default.nix
+++ b/pkgs/tools/misc/hakuneko/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, wxGTK, openssl, curl }:
+
+stdenv.mkDerivation rec {
+  name = "hakuneko-${version}";
+  version = "1.3.12";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/hakuneko/hakuneko_${version}_src.tar.gz";
+    sha256 = "24e7281a7f68b24e5260ee17ecfa1c5a3ffec408c8ea6e0121ae6c161898b698";
+  };
+
+  preConfigure = ''
+    substituteInPlace ./configure \
+       --replace /bin/bash $shell
+    '';
+
+  buildInputs = [ wxGTK openssl curl ];
+
+  meta = {
+    description = "Manga downloader";
+    homepage = http://sourceforge.net/projects/hakuneko/;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12873,6 +12873,8 @@ in
 
   hackrf = callPackage ../applications/misc/hackrf { };
 
+  hakuneko = callPackage ../tools/misc/hakuneko { };
+
   hamster-time-tracker = callPackage ../applications/misc/hamster-time-tracker {
     inherit (pythonPackages) pyxdg pygtk dbus sqlite3;
     inherit (gnome) gnome_python;


### PR DESCRIPTION
###### Things done

Added hakuneko to nixpkgs
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

hakuneko is a simple manga downloader from a numerous online viewing
sites
