### PR TITLE
makeself: header wasn't being patched correctly

### DIFF
--- a/pkgs/applications/misc/makeself/default.nix
+++ b/pkgs/applications/misc/makeself/default.nix
@@ -2,19 +2,25 @@
 
 stdenv.mkDerivation rec {
   name = "makeself-2.2.0";
+
   src = fetchgit {
     url = "https://github.com/megastep/makeself.git";
     rev = "b836b9281ae99abe1865608b065551da56c80719";
     sha256 = "f7c97f0f8ad8128f2f1b54383319f2cc44cbb05b60ced222784debdf326f23ad";
   };
+
+  patchPhase = ''
+    sed -e "s|^HEADER=.*|HEADER=$out/share/${name}/makeself-header.sh|" -i makeself.sh
+  '';
+
   installPhase = ''
     mkdir -p $out/{bin,share/{${name},man/man1}}
-    mv makeself.lsm README.md $out/share/${name}
-    mv makeself.sh $out/bin/makeself
-    mv makeself.1  $out/share/man/man1/
-    mv makeself-header.sh $out/share/${name}
-    sed -e 's|HEADER=`dirname "$0"`/makeself-header.sh|HEADER=`dirname $0`/../share/${name}/makeself-header.sh|' -i $out/bin/makeself
+    cp makeself.lsm README.md $out/share/${name}
+    cp makeself.sh $out/bin/makeself
+    cp makeself.1  $out/share/man/man1/
+    cp makeself-header.sh $out/share/${name}
   '';
+
   meta = with stdenv.lib; {
     homepage = http://megastep.org/makeself;
     description = "Utility to create self-extracting packages";


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
