### PR TITLE
unicon: init at 11.7

### DIFF
--- a/pkgs/development/interpreters/unicon-lang/default.nix
+++ b/pkgs/development/interpreters/unicon-lang/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, unzip, gdbm, libX11, libXt }:
+
+stdenv.mkDerivation rec {
+  name = "unicon-lang-${version}";
+  version = "11.7";
+  src = fetchurl {
+    url = "http://unicon.org/dist/uni-2-4-2010.zip";
+    sha256 = "1g9l2dfp99dqih2ir2limqfjgagh3v9aqly6x0l3qavx3qkkwf61";
+  };
+  buildInputs = [ libX11 libXt unzip ];
+
+  sourceRoot = ".";
+
+  configurePhase = ''
+    case "$(uname -a | sed 's/ /_/g')" in
+    Darwin*Version_9*i386) sys=intel_macos;;
+    Linux*x86_64*) sys=amd64_linux;;
+    Linux*i686*) sys=intel_linux;;
+    *) sys=unknown;;
+    esac
+    echo "all: ; echo" >  uni/3d/makefile
+    make X-Configure name=$sys
+  '';
+
+  buildPhase = ''
+    make Unicon
+  '';
+
+  installPhase = ''
+    mkdir -p $out/
+    cp -r bin $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''A very high level, goal-directed, object-oriented, general purpose applications language'';
+    maintainers = with maintainers; [ vrthra ];
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    homepage = http://unicon.org;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9233,6 +9233,8 @@ in
 
   unicap = callPackage ../development/libraries/unicap {};
 
+  unicon-lang = callPackage ../development/interpreters/unicon-lang {};
+
   tsocks = callPackage ../development/libraries/tsocks { };
 
   unixODBC = callPackage ../development/libraries/unixODBC { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Unicon is a very high level goal-directed, object-oriented, general purpose
applications language
