### PR TITLE
[WIP] php: add hydra builds for PHP 7.0 and 5.5

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5652,6 +5652,10 @@ in
     php56
     php70;
 
+  # PHP aliases
+  php55 = php55;
+  php70 = php70;
+
   picoc = callPackage ../development/interpreters/picoc {};
 
   picolisp = callPackage ../development/interpreters/picolisp {};


### PR DESCRIPTION
###### Motivation for this change

PHP 7.0 and 5.5 are not built on hydra and so don't have binary substitutes ([7.0](http://hydra.nixos.org/search?query=php70) [5.5](http://hydra.nixos.org/search?query=php55))

I suppose that `inherit` alone is too lazy and don't get the inherited packages evaluated by Hydra. 
This is using the same approach ruby does, adding explicit keys for inherited packages.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
