### PR TITLE
iterm2: init at 2.1.4

### DIFF
--- a/pkgs/applications/misc/iterm2/default.nix
+++ b/pkgs/applications/misc/iterm2/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "iterm2-${version}";
+  version = "2.1.4";
+
+  src = fetchurl {
+    url = "https://iterm2.com/downloads/stable/iTerm2-2_1_4.zip";
+    sha256 = "1kb4j1p1kxj9dcsd34709bm2870ffzpq6jig6q9ixp08g0zbhqhh";
+  };
+
+  buildInputs = [ unzip ];
+  installPhase = ''
+    mkdir -p "$out/Applications"
+    mv "$(pwd)" "$out/Applications/iTerm.app"
+  '';
+
+  meta = {
+    description = "A replacement for Terminal and the successor to iTerm";
+    homepage = https://www.iterm2.com/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16942,4 +16942,6 @@ in
   tomb = callPackage ../os-specific/linux/tomb {};
 
   imatix_gsl = callPackage ../development/tools/imatix_gsl {};
+
+  iterm2 = callPackage ../applications/misc/iterm2 {};
 }


### PR DESCRIPTION
###### Motivation for this change

Adds the iTerm2 Terminal emulator.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] OS X
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
