### PR TITLE
sublime: add a desktop item and icons

### DIFF
--- a/pkgs/applications/editors/sublime/default.nix
+++ b/pkgs/applications/editors/sublime/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, glib, xorg, cairo, gtk}:
+{ fetchurl, stdenv, glib, xorg, cairo, gtk, makeDesktopItem }:
 let
   libPath = stdenv.lib.makeLibraryPath [glib xorg.libX11 gtk cairo];
 in
@@ -31,7 +31,26 @@ stdenv.mkDerivation rec {
       --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath ${libPath}:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
       $out/sublime/sublime_text
+
+    mkdir -p $out/share/icons
+
+    for x in $(ls $out/sublime/Icon); do
+      mkdir -p $out/share/icons/hicolor/$x/apps
+      cp -v $out/sublime/Icon/$x/* $out/share/icons/hicolor/$x/apps
+    done
+
+    ln -sv "${desktopItem}/share/applications" $out/share
   '';
+
+  desktopItem = makeDesktopItem {
+    name = "sublime2";
+    exec = "sublime2 %F";
+    comment = meta.description;
+    desktopName = "Sublime Text";
+    genericName = "Text Editor";
+    categories = "TextEditor;Development;";
+    icon = "sublime_text";
+  };
 
   meta = {
     description = "Sophisticated text editor for code, markup and prose";


### PR DESCRIPTION
###### Motivation for this change

Sublime 2 currently doesn't show up in Gnome's application launcher.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
