### PR TITLE
libgpuarray-cuda: init at -9998.0

### DIFF
--- a/pkgs/development/libraries/science/math/clblas/cuda/default.nix
+++ b/pkgs/development/libraries/science/math/clblas/cuda/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, gfortran
+, blas
+, boost
+, python
+, cudatoolkit
+, nvidia_x11
+}:
+
+stdenv.mkDerivation rec {
+  name = "clblas-cuda-${version}"; 
+  version = "git-20160505"; 
+
+  src = fetchFromGitHub {
+    owner = "clMathLibraries"; 
+    repo = "clBLAS";
+    rev = "d20977ec4389c6b3751e318779410007c5e272f8";
+    sha256 = "1jna176cxznv7iz43svd6cjrbbf0fc2lrbpfpg4s08vc7xnwp0n4";
+  }; 
+
+  patches = [ ./platform.patch ]; 
+
+  postPatch = ''
+    sed -i -re 's/(set\(\s*Boost_USE_STATIC_LIBS\s+).*/\1OFF\ \)/g' src/CMakeLists.txt
+  '';
+
+  configurePhase = ''    
+    findInputs ${boost} boost_dirs propagated-native-build-inputs
+
+    export BOOST_INCLUDEDIR=$(echo $boost_dirs | sed -e s/\ /\\n/g - | grep '\-dev')/include
+    export BOOST_LIBRARYDIR=$(echo $boost_dirs | sed -e s/\ /\\n/g - | grep -v '\-dev')/lib
+
+    mkdir -p Build
+    pushd Build
+
+    export LD_LIBRARY_PATH="${blas}/lib:${nvidia_x11}/lib"
+
+    cmake ../src -DCMAKE_INSTALL_PREFIX=$out \
+                 -DCMAKE_BUILD_TYPE=Release \
+                 -DOPENCL_ROOT=${cudatoolkit} \
+  '';
+
+  dontStrip = true; 
+
+  buildInputs = [
+    cmake
+    gfortran
+    blas
+    python
+    cudatoolkit
+    nvidia_x11
+  ]; 
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/clMathLibraries/clBLAS;
+    description = "A software library containing BLAS functions written in OpenCL";
+    longDescription = ''
+      This package contains a library of BLAS functions on top of OpenCL. 
+      The current version is linked to the NVIDIA OpenCL implementation provided by the CUDA toolkit. 
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ artuuge ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/development/libraries/science/math/clblas/cuda/platform.patch
+++ b/pkgs/development/libraries/science/math/clblas/cuda/platform.patch
@@ -1,0 +1,34 @@
+diff --git a/src/library/tools/ktest/config.cpp b/src/library/tools/ktest/config.cpp
+index 8b20128..faf9bde 100644
+--- a/src/library/tools/ktest/config.cpp
++++ b/src/library/tools/ktest/config.cpp
+@@ -24,8 +24,6 @@
+ 
+ using namespace clMath;
+ 
+-static const char DEFAULT_PLATFORM_NAME[] = "AMD Accelerated Parallel Processing";
+-
+ Config::Config() :
+     defaultConfig_(""),
+     cpp_("ktest.cpp"),
+@@ -35,7 +33,10 @@ Config::Config() :
+     hasFuncID_(false), hasSubdims_(false),
+     skipAccuracy_(false)
+ {
+-    setPlatform(DEFAULT_PLATFORM_NAME);
++    platform_ = NULL;
++    setPlatform("");
++
++    device_ = NULL;
+     setDevice("");
+ 
+     memset(&kargs_, 0, sizeof(kargs_));
+@@ -262,7 +263,7 @@ Config::setPlatform(const std::string& name)
+             continue;
+         }
+         if (name.empty()) {
+-            found = (strcmp(pname, DEFAULT_PLATFORM_NAME) == 0);
++	    found = true;
+         }
+         else {
+             found = (strcmp(pname, name.c_str()) == 0);

--- a/pkgs/development/python-modules/libgpuarray/cuda/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/cuda/default.nix
@@ -1,0 +1,130 @@
+{ stdenv 
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, cython
+, numpy
+, Mako
+, six
+, nose
+, beaker
+, memcached
+, pkgconfig
+, glibc
+, clblas
+, Babel
+, pygments
+, scipy
+, python
+, cudatoolkit
+, nvidia_x11
+}: 
+
+buildPythonPackage rec {
+  name = "libgpuarray-cuda-${version}";
+  version = "-9998.0"; 
+
+  src = fetchFromGitHub {
+    owner = "Theano"; 
+    repo = "libgpuarray";
+    rev = "fc36a40526c0a8303ace6c574ffdefba7feafe17"; 
+    sha256 = "1kb0k42addqjxiahlcbv6v6271yhsmz71j12186fpy60870i7zm7"; 
+  }; 
+
+  doCheck = true;
+
+  configurePhase = ''
+    mkdir -p Build/Install
+    pushd Build
+
+    cmake .. -DCMAKE_BUILD_TYPE=Release \
+             -DCMAKE_INSTALL_PREFIX=./Install \
+             -DCLBLAS_ROOT_DIR=${clblas}
+
+    popd
+  ''; 
+
+  preBuild = ''
+    pushd Build
+    make 
+    make install
+
+    function fixRunPath {
+      p=$(patchelf --print-rpath $1)
+      patchelf --set-rpath "$p:${cudatoolkit}/lib:${clblas}/lib:${nvidia_x11}/lib" $1
+    }
+
+    fixRunPath Install/lib/libgpuarray.so
+
+    popd
+  ''; 
+
+  setupPyBuildFlags = [ "-L $(pwd)/Build/Install/lib" "-I $(pwd)/Build/Install/include" ];
+
+  preInstall = ''
+    cp -r Build/Install $out
+  '';
+
+  postInstall = ''
+    pushd $out/${python.sitePackages}/pygpu
+    for f in $(find $out/pygpu -name "*.h"); do
+      ln -s $f $(basename $f)
+    done
+    popd
+  ''; 
+  checkPhase = ''
+    mkdir -p my_bin
+    pushd my_bin
+
+    cat > libgpuarray_run_tests << EOF
+#!/bin/sh
+if [ \$# -eq 0 ]; then 
+  echo "No argument provided."
+  echo "Available tests:"
+  ls $out/${python.sitePackages}/pygpu/tests | grep "test_"
+  exit 1
+else
+  nosetests -v "$out/${python.sitePackages}/pygpu/tests/\$@"
+fi
+EOF
+
+    chmod +x libgpuarray_run_tests
+    popd
+
+    cp -r my_bin $out/bin
+  '';
+
+  dontStrip = true; 
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    nose
+    six
+    Mako
+  ];
+
+  buildInputs = [ 
+    cmake 
+    cython 
+    beaker 
+    memcached 
+    pkgconfig 
+    glibc 
+    Babel 
+    pygments 
+    numpy.blas 
+    cudatoolkit
+    nvidia_x11
+    clblas
+  ]; 
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Theano/libgpuarray;
+    description = "Library to manipulate tensors on GPU.";
+    license = licenses.free;
+    maintainers = with maintainers; [ artuuge ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/development/python-modules/libgpuarray/cuda/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/cuda/default.nix
@@ -18,8 +18,14 @@
 , python
 , cudatoolkit
 , nvidia_x11
+, setuptools
 }: 
-
+let
+  scipy_numpy = scipy.override (let inherit numpy; in {
+    passthru = { blas = numpy.blas; };
+    propagatedBuildInputs = [ numpy.blas numpy ] ++ [ python setuptools ];
+  });
+in
 buildPythonPackage rec {
   name = "libgpuarray-cuda-${version}";
   version = "-9998.0"; 
@@ -98,7 +104,7 @@ EOF
 
   propagatedBuildInputs = [
     numpy
-    scipy
+    scipy_numpy
     nose
     six
     Mako

--- a/pkgs/development/python-modules/libgpuarray/cuda/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/cuda/default.nix
@@ -18,14 +18,7 @@
 , python
 , cudatoolkit
 , nvidia_x11
-, setuptools
 }: 
-let
-  scipy_numpy = scipy.override (let inherit numpy; in {
-    passthru = { blas = numpy.blas; };
-    propagatedBuildInputs = [ numpy.blas numpy ] ++ [ python setuptools ];
-  });
-in
 buildPythonPackage rec {
   name = "libgpuarray-cuda-${version}";
   version = "-9998.0"; 
@@ -104,7 +97,7 @@ EOF
 
   propagatedBuildInputs = [
     numpy
-    scipy_numpy
+    scipy
     nose
     six
     Mako

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15945,6 +15945,15 @@ in
 
   blas = callPackage ../development/libraries/science/math/blas { };
 
+  clblas-cuda = callPackage ../development/libraries/science/math/clblas/cuda {
+    cudatoolkit = pkgs.cudatoolkit75;
+    inherit (linuxPackages) nvidia_x11;
+    python = pkgs.python34Packages.python;
+    boost = pkgs.boost159.override {
+      inherit python;
+    };
+  };
+
   jags = callPackage ../applications/science/math/jags { };
 
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1550,8 +1550,6 @@ in
 
   libbladeRF = callPackage ../development/libraries/libbladeRF { };
 
-  libgpuarray-cuda = python34Packages.libgpuarray-cuda;
-
   lp_solve = callPackage ../applications/science/math/lp_solve { };
 
   lprof = callPackage ../tools/graphics/lprof { };
@@ -15950,10 +15948,6 @@ in
   clblas-cuda = callPackage ../development/libraries/science/math/clblas/cuda {
     cudatoolkit = pkgs.cudatoolkit75;
     inherit (linuxPackages) nvidia_x11;
-    python = pkgs.python34Packages.python;
-    boost = pkgs.boost159.override {
-      inherit python;
-    };
   };
 
   jags = callPackage ../applications/science/math/jags { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1550,6 +1550,8 @@ in
 
   libbladeRF = callPackage ../development/libraries/libbladeRF { };
 
+  libgpuarray-cuda = python34Packages.libgpuarray-cuda;
+
   lp_solve = callPackage ../applications/science/math/lp_solve { };
 
   lprof = callPackage ../tools/graphics/lprof { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11890,6 +11890,20 @@ in modules // {
     };
   });
 
+  libgpuarray-cuda = callPackage ../development/python-modules/libgpuarray/cuda/default.nix rec {
+    numpy = self.numpy_1_10;
+    scipy = self.buildScipyPackage rec {
+      version = "0.17.1";
+      src = pkgs.fetchurl {
+        url = "mirror://pypi/s/scipy/scipy-${version}.tar.gz";
+        sha256 = "1b1qpfz2j2rvmlplsjbnznnxnqr9ckbmis506110ii1w07wd4k4w";
+      };
+      inherit numpy;
+    };
+    inherit (pkgs.linuxPackages) nvidia_x11;
+    cudatoolkit = pkgs.cudatoolkit75;
+    clblas = pkgs.clblas-cuda;
+  };
 
   limnoria = buildPythonPackage rec {
     name = "limnoria-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11891,8 +11891,7 @@ in modules // {
   });
 
   libgpuarray-cuda = callPackage ../development/python-modules/libgpuarray/cuda/default.nix rec {
-    numpy = self.numpy_1_10;
-    inherit (self) scipy;
+    inherit (self) numpy scipy;
     inherit (pkgs.linuxPackages) nvidia_x11;
     cudatoolkit = pkgs.cudatoolkit75;
     clblas = pkgs.clblas-cuda;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11892,14 +11892,7 @@ in modules // {
 
   libgpuarray-cuda = callPackage ../development/python-modules/libgpuarray/cuda/default.nix rec {
     numpy = self.numpy_1_10;
-    scipy = self.buildScipyPackage rec {
-      version = "0.17.1";
-      src = pkgs.fetchurl {
-        url = "mirror://pypi/s/scipy/scipy-${version}.tar.gz";
-        sha256 = "1b1qpfz2j2rvmlplsjbnznnxnqr9ckbmis506110ii1w07wd4k4w";
-      };
-      inherit numpy;
-    };
+    inherit (self) scipy;
     inherit (pkgs.linuxPackages) nvidia_x11;
     cudatoolkit = pkgs.cudatoolkit75;
     clblas = pkgs.clblas-cuda;


### PR DESCRIPTION
###### Motivation for this change

The `libgpuarray` package is required to run `Theano` on GPU. It has a dependency on the `clblas` library. The present pull request defines `libgpuarray` for the NVIDIA CUDA platform. It is built on top of `clblas-cuda`, the corresponding realization of `clblas` linked to the OpenCL implementation from `cudatoolkit`.

To run the tests after the installation of the package, drop yourself into a nix shell:

``` bash
nix-shell -p pkgs.libgpuarray-cuda
```

and run the script `libgpuarray_run_tests`. This should yield a list of available groups of tests. To select a group, provide the corresponding filename, for example:

``` bash
libgpuarray_run_tests test_blas.py
```

I have been able to run successfully all the tests on `Quadro 2000M`, up to those tests which are skipped. 

The git commit for the source code is chosen in such a way that it is compatible with Theano-0.8.2. I have been able to pass the `Theano` tests successfully on my machine after a natural upgrade from version 0.8.1. 

The tests for `clblas-cuda` are a little more problematic since the current `cudatoolkit` implements OpenCL only up to the version 1.2, but the package seems to work.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
