### PR TITLE
all-packages references to Go packages includes all outputs

### DIFF
--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -141,6 +141,25 @@ the following arguments are of special significance to the function:
 </para>
 
 <para>
+  <varname>buildGoPackage</varname> produces <xref linkend='chap-multiple-output' xrefstyle="select: title" />
+  where <varname>bin</varname> includes program binaries. You can test build a Go binary as follows:
+
+  <screen>
+    $ nix-build -A deis.bin
+  </screen>
+
+  or build all outputs with:
+
+  <screen>
+    $ nix-build -A deis.all
+  </screen>
+
+  <varname>bin</varname> output will be installed by default with <varname>nix-env -i</varname>
+  or <varname>systemPackages</varname>.
+
+</para>
+
+<para>
 You may use Go packages installed into the active Nix profiles by adding
 the following to your ~/.bashrc:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -446,7 +446,7 @@ in
 
   ascii = callPackage ../tools/text/ascii { };
 
-  asciinema = (callPackage ../tools/misc/asciinema {}).bin;
+  asciinema = callPackage ../tools/misc/asciinema {};
 
   asymptote = callPackage ../tools/graphics/asymptote {
     texLive = texlive.combine { inherit (texlive) scheme-small epsf cm-super; };
@@ -730,7 +730,7 @@ in
 
   ddate = callPackage ../tools/misc/ddate { };
 
-  deis = (callPackage ../development/tools/deis {}).bin;
+  deis = callPackage ../development/tools/deis {};
 
   dfilemanager = self.kde5.dfilemanager;
 
@@ -819,7 +819,7 @@ in
 
   heatseeker = callPackage ../tools/misc/heatseeker { };
 
-  interlock = (callPackage ../servers/interlock {}).bin;
+  interlock = callPackage ../servers/interlock {};
 
   mathics = pythonPackages.mathics;
 
@@ -881,7 +881,7 @@ in
 
   mcrypt = callPackage ../tools/misc/mcrypt { };
 
-  mongodb-tools = (callPackage ../tools/misc/mongodb-tools { }).bin;
+  mongodb-tools = callPackage ../tools/misc/mongodb-tools { };
 
   mstflint = callPackage ../tools/misc/mstflint { };
 
@@ -1514,7 +1514,7 @@ in
     inherit (perlPackages) ImageExifTool JSON;
   };
 
-  flannel = (callPackage ../tools/networking/flannel {}).bin;
+  flannel = callPackage ../tools/networking/flannel { };
 
   flashbench = callPackage ../os-specific/linux/flashbench { };
 
@@ -1644,7 +1644,7 @@ in
   gawkInteractive = appendToName "interactive"
     (gawk.override { interactive = true; });
 
