### PR TITLE
Enhance gnupg experience on OS X

### DIFF
--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -35,7 +35,8 @@ stdenv.mkDerivation rec {
     patch gl/stdint_.h < ${./clang.patch}
   '';
 
-  configureFlags = optional guiSupport "--with-pinentry-pgm=${pinentry}/bin/pinentry";
+  pinentryBinaryPath = pinentry.binaryPath or "bin/pinentry";
+  configureFlags = optional guiSupport "--with-pinentry-pgm=${pinentry}/${pinentryBinaryPath}";
 
   postConfigure = "substituteAllInPlace tools/gpgkey2ssh.c";
 

--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -3,13 +3,13 @@
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
-, pinentry ? null, x11Support ? true
+, pinentry ? null, guiSupport ? true
 , openldap ? null, bzip2 ? null, libusb ? null, curl ? null
 }:
 
 with stdenv.lib;
 
-assert x11Support -> pinentry != null;
+assert guiSupport -> pinentry != null;
 
 stdenv.mkDerivation rec {
   name = "gnupg-2.0.30";
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     patch gl/stdint_.h < ${./clang.patch}
   '';
 
-  configureFlags = optional x11Support "--with-pinentry-pgm=${pinentry}/bin/pinentry";
+  configureFlags = optional guiSupport "--with-pinentry-pgm=${pinentry}/bin/pinentry";
 
   postConfigure = "substituteAllInPlace tools/gpgkey2ssh.c";
 

--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -32,7 +32,8 @@ stdenv.mkDerivation rec {
     sed -i 's,"libpcsclite\.so[^"]*","${pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
   ''; #" fix Emacs syntax highlighting :-(
 
-  configureFlags = optional guiSupport "--with-pinentry-pgm=${pinentry}/bin/pinentry";
+  pinentryBinaryPath = pinentry.binaryPath or "bin/pinentry";
+  configureFlags = optional guiSupport "--with-pinentry-pgm=${pinentry}/${pinentryBinaryPath}";
 
   meta = with stdenv.lib; {
     homepage = http://gnupg.org;

--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -3,14 +3,14 @@
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
-, pinentry ? null, x11Support ? true
+, pinentry ? null, guiSupport ? true
 , adns ? null, gnutls ? null, libusb ? null, openldap ? null
 , readline ? null, zlib ? null, bzip2 ? null
 }:
 
 with stdenv.lib;
 
-assert x11Support -> pinentry != null;
+assert guiSupport -> pinentry != null;
 
 stdenv.mkDerivation rec {
   name = "gnupg-${version}";
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     sed -i 's,"libpcsclite\.so[^"]*","${pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
   ''; #" fix Emacs syntax highlighting :-(
 
-  configureFlags = optional x11Support "--with-pinentry-pgm=${pinentry}/bin/pinentry";
+  configureFlags = optional guiSupport "--with-pinentry-pgm=${pinentry}/bin/pinentry";
 
   meta = with stdenv.lib; {
     homepage = http://gnupg.org;

--- a/pkgs/tools/security/pinentry-mac/default.nix
+++ b/pkgs/tools/security/pinentry-mac/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
     mv build/Release/pinentry-mac.app $out/Applications
   '';
 
+  passthru = {
+    binaryPath = "Applications/pinentry-mac.app/Contents/MacOS/pinentry-mac";
+  };
+
   meta = {
     description = "Pinentry for GPG on Mac";
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1845,8 +1845,12 @@ in
   gnupg1orig = callPackage ../tools/security/gnupg/1.nix { };
   gnupg1compat = callPackage ../tools/security/gnupg/1compat.nix { };
   gnupg1 = gnupg1compat;    # use config.packageOverrides if you prefer original gnupg1
-  gnupg20 = callPackage ../tools/security/gnupg/20.nix { };
-  gnupg21 = callPackage ../tools/security/gnupg/21.nix { };
+  gnupg20 = callPackage ../tools/security/gnupg/20.nix {
+    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry;
+  };
+  gnupg21 = callPackage ../tools/security/gnupg/21.nix {
+    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry;
+  };
   gnupg = gnupg21;
 
   gnuplot = callPackage ../tools/graphics/gnuplot { qt = qt4; };


### PR DESCRIPTION
This set of changes, basically, has one goal: make gnupg work out of the box on OS X.
1. `pinentry_mac` is now used instead of `pinentry` by default on Darwin.
2. `gnupg` is built with the correct path to the `pinentry` binary.

I should point out that I did not test this changes on Linux but I expect them not to affect anything.
