### PR TITLE
pythonPackages.pygit2: 0.23.1 -> 0.24.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16969,8 +16969,7 @@ in modules // {
       export DYLD_LIBRARY_PATH="${pkgs.libgit2}/lib"
     '' else "" );
 
-    buildInputs = with self; [ six ];
-    propagatedBuildInputs = with self; [ pkgs.libgit2 ] ++ optionals (!isPyPy) [ cffi ];
+    propagatedBuildInputs = with self; [ pkgs.libgit2 six ] ++ optionals (!isPyPy) [ cffi ];
 
     preCheck = ''
       # disable tests that require networking

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16958,11 +16958,11 @@ in modules // {
   };
 
   pygit2 = buildPythonPackage rec {
-    name = "pygit2-0.23.1";
+    name = "pygit2-0.24.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/pygit2/${name}.tar.gz";
-      sha256 = "04201vcal7jq8lbpk9ylscrhjxdcf2aihiw25k4imjjqgfmvldf7";
+      sha256 = "01c155ls0h5pvpdkrk8ld6fscshmz4fchcwxrg488dbij1zdjxms";
     };
 
     preConfigure = ( if stdenv.isDarwin then ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16969,6 +16969,7 @@ in modules // {
       export DYLD_LIBRARY_PATH="${pkgs.libgit2}/lib"
     '' else "" );
 
+    buildInputs = with self; [ six ];
     propagatedBuildInputs = with self; [ pkgs.libgit2 ] ++ optionals (!isPyPy) [ cffi ];
 
     preCheck = ''


### PR DESCRIPTION
###### Motivation for this change

GH issue: https://github.com/NixOS/nixpkgs/issues/15985

fixes python2.7-powerline build which pygit2 0.23 dep required a corresponding libgit2 0.23.x version:

```

gcc -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/usr/local/include -I/nix/store/89v0gq67zsy9vlrxm5ms89s5jf02ibhy-python-2.7.11/include/python2.7 -c src/treebuilder.c -o build/temp.linux-x86_64-2.7/src/treebuilder.o
In file included from src/utils.h:34:0,
                 from src/treebuilder.c:32:
src/types.h:36:2: error: #error You need a compatible libgit2 version (v0.23.x)
 #error You need a compatible libgit2 version (v0.23.x)
  ^
error: command 'gcc' failed with exit status 1
builder for ‘/nix/store/lzs99vnjr1haihbnbdgbl34fsswppd4w-python2.7-pygit2-0.23.1.drv’ failed with exit code 1
cannot build derivation ‘/nix/store/84jr9k9c95b716q9zpjcnpry6sgblln9-python2.7-powerline-2.1.4.drv’: 1 dependencies couldn't be built
cannot build derivation ‘/nix/store/6mcx8fcas098y1jnwacq555p68h50mk2-all.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/6mcx8fcas098y1jnwacq555p68h50mk2-all.drv’ failed
```

```
creating build/bdist.linux-x86_64/wheel/pygit2-0.24.0.dist-info/WHEEL
installing
/tmp/nix-build-python2.7-pygit2-0.24.0.drv-0/pygit2-0.24.0/dist /tmp/nix-build-python2.7-pygit2-0.24.0.drv-0/pygit2-0.24.0
Ignoring indexes: https://pypi.python.org/simple
Processing ./pygit2-0.24.0-cp27-cp27mu-linux_x86_64.whl
Collecting six (from pygit2==0.24.0)
  Could not find a version that satisfies the requirement six (from pygit2==0.24.0) (from versions: )
No matching distribution found for six (from pygit2==0.24.0)
builder for ‘/nix/store/84kvvycmhjg6fqpnxhh6k2xh6h5zbykz-python2.7-pygit2-0.24.0.drv’ failed with exit code 1
cannot build derivation ‘/nix/store/mdpmiy430cbvqmxj0lc9vvq575d6d639-python2.7-powerline-2.1.4.drv’: 1 dependencies couldn't be built
cannot build derivation ‘/nix/store/5nxmmixwf0wfml3hqqf8si1dk7j16c5r-all.drv’: 1 dependencies couldn't be built
error: build of ‘/nix/store/5nxmmixwf0wfml3hqqf8si1dk7j16c5r-all.drv’ failed
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
