### PR TITLE
travis-ci: attempt to fix linux builds

### DIFF
--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -13,6 +13,10 @@ if [[ $1 == nix ]]; then
     sudo mkdir /etc/nix
     sudo sh -c 'echo "build-max-jobs = 4" > /etc/nix/nix.conf'
 
+    # Nix builds in /tmp and we need exec support
+    sudo mount
+    sudo mount -o remount,exec /run
+
     # Verify evaluation
     echo "=== Verifying that nixpkgs evaluates..."
     nix-env -f. -qa --json >/dev/null


### PR DESCRIPTION
From https://github.com/NixOS/nixpkgs/pull/16013#issuecomment-223920896:

Travis on Linux is still broken from around the time it was last touched by adding the Darwin support. (Looks like /tmp is now noexec or something). Please investigate.
