### PR TITLE
neovim: fix broken build

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -111,7 +111,7 @@ let
       install_name_tool -change libjemalloc.1.dylib \
                 ${jemalloc}/lib/libjemalloc.1.dylib \
                 $out/bin/nvim
-      sed -i -e "s|'xsel|'${xsel}/bin/xsel|" share/nvim/runtime/autoload/provider/clipboard.vim
+      sed -i -e "s|'xsel|'${xsel}/bin/xsel|" $out/share/nvim/runtime/autoload/provider/clipboard.vim
     '' + optionalString withPython ''
       ln -s ${pythonEnv}/bin/python $out/bin/nvim-python
     '' + optionalString withPyGUI ''


### PR DESCRIPTION
###### Motivation for this change

It seems to me that https://github.com/NixOS/nixpkgs/commit/e9c86755ddf9ccf95e4e270b4ea74dfb9674c953 broke neovim: 

```
patching /nix/store/x8aizkvlv1d8rnns1qf1z6g10xknif9g-neovim-0.1.3/bin/nvim
sed: can't read share/nvim/runtime/autoload/provider/clipboard.vim: No such file or directory
builder for ‘/nix/store/rky8g8kw2hib04vq2v6b977xv39kcyv7-neovim-0.1.3.drv’ failed with exit code 2
error: build of ‘/nix/store/rky8g8kw2hib04vq2v6b977xv39kcyv7-neovim-0.1.3.drv’ failed
```

Seems to me that the fix is to patch `$out/share/...` instead of `share/...` which is what this PR changes. /cc @garbas 
