### PR TITLE
green-pdf-viewer: init at nightly-2014-04-22 (work in progress)

### DIFF
--- a/pkgs/applications/misc/green-pdfviewer/default.nix
+++ b/pkgs/applications/misc/green-pdfviewer/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, poppler, pkgconfig, perl, gdk_pixbuf, SDL, gtk }:
+
+stdenv.mkDerivation rec {
+  name = "green-pdfviewer-${version}";
+  version = "nightly-2014-04-22";
+
+  src = fetchFromGitHub {
+    owner = "schandinat";
+    repo = "green";
+    rev = "0b516aec17915d9742d8e505d2ed383a3bdcea61";
+    sha256 = "0d0lv33flhgsxhc77kfp2avdz5gvml04r8l1j95yjz2rr096lzlj";
+  };
+
+  buildInputs = [ poppler pkgconfig perl gdk_pixbuf SDL gtk ];
+
+  patches = [
+    ./gdk-libs.patch
+  ];
+
+  buildPhase = ''
+    make PREFIX=$out
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man1
+    make install PREFIX=$out MANDIR=$out/share
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/schandinat/green/;
+    description = "Viewer for PDF files, uses SDL and libpoppler";
+
+    platforms = platforms.unix;
+    license  = licenses.gpl3;
+    maintainers = [ maintainers.vrthra ];
+  };
+}

--- a/pkgs/applications/misc/green-pdfviewer/gdk-libs.patch
+++ b/pkgs/applications/misc/green-pdfviewer/gdk-libs.patch
@@ -1,0 +1,55 @@
+Common subdirectories: green.old/debian and green.new/debian
+diff -u green.old/green.h green.new/green.h
+--- green.old/green.h	2016-06-12 18:11:56.779434416 -0700
++++ green.new/green.h	2016-06-12 18:14:38.830557379 -0700
+@@ -19,7 +19,14 @@
+ 
+ 
+ #include <stdbool.h>
+-#include "glib/poppler.h"
++#include "poppler.h"
++#include "gdk-pixbuf/gdk-pixbuf.h"
++#include "gdk-pixbuf/gdk-pixbuf-core.h"
++#include "gdk-pixbuf/gdk-pixbuf-features.h"
++#include "gdk-pixbuf/gdk-pixbuf-enum-types.h"
++ 
++ #define GREEN_FULLSCREEN	0x0001
++ 
+ 
+ 
+ #define GREEN_FULLSCREEN	0x0001
+diff -u green.old/Makefile green.new/Makefile
+--- green.old/Makefile	2016-06-12 18:11:56.779434416 -0700
++++ green.new/Makefile	2016-06-12 18:13:09.591974048 -0700
+@@ -17,6 +17,12 @@
+ SDL_CFLAGS	:=	$$(sdl-config --cflags)
+ SDL_LIBS	:=	$$(sdl-config --libs)
+ 
++GDKPIXBUF_CFLAGS	:=	$$(pkg-config gdk-pixbuf-2.0 --cflags)
++GDKPIXBUF_LIBS	:=	$$(pkg-config gdk-pixbuf-2.0 --libs)
++
++GTK_CFLAGS	:=	$$(pkg-config gtk+-2.0 --cflags)
++GTK_LIBS	:=	$$(pkg-config gtk+-2.0 --libs)
++
+ 
+ all: green
+ 
+@@ -28,13 +34,14 @@
+ 	$(INSTALL) green.1 $(MANDIR)/man1/
+ 
+ green: main.o green.o sdl.o
+-	$(CC) $^ $(POPPLER_LIBS) $(SDL_LIBS) -o $@
++	$(CC) $^ $(POPPLER_LIBS) $(SDL_LIBS) $(GDKPIXBUF_LIBS) $(GTK_LIBS) -o $@
+ 
+ main.o: main.c green.h
+-	$(CC) $(CONFIG) $(CFLAGS) -c $< $(POPPLER_CFLAGS) -o $@
++	$(CC) $(CONFIG) $(CFLAGS) $(GDKPIXBUF_CFLAGS) -c $< $(POPPLER_CFLAGS) -o $@
+ 
+ green.o: green.c green.h
+-	$(CC) $(CFLAGS) -c $< $(POPPLER_CFLAGS) -o $@
++	$(CC) $(CFLAGS) -c $< $(POPPLER_CFLAGS)  $(GDKPIXBUF_CFLAGS) -o $@
+ 
+ sdl.o: sdl.c green.h
+-	$(CC) $(CFLAGS) -c $< $(POPPLER_CFLAGS) $(SDL_CFLAGS) -o $@
++	$(CC) $(CFLAGS) -c $< $(POPPLER_CFLAGS) $(SDL_CFLAGS) $(GDKPIXBUF_CFLAGS) $(GTK_CFLAGS) -o $@
++

--- a/pkgs/development/libraries/SDL_sixel/default.nix
+++ b/pkgs/development/libraries/SDL_sixel/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, audiofile, libcap }:
+
+stdenv.mkDerivation rec {
+  version = "1.2";
+  name    = "SDL_sixel-${version}";
+
+  src = fetchFromGitHub {
+    owner = "saitoha";
+    repo = "SDL1.2-SIXEL";
+    rev = "ab3fccac6e34260a617be511bd8c2b2beae41952";
+    sha256 = "0gm2vngdac17lzw9azkhzazmfq3byjddms14gqjk18vnynfqp5wp";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform multimedia library";
+    homepage    = http://www.libsdl.org/;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.unix;
+    license     = licenses.lgpl21;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8990,6 +8990,8 @@ in
     inherit (darwin.apple_sdk.frameworks) OpenGL CoreAudio CoreServices AudioUnit Kernel Cocoa;
   };
 
+  SDL_sixel = callPackage ../development/libraries/SDL_sixel { };
+
   SDL_gfx = callPackage ../development/libraries/SDL_gfx { };
 
   SDL_image = callPackage ../development/libraries/SDL_image { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -475,6 +475,10 @@ in
 
   grc = callPackage ../tools/misc/grc { };
 
+  green-pdfviewer = callPackage ../applications/misc/green-pdfviewer {
+   SDL = SDL_sixel;
+  };
+
   lastpass-cli = callPackage ../tools/security/lastpass-cli { };
 
   pass = callPackage ../tools/security/pass { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Green pdf viewer uses SDL and libpoppler to render pdf.
