### PR TITLE
mate-icon-theme-faenza: init at 1.14.1

### DIFF
--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -1,0 +1,4 @@
+{ callPackage, pkgs }:
+rec {
+  mate-common = callPackage ./mate-common { };
+}

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -1,4 +1,5 @@
 { callPackage, pkgs }:
 rec {
   mate-common = callPackage ./mate-common { };
+  mate-icon-theme-faenza = callPackage ./mate-icon-theme-faenza { };
 }

--- a/pkgs/desktops/mate/mate-common/default.nix
+++ b/pkgs/desktops/mate/mate-common/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "mate-common-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.14";
+  minor-ver = "0";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "1xkcwn3w6vrgnkcw7mcvihrsqclpkbqqxs1ivj4cq0dkqrm1kdq4";
+  };
+
+  meta = {
+    description = "Common files for development of MATE packages";
+    homepage = "http://mate-desktop.org";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, autoreconfHook, mate, hicolor_icon_theme }:
+
+stdenv.mkDerivation rec {
+  name = "mate-icon-theme-faenza-${version}";
+  version = "${major-ver}.${minor-ver}";
+  major-ver = "1.14";
+  minor-ver = "0";
+
+  src = fetchurl {
+    url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
+    sha256 = "115rbw4rbk8jqbjpbh5bfqjzsbwj5723r6cw96b1xrq1dv4gy4nr";
+  };
+
+  nativeBuildInputs = [ autoreconfHook mate.mate-common ];
+
+  buildInputs = [ hicolor_icon_theme ];
+  
+  meta = {
+    description = "Faenza icon theme from MATE";
+    homepage = "http://mate-desktop.org";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15730,6 +15730,10 @@ in
 
     in makeOverridable makePackages extra;
 
+  mate = recurseIntoAttrs (callPackage ../desktops/mate {
+    callPackage = newScope pkgs.mate;
+  });
+
   pantheon = recurseIntoAttrs rec {
     callPackage = newScope pkgs.pantheon;
     pantheon-terminal = callPackage ../desktops/pantheon/apps/pantheon-terminal { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
