### PR TITLE
Additions to the Idris platform

### DIFF
--- a/pkgs/development/idris-modules/TODO.md
+++ b/pkgs/development/idris-modules/TODO.md
@@ -1,3 +1,5 @@
 * Build the RTS separately from Idris
 * idris2nix
 * Only require gmp, rts when compiling executables
+* Versioning
+* Explicit list of packages (to be discussed)

--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -4,12 +4,12 @@
 #       name and src.
 { stdenv, idris, gmp }: args: stdenv.mkDerivation ({
   preHook = ''
-    mkdir idris-libs
+    mkdir -p idris-libs
     export IDRIS_LIBRARY_PATH=$PWD/idris-libs
 
     addIdrisLibs () {
       if [ -d $1/lib/${idris.name} ]; then
-        ln -sv $1/lib/${idris.name}/* $IDRIS_LIBRARY_PATH
+        ln -svf $1/lib/${idris.name}/* $IDRIS_LIBRARY_PATH
       fi
     }
 

--- a/pkgs/development/idris-modules/containers.nix
+++ b/pkgs/development/idris-modules/containers.nix
@@ -1,0 +1,28 @@
+{ build-idris-package
+, fetchFromGitHub
+, prelude
+, base
+, effects
+, test
+, lib
+, idris
+}: build-idris-package {
+  name = "containers";
+
+  src = fetchFromGitHub {
+    owner = "jfdm";
+    repo = "idris-containers";
+    rev = "4a7c1c3b84bf9eab956fdc5b5c19728b6b290aeb";
+    sha256 = "09bs9q0hhij455vs14ys8bj6p3ydkx65ymprq7aql6zlh0c86gb8";
+  };
+
+  propagatedBuildInputs = [ prelude base effects test ];
+
+  meta = {
+    description = "Various data structures for use in Idris";
+    homepage = https://github.com/ziman/lightyear;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ gpyh ];
+    inherit (idris.meta) platforms;
+  };
+}

--- a/pkgs/development/idris-modules/idrisscript.nix
+++ b/pkgs/development/idris-modules/idrisscript.nix
@@ -1,0 +1,27 @@
+{ build-idris-package
+, fetchFromGitHub
+, prelude
+, base
+, effects
+, lib
+, idris
+}: build-idris-package {
+  name = "idrisscript";
+
+  src = fetchFromGitHub {
+    owner = "idris-hackers";
+    repo = "IdrisScript";
+    rev = "d0609233956efd296ceb2b2a627c205514216aed";
+    sha256 = "1xfhdkiycjhirg6050iv1madwpg2vm4i1in4zx4510djzhvis5kc";
+  };
+
+  propagatedBuildInputs = [ prelude base ];
+
+  meta = {
+    description = "FFI Bindings to JavaScript";
+    homepage = https://github.com/idris-hackers/IdrisScript;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ gpyh ];
+    inherit (idris.meta) platforms;
+  };
+}

--- a/pkgs/development/idris-modules/lightyear.nix
+++ b/pkgs/development/idris-modules/lightyear.nix
@@ -1,0 +1,27 @@
+{ build-idris-package
+, fetchFromGitHub
+, prelude
+, base
+, effects
+, lib
+, idris
+}: build-idris-package {
+  name = "lightyear";
+
+  src = fetchFromGitHub {
+    owner = "ziman";
+    repo = "lightyear";
+    rev = "3d4f025a77159af3a2d12c803d783405c9b0a04b";
+    sha256 = "1cbxxhwqsn5nv1y5wzgyl61qcjsah6lz532szpg1jicwwzh748vs";
+  };
+
+  propagatedBuildInputs = [ prelude base effects ];
+
+  meta = {
+    description = "Parser combinators for Idris";
+    homepage = https://github.com/ziman/lightyear;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ gpyh ];
+    inherit (idris.meta) platforms;
+  };
+}

--- a/pkgs/development/idris-modules/test.nix
+++ b/pkgs/development/idris-modules/test.nix
@@ -1,0 +1,34 @@
+{ build-idris-package
+, fetchFromGitHub
+, prelude
+, base
+, effects
+, lib
+, idris
+}: build-idris-package {
+  name = "test";
+
+  src = fetchFromGitHub {
+    owner = "jfdm";
+    repo = "idris-testing";
+    rev = "24a75bb71350fd64b00b72f69daa93530b49e61a";
+    sha256 = "1k2qqz9vn9h8g4zxslx61z2g9ks5y29y3fmrlv7vawymkhcjrcl5";
+  };
+
+  propagatedBuildInputs = [ prelude base effects ];
+
+  # No suite test
+  doCheck = false;
+
+  patchPhase = ''
+    rm testparse.ipkg
+  '';
+
+  meta = {
+    description = "Testing utilities for Idris programs";
+    homepage = https://github.com/jfdm/idris-testing;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ gpyh ];
+    inherit (idris.meta) platforms;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

I am currently using the Idris programming language a lot, and doing so in NixOS is painful.
@shelvy did most of the work though by adding an Idris platform in Nix. My two commits respectively add some popular libraries and ease its use in a development setup.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
