### PR TITLE
Postfix: Add an option to enable Submission

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -210,12 +210,13 @@ in
 
       submissionOptions = mkOption {
         type = types.attrs;
-        default = { "smtpd_tls_security_level" = "encrypt";
+        default = {};
+        description = "Options for the submission config in master.cf";
+        example = { "smtpd_tls_security_level" = "encrypt";
                     "smtpd_sasl_auth_enable" = "yes";
                     "smtpd_client_restrictions" = "permit_sasl_authenticated,reject";
+                    "milter_macro_daemon_name" = "ORIGINATING";
                   };
-        description = "Options for the submission config in master.cf";
-        example = { "milter_macro_daemon_name" = "ORIGINATING"; };
       };
 
       setSendmail = mkOption {

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -210,10 +210,15 @@ in
 
       submissionOptions = mkOption {
         type = types.attrs;
-        default = {};
+        default = { "smtpd_tls_security_level" = "encrypt";
+                    "smtpd_sasl_auth_enable" = "yes";
+                    "smtpd_client_restrictions" = "permit_sasl_authenticated,reject";
+                    "milter_macro_daemon_name" = "ORIGINATING";
+                  };
         description = "Options for the submission config in master.cf";
         example = { "smtpd_tls_security_level" = "encrypt";
                     "smtpd_sasl_auth_enable" = "yes";
+                    "smtpd_sasl_type" = "dovecot";
                     "smtpd_client_restrictions" = "permit_sasl_authenticated,reject";
                     "milter_macro_daemon_name" = "ORIGINATING";
                   };

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -129,10 +129,7 @@ let
     smtp      inet  n       -       n       -       -       smtpd
   '' + optionalString cfg.enableSubmission ''
     submission inet n       -       n       -       -       smtpd
-      -o smtpd_tls_security_level=encrypt
-      -o smtpd_sasl_auth_enable=yes
-      -o smtpd_client_restrictions=permit_sasl_authenticated,reject
-      ${cfg.extraSubmissionOptions}
+      ${concatStringsSep "\n  " (mapAttrsToList (x: y: "-o " + x + "=" + y) cfg.submissionOptions)}
   ''
   + ''
     pickup    unix  n       -       n       60      1       pickup
@@ -208,14 +205,17 @@ in
       enableSubmission = mkOption {
         type = types.bool;
         default = false;
-        description = "Whether to enable smtp submission in master.cf.";
+        description = "Whether to enable smtp submission";
       };
 
-      extraSubmissionOptions = mkOption {
-        type = types.str;
-        default = "";
-        description = "Extra options for the submission config in master.cf.";
-        example = "-o milter_macro_daemon_name=ORIGINATING";
+      submissionOptions = mkOption {
+        type = types.attrs;
+        default = { "smtpd_tls_security_level" = "encrypt";
+                    "smtpd_sasl_auth_enable" = "yes";
+                    "smtpd_client_restrictions" = "permit_sasl_authenticated,reject";
+                  };
+        description = "Options for the submission config in master.cf";
+        example = { "milter_macro_daemon_name" = "ORIGINATING"; };
       };
 
       setSendmail = mkOption {

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -127,11 +127,14 @@ let
     #               (yes)   (yes)   (no)    (never) (100)
     # ==========================================================================
     smtp      inet  n       -       n       -       -       smtpd
-    #submission inet n       -       n       -       -       smtpd
-    #  -o smtpd_tls_security_level=encrypt
-    #  -o smtpd_sasl_auth_enable=yes
-    #  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
-    #  -o milter_macro_daemon_name=ORIGINATING
+  '' + optionalString cfg.enableSubmission ''
+    submission inet n       -       n       -       -       smtpd
+      -o smtpd_tls_security_level=encrypt
+      -o smtpd_sasl_auth_enable=yes
+      -o smtpd_client_restrictions=permit_sasl_authenticated,reject
+      ${cfg.extraSubmissionOptions}
+  ''
+  + ''
     pickup    unix  n       -       n       60      1       pickup
     cleanup   unix  n       -       n       -       0       cleanup
     qmgr      unix  n       -       n       300     1       qmgr
@@ -200,6 +203,19 @@ in
       enableSmtp = mkOption {
         default = true;
         description = "Whether to enable smtp in master.cf.";
+      };
+      
+      enableSubmission = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable smtp submission in master.cf.";
+      };
+
+      extraSubmissionOptions = mkOption {
+        type = types.str;
+        default = "";
+        description = "Extra options for the submission config in master.cf.";
+        example = "-o milter_macro_daemon_name=ORIGINATING";
       };
 
       setSendmail = mkOption {


### PR DESCRIPTION
###### Motivation for this change

Before postfix didn't have a nice integration to enable submission.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Adds services.postfix.enableSubmission and services.postfix.extraSubmissionOptions to make it easy to enable submission in master.cf
