### PR TITLE
mlterm: init at 3.3.8

### DIFF
--- a/pkgs/applications/misc/mlterm/default.nix
+++ b/pkgs/applications/misc/mlterm/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, pkgconfig, libX11, gdk_pixbuf, cairo, libXft, gtk2, fribidi }:
+
+stdenv.mkDerivation rec {
+  name = "mlterm-${version}";
+  version = "3.3.8";
+
+  src = fetchurl {
+    url = "https://downloads.sourceforge.net/project/mlterm/01release/${name}/${name}.tar.gz";
+    sha256 = "088pgxynzxxii7wdmjp2fdkxydirx4k05588zkhlzalkb5l8ji1i";
+  };
+
+  buildInputs = [ pkgconfig libX11 gdk_pixbuf cairo libXft gtk2 fribidi ];
+
+  preConfigure = ''
+    sed -ie 's#-L/usr/local/lib -R/usr/local/lib##g' \
+      xwindow/libtype/Makefile.in \
+      main/Makefile.in \
+      java/Makefile.in \
+      tool/mlimgloader/Makefile.in \
+      tool/registobmp/Makefile.in \
+      tool/mlconfig/Makefile.in
+    sed -ie 's;cd ..srcdir. && rm -f ...lang..gmo.*;;g' tool/mlconfig/po/Makefile.in.in
+  '';
+
+  configureFlags = [
+    "--with-imagelib=gdk-pixbuf"
+    "--with-type-engines=cairo,xft,xcore"
+    "--with-x"
+    "--enable-ind"
+ ];
+
+  meta = with stdenv.lib; {
+    homepage = https://sourceforge.net/projects/mlterm/;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14868,6 +14868,8 @@ in
 
   xterm = callPackage ../applications/misc/xterm { };
 
+  mlterm = callPackage ../applications/misc/mlterm { };
+
   finalterm = callPackage ../applications/misc/finalterm { };
 
   roxterm = callPackage ../applications/misc/roxterm {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

A multi-lingual terminal that supports REGIS and SIXEL graphics
