### PR TITLE
accountsservice: refactor package and service

### DIFF
--- a/nixos/modules/services/desktops/accountsservice.nix
+++ b/nixos/modules/services/desktops/accountsservice.nix
@@ -35,6 +35,14 @@ with lib;
     services.dbus.packages = [ pkgs.accountsservice ];
 
     systemd.packages = [ pkgs.accountsservice ];
+
+    systemd.services.accounts-daemon= {
+
+      wantedBy = [ "graphical.target" ];
+
+    } // (mkIf (!config.users.mutableUsers) {
+      environment.NIXOS_USERS_PURE = "true";
+    });
   };
 
 }

--- a/pkgs/development/libraries/accountsservice/Add-nixbld-to-user-blacklist.patch
+++ b/pkgs/development/libraries/accountsservice/Add-nixbld-to-user-blacklist.patch
@@ -1,0 +1,27 @@
+From e069102365a9ff03822667f435e662f938e8d768 Mon Sep 17 00:00:00 2001
+From: Alexander Ried <ried@mytum.de>
+Date: Wed, 1 Jun 2016 12:49:48 +0200
+Subject: [PATCH] Add nixbld* to user blacklist
+
+---
+ src/user-classify.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/user-classify.c b/src/user-classify.c
+index 69e6809..0e152b6 100644
+--- a/src/user-classify.c
++++ b/src/user-classify.c
+@@ -75,6 +75,10 @@ user_classify_is_blacklisted (const char *username)
+                 return TRUE;
+         }
+ 
++        if (g_str_has_prefix (username, "nixbld")) {
++                return TRUE;
++        }
++
+         return FALSE;
+ }
+ 
+-- 
+2.7.4
+

