### PR TITLE
kodiPlugins.pvr-hts: fix load

### DIFF
--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -245,7 +245,7 @@ in
     # them. Symlinking .so, as setting LD_LIBRARY_PATH is of no use
     installPhase = ''
       make install
-      ln -s $out/lib/kodi/addons/pvr.hts/pvr.hts.so* $out/share/kodi/addons/pvr.hts
+      ln -s $out/lib/addons/pvr.hts/pvr.hts.so* $out/share/kodi/addons/pvr.hts
     '';
   };
 


### PR DESCRIPTION
###### Motivation for this change

Kodi could not find the plugin, so it would not load.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
