### PR TITLE
Unity3D package

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -79,6 +79,7 @@
   ./programs/ssh.nix
   ./programs/ssmtp.nix
   ./programs/tmux.nix
+  ./programs/unity3d.nix
   ./programs/venus.nix
   ./programs/wvdial.nix
   ./programs/xfs_quota.nix

--- a/nixos/modules/programs/unity3d.nix
+++ b/nixos/modules/programs/unity3d.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.unity3d;
+in {
+
+  options = {
+    programs.unity3d.enable = mkEnableOption "Unity3D, a game development tool";
+  };
+
+  config = mkIf cfg.enable {
+    security.setuidOwners = [{
+      program = "unity-chrome-sandbox";
+      source = "${pkgs.unity3d.sandbox}/bin/unity-chrome-sandbox";
+      owner = "root";
+      #group = "root";
+      setuid = true;
+      #setgid = true;
+    }];
+
+    environment.systemPackages = [ pkgs.unity3d ];
+  };
+
+}

--- a/pkgs/development/tools/unity3d/default.nix
+++ b/pkgs/development/tools/unity3d/default.nix
@@ -1,0 +1,135 @@
+{ GConf
+, alsaLib
+, fetchurl
+, stdenv
+, makeWrapper
+, cairo
+, libcap
+, cups
+, dbus
+, expat
+, postgresql
+, fontconfig
+, freetype
+, gdk_pixbuf
+, getopt
+, fakeroot
+, glib
+, gtk
+, mesa_glu
+, nspr
+, nss
+, pango
+, xorg
+, monodevelop
+, xdg_utils
+}:
+
+let
+  deps = [
+    GConf
+    alsaLib
+    cairo
+    cups
+    libcap
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gtk
+    gdk_pixbuf
+    mesa_glu
+    nspr
+    postgresql
+    nss
+    pango
+    xorg.libXcomposite
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+  ];
+  libPath = stdenv.lib.makeLibraryPath deps;
+  ver = "5.1.0";
+  build = "f3";
+  date = "2015091501";
+  pkgVer = "${ver}${build}";
+  fullVer = "${pkgVer}+${date}";
+in stdenv.mkDerivation rec {
+  name = "unity-editor-${version}";
+  version = pkgVer;
+  buildInputs = [ makeWrapper monodevelop xdg_utils getopt fakeroot ];
+
+  src = fetchurl {
+    url = "http://download.unity3d.com/download_unity/unity-editor-installer-${fullVer}.sh";
+    sha256 = "77b351d80fc4b63284f118093df486e16c13d7b136debae6534245878029a5ca";
+  };
+
+  outputs = ["out" "sandbox"];
+
+  unpackPhase = ''
+    # 'yes | fakeroot'
+    echo -e 'q\ny' | fakeroot sh $src
+    sourceRoot="unity-editor-${pkgVer}"
+  '';
+
+  installPhase = ''
+    unitydir=$out/opt/Unity
+
+    mkdir -p $out/{bin,opt}
+    mkdir -p $sandbox/bin
+    mkdir -p $unitydir
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons/hicolor/{256x256,48x48}/apps
+
+    mv Editor $unitydir
+    mv MonoDevelop $unitydir
+
+    echo "exec $unitydir/Editor/Unity \"\$@\"" > $out/bin/unity-editor
+    chmod +x $out/bin/unity-editor
+
+    sed "/^Exec=/c\Exec=$out/bin/unity-editor" < unity-editor.desktop \
+                                               > $out/share/applications/unity-editor.desktop
+
+    #sed -i "/^Exec=/c\Exec=$out/bin/monodevelop-unity" unity-monodevelop.desktop
+
+    cp unity-editor-icon.png $out/share/icons/hicolor/256x256/apps
+    # cp $unitydir/unity-monodevelop.png $out/share/icons/hicolor/48x48/apps
+
+    rpath="$unitydir/Editor/Data/Tools:$unitydir/Editor:${stdenv.cc.cc}/lib"
+
+    patchelf \
+      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      $unitydir/Editor/chrome-sandbox
+
+    cp $unitydir/Editor/chrome-sandbox $sandbox/bin
+    rm  $unitydir/Editor/chrome-sandbox
+
+    patchelf \
+      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "$rpath" \
+      $unitydir/Editor/Unity
+
+    wrapProgram $out/bin/unity-editor \
+      --prefix LD_LIBRARY_PATH : "${libPath}"
+
+  '';
+
+  dontStrip = true;
+
+  meta = {
+    homepage = https://unity3d.com/;
+    description = "Game development tool";
+    longDescription = ''
+      Popular development platform for creating 2D and 3D multiplatform games
+      and interactive experiences.
+    '';
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with stdenv.lib.maintainers; [ jb55 ];
+  };
+}

