### PR TITLE
{lib}mediainfo{-gui}: 0.7.84 -> 0.7.86

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -2,11 +2,11 @@
 , desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.84";
+  version = "0.7.86";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0w3hm34amfy5bq3n1jihbwqvwqn0f8kvvq3lfc8nfwf8v7mjn7q9";
+    sha256 = "15w6m75bk6rsxxdrdibi330ch1x0cw131gynbhmhbsppsg0v5vb5";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.84";
+  version = "0.7.86";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "0w3hm34amfy5bq3n1jihbwqvwqn0f8kvvq3lfc8nfwf8v7mjn7q9";
+    sha256 = "15w6m75bk6rsxxdrdibi330ch1x0cw131gynbhmhbsppsg0v5vb5";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.84";
+  version = "0.7.86";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "0k657ynfxcw6lvakc8plz0pzfixlqbsiih2idimk9k1dd4xzhq3d";
+    sha256 = "14m7cgd93mglc9a4x28pb4yc6nfxhqk7vfryca83vpn80la1lxy0";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

From the changelog:

```
Version 0.7.86, 2016-05-31

+ Linux/Mac: more output formats (PBCore, EBUCore, FIMS)
+ FFV1 parsing optimization, avoiding by default a too verbose trace
+ Matroska: more elements support and typo fixes in the trace
+ #I172, Trace feature: provide the name of the main parser in the media element
+ Matroska: consider all values below 0x10 EBML names as 1-byte junk
x Matroska: better support (including speed improvement) of huge lossless frames (e.g. 20 MB FFV1 4K)
x #I144, Python binding: Python 2 on Linux does not automatically provide the locale to the shared object
x HTML output: don't escape carriage returns from the input file
x FFV1: some streams were rejected despite the fact they are valid
x Python binding: some errors during call of Get() API with Python3 on Linux/Mac
```
