### PR TITLE
Agda 2.4 -> 2.5.1

### DIFF
--- a/pkgs/development/libraries/agda/Agda-Sheaves/default.nix
+++ b/pkgs/development/libraries/agda/Agda-Sheaves/default.nix
@@ -19,5 +19,6 @@ agda.mkDerivation (self: rec {
     license = stdenv.lib.licenses.cc-by-40;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+    broken = true;  # replaced by constructive-sheaf-semantics
   };
 })

--- a/pkgs/development/libraries/agda/TotalParserCombinators/default.nix
+++ b/pkgs/development/libraries/agda/TotalParserCombinators/default.nix
@@ -21,5 +21,6 @@ agda.mkDerivation (self: rec {
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with maintainers; [ fuuzetsu ];
+    broken = true;
   };
 })

--- a/pkgs/development/libraries/agda/agda-base/default.nix
+++ b/pkgs/development/libraries/agda/agda-base/default.nix
@@ -18,5 +18,6 @@ agda.mkDerivation (self: rec {
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+    broken = true;  # largely replaced by HoTT-Agda
   };
 })

--- a/pkgs/development/libraries/agda/agda-prelude/default.nix
+++ b/pkgs/development/libraries/agda/agda-prelude/default.nix
@@ -1,13 +1,13 @@
 { stdenv, agda, fetchgit }:
 
 agda.mkDerivation (self: rec {
-  version = "d598f35d88596c5a63766a7188a0c0144e467c8c";
+  version = "0dca24a81d417db2ae8fc871eccb7776f7eae952";
   name = "agda-prelude-${version}";
 
   src = fetchgit {
     url = "https://github.com/UlfNorell/agda-prelude.git";
     rev = version;
-    sha256 = "bdcffb675d0ad1bafa2b47f581b6a9b90347ae739b6218f89f365fda2cc4f8c8";
+    sha256 = "0gwfgvj96i1mx5v01bi46h567d1q1fbgvzv6z8zv91l2jhybwff5";
   };
 
   topSourceDirectories = [ "src" ];
@@ -18,6 +18,6 @@ agda.mkDerivation (self: rec {
     description = "Programming library for Agda";
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;
-    maintainers = with maintainers; [ fuuzetsu ];
+    maintainers = with maintainers; [ fuuzetsu mudri ];
   };
 })

--- a/pkgs/development/libraries/agda/agda-stdlib/default.nix
+++ b/pkgs/development/libraries/agda/agda-stdlib/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, agda, fetchgit, ghcWithPackages }:
+{ stdenv, agda, fetchFromGitHub, ghcWithPackages }:
 
 agda.mkDerivation (self: rec {
-  version = "2.4.2.3";
+  version = "0.12";
   name = "agda-stdlib-${version}";
 
-  src = fetchgit {
-    url = "git://github.com/agda/agda-stdlib";
-    rev = "9c9b3cb28f9a7d39a256890a1469c1a3f7fc4faf";
-    sha256 = "521899b820e70abbae7cb30008b87a2f8676bc6265b78865e42982fc2e5c972f";
+  src = fetchFromGitHub {
+    repo = "agda-stdlib";
+    owner = "agda";
+    rev = "v${version}";
+    sha256 = "1n5hn3xa0bqyq8rjvfsfmh6z3l8rr4z3s7gyfmf3kiv9f235bnd2";
   };
 
   nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];
@@ -22,6 +23,6 @@ agda.mkDerivation (self: rec {
     description = "A standard library for use with the Agda compiler";
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.unix;
-    maintainers = with maintainers; [ jwiegley fuuzetsu ];
+    maintainers = with maintainers; [ jwiegley fuuzetsu mudri ];
   };
 })

--- a/pkgs/development/libraries/agda/bitvector/default.nix
+++ b/pkgs/development/libraries/agda/bitvector/default.nix
@@ -19,5 +19,6 @@ agda.mkDerivation (self: rec {
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
+    broken = true;
   };
 })


### PR DESCRIPTION
###### Motivation for this change

Fixed version of #15595. Doesn't modify auto-generated file, and makes all of the same intended changes.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
