### PR TITLE
ktikz: init at 0.10

### DIFF
--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -1,0 +1,78 @@
+{ withKDE ? true
+, stdenv, fetchurl, gettext, poppler_qt4, qt4
+# Qt only (no KDE):
+, pkgconfig
+# With KDE
+, cmake, automoc4, kdelibs
+}:
+
+# Warning: You will also need a working pdflatex installation containing (at
+# least) auctex and pgf.
+
+assert withKDE -> kdelibs != null;
+
+let
+  version = "0.10";
+
+  qtikz = {
+    name = "qtikz-${version}";
+
+    conf = ''
+      # installation prefix:
+      #PREFIX = ""
+
+      # install desktop file here (*nix only):
+      DESKTOPDIR = ''$''${PREFIX}/share/applications
+
+      # install mimetype here:
+      MIMEDIR = ''$''${PREFIX}/share/mime/packages
+
+      CONFIG -= debug
+      CONFIG += release
+
+      # qmake command:
+      QMAKECOMMAND = qmake
+      # lrelease command:
+      LRELEASECOMMAND = lrelease
+      # qcollectiongenerator command:
+      #QCOLLECTIONGENERATORCOMMAND = qcollectiongenerator
+
+      # TikZ documentation default file path:
+      TIKZ_DOCUMENTATION_DEFAULT = ''$''${PREFIX}/share/doc/texmf/pgf/pgfmanual.pdf.gz
+    '';
+
+    patchPhase = ''
+      echo "$conf" > conf.pri
+    '';
+
+    configurePhase = ''
+      qmake PREFIX="$out" ./qtikz.pro
+    '';
+
+    buildInputs = [ gettext qt4 poppler_qt4 pkgconfig ];
+  };
+
+  ktikz = {
+    name = "ktikz-${version}";
+    buildInputs = [ kdelibs cmake qt4 automoc4 gettext poppler_qt4 ];
+  };
+
+  common = {
+    inherit version;
+    src = fetchurl {
+      url = "http://www.hackenberger.at/ktikz/ktikz_${version}.tar.gz";
+      md5 = "e8f0826cba2447250bcdcd389a71a2ac";
+    };
+
+    enableParallelBuilding = true;
+
+    meta = with stdenv.lib; {
+      description = "Editor for the TikZ language";
+      license = licenses.gpl2;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.layus ];
+    };
+  };
+
+in stdenv.mkDerivation (common // (if withKDE then ktikz else qtikz))
+

--- a/pkgs/tools/typesetting/tex/auctex/default.nix
+++ b/pkgs/tools/typesetting/tex/auctex/default.nix
@@ -1,9 +1,16 @@
-{ stdenv, fetchurl, emacs, texLive }:
+{ stdenv, fetchurl, emacs, texlive, ghostscript }:
  
-stdenv.mkDerivation ( rec {
-  pname = "auctex";
+let auctex = stdenv.mkDerivation ( rec {
   version = "11.89";
   name = "${pname}-${version}";
+
+  # Make this a valid tex(live-new) package;
+  # the pkgs attribute is provided with a hack below.
+  pname = "auctex";
+  tlType = "run";
+
+
+  outputs = [ "out" "tex" ];
 
   meta = {
     description = "Extensible package for writing and formatting TeX files in GNU Emacs and XEmacs";
@@ -15,10 +22,16 @@ stdenv.mkDerivation ( rec {
     sha256 = "1cf9fkkmzjxa4jvk6c01zgxdikr4zzb5pcx8i4r0hwdk0xljkbwq";
   };
 
-  buildInputs = [ emacs texLive ];
+  buildInputs = [ emacs texlive.combined.scheme-basic ghostscript ];
+
+  preConfigure = ''
+    mkdir -p "$tex"
+  '';
 
   configureFlags = [
     "--with-lispdir=\${out}/share/emacs/site-lisp"
-    "--disable-preview"
+    "--with-texmf-dir=\${tex}"
   ];
-})
+});
+
+in auctex // { pkgs = [ auctex.tex ]; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3101,6 +3101,11 @@ in
 
   qshowdiff = callPackage ../tools/text/qshowdiff { };
 
+  qtikz = callPackage ../applications/graphics/ktikz {
+    withKDE = false;
+    kdelibs = null;
+  };
+
   quicktun = callPackage ../tools/networking/quicktun { };
 
   quilt = callPackage ../development/tools/quilt { };
@@ -15640,6 +15645,8 @@ in
           kipi_plugins = callPackage ../applications/graphics/kipi-plugins { };
 
           konversation = callPackage ../applications/networking/irc/konversation { };
+
+          ktikz = callPackage ../applications/graphics/ktikz { };
 
           kvirc = callPackage ../applications/networking/irc/kvirc { };
 


### PR DESCRIPTION
I am quite proud to introduce this changeset. This is a working qtikz with the required "preview" tex package.

To use it, you need a working texlive setup with tikz (obviously) and some more packages (pdftex, ...).
I have found the following texlive setup to work.

``` nix
with pkgs; texlive.combine {
  inherit (texlive) scheme-basic collection-pictures collection-latexrecommended pdftex;
  inherit auctex;
}
```

It is difficult to do better than this without hooks to propagate auctex in the user's combined texlive. This feature is discussed from time to time, but not yet implemented.
