### PR TITLE
tmux module: set TMUX_TMPDIR via environment instead of wrapper

### DIFF
--- a/nixos/modules/programs/tmux.nix
+++ b/nixos/modules/programs/tmux.nix
@@ -156,8 +156,13 @@ in {
 
   config = mkIf cfg.enable {
     environment = {
-      systemPackages = [ pkgs.tmux ];
       etc."tmux.conf".text = tmuxConf;
+
+      systemPackages = [ pkgs.tmux ];
+
+      variables = {
+        TMUX_TMPDIR = ''''${XDG_RUNTIME_DIR:-"/run/user/\$(id -u)"}'';
+      };
     };
   };
 }

--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -34,9 +34,6 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share/bash-completion/completions
     cp -v ${bashCompletion}/completions/tmux $out/share/bash-completion/completions/tmux
-
-    wrapProgram $out/bin/tmux \
-      --set TMUX_TMPDIR \''${XDG_RUNTIME_DIR:-"/run/user/\$(id -u)"}
   '';
 
   meta = {


### PR DESCRIPTION
This undoes the damage to tmux on Mac and has the nixos module handle the environment variable.

Refer to:
- #15693
- #15717

cc @gilligan @joachifm @cleverca22 
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
