### PR TITLE
kde5: fix plasma build

### DIFF
--- a/pkgs/desktops/kde-5/plasma-5.6/kdeplasma-addons.nix
+++ b/pkgs/desktops/kde-5/plasma-5.6/kdeplasma-addons.nix
@@ -2,6 +2,7 @@
 , kconfigwidgets, kcoreaddons, kcmutils, kdelibs4support, ki18n
 , kio, knewstuff, kross, krunner, kservice, kunitconversion
 , plasma-framework, plasma-workspace, qtdeclarative, qtx11extras
+, libksysguard
 }:
 
 plasmaPackage {
@@ -13,6 +14,6 @@ plasmaPackage {
   propagatedBuildInputs = [
     kdelibs4support kio kross krunner plasma-framework plasma-workspace
     qtdeclarative qtx11extras ibus kconfig kconfigwidgets kcoreaddons kcmutils
-    knewstuff kservice kunitconversion
+    knewstuff kservice kunitconversion libksysguard
   ];
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

http://hydra.nixos.org/build/36743787/log/raw

CMake Error at /nix/store/0l3swqskvpqndhcz22qp45x61d34fsxr-cmake-3.4.3/share/cmake-3.4/Modules/CMakeFindDependencyMacro.cmake:65 (find_package):
  By not providing "FindKF5SysGuard.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "KF5SysGuard", but CMake did not find one.

  Could not find a package configuration file provided by "KF5SysGuard" with
  any of the following names:

```
KF5SysGuardConfig.cmake
kf5sysguard-config.cmake
```

  Add the installation prefix of "KF5SysGuard" to CMAKE_PREFIX_PATH or set
  "KF5SysGuard_DIR" to a directory containing one of the above files.  If
  "KF5SysGuard" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /nix/store/ciiwri0pz99kph3qmpsiwhxpxrhxkb1b-plasma-workspace-5.6.4-dev/lib/cmake/LibTaskManager/LibTaskManagerConfig.cmake:71 (find_dependency)
  CMakeLists.txt:54 (find_package)
