### PR TITLE
nixos-container: fix allow alternative nixos paths

### DIFF
--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -6,6 +6,7 @@ use File::Path;
 use File::Slurp;
 use Fcntl ':flock';
 use Getopt::Long qw(:config gnu_getopt);
+use Cwd 'abs_path';
 
 my $nsenter = "@utillinux@/bin/nsenter";
 my $su = "@su@";
@@ -18,13 +19,13 @@ umask 0022;
 sub showHelp {
     print <<EOF;
 Usage: nixos-container list
-       nixos-container create <container-name> [--nixos-path <path>] [--system-path <path>] [--config <string>] [--ensure-unique-name] [--auto-start]
+       nixos-container create <container-name> [--nixos-path <path>] [--system-path <path>] [--config-file <path>] [--config <string>] [--ensure-unique-name] [--auto-start]
        nixos-container destroy <container-name>
        nixos-container start <container-name>
        nixos-container stop <container-name>
        nixos-container kill <container-name> [--signal <signal-specifier>]
        nixos-container status <container-name>
-       nixos-container update <container-name> [--config <string>] [--nixos-path <path>]
+       nixos-container update <container-name> [--config <string>] [--config-file <path>]
        nixos-container login <container-name>
        nixos-container root-login <container-name>
        nixos-container run <container-name> -- args...
@@ -40,6 +41,7 @@ my $ensureUniqueName = 0;
 my $autoStart = 0;
 my $extraConfig;
 my $signal;
+my $configFile;
 
 GetOptions(
     "help" => sub { showHelp() },
@@ -48,11 +50,16 @@ GetOptions(
     "system-path=s" => \$systemPath,
     "signal=s" => \$signal
     "nixos-path=s" => \$nixosPath,
-    "config=s" => \$extraConfig
+    "config=s" => \$extraConfig,
+    "config-file=s" => \$configFile
     ) or exit 1;
 
 my $action = $ARGV[0] or die "$0: no action specified\n";
 
+if (defined $configFile and defined $extraConfig) {
+    die "--config and --config-file are mutually incompatible. " .
+        "Please define on or the other, but not both";
+}
 
 # Execute the selected action.
 
@@ -73,6 +80,17 @@ $containerName =~ /^[a-zA-Z0-9\-]+$/ or die "$0: invalid container name\n";
 sub writeNixOSConfig {
     my ($nixosConfigFile) = @_;
 
+    my $localExtraConfig = "";
+
+
+
+    if ($extraConfig) {
+        $localExtraConfig = $extraConfig
+    } elsif ($configFile) {
+        my $resolvedFile = abs_path($configFile);
+        $localExtraConfig = "imports = [ $resolvedFile ];"
+    }
+
     my $nixosConfig = <<EOF;
 { config, lib, pkgs, ... }:
 
@@ -81,7 +99,7 @@ with lib;
 { boot.isContainer = true;
   networking.hostName = mkDefault "$containerName";
   networking.useDHCP = false;
-  $extraConfig
+  $localExtraConfig
 }
 EOF
 
@@ -273,11 +291,13 @@ elsif ($action eq "update") {
 
     # FIXME: may want to be more careful about clobbering the existing
     # configuration.nix.
-    writeNixOSConfig $nixosConfigFile if (defined $extraConfig && $extraConfig ne "");
+    if ((defined $extraConfig && $extraConfig ne "") ||
+         (defined $configFile && $configFile ne "")) {
+        writeNixOSConfig $nixosConfigFile;
+    }
 
-    my $nixenvF = $nixosPath // "<nixpkgs/nixos>";
     system("nix-env", "-p", "$profileDir/system",
-           "-I", "nixos-config=$nixosConfigFile", "-f", "$nixenvF",
+           "-I", "nixos-config=$nixosConfigFile", "-f", "<nixpkgs/nixos>",
            "--set", "-A", "system") == 0
         or die "$0: failed to build container configuration\n";
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This should be completely backwards compatible. It allows the '-f' part
of the nix-env command to be configured. This greatly eases using
nixos-container as part of development where several nixpkgs
repositories might be tested at the same time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/15967)

<!-- Reviewable:end -->
