### PR TITLE
mlterm: Disable darwin compilaton

### DIFF
--- a/pkgs/applications/misc/mlterm/default.nix
+++ b/pkgs/applications/misc/mlterm/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     homepage = https://sourceforge.net/projects/mlterm/;
     license = licenses.bsd2;
     maintainers = [ maintainers.vrthra ];
-    platforms = with platforms; linux ++ darwin;
+    platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Failing hydra nightly on darwin
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Mlterm does not compile on darwin due to utmp.h not found.
