### PR TITLE
dpdk: refactor to allow building extapps

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -11,6 +11,7 @@
   abaldeau = "Andreas Baldeau <andreas@baldeau.net>";
   abbradar = "Nikolay Amiantov <ab@fmap.me>";
   aboseley = "Adam Boseley <adam.boseley@gmail.com>";
+  abuibrahim = "Ruslan Babayev <ruslan@babayev.com>";
   adev = "Adrien Devresse <adev@adev.name>";
   Adjective-Object = "Maxwell Huang-Hobbs <mhuan13@gmail.com>";
   adnelson = "Allen Nelson <ithinkican@gmail.com>";

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation rec {
     mkdir $out
     cp -pr x86_64-native-linuxapp-gcc/{app,lib,include,kmod} $out/
 
-    mkdir $examples
-    cp -pr examples/* $examples/
+    mkdir -p $examples/bin
+    find examples -type f -executable -exec cp {} $examples/bin \;
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -29,8 +29,25 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir $out
-    cp -pr x86_64-native-linuxapp-gcc/{lib,include} $out/
+    install -m 0755 -d $out/lib
+    install -m 0644 ${RTE_TARGET}/lib/*.a $out/lib
+
+    install -m 0755 -d $out/include
+    install -m 0644 ${RTE_TARGET}/include/*.h $out/include
+
+    install -m 0755 -d $out/include/generic
+    install -m 0644 ${RTE_TARGET}/include/generic/*.h $out/include/generic
+
+    install -m 0755 -d $out/include/exec-env
+    install -m 0644 ${RTE_TARGET}/include/exec-env/*.h $out/include/exec-env
+
+    install -m 0755 -d $out/${RTE_TARGET}
+    install -m 0644 ${RTE_TARGET}/.config $out/${RTE_TARGET}
+
+    install -m 0755 -d $out/${RTE_TARGET}/include
+    install -m 0644 ${RTE_TARGET}/include/rte_config.h $out/${RTE_TARGET}/include
+
+    cp -pr mk scripts $out/
 
     mkdir -p $kmod/lib/modules/${kernel.modDirVersion}/kernel/drivers/net
     cp ${RTE_TARGET}/kmod/*.ko $kmod/lib/modules/${kernel.modDirVersion}/kernel/drivers/net

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [ "-march=core2" ];
 
   enableParallelBuilding = true;
-  outputs = [ "out" "examples" ];
+  outputs = [ "out" "kmod" "examples" ];
 
   buildPhase = ''
     make T=x86_64-native-linuxapp-gcc config
@@ -30,7 +30,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir $out
-    cp -pr x86_64-native-linuxapp-gcc/{lib,include,kmod} $out/
+    cp -pr x86_64-native-linuxapp-gcc/{lib,include} $out/
+
+    mkdir -p $kmod/lib/modules/${kernel.modDirVersion}/kernel/drivers/net
+    cp ${RTE_TARGET}/kmod/*.ko $kmod/lib/modules/${kernel.modDirVersion}/kernel/drivers/net
 
     mkdir -p $examples/bin
     find examples ${RTE_TARGET}/app -type f -executable -exec cp {} $examples/bin \;

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -30,10 +30,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir $out
-    cp -pr x86_64-native-linuxapp-gcc/{app,lib,include,kmod} $out/
+    cp -pr x86_64-native-linuxapp-gcc/{lib,include,kmod} $out/
 
     mkdir -p $examples/bin
-    find examples -type f -executable -exec cp {} $examples/bin \;
+    find examples ${RTE_TARGET}/app -type f -executable -exec cp {} $examples/bin \;
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, kernel, fetchurl }:
+{ stdenv, lib, kernel, fetchurl, pkgconfig, libvirt }:
 
 assert lib.versionAtLeast kernel.version "3.18";
 
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     url = "http://dpdk.org/browse/dpdk/snapshot/dpdk-${version}.tar.gz";
     sha256 = "0yrz3nnhv65v2jzz726bjswkn8ffqc1sr699qypc9m78qrdljcfn";
   };
+
+  buildInputs = [ pkgconfig libvirt ];
 
   RTE_KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   RTE_TARGET = "x86_64-native-linuxapp-gcc";

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, dpdk, libpcap, utillinux }:
+
+stdenv.mkDerivation rec {
+  name = "pktgen-${version}";
+  version = "3.0.00";
+
+  src = fetchurl {
+    url = "http://dpdk.org/browse/apps/pktgen-dpdk/snapshot/pktgen-${version}.tar.gz";
+    sha256 = "703f8bd615aa4ae3a3085055483f9889dda09d082abb58afd33c1ba7c766ea65";
+  };
+
+  buildInputs = [ dpdk libpcap ];
+
+  RTE_SDK = "${dpdk}";
+  RTE_TARGET = "x86_64-native-linuxapp-gcc";
+
+  enableParallelBuilding = true;
+
+  patchPhase = ''
+    sed -i -e s:/usr/local:$out:g lib/lua/src/luaconf.h
+    sed -i -e s:/usr/bin/lscpu:${utillinux}/bin/lscpu:g lib/common/wr_lscpu.h
+  '';
+
+  installPhase = ''
+    install -d $out/bin
+    install -m 0755 app/app/${RTE_TARGET}/app/pktgen $out/bin
+    install -d $out/lib/lua/5.3
+    install -m 0644 Pktgen.lua $out/lib/lua/5.3
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Traffic generator powered by DPDK";
+    homepage = http://dpdk.org/;
+    license = licenses.bsdOriginal;
+    platforms =  [ "x86_64-linux" ];
+    maintainers = [ maintainers.abuibrahim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10844,6 +10844,8 @@ in
 
     dpdk = callPackage ../os-specific/linux/dpdk { };
 
+    pktgen = callPackage ../os-specific/linux/pktgen { };
+
     e1000e = callPackage ../os-specific/linux/e1000e {};
 
     v4l2loopback = callPackage ../os-specific/linux/v4l2loopback { };


### PR DESCRIPTION
###### Motivation for this change

These patches enable building external DPDK apps like pktgen. The primary output can now be used as RTE_SDK root.

Kernel modules are split into "kmod".

All apps and examples are bundled together and copied to bin thus ending up on PATH.

After adding the missing dependencies vm_power_mgr is now built into "examples" output.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
