### PR TITLE
python: add python.withPackages function

### DIFF
--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -581,6 +581,37 @@ specified packages in its path.
 * `postBuild`: Shell command executed after the build of environment.
 * `ignoreCollisions`: Ignore file collisions inside the environment (default is `false`).
 
+#### python.withPackages function
+
+The `python.withPackages` function provides a simpler interface to the `python.buildEnv` functionality.
+It takes a function as an argument that is passed the set of python packages and returns the list 
+of the packages to be included in the environment. Using the `withPackages` function, the previous
+example for the Pyramid Web Framework environment can be written like this:
+
+    with import {};
+
+    python.withPackages (ps: [ps.pyramid])
+
+`withPackages` passes the correct package set for the specific interpreter version as an 
+argument to the function. In the above example, `ps` equals `pythonPackages`.
+But you can also easily switch to using python3:
+    
+    with import {};
+
+    python3.withPackages (ps: [ps.pyramid])
+
+Now, `ps` is set to `python3Packages`, matching the version of the interpreter.
+
+As `python.withPackages` simply uses `python.buildEnv` under the hood, it also supports the `env`
+attribute. The `shell.nix` file from the previous section can thus be also written like this:
+
+    with import {};
+
+    (python33.withPackages (ps: [ps.numpy ps.requests])).env
+
+In contrast to `python.buildEnv`, `python.withPackages` does not support the more advanced options
+such as `ignoreCollisions = true` or `postBuild`. If you need them, you have to use `python.buildEnv`.
+
 ### Development mode
 
 Development or editable mode is supported. To develop Python packages

--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -545,7 +545,7 @@ Python environments can be created using the low-level `pkgs.buildEnv` function.
 This example shows how to create an environment that has the Pyramid Web Framework.
 Saving the following as `default.nix`
 
