### PR TITLE
emscripten: revision bump from 1.35.4 to 1.36.4, was tested with comp…

### DIFF
--- a/pkgs/development/compilers/emscripten-fastcomp/default.nix
+++ b/pkgs/development/compilers/emscripten-fastcomp/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, python }:
 
 let
-  tag = "1.35.4";
+  tag = "1.36.4";
 in
 
 stdenv.mkDerivation rec {
@@ -10,13 +10,13 @@ stdenv.mkDerivation rec {
   srcFC = fetchgit {
     url = git://github.com/kripken/emscripten-fastcomp;
     rev = "refs/tags/${tag}";
-    sha256 = "3bd50787d78381f684f9b3f46fc91cc3d1803c3389e19ec41ee59c2deaf727d8";
+    sha256 = "0qmrc83yrlmlb11gqixxnwychif964054lgdiycz0l10yj0q37j5";
   };
 
   srcFL = fetchgit {
     url = git://github.com/kripken/emscripten-fastcomp-clang;
     rev = "refs/tags/${tag}";
-    sha256 = "ec0d22c04eec5f84695401e19a52704b28e8d2779b87388f399b5f63b54a9862";
+    sha256 = "1av58y9s24l32hsdgp3jh4fkc5005xbzzjd27in2r9q3p6igd5d4";
   };
 
   buildInputs = [ python ];
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/kripken/emscripten-fastcomp;
     description = "emscripten llvm";
     platforms = platforms.all;
-    maintainers = with maintainers; [ bosu ];
+    maintainers = with maintainers; [ qknight ];
     license = stdenv.lib.licenses.ncsa;
   };
 }

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, emscriptenfastcomp, python, nodejs, closurecompiler, jre }:
 
 let
-  tag = "1.35.4";
+  tag = "1.36.4";
   appdir = "share/emscripten";
 in
 
@@ -11,10 +11,10 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = git://github.com/kripken/emscripten;
     rev = "refs/tags/${tag}";
-    sha256 = "466500356c8c0fbcee495b2dbd2ccf0bf9d7eaf303d274ebaf491122759dd233";
+    sha256 = "02m85xh9qx29kb6v11y072gk8fvyc23964wclr70c69j2gal2qpr";
   };
 
-  buildCommand = ''
+  buildCommand = '' 
     mkdir -p $out/${appdir}
     cp -r $src/* $out/${appdir}
     chmod -R +w $out/${appdir}
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/kripken/emscripten;
     description = "An LLVM-to-JavaScript Compiler";
     platforms = platforms.all;
-    maintainers = with maintainers; [ bosu ];
+    maintainers = with maintainers; [ qknight ];
     license = licenses.ncsa;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

xml.js would not compile with an older version. the 1.36.4 was tested by compiling xml.js from https://github.com/kripken/xml.js/commit/95addcf845fa8393f3d3b1a0f747404a1a51ec2c 

see also:
https://github.com/NixOS/nixpkgs/issues/15636

requires:
`export EMCONFIGURE_JS=2` to make `tests` pass

@matthewbauer i know you are using it. maybe you want to say something about this before i hit merge.
