### PR TITLE
cassandra: Add 3.0

### DIFF
--- a/pkgs/servers/nosql/cassandra/3.0.nix
+++ b/pkgs/servers/nosql/cassandra/3.0.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, fetchurl
+, jre
+, python
+, makeWrapper
+, gawk
+, bash
+, getopt
+, procps
+}:
+
+let
+
+  version = "3.0.7";
+  sha256 = "0g4nf9zw3by8api9c8np0ixianmwcldcq2mpkqqirj0zlpiii68d";
+
+in
+
+stdenv.mkDerivation rec {
+  name = "cassandra-${version}";
+
+  src = fetchurl {
+    inherit sha256;
+    url = "mirror://apache/cassandra/${version}/apache-${name}-bin.tar.gz";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir $out
+    mv * $out
+
+    for cmd in cassandra nodetool sstableloader sstableupgrade
+      do wrapProgram $out/bin/$cmd \
+        --set JAVA_HOME ${jre} \
+        --prefix PATH : ${stdenv.lib.makeBinPath [ bash getopt gawk procps ]}
+    done
+
+    wrapProgram $out/bin/cqlsh --prefix PATH : ${python}/bin
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://cassandra.apache.org/;
+    description = "A massively scalable open source NoSQL database";
+    platforms = platforms.all;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nckx rushmorem ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2527,7 +2527,7 @@ in
   netatalk = callPackage ../tools/filesystems/netatalk { };
 
   netcdf = callPackage ../development/libraries/netcdf { };
- 
+
   netcdf-mpi = appendToName "mpi" (netcdf.override {
     hdf5 = hdf5-mpi;
   });
@@ -4491,7 +4491,7 @@ in
   inherit (self.haskellPackages) ghc;
 
   cabal-install = haskell.lib.disableSharedExecutables haskellPackages.cabal-install;
-   
+
   stack = haskell.lib.overrideCabal haskellPackages.stack (drv: {
     enableSharedExecutables = false;
     isLibrary = false;
@@ -7514,7 +7514,7 @@ in
   };
   libkrb5 = self.krb5Full.override { type = "lib"; };
 
-  lasso = callPackage ../development/libraries/lasso { };  
+  lasso = callPackage ../development/libraries/lasso { };
 
   LASzip = callPackage ../development/libraries/LASzip { };
 
@@ -9840,7 +9840,8 @@ in
   cassandra_1_2 = callPackage ../servers/nosql/cassandra/1.2.nix { };
   cassandra_2_0 = callPackage ../servers/nosql/cassandra/2.0.nix { };
   cassandra_2_1 = callPackage ../servers/nosql/cassandra/2.1.nix { };
-  cassandra = self.cassandra_2_1;
+  cassandra_3_0 = callPackage ../servers/nosql/cassandra/3.0.nix { };
+  cassandra = self.cassandra_3_0;
 
   apache-jena = callPackage ../servers/nosql/apache-jena/binary.nix {
     java = jdk;
@@ -10842,7 +10843,7 @@ in
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
     bcc = callPackage ../os-specific/linux/bcc { };
-    
+
     bbswitch = callPackage ../os-specific/linux/bbswitch {};
 
     ati_drivers_x11 = callPackage ../os-specific/linux/ati-drivers { };
@@ -16017,7 +16018,7 @@ in
 
   openspecfun = callPackage ../development/libraries/science/math/openspecfun {};
 
-  magma = callPackage ../development/libraries/science/math/magma { };  
+  magma = callPackage ../development/libraries/science/math/magma { };
 
   mathematica = callPackage ../applications/science/math/mathematica { };
   mathematica9 = callPackage ../applications/science/math/mathematica/9.nix { };


### PR DESCRIPTION
###### Motivation for this change

The latest Cassandra in NixOS is 2.1.
In order to communicate with 3.0 servers via the cqlsh shell, an updated package is required.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I did not test _all_ binaries, but those that I required (`cqlsh`, `nodetool`).
I added 3.0 rather than replacing 2.1 due to the incompatibilities between Cassandra versions. I did not want to leave 2.1 users locked out of their database...
