### PR TITLE
docker: 1.10.3 -> 1.11.1

### DIFF
--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub
+, go, libapparmor, apparmor-parser, libseccomp }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "containerd-${version}";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "docker";
+    repo = "containerd";
+    rev = "v${version}";
+    sha256 = "07axhrvy45zwnsrvr2618227bzrnqdcjdl7j0mnrhvlryypiic0l";
+  };
+
+  buildInputs = [ go libapparmor libseccomp ];
+
+  makeFlags = ''BUILDTAGS+=seccomp BUILDTAGS+=apparmor'';
+
+  preBuild = ''
+    ln -s $(pwd) vendor/src/github.com/docker/containerd
+    substituteInPlace vendor/src/github.com/opencontainers/runc/libcontainer/apparmor/apparmor.go \
+        --replace /sbin/apparmor_parser ${apparmor-parser}/bin/apparmor_parser
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/* $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://containerd.tools/;
+    description = "A daemon to control runC";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ offline ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub
-, go, libapparmor, apparmor-parser, libseccomp }:
+{ stdenv, fetchFromGitHub, makeWrapper, go, runc, criu }:
 
 with stdenv.lib;
 
@@ -14,19 +13,16 @@ stdenv.mkDerivation rec {
     sha256 = "07axhrvy45zwnsrvr2618227bzrnqdcjdl7j0mnrhvlryypiic0l";
   };
 
-  buildInputs = [ go libapparmor libseccomp ];
-
-  makeFlags = ''BUILDTAGS+=seccomp BUILDTAGS+=apparmor'';
+  buildInputs = [ makeWrapper go ];
 
   preBuild = ''
     ln -s $(pwd) vendor/src/github.com/docker/containerd
-    substituteInPlace vendor/src/github.com/opencontainers/runc/libcontainer/apparmor/apparmor.go \
-        --replace /sbin/apparmor_parser ${apparmor-parser}/bin/apparmor_parser
   '';
 
   installPhase = ''
     mkdir -p $out/bin
     cp bin/* $out/bin
+    wrapProgram $out/bin/containerd --prefix PATH : "${runc}/bin:${criu}/bin:$out/bin"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/virtualization/runc/default.nix
+++ b/pkgs/applications/virtualization/runc/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub, md2man
+, go, libapparmor, apparmor-parser, libseccomp }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "runc-${rev}";
+  rev = "baf6536d";
+
+  src = fetchFromGitHub {
+    owner = "opencontainers";
+    repo = "runc";
+    rev = "${rev}";
+    sha256 = "09fm7f1k4lvx8v3crqb0cli1x2brlz8ka7f7qa8d2sb6ln58h7w7";
+  };
+  outputs = [ "out" "man" ];
+  buildInputs = [ md2man go libseccomp libapparmor apparmor-parser ];
+
+  makeFlags = ''BUILDTAGS+=seccomp BUILDTAGS+=apparmor'';
+
+  preBuild = ''
+    patchShebangs .
+    substituteInPlace libcontainer/apparmor/apparmor.go \
+      --replace /sbin/apparmor_parser ${apparmor-parser}/bin/apparmor_parser
+  '';
+
+  installPhase = ''
+    install -Dm755 runc $out/bin/runc
+
+    # Include contributed man pages
+    man/md2man-all.sh -q
+    manRoot="$man/share/man"
+    mkdir -p "$manRoot"
+    for manDir in man/man?; do
+      manBase="$(basename "$manDir")" # "man1"
+      for manFile in "$manDir"/*; do
+        manName="$(basename "$manFile")" # "docker-build.1"
+        mkdir -p "$manRoot/$manBase"
+        gzip -c "$manFile" > "$manRoot/$manBase/$manName.gz"
+      done
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://runc.io/;
+    description = "A CLI tool for spawning and running containers according to the OCI specification";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ offline ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12159,7 +12159,7 @@ in
 
   docker = callPackage ../applications/virtualization/docker {
     btrfs-progs = btrfs-progs_4_4_1;
-    go = go_1_4;
+    md2man = goPackages.go-md2man;
   };
 
   docker-gc = callPackage ../applications/virtualization/docker/gc.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13916,6 +13916,10 @@ in
 
   rubyripper = callPackage ../applications/audio/rubyripper {};
 
+  runc = callPackage ../applications/virtualization/runc {
+    md2man = goPackages.go-md2man;
+  };
+
   rxvt = callPackage ../applications/misc/rxvt { };
 
   # urxvt

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12065,6 +12065,8 @@ in
   conkeror-unwrapped = callPackage ../applications/networking/browsers/conkeror { };
   conkeror = self.wrapFirefox conkeror-unwrapped { };
 
+  containerd = callPackage ../applications/virtualization/containerd { };
+
   csdp = callPackage ../applications/science/math/csdp {
     liblapack = liblapackWithoutAtlas;
   };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Now docker requires containerd and runc, as it was split in separated components. I still have to test this on nixos.
