### PR TITLE
containers: Create an empty machine-id file

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -309,6 +309,10 @@ in
             touch "$root/etc/os-release"
           fi
 
+          if ! [ -e "$root/etc/machine-id" ]; then
+            touch "$root/etc/machine-id"
+          fi
+
           mkdir -p -m 0755 \
             "/nix/var/nix/profiles/per-container/$INSTANCE" \
             "/nix/var/nix/gcroots/per-container/$INSTANCE"


### PR DESCRIPTION
Since systemd version 230, it is required to have a machine-id file prior to the startup of the container. If the file is empty, a transient machine ID is generated by `systemd-nspawn`.

See systemd/systemd#3014 for more details on the matter.

This unbreaks all of the `containers-*` NixOS tests.

Cc: @edolstra
