### PR TITLE
nixpkgs manual: cleanup

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -52,9 +52,8 @@ stdenv.mkDerivation {
       outputFile = "./languages-frameworks/python.xml";
     }
   + toDocbook {
-      inputFile = ./haskell-users-guide.md;
-      outputFile = "haskell-users-guide.xml";
-      useChapters = true;
+      inputFile = ./languages-frameworks/haskell.md;
+      outputFile = "./languages-frameworks/haskell.xml";
     }
   + toDocbook {
       inputFile = ./../pkgs/development/idris-modules/README.md;

--- a/doc/languages-frameworks/beam.xml
+++ b/doc/languages-frameworks/beam.xml
@@ -1,10 +1,10 @@
-<chapter xmlns="http://docbook.org/ns/docbook"
+<section xmlns="http://docbook.org/ns/docbook"
          xmlns:xlink="http://www.w3.org/1999/xlink"
-         xml:id="users-guide-to-the-erlang-infrastructure">
+         xml:id="sec-beam">
 
-  <title>User's Guide to the Beam Infrastructure</title>
+  <title>Beam Languages (Erlang &amp; Elixir)</title>
   <section xml:id="beam-introduction">
-    <title>Beam Languages (Erlang &amp; Elixir) on Nix</title>
+    <title>Introduction</title>
     <para>
       In this document and related Nix expressions we use the term
       <emphasis>Beam</emphasis> to describe the environment. Beam is
@@ -373,4 +373,4 @@ $ nix-build -A beamPackages
       that.
     </para>
 </section>
-</chapter>
+</section>

--- a/doc/languages-frameworks/haskell.md
+++ b/doc/languages-frameworks/haskell.md
@@ -3,7 +3,7 @@ title: User's Guide for Haskell in Nixpkgs
 author: Peter Simons
 date: 2015-06-01
 ---
-# User's Guide to the Haskell Infrastructure
+# Haskell
 
 
 ## How to install Haskell packages

--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -13,19 +13,20 @@ in Nixpkgs to easily build packages for other programming languages,
 such as Perl or Haskell.  These are described in this chapter.</para>
 
 
-<xi:include href="perl.xml" />
-<xi:include href="python.xml" />
-<xi:include href="ruby.xml" />
+<xi:include href="beam.xml" />
+<xi:include href="bower.xml" />
+<xi:include href="coq.xml" />
 <xi:include href="go.xml" />
+<xi:include href="haskell.xml" />
+<xi:include href="idris.xml" /> <!-- generated from ../../pkgs/development/idris-modules/README.md  -->
 <xi:include href="java.xml" />
 <xi:include href="lua.xml" />
-<xi:include href="coq.xml" />
-<xi:include href="idris.xml" /> <!-- generated from ../../pkgs/development/idris-modules/README.md  -->
-<xi:include href="r.xml" /> <!-- generated from ../../pkgs/development/r-modules/README.md  -->
+<xi:include href="perl.xml" />
+<xi:include href="python.xml" />
 <xi:include href="qt.xml" />
+<xi:include href="r.xml" /> <!-- generated from ../../pkgs/development/r-modules/README.md  -->
+<xi:include href="ruby.xml" />
 <xi:include href="texlive.xml" />
-<xi:include href="bower.xml" />
 
 
 </chapter>
-

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -20,8 +20,6 @@
   <xi:include href="package-notes.xml" />
   <xi:include href="coding-conventions.xml" />
   <xi:include href="submitting-changes.xml" />
-  <xi:include href="haskell-users-guide.xml" />
-  <xi:include href="beam-users-guide.xml" />
   <xi:include href="contributing.xml" />
 
 </book>


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This bring the following improvements for the nixpkgs manual:
- move haskell section inside "Support for specific programming languages and frameworks"
- move beam section inside "Support for specific programming languages and frameworks"
- order "Support for specific programming languages and frameworks" entries by alphabetical order
