### PR TITLE
gemconfig: rmagick requires which as of 2.15.4 (16.03)

### DIFF
--- a/pkgs/development/interpreters/ruby/gemconfig/default.nix
+++ b/pkgs/development/interpreters/ruby/gemconfig/default.nix
@@ -105,7 +105,7 @@ in
   };
 
   rmagick = attrs: {
-    buildInputs = [ imagemagick pkgconfig ];
+    buildInputs = [ imagemagick pkgconfig which ];
   };
 
   rugged = attrs: {


### PR DESCRIPTION
###### Motivation for this change

Using rmagick version 2.15.4 requires which to find imagemagick, with this patch it builds just fine.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
