### PR TITLE
cloc: 1.64 -> 1.66

### DIFF
--- a/pkgs/tools/misc/cloc/default.nix
+++ b/pkgs/tools/misc/cloc/default.nix
@@ -1,31 +1,29 @@
-{ stdenv, fetchurl, fetchpatch, perl, AlgorithmDiff, RegexpCommon }:
+{ stdenv, fetchFromGitHub, makeWrapper, perl, AlgorithmDiff, RegexpCommon }:
 
 stdenv.mkDerivation rec {
-
   name = "cloc-${version}";
+  version = "1.66";
 
-  version = "1.64";
-
-  src = fetchurl {
-    url = "mirror://sourceforge/cloc/cloc-${version}.tar.gz";
-    sha256 = "1w3mz69h2i7pscvi9q7yp7wimds8g38c5ph78cj5pvjl5wa035rh";
+  src = fetchFromGitHub {
+    owner = "AlDanial";
+    repo = "cloc";
+    rev = "v${version}";
+    sha256 = "1xj6d8x8zwijym5wznm0k1478z7zx3bfjsx20r3aqb1vhkvcjsm9";
   };
 
-  patches = [ (fetchpatch {
-    name = "perl-5.22.patch";
-    url = "https://bugs.archlinux.org/task/45494?getfile=13174";
-    sha256 = "1xxwqjy2q2fdza7kfp9ld0yzljkdsrgm8a9pwnmx5q4adigcjjsz";
-  }) ];
+  sourceRoot = "cloc-v${version}-src/Unix";
 
-  buildInputs = [ perl AlgorithmDiff RegexpCommon ];
+  buildInputs = [ makeWrapper perl AlgorithmDiff RegexpCommon ];
 
   makeFlags = [ "prefix=" "DESTDIR=$(out)" "INSTALL=install" ];
 
+  postFixup = "wrapProgram $out/bin/cloc --prefix PERL5LIB : $PERL5LIB";
+
   meta = {
     description = "A program that counts lines of source code";
-    homepage = http://cloc.sourceforge.net;
+    homepage = https://github.com/AlDanial/cloc;
     license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.all;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
   };
-
 }


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC maintainer @Fuuzetsu
