### PR TITLE
ghc801: fix xmobar - build without datezone

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -53,4 +53,22 @@ self: super: {
     license = pkgs.stdenv.lib.licenses.bsd3;
   }) {};
 
+  # Remove upper limit of dependency on time < 1.6
+  # Fix overlapping instance in tests.
+  libmpd = overrideCabal super.libmpd (drv: {
+     preConfigure = ''
+        sed -i -e 's,time .* < *1.6,time >= 1.5,' libmpd.cabal
+        sed -i -e '54s/instance /instance {-# OVERLAPS #-}/' tests/Arbitrary.hs
+     '';
+  });
+
+  xmobar = (overrideCabal super.xmobar (drv: {
+    # Skip -fwith_datezone
+    configureFlags = [ "-fwith_xft" "-fwith_utf8" "-fwith_inotify"
+                       "-fwith_iwlib" "-fwith_mpd" "-fwith_alsa"
+                       "-fwith_mpris" "-fwith_dbus" "-fwith_xpm" ];
+  })).override {
+     timezone-series = null;
+     timezone-olson = null;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes #15964
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
