### PR TITLE
taskwarrior: enable on darwin

### DIFF
--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = http://taskwarrior.org;
     license = licenses.mit;
     maintainers = with maintainers; [ marcweber jgeerds ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I use both nix and taskwarrior on OS X, and would like to use one to install the other. 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] ~~NixOS~~
  - [x] OS X
  - [x] ~~Linux~~
- [x] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
