### PR TITLE
efl: 1.17.0 -> 1.17.1, elementary: 1.17.0 -> 1.17.1

### DIFF
--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -3,13 +3,15 @@
 
 stdenv.mkDerivation rec {
   name = "efl-${version}";
-  version = "1.17.0";
+  version = "1.17.1";
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/efl/${name}.tar.xz";
-    sha256 = "1zisnz4x54mn9sm46kcr571faqnazkcglyf0lbz19l34syx40df1";
+    sha256 = "0d58bhvwg7c5hp07wywlwnqi01k4jhmpgac7gkx9lil1x6kmahqs";
   };
 
-  buildInputs = [ pkgconfig openssl zlib freetype fontconfig fribidi SDL2 SDL mesa
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ openssl zlib freetype fontconfig fribidi SDL2 SDL mesa
     giflib libpng libtiff glib gst_all_1.gstreamer gst_all_1.gst-plugins-base
     gst_all_1.gst-libav libpulseaudio libsndfile xorg.libXcursor xorg.printproto
     xorg.libX11 udev utillinux systemd ];

--- a/pkgs/desktops/enlightenment/elementary.nix
+++ b/pkgs/desktops/enlightenment/elementary.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchurl, pkgconfig, efl, libcap, automake, autoconf, libdrm, gdbm }:
 stdenv.mkDerivation rec {
   name = "elementary-${version}";
-  version = "1.17.0";
+  version = "1.17.1";
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/elementary/${name}.tar.xz";
-    sha256 = "0avb0d6nk4d88l81c2j6py13vdfnvg080ycw2y3qvawyjf1mhska";
+    sha256 = "149xjq4z71l44w1kd8zks9b2g0wjc9656w46hzd27b58afj1dqc5";
   };
-  buildInputs = [ pkgconfig efl libdrm gdbm automake autoconf ] ++ stdenv.lib.optionals stdenv.isLinux [ libcap ];
+  nativeBuildInputs = [ pkgconfig automake autoconf ];
+  buildInputs = [ efl libdrm gdbm ] ++ stdenv.lib.optionals stdenv.isLinux [ libcap ];
   NIX_CFLAGS_COMPILE = [ "-I${libdrm.dev}/include/libdrm" ];
   patches = [ ./elementary.patch ];
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Update Enlightenment libraries.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
