### PR TITLE
nethack: include xlogfile as copied file in nethackuserdir

### DIFF
--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -53,7 +53,7 @@ in stdenv.mkDerivation {
 
   postInstall = ''
     mkdir -p $out/games/lib/nethackuserdir
-    for i in logfile perm record save; do
+    for i in xlogfile logfile perm record save; do
       mv $out/games/lib/nethackdir/$i $out/games/lib/nethackuserdir
     done
 


### PR DESCRIPTION
###### Motivation for this change

Nethack User directory needs the xlogdir so that nethack can write to its extended log. FIxes #15942 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
