### PR TITLE
yabar: init at 0.4.0

### DIFF
--- a/pkgs/applications/window-managers/yabar/default.nix
+++ b/pkgs/applications/window-managers/yabar/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, cairo, gdk_pixbuf, libconfig, pango, pkgconfig, xcbutilwm }:
+
+let
+  version = "0.4.0";
+in
+
+stdenv.mkDerivation rec {
+  name = "yabar-${version}";
+
+  src = fetchFromGitHub {
+    owner = "geommer";
+    repo = "yabar";
+    rev = "746387f0112f9b7aa2e2e27b3d69cb2892d8c63b";
+    sha256 = "1nw9dar1caqln5fr0dqk7dg6naazbpfwwzxwlkxz42shsc3w30a6";
+  };
+
+  buildInputs = [ cairo gdk_pixbuf libconfig pango pkgconfig xcbutilwm ];
+
+  buildPhase = ''
+    substituteInPlace ./Makefile --replace "\$(shell git describe)" "${version}"
+    make DESTDIR=$out PREFIX=/
+  '';
+
+  installPhase = ''
+    make DESTDIR=$out PREFIX=/ install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A modern and lightweight status bar for X window managers";
+    homepage = "https://github.com/geommer/yabar";
+    maintainers = [ maintainers.hiberno ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14870,6 +14870,8 @@ in
 
   xzgv = callPackage ../applications/graphics/xzgv { };
 
+  yabar = callPackage ../applications/window-managers/yabar { };
+
   yate = callPackage ../applications/misc/yate { };
 
   inherit (gnome3) yelp;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
