### PR TITLE
bluez-tools: fix sha256 hash.

### DIFF
--- a/pkgs/tools/bluetooth/bluez-tools/default.nix
+++ b/pkgs/tools/bluetooth/bluez-tools/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     inherit rev;
     url    = "https://github.com/khvzak/bluez-tools.git";
-    sha256 = "3f264d14ba8ef1b0d3c45e621a5c685035a60d789da64f64d25055047f45c55b";
+    sha256 = "0ylk10gfqlwmiz1k355axdhraixc9zym9f87xhag23934x64m8wa";
   };
   preConfigure = ''
     ./autogen.sh


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
