### PR TITLE
NAT module: allow hot rules replace after `nixos-rebuild switch`

### DIFF
--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -170,7 +170,7 @@ in
 
     systemd.services = mkIf (!config.networking.firewall.enable) { nat = {
       description = "Network Address Translation";
-      wantedBy = [ "network.target" ];
+      wantedBy = [ "network.target" "default.target" ];
       after = [ "network-interfaces.target" "systemd-modules-load.service" ];
       path = [ pkgs.iptables ];
       unitConfig.ConditionCapability = "CAP_NET_ADMIN";


### PR DESCRIPTION
I was playing with NAT module and suddenly realized, that nothing changes whatever options I set. Port forwarding didn't work. I checked `iptables -t nat -L` --- it was empty for this configuration:

```
   networking.nat.enable = true;
   networking.nat.forwardPorts = [
     { destination = "127.0.0.1:22"; sourcePort = 1022; }
   ];
```

After a bit of struggle and couple of lost hours I added locally this line:

```
systemd.services.nat.wantedBy = [ "default.target" ];
```

Now I can change nat rules in configuration.nix and they are correctly applied after `switch`.
