### PR TITLE
vimPlugins: added deoplete-jedi

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -375,6 +375,17 @@ rec {
 
   };
 
+  deoplete-jedi = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "deoplete-jedi-2016-06-5";
+    src = fetchgit {
+      url = "git://github.com/zchee/deoplete-jedi";
+      rev = "36aec0d7166f9e18e05b45468e161f01909d77ec";
+      sha256 = "0h8vn7r5fkwvbxhqx6xh95iq1klz9ppbax9l3rxlfkp3w67kkj2k";
+    };
+    dependencies = [];
+
+  };
+
   Spacegray-vim = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "Spacegray-vim-2016-06-04";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -22,6 +22,7 @@
 "github:Chiel92/vim-autoformat"
 "github:LnL7/vim-nix"
 "github:Shougo/deoplete.nvim"
+"github:zchee/deoplete-jedi"
 "github:ajh17/Spacegray.vim"
 "github:alvan/vim-closetag"
 "github:ap/vim-css-color"


### PR DESCRIPTION
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)

---
