### PR TITLE
kernel: enable OverlayFS

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -254,6 +254,9 @@ with stdenv.lib;
   ${optionalString (versionAtLeast version "3.19") ''
     SQUASHFS_LZ4 y
   ''}
+  ${optionalString (versionAtLeast version "3.18") ''
+    OVERLAY_FS y
+  ''}
 
   # Security related features.
   STRICT_DEVMEM y # Filter access to /dev/mem


### PR DESCRIPTION
###### Motivation for this change

It would be nice to support [OverlayFS](https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt) out-of-the-box.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See: https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt

Partial fix for #15879
