### PR TITLE
nixpkgs manual: more extensible example for allowUnfreePredicate

### DIFF
--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -46,10 +46,10 @@ $ export NIXPKGS_ALLOW_UNFREE=1
 allowUnfreePredicate = (pkg: ...);
 </programlisting>
 
-    Example to allow flash player only:
+    Example to allow flash player and visual studio code only:
 
 <programlisting>
-allowUnfreePredicate = (pkg: pkgs.lib.hasPrefix "flashplayer-" pkg.name);
+allowUnfreePredicate = with builtins; (pkg: elem (parseDrvName pkg.name).name [ "flashplayer" "vscode" ]);
 </programlisting>
 
     </para>


### PR DESCRIPTION
Hello,

I propose a small change to the suggested use of `allowUnfreePredicate`.
The proposed function is easily extensible because it contains a list of package names that the user which to white-list.
It's easy, even for a new user, to understand how to tweak this function.
Maybe the use of `allowUnfreePredicate` should be promoted instead of `allowUnfree` (as suggested in #2188).
