### PR TITLE
owncloud-client: 2.1.1 -> 2.2.1

### DIFF
--- a/pkgs/applications/networking/owncloud-client/default.nix
+++ b/pkgs/applications/networking/owncloud-client/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "owncloud-client" + "-" + version;
 
-  version = "2.1.1";
+  version = "2.2.1";
 
   src = fetchurl {
     url = "https://download.owncloud.com/desktop/stable/owncloudclient-${version}.tar.xz";
-    sha256 = "4e7cfeb72ec565392e7968f352c4a7f0ef2988cc577ebdfd668a3887d320b1cb";
+    sha256 = "1wis62jk4y4mbr25y39y6af57pi6vp2mbryazmvn6zgnygf69m3h";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)

Used: `nix-env --option build-use-sandbox true -f . -iA owncloud-client` for installing.
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

```
$ nix-shell -p nox --run "nox-review wip --against master"
Building in /run/user/1000/nox-review-323c91lv: owncloudclient
/nix/store/pzbh9yn77iw59fbdxk51y9qhxl7lrxw9-owncloud-client-2.2.1
Result in /run/user/1000/nox-review-323c91lv
total 0
lrwxrwxrwx 1 m users 65 Jun 16 19:22 result -> /nix/store/pzbh9yn77iw59fbdxk51y9qhxl7lrxw9-owncloud-client-2.2.1
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
