### PR TITLE
mt-st: init at 1.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -306,6 +306,7 @@
   rasendubi = "Alexey Shmalko <rasen.dubi@gmail.com>";
   raskin = "Michael Raskin <7c6f434c@mail.ru>";
   redbaron = "Maxim Ivanov <ivanov.maxim@gmail.com>";
+  redvers = "Redvers Davies <red@infect.me>";
   refnil = "Martin Lavoie <broemartino@gmail.com>";
   relrod = "Ricky Elrod <ricky@elrod.me>";
   renzo = "Renzo Carbonara <renzocarbonara@gmail.com>";

--- a/pkgs/tools/backup/mt-st/default.nix
+++ b/pkgs/tools/backup/mt-st/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "mt-st-1.3";
+
+  src = fetchurl {
+    url = "https://github.com/iustin/mt-st/releases/download/${name}/${name}.tar.gz";
+    sha256 = "b552775326a327cdcc076c431c5cbc4f4e235ac7c41aa931ad83f94cccb9f6de";
+  };
+
+  installFlags = [ "PREFIX=$(out)" "EXEC_PREFIX=$(out)" ];
+
+  meta = {
+    description = "Magnetic Tape control tools for Linux";
+    longDescription = ''
+      Fork of the standard "mt" tool with additional Linux-specific IOCTLs.
+    '';
+    homepage = https://github.com/iustin/mt-st;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.redvers ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/backup/mtx/default.nix
+++ b/pkgs/tools/backup/mtx/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "mtx-1.3.12";
+
+  src = fetchurl {
+    url = "mirror://gentoo/distfiles/${name}.tar.gz";
+    sha256 = "0261c5e90b98b6138cd23dadecbc7bc6e2830235145ed2740290e1f35672d843";
+  };
+
+  doCheck = false;
+
+  meta = {
+    description = "Media Changer Tools";
+    longDescription = ''
+      The mtx command controls single or multi-drive SCSI media changers such as
+      tape changers, autoloaders, tape libraries, or optical media jukeboxes. It
+      can also be used with media changers that use the 'ATTACHED' API, presuming
+      that they properly report the MChanger bit as required by the SCSI T-10 SMC
+      specification.
+    '';
+    homepage = https://sourceforge.net/projects/mtx/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.redvers ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2505,6 +2505,8 @@ in
 
   mtr = callPackage ../tools/networking/mtr {};
 
+  mtx = callPackage ../tools/backup/mtx {};
+
   multitran = recurseIntoAttrs (let callPackage = newScope pkgs.multitran; in rec {
     multitrandata = callPackage ../tools/text/multitran/data { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2507,6 +2507,8 @@ in
 
   mtx = callPackage ../tools/backup/mtx {};
 
+  mt-st = callPackage ../tools/backup/mt-st {};
+
   multitran = recurseIntoAttrs (let callPackage = newScope pkgs.multitran; in rec {
     multitrandata = callPackage ../tools/text/multitran/data { };
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
