### PR TITLE
nix-tour: init at 0.0.1 - touf of nix for offline use

### DIFF
--- a/pkgs/applications/misc/nix-tour/default.nix
+++ b/pkgs/applications/misc/nix-tour/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchgit, electron } :
+
+stdenv.mkDerivation rec {
+  name = "nix-tour";
+
+  buildInputs = [ electron ];
+
+  version = "v0.0.1";
+
+  src = fetchgit {
+    url = "https://github.com/nixcloud/tour_of_nix";
+    rev = "refs/tags/${version}";
+    sha256 = "09b1vxli4zv1nhqnj6c0vrrl51gaira94i8l7ww96fixqxjgdwvb";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share
+    cp -R * $out/share
+    chmod 0755 $out/share/ -R
+    echo "#!${stdenv.shell}" > $out/bin/nix-tour
+    echo "cd $out/share/" >> $out/bin/nix-tour
+    echo "${electron}/bin/electron $out/share/electron-main.js" >> $out/bin/nix-tour
+    chmod 0755 $out/bin/nix-tour
+  '';
+
+  meta = with stdenv.lib; {
+    description = "'the tour of nix' from nixcloud.io/tour as offline version";
+    homepage = "https://nixcloud.io/tour";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ qknight ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10018,6 +10018,8 @@ in
 
   nix-binary-cache = callPackage ../servers/http/nix-binary-cache {};
 
+  nix-tour = callPackage ../applications/misc/nix-tour {};
+
   nsd = callPackage ../servers/dns/nsd (config.nsd or {});
 
   nsq = callPackage ../servers/nsq { };


### PR DESCRIPTION
###### Motivation for this change

makes https://nixcloud.io/tour available offline!
###### Things done
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux

we assume it will also work on OS X and Linux in general but it is not tested.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
