### PR TITLE
mononoki: init at 1.2

### DIFF
--- a/pkgs/data/fonts/mononoki/default.nix
+++ b/pkgs/data/fonts/mononoki/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "mononoki-${version}";
+  version = "1.2";
+
+  src = fetchurl {
+    url = "https://github.com/madmalik/mononoki/releases/download/${version}/mononoki.zip";
+    sha256 = "0n66bnn2i776fbky14qjijwsbrja9yzc1xfsmvz99znvcdvflafg";
+  };
+
+  buildInputs = [ unzip ];
+  phases = [ "unpackPhase" ];
+
+  unpackPhase = ''
+    mkdir -p $out/share/fonts/mononoki
+    unzip $src -d $out/share/fonts/mononoki
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/madmalik/mononoki;
+    description = "A font for programming and code review";
+    license = licenses.ofl;
+    maintainers = [ maintainers.hiberno ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11648,6 +11648,8 @@ in
 
   mobile_broadband_provider_info = callPackage ../data/misc/mobile-broadband-provider-info { };
 
+  mononoki = callPackage ../data/fonts/mononoki { };
+
   montserrat = callPackage ../data/fonts/montserrat { };
 
   mph_2b_damase = callPackage ../data/fonts/mph-2b-damase { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
