### PR TITLE
pythonPackages.pywinrm: old rev -> 0.1.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18946,23 +18946,23 @@ in modules // {
     };
   };
 
-  pywinrm = buildPythonPackage (rec {
-    name = "pywinrm";
+  pywinrm = buildPythonPackage rec {
+    version = "0.1.1";
+    name = "pywinrm-${version}";
 
-    src = pkgs.fetchgit {
-      url = https://github.com/diyan/pywinrm.git;
-      rev = "c9ce62d500007561ab31a8d0a5d417e779fb69d9";
-      sha256 = "0n0qlcgin2g5lpby07qbdlnpq5v2qc2yns9zc4zm5prwh2mhs5za";
+    src = pkgs.fetchurl {
+      url = "https://github.com/diyan/pywinrm/archive/v${version}.tar.gz";
+      sha256 = "1pc0987f6q5sxcgm50a1k1xz2pk45ny9xxnyapaf60662rcavvfb";
     };
 
-    propagatedBuildInputs = with self; [ xmltodict isodate ];
+    propagatedBuildInputs = with self; [ isodate kerberos xmltodict ];
 
     meta = {
       homepage = "http://github.com/diyan/pywinrm/";
       description = "Python library for Windows Remote Management";
       license = licenses.mit;
     };
-  });
+  };
 
   PyXAPI = stdenv.mkDerivation rec {
     name = "PyXAPI-0.1";


### PR DESCRIPTION
###### Motivation for this change

This was previously tied to an older commit rev and not an actual release version; and that old commit was causing connectivity issues due to improper SSL support. That is fixed in the 0.1.1 release.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note that I did test with `nox-review wip`, but get the following error:

```
error: libgssapi_krb5.so: cannot open shared object file: No such file or directory
builder for ‘/nix/store/brsyi1qw9b1nrwsmfd4l7dridhnjr191-python3.5-pywinrm-0.1.1.drv’ failed with exit code 1
```

...but the [Kerberos support is optional](https://github.com/diyan/pywinrm/tree/v0.1.x#to-use-kerberos-authentication-you-need-these-optional-dependencies), and I wasn't sure how to have it completely ignored. Outside of nox-review, everything works as expected connecting to Windows hosts without Kerberos. Any suggestions on how that optional dep should be handled better?
