### PR TITLE
s3ql: 1.17.1 -> 1.18.1

### DIFF
--- a/pkgs/tools/backup/s3ql/default.nix
+++ b/pkgs/tools/backup/s3ql/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, fetchurl, python3Packages, sqlite  }:
+{ stdenv, fetchurl, python27Packages, sqlite  }:
 
-python3Packages.buildPythonApplication rec {
+python27Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "s3ql";
-  version = "2.17.1";
+  version = "1.18.1";
 
   src = fetchurl {
     url = "https://bitbucket.org/nikratio/${pname}/downloads/${name}.tar.bz2";
-    sha256 = "049vpvvkyia7v4v97rg2l01n43shrdxc1ik38bmjb2q4fvsh1pgx";
+    sha256 = "19bp3cz7by8025dar5d4lnqxyimsn0v10myqykhl4c818g9bi778";
   };
 
-  propagatedBuildInputs = with python3Packages;
-    [ sqlite apsw pycrypto requests2 defusedxml dugong llfuse ];
+  propagatedBuildInputs = with python27Packages;
+    [ sqlite apsw pycrypto pycryptopp requests2 defusedxml dugong llfuse ];
 
   meta = with stdenv.lib; {
     description = "A full-featured file system for online data storage";
     homepage = "https://bitbucket.org/nikratio/s3ql";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ rushmorem ];
+    maintainers = [ maintainers.rushmorem ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
