### PR TITLE
sonarr: init at 2.0.0.4146 + sonarr service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -258,6 +258,7 @@
   ./services/misc/ripple-data-api.nix
   ./services/misc/rogue.nix
   ./services/misc/siproxd.nix
+  ./services/misc/sonarr.nix
   ./services/misc/spice-vdagentd.nix
   ./services/misc/subsonic.nix
   ./services/misc/sundtek.nix

--- a/nixos/modules/services/misc/sonarr.nix
+++ b/nixos/modules/services/misc/sonarr.nix
@@ -1,0 +1,44 @@
+{ config, pkgs, lib, mono, ... }:
+
+with lib;
+
+let
+  cfg = config.services.sonarr;
+in
+{
+  options = {
+    services.sonarr = {
+      enable = mkEnableOption "Sonarr";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.sonarr = {
+      description = "Sonarr";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      preStart = ''
+        test -d /var/lib/sonarr/ || {
+          echo "Creating sonarr data directory in /var/lib/sonarr/"
+          mkdir -p /var/lib/sonarr/
+        }
+        chown -R sonarr /var/lib/sonarr/
+        chmod 0700 /var/lib/sonarr/
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        User = "sonarr";
+        Group = "nogroup";
+        PermissionsStartOnly = "true";
+        ExecStart = "${pkgs.sonarr}/bin/NzbDrone --no-browser";
+        Restart = "on-failure";
+      };
+    };
+
+    users.extraUsers.sonarr = {
+      home = "/var/lib/sonarr";
+    };
+
+  };
+}

--- a/pkgs/servers/sonarr/default.nix
+++ b/pkgs/servers/sonarr/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, mono, libmediainfo, sqlite, makeWrapper, ... }:
+
+stdenv.mkDerivation rec {
+  name = "sonarr-${version}";
+  version = "2.0.0.4230";
+
+  src = fetchurl {
+    url = "http://download.sonarr.tv/v2/master/mono/NzbDrone.master.${version}.mono.tar.gz";
+    sha256 = "16nx0v5hpqlwna2hzpcpzvm7qc361yjxbqnwz5bfnnkb0h7ik5m6";
+  };
+
+  buildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r * $out/bin/
+
+    makeWrapper "${mono}/bin/mono" $out/bin/NzbDrone \
+      --add-flags "$out/bin/NzbDrone.exe" \
+      --prefix LD_LIBRARY_PATH ':' "${sqlite.out}/lib" \
+      --prefix LD_LIBRARY_PATH ':' "${libmediainfo}/lib"
+  '';
+
+  meta = {
+    description = "Smart PVR for newsgroup and bittorrent users";
+    homepage = https://sonarr.tv/;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.fadenb ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3474,6 +3474,8 @@ in
 
   solvespace = callPackage ../applications/graphics/solvespace { };
 
+  sonarr = callPackage ../servers/sonarr { };
+
   sonata = callPackage ../applications/audio/sonata {
     inherit (python3Packages) buildPythonApplication python isPy3k dbus pygobject3 mpd2;
   };


### PR DESCRIPTION
###### Motivation for this change
- Initial package
- Simple service to use sonarr
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
