### PR TITLE
structured-haskell-mode: fix emacs package

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -1531,6 +1531,7 @@ let
     src = external.structured-haskell-mode.src;
     packageRequires = [ haskell-mode ];
     fileSpecs = [ "elisp/*.el" ];
+    propagatedUserEnvPkgs = [ external.structured-haskell-mode ];
 
     meta = {
       description = "Structured editing Emacs mode for Haskell";


### PR DESCRIPTION
###### Motivation for this change

This makes structured-haskell-mode function correctly when used with emacsWithPackages.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This emacs package requires the binary from the external package to be
in exec-path.
