### PR TITLE
libc++, libc++abi, lldb: fix 3.8

### DIFF
--- a/pkgs/development/compilers/llvm/3.8/libc++/darwin.patch
+++ b/pkgs/development/compilers/llvm/3.8/libc++/darwin.patch
@@ -1,16 +1,18 @@
-diff -ru -x '*~' libcxx-3.4.2.src-orig/lib/CMakeLists.txt libcxx-3.4.2.src/lib/CMakeLists.txt
---- libcxx-3.4.2.src-orig/lib/CMakeLists.txt	2013-11-15 18:18:57.000000000 +0100
-+++ libcxx-3.4.2.src/lib/CMakeLists.txt	2014-09-24 14:04:01.000000000 +0200
-@@ -56,7 +56,7 @@
+--- libcxx-3.8.0.src.org/lib/CMakeLists.txt	2015-12-16 15:41:05.000000000 -0800
++++ libcxx-3.8.0.src/lib/CMakeLists.txt	2016-06-17 19:40:00.293394500 -0700
+@@ -94,30 +94,30 @@
+     add_definitions(-D__STRICT_ANSI__)
+     add_link_flags(
        "-compatibility_version 1"
-       "-current_version ${LIBCXX_VERSION}"
-       "-install_name /usr/lib/libc++.1.dylib"
+       "-current_version 1"
+-      "-install_name /usr/lib/libc++.1.dylib"
 -      "-Wl,-reexport_library,/usr/lib/libc++abi.dylib"
++      "-install_name ${LIBCXX_LIBCXXABI_LIB_PATH}/libc++.1.dylib"
 +      "-Wl,-reexport_library,${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib"
        "-Wl,-unexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++unexp.exp"
        "/usr/lib/libSystem.B.dylib")
    else()
-@@ -64,14 +64,14 @@
+     if ( ${CMAKE_OSX_SYSROOT} )
        list(FIND ${CMAKE_OSX_ARCHITECTURES} "armv7" OSX_HAS_ARMV7)
        if (OSX_HAS_ARMV7)
          set(OSX_RE_EXPORT_LINE
@@ -23,8 +25,15 @@ diff -ru -x '*~' libcxx-3.4.2.src-orig/lib/CMakeLists.txt libcxx-3.4.2.src/lib/C
 +          "-Wl,-reexport_library,${CMAKE_OSX_SYSROOT}${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib")
        endif()
      else()
--      set (OSX_RE_EXPORT_LINE "/usr/lib/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
-+      set (OSX_RE_EXPORT_LINE "${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
+-      set(OSX_RE_EXPORT_LINE "/usr/lib/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
++      set(OSX_RE_EXPORT_LINE "${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
      endif()
  
-     list(APPEND link_flags
+     add_link_flags(
+       "-compatibility_version 1"
+-      "-install_name /usr/lib/libc++.1.dylib"
++      "-install_name ${LIBCXX_LIBCXXABI_LIB_PATH}/libc++.1.dylib"
+       "-Wl,-unexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++unexp.exp"
+       "${OSX_RE_EXPORT_LINE}"
+       "-Wl,-force_symbols_not_weak_list,${CMAKE_CURRENT_SOURCE_DIR}/notweak.exp"
+       "-Wl,-force_symbols_weak_list,${CMAKE_CURRENT_SOURCE_DIR}/weak.exp")

--- a/pkgs/development/compilers/llvm/3.8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "0i7iyzk024krda5spfpfi8jksh83yp3bxqkal0xp76ffi11bszrm";
+  src = fetch "libcxx" "0yr3fh8vj38289b9cwk37zsy7x98dcd3kjy7xxy8mg20p48lb01n";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/3.8/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "0ambfcmr2nh88hx000xb7yjm9lsqjjz49w5mlf6dlxzmj3nslzx4";
+  src = fetch "libcxxabi" "0175rv2ynkklbg96kpw13iwhnzyrlw3r12f4h09p9v7nmxqhivn5";
 
   buildInputs = [ cmake ] ++ stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
 

--- a/pkgs/development/compilers/llvm/3.8/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.8/lldb.nix
@@ -15,12 +15,14 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "008fdbyza13ym3v0xpans4z4azw4y16hcbgrrnc4rx2mxwaw62ws";
+  src = fetch "lldb" "0dasg12gf5crrd9pbi5rd1y8vwlgqp8nxgw9g4z47w3x2i28zxp3";
 
-  patchPhase = ''
-    sed -i 's|/usr/bin/env||' \
-      scripts/Python/finish-swig-Python-LLDB.sh \
-      scripts/Python/build-swig-Python.sh
+  postUnpack = ''
+    # Hack around broken standalone builf as of 3.8
+    unpackFile ${llvm.src}
+    srcDir="$(ls -d lldb-*.src)"
+    mkdir -p "$srcDir/tools/lib/Support"
+    cp "$(ls -d llvm-*.src)/lib/Support/regex_impl.h" "$srcDir/tools/lib/Support/"
   '';
 
   buildInputs = [ cmake python which swig ncurses zlib libedit ];
@@ -33,7 +35,9 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
     "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
+    "-DLLVM_MAIN_INCLUDE_DIR=${llvm}/include"
     "-DLLDB_PATH_TO_CLANG_BUILD=${clang-unwrapped}"
+    "-DCLANG_MAIN_INCLUDE_DIR=${clang-unwrapped}/include"
     "-DPYTHON_VERSION_MAJOR=2"
     "-DPYTHON_VERSION_MINOR=7"
   ];


### PR DESCRIPTION
###### Motivation for this change

When LLVM and clang were updated to 3.8, libc++, libc++abi, and lldb were skipped, leaving them with incorrect hashes and broken builds. This gets them building again.

I don't have OSX to test on, so the tweaked darwin patch should be reviewed by someone who does.

This fix should probably be backported to all branches that contain llvm 3.8, including nixos-16.03.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
