### PR TITLE
pstoedit: depend on libwebp to fix linker failure

### DIFF
--- a/pkgs/tools/graphics/pstoedit/default.nix
+++ b/pkgs/tools/graphics/pstoedit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, ghostscript, gd, libjpeg, zlib, plotutils }:
+{ stdenv, fetchurl, pkgconfig, ghostscript, gd, libjpeg, zlib, plotutils, libwebp }:
 
 stdenv.mkDerivation rec {
   name = "pstoedit-3.62";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0j410dm9nqwa7n03yiyz0jwvln0jlqc3n9iv4nls33yl6x3c8x40";
   };
 
-  buildInputs = [ pkgconfig ghostscript gd libjpeg zlib plotutils ];
+  buildInputs = [ pkgconfig ghostscript gd libjpeg zlib plotutils libwebp ];
 
   meta = { 
     description = "Translates PostScript and PDF graphics into other vector formats";


### PR DESCRIPTION
###### Motivation for this change

I can not install pstoedit by `nix-env -i pstoedit`, because the compilation failed with

```
/nix/store/kqy04h4bifynyvvd12r389zhrnkczjs8-binutils-2.26/bin/ld: cannot find -lwebp
collect2: error: ld returned 1 exit status
Makefile:569: recipe for target 'libpstoedit.la' failed
make[2]: *** [libpstoedit.la] Error 1
make[2]: Leaving directory '/tmp/nix-build-pstoedit-3.62.drv-0/pstoedit-3.62/src'
Makefile:452: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/tmp/nix-build-pstoedit-3.62.drv-0/pstoedit-3.62/src'
Makefile:278: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
builder for ‘/nix/store/3nzpahndhx6xzcafgkfyamvki1lrkqvj-pstoedit-3.62.drv’ failed with exit code 2
error: build of ‘/nix/store/3nzpahndhx6xzcafgkfyamvki1lrkqvj-pstoedit-3.62.drv’ failed
```

However I am not sure whether this is a good fix or not, since the automatic build of this package on hydra looks fine.
cc @joachifm 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
