### PR TITLE
go2nix: 20160307 -> 0.1.0

### DIFF
--- a/pkgs/development/go-modules/libs.json
+++ b/pkgs/development/go-modules/libs.json
@@ -1291,8 +1291,8 @@
     "fetch": {
       "type": "git",
       "url": "https://github.com/Masterminds/vcs",
-      "rev": "9c0db6583837118d5df7c2ae38ab1c194e434b35",
-      "sha256": "0590ww2av4407y7zy3bcmnr8i74fv00k9zzcxcpjxivl6qszna0d"
+      "rev": "7af28b64c5ec41b1558f5514fd938379822c237c",
+      "sha256": "127pamr5lkym3iq6z747bm4y4gyc02glrqb61yv82z1rdyv1dcf6"
     }
   },
   {
@@ -1527,6 +1527,15 @@
       "url": "https://gopkg.in/kothar/go-backblaze.v0",
       "rev": "373819725fc560fa962c6cd883b533d2ebec4844",
       "sha256": "1kmlwfnnfd4h46bb9pz2gw1hxqm1pzkwvidfmnc0zkrilaywk6fx"
+    }
+  },
+  {
+    "goPackagePath": "github.com/jawher/mow.cli",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/jawher/mow.cli",
+      "rev": "772320464101e904cd51198160eb4d489be9cc49",
+      "sha256": "1a8hnh2k3vc3prjhnz4rjbiwhqq6r3mi18h9cdb6fc6s6yzjc19j"
     }
   }
 ]

--- a/pkgs/development/tools/go2nix/default.nix
+++ b/pkgs/development/tools/go2nix/default.nix
@@ -1,17 +1,18 @@
-{ stdenv, lib, buildGoPackage, go-bindata, goimports, nix-prefetch-git, git, makeWrapper,
-  fetchgit, fetchhg, fetchbzr, fetchsvn }:
+{ stdenv, buildGoPackage, go-bindata, goimports, nix-prefetch-git, git, makeWrapper,
+  fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "go2nix-${version}";
-  version = "20160307-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "4c552dadd855e3694ed3499feb46dca9cd855f60";
+  version = "0.1.0";
+  rev = "v${version}";
 
   goPackagePath = "github.com/kamilchm/go2nix";
 
-  src = fetchgit {
+  src = fetchFromGitHub {
     inherit rev;
-    url = "https://github.com/kamilchm/go2nix";
-    sha256 = "1pwnm1vrjxvgl17pk9n1k5chmhgwxkrwp2s1bzi64xf12anibj63";
+    owner = "kamilchm";
+    repo = "go2nix";
+    sha256 = "10nz7gva3n6wk01wphrjjb31sy33kf9ji03zr849x21a669fnmjf";
   };
 
   goDeps = ./deps.json;

--- a/pkgs/development/tools/go2nix/deps.json
+++ b/pkgs/development/tools/go2nix/deps.json
@@ -2,10 +2,8 @@
   {
     "include": "../../libs.json",
     "packages": [
-      "github.com/alecthomas/template",
-      "github.com/alecthomas/units",
-      "gopkg.in/alecthomas/kingpin.v2",
-      "github.com/Masterminds/vcs"
+      "github.com/Masterminds/vcs",
+      "github.com/jawher/mow.cli"
     ]
   }
 ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9617,7 +9617,7 @@ in
 
   buildGoPackage = buildGo16Package;
 
-  go2nix = callPackage ../development/tools/go2nix { };
+  go2nix = (callPackage ../development/tools/go2nix { }).bin;
 
   ### DEVELOPMENT / LISP MODULES
 


### PR DESCRIPTION
go2nix compatible with https://github.com/NixOS/nixpkgs/pull/16017
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
