### PR TITLE
scanbd: add missing jpeg dependency

### DIFF
--- a/pkgs/tools/graphics/scanbd/default.nix
+++ b/pkgs/tools/graphics/scanbd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig
-, dbus, libconfuse, sane-backends, systemd }:
+, dbus, libconfuse, libjpeg, sane-backends, systemd }:
 
 stdenv.mkDerivation rec {
   name = "scanbd-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ dbus libconfuse sane-backends systemd ];
+  buildInputs = [ dbus libconfuse libjpeg sane-backends systemd ];
 
   configureFlags = [
     "--disable-Werror"


### PR DESCRIPTION
###### Motivation for this change

I tried to install `scanbd`, but it failed due to a missing dependency.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

_I'd like to prevent other missing dependencies, but I'm not completely sure how to test this in isolation; the link in the pull request template ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox)) does not work properly._
