### PR TITLE
releasenotes: fix opengl.extraPackages option name

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1603.xml
+++ b/nixos/doc/manual/release-notes/rl-1603.xml
@@ -284,7 +284,7 @@ fileSystems."/example" = {
 
   <listitem>
     <para><literal>services.xserver.vaapiDrivers</literal> has been removed. Use
-    <literal>services.hardware.opengl.extraPackages{,32}</literal> instead. You can
+    <literal>hardware.opengl.extraPackages{,32}</literal> instead. You can
     also specify VDPAU drivers there.</para>
   </listitem>
 


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Should be merged into master and release-16.03 I guess
