### PR TITLE
emcee: init at 2.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -183,7 +183,19 @@ in modules // {
     };
   };
 
-
+  emcee = buildPythonPackage {
+    name = "emcee-2.1.0";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/de/00/2358f12c98fa74ab58d78e6a4a4f9a8152fadf6ade2d809d98d771dcc31b/emcee-2.1.0.tar.gz";
+      md5 = "c6b6fad05c824d40671d4a4fc58dfff7";
+    };
+    propagatedBuildInputs = [ self.numpy ];
+    meta = {
+      homepage = "http://dan.iel.fm/emcee";
+      license = "MIT";
+      description = "Kick ass affine-invariant ensemble MCMC sampling";
+    };
+  };
 
   dbus = callPackage ../development/python-modules/dbus {
     dbus = pkgs.dbus;


### PR DESCRIPTION
###### Motivation for this change

I need the emcee python MCMC sampler for my science work. Nixpkgs currently does not have a recipe for it. 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
