### PR TITLE
redo: Init at 1.2

### DIFF
--- a/pkgs/development/tools/build-managers/redo/default.nix
+++ b/pkgs/development/tools/build-managers/redo/default.nix
@@ -1,0 +1,28 @@
+{stdenv, fetchurl, perl }:
+
+stdenv.mkDerivation rec {
+  name = "redo-1.2";
+  src = fetchurl {
+    url = "http://homepage.ntlworld.com/jonathan.deboynepollard/Softwares/${name}.tar.bz2";
+    sha256 = "0hfbiljmgl821a0sf7abrfx29f22ahrgs86mrlrm8m95s7387kpp";
+  };
+
+  nativeBuildInputs = [ perl /* for pod2man */ ];
+
+  sourceRoot = ".";
+
+  buildPhase = ''
+    ./package/compile
+  '';
+  installPhase = ''
+    ./package/export $out/
+  '';
+
+  meta = {
+    homepage = http://homepage.ntlworld.com/jonathan.deboynepollard/Softwares/redo.html;
+    description = "A system for building target files from source files";
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = [ stdenv.lib.maintainers.vrthra ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6373,6 +6373,8 @@ in
     ruby = ruby_2_0;
   };
 
+  redo = callPackage ../development/tools/build-managers/redo { };
+
   re2c = callPackage ../development/tools/parsing/re2c { };
 
   remake = callPackage ../development/tools/build-managers/remake { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Redo is an alternative for Make. This package is a C++ implementation
of redo.
