### PR TITLE
elm-format: init at 0.3.1

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, buildEnv, haskell, nodejs, fetchurl, fetchpatch, makeWrapper }:
+{ lib, stdenv, buildEnv, haskell, nodejs, fetchurl, fetchpatch, makeWrapper,
+callPackage }:
 
 # To update:
 # 1) Update versions in ./update-elm.rb and run it.
@@ -62,6 +63,16 @@ let
                     --prefix PATH ':' ${bins}
                 '';
             });
+            
+            /*
+            This is not a core Elm package, and it's hosted on GitHub.
+            To update, run:
+
+                cabal2nix --jailbreak --revision refs/tags/foo http://github.com/avh4/elm-format > packages/elm-format.nix
+                    
+            where foo is a tag for a new version, for example "0.3.1-alpha". 
+            */
+            elm-format = self.callPackage ./packages/elm-format.nix { };
 
           };
       in elmPkgs // {

--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -1,0 +1,36 @@
+{ mkDerivation, aeson, ansi-terminal, ansi-wl-pprint, base, binary
+, bytestring, containers, directory, edit-distance, fetchgit
+, filemanip, filepath, HUnit, indents, mtl, optparse-applicative
+, parsec, pretty, process, QuickCheck, quickcheck-io
+, regex-applicative, split, stdenv, test-framework
+, test-framework-hunit, test-framework-quickcheck2, text
+, union-find, wl-pprint
+}:
+mkDerivation {
+  pname = "elm-format";
+  version = "0.3.1";
+  src = fetchgit {
+    url = "http://github.com/avh4/elm-format";
+    sha256 = "04kl50kzvjf4i140dlhs6f9fd2wmk6cnvyfamx2xh8vbwbnwrkj4";
+    rev = "0637f3772de2297d12ea35f5b66961e1d827552c";
+  };
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    aeson ansi-terminal ansi-wl-pprint base binary bytestring
+    containers directory edit-distance filemanip filepath indents mtl
+    optparse-applicative parsec pretty process regex-applicative split
+    text
+  ];
+  testHaskellDepends = [
+    aeson ansi-terminal base binary bytestring containers directory
+    edit-distance filemanip filepath HUnit indents mtl parsec pretty
+    process QuickCheck quickcheck-io regex-applicative split
+    test-framework test-framework-hunit test-framework-quickcheck2 text
+    union-find wl-pprint
+  ];
+  jailbreak = true;
+  homepage = "http://elm-lang.org";
+  description = "A source code formatter for Elm";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
###### Motivation for this change

elm-format is a de-facto standard tool in the elm community for automatically formatting elm code
according to the official style guide. As such it should be included with the elm platform on nixos.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
