### PR TITLE
reattach-to-user-namespace: fix sha

### DIFF
--- a/pkgs/os-specific/darwin/reattach-to-user-namespace/default.nix
+++ b/pkgs/os-specific/darwin/reattach-to-user-namespace/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "reattach-to-user-namespace-2.4";
   src = fetchgit {
     url = "https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard.git";
-    sha256 = "1f9q1wxq764zidnx5hbdkbbyxxzfih0l0cjpgr0pxzwbmd2q6cvv";
+    sha256 = "0hrh95di5dvpynq2yfcrgn93l077h28i6msham00byw68cx0dd3z";
     rev = "2765aeab8f337c29e260a912bf4267a2732d8640";
   };
   buildFlags = "ARCHES=x86_64";


### PR DESCRIPTION
###### Motivation for this change

The build failed because the sha was incorrect. Actually I don't quite understand how this can happen since a specific revision was specified. This PR fixes the sha.
- Built on platform(s)
  - [X] OS X
