### PR TITLE
netcdf: added parallel i/o support

### DIFF
--- a/pkgs/development/libraries/netcdf/default.nix
+++ b/pkgs/development/libraries/netcdf/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchurl,
   zlib, hdf5, m4,
-  curl # for DAP
+  curl, # for DAP
+  mpiEnabled ? false,
+  openmpi, hdf5-mpi # For parallel I/O
 }:
     
 stdenv.mkDerivation rec {
@@ -11,12 +13,15 @@ stdenv.mkDerivation rec {
     };
 
     buildInputs = [
-        zlib hdf5 m4 curl
-    ];
+        ( if mpiEnabled == true then hdf5-mpi else hdf5 )
+        zlib m4 curl
+    ]
+    ++ (stdenv.lib.optionals mpiEnabled [ openmpi ]);
 
     configureFlags = [
         "--enable-netcdf-4"
         "--enable-dap"
         "--enable-shared"
-    ];
+    ]
+    ++ (stdenv.lib.optionals mpiEnabled [ "--enable-parallel-tests" ]);
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2423,6 +2423,8 @@ let
   netatalk = callPackage ../tools/filesystems/netatalk { };
 
   netcdf = callPackage ../development/libraries/netcdf { };
+ 
+  netcdf-mpi = callPackage ../development/libraries/netcdf { mpiEnabled = true; };
 
   netcdfcxx4 = callPackage ../development/libraries/netcdf-cxx4 { };
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
