### PR TITLE
libsrtp: 1.5.4 + 2.0 as libsrtp2

### DIFF
--- a/pkgs/development/libraries/srtp/2.nix
+++ b/pkgs/development/libraries/srtp/2.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pkgconfig
+, openssl ? null, libpcap ? null
+}:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "libsrtp2-${version}";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "cisco";
+    repo = "libsrtp";
+    rev = "v${version}";
+    sha256 = "1ilrqryvnspbkfnzy1f4pgcjb9765d1z4cx7m9g8hxn0wx5rmysg";
+  };
+
+  buildInputs = [ pkgconfig ];
+
+  # libsrtp.pc references -lcrypto -lpcap without -L
+  propagatedBuildInputs = [ openssl libpcap ];
+
+  configureFlags = [
+    "--disable-debug"
+  ] ++ optional (openssl != null) "--enable-openssl";
+
+  postInstall = ''
+    rm -rf $out/bin
+  '';
+
+  meta = {
+    homepage = https://github.com/cisco/libsrtp;
+    description = "Secure RTP (SRTP) Reference Implementation";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9065,6 +9065,10 @@ in
     libpcap = if stdenv.isLinux then libpcap else null;
   };
 
+  srtp2 = callPackage ../development/libraries/srtp/2.nix {
+    libpcap = if stdenv.isLinux then libpcap else null;
+  };
+
   stxxl = callPackage ../development/libraries/stxxl { parallel = true; };
 
   sqlite = lowPrio (callPackage ../development/libraries/sqlite { });
@@ -9914,6 +9918,8 @@ in
 
   ircdHybrid = callPackage ../servers/irc/ircd-hybrid { };
 
+  janus  = callPackage ../servers/janus { };
+
   jboss = callPackage ../servers/http/jboss { };
 
   jboss_mysql_jdbc = callPackage ../servers/http/jboss/jdbc/mysql { };
@@ -10259,6 +10265,8 @@ in
   slurm-llnl = callPackage ../servers/computing/slurm { gtk = null; };
 
   slurm-llnl-full = appendToName "full" (callPackage ../servers/computing/slurm { });
+
+  sylkserver = callPackage ../servers/sylkserver { };
 
   tomcat5 = callPackage ../servers/http/tomcat/5.0.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

A new release of this library which is a requirement for another package I'm adding. Because it is a full release (from 1.x to 2.x series) I thought it would be logical to add it as libsrtp2 to not break all the previous stuff... Is that correct?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