-  gawp = (callPackage ../tools/misc/gawp {}).bin;
+  gawp = callPackage ../tools/misc/gawp { };
 
   gazeboSimulator = recurseIntoAttrs {
     sdformat = gazeboSimulator.sdformat4;
@@ -1690,7 +1690,7 @@ in
 
   gifsicle = callPackage ../tools/graphics/gifsicle { };
 
-  git-lfs = (callPackage ../applications/version-management/git-lfs {}).bin;
+  git-lfs = callPackage ../applications/version-management/git-lfs { };
 
   gitfs = callPackage ../tools/filesystems/gitfs { };
 
@@ -1758,14 +1758,14 @@ in
 
   goaccess = callPackage ../tools/misc/goaccess { };
 
-  go-mtpfs = (callPackage ../tools/filesystems/go-mtpfs { }).bin;
+  go-mtpfs = callPackage ../tools/filesystems/go-mtpfs { };
 
-  go-pup = (callPackage ../development/tools/pup { }).bin;
+  go-pup = callPackage ../development/tools/pup { };
 
-  go-sct = (callPackage ../tools/X11/go-sct { }).bin;
+  go-sct = callPackage ../tools/X11/go-sct { };
 
   # rename to upower-notify?
-  go-upower-notify = (callPackage ../tools/misc/upower-notify { }).bin;
+  go-upower-notify = callPackage ../tools/misc/upower-notify { };
 
   googleAuthenticator = callPackage ../os-specific/linux/google-authenticator { };
 
@@ -2350,7 +2350,7 @@ in
   lshw = callPackage ../tools/system/lshw { };
 
   lxc = callPackage ../os-specific/linux/lxc { };
-  lxd = (callPackage ../tools/admin/lxd { }).bin;
+  lxd = callPackage ../tools/admin/lxd { };
 
   lzip = callPackage ../tools/compression/lzip { };
 
@@ -2607,7 +2607,7 @@ in
 
   ngrep = callPackage ../tools/networking/ngrep { };
 
-  ngrok = (callPackage ../tools/networking/ngrok { }).bin;
+  ngrok = callPackage ../tools/networking/ngrok { };
 
   noip = callPackage ../tools/networking/noip { };
 
@@ -3237,7 +3237,7 @@ in
 
   s3cmd = callPackage ../tools/networking/s3cmd { };
 
-  s3gof3r = (callPackage ../tools/networking/s3gof3r { }).bin;
+  s3gof3r = callPackage ../tools/networking/s3gof3r { };
 
   s6Dns = callPackage ../tools/networking/s6-dns { };
 
@@ -3329,7 +3329,7 @@ in
 
   skippy-xd = callPackage ../tools/X11/skippy-xd {};
 
-  skydns = (callPackage ../servers/skydns { }).bin;
+  skydns = callPackage ../servers/skydns { };
 
   sipcalc = callPackage ../tools/networking/sipcalc { };
 
@@ -3714,7 +3714,7 @@ in
 
   weather = callPackage ../applications/misc/weather { };
 
-  wego = (callPackage ../applications/misc/wego { }).bin;
+  wego = callPackage ../applications/misc/wego { };
 
   wal_e = callPackage ../tools/backup/wal-e { };
 
@@ -3740,7 +3740,7 @@ in
 
   testdisk = callPackage ../tools/misc/testdisk { };
 
-  textql = (callPackage ../development/tools/textql { }).bin;
+  textql = callPackage ../development/tools/textql { };
 
   html2text = callPackage ../tools/text/html2text { };
 
@@ -4085,7 +4085,7 @@ in
 
   mksh = callPackage ../shells/mksh { };
 
-  oh = (callPackage ../shells/oh { }).bin;
+  oh = callPackage ../shells/oh { };
 
   pash = callPackage ../shells/pash { };
 
@@ -4551,9 +4551,9 @@ in
 
   go = self.go_1_6;
 
-  go-repo-root = (callPackage ../development/tools/go-repo-root { }).bin;
+  go-repo-root = callPackage ../development/tools/go-repo-root { };
 
-  gox = (callPackage ../development/tools/gox { }).bin;
+  gox = callPackage ../development/tools/gox { };
 
   gprolog = callPackage ../development/compilers/gprolog { };
 
@@ -5606,7 +5606,7 @@ in
     perf = linuxPackages.perf;
   };
 
-  mesos-dns = (callPackage ../servers/mesos-dns { }).bin;
+  mesos-dns = callPackage ../servers/mesos-dns { };
 
   mujs = callPackage ../development/interpreters/mujs { };
 
@@ -6215,7 +6215,7 @@ in
 
   gob2 = callPackage ../development/tools/misc/gob2 { };
 
-  gotty = (callPackage ../servers/gotty { }).bin;
+  gotty = callPackage ../servers/gotty { };
 
   gradleGen = callPackage ../development/tools/build-managers/gradle { };
   gradle = self.gradleGen.gradleLatest;
@@ -9627,7 +9627,7 @@ in
 
   buildGoPackage = buildGo16Package;
 
-  go2nix = (callPackage ../development/tools/go2nix { }).bin;
+  go2nix = callPackage ../development/tools/go2nix { };
 
   ### DEVELOPMENT / LISP MODULES
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/16129#discussion_r66707626
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @rushmorem 
