### PR TITLE
i3-gaps: init at 4.12

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -131,6 +131,7 @@
   falsifian = "James Cook <james.cook@utoronto.ca>";
   flosse = "Markus Kohlhase <mail@markus-kohlhase.de>";
   fluffynukeit = "Daniel Austin <dan@fluffynukeit.com>";
+  fmthoma = "Franz Thoma <f.m.thoma@googlemail.com>";
   forkk = "Andrew Okin <forkk@forkk.net>";
   fornever = "Friedrich von Never <friedrich@fornever.me>";
   fpletz = "Franz Pletz <fpletz@fnordicwalking.de>";

--- a/nixos/modules/services/x11/window-managers/i3.nix
+++ b/nixos/modules/services/x11/window-managers/i3.nix
@@ -3,37 +3,43 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.i3;
+  wmCfg = config.services.xserver.windowManager;
+
+  i3option = name: {
+    enable = mkEnableOption name;
+    configFile = mkOption {
+      default = null;
+      type = types.nullOr types.path;
+      description = ''
+        Path to the i3 configuration file.
+        If left at the default value, $HOME/.i3/config will be used.
+      '';
+    };
+  };
+
+  i3config = name: pkg: cfg: {
+    services.xserver.windowManager.session = [{
+      inherit name;
+      start = ''
+        ${pkg}/bin/i3 ${optionalString (cfg.configFile != null)
+          "-c \"${cfg.configFile}\""
+        } &
+        waitPID=$!
+      '';
+    }];
+    environment.systemPackages = [ pkg ];
+  };
+
 in
 
 {
-  options = {
-    services.xserver.windowManager.i3 = {
-      enable = mkEnableOption "i3";
-
-      configFile = mkOption {
-        default = null;
-        type = types.nullOr types.path;
-        description = ''
-          Path to the i3 configuration file.
-          If left at the default value, $HOME/.i3/config will be used.
-        '';
-      };
-    };
+  options.services.xserver.windowManager = {
+    i3 = i3option "i3";
+    i3-gaps = i3option "i3-gaps";
   };
 
-  config = mkIf cfg.enable {
-    services.xserver.windowManager = {
-      session = [{
-        name = "i3";
-        start = ''
-          ${pkgs.i3}/bin/i3 ${optionalString (cfg.configFile != null)
-            "-c \"${cfg.configFile}\""
-          } &
-          waitPID=$!
-        '';
-      }];
-    };
-    environment.systemPackages = with pkgs; [ i3 ];
-  };
+  config = mkMerge [
+    (mkIf wmCfg.i3.enable (i3config "i3" pkgs.i3 wmCfg.i3))
+    (mkIf wmCfg.i3-gaps.enable (i3config "i3-gaps" pkgs.i3-gaps wmCfg.i3-gaps))
+  ];
 }

--- a/pkgs/applications/window-managers/i3/gaps.nix
+++ b/pkgs/applications/window-managers/i3/gaps.nix
@@ -1,0 +1,44 @@
+{ fetchurl, stdenv, i3 }:
+
+i3.overrideDerivation (super : rec {
+
+  name = "i3-gaps-${version}";
+  version = "4.12";
+  releaseDate = "2016-03-06";
+
+  src = fetchurl {
+    url = "https://github.com/Airblader/i3/archive/${version}.tar.gz";
+    sha256 = "1i9l993cak85fcw12zgrb5cpspmjixr3yf8naa4zb8589mg4rb8s";
+  };
+
+  postUnpack = ''
+      echo -n "${version} (${releaseDate}, branch \\\"gaps-next\\\")" > ./i3-${version}/I3_VERSION
+      echo -n "${version}" > ./i3-${version}/VERSION
+  '';
+
+  postInstall = ''
+    wrapProgram "$out/bin/i3-save-tree" --prefix PERL5LIB ":" "$PERL5LIB"
+    for program in $out/bin/i3-sensible-*; do
+      sed -i 's/which/command -v/' $program
+    done
+  '';
+
+}) // {
+
+  meta = with stdenv.lib; {
+    description = "A fork of the i3 tiling window manager with some additional features";
+    homepage    = "https://github.com/Airblader/i3";
+    maintainers = with maintainers; [ fmthoma ];
+    license     = licenses.bsd3;
+    platforms   = platforms.all;
+
+    longDescription = ''
+      Fork of i3wm, a tiling window manager primarily targeted at advanced users
+      and developers. Based on a tree as data structure, supports tiling,
+      stacking, and tabbing layouts, handled dynamically, as well as floating
+      windows. This fork adds a few features such as gaps between windows.
+      Configured via plain text file. Multi-monitor. UTF-8 clean.
+    '';
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13025,6 +13025,8 @@ in
     xcb-util-cursor = if stdenv.isDarwin then xcb-util-cursor-HEAD else xcb-util-cursor;
   };
 
+  i3-gaps = callPackage ../applications/window-managers/i3/gaps.nix { };
+
   i3blocks = callPackage ../applications/window-managers/i3/blocks.nix { };
 
   i3cat = callPackage ../tools/misc/i3cat { };


### PR DESCRIPTION
###### Motivation for this change

Add the popular i3-gaps fork of the i3 window manager as package and as services.xserver.windowManager option.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

`pkgs/applications/window-managers/i3-gaps/default.nix` tries to re-use as much as possible from vanilla i3 build.
