### PR TITLE
Improve slurm job scheduler packaging

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, curl, python, munge, perl, pam, openssl,
-  ncurses, mysql, gtk }:
+  ncurses, mysql, gtk, lua, hwloc, numactl }:
 
 stdenv.mkDerivation rec {
   name = "slurm-llnl-${version}";
@@ -10,16 +10,24 @@ stdenv.mkDerivation rec {
     sha256 = "05si1cn7zivggan25brsqfdw0ilvrlnhj96pwv16dh6vfkggzjr1";
   };
 
-  buildInputs = [ pkgconfig curl python munge perl pam openssl mysql.lib ncurses gtk ];
+  buildInputs = [ pkgconfig curl python munge perl pam openssl mysql.lib 
+		  ncurses gtk lua hwloc numactl ];
 
   configureFlags =
     [ "--with-munge=${munge}"
       "--with-ssl=${openssl.dev}"
+      "--sysconfdir=/etc/slurm"
     ] ++ stdenv.lib.optional (gtk == null)  "--disable-gtktest";
 
   preConfigure = ''
     substituteInPlace ./doc/html/shtml2html.py --replace "/usr/bin/env python" "${python.interpreter}"
     substituteInPlace ./doc/man/man2html.py --replace "/usr/bin/env python" "${python.interpreter}"
+  '';
+
+  postInstall = ''
+	# remove libtool files
+        rm -f $out/lib/*.la
+        rm -f $out/lib/slurm/*.la
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- add support for numa and hwloc
- add support for lua scripting module
- make slurm compatible with system configuration by default, in case of  Nix used
  as a side package manager (tested on redhat)
- strip the libtool generated files
- add possibility to add system specific modules
