### PR TITLE
libmcrypt: Fixed missing nmedit on darwin

### DIFF
--- a/pkgs/development/libraries/libmcrypt/default.nix
+++ b/pkgs/development/libraries/libmcrypt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, disablePosixThreads ? false }:
+{ stdenv, fetchurl, darwin, disablePosixThreads ? false }:
 
 with stdenv.lib;
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0gipgb939vy9m66d3k8il98rvvwczyaw2ixr8yn6icds9c3nrsz4";
   };
 
-  buildInputs = [];
+  buildInputs = optional stdenv.isDarwin darwin.cctools;
 
   configureFlags = optional disablePosixThreads
     [ "--disable-posix-threads" ];
@@ -19,5 +19,6 @@ stdenv.mkDerivation rec {
     description = "Replacement for the old crypt() package and crypt(1) command, with extensions";
     homepage = http://mcrypt.sourceforge.net;
     license = "GPL";
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This change fixes `libmcrypt` not building on OS X (see #15482). It does by adding the missing `nmedit` dependency which is distributed via the OS X `cctools`.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS (not affected by this change)
  - [x] OS X
  - [ ] Linux (not affected by this change)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
