### PR TITLE
shiboken: add support for Python 3.5

### DIFF
--- a/pkgs/development/python-modules/pyside/shiboken.nix
+++ b/pkgs/development/python-modules/pyside/shiboken.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, cmake, libxml2, libxslt, pysideApiextractor, pysideGeneratorrunner, python, sphinx, qt4, isPy3k, isPy35 }:
 
 # Python 3.5 is not supported: https://github.com/PySide/Shiboken/issues/77
-if isPy35 then throw "shiboken not supported for interpreter ${python.executable}" else stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "${python.libPrefix}-pyside-shiboken-${version}";
   version = "1.2.4";
 
@@ -19,6 +19,7 @@ if isPy35 then throw "shiboken not supported for interpreter ${python.executable
     substituteInPlace generator/CMakeLists.txt --replace \
       \"$\{GENERATORRUNNER_PLUGIN_DIR}\" lib/generatorrunner/
   '';
+  patches = if isPy35 then [ ./shiboken_py35.patch ] else null;
 
   cmakeFlags = if isPy3k then "-DUSE_PYTHON3=TRUE" else null;
 

--- a/pkgs/development/python-modules/pyside/shiboken_py35.patch
+++ b/pkgs/development/python-modules/pyside/shiboken_py35.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/Modules/FindPython3Libs.cmake b/cmake/Modules/FindPython3Libs.cmake
+--- a/cmake/Modules/FindPython3Libs.cmake
++++ b/cmake/Modules/FindPython3Libs.cmake
+@@ -27,7 +27,7 @@ INCLUDE(CMakeFindFrameworks)
+ # Search for the python framework on Apple.
+ # CMAKE_FIND_FRAMEWORKS(Python)
+ 
+-FOREACH(_CURRENT_VERSION 3.4 3.3 3.2 3.1 3.0)
++FOREACH(_CURRENT_VERSION 3.5 3.4 3.3 3.2 3.1 3.0)
+   IF(_CURRENT_VERSION GREATER 3.1)
+       SET(_32FLAGS "m" "u" "mu" "dm" "du" "dmu" "")
+   ELSE()


### PR DESCRIPTION
###### Motivation for this change

Shiboken (and thus pyside) do not support Python 3.5 for a trivial reason (3.5 is not listed in the list of supported versions).

Upstream development is stalled as these trivial patches are not being merged:

https://github.com/PySide/Shiboken/pull/78
https://github.com/PySide/Shiboken/pull/79
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- 
  [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Development upstream is stalled, but this is a trivial patch.
