### PR TITLE
Python: buildPyPIPackage and generated data

### DIFF
--- a/pkgs/development/interpreters/python/buildpypi.nix
+++ b/pkgs/development/interpreters/python/buildpypi.nix
@@ -1,0 +1,35 @@
+/* This function wraps buildPythonPackage and uses pre-fetched data from PyPI to build a package.
+*/
+{ buildPythonPackage
+, fetchurl
+, fetchgit
+, lib
+}:
+
+
+{ name
+, version ? ""
+, ... } @ attrs:
+
+let
+  pypi-src = fetchgit {
+    url = "https://github.com/FRidh/srcs-pypi.git";
+    rev = "12bc2a4cbcec42a867e4cc2fdef67e76b2c0b169";
+    sha256 = "0j3fhfnj36wsm6z3r0mnsr7c90vihi1j61nwdz31dz4y2r0w2vg4";
+  };
+
+  data = import (pypi-src) {inherit name;};
+
+  # Whether to actually use PyPI
+  pypi = !(builtins.hasAttr "src" attrs || builtins.hasAttr "srcs" attrs);
+
+  # Use Meta data from PyPI
+  pypimeta = if pypi then data.meta else {};
+
+  # Version. When specified, use that.
+  # Otherwise, if src is not given and there is a PyPI source available, then use the latest version available.
+  version = attrs.version or (if pypi then data.latest_version else "");
+  # Use src if given. Otherwise, pick the right version via PyPI.
+  src = attrs.src or attrs.srcs or (fetchurl data.versions.${version});
+
+in buildPythonPackage ( attrs // {name = name + "-" + version; src=src; meta = pypimeta;} )

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27,6 +27,14 @@ let
 
   buildPythonApplication = args: buildPythonPackage ({namePrefix="";} // args );
 
+  buildPyPIPackage = makeOverridable (callPackage ../development/interpreters/python/buildpypi.nix {
+    buildPythonPackage = buildPythonPackage;
+  });
+
+  buildPyPIApplication = makeOverridable (callPackage ../development/interpreters/python/buildpypi.nix {
+    buildPythonPackage = buildPythonApplication;
+  });
+
 in {
 
   inherit python bootstrapped-pip isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k mkPythonDerivation buildPythonPackage buildPythonApplication;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24753,14 +24753,8 @@ in {
     };
   };
 
-  toolz = buildPythonPackage rec{
-    name = "toolz-${version}";
-    version = "0.8.0";
-
-    src = pkgs.fetchurl{
-      url = "mirror://pypi/t/toolz/toolz-${version}.tar.gz";
-      sha256 = "e8451af61face57b7c5d09e71c0d27b8005f001ead56e9fdf470417e5cc6d479";
-    };
+  toolz = buildPyPIPackage rec{
+    name = "toolz";
 
     buildInputs = with self; [ nose ];
 


### PR DESCRIPTION
###### Motivation for this change

In https://github.com/NixOS/nixpkgs/pull/15007 I presented a script to generate metadata from PyPI and a function to build Python packages using that metadata. 

In this PR the metadata is no longer stored in Nixpkgs but in an external repository, https://github.com/FRidh/srcs-pypi.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

These two functions wrap respectively buildPythonPackage and buildPythonApplication, but use by default a repository with metadata retrieved from PyPI.
