### PR TITLE
fcitx-cloudpinyin: init at 0.3.4

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-cloudpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-cloudpinyin/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, cmake, pkgconfig, fcitx, gettext, curl }:
+
+stdenv.mkDerivation rec {
+  name = "fcitx-cloudpinyin-${version}";
+  version = "0.3.4";
+
+  src = fetchurl {
+    url = "http://download.fcitx-im.org/fcitx-cloudpinyin/${name}.tar.xz";
+    sha256 = "143x9gbswzfngvgfy77zskrzrpywj8qg2d19kisgfwfisk7yhcf1";
+  };
+
+  buildInputs = [ cmake pkgconfig fcitx gettext curl ];
+
+  preInstall = ''
+    substituteInPlace src/cmake_install.cmake \
+      --replace ${fcitx} $out
+    substituteInPlace po/cmake_install.cmake \
+      --replace ${fcitx} $out
+  '';
+
+  meta = with stdenv.lib; {
+    isFcitxEngine = true;
+    description  = "A standalone module for fcitx that uses web API to provide better pinyin result";
+    homepage     = https://github.com/fcitx/fcitx-cloudpinyin;
+    license      = licenses.gpl3Plus;
+    platforms    = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1488,6 +1488,7 @@ in
 
     table-other = callPackage ../tools/inputmethods/fcitx-engines/fcitx-table-other { };
 
+    cloudpinyin = callPackage ../tools/inputmethods/fcitx-engines/fcitx-cloudpinyin { };
   };
 
   fcitx-configtool = callPackage ../tools/inputmethods/fcitx/fcitx-configtool.nix { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add cloudpinyin fcitx engine.
