### PR TITLE
libinput: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -15,11 +15,11 @@ in
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "libinput-1.3.0";
+  name = "libinput-1.3.1";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/libinput/${name}.tar.xz";
-    sha256 = "1sn1s1bz06fa49izqkqf519sjclsvhf42i6slzx1w5hx4vxpb2lr";
+    sha256 = "1adcc82746ywwymr9b3mvr2vq539hvp1zxks6s7p2p1rjcynbzyd";
   };
 
   outputs = [ "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change

[Changelog](https://lists.freedesktop.org/archives/wayland-devel/2016-May/029126.html)

> libinput 1.3.1 is now available. 
> 
> Some fixes to touchpads that wobble too much on small interactions (affected
> are the Lenovo Yoga 2 and a bunch of ALPS touchpads).
> The pressure change check we used to detect finger releases has been
> adjusted to just apply to the Lenovo *50 and *60 series, it didn't work too
> well on other touchpads and resulted in jerky motion.
> An error message was generated for 3-finger swipes on some touchads that had
> gestures disabled, this is fixed now.
> Finally, couple of doc fixes and the missing svg files were added so the
> tarball is complete now.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
