### PR TITLE
Python: fix the wheel package

### DIFF
--- a/pkgs/development/python-modules/generic/catch_conflicts.py
+++ b/pkgs/development/python-modules/generic/catch_conflicts.py
@@ -9,7 +9,7 @@ for f in sys.path:
     for req in pkg_resources.find_distributions(f):
         if req not in packages[req.project_name]:
             # some exceptions inside buildPythonPackage
-            if req.project_name in ['setuptools', 'pip']:
+            if req.project_name in ['setuptools', 'pip', 'wheel']:
                 continue
             packages[req.project_name].append(req)
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -23607,6 +23607,8 @@ in modules // {
 
     propagatedBuildInputs = with self; [ jsonschema ];
 
+    installFlags = [ "--ignore-installed" ];
+
     meta = {
       description = "A built-package format for Python";
       license = with licenses; [ mit ];


### PR DESCRIPTION
###### Motivation for this change

The wheel package could not be installed, now it can.
This is an alternative to #16245.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
