### PR TITLE
tmux: enable multiple outputs

### DIFF
--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   name = "tmux-${version}";
   version = "2.2";
 
+  outputs = [ "out" "bin" "man" ];
+
   src = fetchFromGitHub {
     owner = "tmux";
     repo = "tmux";


### PR DESCRIPTION
###### Motivation for this change

Split man pages into a separate output.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
