### PR TITLE
syncthing: Update to 0.13.2. Update legacy version to 0.12.25

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14191,7 +14191,7 @@ in
   symlinks = callPackage ../tools/system/symlinks { };
 
   syncthing = go15Packages.syncthing.bin // { outputs = [ "bin" ]; };
-  syncthing011 = go15Packages.syncthing011.bin // { outputs = [ "bin" ]; };
+  syncthing012 = go15Packages.syncthing012.bin // { outputs = [ "bin" ]; };
 
   # linux only by now
   synergy = callPackage ../applications/misc/synergy { };

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -3723,11 +3723,11 @@ let
   };
 
   syncthing = buildFromGitHub rec {
-    version = "0.12.23";
+    version = "0.13.2";
     rev = "v${version}";
     owner = "syncthing";
     repo = "syncthing";
-    sha256 = "0v8343k670ncjfd25hzhyfi87cz46k57rmv6pf30v7iclfhpmy1s";
+    sha256 = "1n56a92r1sny5ilcwcvcid5wdlr0wzryppfz1isqn38gs9zplip7";
     buildFlags = [ "-tags noupgrade,release" ];
     disabled = isGo14;
     buildInputs = [
@@ -3740,14 +3740,14 @@ let
     '';
   };
 
-  syncthing011 = buildFromGitHub rec {
-    version = "0.11.26";
+  syncthing012 = buildFromGitHub rec {
+    version = "0.12.25";
     rev = "v${version}";
     owner = "syncthing";
     repo = "syncthing";
-    sha256 = "0c0dcvxrvjc84dvrsv90790aawkmavsj9bwp8c6cd6wrwj3cp9lq";
+    sha256 = "108w7gvm3nbbsgp3h5p84fj4ba0siaz932i7yyryly486gzvpm43";
     buildInputs = [
-      go-lz4 du luhn xdr snappy ratelimit osext syncthing-protocol011
+      go-lz4 du luhn xdr snappy ratelimit osext
       goleveldb suture qart crypto net text
     ];
     postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Version 0.13.x is the latest release series of Syncthing, including many improvements and bug fixes, including a security fix:
https://forum.syncthing.net/t/syncthing-v0-13-2-and-v0-12-25-released/7421

We keep the previous release series packaged because there are 3rd party implementations that may not have been updated to 0.13.x, which is incompatible with 0.12.x.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- pkgs/top-level/go-packages.nix (syncthing): Update to 0.13.2.
  (syncthing-011): Replace with ...
  (syncthing-012): ... this.
