### PR TITLE
runit: fix closure size

### DIFF
--- a/pkgs/tools/system/runit/default.nix
+++ b/pkgs/tools/system/runit/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "065s8w62r6chjjs6m9hapcagy33m75nlnxb69vg0f4ngn061dl3g";
   };
 
-  phases = [ "unpackPhase" "patchPhase" "buildPhase" "checkPhase" "installPhase" ];
-
   patches = [ ./Makefile.patch ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- Built on platform(s)
  - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

the fixup phase was missing, so it depended on gcc and a few others, this drops the closure from 146mb to 20mb
