### PR TITLE
linux_mptcp: update 0.90 -> 0.90.1

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  mptcpVersion = "0.90";
-  modDirVersion = "3.18.20";
+  mptcpVersion = "0.90.1";
+  modDirVersion = "3.18.25";
   version = "${modDirVersion}-mptcp_v${mptcpVersion}";
 
   extraMeta = {
@@ -12,7 +12,7 @@ import ./generic.nix (args // rec {
 
   src = fetchurl {
     url = "https://github.com/multipath-tcp/mptcp/archive/v${mptcpVersion}.tar.gz";
-    sha256 = "1wzdvd1j1wqjkysj98g451y6mxr9a5hff5kn9inxwbzm9yg4icj5";
+    sha256 = "088cpxl960xzrsz7x2lkq28ksa4gzjb1hp5yf8hxshihyhdaspwl";
   };
 
   extraConfig = ''


### PR DESCRIPTION
###### Motivation for this change

Update MPTCP-capable kernel.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
