### PR TITLE
serpent: init at 2016-03-05

### DIFF
--- a/pkgs/development/compilers/serpent/default.nix
+++ b/pkgs/development/compilers/serpent/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, ... }:
+
+stdenv.mkDerivation rec {
+  name = "serpent-${version}";
+
+  # I can't find any version numbers, so we're just using the date
+  # of the last commit.
+  version = "2016-03-05";
+
+  src = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "serpent";
+    rev = "51ee60857fe53c871fa916ef66fc1b4255bb9433";
+    sha256 = "1bns9wgn5i1ahj19qx7v1wwdy8ca3q3pigxwznm5nywsw7s7lqxs";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv serpent $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Compiler for the Serpent language for Ethereum";
+    longDescription = ''
+      Serpent is one of the high-level programming languages used to
+      write Ethereum contracts. The language, as suggested by its name,
+      is designed to be very similar to Python; it is intended to be
+      maximally clean and simple, combining many of the efficiency
+      benefits of a low-level language with ease-of-use in programming
+      style, and at the same time adding special domain-specific
+      features for contract programming.
+    '';
+    homepage = https://github.com/ethereum/wiki/wiki/Serpent;
+    license = with licenses; [ wtfpl ];
+    maintainers = with maintainers; [ chris-martin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5319,6 +5319,8 @@ in
 
   sdcc = callPackage ../development/compilers/sdcc { boost = boost159; };
 
+  serpent = callPackage ../development/compilers/serpent { };
+
   smlnjBootstrap = callPackage ../development/compilers/smlnj/bootstrap.nix { };
   smlnj = if stdenv.isDarwin
             then callPackage ../development/compilers/smlnj { }


### PR DESCRIPTION
###### Motivation for this change

[Serpent](https://github.com/ethereum/wiki/wiki/Serpent) is a high-level language for Ethereum. This package provides the compiler.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
