### PR TITLE
bazaar: 2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/applications/version-management/bazaar/add_certificates.patch
+++ b/pkgs/applications/version-management/bazaar/add_certificates.patch
@@ -1,11 +1,11 @@
-diff -ru orig/bzrlib/transport/http/_urllib2_wrappers.py bzr-2.6.0/bzrlib/transport/http/_urllib2_wrappers.py
---- orig/bzrlib/transport/http/_urllib2_wrappers.py	2013-07-27 13:50:53.000000000 +0200
-+++ bzr-2.6.0/bzrlib/transport/http/_urllib2_wrappers.py	2014-02-04 18:34:15.838622492 +0100
-@@ -86,6 +86,7 @@
-     u"/usr/local/share/certs/ca-root-nss.crt", # FreeBSD
+diff -ru orig/bzrlib/transport/http/_urllib2_wrappers.py bzr-2.7.0/bzrlib/transport/http/_urllib2_wrappers.py
+--- orig/bzr-2.7.0/bzrlib/transport/http/_urllib2_wrappers.py	2016-02-01 20:49:17.000000000 +0100
++++ bzr-2.7.0/bzrlib/transport/http/_urllib2_wrappers.py	2016-06-18 23:15:21.089511349 +0200
+@@ -95,6 +95,7 @@
+     u"/usr/local/share/certs/ca-root-nss.crt",  # FreeBSD
      # XXX: Needs checking, can't trust the interweb ;) -- vila 2012-01-25
-     u'/etc/openssl/certs/ca-certificates.crt', # Solaris
+     u'/etc/openssl/certs/ca-certificates.crt',  # Solaris
 +    u'@certPath@',
-     ]
- def default_ca_certs():
-     if sys.platform == 'win32':
+ ]
+
+

--- a/pkgs/applications/version-management/bazaar/default.nix
+++ b/pkgs/applications/version-management/bazaar/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pythonPackages }:
 
 stdenv.mkDerivation rec {
-  version = "2.6";
+  version = "2.7";
   release = ".0";
   name = "bazaar-${version}${release}";
 
   src = fetchurl {
-    url = "http://launchpad.net/bzr/${version}/${version}${release}/+download/bzr-${version}${release}.tar.gz";
-    sha256 = "1c6sj77h5f97qimjc14kr532kgc0jk3wq778xrkqi0pbh9qpk509";
+    url = "https://launchpad.net/bzr/${version}/${version}${release}/+download/bzr-${version}${release}.tar.gz";
+    sha256 = "1cysix5k3wa6y7jjck3ckq3abls4gvz570s0v0hxv805nwki4i8d";
   };
 
   buildInputs = [ pythonPackages.python pythonPackages.wrapPython ];


### PR DESCRIPTION
###### Motivation for this change

Update bazaar to the last version
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
