### PR TITLE
ldc-calypso: 0.17.1

### DIFF
--- a/pkgs/development/compilers/ldc/calypso.nix
+++ b/pkgs/development/compilers/ldc/calypso.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "LDC fork to experiment direct interfacing with C++.";
+    description = "Fork of LDC to experiment direct interfacing with C++";
     hompage = https://github.com/Syniurge/Calypso;
     priority = 10;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/compilers/ldc/calypso.nix
+++ b/pkgs/development/compilers/ldc/calypso.nix
@@ -1,0 +1,36 @@
+{stdenv, lib, fetchgit, cmake, libconfig, llvm_36, gcc6}:
+
+stdenv.mkDerivation rec {
+  name = "ldc-calypso-${version}";
+  version = "0.17.1";
+
+  src = fetchgit {
+    url = "https://github.com/Syniurge/Calypso.git";
+    rev = "af189b9da8520f872fe8c034a8f42e793a06cbb9";
+    sha256 = "1y36dvdcikbdxlvn0dy22rdpm0ps6f0vrw3qsw0vh9f318jsv21i";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [cmake libconfig llvm_36];
+
+  enableParallelBuilding = true;
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_CXX_FLAGS_RELEASE=-std=c++11"
+    "-DLLVM_ROOT_DIR=${llvm_36}"
+    "-DCMAKE_C_COMPILER=${gcc6}/bin/cc"
+    "-DCMAKE_CXX_COMPILER=${gcc6}/bin/g++"
+  ];
+
+  postInstall = ''
+    cp $out/bin/ldc2 $out/bin/ldc2-calypso
+  '';
+
+  meta = {
+    description = "LDC fork to experiment direct interfacing with C++.";
+    hompage = https://github.com/Syniurge/Calypso;
+    priority = 10;
+    platforms = stdenv.lib.platforms.unix;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation {
     owner = "D-Programming-Language";
   };
 
-  buildInputs = [ curl ];
-  propagatedBuildInputs = [ gcc dmd ];
+  buildInputs = [ curl gcc dmd ];
 
   buildPhase = ''
       # Avoid that the version file is overwritten

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1322,6 +1322,8 @@ in
 
   dmd = callPackage ../development/compilers/dmd { };
 
+  ldc-calypso = callPackage ../development/compilers/ldc/calypso.nix { };
+
   dmg2img = callPackage ../tools/misc/dmg2img { };
 
   docbook2odf = callPackage ../tools/typesetting/docbook2odf {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Adds a package for `ldc-calypso` a fork of `ldc` that allows automatic wrapping and handling of c++ in d.

Designed as a companion to #15572

I have given this package a lower priority and a copy of the resulting `ldc2` binary called `ldc2-calypso` for disambiguation should `ldc` and `ldc-calypso` packages be used at the same time.
