### PR TITLE
Squeezelite package and service init

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -269,6 +269,7 @@
       nzbget = 245;
       mosquitto = 246;
       toxvpn = 247;
+      squeezelite = 248;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -508,6 +509,7 @@
       nzbget = 245;
       mosquitto = 246;
       #toxvpn = 247; # unused
+      #squeezelite = 248; #unused
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -110,6 +110,7 @@
   ./services/audio/liquidsoap.nix
   ./services/audio/mpd.nix
   ./services/audio/mopidy.nix
+  ./services/audio/squeezelite.nix
   ./services/backup/almir.nix
   ./services/backup/bacula.nix
   ./services/backup/crashplan.nix

--- a/nixos/modules/services/audio/squeezelite.nix
+++ b/nixos/modules/services/audio/squeezelite.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  uid = config.ids.uids.squeezelite;
+  cfg = config.services.squeezelite;
+
+in {
+
+  ###### interface
+
+  options = {
+
+    services.squeezelite= {
+
+      enable = mkEnableOption "Squeezelite, a software Squeezebox emulator";
+
+      dataDir = mkOption {
+        default = "/var/lib/squeezelite";
+        type = types.str;
+        description = ''
+          The directory where Squeezelite stores its name file.
+        '';
+      };
+
+      extraArguments = mkOption {
+        default = "";
+        type = types.str;
+        description = ''
+          Additional command line arguments to pass to Squeezelite.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.services.squeezelite= {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "sound.target" ];
+      description = "Software Squeezebox emulator";
+      preStart = "mkdir -p ${cfg.dataDir} && chown -R squeezelite ${cfg.dataDir}";
+      serviceConfig = {
+        ExecStart = "${pkgs.squeezelite}/bin/squeezelite -N ${cfg.dataDir}/player-name ${cfg.extraArguments}";
+        User = "squeezelite";
+        PermissionsStartOnly = true;
+      };
+    };
+
+    users.extraUsers.squeezelite= {
+      inherit uid;
+      group = "nogroup";
+      extraGroups = [ "audio" ];
+      description = "Squeezelite user";
+      home = "${cfg.dataDir}";
+    };
+
+  };
+
+}

--- a/pkgs/applications/audio/squeezelite/default.nix
+++ b/pkgs/applications/audio/squeezelite/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, alsaLib, faad2, flac, libmad, libvorbis, mpg123 }:
+
+stdenv.mkDerivation {
+  name = "squeezelite-git-2016-05-27";
+
+  src = fetchFromGitHub {
+    owner = "ralph-irving";
+    repo = "squeezelite";
+    rev = "e37ed17fed9e11a7346cbe9f1e1deeccc051f42e";
+    sha256 = "15ihx2dbp4kr6k6r50g9q5npqad5zyv8nqf5cr37bhg964syvbdm";
+  };
+
+  buildInputs = [ alsaLib faad2 flac libmad libvorbis mpg123 ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp squeezelite $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Lightweight headless squeezebox client emulator";
+    homepage = https://github.com/ralph-irving/squeezelite;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14229,6 +14229,8 @@ in
     apiKey = config.libspotify.apiKey or null;
   };
 
+  squeezelite = callPackage ../applications/audio/squeezelite { };
+
   ltunify = callPackage ../tools/misc/ltunify { };
 
   src = callPackage ../applications/version-management/src/default.nix {


### PR DESCRIPTION
###### Motivation for this change

This PR adds a package and service definition for Squeezelite, a headless Squeezebox emulator. This software works with Logitech Media Server for synchronized multi-device playing of local and "cloud" music sources.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
