### PR TITLE
canto-{curses,daemon}: 0.9.{6,5} -> 0.9.{7,6}

### DIFF
--- a/pkgs/applications/networking/feedreaders/canto-curses/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-curses/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, python34Packages, readline, ncurses, canto-daemon }:
 
 python34Packages.buildPythonApplication rec {
-  version = "0.9.6";
+  version = "0.9.7";
   name = "canto-curses-${version}";
 
   src = fetchFromGitHub {
     owner = "themoken";
     repo = "canto-curses";
     rev = "v${version}";
-    sha256 = "0hxzpx314cflxq68gswjf2vrqf1z1ci9mxhxgwrk7sa6di86ygy0";
+    sha256 = "0ap1b4m5gbzi0l7vj6pwvvg77i2aarbynbdc147z2b1lzvr985zq";
   };
 
   buildInputs = [ readline ncurses canto-daemon ];

--- a/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
+++ b/pkgs/applications/networking/feedreaders/canto-daemon/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python34Packages, }:
 
 python34Packages.buildPythonApplication rec {
-  version = "0.9.5";
+  version = "0.9.6";
   name = "canto-daemon-${version}";
   namePrefix = "";
 
@@ -9,7 +9,7 @@ python34Packages.buildPythonApplication rec {
     owner = "themoken";
     repo = "canto-next";
     rev = "v${version}";
-    sha256 = "1ycwrg5n2il833mdxgzz07r0vb4rxz89rk5c6l9g5x33ifinykdq";
+    sha256 = "0ibakwmsbpk10bvxsr5vvka0pks89arric428y5cmfgcpr72sqzw";
   };
 
   propagatedBuildInputs = with python34Packages; [ feedparser ];


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Unfortunately there is no changelog available.
