### PR TITLE
rofi-pass: 1.3.1 -> 1.3.2

### DIFF
--- a/pkgs/tools/security/pass/rofi-pass.nix
+++ b/pkgs/tools/security/pass/rofi-pass.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchgit
-, pass, rofi, coreutils, utillinux, xdotool, gnugrep, pwgen, findutils
+, pass, rofi, coreutils, utillinux, xdotool, gnugrep, pwgen, findutils, gawk
 , makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "rofi-pass-${version}";
-  version = "1.3.1";
+  version = "1.3.2";
 
   src = fetchgit {
     url = "https://github.com/carnager/rofi-pass";
     rev = "refs/tags/${version}";
-    sha256 = "1r206fq96avhlgkf2fzf8j2a25dav0s945qv66hwvqwhxq74frrv";
+    sha256 = "1xqp8s0yyjs2ca9mf8lbz8viwl9xzxf5kk1v68v9hqdgxj26wgls";
   };
 
   buildInputs = [ makeWrapper ];
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     rofi
     utillinux
     xdotool
+    gawk
   ];
 
   fixupPhase = ''


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: You'll need to add the `_rofi` command to your config of rofi-pass
to make this release work. Refer to config.example for an example of
how this might look like. For more information on this change, see
https://github.com/carnager/rofi-pass/commit/75cf7151588927122d696dc1daa95fee1ba43644.
