### PR TITLE
btfs: 2.8 -> 2.9

### DIFF
--- a/pkgs/os-specific/linux/btfs/default.nix
+++ b/pkgs/os-specific/linux/btfs/default.nix
@@ -1,24 +1,23 @@
-{ stdenv, fetchFromGitHub, pkgconfig, autoconf, automake,
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig,
   python, boost, fuse, libtorrentRasterbar, curl }:
 
 stdenv.mkDerivation rec {
   name = "btfs-${version}";
-  version = "2.8";
+  version = "2.9";
 
   src = fetchFromGitHub {
     owner = "johang";
     repo = "btfs";
-    rev = "0567010e553b290eaa50b1afaa717dd7656c82de";
-    sha256 = "1x3x1v7fhcfcpffprf63sb720nxci2ap2cq92jy1xd68kmshdmwd";
+    rev = "3ee6671eca2c0e326ac38d07cab4989ebad3495c";
+    sha256 = "0f7yc7hkfwdj9hixsyswf17yrpcpwxxb0svj5lfqcir8a45kf100";
   };
-  
+
   buildInputs = [
-    pkgconfig autoconf automake boost
+    boost autoreconfHook pkgconfig
     fuse libtorrentRasterbar curl
   ];
 
-  preConfigure = ''
-    autoreconf -i
+  preInstall = ''
     substituteInPlace scripts/btplay \
       --replace "/usr/bin/env python" "${python}/bin/python"
   '';


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
