### PR TITLE
cutee: init -> 0.4.2

### DIFF
--- a/pkgs/development/libraries/cutee/default.nix
+++ b/pkgs/development/libraries/cutee/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "cutee";
+  version = "0.4.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url    = "http://www.codesink.org/download/${pname}-${version}.tar.gz";
+    sha256 = "18bzvhzx8k24mpcim5669n3wg9hd0sfsxj8zjpbr24hywrlppgc2";
+  };
+
+  buildFlags = "cutee";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp cutee $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "C++ Unit Testing Easy Environment";
+    homepage    = http://codesink.org/cutee_unit_testing.html;
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ leenaars];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6823,6 +6823,8 @@ in
 
   cryptopp = callPackage ../development/libraries/crypto++ { };
 
+  cutee = callPackage ../development/libraries/cutee { };
+
   cwiid = callPackage ../development/libraries/cwiid { };
 
   cyrus_sasl = callPackage ../development/libraries/cyrus-sasl {


### PR DESCRIPTION
###### Motivation for this change

GPLv2+ based test C++ framework used by e.g. mimetic MIME library.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
