### PR TITLE
libinput: 1.3.1 -> 1.3.2

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -15,11 +15,11 @@ in
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "libinput-1.3.1";
+  name = "libinput-1.3.2";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/libinput/${name}.tar.xz";
-    sha256 = "1adcc82746ywwymr9b3mvr2vq539hvp1zxks6s7p2p1rjcynbzyd";
+    sha256 = "10x1jbz0kjww8ynndqxc4gkmammilwaxm1mf20ahz75mh43j6087";
   };
 
   outputs = [ "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change

[Announcement](https://lists.freedesktop.org/archives/wayland-devel/2016-June/029485.html):

> A relatively mild update, the commits mainly change a few warnings.
> Specifically: we now warn when a touchpad's events are significantly outside
> the kernel-announced range. This usually indicates that a hwdb entry is
> needed to make the touchpad work properly.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
