### PR TITLE
cytoscape: init at 3.4.0

### DIFF
--- a/pkgs/applications/science/misc/cytoscape/default.nix
+++ b/pkgs/applications/science/misc/cytoscape/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "cytoscape-${version}";
+  version = "3.4.0";
+
+  src = fetchurl {
+    url = "http://chianti.ucsd.edu/${name}/${name}.tar.gz";
+    sha256 = "065fsqa01w7j85nljwwc0677lfw112xphnyn1c4hb04166q082p2";
+  };
+
+  buildInputs = [jre makeWrapper];
+
+  installPhase = ''
+    mkdir -pv $out/{share,bin}
+    cp -Rv * $out/share/
+
+    ln -s $out/share/cytoscape.sh $out/bin/cytoscape
+
+    wrapProgram $out/share/gen_vmoptions.sh \
+      --set JAVA_HOME "${jre}" \
+      --set JAVA  "${jre}/bin/java"
+
+    chmod +x $out/bin/cytoscape
+  '';
+
+  meta = {
+    homepage = "http://www.cytoscape.org";
+    description = "A general platform for complex network analysis and visualization";
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [stdenv.lib.maintainers.mimadrid];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4493,7 +4493,7 @@ in
   inherit (self.haskellPackages) ghc;
 
   cabal-install = haskell.lib.disableSharedExecutables haskellPackages.cabal-install;
-   
+
   stack = haskell.lib.overrideCabal haskellPackages.stack (drv: {
     enableSharedExecutables = false;
     isLibrary = false;
@@ -10831,7 +10831,7 @@ in
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
     bcc = callPackage ../os-specific/linux/bcc { };
-    
+
     bbswitch = callPackage ../os-specific/linux/bbswitch {};
 
     ati_drivers_x11 = callPackage ../os-specific/linux/ati-drivers { };
@@ -15950,7 +15950,7 @@ in
 
   openspecfun = callPackage ../development/libraries/science/math/openspecfun {};
 
-  magma = callPackage ../development/libraries/science/math/magma { };  
+  magma = callPackage ../development/libraries/science/math/magma { };
 
   mathematica = callPackage ../applications/science/math/mathematica { };
   mathematica9 = callPackage ../applications/science/math/mathematica/9.nix { };
@@ -16310,6 +16310,8 @@ in
     lua = lua5_1;
     inherit (pkgs.gnome) gtkglext;
   };
+
+  cytoscape = callPackage ../applications/science/misc/cytoscape { };
 
   fityk = callPackage ../applications/science/misc/fityk { };
 


### PR DESCRIPTION
This is my first init so I hope that I have done it well.
###### Motivation for this change

Add cytoscape to NixOS
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
