### PR TITLE
p7zip: Fix darwin build

### DIFF
--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     makeFlagsArray=(DEST_HOME=$out)
     buildFlags=all3
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
-    cp makefile.macosx_64bits makefile.machine
+    cp makefile.macosx_llvm_64bits makefile.machine
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Due to p7zip moving a mac-specific Makefile, building broke on Darwin. This fixes it.
###### Things done
- Built on platform(s)
  - [ ] NixOS
  - [X ] OS X
  - [ ] Linux
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
