### PR TITLE
secp256k1: init (native lib, and python ffi bindings at 0.12.1)

### DIFF
--- a/pkgs/tools/security/secp256k1/default.nix
+++ b/pkgs/tools/security/secp256k1/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, ... }:
+
+stdenv.mkDerivation rec {
+  name = "secp256k1-${version}";
+
+  # I can't find any version numbers, so we're just using the date
+  # of the last commit.
+  version = "2016-05-30";
+
+  src = fetchFromGitHub {
+    owner = "bitcoin-core";
+    repo = "secp256k1";
+    rev = "b3be8521e694eaf45dd29baea035055183c42fe2";
+    sha256 = "1pgsy72w87yxbiqn96hnm8alsfx3rj7d9jlzdsypyf6i1rf6w4bq";
+  };
+
+  buildInputs = [ autoconf automake libtool ];
+
+  configureFlags = [ "--enable-module-recovery" ];
+
+  preConfigure = "./autogen.sh";
+
+  meta = with stdenv.lib; {
+    description = "Optimized C library for EC operations on curve secp256k1";
+    longDescription = ''
+      Optimized C library for EC operations on curve secp256k1.
+      Part of Bitcoin Core. This library is a work in progress
+      and is being used to research best practices. Use at your
+      own risk.
+    '';
+    homepage = https://github.com/bitcoin-core/secp256k1;
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ chris-martin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3271,6 +3271,8 @@ in
 
   seccure = callPackage ../tools/security/seccure { };
 
+  secp256k1 = callPackage ../tools/security/secp256k1 { };
+
   securefs = callPackage ../tools/filesystems/securefs { };
 
   setroot = callPackage  ../tools/X11/setroot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21214,6 +21214,33 @@ in modules // {
     };
   };
 
+  secp256k1 = buildPythonPackage rec {
+    name = "secp256k1-${version}";
+    version = "0.12.1";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/s/secp256k1/${name}.tar.gz";
+      sha256 = "0zrjxvzxqm4bz2jcy8sras8jircgbs6dkrw8j3nc6jhvzlikwwxl";
+    };
+
+    buildInputs = [ pkgs.pkgconfig ];
+    propagatedBuildInputs = [ self.cffi pkgs.secp256k1 ];
+
+    preConfigure = ''
+      cp -r ${pkgs.secp256k1.src} libsecp256k1
+      touch libsecp256k1/autogen.sh
+      export INCLUDE_DIR=${pkgs.secp256k1}/include
+      export LIB_DIR=${pkgs.secp256k1}/lib
+    '';
+
+    meta = {
+      homepage = https://github.com/ludbb/secp256k1-py;
+      description = "Python FFI bindings for secp256k1";
+      license = with licenses; [ mit ];
+      maintainers = with maintainers; [ chris-martin ];
+    };
+  };
+
   semantic-version = buildPythonPackage rec {
     name = "semantic_version-2.4.2";
     src = pkgs.fetchurl {


### PR DESCRIPTION
This adds the [secp256k1](https://github.com/bitcoin-core/secp256k1) C lib from bitcoin-core, and [the corresponding python wrapper](https://github.com/ludbb/secp256k1-py).

There are no executables provided by either of these packages. I'm adding them because they're dependencies of [pyethereum](https://github.com/ethereum/pyethereum) (which will be coming in another PR).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (new package, there are none)
- [x] Tested execution of all binary files (usually in `./result/bin/`) (there are none)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
