### PR TITLE
cleanSource: filter out also nix result symlinks

### DIFF
--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -20,7 +20,9 @@ rec {
       lib.hasSuffix "~" baseName ||
       # Filter out generates files.
       lib.hasSuffix ".o" baseName ||
-      lib.hasSuffix ".so" baseName
+      lib.hasSuffix ".so" baseName ||
+      # Filter out nix-build result symlinks
+      (type == "symlink" && lib.hasPrefix "result" baseName)
     );
     in src: builtins.filterSource filter src;
 


### PR DESCRIPTION
Convenient for multiple `nix-build` invocations during development of software using `default.nix`.

cc @edolstra 
