### PR TITLE
fish: fix completion from NIX_PROFILES

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
 
     # make fish pick up completions from nix profile
     if status --is-interactive
-      set -l profiles (echo $NIX_PROFILES | ${coreutils}/bin/tr ' ' '\n')
+      set -l profiles (echo \$NIX_PROFILES | ${coreutils}/bin/tr ' ' '\n')
       set fish_complete_path \$profiles"/share/fish/vendor_completions.d" \$fish_complete_path
     end
     EOF


### PR DESCRIPTION
###### Motivation for this change

The NIX_PROFILES variable was missed in this pull request: https://github.com/NixOS/nixpkgs/pull/16039

It should be added to the startup script instead of evaluated at build time.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Load NIX_PROFILES at shell startup, not at build time.
This one was missed in #16039.
