### PR TITLE
xorg-server-1.18 and fglrx compat

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1609.xml
+++ b/nixos/doc/manual/release-notes/rl-1609.xml
@@ -16,6 +16,10 @@ has the following highlights: </para>
     See <xref linkend="sec-booting-from-pxe" /> for documentation.</para>
   </listitem>
 
+  <listitem>
+    <para>Xorg-server-1.18.*. If you choose <literal>"ati_unfree"</literal> driver,
+    1.17.* is still used due to ABI incompatibility.</para>
+  </listitem>
 </itemizedlist>
 
 <para>The following new services were added since the last release:</para>

--- a/nixos/modules/hardware/video/ati.nix
+++ b/nixos/modules/hardware/video/ati.nix
@@ -18,6 +18,8 @@ in
 
   config = mkIf enabled {
 
+    nixpkgs.config.xorg.fglrxCompat = true;
+
     services.xserver.drivers = singleton
       { name = "fglrx"; modules = [ ati_x11 ]; libPath = [ "${ati_x11}/lib" ]; };
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -462,7 +462,14 @@ in
           { source = "${cfg.xkbDir}";
             target = "X11/xkb";
           }
-        ]);
+        ])
+      # Needed since 1.18; see https://bugs.freedesktop.org/show_bug.cgi?id=89023#c5
+      ++ (let cfgPath = "/X11/xorg.conf.d/10-evdev.conf"; in
+        [{
+          source = xorg.xf86inputevdev.out + "/share" + cfgPath;
+          target = cfgPath;
+        }]
+      );
 
     environment.systemPackages =
       [ xorg.xorgserver.out
@@ -478,6 +485,7 @@ in
         xorg.xauth
         pkgs.xterm
         pkgs.xdg_utils
+        xorg.xf86inputevdev.out # get evdev.4 man page
       ]
       ++ optional (elem "virtualbox" cfg.videoDrivers) xorg.xrefresh;
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -535,7 +535,7 @@ in
     services.xserver.modules =
       concatLists (catAttrs "modules" cfg.drivers) ++
       [ xorg.xorgserver.out
-        xorg.xf86inputevdev
+        xorg.xf86inputevdev.out
       ];
 
     services.xserver.xkbDir = mkDefault "${pkgs.xkeyboard_config}/etc/X11/xkb";

--- a/pkgs/desktops/kde-5/plasma-5.6/plasma-desktop/default.nix
+++ b/pkgs/desktops/kde-5/plasma-5.6/plasma-desktop/default.nix
@@ -36,7 +36,7 @@ plasmaPackage rec {
   ];
   NIX_CFLAGS_COMPILE = [ "-I${xorgserver}/include/xorg" ];
   cmakeFlags = [
-    "-DEvdev_INCLUDE_DIRS=${xf86inputevdev}/include/xorg"
+    "-DEvdev_INCLUDE_DIRS=${xf86inputevdev.dev}/include/xorg"
     "-DSynaptics_INCLUDE_DIRS=${xf86inputsynaptics}/include/xorg"
   ];
   postInstall = ''

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2348,11 +2348,11 @@ let
   }) // {inherit ;};
 
   xorgserver = (mkDerivation "xorgserver" {
-    name = "xorg-server-1.17.4";
+    name = "xorg-server-1.18.3";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/xserver/xorg-server-1.17.4.tar.bz2;
-      sha256 = "0mv4ilpqi5hpg182mzqn766frhi6rw48aba3xfbaj4m82v0lajqc";
+      url = mirror://xorg/individual/xserver/xorg-server-1.18.3.tar.bz2;
+      sha256 = "1ka206v4nbw6qz072gh0543aq44azq2zv9f0yysy5nvwa4i9qwza";
     };
     buildInputs = [pkgconfig dri2proto dri3proto renderproto libdrm openssl libX11 libXau libXaw libxcb xcbutil xcbutilwm xcbutilimage xcbutilkeysyms xcbutilrenderutil libXdmcp libXfixes libxkbfile libXmu libXpm libXrender libXres libXt ];
     meta.platforms = stdenv.lib.platforms.unix;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -363,7 +363,22 @@ in
     '';
   };
 
