### PR TITLE
haskell.lib.buildStackProject: allow passing in a custom GHC version.

### DIFF
--- a/doc/languages-frameworks/haskell.md
+++ b/doc/languages-frameworks/haskell.md
@@ -389,10 +389,10 @@ in `stack.yaml` (only works with Stack >= 1.1.3):
 
     let R = pkgs.R.override { enableStrictBarrier = true; };
     in
-	haskell.lib.buildStackProject {
+    haskell.lib.buildStackProject {
       name = "HaskellR";
-	  buildInputs = [ R zeromq zlib ];
-	  inherit ghc;
+      buildInputs = [ R zeromq zlib ];
+      inherit ghc;
     }
 
 [stack-nix-doc]: http://docs.haskellstack.org/en/stable/nix_integration.html

--- a/doc/languages-frameworks/haskell.md
+++ b/doc/languages-frameworks/haskell.md
@@ -378,6 +378,23 @@ special options turned on:
 	  buildInputs = [ R zeromq zlib ];
     }
 
+You can select a particular GHC version to compile with by setting the
+`ghc` attribute as an argument to `buildStackProject`. Better yet, let
+Stack choose what GHC version it wants based on the snapshot specified
+in `stack.yaml` (only works with Stack >= 1.1.3):
+
+    {nixpkgs ? import <nixpkgs> { }, ghc ? nixpkgs.ghc}
+
+    with nixpkgs;
+
+    let R = pkgs.R.override { enableStrictBarrier = true; };
+    in
+	haskell.lib.buildStackProject {
+      name = "HaskellR";
+	  buildInputs = [ R zeromq zlib ];
+	  inherit ghc;
+    }
+
 [stack-nix-doc]: http://docs.haskellstack.org/en/stable/nix_integration.html
 
 ### How to create ad hoc environments for `nix-shell`

--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 { buildInputs ? []
 , extraArgs ? []
-, LD_LIBRARY_PATH ? ""
+, LD_LIBRARY_PATH ? []
 , ghc ? ghc
 , ...
 }@args:
@@ -23,7 +23,7 @@ stdenv.mkDerivation (args // {
     extraArgs;
 
   # XXX: workaround for https://ghc.haskell.org/trac/ghc/ticket/11042.
-  LD_LIBRARY_PATH = "${makeLibraryPath buildInputs}:${LD_LIBRARY_PATH}";
+  LD_LIBRARY_PATH = makeLibraryPath (LD_LIBRARY_PATH ++ buildInputs);
 
   preferLocalBuild = true;
 

--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -5,6 +5,7 @@ with stdenv.lib;
 { buildInputs ? []
 , extraArgs ? []
 , LD_LIBRARY_PATH ? ""
+, ghc ? ghc
 , ...
 }@args:
 


### PR DESCRIPTION
Previously, the user could only compile using the default version of GHC
in Nixpkgs. Now this can be changed by setting the `ghc` attribute
appropriately.
