### PR TITLE
icon: Init at 9.5.1

### DIFF
--- a/pkgs/development/interpreters/icon-lang/default.nix
+++ b/pkgs/development/interpreters/icon-lang/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, libX11, libXt }:
+
+stdenv.mkDerivation rec {
+  name = "icon-${version}";
+  version = "9.5.1";
+  src = fetchFromGitHub {
+    rev = "39d7438e8d23ccfe20c0af8bbbf61e34d9c715e9";
+    owner = "gtownsend";
+    repo = "icon";
+    sha256 = "1gkvj678ldlr1m5kjhx6zpmq11nls8kxa7pyy64whgakfzrypynw";
+  };
+  buildInputs = [ libX11 libXt ];
+
+  configurePhase = ''
+    make X-Configure name=linux
+  '';
+
+  installPhase = ''
+    make Install dest=$out
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''A very high level general-purpose programming language'';
+    maintainers = with maintainers; [ vrthra ];
+    platforms = platforms.linux;
+    license = licenses.publicDomain;
+    homepage = http://www.cs.arizona.edu/icon/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6834,6 +6834,8 @@ in
 
   gio-sharp = callPackage ../development/libraries/gio-sharp { };
 
+  icon-lang = callPackage ../development/interpreters/icon-lang { };
+
   libgit2 = callPackage ../development/libraries/git2 (
     stdenv.lib.optionalAttrs stdenv.isDarwin {
       inherit (darwin) libiconv;


### PR DESCRIPTION
###### Motivation for this change

New package for Icon Language
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Icon is a very high level general-purpose programming language with
extensive features for processing strings (text) and data structures.
