### PR TITLE
vdirsyncer: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -3,13 +3,12 @@
 # Packaging documentation at:
 # https://github.com/untitaker/vdirsyncer/blob/master/docs/packaging.rst
 pythonPackages.buildPythonApplication rec {
-  version = "0.10.0";
+  version = "0.11.0";
   name = "vdirsyncer-${version}";
-  namePrefix = "";
 
   src = fetchurl {
-    url = "https://pypi.python.org/packages/0b/fb/c42223e1e9169e4770194e62143d431755724b080d8cb77f14705b634815/vdirsyncer-0.10.0.tar.gz";
-    sha256 = "1gf86sbd6w0w4zayh9r3irlp5jwrzbjikjc0vs5zkdpa5c199f78";
+    url = "mirror://pypi/v/vdirsyncer/${name}.tar.gz";
+    sha256 = "1bf0vk29qdswar0q4267aamfriq3134302i2p3qcqxpmmcwx3qfv";
   };
 
   propagatedBuildInputs = with pythonPackages; [


### PR DESCRIPTION
###### Motivation for this change

package update
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
