### PR TITLE
modules/misc/version.nix: populate nixosRevision based on <nixpkgs/.g…

### DIFF
--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -29,4 +29,30 @@ rec {
       in type == "directory" || lib.any (ext: lib.hasSuffix ext base) exts;
     in builtins.filterSource filter path;
 
+  # Get the commit id of a git repo
+  # Example: commitIdFromGitRepo <nixpkgs/.git>
+  commitIdFromGitRepo =
+    let readCommitFromFile = path: file:
+      with builtins;
+        let fileName       = toString path + "/" + file;
+            packedRefsName = toString path + "/packed-refs";
+        in if lib.pathExists fileName
+           then
+             let fileContent = readFile fileName;
+                 # Sometimes git stores the commitId directly in the file but
+                 # sometimes it stores something like: «ref: refs/heads/branch-name»
+                 matchRef    = match "^ref: (.*)\n$" fileContent;
+             in if   isNull matchRef
+                then lib.removeSuffix "\n" fileContent
+                else readCommitFromFile path (lib.head matchRef)
+           # Sometimes, the file isn't there at all and has been packed away in the
+           # packed-refs file, so we have to grep through it:
+           else if lib.pathExists packedRefsName
+           then
+             let packedRefs  = lib.splitString "\n" (readFile packedRefsName);
+                 matchRule   = match ("^(.*) " + file + "$");
+                 matchedRefs = lib.flatten (lib.filter (m: ! (isNull m)) (map matchRule packedRefs));
+             in lib.head matchedRefs
+           else throw ("Not a .git directory: " + path);
+    in lib.flip readCommitFromFile "HEAD";
 }

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -5,9 +5,11 @@ with lib;
 let
   cfg = config.system;
 
-  releaseFile = "${toString pkgs.path}/.version";
-  suffixFile = "${toString pkgs.path}/.version-suffix";
+  releaseFile  = "${toString pkgs.path}/.version";
+  suffixFile   = "${toString pkgs.path}/.version-suffix";
   revisionFile = "${toString pkgs.path}/.git-revision";
+  gitRepo      = "${toString pkgs.path}/.git";
+  gitCommitId  = lib.substring 0 7 (commitIdFromGitRepo gitRepo);
 in
 
 {
@@ -102,6 +104,8 @@ in
       # changing them would not rebuild the manual
       nixosLabel   = mkDefault (maybeEnv "NIXOS_LABEL" cfg.nixosVersion);
       nixosVersion = mkDefault (maybeEnv "NIXOS_VERSION" (cfg.nixosRelease + cfg.nixosVersionSuffix));
+      nixosRevision      = mkIf (pathExists gitRepo) (mkDefault            gitCommitId);
+      nixosVersionSuffix = mkIf (pathExists gitRepo) (mkDefault (".git." + gitCommitId));
 
       # Note: code names must only increase in alphabetical order.
       nixosCodeName = "Flounder";


### PR DESCRIPTION
`modules/misc/version.nix:` populate `nixosRevision` based on `<nixpkgs/.git>` when possible

Example:

```
$ nixos-option system.nixosLabel
Value:
"16.09.git.4643ca1"
```

cc @domenkozar @oxij @edolstra @nbp
