### PR TITLE
stumpwm: Added newer version of stumpwm from its git repository (alon…

### DIFF
--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -13,7 +13,7 @@ let
     "latest" = {
       name = "0.9.9";
       rev = "refs/tags/0.9.9";
-      sha256 = "05fkng2wlmhy3kb9zhrrv9zpa16g2p91p5y0wvmwkppy04cw04ps";
+      sha256 = "0hmvbdk2yr5wrkiwn9dfzf65s4xc2qifj0sn6w2mghzp96cph79k";
       patches = [ ./fix-module-path.patch ];
     };
     "git" = {

--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -1,23 +1,41 @@
 { stdenv, pkgs, fetchgit, autoconf, sbcl, lispPackages, xdpyinfo, texinfo4
 , makeWrapper , rlwrap, gnused, gnugrep, coreutils, xprop
-, extraModulePaths ? [] }:
+, extraModulePaths ? []
+, version }:
 
 let
-  version = "0.9.9";
   contrib = (fetchgit {
     url = "https://github.com/stumpwm/stumpwm-contrib.git";
     rev = "9bebe3622b2b6c31a6bada9055ef3862fa79b86f";
     sha256 = "1ml6mjk2fsfv4sf65fdbji3q5x0qiq99g1k8w7a99gsl2i8h60gc";
   });
+  versionSpec = {
+    "latest" = {
+      name = "0.9.9";
+      rev = "refs/tags/0.9.9";
+      sha256 = "05fkng2wlmhy3kb9zhrrv9zpa16g2p91p5y0wvmwkppy04cw04ps";
+      patches = [ ./fix-module-path.patch ];
+    };
+    "git" = {
+        name = "git-20160617";
+        rev = "7d5b5eb76aa656baf5a8713f514937765f66b10a";
+	sha256 = "1b7lr9rj29qrazzx4xwr69fw6a89pnkycpy9jn81k84k0v22n1q0";
+	patches = [];
+    };
+  }.${version};
 in
 stdenv.mkDerivation rec {
-  name = "stumpwm-${version}";
+  name = "stumpwm-${versionSpec.name}";
 
   src = fetchgit {
     url = "https://github.com/stumpwm/stumpwm";
-    rev = "refs/tags/${version}";
-    sha256 = "0hmvbdk2yr5wrkiwn9dfzf65s4xc2qifj0sn6w2mghzp96cph79k";
+    rev = "${versionSpec.rev}";
+    sha256 = "${versionSpec.sha256}";
   };
+
+  # NOTE: The patch needs an update for the next release.
+  # `(stumpwm:set-module-dir "@MODULE_DIR@")' needs to be in it.
+  patches = versionSpec.patches;
 
   buildInputs = [
     texinfo4 makeWrapper autoconf
@@ -27,9 +45,6 @@ stdenv.mkDerivation rec {
     xdpyinfo
   ];
 
-  # NOTE: The patch needs an update for the next release.
-  # `(stumpwm:set-module-dir "@MODULE_DIR@")' needs to be in it.
-  patches = [ ./fix-module-path.patch ];
 
   # Stripping destroys the generated SBCL image
   dontStrip = true;

--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -19,7 +19,7 @@ let
     "git" = {
         name = "git-20160617";
         rev = "7d5b5eb76aa656baf5a8713f514937765f66b10a";
-	sha256 = "1b7lr9rj29qrazzx4xwr69fw6a89pnkycpy9jn81k84k0v22n1q0";
+	sha256 = "1jpj978r54086hypjxqxi0r3zacqpkr61dp6dbi0lykgx7m5bjfb";
 	patches = [];
     };
   }.${version};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14258,6 +14258,12 @@ in
   stp = callPackage ../applications/science/logic/stp {};
 
   stumpwm = callPackage ../applications/window-managers/stumpwm {
+    version = "latest";
+    sbcl = sbcl_1_2_5;
+    lispPackages = lispPackagesFor (wrapLisp sbcl_1_2_5);
+  };
+  stumpwm-git = callPackage ../applications/window-managers/stumpwm {
+    version = "git";
     sbcl = sbcl_1_2_5;
     lispPackages = lispPackagesFor (wrapLisp sbcl_1_2_5);
   };


### PR DESCRIPTION
###### Motivation for this change

Just wanted a newer version of stumpwm.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
