### PR TITLE
gnumake: add version 4.2

### DIFF
--- a/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl }:
+
+let
+  version = "4.2";
+in
+stdenv.mkDerivation {
+  name = "gnumake-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnu/make/make-${version}.tar.bz2";
+    sha256 = "0pv5rvz5pp4njxiz3syf786d2xp4j7gzddwjvgw5zmz55yvf6p2f";
+  };
+
+  patchFlags = "-p0";
+  patches = [
+    # Purity: don't look for library dependencies (of the form `-lfoo') in /lib
+    # and /usr/lib. It's a stupid feature anyway. Likewise, when searching for
+    # included Makefiles, don't look in /usr/include and friends.
+    ./impure-dirs.patch
+  ];
+
+  outputs = [ "out" "doc" ];
+
+  meta = {
+    homepage = http://www.gnu.org/software/make/;
+    description = "A tool to control the generation of non-source files from sources";
+    license = stdenv.lib.licenses.gpl3Plus;
+
+    longDescription = ''
+      Make is a tool which controls the generation of executables and
+      other non-source files of a program from the program's source files.
+
+      Make gets its knowledge of how to build your program from a file
+      called the makefile, which lists each of the non-source files and
+      how to compute it from other files. When you write a program, you
+      should write a makefile for it, so that it is possible to use Make
+      to build and install the program.
+    '';
+
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/tools/build-managers/gnumake/4.2/impure-dirs.patch
+++ b/pkgs/development/tools/build-managers/gnumake/4.2/impure-dirs.patch
@@ -1,0 +1,34 @@
+diff -rc read.c read.c
+*** read.c	2006-03-17 15:24:20.000000000 +0100
+--- read.c	2007-05-24 17:16:31.000000000 +0200
+***************
+*** 99,107 ****
+--- 99,109 ----
+  #endif
+      INCLUDEDIR,
+  #ifndef _AMIGA
++ #if 0    
+      "/usr/gnu/include",
+      "/usr/local/include",
+      "/usr/include",
++ #endif    
+  #endif
+      0
+    };
+diff -rc reremake.c
+*** remake.c	2006-03-20 03:36:37.000000000 +0100
+--- remake.c	2007-05-24 17:06:54.000000000 +0200
+***************
+*** 1452,1460 ****
+--- 1452,1462 ----
+    static char *dirs[] =
+      {
+  #ifndef _AMIGA
++ #if 0
+        "/lib",
+        "/usr/lib",
+  #endif
++ #endif
+  #if defined(WINDOWS32) && !defined(LIBDIR)
+  /*
+   * This is completely up to the user at product install time. Just define

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6146,6 +6146,7 @@ in
   gnumake3 = self.gnumake382;
   gnumake40 = callPackage ../development/tools/build-managers/gnumake/4.0 { };
   gnumake41 = callPackage ../development/tools/build-managers/gnumake/4.1 { };
+  gnumake42 = callPackage ../development/tools/build-managers/gnumake/4.2 { };
   gnumake = self.gnumake41;
 
   gob2 = callPackage ../development/tools/misc/gob2 { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Obviously, I just copied the package for 4.1, removing the patch that was already applied.  The complete set of dependent builds seemed a little too big to run on my machine, but I built a few of them and they seemed to do okay.
