### PR TITLE
libxfce4ui: add libICE and libSM as propagated build inputs

### DIFF
--- a/pkgs/desktops/xfce/core/libxfce4ui.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui.nix
@@ -18,8 +18,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "dev" "out" "docdev" ];
 
+  nativeBuildInputs = [ pkgconfig intltool ];
+
   buildInputs =
-    [ pkgconfig intltool gtk libxfce4util xfconf libglade
+    [ gtk libxfce4util xfconf libglade
       libstartup_notification hicolor_icon_theme
     ] ++ optional withGtk3 gtk3;
 

--- a/pkgs/desktops/xfce/core/libxfce4ui.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk, libxfce4util, xfconf
+{ stdenv, fetchurl, pkgconfig, intltool, xorg, gtk, libxfce4util, xfconf
 , libglade, libstartup_notification, hicolor_icon_theme
 , withGtk3 ? false, gtk3
 }:
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
     [ gtk libxfce4util xfconf libglade
       libstartup_notification hicolor_icon_theme
     ] ++ optional withGtk3 gtk3;
+
+  propagatedBuildInputs = [ xorg.libICE xorg.libSM ];
 
   #TODO: glade?
   configureFlags = optional withGtk3 "--enable-gtk3";


### PR DESCRIPTION
###### Motivation for this change

The packages `xorg.libICE` and  `xorg.libSM` are runtime dependencies for `xfce.libxfce4ui` that was missing in the nix expression. Probably they had somehow been propagated from somewhere else before and now they are not. Without them Xfce does not logout.

Closes #15474
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
