### PR TITLE
darktable: readd map/geotagging feature

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -3,7 +3,7 @@
 , libgnome_keyring, gtk3, ilmbase, intltool, lcms, lcms2
 , lensfun, libXau, libXdmcp, libexif, libglade, libgphoto2, libjpeg
 , libpng, libpthreadstubs, librsvg, libtiff, libxcb
-, openexr, pixman, pkgconfig, sqlite, bash, libxslt, openjpeg
+, openexr, osm-gps-map, pixman, pkgconfig, sqlite, bash, libxslt, openjpeg
 , mesa, lua, pugixml, colord, colord-gtk, libxshmfence, libxkbcommon
 , epoxy, at_spi2_core, libwebp, libsecret, wrapGAppsHook, gnome3
 }:
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
       libsoup graphicsmagick SDL json_glib openjpeg mesa lua pugixml
       colord colord-gtk libxshmfence libxkbcommon epoxy at_spi2_core
       libwebp libsecret wrapGAppsHook gnome3.adwaita-icon-theme
+      osm-gps-map
     ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/osm-gps-map/default.nix
+++ b/pkgs/development/libraries/osm-gps-map/default.nix
@@ -1,0 +1,29 @@
+{ cairo, fetchzip, glib, gnome3, gobjectIntrospection, pkgconfig, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "osm-gps-map-${version}";
+  version = "1.1.0";
+
+  src = fetchzip {
+    url = "https://github.com/nzjrs/osm-gps-map/releases/download/${version}/osm-gps-map-${version}.tar.gz";
+    sha256 = "0fal3mqcf3yypir4f7njz0dm5wr7lqwpimjx28wz9imh48cqx9n9";
+  };
+
+  outputs = [ "dev" "out" "doc" ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [
+    cairo glib gobjectIntrospection
+  ] ++ (with gnome3; [
+    gnome_common gtk libsoup
+  ]);
+
+  meta = with stdenv.lib; {
+    description = "Gtk+ widget for displaying OpenStreetMap tiles";
+    homepage = https://nzjrs.github.io/osm-gps-map;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ hrdinka ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8682,6 +8682,8 @@ in
 
   ortp = callPackage ../development/libraries/ortp { };
 
+  osm-gps-map = callPackage ../development/libraries/osm-gps-map { };
+
   p11_kit = callPackage ../development/libraries/p11-kit { };
 
   paperkey = callPackage ../tools/security/paperkey { };


### PR DESCRIPTION
###### Motivation for this change

Darktables map feature got lost in one of its previous updates. This readds it.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @cillianderoiste @rickynils @flosse
