### PR TITLE
hiera-eyaml: init at 2.1.0

### DIFF
--- a/pkgs/tools/system/hiera-eyaml/Gemfile
+++ b/pkgs/tools/system/hiera-eyaml/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'hiera-eyaml', '2.1.0'

--- a/pkgs/tools/system/hiera-eyaml/Gemfile.lock
+++ b/pkgs/tools/system/hiera-eyaml/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    hiera-eyaml (2.1.0)
+      highline (~> 1.6.19)
+      trollop (~> 2.0)
+    highline (1.6.21)
+    trollop (2.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  hiera-eyaml (= 2.1.0)
+
+BUNDLED WITH
+   1.11.2

--- a/pkgs/tools/system/hiera-eyaml/default.nix
+++ b/pkgs/tools/system/hiera-eyaml/default.nix
@@ -1,0 +1,28 @@
+{ lib, bundlerEnv, stdenv }:
+
+let
+  name = "hiera-eyaml-${env.gems.hiera-eyaml.version}";
+
+  env = bundlerEnv {
+    inherit name;
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+
+in stdenv.mkDerivation {
+  inherit name;
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    ln -s ${env}/bin/eyaml $out/bin/eyaml
+  '';
+
+  meta = with lib; {
+    description = "Per-value asymmetric encryption of sensitive data for Hiera";
+    homepage = https://github.com/TomPoulton/hiera-eyaml;
+    license = licenses.mit;
+    maintainers = [ maintainers.benley ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/system/hiera-eyaml/gemset.nix
+++ b/pkgs/tools/system/hiera-eyaml/gemset.nix
@@ -1,0 +1,26 @@
+{
+  hiera-eyaml = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1h25pfv89macjf3sjdrx7slhlq1af4zybai42ci3gj02b6hli4a6";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  highline = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06bml1fjsnrhd956wqq5k3w8cyd09rv1vixdpa3zzkl6xs72jdn1";
+      type = "gem";
+    };
+    version = "1.6.21";
+  };
+  trollop = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0415y63df86sqj43c0l82and65ia5h64if7n0znkbrmi6y0jwhl8";
+      type = "gem";
+    };
+    version = "2.1.2";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1933,6 +1933,8 @@ in
 
   hevea = callPackage ../tools/typesetting/hevea { };
 
+  hiera-eyaml = callPackage ../tools/system/hiera-eyaml { };
+
   hfsprogs = callPackage ../tools/filesystems/hfsprogs { };
 
   highlight = callPackage ../tools/text/highlight {


### PR DESCRIPTION
###### Motivation for this change

Useful as a commandline tool for developers dealing with Puppet for non-nixos platforms.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
