### PR TITLE
Fix jsoncpp darwin

### DIFF
--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/open-source-parsers/jsoncpp;
     description = "A simple API to manipulate JSON data in C++";
     maintainers = with stdenv.lib.maintainers; [ ttuegel page ];
+    platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.mit;
     branch = "1.6";
   };

--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake python ];
 
+  CXXFLAGS = "-Wno-shift-negative-value";
+
   cmakeFlags = [
     "-DJSONCPP_LIB_BUILD_SHARED=ON"
     "-DJSONCPP_LIB_BUILD_STATIC=OFF"


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
