### PR TITLE
terraria-server: 1.3.0.8 -> 1.3.1.1

### DIFF
--- a/pkgs/games/terraria-server/default.nix
+++ b/pkgs/games/terraria-server/default.nix
@@ -1,26 +1,23 @@
-{ stdenv, lib, file, fetchurl }:
+{ stdenv, lib, file, fetchurl, unzip }:
 assert stdenv.system == "x86_64-linux";
 
 stdenv.mkDerivation rec {
   name    = "terraria-server-${version}";
-  version = "1308";
+  version = "1.3.1.1";
+  urlVersion = lib.replaceChars ["."] [""] version;
 
   src = fetchurl {
-    url = http://terraria.org/server/terraria-server-linux-1308.tar.gz;
-    sha256 = "0cx3nx7wmzcw9l0nz9zm4amccl8nrd09hlb3jc1yrqcaswbyxc8a";
+    url = "http://terraria.org/server/terraria-server-${urlVersion}.zip";
+    sha256 = "0bwh0na0dy6cjc1xchd5sp3c7av50q38hk03219dmqd72n9p44rq";
   };
 
-  buildInputs = [ file ];
-
-  sourceRoot = ".";
+  buildInputs = [ file unzip ];
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -r * $out/
-    ln -s $out/terraria-server-linux-${version}/TerrariaServer.bin.x86_64 $out/bin/TerrariaServer
-
+    cp -r Linux $out/
+    ln -s "$out/Linux/TerrariaServer.bin.x86_64" $out/bin/TerrariaServer
     # Fix "/lib64/ld-linux-x86-64.so.2" like references in ELF executables.
-    echo "running patchelf on prebuilt binaries:"
     find "$out" | while read filepath; do
       if file "$filepath" | grep -q "ELF.*executable"; then
         echo "setting interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) in $filepath"
@@ -32,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = http://terraria.org;
-    description = "Dedicated server for the main game";
+    description = "Dedicated server for Terraria, a 2D action-adventure sandbox";
     platforms = platforms.linux;
     license = licenses.unfree;
   };


### PR DESCRIPTION
###### Motivation for this change

Update to latest version
###### Things done

Did a nix-build of the package and tested the resulting binary; was able to create a new world and connect to it via my client running 1.3.1.1 via Steam.
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note that they changed their releases to package Mac+Windows+Linux in a single binary now for some reason, which is why I had to change as much as I did.
