### PR TITLE
opensmtpd: 5.7.3p2 -> 5.9.2p1

### DIFF
--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -107,7 +107,16 @@ in {
       wantedBy = [ "multi-user.target" ];
       wants = [ "network.target" ];
       after = [ "network.target" ];
-      preStart = "mkdir -p /var/spool";
+      preStart = ''
+        mkdir -p /var/spool/smtpd
+
+        mkdir -p /var/spool/smtpd/offline
+        chown root.smtpq /var/spool/smtpd/offline
+        chmod 770 /var/spool/smtpd/offline
+
+        mkdir -p /var/spool/smtpd/purge
+        chmod 700 /var/spool/smtpd/purge
+      '';
       serviceConfig.ExecStart = "${opensmtpd}/sbin/smtpd -d -f ${conf} ${args}";
       environment.OPENSMTPD_PROC_PATH = "${procEnv}/libexec/opensmtpd";
     };

--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchurl, autoconf, automake, libtool, bison
-, libasr, libevent, zlib, openssl, db, pam, cacert
+, libasr, libevent, zlib, openssl, db, pam
 }:
 
 stdenv.mkDerivation rec {
   name = "opensmtpd-${version}";
-  version = "5.7.3p2";
+  version = "5.9.2p1";
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ libasr libevent zlib openssl db pam ];
 
   src = fetchurl {
     url = "http://www.opensmtpd.org/archives/${name}.tar.gz";
-    sha256 = "0d2973008d0f66bebb84bed516be6c32617735241cc54dd26643529281a8e52b";
+    sha256 = "07d7f1m5sxyz6mkk228rcm7fsf7350994ayvmhgph333q5rz48im";
   };
 
   patches = [ ./proc_path.diff ];
@@ -23,8 +23,9 @@ stdenv.mkDerivation rec {
     "--with-pam"
     "--without-bsd-auth"
     "--with-sock-dir=/run"
-    "--with-privsep-user=smtpd"
-    "--with-queue-user=smtpq"
+    "--with-user-smtpd=smtpd"
+    "--with-user-queue=smtpq"
+    "--with-group-queue=smtpq"
     "--with-ca-file=/etc/ssl/certs/ca-certificates.crt"
     "--with-libevent-dir=${libevent.dev}"
     "--enable-table-db"
@@ -35,14 +36,14 @@ stdenv.mkDerivation rec {
     "localstatedir=\${TMPDIR}"
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://www.opensmtpd.org/;
     description = ''
       A free implementation of the server-side SMTP protocol as defined by
       RFC 5321, with some additional standard extensions
     '';
-    license = stdenv.lib.licenses.isc;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.rickynils ];
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rickynils obadz ];
   };
 }

