### PR TITLE
WIP/RFC: stdenv: deprecate passing a string for configureFlags

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -50,8 +50,8 @@ let
     # $out/lib/perl5 - this is the general default, but because $out
     # contains the string "perl", Configure would select $out/lib.
     # Miniperl needs -lm. perl needs -lrt.
-    configureFlags =
-      [ "-de"
+    configureFlags = [
+        "-de"
         "-Dcc=cc"
         "-Uinstallusrbinperl"
         "-Dinstallstyle=lib/perl5"
@@ -68,9 +68,10 @@ let
 
     enableParallelBuilding = true;
 
-    preConfigure =
-      ''
-        configureFlags="$configureFlags -Dprefix=$out -Dman1dir=$out/share/man/man1 -Dman3dir=$out/share/man/man3"
+    preConfigure = ''
+        configureFlags+=("-Dprefix=$out")
+        configureFlags+=("-Dman1dir=$out/share/man/man1")
+        configureFlags+=("-Dman3dir=$out/share/man/man3")
     '' + optionalString stdenv.isArm ''
       configureFlagsArray=(-Dldflags="-lm -lrt")
       '' + optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -20,7 +20,16 @@ stdenv.mkDerivation rec {
     sed -e '/^\/\//d' -i include/acl.h
   '';
 
-  configureFlags = "MAKE=make MSGFMT=msgfmt MSGMERGE=msgmerge XGETTEXT=xgettext ZIP=gzip ECHO=echo SED=sed AWK=gawk";
+  configureFlags = [
+    "MAKE=make"
+    "MSGFMT=msgfmt"
+    "MSGMERGE=msgmerge"
+    "XGETTEXT=xgettext"
+    "ZIP=gzip"
+    "ECHO=echo"
+    "SED=sed"
+    "AWK=gawk"
+  ];
 
   installTargets = "install install-lib install-dev";
 

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -12,7 +12,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ gettext ];
 
-  configureFlags = "MAKE=make MSGFMT=msgfmt MSGMERGE=msgmerge XGETTEXT=xgettext ECHO=echo SED=sed AWK=gawk";
+  configureFlags = [
+    "MAKE=make"
+    "MSGFMT=msgfmt"
+    "MSGMERGE=msgmerge"
+    "XGETTEXT=xgettext"
+    "ECHO=echo"
+    "SED=sed"
+    "AWK=gawk"
+  ];
 
   installTargets = "install install-lib install-dev";
 

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     # FreeType requires GNU Make, which is not part of stdenv on FreeBSD.
     ++ optional (!stdenv.isLinux) gnumake;
 
-  configureFlags = "--disable-static --bindir=$(dev)/bin";
+  configureFlags = [ "--disable-static" "--bindir=$(dev)/bin" ];
 
   # from Gentoo, see https://bugzilla.redhat.com/show_bug.cgi?id=506840
   NIX_CFLAGS_COMPILE = "-fno-strict-aliasing";

--- a/pkgs/development/libraries/gmp/4.3.2.nix
+++ b/pkgs/development/libraries/gmp/4.3.2.nix
@@ -21,8 +21,12 @@ stdenv.mkDerivation rec {
     then "ln -sf configfsf.guess config.guess"
     else ''echo "Darwin host is `./config.guess`."'';
 
-  configureFlags = (if cxx then "--enable-cxx" else "--disable-cxx") +
-    stdenv.lib.optionalString stdenv.isDarwin " ac_cv_build=x86_64-apple-darwin13.4.0 ac_cv_host=x86_64-apple-darwin13.4.0";
+  configureFlags = with stdenv.lib; [
+    (enableFeature cxx "cxx")
+  ] ++ (optionals stdenv.isDarwin [
+    "ac_cv_build=x86_64-apple-darwin13.4.0"
+    "ac_cv_host=x86_64-apple-darwin13.4.0"
+  ]);
 
   # The test t-lucnum_ui fails (on Linux/x86_64) when built with GCC 4.8.
   # Newer versions of GMP don't have that issue anymore.

--- a/pkgs/development/libraries/icu/default.nix
+++ b/pkgs/development/libraries/icu/default.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation ({
     sed -i -e "s|/bin/sh|${stdenv.shell}|" configure
   '';
 
-  configureFlags = "--disable-debug" +
-    stdenv.lib.optionalString (stdenv.isFreeBSD || stdenv.isDarwin) " --enable-rpath";
+  configureFlags = [ "--disable-debug" ]
+    ++ stdenv.lib.optional (stdenv.isFreeBSD || stdenv.isDarwin) "--enable-rpath";
 
   # remove dependency on bootstrap-tools in early stdenv build
   postInstall = stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  configureFlags = "--with-syscmd-shell=${stdenv.shell}";
+  configureFlags = [ "--with-syscmd-shell=${stdenv.shell}" ];
 
   # Upstream is aware of it; it may be in the next release.
   patches = [ ./s_isdir.patch ];

--- a/pkgs/shells/bash/default.nix
+++ b/pkgs/shells/bash/default.nix
@@ -7,7 +7,7 @@ let
   version = "4.3";
   realName = "bash-${version}";
   shortName = "bash43";
-  baseConfigureFlags = if interactive then "--with-installed-readline" else "--disable-readline";
+  baseConfigureFlags = if interactive then [ "--with-installed-readline" ] else [ "--disable-readline" ];
   sha256 = "1m14s1f61mf6bijfibcjm9y6pkyvz6gibyl8p4hxq90fisi8gimg";
 
   inherit (stdenv.lib) optional optionalString;
@@ -49,15 +49,17 @@ stdenv.mkDerivation rec {
       ++ optional stdenv.isCygwin ./cygwin-bash-4.3.33-1.src.patch;
 
   crossAttrs = {
-    configureFlags = baseConfigureFlags +
-      " bash_cv_job_control_missing=nomissing bash_cv_sys_named_pipes=nomissing" +
-      optionalString stdenv.isCygwin ''
-        --without-libintl-prefix --without-libiconv-prefix
-        --with-installed-readline
-        bash_cv_dev_stdin=present
-        bash_cv_dev_fd=standard
-        bash_cv_termcap_lib=libncurses
-      '';
+    configureFlags = baseConfigureFlags ++ [
+      "bash_cv_job_control_missing=nomissing"
+      "bash_cv_sys_named_pipes=nomissing"
+    ] ++ stdenv.lib.optionals stdenv.isCygwin [
+      "--without-libintl-prefix"
+      "--without-libiconv-prefix"
+      "--with-installed-readline"
+      "bash_cv_dev_stdin=present"
+      "bash_cv_dev_fd=standard"
+      "bash_cv_termcap_lib=libncurses"
+    ];
   };
 
   configureFlags = baseConfigureFlags;

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -34,9 +34,7 @@ rec {
   makeStaticBinaries = stdenv: stdenv //
     { mkDerivation = args: stdenv.mkDerivation (args // {
         NIX_CFLAGS_LINK = "-static";
-        configureFlags =
-          toString args.configureFlags or ""
-          + " --disable-shared"; # brrr...
+        configureFlags = (args.configureFlags or []) ++ [ "--disable-shared" ];
       });
       isStatic = true;
     };
@@ -47,9 +45,10 @@ rec {
   makeStaticLibraries = stdenv: stdenv //
     { mkDerivation = args: stdenv.mkDerivation (args // {
         dontDisableStatic = true;
-        configureFlags =
-          toString args.configureFlags or ""
-          + " --enable-static --disable-shared";
+        configureFlags = (args.configureFlags or []) ++ [
+          "--enable-static"
+          "--disable-shared"
+        ];
       });
     };
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -173,8 +173,18 @@ let
         (removeAttrs attrs
           ["meta" "passthru" "crossAttrs" "pos"
            "__impureHostDeps" "__propagatedImpureHostDeps"
-           "sandboxProfile" "propagatedSandboxProfile"])
-        // (let
+           "sandboxProfile" "propagatedSandboxProfile"
+           "configureFlags"])
+        // (if builtins.hasAttr "configureFlags" attrs then {
+          configureFlags = if builtins.isList attrs.configureFlags
+            then builtins.concatStringsSep "\t" attrs.configureFlags
+            else (if lib.versionAtLeast lib.nixpkgsVersion "17.03"
+              then abort "${attrs.name}: configureFlags must be a list (since 17.03)."
+              else builtins.trace ''
+                ${attrs.name}: Passing a string for configureFlags is deprecated; use a list instead.
+                This will become a hard error in 17.03.
+              '' attrs.configureFlags);
+        } else {}) // (let
           computedSandboxProfile =
             lib.concatMap (input: input.__propagatedSandboxProfile or []) (extraBuildInputs ++ buildInputs ++ nativeBuildInputs);
           computedPropagatedSandboxProfile =

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -641,6 +641,10 @@ fixLibtool() {
 
 
 configurePhase() {
+    # Convert configureFlags into an array first
+    # so it can safely be modified by preConfigure
+    IFS="$(printf "\t")" read -a configureFlags <<< "$configureFlags"
+
     runHook preConfigure
 
     if [ -z "$configureScript" -a -x ./configure ]; then
@@ -655,26 +659,26 @@ configurePhase() {
     fi
 
     if [ -z "$dontAddPrefix" -a -n "$prefix" ]; then
-        configureFlags="${prefixKey:---prefix=}$prefix $configureFlags"
+        configureFlags+=("${prefixKey:---prefix=}$prefix")
     fi
 
     # Add --disable-dependency-tracking to speed up some builds.
     if [ -z "$dontAddDisableDepTrack" ]; then
         if [ -f "$configureScript" ] && grep -q dependency-tracking "$configureScript"; then
-            configureFlags="--disable-dependency-tracking $configureFlags"
+            configureFlags+=("--disable-dependency-tracking")
         fi
     fi
 
     # By default, disable static builds.
     if [ -z "$dontDisableStatic" ]; then
         if [ -f "$configureScript" ] && grep -q enable-static "$configureScript"; then
-            configureFlags="--disable-static $configureFlags"
+            configureFlags+=("--disable-static")
         fi
     fi
 
     if [ -n "$configureScript" ]; then
-        echo "configure flags: $configureFlags ${configureFlagsArray[@]}"
-        $configureScript $configureFlags "${configureFlagsArray[@]}"
+        echo "configure flags: ${configureFlags[@]} ${configureFlagsArray[@]}"
+        $configureScript ${configureFlags[@]} "${configureFlagsArray[@]}"
     else
         echo "no configure script, doing nothing"
     fi

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -30,7 +30,7 @@ let
     outputs = [ "out" "info" ];
 
     nativeBuildInputs = [ perl xz.bin ];
-    configureFlags = optionalString stdenv.isSunOS "ac_cv_func_inotify_init=no";
+    configureFlags = optional stdenv.isSunOS "ac_cv_func_inotify_init=no";
 
     buildInputs = [ gmp ]
       ++ optional aclSupport acl

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   # package. To avoid this issue, X11 support is explicitly disabled.
   # Note: If we ever want to *enable* X11 support, then we'll probably
   # have to pass "--with-appresdir", too.
-  configureFlags = "--without-x";
+  configureFlags = [ "--without-x" ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

See below.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Currently, configureFlags can be passed as a string or a list.
Passing a string works OK for small cases but it becomes hard to manage
interspersing spaces between the flags with many options, and doesn't
match the semantics of each flag being a separate item.
Passing a list (of strings) is a better fit for the type of data, but
it currently relies on Nix's regular conversion to an environment
variable, which simply concatenates the contents with spaces.
This breaks if any of the configure flags themselves contain spaces.
configureFlagsArray was added as a way to get around this limitation,
but is unsatisfactory to use because items must be appended via bash
in a preConfigure hook.

So, update configureFlags to be more ergonomic:
- Deprecate passing a string for configureFlags (require a list),
  and include helpful trace/abort messages.
- Pass the list to the builder in a smarter way: instead of relying
  on Nix's conversion to a string, perform our own conversion by
  interspersing tabs. Tabs should be fairly rare in configureFlags;
  in case a literal tab needs to be passed, it must be given extra
  escapes:
  configureFlags = [ "--with-some-arg-with-a-\\t-character" ](The only alternative would require usage of eval.)
  This also fixes passing flags that contain spaces.
- Make the list available during preConfigure as a bash array, so any
  dynamic modifications to the configure flags can be done there.

There are roughly 1500 uses of configureFlags at present, which is too
many to change all at one time, and it is a commonly used flag (e.g.
in packages outside of nixpkgs). So, use a generous deprecation
timetable: start warning in the next release (16.09), and convert to a
hard error in the release after that (17.03). Since we are mid-way
between releases, this gives 9 months and 1.5 releases for users to
upgrade; switching from strings to lists is not too hard.

These changes make also configureFlagsArray redundant. There are roughly
70 uses of configureFlagsArray at present, which is enough to remove all
at once (in a future patchset).

This is a WIP that I'm posting as an RFC; I've updated enough files
to be able to build bash successfully. More to come if this is
welcomed, but I'd like to get help with converting all the uses.
I'd also like to know which docs need to be updated.
