### PR TITLE
kernel: 4.5.5 -> 4.5.6

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.5.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.5.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.5.5";
+  version = "4.5.6";
   extraMeta.branch = "4.5";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0l7wnilqqhg3im2v04g6k2x621yckdb9bpfh8s8jq9l2fixjln99";
+    sha256 = "1bdyviimgnc4zbgd9v1xk87sj9h8cprjykifriddwslqxyr2yh0y";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
