### PR TITLE
hiredis: 0.13.1 -> 0.13.3

### DIFF
--- a/pkgs/development/libraries/hiredis/default.nix
+++ b/pkgs/development/libraries/hiredis/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "hiredis-${version}";
-  version = "0.13.1";
+  version = "0.13.3";
 
   src = fetchFromGitHub {
     owner = "redis";
     repo = "hiredis";
     rev = "v${version}";
-    sha256 = "15rzq7n7z9h143smrnd34f9gh24swwal6r9z9xlxsl0jxabiv71l";
+    sha256 = "1qxiv61bsp6s847hhkxqj7vnbdlac089r2qdp3zgxhhckaflhb7r";
   };
 
   PREFIX = "\${out}";


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
