### PR TITLE
fcitx-libpinyin: init at 0.3.3

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, cmake, pkgconfig, fcitx, gettext, libpinyin, glib, qt4, pcre, curl, cacert }:
+
+stdenv.mkDerivation rec {
+  name = "fcitx-libpinyin-${version}";
+  version = "0.3.3";
+
+  src = fetchurl {
+    url = "http://download.fcitx-im.org/fcitx-libpinyin/${name}.tar.xz";
+    sha256 = "08r8kw6gwy5lmx9z4rjsnqzx9qzaylgzvy6s0ppk7dvh0b612nx8";
+  };
+
+  buildInputs = [ cmake pkgconfig fcitx gettext glib qt4 pcre libpinyin curl ];
+
+  cmakeFlags = ["-DCMAKE_VERBOSE_MAKEFILE=ON"];
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  preInstall = ''
+    substituteInPlace src/cmake_install.cmake \
+      --replace ${fcitx} $out
+    substituteInPlace data/cmake_install.cmake \
+      --replace ${fcitx} $out
+    substituteInPlace po/cmake_install.cmake \
+      --replace ${fcitx} $out
+    substituteInPlace dictmanager/cmake_install.cmake \
+      --replace ${fcitx} $out
+  '';
+
+  meta = with stdenv.lib; {
+    isFcitxEngine = true;
+    description  = "Libpinyin Wrapper for Fcitx";
+    homepage     = https://github.com/fcitx/fcitx-libpinyin;
+    license      = licenses.gpl3Plus;
+    platforms    = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1488,6 +1488,7 @@ in
 
     table-other = callPackage ../tools/inputmethods/fcitx-engines/fcitx-table-other { };
 
+    libpinyin = callPackage ../tools/inputmethods/fcitx-engines/fcitx-libpinyin { };
   };
 
   fcitx-configtool = callPackage ../tools/inputmethods/fcitx/fcitx-configtool.nix { };
@@ -4455,7 +4456,7 @@ in
   inherit (self.haskellPackages) ghc;
 
   cabal-install = haskell.lib.disableSharedExecutables haskellPackages.cabal-install;
-   
+
   stack = haskell.lib.overrideCabal haskellPackages.stack (drv: {
     enableSharedExecutables = false;
     isLibrary = false;
@@ -10789,7 +10790,7 @@ in
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
     bcc = callPackage ../os-specific/linux/bcc { };
-    
+
     bbswitch = callPackage ../os-specific/linux/bbswitch {};
 
     ati_drivers_x11 = callPackage ../os-specific/linux/ati-drivers { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4456,7 +4456,7 @@ in
   inherit (self.haskellPackages) ghc;
 
   cabal-install = haskell.lib.disableSharedExecutables haskellPackages.cabal-install;
-
+   
   stack = haskell.lib.overrideCabal haskellPackages.stack (drv: {
     enableSharedExecutables = false;
     isLibrary = false;
@@ -10790,7 +10790,7 @@ in
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
     bcc = callPackage ../os-specific/linux/bcc { };
-
+    
     bbswitch = callPackage ../os-specific/linux/bbswitch {};
 
     ati_drivers_x11 = callPackage ../os-specific/linux/ati-drivers { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add libpinyin fcitx engine.
