### PR TITLE
mecab: init at 0.996

### DIFF
--- a/pkgs/tools/text/mecab/base.nix
+++ b/pkgs/tools/text/mecab/base.nix
@@ -1,0 +1,16 @@
+{ fetchurl }:
+
+rec {
+    version = "0.996";
+
+    src = fetchurl {
+      url = https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE;
+      name = "mecab-0.996.tar.gz";
+      sha256 = "0ncwlqxl1hdn1x4v4kr2sn1sbbcgnhdphp0lcvk74nqkhdbk4wz0";
+    };
+
+    buildPhase = ''
+      make
+      make check
+    '';
+}

--- a/pkgs/tools/text/mecab/default.nix
+++ b/pkgs/tools/text/mecab/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, mecab-ipadic }:
+
+let
+  mecab-base = import ./base.nix { inherit fetchurl; };
+in
+stdenv.mkDerivation (mecab-base // {
+    name = "mecab-${mecab-base.version}";
+
+    postInstall = ''
+      sed -i 's|^dicdir = .*$|dicdir = ${mecab-ipadic}|' "$out/etc/mecabrc"
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Japanese morphological analysis system";
+      homepage = http://taku910.github.io/mecab/;
+      license = licenses.bsd3;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ auntie ];
+    };
+})

--- a/pkgs/tools/text/mecab/ipadic.nix
+++ b/pkgs/tools/text/mecab/ipadic.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl, mecab-nodic }:
+
+stdenv.mkDerivation rec {
+  name = "mecab-ipadic-${version}";
+  version = "2.7.0-20070801";
+
+  src = fetchurl {
+    url = https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7MWVlSDBCSXZMTXM;
+    name = "mecab-ipadic-2.7.0-20070801.tar.gz";
+    sha256 = "08rmkvj0f0x6jq0axrjw2y5nam0mavv6x77dp9v4al0wi1ym4bxn";
+  };
+
+  buildInputs = [ mecab-nodic ];
+
+  configurePhase = ''
+    ./configure --with-dicdir="$out"
+  '';
+}

--- a/pkgs/tools/text/mecab/nodic.nix
+++ b/pkgs/tools/text/mecab/nodic.nix
@@ -1,0 +1,8 @@
+{ stdenv, fetchurl }:
+
+let
+  mecab-base = import ./base.nix { inherit fetchurl; };
+in
+stdenv.mkDerivation (mecab-base // {
+    name = "mecab-nodic-${mecab-base.version}";
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2400,6 +2400,16 @@ in
 
   mbuffer = callPackage ../tools/misc/mbuffer { };
 
+  mecab =
+    let
+      mecab-nodic = callPackage ../tools/text/mecab/nodic.nix { };
+    in
+    callPackage ../tools/text/mecab {
+      mecab-ipadic = callPackage ../tools/text/mecab/ipadic.nix {
+        inherit mecab-nodic;
+      };
+    };
+
   memtest86 = callPackage ../tools/misc/memtest86 { };
 
   memtest86plus = callPackage ../tools/misc/memtest86+ { };


### PR DESCRIPTION
###### Motivation for this change

Anki has a few plugins that use mecab for parsing Japanese text. Packaging mecab was easier than using the 32bit binary downloaded by Anki.

The chicken-and-egg setup of the derivation is because mecab has a tool called mecab-config for processing new dictionaries. We can't bundle a dictionary with mecab without building mecab first, then processing the dictionary in a second derivation, and finally building a third derivation of mecab that includes a dictionary.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  (Note: Anki does not depend on mecab, only anki's plugins do)
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
