### PR TITLE
fzy: init at 0.4

### DIFF
--- a/pkgs/tools/misc/fzy/default.nix
+++ b/pkgs/tools/misc/fzy/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "fzy-${version}";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "jhawthorn";
+    repo = "fzy";
+    rev = version;
+    sha256 = "1sbwy4v5kz0fcl7kzf414phxv9cppvjvfq9jqkcda4bkzqh2xgia";
+  };
+
+  makeFlags = "PREFIX=$(out)";
+
+  meta = {
+    description = "A better fuzzy finder";
+    homepage = https://github.com/jhawthorn/fzy;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -797,6 +797,8 @@ in
 
   fzf = goPackages.fzf.bin // { outputs = [ "bin" ]; };
 
+  fzy = callPackage ../tools/misc/fzy { };
+
   gencfsm = callPackage ../tools/security/gencfsm { };
 
   genromfs = callPackage ../tools/filesystems/genromfs { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
