### PR TITLE
cudnn: add cudatoolkit to propagatedBuildInputs

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile }:
+{ stdenv, requireFile, cudatoolkit }:
 
 stdenv.mkDerivation rec {
   version = "4.0";
@@ -18,17 +18,13 @@ stdenv.mkDerivation rec {
 
   phases = "unpackPhase installPhase fixupPhase";
 
+  propagatedBuildInputs = [ cudatoolkit ];
+
   installPhase = ''
     mkdir -p $out
     cp -a include $out/include
     cp -a lib64 $out/lib64
   '';
-
-  # all binaries are already stripped
-  #dontStrip = true;
-
-  # we did this in prefixup already
-  #dontPatchELF = true;
 
   meta = {
     description = "NVIDIA CUDA Deep Neural Network library (cuDNN)";


### PR DESCRIPTION
###### Motivation for this change

cudatoolkit is necessary for cuDNN at runtime as @artuuge pointed out in Pull Request #15664 
This cudnn package was tested with theano in my test machine.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
