### PR TITLE
geth: add top-level package

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9870,6 +9870,8 @@ in
 
   gatling = callPackage ../servers/http/gatling { };
 
+  geth = goPackages.ethereum.bin // { outputs = [ "bin" ]; };
+
   glabels = callPackage ../applications/graphics/glabels { };
 
   grafana = (callPackage ../servers/monitoring/grafana { }).bin // { outputs = ["bin"]; };


### PR DESCRIPTION
I didn't realize when I added `goPackages.ethereum` that I also should have added a top-level link to make it more useful.
