### PR TITLE
nix-serve: wrap binary with paths

### DIFF
--- a/pkgs/tools/package-management/nix-serve/default.nix
+++ b/pkgs/tools/package-management/nix-serve/default.nix
@@ -2,7 +2,6 @@
   bzip2,
   fetchFromGitHub,
   lib,
-  makeWrapper,
   nix,
   perl,
   perlPackages,
@@ -20,8 +19,6 @@ stdenv.mkDerivation rec {
     inherit rev;
     sha256 = "0mjzsiknln3isdri9004wwjjjpak5fj8ncizyncf5jv7g4m4q1pj";
   };
-
-  buildInputs = [ makeWrapper ];
 
   propagatedBuildInputs = [
     nix
@@ -41,14 +38,13 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cat > $out/bin/nix-serve <<EOF
     #! ${stdenv.shell}
+    export PATH=${nix.out}/bin:\$PATH
+    export PATH=${bzip2.out}/bin:\$PATH
+    export PERL5LIB=$PERL5LIB
     exec ${perlPackages.Starman}/bin/starman $out/libexec/nix-serve/nix-serve.psgi "\$@"
     EOF
     chmod +x $out/bin/nix-serve
-
-    wrapProgram $out/bin/nix-serve \
-      --prefix PATH : "${nix.out}/bin:${bzip2.out}/bin" \
-      --prefix PERL5LIB : $PERL5LIB
-    '';
+  '';
 
   meta = {
     homepage = https://github.com/edolstra/nix-serve;

--- a/pkgs/tools/package-management/nix-serve/default.nix
+++ b/pkgs/tools/package-management/nix-serve/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   propagatedBuildInputs = [
+    bzip2
     nix
     perl
     perlPackages.DBDSQLite
@@ -38,8 +39,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cat > $out/bin/nix-serve <<EOF
     #! ${stdenv.shell}
-    export PATH=${nix.out}/bin:\$PATH
-    export PATH=${bzip2.out}/bin:\$PATH
+    export PATH=${lib.makeBinPath [nix bzip2]}:\$PATH
     export PERL5LIB=$PERL5LIB
     exec ${perlPackages.Starman}/bin/starman $out/libexec/nix-serve/nix-serve.psgi "\$@"
     EOF


### PR DESCRIPTION
###### Motivation for this change

The `nix-serve` utility depends on binaries (e.g. `nix-store` and `bzip2`) that it doesn't wrap its binary with, and in some cases (`bzip2`) doesn't even declare as an input. This fixes that. 
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@edolstra 
