### PR TITLE
idea-community, idea-ultimate: 2016.1.2 -> 2016.1.3

### DIFF
--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -188,13 +188,13 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2016.1.2";
-    build = "IC-145.971.21";
+    version = "2016.1.3";
+    build = "IC-145.1617.8";
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "15c92wsfw16j48k12x4vw78886yf9yjx7hwwjamgf28lmzvc37iz";
+      sha256 = "0yd1jqz4arywyjsiakszrr48w2xqnik6vnl1a6l0ph2hssgkzkfi";
     };
     wmClass = "jetbrains-idea-ce";
   };
@@ -227,13 +227,13 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2016.1.2";
-    build = "IU-145.971.21";
+    version = "2016.1.3";
+    build = "IU-145.1617.8";
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
-      sha256 = "0dxpx4nx845vgqxl5qz029d3w3kn3hi98wgzympidplxrphgalgy";
+      sha256 = "1zzxwdnw2bbnl86kj7fjk5p8c99d0hdn1ki2alw5xm8wp4k0w7rv";
     };
     wmClass = "jetbrains-idea";
   };


### PR DESCRIPTION
###### Motivation for this change

IntelliJ IDEA version 2016.1.2 distribution seems to be unavailable anymore. So update to the latest one.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
