### PR TITLE
texlive: package "mfirstuc"

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive-new/pkgs.nix
+++ b/pkgs/tools/typesetting/tex/texlive-new/pkgs.nix
@@ -5438,6 +5438,7 @@ tl: { # no indentation
   deps."menukeys" = tl."menukeys";
   deps."method" = tl."method";
   deps."metre" = tl."metre";
+  deps."mfirstuc" = tl."mfirstuc";
   deps."mftinc" = tl."mftinc";
   deps."midpage" = tl."midpage";
   deps."minibox" = tl."minibox";
@@ -14865,6 +14866,14 @@ tl: { # no indentation
   md5.doc = "4aa0350edb2a6d1ab18246284ecd6ebe";
   hasRunfiles = true;
   version = "2.5a";
+};
+"mfirstuc" = {
+  stripPrefix = 0;
+  md5.run = "73871f101c1139846cd2993910333dd1";
+  md5.doc = "aaa0350edb2a6d1ab18246284ecd6ebe";
+  md5.source = "2780f59815ed74b79006057724eb8d9e";
+  hasRunfiles = true;
+  version = "2.02";
 };
 "mflogo" = {
   stripPrefix = 0;


### PR DESCRIPTION
###### Motivation for this change

Closes #15828 
###### Things done

Add the `mfirstuc` package in the texlive distribution.

**This is not well-tested, it fixes my issue but the `doc` and `src` hashes might be wrong as I don't know how to build the appropriate outputs to test them**
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@vcunat 
