### PR TITLE
avian: init at 1.2.0

### DIFF
--- a/pkgs/development/compilers/avian/default.nix
+++ b/pkgs/development/compilers/avian/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, zlib, jdk }:
+
+stdenv.mkDerivation rec {
+  name = "avian-${version}";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "readytalk";
+    repo = "avian";
+    rev = "v${version}";
+    sha256 = "1j2y45cpqk3x6a743mgpg7z3ivwm7qc9jy6xirvay7ah1qyxmm48";
+  };
+
+  buildInputs = [
+    zlib
+    jdk
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp build/*/avian $out/bin/
+    cp build/*/avian-dynamic $out/bin/
+  '';
+
+  meta = {
+    description = "Lightweight Java virtual machine";
+    longDescription = ''
+      Avian is a lightweight virtual machine and class library designed
+      to provide a useful subset of Java’s features, suitable for
+      building self-contained applications.
+    '';
+    homepage = https://readytalk.github.io/avian/;
+    license = stdenv.lib.licenses.isc;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4107,6 +4107,10 @@ in
 
   avra = callPackage ../development/compilers/avra { };
 
+  avian = callPackage ../development/compilers/avian {
+    stdenv = overrideCC stdenv gcc49;
+  };
+
   bigloo = callPackage ../development/compilers/bigloo {
     stdenv = overrideCC stdenv gcc49;
   };


### PR DESCRIPTION
###### Motivation for this change

Allow nix users to easily install Avian.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
