### PR TITLE
uif2iso: init at 0.1.7

### DIFF
--- a/pkgs/tools/cd-dvd/uif2iso/default.nix
+++ b/pkgs/tools/cd-dvd/uif2iso/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, unzip, zlib }:
+
+stdenv.mkDerivation rec {
+  nameNoVer = "uif2iso";
+  name = "${nameNoVer}-0.1.7";
+
+  src = fetchurl {
+    url = "http://aluigi.altervista.org/mytoolz/${nameNoVer}.zip";
+    sha256 = "1v18fmlzhkkhv8xdc9dyvl8vamwg3ka4dsrg7vvmk1f2iczdx3dp";
+  };
+
+  buildInputs = [unzip zlib];
+
+  installPhase = ''
+    make -C . prefix="$out" install;
+  '';
+
+  meta = {
+    description = "Tool for converting single/multi part UIF image files to ISO";
+    homepage = "http://aluigi.org/mytoolz.htm#uif2iso";
+    license = stdenv.lib.licenses.gpl1Plus;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3608,6 +3608,8 @@ in
 
   uget = callPackage ../tools/networking/uget { };
 
+  uif2iso = callPackage ../tools/cd-dvd/uif2iso { };
+
   umlet = callPackage ../tools/misc/umlet { };
 
   unetbootin = callPackage ../tools/cd-dvd/unetbootin { };


### PR DESCRIPTION
###### Motivation for this change

Want to use uif2iso
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

a program for converting UIF files (Universal Image Format, used by MagicISO)
to uncompressed images depending on the input file type:
ISO, BIN/CUE, MDS/MDF, CCD/IMG/SUB and NRG.
