### PR TITLE
casperjs: do not move the current working directory

### DIFF
--- a/pkgs/development/tools/casperjs/default.nix
+++ b/pkgs/development/tools/casperjs/default.nix
@@ -28,9 +28,8 @@ in stdenv.mkDerivation rec {
     make test
   '';
 
-
   installPhase = ''
-    mv $PWD $out
+    cp -r . $out
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

same as https://github.com/NixOS/nixpkgs/pull/15750, but use cp instead of mv
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

If /tmp and /nix are in different filesystems, this causes the `find`s
in the fixup phase to fail because of a stale file handle:

```
find: cannot get current directory: No such file or directory
```
