### PR TITLE
wayland & weston: 1.10.0 -> 1.11.0

### DIFF
--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   name = "weston-${version}";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchurl {
     url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "1hd5593zz5s3s07vb6linp6akbs62wy2ijh3g7gksafq016h1cp0";
+    sha256 = "09biddxw3ar797kxf9mywjkb2iwky6my39gpp51ni846y7lqdq05";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -8,11 +8,11 @@ assert expat != null;
 
 stdenv.mkDerivation rec {
   name = "wayland-${version}";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchurl {
     url = "http://wayland.freedesktop.org/releases/${name}.tar.xz";
-    sha256 = "1p307ly1yyqjnzn9dbv78yffql2qszn84qk74lwanl3gma8fgxjb";
+    sha256 = "1c0d5ivy9n44hykvw2ggrvqrnn7naw3wg11vbvgwzgi8g5gr4h4m";
   };
 
   configureFlags = "--with-scanner --disable-documentation";


### PR DESCRIPTION
###### Motivation for this change

[wayland announcement / changelog](https://lists.freedesktop.org/archives/wayland-devel/2016-June/029163.html)
[weston announcement / changelog](https://lists.freedesktop.org/archives/wayland-devel/2016-June/029163.html)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Travis: 

```
The log length has exceeded the limit of 4 MB (this usually means that the test suite is raising the same exception over and over).
```
