### PR TITLE
[16.03] openvswitch: 2.3.1 -> 2.3.3 (CVE-2016-2074)

### DIFF
--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -6,12 +6,12 @@ with stdenv.lib;
 let
   _kernel = kernel;
 in stdenv.mkDerivation rec {
-  version = "2.3.1";
+  version = "2.3.3";
   name = "openvswitch-${version}";
 
   src = fetchurl {
     url = "http://openvswitch.org/releases/${name}.tar.gz";
-    sha256 = "1lmwyhm5wmdv1l4v1v5xd36d5ra21jz9ix57nh1lgm8iqc0lj5r1";
+    sha256 = "0wc4rjw4jalbvmfbw08d2vhpvjy6wa4k7jm6ilcndsnyxr7zq6m6";
   };
 
   kernel = optional (_kernel != null) _kernel.dev;


### PR DESCRIPTION
###### Motivation for this change

This fixes CVE-2016-2074 and includes lots of other fixes since 2.3.1.

Works on my simple server. Opening other PR for 2.5.0 in master.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
