### PR TITLE
makeWrapper: document invocation flags

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -1,3 +1,40 @@
+#!bash
+# Usage: makeWrapper <original> <wrapper> [OPTIONS]
+#
+# Builds a wrapper script that executes a number of commands before executing
+# the <original> program.
+#
+# Options:
+#
+#   --set <name> <value>
+#     Adds the given environment variable
+#
+#   --unset <name>
+#     Removes the given environment variable
+#
+#   --run <command>
+#     Adds a pre-command to be executed. It can also be used to append flags
+#     to the $extraFlagsArray.
+#
+#   --suffix, --prefix <name> <separator> <value>
+#     Appends / prepends the <value> to the <name> environment variable,
+#     separated by the <separator>.
+#
+#   --suffix-each <name> <separator> "<value1> ..."
+#     Appends all the space-separated values to the <name> environment
+#     variable, separated by the <separator>.
+#
+#   --suffix-contents, --prefix-contents <name> <separator> <filename>
+#     Appens / prepents the content of <filename> to the <name> environment
+#     variable, seprated by the <separator>.
+#
+#   --add-flags "<flag1> ..."
+#     Prepends the space-separated flags to the execution of the program.
+#
+#   --argv0 <executable>
+#     Sets $0 value to <executable> during execution. Useful to hide the
+#     .wrapper postfix.
+#
 makeWrapper() {
     local original=$1
     local wrapper=$2


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I always forget how to use makeWrapper. Instead of scanning other
packages for the usage or reading the code, document the usage directly
in the header of makeWrapper.
