### PR TITLE
beancount: Fix and use python 3.4 instead of 3.5

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14940,7 +14940,7 @@ in
   bastet = callPackage ../games/bastet {};
 
   beancount = callPackage ../applications/office/beancount {
-      pythonPackages = python3Packages;
+      pythonPackages = python34Packages;
   };
 
   beret = callPackage ../games/beret { };


### PR DESCRIPTION
###### Motivation for this change

Supercedes #15753 

Fixes build for `beancount` as a dependency does not build with 3.5 and beancount itself needs 3.3 or higher, 3.4 seems to work (build).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
