### PR TITLE
haskellPackages.ShellCheck: add to all-packages.nix

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6442,6 +6442,8 @@ in
   sbt = callPackage ../development/tools/build-managers/sbt { };
   simpleBuildTool = sbt;
 
+  shellcheck = self.haskellPackages.ShellCheck;
+
   sigrok-cli = callPackage ../development/tools/sigrok-cli { };
 
   simpleTpmPk11 = callPackage ../tools/security/simple-tpm-pk11 { };


### PR DESCRIPTION
###### Motivation for this change

Package is suitable to being used as a tool in the global namespace.

https://www.reddit.com/r/NixOS/comments/4gqcra/how_to_find_packages_quickly_shellcheck_as_an/
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There's some history to the packaging of shellcheck in Nix, e.g.:
- https://github.com/NixOS/nixpkgs/commit/5d294db3b2bc205f536eb2c9ac62332050297fa9
- https://github.com/NixOS/nixpkgs/commit/324719a5a611501d7b54e14f205465f5da1242b1
