### PR TITLE
comeonin: init at 2.4.0

### DIFF
--- a/pkgs/development/beam-modules/comeonin/default.nix
+++ b/pkgs/development/beam-modules/comeonin/default.nix
@@ -1,0 +1,22 @@
+{stdenv, fetchFromGitHub, beamPackages }:
+
+beamPackages.buildMix {
+  name = "comeonin";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+      owner = "elixircnx";
+      repo = "comeonin";
+      rev = "a158b18e52fac1adc715d9b0f7cd6efe6336b73b";
+      sha256 = "0sw2zlpa391s31xna2kg6500bhcznwsmhpjydynkdbcswiy74nhx";
+  };
+
+  beamDeps = [ beamPackages.earmark beamPackages.ex_doc ];
+
+  meta = {
+    description = "Password hashing (bcrypt, pbkdf2_sha512) library for Elixir";
+    license = stdenv.lib.licenses.bsd;
+    homepage = "https://github.com/elixircnx/comeonin";
+    maintainers = with stdenv.lib.maintainers; [ ericbmerritt ];
+  };
+}

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -10,6 +10,7 @@ let
     buildMix = callPackage ./build-mix.nix {};
 
     ## Non hex packages
+    comeonin = callPackage ./comeonin {};
     hex = callPackage ./hex {};
     webdriver = callPackage ./webdriver {};
   };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/15905)

<!-- Reviewable:end -->
