### PR TITLE
nixos kde5: improve test

### DIFF
--- a/nixos/tests/sddm-kde5.nix
+++ b/nixos/tests/sddm-kde5.nix
@@ -1,4 +1,6 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix ({ pkgs, ...} :
+
+{
   name = "sddm";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ttuegel ];
@@ -6,6 +8,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   machine = { lib, ... }: {
     imports = [ ./common/user-account.nix ];
+    virtualisation.memorySize = 1024;
     services.xserver.enable = true;
     services.xserver.displayManager.sddm = {
       enable = true;
@@ -14,18 +17,38 @@ import ./make-test.nix ({ pkgs, ...} : {
         user = "alice";
       };
     };
-    services.xserver.windowManager.default = "icewm";
-    services.xserver.windowManager.icewm.enable = true;
-    services.xserver.desktopManager.default = "none";
     services.xserver.desktopManager.kde5.enable = true;
   };
 
   enableOCR = true;
 
-  testScript = { nodes, ... }: ''
-    startAll;
-    $machine->waitForFile("/home/alice/.Xauthority");
-    $machine->succeed("xauth merge ~alice/.Xauthority");
-    $machine->waitForWindow("^IceWM ");
+  testScript = { nodes, ... }:
+  let xdo = "${pkgs.xdotool}/bin/xdotool"; in
+   ''     
+    sub krunner {
+      my ($win,) = @_;
+      $machine->execute("${xdo} key Alt+F2 sleep 1 type $win");
+      $machine->execute("${xdo} search --sync --onlyvisible --class krunner sleep 5 key Return");
+    }
+
+    $machine->waitUntilSucceeds("pgrep plasmashell");
+    $machine->succeed("xauth merge ~alice/.Xauthority");    
+    $machine->waitForWindow(qr/Desktop.*/);
+
+    # Check that logging in has given the user ownership of devices.
+    $machine->succeed("getfacl /dev/snd/timer | grep -q alice");
+    
+    krunner("dolphin");
+    $machine->waitForWindow(qr/.*Dolphin/);
+    
+    krunner("konsole");
+    $machine->waitForWindow(qr/.*Konsole/);
+    
+    krunner("systemsettings5");
+    $machine->waitForWindow(qr/.*Settings/);
+    $machine->sleep(20);
+
+    $machine->execute("${xdo} key Alt+F1 sleep 10");
+    $machine->screenshot("screen");
   '';
 })


### PR DESCRIPTION
IceWM is not part of KDE 5 and is now no longer part of the test. KDE 5
applications: Dolphin, System Monitor, and System Settings are started
in this test.

Screen dump:
![image](https://cloud.githubusercontent.com/assets/336631/15714389/9c5c2c4c-281a-11e6-8dab-3e1477abe82e.png)

Dump on latest release:
![image](https://cloud.githubusercontent.com/assets/336631/15714873/a0dc4d68-281c-11e6-8a1c-c9c458a3fb68.png)
