### PR TITLE
man-db: make it the default man provider

### DIFF
--- a/nixos/modules/programs/man.nix
+++ b/nixos/modules/programs/man.nix
@@ -19,7 +19,7 @@ with lib;
 
   config = mkIf config.programs.man.enable {
 
-    environment.systemPackages = [ pkgs.man ];
+    environment.systemPackages = [ pkgs.man-db ];
 
     environment.pathsToLink = [ "/share/man" ];
 

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, nettools, python, which, groff, gettext, man_db,
+{ stdenv, fetchurl, ncurses, nettools, python, which, groff, gettext, man-db,
   bc, libiconv, coreutils, gnused, kbd, utillinux, glibc }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   # Required binaries during execution
   # Python: Autocompletion generated from manpages and config editing
   propagatedBuildInputs = [ python which groff gettext ]
-                          ++ stdenv.lib.optional (!stdenv.isDarwin) man_db
+                          ++ stdenv.lib.optional (!stdenv.isDarwin) man-db
                           ++ [ bc coreutils ];
 
   postInstall = ''
@@ -55,8 +55,8 @@ stdenv.mkDerivation rec {
     done
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     sed -i "s|(hostname\||(${nettools}/bin/hostname\||" "$out/share/fish/functions/fish_prompt.fish"
-    sed -i "s|Popen(\['manpath'|Popen(\['${man_db}/bin/manpath'|" "$out/share/fish/tools/create_manpage_completions.py"
-    sed -i "s|command manpath|command ${man_db}/bin/manpath|" "$out/share/fish/functions/man.fish"
+    sed -i "s|Popen(\['manpath'|Popen(\['${man-db}/bin/manpath'|" "$out/share/fish/tools/create_manpage_completions.py"
+    sed -i "s|command manpath|command ${man-db}/bin/manpath|" "$out/share/fish/functions/man.fish"
   '' + ''
     sed -i "s|/sbin /usr/sbin||" \
            "$out/share/fish/functions/__fish_complete_subcommand_root.fish"

--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -1,19 +1,24 @@
 { stdenv, fetchurl, pkgconfig, libpipeline, db, groff }:
- 
+
 stdenv.mkDerivation rec {
   name = "man-db-2.7.5";
-  
+
   src = fetchurl {
     url = "mirror://savannah/man-db/${name}.tar.xz";
     sha256 = "056a3il7agfazac12yggcg4gf412yq34k065im0cpfxbcw6xskaw";
   };
-  
-  buildInputs = [ pkgconfig libpipeline db groff ];
+
+  outputs = [ "out" "doc" ];
+  outputMan = "out"; # users will want `man man` to work
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libpipeline db groff ];
 
   configureFlags = [
     "--disable-setuid"
-    "--sysconfdir=/etc"
     "--localstatedir=/var"
+    # Don't try /etc/man_db.conf by default, so we avoid error messages.
+    "--with-config-file=\${out}/etc/man_db.conf"
     "--with-systemdtmpfilesdir=\${out}/lib/tmpfiles.d"
     "--with-eqn=${groff}/bin/eqn"
     "--with-neqn=${groff}/bin/neqn"
@@ -23,15 +28,9 @@ stdenv.mkDerivation rec {
     "--with-tbl=${groff}/bin/tbl"
   ];
 
-  installFlags = [ "DESTDIR=\${out}" ];
+  enableParallelBuilding = true;
 
-  postInstall = ''
-    mv $out/$out/* $out
-    DIR=$out/$out
-    while rmdir $DIR 2>/dev/null; do
-      DIR="$(dirname "$DIR")"
-    done
-  '';
+  doCheck = true;
 
   meta = with stdenv.lib; {
     homepage = "http://man-db.nongnu.org";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -64,6 +64,8 @@ doNotDisplayTwice rec {
   lttngTools = lttng-tools;  # added 2014-07-31
   lttngUst = lttng-ust;  # added 2014-07-31
   manpages = man-pages; # added 2015-12-06
+  man_db = man-db; # added 2016-05
+  man = man-db; # added 2016-05
   midoriWrapper = midori; # added 2015-01
   mlt-qt5 = qt5.mlt;  # added 2015-12-19
   module_init_tools = kmod; # added 2016-04-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2379,9 +2379,9 @@ in
 
   makemkv = callPackage ../applications/video/makemkv { };
 
-  man = callPackage ../tools/misc/man { };
+  man-old = callPackage ../tools/misc/man { };
 
-  man_db = callPackage ../tools/misc/man-db { };
+  man-db = callPackage ../tools/misc/man-db { };
 
   mawk = callPackage ../tools/text/mawk { };
 


### PR DESCRIPTION
Continuation of #13816. Our current `man` is long unmaintained.

The package is slightly larger but its closure is actually ~8 MB smaller. (For example it saves ncurses but adds db.)

I'm using `man-db` now and I tested it detects our usual locations of man pages. (For a minor caveat see description of b9df431.)
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of **some** binary files (usually in `./result/bin/`)
- [X] _probably_ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
