### PR TITLE
fcitx: 4.2.9 -> 4.2.9.1, fix build

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/default.nix
+++ b/pkgs/tools/inputmethods/fcitx/default.nix
@@ -1,27 +1,34 @@
 { stdenv, fetchurl, pkgconfig, cmake, intltool, gettext
 , libxml2, enchant, isocodes, icu, libpthreadstubs
-, pango, cairo, libxkbfile, libXau, libXdmcp
+, pango, cairo, libxkbfile, libXau, libXdmcp, libxkbcommon
 , dbus, gtk2, gtk3, qt4, kde5
 }:
 
 stdenv.mkDerivation rec {
   name = "fcitx-${version}";
-  version = "4.2.9";
+  version = "4.2.9.1";
 
   src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx/${name}_dict.tar.xz";
-    sha256 = "0v7wdf3qf74vz8q090w8k574wvfcpj9ksfcfdw93nmzyk1q5p4rs";
+    url    = "http://download.fcitx-im.org/fcitx/${name}_dict.tar.xz";
+    sha256 = "0xvcmm4yi7kagf55d0yl3ql5ssbkm9410fwbz3kd988pchichdsk";
   };
 
-  patchPhase = ''
+  postUnpack = ''
+    ln -s ${kde5.extra-cmake-modules}/share/ECM/modules/ECMFindModuleHelpers.cmake \
+      $sourceRoot/cmake/
+  '';
+
+  patches = [ ./fcitx-ecm.patch ];
+
+  postPatch = ''
     substituteInPlace src/frontend/qt/CMakeLists.txt \
       --replace $\{QT_PLUGINS_DIR} $out/lib/qt4/plugins
   '';
 
-  buildInputs = with stdenv.lib; [
-    cmake enchant pango gettext libxml2 isocodes pkgconfig libxkbfile
-    intltool cairo icu libpthreadstubs libXau libXdmcp
-    dbus gtk2 gtk3 qt4 kde5.extra-cmake-modules
+  buildInputs = [
+    cmake enchant gettext isocodes pkgconfig intltool icu
+    libpthreadstubs libXau libXdmcp libxkbfile libxkbcommon libxml2
+    dbus cairo gtk2 gtk3 pango qt4
   ];
 
   cmakeFlags = ''
@@ -34,11 +41,11 @@ stdenv.mkDerivation rec {
     -DENABLE_XDGAUTOSTART=OFF
   '';
 
-  meta = {
-    homepage = "https://code.google.com/p/fcitx/";
+  meta = with stdenv.lib; {
+    homepage    = "https://github.com/fcitx/fcitx";
     description = "A Flexible Input Method Framework";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ ericsagnes ];
+    license     = licenses.gpl2;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ericsagnes ];
   };
 }

--- a/pkgs/tools/inputmethods/fcitx/fcitx-ecm.patch
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-ecm.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fd54ad8..ebb33d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,8 +5,7 @@ project(fcitx)
+ set(version 4.2.9)
+ 
+ 
+-find_package(ECM 0.0.11 REQUIRED NO_MODULE)
+-set(CMAKE_MODULE_PATH "${ECM_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
++set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+ set(CMAKE_AUTOMOC_RELAXED_MODE TRUE)
+ 
+ set_property(GLOBAL PROPERTY "__FCITX_INTERNAL_BUILD" On)
+--- a/cmake/FindXKBCommon.cmake
++++ b/cmake/FindXKBCommon.cmake
+@@ -1,5 +1,5 @@
+ 
+-include(ECMFindModuleHelpersStub)
++include(ECMFindModuleHelpers)
+ 
+ ecm_find_package_version_check(XKBCommon)
+ 
+-- 
+2.8.0


### PR DESCRIPTION
###### Motivation for this change

Build was [broke](https://hydra.nixos.org/build/36568876) due to recent changes to `extra-cmake-modules`.
The fix take the same approach as `fcitx-qt5`, linking the only needed `extra-cmake-module` file in the package source during the build.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
