### PR TITLE
sipcmd: refactoring

### DIFF
--- a/pkgs/applications/networking/sipcmd/default.nix
+++ b/pkgs/applications/networking/sipcmd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, opal, ptlib }:
+{ stdenv, fetchFromGitHub, opal, ptlib }:
 
 stdenv.mkDerivation rec {
 
@@ -6,9 +6,10 @@ stdenv.mkDerivation rec {
 
   name = "sipcmd-${rev}";
   
-  src = fetchgit {
-    url = "https://github.com/tmakkonen/sipcmd";
-    rev = "${rev}";
+  src = fetchFromGitHub {
+    repo = "sipcmd";
+    owner = "tmakkonen";
+    inherit rev;
     sha256 = "072h9qapmz46r8pxbzkfmc4ikd7dv9g8cgrfrw21q942icbrvq2c";
   };
 
@@ -25,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = https://github.com/tmakkonen/sipcmd;
-    description = "sipcmd - the command line SIP/H.323/RTP softphone";
+    description = "The command line SIP/H.323/RTP softphone";
     platforms = with stdenv.lib.platforms; linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Use `fetchFromGitHub`
- meta cleanups
