### PR TITLE
augeas: 1.2.0 -> 1.5.0

### DIFF
--- a/pkgs/tools/system/augeas/default.nix
+++ b/pkgs/tools/system/augeas/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "augeas-${version}";
-  version = "1.2.0";
+  version = "1.5.0";
 
   src = fetchurl {
     url = "http://download.augeas.net/${name}.tar.gz";
-    sha256 = "1q41yilxc0nvjz5h9phm38k2b73k2v0b9jg11y92228bps7b5bpl";
+    sha256 = "0gzpafrflkr0incq58vjkabfncrpc97d7mdgglkr57iyzvkbcfr2";
   };
 
   buildInputs = [ pkgconfig readline libxml2 ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
