### PR TITLE
fcitx-qt5: kde5PackagesFun -> qt5LibsFun

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5-ecm.patch
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5-ecm.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b8e729a..ebd3603 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,9 +5,7 @@ project(fcitx-qt5)
+ set(FcitxQt5_VERSION 1.0.0)
+ set(REQUIRED_QT_VERSION 5.1.0)
+ 
+-find_package(ECM 1.4.0 REQUIRED NO_MODULE)
+-
+-set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
++set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ 
+ include(GNUInstallDirs)
+ include(FeatureSummary)
+diff --git a/cmake/FindXKBCommon.cmake b/cmake/FindXKBCommon.cmake
+index a645584..de0007d 100644
+--- a/cmake/FindXKBCommon.cmake
++++ b/cmake/FindXKBCommon.cmake
+@@ -1,5 +1,5 @@
+ 
+-include(ECMFindModuleHelpersStub)
++include(ECMFindModuleHelpers)
+ 
+ ecm_find_package_version_check(XKBCommon)
+ 
+-- 
+2.8.0
+

--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fcitx, extra-cmake-modules, qtbase }:
+{ stdenv, lib, fetchurl, cmake, fcitx, pkgconfig, qtbase, kde5 }:
 
 stdenv.mkDerivation rec {
   name = "fcitx-qt5-${version}";
@@ -9,7 +9,19 @@ stdenv.mkDerivation rec {
     sha256 = "1pj1b04n8r4kl7jh1qdv0xshgzb3zrmizfa3g5h3yk589h191vwc";
   };
 
-  buildInputs = [ cmake fcitx extra-cmake-modules qtbase ];
+  # The following is to not have a dependency on kde5 so the plugin can be part of qt5LibsFun
+  postUnpack = ''
+    ${lib.concatMapStrings (f: ''
+      ln -s ${kde5.extra-cmake-modules}/share/ECM/modules/${f} $sourceRoot/cmake/
+    '')
+    [ "ECMFindModuleHelpers.cmake" "ECMGenerateHeaders.cmake"
+      "ECMPackageConfigHelpers.cmake" "ECMQueryQmake.cmake"
+      "ECMSetupVersion.cmake" "ECMVersionHeader.h.in" ]}
+  '';
+
+  patches = [ ./fcitx-qt5-ecm.patch ];
+
+  buildInputs = [ cmake fcitx pkgconfig qtbase ];
 
   preInstall = ''
     substituteInPlace platforminputcontext/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx/wrapper.nix
+++ b/pkgs/tools/inputmethods/fcitx/wrapper.nix
@@ -1,9 +1,9 @@
-{ stdenv, symlinkJoin, fcitx, fcitx-configtool, makeWrapper, plugins, kde5 }:
+{ stdenv, symlinkJoin, fcitx, fcitx-configtool, makeWrapper, plugins, qt55 }:
 
 symlinkJoin {
   name = "fcitx-with-plugins-${fcitx.version}";
 
-  paths = [ fcitx fcitx-configtool kde5.fcitx-qt5 ] ++ plugins;
+  paths = [ fcitx fcitx-configtool qt55.fcitx-qt5 ] ++ plugins;
 
   buildInputs = [ makeWrapper ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8760,6 +8760,8 @@ in
 
     accounts-qt = callPackage ../development/libraries/accounts-qt { };
 
+    fcitx-qt5 = callPackage ../tools/inputmethods/fcitx/fcitx-qt5.nix { };
+
     grantlee = callPackage ../development/libraries/grantlee/5.x.nix { };
 
     libcommuni = callPackage ../development/libraries/libcommuni { };
@@ -15727,8 +15729,6 @@ in
     colord-kde = callPackage ../tools/misc/colord-kde/0.5.nix {};
 
     dfilemanager = callPackage ../applications/misc/dfilemanager { };
-
-    fcitx-qt5 = callPackage ../tools/inputmethods/fcitx/fcitx-qt5.nix { };
 
     k9copy = callPackage ../applications/video/k9copy {};
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This PR goal is to remove `extra-cmake-modules` dependency from `fcitx-qt5` so it can be moved from `kde5PackagesFun` to `qt5LibsFun` and be used with any versions of Qt5.

~~This address #15569 and should be tested and merged with #15498 fix.~~

~~`fcitx-qt5` was only using a few `extra-cmake-modules` functions, so I chose the simple approach to patch the source to bring the needed modules. 
Any improvement/feedback is welcomed.~~

~~I have tested this with in fcitx-wrapper:~~
~~\- `qt5.fcitx-qt5` -> kate (qt56) is working, qutebrowser (qt55) is not~~
~~\- `qt55.fcitx-qt5` -> kate (qt56) is not working, qutebrowser (qt55) is~~

**Update** (2016-05-21):

I changed the commit to use the modules from `kde5.extra-cmake-modules` directly by linking them in `fcitx-qt5` source, that way can use the few required extra cmake modules without having `fcitx-qt5` be part of `kde5PackagesFun`, and this make the patch much lighter.

By using `qt55.fcitx-qt5` in `fcitx-wrapper`, fcitx is working fine in Qt 5.5 and Qt 5.6 applications (tested with kate and qutebrowser).

I don't know the reason, but suppose that this is due to the plugin ABI being compatible between these 2 versions.

So this PR will improve the situation as soon as it gets merged, and because it moves `fcitx-qt5` to `qt5LibsFun`, should help `fcitx-qt5` to be integrated in #15498 fix.

cc @ttuegel