--- a/pkgs/development/tools/unity3d/default.nix
+++ b/pkgs/development/tools/unity3d/default.nix
@@ -1,135 +1,142 @@
-{ GConf
-, alsaLib
-, fetchurl
-, stdenv
-, makeWrapper
-, cairo
-, libcap
-, cups
-, dbus
-, expat
-, postgresql
-, fontconfig
-, freetype
-, gdk_pixbuf
-, getopt
-, fakeroot
-, glib
-, gtk
-, mesa_glu
-, nspr
-, nss
-, pango
-, xorg
-, monodevelop
-, xdg_utils
+{ stdenv, lib, fetchurl, makeWrapper, fakeroot, file, getopt
+, gtk2, gdk_pixbuf, glib, mesa_glu, postgresql, nss, nspr
+, alsaLib, GConf, cups, libcap, fontconfig, freetype, pango
+, cairo, dbus, expat, zlib, libpng12, nodejs, gnutar, gcc, gcc_32bit
+, libX11, libXcursor, libXdamage, libXfixes, libXrender, libXi
+, libXcomposite, libXext, libXrandr, libXtst, libSM, libICE, libxcb
+, mono, libgnomeui, gnome_vfs, gnome-sharp, gtk-sharp
 }:
 
 let
-  deps = [
-    GConf
-    alsaLib
-    cairo
-    cups
-    libcap
-    dbus
-    expat
-    fontconfig
-    freetype
-    glib
-    gtk
-    gdk_pixbuf
-    mesa_glu
-    nspr
-    postgresql
-    nss
-    pango
-    xorg.libXcomposite
-    xorg.libX11
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXtst
+  libPath64 = lib.makeLibraryPath [
+    gcc.cc gtk2 gdk_pixbuf glib mesa_glu postgresql nss nspr
+    alsaLib GConf cups libcap fontconfig freetype pango
+    cairo dbus expat zlib libpng12
+    libX11 libXcursor libXdamage libXfixes libXrender libXi
+    libXcomposite libXext libXrandr libXtst libSM libICE libxcb
   ];
-  libPath = stdenv.lib.makeLibraryPath deps;
-  ver = "5.1.0";
-  build = "f3";
-  date = "2015091501";
+  libPath32 = lib.makeLibraryPath [ gcc_32bit.cc ];
+  binPath = lib.makeBinPath [ nodejs gnutar ];
+  developBinPath = lib.makeBinPath [ mono ];
+  developLibPath = lib.makeLibraryPath [
+    glib libgnomeui gnome_vfs gnome-sharp gtk-sharp gtk-sharp.gtk
+  ];
+  developDotnetPath = lib.concatStringsSep ":" [
+    gnome-sharp gtk-sharp
+  ];
+
+  ver = "5.3.5";
+  build = "f1";
+  date = "20160525";
   pkgVer = "${ver}${build}";
   fullVer = "${pkgVer}+${date}";
+
 in stdenv.mkDerivation rec {
   name = "unity-editor-${version}";
   version = pkgVer;
-  buildInputs = [ makeWrapper monodevelop xdg_utils getopt fakeroot ];
 
   src = fetchurl {
-    url = "http://download.unity3d.com/download_unity/unity-editor-installer-${fullVer}.sh";
-    sha256 = "77b351d80fc4b63284f118093df486e16c13d7b136debae6534245878029a5ca";
+    url = "http://download.unity3d.com/download_unity/linux/unity-editor-installer-${fullVer}.sh";
+    sha256 = "0lmc65175fdvbyn3565pjlg6cc4l5i58fj7bxzi5cqykkbzv5wdm";
   };
 
-  outputs = ["out" "sandbox"];
+  nosuidLib = ./unity-nosuid.c;
+
+  nativeBuildInputs = [ makeWrapper fakeroot file getopt ];
+
+  outputs = [ "out" "monodevelop" "sandbox" ];
 
   unpackPhase = ''
-    # 'yes | fakeroot'
     echo -e 'q\ny' | fakeroot sh $src
     sourceRoot="unity-editor-${pkgVer}"
   '';
 
+  buildPhase = ''
+    patchFile() {
+      ftype="$(file -b "$1")"
+      if [[ "$ftype" =~ LSB\ .*dynamically\ linked ]]; then
+        if [[ "$ftype" =~ 32-bit ]]; then
+          rpath="${libPath32}"
+          intp="$(cat $NIX_CC/nix-support/dynamic-linker-m32)"
+        else
+          rpath="${libPath64}"
+          intp="$(cat $NIX_CC/nix-support/dynamic-linker)"
+        fi
+
+        rpath="$(patchelf --print-rpath "$1"):$rpath"
+        if [[ "$ftype" =~ LSB\ shared ]]; then
+          patchelf \
+            --set-rpath "$rpath" \
+            "$1"
+        elif [[ "$ftype" =~ LSB\ executable ]]; then
+          patchelf \
+            --set-rpath "$rpath" \
+            --interpreter "$intp" \
+            "$1"
+        fi
+      fi
+    }
+
+    cd Editor
+
+    $CC -fPIC -shared -o libunity-nosuid.so $nosuidLib -ldl
+    strip libunity-nosuid.so
+
+    # Exclude PlaybackEngines to build something that can be run on FHS-compliant Linuxes
+    find . -name PlaybackEngines -prune -o -executable -type f -print | while read path; do
+      patchFile "$path"
+    done
+
+    cd ..
+  '';
+
   installPhase = ''
-    unitydir=$out/opt/Unity
+    install -Dm755 Editor/chrome-sandbox $sandbox/bin/unity-chrome-sandbox
 
-    mkdir -p $out/{bin,opt}
-    mkdir -p $sandbox/bin
+    unitydir="$out/opt/Unity/Editor"
     mkdir -p $unitydir
+    mv Editor/* $unitydir
+    ln -sf /var/setuid-wrappers/unity-chrome-sandbox $unitydir/chrome-sandbox
+
     mkdir -p $out/share/applications
-    mkdir -p $out/share/icons/hicolor/{256x256,48x48}/apps
+    sed "/^Exec=/c\Exec=$out/bin/unity-editor" \
+      < unity-editor.desktop \
+      > $out/share/applications/unity-editor.desktop
 
-    mv Editor $unitydir
-    mv MonoDevelop $unitydir
+    install -D unity-editor-icon.png $out/share/icons/hicolor/256x256/apps/unity-editor-icon.png
 
-    echo "exec $unitydir/Editor/Unity \"\$@\"" > $out/bin/unity-editor
-    chmod +x $out/bin/unity-editor
+    mkdir -p $out/bin
+    makeWrapper $unitydir/Unity $out/bin/unity-editor \
+      --prefix LD_PRELOAD : "$unitydir/libunity-nosuid.so" \
+      --prefix PATH : "${binPath}"
 
-    sed "/^Exec=/c\Exec=$out/bin/unity-editor" < unity-editor.desktop \
-                                               > $out/share/applications/unity-editor.desktop
+    developdir="$monodevelop/opt/Unity/MonoDevelop"
+    mkdir -p $developdir
+    mv MonoDevelop/* $developdir
 
-    #sed -i "/^Exec=/c\Exec=$out/bin/monodevelop-unity" unity-monodevelop.desktop
+    mkdir -p $monodevelop/share/applications
+    sed "/^Exec=/c\Exec=$monodevelop/bin/unity-monodevelop" \
+      < unity-monodevelop.desktop \
+      > $monodevelop/share/applications/unity-monodevelop.desktop
 
-    cp unity-editor-icon.png $out/share/icons/hicolor/256x256/apps
-    # cp $unitydir/unity-monodevelop.png $out/share/icons/hicolor/48x48/apps
-
-    rpath="$unitydir/Editor/Data/Tools:$unitydir/Editor:${stdenv.cc.cc}/lib"
-
-    patchelf \
-      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      $unitydir/Editor/chrome-sandbox
-
-    cp $unitydir/Editor/chrome-sandbox $sandbox/bin
-    rm  $unitydir/Editor/chrome-sandbox
-
-    patchelf \
-      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "$rpath" \
-      $unitydir/Editor/Unity
-
-    wrapProgram $out/bin/unity-editor \
-      --prefix LD_LIBRARY_PATH : "${libPath}"
-
+    mkdir -p $monodevelop/bin
+    makeWrapper $developdir/bin/monodevelop $monodevelop/bin/unity-monodevelop \
+      --prefix PATH : "${developBinPath}" \
+      --prefix LD_LIBRARY_PATH : "${developLibPath}" \
+      --prefix MONO_GAC_PREFIX : "${developDotnetPath}"
   '';
 
   dontStrip = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://unity3d.com/;
     description = "Game development tool";
     longDescription = ''
       Popular development platform for creating 2D and 3D multiplatform games
       and interactive experiences.
     '';
-    license = stdenv.lib.licenses.unfree;
-    maintainers = with stdenv.lib.maintainers; [ jb55 ];
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jb55 ];
   };
 }

--- a/pkgs/development/tools/unity3d/unity-nosuid.c
+++ b/pkgs/development/tools/unity3d/unity-nosuid.c
@@ -1,0 +1,32 @@
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dlfcn.h>
+
+static const char sandbox_path[] = "/chrome-sandbox";
+
+int __xstat(int ver, const char* path, struct stat* stat_buf) {
+  static int (*original_xstat)(int, const char*, struct stat*) = NULL;
+  if (original_xstat == NULL) {
+    int (*fun)(int, const char*, struct stat*) = dlsym(RTLD_NEXT, "__xstat");
+    if (fun == NULL) {
+      return -1;
+    };
+    original_xstat = fun;
+  };
+
+  int res = (*original_xstat)(ver, path, stat_buf);
+  if (res == 0) {
+    char* pos = strstr(path, sandbox_path);
+    if (pos != NULL && *(pos + sizeof(sandbox_path) - 1) == '\0') {
+      printf("Lying about chrome-sandbox access rights...\n");
+      stat_buf->st_uid = 0;
+      stat_buf->st_gid = 0;
+      stat_buf->st_mode = 0104755;
+    };
+  }
+  return res;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16749,6 +16749,8 @@ in
 
   ums = callPackage ../servers/ums { };
 
+  unity3d = callPackage ../development/tools/unity3d { inherit (gnome) GConf; };
+
   urbit = callPackage ../misc/urbit { };
 
   utf8proc = callPackage ../development/libraries/utf8proc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16749,7 +16749,11 @@ in
 
   ums = callPackage ../servers/ums { };
 
-  unity3d = callPackage ../development/tools/unity3d { inherit (gnome) GConf; };
+  unity3d = callPackage ../development/tools/unity3d {
+    stdenv = stdenv_32bit;
+    gcc_32bit = pkgsi686Linux.gcc;
+    inherit (gnome2) GConf libgnomeui gnome_vfs;
+  };
 
   urbit = callPackage ../misc/urbit { };
 


### PR DESCRIPTION
###### Motivation for this change

Another attempt at https://github.com/NixOS/nixpkgs/issues/10452. Now Unity fully works, but requires SUID binary and also a small C `LD_PRELOAD`ed library which hack-forces Unity to believe some things about `chrome-sandbox`. To use, enable it with `programs.unity3d.enable = true` and run `unity-editor`. Compiled games can be run with `steam-run`.

Further work would be to build `libcef` by ourselves to enable userns -- then Unity wouldn't require a SUID binary (and hence NixOS module).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
