### PR TITLE
wayland-protocols: 1.3 -> 1.4

### DIFF
--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "wayland-protocols-${version}";
-  version = "1.3";
+  version = "1.4";
 
   src = fetchurl {
     url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "0byqvrsm6bkvylvzqy8wh5wpszwl5ra1z0yjqzqmw8przlrhdkbb";
+    sha256 = "0wpm7mz7ww6nn3vrgz7a9iyk7mk6za73wnq0n54lzl8yq8irljh1";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

> This release include one new stable protocol extension:
> 
>  . viewporter
> 
> The viewporter porter has previously been known as "wl_scaler" and enables a
> client to crop and scale a surface server side. Clients and compositors
> previously implementing support for wl_scaler should adapt accordingly. See the
> corresponding XML file for details.
> 
> Other changes included in this release are various grammatical corrections to the
> presentation-time, tablet, relative-pointer, pointer-constraints, linux-dmabuf,
> input-method and fullscreen-shell protocols.
> 
> It's now also possible to use autotools build files to install on platforms
> where the host CPU is not recognized.
