### PR TITLE
lsyncd: removed support for Darwin

### DIFF
--- a/pkgs/applications/networking/sync/lsyncd/default.nix
+++ b/pkgs/applications/networking/sync/lsyncd/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/axkibe/lsyncd;
     description = "A utility that synchronizes local directories with remote targets";
     license = licenses.gpl2;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ bobvanderlinden ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I don't have any Darwin systems to test this on, so I cannot support Darwin. Hydra is telling me this package is failing on Darwin. If anyone wants to maintain the Darwin version, let me know.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
