### PR TITLE
Declarative nginx module with ACME support

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -54,6 +54,8 @@ let
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
+      proxy_set_header        X-Forwarded-Host $host;
+      proxy_set_header        X-Forwarded-Server $host;
       proxy_set_header        Accept-Encoding "";
 
       proxy_redirect          off;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -16,6 +16,8 @@ let
     error_log stderr;
     daemon off;
 
+    ${cfg.config}
+
     http {
       include ${cfg.package}/conf/mime.types;
       include ${cfg.package}/conf/fastcgi.conf;
@@ -86,18 +88,10 @@ let
           }
         }
       ''}
-    }
 
-    ${cfg.config}
-
-    # Keep this seperate to allow overriding previous settings
-    ${optionalString (cfg.httpConfig != "") ''
-    http {
-      include ${cfg.package}/conf/mime.types;
-      include ${cfg.package}/conf/fastcgi.conf;
       ${cfg.httpConfig}
     }
-    ''}
+
     ${cfg.appendConfig}
   '';
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -248,10 +248,14 @@ in
       };
     };
 
-    security.acme.certs = mapAttrs (vhostName: vhostConfig: {
-      webroot = vhostConfig.acmeRoot;
-      extraDomains = genAttrs vhostConfig.serverAliases (alias: null);
-    }) virtualHosts;
+    security.acme.certs = filterAttrs (n: v: v != {}) (
+      mapAttrs (vhostName: vhostConfig:
+        optionalAttrs vhostConfig.enableACME {
+          webroot = vhostConfig.acmeRoot;
+          extraDomains = genAttrs vhostConfig.serverAliases (alias: null);
+        }
+      ) virtualHosts
+    );
 
 
     users.extraUsers = optionalAttrs (cfg.user == "nginx") (singleton

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -85,7 +85,9 @@ let
 
             server_name ${serverName} ${concatStringsSep " " vhost.serverAliases};
             ${optionalString vhost.enableACME "location /.well-known/acme-challenge { root ${vhost.acmeRoot}; }"}
-            return 301 https://$host${optionalString (port != 443) ":${port}"}$request_uri;
+            location / {
+              return 301 https://$host${optionalString (port != 443) ":${port}"}$request_uri;
+            }
           }
         ''}
 
@@ -227,9 +229,7 @@ in
 
     security.acme.certs = mapAttrs (vhostName: vhostConfig: {
       webroot = vhostConfig.acmeRoot;
-      extraDomains = genAttrs vhostConfig.serverAliases (alias: {
-        "${alias}" = null;
-      });
+      extraDomains = genAttrs vhostConfig.serverAliases (alias: null);
     }) virtualHosts;
 
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -84,7 +84,9 @@ let
 
           location /nginx_status {
             stub_status on;
+            access_log off;
             allow 127.0.0.1;
+            allow ::1;
             deny all;
           }
         }

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -69,7 +69,23 @@ let
       client_max_body_size    10m;
 
       server_tokens ${if cfg.serverTokens then "on" else "off"};
+
       ${vhosts}
+
+      ${optionalString cfg.statusPage ''
+        server {
+          listen 80;
+          listen [::]:80;
+
+          server_name localhost;
+
+          location /nginx_status {
+            stub_status on;
+            allow 127.0.0.1;
+            deny all;
+          }
+        }
+      ''}
     }
 
     ${cfg.config}
