### PR TITLE
nixos-install: fix SSL certificate error

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -91,12 +91,10 @@ ln -s /run $mountPoint/var/run
 rm -f $mountPoint/etc/{resolv.conf,hosts}
 cp -Lf /etc/resolv.conf /etc/hosts $mountPoint/etc/
 
-if [ -e "$SSL_CERT_FILE" ]; then
-    cp -Lf "$SSL_CERT_FILE" "$mountPoint/tmp/ca-cert.crt"
-    export SSL_CERT_FILE=/tmp/ca-cert.crt
-    # For Nix 1.7
-    export CURL_CA_BUNDLE=/tmp/ca-cert.crt
-fi
+cp -Lf "@cacert@" "$mountPoint/tmp/ca-cert.crt"
+export SSL_CERT_FILE=/tmp/ca-cert.crt
+# For Nix 1.7
+export CURL_CA_BUNDLE=/tmp/ca-cert.crt
 
 if [ -n "$runChroot" ]; then
     if ! [ -L $mountPoint/nix/var/nix/profiles/system ]; then

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -23,6 +23,7 @@ let
 
     inherit (pkgs) perl pathsFromGraph;
     nix = config.nix.package.out;
+    cacert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 
     nixClosure = pkgs.runCommand "closure"
       { exportReferencesGraph = ["refs" config.nix.package.out]; }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

When trying to run `nixos-install` from the latest unstable ISO I got `could not download https://cache.nixos.org/nix-cache-info` with an SSL error. `curl`ing this URL worked fine. The problem, IIUC, is because we don't have `SSL_CERT_FILE` set in the ISO environment, so this (patched now) code hasn't copied the CA bundle. I don't see any reason why not just use CA bundle from nixpkgs, so this patch does just that. My theory appears to be correct because exporting this variable and running `nixos-install` from an unpatched ISO also fixes this problem.

cc @aszlig as the author of https://github.com/NixOS/nixpkgs/commit/cf7f15c92ca07d2d6d249fd2965b9e1950fb11a5
