### PR TITLE
Krb5 fix compilation for storages with +'es in the nix storage path

### DIFF
--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl ]
     ++ optionals (!libOnly) [ openldap libedit ];
 
+  patches = [ ./path_char_fix.patch ];
+
   preConfigure = "cd ./src";
 
   buildPhase = optionalString libOnly ''

--- a/pkgs/development/libraries/kerberos/path_char_fix.patch
+++ b/pkgs/development/libraries/kerberos/path_char_fix.patch
@@ -1,0 +1,37 @@
+diff --git a/src/include/Makefile.in b/src/include/Makefile.in
+index 4bb11e4..cb4b44b 100644
+--- a/src/include/Makefile.in
++++ b/src/include/Makefile.in
+@@ -57,19 +57,19 @@ SBINDIR = @sbindir@
+ LIBDIR  = @libdir@
+ SYSCONFCONF = @SYSCONFCONF@
+ 
+-PROCESS_REPLACE = -e "s+@KRB5RCTMPDIR+$(KRB5RCTMPDIR)+" \
+-		  -e "s+@PREFIX+$(INSTALL_PREFIX)+" \
+-		  -e "s+@EXEC_PREFIX+$(INSTALL_EXEC_PREFIX)+" \
+-		  -e "s+@BINDIR+$(BINDIR)+" \
+-		  -e "s+@LIBDIR+$(LIBDIR)+" \
+-		  -e "s+@SBINDIR+$(SBINDIR)+" \
+-		  -e "s+@MODULEDIR+$(MODULE_DIR)+" \
+-		  -e "s+@GSSMODULEDIR+$(GSS_MODULE_DIR)+" \
+-		  -e 's+@LOCALSTATEDIR+$(LOCALSTATEDIR)+' \
+-		  -e 's+@RUNSTATEDIR+$(RUNSTATEDIR)+' \
+-		  -e 's+@SYSCONFDIR+$(SYSCONFDIR)+' \
+-		  -e 's+@DYNOBJEXT+$(DYNOBJEXT)+' \
+-		  -e 's+@SYSCONFCONF+$(SYSCONFCONF)+'
++PROCESS_REPLACE = -e "s\"@KRB5RCTMPDIR\"$(KRB5RCTMPDIR)\"" \
++		  -e "s\"@PREFIX\"$(INSTALL_PREFIX)\"" \
++		  -e "s\"@EXEC_PREFIX\"$(INSTALL_EXEC_PREFIX)\"" \
++		  -e "s\"@BINDIR\"$(BINDIR)\"" \
++		  -e "s\"@LIBDIR\"$(LIBDIR)\"" \
++		  -e "s\"@SBINDIR\"$(SBINDIR)\"" \
++		  -e "s\"@MODULEDIR\"$(MODULE_DIR)\"" \
++		  -e "s\"@GSSMODULEDIR\"$(GSS_MODULE_DIR)\"" \
++		  -e "s\"@LOCALSTATEDIR\"$(LOCALSTATEDIR)\"" \
++		  -e "s\"@RUNSTATEDIR\"$(RUNSTATEDIR)\"" \
++		  -e "s\"@SYSCONFDIR\"$(SYSCONFDIR)\"" \
++		  -e "s\"@DYNOBJEXT\"$(DYNOBJEXT)\"" \
++		  -e "s\"@SYSCONFCONF\"$(SYSCONFCONF)\""
+ 
+ OSCONFSRC = $(srcdir)/osconf.hin
+ 


### PR DESCRIPTION
###### Motivation for this change

'+' character in the nix storage path would break the compilation, this fixes it.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
