### PR TITLE
diod service: Capabilities -> CapabilityBoundingSet

### DIFF
--- a/nixos/modules/services/network-filesystems/diod.nix
+++ b/nixos/modules/services/network-filesystems/diod.nix
@@ -153,7 +153,7 @@ in
       after = [ "network.target" ];
       serviceConfig = {
         ExecStart = "${pkgs.diod}/sbin/diod -f -c ${diodConfig}";
-        Capabilities = "cap_net_bind_service+=ep";
+        CapabilityBoundingSet = "cap_net_bind_service+=ep";
       };
     };
   };


### PR DESCRIPTION
`Capabilities` is obsolete in recent systemd and will be simply ignored.

Note: this is the only service using `Capabilites`, per `git grep`.
