### PR TITLE
openrw: init at 2016-06-29

### DIFF
--- a/pkgs/games/openrw/default.nix
+++ b/pkgs/games/openrw/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchgit, cmake, sfml, mesa, bullet, glm, libmad, x11 }:
+
+stdenv.mkDerivation rec {
+  version = "2016-06-29";
+  name = "openrw-${version}";
+  src = fetchgit {
+    url = "https://github.com/rwengine/openrw";
+    rev = "46a7254a41d9f6e1eda8d31e742de492abb2540e";
+    sha256 = "1bjzwjp1b1539kzdf8ks0ndzc5q2zlckayv4pc22wbbnw2wmyqvi";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ cmake sfml mesa bullet glm libmad x11 ];
+
+  meta = with stdenv.lib; {
+    description = "Unofficial open source recreation of the classic Grand Theft Auto III game executable";
+    homepage = https://github.com/rwengine/openrw;
+    license = licenses.gpl3;
+    longDescription = ''
+      OpenRW is an open source re-implementation of Rockstar Games' Grand Theft
+      Auto III, a classic 3D action game first published in 2001.
+    '';
+    maintainers = with maintainers; [ kragniz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15152,6 +15152,8 @@ in
 
   openra = callPackage ../games/openra { lua = lua5_1; };
 
+  openrw = callPackage ../games/openrw { };
+
   openspades = callPackage ../games/openspades {};
 
   openspades-git = lowPrio (callPackage ../games/openspades/git.nix {});


### PR DESCRIPTION
###### Motivation for this change

Openrw is pretty cool.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
