### PR TITLE
pycuda: init at 2016.1

### DIFF
--- a/pkgs/development/python-modules/pycuda/compyte.nix
+++ b/pkgs/development/python-modules/pycuda/compyte.nix
@@ -1,0 +1,21 @@
+{ mkDerivation 
+, fetchFromGitHub
+}:
+
+mkDerivation rec {
+  name = "compyte-${version}";
+  version = "git-20150817"; 
+
+  src = fetchFromGitHub {
+    owner = "inducer";
+    repo = "compyte";
+    rev = "ac1c71d46428c14aa1bd1c09d7da19cd0298d5cc";
+    sha256 = "1980h017qi52b7fqwm75m481xs2napgdd3fbrzkfc29k085cbign";
+  };
+
+  installPhase = '' 
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+}

--- a/pkgs/development/python-modules/pycuda/default.nix
+++ b/pkgs/development/python-modules/pycuda/default.nix
@@ -11,6 +11,7 @@
 , python
 , mkDerivation
 , stdenv
+, pythonOlder
 }:
 let
   compyte = import ./compyte.nix {
@@ -43,6 +44,8 @@ buildPythonPackage rec {
   postInstall = ''
     ln -s ${compyte} $out/${python.sitePackages}/pycuda/compyte 
   '';
+
+  doCheck = pythonOlder "3.5";
 
   propagatedBuildInputs = [
     numpy

--- a/pkgs/development/python-modules/pycuda/default.nix
+++ b/pkgs/development/python-modules/pycuda/default.nix
@@ -1,0 +1,66 @@
+{ buildPythonPackage 
+, fetchFromGitHub
+, boost
+, numpy
+, pytools
+, pytest
+, decorator
+, appdirs
+, six
+, cudatoolkit
+, python
+, mkDerivation
+, stdenv
+}:
+let
+  compyte = import ./compyte.nix {
+    inherit mkDerivation fetchFromGitHub;
+  };
+in
+buildPythonPackage rec {
+  name = "pycuda-${version}"; 
+  version = "2016.1"; 
+
+  src = fetchFromGitHub {
+    owner = "inducer"; 
+    repo = "pycuda";
+    rev = "609817e22c038249f5e9ddd720b3ca5a9d58ca11"; 
+    sha256 = "0kg6ayxsw2gja9rqspy6z8ihacf9jnxr8hzywjwmj1izkv24cff7"; 
+  }; 
+
+  preConfigure = ''
+    findInputs ${boost} boost_dirs propagated-native-build-inputs
+
+    export BOOST_INCLUDEDIR=$(echo $boost_dirs | sed -e s/\ /\\n/g - | grep '\-dev')/include
+    export BOOST_LIBRARYDIR=$(echo $boost_dirs | sed -e s/\ /\\n/g - | grep -v '\-dev')/lib
+    
+    ${python.interpreter} configure.py --boost-inc-dir=$BOOST_INCLUDEDIR \
+                            --boost-lib-dir=$BOOST_LIBRARYDIR \
+                            --no-use-shipped-boost \
+                            --boost-python-libname=boost_python
+  '';
+
+  postInstall = ''
+    ln -s ${compyte} $out/${python.sitePackages}/pycuda/compyte 
+  '';
+
+  propagatedBuildInputs = [
+    numpy
+    pytools
+    pytest
+    decorator
+    appdirs
+    six
+    cudatoolkit
+    compyte
+    python
+  ]; 
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/inducer/pycuda/;
+    description = "CUDA integration for Python.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ artuuge ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7511,6 +7511,7 @@ in modules // {
   pycuda = callPackage ../development/python-modules/pycuda rec {
     cudatoolkit = pkgs.cudatoolkit75;
     inherit (pkgs.stdenv) mkDerivation;
+    inherit pythonOlder;
   };
 
   python-axolotl = buildPythonPackage rec {
@@ -7794,6 +7795,8 @@ in modules // {
       rev = "e357a9de14d0ff5131284f369d220d8b439a7906";
       sha256 = "0g5w1cira1bl9f2ji11cbr9daj947nrfydydymjp4bbxbpl2jnaq";
     };
+
+    doCheck = pythonOlder "3.5";
 
     buildInputs = with self; [
       decorator

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7508,6 +7508,11 @@ in modules // {
     };
   };
 
+  pycuda = callPackage ../development/python-modules/pycuda rec {
+    cudatoolkit = pkgs.cudatoolkit75;
+    inherit (pkgs.stdenv) mkDerivation;
+  };
+
   python-axolotl = buildPythonPackage rec {
     name = "python-axolotl-${version}";
     version = "0.1.7";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7779,6 +7779,33 @@ in modules // {
     };
   };
 
+  pytools = buildPythonPackage rec { 
+    name = "pytools-${version}"; 
+    version = "2016.2.1"; 
+
+    src = pkgs.fetchFromGitHub {
+      owner = "inducer";
+      repo = "pytools";
+      rev = "e357a9de14d0ff5131284f369d220d8b439a7906";
+      sha256 = "0g5w1cira1bl9f2ji11cbr9daj947nrfydydymjp4bbxbpl2jnaq";
+    };
+
+    buildInputs = with self; [
+      decorator
+      appdirs
+      six
+      numpy
+    ];
+
+    meta = {
+      homepage = https://github.com/inducer/pytools/; 
+      description = "Miscellaneous Python lifesavers.";
+      license = licenses.mit;
+      maintainers = with maintainers; [ artuuge ];
+    };
+
+  };
+
   radicale = buildPythonPackage rec {
     name = "radicale-${version}";
     namePrefix = "";


### PR DESCRIPTION
###### Motivation for this change

PyCUDA lets you access Nvidia's CUDA parallel computation API from Python.  
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
