### PR TITLE
mimetic: init -> 0.9.8

### DIFF
--- a/pkgs/development/libraries/mimetic/default.nix
+++ b/pkgs/development/libraries/mimetic/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, cutee }:
+
+stdenv.mkDerivation rec {
+  pname = "mimetic";
+  version = "0.9.8";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url    = "http://www.codesink.org/download/${pname}-${version}.tar.gz";
+    sha256 = "003715lvj4nx23arn1s9ss6hgc2yblkwfy5h94li6pjz2a6xc1rs";
+  };
+
+  buildInputs = [ cutee ];
+
+  meta = with stdenv.lib; {
+    description = "MIME handling library";
+    homepage    = http://codesink.org/mimetic_mime_library.html;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ leenaars];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2429,6 +2429,8 @@ in
 
   mimeo = callPackage ../tools/misc/mimeo { };
 
+  mimetic = callPackage ../development/libraries/mimetic { };
+
   minissdpd = callPackage ../tools/networking/minissdpd { };
 
   miniupnpc = callPackage ../tools/networking/miniupnpc { };


### PR DESCRIPTION
###### Motivation for this change

Mimetic is a MIME library used by e.g. the Trojita IMAP client. It has an extensive test suite with cutee. It is a new addition to nixpkgs.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
