### PR TITLE
timetrap: init at 1.10.0

### DIFF
--- a/pkgs/applications/office/timetrap/Gemfile
+++ b/pkgs/applications/office/timetrap/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'timetrap'

--- a/pkgs/applications/office/timetrap/Gemfile.lock
+++ b/pkgs/applications/office/timetrap/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    chronic (0.10.2)
+    sequel (4.0.0)
+    sqlite3 (1.3.11)
+    timetrap (1.10.0)
+      chronic (~> 0.10.2)
+      sequel (~> 4.0.0)
+      sqlite3 (~> 1.3.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  timetrap
+
+BUNDLED WITH
+   1.10.6

--- a/pkgs/applications/office/timetrap/default.nix
+++ b/pkgs/applications/office/timetrap/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, lib, bundlerEnv, ruby }:
+
+bundlerEnv {
+  name = "timetrap-1.10.0";
+
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  meta = {
+    description = "a simple command line time tracker written in ruby";
+    homepage = https://github.com/samg/timetrap;
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/applications/office/timetrap/gemset.nix
+++ b/pkgs/applications/office/timetrap/gemset.nix
@@ -1,0 +1,34 @@
+{
+  chronic = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hrdkn4g8x7dlzxwb1rfgr8kw3bp4ywg5l4y4i9c2g5cwv62yvvn";
+      type = "gem";
+    };
+    version = "0.10.2";
+  };
+  sequel = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17kqm0vd15p9qxbgcysvmg6a046fd7zvxl3xzpsh00pg6v454svm";
+      type = "gem";
+    };
+    version = "4.0.0";
+  };
+  sqlite3 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19r06wglnm6479ffj9dl0fa4p5j2wi6dj7k6k3d0rbx7036cv3ny";
+      type = "gem";
+    };
+    version = "1.3.11";
+  };
+  timetrap = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rdaa27zvdgmbsbwa59g3dvfwb95nz7x1wycmviby94j5lywyzfc";
+      type = "gem";
+    };
+    version = "1.10.0";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3410,6 +3410,8 @@ in
 
   timemachine = callPackage ../applications/audio/timemachine { };
 
+  timetrap = callPackage ../applications/office/timetrap { };
+
   tinc = callPackage ../tools/networking/tinc { };
 
   tinc_pre = callPackage ../tools/networking/tinc/pre.nix { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
