### PR TITLE
go/errcheck: bump version, remove postPatch

### DIFF
--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -831,16 +831,10 @@ let
   };
 
   errcheck = buildFromGitHub {
-    rev = "f76568f8d87e48ccbbd17a827c2eaf31805bf58c";
+    rev = "8e25ad9d46f6c5d4e994edf82c57eb773a9aa73d";
     owner = "kisielk";
     repo = "errcheck";
-    sha256 = "1y1cqd0ibgr03zf96q6aagk65yhv6vcnq9xa8nqhjpnz7jhfndhs";
-    postPatch = ''
-      for f in $(find -name "*.go"); do
-        substituteInPlace $f \
-          --replace '"go/types"' '"golang.org/x/tools/go/types"'
-      done
-    '';
+    sha256 = "1089qf05q8db8h6ayn1c1iaq4fcpv18z3k94dr27v31k6f73dzhg";
     excludedPackages = [ "testdata" ];
     buildInputs = [ gotool tools ];
   };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
