### PR TITLE
emacs|emacs25pre: Check AT_FDCWD is not defined before define it

### DIFF
--- a/pkgs/applications/editors/emacs-24/at-fdcwd.patch
+++ b/pkgs/applications/editors/emacs-24/at-fdcwd.patch
@@ -1,12 +1,14 @@
 diff --git a/lib/careadlinkat.h b/lib/careadlinkat.h
-index 5cdb813..7a272e8 100644
+index 84ede3e..8e8f42e 100644
 --- a/lib/careadlinkat.h
 +++ b/lib/careadlinkat.h
-@@ -23,6 +23,8 @@
+@@ -23,6 +23,10 @@
  #include <fcntl.h>
  #include <unistd.h>
  
++#ifndef AT_FDCWD
 +#define AT_FDCWD -2
++#endif
 +
  struct allocator;
  

--- a/pkgs/applications/editors/emacs-25/at-fdcwd.patch
+++ b/pkgs/applications/editors/emacs-25/at-fdcwd.patch
@@ -1,12 +1,14 @@
 diff --git a/lib/careadlinkat.h b/lib/careadlinkat.h
-index 5cdb813..7a272e8 100644
+index 84ede3e..8e8f42e 100644
 --- a/lib/careadlinkat.h
 +++ b/lib/careadlinkat.h
-@@ -23,6 +23,8 @@
+@@ -23,6 +23,10 @@
  #include <fcntl.h>
  #include <unistd.h>
  
++#ifndef AT_FDCWD
 +#define AT_FDCWD -2
++#endif
 +
  struct allocator;
  


### PR DESCRIPTION
###### Motivation for this change

This will fix https://github.com/NixOS/nixpkgs/issues/11723
The patch file is not needed for El Capitan. So when stop supporting 10.9, this file can be removed.
After build, run `src/emacs -batch -eval '(make-temp-name "abc")'` should produce no error message
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [X] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

https://github.com/NixOS/nixpkgs/issues/11723
