### PR TITLE
zsnes: add desktop item

### DIFF
--- a/pkgs/misc/emulators/zsnes/default.nix
+++ b/pkgs/misc/emulators/zsnes/default.nix
@@ -1,6 +1,18 @@
-{stdenv, fetchurl, fetchpatch, nasm, SDL, zlib, libpng, ncurses, mesa}:
+{stdenv, fetchurl, fetchpatch, nasm, SDL, zlib, libpng, ncurses, mesa
+, makeDesktopItem }:
 
-stdenv.mkDerivation {
+let
+  desktopItem = makeDesktopItem {
+    name = "zsnes";
+    exec = "zsnes";
+    icon = "zsnes";
+    comment = "A SNES emulator";
+    desktopName = "zsnes";
+    genericName = "zsnes";
+    categories = "Game;";
+  };
+
+in stdenv.mkDerivation {
   name = "zsnes-1.51";
 
   src = fetchurl {
@@ -38,6 +50,20 @@ stdenv.mkDerivation {
   '';
 
   configureFlags = [ "--enable-release" ];
+
+  postInstall = ''
+    function installIcon () {
+        mkdir -p $out/share/icons/hicolor/$1/apps/
+        cp icons/$1x32.png $out/share/icons/hicolor/$1/apps/zsnes.png
+    }
+    installIcon "16x16"
+    installIcon "32x32"
+    installIcon "48x48"
+    installIcon "64x64"
+
+    mkdir -p $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+  '';
 
   meta = {
     description = "A Super Nintendo Entertainment System Emulator";


### PR DESCRIPTION
###### Motivation for this change

add desktop item so zsnes can be used without the terminal

Icon from https://commons.wikimedia.org/wiki/File:Zsnes_icon.png
Icon license: GPL 2 or later
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
