### PR TITLE
bup: add ${git} to the $PATH of the wrapper

### DIFF
--- a/pkgs/tools/backup/bup/default.nix
+++ b/pkgs/tools/backup/bup/default.nix
@@ -42,8 +42,8 @@ stdenv.mkDerivation rec {
     "LIBDIR=$(out)/lib/bup"
   ];
 
-  postInstall = optionalString (elem stdenv.system platforms.linux) ''
-    wrapProgram $out/bin/bup --prefix PYTHONPATH : \
+  postInstall = ''wrapProgram $out/bin/bup --prefix PATH : ${git}/bin ''
+   + optionalString (elem stdenv.system platforms.linux) '' --prefix PYTHONPATH : \
       ${stdenv.lib.concatStringsSep ":"
           (map (path: "$(toPythonPath ${path})") [ pyxattr pylibacl setuptools fuse ])}
   '';


### PR DESCRIPTION
###### Motivation for this change

Current bup does not work without git also installed in the profile. This fixes that issue.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Otherwise, bup tries to run git from the user's PATH, which may or may not
exist.
