### PR TITLE
e2tools: init -> 0.0.16

### DIFF
--- a/pkgs/tools/filesystems/e2tools/default.nix
+++ b/pkgs/tools/filesystems/e2tools/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, pkgconfig, e2fsprogs }:
+
+stdenv.mkDerivation rec {
+  pname = "e2tools";
+  version = "0.0.16";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://home.earthlink.net/~k_sheff/sw/${pname}/${name}.tar.gz";
+    sha256 = "16wlc54abqz06dpipjdkw58bncpkxlj5f55lkzy07k3cg0bqwg2f";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ e2fsprogs ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = http://home.earthlink.net/~k_sheff/sw/e2tools/;
+    description = "Utilities to read/write/manipulate files in an ext2/ext3 filesystem";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1369,6 +1369,8 @@ in
 
   dvtm = callPackage ../tools/misc/dvtm { };
 
+  e2tools = callPackage ../tools/filesystems/e2tools { };
+
   e2fsprogs = callPackage ../tools/filesystems/e2fsprogs { };
 
   easyrsa = callPackage ../tools/networking/easyrsa { };


### PR DESCRIPTION
###### Motivation for this change

This toolset is generally useful for people working with ext2/ext3 filesystems. It also happens to be a dependency for Binary Analysis Tool which I want to get running under Nix.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
