### PR TITLE
adapta-gtk-theme: Init at 3.21.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -359,6 +359,7 @@
   spinus = "Tomasz Czyż <tomasz.czyz@gmail.com>";
   sprock = "Roger Mason <rmason@mun.ca>";
   spwhitt = "Spencer Whitt <sw@swhitt.me>";
+  SShrike = "Severen Redwood <severen@shrike.me>";
   stephenmw = "Stephen Weinberg <stephen@q5comm.com>";
   steveej = "Stefan Junker <mail@stefanjunker.de>";
   swistak35 = "Rafał Łasocha <me@swistak35.com>";

--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "adapta-gtk-theme-${version}";
+  version = "3.21.2";
+
+  meta = with stdenv.lib; {
+    description = "An adaptive GTK+ theme based on Material Design";
+    homepage = "https://github.com/tista500/Adapta";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.SShrike ];
+  };
+
+  src = fetchFromGitHub {
+    owner = "tista500";
+    repo = "Adapta";
+    rev = "c48da995abc46087c22b05d2cdb0975d10774641";
+    sha256 = "17w9nsrwqwgafswyvhc5h8ld2ggi96ix5fjv6yf1hfz3l1ln9qg7";
+  };
+
+  preferLocalBuild = true;
+  buildInputs = [ gtk-engine-murrine ];
+  nativeBuildInputs = [ autoreconfHook ];
+
+  configureFlags = "--enable-chrome --disable-unity";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -501,6 +501,8 @@ in
 
   arc-gtk-theme = callPackage ../misc/themes/arc { };
 
+  adapta-gtk-theme = callPackage ../misc/themes/adapta { };
+
   aria2 = callPackage ../tools/networking/aria2 {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

I wanted to use the Adapta GTK theme with NixOS, so I packaged it for Nix. It should build on NixOS and Linux (OS X/macOS is not applicable AFAIK).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X (N/A) 
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
