### PR TITLE
Updated synergy to 1.7.6

### DIFF
--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -5,13 +5,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "synergy-${version}";
-  version = "1.7.5";
+  version = "1.7.6";
 
   src = fetchFromGitHub {
     owner = "symless";
     repo = "synergy";
     rev = "v${version}-stable";
-    sha256 = "02zv8m7yagx80wi7m0ckglfqjqyrj6rd1gywxzqzl6841scmf87n";
+    sha256 = "1bjksvdr74mc3xh11z4fd6qlhgklny51q5r6gqg1bhnvn9dzyrxw";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Clipboard copying from client to server doesn't work in 1.7.5.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Unsure how to do the above things on the checklist. Are all necessary?
