### PR TITLE
neovim: fix Man command

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, gettext, glib, libmsgpack, libtermkey
-, libtool, libuv, lpeg, lua, luajit, luaMessagePack, luabitop, ncurses, perl
-, pkgconfig, unibilium, makeWrapper, vimUtils
+, libtool, libuv, lpeg, lua, luajit, luaMessagePack, luabitop, man, ncurses
+, perl, pkgconfig, unibilium, makeWrapper, vimUtils
 
 , withPython ? true, pythonPackages, extraPythonPackages ? []
 , withPython3 ? true, python3Packages, extraPython3Packages ? []
@@ -98,7 +98,10 @@ let
     LUA_CPATH="${lpeg}/lib/lua/${lua.luaversion}/?.so;${luabitop}/lib/lua/5.2/?.so";
     LUA_PATH="${luaMessagePack}/share/lua/5.1/?.lua";
 
-    preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+    preConfigure = ''
+      substituteInPlace runtime/autoload/man.vim \
+        --replace /usr/bin/man ${man}/bin/man
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
       export DYLD_LIBRARY_PATH=${jemalloc}/lib
       substituteInPlace src/nvim/CMakeLists.txt --replace "    util" ""
     '';


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

`/usr/bin/man` is used in two places in [the targeted file](https://github.com/neovim/neovim/blob/9d3449852bd35c9283948186d0259c1bf73b8579/runtime/autoload/man.vim).  All the files in the `runtime` directory seem to be copied to `~/.config/nvim` on installation, so I thought changing them in preInstall was the right move, but if I'm mistaken on that or anything else, I'd be happy to fix it.
