### PR TITLE
oraclejdk: Revert "oraclejdk8: 8u91 -> 8u92"

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "92";
+  patchVersion = "91";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "095j2hh2xas05jajy4qdj9hxq3k460x4m12rcaxkaxw754imj0vj";
-  sha256_x86_64 = "11wrqd3qbkhimbw9n4g9i0635pjhhnijwxyid7lvjv26kdgg58vr";
+  sha256_i686 = "0lndni81vfpz2l6zb8zsshaavk0483q5jc8yzj4fdjv6wnshbkay";
+  sha256_x86_64 = "0lkm3fz1vdi69f34sysavvh3abx603j1frc9hxvr08pwvmm536vg";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Motivation for this change

`oraclejdk8` should be 8u91. It is a Critical Patch Update (CPU), contains only security vulnerability fixes.
The package for 8u92 is `oraclejdk8psu`. 8u92 is a Patch Set Update (PSU), contains security vulnerability fixes and other bug fixes.

Oracle says "Oracle strongly recommends that all Java SE users upgrade to the latest CPU release available for a release family. Most users should choose the CPU release."
http://www.oracle.com/technetwork/java/javase/downloads/cpu-psu-explained-2331472.html
So I made the CPU package as the default package `oraclejdk8`.

This reverts commit 9e56f3a9b50d56afd26440f697ac73bd73eaf2ee.

cc @fpletz 
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
