### PR TITLE
urbit: 2015.09.26 -> 2016-06-02

### DIFF
--- a/pkgs/misc/urbit/default.nix
+++ b/pkgs/misc/urbit/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchgit, gcc, gmp, libsigsegv, openssl, automake, autoconf, ragel,
+{ stdenv, fetchFromGitHub, gcc, gmp, libsigsegv, openssl, automake, autoconf, ragel,
   cmake, re2c, libtool, ncurses, perl, zlib, python }:
 
 stdenv.mkDerivation rec {
 
   name = "urbit-${version}";
-  version = "2015.09.26";
+  version = "2016-06-02";
 
-  src = fetchgit {
-    url = "https://github.com/urbit/urbit.git";
-    rev = "c9592664c797b2dd74f26886528656f8a7058640";
-    sha256 = "0sgrxnmpqh54mgar81wlb6gff8c0pc24p53xwxr448g5shvnzjx9";
+  src = fetchFromGitHub {
+    owner = "urbit";
+    repo = "urbit";
+    rev = "8c113559872e4a97bce3f3ee5b370ad9545c7459";
+    sha256 = "055qdpp4gm0v04pddq4380pdsi0gp2ybgv1d2lchkhwsnjyl46jl";
   };
 
   buildInputs = with stdenv.lib; [
@@ -34,8 +35,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "an operating function";
-    homepage = http://urbit.org/preview/~2015.9.25/materials;
+    description = "An operating function";
+    homepage = http://urbit.org;
     license = licenses.mit;
     maintainers = with maintainers; [ mudri ];
   };


### PR DESCRIPTION
###### Motivation for this change

urbit wasn't building because the source git repo changed and the relevant revision was missing
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Updated to latest revision in urbit git master, fixes build error caused by missing sources.
Updated description and website.
Fixed date/version format to ISO 8061.
