### PR TITLE
ocamlPackages.ppx_tools : discriminate on compiler version

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -1,15 +1,36 @@
-{ stdenv, fetchzip, ocaml, findlib }:
+{ stdenv, fetchFromGitHub, ocaml, buildOcaml, lib }:
 
-stdenv.mkDerivation {
-  name = "ocaml-ppx_tools-5.0+4.02";
-  src = fetchzip {
-    url = https://github.com/alainfrisch/ppx_tools/archive/5.0+4.02.0.tar.gz;
-    sha256 = "16drjk0qafjls8blng69qiv35a84wlafpk16grrg2i3x19p8dlj8";
+let
+  # The library has different releases for each version of Ocaml
+  checksums = {
+    "4.02.0" = "16drjk0qafjls8blng69qiv35a84wlafpk16grrg2i3x19p8dlj8";
+    "4.03.0" = "061v1fl5z7z3ywi4ppryrlcywnvnqbsw83ppq72qmkc7ma4603jg";
   };
+  ocamlVersion = lib.getVersion ocaml;
 
-  buildInputs = [ ocaml findlib ];
+  # get the version corresponding to the current compiler
+  variant = lib.fold (accu: cur:
+    if lib.versionAtLeast ocamlVersion cur
+        && lib.versionAtLeast cur accu
+    then
+      cur
+    else accu
+    )
+    "0"
+    (lib.mapAttrsToList (name: _: name) checksums);
+in
 
-  createFindlibDestdir = true;
+assert (variant != "0");
+
+buildOcaml rec {
+  version = "5.0";
+  name = "ppx_tools";
+  src = fetchFromGitHub {
+    owner = "alainfrisch";
+    repo = name;
+    rev = version + "+" + variant;
+    sha256 = checksums."${variant}";
+  };
 
   meta = with stdenv.lib; {
     description = "Tools for authors of ppx rewriters";


### PR DESCRIPTION
###### Motivation for this change

Update and compatibility with newer versions of the ocaml compiler

I find the way I choose the version to use depending on the compiler version rather ugly, if there is a better way to to it, i'd be happy to update the PR.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
