### PR TITLE
eot-utilities: init -> 1.1

### DIFF
--- a/pkgs/tools/misc/eot-utilities/default.nix
+++ b/pkgs/tools/misc/eot-utilities/default.nix
@@ -1,0 +1,22 @@
+{stdenv, fetchurl, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "eot_utilities";
+  version = "1.1";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://www.w3.org/Tools/eot-utils/eot-utilities-${version}.tar.gz";
+    sha256 = "0cb41riabss23hgfg7vxhky09d6zqwjy1nxdvr3l2bh5qzd4kvaf";
+  };
+
+  buildInputs = [ pkgconfig ];
+
+  meta = {
+    homepage = "http://www.w3.org/Tools/eot-utils/";
+    description = "Create Embedded Open Type from OpenType or TrueType font";
+    license = stdenv.lib.licenses.w3c;
+    maintainers = with stdenv.lib.maintainers; [ leenaars ];
+    platforms = with stdenv.lib.platforms; linux; 
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1416,6 +1416,8 @@ in
 
   entr = callPackage ../tools/misc/entr { };
 
+  eot_utilities = callPackage ../tools/misc/eot-utilities { };
+
   eplot = callPackage ../tools/graphics/eplot { };
 
   ethtool = callPackage ../tools/misc/ethtool { };


### PR DESCRIPTION
###### Motivation for this change

A tool created by Bert Bos from W3C to work with fonts. It is a dependency for Binary Analysis Tool.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
