### PR TITLE
dart: 0.4 -> 1.16.1

### DIFF
--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -1,10 +1,27 @@
-{ stdenv, fetchurl }:
- 
-assert stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux";
+{ stdenv, fetchurl, unzip }:
 
+let
+  version = "1.16.1";
+in
 stdenv.mkDerivation {
-  name = "dart-0.4";
- 
+  name = "dart-${version}";
+
+  nativeBuildInputs = [
+    unzip
+  ];
+  
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-linux-x64-release.zip";
+        sha256 = "01cbnc8hd2wwprmivppmzvld9ps644k16wpgqv31h1596l5p82n2";
+      }
+    else
+      fetchurl {
+        url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-linux-ia32-release.zip";
+        sha256 = "0jfwzc3jbk4n5j9ka59s9bkb25l5g85fl1nf676mvj36swcfykx3";
+      };
+
   installPhase = ''
     mkdir -p $out
     cp -R * $out/
@@ -12,28 +29,21 @@ stdenv.mkDerivation {
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
              --set-rpath $libPath \
              $out/bin/dart
-    
-    # Hack around weird dart2js resolving bug
-    mv $out/bin/dart2js $out/bin/.dart2js
-    echo "#!/bin/sh" > $out/bin/dart2js
-    echo "$out/bin/.dart2js \$*" >> $out/bin/dart2js
-    chmod +x $out/bin/dart2js
   '';
-  
-  
-  src =
-    if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        url = http://download.zef.s3.amazonaws.com/dartsdk-m4-linux-64.tar.gz;
-        sha256 = "1riwxxczskfsaax7n03m7isnbxf3walky0cac1w8j5apr1xvg5ma";
-      }
-    else
-      fetchurl {
-        url = http://download.zef.s3.amazonaws.com/dartsdk-m4-linux-32.tar.gz;
-        sha256 = "00935c4vxfj2h3x354g75qdazswwissbwc7kj5k05l1m3lizikf6";
-      };
- 
+
   libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc ];
  
   dontStrip = true;
+  
+  meta = {
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    homepage = "https://www.dartlang.org/";
+    description = "Scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps";
+    longDescription = ''
+      Dart is a class-based, single inheritance, object-oriented language
+      with C-style syntax. It offers compilation to JavaScript, interfaces,
+      mixins, abstract classes, reified generics, and optional typing.
+    '';
+    license = stdenv.lib.licenses.bsd3;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Update to the original PR #468. Package is still based on binary release.

I've been working with it for a day and it seems to be working. It is my first package,
so if you have any comments and suggestions for improvements, would be
glad to hear them.
