### PR TITLE
crrcsim: 0.9.12 -> 0.9.13

### DIFF
--- a/pkgs/games/crrcsim/default.nix
+++ b/pkgs/games/crrcsim/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, mesa, SDL, SDL_mixer, plib, libjpeg }:
 let
-  version = "0.9.12";
+  version = "0.9.13";
 in
 stdenv.mkDerivation rec {
   name = "crrcsim-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/crrcsim/${name}.tar.gz";
-    sha256 = "1yx3cn7ilwj92v6rk3zm565ap92vmky4r39na814lfglkzn6l5id";
+    sha256 = "abe59b35ebb4322f3c48e6aca57dbf27074282d4928d66c0caa40d7a97391698";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

New features e.g. anti-aliasing.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
