### PR TITLE
J: fix build

### DIFF
--- a/pkgs/development/interpreters/j/default.nix
+++ b/pkgs/development/interpreters/j/default.nix
@@ -10,9 +10,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ readline ];
   bits = if stdenv.is64bit then "64" else "32";
 
-  buildPhase = ''
-    set -e
+  doCheck = true;
 
+  buildPhase = ''
     sed -i bin/jconfig -e '
         s@bits=32@bits=${bits}@g;
         s@readline=0@readline=1@;
@@ -40,8 +40,11 @@ stdenv.mkDerivation rec {
         "
   '';
 
+  checkPhase = ''
+    echo 'i. 5' | j/bin/jconsole | fgrep "0 1 2 3 4"
+  '';
+
   installPhase = ''
-    ls -R
     mkdir -p "$out"
     cp -r j/bin "$out/bin"
     rm "$out/bin/profilex_template.ijs"

--- a/pkgs/development/interpreters/j/default.nix
+++ b/pkgs/development/interpreters/j/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "J programming language, an ASCII-based APL successor";
     maintainers = with maintainers; [ raskin ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     license = licenses.gpl3Plus;
     homepage = http://jsoftware.com/;
   };


### PR DESCRIPTION
###### Motivation for this change

jconsole would fail with an error "libj.so not found".

The fix is probably not portable to non-Linux, but I think this package did not work on non-Linux to begin with and I don't have the OS X machine to test & fix that.

Note that I did not upgrade to a later version of J, because there seems to be source code only available for the latest unreleased versions, the latest release is only available as binary.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
