### PR TITLE
webkitgtk: 2.12.0 -> 2.12.3

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.12.nix
+++ b/pkgs/development/libraries/webkitgtk/2.12.nix
@@ -11,7 +11,7 @@ assert enableGeoLocation -> geoclue2 != null;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "webkitgtk-${version}";
-  version = "2.12.0";
+  version = "2.12.3";
 
   meta = {
     description = "Web content rendering engine, GTK+ port";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://webkitgtk.org/releases/${name}.tar.xz";
-    sha256 = "19jyvyw8ss4bacq3f7ybdb0r16r84q12j2bpciyj9jqvzpw091m6";
+    sha256 = "01y34v62khf03w25fnzgd42rrai5mf1m95lr5vjyw8ya5sdbng0p";
   };
 
   patches = [ ./finding-harfbuzz-icu.patch ];


### PR DESCRIPTION
###### Motivation for this change

update contains CVE fixes
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
