### PR TITLE
neovim: fix neovim on darwin (requires libmpack)

### DIFF
--- a/pkgs/development/libraries/libmpack/default.nix
+++ b/pkgs/development/libraries/libmpack/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tarruda/libmpack/";
     license = licenses.mit;
     maintainers = with maintainers; [ lovek323 garbas ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

To install Neovim on Darwin without setting `allowBroken` for nixpkgs, the `libmpack` library requires Darwin as a supported platform.

Is this an appropriate solution, @matthewbauer ?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
