### PR TITLE
qnial: Init at 6.3

### DIFF
--- a/pkgs/development/interpreters/qnial/default.nix
+++ b/pkgs/development/interpreters/qnial/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, unzip, pkgconfig, makeWrapper, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "qnial-${version}";
+  version = "6.3";
+
+  src = fetchFromGitHub {
+    sha256 = "0426hb8w0wpkisvmf3danj656j6g7rc6v91gqbgzkcj485qjaliw";
+    rev = "cfe8720a4577d6413034faa2878295431bfe39f8";
+    repo = "qnial";
+    owner = "vrthra";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  preConfigure = ''
+    cd build;
+  '';
+
+  installPhase = ''
+    cd ..
+    mkdir -p $out/bin $out/lib
+    cp build/nial $out/bin/
+    cp -r niallib $out/lib/
+  '';
+
+  buildInputs = [
+     unzip
+     pkgconfig
+     ncurses
+  ];
+
+  meta = {
+    description = "An array language from Nial Systems";
+    homepage = http://www.nial.com;
+    license = stdenv.lib.licenses.artistic1;
+    maintainers = [ stdenv.lib.maintainers.vrthra ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3048,6 +3048,8 @@ in
     sip = pythonPackages.sip_4_16;
   };
 
+  qnial = callPackage ../development/interpreters/qnial {};
+
   ocz-ssd-guru = callPackage ../tools/misc/ocz-ssd-guru { };
 
   qalculate-gtk = callPackage ../applications/science/math/qalculate-gtk { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Qnial is an implementation of the Nial (Nested Array) Language
