### PR TITLE
httrack: 3.48.21 -> 3.48.22

### DIFF
--- a/pkgs/tools/backup/httrack/default.nix
+++ b/pkgs/tools/backup/httrack/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, zlib, openssl, libiconv }:
 
 stdenv.mkDerivation rec {
-  version = "3.48.21";
+  version = "3.48.22";
   name = "httrack-${version}";
 
   src = fetchurl {
     url = "http://mirror.httrack.com/httrack-${version}.tar.gz";
-    sha256 = "10p4gf8y9h7mxkqlbs3hqgvmvbgvcbax8jp1whbw4yidwahn06w7";
+    sha256 = "13y4m4rhvmgbbpc3lig9hzmzi86a5fkyi79sz1ckk4wfnkbim0xj";
   };
 
   buildInputs = [ zlib openssl ] ++ stdenv.lib.optional stdenv.isDarwin libiconv;


### PR DESCRIPTION
###### Motivation for this change

Mirror was missing the other version
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
