### PR TITLE
subversionClient: fix build with gcc5

### DIFF
--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -37,6 +37,10 @@ let
 
     patches = [ ./apr-1.patch ];
 
+    # SVN build seems broken on gcc5:
+    # https://gcc.gnu.org/gcc-5/porting_to.html
+    CPPFLAGS = "-P";
+
     configureFlags = ''
       ${if bdbSupport then "--with-berkeley-db" else "--without-berkeley-db"}
       ${if httpServer then "--with-apxs=${apacheHttpd}/bin/apxs" else "--without-apxs"}


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See https://gcc.gnu.org/gcc-5/porting_to.html
fixes #15483
