### PR TITLE
stage2: if no /proc, also mount /sys

### DIFF
--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -41,6 +41,8 @@ if [ ! -e /proc/1 ]; then
     mount -n -t proc proc /proc
     mkdir -m 0755 -p /dev
     mount -t devtmpfs devtmpfs /dev
+    mkdir -m 0755 -p /sys
+    mount -t sysfs sysfs /sys
 fi
 
 


### PR DESCRIPTION
###### Motivation for this change

For Cerana we do a bunch of additional configuration before systemd launches. Some of it needs access to `/sys`. I'm pretty sure this should be fine upstream in NixOS too.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
