### PR TITLE
Qt: 5.6.0 -> 5.6.1

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/fetchsrcs.sh
+++ b/pkgs/development/libraries/qt-5/5.6/fetchsrcs.sh
@@ -4,7 +4,7 @@
 set -x
 
 # The trailing slash at the end is necessary!
-RELEASE_URL="http://download.qt.io/official_releases/qt/5.6/5.6.0/submodules/"
+RELEASE_URL="http://download.qt.io/official_releases/qt/5.6/5.6.1/submodules/"
 EXTRA_WGET_ARGS='-A *.tar.xz'
 
 mkdir tmp; cd tmp
@@ -12,7 +12,7 @@ mkdir tmp; cd tmp
 wget -nH -r -c --no-parent $RELEASE_URL $EXTRA_WGET_ARGS
 
 cat >../srcs.nix <<EOF
-# DO NOT EDIT! This file is generated automatically by manifest.sh
+# DO NOT EDIT! This file is generated automatically by fetchsrcs.sh
 { fetchurl, mirror }:
 
 {

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/cmake-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/cmake-paths.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+Index: qtbase-opensource-src-5.6.0/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+--- qtbase-opensource-src-5.6.0.orig/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
++++ qtbase-opensource-src-5.6.0/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 @@ -9,30 +9,6 @@ if (CMAKE_VERSION VERSION_LESS 3.0.0)
  endif()
  !!ENDIF
@@ -182,10 +182,10 @@ Index: qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5
  !!ELSE
          set(imported_location \"$${CMAKE_PLUGIN_DIR}${PLUGIN_LOCATION}\")
  !!ENDIF
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/gui/Qt5GuiConfigExtras.cmake.in
+Index: qtbase-opensource-src-5.6.0/src/gui/Qt5GuiConfigExtras.cmake.in
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/gui/Qt5GuiConfigExtras.cmake.in
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/gui/Qt5GuiConfigExtras.cmake.in
+--- qtbase-opensource-src-5.6.0.orig/src/gui/Qt5GuiConfigExtras.cmake.in
++++ qtbase-opensource-src-5.6.0/src/gui/Qt5GuiConfigExtras.cmake.in
 @@ -2,7 +2,7 @@
  !!IF !isEmpty(CMAKE_ANGLE_EGL_DLL_RELEASE)
  
@@ -211,10 +211,10 @@ Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/gui/Qt5GuiConfigExtras.cmak
  !!ELSE
      set(imported_implib \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
  !!ENDIF
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+Index: qtbase-opensource-src-5.6.0/src/widgets/Qt5WidgetsConfigExtras.cmake.in
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/widgets/Qt5WidgetsConfigExtras.cmake.in
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+--- qtbase-opensource-src-5.6.0.orig/src/widgets/Qt5WidgetsConfigExtras.cmake.in
++++ qtbase-opensource-src-5.6.0/src/widgets/Qt5WidgetsConfigExtras.cmake.in
 @@ -3,7 +3,7 @@ if (NOT TARGET Qt5::uic)
      add_executable(Qt5::uic IMPORTED)
  
@@ -224,10 +224,10 @@ Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/widgets/Qt5WidgetsConfigExt
  !!ELSE
      set(imported_location \"$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
  !!ENDIF
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/Qt5CoreConfigExtras.cmake.in
+Index: qtbase-opensource-src-5.6.0/src/corelib/Qt5CoreConfigExtras.cmake.in
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/corelib/Qt5CoreConfigExtras.cmake.in
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/Qt5CoreConfigExtras.cmake.in
+--- qtbase-opensource-src-5.6.0.orig/src/corelib/Qt5CoreConfigExtras.cmake.in
++++ qtbase-opensource-src-5.6.0/src/corelib/Qt5CoreConfigExtras.cmake.in
 @@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qmake)
      add_executable(Qt5::qmake IMPORTED)
  
@@ -273,10 +273,10 @@ Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/Qt5CoreConfigExtras
  !!ELSE
      set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
  !!ENDIF
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
+Index: qtbase-opensource-src-5.6.0/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
+--- qtbase-opensource-src-5.6.0.orig/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
++++ qtbase-opensource-src-5.6.0/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
 @@ -1,6 +1,6 @@
  
  !!IF isEmpty(CMAKE_INSTALL_DATA_DIR_IS_ABSOLUTE)
@@ -285,10 +285,10 @@ Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/Qt5CoreConfigExtras
  !!ELSE
  set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
  !!ENDIF
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
+Index: qtbase-opensource-src-5.6.0/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
+--- qtbase-opensource-src-5.6.0.orig/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
++++ qtbase-opensource-src-5.6.0/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
 @@ -1,6 +1,6 @@
  
  !!IF isEmpty(CMAKE_HOST_DATA_DIR_IS_ABSOLUTE)
@@ -297,10 +297,10 @@ Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/Qt5CoreConfigExtras
  !!ELSE
  set(_qt5_corelib_extra_includes \"$${CMAKE_HOST_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
  !!ENDIF
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/dbus/Qt5DBusConfigExtras.cmake.in
+Index: qtbase-opensource-src-5.6.0/src/dbus/Qt5DBusConfigExtras.cmake.in
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/dbus/Qt5DBusConfigExtras.cmake.in
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/dbus/Qt5DBusConfigExtras.cmake.in
+--- qtbase-opensource-src-5.6.0.orig/src/dbus/Qt5DBusConfigExtras.cmake.in
++++ qtbase-opensource-src-5.6.0/src/dbus/Qt5DBusConfigExtras.cmake.in
 @@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qdbuscpp2xml)
      add_executable(Qt5::qdbuscpp2xml IMPORTED)
  

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/compose-search-path.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/compose-search-path.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
+Index: qtbase-opensource-src-5.6.0/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
+--- qtbase-opensource-src-5.6.0.orig/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
++++ qtbase-opensource-src-5.6.0/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
 @@ -251,10 +251,7 @@ void TableGenerator::initPossibleLocatio
      // the QTCOMPOSE environment variable
      if (qEnvironmentVariableIsSet("QTCOMPOSE"))

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/decrypt-ssl-traffic.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/decrypt-ssl-traffic.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.5.1/qtbase/src/network/ssl/qsslsocket_openssl.cpp
+Index: qtbase-opensource-src-5.5.1/src/network/ssl/qsslsocket_openssl.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.5.1.orig/qtbase/src/network/ssl/qsslsocket_openssl.cpp
-+++ qt-everywhere-opensource-src-5.5.1/qtbase/src/network/ssl/qsslsocket_openssl.cpp
+--- qtbase-opensource-src-5.5.1.orig/src/network/ssl/qsslsocket_openssl.cpp
++++ qtbase-opensource-src-5.5.1/src/network/ssl/qsslsocket_openssl.cpp
 @@ -48,7 +48,7 @@
  ****************************************************************************/
  

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-dbus.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-dbus.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.5.1/qtbase/src/dbus/qdbus_symbols.cpp
+Index: qtbase-opensource-src-5.5.1/src/dbus/qdbus_symbols.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.5.1.orig/qtbase/src/dbus/qdbus_symbols.cpp
-+++ qt-everywhere-opensource-src-5.5.1/qtbase/src/dbus/qdbus_symbols.cpp
+--- qtbase-opensource-src-5.5.1.orig/src/dbus/qdbus_symbols.cpp
++++ qtbase-opensource-src-5.5.1/src/dbus/qdbus_symbols.cpp
 @@ -89,7 +89,7 @@ bool qdbus_loadLibDBus()
  #ifdef Q_OS_WIN
          QLatin1String("dbus-1"),

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-gl.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-gl.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.5.1/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
+Index: qtbase-opensource-src-5.5.1/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.5.1.orig/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
-+++ qt-everywhere-opensource-src-5.5.1/qtbase/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
+--- qtbase-opensource-src-5.5.1.orig/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
++++ qtbase-opensource-src-5.5.1/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
 @@ -563,7 +563,12 @@ void (*QGLXContext::getProcAddress(const
              {
                  extern const QString qt_gl_library_name();

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-gtkstyle.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-gtkstyle.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.5.1/qtbase/src/widgets/styles/qgtk2painter.cpp
+Index: qtbase-opensource-src-5.5.1/src/widgets/styles/qgtk2painter.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.5.1.orig/qtbase/src/widgets/styles/qgtk2painter.cpp
-+++ qt-everywhere-opensource-src-5.5.1/qtbase/src/widgets/styles/qgtk2painter.cpp
+--- qtbase-opensource-src-5.5.1.orig/src/widgets/styles/qgtk2painter.cpp
++++ qtbase-opensource-src-5.5.1/src/widgets/styles/qgtk2painter.cpp
 @@ -96,7 +96,7 @@ static void initGtk()
      static bool initialized = false;
      if (!initialized) {
@@ -11,10 +11,10 @@ Index: qt-everywhere-opensource-src-5.5.1/qtbase/src/widgets/styles/qgtk2painter
  
          QGtk2PainterPrivate::gdk_pixmap_new = (Ptr_gdk_pixmap_new)libgtk.resolve("gdk_pixmap_new");
          QGtk2PainterPrivate::gdk_pixbuf_get_from_drawable = (Ptr_gdk_pixbuf_get_from_drawable)libgtk.resolve("gdk_pixbuf_get_from_drawable");
-Index: qt-everywhere-opensource-src-5.5.1/qtbase/src/widgets/styles/qgtkstyle_p.cpp
+Index: qtbase-opensource-src-5.5.1/src/widgets/styles/qgtkstyle_p.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.5.1.orig/qtbase/src/widgets/styles/qgtkstyle_p.cpp
-+++ qt-everywhere-opensource-src-5.5.1/qtbase/src/widgets/styles/qgtkstyle_p.cpp
+--- qtbase-opensource-src-5.5.1.orig/src/widgets/styles/qgtkstyle_p.cpp
++++ qtbase-opensource-src-5.5.1/src/widgets/styles/qgtkstyle_p.cpp
 @@ -327,7 +327,7 @@ void QGtkStylePrivate::gtkWidgetSetFocus
  void QGtkStylePrivate::resolveGtk() const
  {

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-libXcursor.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-libXcursor.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/plugins/platforms/xcb/qxcbcursor.cpp
+Index: qtbase-opensource-src-5.6.0/src/plugins/platforms/xcb/qxcbcursor.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/plugins/platforms/xcb/qxcbcursor.cpp
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/plugins/platforms/xcb/qxcbcursor.cpp
+--- qtbase-opensource-src-5.6.0.orig/src/plugins/platforms/xcb/qxcbcursor.cpp
++++ qtbase-opensource-src-5.6.0/src/plugins/platforms/xcb/qxcbcursor.cpp
 @@ -303,10 +303,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *c
  #if defined(XCB_USE_XLIB) && !defined(QT_NO_LIBRARY)
      static bool function_ptrs_not_initialized = true;

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-openssl.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-openssl.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/network/ssl/qsslsocket_openssl_symbols.cpp
+Index: qtbase-opensource-src-5.6.0/src/network/ssl/qsslsocket_openssl_symbols.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/network/ssl/qsslsocket_openssl_symbols.cpp
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/network/ssl/qsslsocket_openssl_symbols.cpp
+--- qtbase-opensource-src-5.6.0.orig/src/network/ssl/qsslsocket_openssl_symbols.cpp
++++ qtbase-opensource-src-5.6.0/src/network/ssl/qsslsocket_openssl_symbols.cpp
 @@ -652,8 +652,8 @@ static QPair<QLibrary*, QLibrary*> loadO
  #endif
  #if defined(SHLIB_VERSION_NUMBER) && !defined(Q_OS_QNX) // on QNX, the libs are always libssl.so and libcrypto.so

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-resolv.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/dlopen-resolv.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/network/kernel/qdnslookup_unix.cpp
+Index: qtbase-opensource-src-5.6.0/src/network/kernel/qdnslookup_unix.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/network/kernel/qdnslookup_unix.cpp
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/network/kernel/qdnslookup_unix.cpp
+--- qtbase-opensource-src-5.6.0.orig/src/network/kernel/qdnslookup_unix.cpp
++++ qtbase-opensource-src-5.6.0/src/network/kernel/qdnslookup_unix.cpp
 @@ -79,7 +79,7 @@ static void resolveLibrary()
      if (!lib.load())
  #endif
@@ -11,10 +11,10 @@ Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/network/kernel/qdnslookup_u
          if (!lib.load())
              return;
      }
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/network/kernel/qhostinfo_unix.cpp
+Index: qtbase-opensource-src-5.6.0/src/network/kernel/qhostinfo_unix.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/network/kernel/qhostinfo_unix.cpp
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/network/kernel/qhostinfo_unix.cpp
+--- qtbase-opensource-src-5.6.0.orig/src/network/kernel/qhostinfo_unix.cpp
++++ qtbase-opensource-src-5.6.0/src/network/kernel/qhostinfo_unix.cpp
 @@ -95,7 +95,7 @@ static void resolveLibrary()
      if (!lib.load())
  #endif

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/libressl.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/libressl.patch
@@ -9,10 +9,10 @@ is defined in openssl, but not in libressl.
  src/network/ssl/qsslcontext_openssl.cpp | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/network/ssl/qsslcontext_openssl.cpp
+Index: qtbase-opensource-src-5.6.0/src/network/ssl/qsslcontext_openssl.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/network/ssl/qsslcontext_openssl.cpp
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/network/ssl/qsslcontext_openssl.cpp
+--- qtbase-opensource-src-5.6.0.orig/src/network/ssl/qsslcontext_openssl.cpp
++++ qtbase-opensource-src-5.6.0/src/network/ssl/qsslcontext_openssl.cpp
 @@ -340,7 +340,7 @@ init_context:
  
      const QVector<QSslEllipticCurve> qcurves = sslContext->sslConfiguration.ellipticCurves();

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/mkspecs-libgl.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/mkspecs-libgl.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.5.1/qtbase/mkspecs/common/linux.conf
+Index: qtbase-opensource-src-5.5.1/mkspecs/common/linux.conf
 ===================================================================
---- qt-everywhere-opensource-src-5.5.1.orig/qtbase/mkspecs/common/linux.conf
-+++ qt-everywhere-opensource-src-5.5.1/qtbase/mkspecs/common/linux.conf
+--- qtbase-opensource-src-5.5.1.orig/mkspecs/common/linux.conf
++++ qtbase-opensource-src-5.5.1/mkspecs/common/linux.conf
 @@ -12,8 +12,8 @@ QMAKE_INCDIR            =
  QMAKE_LIBDIR            =
  QMAKE_INCDIR_X11        =

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/nix-profiles-library-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/nix-profiles-library-paths.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/kernel/qcoreapplication.cpp
+Index: qtbase-opensource-src-5.6.0/src/corelib/kernel/qcoreapplication.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/corelib/kernel/qcoreapplication.cpp
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/kernel/qcoreapplication.cpp
+--- qtbase-opensource-src-5.6.0.orig/src/corelib/kernel/qcoreapplication.cpp
++++ qtbase-opensource-src-5.6.0/src/corelib/kernel/qcoreapplication.cpp
 @@ -2533,7 +2533,17 @@ QStringList QCoreApplication::libraryPat
          QStringList *app_libpaths = new QStringList;
          coreappdata()->app_libpaths.reset(app_libpaths);

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/tzdir.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/tzdir.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/tools/qtimezoneprivate_tz.cpp
+Index: qtbase-opensource-src-5.6.0/src/corelib/tools/qtimezoneprivate_tz.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/corelib/tools/qtimezoneprivate_tz.cpp
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/tools/qtimezoneprivate_tz.cpp
+--- qtbase-opensource-src-5.6.0.orig/src/corelib/tools/qtimezoneprivate_tz.cpp
++++ qtbase-opensource-src-5.6.0/src/corelib/tools/qtimezoneprivate_tz.cpp
 @@ -62,7 +62,10 @@ typedef QHash<QByteArray, QTzTimeZone> Q
  // Parse zone.tab table, assume lists all installed zones, if not will need to read directories
  static QTzTimeZoneHash loadTzTimeZones()

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/xdg-config-dirs.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/xdg-config-dirs.patch
@@ -1,7 +1,7 @@
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/io/qsettings.cpp
+Index: qtbase-opensource-src-5.6.0/src/corelib/io/qsettings.cpp
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/corelib/io/qsettings.cpp
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/io/qsettings.cpp
+--- qtbase-opensource-src-5.6.0.orig/src/corelib/io/qsettings.cpp
++++ qtbase-opensource-src-5.6.0/src/corelib/io/qsettings.cpp
 @@ -1155,6 +1155,24 @@ QConfFileSettingsPrivate::QConfFileSetti
      if (!application.isEmpty())
          confFiles[F_System | F_Application].reset(QConfFile::fromName(systemPath + appFile, false));
@@ -27,10 +27,10 @@ Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/io/qsettings.cpp
  #else
      QString confName = getPath(format, QSettings::UserScope) + org;
      if (!application.isEmpty())
-Index: qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/io/qsettings_p.h
+Index: qtbase-opensource-src-5.6.0/src/corelib/io/qsettings_p.h
 ===================================================================
---- qt-everywhere-opensource-src-5.6.0.orig/qtbase/src/corelib/io/qsettings_p.h
-+++ qt-everywhere-opensource-src-5.6.0/qtbase/src/corelib/io/qsettings_p.h
+--- qtbase-opensource-src-5.6.0.orig/src/corelib/io/qsettings_p.h
++++ qtbase-opensource-src-5.6.0/src/corelib/io/qsettings_p.h
 @@ -241,7 +241,7 @@ public:
          F_Organization = 0x1,
          F_User = 0x0,

--- a/pkgs/development/libraries/qt-5/5.6/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.6/srcs.nix
@@ -1,261 +1,261 @@
-# DO NOT EDIT! This file is generated automatically by manifest.sh
+# DO NOT EDIT! This file is generated automatically by fetchsrcs.sh
 { fetchurl, mirror }:
 
 {
-  qttools = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qttools-opensource-src-5.6.0.tar.xz";
-      sha256 = "1791c9a1vxv0q2ywr00ya5rxaggidsq81s8h8fwmql75pdhlq90d";
-      name = "qttools-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtwebengine = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtwebengine-opensource-src-5.6.0.tar.xz";
-      sha256 = "00vaqx3mypqlnjkfwhx54r6ygfs07amkwc4rma0sg64zdjnvb8la";
-      name = "qtwebengine-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtserialbus = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtserialbus-opensource-src-5.6.0.tar.xz";
-      sha256 = "13hbmj9pilh5gkbbngfbp225qvc650pnzvpzawpnf69zwl757jlc";
-      name = "qtserialbus-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtwayland = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtwayland-opensource-src-5.6.0.tar.xz";
-      sha256 = "1k5zsgz54wlkxm3ici55lbbz286bk2791vri02bjgja5y9102pdm";
-      name = "qtwayland-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qt5 = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qt5-opensource-src-5.6.0.tar.xz";
-      sha256 = "195dl9pk9slbiy6mgwwpc70vaw62sdhxc3lxmlnyddk99widqa3k";
-      name = "qt5-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtimageformats = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtimageformats-opensource-src-5.6.0.tar.xz";
-      sha256 = "1nmsh682idxl0642q7376r9qfxkx0736q9pl4jx179c9lrsl519c";
-      name = "qtimageformats-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtactiveqt = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtactiveqt-opensource-src-5.6.0.tar.xz";
-      sha256 = "0xrjr9jwkxxcv46a8vj77px3v1p36nm6rpvyxma0wb4xhpippp3a";
-      name = "qtactiveqt-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtdoc = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtdoc-opensource-src-5.6.0.tar.xz";
-      sha256 = "1z69yl8nkvp21arjhzl34gr8gvxm5b03d58lwnddl4mkaxbi4vap";
-      name = "qtdoc-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtsensors = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtsensors-opensource-src-5.6.0.tar.xz";
-      sha256 = "0blwqmkh0hn1716d5fvy0vnh56y9iikl34ayz6ksl0ayxhpkk3si";
-      name = "qtsensors-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtwebchannel = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtwebchannel-opensource-src-5.6.0.tar.xz";
-      sha256 = "0ky1njksczyfb7y7p5kfgzbx9vgajzy51g2y3vrpfvl6bs9j8m62";
-      name = "qtwebchannel-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtmacextras = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtmacextras-opensource-src-5.6.0.tar.xz";
-      sha256 = "1jkmwppapvymdr1kwdrbjlxhcafcn4jb23ssnhrvvgcq3lnl5lhj";
-      name = "qtmacextras-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtwebsockets = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtwebsockets-opensource-src-5.6.0.tar.xz";
-      sha256 = "17vi3n27gx3f3c2lii3b70pzz6mpblam3236v6mj439xzrlvi2i6";
-      name = "qtwebsockets-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtconnectivity = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtconnectivity-opensource-src-5.6.0.tar.xz";
-      sha256 = "1ss0ibabiv7n5hakkxmkc4msrwgqcvfffdjajnv5jrq0030v0p0c";
-      name = "qtconnectivity-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtscript = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtscript-opensource-src-5.6.0.tar.xz";
-      sha256 = "0hjhkh4lia1i0iir1i8dr57gizi74h73j0phhir3q3wsglcpax5c";
-      name = "qtscript-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qttranslations = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qttranslations-opensource-src-5.6.0.tar.xz";
-      sha256 = "0jfdfj2z0nvf1xblmdxaphn0psjycrb5g3jxxcddkci214gka2cq";
-      name = "qttranslations-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtlocation = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtlocation-opensource-src-5.6.0.tar.xz";
-      sha256 = "1jakjrwic01b5vyij6hfzdfpipandpkj9li3d7wf9bzws0cia3in";
-      name = "qtlocation-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtserialport = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtserialport-opensource-src-5.6.0.tar.xz";
-      sha256 = "07rwhmh9y7b3ycvx4d4d1j32nahf8nhsb9qj99kxz5xrdfv7zvhn";
-      name = "qtserialport-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtsvg = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtsvg-opensource-src-5.6.0.tar.xz";
-      sha256 = "07v4bzxd31dhkhp52y4g2ii0sslmk48cqkkz32v41frqj4qrk1vr";
-      name = "qtsvg-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtwebview = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtwebview-opensource-src-5.6.0.tar.xz";
-      sha256 = "0mqbh125bq37xybwslhri4pl861r26cnraiz9ivh4881kqzab3x4";
-      name = "qtwebview-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtcanvas3d = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtcanvas3d-opensource-src-5.6.0.tar.xz";
-      sha256 = "1kwykm1ffgpjgb3ggd4h2d2x3yhp9jsc0gnwlks620bahagdbbb6";
-      name = "qtcanvas3d-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtwinextras = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtwinextras-opensource-src-5.6.0.tar.xz";
-      sha256 = "14xvm081wjyild2wi7pcilqxdkhc8b0lf9yn7yf7zp576i9ir5aq";
-      name = "qtwinextras-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtgraphicaleffects = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtgraphicaleffects-opensource-src-5.6.0.tar.xz";
-      sha256 = "1s0n8hrmrfs53cmm7i45p8zavvmsl0aisd5sgj93p8c5rzyi3s81";
-      name = "qtgraphicaleffects-opensource-src-5.6.0.tar.xz";
-    };
-  };
   qtxmlpatterns = {
-    version = "5.6.0";
+    version = "5.6.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtxmlpatterns-opensource-src-5.6.0.tar.xz";
-      sha256 = "1m0rr0m9zg2d6rdban2p5qyx8rdnjnjsfk3bm72bh47hscxipvds";
-      name = "qtxmlpatterns-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtquickcontrols2 = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtquickcontrols2-opensource-src-5.6.0.tar.xz";
-      sha256 = "1q7yp7l32jd3p28587ldxzkj58z1aad9gcs80w6vqc9952i6xv2r";
-      name = "qtquickcontrols2-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtbase = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtbase-opensource-src-5.6.0.tar.xz";
-      sha256 = "0ynnvcs5idivzldsq5ciqg9myg82b3l3906l4vjv54lyamf8mykf";
-      name = "qtbase-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qt3d = {
-    version = "5.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qt3d-opensource-src-5.6.0.tar.xz";
-      sha256 = "17a37xhav5mxspx2c9wsgvcilv7ys40q6minmlqd1gnfmsfphqdr";
-      name = "qt3d-opensource-src-5.6.0.tar.xz";
-    };
-  };
-  qtenginio = {
-    version = "1.6.0";
-    src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtenginio-opensource-src-1.6.0.tar.xz";
-      sha256 = "033z2jncci64s7s9ml5rsfsnrkdmhx1g5dfvr61imv63pzxxqzb2";
-      name = "qtenginio-opensource-src-1.6.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtxmlpatterns-opensource-src-5.6.1.tar.xz";
+      sha256 = "0q412jv3xbg7v05b8pbahifwx17gzlp96s90akh6zwhpm8i6xx34";
+      name = "qtxmlpatterns-opensource-src-5.6.1.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.6.0";
+    version = "5.6.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtx11extras-opensource-src-5.6.0.tar.xz";
-      sha256 = "099lc7kxcxgp5s01ddnd6n955fc8866caark43xfs2dw0a6pdva7";
-      name = "qtx11extras-opensource-src-5.6.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtx11extras-opensource-src-5.6.1.tar.xz";
+      sha256 = "0l736qiz8adrnh267xz63hv4sph6nhy90h836qfnnmv3p78ipsz8";
+      name = "qtx11extras-opensource-src-5.6.1.tar.xz";
     };
   };
-  qtdeclarative = {
-    version = "5.6.0";
+  qtwinextras = {
+    version = "5.6.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtdeclarative-opensource-src-5.6.0.tar.xz";
-      sha256 = "0k70zlyx1nh35caiav4s3jvg5l029pvilm6sarxmfj73y19z0mcc";
-      name = "qtdeclarative-opensource-src-5.6.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwinextras-opensource-src-5.6.1.tar.xz";
+      sha256 = "1db3lcrj8af0z8lnh99lfbwz1cq9il7rr27rk9l38dff65qkssm8";
+      name = "qtwinextras-opensource-src-5.6.1.tar.xz";
     };
   };
-  qtmultimedia = {
-    version = "5.6.0";
+  qtwebview = {
+    version = "5.6.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtmultimedia-opensource-src-5.6.0.tar.xz";
-      sha256 = "11h66xcr3y3w8hhvx801r66yirvf1kppasjlhm25qvr6rpb9jgqh";
-      name = "qtmultimedia-opensource-src-5.6.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwebview-opensource-src-5.6.1.tar.xz";
+      sha256 = "0q869wl61vidds551w3z49ysx88xqyn6igbz07zxac7d0gwgwpda";
+      name = "qtwebview-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtwebsockets = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwebsockets-opensource-src-5.6.1.tar.xz";
+      sha256 = "0fkj52i4yi6gmq4jfjgdij08cspxspac6mbpf0fknnllimmkl7jm";
+      name = "qtwebsockets-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtwebengine = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwebengine-opensource-src-5.6.1.tar.xz";
+      sha256 = "0yv0cflgywsyfn84vv2vc9rwpm8j7hin61rxqjqh498nnl2arw5x";
+      name = "qtwebengine-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtwebchannel = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwebchannel-opensource-src-5.6.1.tar.xz";
+      sha256 = "01q80917a1048hdhaii4v50dqs84h16lc9w3v99r9xvspk8vab7q";
+      name = "qtwebchannel-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtwayland = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwayland-opensource-src-5.6.1.tar.xz";
+      sha256 = "1jgghjfrg0wwyfzfwgwhagwxz9k936ylv3w2l9bwlpql8rgm8d11";
+      name = "qtwayland-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qttranslations = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qttranslations-opensource-src-5.6.1.tar.xz";
+      sha256 = "008wyk00mqz116pigm0qq78rvg28v6ykjnjxppkjnk0yd6i2vmb9";
+      name = "qttranslations-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qttools = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qttools-opensource-src-5.6.1.tar.xz";
+      sha256 = "0wbzq60d7lkvlb7b5lqcw87qgy6kyjz1npjavz8f4grdxsaqi8vp";
+      name = "qttools-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtsvg = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtsvg-opensource-src-5.6.1.tar.xz";
+      sha256 = "08ca5g46g75acy27jfnvnalmcias5hxmjp7491v3y4k9y7a4ybpi";
+      name = "qtsvg-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtserialport = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtserialport-opensource-src-5.6.1.tar.xz";
+      sha256 = "1hp63cgqhps6y1k041lzhcb2b0rcpcmszabnn293q5ilbvla4x0b";
+      name = "qtserialport-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtserialbus = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtserialbus-opensource-src-5.6.1.tar.xz";
+      sha256 = "1h683dkvnf2rdgxgisybnp8miqgn2gpi597rgx5zc7qk2k8kyidz";
+      name = "qtserialbus-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtsensors = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtsensors-opensource-src-5.6.1.tar.xz";
+      sha256 = "0bll7ll6s5g8w89knyrc0famjwqyfzwpn512m1f96bf6xwacs967";
+      name = "qtsensors-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtscript = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtscript-opensource-src-5.6.1.tar.xz";
+      sha256 = "17zp5dlfplrnzlw233lzapj55drjqchvayajd02qsggzms3yzchw";
+      name = "qtscript-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtquickcontrols2 = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtquickcontrols2-opensource-src-5.6.1.tar.xz";
+      sha256 = "13zbiv63b76ifpjalx5616nixfwjk48q977bzb1xxj363b7xv85v";
+      name = "qtquickcontrols2-opensource-src-5.6.1.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.6.0";
+    version = "5.6.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtquickcontrols-opensource-src-5.6.0.tar.xz";
-      sha256 = "12vqkxpz5y2bbh083lpsxcianykl8x7am49pmc4x221a5xwrc27c";
-      name = "qtquickcontrols-opensource-src-5.6.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtquickcontrols-opensource-src-5.6.1.tar.xz";
+      sha256 = "14d68ryn7r7rs7klpldnavcsccvyyg0xhwqkvjlm5wwplv2acah1";
+      name = "qtquickcontrols-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtmultimedia = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtmultimedia-opensource-src-5.6.1.tar.xz";
+      sha256 = "058523c2qra3d8fq46ygcndnkrbwlh316zy28s2cr5pjr5gmnjyj";
+      name = "qtmultimedia-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtmacextras = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtmacextras-opensource-src-5.6.1.tar.xz";
+      sha256 = "147yhv7fb0yaakrffqiw6xz8ycqdc7qsnxvnpr6j8rarw5xmdc73";
+      name = "qtmacextras-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtlocation = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtlocation-opensource-src-5.6.1.tar.xz";
+      sha256 = "0qahs7a2n3l4h0bl8bnwci9mzy1vra3zncnzr40csic9ys67ddfk";
+      name = "qtlocation-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtimageformats = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtimageformats-opensource-src-5.6.1.tar.xz";
+      sha256 = "020v1148433zx4g87z2r8fgff32n0laajxqqsja1l3yzz7jbrwvl";
+      name = "qtimageformats-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtgraphicaleffects = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtgraphicaleffects-opensource-src-5.6.1.tar.xz";
+      sha256 = "1n0i2drfr7fvydgg810dcij8mxnygdpvqcqv7l1a9a1kv9ap3sap";
+      name = "qtgraphicaleffects-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtenginio = {
+    version = "1.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtenginio-opensource-src-1.6.1.tar.xz";
+      sha256 = "1iq4lnz3s6mfdgml61b9lsjisky55bbvsdj72kh003j94mzrc3l5";
+      name = "qtenginio-opensource-src-1.6.1.tar.xz";
+    };
+  };
+  qtdoc = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtdoc-opensource-src-5.6.1.tar.xz";
+      sha256 = "0yg7903vk4w3h6jjyanssfcig0s2s660q11sj14nw6gcjs7kfa5z";
+      name = "qtdoc-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtdeclarative-render2d = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtdeclarative-render2d-opensource-src-5.6.1.tar.xz";
+      sha256 = "1m08x8x355545r9wgrjl5p26zjhp5q1yh3h25dww8pk25v6cn8dg";
+      name = "qtdeclarative-render2d-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtdeclarative = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtdeclarative-opensource-src-5.6.1.tar.xz";
+      sha256 = "1d2217kxk85kpi7ls08b41hqzy26hvch8m4cgzq6km5sqi5zvz0j";
+      name = "qtdeclarative-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtconnectivity = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtconnectivity-opensource-src-5.6.1.tar.xz";
+      sha256 = "06fr9321f52kf0nda9zjjfzp5694hbnx0y0v315iw28mnpvandas";
+      name = "qtconnectivity-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtcanvas3d = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtcanvas3d-opensource-src-5.6.1.tar.xz";
+      sha256 = "0q17hwmj893pk0lhxmibxmgk6h1gy4ksqfi62rkfzcf81bg2q7hr";
+      name = "qtcanvas3d-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtbase = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtbase-opensource-src-5.6.1.tar.xz";
+      sha256 = "0r3jrqymnnxrig4f11xvs33c26f0kzfakbp3kcbdpv795gpc276h";
+      name = "qtbase-opensource-src-5.6.1.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.6.0";
+    version = "5.6.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.0/submodules/qtandroidextras-opensource-src-5.6.0.tar.xz";
-      sha256 = "1qhrn8vhfn0z73bc2ls1b4zfvr7r5gn7b5xdmjp26hi338j55vp0";
-      name = "qtandroidextras-opensource-src-5.6.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtandroidextras-opensource-src-5.6.1.tar.xz";
+      sha256 = "0prkpb57j0s8k36sba47k2bhs3ajf01rdwc7qf5gkvhs991rwckc";
+      name = "qtandroidextras-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qtactiveqt = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtactiveqt-opensource-src-5.6.1.tar.xz";
+      sha256 = "0a2p0w03d04hqg71hlihj9mr6aasvb0h8jfa5rnq8b5rkm8haf4f";
+      name = "qtactiveqt-opensource-src-5.6.1.tar.xz";
+    };
+  };
+  qt3d = {
+    version = "5.6.1";
+    src = fetchurl {
+      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qt3d-opensource-src-5.6.1.tar.xz";
+      sha256 = "03d81sls30a20yna6940np15112ciwy5024f8n5imaxicm8h34xd";
+      name = "qt3d-opensource-src-5.6.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested Krita (#15891) with this, works fine. Notice changes in the build process for `qtbase` -- `qt-everywhere-*` archive is no longer required (nor available). Patches was modified with regular expressions to accommodate for changes. cc @ttuegel 
