### PR TITLE
mod_auth_mellon: init at 0.12.0 and dependency lasso: init at 2.5.1

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -337,6 +337,7 @@ let
         allModules =
           concatMap (svc: svc.extraModulesPre) allSubservices
           ++ map (name: {inherit name; path = "${httpd}/modules/mod_${name}.so";}) apacheModules
+          ++ optional mainCfg.enableMellon { name = "auth_mellon"; path = "${pkgs.apacheHttpdPackages.mod_auth_mellon}/modules/mod_auth_mellon.so"; }
           ++ optional enablePHP { name = "php5"; path = "${php}/modules/libphp5.so"; }
           ++ concatMap (svc: svc.extraModules) allSubservices
           ++ extraForeignModules;
@@ -541,6 +542,12 @@ in
         '';
       };
 
+      enableMellon = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the mod_auth_mellon module.";
+      };
+
       enablePHP = mkOption {
         type = types.bool;
         default = false;
@@ -650,6 +657,7 @@ in
 
         environment =
           optionalAttrs enablePHP { PHPRC = phpIni; }
+          // optionalAttrs mainCfg.enableMellon { LD_LIBRARY_PATH  = "${pkgs.xmlsec}/lib"; }
           // (listToAttrs (concatMap (svc: svc.globalEnvVars) allSubservices));
 
         preStart =

--- a/pkgs/development/libraries/lasso/default.nix
+++ b/pkgs/development/libraries/lasso/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, autoconf, automake, autoreconfHook, fetchurl, glib, gobjectIntrospection, gtk_doc, libtool, libxml2, libxslt, openssl, pkgconfig, python27Packages, xmlsec, zlib }:
+
+stdenv.mkDerivation rec {
+
+  name = "lasso-${version}";
+  version = "2.5.1";
+
+  src = fetchurl {
+    url = "https://dev.entrouvert.org/lasso/lasso-${version}.tar.gz";
+    sha256 = "0n10zjjw84303c9vfy9bqhyzdl01459akbwy86cbgphd826mq45y";
+
+  };
+
+  buildInputs = [ autoconf automake autoreconfHook glib gobjectIntrospection gtk_doc libtool libxml2 libxslt openssl pkgconfig python27Packages.six xmlsec zlib ];
+
+  configurePhase = ''
+    ./configure --with-pkg-config=$PKG_CONFIG_PATH \
+                --disable-python \
+                --disable-perl \
+                --prefix=$out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://lasso.entrouvert.org/;
+    description = "Liberty Alliance Single Sign-On library";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ womfoo ];
+  };
+
+}

--- a/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, apacheHttpd, autoconf, automake, autoreconfHook, curl, fetchFromGitHub, glib, lasso, libtool, libxml2, libxslt, openssl, pkgconfig, xmlsec }:
+
+stdenv.mkDerivation rec {
+
+  name = "mod_auth_mellon-${version}";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "UNINETT";
+    repo = "mod_auth_mellon";
+    rev = "v${version}";
+    sha256 = "1p6v6vgrfvgvc5y2ygqyyxi0klpm3nxaw3fg35zmpmw663w8skqn";
+  };
+
+  patches = [
+    ./fixdeps.patch
+  ];
+
+  buildInputs = [ apacheHttpd autoconf autoreconfHook automake curl glib lasso libtool libxml2 libxslt openssl pkgconfig xmlsec ];
+
+  configureFlags = ["--with-apxs2=${apacheHttpd}/bin/apxs" "--exec-prefix=$out"];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./mellon_create_metadata.sh $out/bin
+    mkdir -p $out/modules
+    cp ./.libs/mod_auth_mellon.so $out/modules
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/UNINETT/mod_auth_mellon;
+    description = "An Apache module with a simple SAML 2.0 service provider";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ womfoo ];
+  };
+
+}

