### PR TITLE
electrong: 0.36.2 to 1.2.2 bump

### DIFF
--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, lib, callPackage, fetchurl, unzip, atomEnv }:
+{ stdenv, lib, callPackage, fetchurl, unzip, atomEnv, xorg }:
 
 stdenv.mkDerivation rec {
   name = "electron-${version}";
-  version = "0.36.2";
+  version = "1.2.2";
 
   src = fetchurl {
     url = "https://github.com/atom/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
-    sha256 = "01d78j8dfrdygm1r141681b3bfz1f1xqg9vddz7j52z1mlfv9f1d";
+    sha256 = "0jqzs1297f6w7s4j9pd7wyyqbidb0c61yjz47raafslg6nljgp1c";
     name = "${name}.zip";
   };
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
     patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${atomEnv.libPath}:$out/lib/electron" \
+      --set-rpath "${atomEnv.libPath}:${xorg.libXScrnSaver}/lib:${xorg.libXScrnSaver}/lib64:$out/lib/electron" \
       $out/lib/electron/electron
   '';
 


### PR DESCRIPTION
###### Motivation for this change

electron-quick-start guide won't work with **0.36.2** so i had to bump it to **1.2.2!**

```
electron main.js
```

works now out of the box
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
