### PR TITLE
texlive-bin: remove detecting of local directory from mktex*

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive-new/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive-new/bin.nix
@@ -64,6 +64,12 @@ core = stdenv.mkDerivation rec {
     perl
   ];
 
+  postPatch = ''
+    for i in texk/kpathsea/mktex*; do
+      sed -i '/^mydir=/d' "$i"
+    done
+  '';
+
   preConfigure = ''
     rm -r libs/{cairo,freetype2,gd,gmp,graphite2,harfbuzz,icu,libpaper,libpng} \
       libs/{mpfr,pixman,poppler,potrace,xpdf,zlib,zziplib}


### PR DESCRIPTION
###### Motivation for this change

`mktexpk` uses argv0 to prepend its path to`PATH`, using un-wrapped binaries from texlive. This patch should stop it (and possible other such violations).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @vcunat. Tested it with several my documents -- works and generally seems safe. I'll merge in few days if you won't outrun me.
