### PR TITLE
buildEnv: respect user-chosen output even with extraOutputsToInstall

### DIFF
--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -52,13 +52,13 @@ runCommand name
         # and otherwise use `meta.outputsToInstall`. The attribute is guaranteed
         # to exist in mkDerivation-created cases. The other cases (e.g. runCommand)
         # aren't expected to have multiple outputs.
-        (if drv.outputUnspecified or false
-            && drv.meta.outputsToInstall or null != null
+        if drv.outputUnspecified or false
+           && drv.meta.outputsToInstall or null != null
           then map (outName: drv.${outName}) drv.meta.outputsToInstall
-          else [ drv ])
+               ++ lib.filter (p: p!=null)
+                  (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall)
+          else [ drv ];
         # Add any extra outputs specified by the caller of `buildEnv`.
-        ++ lib.filter (p: p!=null)
-          (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
       priority = drv.meta.priority or 5;
     }) paths);
     preferLocalBuild = true;


### PR DESCRIPTION
###### Motivation for this change

When user gives an explicit output for `buildEnv`, for example `gcc.cc.lib`, if `extraOutputsToInstall` is specified `gcc.cc.lib.foo` would also be included, even though this might not be what the user wanted. This reverses the behaviour, so if an output is explicitly specified no additional ones would be installed.

For example of when this is useful: this removes `gcc.out` references from `buildFHSEnv` environments.

Not mass-rebuildy as far as I can see.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
