### PR TITLE
selenium: 2.44 to 2.52 (2.53 tested but not working well; 2.44 fails …

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20415,10 +20415,10 @@ in modules // {
   };
 
   selenium = buildPythonPackage rec {
-    name = "selenium-2.44.0";
+    name = "selenium-2.52.0";
     src = pkgs.fetchurl {
       url = "mirror://pypi/s/selenium/${name}.tar.gz";
-      sha256 = "0l70pqwg88imbylcd831vg8nj8ipy4zr331f6qjccss7vn56i2h5";
+      sha256 = "0971rd9b8kb97xp9fvrwzvxr8vqfdjc020cs75n787ya82km01c2";
     };
 
     buildInputs = with self; [pkgs.xorg.libX11];
@@ -20429,8 +20429,8 @@ in modules // {
       pkgs.fetchFromGitHub {
         owner = "SeleniumHQ";
         repo = "selenium";
-        rev = "selenium-2.44.0";
-        sha256 = "13aqm0dwy17ghimy7m2mxjwlyc1k7zk5icxzrs1sa896056f1dyy";
+        rev = "selenium-2.52.0";
+        sha256 = "1n58akim9np2jy22jfgichq1ckvm8gglqi2hn3syphh0jjqq6cfx";
       };
 
     patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change
## 2.44

2.44 no longer works as the firefox extension won't work with 46.0.1 onwards as it is not signed. this has been fixed in later releases of selenium.
- https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/8399
- https://wiki.mozilla.org/Add-ons/Extension_Signing
## 2.52

**the latest working release seems to be 2.52**
## 2.53

2.53 does not work either:

```
[nix-shell:~/Desktop/projects/nlnet/nlnet]$ python3 selenium_test.py 
Traceback (most recent call last):
  File "selenium_test.py", line 8, in <module>
    driver = webdriver.Firefox()
  File "/nix/store/2w9rzalqavjfc9md287fyj3kplghgcxd-python3.5-selenium-2.53.0/lib/python3.5/site-packages/selenium/webdriver/firefox/webdriver.py", line 62, in __init__
    firefox_options.binary_location = self.binary if isinstance(self.binary, basestring) else self.binary._get_firefox_start_cmd()
NameError: name 'basestring' is not defined

```

this is a known bug and being fixed in 2.53.1 which, at the time of writing, was not release yet.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
