### PR TITLE
Add http-prompt

### DIFF
--- a/pkgs/tools/networking/http-prompt/default.nix
+++ b/pkgs/tools/networking/http-prompt/default.nix
@@ -1,17 +1,19 @@
-{ pkgs, stdenv, fetchurl, buildPythonApplication, pythonPackages }:
+{ stdenv, fetchFromGitHub, pythonPackages, httpie }:
 
-buildPythonApplication rec {
-  version = "0.1.1";
+pythonPackages.buildPythonApplication rec {
+  version = "0.2.0";
   name = "http-prompt";
 
-  src = fetchurl {
-    url = "https://github.com/eliangcs/http-prompt/archive/v${version}.tar.gz";
-    sha256 = "1kzrg357vplfz5hk47inzfpqckf77jzbd2qlqakil8x5n7gz19mm";
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    repo = "http-prompt";
+    owner = "eliangcs";
+    sha256 = "0hgw3kx9rfdg394darms3vqcjm6xw6qrm8gnz54nahmyxnhrxnpp";
   };
 
   propagatedBuildInputs = with pythonPackages; [
     click
-    pkgs.httpie
+    httpie
     parsimonious
     prompt_toolkit
     pygments
@@ -19,7 +21,7 @@ buildPythonApplication rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "an interactive command-line HTTP client featuring autocomplete and syntax highlighting";
+    description = "An interactive command-line HTTP client featuring autocomplete and syntax highlighting";
     homepage = "https://github.com/eliangcs/http-prompt";
     license = licenses.mit;
     maintainers = with maintainers; [ matthiasbeyer ];

--- a/pkgs/tools/networking/http-prompt/default.nix
+++ b/pkgs/tools/networking/http-prompt/default.nix
@@ -1,0 +1,28 @@
+{ pkgs, stdenv, fetchurl, buildPythonApplication, pythonPackages }:
+
+buildPythonApplication rec {
+  version = "0.1.1";
+  name = "http-prompt";
+
+  src = fetchurl {
+    url = "https://github.com/eliangcs/http-prompt/archive/v${version}.tar.gz";
+    sha256 = "1kzrg357vplfz5hk47inzfpqckf77jzbd2qlqakil8x5n7gz19mm";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    click
+    pkgs.httpie
+    parsimonious
+    prompt_toolkit
+    pygments
+    six
+  ];
+
+  meta = with stdenv.lib; {
+    description = "an interactive command-line HTTP client featuring autocomplete and syntax highlighting";
+    homepage = "https://github.com/eliangcs/http-prompt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = platforms.linux; # can only test on linux
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1958,6 +1958,8 @@ in
 
   hping = callPackage ../tools/networking/hping { };
 
+  http-prompt = callPackage ../tools/networking/http-prompt { };
+
   httpie = callPackage ../tools/networking/httpie { };
 
   httping = callPackage ../tools/networking/httping {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25867,11 +25867,12 @@ in modules // {
   };
 
   parsimonious = buildPythonPackage rec {
-    name = "parsimonious-0.6.0";
+    version = "0.6.2";
+    name = "parsimonious-${version}";
     disabled = ! isPy27;
     src = pkgs.fetchurl {
-      url = "https://github.com/erikrose/parsimonious/archive/0.6.tar.gz";
-      sha256 = "7ad992448b69a3f3d943bac0be132bced3f13937c8ca150ba2fd1d7b6534f846";
+      url = "https://github.com/erikrose/parsimonious/archive/${version}.tar.gz";
+      sha256 = "133vn0nrg2xxap7g6akv78433ga3i5bpfz6r11bbyz8xi8m2k3rm";
     };
 
     propagatedBuildInputs = with self; [ nose ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
