### PR TITLE
buildFHSUserEnv: fix for when libc doesn't have lib64 folder

### DIFF
--- a/pkgs/build-support/build-fhs-chrootenv/env.nix
+++ b/pkgs/build-support/build-fhs-chrootenv/env.nix
@@ -162,7 +162,9 @@ let
 
     # copy gcc libs
     cp -rsHf ${chosenGcc.cc.lib}/lib/*   lib32/
-    cp -rsHf ${chosenGcc.cc.lib}/lib64/* lib64/
+    if [ -d ${chosenGcc.cc.lib}/lib64/ ]; then
+      cp -rsHf ${chosenGcc.cc.lib}/lib64/* lib64/
+    fi
 
     # symlink 32-bit ld-linux.so
     ln -s ${staticUsrProfileTarget}/lib/32/ld-linux.so.2 lib/


### PR DESCRIPTION
@vcunat this made it possible for me to build VidyoDesktop
