### PR TITLE
kmod-debian-aliases: 21-1 -> 22-1.1

### DIFF
--- a/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
+++ b/pkgs/os-specific/linux/kmod-debian-aliases/default.nix
@@ -1,13 +1,12 @@
 { stdenv, fetchurl, lib }:
-let
-  version = "21-1";
-in
-stdenv.mkDerivation {
+
+stdenv.mkDerivation rec {
   name = "kmod-debian-aliases-${version}.conf";
+  version = "22-1.1";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/k/kmod/kmod_${version}.debian.tar.xz";
-    sha256 = "1abpf8g3yx972by2xpmz6dwwyc1pgh6gjbvrivmrsws69vs0xjsy";
+    sha256 = "0daap2n4bvjqcnksaayy6csmdb1px4r02w3xp36bcp6w3lbnqamh";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

The current package doesn't build right now because its sources have been removed from the debian mirror.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Mathnerd314.
