### PR TITLE
cppo: 1.1.2 -> 1.3.2

### DIFF
--- a/pkgs/development/tools/ocaml/cppo/default.nix
+++ b/pkgs/development/tools/ocaml/cppo/default.nix
@@ -1,7 +1,7 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{ stdenv, fetchFromGitHub, ocaml, findlib }:
 let
   pname = "cppo";
-  version = "1.1.2";
+  version = "1.3.2";
   webpage = "http://mjambon.com/${pname}.html";
 in
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12";
@@ -9,9 +9,11 @@ stdenv.mkDerivation rec {
 
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "http://mjambon.com/releases/${pname}/${name}.tar.gz";
-    sha256 = "1pfzch4ys5gjac2lrkqq0gzmm5plkq2jl17b2m3n06kmwashqplp";
+  src = fetchFromGitHub {
+    owner = "mjambon";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06j0zr78f04ahxi2459vjn61z25hkvs4dfj76200ydg3g6ifb3k1";
   };
 
   buildInputs = [ ocaml findlib ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
