### PR TITLE
systemd: Set KillUserProcesses=no in logind.conf

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -669,6 +669,7 @@ in
 
       "systemd/logind.conf".text = ''
         [Login]
+        KillUserProcesses=no
         ${config.services.logind.extraConfig}
       '';
 


### PR DESCRIPTION
###### Motivation for this change

systemd 230 adds the behavior that all user processes are automatically killed on logout, and expects users to jump through hoops to opt out. Previously, you had to explicitly opt in to this behavior by running your software as a systemd user unit.

There's been a lot of discussion at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=825394 already, so I see no reason to rehash every little bit of this, but suffice to say that this new default is obnoxious in the extreme. NixOS is, additionally, even more of a server OS than Debian. Pretty much everyone will run into this.

Therefore turning it off.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
