### PR TITLE
factor: disable build on i686-linux

### DIFF
--- a/pkgs/development/compilers/factor-lang/default.nix
+++ b/pkgs/development/compilers/factor-lang/default.nix
@@ -89,6 +89,6 @@ stdenv.mkDerivation rec {
     description = "A concatenative, stack-based programming language";
 
     maintainers = [ maintainers.vrthra ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The factor language should be built only on x86_64 machines. It failed on i686 hydra because the image is specific to x86_64
