### PR TITLE
gtypist: darwin compatibility

### DIFF
--- a/pkgs/games/gtypist/default.nix
+++ b/pkgs/games/gtypist/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, makeWrapper, ncurses, perl, fortune}:
+{stdenv, fetchurl, makeWrapper, libiconv, ncurses, perl, fortune}:
 
 stdenv.mkDerivation rec {
   name = "gtypist-${version}";
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0xzrkkmj0b1dw3yr0m9hml2y634cc4h61im6zwcq57s7285z8fn1";
   };
 
-  buildInputs = [ makeWrapper ncurses perl fortune ];
+  buildInputs = [ makeWrapper ncurses perl fortune ]
+   ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
   preFixup = ''
      wrapProgram "$out/bin/typefortune" \
@@ -20,7 +21,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.gnu.org/software/gtypist;
     description = "Universal typing tutor";
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ pSub ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I use typist on OSX, and would like to be able to install it with nix rather than homebrew.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [x] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
