### PR TITLE
gap : 4.4.12 -> 4.8.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -74,6 +74,7 @@
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";
   chattered = "Phil Scott <me@philscotted.com>";
   choochootrain = "Hurshal Patel <hurshal@imap.cc>";
+  chrisjefferson = "Christopher Jefferson <chris@bubblescope.net>";
   christopherpoole = "Christopher Mark Poole <mail@christopherpoole.net>";
   cleverca22 = "Michael Bishop <cleverca22@gmail.com>";
   cmcdragonkai = "Roger Qiu <roger.qiu@matrix.ai>";


### PR DESCRIPTION
###### Motivation for this change

GAP version was very out of date and did not build any packages. This adds a newer versions, and correctly builds many of GAP's packages (not all of them, some of the require other pieces of software not yet packaged by nix, but almost no users build all packages. I will work towards this).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)

sandboxing currently broken on darwin
- Built on platform(s)
  - [X ] OS X
- [X ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [X ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
