### PR TITLE
xflux-gui: init at 1.1.1

### DIFF
--- a/pkgs/tools/misc/xflux/gui.nix
+++ b/pkgs/tools/misc/xflux/gui.nix
@@ -1,0 +1,47 @@
+{ stdenv, pkgs, fetchFromGitHub, buildPythonPackage,
+  pexpect,
+  pyGtkGlade,
+  pygobject,
+  pyxdg,
+  gnome_python,
+}:
+buildPythonPackage rec {
+  version = "1.1.1";
+  name = "xflux-gui-${version}";
+
+  src = fetchFromGitHub {
+    repo = "xflux-gui";
+    owner = "xflux-gui";
+    rev = "d897dfd";
+    sha256 = "1mx1r2hz3g3waafn4w8hql0gaasfizbzz60bk5llw007k4k8892r";
+  };
+
+  # remove messing with shipped binary
+  patches = [ ./setup.patch ];
+
+  # not sure if these need to be propogated or not?
+  propagatedBuildInputs = [
+    pexpect
+    pyGtkGlade
+    pygobject
+    pyxdg
+    pkgs.libappindicator-gtk2
+    gnome_python
+  ];
+
+  buildInputs = [
+    pkgs.xflux
+  ];
+
+  postPatch = ''
+     substituteInPlace src/fluxgui/xfluxcontroller.py --replace "pexpect.spawn(\"xflux\"" "pexpect.spawn(\"${pkgs.xflux}/bin/xflux\""
+  '';
+
+  meta = {
+    description = "Better lighting for Linux. Open source GUI for xflux";
+    homepage = https://justgetflux.com/linux.html;
+    license = stdenv.lib.licenses.unfree; # marked as unfree since the source code contains a copy of the unfree xflux binary
+    maintainers = [ stdenv.lib.maintainers.sheenobu ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/xflux/setup.patch
+++ b/pkgs/tools/misc/xflux/setup.patch
@@ -1,0 +1,28 @@
+diff --git a/setup.py b/setup.py
+index e11f199..b1cb0e5 100644
+--- a/setup.py
++++ b/setup.py
+@@ -4,13 +4,6 @@ from distutils.core import setup
+ from sys import maxsize
+ from os import rename
+ 
+-# Determines which is the appropriate executable for 32-bit
+-if maxsize == 2147483647:
+-    rename("xflux32", "xflux")
+-# ... or 64-bit processors
+-elif maxsize == 9223372036854775807:
+-    rename("xflux64", "xflux")
+-
+ setup(name = "f.lux indicator applet",
+     version = "1.1.8",
+     description = "f.lux indicator applet - better lighting for your computer",
+@@ -22,8 +15,7 @@ setup(name = "f.lux indicator applet",
+     packages = ["fluxgui",],
+     package_data = {"fluxgui" : ["*.glade"] },
+     data_files=[('share/icons/hicolor/scalable/apps', ['fluxgui.svg', 'fluxgui-light.svg', 'fluxgui-dark.svg']),
+-            ('share/applications', ['desktop/fluxgui.desktop']),
+-            ('bin', ['xflux']),],
++            ('share/applications', ['desktop/fluxgui.desktop']),],
+     scripts = ["fluxgui"],
+     long_description = """f.lux indicator applet is an indicator applet to
+     control xflux, an application that makes the color of your computer's

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3920,6 +3920,13 @@ in
   xe-guest-utilities = callPackage ../tools/virtualization/xe-guest-utilities { };
 
   xflux = callPackage ../tools/misc/xflux { };
+  xflux-gui = callPackage ../tools/misc/xflux/gui.nix {
+    pexpect = pythonPackages.pexpect;
+    pyGtkGlade = pythonPackages.pyGtkGlade;
+    pygobject = pythonPackages.pygobject;
+    pyxdg = pythonPackages.pyxdg;
+    gnome_python = gnome.gnome_python;
+  };
 
   xfsprogs = callPackage ../tools/filesystems/xfsprogs { };
   libxfs = self.xfsprogs.dev; # outputs TODO


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
