### PR TITLE
Remove nvidia-cg-toolkit as input for retroarch.

### DIFF
--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -1,6 +1,12 @@
-{ stdenv, fetchgit, makeDesktopItem, pkgconfig, ffmpeg, mesa, nvidia_cg_toolkit
-, freetype, libxml2, libv4l, coreutils, python34, which, udev, alsaLib
-, libX11, libXext, libXxf86vm, libXdmcp, SDL, libpulseaudio ? null }:
+{ stdenv, fetchFromGitHub, makeDesktopItem, coreutils, which, pkgconfig
+, ffmpeg, mesa, freetype, libxml2, python34
+, enableNvidiaCgToolkit ? false, nvidia_cg_toolkit ? null
+, alsaLib ? null, libv4l ? null
+, udev ? null, libX11 ? null, libXext ? null, libXxf86vm ? null
+, libXdmcp ? null, SDL ? null, libpulseaudio ? null
+}:
+
+with stdenv.lib;
 
 let
   desktopItem = makeDesktopItem {
@@ -9,25 +15,28 @@ let
     icon = "retroarch";
     comment = "Multi-Engine Platform";
     desktopName = "RetroArch";
-    genericName = "Libretro Frontend";    
+    genericName = "Libretro Frontend";
     categories = "Game;Emulator;";
     #keywords = "multi;engine;emulator;xmb;";
   };
-  
 in
 
 stdenv.mkDerivation rec {
   name = "retroarch-bare-${version}";
-  version = "2015-11-20";
+  version = "1.3.4";
 
-  src = fetchgit {
-    url = https://github.com/libretro/RetroArch.git;
-    rev = "09dda14549fc13231311fd522a07a75e923889aa";
-    sha256 = "0yrisl61iaa70ahswzgb505bvm5cxq8ndnv2bw7gqrlm5qrh54qy";
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "RetroArch";
+    sha256 = "0ccp17580w0884baxj5kcynlm03jgd7i62dprz1ajxbi2s7b3mi3";
+    rev = "v${version}";
   };
 
-  buildInputs = [ pkgconfig ffmpeg mesa nvidia_cg_toolkit freetype libxml2 libv4l coreutils
-                  python34 which udev alsaLib libX11 libXext libXxf86vm libXdmcp SDL libpulseaudio ];
+  buildInputs = [ pkgconfig ffmpeg mesa freetype libxml2 coreutils python34 which SDL ]
+                ++ optional enableNvidiaCgToolkit nvidia_cg_toolkit
+                ++ optionals stdenv.isLinux [ udev alsaLib libX11 libXext libXxf86vm libXdmcp libv4l libpulseaudio ];
+
+  configureScript = "sh configure";
 
   patchPhase = ''
     export GLOBAL_CONFIG_DIR=$out/etc
@@ -44,11 +53,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = {
     homepage = http://libretro.org/;
     description = "Multi-platform emulator frontend for libretro cores";
     license = licenses.gpl3;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with maintainers; [ MP2E edwtjo ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ MP2E edwtjo matthewbauer ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

see #15707
