### PR TITLE
qlcplus: init at 4.10.4

### DIFF
--- a/pkgs/applications/misc/qlcplus/default.nix
+++ b/pkgs/applications/misc/qlcplus/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, pkgconfig, ccache, makeWrapper, qmake4Hook, qt4, libftdi1, alsaLib, libudev, libusb}:
+
+stdenv.mkDerivation rec {
+  name = "qlcplus-${version}";
+  version = "4.10.4";
+
+  src = fetchurl {
+    url = "http://www.qlcplus.org/downloads/${version}/qlcplus_${version}.tar.gz";
+    sha256 = "0khwv6bgjllci56g4khzmqkmhhvz5rmr93466qyvnqrcxvn5mdql";
+  };
+
+  preConfigure = ''
+    substituteInPlace ./variables.pri \
+      --replace "INSTALLROOT += /usr" "INSTALLROOT = $out"
+  '';
+
+  buildInputs = [ ccache libudev pkgconfig libftdi1 qmake4Hook makeWrapper qt4 alsaLib libusb ];
+
+  qmakeFlags = [ 
+    "QMAKE_CXXFLAGS+=-Wno-error=unused-variable"
+  ];
+  
+  dontAddPrefix = true;
+  installFlags = [ "INSTALL_ROOT=/" ];
+
+
+  postFixup= ''
+    wrapProgram $out/bin/qlcplus \
+      --prefix LD_LIBRARY_PATH : $out/lib
+    wrapProgram $out/bin/qlcplus-fixtureeditor \
+      --prefix LD_LIBRARY_PATH : $out/lib
+  '';
+
+  meta = {
+    description = "The open DMX lighting desk software for controlling professional lighting fixtures";
+    homepage = http://www.qlcplus.org;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ sleexyz ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8792,6 +8792,7 @@ in
     });
 
   };
+  qlcplus = callPackage ../applications/misc/qlcplus { };
 
   qtEnv = qt5.env;
   qt5Full = qt5.full;


### PR DESCRIPTION
###### Motivation for this change

Bringing DMX lighting software to NixOS!
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
