### PR TITLE
fish: fix completions

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     # make fish pick up completions from nix profile
     if status --is-interactive
       set -l profiles (echo $NIX_PROFILES | ${coreutils}/bin/tr ' ' '\n')
-      set fish_complete_path $profiles"/share/fish/vendor_completions.d" $fish_complete_path
+      set fish_complete_path \$profiles"/share/fish/vendor_completions.d" \$fish_complete_path
     end
     EOF
   '';


### PR DESCRIPTION
###### Motivation for this change

Tab completion was not working in fish shell.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Completion was broken because some variables were resolved at
installation time instead of being added to the script.
