### PR TITLE
syncthing: 0.12.25 -> 0.13.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -296,6 +296,7 @@
   pmiddend = "Philipp Middendorf <pmidden@secure.mailbox.org>";
   prikhi = "Pavan Rikhi <pavan.rikhi@gmail.com>";
   profpatsch = "Profpatsch <mail@profpatsch.de>";
+  pshendry = "Paul Hendry <paul@pshendry.com>";
   psibi = "Sibi <sibi@psibi.in>";
   pSub = "Pascal Wittmann <mail@pascal-wittmann.de>";
   puffnfresh = "Brian McKenna <brian@brianmckenna.org>";

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit, go }:
+
+stdenv.mkDerivation rec {
+  version = "0.13.4";
+  name = "syncthing-${version}";
+
+  src = fetchgit {
+    url = https://github.com/syncthing/syncthing;
+    rev = "refs/tags/v${version}";
+    sha256 = "0aa0nqi0gmka5r5dzph4g51jlsy7w5q4ri8f4gy3qnma4pgp7pg2";
+  };
+
+  buildInputs = [ go ];
+
+  buildPhase = ''
+    mkdir -p src/github.com/syncthing
+    ln -s $(pwd) src/github.com/syncthing/syncthing
+    export GOPATH=$(pwd)
+    # Required for Go 1.5, can be removed for Go 1.6+
+    export GO15VENDOREXPERIMENT=1
+
+    # Syncthing's build.go script expects this working directory
+    cd src/github.com/syncthing/syncthing
+
+    go run build.go -no-upgrade -version v${version} install all
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/* $out/bin
+  '';
+
+  meta = {
+    homepage = https://www.syncthing.net/;
+    description = "Open Source Continuous File Synchronization";
+    license = stdenv.lib.licenses.mpl20;
+    maintainers = with stdenv.lib.maintainers; [pshendry];
+    platforms = with stdenv.lib.platforms; linux ++ freebsd ++ openbsd ++ netbsd;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14219,8 +14219,9 @@ in
 
   symlinks = callPackage ../tools/system/symlinks { };
 
-  syncthing = go15Packages.syncthing.bin // { outputs = [ "bin" ]; };
-  syncthing011 = go15Packages.syncthing011.bin // { outputs = [ "bin" ]; };
+  syncthing = callPackage ../applications/networking/syncthing { };
+
+  syncthing012 = go15Packages.syncthing012.bin // { outputs = [ "bin" ]; };
 
   # linux only by now
   synergy = callPackage ../applications/misc/synergy { };

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -3716,7 +3716,7 @@ let
     sha256 = "094ksr2nlxhvxr58nbnzzk0prjskb21r86jmxqjr3rwg4rkwn6d4";
   };
 
-  syncthing = buildFromGitHub rec {
+  syncthing012 = buildFromGitHub rec {
     version = "0.12.25";
     rev = "v${version}";
     owner = "syncthing";
@@ -3734,30 +3734,14 @@ let
     '';
   };
 
-  syncthing011 = buildFromGitHub rec {
-    version = "0.11.26";
-    rev = "v${version}";
-    owner = "syncthing";
-    repo = "syncthing";
-    sha256 = "0c0dcvxrvjc84dvrsv90790aawkmavsj9bwp8c6cd6wrwj3cp9lq";
-    buildInputs = [
-      go-lz4 du luhn xdr snappy ratelimit osext syncthing-protocol011
-      goleveldb suture qart crypto net text
-    ];
-    postPatch = ''
-      # Mostly a cosmetic change
-      sed -i 's,unknown-dev,${version},g' cmd/syncthing/main.go
-    '';
-  };
-
   syncthing-lib = buildFromGitHub {
-    inherit (syncthing) rev owner repo sha256;
+    inherit (syncthing012) rev owner repo sha256;
     subPackages = [ "lib/sync" ];
-    propagatedBuildInputs = syncthing.buildInputs;
+    propagatedBuildInputs = syncthing012.buildInputs;
   };
 
   syncthing-protocol = buildFromGitHub {
-    inherit (syncthing) rev owner repo sha256;
+    inherit (syncthing012) rev owner repo sha256;
     subPackages = [ "lib/protocol" ];
     propagatedBuildInputs = [
       go-lz4
@@ -3765,15 +3749,6 @@ let
       luhn
       xdr
       text ];
-  };
-
-  syncthing-protocol011 = buildFromGitHub {
-    rev = "84365882de255d2204d0eeda8dee288082a27f98";
-    version = "2015-08-28";
-    owner = "syncthing";
-    repo = "protocol";
-    sha256 = "07xjs43lpd51pc339f8x487yhs39riysj3ifbjxsx329kljbflwx";
-    propagatedBuildInputs = [ go-lz4 logger luhn xdr text ];
   };
 
   tablewriter = buildFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/15674. This is my attempt (as a nix newbie) to both update syncthing to 0.13.4 and use a less brittle packaging strategy going forward by using the build script from syncthing's official build instructions.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Rename v0.12.25 package from 'syncthing' to 'syncthing012'
- Remove syncthing011
