### PR TITLE
openldap: add -h urlList in service so LDAP TLS could be enabled

### DIFF
--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -40,6 +40,13 @@ in
         description = "Group account under which slapd runs.";
       };
 
+      urlList = mkOption {
+        type = types.listOf types.string;
+        default = [ "ldap:///" ];
+        description = "URL list slapd should listen on.";
+        example = [ "ldaps:///" ];
+      };
+
       dataDir = mkOption {
         type = types.string;
         default = "/var/db/openldap";
@@ -50,7 +57,7 @@ in
         type = types.lines;
         default = "";
         description = "
-          sldapd.conf configuration
+          slapd.conf configuration
         ";
         example = ''
             include ''${pkgs.openldap}/etc/openldap/schema/core.schema
@@ -87,7 +94,7 @@ in
         mkdir -p ${cfg.dataDir}
         chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}
       '';
-      serviceConfig.ExecStart = "${openldap.out}/libexec/slapd -u ${cfg.user} -g ${cfg.group} -d 0 -f ${configFile}";
+      serviceConfig.ExecStart = "${openldap.out}/libexec/slapd -u ${cfg.user} -g ${cfg.group} -d 0 -h \"${concatStringsSep " " cfg.urlList}\" -f ${configFile}";
     };
 
     users.extraUsers.openldap =


### PR DESCRIPTION
snip from the slapd manpage:

```
-h URLlist
       slapd will by default serve ldap:/// (LDAP over TCP on all interfaces on default LDAP port).  That is, it will bind using INADDR_ANY and port 389.  The -h option may be used to specify LDAP (and other  scheme)  URLs  to
       serve.   For  example,  if slapd is given -h "ldap://127.0.0.1:9009/ ldaps:/// ldapi:///", it will listen on 127.0.0.1:9009 for LDAP, 0.0.0.0:636 for LDAP over TLS, and LDAP over IPC (Unix domain sockets).  Host 0.0.0.0
       represents INADDR_ANY (any interface).  A space separated list of URLs is expected.  The URLs should be of the LDAP, LDAPS, or LDAPI schemes, and generally without a DN or other optional parameters  (excepting  as  dis‐
       cussed below).  Support for the latter two schemes depends on selected configuration options.  Hosts may be specified by name or IPv4 and IPv6 address formats.  Ports, if specified, must be numeric.  The default ldap://
       port is 389 and the default ldaps:// port is 636.
```
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I'd also like to backport this to 16.03 if no one objects.
