### PR TITLE
cpputest: 3.7.2 -> 3.8

### DIFF
--- a/pkgs/development/libraries/cpputest/default.nix
+++ b/pkgs/development/libraries/cpputest/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  version = "3.7.2";
+  version = "3.8";
   name = "cpputest-${version}";
 
   src = fetchurl {
-    url = "https://github.com/cpputest/cpputest/releases/download/${version}/${name}.tar.gz";
-    sha256 = "0lwn226d8mrppdyzcvr08vsnnp6h0mpy5kz5a475ish87az00pcc";
+    url = "https://github.com/cpputest/cpputest/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "0mk48xd3klyqi7wf3f4wn4zqxxzmvrhhl32r25jzrixzl72wq7f8";
   };
 
   meta = {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
