### PR TITLE
elixir: 1.2.5 -> 1.2.6

### DIFF
--- a/pkgs/development/interpreters/elixir/default.nix
+++ b/pkgs/development/interpreters/elixir/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "elixir-${version}";
-  version = "1.2.5";
+  version = "1.2.6";
 
   src = fetchFromGitHub {
     owner = "elixir-lang";
     repo = "elixir";
     rev = "v${version}";
-    sha256 = "0qnmsmzmr431y1chkzk2aq501fk734mncdbn7nsiq98bnqgb6php";
+    sha256 = "0zrsy0jy33m7krpwf1vymmiirl068sj4hfjji77wkhn8k88awmfb";
   };
 
   buildInputs = [ erlang rebar makeWrapper ];

--- a/pkgs/servers/xmpp/ejabberd/default.nix
+++ b/pkgs/servers/xmpp/ejabberd/default.nix
@@ -76,7 +76,7 @@ in stdenv.mkDerivation rec {
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "0nf2fgfiapxg26c7bxl985pszpgnzyan4j4jiaf5zvflza67h777";
+    outputHash = "0jrxd3v6p35wjrpw0jbb6m8nrm2lffhfgdcqmzcvsvjzji7nlkzx";
   };
 
   configureFlags =


### PR DESCRIPTION
###### Motivation for this change

Update elixir version.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also `ejabberd-deps` outputHash is updated.

I'm not an ejabberd user, so i interested in reasons why ejabberd with elixir is marked as broken? (cc @abbradar)
