### PR TITLE
User shell config

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -100,6 +100,10 @@ rec {
         in if isDerivation res then res else toDerivation res;
     };
 
+    shellPackage = package // {
+      check = x: (package.check x) && (hasAttr "shellPath" x);
+    };
+
     path = mkOptionType {
       name = "path";
       # Hacky: there is no ‘isPath’ primop.

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -8,4 +8,10 @@ rec {
    replaceChars ["/" "-" " "] ["-" "\\x2d" "\\x20"]
     (if hasPrefix "/" s then substring 1 (stringLength s) s else s);
 
+  # Returns a system path for a given shell package
+  toShellPath = shell:
+    if types.shellPackage.check shell then
+      "/run/current-system/sw${shell.shellPath}"
+    else
+      shell;
 }

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -1,7 +1,7 @@
 # This module defines a global environment configuration and
 # a common configuration for all shells.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, utils, pkgs, ... }:
 
 with lib;
 
@@ -135,13 +135,13 @@ in
 
     environment.shells = mkOption {
       default = [];
-      example = [ "/run/current-system/sw/bin/zsh" ];
+      example = literalExample "[ pkgs.bashInteractive pkgs.zsh ]";
       description = ''
         A list of permissible login shells for user accounts.
         No need to mention <literal>/bin/sh</literal>
         here, it is placed into this list implicitly.
       '';
-      type = types.listOf types.path;
+      type = types.listOf (types.either types.shellPackage types.path);
     };
 
   };
@@ -158,7 +158,7 @@ in
 
     environment.etc."shells".text =
       ''
-        ${concatStringsSep "\n" cfg.shells}
+        ${concatStringsSep "\n" (map utils.toShellPath cfg.shells)}
         /bin/sh
       '';
 

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -200,7 +200,7 @@ in
     # Configuration for readline in bash.
     environment.etc."inputrc".source = ./inputrc;
 
-    users.defaultUserShell = mkDefault "/run/current-system/sw/bin/bash";
+    users.defaultUserShell = mkDefault pkgs.bashInteractive;
 
     environment.pathsToLink = optionals cfg.enableCompletion [
       "/etc/bash_completion.d"

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -1,6 +1,6 @@
 # Configuration for the pwdutils suite of tools: passwd, useradd, etc.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, utils, pkgs, ... }:
 
 with lib;
 
@@ -43,13 +43,13 @@ in
     users.defaultUserShell = lib.mkOption {
       description = ''
         This option defines the default shell assigned to user
-        accounts.  This must not be a store path, since the path is
+        accounts. This can be either a full system path or a shell package.
+
+        This must not be a store path, since the path is
         used outside the store (in particular in /etc/passwd).
-        Rather, it should be the path of a symlink that points to the
-        actual shell in the Nix store.
       '';
-      example = "/run/current-system/sw/bin/zsh";
-      type = types.path;
+      example = literalExample "pkgs.zsh";
+      type = types.either types.path types.shellPackage;
     };
 
   };
@@ -60,7 +60,9 @@ in
   config = {
 
     environment.systemPackages =
-      lib.optional config.users.mutableUsers pkgs.shadow;
+      lib.optional config.users.mutableUsers pkgs.shadow ++
+      lib.optional (types.shellPackage.check config.users.defaultUserShell)
+        config.users.defaultUserShell;
 
     environment.etc =
       [ { # /etc/login.defs: global configuration for pwdutils.  You
@@ -74,7 +76,7 @@ in
             ''
               GROUP=100
               HOME=/home
-              SHELL=${config.users.defaultUserShell}
+              SHELL=${utils.toShellPath config.users.defaultUserShell}
             '';
           target = "default/useradd";
         }

--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -53,5 +53,8 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://pkg-shadow.alioth.debian.org/;
     description = "Suite containing authentication-related tools such as passwd and su";
+    passthru = {
+      shellPath = "/bin/nologin";
+    };
   };
 }

--- a/pkgs/shells/dash/default.nix
+++ b/pkgs/shells/dash/default.nix
@@ -13,4 +13,8 @@ stdenv.mkDerivation rec {
     description = "A POSIX-compliant implementation of /bin/sh that aims to be as small as possible";
     hydraPlatforms = stdenv.lib.platforms.linux;
   };
+
+  passthru = {
+    shellPath = "/bin/dash";
+  };
 }

--- a/pkgs/shells/es/default.nix
+++ b/pkgs/shells/es/default.nix
@@ -43,4 +43,8 @@ stdenv.mkDerivation {
     maintainers = [ maintainers.sjmackenzie ];
     platforms = platforms.all;
   };
+
+  passthru = {
+    shellPath = "/bin/es";
+  };
 }

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -87,4 +87,8 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [ ocharles ];
   };
+
+  passthru = {
+    shellPath = "/bin/fish";
+  };
 }

--- a/pkgs/shells/mksh/default.nix
+++ b/pkgs/shells/mksh/default.nix
@@ -43,4 +43,8 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ AndersonTorres nckx ];
     platforms = platforms.unix;
   };
+
+  passthru = {
+    shellPath = "/bin/mksh";
+  };
 }

--- a/pkgs/shells/pash/default.nix
+++ b/pkgs/shells/pash/default.nix
@@ -22,4 +22,8 @@ buildDotnetPackage rec {
     platforms = platforms.all;
     license = with licenses; [ bsd3 gpl3 ];
   };
+
+  passthru = {
+    shellPath = "/bin/pash";
+  };
 }

--- a/pkgs/shells/rush/default.nix
+++ b/pkgs/shells/rush/default.nix
@@ -35,4 +35,8 @@ stdenv.mkDerivation rec {
     maintainers = [ stdenv.lib.maintainers.bjg ];
     platforms = stdenv.lib.platforms.all;
   };
+
+  passthru = {
+    shellPath = "/bin/rush";
+  };
 }

--- a/pkgs/shells/tcsh/default.nix
+++ b/pkgs/shells/tcsh/default.nix
@@ -19,4 +19,8 @@ stdenv.mkDerivation rec {
     homepage = http://www.tcsh.org/;
     description = "An enhanced version of the Berkeley UNIX C shell (csh)";
   };
+
+  passthru = {
+    shellPath = "/bin/tcsh";
+  };
 }

--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -41,4 +41,8 @@ python3Packages.buildPythonApplication rec {
     maintainers = with maintainers; [ spwhitt garbas ];
     platforms = platforms.all;
   };
+
+  passthru = {
+    shellPath = "/bin/xonsh";
+  };
 }

--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -80,4 +80,8 @@ EOF
     maintainers = with stdenv.lib.maintainers; [ chaoflow pSub ];
     platforms = stdenv.lib.platforms.unix;
   };
+
+  passthru = {
+    shellPath = "/bin/zsh";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2233,6 +2233,9 @@ in
   else
     nodePackages_4_x;
 
+  # Can be used as a user shell
+  nologin = shadow;
+
   npm2nix = nodePackages.npm2nix;
 
   ldapvi = callPackage ../tools/misc/ldapvi { };


### PR DESCRIPTION
###### Motivation for this change

NixOS should automatically figure out the shell path based on the package that the user provides.

This introduces a new passthru attribute that each package can use to designate their shell binary and accompanying changes in the nixos modules so that the user can simply set

``` nix
{
  users.extraUsers.myuser.shell = pkgs.zsh;
  # and
  users.defaultUserShell = pkgs.tcsh;
}
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
