### PR TITLE
libsixel: init at 1.6.1

### DIFF
--- a/pkgs/development/libraries/libsixel/default.nix
+++ b/pkgs/development/libraries/libsixel/default.nix
@@ -1,0 +1,19 @@
+{stdenv, fetchFromGitHub}:
+stdenv.mkDerivation rec {
+  version = "1.6.1";
+  name = "libsixel-${version}";
+
+  src = fetchFromGitHub {
+    repo = "libsixel";
+    rev = "ef4374f80385edc48e0844cf324d7ef757688e44";
+    owner = "saitoha";
+    sha256 = "08m5q2ppk235bzbwff1wg874vr1bh4080qdj26l39v8lw1xzlqcp";
+  };
+
+  meta = with stdenv.lib; {
+    description = "The SIXEL library for console graphics, and converter programs";
+    homepage = http://saitoha.github.com/libsixel;
+    maintainers = with maintainers; [ vrthra ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7970,6 +7970,8 @@ in
 
   libsieve = callPackage ../development/libraries/libsieve { };
 
+  libsixel = callPackage ../development/libraries/libsixel { };
+
   libsolv = callPackage ../development/libraries/libsolv { };
 
   libspectre = callPackage ../development/libraries/libspectre { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

libsixel is a library for display of graphics in console.