@@ -162,6 +178,14 @@ in
   options = {
     services.nginx = {
       enable = mkEnableOption "Nginx Web Server";
+
+      statusPage = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable status page reachable from localhost on http://127.0.0.1/nginx_status.
+        ";
+      };
 
       recommendedTlsSettings = mkOption {
         default = false;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -35,7 +35,7 @@ let
       ssl_session_timeout 23m;
 
       ssl_ciphers ${cfg.sslCiphers};
-      ssl_ecdh_curve secp521r1;
+      ssl_ecdh_curve secp384r1;
       ssl_prefer_server_ciphers on;
       ${optionalString (cfg.sslDhparam != null) "ssl_dhparam ${cfg.sslDhparam};"}
 
@@ -79,7 +79,7 @@ let
       let
         ssl = vhost.enableSSL || vhost.forceSSL;
         port = if vhost.port != null then vhost.port else (if ssl then 443 else 80);
-        listenString = toString port + optionalString ssl " ssl spdy"
+        listenString = toString port + optionalString ssl " ssl http2"
           + optionalString vhost.default " default";
         acmeLocation = optionalString vhost.enableACME ''
           location /.well-known/acme-challenge {
@@ -221,7 +221,7 @@ in
 
       sslCiphers = mkOption {
         type = types.str;
-        default = "EDH+CHACHA20:EDH+AES:EECDHE+CHACHA20:ECDHE+AES:+AES128:-DSS";
+        default = "EECDH+aRSA+AESGCM:EDH+aRSA:EECDH+aRSA:+AES256:+AES128:+SHA1:!CAMELLIA:!SEED:!3DES:!DES:!RC4:!eNULL";
         description = "Ciphers to choose from when negotiating tls handshakes.";
       };
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -34,7 +34,7 @@ let
       ssl_session_cache shared:SSL:42m;
       ssl_session_timeout 23m;
 
-      ssl_ciphers EDH+aRSA+AES256:+AESGCM:ECDHE+aRSA+AES256;
+      ssl_ciphers ${cfg.sslCiphers};
       ssl_ecdh_curve secp521r1;
       ssl_prefer_server_ciphers on;
 
@@ -189,6 +189,12 @@ in
         type = types.bool;
         default = false;
         description = "Show nginx version in headers and error pages";
+      };
+
+      sslCiphers = mkOption {
+        type = types.str;
+        default = "EDH+CHACHA20:EDH+AES:EECDHE+CHACHA20:ECDHE+AES:+AES128:-DSS";
+        description = "Ciphers to choose from when negotiating tls handshakes.";
       };
 
       sslProtocols = mkOption {

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -77,7 +77,8 @@ let
       let
         ssl = vhost.enableSSL || vhost.forceSSL;
         port = if vhost.port != null then vhost.port else (if ssl then 443 else 80);
-        listenString = toString port + optionalString ssl " ssl spdy";
+        listenString = toString port + optionalString ssl " ssl spdy"
+          + optionalString vhost.default " default";
         acmeLocation = optionalString vhost.enableACME ''
           location /.well-known/acme-challenge {
             try_files $uri @acme-fallback;
@@ -92,8 +93,8 @@ let
       in ''
         ${optionalString vhost.forceSSL ''
           server {
-            listen 80;
-            listen [::]:80;
+            listen 80 ${optionalString vhost.default "default"};
+            listen [::]:80 ${optionalString vhost.default "default"};
 
             server_name ${serverName} ${concatStringsSep " " vhost.serverAliases};
             ${acmeLocation}

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -37,6 +37,7 @@ let
       ssl_ciphers ${cfg.sslCiphers};
       ssl_ecdh_curve secp521r1;
       ssl_prefer_server_ciphers on;
+      ${optionalString (cfg.sslDhparam != null) "ssl_dhparam ${cfg.sslDhparam};"}
 
       ssl_stapling on;
       ssl_stapling_verify on;
@@ -202,6 +203,13 @@ in
         default = "TLSv1.2";
         example = "TLSv1 TLSv1.1 TLSv1.2";
         description = "Allowed TLS protocol versions.";
+      };
+
+      sslDhparam = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = literalExample "/path/to/dhparams.pem";
+        description = "Path to DH parameters file.";
       };
 
       virtualHosts = mkOption {

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -7,18 +7,107 @@ let
   nginx = cfg.package;
   configFile = pkgs.writeText "nginx.conf" ''
     user ${cfg.user} ${cfg.group};
+    error_log stderr;
     daemon off;
 
     ${cfg.config}
 
-    ${optionalString (cfg.httpConfig != "") ''
     http {
       include ${cfg.package}/conf/mime.types;
+      include ${cfg.package}/conf/fastcgi.conf;
+
+      # optimisation
+      sendfile on;
+      tcp_nopush on;
+      tcp_nodelay on;
+      keepalive_timeout 65;
+      types_hash_max_size 2048;
+
+      # use secure TLS defaults
+      ssl_protocols TLSv1.2;
+      ssl_session_cache shared:SSL:42m;
+      ssl_session_timeout 23m;
+
+      ssl_ciphers EDH+aRSA+AES256:+AESGCM:ECDHE+aRSA+AES256;
+      ssl_ecdh_curve secp521r1;
+      ssl_prefer_server_ciphers on;
+
+      ssl_stapling on;
+      ssl_stapling_verify on;
+
+      gzip on;
+      gzip_disable "msie6";
+      gzip_proxied any;
+      gzip_comp_level 9;
+      gzip_buffers 16 8k;
+      gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+      # sane proxy settings/headers
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+      proxy_set_header        Accept-Encoding "";
+
+      proxy_redirect          off;
+      client_max_body_size    10m;
+      client_body_buffer_size 128k;
+      proxy_connect_timeout   90;
+      proxy_send_timeout      90;
+      proxy_read_timeout      90;
+      proxy_buffers           32 4k;
+      proxy_buffer_size       8k;
+      proxy_http_version      1.0;
+
+      server_tokens ${if cfg.serverTokens then "on" else "off"};
+      ${vhosts}
       ${cfg.httpConfig}
     }
-    ''}
     ${cfg.appendConfig}
   '';
+
+  vhosts = concatStringsSep "\n" (mapAttrsToList (serverName: vhost:
+      let
+        ssl = vhost.enableSSL || vhost.forceSSL;
+        port = if vhost.port != null then vhost.port else (if ssl then 443 else 80);
+        listenString = toString port + optionalString ssl " ssl spdy";
+      in ''
+        ${if vhost.forceSSL then ''
+          server {
+            listen 80;
+            listen [::]:80;
+
+            server_name ${serverName} ${concatStringsSep " " vhost.serverAliases};
+            return 301 https://$host${optionalString (port != 443) ":${port}"}$request_uri;
+          }
+        '' else ""}
+
+        server {
+          listen ${listenString};
+          listen [::]:${listenString};
+
+          server_name ${serverName} ${concatStringsSep " " vhost.serverAliases};
+          ${optionalString (vhost.root != null) "root ${vhost.root};"}
+          ${optionalString (vhost.globalRedirect != null) ''
+            return 301 https://${vhost.globalRedirect}$request_uri;
+          ''}
+          ${optionalString ssl ''
+            ssl_certificate ${vhost.sslCertificate};
+            ssl_certificate_key ${vhost.sslCertificateKey};
+          ''}
+
+          ${genLocations vhost.locations}
+
+          ${vhost.extraConfig}
+        }
+      ''
+  ) cfg.virtualHosts);
+  genLocations = locations: concatStringsSep "\n" (mapAttrsToList (location: config: ''
+    location ${location} {
+      ${optionalString (config.proxyPass != null) "proxy_pass ${config.proxyPass};"}
+      ${optionalString (config.root != null) "root ${config.root};"}
+    }
+  '') locations);
 in
 
 {
@@ -86,8 +175,24 @@ in
         description = "Group account under which nginx runs.";
       };
 
-    };
+      serverTokens = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Show nginx version in headers and error pages";
+      };
 
+      virtualHosts = mkOption {
+        type = types.attrsOf (types.submodule (import ./vhost-options.nix {
+          inherit lib;
+        }));
+        default = {
+          localhost = {};
+        };
+        example = [];
+        description = ''
+        '';
+      };
+    };
   };
 
   config = mkIf cfg.enable {
@@ -107,7 +212,7 @@ in
       serviceConfig = {
         ExecStart = "${nginx}/bin/nginx -c ${configFile} -p ${cfg.stateDir}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-        Restart = "on-failure";
+        Restart = "always";
         RestartSec = "10s";
         StartLimitInterval = "1min";
       };

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -68,7 +68,7 @@ let
         proxy_http_version      1.0;
       ''}
 
-      client_max_body_size    10m;
+      client_max_body_size ${cfg.clientMaxBodySize};
 
       server_tokens ${if cfg.serverTokens then "on" else "off"};
 
@@ -270,7 +270,13 @@ in
       serverTokens = mkOption {
         type = types.bool;
         default = false;
-        description = "Show nginx version in headers and error pages";
+        description = "Show nginx version in headers and error pages.";
+      };
+
+      clientMaxBodySize = mkOption {
+        type = types.string;
+        default = "10m";
+        description = "Set nginx global client_max_body_size.";
       };
 
       sslCiphers = mkOption {

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -70,8 +70,14 @@ let
 
       server_tokens ${if cfg.serverTokens then "on" else "off"};
       ${vhosts}
+    }
+    ${optionalString (cfg.httpConfig != "") ''
+    http {
+      include ${cfg.package}/conf/mime.types;
+      include ${cfg.package}/conf/fastcgi.conf;
       ${cfg.httpConfig}
     }
+    ''}
     ${cfg.appendConfig}
   '';
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -30,7 +30,7 @@ let
       types_hash_max_size 2048;
 
       # use secure TLS defaults
-      ssl_protocols TLSv1.2;
+      ssl_protocols ${cfg.sslProtocols};
       ssl_session_cache shared:SSL:42m;
       ssl_session_timeout 23m;
 
@@ -189,6 +189,13 @@ in
         type = types.bool;
         default = false;
         description = "Show nginx version in headers and error pages";
+      };
+
+      sslProtocols = mkOption {
+        type = types.str;
+        default = "TLSv1.2";
+        example = "TLSv1 TLSv1.1 TLSv1.2";
+        description = "Allowed TLS protocol versions.";
       };
 
       virtualHosts = mkOption {

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -16,61 +16,65 @@ let
     error_log stderr;
     daemon off;
 
-    ${cfg.config}
-
     http {
       include ${cfg.package}/conf/mime.types;
       include ${cfg.package}/conf/fastcgi.conf;
 
-      # optimisation
-      sendfile on;
-      tcp_nopush on;
-      tcp_nodelay on;
-      keepalive_timeout 65;
-      types_hash_max_size 2048;
+      ${optionalString (cfg.recommendedOptimisation) ''
+        # optimisation
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+      ''}
 
-      # use secure TLS defaults
       ssl_protocols ${cfg.sslProtocols};
-      ssl_session_cache shared:SSL:42m;
-      ssl_session_timeout 23m;
-
       ssl_ciphers ${cfg.sslCiphers};
-      ssl_ecdh_curve secp384r1;
-      ssl_prefer_server_ciphers on;
       ${optionalString (cfg.sslDhparam != null) "ssl_dhparam ${cfg.sslDhparam};"}
 
-      ssl_stapling on;
-      ssl_stapling_verify on;
+      ${optionalString (cfg.recommendedTlsSettings) ''
+        ssl_session_cache shared:SSL:42m;
+        ssl_session_timeout 23m;
+        ssl_ecdh_curve secp384r1;
+        ssl_prefer_server_ciphers on;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+      ''}
 
-      gzip on;
-      gzip_disable "msie6";
-      gzip_proxied any;
-      gzip_comp_level 9;
-      gzip_buffers 16 8k;
-      gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+      ${optionalString (cfg.recommendedGzipSettings) ''
+        gzip on;
+        gzip_disable "msie6";
+        gzip_proxied any;
+        gzip_comp_level 9;
+        gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+      ''}
 
-      # sane proxy settings/headers
-      proxy_set_header        Host $host;
-      proxy_set_header        X-Real-IP $remote_addr;
-      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header        X-Forwarded-Proto $scheme;
-      proxy_set_header        X-Forwarded-Host $host;
-      proxy_set_header        X-Forwarded-Server $host;
-      proxy_set_header        Accept-Encoding "";
+      ${optionalString (cfg.recommendedProxySettings) ''
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Forwarded-Host $host;
+        proxy_set_header        X-Forwarded-Server $host;
+        proxy_set_header        Accept-Encoding "";
 
-      proxy_redirect          off;
+        proxy_redirect          off;
+        proxy_connect_timeout   90;
+        proxy_send_timeout      90;
+        proxy_read_timeout      90;
+        proxy_http_version      1.0;
+      ''}
+
       client_max_body_size    10m;
-      client_body_buffer_size 128k;
-      proxy_connect_timeout   90;
-      proxy_send_timeout      90;
-      proxy_read_timeout      90;
-      proxy_buffers           32 4k;
-      proxy_buffer_size       8k;
-      proxy_http_version      1.0;
 
       server_tokens ${if cfg.serverTokens then "on" else "off"};
       ${vhosts}
     }
+
+    ${cfg.config}
+
+    # Keep this seperate to allow overriding previous settings
     ${optionalString (cfg.httpConfig != "") ''
     http {
       include ${cfg.package}/conf/mime.types;
@@ -157,11 +161,37 @@ in
 {
   options = {
     services.nginx = {
-      enable = mkOption {
+      enable = mkEnableOption "Nginx Web Server";
+
+      recommendedTlsSettings = mkOption {
         default = false;
         type = types.bool;
         description = "
-          Enable the nginx Web Server.
+          Enable recommended TLS settings.
+        ";
+      };
+
+      recommendedOptimisation = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable recommended optimisation settings.
+        ";
+      };
+
+      recommendedGzipSettings = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable recommended gzip settings.
+        ";
+      };
+
+      recommendedProxySettings = mkOption {
+        default = false;
+        type = types.bool;
+        description = "
+          Enable recommended proxy settings.
         ";
       };
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -118,19 +118,31 @@ let
             ssl_certificate_key ${vhost.sslCertificateKey};
           ''}
 
-          ${genLocations vhost.locations}
+          ${optionalString (vhost.basicAuth != {}) (mkBasicAuth serverName vhost.basicAuth)}
+
+          ${mkLocations vhost.locations}
 
           ${vhost.extraConfig}
         }
       ''
   ) virtualHosts);
-  genLocations = locations: concatStringsSep "\n" (mapAttrsToList (location: config: ''
+  mkLocations = locations: concatStringsSep "\n" (mapAttrsToList (location: config: ''
     location ${location} {
       ${optionalString (config.proxyPass != null) "proxy_pass ${config.proxyPass};"}
       ${optionalString (config.root != null) "root ${config.root};"}
       ${config.extraConfig}
     }
   '') locations);
+  mkBasicAuth = serverName: authDef: let
+    htpasswdFile = pkgs.writeText "${serverName}.htpasswd" (
+      concatStringsSep "\n" (mapAttrsToList (user: password: ''
+        ${user}:{PLAIN}${password}
+      '') authDef)
+    );
+  in ''
+    auth_basic secured;
+    auth_basic_user_file ${htpasswdFile};
+  '';
 in
 
 {

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -235,7 +235,7 @@ in
       sslDhparam = mkOption {
         type = types.nullOr types.path;
         default = null;
-        example = literalExample "/path/to/dhparams.pem";
+        example = "/path/to/dhparams.pem";
         description = "Path to DH parameters file.";
       };
 
@@ -246,9 +246,18 @@ in
         default = {
           localhost = {};
         };
-        example = [];
-        description = ''
+        example = literalExample ''
+          {
+            "hydra.example.com" = {
+              forceSSL = true;
+              enableACME = true;
+              locations."/" = {
+                proxyPass = "http://localhost:3000";
+              };
+            };
+          };
         '';
+        description = "Declarative vhost config";
       };
     };
   };

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -82,8 +82,10 @@ let
           location /.well-known/acme-challenge {
             try_files $uri @acme-fallback;
             root ${vhost.acmeRoot};
+            auth_basic off;
           }
           location @acme-fallback {
+            auth_basic off;
             proxy_pass http://${vhost.acmeFallbackHost};
           }
         '';

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -117,6 +117,7 @@ let
     location ${location} {
       ${optionalString (config.proxyPass != null) "proxy_pass ${config.proxyPass};"}
       ${optionalString (config.root != null) "root ${config.root};"}
+      ${config.extraConfig}
     }
   '') locations);
 in

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -111,7 +111,7 @@ let
           ${acmeLocation}
           ${optionalString (vhost.root != null) "root ${vhost.root};"}
           ${optionalString (vhost.globalRedirect != null) ''
-            return 301 https://${vhost.globalRedirect}$request_uri;
+            return 301 http${optionalString ssl "s"}://${vhost.globalRedirect}$request_uri;
           ''}
           ${optionalString ssl ''
             ssl_certificate ${vhost.sslCertificate};

--- a/nixos/modules/services/web-servers/nginx/location-options.nix
+++ b/nixos/modules/services/web-servers/nginx/location-options.nix
@@ -27,6 +27,14 @@ with lib;
         Root directory for requests.
       '';
     };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        These lines go to the end of the location verbatim.
