### PR TITLE
gephi: init at 0.9.1

### DIFF
--- a/pkgs/applications/science/misc/gephi/default.nix
+++ b/pkgs/applications/science/misc/gephi/default.nix
@@ -1,0 +1,37 @@
+{stdenv, fetchurl, jdk}:
+
+with stdenv.lib;
+
+let version = "0.9.1"; in
+stdenv.mkDerivation {
+  name = "gephi-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/gephi/gephi/releases/download/v${version}/gephi-${version}-linux.tar.gz";
+    sha256 = "f1d54157302df05a53b94e1518880c949c43ba4ab21e52d57f3edcbdaa06c7ee";
+  };
+
+  meta = {
+    inherit version;
+    description = "A platform for visualizing and manipulating large graphs";
+    homepage = https://gephi.org;
+    license = licenses.gpl3;
+    maintainers = [maintainers.taeer];
+    platforms = platforms.linux;
+  };
+
+  buildInputs = [jdk];
+
+  configurePhase = "
+    echo \"jdkhome=${jdk}\" >> etc/gephi.conf
+  ";
+
+  dontBuild = true;
+
+  installPhase = "
+    mkdir $out
+    for a in ./*; do
+      mv $a $out
+    done
+  ";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7038,6 +7038,8 @@ in
   gecode_4 = callPackage ../development/libraries/gecode { };
   gecode = self.gecode_4;
 
+  gephi = callPackage ../applications/science/misc/gephi { };
+
   gegl = callPackage ../development/libraries/gegl { };
 
   gegl_0_3 = callPackage ../development/libraries/gegl/3.0.nix { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
