### PR TITLE
piqi-ocaml: 0.7.4 -> 0.7.5

### DIFF
--- a/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, ocaml, findlib, piqi, ulex, easy-format, xmlm, base64, camlp4}:
 
 stdenv.mkDerivation rec {
-  version = "0.7.4";
+  version = "0.7.5";
   name    = "piqi-ocaml-${version}";
 
   src = fetchurl {
     url = "https://github.com/alavrik/piqi-ocaml/archive/v${version}.tar.gz";
-    sha256 = "064c74f031l847q6s1vilj77n7h7i84jn8c83yid9nha3dssaf7m";
+    sha256 = "0ngz6y8i98i5v2ma8nk6mc83pdsmf2z0ks7m3xi6clfg3zqbddrv";
   };
 
   buildInputs = [ocaml findlib piqi base64 camlp4];

--- a/pkgs/development/ocaml-modules/piqi/default.nix
+++ b/pkgs/development/ocaml-modules/piqi/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, ocaml, findlib, camlp4, which, ulex, easy-format, ocaml_optcomp, xmlm, base64}:
 
 stdenv.mkDerivation rec {
-  version = "0.6.12";
+  version = "0.6.13";
   name    = "piqi-${version}";
  
   src = fetchurl {
     url = "https://github.com/alavrik/piqi/archive/v${version}.tar.gz";
-    sha256 = "1ifnawnblvibf5rgp6gr4f20266dckfrlryikg1iiq3dx2wfl7f8";
+    sha256 = "1whqr2bb3gds2zmrzqnv8vqka9928w4lx6mi6g244kmbwb2h8d8l";
   };
 
   buildInputs = [ocaml findlib camlp4 which ocaml_optcomp base64];


### PR DESCRIPTION
###### Motivation for this change

Update an OCaml library and one of its dependencies
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc maintainer @maurer 
