### PR TITLE
oath-toolkit: 2.4.1 -> 2.6.1

### DIFF
--- a/pkgs/tools/security/oath-toolkit/default.nix
+++ b/pkgs/tools/security/oath-toolkit/default.nix
@@ -6,11 +6,11 @@ let
     else pam;
 in
 stdenv.mkDerivation rec {
-  name = "oath-toolkit-2.4.1";
+  name = "oath-toolkit-2.6.1";
 
   src = fetchurl {
     url = "mirror://savannah/oath-toolkit/${name}.tar.gz";
-    sha256 = "094vbq66sn5f2dsy14hajpsfdnaivjxf70xzs91nrsq0q75l5ylv";
+    sha256 = "0ybg0gnddmhxga0jwdipyz8jv5mxs0kiiflhvzffl9mw0wcq6mww";
   };
 
   


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
