### PR TITLE
mate-icon-theme: 1.6.3 -> 1.14.1

### DIFF
--- a/pkgs/misc/themes/mate-icon-theme/default.nix
+++ b/pkgs/misc/themes/mate-icon-theme/default.nix
@@ -1,19 +1,25 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk2, iconnamingutils }:
+{ stdenv, fetchurl, pkgconfig, intltool, iconnamingutils, hicolor_icon_theme }:
 
-stdenv.mkDerivation {
-  name = "mate-icon-theme-1.6.3";
+stdenv.mkDerivation rec {
+  name = "mate-icon-theme-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.14";
+  minor-ver = "0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/1.6/mate-icon-theme-1.6.3.tar.xz";
-    sha256 = "1r3qkx4k9svmxdg453r9d3hs47cgagxsngzi8rp6yry0c9bw5r5w";
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "1d8y4vlna8higz05mc01srrgspxmzw04vh3hyzcd9ms603njpfqm";
   };
 
-  buildInputs = [ pkgconfig intltool gtk2 iconnamingutils ];
+  nativeBuildInputs = [ pkgconfig intltool iconnamingutils ];
+
+  buildInputs = [ hicolor_icon_theme ];
 
   meta = {
     description = "Icon themes from MATE";
     homepage = "http://mate-desktop.org";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.lgpl3;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
