### PR TITLE
fcitx-wrapper: remove outdated comments

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/wrapper.nix
+++ b/pkgs/tools/inputmethods/fcitx/wrapper.nix
@@ -1,17 +1,5 @@
 { stdenv, symlinkJoin, fcitx, fcitx-configtool, makeWrapper, plugins, kde5 }:
 
-# This is based on the pidgin-with-plugins package.
-# Users should be able to configure what plugins are used
-# by putting the following in their /etc/nixos/configuration.nix:
-# environment.systemPackages = with pkgs; [
-#     (fcitx-with-plugins.override { plugins = [ fcitx-anthy ]; })
-# ]
-# Or, a normal user could use it by putting the following in his
-# ~/.nixpkgs/config.nix:
-# packageOverrides = pkgs: with pkgs; rec {
-#     (fcitx-with-plugins.override { plugins = [ fcitx-anthy ]; })
-# }
-
 symlinkJoin {
   name = "fcitx-with-plugins-${fcitx.version}";
 
@@ -24,4 +12,3 @@ symlinkJoin {
       --set FCITXDIR "$out/"
   '';
 }
-


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

These comments are outdated and documentation regarding input methods is in the [manual](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/i18n/input-method/default.xml).
