### PR TITLE
Add ocamlPackages.sqlexpr and ocamlPackages.estring

### DIFF
--- a/pkgs/development/ocaml-modules/estring/default.nix
+++ b/pkgs/development/ocaml-modules/estring/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildOcaml, fetchurl }:
+
+buildOcaml rec {
+  name = "estring";
+  version = "1.3";
+
+  src = fetchurl {
+    url = "https://forge.ocamlcore.org/frs/download.php/1012/estring-${version}.tar.gz";
+    sha256 = "0b6znz5igm8pp28w4b7sgy82rpd9m5aw6ss933rfbw1mrh05gvcg";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "http://estring.forge.ocamlcore.org/";
+    description = "Extension for string literals";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/ocaml-modules/sqlexpr/default.nix
+++ b/pkgs/development/ocaml-modules/sqlexpr/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildOcaml, fetchurl, ocaml_batteries, csv, ocaml_lwt, ocaml_sqlite3, estring }:
+
+buildOcaml rec {
+  name = "sqlexpr";
+  version = "0.5.5";
+
+  src = fetchurl {
+    url = "https://forge.ocamlcore.org/frs/download.php/1203/ocaml-sqlexpr-${version}.tar.gz";
+    sha256 = "02pi0xxr3xzalwpvcaq96k57wz2vxj20l2mga1a4d2ddvhran8kr";
+  };
+
+  propagatedBuildInputs = [ ocaml_batteries csv ocaml_lwt ocaml_sqlite3 estring ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/mfp/ocaml-sqlexpr";
+    description = "Type-safe, convenient SQLite database access";
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5097,6 +5097,8 @@ in
 
     sequence = callPackage ../development/ocaml-modules/sequence { };
 
+    sqlexpr = callPackage ../development/ocaml-modules/sqlexpr { };
+
     tuntap = callPackage ../development/ocaml-modules/tuntap { };
 
     tyxml = callPackage ../development/ocaml-modules/tyxml { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4916,6 +4916,8 @@ in
 
     erm_xmpp = callPackage ../development/ocaml-modules/erm_xmpp { };
 
+    estring = callPackage ../development/ocaml-modules/estring { };
+
     ezjsonm = callPackage ../development/ocaml-modules/ezjsonm {
       lwt = ocaml_lwt;
     };


### PR DESCRIPTION
###### Motivation for this change

ocamlPackages.sqlexpr: init at 0.5.5
ocamlPackages.estring: init at 1.3
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
