### PR TITLE
new packages of some themes: arc-icon-theme, moka-icon-theme, faba-icon-theme, faba-mono-icons

### DIFF
--- a/pkgs/data/icons/arc-icon-theme/default.nix
+++ b/pkgs/data/icons/arc-icon-theme/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, moka-icon-theme }:
+
+stdenv.mkDerivation rec {
+  name = "${package-name}-${version}";
+  package-name = "arc-icon-theme";
+  version = "2016-06-06";
+
+  src = fetchFromGitHub {
+    owner = "horst3180";
+    repo = package-name;
+    rev = "69da5eed0761237fd287ea2fc95c708353ccc332";
+    sha256 = "04ym3ix2cpjh1q7lwvhl578pv41mn9zsadlsygl0nck8yd22widq";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ moka-icon-theme ];
+
+  meta = with stdenv.lib; {
+    description = "Arc icon theme";
+    homepage = https://github.com/horst3180/arc-icon-theme;
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/data/icons/faba-icon-theme/default.nix
+++ b/pkgs/data/icons/faba-icon-theme/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, elementary-icon-theme }:
+
+stdenv.mkDerivation rec {
+  name = "${package-name}-${version}";
+  package-name = "faba-icon-theme";
+  version = "2016-06-02";
+
+  src = fetchFromGitHub {
+    owner = "moka-project";
+    repo = package-name;
+    rev = "e50649d0171fd8cce42404c7c5002d77710ffcfc";
+    sha256 = "1fn969a6l58asnl9181c2z1fsj4dybl2mgbcpwig20bri6q7yz20";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ elementary-icon-theme ];
+
+  postPatch = ''
+    substituteInPlace Makefile.am --replace '$(DESTDIR)'/usr $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A sexy and modern icon theme with Tango influences";
+    homepage = https://snwh.org/moka;
+    license = with licenses; [ cc-by-sa-40 gpl3 ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/data/icons/faba-mono-icons/default.nix
+++ b/pkgs/data/icons/faba-mono-icons/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, moka-icon-theme  }:
+
+stdenv.mkDerivation rec {
+  name = "${package-name}-${version}";
+  package-name = "faba-mono-icons";
+  version = "2016-04-30";
+
+  src = fetchFromGitHub {
+    owner = "moka-project";
+    repo = package-name;
+    rev = "2006c5281eb988c799068734f289a85443800cda";
+    sha256 = "0nisfl92y6hrbakp9qxi0ygayl6avkzrhwirg6854bwqjy2dvjv9";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ moka-icon-theme ];
+
+  meta = with stdenv.lib; {
+    description = "The full set of Faba monochrome panel icons";
+    homepage = https://snwh.org/moka;
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/data/icons/moka-icon-theme/default.nix
+++ b/pkgs/data/icons/moka-icon-theme/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, faba-icon-theme }:
+
+stdenv.mkDerivation rec {
+  name = "${package-name}-${version}";
+  package-name = "moka-icon-theme";
+  version = "2016-06-07";
+
+  src = fetchFromGitHub {
+    owner = "moka-project";
+    repo = package-name;
+    rev = "a03d14e30dbdf05e8ea904994b8081ad0824e155";
+    sha256 = "1j1cnrrg0gfr4vfzxlabrv8090fg4yni99g61s82vnyszkiy1rcm";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ faba-icon-theme ];
+
+  postPatch = ''
+    substituteInPlace Makefile.am --replace '$(DESTDIR)'/usr $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An icon theme designed with a minimal flat style using simple geometry and bright colours";
+    homepage = https://snwh.org/moka;
+    license = with licenses; [ cc-by-sa-40 gpl3 ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11566,6 +11566,8 @@ in
 
   eb-garamond = callPackage ../data/fonts/eb-garamond { };
 
+  faba-icon-theme = callPackage ../data/icons/faba-icon-theme { };
+
   fantasque-sans-mono = callPackage ../data/fonts/fantasque-sans-mono {};
 
   fira = callPackage ../data/fonts/fira { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11656,6 +11656,8 @@ in
 
   mononoki = callPackage ../data/fonts/mononoki { };
 
+  moka-icon-theme = callPackage ../data/icons/moka-icon-theme { };
+
   montserrat = callPackage ../data/fonts/montserrat { };
 
   mph_2b_damase = callPackage ../data/fonts/mph-2b-damase { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11492,6 +11492,8 @@ in
 
   anonymousPro = callPackage ../data/fonts/anonymous-pro { };
 
+  arc-icon-theme = callPackage ../data/icons/arc-icon-theme { };
+
   arkpandora_ttf = callPackage ../data/fonts/arkpandora { };
 
   aurulent-sans = callPackage ../data/fonts/aurulent-sans { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11570,6 +11570,8 @@ in
 
   faba-icon-theme = callPackage ../data/icons/faba-icon-theme { };
 
+  faba-mono-icons = callPackage ../data/icons/faba-mono-icons { };
+
   fantasque-sans-mono = callPackage ../data/fonts/fantasque-sans-mono {};
 
   fira = callPackage ../data/fonts/fira { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
