### PR TITLE
ocaml-lwt: 2.5.0 -> 2.5.2

### DIFF
--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip, which, cryptopp, ocaml, findlib, ocaml_react, ocaml_ssl, libev, pkgconfig, ncurses, ocaml_oasis, ocaml_text, glib, camlp4, ppx_tools }:
 
 let
-  version = "2.5.0";
+  version = "2.5.2";
   inherit (stdenv.lib) optional getVersion versionAtLeast;
   ocaml_version = getVersion ocaml;
 in
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   src = fetchzip {
     url = "https://github.com/ocsigen/lwt/archive/${version}.tar.gz";
-    sha256 = "0jgg51aqbnia33l7bhgirnfpqybjwzpd85qzzd9znnc1a27gv8vr";
+    sha256 = "0gmhm282r8yi0gwcv0g2s7qchkfjmhqbqf4j9frlyv665ink9kxl";
   };
 
   buildInputs = [ ocaml_oasis pkgconfig which cryptopp ocaml findlib glib ncurses camlp4 ppx_tools ];

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchzip, ocaml, findlib }:
 
 stdenv.mkDerivation {
-  name = "ocaml-ppx_tools-0.99.2";
+  name = "ocaml-ppx_tools-4.02.3";
   src = fetchzip {
-    url = https://github.com/alainfrisch/ppx_tools/archive/ppx_tools_0.99.2.tar.gz;
-    sha256 = "1m09r2sjcb37i4dyhpbk9n2wxkcvpib6bvairsird91fm9w0vqw7";
+    url = https://github.com/alainfrisch/ppx_tools/archive/v4.02.3.tar.gz;
+    sha256 = "0varkd93hgrarwwkrjp2yy735q7jqzba75sskyanmvkb576wpcxv";
   };
 
   buildInputs = [ ocaml findlib ];


### PR DESCRIPTION
###### Motivation for this change

Updates ocaml-lwt to the latest version. This in turn requires to update a dependency of lwt, namely ppx_tools.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
