### PR TITLE
Travis: Enable OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
-language: python
-python: "3.4"
-sudo: required
-dist: trusty
-before_install: ./maintainers/scripts/travis-nox-review-pr.sh nix
+matrix:
+    include:
+        - os: linux
+          language: python
+          python: "3.4"
+          sudo: required
+          dist: trusty
+          before_install: ./maintainers/scripts/travis-nox-review-pr.sh nix
+        - os: osx
+          language: generic
+          osx_image: xcode7.3
+          before_install:
+              - brew upgrade && brew install python
+              - ./maintainers/scripts/travis-nox-review-pr.sh nix
 install: ./maintainers/scripts/travis-nox-review-pr.sh nox
 script: ./maintainers/scripts/travis-nox-review-pr.sh build

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -27,7 +27,11 @@ elif [[ $1 == build ]]; then
     nix-build nixos/release.nix -A options
 
     echo "=== Checking tarball creation"
-    nix-build pkgs/top-level/release.nix -A tarball
+    if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+        echo "Skipped, as not working on darwin"
+    else
+        nix-build pkgs/top-level/release.nix -A tarball
+    fi
 
     if [[ $TRAVIS_PULL_REQUEST == false ]]; then
         echo "=== Not a pull request"


### PR DESCRIPTION
###### Motivation for this change

[Someone on hackernews yesterday suggested that enabling a CI for OS X could improve the package quality OS X](https://news.ycombinator.com/item?id=11803118). IMO this is a great idea :)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
