### PR TITLE
pbrt: init at 2016-05-19

### DIFF
--- a/pkgs/applications/graphics/pbrt/default.nix
+++ b/pkgs/applications/graphics/pbrt/default.nix
@@ -1,0 +1,25 @@
+{stdenv, fetchgit, flex, bison, cmake, git, zlib}:
+
+stdenv.mkDerivation rec {
+
+  version = "2016-05-19";
+  name = "pbrt-v3-${version}";
+  src = fetchgit {
+    url = "https://github.com/mmp/pbrt-v3.git";
+    rev = "638249e5cf4596e129695c8df8525d43f11573ff";
+    sha256 = "10ykqrg4zcfb4sfsg3z793c6vld6b6g8bzfyk7ya3yvvc9sdlr5g";
+  };
+
+  fetchSubmodules = true;
+
+  buildInputs = [ git flex bison cmake zlib ];
+
+  meta = {
+    homepage = "http://pbrt.org";
+    description = "The renderer described in the third edition of the book 'Physically Based Rendering: From Theory To Implementation'";
+    platforms = stdenv.lib.platforms.linux ;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.juliendehos ];
+    priority = 10;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13665,6 +13665,8 @@ in
 
   paraview = callPackage ../applications/graphics/paraview { };
 
+  pbrt = callPackage ../applications/graphics/pbrt { };
+
   pcsx2 = callPackage_i686 ../misc/emulators/pcsx2 { };
 
   pencil = callPackage ../applications/graphics/pencil { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
