### PR TITLE
i2p: 0.9.25 -> 0.9.26

### DIFF
--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -1,10 +1,10 @@
 { stdenv, procps, coreutils, fetchurl, jdk, jre, ant, gettext, which }:
 
 stdenv.mkDerivation rec {
-  name = "i2p-0.9.25";
+  name = "i2p-0.9.26";
   src = fetchurl {
     url = "https://github.com/i2p/i2p.i2p/archive/${name}.tar.gz";
-    sha256 = "1lj4khln0k0b4f55hjighwn5j3cyal8flmapjmadjyj6cd5py0v8";
+    sha256 = "0h672w69a5xzgcrls64bpss3ga9hgpnrq90dr5lb5912pwwq9pa1";
   };
   buildInputs = [ jdk ant gettext which ];
   patches = [ ./i2p.patch ];


### PR DESCRIPTION
###### Motivation for this change

maintenance
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
