### PR TITLE
facetimehd: git-20160127 -> git-20160503

### DIFF
--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -6,13 +6,13 @@ assert stdenv.lib.versionAtLeast kernel.version "3.19";
 stdenv.mkDerivation rec {
 
   name = "facetimehd-${version}-${kernel.version}";
-  version = "git-20160127";
+  version = "git-20160503";
 
   src = fetchFromGitHub {
     owner = "patjak";
     repo = "bcwc_pcie";
-    rev = "186e9f9101ed9bbd7cc8d470f840d4a74c585ca7";
-    sha256 = "1frsf6z6v94cz9fww9rbnk926jzl36fp3w2d1aw6djhzwm80a5gs";
+    rev = "5a7083bd98b38ef3bd223f7ee531d58f4fb0fe7c";
+    sha256 = "0d455kajvn5xav9iilqy7s1qvsy4yb8vzjjxx7bvcgp7aj9ljvdp";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

fixes issues with kernels newer than 4.4
