### PR TITLE
pithos: use Python 3.5

### DIFF
--- a/pkgs/applications/audio/pithos/default.nix
+++ b/pkgs/applications/audio/pithos/default.nix
@@ -6,14 +6,15 @@ pythonPackages.buildPythonApplication rec {
   version = "1.1.2";
   name = "${pname}-${version}";
 
-  namePrefix = "";
-
   src = fetchFromGitHub {
     owner = pname;
     repo  = pname;
     rev = version;
     sha256 = "0zk9clfawsnwmgjbk7y5d526ksxd1pkh09ln6sb06v4ygaiifcxp";
   };
+
+  # No tests in repo
+  doCheck = false;
 
   postPatch = ''
     substituteInPlace setup.py --replace "/usr/share" "$out/share"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13769,7 +13769,7 @@ in
   pidgin-opensteamworks = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks { };
 
   pithos = callPackage ../applications/audio/pithos {
-    pythonPackages = python34Packages;
+    pythonPackages = python3Packages;
   };
 
   pinfo = callPackage ../applications/misc/pinfo { };


### PR DESCRIPTION
###### Motivation for this change

Use Python 3.5 since that is the default 3.x interpreter. Checks had to be disabled because no tests were included and because of https://github.com/NixOS/nixpkgs/issues/14849
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @obadz @jgeerds 
