### PR TITLE
klavaro: 3.01 -> 3.02

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -238,6 +238,7 @@
   meisternu = "Matt Miemiec <meister@krutt.org>";
   michaelpj = "Michael Peyton Jones <michaelpj@gmail.com>";
   michelk = "Michel Kuhlmann <michel@kuhlmanns.info>";
+  mimadrid = "Miguel Madrid <mimadrid@ucm.es>";
   mingchuan = "Ming Chuan <ming@culpring.com>";
   mirdhyn = "Merlin Gaillard <mirdhyn@gmail.com>";
   mirrexagon = "Andrew Abbott <mirrexagon@mirrexagon.com>";

--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, makeWrapper, pkgconfig, intltool, curl, gtk3 }:
 
 stdenv.mkDerivation rec {
-  name = "klavaro-3.01";
+  name = "klavaro-${version}";
+  version = "3.02";
 
   src = fetchurl {
     url = "mirror://sourceforge/klavaro/${name}.tar.bz2";
-    sha256 = "11ay04lg362bh2di6y5r9g58bgmgbpwwnrbsa7bda4wiq8idawgd";
+    sha256 = "5f77730a8c1c8dfd4443ec8390c7226e3f82537df0882cd1222b140f0d0fcd6c";
   };
 
   buildInputs = [ makeWrapper pkgconfig intltool curl gtk3 ];

--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -21,5 +21,6 @@ stdenv.mkDerivation rec {
     homepage = http://klavaro.sourceforge.net/;
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.linux;
+    maintainer = [stdenv.lib.maintainers.mimadrid];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update klavaro to the last version.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
