### PR TITLE
exif: use libintl on darwin

### DIFF
--- a/pkgs/tools/graphics/exif/default.nix
+++ b/pkgs/tools/graphics/exif/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libexif, popt }:
+{ stdenv, fetchurl, pkgconfig, libexif, popt, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
   name = "exif-0.6.21";
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1zb9hwdl783d4vd2s2rw642hg8hd6n0mfp6lrbiqmp9jmhlq5rsr";
   };
 
-  buildInputs = [ pkgconfig libexif popt ];
-  
+  buildInputs = [ pkgconfig libexif popt ] ++ libintlOrEmpty;
+
   meta = {
     homepage = http://libexif.sourceforge.net/;
     description = "A utility to read and manipulate EXIF data in digital photographs";


### PR DESCRIPTION
###### Motivation for this change

exif needs libintl on darwin
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

fixes #16034
