### PR TITLE
acbuild: 0.2.2 -> 0.3.0

### DIFF
--- a/pkgs/applications/misc/acbuild/default.nix
+++ b/pkgs/applications/misc/acbuild/default.nix
@@ -2,19 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "acbuild-${version}";
-  version = "0.2.2";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "appc";
     repo = "acbuild";
     rev = "v${version}";
-    sha256 = "0sajmjg655irwy5fywk88cmwhc1q186dg5w8589pab2jhwpavdx4";
+    sha256 = "19f2fybz4m7d5sp1v8zkl26ig4dacr27qan9h5lxyn2v7a5z34rc";
   };
 
   buildInputs = [ go ];
 
   patchPhase = ''
-    sed -i -e 's|\$(git describe --dirty)|"${version}"|' build
+    sed -i -e 's|\git describe --dirty|echo "${version}"|' build
   '';
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

A new version of acbuild was released.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