-    with import {};
+    with import <nixpkgs> {};
 
     python.buildEnv.override {
       extraLibs = [ pkgs.pythonPackages.pyramid ];
@@ -562,7 +562,7 @@ You can also use the `env` attribute to create local environments with needed
 packages installed. This is somewhat comparable to `virtualenv`. For example,
 running `nix-shell` with the following `shell.nix`
 
-    with import {};
+    with import <nixpkgs> {};
 
     (python3.buildEnv.override {
       extraLibs = with python3Packages; [ numpy requests ];
@@ -585,7 +585,7 @@ It takes a function as an argument that is passed the set of python packages and
 of the packages to be included in the environment. Using the `withPackages` function, the previous
 example for the Pyramid Web Framework environment can be written like this:
 
-    with import {};
+    with import <nixpkgs> {};
 
     python.withPackages (ps: [ps.pyramid])
 
@@ -593,7 +593,7 @@ example for the Pyramid Web Framework environment can be written like this:
 argument to the function. In the above example, `ps` equals `pythonPackages`.
 But you can also easily switch to using python3:
     
-    with import {};
+    with import <nixpkgs> {};
 
     python3.withPackages (ps: [ps.pyramid])
 
@@ -602,7 +602,7 @@ Now, `ps` is set to `python3Packages`, matching the version of the interpreter.
 As `python.withPackages` simply uses `python.buildEnv` under the hood, it also supports the `env`
 attribute. The `shell.nix` file from the previous section can thus be also written like this:
 
-    with import {};
+    with import <nixpkgs> {};
 
     (python33.withPackages (ps: [ps.numpy ps.requests])).env
 
@@ -619,7 +619,7 @@ Warning: `shellPhase` is executed only if `setup.py` exists.
 
 Given a `default.nix`:
 
-    with import {};
+    with import <nixpkgs> {};
 
     buildPythonPackage { name = "myproject";
 

--- a/pkgs/development/interpreters/python/2.6/default.nix
+++ b/pkgs/development/interpreters/python/2.6/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, zlib ? null, zlibSupport ? true, bzip2, includeModules ? false
-, sqlite, tcl, tk, xlibsWrapper, openssl, readline, db, ncurses, gdbm, self, callPackage }:
+, sqlite, tcl, tk, xlibsWrapper, openssl, readline, db, ncurses, gdbm, self, callPackage
+, python26Packages }:
 
 assert zlibSupport -> zlib != null;
 
@@ -97,6 +98,7 @@ let
       isPy2 = true;
       isPy26 = true;
       buildEnv = callPackage ../wrapper.nix { python = self; };
+      withPackages = import ../with-packages.nix { inherit buildEnv; pythonPackages = python26Packages; };
       libPrefix = "python${majorVersion}";
       executable = libPrefix;
       sitePackages = "lib/${libPrefix}/site-packages";

--- a/pkgs/development/interpreters/python/2.7/default.nix
+++ b/pkgs/development/interpreters/python/2.7/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, self, callPackage
+{ stdenv, fetchurl, self, callPackage, python27Packages
 , bzip2, openssl, gettext
 
 , includeModules ? false
@@ -151,6 +151,7 @@ let
       isPy2 = true;
       isPy27 = true;
       buildEnv = callPackage ../wrapper.nix { python = self; };
+      withPackages = import ../with-packages.nix { inherit buildEnv; pythonPackages = python27Packages; };
       libPrefix = "python${majorVersion}";
       executable = libPrefix;
       sitePackages = "lib/${libPrefix}/site-packages";

--- a/pkgs/development/interpreters/python/3.3/default.nix
+++ b/pkgs/development/interpreters/python/3.3/default.nix
@@ -12,6 +12,7 @@
 , zlib
 , callPackage
 , self
+, python33Packages
 }:
 
 assert readline != null -> ncurses != null;
@@ -81,6 +82,7 @@ stdenv.mkDerivation {
     libPrefix = "python${majorVersion}";
     executable = "python3.3m";
     buildEnv = callPackage ../wrapper.nix { python = self; };
+    withPackages = import ../with-packages.nix { inherit buildEnv; pythonPackages = python33Packages; };
     isPy3 = true;
     isPy33 = true;
     is_py3k = true;  # deprecated

--- a/pkgs/development/interpreters/python/3.4/default.nix
+++ b/pkgs/development/interpreters/python/3.4/default.nix
@@ -12,6 +12,7 @@
 , zlib
 , callPackage
 , self
+, python34Packages
 
 , CF, configd
 }:
@@ -104,6 +105,7 @@ stdenv.mkDerivation {
     libPrefix = "python${majorVersion}";
     executable = "python3.4m";
     buildEnv = callPackage ../wrapper.nix { python = self; };
+    withPackages = import ../with-packages.nix { inherit buildEnv; pythonPackages = python34Packages; };
     isPy3 = true;
     isPy34 = true;
     is_py3k = true;  # deprecated

--- a/pkgs/development/interpreters/python/3.5/default.nix
+++ b/pkgs/development/interpreters/python/3.5/default.nix
@@ -12,6 +12,7 @@
 , zlib
 , callPackage
 , self
+, python35Packages
 
 , CF, configd
 }:
@@ -104,6 +105,7 @@ stdenv.mkDerivation {
     libPrefix = "python${majorVersion}";
     executable = "python${majorVersion}m";
     buildEnv = callPackage ../wrapper.nix { python = self; };
+    withPackages = import ../with-packages.nix { inherit buildEnv; pythonPackages = python35Packages; };
     isPy3 = true;
     isPy35 = true;
     is_py3k = true;  # deprecated

--- a/pkgs/development/interpreters/python/with-packages.nix
+++ b/pkgs/development/interpreters/python/with-packages.nix
@@ -1,0 +1,3 @@
+{ buildEnv, pythonPackages }:
+
+f: let packages = f pythonPackages; in buildEnv.override { extraLibs = packages; }


### PR DESCRIPTION
I've tested this with all python versions in nixpkgs (except python 2.6, because I haven't found a package that builds with it), it works like this:

```
nix-build -E 'with (import <nixpkgs> {}); python35.withPackages (ps: [ps.dbus])' 
```

Then there is a `result/bin/python3` executable that knows about the `dbus` python package.

A problem with this implementation is that the following code won't work:

```
customPython = python3.override { .... };
wrapped = customPython.withPackages (ps: []) # here, ps will by python3Packages using python3, not customPython, to build packages.
```

Instead, you have to use this:

```
customPython = python3.override { ...; pythonPackages = customPythonPackages; };
customPythonPackages = python3Packages.override { python = customPython; self = customPythonPackages; };
wrapped = customPython.withPackages (ps: [...]);
```

Solving this requires either duplicating the code from `all-packages.nix` for `pythonXXPackages` or moving that code to the interpreters' default.nix file and then have something like:

```
python35Packages = python35.packages
```

in all-packages.nix. Since I'm not very involved in python packaging, I'm not sure what the best way to proceed is here. 

Fixes #15801
