### PR TITLE
musl service pack

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -108,6 +108,7 @@
   dochang = "Desmond O. Chang <dochang@gmail.com>";
   doublec = "Chris Double <chris.double@double.co.nz>";
   drewkett = "Andrew Burkett <burkett.andrew@gmail.com>";
+  dvc94ch = "David Craven <david@craven.ch>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";
   eduarrrd = "Eduard Bachmakov <e.bachmakov@gmail.com>";

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -244,7 +244,8 @@ stdenv.mkDerivation {
   # The dynamic linker has different names on different Linux platforms.
   dynamicLinker =
     if !nativeLibc then
-      (if stdenv.system == "i686-linux" then "ld-linux.so.2" else
+      (if libc.isMusl or false then libc.dynamicLinker else
+       if stdenv.system == "i686-linux" then "ld-linux.so.2" else
        if stdenv.system == "x86_64-linux" then "ld-linux-x86-64.so.2" else
        # ARM with a wildcard, which can be "" or "-armhf".
        if stdenv.isArm then "ld-linux*.so.3" else
@@ -265,7 +266,8 @@ stdenv.mkDerivation {
     # the style in the gcc-cross-wrapper, but to keep a stable stdenv now I
     # do this sufficient if/else.
     dynamicLinker =
-      (if stdenv.cross.arch == "arm" then "ld-linux.so.3" else
+      (if stdenv.cross.libc == "musl" then muslCross.dynamicLinker else
+       if stdenv.cross.arch == "arm" then "ld-linux.so.3" else
        if stdenv.cross.arch == "mips" then "ld.so.1" else
        if stdenv.lib.hasSuffix "pc-gnu" stdenv.cross.config then "ld.so.1" else
        abort "don't know the name of the dynamic linker for this platform");

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -190,7 +190,10 @@ let version = "6.1.0";
             else (if cross.libc == "uclibc" then
               # In uclibc cases, libgomp needs an additional '-ldl'
               # and as I don't know how to pass it, I disable libgomp.
-              " --disable-libgomp" else "") +
+              " --disable-libgomp"
+            else if cross.libc == "musl" then
+              " --disable-libsanitizer"
+            else "") +
             " --enable-threads=posix" +
             " --enable-nls" +
             " --disable-decimal-float") # No final libdecnumber (it may work only in 386)

--- a/pkgs/development/compilers/gcc/libgcc.nix
+++ b/pkgs/development/compilers/gcc/libgcc.nix
@@ -1,0 +1,27 @@
+{ stdenv, gcc, glibc }:
+
+stdenv.mkDerivation rec {
+  name = "libgcc-${version}";
+  version = gcc.cc.version;
+  arch = "x86_64-unknown-linux-gnu";
+  path = "${gcc.cc}/lib/gcc/${arch}/${version}";
+
+  buildCommand = ''
+    mkdir -p "$out/lib"
+
+    cp -r ${path}/libgcc.a $out/lib
+    cp -r ${path}/crtbegin.o $out/lib
+    cp -r ${path}/crtbeginS.o $out/lib
+    cp -r ${path}/crtbeginT.o $out/lib
+    cp -r ${path}/crtendS.o $out/lib
+    cp -r ${path}/crtend.o $out/lib
+
+    cp -r ${path}/crtfastmath.o $out/lib
+    cp -r ${path}/crtprec32.o $out/lib
+    cp -r ${path}/crtprec80.o $out/lib
+    cp -r ${path}/crtprec64.o $out/lib
+    cp -r ${path}/libgcc_eh.a $out/lib
+
+    cp -r ${glibc.out}/lib/libgcc_s.so.1 $out/lib/libgcc_s.so
+  '';
+}

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -1,7 +1,6 @@
-{ stdenv, fetchurl, musl
+{ stdenv, fetchurl
 , enableStatic ? false
 , enableMinimal ? false
-, useMusl ? false
 , extraConfig ? ""
 }:
 
@@ -61,8 +60,6 @@ stdenv.mkDerivation rec {
     EOF
 
     make oldconfig
-  '' + stdenv.lib.optionalString useMusl ''
-    makeFlagsArray+=("CC=gcc -isystem ${musl}/include -B${musl}/lib -L${musl}/lib")
   '';
 
   crossAttrs = {

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -1,32 +1,47 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, cross ? null, gccCross ? null }:
 
 stdenv.mkDerivation rec {
-  name    = "musl-${version}";
-  version = "1.1.11";
+  name    = "musl-${version}${stdenv.lib.optionalString (cross != null) ''-${cross.arch}''}";
+  version = "1.1.14";
 
   src = fetchurl {
-    url    = "http://www.musl-libc.org/releases/${name}.tar.gz";
-    sha256 = "0grmmah3d9wajii26010plpinv3cbiq3kfqsblgn84kv3fjnv7mv";
+    url    = "http://www.musl-libc.org/releases/musl-${version}.tar.gz";
+    sha256 = "1ddral87srzk741cqbfrx9aygnh8fpgfv7mjvbain2d6hh6c1xim";
   };
 
-  enableParallelBuilding = true;
+  buildInputs = stdenv.lib.optional (gccCross != null) gccCross;
+  CROSS_COMPILE = stdenv.lib.optionalString (cross != null) "${cross.config}-";
 
   preConfigure = ''
     configureFlagsArray+=("--syslibdir=$out/lib")
+    ${stdenv.lib.optionalString (gccCross != null) ''export CC="${cross.config}-gcc"''}
   '';
 
   configureFlags = [
     "--enable-shared"
     "--enable-static"
-  ];
+    "--disable-gcc-wrapper"
+  ] ++ stdenv.lib.optional (cross != null) "--target=${cross.arch}";
 
+  outputs = ["dev" "out"];
+  enableParallelBuilding = true;
   dontDisableStatic = true;
+  dontSetConfigureCross = true;
+  dontStrip = true;
+  dontCrossStrip = true;
+
+  passthru = {
+    # isMusl can be dropped when/if providing the dynamicLinker
+    # name through the libc is adopted
+    isMusl = true;
+    dynamicLinker = "libc.so";
+  };
 
   meta = {
     description = "An efficient, small, quality libc implementation";
     homepage    = "http://www.musl-libc.org";
     license     = stdenv.lib.licenses.mit;
     platforms   = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    maintainers = with stdenv.lib.maintainers; [ dvc94ch thoughtpolice ];
   };
 }

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -13,7 +13,7 @@ rec {
   tarMinimal = gnutar.override { acl = null; };
 
   busyboxMinimal = busybox.override {
-    useMusl = true;
+    stdenv = muslStdenv;
     enableStatic = true;
     enableMinimal = true;
     extraConfig = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4199,6 +4199,8 @@ in
 
   gcc = gcc5;
 
+  libgcc = callPackage ../development/compilers/gcc/libgcc.nix {};
+
   wrapCCMulti = cc:
     if system == "x86_64-linux" then lowPrio (
       let
@@ -7117,6 +7119,7 @@ in
 
   # We can choose:
   libcCrossChooser = name: if name == "glibc" then glibcCross
+    else if name == "musl" then muslCross
     else if name == "uclibc" then uclibcCross
     else if name == "msvcrt" then windows.mingw_w64
     else if name == "libSystem" then darwin.xcode
@@ -11127,6 +11130,11 @@ in
   multipath-tools = callPackage ../os-specific/linux/multipath-tools { };
 
   musl = callPackage ../os-specific/linux/musl { };
+  muslStdenv = overrideCC stdenv (gcc.override { libc = musl; });
+  muslCross = forceNativeDrv (musl.override {
+    gccCross = gccCrossStageStatic;
+    cross = assert crossSystem != null; crossSystem;
+  });
 
   nettools = callPackage ../os-specific/linux/net-tools { };
 


### PR DESCRIPTION
###### Motivation for this change

checked with readelf to make sure there isn't any leakage. (on all tested platforms)

```
0x0000000000000001 (NEEDED)             Shared library: [libc.so]
0x000000000000001d (RUNPATH)            Library runpath: [/nix/store/jxidsh8n95901m8i5yvzxxnk4azhqg2g-gcc-hello-0.0.1/lib64:/nix/store/jxidsh8n95901m8i5yvzxxnk4azhqg2g-gcc-hello-0.0.1/lib:/nix/store/wdk2l0n50qy1jy62i211b896hirfwrkb-libgcc-5.3.0/lib:/nix/store/16c974l1kqra3cr475gcgy2gsii45liq-musl-1.1.14/lib]
```

```
result/bin/hello: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /nix/store/16c974l1kqra3cr475gcgy2gsii45liq-musl-1.1.14/lib/libc.so, not stripped
```

built and tested an arm-unknown-linux-musleabi cross toolchain (depends on #15867, gcc6) 

built and tested a clang based toolchain, even the bsds still have a libgcc package. I think it should be it's own package. It's currently provided by the glibc package.

It appears I was reading outdated information, need to investigate the libgcc dependency further:
https://svnweb.freebsd.org/base?view=revision&revision=260849

``` nix
clangWrapSelf = build: callPackage ../build-support/cc-wrapper {
    cc = build;
    isClang = true;
    stdenv = clangStdenv;
    libc = musl;
    extraPackages = [ libgcc libcxx libcxxabi ];
    nativeTools = false;
    nativeLibc = false;
  };
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