-  xorgserver = with xorg; attrs: attrs //
+  xorgserver = with xorg; attrs_passed:
+    # exchange attrs if fglrxCompat is set
+    let
+      attrs = if !args.fglrxCompat then attrs_passed else
+        with args; {
+          name = "xorg-server-1.17.4";
+          builder = ./builder.sh;
+          src = fetchurl {
+            url = mirror://xorg/individual/xserver/xorg-server-1.17.4.tar.bz2;
+            sha256 = "0mv4ilpqi5hpg182mzqn766frhi6rw48aba3xfbaj4m82v0lajqc";
+          };
+          buildInputs = [pkgconfig dri2proto dri3proto renderproto libdrm openssl libX11 libXau libXaw libxcb xcbutil xcbutilwm xcbutilimage xcbutilkeysyms xcbutilrenderutil libXdmcp libXfixes libxkbfile libXmu libXpm libXrender libXres libXt ];
+          meta.platforms = stdenv.lib.platforms.unix;
+        };
+
+    in attrs //
     (let
       version = (builtins.parseDrvName attrs.name).version;
       commonBuildInputs = attrs.buildInputs ++ [ xtrans ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -286,6 +286,7 @@ in
   };
 
   xf86inputevdev = attrs: attrs // {
+    outputs = [ "dev" "out" ]; # to get rid of xorgserver.dev; man is tiny
     preBuild = "sed -e '/motion_history_proc/d; /history_size/d;' -i src/*.c";
     installFlags = "sdkdir=\${out}/include/xorg";
     buildInputs = attrs.buildInputs ++ [ args.mtdev args.libevdev ];

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -184,7 +184,7 @@ mirror://xorg/individual/app/xlsfonts-1.0.5.tar.bz2
 mirror://xorg/individual/app/xmag-1.0.6.tar.bz2
 mirror://xorg/individual/app/xmodmap-1.0.9.tar.bz2
 mirror://xorg/individual/doc/xorg-docs-1.7.1.tar.bz2
-mirror://xorg/individual/xserver/xorg-server-1.17.4.tar.bz2
+mirror://xorg/individual/xserver/xorg-server-1.18.3.tar.bz2
 mirror://xorg/X11R7.7/src/everything/xorg-sgml-doctools-1.11.tar.bz2
 mirror://xorg/X11R7.7/src/everything/xpr-1.0.4.tar.bz2
 mirror://xorg/individual/app/xprop-1.2.2.tar.bz2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10268,7 +10268,7 @@ in
     mesa = mesa_noglu;
     udev = if stdenv.isLinux then udev else null;
     libdrm = if stdenv.isLinux then libdrm else null;
-    fglrxCompat = false;
+    fglrxCompat = config.xorg.fglrxCompat or false; # `config` because we have no `xorg.override`
   } // { inherit xlibsWrapper; } );
 
   xwayland = callPackage ../servers/x11/xorg/xwayland.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10268,6 +10268,7 @@ in
     mesa = mesa_noglu;
     udev = if stdenv.isLinux then udev else null;
     libdrm = if stdenv.isLinux then libdrm else null;
+    fglrxCompat = false;
   } // { inherit xlibsWrapper; } );
 
   xwayland = callPackage ../servers/x11/xorg/xwayland.nix { };


### PR DESCRIPTION
Supersedes #15583 and  #12420. I'm running fine on it now, after solving the evdev problem. I'll wait a few days before merging to master; you can pre-test earlier if you like as rebuild impact is minimal.

---
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of **some** pkgs that depend on this change
- [X] Tested execution of **some** binary files (usually in `./result/bin/`)
- [X] _probably_ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
