### PR TITLE
rakudo: 2016.01 -> 2016.04

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "rakudo-star-${version}";
-  version = "2016.01";
+  version = "2016.04";
 
   src = fetchurl {
     url    = "http://rakudo.org/downloads/star/${name}.tar.gz";
-    sha256 = "feb385c5d05166061f413882e442d3a0ec53884918768940d3f00bb63bc85497";
+    sha256 = "11xzgwy155xpagrn3gzg8vqnqgjxwar70a3gzzmc9sica5064pva";
   };
 
   buildInputs = [ icu zlib gmp readline perl ];
@@ -17,11 +17,11 @@ stdenv.mkDerivation rec {
       "--gen-nqp"
     ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A Perl 6 implementation";
     homepage    = "http://www.rakudo.org";
-    license     = stdenv.lib.licenses.artistic2;
-    platforms   = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    license     = licenses.artistic2;
+    platforms   = platforms.unix;
+    maintainers = [ maintainers.thoughtpolice ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update Rakudo version
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Updating Rakudo (Perl 6 compiler) to 2016.04