--- a/pkgs/servers/mail/opensmtpd/proc_path.diff
+++ b/pkgs/servers/mail/opensmtpd/proc_path.diff
@@ -1,11 +1,12 @@
-diff -Naur opensmtpd-5.7.1p1/smtpd/parse.y opensmtpd-5.7.1p1.patched/smtpd/parse.y
---- opensmtpd-5.7.1p1/smtpd/parse.y	2015-06-30 10:13:34.000000000 +0200
-+++ opensmtpd-5.7.1p1.patched/smtpd/parse.y	2015-09-26 08:41:17.012472516 +0200
-@@ -2519,13 +2519,19 @@
+diff --git a/smtpd/parse.y b/smtpd/parse.y
+index ab02719..c1c77d9 100644
+--- a/smtpd/parse.y
++++ b/smtpd/parse.y
+@@ -2534,13 +2534,19 @@ create_filter_proc(char *name, char *prog)
  {
  	struct filter_conf	*f;
  	char			*path;
-+        const char              *proc_path;
++	const char		*proc_path;
  
  	if (dict_get(&conf->sc_filters, name)) {
  		yyerror("filter \"%s\" already defined", name);
@@ -13,64 +14,71 @@ diff -Naur opensmtpd-5.7.1p1/smtpd/parse.y opensmtpd-5.7.1p1.patched/smtpd/parse
  	}
  
 -	if (asprintf(&path, "%s/filter-%s", PATH_LIBEXEC, prog) == -1) {
-+        proc_path = getenv("OPENSMTPD_PROC_PATH");
-+        if (proc_path == NULL) {
-+                proc_path = PATH_LIBEXEC;
-+        }
++	proc_path = getenv("OPENSMTPD_PROC_PATH");
++	if (proc_path == NULL) {
++		proc_path = PATH_LIBEXEC;
++	}
 +
 +	if (asprintf(&path, "%s/filter-%s", proc_path, prog) == -1) {
  		yyerror("filter \"%s\" asprintf failed", name);
  		return (0);
  	}
-diff -Naur opensmtpd-5.7.1p1/smtpd/smtpd.c opensmtpd-5.7.1p1.patched/smtpd/smtpd.c
---- opensmtpd-5.7.1p1/smtpd/smtpd.c	2015-06-30 10:13:34.000000000 +0200
-+++ opensmtpd-5.7.1p1.patched/smtpd/smtpd.c	2015-09-26 08:41:16.998472557 +0200
-@@ -854,6 +854,7 @@
+diff --git a/smtpd/smtpd.c b/smtpd/smtpd.c
+index afc8891..9b0a80f 100644
+--- a/smtpd/smtpd.c
++++ b/smtpd/smtpd.c
+@@ -795,6 +795,7 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
  	char		path[PATH_MAX];
  	char		name[PATH_MAX];
  	char		*arg;
-+        char            *proc_path;
++	char		*proc_path;
  
  	if (strlcpy(name, conf, sizeof(name)) >= sizeof(name)) {
  		log_warnx("warn: %s-proc: conf too long", key);
-@@ -864,7 +865,12 @@
+@@ -805,7 +806,12 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
  	if (arg)
  		*arg++ = '\0';
  
 -	if (snprintf(path, sizeof(path), PATH_LIBEXEC "/%s-%s", key, name) >=
-+        proc_path = getenv("OPENSMTPD_PROC_PATH");
-+        if (proc_path == NULL) {
-+                proc_path = PATH_LIBEXEC;
-+        }
++	proc_path = getenv("OPENSMTPD_PROC_PATH");
++	if (proc_path == NULL) {
++		proc_path = PATH_LIBEXEC;
++	}
 +
 +	if (snprintf(path, sizeof(path), "%s/%s-%s", proc_path, key, name) >=
  	    (ssize_t)sizeof(path)) {
  		log_warn("warn: %s-proc: exec path too long", key);
  		return (-1);
-diff -Naur opensmtpd-5.7.1p1/smtpd/table.c opensmtpd-5.7.1p1.patched/smtpd/table.c
---- opensmtpd-5.7.1p1/smtpd/table.c	2015-06-30 10:13:34.000000000 +0200
-+++ opensmtpd-5.7.1p1.patched/smtpd/table.c	2015-09-26 08:41:17.005472536 +0200
-@@ -201,6 +201,7 @@
+diff --git a/smtpd/table.c b/smtpd/table.c
+index 21ee237..95b5164 100644
+--- a/smtpd/table.c
++++ b/smtpd/table.c
+@@ -193,6 +193,7 @@ table_create(const char *backend, const char *name, const char *tag,
  	struct table_backend	*tb;
  	char			 buf[LINE_MAX];
  	char			 path[LINE_MAX];
-+        const char              *proc_path;
++	const char		*proc_path;
  	size_t			 n;
  	struct stat		 sb;
  
-@@ -215,8 +216,14 @@
+@@ -207,11 +208,16 @@ table_create(const char *backend, const char *name, const char *tag,
  	if (name && table_find(name, NULL))
  		fatalx("table_create: table \"%s\" already defined", name);
  
-+        proc_path = getenv("OPENSMTPD_PROC_PATH");
-+        if (proc_path == NULL) {
-+                proc_path = PATH_LIBEXEC;
-+        }
++	proc_path = getenv("OPENSMTPD_PROC_PATH");
++	if (proc_path == NULL) {
++		proc_path = PATH_LIBEXEC;
++	}
 +
  	if ((tb = table_backend_lookup(backend)) == NULL) {
--		if ((size_t)snprintf(path, sizeof(path), PATH_LIBEXEC "/table-%s",
+-		if ((size_t)snprintf(path, sizeof(path), PATH_LIBEXEC"/table-%s",
+-			backend) >= sizeof(path)) {
+-			fatalx("table_create: path too long \""
+-			    PATH_LIBEXEC"/table-%s\"", backend);
 +		if ((size_t)snprintf(path, sizeof(path), "%s/table-%s",
-+                    proc_path,
- 		    backend) >= sizeof(path)) {
- 			fatalx("table_create: path too long \""
- 			    PATH_LIBEXEC "/table-%s\"", backend);
++			proc_path, backend) >= sizeof(path)) {
++			fatalx("table_create: path too long \"%s/table-%s\"",
++				proc_path, backend);
+ 		}
+ 		if (stat(path, &sb) == 0) {
+ 			tb = table_backend_lookup("proc");


### PR DESCRIPTION
Used this VM to test it:

``` nix
{ config, pkgs, lib, ... }:

let
  ipv6          = true;
  hostName      = "mxtest";
  fullHostName  = "${hostName}.test-domain.org";
in {
  users.extraUsers.root.openssh.authorizedKeys.keys = lib.splitString "\n" (builtins.readFile (builtins.getEnv "HOME" + "/.ssh/authorized_keys"));

  services = {
    openssh.enable = true;

    opensmtpd = {
      enable = true;
      serverConfiguration = ''
        table creds file:/${pkgs.writeText "creds" "blah notapassword"}
        table vdoms file:/${pkgs.writeText "vdoms" "test-domain.org"}
        table vmap  file:/${pkgs.writeText "vmap"  "a@test-domain.org b"}

        pki ${fullHostName} certificate  "/etc/smtpd-tls/${fullHostName}.crt"
        pki ${fullHostName} key          "/etc/smtpd-tls/${fullHostName}.key"

        listen on 0.0.0.0          tls                      pki ${fullHostName} tag inbound
        ${lib.optionalString ipv6 ''
        listen on ::               tls                      pki ${fullHostName} tag inbound
        ''}
        listen on 0.0.0.0 port 587 tls-require auth <creds> pki ${fullHostName} tag outbound

        accept tagged outbound from local for any relay                       hostname ${fullHostName}
        accept                 from local for any relay as "@${fullHostName}" hostname ${fullHostName}
        accept                 from any for domain <vdoms> virtual <vmap>
      '';
    };
  };

  systemd.services.opensmtpd.preStart = ''
    mkdir -m 700 -p /etc/smtpd-tls
    pushd /etc/smtpd-tls >/dev/null

    if [ -f "${fullHostName}".crt ] && [ -f "${fullHostName}".key ]
    then
      echo "Certificate already exists, not generating new one."
    else
      echo "No certificate found, generating new one:"
      export RANDFILE="$PWD/.rnd"

      ${pkgs.openssl.bin}/bin/openssl req \
        -new -batch -x509 -nodes \
        -newkey rsa:4096 \
        -days   1095 \
        -keyout "${fullHostName}".key \
        -out    "${fullHostName}".crt \
        -subj   "/CN=${fullHostName}"

      chmod 400 "${fullHostName}".key
      chmod 444 "${fullHostName}".crt
      rm -vf "$RANDFILE"
    fi

    popd >/dev/null
  '';

  networking = {
    inherit hostName;
    firewall.enable = false;
  };
}
```

```
$ nix-build -I nixos-config=./test-configuration.nix '<nixpkgs/nixos>' -A vm && QEMU_NET_OPTS="hostfwd=tcp::20000-:22,hostfwd=tcp::2525-:25" ./result/bin/run-*-vm
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