--- a/pkgs/development/libraries/accountsservice/Disable-methods-that-change-files-in-etc.patch
+++ b/pkgs/development/libraries/accountsservice/Disable-methods-that-change-files-in-etc.patch
@@ -1,0 +1,130 @@
+From 6f172007452b39bfda5062fc29ea5382671ac16e Mon Sep 17 00:00:00 2001
+From: Alexander Ried <ried@mytum.de>
+Date: Thu, 26 May 2016 19:54:21 +0200
+Subject: [PATCH] Disable methods that change files in /etc
+
+Only if environment variable NIXOS_USERS_PURE is set.
+---
+ src/daemon.c | 10 ++++++++++
+ src/user.c   | 35 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 45 insertions(+)
+
+diff --git a/src/daemon.c b/src/daemon.c
+index e62e124..87459b2 100644
+--- a/src/daemon.c
++++ b/src/daemon.c
+@@ -931,6 +931,11 @@ daemon_create_user (AccountsAccounts      *accounts,
+                     const gchar           *real_name,
+                     gint                   account_type)
+ {
++        if (getenv("NIXOS_USERS_PURE")) {
++                throw_error (context, ERROR_NOT_SUPPORTED, "Modifying users not supported without users.mutableUsers");
++                return;
++        }
++
+         Daemon *daemon = (Daemon*)accounts;
+         CreateUserData *data;
+ 
+@@ -1138,6 +1143,11 @@ daemon_delete_user (AccountsAccounts      *accounts,
+                     gint64                 uid,
+                     gboolean               remove_files)
+ {
++        if (getenv("NIXOS_USERS_PURE")) {
++                throw_error (context, ERROR_NOT_SUPPORTED, "Modifying users not supported without users.mutableUsers");
++                return;
++        }
++
+         Daemon *daemon = (Daemon*)accounts;
+         DeleteUserData *data;
+ 
+diff --git a/src/user.c b/src/user.c
+index 0fb1a17..dbdebaf 100644
+--- a/src/user.c
++++ b/src/user.c
+@@ -904,6 +904,11 @@ user_set_real_name (AccountsUser          *auser,
+                     GDBusMethodInvocation *context,
+                     const gchar           *real_name)
+ {
++        if (getenv("NIXOS_USERS_PURE")) {
++                throw_error (context, ERROR_NOT_SUPPORTED, "Modifying users not supported without users.mutableUsers");
++                return;
++        }
++
+         User *user = (User*)auser;
+         int uid;
+         const gchar *action_id;
+@@ -981,6 +986,11 @@ user_set_user_name (AccountsUser          *auser,
+                     GDBusMethodInvocation *context,
+                     const gchar           *user_name)
+ {
++        if (getenv("NIXOS_USERS_PURE")) {
++                throw_error (context, ERROR_NOT_SUPPORTED, "Modifying users not supported without users.mutableUsers");
++                return;
++        }
++
+         User *user = (User*)auser;
+         daemon_local_check_auth (user->daemon,
+                                  user,
+@@ -1263,6 +1273,11 @@ user_set_home_directory (AccountsUser          *auser,
+                          GDBusMethodInvocation *context,
+                          const gchar           *home_dir)
+ {
++        if (getenv("NIXOS_USERS_PURE")) {
++                throw_error (context, ERROR_NOT_SUPPORTED, "Modifying users not supported without users.mutableUsers");
++                return;
++        }
++
+         User *user = (User*)auser;
+         daemon_local_check_auth (user->daemon,
+                                  user,
+@@ -1322,6 +1337,11 @@ user_set_shell (AccountsUser          *auser,
+                 GDBusMethodInvocation *context,
+                 const gchar           *shell)
+ {
++        if (getenv("NIXOS_USERS_PURE")) {
++                throw_error (context, ERROR_NOT_SUPPORTED, "Modifying users not supported without users.mutableUsers");
++                return;
++        }
++
+         User *user = (User*)auser;
+         daemon_local_check_auth (user->daemon,
+                                  user,
+@@ -1602,6 +1622,11 @@ user_set_locked (AccountsUser          *auser,
+                  GDBusMethodInvocation *context,
+                  gboolean               locked)
+ {
++        if (getenv("NIXOS_USERS_PURE")) {
++                throw_error (context, ERROR_NOT_SUPPORTED, "Modifying users not supported without users.mutableUsers");
++                return;
++        }
++
+         User *user = (User*)auser;
+         daemon_local_check_auth (user->daemon,
+                                  user,
+@@ -1814,6 +1839,11 @@ user_set_password_mode (AccountsUser          *auser,
+                         GDBusMethodInvocation *context,
+                         gint                   mode)
+ {
++        if (getenv("NIXOS_USERS_PURE")) {
++                throw_error (context, ERROR_NOT_SUPPORTED, "Modifying users not supported without users.mutableUsers");
++                return;
++        }
++
+         User *user = (User*)auser;
+         const gchar *action_id;
+ 
+@@ -1905,6 +1935,11 @@ user_set_password (AccountsUser          *auser,
+                    const gchar           *password,
+                    const gchar           *hint)
+ {
++        if (getenv("NIXOS_USERS_PURE")) {
++                throw_error (context, ERROR_NOT_SUPPORTED, "Modifying users not supported without users.mutableUsers");
++                return;
++        }
++
+         User *user = (User*)auser;
+         gchar **data;
+ 
+-- 
+2.9.3
+

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, intltool, makeWrapper
+{ stdenv, fetchurl, pkgconfig, glib, intltool, makeWrapper, shadow
 , libtool, gobjectIntrospection, polkit, systemd, coreutils }:
 
 stdenv.mkDerivation rec {
@@ -16,8 +16,12 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
                      "--localstatedir=/var" ];
   prePatch = ''
-    substituteInPlace src/daemon.c --replace '"/usr/sbin/' '"/run/current-system/sw/sbin/'
-    substituteInPlace src/user.c --replace '"/usr/sbin/' '"/run/current-system/sw/sbin/' --replace '"/usr/bin/' '"/run/current-system/sw/bin' --replace '"/bin/cat"' '"/run/current-system/sw/bin/cat"'
+    substituteInPlace src/daemon.c --replace '"/usr/sbin/useradd"' '"${shadow}/bin/useradd"' \
+                                   --replace '"/usr/sbin/userdel"' '"${shadow}/bin/userdel"'
+    substituteInPlace src/user.c   --replace '"/usr/sbin/usermod"' '"${shadow}/bin/usermod"' \
+                                   --replace '"/usr/bin/chage"' '"${shadow}/bin/chage"' \
+                                   --replace '"/usr/bin/passwd"' '"${shadow}/bin/passwd"' \
+                                   --replace '"/bin/cat"' '"${coreutils}/bin/cat"'
   '';
 
   patches = [

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
                      "--localstatedir=/var" ];
 
   patches = [ ./no-create-dirs.patch ];
-  patchFlags = "-p0";
   
   preFixup = ''
     wrapProgram "$out/libexec/accounts-daemon" \

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "accountsservice-${version}";
-  version = "0.6.40";
-  
+  version = "0.6.42";
+
   src = fetchurl {
     url = "http://www.freedesktop.org/software/accountsservice/accountsservice-${version}.tar.xz";
-    sha256 = "0ayb3y3l25dmwxlh9g071h02mphjfbkvi2k5f635bayb01k7akzh";
+    sha256 = "0zh0kjpdc631qh36plcgpwvnmh9wj8l5cki3aw5r09w6y7198r75";
   };
 
   buildInputs = [ pkgconfig glib intltool libtool makeWrapper

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -20,8 +20,11 @@ stdenv.mkDerivation rec {
     substituteInPlace src/user.c --replace '"/usr/sbin/' '"/run/current-system/sw/sbin/' --replace '"/usr/bin/' '"/run/current-system/sw/bin' --replace '"/bin/cat"' '"/run/current-system/sw/bin/cat"'
   '';
 
-  patches = [ ./no-create-dirs.patch ];
-  
+  patches = [
+    ./no-create-dirs.patch
+    ./Add-nixbld-to-user-blacklist.patch
+  ];
+
   preFixup = ''
     wrapProgram "$out/libexec/accounts-daemon" \
       --run "${coreutils}/bin/mkdir -p /var/lib/AccountsService/users" \

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
                      "--localstatedir=/var" ];
+  prePatch = ''
+    substituteInPlace src/daemon.c --replace '"/usr/sbin/' '"/run/current-system/sw/sbin/'
+    substituteInPlace src/user.c --replace '"/usr/sbin/' '"/run/current-system/sw/sbin/' --replace '"/usr/bin/' '"/run/current-system/sw/bin' --replace '"/bin/cat"' '"/run/current-system/sw/bin/cat"'
+  '';
 
   patches = [ ./no-create-dirs.patch ];
   

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./no-create-dirs.patch
     ./Add-nixbld-to-user-blacklist.patch
+    ./Disable-methods-that-change-files-in-etc.patch
   ];
 
   preFixup = ''

--- a/pkgs/development/libraries/accountsservice/no-create-dirs.patch
+++ b/pkgs/development/libraries/accountsservice/no-create-dirs.patch
@@ -1,5 +1,5 @@
---- src/Makefile.in.orig	2014-04-23 22:30:00.276005326 +0200
-+++ src/Makefile.in	2014-04-23 22:30:16.809409113 +0200
+--- a/src/Makefile.in	2014-04-23 22:30:00.276005326 +0200
++++ b/src/Makefile.in	2014-04-23 22:30:16.809409113 +0200
 @@ -881,8 +881,8 @@
  	gdbus-codegen --generate-c-code accounts-user-generated --c-namespace Accounts --interface-prefix=org.freedesktop.Accounts. $(top_srcdir)/data/org.freedesktop.Accounts.User.xml
  


### PR DESCRIPTION
###### Motivation for this change

This makes the following changes to accountsservice:
- Add `nixbld*` to the blacklist (so they will not be listed on login screen, etc)
- Fix a few path to `/run/current-system/sw/...`
- Remove the functions that manipulate `/etc/{passwd, ...}` when `mutableUsers` is set to `false`

I left the functions that modify `/var/lib/AccountsService/` active because these files are not managed by nix and are relevant for desktop environments (icon, etc.)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

before (`mutableUsers = *`):

```
$ dbus-send --print-reply --system --dest=org.freedesktop.Accounts /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:abc string:"max mustermann" int32:1
Error org.freedesktop.Accounts.Error.Failed: running '/usr/sbin/useradd' failed: Failed to execute child process "/usr/sbin/useradd" (No such file or directory)
```

now (`mutableUsers = true`):

```
$ dbus-send --print-reply --system --dest=org.freedesktop.Accounts /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:abc string:"max mustermann" int32:1
method return time=1464780613.660190 sender=:1.267 -> destination=:1.269 serial=15 reply_serial=2
   object path "/org/freedesktop/Accounts/User1001"
% grep abc /etc/passwd
abc:x:1001:100:max mustermann:/home/abc:/run/current-system/sw/bin/zsh
```

now (`mutableUsers = false`):

```
$ sudo dbus-send --print-reply --system --dest=org.freedesktop.Accounts /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:abc string:"max mustermann" int32:1
Error org.freedesktop.Accounts.Error.NotSupported: Modifying users not supported without users.mutableUsers
```

CC: @pSub 
