### PR TITLE
xterm: 320 -> 325

### DIFF
--- a/pkgs/applications/misc/xterm/default.nix
+++ b/pkgs/applications/misc/xterm/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, xorg, ncurses, freetype, fontconfig, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "xterm-320";
+  name = "xterm-325";
 
   src = fetchurl {
     url = "ftp://invisible-island.net/xterm/${name}.tgz";
-    sha256 = "19r4rs5pjq944m7aiqligazf6wgmv4f023x3bx183h1l8dbvn3d6";
+    sha256 = "06sz66z4hvjjkvm3r5a5z442iis8lz8yjfzc629pwhj01ixb0c9v";
   };
 
   buildInputs =
@@ -13,9 +13,15 @@ stdenv.mkDerivation rec {
       ncurses freetype fontconfig pkgconfig xorg.libXft xorg.luit
     ];
 
+  patches = [
+    ./sixel-256.support.patch
+  ];
+
   configureFlags = [
     "--enable-wide-chars"
     "--enable-256-color"
+    "--enable-sixel-graphics"
+    "--enable-regis-graphics"
     "--enable-load-vt-fonts"
     "--enable-i18n"
     "--enable-doublechars"
@@ -39,7 +45,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://invisible-island.net/xterm;
     license = "BSD";
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [viric vrthra];
     platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/xterm/sixel-256.support.patch
+++ b/pkgs/applications/misc/xterm/sixel-256.support.patch
@@ -1,0 +1,11 @@
+--- xterm-325/graphics.c	2016-05-17 03:04:40.000000000 -0700
++++ xterm-325/graphics.c	2016-06-11 16:37:29.552584281 -0700
+@@ -667,7 +667,7 @@
+     case 330:
+ 	return 4U;
+     case 340:
+-	return 16U;
++	return 256U;
+     case 382:
+ 	return 2U;
+     default:


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Updates xterm to 325, and also enable sixel support for drawing images on the screen.
