### PR TITLE
pkgs.runCommand: passAsFile (buildCommand can be very long)

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -8,6 +8,7 @@ rec {
   runCommand = name: env: buildCommand:
     stdenv.mkDerivation ({
       inherit name buildCommand;
+      passAsFile = [ "buildCommand" ];
     } // env);
 
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -827,6 +827,10 @@ showPhaseHeader() {
 
 
 genericBuild() {
+    if [ -f "$buildCommandPath" ]; then
+        eval "$(cat $buildCommandPath)"
+        return
+    fi
     if [ -n "$buildCommand" ]; then
         eval "$buildCommand"
         return


### PR DESCRIPTION
This avoids the error:

```
$ nix-build test.nix 
these derivations will be built:
  /nix/store/4a0biq2941jb1bfk768siggssbpxj9p6-boo.drv
building path(s) ‘/nix/store/0dgrsami9039ia7vrai3v0mpbgmkkpq9-boo’
while setting up the build environment: executing ‘/nix/store/i7hx6w6zy3bv53f2xm1r23ya8qbzn4is-bash-4.3-p42/bin/bash’: Argument list too long
builder for ‘/nix/store/4a0biq2941jb1bfk768siggssbpxj9p6-boo.drv’ failed with exit code 1
error: build of ‘/nix/store/4a0biq2941jb1bfk768siggssbpxj9p6-boo.drv’ failed
```

Here is a http://sscce.org/:

```
with (import <nixpkgs> {});
with lib;

pkgs.runCommand "boo" {} ''
  ${concatMapStringsSep "\n" (i: "echo baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") (range 1 30000)}
''
```

Note: I wanted to make it optional based on`buildCommand` length,
but that seems pointless as I'm sure it's less performant.

This doesn't work yet, because stdenv has to be changed, but I'd like to know if in general it's something that can be generally used.

cc @edolstra if this is a bad idea (for performance reasons)
