### PR TITLE
minify: init at v2.0.0

### DIFF
--- a/pkgs/development/go-modules/libs.json
+++ b/pkgs/development/go-modules/libs.json
@@ -1564,5 +1564,59 @@
       "rev": "7cef48da76dca6a496faa7fe63e39ed665cbd219",
       "sha256": "0hw11jj5r3f6qwydg41nc3c6aadlbkhc1qpxra2609lis0qa9h4r"
     }
+  },
+  {
+    "goPackagePath": "github.com/tdewolff/buffer",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/tdewolff/buffer",
+      "rev": "0edfcb7b750146ff879e95831de2ef53605a5cb5",
+      "sha256": "1mdd4k9byp22mw0a399j3w73zjb5g0vn58g76rjy7ajb0dzm80vl"
+    }
+  },
+  {
+    "goPackagePath": "github.com/tdewolff/parse",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/tdewolff/parse",
+      "rev": "34d5c1160d4503da4b456e5094609f2331d6dde3",
+      "sha256": "0hxf65fgkrc1q4p99p33xxxy1s6wxpn1vfsnqf9p846awwbqsy0v"
+    }
+  },
+  {
+    "goPackagePath": "github.com/tdewolff/strconv",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/tdewolff/strconv",
+      "rev": "3e8091f4417ebaaa3910da63a45ea394ebbfb0e3",
+      "sha256": "00w2mryfjhz3vaqzxvbwvyhi1vgpc1s4xfv1r9hxn8hwa078q5gp"
+    }
+  },
+  {
+    "goPackagePath": "github.com/matryer/try",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/matryer/try",
+      "rev": "93d30e50512f879b73829eb79867df38084bcd31",
+      "sha256": "0dmc8iar9685ks1ba3vnycjsx8qxwyqv51jb7677dvwnzbqhgw6f"
+    }
+  },
+  {
+    "goPackagePath": "github.com/fsnotify/fsnotify",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/fsnotify/fsnotify",
+      "rev": "30411dbcefb7a1da7e84f75530ad3abe4011b4f8",
+      "sha256": "0kbpvyi6p9942k0vmcw5z13mja47f7hq7nqd332pn2zydss6kddm"
+    }
+  },
+  {
+    "goPackagePath": "github.com/ogier/pflag",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/ogier/pflag",
+      "rev": "45c278ab3607870051a2ea9040bb85fcb8557481",
+      "sha256": "0620v75wppfd84d95n312wpngcb73cph4q3ivs1h0waljfnsrd5l"
+    }
   }
 ]

--- a/pkgs/development/web/minify/default.nix
+++ b/pkgs/development/web/minify/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "minify-${version}";
+  version = "v2.0.0";
+  rev = "41f3effd65817bac8acea89d49b3982211803a4d";
+
+  goPackagePath = "github.com/tdewolff/minify";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "tdewolff";
+    repo = "minify";
+    sha256 = "15d9ivg1a9v9c2n0a9pfw74952xhd4vqgx8d60dhvif9lx1d8wlq";
+  };
+
+  goDeps = ./deps.json;
+}

--- a/pkgs/development/web/minify/deps.json
+++ b/pkgs/development/web/minify/deps.json
@@ -1,0 +1,15 @@
+[
+    {
+        "include": "../../libs.json",
+        "packages": [
+            "github.com/tdewolff/buffer",
+            "github.com/tdewolff/parse",
+            "github.com/tdewolff/strconv",
+            "github.com/dustin/go-humanize",
+            "github.com/fsnotify/fsnotify",
+            "github.com/matryer/try",
+            "github.com/ogier/pflag",
+            "golang.org/x/sys"
+        ]
+    }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6419,6 +6419,8 @@ in
   maven = maven3;
   maven3 = callPackage ../development/tools/build-managers/apache-maven { };
 
+  minify = callPackage ../development/web/minify { };
+
   mk = callPackage ../development/tools/build-managers/mk { };
 
   msitools = callPackage ../development/tools/misc/msitools { };


### PR DESCRIPTION
###### Motivation for this change

Added [minify](https://github.com/tdewolff/minify), an HTML5, CSS3, JS, JSON, SVG and XML minifier.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
