### PR TITLE
unifi: 4.8.15 -> 5.0.6

### DIFF
--- a/pkgs/servers/unifi/default.nix
+++ b/pkgs/servers/unifi/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "unifi-controller-${version}";
-  version = "4.8.15";
+  version = "5.0.6";
 
   src = fetchurl {
     url = "https://dl.ubnt.com/unifi/${version}/UniFi.unix.zip";
-    sha256 = "1p77l2186mw32l59inyd79rpachcs634z891k1vqcwn9gm7a39r2";
+    sha256 = "0splrxgh1ppxnf4nynawbn8mwywqsvaib7m60wgnz4inpxhp3pp8";
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

New major version released yesterday: https://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-5-0-6-is-released/ba-p/1579716
###### Things done

Did some quick testing with a small wireless setup and upgrading worked seamlessly. 
- Built on platform(s)
  - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
