### PR TITLE
services/avahi: Add domainName setting.

### DIFF
--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -24,6 +24,7 @@ let
     use-ipv4=${if ipv4 then "yes" else "no"}
     use-ipv6=${if ipv6 then "yes" else "no"}
     ${optionalString (interfaces!=null) "allow-interfaces=${concatStringsSep "," interfaces}"}
+    ${optionalString (domainName!=null) "domain-name=${domainName}"}
 
     [wide-area]
     enable-wide-area=${if wideArea then "yes" else "no"}
@@ -62,6 +63,14 @@ in
         description = ''
           Host name advertised on the LAN. If not set, avahi will use the value
           of config.networking.hostName.
+        '';
+      };
+
+      domainName = mkOption {
+        type = types.str;
+        description = ''
+          Domain name for all advertisements. If unset, Avahi will use
+          "local".
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

I wanted to access this not-yet-hooked-up Avahi setting.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested on live hardware; works as intended.
