### PR TITLE
inline-c-cpp: fix build on darwin

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -225,6 +225,15 @@ self: super: {
         '';
       })) pkgs.libcxx;
 
+  inline-c-cpp = if !pkgs.stdenv.isDarwin
+    then super.inline-c-cpp
+    else addExtraLibrary (overrideCabal super.inline-c-cpp (drv:
+      {
+        postPatch = ''
+          substituteInPlace inline-c-cpp.cabal --replace stdc++ c++
+        '';
+      })) pkgs.libcxx;
+
   # tests don't compile for some odd reason
   jwt = dontCheck super.jwt;
 


### PR DESCRIPTION
@peti this fixes the build of `inline-c-cpp` on OS X. See: https://github.com/NixOS/nixpkgs/issues/16213.
