### PR TITLE
gmsh: init at 2.12.0

### DIFF
--- a/pkgs/applications/science/math/gmsh/CMakeLists.txt.patch
+++ b/pkgs/applications/science/math/gmsh/CMakeLists.txt.patch
@@ -1,0 +1,37 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -324,25 +324,16 @@
+         set_config_option(HAVE_BLAS "Blas(IntelMKL)")
+         set_config_option(HAVE_LAPACK "Lapack(IntelMKL)")
+       else(LAPACK_LIBRARIES)
+-        # on Linux also try to find ATLAS without a Fortran compiler, because
+-        # cmake ships with a buggy FindBLAS e.g. on Ubuntu Lucid Lynx
+-        set(ATLAS_LIBS_REQUIRED lapack f77blas cblas atlas)
+-        find_all_libraries(LAPACK_LIBRARIES ATLAS_LIBS_REQUIRED "" "")
++        # try with generic names
++        set(GENERIC_LIBS_REQUIRED lapack blas pthread)
++        find_all_libraries(LAPACK_LIBRARIES GENERIC_LIBS_REQUIRED "" "")
+         if(LAPACK_LIBRARIES)
+-          set_config_option(HAVE_BLAS "Blas(ATLAS)")
+-          set_config_option(HAVE_LAPACK "Lapack(ATLAS)")
+-        else(LAPACK_LIBRARIES)
+-          # try with generic names
+-          set(GENERIC_LIBS_REQUIRED lapack blas pthread)
+-          find_all_libraries(LAPACK_LIBRARIES GENERIC_LIBS_REQUIRED "" "")
+-          if(LAPACK_LIBRARIES)
+-            set_config_option(HAVE_BLAS "Blas(Generic)")
+-            set_config_option(HAVE_LAPACK "Lapack(Generic)")
+-            find_library(GFORTRAN_LIB gfortran)
+-            if(GFORTRAN_LIB)
+-              list(APPEND LAPACK_LIBRARIES ${GFORTRAN_LIB})
+-            endif(GFORTRAN_LIB)
+-          endif(LAPACK_LIBRARIES)
++          set_config_option(HAVE_BLAS "Blas(Generic)")
++          set_config_option(HAVE_LAPACK "Lapack(Generic)")
++          find_library(GFORTRAN_LIB gfortran)
++          if(GFORTRAN_LIB)
++            list(APPEND LAPACK_LIBRARIES ${GFORTRAN_LIB})
++          endif(GFORTRAN_LIB)
+         endif(LAPACK_LIBRARIES)
+       endif(LAPACK_LIBRARIES)
+     elseif(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")

--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, cmake, blas, liblapack, gfortran, fltk, libjpeg
+, zlib, mesa, mesa_glu, xorg }:
+
+let version = "2.12.0"; in
+
+stdenv.mkDerivation {
+  name = "gmsh-${version}";
+
+  src = fetchurl {
+    url = "http://gmsh.info/src/gmsh-${version}-source.tgz";
+    sha256 = "02cx2mfbxx6m18s54z4yzbk4ybch3v9489z7cr974y8y0z42xgbz";
+  };
+
+  # The original CMakeLists tries to use some version of the Lapack lib
+  # that is supposed to work without Fortran but didn't for me.
+  patches = [ ./CMakeLists.txt.patch ];
+
+  buildInputs = [ cmake blas liblapack gfortran fltk libjpeg zlib mesa
+    mesa_glu xorg.libXrender xorg.libXcursor xorg.libXfixes xorg.libXext
+    xorg.libXft xorg.libXinerama xorg.libX11 xorg.libSM xorg.libICE
+  ];
+
+  meta = {
+    description = "A three-dimensional finite element mesh generator";
+    homepage = http://gmsh.info/;
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16009,6 +16009,8 @@ in
 
   ipopt = callPackage ../development/libraries/science/math/ipopt { openblas = openblasCompat; };
 
+  gmsh = callPackage ../applications/science/math/gmsh { };
+
   ### SCIENCE/MOLECULAR-DYNAMICS
 
   lammps = callPackage ../applications/science/molecular-dynamics/lammps {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is the first time I submit a new package.

I don't know a lot about the program. Under NixOS I can successfully open the GUI and use it from within an Octave module (`msh`). For the GUI I also did this with `nix-shell -I nixpkgs=. --pure -p gmsh`.

The homepage provides versions for MacOS and Windows, so I set `platforms` to `all`, but I didn't test any of this.

The patch is mainly based on trial-and-error. The original thing would compile, but fail linking because of missing Fortran functions.

I'm also not sure about the position in the hierarchy: For my use case with Octave, it is more of a library, but since it has a GUI, I figured it was an application.
