### PR TITLE
gd: multiple outputs

### DIFF
--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ zlib fontconfig freetype libjpeg libpng libtiff libXpm ];
 
+  outputs = [ "dev" "out" "bin" ];
+
+  postFixup = ''moveToOutput "bin/gdlib-config" $dev'';
+
   meta = with stdenv.lib; {
     homepage = https://libgd.github.io/;
     description = "A dynamic image creation library";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Built most direct dependencies ...
