### PR TITLE
Remove servant overrides from configuration-ghc8

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -112,10 +112,6 @@ self: super: {
 
   sdl2           = doJailbreak super.sdl2;
 
-  servant        = dontCheck (doJailbreak super.servant_0_7);
-  servant-client = dontCheck (doJailbreak super.servant-client_0_7);
-  servant-server = dontCheck (doJailbreak super.servant-server_0_7);
-
   # packaged shelly 1.6.6 complains: time >=1.3 && <1.6
   shelly         = doJailbreak super.shelly;
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Since servant-0.7 series are now default on hackage-packages.nix.

cc @peti 
