### PR TITLE
php: Fixed libiconv error

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -23,8 +23,7 @@ let
 
       configureFlags = [
         "EXTENSION_DIR=$(out)/lib/php/extensions"
-        "--with-iconv=${libiconv}"
-      ];
+      ] ++ lib.optional stdenv.isDarwin "--with-iconv=${libiconv}";
 
       flags = {
 


### PR DESCRIPTION
###### Motivation for this change

Fix for php configure failure on linux introduced in #16078.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
