### PR TITLE
gnome-online-accounts: use wrapGAppsHook instead of own fixup

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/gnome-online-accounts/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, glib, libxslt, gtk, makeWrapper
 , webkitgtk, json_glib, rest, libsecret, dbus_glib, gnome_common
 , telepathy_glib, intltool, dbus_libs, icu, autoreconfHook
-, libsoup, docbook_xsl_ns, docbook_xsl, gnome3
+, libsoup, docbook_xsl_ns, docbook_xsl, gnome3, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -16,15 +16,10 @@ stdenv.mkDerivation rec {
     sed "/if HAVE_INTROSPECTION/a INTROSPECTION_COMPILER_ARGS = --shared-library=$out/lib/libgoa-1.0.so" -i src/goa/Makefile.am
   '';
 
-  buildInputs = [ pkgconfig glib libxslt gtk webkitgtk json_glib rest gnome_common makeWrapper
+  buildInputs = [ pkgconfig glib libxslt gtk webkitgtk json_glib rest gnome_common wrapGAppsHook
                   libsecret dbus_glib telepathy_glib intltool icu libsoup autoreconfHook
-                  docbook_xsl_ns docbook_xsl gnome3.defaultIconTheme ];
+                  docbook_xsl_ns docbook_xsl gnome3.defaultIconTheme  ];
 
-  preFixup = ''
-    for f in "$out/libexec/"*; do
-      wrapProgram "$f" --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-    done
-  '';
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

fix #15531 

this is my first pr on nixpkgs, please guide wrt testing
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

addresses #15531
