### PR TITLE
WIP zathura: Enable synctex support

### DIFF
--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, gtk, girara, ncurses, gettext, docutils, file, makeWrapper, zathura_icon, sqlite, glib }:
+{ stdenv, lib, fetchurl, pkgconfig, gtk, girara, ncurses, gettext, docutils, file, makeWrapper, zathura_icon, sqlite, glib
+, synctexSupport ? true, texlive ? null
+}:
+
+assert synctexSupport -> texlive != null;
 
 stdenv.mkDerivation rec {
   version = "0.3.6";
@@ -9,7 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0fyb5hak0knqvg90rmdavwcmilhnrwgg1s5ykx9wd3skbpi8nsh8";
   };
 
-  buildInputs = [ pkgconfig file gtk girara gettext makeWrapper sqlite glib ];
+  buildInputs = [ pkgconfig file gtk girara gettext makeWrapper sqlite glib
+  ] ++ lib.optional synctexSupport [ texlive.bin.core ];
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
@@ -18,7 +23,7 @@ stdenv.mkDerivation rec {
     "RSTTOMAN=${docutils}/bin/rst2man.py"
     "VERBOSE=1"
     "TPUT=${ncurses.out}/bin/tput"
-  ];
+  ] ++ lib.optional synctexSupport "WITH_SYNCTEX=1";
 
   postInstall = ''
     wrapProgram "$out/bin/zathura" \

--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, lib, pkgs, fetchurl, stdenv, useMupdf }:
+{ callPackage, lib, pkgs, fetchurl, stdenv, useMupdf, synctexSupport ? true }:
 
 rec {
   inherit stdenv;
@@ -8,6 +8,7 @@ rec {
   zathura_core = callPackage ./core {
     gtk = pkgs.gtk3;
     zathura_icon = icon;
+    inherit synctexSupport;
   };
 
   zathura_pdf_poppler = callPackage ./pdf-poppler { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Zathura has synctex support. It's enabled by passing `WITH_SYNCTEX=1` to the make.

I would like to prepare the patch myself but has an issue. After adding `WITH_SYNCTEX=1` to the `makeFlags` I get next error:

```
zathura/synctex.c:8:36: fatal error: synctex/synctex_parser.h: No such file or directory
```

I looked through Gentoo's ebuild for zathura and found it adds `app-text/texlive-core` to dependencies.

Adding `texlive.synctex` to the `buildInputs` doesn't help.

/cc @garbas 
