### PR TITLE
cura: Fix breakage due to numpy change.

### DIFF
--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
 
   configurePhase = "";
   buildPhase = "";
+  
+  patches = [ ./numpy-cast.patch ];
 
   installPhase = ''
     # Install Python code.

--- a/pkgs/applications/misc/cura/numpy-cast.patch
+++ b/pkgs/applications/misc/cura/numpy-cast.patch
@@ -1,0 +1,12 @@
+diff -urN Cura-15.04.old/Cura/util/sliceEngine.py Cura-15.04/Cura/util/sliceEngine.py
+--- Cura-15.04.old/Cura/util/sliceEngine.py	2016-05-07 20:34:17.305020334 +0200
++++ Cura-15.04/Cura/util/sliceEngine.py	2016-05-07 20:40:02.993286467 +0200
+@@ -343,7 +343,7 @@
+ 						objMax[1] = max(oMax[1], objMax[1])
+ 			if objMin is None:
+ 				return
+-			pos += (objMin + objMax) / 2.0 * 1000
++			pos = numpy.add( pos, (objMin + objMax) / 2.0 * 1000, out=pos, casting='unsafe')
+ 			commandList += ['-s', 'posx=%d' % int(pos[0]), '-s', 'posy=%d' % int(pos[1])]
+ 
+ 			vertexTotal = [0] * 4


### PR DESCRIPTION
###### Motivation for this change

Slicing is broken
Please backport to 16.03 as well.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Upstream bug report: https://github.com/daid/Cura/issues/1461
