### PR TITLE
buildRubyGem: don't set the GEM_HOME

### DIFF
--- a/pkgs/development/ruby-modules/gem/gem-post-build.rb
+++ b/pkgs/development/ruby-modules/gem/gem-post-build.rb
@@ -7,7 +7,7 @@ ruby = File.join(ENV["ruby"], "bin", RbConfig::CONFIG['ruby_install_name'])
 out = ENV["out"]
 bin_path = File.join(ENV["out"], "bin")
 gem_home = ENV["GEM_HOME"]
-gem_path = ENV["GEM_PATH"].split(":")
+gem_path = ENV["GEM_PATH"].split(File::PATH_SEPARATOR)
 install_path = Dir.glob("#{gem_home}/gems/*").first
 gemspec_path = ARGV[0]
 
@@ -64,11 +64,16 @@ spec.executables.each do |exe|
 # this file is here to facilitate running it.
 #
 
-Gem.use_paths "#{gem_home}", #{gem_path.to_s}
-
 require 'rubygems'
 
-load Gem.bin_path(#{spec.name.inspect}, #{exe.inspect})
+Gem.paths = {
+  'GEM_PATH' => (
+    ENV['GEM_PATH'].to_s.split(File::PATH_SEPARATOR) +
+    #{([gem_home] + gem_path).to_s}
+  ).join(File::PATH_SEPARATOR)
+}
+
+load Gem.activate_bin_path(#{spec.name.inspect}, #{exe.inspect}, #{spec.version.to_s.inspect})
     EOF
   end
 


### PR DESCRIPTION
###### Motivation for this change

The bundler package was unusable because of this.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

bundler for example needs to have the GEM_HOME being passed trough to
function properly.

For gems that are loading content dynamically, or can use plugins, use
buildRubyGem.

For executables that are wrapped in their own sealed thing use
bundlerEnv.
