### PR TITLE
Fix qgroundcontrol configure stage

### DIFF
--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -28,7 +28,15 @@ stdenv.mkDerivation rec {
 
   patches = [ ./0001-fix-gcc-cmath-namespace-issues.patch ];
 
+  configurePhase = ''
+    mkdir build
+    cd build
+    qmake ../qgroundcontrol.pro
+  '';
+
   installPhase = ''
+    cd ..
+
     mkdir -p $out/share/applications
     cp -v qgroundcontrol.desktop $out/share/applications
     


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've been trying to use qgroundcontrol, but couldn't install it due to
an error in the configure stage:

```
~ $ nix-shell --pure -p qgroundcontrol
these derivations will be built:
  /nix/store/ah0hfb91hyg22ls10nnf9k4s0vnwkq7c-qgroundcontrol-2.9.4.drv
building path(s) ‘/nix/store/hqshfrdwpknbgh8cv2rjhw702wk236v0-qgroundcontrol-2.9.4’
qmake: File exists
_makeQtWrapperSetup
unpacking sources
unpacking source archive /nix/store/2rwixfzm7fj3gbqj1rs2c9p965jfxiw4-qgroundcontrol
source root is qgroundcontrol
patching sources
applying patch /nix/store/9jxhwhkw7j2751wwx75g9hjx23hwhmnm-0001-fix-gcc-cmath-namespace-issues.patch
patching file src/Vehicle/Vehicle.cc
patching file src/comm/QGCFlightGearLink.cc
patching file src/comm/QGCJSBSimLink.cc
patching file src/uas/UAS.cc
patching file src/ui/QGCDataPlot2D.cc
configuring
Project ERROR: You must use shadow build.
builder for ‘/nix/store/ah0hfb91hyg22ls10nnf9k4s0vnwkq7c-qgroundcontrol-2.9.4.drv’ failed with exit code 3
error: build of ‘/nix/store/ah0hfb91hyg22ls10nnf9k4s0vnwkq7c-qgroundcontrol-2.9.4.drv’ failed
/run/current-system/sw/bin/nix-shell: failed to build all dependencies
```

This solution probably isn't the best or cleanest, but applying this
patch makes it build successfully for me.