+      '';
+    };
   };
 }
 

--- a/nixos/modules/services/web-servers/nginx/location-options.nix
+++ b/nixos/modules/services/web-servers/nginx/location-options.nix
@@ -1,0 +1,32 @@
+# This file defines the options that can be used both for the Apache
+# main server configuration, and for the virtual hosts.  (The latter
+# has additional options that affect the web server as a whole, like
+# the user/group to run under.)
+
+{ lib }:
+
+with lib;
+
+{
+  options = {
+    proxyPass = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "http://www.example.org/";
+      description = ''
+        Adds proxy_pass directive and sets default proxy headers Host, X-Real-Ip
+        and X-Forwarded-For.
+      '';
+    };
+
+    root = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = /your/root/directory;
+      description = ''
+        Root directory for requests.
+      '';
+    };
+  };
+}
+

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -80,6 +80,14 @@ with lib;
       '';
     };
 
+    default = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Makes this vhost the default.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -1,0 +1,96 @@
+# This file defines the options that can be used both for the Apache
+# main server configuration, and for the virtual hosts.  (The latter
+# has additional options that affect the web server as a whole, like
+# the user/group to run under.)
+
+{ lib }:
+
+with lib;
+{
+  options = {
+    serverAliases = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = ["www.example.org" "example.org"];
+      description = ''
+        Additional names of virtual hosts served by this virtual host configuration.
+      '';
+    };
+
+    port = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      description = ''
+        Port for the server. 80 for http
+        and 443 for https (i.e. when enableSSL is set).
+      '';
+    };
+
+    enableSSL = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable SSL (https) support.";
+    };
+
+    forceSSL = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to always redirect to https.";
+    };
+
+    sslCertificate = mkOption {
+      type = types.path;
+      example = "/var/host.cert";
+      description = "Path to server SSL certificate.";
+    };
+
+    sslCertificateKey= mkOption {
+      type = types.path;
+      example = "/var/host.key";
+      description = "Path to server SSL certificate key.";
+    };
+
+    root = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/data/webserver/docs";
+      description = ''
+        The path of the web root directory.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        These lines go to the end of the vhost verbatim.
+      '';
+    };
+
+    globalRedirect = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = http://newserver.example.org/;
+      description = ''
+        If set, all requests for this host are redirected permanently to
+        the given URL.
+      '';
+    };
+
+    basicAuth = mkOption {
+      type = types.attrsOf types.str;
+      default = {};
+      description = "user = password";
+    };
+
+    locations = mkOption {
+      type = types.attrsOf (types.submodule (import ./location-options.nix {
+        inherit lib;
+      }));
+      default = {};
+      example = {};
+      description = ''
+      '';
+    };
+  };
+}

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -26,6 +26,18 @@ with lib;
       '';
     };
 
