### PR TITLE
libu2f-server: mark as linux only

### DIFF
--- a/pkgs/development/libraries/libu2f-server/default.nix
+++ b/pkgs/development/libraries/libu2f-server/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     homepage = https://developers.yubico.com/libu2f-server/;
     description = "A C library that implements the server-side of the U2F protocol";
     license = licenses.bsd2;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ philandstuff ];
   };
 }


### PR DESCRIPTION
The darwin build of libu2f-server has been failing for a long time, and I don't have time
or resources to determine why.
