### PR TITLE
ldc: 0.17.1

### DIFF
--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "https://github.com/ldc-developers/ldc.git";
     rev = "refs/tags/v${version}";
-    sha256 = "1jbvl4iv7r50lxrdiqpdgp5b0kv3igy9sz12cyr3nkjs0fkr54sx";
+    sha256 = "12xbzc9b0hhgda8n0125yn4g545qpazhfpv8hjr26pc8qjg9rlq4";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    description = "The LLVM-based D compiler.";
+    description = "The LLVM-based D compiler";
     hompage = https://wiki.dlang.org/LDC;
     downloadPage = https://github.com/ldc-developers/ldc;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,0 +1,32 @@
+{stdenv, lib, fetchgit, cmake, libconfig, llvm, gcc6}:
+
+stdenv.mkDerivation rec {
+  name = "ldc-${version}";
+  version = "0.17.1";
+
+  src = fetchgit {
+    url = "https://github.com/ldc-developers/ldc.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "1jbvl4iv7r50lxrdiqpdgp5b0kv3igy9sz12cyr3nkjs0fkr54sx";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [cmake libconfig llvm];
+
+  enableParallelBuilding = true;
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_CXX_FLAGS_RELEASE=-std=c++11"
+    "-DLLVM_ROOT_DIR=${llvm}"
+    "-DCMAKE_C_COMPILER=${gcc6}/bin/cc"
+    "-DCMAKE_CXX_COMPILER=${gcc6}/bin/g++"
+  ];
+
+  meta = {
+    description = "The LLVM-based D compiler.";
+    hompage = https://wiki.dlang.org/LDC;
+    downloadPage = https://github.com/ldc-developers/ldc;
+    platforms = stdenv.lib.platforms.unix;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation {
     owner = "D-Programming-Language";
   };
 
-  buildInputs = [ curl ];
-  propagatedBuildInputs = [ gcc dmd ];
+  buildInputs = [ curl gcc dmd ];
 
   buildPhase = ''
       # Avoid that the version file is overwritten

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1322,6 +1322,8 @@ in
 
   dmd = callPackage ../development/compilers/dmd { };
 
+  ldc = callPackage ../development/compilers/ldc { };
+
   dmg2img = callPackage ../tools/misc/dmg2img { };
 
   docbook2odf = callPackage ../tools/typesetting/docbook2odf {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This adds a package for `ldc` the llvm based d compiler.

I have made a small change to the `dub` (the d build/dependency manager) package to allow it to detect whichever d compiler you give to the environment. In the past `dmd` was passed as via `propagatedBuildInputs` which means that when the `dub` and `ldc` packages are used together, `dub` uses `dmd` to compile when your package may have `buildInputs = [dub ldc];` which would be unexpected.

For some reason I could not get this to compile with anything older than `gcc6` and `clang` just would not compile it at any version.
