### PR TITLE
mate-themes: 1.6.3 -> 3.18.1

### DIFF
--- a/pkgs/misc/themes/mate-themes/default.nix
+++ b/pkgs/misc/themes/mate-themes/default.nix
@@ -1,19 +1,26 @@
-{ stdenv, fetchurl, pkgconfig, intltool, iconnamingutils, gtk2 }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk2, gtk_engines,
+gtk-engine-murrine, gdk_pixbuf, librsvg }:
 
-stdenv.mkDerivation {
-  name = "mate-themes-1.6.3";
+stdenv.mkDerivation rec {
+  name = "mate-themes-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "3.18";
+  minor-ver = "1";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/1.6/mate-themes-1.6.3.tar.xz";
-    sha256 = "1wakr9z3byw1yvnbaxg8cpfhp1bp1fmnaz742738m0fx6bzznj9i";
+    url = "http://pub.mate-desktop.org/releases/themes/${major-ver}/${name}.tar.xz";
+    sha256 = "0lkp6jqvnxp6jly35iw89paqs279nvhqg01ig92n1xcfp8yrqq9c";
   };
 
-  buildInputs = [ pkgconfig intltool iconnamingutils gtk2 ];
+  nativeBuildInputs = [ pkgconfig intltool ];
+
+  buildInputs = [ gtk2 gtk_engines gtk-engine-murrine gdk_pixbuf librsvg ];
 
   meta = {
     description = "A set of themes from MATE";
     homepage = "http://mate-desktop.org";
     license = stdenv.lib.licenses.lgpl21;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
