### PR TITLE
Escape all shell arguments uniformly

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -213,7 +213,16 @@ rec {
        escapeShellArg "so([<>])me"
        => "so\\(\\[\\<\\>\\]\\)me"
   */
-  escapeShellArg = lib.escape (stringToCharacters "\\ ';$`()|<>\t*[]");
+  escapeShellArg = arg:
+    lib.escape (stringToCharacters "\\ ';$`()|<>\t*[]") (toString arg);
+
+  /* Escape all arguments to be passed to the Bourne shell.
+
+     Example:
+       escapeShellArgs ["one" "two three"]
+       => "one two\\ three"
+  */
+  escapeShellArgs = concatMapStringsSep " " escapeShellArg;
 
   /* Obsolete - use replaceStrings instead. */
   replaceChars = builtins.replaceStrings or (

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -187,7 +187,7 @@ in
                   script = ''
                     cd '${cpath}'
                     set +e
-                    simp_le ${concatMapStringsSep " " (arg: escapeShellArg (toString arg)) cmdline}
+                    simp_le ${escapeShellArgs cmdline}
                     EXITCODE=$?
                     set -e
                     echo "$EXITCODE" > /tmp/lastExitCode

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -101,7 +101,7 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
-        ExecStart = "${pkgs.opendkim}/bin/opendkim ${concatMapStringsSep " " escapeShellArg args}";
+        ExecStart = "${pkgs.opendkim}/bin/opendkim ${escapeShellArgs args}";
         User = cfg.user;
         Group = cfg.group;
         RuntimeDirectory = optional (cfg.socket == defaultSock) "opendkim";

--- a/nixos/modules/services/misc/taskserver/default.nix
+++ b/nixos/modules/services/misc/taskserver/default.nix
@@ -152,8 +152,6 @@ let
     };
   };
 
-  mkShellStr = val: "'${replaceStrings ["'"] ["'\\''"] val}'";
-
   certtool = "${pkgs.gnutls.bin}/bin/certtool";
 
   nixos-taskserver = pkgs.buildPythonPackage {

--- a/nixos/modules/services/networking/ejabberd.nix
+++ b/nixos/modules/services/networking/ejabberd.nix
@@ -13,7 +13,7 @@ let
 
   ectl = ''${cfg.package}/bin/ejabberdctl ${if cfg.configFile == null then "" else "--config ${cfg.configFile}"} --ctl-config "${ctlcfg}" --spool "${cfg.spoolDir}" --logs "${cfg.logsDir}"'';
 
-  dumps = lib.concatMapStringsSep " " lib.escapeShellArg cfg.loadDumps;
+  dumps = lib.escapeShellArgs cfg.loadDumps;
 
 in {
 

--- a/pkgs/build-support/vm/windows/controller/default.nix
+++ b/pkgs/build-support/vm/windows/controller/default.nix
@@ -71,8 +71,6 @@ let
     };
   };
 
-  shellEscape = x: "'${replaceChars ["'"] [("'\\'" + "'")] x}'";
-
   loopForever = "while :; do ${coreutils}/bin/sleep 1; done";
 
   initScript = writeScript "init.sh" (''
@@ -132,7 +130,7 @@ let
       -o StrictHostKeyChecking=no \
       -i /ssh.key \
       -l Administrator \
-      192.168.0.1 -- ${shellEscape command}
+      192.168.0.1 -- ${lib.escapeShellArg command}
   '') + optionalString (suspendTo != null) ''
     ${coreutils}/bin/touch /xchg/suspend_now
     ${loopForever}

--- a/pkgs/development/ruby-modules/bundler-env/default.nix
+++ b/pkgs/development/ruby-modules/bundler-env/default.nix
@@ -16,8 +16,6 @@
 }@args:
 
 let
-
-  shellEscape = x: "'${lib.replaceChars ["'"] [("'\\'" + "'")] x}'";
   importedGemset = import gemset;
   filteredGemset = (lib.filterAttrs (name: attrs:
     if (builtins.hasAttr "groups" attrs)
@@ -58,8 +56,8 @@ let
         "${confFiles}/Gemfile" \
         "$out/${ruby.gemPath}" \
         "${bundler}/${ruby.gemPath}" \
-        ${shellEscape (toString envPaths)} \
-        ${shellEscape (toString groups)}
+        ${lib.escapeShellArg envPaths} \
+        ${lib.escapeShellArg groups}
     '' + lib.optionalString (postBuild != null) postBuild;
     passthru = rec {
       inherit ruby bundler meta gems;

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -18,8 +18,8 @@
 # Normal gem packages can be used outside of bundler; a binstub is created in
 # $out/bin.
 
-{ lib, ruby, bundler, fetchurl, fetchgit, makeWrapper, git,
-  buildRubyGem, darwin
+{ lib, fetchurl, fetchgit, makeWrapper, git, darwin
+, ruby, bundler
 } @ defs:
 
 lib.makeOverridable (
@@ -53,7 +53,6 @@ lib.makeOverridable (
 , ...} @ attrs:
 
 let
-  shellEscape = x: "'${lib.replaceChars ["'"] [("'\\'" + "'")] x}'";
   src = attrs.src or (
     if type == "gem" then
       fetchurl {
@@ -165,7 +164,7 @@ stdenv.mkDerivation (attrs // {
       ${src} \
       ${attrs.rev} \
       ${version} \
-      ${shellEscape (toString buildFlags)}
+      ${lib.escapeShellArgs buildFlags}
     ''}
 
     ${lib.optionalString (type == "gem") ''

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -37,7 +37,6 @@
 # that point into the user's profile.
 
 let
-  shellEscape = x: "'${lib.replaceChars ["'"] [("'\\'" + "'")] x}'";
   installer = writeScript "xquartz-install" ''
     NIX_LINK=$HOME/.nix-profile
 
@@ -138,7 +137,7 @@ in stdenv.mkDerivation {
     defaultStartX="$out/bin/startx -- $out/bin/Xquartz"
 
     ruby ${./patch_plist.rb} \
-      ${shellEscape (builtins.toXML {
+      ${lib.escapeShellArg (builtins.toXML {
         XQUARTZ_DEFAULT_CLIENT = "${xterm}/bin/xterm";
         XQUARTZ_DEFAULT_SHELL  = "${shell}";
         XQUARTZ_DEFAULT_STARTX = "@STARTX@";


### PR DESCRIPTION
###### Motivation for this change

This removes duplication and potentially variances in how shell arguments are being escaped.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
