### PR TITLE
libxml2: 2.9.3 -> 2.9.4 for three CVEs

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "libxml2-${version}";
-  version = "2.9.3";
+  version = "2.9.4";
 
   src = fetchurl {
     url = "http://xmlsoft.org/sources/${name}.tar.gz";
-    sha256 = "0bd17g6znn2r98gzpjppsqjg33iraky4px923j3k8kdl8qgy7sad";
+    sha256 = "0g336cr0bw6dax1q48bblphmchgihx9p1pjmxdnrd6sh3qci3fgz";
   };
 
   outputs = [ "dev" "out" "bin" "doc" ]


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- CVE-2016-4447: libxml2: Heap-based buffer underreads due to xmlParseName
  https://bugzilla.redhat.com/show_bug.cgi?id=1338686
- CVE-2016-4448 libxml2: Format string vulnerability
  https://bugzilla.redhat.com/show_bug.cgi?id=1338700
- CVE-2016-4449 libxml2: Inappropriate fetch of entities content
  https://bugzilla.redhat.com/show_bug.cgi?id=1338701

and many other fixed issues, available at http://www.xmlsoft.org/news.html

---

Please backport to 16.03 and 15.09.
