### PR TITLE
cudnn: init at 4.0

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, requireFile }:
+
+stdenv.mkDerivation rec {
+  version = "4.0";
+
+  name = "cudnn-${version}";
+
+  src = requireFile rec {
+    name = "cudnn-7.0-linux-x64-v${version}-prod.tgz";
+    message = '' 
+      This nix expression requires that ${name} is
+      already part of the store. Register yourself to NVIDIA Accelerated Computing Developer Program
+      and download cuDNN library at https://developer.nvidia.com/cudnn, and store it to the nix store with nix-store --add-fixed sha256 <FILE>.
+    '';
+    sha256 = "0zgr6qdbc29qw6sikhrh6diwwz7150rqc8a49f2qf37j2rvyyr2f";
+
+  };
+
+  phases = "unpackPhase installPhase fixupPhase";
+
+  installPhase = ''
+    mkdir -p $out
+    cp -a include $out/include
+    cp -a lib64 $out/lib64
+  '';
+
+  # all binaries are already stripped
+  #dontStrip = true;
+
+  # we did this in prefixup already
+  #dontPatchELF = true;
+
+  meta = {
+    description = "NVIDIA CUDA Deep Neural Network library (cuDNN)";
+    homepage = "https://developer.nvidia.com/cudnn";
+    license = stdenv.lib.licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1201,6 +1201,8 @@ in
 
   cudatoolkit = self.cudatoolkit7;
 
+  cudnn = callPackage ../development/libraries/science/math/cudnn/default.nix {};
+
   curlFull = self.curl.override {
     idnSupport = true;
     ldapSupport = true;


### PR DESCRIPTION
cuDNN: NVIDIA CUDA Deep Neural Network library. 
Nix expression for a non-free library. 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
