### PR TITLE
lizardfs: init at 3.9.4

### DIFF
--- a/pkgs/tools/filesystems/lizardfs/check-includes.patch
+++ b/pkgs/tools/filesystems/lizardfs/check-includes.patch
@@ -1,0 +1,30 @@
+From 60f64d7077ebd2b29b18faa3b25ee593e126e347 Mon Sep 17 00:00:00 2001
+From: Dmitry Smirnov <onlyjob@member.fsf.org>
+Date: Sun, 20 Dec 2015 14:03:20 +1100
+Subject: [PATCH] build: Fix FTBFS with CMake-3.4
+
+Closes: #363
+
+~~~~
+ CMake Error at CheckIncludes.cmake:4 (check_include_files):
+   Unknown CMake command "check_include_files".
+ Call Stack (most recent call first):
+   CMakeLists.txt:113 (check_includes)
+~~~~
+
+Change-Id: I70f03d829c40ae560083a98c2bcf6344dbac3ad6
+Signed-off-by: Dmitry Smirnov <onlyjob@member.fsf.org>
+---
+ CheckIncludes.cmake | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/CheckIncludes.cmake b/CheckIncludes.cmake
+index 19ed485..f51075a 100644
+--- a/CheckIncludes.cmake
++++ b/CheckIncludes.cmake
+@@ -1,3 +1,5 @@
++include(CheckIncludeFiles)
++
+ function(check_includes INCLUDES)
+   set(INCLUDE_MISSING FALSE)
+   foreach(INCLUDE_FILE ${INCLUDES})

--- a/pkgs/tools/filesystems/lizardfs/default.nix
+++ b/pkgs/tools/filesystems/lizardfs/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, makeWrapper
+, python
+, fuse
+# The following are required for manpages
+#, asciidoc, libxml2
+, boost
+, pkgconfig
+, judy
+, pam
+, zlib # optional
+}:
+
+stdenv.mkDerivation rec {
+  name = "lizardfs-${version}";
+  version = "3.9.4";
+
+  src = fetchFromGitHub {
+    owner = "lizardfs";
+    repo = "lizardfs";
+    rev = "v.${version}";
+    sha256 = "1vg33jy280apm4lp5dn3x51pkf7035ijqjm8wbmyha2g35gfjrlx";
+  };
+
+  # Manpages don't build in the current release
+  buildInputs = [ cmake fuse /* asciidoc libxml2.bin */ zlib boost pkgconfig judy pam makeWrapper ];
+
+  # Fixed in upcoming 3.10.0
+  patches = [ ./check-includes.patch ];
+
+  postInstall = ''
+    wrapProgram $out/sbin/lizardfs-cgiserver \
+        --prefix PATH ":" "${python}/bin"
+
+    # mfssnapshot and mfscgiserv are deprecated
+    rm -f $out/bin/mfssnapshot $out/sbin/mfscgiserv
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://lizardfs.com;
+    description = "A highly reliable, scalable and efficient distributed file system";
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.rushmorem ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4672,6 +4672,8 @@ in
 
   liquibase = callPackage ../development/tools/database/liquibase { };
 
+  lizardfs = callPackage ../tools/filesystems/lizardfs { };
+
   llvm = self.llvmPackages.llvm;
 
   llvm_38 = self.llvmPackages_38.llvm;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

LizardFS is a highly reliable, scalable and efficient distributed file
system.
