### PR TITLE
haskell: generic-stack-builder was missing an env var

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation (args // {
     optional stdenv.isLinux glibcLocales ++
     [ ghc pkgconfig ];
 
+  STACK_PLATFORM_VARIANT="nix";
   STACK_IN_NIX_SHELL=1;
   STACK_IN_NIX_EXTRA_ARGS =
     concatMap (pkg: ["--extra-lib-dirs=${pkg}/lib"


### PR DESCRIPTION
###### Motivation for this change

The haskell.lib.buildStackProject function (provided by `haskell-modules/generic-stack-builder`)
was not setting STACK_PLATFORM_VARIANT="nix".
This is an issue (as exposed in https://github.com/commercialhaskell/stack/issues/2258) because stack sandboxes packages, those built with its own GHC are separated from those built with GHC from Nixpkgs.
This env var is how stack distinguishes the sandboxes.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
