### PR TITLE
fcgiwrap: fix build with systemd 230

### DIFF
--- a/pkgs/servers/fcgiwrap/default.nix
+++ b/pkgs/servers/fcgiwrap/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ autoreconfHook systemd fcgi pkgconfig ];
 
+  # systemd 230 no longer has libsystemd-daemon as a separate entity from libsystemd
+  postPatch = ''
+    substituteInPlace configure.ac --replace libsystemd-daemon libsystemd
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://nginx.localdomain.pl/wiki/FcgiWrap;
     description = "Simple server for running CGI applications over FastCGI";


### PR DESCRIPTION
systemd 230 no longer has libsystemd-daemon as a separate entity from libsystemd.

Current build fails without this patch.
Tested on NixOS, build successful after patch.

Closes #15791.
