### PR TITLE
pulseaudio service: set DISPLAY

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -161,6 +161,7 @@ in {
             ExecStart = "${getBin cfg.package}/bin/pulseaudio --daemonize=no";
             Restart = "on-failure";
           };
+          environment = { DISPLAY = ":${toString config.services.xserver.display}"; };
         };
 
         sockets.pulseaudio = {

--- a/nixos/modules/services/misc/cgminer.nix
+++ b/nixos/modules/services/misc/cgminer.nix
@@ -126,7 +126,7 @@ in
 
       environment = {
         LD_LIBRARY_PATH = ''/run/opengl-driver/lib:/run/opengl-driver-32/lib'';
-        DISPLAY = ":0";
+        DISPLAY = ":${toString config.services.xserver.display}";
         GPU_MAX_ALLOC_PERCENT = "100";
         GPU_USE_SYNC_OBJECTS = "1";
       };

--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -108,7 +108,7 @@ in {
         RestartSec = 3;
         Restart = "always";
       };
-      environment = { DISPLAY = ":0"; };
+      environment = { DISPLAY = ":${toString config.services.xserver.display}"; };
     };
   };
 

--- a/nixos/modules/services/x11/unclutter.nix
+++ b/nixos/modules/services/x11/unclutter.nix
@@ -39,12 +39,6 @@ in {
       default = 1;
     };
 
-    displayName = mkOption {
-      description = "Name of the X11 display";
-      type = types.str;
-      default = ":0";
-    };
-
     excluded = mkOption {
       description = "Names of windows where unclutter should not apply";
       type = types.listOf types.str;
@@ -67,7 +61,7 @@ in {
       serviceConfig.ExecStart = ''
         ${cfg.package}/bin/unclutter \
           -idle ${toString cfg.timeout} \
-          -display ${cfg.displayName} \
+          -display :${toString config.services.xserver.display} \
           -jitter ${toString (cfg.threeshold - 1)} \
           ${optionalString cfg.keystroke "-keystroke"} \
           ${concatMapStrings (x: " -"+x) cfg.extraOptions} \


### PR DESCRIPTION
###### Motivation for this change

I was seeing

```
May 28 22:41:49 gurney systemd[935]: Starting PulseAudio Server...
May 28 22:41:49 gurney pulseaudio[941]: E: [pulseaudio] module-jackdbus-detect.c: Unable to contact D-Bus session bus: org.freedesktop.DBus.Error.NotSupported: Unable to autolaunch a dbus-daemon without a $DISPLAY for X11
May 28 22:41:49 gurney pulseaudio[941]: E: [pulseaudio] module.c: Failed to load module "module-jackdbus-detect" (argument: "channels=2"): initialization failed.
May 28 22:41:49 gurney pulseaudio[941]: E: [pulseaudio] main.c: Module load failed.
May 28 22:41:49 gurney pulseaudio[941]: W: [pulseaudio] server-lookup.c: Unable to contact D-Bus: org.freedesktop.DBus.Error.NotSupported: Unable to autolaunch a dbus-daemon without a $DISPLAY for X11
May 28 22:41:49 gurney pulseaudio[941]: W: [pulseaudio] main.c: Unable to contact D-Bus: org.freedesktop.DBus.Error.NotSupported: Unable to autolaunch a dbus-daemon without a $DISPLAY for X11
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

it's needed by the jack support
