### PR TITLE
fava: init at 1.0

### DIFF
--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -63,10 +63,8 @@ python3Packages.buildPythonApplication rec {
   checkPhase = "py.test";
 
   propagatedBuildInputs = with python3Packages;
-    [ flask dateutil pygments livereload wheel markdown2 flaskbabel tornado
-      click
-      beancount-pygments-lexer ] ++
-    [ beancount ];
+    [ flask dateutil pygments wheel markdown2 flaskbabel tornado
+      click beancount ];
 
   meta = {
     homepage = https://github.com/aumayr/fava;

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -7,12 +7,12 @@ let
   # master branch of the beancount repository (as the maintainer does not
   # release versions).
   beancount = python3Packages.buildPythonPackage rec {
-    version = "2.0b11";
+    version = "2.0b12";
     name = "beancount-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/b/beancount/${name}.tar.gz";
-      sha256 = "0x7mflb6s1s0jd3pbcyf9rk19fj78spwpyb8ha7nslklfizml7qh";
+      sha256 = "0n0wyi2yhmf8l46l5z68psk4rrzqkgqaqn93l0wnxsmp1nmqly9z";
     };
 
     buildInputs = with python3Packages; [ nose ];
@@ -49,12 +49,12 @@ let
 
 in
 python3Packages.buildPythonApplication rec {
-  version = "0.3.0";
+  version = "1.0";
   name = "fava-${version}";
 
   src = fetchurl {
     url = "https://github.com/aumayr/fava/releases/download/v${version}/beancount-fava-${version}.tar.gz";
-    sha256 = "1a5ws0amy2wf9vh4rxk9vn8822zfyizfprhrlnndwfps6mxd63np";
+    sha256 = "1yks1vy4cskv1h4dib0zx2cl8xz4kz4qx9n8v76w3di21w2gmak3";
   };
 
   buildInputs = with python3Packages; [ pytest ];

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -1,0 +1,73 @@
+{ stdenv, pkgs, fetchurl, python3Packages }:
+
+let
+
+  # We're building beancount here as dependency-only package because fava 0.3.0
+  # depends on beancount-2.0b2, but beancount as in pkgs.beancount is from the
+  # master branch of the beancount repository (as the maintainer does not
+  # release versions).
+  beancount = python3Packages.buildPythonPackage rec {
+    version = "2.0b11";
+    name = "beancount-${version}";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/b/beancount/${name}.tar.gz";
+      sha256 = "0x7mflb6s1s0jd3pbcyf9rk19fj78spwpyb8ha7nslklfizml7qh";
+    };
+
+    buildInputs = with python3Packages; [ nose ];
+
+    # Automatic tests cannot be run because it needs to import some local modules for tests.
+    doCheck = false;
+    checkPhase = ''
+      nosetests
+    '';
+
+    propagatedBuildInputs = with python3Packages; [
+      beautifulsoup4
+      bottle
+      chardet
+      dateutil
+      google_api_python_client
+      lxml
+      ply
+      python_magic
+    ];
+
+    meta = {
+      homepage = http://furius.ca/beancount/;
+      description = "Double-entry bookkeeping computer language";
+      longDescription = ''
+          A double-entry bookkeeping computer language that lets you define
+          financial transaction records in a text file, read them in memory,
+          generate a variety of reports from them, and provides a web interface.
+      '';
+      license = stdenv.lib.licenses.gpl2;
+      maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+    };
+  };
+
+in
+python3Packages.buildPythonApplication rec {
+  version = "0.3.0";
+  name = "fava-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/aumayr/fava/releases/download/v${version}/beancount-fava-${version}.tar.gz";
+    sha256 = "1a5ws0amy2wf9vh4rxk9vn8822zfyizfprhrlnndwfps6mxd63np";
+  };
+
+  propagatedBuildInputs = with python3Packages;
+    [ flask dateutil pygments livereload wheel markdown2 flaskbabel tornado
+      click
+      beancount-pygments-lexer ] ++
+    [ beancount ];
+
+  meta = {
+    homepage = https://github.com/aumayr/fava;
+    description = "Web interface for beancount";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, fetchurl, python3Packages }:
+{ stdenv, pkgs, fetchurl, python3Packages, fetchFromGitHub, fetchzip, python3 }:
 
 let
 
@@ -52,15 +52,32 @@ python3Packages.buildPythonApplication rec {
   version = "1.0";
   name = "fava-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/aumayr/fava/releases/download/v${version}/beancount-fava-${version}.tar.gz";
-    sha256 = "1yks1vy4cskv1h4dib0zx2cl8xz4kz4qx9n8v76w3di21w2gmak3";
+  src = fetchFromGitHub {
+    owner = "aumayr";
+    repo = "fava";
+    rev = "v${version}";
+    sha256 = "0dm4x6z80m04r9qa55psvz7f41qnh13hnj2qhvxkrk22yqmkqrka";
   };
 
-  buildInputs = with python3Packages; [ pytest ];
+  assets = fetchzip {
+    url = "https://github.com/aumayr/fava/releases/download/v${version}/beancount-fava-${version}.tar.gz";
+    sha256 = "1vvidwfn5882dslz6qqkkd84m7w52kd34x10qph8yhipyjv1dimc";
+  };
 
-  doCheck = false;
-  checkPhase = "py.test";
+  buildInputs = with python3Packages; [ pytest_30 ];
+
+  checkPhase = ''
+    # pyexcel is optional
+    # the other 2 tests fail due non-unicode locales
+    PATH=$out/bin:$PATH pytest tests \
+      --ignore tests/test_util_excel.py \
+      --ignore tests/test_cli.py \
+      --ignore tests/test_translations.py \
+  '';
+
+  postInstall = ''
+    cp -r $assets/fava/static/gen $out/${python3.sitePackages}/fava/static
+  '';
 
   propagatedBuildInputs = with python3Packages;
     [ flask dateutil pygments wheel markdown2 flaskbabel tornado

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -59,6 +59,7 @@ python3Packages.buildPythonApplication rec {
 
   buildInputs = with python3Packages; [ pytest ];
 
+  doCheck = false;
   checkPhase = "py.test";
 
   propagatedBuildInputs = with python3Packages;

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -57,6 +57,10 @@ python3Packages.buildPythonApplication rec {
     sha256 = "1a5ws0amy2wf9vh4rxk9vn8822zfyizfprhrlnndwfps6mxd63np";
   };
 
+  buildInputs = with python3Packages; [ pytest ];
+
+  checkPhase = "py.test";
+
   propagatedBuildInputs = with python3Packages;
     [ flask dateutil pygments livereload wheel markdown2 flaskbabel tornado
       click

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15452,6 +15452,8 @@ in
 
   fairymax = callPackage ../games/fairymax {};
 
+  fava = callPackage ../applications/office/fava {};
+
   fish-fillets-ng = callPackage ../games/fish-fillets-ng {};
 
   flightgear = qt5.callPackage ../games/flightgear { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1891,6 +1891,24 @@ in modules // {
     };
   };
 
+  beancount-pygments-lexer = buildPythonPackage (rec {
+    version = "0.1.2";
+    name = "beancount-pygments-lexer-${version}";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/b/beancount-pygments-lexer/${name}.tar.gz";
+      sha256 = "0qil39ckf6jhlgjwlxjrfphmx5zs9zhp0b92mrw99kbi06f1qcdq";
+    };
+
+    buildInputs = with self; [ pygments ];
+
+    meta = {
+      homepage = https://github.com/aumayr/beancount-pygments-lexer/;
+      license = licenses.mit;
+      description = "pygments-Lexer for beancount-files";
+    };
+  });
+
   beautifulsoup = buildPythonPackage (rec {
     name = "beautifulsoup-3.2.1";
     disabled = isPy3k;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15662,6 +15662,25 @@ in modules // {
     };
   };
 
+  livereload = buildPythonPackage rec {
+    version = "2.4.1";
+    name = "livereload-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/lepture/python-livereload/archive/v${version}.tar.gz";
+      sha256 = "0m8b4f6wkrsh45ldqrq2l9ynv2dzlgb34bkwc7hzi0cihsfgwaca";
+    };
+
+    buildInputs = with self; [ tornado six ];
+
+    meta = {
+      homepage = https://github.com/lepture/python-livereload;
+      description = ''livereload server in python'';
+      license = licenses.bsd2;
+      maintainers = with maintainers; [ matthiasbeyer ];
+    };
+  };
+
   livestreamer = buildPythonPackage rec {
     version = "1.12.2";
     name = "livestreamer-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4812,6 +4812,16 @@ in modules // {
     };
   };
 
+  pytest_30 = self.pytest_27.override rec {
+    name = "pytest-3.0.3";
+
+    propagatedBuildInputs = with self; [ hypothesis py ];
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/p/pytest/${name}.tar.gz";
+      sha256 = "1rxydacrdb8s312l3bn0ybrqsjp13abzyim1x21s80386l5504zj";
+    };
+  };
+
   pytestcache = buildPythonPackage rec {
     name = "pytest-cache-1.0";
     src = pkgs.fetchurl {


### PR DESCRIPTION
**WIP**

It wants `flask-babel`, though adding the package `flaskbabel` (after upgrading it from 0.9 to 0.10 [which does not change the hash?]) doesn't help. The build also says that the requirement is already satisfied. :curly_loop: 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
