### PR TITLE
gksu: use nativeBuildInputs and wrapGAppsHook

### DIFF
--- a/pkgs/applications/misc/gksu/default.nix
+++ b/pkgs/applications/misc/gksu/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, makeWrapper, gtk, gnome3, libgksu,
-  intltool, libstartup_notification, gtk_doc
+{ stdenv, fetchurl, pkgconfig, gtk, gnome3, libgksu,
+  intltool, libstartup_notification, gtk_doc, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -12,6 +12,18 @@ stdenv.mkDerivation rec {
     sha256 = "0npfanlh28daapkg25q4fncxd89rjhvid5fwzjaw324x0g53vpm1";
   };
 
+  nativeBuildInputs = [
+    pkgconfig intltool gtk_doc wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk gnome3.gconf libstartup_notification gnome3.libgnome_keyring
+  ];
+
+  propagatedBuildInputs = [
+    libgksu
+  ];
+
   patches = [
     # https://savannah.nongnu.org/bugs/index.php?36127
     ./gksu-2.0.2-glib-2.31.patch
@@ -22,15 +34,6 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = "--disable-nautilus-extension";
-
-  buildInputs = [
-    pkgconfig makeWrapper gtk gnome3.gconf intltool
-    libstartup_notification gnome3.libgnome_keyring gtk_doc
-  ];
-
-  propagatedBuildInputs = [
-    libgksu
-  ];
 
   meta = {
     description = "A graphical frontend for libgksu";

--- a/pkgs/development/libraries/libgksu/default.nix
+++ b/pkgs/development/libraries/libgksu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, makeWrapper, gtk, gnome, gnome3,
+{ stdenv, fetchurl, pkgconfig, wrapGAppsHook, gtk, gnome, gnome3,
   libstartup_notification, libgtop, perl, perlXMLParser,
   autoreconfHook, intltool, gtk_doc, docbook_xsl, xauth, sudo
 }:
@@ -12,6 +12,17 @@ stdenv.mkDerivation rec {
     url = "http://people.debian.org/~kov/gksu/${name}.tar.gz";
     sha256 = "1brz9j3nf7l2gd3a5grbp0s3nksmlrp6rxmgp5s6gjvxcb1wzy92";
   };
+
+  nativeBuildInputs = [
+    pkgconfig autoreconfHook intltool gtk_doc docbook_xsl wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk gnome.GConf libstartup_notification
+    gnome3.libgnome_keyring libgtop gnome.libglade perl perlXMLParser
+  ];
+
+  enableParallelBuilding = true;
 
   patches = [
         # Patches from the gentoo ebuild
@@ -53,19 +64,6 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     intltoolize --force --copy --automake
   '';
-
-  buildInputs = [
-    pkgconfig makeWrapper gtk gnome.GConf libstartup_notification
-    gnome3.libgnome_keyring libgtop gnome.libglade perl perlXMLParser
-    autoreconfHook intltool gtk_doc docbook_xsl
-  ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/gksu-properties" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
-  '';
-
-  enableParallelBuilding = true;
 
   meta = {
     description = "A library for integration of su into applications";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
