### PR TITLE
krita: init at 3.0

### DIFF
--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchgit, cmake, extra-cmake-modules, makeQtWrapper
+, karchive, kconfig, kwidgetsaddons, kcompletion, kcoreaddons
+, kguiaddons, ki18n, kitemmodels, kitemviews, kwindowsystem
+, kio, kcrash
+, boost, libraw, fftw, eigen, exiv2, lcms2, gsl, openexr
+, openjpeg, opencolorio, vc, poppler_qt5, curl, ilmbase
+}:
+
+stdenv.mkDerivation rec {
+  name = "krita-${version}";
+  version = "3.0";
+
+  src = fetchgit {
+    url = "http://phabricator.kde.org/diffusion/KRITA/krita.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "0aas86667ncp8jz00c8qk7bm26g76l65cysh06wxr8kxbvqynrdn";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules makeQtWrapper ];
+
+  buildInputs = [
+    karchive kconfig kwidgetsaddons kcompletion kcoreaddons kguiaddons
+    ki18n kitemmodels kitemviews kwindowsystem kio kcrash
+    boost libraw fftw eigen exiv2 lcms2 gsl openexr
+    openjpeg opencolorio vc poppler_qt5 curl ilmbase
+  ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${ilmbase}/include/OpenEXR" ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    for i in $out/bin/*; do
+      wrapQtProgram "$i"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A free an open source painting application";
+    homepage = "https://krita.org/";
+    maintainers = with maintainers; [ abbradar ];
+    platforms = platforms.linux;
+    licenses = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15790,6 +15790,11 @@ in
 
     konversation = callPackage ../applications/networking/irc/konversation/1.6.nix { };
 
+    krita = callPackage ../applications/graphics/krita {
+      vc = vc_0_7;
+      openjpeg = openjpeg_1;
+    };
+
     phonon = callPackage ../development/libraries/phonon { };
 
     phonon-backend-gstreamer = callPackage ../development/libraries/phonon/backends/gstreamer.nix { };


### PR DESCRIPTION
###### Motivation for this change

Krita is now split from Calligra -- make a new updated package.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closes: #9378
Fixes: #9238

I get this error when trying to run because of #15498:

```
result/bin/krita: symbol lookup error: /nix/store/3kkjwr7jkjss3n57jr7qjal98nfhnhab-qtbase-5.5.1/lib/libQt5XcbQpa.so.5: undefined symbol: _ZN22QWindowSystemInterface19registerTouchDeviceEP12QTouchDevice
```
