### PR TITLE
WIP: Show bash backtrace on error

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+# vim: sw=4 et
 set -e
 set -o pipefail
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -866,6 +866,21 @@ showPhaseHeader() {
     esac
 }
 
+# Evaluate the variable named $name if it exists, otherwise the
+# function named $name.
+evalPhase() {
+    local name=$1
+    local source=$NIX_BUILD_TOP/eval/$name
+
+    # source exists?
+    if [ -n "${!name}" ]; then
+        mkdir -p "$(dirname "$source")"
+        echo "${!name}" > "$source"
+        source "$source"
+    else # call the function
+        "$name"
+    fi
+}
 
 genericBuild() {
     if [ -n "$buildCommand" ]; then
@@ -896,9 +911,7 @@ genericBuild() {
         showPhaseHeader "$curPhase"
         dumpVars
 
-        # Evaluate the variable named $curPhase if it exists, otherwise the
-        # function named $curPhase.
-        eval "${!curPhase:-$curPhase}"
+        evalPhase "$curPhase"
 
         if [ "$curPhase" = unpackPhase ]; then
             cd "${sourceRoot:-.}"


### PR DESCRIPTION
###### Motivation for this change

When build fails it's not always obvious where the error occurs. This is an attempt to use bash's errtrace mechanism to show a proper backtrace on error.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
