### PR TITLE
unbound service: do not initialize root cert when enableRootTrustAnchor is false

### DIFF
--- a/nixos/modules/services/networking/unbound.nix
+++ b/nixos/modules/services/networking/unbound.nix
@@ -106,8 +106,10 @@ in
       preStart = ''
         mkdir -m 0755 -p ${stateDir}/dev/
         cp ${confFile} ${stateDir}/unbound.conf
+        ${optionalString cfg.enableRootTrustAnchor ''
         ${pkgs.unbound}/bin/unbound-anchor -a ${rootTrustAnchorFile}
         chown unbound ${stateDir} ${rootTrustAnchorFile}
+        ''}
         touch ${stateDir}/dev/random
         ${pkgs.utillinux}/bin/mount --bind -n /dev/random ${stateDir}/dev/random
       '';


### PR DESCRIPTION
When enableRootTrustAnchor is set to false, there is really no point in
initializing the root key before starting unbound.

Furthermore it seemed to me as if initializing the root cert fails when there is no network connection available when unbound is started. At least the nixos-test for my server failed to start unbound. (The VMs of nixos test mechanism have no connection to the outside.)

I think this should also be ported to master.

cc @fpletz 
