### PR TITLE
uhc: 1.1.9.3 -> 1.1.9.4

### DIFF
--- a/pkgs/development/compilers/uhc/default.nix
+++ b/pkgs/development/compilers/uhc/default.nix
@@ -4,14 +4,14 @@
 
 let wrappedGhc = ghcWithPackages (hpkgs: with hpkgs; [fgl vector syb uulib network binary hashable uhc-util mtl transformers directory containers array process filepath shuffle uuagc] );
 in stdenv.mkDerivation rec {
-  version = "1.1.9.3";
+  version = "1.1.9.4";
   name = "uhc-${version}";
 
   src = fetchFromGitHub {
     owner = "UU-ComputerScience";
     repo = "uhc";
     rev = "v${version}";
-    sha256 = "1r3mja77dqj2ncgp1d9nnc7dhp3gzrb1b1qvml3rq2321mn3m2ad";
+    sha256 = "1s84csk6zgzj09igxgdza7gb52jdn3jsr8lygl5xplshv8yzl34n";
   };
 
   postUnpack = "sourceRoot=\${sourceRoot}/EHC";


### PR DESCRIPTION
###### Motivation for this change

Adds GHC8 support, fixes broken build.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux (Fedora)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
