### PR TITLE
init bwa at 0.7.15

### DIFF
--- a/pkgs/applications/science/biology/bwa/default.nix
+++ b/pkgs/applications/science/biology/bwa/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "bwa-${version}";
+  version = "0.7.15";
+
+  src = fetchurl {
+    url = "https://github.com/lh3/bwa/releases/download/v0.7.15/bwa-0.7.15.tar.bz2";
+    sha256 = "0585ikg0gv0mpyw9iq0bq9n0hr95867bbv8jbzs9pk4slkpsymig";
+  };
+
+  buildInputs = [ zlib ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bwa $out/bin
+    '';
+
+  meta = with stdenv.lib; {
+    description = "A software package for mapping low-divergent sequences against a large reference genome, such as the human genome";
+    license = licenses.gpl3;
+    homepage = http://bio-bwa.sourceforge.net/;
+    maintainers = with maintainers; [ luispedro ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15942,6 +15942,8 @@ in
 
   samtools = callPackage ../applications/science/biology/samtools/default.nix { };
 
+  bwa = callPackage ../applications/science/biology/bwa/default.nix { };
+
 
   ### SCIENCE/MATH
 


### PR DESCRIPTION
###### Motivation for this change

Adds bwa, a standard bioinformatics tool for aligning short reads to references (e.g., genomes)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

No packages depend on this one
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
