### PR TITLE
picat: init at 1.9-4

### DIFF
--- a/pkgs/development/compilers/picat/default.nix
+++ b/pkgs/development/compilers/picat/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "picat-1.9-4";
+
+  src = fetchurl {
+    url = http://picat-lang.org/download/picat19_src.tar.gz;
+    sha256 = "0wvl95gf4pjs93632g4wi0mw1glzzhjp9g4xg93ll2zxggbxibli";
+  };
+
+  ARCH = if stdenv.system == "i686-linux" then "linux32"
+         else if stdenv.system == "x86_64-linux" then "linux64"
+         else throw "Unsupported system";
+
+  buildPhase = ''
+    cd emu
+    make -f Makefile.picat.$ARCH
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp picat_$ARCH $out/bin/picat
+  '';
+
+  meta = {
+    description = "Logic-based programming langage";
+    longDescription = ''
+      Picat is a simple, and yet powerful, logic-based multi-paradigm
+      programming language aimed for general-purpose applications.
+    '';
+    homepage = http://picat-lang.org/;
+    license = stdenv.lib.licenses.mpl20;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5219,6 +5219,10 @@ in
 
   ocamlnat = newScope pkgs.ocamlPackages_3_12_1 ../development/ocaml-modules/ocamlnat { };
 
+  picat = callPackage ../development/compilers/picat {
+    stdenv = overrideCC stdenv gcc49;
+  };
+
   ponyc = callPackage ../development/compilers/ponyc {
     llvm = llvm_36;
   };


### PR DESCRIPTION
###### Motivation for this change

Allow nix users to easily install Picat.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
