### PR TITLE
Fpga toolchain updates

### DIFF
--- a/pkgs/applications/science/electronics/verilator/default.nix
+++ b/pkgs/applications/science/electronics/verilator/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "verilator-${version}";
-  version = "3.874";
+  version = "3.884";
 
   src = fetchurl {
     url    = "http://www.veripool.org/ftp/${name}.tgz";
-    sha256 = "070binwp0jnashi6w45km26vrn6200b8hdg4179lcqyzdxi8c06j";
+    sha256 = "1j159dg7m2ych5lwglb1qq1fgqh3kwhaa1r3jx84qdisg0icln2y";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -1,14 +1,22 @@
-{stdenv, fetchurl, gperf, flex, bison}:
+{ stdenv, fetchFromGitHub, autoconf, gperf, flex, bison }:
 
 stdenv.mkDerivation rec {
-  name = "verilog-0.9.7";
+  name = "iverilog-${version}";
+  version = "2016.05.21";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/iverilog/${name}.tar.gz";
-    sha256 = "0m3liqw7kq24vn7k8wvi630ljz0awz23r3sd4rcklk7vgghp4pks";
+  src = fetchFromGitHub {
+    owner = "steveicarus";
+    repo = "iverilog";
+    rev = "45fbf558065c0fdac9aa088ecd34e9bf49e81305";
+    sha256 = "137p7gkmp5kwih93i2a3lcf36a6k38j7fxglvw9y59w0233vj452";
   };
 
-  buildInputs = [ gperf flex bison ];
+  patchPhase = ''
+    chmod +x $PWD/autoconf.sh
+    $PWD/autoconf.sh
+  '';
+
+  buildInputs = [ autoconf gperf flex bison ];
 
   meta = {
     description = "Icarus Verilog compiler";

--- a/pkgs/development/compilers/arachne-pnr/default.nix
+++ b/pkgs/development/compilers/arachne-pnr/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "arachne-pnr-${version}";
-  version = "2015.12.29";
+  version = "2016.05.21";
 
   src = fetchFromGitHub {
     owner = "cseed";
     repo = "arachne-pnr";
-    rev = "1a4fdf96a7fd08806c032d41a2443c8e17c72c80";
-    sha256 = "1dj7ycffwkmlsh12117fbybkdfnlhxbbxkbfgwfyvcgmg3cacgl1";
+    rev = "6b8336497800782f2f69572d40702b60423ec67f";
+    sha256 = "11hg17f4lp8azc0ir0i473fz9c0dra82r4fn45cr3amd57v00qbf";
   };
 
   preBuild = ''

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "yosys-${version}";
-  version = "2015.12.29";
+  version = "2016.05.21";
 
   srcs = [
     (fetchFromGitHub {
       owner = "cliffordwolf";
       repo = "yosys";
-      rev = "1d62f8710f04fec405ef79b9e9a4a031afcf7d42";
-      sha256 = "0q1dk9in3gmrihb58pjckncx56lj7y4b6y34jgb68f0fh91fdvfx";
+      rev = "8e9e793126a2772eed4b041bc60415943c71d5ee";
+      sha256 = "1s0x7n7qh2qbfc0d7p4q10fvkr61jdqgyqzijr422rabh9zl4val";
       name = "yosys";
     })
     (fetchFromBitbucket {
       owner = "alanmi";
       repo = "abc";
-      rev = "c3698e053a7a";
-      sha256 = "05p0fvbr7xvb6w3d7j2r6gynr3ljb6r5q6jvn2zs3ysn2b003qwd";
+      rev = "d9559ab";
+      sha256 = "08far669khb65kfpqvjqmqln473j949ak07xibfdjdmiikcy533i";
       name = "abc";
     })
   ];
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
       Yosys is a framework for RTL synthesis tools. It currently has
       extensive Verilog-2005 support and provides a basic set of
       synthesis algorithms for various application domains.
-
       Yosys can be adapted to perform any synthesis job by combining
       the existing passes (algorithms) using synthesis scripts and
       adding additional passes as needed by extending the yosys C++

--- a/pkgs/development/tools/icestorm/default.nix
+++ b/pkgs/development/tools/icestorm/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "icestorm-${version}";
-  version = "2015.12.29";
+  version = "2016.05.21";
 
   src = fetchFromGitHub {
     owner = "cliffordwolf";
     repo = "icestorm";
-    rev = "7852514c2cde208da87b62777b2c5e482092f50d";
-    sha256 = "1ya1nk5h28hjdmd8jdrlfiayr2434rnvi133gs1p0ay21qb3iwfz";
+    rev = "fb67695a883b29ca670b43ed2733eca9ca161e4d";
+    sha256 = "0zsjpz49qr09g33nz4nfi1inshg37y5zdxnv6f8gkwq7x948rh3z";
   };
 
   buildInputs = [ python3 libftdi ];
   preBuild = ''
-    makeFlags="DESTDIR=$out $makeFlags"
+    makeFlags="PREFIX=$out $makeFlags"
   '';
 
   meta = {


### PR DESCRIPTION
Various updates to fpga/verilog related packages.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