--- a/pkgs/servers/http/apache-modules/mod_auth_mellon/fixdeps.patch
+++ b/pkgs/servers/http/apache-modules/mod_auth_mellon/fixdeps.patch
@@ -1,0 +1,30 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -74,6 +74,16 @@ PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.12])
+ AC_SUBST(GLIB_CFLAGS)
+ AC_SUBST(GLIB_LIBS)
+ 
++#include <libxml/uri.h>
++PKG_CHECK_MODULES(LIBXML2, libxml-2.0)
++AC_SUBST(LIBXML2_CFLAGS)
++AC_SUBST(LIBXML2_LIBS)
++
++#include <xmlsec/xmlenc.h>
++PKG_CHECK_MODULES(XMLSEC, xmlsec1-openssl)
++AC_SUBST(XMLSEC_CFLAGS)
++AC_SUBST(XMLSEC_LIBS)
++
+ # Test to see if we can include lasso/utils.h
+ # AC_CHECK_HEADER won't work correctly unless we specifiy the include directories
+ # found in the LASSO_CFLAGS. Save and restore CFLAGS and CPPFLAGS.
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -25,7 +25,7 @@
+ all:	mod_auth_mellon.la
+ 
+ mod_auth_mellon.la: $(SRC) auth_mellon.h auth_mellon_compat.h
+-	@APXS2@ -Wc,"-std=c99 @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@ @CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
++	@APXS2@ -Wc,"-std=c99 @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@ @CFLAGS@ @LIBXML2_CFLAGS@ @XMLSEC_CFLAGS@ @CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@ @LIBXML2_LIBS@ @XMLSEC_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
+ 
+ 
+ # Building configure (for distribution)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9731,6 +9731,8 @@ in
   apacheHttpdPackagesFor = apacheHttpd: self: let callPackage = newScope self; in {
     inherit apacheHttpd;
 
+    mod_auth_mellon = callPackage ../servers/http/apache-modules/mod_auth_mellon { };
+
     mod_dnssd = callPackage ../servers/http/apache-modules/mod_dnssd { };
 
     mod_evasive = callPackage ../servers/http/apache-modules/mod_evasive { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7430,6 +7430,8 @@ in
   };
   libkrb5 = self.krb5Full.override { type = "lib"; };
 
+  lasso = callPackage ../development/libraries/lasso { };  
+
   LASzip = callPackage ../development/libraries/LASzip { };
 
   lcms = self.lcms1;


### PR DESCRIPTION
I've been using this branch internally for some time with this apache module working fine. I just need help getting rid of the LD_LIBRARY_PATH hack inside the systemd service.

Without this, the apache spits out:

```
(process:5891): Lasso-CRITICAL **: 2016-05-25 02:24:05 (lasso.c/:182) Unable to load default xmlsec-crypto library. Make surethat you have it installed and check shared libraries path(LD_LIBRARY_PATH) environment variable.
[Wed May 25 02:31:22.268509 2016] [auth_digest:notice] [pid 9751] AH01757: generating secret for digest authentication ...
[Wed May 25 02:31:22.270075 2016] [mpm_prefork:notice] [pid 9751] AH00163: Apache/2.4.18 (Unix) configured -- resuming normal operations
[Wed May 25 02:31:22.270094 2016] [core:notice] [pid 9751] AH00094: Command line: 'httpd -f /nix/store/fn7p4icpr9aqf4hhzqwg9rhxgny7gpw1-httpd.conf'
[Wed May 25 02:31:33.133642 2016] [:error] [pid 9752] [client ::1:34196] Error initializing lasso server object. Please verify the following configuration directives: MellonSPMetadataFile and MellonSPPrivateKeyFile., referer: http://localhost/
[Wed May 25 02:31:33.134854 2016] [:error] [pid 9752] [client ::1:34196] Error initializing lasso server object. Please verify the following configuration directives: MellonSPMetadataFile and MellonSPPrivateKeyFile., referer: http://localhost/
```

ldd shows xmlsec libs but I'm not sure why its still fails.

```
$ ldd /nix/store/nky7w3k2qc7y7kpc7sq3hh3l3s4l7zvh-mod_auth_mellon-0.12.0/modules/mod_auth_mellon.so | grep xml
    libxmlsec1-openssl.so.1 => /nix/store/7zx4sxcwkhnfqabgc6v1qs99m080lgpi-xmlsec-1.2.20/lib/libxmlsec1-openssl.so.1 (0x00007efe23e96000)
    libxmlsec1.so.1 => /nix/store/7zx4sxcwkhnfqabgc6v1qs99m080lgpi-xmlsec-1.2.20/lib/libxmlsec1.so.1 (0x00007efe23c2f000)
    libxml2.so.2 => /nix/store/zpv590jwvr272qlh9iqyr41f6izd0x9z-libxml2-2.9.3/lib/libxml2.so.2 (0x00007efe22dc3000)
```

Anyone experienced this issue before?

If you want to help out testing this, here is a [gist](https://gist.github.com/womfoo/f8a4413cfe57c8de7e6220ad82aadb0f) with a sample config.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
