### PR TITLE
nanomsg: 0.8-beta -> 1.0.0

### DIFF
--- a/pkgs/development/libraries/nanomsg/default.nix
+++ b/pkgs/development/libraries/nanomsg/default.nix
@@ -1,18 +1,17 @@
-{ stdenv, fetchurl }:
+{ stdenv, cmake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.8-beta";
+  version = "1.0.0";
   name = "nanomsg-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/nanomsg/nanomsg/releases/download/0.8-beta/${name}.tar.gz";
-    sha256 = "0ix9yd6shqmgm1mxig8ww2jpbgg2n5dms0wrv1q81ihclml0rkkm";
+  src = fetchFromGitHub {
+    owner = "nanomsg";
+    repo = "nanomsg";
+    rev = version;
+    sha256 = "1iqlmvz5k8m4srb120g3kfkmm1w2p16hyxmx2asvihd21j285fmw";
   };
 
-  installPhase = ''
-    mkdir -p "$out"
-    make install PREFIX="$out"
-  '';
+  buildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     description= "Socket library that provides several common communication patterns";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
