### PR TITLE
utop: 1.17 -> 1.19.2

### DIFF
--- a/pkgs/development/ocaml-modules/lambda-term/default.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchurl, libev, ocaml, findlib, ocaml_lwt, ocaml_react, zed, camlp4 }:
+{ stdenv, fetchurl, libev, ocaml, findlib, ocaml_lwt, ocaml_react, zed }:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
 
 stdenv.mkDerivation rec {
-  version = "1.8";
+  version = "1.10";
   name = "lambda-term-${version}";
 
   src = fetchurl {
-    url = https://github.com/diml/lambda-term/archive/1.8.tar.gz;
-    sha256 = "0hy11x48q5bbh9czjp0w756cyxzr2c6qcnfm5n9f0i1l4qljwpgc";
+    url = "https://github.com/diml/lambda-term/archive/${version}.tar.gz";
+    sha256 = "1kwpsqds51xmy3z3ddkam92hkl7arlzy9awhzsq62ysxcl91fb8m";
   };
 
   buildInputs = [ libev ocaml findlib ocaml_react ];
 
-  propagatedBuildInputs = [ camlp4 zed ocaml_lwt ];
+  propagatedBuildInputs = [ zed ocaml_lwt ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -1,23 +1,24 @@
 {stdenv, fetchurl, ocaml, findlib, lambdaTerm, ocaml_lwt, makeWrapper,
- ocaml_react, camomile, zed, cppo, camlp4
+ ocaml_react, camomile, zed, cppo, camlp4, ppx_tools
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.17";
+  version = "1.19.2";
   name = "utop-${version}";
 
   src = fetchurl {
     url = "https://github.com/diml/utop/archive/${version}.tar.gz";
-    sha256 = "0l9lz2nypl2ls3kqzmp738m02yvscabhsfpj70ckp0p98pimnnfd";
+    sha256 = "0hxybkqmrh0sz1yyyrgzdmxp46gda4vk22pv07s0qpfg2dpv56jh";
   };
 
-  buildInputs = [ ocaml findlib makeWrapper cppo camlp4 ];
+  buildInputs = [ ocaml findlib makeWrapper cppo camlp4 ppx_tools ];
 
   propagatedBuildInputs = [ lambdaTerm ocaml_lwt ];
 
   createFindlibDestdir = true;
 
-  configureFlags = "--enable-camlp4";
+  configureFlags = [ "--enable-camlp4" ]
+  ++ stdenv.lib.optional (ppx_tools != null) "--enable-interact";
 
   buildPhase = ''
     make


### PR DESCRIPTION
###### Motivation for this change

Updates utop and a dependency (lambda-term).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