+    enableACME = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to ask Let's Encrypt to sign a certificate for this vhost.";
+    };
+
+    acmeRoot = mkOption {
+      type = types.str;
+      default = "/var/lib/acme/acme-challenge";
+      description = "Directory to store certificates and keys managed by the ACME service.";
+    };
+
     enableSSL = mkOption {
       type = types.bool;
       default = false;
@@ -44,7 +56,7 @@ with lib;
       description = "Path to server SSL certificate.";
     };
 
-    sslCertificateKey= mkOption {
+    sslCertificateKey = mkOption {
       type = types.path;
       example = "/var/host.key";
       description = "Path to server SSL certificate key.";

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -38,6 +38,15 @@ with lib;
       description = "Directory to store certificates and keys managed by the ACME service.";
     };
 
+    acmeFallbackHost = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = ''
+        Host which to proxy requests to if acme challenge is not found. Useful
+        if you want multiple hosts to be able to verify the same domain name.
+      '';
+    };
+
     enableSSL = mkOption {
       type = types.bool;
       default = false;

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -21,7 +21,7 @@ with lib;
       type = types.nullOr types.int;
       default = null;
       description = ''
-        Port for the server. 80 for http
+        Port for the server. Defaults to 80 for http
         and 443 for https (i.e. when enableSSL is set).
       '';
     };
@@ -109,7 +109,17 @@ with lib;
     basicAuth = mkOption {
       type = types.attrsOf types.str;
       default = {};
-      description = "user = password";
+      example = literalExample ''
+        {
+          user = "password";
+        };
+      '';
+      description = ''
+        Basic Auth protection for a vhost.
+
+        WARNING: This is implemented to store the password in plain text in the
+        nix store.
+      '';
     };
 
     locations = mkOption {
@@ -117,9 +127,14 @@ with lib;
         inherit lib;
       }));
       default = {};
-      example = {};
-      description = ''
+      example = literalExample ''
+        {
+          "/" = {
+            proxyPass = "http://localhost:3000";
+          };
+        };
       '';
+      description = "Declarative location config";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Make the nginx config declaritive and therefore to easily generate locations/vhosts e.g. for many domains on a reverse proxy.
###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested excessively on multiple production machines since around february.
