### PR TITLE
cloud-utils: fix dependency on gnused in $PATH

### DIFF
--- a/nixos/modules/virtualisation/amazon-grow-partition.nix
+++ b/nixos/modules/virtualisation/amazon-grow-partition.nix
@@ -11,7 +11,6 @@
       copy_bin_and_libs ${pkgs.gnused}/bin/sed
       copy_bin_and_libs ${pkgs.utillinux}/sbin/sfdisk
       cp -v ${pkgs.cloud-utils}/bin/growpart $out/bin/growpart
-      ln -s sed $out/bin/gnused
     '';
 
     boot.initrd.postDeviceCommands = ''

--- a/pkgs/tools/misc/cloud-utils/default.nix
+++ b/pkgs/tools/misc/cloud-utils/default.nix
@@ -11,7 +11,6 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     cp bin/growpart $out/bin/growpart
     sed -i 's|awk|gawk|' $out/bin/growpart
-    sed -i 's|sed|gnused|' $out/bin/growpart
   '';
   dontInstall = true;
   dontPatchShebangs = true;


### PR DESCRIPTION
###### Motivation for this change

Fixes #15736
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The cloud-utils package was extracted from inline use in
`amazon-grow-partition` where it used `gnused` in the initrd, probably
for legacy reasons. Now that it can be used separately, it should use
just `sed` which is provided by the stdenv.

Also, `amazon-grow-partition` can now do away with the `gnused` alias.
