### PR TITLE
erlang: 18.3 -> 18.3.4

### DIFF
--- a/pkgs/development/interpreters/erlang/R18.nix
+++ b/pkgs/development/interpreters/erlang/R18.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, perl, gnum4, ncurses, openssl
-, gnused, gawk, makeWrapper
+{ stdenv, fetchurl, fetchFromGitHub, perl, gnum4, ncurses, openssl
+, gnused, gawk, autoconf, libxslt, libxml2, makeWrapper
 , Carbon, Cocoa
 , odbcSupport ? false, unixODBC ? null
 , wxSupport ? true, mesa ? null, wxGTK ? null, xorg ? null, wxmac ? null
@@ -20,15 +20,21 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "erlang-" + version + "${optionalString odbcSupport "-odbc"}"
   + "${optionalString javacSupport "-javac"}";
-  version = "18.2";
+  version = "18.3.4";
 
-  src = fetchurl {
-    url = "http://www.erlang.org/download/otp_src_${version}.tar.gz";
-    sha256 = "1l1zzf245w1abiylll8pjm0pppqwvvw4fihknqkcybkx62n2ipj3";
+  # Minor OTP releases are not always released as tarbals at
+  # http://erlang.org/download/ So we have to download from
+  # github. And for the same reason we can't use a prebuilt manpages
+  # tarball and need to build manpages ourselves.
+  src = fetchFromGitHub {
+    owner = "erlang";
+    repo = "otp";
+    rev = "OTP-${version}";
+    sha256 = "1f8nhybzsdmjvkmkzpjj3wj9jzx8mihlvi6gfp47fxkalansz39h";
   };
 
   buildInputs =
-    [ perl gnum4 ncurses openssl makeWrapper
+    [ perl gnum4 ncurses openssl autoconf libxslt libxml2 makeWrapper
     ] ++ optionals wxSupport (if stdenv.isDarwin then [ wxmac ] else [ mesa wxGTK xorg.libX11 ])
       ++ optional odbcSupport unixODBC
       ++ optional javacSupport openjdk
@@ -36,11 +42,23 @@ stdenv.mkDerivation rec {
 
   debugInfo = enableDebugInfo;
 
-  patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure erts/configure '';
+  rmAndPwdPatch = fetchurl {
+     url = "https://github.com/erlang/otp/commit/98b8650d22e94a5ff839170833f691294f6276d0.patch";
+     sha256 = "0cd5pkqrigiqz6cyma5irqwzn0bi17k371k9vlg8ir31h3zmqfip";
+  };
+
+  envAndCpPatch = fetchurl {
+     url = "https://github.com/binarin/otp/commit/9f9841eb7327c9fe73e84e197fd2965a97b639cf.patch";
+     sha256 = "10h5348p6g279b4q01i5jdqlljww5chcvrx5b4b0dv79pk0p0m9f";
+  };
+
+  patches = [
+    rmAndPwdPatch
+    envAndCpPatch
+  ];
 
   preConfigure = ''
-    export HOME=$PWD/../
-    sed -e s@/bin/pwd@pwd@g -i otp_build
+    ./otp_build autoconf
   '';
 
   configureFlags= [
@@ -51,19 +69,12 @@ stdenv.mkDerivation rec {
     ++ optional javacSupport "--with-javac"
     ++ optional stdenv.isDarwin "--enable-darwin-64bit";
 
-  postInstall = let
-    manpages = fetchurl {
-      url = "http://www.erlang.org/download/otp_doc_man_${version}.tar.gz";
-      sha256 = "0abaqnw6hkr1h1zw6cdqwg2k7rfmj2b9sqqldnqf3qaj0shz759n";
-    };
-  in ''
+  # install-docs will generate and install manpages and html docs
+  # (PDFs are generated only when fop is available).
+  installTargets = "install install-docs";
+
+  postInstall = ''
     ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
-    tar xf "${manpages}" -C "$out/lib/erlang"
-    for i in "$out"/lib/erlang/man/man[0-9]/*.[0-9]; do
-      prefix="''${i%/*}"
-      ensureDir "$out/share/man/''${prefix##*/}"
-      ln -s "$i" "$out/share/man/''${prefix##*/}/''${i##*/}erl"
-    done
   '';
 
   # Some erlang bin/ scripts run sed and awk


### PR DESCRIPTION
###### Motivation for this change

Minor OTP releases (and their manpages) are not available for dowload at
http://erlang.org/download
But e.g.:
- 18.3.1 contains an important fix for mnesia
- 18.3.1-18.3.4 has a lot of SSL/TLS fixes

So we have to fetch from GitHub and build everything ourselves.

Also replace explicit path patching with upstream patches:
- https://github.com/erlang/otp/pull/1023
- https://github.com/erlang/otp/pull/1103 - with this patch it's now
  possible to build erlang in sandboxed mode
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
