### PR TITLE
armadillo: init at 7.200.1b

### DIFF
--- a/pkgs/development/libraries/armadillo/default.nix
+++ b/pkgs/development/libraries/armadillo/default.nix
@@ -1,0 +1,23 @@
+{stdenv, fetchurl, cmake, pkgconfig, atlas, blas, openblas}:
+
+stdenv.mkDerivation rec {
+  version = "7.200.1b";
+  name = "armadillo-${version}";
+  
+  src = fetchurl {
+    url = "http://sourceforge.net/projects/arma/files/armadillo-${version}.tar.xz";
+    sha256 = "00s8xrywc4aipipq1zpd6q9gzqmsiv8cwd25zvb1csrpninmidvc";
+  };
+
+  unpackCmd = [ "tar -xf ${src}" ];
+  
+  nativeBuildInputs = [ cmake atlas blas openblas ];
+  
+  meta = with stdenv.lib; {
+    description = "C++ linear algebra library";
+    homepage = "http://arma.sourceforge.net" ;
+    license = licenses.mpl20;
+    platforms = stdenv.lib.platforms.linux ;
+    maintainers = [ stdenv.lib.maintainers.juliendehos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6610,6 +6610,8 @@ in
     #      apr with db58 on freebsd (nov 2015), for unknown reasons
   };
 
+  armadillo = callPackage ../development/libraries/armadillo {};
+
   assimp = callPackage ../development/libraries/assimp { };
 
   asio = callPackage ../development/libraries/asio { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
