### PR TITLE
Add new package "shfmt"

### DIFF
--- a/pkgs/tools/text/shfmt/default.nix
+++ b/pkgs/tools/text/shfmt/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "shfmt-${version}";
+  version = "2016-06-15";
+  rev = "233b276a55cdd4aaa4625893255382993bbb0533";
+
+  goPackagePath = "github.com/mvdan/sh";
+
+  src = fetchFromGitHub {
+    owner = "mvdan";
+    repo = "sh";
+    inherit rev;
+    sha256 = "09rq99gw2g6az6dmdg82nql8zp3c3mrqavqwvx76dirabzjhsbj6";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mvdan/sh;
+    description = "A shell parser and formatter";
+    longDescription = ''
+      shfmt formats shell programs. It can use tabs or any number of spaces to indent.
+      You can feed it standard input, any number of files or any number of directories to recurse into.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14102,6 +14102,8 @@ in
     gtk = gtk3;
   };
 
+  shfmt = callPackage ../tools/text/shfmt { };
+
   shutter = callPackage ../applications/graphics/shutter { };
 
   simple-scan = callPackage ../applications/graphics/simple-scan { };


### PR DESCRIPTION
###### Motivation for this change

New package of a tool for consistently formatting shell scripts
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
