### PR TITLE
apache-kafka: 0.8.2.1 -> 0.9.0.1

### DIFF
--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, jre, makeWrapper, bash }:
 
 let
-  kafkaVersion = "0.8.2.1";
-  scalaVersion = "2.10";
+  kafkaVersion = "0.9.0.1";
+  scalaVersion = "2.11";
 
 in
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://apache/kafka/${kafkaVersion}/kafka_${version}.tgz";
-    sha256 = "1klri23fjxbzv7rmi05vcqqfpy7dzi1spn2084y1dxsi1ypfkvc9";
+    sha256 = "0ykcjv5dz9i5bws9my2d60pww1g9v2p2nqr67h0i2xrjm7az8a6v";
   };
 
   buildInputs = [ jre makeWrapper bash ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

```
$ nix-shell -p nox --run "nox-review wip --against upstream/master"
==> We're in a git repo, trying to fetch it
Building in /run/user/1000/nox-review-j6peuln_: apacheKafka
/nix/store/xbijb378y89kd3jc2xjygfw8d60rc479-apache-kafka-2.11-0.9.0.1
Result in /run/user/1000/nox-review-j6peuln_
total 0
lrwxrwxrwx 1 maarten maarten 69 May 23 15:46 result -> /nix/store/xbijb378y89kd3jc2xjygfw8d60rc479-apache-kafka-2.11-0.9.0.1
```
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
