### PR TITLE
pktgen: build with the same CFLAGS as dpdk

### DIFF
--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  NIX_CFLAGS_COMPILE = [ "-march=core2" ];
+
   patchPhase = ''
     sed -i -e s:/usr/local:$out:g lib/lua/src/luaconf.h
     sed -i -e s:/usr/bin/lscpu:${utillinux}/bin/lscpu:g lib/common/wr_lscpu.h


### PR DESCRIPTION
###### Motivation for this change

This is related to PR https://github.com/NixOS/nixpkgs/pull/15962, cherry-picked from master branch.

Unbreak the master build failure https://hydra.nixos.org/build/36613719
pktgen requires SSE3 instructions - same as DPDK.

Interestingly build wasn't failing on release-16.03 with gcc-4.9.3 but fails with gcc-5.3.0.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
