### PR TITLE
libpipeline: fix build for osx

### DIFF
--- a/pkgs/development/libraries/libpipeline/default.nix
+++ b/pkgs/development/libraries/libpipeline/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1vmrs4nvdsmb550bk10cankrd42ffczlibpsnafxpak306rdfins";
   };
 
+  patches = stdenv.lib.optionals stdenv.isDarwin [ ./fix-on-osx.patch ];
+
   meta = with stdenv.lib; {
     homepage = "http://libpipeline.nongnu.org";
     description = "C library for manipulating pipelines of subprocesses in a flexible and convenient way";

--- a/pkgs/development/libraries/libpipeline/fix-on-osx.patch
+++ b/pkgs/development/libraries/libpipeline/fix-on-osx.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/pipeline.c b/lib/pipeline.c
+index 26478f9..1612307 100644
+--- a/lib/pipeline.c
++++ b/lib/pipeline.c
+@@ -75,6 +75,8 @@
+ #   endif
+ #endif
+ 
++const char* program_name = "libpipeline";
++
+ #if defined(HAVE_SETENV) && !defined(HAVE_CLEARENV)
+ int clearenv (void)
+ {


### PR DESCRIPTION
###### Motivation for this change

As describedin https://github.com/NixOS/nixpkgs/issues/15694 libpipeline currently does not build on OSX. This is because libpipleine uses error.h which relies on `program_name` to exist which is used for error reporting (`error_at_line` prints the program name). However BSD does not set `program_name`. 

This PR applies a patch (for darwin only) which adds `const char* program_name = "libpipeline"` to fix builds on OSX.
