### PR TITLE
odp-dpdk: init at 1.8.0.0

### DIFF
--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit, autoreconfHook, openssl, libpcap, dpdk, bash }:
+
+stdenv.mkDerivation rec {
+  name = "odp-dpdk-${version}";
+  version = "1.8.0.0";
+
+  src = fetchgit {
+    url = "https://git.linaro.org/lng/odp-dpdk.git";
+    rev = "438a207a39bad213cdc03929452a8199caef5d8c";
+    sha256 = "0k4g5zbirbfdcgqz0nbn9san66y178qnigyvrr2apj3apzjjy7zv";
+  };
+
+  nativeBuildInputs = [ autoreconfHook bash ];
+  buildInputs = [ stdenv openssl dpdk libpcap ];
+
+  RTE_SDK = "${dpdk}";
+  RTE_TARGET = "x86_64-native-linuxapp-gcc";
+
+  patchPhase = ''
+    substituteInPlace scripts/git_hash.sh --replace /bin/bash /bin/sh
+    echo -n ${version} > .scmversion
+  '';
+
+  dontDisableStatic = true;
+
+  configureFlags = [
+    "--with-platform=linux-dpdk"
+    "--disable-shared"
+    "--disable-shared-dpdk"
+    "--with-sdk-install-path=${dpdk}/${RTE_TARGET}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Open Data Plane optimized for DPDK";
+    homepage = http://www.opendataplane.org;
+    license = licenses.bsd3;
+    platforms =  [ "x86_64-linux" ];
+    maintainers = [ maintainers.abuibrahim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10867,6 +10867,8 @@ in
 
     pktgen = callPackage ../os-specific/linux/pktgen { };
 
+    odp-dpdk = callPackage ../os-specific/linux/odp-dpdk { };
+
     e1000e = callPackage ../os-specific/linux/e1000e {};
 
     v4l2loopback = callPackage ../os-specific/linux/v4l2loopback { };


### PR DESCRIPTION
###### Motivation for this change

The OpenDataPlane (ODP) project is an open-source, cross-platform set of application programming interfaces (APIs) for the networking data plane.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Signed-off-by: Ruslan Babayev ruslan@babayev.com
