### PR TITLE
runningx: init at 1.0

### DIFF
--- a/pkgs/tools/X11/runningx/default.nix
+++ b/pkgs/tools/X11/runningx/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, pkgconfig, libX11 }:
+
+stdenv.mkDerivation rec {
+  name = "runningx-${version}";
+  version = "1.0";
+  
+  src = fetchurl {
+    url = "http://www.fiction.net/blong/programs/mutt/autoview/RunningX.c";
+    sha256 = "1mikkhrx6jsx716041qdy3nwjac08pxxvxyq2yablm8zg9hrip0d";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ libX11 ];
+
+  phases = [ "buildPhase" "installPhase" ];
+
+  buildPhase = ''
+    gcc -O2 -o RunningX $(pkg-config --cflags --libs x11) $src
+  '';
+
+  installPhase = ''
+    mkdir -p "$out"/bin
+    cp -vai RunningX "$out/bin"
+  '';
+
+  meta = {
+    homepage = http://www.fiction.net/blong/programs/mutt/;
+    description = "A program for testing if X is running";
+    license = stdenv.lib.licenses.free;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3206,6 +3206,8 @@ in
 
   rubber = callPackage ../tools/typesetting/rubber { };
 
+  runningx = callPackage ../tools/X11/runningx { };
+
   runzip = callPackage ../tools/archivers/runzip { };
 
   rxp = callPackage ../tools/text/xml/rxp { };


### PR DESCRIPTION
###### Motivation for this change

`RunningX` is a program that uses an X call to determine if X is running.  It is commonly used to determine which type of content viewer should be used for viewing attachments in the `mutt` mail reader by placing `test = RunningX` in `mailcap` entries.

It returns 0 if we are running X, 1 if not.

More information can be found at the [Gary Johnson's Mutt Page](http://www.spocom.com/users/gjohnson/mutt/)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
