### PR TITLE
ffmpeg-sixel-nightly: init at 2.3.x

### DIFF
--- a/pkgs/development/libraries/ffmpeg-sixel/default.nix
+++ b/pkgs/development/libraries/ffmpeg-sixel/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, pkgconfig, perl, libsixel, yasm
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "ffmpeg-sixel-${version}";
+  version = "nightly-2.3.x";
+
+  src = fetchFromGitHub {
+    owner = "saitoha";
+    repo = "FFmpeg-SIXEL";
+    rev = "8566fdb8b7516b54aed58f329dc216e06fc10052";
+    sha256 = "00s2lggfdj2ibpngpyqqg7360p7yb69ys1ppg59yvv0m0mxk5x3k";
+  };
+
+  buildInputs = [
+    pkgconfig
+    libsixel
+    yasm
+  ];
+
+  configurePhase = ''
+    ./configure --enable-libsixel --prefix=$out
+  '';
+
+  postInstall = ''
+    mv $out/bin/ffmpeg $out/bin/ffmpeg-sixel
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A complete, cross-platform solution to record, convert and stream audio and video, extended to support console graphics";
+    homepage = http://www.ffmpeg.org/;
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ vrthra ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6961,6 +6961,8 @@ in
 
   ffmpegthumbnailer = callPackage ../development/libraries/ffmpegthumbnailer { };
 
+  ffmpeg-sixel = callPackage ../development/libraries/ffmpeg-sixel { };
+
   ffms = callPackage ../development/libraries/ffms { };
 
   fftw = callPackage ../development/libraries/fftw { };


### PR DESCRIPTION
###### Motivation for this change

This fork of ffmpeg allows display of video streams in a sixel supporting terminal (such as mlterm or xterm).

It requires previous PR #16136 for `libsixel`
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
