### PR TITLE
config.fonts.fontdir: use runCommand instead of builderDefs

### DIFF
--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -4,47 +4,17 @@ with lib;
 
 let
 
-  fontDirs = config.fonts.fonts;
-
-  localDefs = with pkgs.builderDefs; pkgs.builderDefs.passthru.function rec {
-    src = "";/* put a fetchurl here */
-    buildInputs = [pkgs.xorg.mkfontdir pkgs.xorg.mkfontscale];
-    inherit fontDirs;
-    installPhase = fullDepEntry ("
-    list='';
-    for i in ${toString fontDirs} ; do
-      if [ -d \$i/ ]; then
-        list=\"\$list \$i\";
-      fi;
-    done
-    list=\$(find \$list -name fonts.dir -o -name '*.ttf' -o -name '*.otf');
-    fontDirs='';
-    for i in \$list ; do
-      fontDirs=\"\$fontDirs \$(dirname \$i)\";
-    done;
-    mkdir -p \$out/share/X11-fonts/;
-    find \$fontDirs -type f -o -type l | while read i; do
-      j=\"\${i##*/}\"
-      if ! test -e \"\$out/share/X11-fonts/\${j}\"; then
-        ln -s \"\$i\" \"\$out/share/X11-fonts/\${j}\";
-      fi;
-    done;
-    cd \$out/share/X11-fonts/
-    rm fonts.dir
-    rm fonts.scale
-    rm fonts.alias
-    mkfontdir
-    mkfontscale
-    cat \$( find ${pkgs.xorg.fontalias}/ -name fonts.alias) >fonts.alias
-  ") ["minInit" "addInputs"];
-  };
-
-  x11Fonts = with localDefs; stdenv.mkDerivation rec {
-    name = "X11-fonts";
-    builder = writeScript (name + "-builder")
-      (textClosure localDefs
-        [installPhase doForceShare doPropagate]);
-  };
+  x11Fonts = pkgs.runCommand "X11-fonts" { } ''
+    mkdir -p "$out/share/X11-fonts"
+    find ${toString config.fonts.fonts} \
+      \( -name fonts.dir -o -name '*.ttf' -o -name '*.otf' \) \
+      -exec ln -sf -t "$out/share/X11-fonts" '{}' \;
+    cd "$out/share/X11-fonts"
+    rm -f fonts.dir fonts.scale fonts.alias
+    ${pkgs.xorg.mkfontdir}/bin/mkfontdir
+    ${pkgs.xorg.mkfontscale}/bin/mkfontscale
+    cat $(find ${pkgs.xorg.fontalias}/ -name fonts.alias) >fonts.alias
+  '';
 
 in
 
@@ -69,6 +39,8 @@ in
   config = mkIf config.fonts.enableFontDir {
 
     environment.systemPackages = [ x11Fonts ];
+
+    environment.pathsToLink = [ "/share/X11-fonts" ];
 
   };
 


### PR DESCRIPTION
###### Motivation for this change
#4210

---

This is basically just some old cruft in my repo; will look into cleaning it up at some point, but not now.
I _think_ this is equivalent to the old version.
