### PR TITLE
openldap: fix example for multiple-outputs and formatting

### DIFF
--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -52,11 +52,12 @@ in
         description = "
           sldapd.conf configuration
         ";
-        example = ''
-            include ''${pkgs.openldap}/etc/openldap/schema/core.schema
-            include ''${pkgs.openldap}/etc/openldap/schema/cosine.schema
-            include ''${pkgs.openldap}/etc/openldap/schema/inetorgperson.schema
-            include ''${pkgs.openldap}/etc/openldap/schema/nis.schema
+        example = literalExample ''
+            '''
+            include ${pkgs.openldap.out}/etc/openldap/schema/core.schema
+            include ${pkgs.openldap.out}/etc/openldap/schema/cosine.schema
+            include ${pkgs.openldap.out}/etc/openldap/schema/inetorgperson.schema
+            include ${pkgs.openldap.out}/etc/openldap/schema/nis.schema
 
             database bdb 
             suffix dc=example,dc=org 
@@ -64,6 +65,7 @@ in
             # NOTE: change after first start
             rootpw secret
             directory /var/db/openldap
+            '''
           '';
       };
     };


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
