### PR TITLE
minecraft: use icon in jar

### DIFF
--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, makeDesktopItem
 , jre, libX11, libXext, libXcursor, libXrandr, libXxf86vm
+, openjdk
 , mesa, openal
 , useAlsa ? false, alsaOss ? null }:
 with stdenv.lib;
@@ -7,15 +8,10 @@ with stdenv.lib;
 assert useAlsa -> alsaOss != null;
 
 let
-  icon = fetchurl {
-    url = "https://hydra-media.cursecdn.com/minecraft.gamepedia.com/c/c5/Grass.png";
-    sha256 = "438c0f63e379e92af1b5b2e06cc5e3365ee272810af65ebc102304bce4fa8c4b";
-  };
-
   desktopItem = makeDesktopItem {
     name = "minecraft";
     exec = "minecraft";
-    icon = "${icon}";
+    icon = "minecraft";
     comment = "A sandbox-building game";
     desktopName = "Minecraft";
     genericName = "minecraft";
@@ -49,6 +45,9 @@ in stdenv.mkDerivation {
 
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/
+
+    ${openjdk}/bin/jar xf $out/minecraft.jar favicon.png
+    install -D favicon.png $out/share/icons/hicolor/32x32/apps/minecraft.png
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

This removes the dependency on a wiki image download, which seemed bad
when I first introduced it. Unfortunately, they do not provide a 48x48
icon so we are not satisfying the minimal XDG standard. It introduces the openjdk argument to the derivation to make use of the jar extraction binary.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
