### PR TITLE
tmux: fix TMUX_TMPDIR on OSX

### DIFF
--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -34,11 +34,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share/bash-completion/completions
     cp -v ${bashCompletion}/completions/tmux $out/share/bash-completion/completions/tmux
-
-    wrapProgram $out/bin/tmux \
-      --set TMUX_TMPDIR \''${XDG_RUNTIME_DIR:-"/run/user/\$(id -u)"}
   '';
-
+      
   meta = {
     homepage = http://tmux.github.io/;
     description = "Terminal multiplexer";


### PR DESCRIPTION
###### Motivation for this change

tmux was broken on OSX by 60025e35248193b37dc5f6b5f18f8eb33bea2c3c because neither `XDG_RUNTIME_DIR` nor `/run/user/$(id -u)` exist. This PR sets TMUX_TMPDIR to either `XDG_RUNTIME_DIR` or `/tmp`.
- Built on platform(s)
  - [X] OS X
