### PR TITLE
hub: fix incorrect hash

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/hub/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/hub/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = https://github.com/github/hub.git;
     rev = "refs/tags/v${version}";
-    sha256 = "0iwpy50jvb8w3nn6q857j9c3k7bp17azj8yc5brh04dpkyfysm02";
+    sha256 = "1vswkx4lm6x4s04453qkmv970gjn79ma39fmdg8mnzy7lh2swws6";
   };
 
 


### PR DESCRIPTION
###### Motivation for this change

I'm new to Nix so correct me if I misunderstand something. When I tried to install hub I got the below error:

```
output path ‘/nix/store/r5v6p7zh6av5y7m50vgb0ksqwh2psmiq-hub’ has r:sha256 hash ‘1vswkx4lm6x4s04453qkmv970gjn79ma39fmdg8mnzy7lh2swws6’ when ‘0iwpy50jvb8w3nn6q857j9c3k7bp17azj8yc5brh04dpkyfysm02’ was expected
cannot build derivation ‘/nix/store/wgnqdzxv2lp2rr94s7n2d6jxbmhnr69a-hub-2.2.3.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/wgnqdzxv2lp2rr94s7n2d6jxbmhnr69a-hub-2.2.3.drv’ failed
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
