### PR TITLE
diff-so-fancy: init at 0.9.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -23,6 +23,8 @@ rec {
 
   darcsToGit = callPackage ./darcs-to-git { };
 
+  diff-so-fancy = callPackage ./diff-so-fancy { };
+
   git = appendToName "minimal" gitBase;
 
   # The full-featured Git.

--- a/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
@@ -1,0 +1,49 @@
+{stdenv, git, perl, ncurses, coreutils, fetchFromGitHub, makeWrapper, ...}:
+
+stdenv.mkDerivation rec {
+  name = "diff-so-fancy-${version}";
+  version = "0.9.3";
+
+  # perl is needed here so patchShebangs can do its job
+  buildInputs = [perl makeWrapper];
+
+  src = fetchFromGitHub {
+    owner = "so-fancy";
+    repo = "diff-so-fancy";
+    rev = "v${version}";
+    sha256 = "0b5k54h3l4z81p6f7n14g2r5vz7qdyyrbql0z7rwhb7sw7s7zrgx";
+  };
+
+  buildPhase = null;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/diff-so-fancy
+
+    # diff-so-fancy executable searches for it's library relative to
+    # itself, so we are copying executable to lib, and only symlink it
+    # from bin/
+    cp diff-so-fancy $out/lib/diff-so-fancy
+    cp -r lib $out/lib/diff-so-fancy
+    ln -s $out/lib/diff-so-fancy/diff-so-fancy $out/bin
+
+    # ncurses is needed for `tput`
+    wrapProgram $out/lib/diff-so-fancy/diff-so-fancy \
+      --prefix PATH : "${git}/share/git/contrib/diff-highlight" \
+      --prefix PATH : "${git}/bin" \
+      --prefix PATH : "${coreutils}/bin" \
+      --prefix PATH : "${ncurses.out}/bin"
+  '';
+
+  meta = {
+    homepage = https://github.com/so-fancy/diff-so-fancy;
+    description = "Good-looking diffs filter for git";
+    license = stdenv.lib.licenses.mit;
+
+    longDescription = ''
+      diff-so-fancy builds on the good-lookin' output of git contrib's
+      diff-highlight to upgrade your diffs' appearances.
+    '';
+
+    platforms = stdenv.lib.platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add the script that was mentioned at GitHub blog -
https://github.com/blog/2188-git-2-9-has-been-released :)
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
