### PR TITLE
rethinkdb: 2.3.0 -> 2.3.4

### DIFF
--- a/pkgs/servers/nosql/rethinkdb/default.nix
+++ b/pkgs/servers/nosql/rethinkdb/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "rethinkdb-${version}";
-  version = "2.3.0";
+  version = "2.3.4";
 
   src = fetchurl {
-    url = "http://download.rethinkdb.com/dist/${name}.tgz";
-    sha256 = "0b787ibnrmziypiw86yx4gpmlj4ima6j6g9hzshbpilxy7lrq1cb";
+    url = "https://download.rethinkdb.com/dist/${name}.tgz";
+    sha256 = "19z1m4r1mqnbia207q0nvs39rn7jk8zsr2rvps2d11fp3ryr59wk";
   };
 
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
