### PR TITLE
Facetimehd-Firmware: Update,  add update documentation, add myself as maintainer

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -151,6 +151,7 @@
   goibhniu = "Cillian de Róiste <cillian.deroiste@gmail.com>";
   Gonzih = "Max Gonzih <gonzih@gmail.com>";
   gpyh = "Yacine Hmito <yacine.hmito@gmail.com>";
+  grahamc = "Graham Christensen <graham@grahamc.com>";
   gridaphobe = "Eric Seidel <eric@seidel.io>";
   guibert = "David Guibert <david.guibert@gmail.com>";
   havvy = "Ryan Scheel <ryan.havvy@gmail.com>";

--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/patjak/bcwc_pcie;
     description = "Linux driver for the Facetime HD (Broadcom 1570) PCIe webcam";
     license = licenses.gpl2;
-    maintainers = [ maintainers.womfoo ];
+    maintainers = with maintainers; [ womfoo grahamc ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -11,6 +11,16 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "patjak";
     repo = "bcwc_pcie";
+    # Note: When updating this revision:
+    # 1. Also update pkgs/os-specific/linux/firmware/facetimehd-firmware/
+    # 2. Test the module and firmware change via:
+    #    a. Give some applications a try (Skype, Hangouts, Cheese, etc.)
+    #    b. Run: journalctl -f
+    #    c. Then close the lid
+    #    d. Then open the lid (and maybe press a key to wake it up)
+    #    e. see if the module loads back (apps using the camera won't
+    #       recover and will have to be restarted) and the camera
+    #       still works.
     rev = "5a7083bd98b38ef3bd223f7ee531d58f4fb0fe7c";
     sha256 = "0d455kajvn5xav9iilqy7s1qvsy4yb8vzjjxx7bvcgp7aj9ljvdp";
   };

--- a/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
@@ -2,14 +2,28 @@
 
 let
 
-  version = "1.43";
+  version = "1.43_4";
 
-  dmgRange = "420107885-421933300"; # the whole download is 1.3GB, this cuts it down to 2MB
 
+  # Updated according to https://github.com/patjak/bcwc_pcie/pull/81/files
+  # and https://github.com/patjak/bcwc_pcie/blob/5a7083bd98b38ef3bd223f7ee531d58f4fb0fe7c/firmware/Makefile#L3-L9
+  # and https://github.com/patjak/bcwc_pcie/blob/5a7083bd98b38ef3bd223f7ee531d58f4fb0fe7c/firmware/extract-firmware.sh
+
+  # From the Makefile:
+  dmgUrl = "https://support.apple.com/downloads/DL1877/en_US/osxupd10.11.5.dmg";
+  dmgRange = "205261917-208085450"; # the whole download is 1.3GB, this cuts it down to 2MB
+  # Notes:
+  # 1. Be sure to update the sha256 below in the fetch_url
+  # 2. Be sure to update the homepage in the meta
+
+  # Also from the Makefile (OS_DRV, OS_DRV_DIR), but seems to not change:
   firmwareIn = "./System/Library/Extensions/AppleCameraInterface.kext/Contents/MacOS/AppleCameraInterface";
   firmwareOut = "firmware.bin";
-  firmwareOffset = "81920";
-  firmwareSize = "603715";
+
+  # The following are from the extract-firmware.sh
+  firmwareOffset = "81920"; # Variable: firmw_offsets
+  firmwareSize = "603715"; # Variable: firmw_sizes
+
 
   # separated this here as the script will fail without the 'exit 0'
   unpack = pkgs.writeScriptBin "unpack" ''
@@ -22,10 +36,9 @@ in
 stdenv.mkDerivation {
 
   name = "facetimehd-firmware-${version}";
-
   src = fetchurl {
-    url = "https://support.apple.com/downloads/DL1849/en_US/osxupd10.11.2.dmg";
-    sha256 = "1jw6sy9vj27amfak83cs2c7q856y4mk1wix3rl4q10yvd9bl4k9x";
+    url = dmgUrl;
+    sha256 = "0xqkl4yds0n9fdjvnk0v5mj382q02crry6wm2q7j3ncdqwsv02sv";
     curlOpts = "-r ${dmgRange}";
   };
 
@@ -42,7 +55,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "facetimehd firmware";
-    homepage = https://support.apple.com/downloads/DL1849;
+    homepage = https://support.apple.com/downloads/DL1877;
     license = licenses.unfree;
     maintainers = [ maintainers.womfoo ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
     description = "facetimehd firmware";
     homepage = https://support.apple.com/downloads/DL1877;
     license = licenses.unfree;
-    maintainers = [ maintainers.womfoo ];
+    maintainers = with maintainers; [ womfoo grahamc ];
     platforms = platforms.linux;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Update the firmware for facetimehd in accordance to the recent facetimehd kernel module update.

Also @womfoo requested I add myself as a maintainer, so here goes: https://github.com/NixOS/nixpkgs/pull/15708#issuecomment-221775457
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (cheese, hangouts, skype, zoom.us, appear.in)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
