### PR TITLE
wp-cli: init at 0.23.1

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, writeText, bash, fetchurl, php }:
+
+let
+  phpIni = writeText "wp-cli-php.ini" ''
+    [Phar]
+    phar.readonly = Off
+  '';
+
+in stdenv.mkDerivation rec {
+  version = "0.23.1";
+  name = "wp-cli-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${name}.phar";
+    sha256 = "1sjai8gjsx6j82lsxq9m827bczp4ajnldk6ibj4krcisn9pjva5f";
+  };
+
+  propagatedBuildInputs = [ php ];
+
+  buildCommand = ''
+    mkdir -p $out/bin
+
+    cat >$out/bin/wp <<EOF
+    #! ${bash}/bin/bash -e
+    exec ${php}/bin/php -c ${phpIni} -f ${src} "\$@"
+    EOF
+
+    chmod +x $out/bin/wp
+  '';
+
+  meta = {
+    description = "A command line interface for WordPress";
+    maintainers = [ stdenv.lib.maintainers.peterhoeg ];
+    platforms = stdenv.lib.platforms.all;
+    homepage = https://wp-cli.org;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14561,6 +14561,8 @@ in
 
   wrapFirefox = callPackage ../applications/networking/browsers/firefox/wrapper.nix { };
 
+  wp-cli = callPackage ../development/tools/wp-cli { };
+
   retroArchCores =
     let
       cfg = config.retroarch or {};


### PR DESCRIPTION
For all those other poor, unfortunate people who have to touch WordPress at times.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
