### PR TITLE
xxkb: Split into multiple outputs

### DIFF
--- a/pkgs/applications/misc/xxkb/default.nix
+++ b/pkgs/applications/misc/xxkb/default.nix
@@ -18,12 +18,14 @@ stdenv.mkDerivation rec {
     libX11 libXt libXext libXpm
   ] ++ stdenv.lib.optional svgSupport [ librsvg glib gdk_pixbuf pkgconfig ];
 
+  outputs = [ "out" "man" ];
+
   configurePhase = ''
     xmkmf ${stdenv.lib.optionalString svgSupport "-DWITH_SVG_SUPPORT"}
   '';
 
   preBuild = ''
-    makeFlagsArray=( BINDIR=$out/bin PIXMAPDIR=$out/share/xxkb XAPPLOADDIR=$out/etc/X11/app-defaults MANDIR=$out/man )
+    makeFlagsArray=( BINDIR=$out/bin PIXMAPDIR=$out/share/xxkb XAPPLOADDIR=$out/etc/X11/app-defaults MANDIR=$man/share/man )
   '';
 
   installTargets = "install install.man";
@@ -32,6 +34,7 @@ stdenv.mkDerivation rec {
     description = "A keyboard layout indicator and switcher";
     homepage = "http://xxkb.sourceforge.net/";
     license = stdenv.lib.licenses.artistic2;
+    maintainers = with stdenv.lib.maintainers; [ rasendubi ];
     platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm also adding myself as a maintainer as I'm the original author of the
derivation.
