### PR TITLE
Numix and Paper themes: fix installation dir and update revision

### DIFF
--- a/pkgs/data/icons/numix-icon-theme-circle/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-circle/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "2016-05-18";
+  version = "2016-05-25";
 
   package-name = "numix-icon-theme-circle";
   
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "numixproject";
     repo = package-name;
-    rev = "11a343dcd9b95e2574706157ff7bfe9aa30441d2";
-    sha256 = "0d00fj0hmqchm12j89s1r11ayg7gh8p6cn4fd7zva5n52z35az1w";
+    rev = "e2d2fe68e34e1650584f798c3cdb7e91ef62e6d3";
+    sha256 = "0fah812ymc6kczjhjsz0ai57ih6d8r6pknhvc54i7r3xqxshryc8";
   };
 
   dontBuild = true;

--- a/pkgs/data/icons/paper-icon-theme/default.nix
+++ b/pkgs/data/icons/paper-icon-theme/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
   package-name = "paper-icon-theme";
-  version = "2016-05-21";
+  version = "2016-05-25";
 
   src = fetchFromGitHub {
     owner = "snwh";
     repo = package-name;
-    rev = "f2a34cab78df0fa7db5a10e93e633953cb7c1eb7";
-    sha256 = "0pk848jbskkwz7im73119hcrcyr5nim37jcdrhqf4cwrshmbcacq";
+    rev = "f221537532181a71938faaa1f695c762defe2626";
+    sha256 = "0knsdhgssh1wyhcrbk6lddqy7zn24528lnajqij467mpgiliabfy";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/data/icons/paper-icon-theme/default.nix
+++ b/pkgs/data/icons/paper-icon-theme/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  installPhase = ''
-    make install DESTDIR="$out"
+  postPatch = ''
+    substituteInPlace Makefile.am --replace '$(DESTDIR)'/usr $out
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/misc/themes/numix-gtk-theme/default.nix
+++ b/pkgs/misc/themes/numix-gtk-theme/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gtk-engine-murrine ];
 
-  installPhase = ''
-    make install DESTDIR="$out"
+  postPatch = ''
+    substituteInPlace Makefile --replace '$(DESTDIR)'/usr $out
   '';
 
   meta = {

--- a/pkgs/misc/themes/numix-gtk-theme/default.nix
+++ b/pkgs/misc/themes/numix-gtk-theme/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2016-05-19";
+  version = "2016-05-25";
   name = "numix-gtk-theme-${version}";
 
   src = fetchFromGitHub {
     repo = "numix-gtk-theme";
     owner = "numixproject";
-    rev = "266945047ad8c148d36d0d1f00b39730b84482a9";
-    sha256 = "108qjqwn9shqjkbadyw79y1wbq5ndv30x7xw5wjmbcss5jikr3v1";
+    rev = "e99d167adf1310e110e17f8e7c2baf217c2402aa";
+    sha256 = "1418hf034b2bp32wqagbnn5y3i21h8v2ihjqakq2gaqd5fwg0f9g";
   };
 
   nativeBuildInputs = [ sass glib libxml2 gdk_pixbuf ];

--- a/pkgs/misc/themes/paper-gtk-theme/default.nix
+++ b/pkgs/misc/themes/paper-gtk-theme/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, autoreconfHook, gtk_engines }:
 
 stdenv.mkDerivation rec {
-  version = "2016-05-18";
+  version = "2016-05-25";
   name = "paper-gtk-theme-${version}";
 
   src = fetchFromGitHub {
     owner = "snwh";
     repo = "paper-gtk-theme";
-    rev = "5113d58dc64de70fcc75ad2d6d05c8c8dae2de7f";
-    sha256 = "1j9l50iyvadpqsq5v14zgml24jgraajr5kl9ji0ar62nlak2bi8s";
+    rev = "dea5f97b12e4f41dddbd01a1529760761aa3784e";
+    sha256 = "0fln555827hrn554qcil3rwl9x4x3vdfbh2vplkc8r46a3bn8yng";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/misc/themes/paper-gtk-theme/default.nix
+++ b/pkgs/misc/themes/paper-gtk-theme/default.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gtk_engines ];
 
-  installPhase = ''
-    make install DESTDIR="$out"
+  postPatch = ''
+    substituteInPlace Makefile.am --replace '$(DESTDIR)'/usr $out
   '';
 
   preferLocalBuild = true;


### PR DESCRIPTION
###### Motivation for this change

For the Numix and Paper themes, fix installation directories and updated revision.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
