### PR TITLE
unibilium: enable on darwin

### DIFF
--- a/pkgs/development/libraries/unibilium/default.nix
+++ b/pkgs/development/libraries/unibilium/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A very basic terminfo library";
     license = licenses.lgpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ pSub ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I use neovim on OS X, and was hoping to install it via nix.  Neovim is marked as working on darwin, but unibilium, one of its dependencies, is not.  Which is strange, since it seems to have been the intent of 414d6d9e87b8e74944f4124969633fc45f1e2dac to fix it.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] ~~NixOS~~
  - [x] OS X
  - [ ] ~~Linux~~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
