### PR TITLE
git-up: init at 1.4.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6516,6 +6516,37 @@ in modules // {
 
   };
 
+  git-up = buildPythonPackage rec {
+    version = "1.4.0";
+    name = "git-up-${version}";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "msiemens";
+      repo = "PyGitUp";
+      rev = "v${version}";
+      sha256 = "1g7sxiqg6vxx2jlgg8pg9fqsk1xgvm80d7mcpw8i3mw7r835q4bi";
+    };
+
+    buildInputs = with self; [ pkgs.git nose ];
+    propagatedBuildInputs = with self; [ colorama docopt GitPython six termcolor ];
+
+    # git fails to run as it cannot detect the email address, so we set it
+    # $HOME is by default not a valid dir, so we have to set that too
+    # https://github.com/NixOS/nixpkgs/issues/12591
+    preCheck = ''
+      export HOME=$TMPDIR
+      git config --global user.email "nobody@example.com"
+      git config --global user.name "Nobody"
+    '';
+
+    meta = {
+      homepage = http://github.com/msiemens/PyGitUp;
+      description = "A git pull replacement that rebases all local branches when pulling.";
+      license = licenses.mit;
+      maintainers = with maintainers; [ peterhoeg ];
+    };
+  };
+
   GitPython = buildPythonPackage rec {
     version = "2.0.2";
     name = "GitPython-${version}";


### PR DESCRIPTION
Includes colorama upgrade 0.3.3 -> 0.3.6
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
