### PR TITLE
Update and fix beancount

### DIFF
--- a/pkgs/applications/office/beancount/default.nix
+++ b/pkgs/applications/office/beancount/default.nix
@@ -1,14 +1,13 @@
 { stdenv, fetchhg, pkgs, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
-  version = "2016-04-10-b5721f1c6f01bd168a5781652e5e3167f7f8ceb3";
+  version = "2016-05-27-0d9321ab5322ced861bd7254af3fa81df5652ca0";
   name = "beancount-${version}";
-  namePrefix = "";
 
   src = fetchhg {
     url = "https://bitbucket.org/blais/beancount";
-    rev = "b5721f1c6f01bd168a5781652e5e3167f7f8ceb3";
-    sha256 = "10nv3p9cix7yp23a9hnq5163rpl8cfs3hv75h90ld57dc24nxzn2";
+    rev = "0d9321ab5322ced861bd7254af3fa81df5652ca0";
+    sha256 = "0kav53dlmqicb1vsf9c0ail8fxjqkyq8jqna98ckd1g7mylfzvxy";
   };
 
   buildInputs = with pythonPackages; [ nose ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14940,7 +14940,6 @@ in
   bastet = callPackage ../games/bastet {};
 
   beancount = callPackage ../applications/office/beancount {
-      pythonPackages = python3Packages;
   };
 
   beret = callPackage ../games/beret { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10471,14 +10471,17 @@ in modules // {
 
 
   google_api_python_client = buildPythonPackage rec {
-    name = "google-api-python-client-1.2";
+    version = "1.5.1";
+    name = "google-api-python-client-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://google-api-python-client.googlecode.com/files/google-api-python-client-1.2.tar.gz";
-      sha256 = "0xd619w71xk4ldmikxqhaaqn985rc2hy4ljgwfp50jb39afg7crw";
+      url = "https://github.com/google/google-api-python-client/archive/v${version}.tar.gz";
+      sha256 = "132v1rqlpzp396jr0xkaym0vw1i8kjnjy6yv9v0220jhvmwm1xaj";
     };
 
-    propagatedBuildInputs = with self; [ httplib2 ];
+    propagatedBuildInputs = with self; [ httplib2 uritemplate oauth2client simplejson ];
+
+    buildInputs = with self; [ unittest2 mock google ];
 
     meta = {
       description = "The core Python library for accessing Google APIs";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10481,7 +10481,7 @@ in modules // {
 
     propagatedBuildInputs = with self; [ httplib2 uritemplate oauth2client simplejson ];
 
-    buildInputs = with self; [ unittest2 mock google ];
+    buildInputs = with self; [ unittest2 mock google_appengine ];
 
     meta = {
       description = "The core Python library for accessing Google APIs";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10450,6 +10450,26 @@ in modules // {
     propagatedBuildInputs = with self; [ oauth2client gdata simplejson httplib2 keyring six rsa ];
   };
 
+  google = buildPythonPackage rec {
+    version = "1.9.1";
+    name = "google-${version}";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/g/google/${name}.tar.gz";
+      sha256 = "0vyz8n8jpgq9hk9nrini0vsikqmi6h3xlvhfi7h6x2hjsf0kkp5d";
+    };
+
+    buildInputs = with self; [ beautifulsoup4 ];
+
+    meta = {
+      description = "Python bindings to the Google search engine";
+      homepage = "http://breakingcode.wordpress.com/";
+      license = licenses.bsd;
+      platforms = platforms.unix;
+    };
+  };
+
+
   google_api_python_client = buildPythonPackage rec {
     name = "google-api-python-client-1.2";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22750,6 +22750,25 @@ in modules // {
     };
   };
 
+  uritemplate = buildPythonPackage rec {
+    name = "uritemplate-${version}";
+    version = "0.6";
+
+    src = pkgs.fetchurl {
+      url = "mirrorr//pypi/u/uritemplate/${name}.tar.gz";
+      sha256 = "1zapwg406vkwsirnzc6mwq9fac4az8brm6d9bp5xpgkyxc5263m3";
+    };
+
+		buildInputs = with self; [ simplejson ];
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/uri-templates/uritemplate-py;
+      description = "Python implementation of URI Template";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ matthiasbeyer ];
+    };
+	};
+
   traceback2 = buildPythonPackage rec {
     version = "1.4.0";
     name = "traceback2-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22762,7 +22762,7 @@ in modules // {
       sha256 = "1zapwg406vkwsirnzc6mwq9fac4az8brm6d9bp5xpgkyxc5263m3";
     };
 
-		buildInputs = with self; [ simplejson ];
+    buildInputs = with self; [ simplejson ];
 
     meta = with stdenv.lib; {
       homepage = https://github.com/uri-templates/uritemplate-py;
@@ -22770,7 +22770,7 @@ in modules // {
       license = licenses.asl20;
       maintainers = with maintainers; [ matthiasbeyer ];
     };
-	};
+  };
 
   traceback2 = buildPythonPackage rec {
     version = "1.4.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10491,6 +10491,46 @@ in modules // {
     };
   };
 
+  google_appengine =
+  let
+      webob = buildPythonPackage rec {
+        version = "0.9";
+        name = "webob-${version}";
+
+        src = pkgs.fetchurl {
+          url = "mirror://pypi/W/WebOb/WebOb-${version}.tar.gz";
+          sha256 = "0ihwv8qk8sj2awwwj8i75ngzwfi1vgcrbmz5vkyjxsfjalnjqqgv";
+        };
+
+        propagatedBuildInputs = with self; [ nose ];
+
+        meta = {
+          description = "WSGI request and response object";
+          homepage = http://pythonpaste.org/webob/;
+          platforms = platforms.all;
+        };
+      };
+  in
+  buildPythonPackage rec {
+    name = "google-appengine-1.5.1";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/g/google-appengine/${name}.tar.gz";
+      sha256 = "000bpjzjidfcrkyzxy50mcga6nhm9zjavqk7vcv6n0q01rfj1s6l";
+    };
+
+    buildInputs = with self; [ pyyaml ipaddr webob antlr3 ];
+
+    preConfigure = ''
+      sed -i '/ez_setup/d' setup.py
+    '';
+
+    meta = {
+      description = "Google AppEngine (unofficial easy-installable version of AppEngine SDK)";
+      homepage = https://github.com/worrp/gae-sdk;
+    };
+  };
+
   google_apputils = buildPythonPackage rec {
     name = "google-apputils-0.4.1";
     disabled = isPy3k;


### PR DESCRIPTION
###### Motivation for this change

Update: `beancount`. Beancount doesn't have releases, so I updated to a newer hash.

This changeset introduces more packages as they are new dependencies of beancount or not-yet updated dependencies of it.

I run into issues as `pythonPackages.google` does not provide `google.appengine`. Can someone help me investigate?

I also added `uritemplate` which seems to be `uritemplate_py` renamed and in a new version. Maybe @pSub could help investigate what to do here. Update `uritemplate_py` or add a new package for the renamed project?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
