### PR TITLE
typespeed: fix darwin compatibility

### DIFF
--- a/pkgs/games/typespeed/default.nix
+++ b/pkgs/games/typespeed/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation {
   patches = [ ./typespeed-config-in-home.patch ];
 
   configureFlags = "--datadir=\${out}/share/";
+  makeFlags = ["CC=cc"];
 
   meta = with stdenv.lib; {
     description = "A curses based typing game";


### PR DESCRIPTION
###### Motivation for this change

I use nix on OS X, and I like the game.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
