### PR TITLE
why3: 0.87.0 -> 0.87.1

### DIFF
--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "why3-${version}";
-  version = "0.87.0";
+  version = "0.87.1";
 
   src = fetchurl {
-    url    = https://gforge.inria.fr/frs/download.php/file/35643/why3-0.87.0.tar.gz;
-    sha256 = "0c3vhcb70ay7iwvmq0m25fqh38y40c5x7mki4r9pxf13vgbs3xb0";
+    url    = https://gforge.inria.fr/frs/download.php/file/35893/why3-0.87.1.tar.gz;
+    sha256 = "1ssik2f6fkpvwpdmxz8hrm3p62qas3sjlqya0r57s60ilpkgiwwb";
   };
 
   buildInputs = (with ocamlPackages; [


### PR DESCRIPTION
###### Motivation for this change

[Bugfix release](http://lists.gforge.inria.fr/pipermail/why3-club/2016-June/001354.html)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
