### PR TITLE
android-platform-tools: 23.0.1 -> 24, etc.

### DIFF
--- a/pkgs/development/mobile/androidenv/addon.xml
+++ b/pkgs/development/mobile/androidenv/addon.xml
@@ -1,54 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
- * Copyright (C) 2010 The Android Open Source Project
- *
- * Licensed under the Apache License, version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
--->
+<?xml version="1.0" ?>
 <sdk:sdk-addon xmlns:sdk="http://schemas.android.com/sdk/android/addon/7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<!--Generated on 2016-07-15 21:31:36.580145 with ADRT.-->
+	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
-    <sdk:license id="android-sdk-license" type="text">To get started with the Android SDK, you must agree to the following terms and conditions.
-
-This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
+This is the Android Software Development Kit License Agreement
 
 1. Introduction
 
-1.1 The Android SDK (referred to in the License Agreement as the &quot;SDK&quot; and specifically including the Android system files, packaged APIs, and SDK library files and tools , if and when they are made available) is licensed to you subject to the terms of the License Agreement. The License Agreement forms a legally binding contract between you and Google in relation to your use of the SDK.
+1.1 The Android Software Development Kit (referred to in the License Agreement as the &quot;SDK&quot; and specifically including the Android system files, packaged APIs, and Google APIs add-ons) is licensed to you subject to the terms of the License Agreement. The License Agreement forms a legally binding contract between you and Google in relation to your use of the SDK.
 
 1.2 &quot;Android&quot; means the Android software stack for devices, as made available under the Android Open Source Project, which is located at the following URL: http://source.android.com/, as updated from time to time.
 
-1.3 &quot;Google&quot; means Google Inc., a Delaware corporation with principal place of business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, United States.
+1.3 A &quot;compatible implementation&quot; means any Android device that (i) complies with the Android Compatibility Definition document, which can be found at the Android compatibility website (http://source.android.com/compatibility) and which may be updated from time to time; and (ii) successfully passes the Android Compatibility Test Suite (CTS).
+
+1.4 &quot;Google&quot; means Google Inc., a Delaware corporation with principal place of business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, United States.
+
 
 2. Accepting the License Agreement
 
 2.1 In order to use the SDK, you must first agree to the License Agreement. You may not use the SDK if you do not accept the License Agreement.
 
-2.2 By clicking to accept and/or using the SDK, you hereby agree to the terms of the License Agreement.
+2.2 By clicking to accept, you hereby agree to the terms of the License Agreement.
 
-2.3 You may not use the SDK and may not accept the License Agreement if you are a person barred from receiving the SDK under the laws of the United States or other countries including the country in which you are resident or from which you use the SDK.
+2.3 You may not use the SDK and may not accept the License Agreement if you are a person barred from receiving the SDK under the laws of the United States or other countries, including the country in which you are resident or from which you use the SDK.
 
-2.4 If you will use the SDK internally within your company or organization you agree to be bound by the License Agreement on behalf of your employer or other entity, and you represent and warrant that you have full legal authority to bind your employer or such entity to the License Agreement. If you do not have the requisite authority, you may not accept the License Agreement or use the SDK on behalf of your employer or other entity.
+2.4 If you are agreeing to be bound by the License Agreement on behalf of your employer or other entity, you represent and warrant that you have full legal authority to bind your employer or such entity to the License Agreement. If you do not have the requisite authority, you may not accept the License Agreement or use the SDK on behalf of your employer or other entity.
+
 
 3. SDK License from Google
 
-3.1 Subject to the terms of the License Agreement, Google grants you a royalty-free, non-assignable, non-exclusive, non-sublicensable, limited, revocable license to use the SDK, personally or internally within your company or organization, solely to develop and distribute applications to run on the Android platform.
+3.1 Subject to the terms of the License Agreement, Google grants you a limited, worldwide, royalty-free, non-assignable, non-exclusive, and non-sublicensable license to use the SDK solely to develop applications for compatible implementations of Android.
 
-3.2 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
+3.2 You may not use this SDK to develop applications for other platforms (including non-compatible implementations of Android) or to develop another SDK. You are of course free to develop applications for other platforms, including non-compatible implementations of Android, provided that this SDK is not used for that purpose.
 
-3.3 You may not use the SDK for any purpose not expressly permitted by the License Agreement. Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK; or (b) load any part of the SDK onto a mobile handset or any other hardware device except a personal computer, combine any part of the SDK with other software, or distribute any software or device incorporating a part of the SDK.
+3.3 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
 
-3.4 You agree that you will not take any actions that may cause or result in the fragmentation of Android, including but not limited to distributing, participating in the creation of, or promoting in any way a software development kit derived from the SDK.
+3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement.  Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK; or (b) load any part of the SDK onto a mobile handset or any other hardware device except a personal computer, combine any part of the SDK with other software, or distribute any software or device incorporating a part of the SDK.
 
-3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement. You agree to remain a licensee in good standing in regard to such open source software licenses under all the rights granted and to refrain from any actions that may terminate, suspend, or breach such rights.
+3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement.
 
 3.6 You agree that the form and nature of the SDK that Google provides may change without prior notice to you and that future versions of the SDK may be incompatible with applications developed on previous versions of the SDK. You agree that Google may stop (permanently or temporarily) providing the SDK (or any features within the SDK) to you or to users generally at Google's sole discretion, without prior notice to you.
 
@@ -56,15 +45,16 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 3.8 You agree that you will not remove, obscure, or alter any proprietary rights notices (including copyright and trademark notices) that may be affixed to or contained within the SDK.
 
+
 4. Use of the SDK by You
 
-4.1 Google agrees that nothing in the License Agreement gives Google any right, title or interest from you (or your licensors) under the License Agreement in or to any software applications that you develop using the SDK, including any intellectual property rights that subsist in those applications.
+4.1 Google agrees that it obtains no right, title or interest from you (or your licensors) under the License Agreement in or to any software applications that you develop using the SDK, including any intellectual property rights that subsist in those applications.
 
-4.2 You agree to use the SDK and write applications only for purposes that are permitted by (a) the License Agreement, and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions (including any laws regarding the export of data or software to and from the United States or other relevant countries).
+4.2 You agree to use the SDK and write applications only for purposes that are permitted by (a) the License Agreement and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions (including any laws regarding the export of data or software to and from the United States or other relevant countries).
 
-4.3 You agree that if you use the SDK to develop applications, you will protect the privacy and legal rights of users. If users provide you with user names, passwords, or other login information or personal information, you must make the users aware that the information will be available to your application, and you must provide legally adequate privacy notice and protection for those users. If your application stores personal or sensitive information provided by users, it must do so securely. If users provide you with Google Account information, your application may only use that information to access the user's Google Account when, and for the limited purposes for which, each user has given you permission to do so.
+4.3 You agree that if you use the SDK to develop applications for general public users, you will protect the privacy and legal rights of those users. If the users provide you with user names, passwords, or other login information or personal information, you must make the users aware that the information will be available to your application, and you must provide legally adequate privacy notice and protection for those users. If your application stores personal or sensitive information provided by users, it must do so securely. If the user provides your application with Google Account information, your application may only use that information to access the user's Google Account when, and for the limited purposes for which, the user has given you permission to do so.
 
-4.4 You agree that you will not engage in any activity with the SDK, including the development or distribution of an application, that interferes with, disrupts, damages, or accesses in an unauthorized manner the servers, networks, or other properties or services of Google or any third party.
+4.4 You agree that you will not engage in any activity with the SDK, including the development or distribution of an application, that interferes with, disrupts, damages, or accesses in an unauthorized manner the servers, networks, or other properties or services of any third party including, but not limited to, Google or any mobile communications carrier.
 
 4.5 You agree that you are solely responsible for (and that Google has no responsibility to you or to any third party for) any data, content, or resources that you create, transmit or display through Android and/or applications for Android, and for the consequences of your actions (including any loss or damage which Google may suffer) by doing so.
 
@@ -78,7 +68,8 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 6.1 In order to continually innovate and improve the SDK, Google may collect certain usage statistics from the software including but not limited to a unique identifier, associated IP address, version number of the software, and information on which tools and/or services in the SDK are being used and how they are being used. Before any of this information is collected, the SDK will notify you and seek your consent. If you withhold consent, the information will not be collected.
 
-6.2 The data collected is examined in the aggregate to improve the SDK and is maintained in accordance with Google's Privacy Policy located at http://www.google.com/policies/privacy/.
+6.2 The data collected is examined in the aggregate to improve the SDK and is maintained in accordance with Google's Privacy Policy.
+
 
 7. Third Party Applications
 
@@ -86,15 +77,17 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 7.2 You should be aware the data, content, and resources presented to you through such a third party application may be protected by intellectual property rights which are owned by the providers (or by other persons or companies on their behalf). You may not modify, rent, lease, loan, sell, distribute or create derivative works based on these data, content, or resources (either in whole or in part) unless you have been specifically given permission to do so by the relevant owners.
 
-7.3 You acknowledge that your use of such third party applications, data, content, or resources may be subject to separate terms between you and the relevant third party.
+7.3 You acknowledge that your use of such third party applications, data, content, or resources may be subject to separate terms between you and the relevant third party. In that case, the License Agreement does not affect your legal relationship with these third parties.
 
-8. Using Google APIs
 
-8.1 Google APIs
+8. Using Android APIs
+
+8.1 Google Data APIs
 
 8.1.1 If you use any API to retrieve data from Google, you acknowledge that the data may be protected by intellectual property rights which are owned by Google or those parties that provide the data (or by other persons or companies on their behalf). Your use of any such API may be subject to additional Terms of Service. You may not modify, rent, lease, loan, sell, distribute or create derivative works based on this data (either in whole or in part) unless allowed by the relevant Terms of Service.
 
 8.1.2 If you use any API to retrieve a user's data from Google, you acknowledge and agree that you shall retrieve data only with the user's explicit consent and only when, and for the limited purposes for which, the user has given you permission to do so.
+
 
 9. Terminating the License Agreement
 
@@ -102,31 +95,38 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 9.2 If you want to terminate the License Agreement, you may do so by ceasing your use of the SDK and any relevant developer credentials.
 
-9.3 Google may at any time, terminate the License Agreement, with or without cause, upon notice to you.
+9.3 Google may at any time, terminate the License Agreement with you if:
+(A) you have breached any provision of the License Agreement; or
+(B) Google is required to do so by law; or
+(C) the partner with whom Google offered certain parts of SDK (such as APIs) to you has terminated its relationship with Google or ceased to offer certain parts of the SDK to you; or
+(D) Google decides to no longer provide the SDK or certain parts of the SDK to users in the country in which you are resident or from which you use the service, or the provision of the SDK or certain SDK services to you by Google is, in Google's sole discretion, no longer commercially viable.
 
-9.4 The License Agreement will automatically terminate without notice or other action when Google ceases to provide the SDK or certain parts of the SDK to users in the country in which you are resident or from which you use the service.
+9.4 When the License Agreement comes to an end, all of the legal rights, obligations and liabilities that you and Google have benefited from, been subject to (or which have accrued over time whilst the License Agreement has been in force) or which are expressed to continue indefinitely, shall be unaffected by this cessation, and the provisions of paragraph 14.7 shall continue to apply to such rights, obligations and liabilities indefinitely.
 
-9.5 When the License Agreement is terminated, the license granted to you in the License Agreement will terminate, you will immediately cease all use of the SDK, and the provisions of paragraphs 10, 11, 12 and 14 shall survive indefinitely.
 
-10. DISCLAIMERS
+10. DISCLAIMER OF WARRANTIES
 
 10.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT YOUR USE OF THE SDK IS AT YOUR SOLE RISK AND THAT THE SDK IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTY OF ANY KIND FROM GOOGLE.
 
-10.2 YOUR USE OF THE SDK AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SDK IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH USE. WITHOUT LIMITING THE FOREGOING, YOU UNDERSTAND THAT THE SDK MAY CONTAIN ERRORS, DEFECTS AND SECURITY VULNERABILITIES THAT CAN RESULT IN SIGNIFICANT DAMAGE, INCLUDING THE COMPLETE, IRRECOVERABLE LOSS OF USE OF YOUR COMPUTER SYSTEM OR OTHER DEVICE.
+10.2 YOUR USE OF THE SDK AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SDK IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH USE.
 
 10.3 GOOGLE FURTHER EXPRESSLY DISCLAIMS ALL WARRANTIES AND CONDITIONS OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+
 
 11. LIMITATION OF LIABILITY
 
 11.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT GOOGLE, ITS SUBSIDIARIES AND AFFILIATES, AND ITS LICENSORS SHALL NOT BE LIABLE TO YOU UNDER ANY THEORY OF LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES THAT MAY BE INCURRED BY YOU, INCLUDING ANY LOSS OF DATA, WHETHER OR NOT GOOGLE OR ITS REPRESENTATIVES HAVE BEEN ADVISED OF OR SHOULD HAVE BEEN AWARE OF THE POSSIBILITY OF ANY SUCH LOSSES ARISING.
 
+
 12. Indemnification
 
-12.1 To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless Google, its affiliates and their respective directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees) arising out of or accruing from (a) your use of the SDK, (b) any application you develop on the SDK that infringes any Intellectual Property Rights of any person or defames any person or violates their rights of publicity or privacy, and (c) any non-compliance by you of the License Agreement.
+12.1 To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless Google, its affiliates and their respective directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys fees) arising out of or accruing from (a) your use of the SDK, (b) any application you develop on the SDK that infringes any copyright, trademark, trade secret, trade dress, patent or other intellectual property right of any person or defames any person or violates their rights of publicity or privacy, and (c) any non-compliance by you with the License Agreement.
+
 
 13. Changes to the License Agreement
 
 13.1 Google may make changes to the License Agreement as it distributes new versions of the SDK. When these changes are made, Google will make a new version of the License Agreement available on the website where the SDK is made available.
+
 
 14. General Legal Terms
 
@@ -140,15 +140,13 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 14.5 EXPORT RESTRICTIONS. THE SDK IS SUBJECT TO UNITED STATES EXPORT LAWS AND REGULATIONS. YOU MUST COMPLY WITH ALL DOMESTIC AND INTERNATIONAL EXPORT LAWS AND REGULATIONS THAT APPLY TO THE SDK. THESE LAWS INCLUDE RESTRICTIONS ON DESTINATIONS, END USERS AND END USE.
 
-14.6 The License Agreement may not be assigned or transferred by you without the prior written approval of Google, and any attempted assignment without such approval will be void. You shall not delegate your responsibilities or obligations under the License Agreement without the prior written approval of Google.
+14.6 The rights granted in the License Agreement may not be assigned or transferred by either you or Google without the prior written approval of the other party. Neither you nor Google shall be permitted to delegate their responsibilities or obligations under the License Agreement without the prior written approval of the other party.
 
 14.7 The License Agreement, and your relationship with Google under the License Agreement, shall be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from the License Agreement. Notwithstanding this, you agree that Google shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction.
 
-June 2014.
-    </sdk:license>
 
-
-    <sdk:license id="android-sdk-preview-license" type="text">To get started with the Android SDK Preview, you must agree to the following terms and conditions.
+November 20, 2015</sdk:license>
+	<sdk:license id="android-sdk-preview-license" type="text">To get started with the Android SDK Preview, you must agree to the following terms and conditions.
 As described below, please note that this is a preview version of the Android SDK, subject to change, that you use at your own risk.  The Android SDK Preview is not a stable release, and may contain errors and defects that can result in serious damage to your computer systems, devices and data.
 
 This is the Android SDK Preview License Agreement (the &quot;License Agreement&quot;).
@@ -281,10 +279,8 @@ This is the Android SDK Preview License Agreement (the &quot;License Agreement&q
 
 14.7 The License Agreement, and your relationship with Google under the License Agreement, shall be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from the License Agreement. Notwithstanding this, you agree that Google shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction.
 
-June 2014.
-    </sdk:license>
-
-    <sdk:license id="android-googletv-license" type="text">Terms and Conditions
+June 2014.</sdk:license>
+	<sdk:license id="android-googletv-license" type="text">Terms and Conditions
 
 This is the Google TV Add-on for the Android Software Development Kit License Agreement.
 
@@ -425,924 +421,1223 @@ This is the Google TV Add-on for the Android Software Development Kit License Ag
 14.7 This License Agreement, and your relationship with Google under this License Agreement, shall be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from this License Agreement. Notwithstanding this, you agree that Google shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction.
 
 
-August 15, 2011
-    </sdk:license>
+August 15, 2011</sdk:license>
+	<sdk:license id="google-gdk-license" type="text">This is a Developer Preview of the GDK that is subject to change.
 
-    <!-- ADD-ONS ....................... -->
+Terms and Conditions
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>3</sdk:api-level>
-        <sdk:revision>03</sdk:revision>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>34908058</sdk:size>
-                <sdk:checksum type="sha1">1f92abf3a76be66ae8032257fc7620acbd2b2e3a</sdk:checksum>
-                <sdk:url>google_apis-3-r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
+This is the Glass Development Kit License Agreement.
 
-    <!-- Generated on Tue Nov 24 16:38:28 PST 2009 using donut 20842: Platform. Addon. -->
+1. Introduction
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>4</sdk:api-level>
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android + Google APIs, revision 2</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>42435735</sdk:size>
-                <sdk:checksum type="sha1">9b6e86d8568558de4d606a7debc4f6049608dbd0</sdk:checksum>
-                <sdk:url>google_apis-4_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
+1.1 The Glass Development Kit (referred to in this License Agreement as the &quot;GDK&quot; and specifically including the Android system files, packaged APIs, and GDK library files, if and when they are made available) is licensed to you subject to the terms of this License Agreement. This License Agreement forms a legally binding contract between you and Google in relation to your use of the GDK.
 
-    <!-- Generated on Thu Oct 22 10:16:34 PDT 2009 using eclair-sdk 17704: Platform. Addon. Tools. Doc. -->
+1.2 &quot;Glass&quot; means Glass devices and the Glass software stack for use on Glass devices.
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>5</sdk:api-level>
-        <sdk:revision>01</sdk:revision>
-        <sdk:description>Android + Google APIs, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>49123776</sdk:size>
-                <sdk:checksum type="sha1">46eaeb56b645ee7ffa24ede8fa17f3df70db0503</sdk:checksum>
-                <sdk:url>google_apis-5_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
 
-    <!-- Generated on Mon Nov 23 14:08:02 PST 2009 using eclair-release 20723: Platform. Addon. -->
+1.3 &quot;Android&quot; means the Android software stack for devices, as made available under the Android Open Source Project, which is located at the following URL: http://source.android.com/, as updated from time to time.
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>6</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android + Google APIs, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>53382941</sdk:size>
-                <sdk:checksum type="sha1">5ff545d96e031e09580a6cf55713015c7d4936b2</sdk:checksum>
-                <sdk:url>google_apis-6_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
+1.4 &quot;Google&quot; means Google Inc., a Delaware corporation with principal place of business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, United States.
 
-    <!-- Generated on Mon Dec 21 14:36:17 PST 2009 using eclair-release 22607: Platform. Addon. -->
+2. Accepting this License Agreement
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>7</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android + Google APIs, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>53691339</sdk:size>
-                <sdk:checksum type="sha1">2e7f91e0fe34fef7f58aeced973c6ae52361b5ac</sdk:checksum>
-                <sdk:url>google_apis-7_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
+2.1 In order to use the GDK, you must first agree to this License Agreement. You may not use the GDK if you do not accept this License Agreement.
 
-    <!-- Generated on Wed Jun 30 16:13:06 PDT 2010 using froyo-release 43546: Platform. Addon. -->
+2.2 By clicking to accept, you hereby agree to the terms of this License Agreement.
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>8</sdk:api-level>
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android + Google APIs, API 8, revision 2</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>59505020</sdk:size>
-                <sdk:checksum type="sha1">3079958e7ec87222cac1e6b27bc471b27bf2c352</sdk:checksum>
-                <sdk:url>google_apis-8_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
+2.3 You may not use the GDK and may not accept the License Agreement if you are a person barred from receiving the GDK under the laws of the United States or other countries including the country in which you are resident or from which you use the GDK.
 
-    <!-- Generated on Thu Jan 20 13:47:16 PST 2011 using gingerbread-sdk-release 93351: Addon. -->
+2.4 If you are agreeing to be bound by this License Agreement on behalf of your employer or other entity, you represent and warrant that you have full legal authority to bind your employer or such entity to this License Agreement. If you do not have the requisite authority, you may not accept the License Agreement or use the GDK on behalf of your employer or other entity.
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>9</sdk:api-level>
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android + Google APIs, API 9, revision 2</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>63401546</sdk:size>
-                <sdk:checksum type="sha1">78664645a1e9accea4430814f8694291a7f1ea5d</sdk:checksum>
-                <sdk:url>google_apis-9_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-        <sdk:obsolete/>
-    </sdk:add-on>
+3. GDK License from Google
 
-    <!-- Generated on Thu May  5 15:52:16 PDT 2011 using gingerbread 123630: Addon. -->
+3.1 Subject to the terms of this License Agreement, Google grants you a limited, worldwide, royalty-free, non-assignable and non-exclusive license to use the GDK solely to develop applications to run on the Glass platform for Glass devices.
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>10</sdk:api-level>
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android + Google APIs, API 10, revision 2</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>65781578</sdk:size>
-                <sdk:checksum type="sha1">cc0711857c881fa7534f90cf8cc09b8fe985484d</sdk:checksum>
-                <sdk:url>google_apis-10_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
+3.2 You agree that Google or third parties own all legal right, title and interest in and to the GDK, including any Intellectual Property Rights that subsist in the GDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
 
-    <!-- Generated on Thu Feb 17 08:43:44 PST 2011 using honeycomb 104254: Addon. -->
+3.3 You may not use the GDK for any purpose not expressly permitted by this License Agreement.  Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the GDK or any part of the GDK; or (b) load any part of the GDK onto a mobile handset or wearable computing device or any other hardware device except a Glass device personal computer, combine any part of the GDK with other software, or distribute any software or device incorporating a part of the GDK.
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>11</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android + Google APIs, API 11, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>83477179</sdk:size>
-                <sdk:checksum type="sha1">5eab5e81addee9f3576d456d205208314b5146a5</sdk:checksum>
-                <sdk:url>google_apis-11_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
+3.4 You agree that you will not take any actions that may cause or result in the fragmentation of Glass, including but not limited to distributing, participating in the creation of, or promoting in any way a software development kit derived from the GDK.
 
-    <!-- Generated on Wed May  4 19:44:46 PDT 2011 using honeycomb-mr1 123685: Addon. -->
+3.5 Use, reproduction and distribution of components of the GDK licensed under an open source software license are governed solely by the terms of that open source software license and not this License Agreement.
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>12</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android + Google APIs, API 12, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>86099835</sdk:size>
-                <sdk:checksum type="sha1">e9999f4fa978812174dfeceec0721c793a636e5d</sdk:checksum>
-                <sdk:url>google_apis-12_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
+3.6 You agree that the form and nature of the GDK that Google provides may change without prior notice to you and that future versions of the GDK may be incompatible with applications developed on previous versions of the GDK. You agree that Google may stop (permanently or temporarily) providing the GDK (or any features within the GDK) to you or to users generally at Google's sole discretion, without prior notice to you.
 
-    <!-- Generated on Fri Jul 15 11:51:11 PDT 2011 using honeycomb-mr2 142871: Addon. -->
+3.7 Nothing in this License Agreement gives you a right to use any of Google's trade names, trademarks, service marks, logos, domain names, or other distinctive brand features.
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:api-level>13</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android + Google APIs, API 13, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>88615525</sdk:size>
-                <sdk:checksum type="sha1">3b153edd211c27dc736c893c658418a4f9041417</sdk:checksum>
-                <sdk:url>google_apis-13_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-                <sdk:description>API for Google Maps.</sdk:description>
-            </sdk:lib>
-        </sdk:libs>
-    </sdk:add-on>
+3.8 You agree that you will not remove, obscure, or alter any proprietary rights notices (including copyright and trademark notices) that may be affixed to or contained within the GDK.
 
-    <sdk:add-on>
-        <!-- Generated at Wed Dec  7 13:47:50 2011 from git_ics-mr0 @ 229537 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:api-level>14</sdk:api-level>
-        <sdk:revision>2</sdk:revision>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.android.future.usb.accessory</sdk:name>
-            </sdk:lib>
-        </sdk:libs>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>106533714</sdk:size>
-                <sdk:checksum type="sha1">f8eb4d96ad0492b4c0db2d7e4f1a1a3836664d39</sdk:checksum>
-                <sdk:url>google_apis-14_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-    </sdk:add-on>
 
-    <sdk:add-on>
-        <!-- Generated at Tue Mar 10 10:46:23 2015 from git_ics-mr1 @ 1741834 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:api-level>15</sdk:api-level>
-        <sdk:revision>3</sdk:revision>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.android.future.usb.accessory</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.google.android.media.effects</sdk:name>
-            </sdk:lib>
-        </sdk:libs>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>106624396</sdk:size>
-                <sdk:checksum type="sha1">d0d2bf26805eb271693570a1aaec33e7dc3f45e9</sdk:checksum>
-                <sdk:url>google_apis-15_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:add-on>
+3.9 Your use of any Android system files, packaged APIs, or other components of the GDK which are part of the Android Software Development Kit is subject to the terms of the Android Software Development Kit License Agreement located at http://developer.android.com/sdk/terms.html. These terms are hereby incorporated by reference into this License Agreement.
 
-    <sdk:add-on>
-        <!-- Generated at Tue Mar 10 10:30:21 2015 from git_jb-dev @ 1747107 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:api-level>16</sdk:api-level>
-        <sdk:revision>4</sdk:revision>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.android.future.usb.accessory</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.google.android.media.effects</sdk:name>
-            </sdk:lib>
-        </sdk:libs>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>127341982</sdk:size>
-                <sdk:checksum type="sha1">ee6acf1b01020bfa8a8e24725dbc4478bee5e792</sdk:checksum>
-                <sdk:url>google_apis-16_r04.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:add-on>
+4. Use of the GDK by You
 
-    <sdk:add-on>
-        <!-- Generated at Mon Mar  9 18:24:34 2015 from git_jb-mr1.1-dev @ 1742939 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:api-level>17</sdk:api-level>
-        <sdk:revision>4</sdk:revision>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.android.future.usb.accessory</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.google.android.media.effects</sdk:name>
-            </sdk:lib>
-        </sdk:libs>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>137231243</sdk:size>
-                <sdk:checksum type="sha1">a076be0677f38df8ca5536b44dfb411a0c808c4f</sdk:checksum>
-                <sdk:url>google_apis-17_r04.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:add-on>
+4.1 Google agrees that it obtains no right, title or interest from you (or your licensors) under this License Agreement in or to any software applications that you develop using the GDK, including any intellectual property rights that subsist in those applications.
 
-    <sdk:add-on>
-        <!-- Generated at Mon Mar  9 17:39:57 2015 from git_jb-mr2-dev @ 1743067 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:api-level>18</sdk:api-level>
-        <sdk:revision>4</sdk:revision>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.android.future.usb.accessory</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.google.android.media.effects</sdk:name>
-            </sdk:lib>
-        </sdk:libs>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>143195183</sdk:size>
-                <sdk:checksum type="sha1">6109603409debdd40854d4d4a92eaf8481462c8b</sdk:checksum>
-                <sdk:url>google_apis-18_r04.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:add-on>
+4.2 You agree to use the GDK and write applications only for purposes that are permitted by (a) this License Agreement, (b) the Glass Platform Developer Policies (located at https://developers.google.com/glass/policies, and hereby incorporated into this License Agreement by reference), and (c) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions (including any laws regarding the export of data or software to and from the United States or other relevant countries).
 
-    <sdk:add-on>
-        <!-- Generated at Mon Sep 21 17:01:24 2015 from git_klp-sdk-release @ 2258983 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs (ARM System Image)</sdk:name-display>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:api-level>19</sdk:api-level>
-        <sdk:revision>16</sdk:revision>
-        <sdk:libs>
-            <sdk:lib>
-                <sdk:name>com.google.android.maps</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.android.future.usb.accessory</sdk:name>
-            </sdk:lib>
-            <sdk:lib>
-                <sdk:name>com.google.android.media.effects</sdk:name>
-            </sdk:lib>
-        </sdk:libs>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>182452246</sdk:size>
-                <sdk:checksum type="sha1">d92f2a2fe219e578633c6445397e1f675edc6a28</sdk:checksum>
-                <sdk:url>google_apis-19_r16.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:add-on>
+4.3 You agree that if you use the GDK to develop applications for general public users, you will protect the privacy and legal rights of those users. If the users provide you with user names, passwords, or other login information or personal information, you must make the users aware that the information will be available to your application, and you must provide legally adequate privacy notice and protection for those users. If your application stores personal or sensitive information provided by users, it must do so securely. If the user provides your application with Google Account information, your application may only use that information to access the user's Google Account when, and for the limited purposes for which, the user has given you permission to do so.
 
-    <sdk:add-on>
-        <!-- Generated at Tue Oct 14 22:09:52 2014 from git_lmp-release @ 1504858 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:api-level>21</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:libs/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>179499</sdk:size>
-                <sdk:checksum type="sha1">66a754efb24e9bb07cc51648426443c7586c9d4a</sdk:checksum>
-                <sdk:url>google_apis-21_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:add-on>
+4.4 You agree that you will not engage in any activity with the GDK, including the development or distribution of an application, that interferes with, disrupts, damages, or accesses in an unauthorized manner the servers, networks, or other properties or services of any third party including, but not limited to, Google.
 
-    <sdk:add-on>
-        <!-- Generated at Mon Mar  2 16:24:05 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:api-level>22</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:libs/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>179259</sdk:size>
-                <sdk:checksum type="sha1">5def0f42160cba8acff51b9c0c7e8be313de84f5</sdk:checksum>
-                <sdk:url>google_apis-22_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:add-on>
+4.5 You agree that you are solely responsible for (and that Google has no responsibility to you or to any third party for) any data, content, or resources that you create, transmit or display through Glass and/or applications for Glass, and for the consequences of your actions (including any loss or damage which Google may suffer) by doing so.
 
-    <!-- GOOGLE TV ADDONS ............. -->
+4.6 You agree that you are solely responsible for (and that Google has no responsibility to you or to any third party for) any breach of your obligations under this License Agreement, any applicable third party contract or Terms of Service, or any applicable law or regulation, and for the consequences (including any loss or damage which Google or any third party may suffer) of any such breach.
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_tv_addon</sdk:name-id>
-        <sdk:name-display>Google TV Addon</sdk:name-display>
-        <sdk:api-level>12</sdk:api-level>
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android + Google TV, API 12, preview release</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-googletv-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>78266751</sdk:size>
-                <sdk:checksum type="sha1">92128a12e7e8b0fb5bac59153d7779b717e7b840</sdk:checksum>
-                <sdk:url>google_tv-12_r02.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs/>
-    </sdk:add-on>
 
-    <sdk:add-on>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_tv_addon</sdk:name-id>
-        <sdk:name-display>Google TV Addon</sdk:name-display>
-        <sdk:api-level>13</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android + Google TV, API 13</sdk:description>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:uses-license ref="android-googletv-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>87721879</sdk:size>
-                <sdk:checksum type="sha1">b73f7c66011ac8180b44aa4e83b8d78c66ea9a09</sdk:checksum>
-                <sdk:url>google_tv-13_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:libs/>
-    </sdk:add-on>
+4.7 The GDK is in development, and your testing and feedback are an important part of the development process. By using the GDK, you acknowledge that implementation of some features are still under development and that you should not rely on the GDK, Glass devices, Glass system software, Google Mirror API, or Glass services having the full functionality of a stable release.
 
-    <sdk:add-on>
-        <!-- Generated at Fri Aug 14 15:29:54 2015 from git_mnc-dev @ 2166657 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-id>google_apis</sdk:name-id>
-        <sdk:name-display>Google APIs</sdk:name-display>
-        <sdk:description>Android + Google APIs</sdk:description>
-        <sdk:api-level>23</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:libs/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>179900</sdk:size>
-                <sdk:checksum type="sha1">04c5cc1a7c88967250ebba9561d81e24104167db</sdk:checksum>
-                <sdk:url>google_apis-23_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:add-on>
-    <!-- EXTRAS VENDOR=ANDROID ........................ -->
+5. Your Developer Credentials
 
-    <sdk:extra>
-        <!-- Generated at Tue Oct 13 17:53:10 2015 from git_mnc-supportlib-release @ 2337128 -->
-        <sdk:revision>
-            <sdk:major>23</sdk:major>
-            <sdk:minor>1</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:vendor-display>Android</sdk:vendor-display>
-        <sdk:vendor-id>android</sdk:vendor-id>
-        <sdk:name-display>Android Support Library</sdk:name-display>
-        <sdk:path>support</sdk:path>
-        <sdk:old-paths>compatibility</sdk:old-paths>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>10217600</sdk:size>
-                <sdk:checksum type="sha1">c43a56fcd1c2aa620f6178a0ef529623ed77b3c7</sdk:checksum>
-                <sdk:url>support_r23.1.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:extra>
+5.1 You agree that you are responsible for maintaining the confidentiality of any developer credentials that may be issued to you by Google or which you may choose yourself and that you will be solely responsible for all applications that are developed under your developer credentials.
 
-    <sdk:extra>
-        <!-- Generated at Thu Oct 15 13:57:59 2015 from git_mnc-supportlib-release @ 2343687 -->
-        <sdk:revision>
-            <sdk:major>24</sdk:major>
-        </sdk:revision>
-        <sdk:vendor-display>Android</sdk:vendor-display>
-        <sdk:vendor-id>android</sdk:vendor-id>
-        <sdk:name-display>Android Support Repository</sdk:name-display>
-        <sdk:description>Local Maven repository for Support Libraries</sdk:description>
-        <sdk:path>m2repository</sdk:path>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>149070460</sdk:size>
-                <sdk:checksum type="sha1">5b6d328a572172ec51dc25c3514392760e49bb81</sdk:checksum>
-                <sdk:url>android_m2repository_r24.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:extra>
+6. Privacy and Information
 
-    <!-- EXTRAS VENDOR=GOOGLE ....................... -->
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Repository</sdk:name-display>
-        <sdk:path>m2repository</sdk:path>
-        <sdk:revision>
-            <sdk:major>22</sdk:major>
-        </sdk:revision>
-        <sdk:description>Local Maven repository for Google Libraries</sdk:description>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>59491846</sdk:size>
-                <sdk:checksum type="sha1">4c114ac217f4b2f066d731ce906eeb635ee2a5b4</sdk:checksum>
-                <sdk:url>google_m2repository_r22.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-    </sdk:extra>
+6.1 In order to continually innovate and improve the GDK, Google may collect certain usage statistics from the software including but not limited to a unique identifier, associated IP address, version number of the software, and information on which tools and/or services in the GDK are being used and how they are being used. Before any of this information is collected, the GDK will notify you and seek your consent. If you withhold consent, the information will not be collected.
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Play Licensing Library</sdk:name-display>
-        <sdk:path>play_licensing</sdk:path>
-        <sdk:old-paths>market_licensing</sdk:old-paths>
-        <sdk:revision>
-            <sdk:major>2</sdk:major>
-        </sdk:revision>
-        <sdk:description>Google Play Licensing client library</sdk:description>
-        <sdk:desc-url>http://developer.android.com/guide/publishing/licensing.html</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>75109</sdk:size>
-                <sdk:checksum type="sha1">355e8dc304a92a5616db235af8ee7bd554356254</sdk:checksum>
-                <sdk:url>market_licensing-r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:extra>
+6.2 The data collected is examined in the aggregate to improve the GDK and is maintained in accordance with Google's Privacy Policy.
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Play APK Expansion Library</sdk:name-display>
-        <sdk:path>play_apk_expansion</sdk:path>
-        <sdk:old-paths>market_apk_expansion</sdk:old-paths>
-        <sdk:revision>
-            <sdk:major>3</sdk:major>
-        </sdk:revision>
-        <sdk:description>Google Play APK Expansion library</sdk:description>
-        <sdk:desc-url>http://developer.android.com/guide/market/expansion-files.html</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>110201</sdk:size>
-                <sdk:checksum type="sha1">5305399dc1a56814e86b8459ce24871916f78b8c</sdk:checksum>
-                <sdk:url>market_apk_expansion-r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:extra>
+7. Third Party Applications
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Play services for Froyo</sdk:name-display>
-        <sdk:path>google_play_services_froyo</sdk:path>
-        <sdk:revision>
-            <sdk:major>12</sdk:major>
-        </sdk:revision>
-        <sdk:description>Google Play services client library and sample code</sdk:description>
-        <sdk:desc-url>https://developers.google.com/android/google-play-services/index</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>5265389</sdk:size>
-                <sdk:checksum type="sha1">92558dbc380bba3d55d0ec181167fb05ce7c79d9</sdk:checksum>
-                <sdk:url>google_play_services_3265130_r12.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-    </sdk:extra>
+7.1 If you use the GDK to run applications developed by a third party or that access data, content or resources provided by a third party, you agree that Google is not responsible for those applications, data, content, or resources. You understand that all data, content or resources which you may access through such third party applications are the sole responsibility of the person from which they originated and that Google is not liable for any loss or damage that you may experience as a result of the use or access of any of those third party applications, data, content, or resources.
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Play services</sdk:name-display>
-        <sdk:path>google_play_services</sdk:path>
-        <sdk:revision>
-            <sdk:major>27</sdk:major>
-        </sdk:revision>
-        <sdk:description>Google Play services client library and sample code</sdk:description>
-        <sdk:desc-url>https://developers.google.com/android/google-play-services/index</sdk:desc-url>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>21163425</sdk:size>
-                <sdk:checksum type="sha1">cdb13f826ca82d3c3730cf1df9f3bf58565fd4bb</sdk:checksum>
-                <sdk:url>google_play_services_8115000_r27.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-    </sdk:extra>
+7.2 You should be aware the data, content, and resources presented to you through such a third party application may be protected by intellectual property rights which are owned by the providers (or by other persons or companies on their behalf). You may not modify, rent, lease, loan, sell, distribute or create derivative works based on these data, content, or resources (either in whole or in part) unless you have been specifically given permission to do so by the relevant owners.
 
-    <sdk:extra>
-        <!-- Generated at Wed Sep 17 13:48:28 2014 from lmp-dev @ 1437156 -->
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:desc-url>http://developer.android.com/</sdk:desc-url>
-        <sdk:path>usb_driver</sdk:path>
-        <sdk:description>USB Driver for Windows, revision 11</sdk:description>
-        <sdk:name-display>Google USB Driver</sdk:name-display>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:revision>
-            <sdk:major>11</sdk:major>
-        </sdk:revision>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:url>usb_driver_r11-windows.zip</sdk:url>
-                <sdk:checksum type="sha1">dc8a2ed2fbd7246d4caf9ab10ffe7749dc35d1cc</sdk:checksum>
-                <sdk:size>8682859</sdk:size>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-    </sdk:extra>
+7.3 You acknowledge that your use of such third party applications, data, content, or resources may be subject to separate terms between you and the relevant third party. In that case, this License Agreement does not affect your legal relationship with these third parties.
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Play Billing Library</sdk:name-display>
-        <sdk:path>play_billing</sdk:path>
-        <sdk:old-paths>market_billing</sdk:old-paths>
-        <sdk:revision>
-            <sdk:major>5</sdk:major>
-        </sdk:revision>
-        <sdk:description>Google Play Billing files and sample code</sdk:description>
-        <sdk:desc-url>http://developer.android.com/google/play/billing/index.html</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>436654</sdk:size>
-                <sdk:checksum type="sha1">bd2ac5ce7127070ac3229003eb69cfb806628ac9</sdk:checksum>
-                <sdk:url>play_billing_r05.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:extra>
+8. Using Google APIs
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google AdMob Ads SDK</sdk:name-display>
-        <sdk:path>admob_ads_sdk</sdk:path>
-        <sdk:revision>
-            <sdk:major>11</sdk:major>
-        </sdk:revision>
-        <sdk:description>AdMob Ads SDK</sdk:description>
-        <sdk:desc-url>https://developers.google.com/mobile-ads-sdk/docs/</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>704512</sdk:size>
-                <sdk:checksum type="sha1">0102859d9575baa0bf4fd5eb422af2ad0fe6cb82</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/googleadmobadssdk/googleadmobadssdkandroid-6.4.1.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-    </sdk:extra>
+8.1 Google APIs
 
-    <sdk:extra>
-        <sdk:obsolete/>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Analytics App Tracking SDK</sdk:name-display>
-        <sdk:path>analytics_sdk_v2</sdk:path>
-        <sdk:revision>
-            <sdk:major>3</sdk:major>
-        </sdk:revision>
-        <sdk:description>Analytics App Tracking SDK</sdk:description>
-        <sdk:desc-url>http://developers.google.com/analytics/devguides/collection/</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>211432</sdk:size>
-                <sdk:checksum type="sha1">dc14026bf0ce78315cb5dd00552607de0894de83</sdk:checksum>
-                <sdk:url>https://dl.google.com/gaformobileapps/GoogleAnalyticsAndroid_2.0beta5.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:extra>
+8.1.1 If you use any API to retrieve data from Google, you acknowledge that the data may be protected by intellectual property rights which are owned by Google or those parties that provide the data (or by other persons or companies on their behalf). Your use of any such API may be subject to additional Terms of Service. You may not modify, rent, lease, loan, sell, distribute or create derivative works based on this data (either in whole or in part) unless allowed by the relevant Terms of Service.
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Web Driver</sdk:name-display>
-        <sdk:path>webdriver</sdk:path>
-        <sdk:revision>
-            <sdk:major>2</sdk:major>
-        </sdk:revision>
-        <sdk:description>WebDriver</sdk:description>
-        <sdk:desc-url>http://selenium.googlecode.com</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>4055193</sdk:size>
-                <sdk:checksum type="sha1">13f3a3b2670a5fc04a7342861644be9a01b07e38</sdk:checksum>
-                <sdk:url>webdriver_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:extra>
+8.1.2 If you use any API to retrieve a user's data from Google, you acknowledge and agree that you shall retrieve data only with the user's explicit consent and only when, and for the limited purposes for which, the user has given you permission to do so.
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Google Cloud Messaging for Android Library</sdk:name-display>
-        <sdk:path>gcm</sdk:path>
-        <sdk:revision>
-            <sdk:major>3</sdk:major>
-        </sdk:revision>
-        <sdk:description>GCM library has been moved to Google Play Services (com.google.android.gms.gcm) and this standalone version is no longer supported</sdk:description>
-        <sdk:desc-url>https://developers.google.com/android/gcm/index</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>5901400</sdk:size>
-                <sdk:checksum type="sha1">ad066fd0dc7fc99d8aadac09c65a3c2519fbc7bf</sdk:checksum>
-                <sdk:url>gcm_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:obsolete/>
-    </sdk:extra>
+9. Terminating this License Agreement
 
-    <sdk:extra>
-        <sdk:vendor-id>google</sdk:vendor-id>
-        <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-        <sdk:name-display>Android Auto API Simulators</sdk:name-display>
-        <sdk:path>simulators</sdk:path>
-        <sdk:revision>
-            <sdk:major>1</sdk:major>
-        </sdk:revision>
-        <sdk:description>Android Auto API testing simulators</sdk:description>
-        <sdk:desc-url>http://developer.android.com/auto</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>2167286</sdk:size>
-                <sdk:checksum type="sha1">4fb5344e34e8faab4db18af07dace44c50db26a7</sdk:checksum>
-                <sdk:url>simulator_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:extra>
+9.1 This License Agreement will continue to apply until terminated by either you or Google as set out below.
 
-    <sdk:extra>
-      <sdk:vendor-id>google</sdk:vendor-id>
-      <sdk:vendor-display>Google Inc.</sdk:vendor-display>
-      <sdk:name-display>Android Auto Desktop Head Unit emulator</sdk:name-display>
-      <sdk:path>auto</sdk:path>
-      <sdk:revision>
-        <sdk:major>1</sdk:major>
-        <sdk:minor>0</sdk:minor>
-      </sdk:revision>
-      <sdk:description>
-        Head unit emulator for developers targeting the Android Auto platform.
-      </sdk:description>
-      <sdk:desc-url>http://developer.android.com/tools/help/desktop-head-unit.html</sdk:desc-url>
-      <sdk:archives>
-        <sdk:archive>
-          <sdk:size>1346136</sdk:size>
-          <sdk:checksum type="sha1">e054563f9efdc2f6089693566bce5b8fba2cd1c6</sdk:checksum>
-          <sdk:url>extras/auto/desktop-head-unit-linux_r01.zip</sdk:url>
-          <sdk:host-os>linux</sdk:host-os>
-        </sdk:archive>
-        <sdk:archive>
-          <sdk:size>2691813</sdk:size>
-          <sdk:checksum type="sha1">499bb4520f95e708585947c9fc72efeeb610685f</sdk:checksum>
-          <sdk:url>extras/auto/desktop-head-unit-windows_r01.zip</sdk:url>
-          <sdk:host-os>windows</sdk:host-os>
-        </sdk:archive>
-        <sdk:archive>
-          <sdk:size>2389261</sdk:size>
-          <sdk:checksum type="sha1">64510b97c3c2c6dccab7932a816a20b84d9a5dc3</sdk:checksum>
-          <sdk:url>extras/auto/desktop-head-unit-macosx_r01.zip</sdk:url>
-          <sdk:host-os>macosx</sdk:host-os>
-        </sdk:archive>
-      </sdk:archives>
-      <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:extra>
+9.2 If you want to terminate this License Agreement, you may do so by ceasing your use of the GDK and any relevant developer credentials.
+
+9.3 Google may at any time, terminate this License Agreement with you if:
+(A) you have breached any provision of this License Agreement; or
+(B) Google is required to do so by law; or
+(C) the partner with whom Google offered certain parts of GDK (such as APIs) to you has terminated its relationship with Google or ceased to offer certain parts of the GDK to you; or
+(D) Google decides to no longer provide the GDK or certain parts of the GDK to users in the country in which you are resident or from which you use the service, or the provision of the GDK or certain GDK services to you by Google is, in Google's sole discretion, no longer commercially viable.
+
+9.4 When this License Agreement comes to an end, all of the legal rights, obligations and liabilities that you and Google have benefited from, been subject to (or which have accrued over time whilst this License Agreement has been in force) or which are expressed to continue indefinitely, shall be unaffected by this cessation, and the provisions of paragraph 14.7 shall continue to apply to such rights, obligations and liabilities indefinitely.
+
+10. DISCLAIMER OF WARRANTIES
+
+10.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT YOUR USE OF THE GDK IS AT YOUR SOLE RISK AND THAT THE GDK IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTY OF ANY KIND FROM GOOGLE.
+
+10.2 YOUR USE OF THE GDK AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE GDK IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH USE.
+
+10.3 GOOGLE FURTHER EXPRESSLY DISCLAIMS ALL WARRANTIES AND CONDITIONS OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+
+11. LIMITATION OF LIABILITY
+
+11.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT GOOGLE, ITS SUBSIDIARIES AND AFFILIATES, AND ITS LICENSORS SHALL NOT BE LIABLE TO YOU UNDER ANY THEORY OF LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES THAT MAY BE INCURRED BY YOU, INCLUDING ANY LOSS OF DATA, WHETHER OR NOT GOOGLE OR ITS REPRESENTATIVES HAVE BEEN ADVISED OF OR SHOULD HAVE BEEN AWARE OF THE POSSIBILITY OF ANY SUCH LOSSES ARISING.
+
+12. Indemnification
+
+12.1 To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless Google, its affiliates and their respective directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys fees) arising out of or accruing from (a) your use of the GDK, (b) any application you develop on the GDK that infringes any copyright, trademark, trade secret, trade dress, patent or other intellectual property right of any person or defames any person or violates their rights of publicity or privacy, and (c) any non-compliance by you with this License Agreement.
+
+13. Changes to the License Agreement
+
+13.1 Google may make changes to the License Agreement as it distributes new versions of the GDK. When these changes are made, Google will make a new version of the License Agreement available on the website where the GDK is made available.
+
+14. General Legal Terms
+
+14.1 This License Agreement constitutes the whole legal agreement between you and Google and governs your use of the GDK (excluding any services which Google may provide to you under a separate written agreement), and completely replaces any prior agreements between you and Google in relation to the GDK.
+
+14.2 You agree that if Google does not exercise or enforce any legal right or remedy which is contained in this License Agreement (or which Google has the benefit of under any applicable law), this will not be taken to be a formal waiver of Google's rights and that those rights or remedies will still be available to Google.
+
+14.3 If any court of law, having the jurisdiction to decide on this matter, rules that any provision of this License Agreement is invalid, then that provision will be removed from this License Agreement without affecting the rest of this License Agreement. The remaining provisions of this License Agreement will continue to be valid and enforceable.
+
+14.4 You acknowledge and agree that each member of the group of companies of which Google is the parent shall be third party beneficiaries to this License Agreement and that such other companies shall be entitled to directly enforce, and rely upon, any provision of this License Agreement that confers a benefit on (or rights in favor of) them. Other than this, no other person or company shall be third party beneficiaries to this License Agreement.
+
+14.5 EXPORT RESTRICTIONS. THE GDK IS SUBJECT TO UNITED STATES EXPORT LAWS AND REGULATIONS. YOU MUST COMPLY WITH ALL DOMESTIC AND INTERNATIONAL EXPORT LAWS AND REGULATIONS THAT APPLY TO THE GDK. THESE LAWS INCLUDE RESTRICTIONS ON DESTINATIONS, END USERS AND END USE.
+
+14.6 The rights granted in this License Agreement may not be assigned or transferred by either you or Google without the prior written approval of the other party. Neither you nor Google shall be permitted to delegate their responsibilities or obligations under this License Agreement without the prior written approval of the other party.
+
+14.7 This License Agreement, and your relationship with Google under this License Agreement, shall be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from this License Agreement. Notwithstanding this, you agree that Google shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction.
+
+November 19, 2013</sdk:license>
+	<sdk:license id="intel-android-extra-license" type="text">Intel (R) Hardware Accelerated Execution Manager
+End-User License Agreement
+
+Copyright (c) 2012 Intel Corporation.
+All rights reserved.
+
+Redistribution. Redistribution and use in binary form, without modification, are permitted provided that the following conditions are met:
+
+1.Redistributions must reproduce the above copyright notice and the following disclaimer in the  documentation and/or other materials provided with the distribution.
+
+2.Neither the name of Intel Corporation nor the names of its suppliers may be used to endorse or promote  products derived from this software without specific prior written permission.
+
+3.No reverse engineering, de-compilation, or disassembly of this software is permitted. Limited patent license. Intel Corporation grants a world-wide, royalty-free, non-exclusive license under  patents it now or hereafter owns or controls to make, have made, use, import, offer to sell and sell (&quot;Utilize&quot;) this software, but solely to the extent that any such patent is necessary to Utilize the  software alone. The patent license shall not apply to any combinations which include this software. No  hardware per se is licensed hereunder.
+
+DISCLAIMER.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE  POSSIBILITY OF SUCH DAMAGE.</sdk:license>
+	<sdk:add-on>
+		<!--Generated from bid:12617722, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:39 2016.-->
+				<sdk:size>34908058</sdk:size>
+				<sdk:checksum type="sha1">1f92abf3a76be66ae8032257fc7620acbd2b2e3a</sdk:checksum>
+				<sdk:url>google_apis-3-r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>3</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:13752552, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:43 2016.-->
+				<sdk:size>42435735</sdk:size>
+				<sdk:checksum type="sha1">9b6e86d8568558de4d606a7debc4f6049608dbd0</sdk:checksum>
+				<sdk:url>google_apis-4_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>4</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:13245770, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:47 2016.-->
+				<sdk:size>49123776</sdk:size>
+				<sdk:checksum type="sha1">46eaeb56b645ee7ffa24ede8fa17f3df70db0503</sdk:checksum>
+				<sdk:url>google_apis-5_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>5</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:13752552, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:52 2016.-->
+				<sdk:size>53382941</sdk:size>
+				<sdk:checksum type="sha1">5ff545d96e031e09580a6cf55713015c7d4936b2</sdk:checksum>
+				<sdk:url>google_apis-6_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>6</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:14140606, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:55 2016.-->
+				<sdk:size>53691339</sdk:size>
+				<sdk:checksum type="sha1">2e7f91e0fe34fef7f58aeced973c6ae52361b5ac</sdk:checksum>
+				<sdk:url>google_apis-7_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>7</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:16286500, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:59 2016.-->
+				<sdk:size>59505020</sdk:size>
+				<sdk:checksum type="sha1">3079958e7ec87222cac1e6b27bc471b27bf2c352</sdk:checksum>
+				<sdk:url>google_apis-8_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>8</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:19092731, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:04 2016.-->
+				<sdk:size>63401546</sdk:size>
+				<sdk:checksum type="sha1">78664645a1e9accea4430814f8694291a7f1ea5d</sdk:checksum>
+				<sdk:url>google_apis-9_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>9</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:21121559, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:09 2016.-->
+				<sdk:size>65781578</sdk:size>
+				<sdk:checksum type="sha1">cc0711857c881fa7534f90cf8cc09b8fe985484d</sdk:checksum>
+				<sdk:url>google_apis-10_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>10</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:19633933, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:13 2016.-->
+				<sdk:size>83477179</sdk:size>
+				<sdk:checksum type="sha1">5eab5e81addee9f3576d456d205208314b5146a5</sdk:checksum>
+				<sdk:url>google_apis-11_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>11</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:21121559, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:18 2016.-->
+				<sdk:size>86099835</sdk:size>
+				<sdk:checksum type="sha1">e9999f4fa978812174dfeceec0721c793a636e5d</sdk:checksum>
+				<sdk:url>google_apis-12_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>12</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:22531000, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:23 2016.-->
+				<sdk:size>88615525</sdk:size>
+				<sdk:checksum type="sha1">3b153edd211c27dc736c893c658418a4f9041417</sdk:checksum>
+				<sdk:url>google_apis-13_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>13</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:26085354, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:28 2016.-->
+				<sdk:size>106533714</sdk:size>
+				<sdk:checksum type="sha1">f8eb4d96ad0492b4c0db2d7e4f1a1a3836664d39</sdk:checksum>
+				<sdk:url>google_apis-14_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>14</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:95160078, branch:perforce-->
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:33 2016.-->
+				<sdk:size>106624396</sdk:size>
+				<sdk:checksum type="sha1">d0d2bf26805eb271693570a1aaec33e7dc3f45e9</sdk:checksum>
+				<sdk:url>google_apis-15_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>15</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.google.android.media.effects</sdk:name>
+				<sdk:description>Collection of video effects</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:95160078, branch:perforce-->
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:40 2016.-->
+				<sdk:size>127341982</sdk:size>
+				<sdk:checksum type="sha1">ee6acf1b01020bfa8a8e24725dbc4478bee5e792</sdk:checksum>
+				<sdk:url>google_apis-16_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>16</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.google.android.media.effects</sdk:name>
+				<sdk:description>Collection of video effects</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:94805340, branch:perforce-->
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:46 2016.-->
+				<sdk:size>137231243</sdk:size>
+				<sdk:checksum type="sha1">a076be0677f38df8ca5536b44dfb411a0c808c4f</sdk:checksum>
+				<sdk:url>google_apis-17_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>17</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.google.android.media.effects</sdk:name>
+				<sdk:description>Collection of video effects</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:94805340, branch:perforce-->
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:40:53 2016.-->
+				<sdk:size>143195183</sdk:size>
+				<sdk:checksum type="sha1">6109603409debdd40854d4d4a92eaf8481462c8b</sdk:checksum>
+				<sdk:url>google_apis-18_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>18</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.google.android.media.effects</sdk:name>
+				<sdk:description>Collection of video effects</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:2884604, branch:git_klp-emu-release-->
+		<sdk:revision>20</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Thu May 19 11:35:33 2016.-->
+				<sdk:size>147081</sdk:size>
+				<sdk:checksum type="sha1">5b933abe830b2f25b4c0f171d45e9e0651e56311</sdk:checksum>
+				<sdk:url>google_apis-19_r20.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>19</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.google.android.media.effects</sdk:name>
+				<sdk:description>Collection of video effects</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:77907680, branch:perforce-->
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:41:02 2016.-->
+				<sdk:size>179499</sdk:size>
+				<sdk:checksum type="sha1">66a754efb24e9bb07cc51648426443c7586c9d4a</sdk:checksum>
+				<sdk:url>google_apis-21_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>21</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.google.android.media.effects</sdk:name>
+				<sdk:description>Collection of video effects</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:87569863, branch:perforce-->
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:41:05 2016.-->
+				<sdk:size>179259</sdk:size>
+				<sdk:checksum type="sha1">5def0f42160cba8acff51b9c0c7e8be313de84f5</sdk:checksum>
+				<sdk:url>google_apis-22_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>22</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.google.android.media.effects</sdk:name>
+				<sdk:description>Collection of video effects</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:100722913, branch:perforce-->
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:41:08 2016.-->
+				<sdk:size>179900</sdk:size>
+				<sdk:checksum type="sha1">04c5cc1a7c88967250ebba9561d81e24104167db</sdk:checksum>
+				<sdk:url>google_apis-23_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>23</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.google.android.media.effects</sdk:name>
+				<sdk:description>Collection of video effects</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:24379226, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:41:13 2016.-->
+				<sdk:size>78266751</sdk:size>
+				<sdk:checksum type="sha1">92128a12e7e8b0fb5bac59153d7779b717e7b840</sdk:checksum>
+				<sdk:url>google_tv-12_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-googletv-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_tv_addon</sdk:name-id>
+		<sdk:name-display>Google TV Addon</sdk:name-display>
+		<sdk:api-level>12</sdk:api-level>
+		<sdk:description></sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs/>
+	</sdk:add-on>
+	<sdk:add-on>
+		<!--Generated from bid:41196280, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:41:18 2016.-->
+				<sdk:size>87721879</sdk:size>
+				<sdk:checksum type="sha1">b73f7c66011ac8180b44aa4e83b8d78c66ea9a09</sdk:checksum>
+				<sdk:url>google_tv-13_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-googletv-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_tv_addon</sdk:name-id>
+		<sdk:name-display>Google TV Addon</sdk:name-display>
+		<sdk:api-level>13</sdk:api-level>
+		<sdk:description></sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:libs/>
+	</sdk:add-on>
+	<sdk:extra>
+		<!--Generated from bid:3063959, branch:git_nyc-dev-->
+		<sdk:revision>
+			<sdk:major>34</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 16:41:11 2016.-->
+				<sdk:size>244424374</sdk:size>
+				<sdk:checksum type="sha1">103e1f1001589986c93e04a691bcce0908b16c65</sdk:checksum>
+				<sdk:url>android_m2repository_r34.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>android</sdk:vendor-id>
+		<sdk:vendor-display>Android</sdk:vendor-display>
+		<sdk:description>Local Maven repository for Support Libraries</sdk:description>
+		<sdk:name-display>Android Support Repository</sdk:name-display>
+		<sdk:path>m2repository</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:116899064, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>23</sdk:major>
+			<sdk:minor>2</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:38:38 2016.-->
+				<sdk:size>10850402</sdk:size>
+				<sdk:checksum type="sha1">41121bbc412c2fce0be170d589d20cfa3e78e857</sdk:checksum>
+				<sdk:url>support_r23.2.1.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>android</sdk:vendor-id>
+		<sdk:vendor-display>Android</sdk:vendor-display>
+		<sdk:description></sdk:description>
+		<sdk:name-display>Android Support Library</sdk:name-display>
+		<sdk:path>support</sdk:path>
+		<sdk:old-paths>compatibility</sdk:old-paths>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:108530044, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>1</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>3</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:38:48 2016.-->
+				<sdk:size>12968916</sdk:size>
+				<sdk:checksum type="sha1">7c9ef7544cf0aea030bcc29bd8e12c04fd53e653</sdk:checksum>
+				<sdk:url>gapid_r01_linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:38:46 2016.-->
+				<sdk:size>15824058</sdk:size>
+				<sdk:checksum type="sha1">597eb271349d890566274861eba2770a84ee4c69</sdk:checksum>
+				<sdk:url>gapid_r01_osx.zip</sdk:url>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:38:47 2016.-->
+				<sdk:size>13220091</sdk:size>
+				<sdk:checksum type="sha1">82c9b3eb1b281f27f58fe55025227148b3deb12e</sdk:checksum>
+				<sdk:url>gapid_r01_windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>android</sdk:vendor-id>
+		<sdk:vendor-display>Android</sdk:vendor-display>
+		<sdk:description>Tools that support GPU debugging and profiling within an IDE.</sdk:description>
+		<sdk:name-display>GPU Debugging tools</sdk:name-display>
+		<sdk:path>gapid</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:2994895, branch:git_studio-master-dev-->
+		<sdk:revision>
+			<sdk:major>3</sdk:major>
+			<sdk:minor>1</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Jun 21 13:35:11 2016.-->
+				<sdk:size>31528127</sdk:size>
+				<sdk:checksum type="sha1">a33fe37c87b095171d647385445abe164ae03514</sdk:checksum>
+				<sdk:url>gapid_2994895_linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Jun 21 13:35:14 2016.-->
+				<sdk:size>31908588</sdk:size>
+				<sdk:checksum type="sha1">81dec931c8b0a5fe7c68accd8b3f8c731a9474f3</sdk:checksum>
+				<sdk:url>gapid_2994895_osx.zip</sdk:url>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Jun 21 13:35:13 2016.-->
+				<sdk:size>31656334</sdk:size>
+				<sdk:checksum type="sha1">ce00f4a7364d7fdd5d25d2429f04c4d50f56be1e</sdk:checksum>
+				<sdk:url>gapid_2994895_windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>android</sdk:vendor-id>
+		<sdk:vendor-display>Android</sdk:vendor-display>
+		<sdk:description>Tools that support GPU debugging and profiling within an IDE.</sdk:description>
+		<sdk:name-display>GPU Debugging tools</sdk:name-display>
+		<sdk:path>gapid_3</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:127098392, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>31</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Jul 11 10:11:05 2016.-->
+				<sdk:size>106690833</sdk:size>
+				<sdk:checksum type="sha1">20054f56e8e24c5f1aadd8cdf232d5dd54565aee</sdk:checksum>
+				<sdk:url>google_m2repository_r31.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>Local Maven repository for Support Libraries</sdk:description>
+		<sdk:name-display>Google Repository</sdk:name-display>
+		<sdk:path>m2repository</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:28113395, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>1</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:38:56 2016.-->
+				<sdk:size>75109</sdk:size>
+				<sdk:checksum type="sha1">355e8dc304a92a5616db235af8ee7bd554356254</sdk:checksum>
+				<sdk:url>market_licensing-r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display></sdk:vendor-display>
+		<sdk:description>Android Market Licensing client library</sdk:description>
+		<sdk:desc-url>http://developer.android.com/guide/publishing/licensing.html</sdk:desc-url>
+		<sdk:name-display>Google Play Licensing Library</sdk:name-display>
+		<sdk:path>market_licensing</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:42096985, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>1</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:38:59 2016.-->
+				<sdk:size>110201</sdk:size>
+				<sdk:checksum type="sha1">5305399dc1a56814e86b8459ce24871916f78b8c</sdk:checksum>
+				<sdk:url>market_apk_expansion-r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>Android Market APK Expansion library</sdk:description>
+		<sdk:desc-url>http://developer.android.com/guide/market/expansion-files.html</sdk:desc-url>
+		<sdk:name-display>Google Play APK Expansion library</sdk:name-display>
+		<sdk:path>market_apk_expansion</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:52571120, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>12</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:02 2016.-->
+				<sdk:size>5265389</sdk:size>
+				<sdk:checksum type="sha1">92558dbc380bba3d55d0ec181167fb05ce7c79d9</sdk:checksum>
+				<sdk:url>google_play_services_3265130_r12.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>Google Play services client library and sample code</sdk:description>
+		<sdk:desc-url>https://developers.google.com/android/google-play-services/index</sdk:desc-url>
+		<sdk:name-display>Google Play services for Froyo</sdk:name-display>
+		<sdk:path>google_play_services_froyo</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:125682601, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>31</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Thu Jun 23 11:29:48 2016.-->
+				<sdk:size>11746505</sdk:size>
+				<sdk:checksum type="sha1">3f1b502d0f6361c036cb332b8c15249a1168e08b</sdk:checksum>
+				<sdk:url>google_play_services_9256000_r31.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>Google Play services Javadocs and sample code</sdk:description>
+		<sdk:desc-url>https://developers.google.com/android/google-play-services/index</sdk:desc-url>
+		<sdk:name-display>Google Play services</sdk:name-display>
+		<sdk:path>google_play_services</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:75820409, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>11</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:08 2016.-->
+				<sdk:size>8682859</sdk:size>
+				<sdk:checksum type="sha1">dc8a2ed2fbd7246d4caf9ab10ffe7749dc35d1cc</sdk:checksum>
+				<sdk:url>usb_driver_r11-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>USB Driver for Windows, revision 11</sdk:description>
+		<sdk:desc-url>http://developer.android.com/</sdk:desc-url>
+		<sdk:name-display>Google USB Driver</sdk:name-display>
+		<sdk:path>usb_driver</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:53928043, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>5</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:11 2016.-->
+				<sdk:size>436654</sdk:size>
+				<sdk:checksum type="sha1">bd2ac5ce7127070ac3229003eb69cfb806628ac9</sdk:checksum>
+				<sdk:url>play_billing_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>Google Play Billing files and sample code</sdk:description>
+		<sdk:desc-url>http://developer.android.com/google/play/billing/index.html</sdk:desc-url>
+		<sdk:name-display>Google Play Billing Library</sdk:name-display>
+		<sdk:path>play_billing</sdk:path>
+		<sdk:old-paths>market_billing</sdk:old-paths>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:45484492, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>11</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:14 2016.-->
+				<sdk:size>704512</sdk:size>
+				<sdk:checksum type="sha1">0102859d9575baa0bf4fd5eb422af2ad0fe6cb82</sdk:checksum>
+				<sdk:url>GoogleAdMobAdsSdkAndroid-6.4.1.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>AdMob Ads SDK</sdk:description>
+		<sdk:desc-url>https://developers.google.com/mobile-ads-sdk/docs/</sdk:desc-url>
+		<sdk:name-display>Google AdMob Ads SDK</sdk:name-display>
+		<sdk:path>admob_ads_sdk</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:44867123, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>3</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:17 2016.-->
+				<sdk:size>211432</sdk:size>
+				<sdk:checksum type="sha1">dc14026bf0ce78315cb5dd00552607de0894de83</sdk:checksum>
+				<sdk:url>GoogleAnalyticsAndroid_2.0beta5.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>Analytics App Tracking SDK</sdk:description>
+		<sdk:desc-url>http://developers.google.com/analytics/devguides/collection/</sdk:desc-url>
+		<sdk:name-display>Google Analytics App Tracking SDK</sdk:name-display>
+		<sdk:path>analytics_sdk_v2</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:25118237, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>2</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:20 2016.-->
+				<sdk:size>4055193</sdk:size>
+				<sdk:checksum type="sha1">13f3a3b2670a5fc04a7342861644be9a01b07e38</sdk:checksum>
+				<sdk:url>webdriver_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description></sdk:description>
+		<sdk:desc-url>http://selenium.googlecode.com</sdk:desc-url>
+		<sdk:name-display>Google Web Driver</sdk:name-display>
+		<sdk:path>webdriver</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:32432700, branch:perforce-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>3</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:23 2016.-->
+				<sdk:size>5901400</sdk:size>
+				<sdk:checksum type="sha1">ad066fd0dc7fc99d8aadac09c65a3c2519fbc7bf</sdk:checksum>
+				<sdk:url>gcm_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>GCM library has been moved to Google Play Services (com.google.android.gms.gcm) and this standalone version is no longer supported</sdk:description>
+		<sdk:desc-url>https://developers.google.com/android/gcm/index</sdk:desc-url>
+		<sdk:name-display>Google Cloud Messaging for Android Library</sdk:name-display>
+		<sdk:path>gcm</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:80165500, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>1</sdk:major>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:26 2016.-->
+				<sdk:size>2167286</sdk:size>
+				<sdk:checksum type="sha1">4fb5344e34e8faab4db18af07dace44c50db26a7</sdk:checksum>
+				<sdk:url>simulator_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>Android Auto API testing simulators</sdk:description>
+		<sdk:desc-url>http://developer.android.com/auto</sdk:desc-url>
+		<sdk:name-display>Android Auto API Simulators</sdk:name-display>
+		<sdk:path>simulators</sdk:path>
+	</sdk:extra>
+	<sdk:extra>
+		<!--Generated from bid:107062527, branch:perforce-->
+		<sdk:revision>
+			<sdk:major>1</sdk:major>
+			<sdk:minor>1</sdk:minor>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:34 2016.-->
+				<sdk:size>1346009</sdk:size>
+				<sdk:checksum type="sha1">202a6e1b3009a0eb815f8c672d2d5b3717de6169</sdk:checksum>
+				<sdk:url>desktop-head-unit-linux_r01.1.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:35 2016.-->
+				<sdk:size>2375533</sdk:size>
+				<sdk:checksum type="sha1">8179cbb3914493ebc5eb65b731cba061582f2e84</sdk:checksum>
+				<sdk:url>desktop-head-unit-macosx_r01.1.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Apr  5 11:39:34 2016.-->
+				<sdk:size>2691901</sdk:size>
+				<sdk:checksum type="sha1">99c4a7172d73673552119347bc24c58b47da177b</sdk:checksum>
+				<sdk:url>desktop-head-unit-windows_r01.1.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:description>Head unit emulator for developers targeting the Android Auto platform.</sdk:description>
+		<sdk:desc-url>http://developer.android.com/tools/help/desktop-head-unit.html</sdk:desc-url>
+		<sdk:name-display>Android Auto Desktop Head Unit emulator</sdk:name-display>
+		<sdk:path>auto</sdk:path>
+	</sdk:extra>
 </sdk:sdk-addon>

--- a/pkgs/development/mobile/androidenv/addons.nix
+++ b/pkgs/development/mobile/androidenv/addons.nix
@@ -35,7 +35,7 @@ in
         sha1 = "9b6e86d8568558de4d606a7debc4f6049608dbd0";
       };
       meta = {
-        description = "Android + Google APIs, revision 2";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -47,7 +47,7 @@ in
         sha1 = "46eaeb56b645ee7ffa24ede8fa17f3df70db0503";
       };
       meta = {
-        description = "Android + Google APIs, revision 1";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -59,7 +59,7 @@ in
         sha1 = "5ff545d96e031e09580a6cf55713015c7d4936b2";
       };
       meta = {
-        description = "Android + Google APIs, revision 1";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -71,7 +71,7 @@ in
         sha1 = "2e7f91e0fe34fef7f58aeced973c6ae52361b5ac";
       };
       meta = {
-        description = "Android + Google APIs, revision 1";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -83,7 +83,7 @@ in
         sha1 = "3079958e7ec87222cac1e6b27bc471b27bf2c352";
       };
       meta = {
-        description = "Android + Google APIs, API 8, revision 2";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -95,7 +95,7 @@ in
         sha1 = "78664645a1e9accea4430814f8694291a7f1ea5d";
       };
       meta = {
-        description = "Android + Google APIs, API 9, revision 2";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -107,7 +107,7 @@ in
         sha1 = "cc0711857c881fa7534f90cf8cc09b8fe985484d";
       };
       meta = {
-        description = "Android + Google APIs, API 10, revision 2";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -119,7 +119,7 @@ in
         sha1 = "5eab5e81addee9f3576d456d205208314b5146a5";
       };
       meta = {
-        description = "Android + Google APIs, API 11, revision 1";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -131,7 +131,7 @@ in
         sha1 = "e9999f4fa978812174dfeceec0721c793a636e5d";
       };
       meta = {
-        description = "Android + Google APIs, API 12, revision 1";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -143,7 +143,7 @@ in
         sha1 = "3b153edd211c27dc736c893c658418a4f9041417";
       };
       meta = {
-        description = "Android + Google APIs, API 13, revision 1";
+        description = "Android + Google APIs";
         url = http://developer.android.com/;
       };
     };
@@ -211,8 +211,8 @@ in
   google_apis_19 = buildGoogleApis {
     name = "google_apis-19";
       src = fetchurl {
-        url = https://dl.google.com/android/repository/google_apis-19_r16.zip;
-        sha1 = "d92f2a2fe219e578633c6445397e1f675edc6a28";
+        url = https://dl.google.com/android/repository/google_apis-19_r20.zip;
+        sha1 = "5b933abe830b2f25b4c0f171d45e9e0651e56311";
       };
       meta = {
         description = "Android + Google APIs";
@@ -259,8 +259,8 @@ in
   android_support_extra = buildGoogleApis {
     name = "android_support_extra";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/support_r23.1.zip;
-      sha1 = "c43a56fcd1c2aa620f6178a0ef529623ed77b3c7";
+      url = https://dl.google.com/android/repository/support_r23.2.1.zip;
+      sha1 = "41121bbc412c2fce0be170d589d20cfa3e78e857";
     };
     meta = {
       description = "Android Support Library";
@@ -271,8 +271,8 @@ in
   google_play_services = buildGoogleApis {
     name = "google_play_services";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/google_play_services_8115000_r27.zip;
-      sha1 = "cdb13f826ca82d3c3730cf1df9f3bf58565fd4bb";
+      url = https://dl.google.com/android/repository/google_play_services_9256000_r31.zip;
+      sha1 = "3f1b502d0f6361c036cb332b8c15249a1168e08b";
     };
     meta = {
       description = "Google Play services client library and sample code";

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -11,16 +11,16 @@ with { inherit (stdenv.lib) makeLibraryPath; };
 
 stdenv.mkDerivation rec {
   name = "android-sdk-${version}";
-  version = "24.4";
+  version = "24.4.1";
 
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "http://dl.google.com/android/android-sdk_r${version}-linux.tgz";
-      sha1 = "eec87cdb9778718e4073b4ca326a46cdd084f901";
+      sha1 = "dlr6346lpmxdb8pmryn4xl7py1hb6nvj";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "http://dl.google.com/android/android-sdk_r${version}-macosx.zip";
-      sha1 = "a9b6f025a9691aef430b19b52e01844dbbcbf6b4";
+      sha1 = "rm03hm87f7qcadb3c4gnz7hz1g5wrac5";
     }
     else throw "platform not ${stdenv.system} supported!";
 
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
         do
             wrapProgram `pwd`/$i \
               --prefix PATH : ${file}/bin \
-              --suffix LD_LIBRARY_PATH : `pwd`/lib:${makeLibraryPath [ libX11 libxcb libXau libXdmcp libXext mesa alsaLib]}
+              --suffix LD_LIBRARY_PATH : `pwd`/lib64:${makeLibraryPath [ libX11 libxcb libXau libXdmcp libXext mesa alsaLib ]}
         done
       ''}
     ''}

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -33,35 +33,35 @@ stdenv.mkDerivation rec {
         # These binaries need to find libstdc++ and libgcc_s
         for i in aidl lib/libLLVM.so
         do
-            patchelf --set-rpath ${stdenv_32bit.cc.cc}/lib $i
+            patchelf --set-rpath ${stdenv_32bit.cc.cc.lib}/lib $i
         done
         
         # These binaries need to find libstdc++, libgcc_s and libraries in the current folder
         for i in lib/libbcc.so lib/libbcinfo.so lib/libclang.so aidl
         do
-            patchelf --set-rpath ${stdenv_32bit.cc.cc}/lib:`pwd`/lib $i
+            patchelf --set-rpath ${stdenv_32bit.cc.cc.lib}/lib:`pwd`/lib $i
         done
         
         # Create link to make libtinfo.so.5 work
-        ln -s ${ncurses_32bit}/lib/libncurses.so.5 `pwd`/lib/libtinfo.so.5
+        ln -s ${ncurses_32bit.out}/lib/libncurses.so.5 `pwd`/lib/libtinfo.so.5
         
         # These binaries need to find libstdc++, libgcc_s, ncurses, and libraries in the current folder
         for i in bcc_compat llvm-rs-cc
         do
-            patchelf --set-rpath ${stdenv_32bit.cc.cc}/lib:${ncurses_32bit}/lib:`pwd`/lib $i
+            patchelf --set-rpath ${stdenv_32bit.cc.cc.lib}/lib:${ncurses_32bit.out}/lib:`pwd`/lib $i
         done
 
         # These binaries also need zlib in addition to libstdc++
         for i in arm-linux-androideabi-ld i686-linux-android-ld mipsel-linux-android-ld split-select aapt zipalign
         do
             patchelf --set-interpreter ${stdenv_32bit.cc.libc.out}/lib/ld-linux.so.2 $i
-            patchelf --set-rpath ${stdenv_32bit.cc.cc}/lib:${zlib_32bit.out}/lib:`pwd`/lib $i
+            patchelf --set-rpath ${stdenv_32bit.cc.cc.lib}/lib:${zlib_32bit.out}/lib:`pwd`/lib $i
         done
         
         # These binaries need to find libstdc++, libgcc_s, and zlib
         for i in aapt dexdump
         do
-            patchelf --set-rpath ${stdenv_32bit.cc.cc}/lib:${zlib_32bit.out}/lib:`pwd`/lib $i
+            patchelf --set-rpath ${stdenv_32bit.cc.cc.lib}/lib:${zlib_32bit.out}/lib:`pwd`/lib $i
         done
       ''}
       

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -2,9 +2,7 @@
 
 rec {
   platformTools = import ./platform-tools.nix {
-    inherit (pkgs) stdenv fetchurl unzip;
-    stdenv_32bit = pkgs_i686.stdenv;
-    zlib_32bit = pkgs_i686.zlib;
+    inherit (pkgs) stdenv fetchurl unzip zlib;
   };
   
   buildTools = import ./build-tools.nix {
@@ -167,6 +165,20 @@ rec {
   androidsdk_6_0_extras = androidsdk {
     platformVersions = [ "23" ];
     abiVersions = [ "armeabi-v7a" "x86" "x86_64"];
+    useGoogleAPIs = true;
+    useExtraSupportLibs = true;
+    useGooglePlayServices = true;
+  };
+
+  androidsdk_7_0 = androidsdk {
+    platformVersions = [ "24" ];
+    abiVersions = [ "x86" "x86_64"];
+    useGoogleAPIs = true;
+  };
+
+  androidsdk_7_0_extras = androidsdk {
+    platformVersions = [ "24" ];
+    abiVersions = [ "x86" "x86_64"];
     useGoogleAPIs = true;
     useExtraSupportLibs = true;
     useGooglePlayServices = true;

--- a/pkgs/development/mobile/androidenv/generate-addons.xsl
+++ b/pkgs/development/mobile/androidenv/generate-addons.xsl
@@ -21,7 +21,7 @@ let
     });
 in
 {
-<xsl:for-each select="sdk:add-on[sdk:name-id='google_apis']">
+<xsl:for-each select="sdk:add-on[sdk:name-id='google_apis']"><xsl:sort select="sdk:api-level" data-type="number"/><xsl:sort select="sdk:revision" data-type="number"/>
   google_apis_<xsl:value-of select="sdk:api-level" /> = buildGoogleApis {
     name = "<xsl:value-of select="sdk:name-id" />-<xsl:value-of select="sdk:api-level" />";
       src = fetchurl {

--- a/pkgs/development/mobile/androidenv/generate-platforms.xsl
+++ b/pkgs/development/mobile/androidenv/generate-platforms.xsl
@@ -36,7 +36,7 @@ let
   });
 in
 {
-    <xsl:for-each select="sdk:platform">
+    <xsl:for-each select="sdk:platform"><xsl:sort select="sdk:api-level" data-type="number"/>
   platform_<xsl:value-of select="sdk:api-level" /> = buildPlatform {
     name = "android-platform-<xsl:value-of select="sdk:version" />";
     src = fetchurl {

--- a/pkgs/development/mobile/androidenv/generate-sysimages.xsl
+++ b/pkgs/development/mobile/androidenv/generate-sysimages.xsl
@@ -7,7 +7,7 @@
   <xsl:output omit-xml-declaration="yes" indent="no" />
 
   <xsl:template match="/sdk:sdk-sys-img">
-    <xsl:for-each select="sdk:system-image">
+    <xsl:for-each select="sdk:system-image"><xsl:sort select="sdk:api-level" data-type="number"/><xsl:sort select="sdk:abi"/>
   sysimg_<xsl:value-of select="sdk:abi" />_<xsl:value-of select="sdk:api-level" /> = buildSystemImage {
     name = "sysimg-<xsl:value-of select="sdk:abi" />-<xsl:value-of select="sdk:api-level" />";
     src = fetchurl {

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -1,16 +1,16 @@
-{stdenv, stdenv_32bit, zlib_32bit, fetchurl, unzip}:
+{stdenv, zlib, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "23.0.1";
+  version = "24";
   name = "android-platform-tools-r${version}";
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-linux.zip";
-      sha1 = "94dcc5072b3d0d74cc69e4101958b6c2e227e738";
+      sha1 = "qabpsfhm7shvyjy6amdl7b3d41n64zsr";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-macosx.zip";
-      sha1 = "c461d66f3ca9fbae8ea0fa1a49c203b3b6fd653f";
+      sha1 = "5s808wby36xxkfmrj4va9dnc0rwsz2gh";
     }
     else throw "System ${stdenv.system} not supported!";
 
@@ -24,14 +24,14 @@ stdenv.mkDerivation rec {
       ''
         for i in adb dmtracedump fastboot hprof-conv sqlite3
         do
-            patchelf --set-interpreter ${stdenv_32bit.cc.libc.out}/lib/ld-linux.so.2 $i
-            patchelf --set-rpath ${stdenv_32bit.cc.cc}/lib:`pwd`/lib $i
+            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
+            patchelf --set-rpath ${stdenv.cc.cc.lib}/lib:`pwd`/lib64 $i
         done
         
         for i in etc1tool
         do
-            patchelf --set-interpreter ${stdenv_32bit.cc.libc}/lib/ld-linux.so.2 $i
-            patchelf --set-rpath ${stdenv_32bit.cc.cc}/lib:${zlib_32bit.out}/lib:`pwd`/lib $i
+            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
+            patchelf --set-rpath ${stdenv.cc.cc.lib}/lib:${zlib.out}/lib:`pwd`/lib64 $i
         done
     ''}
 

--- a/pkgs/development/mobile/androidenv/platforms-linux.nix
+++ b/pkgs/development/mobile/androidenv/platforms-linux.nix
@@ -19,71 +19,71 @@ in
   platform_2 = buildPlatform {
     name = "android-platform-1.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-1.1_r1-linux.zip;
+      url = https://dl.google.com/android/repository/android-1.1_r1-linux.zip;
       sha1 = "c054d25c9b4c6251fa49c2f9c54336998679d3fe";
     };
     meta = {
-      description = "Android SDK Platform 1.1_r1";
-      url = http://developer.android.com/sdk/android-1.1.html;
+      description = "Android SDK Platform 2";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_3 = buildPlatform {
     name = "android-platform-1.5";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-1.5_r04-linux.zip;
+      url = https://dl.google.com/android/repository/android-1.5_r04-linux.zip;
       sha1 = "5c134b7df5f4b8bd5b61ba93bdaebada8fa3468c";
     };
     meta = {
-      description = "Android SDK Platform 1.5_r3";
-      url = http://developer.android.com/sdk/android-1.5.html;
+      description = "Android SDK Platform 3";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_4 = buildPlatform {
     name = "android-platform-1.6";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-1.6_r03-linux.zip;
+      url = https://dl.google.com/android/repository/android-1.6_r03-linux.zip;
       sha1 = "483ed088e45bbdf3444baaf9250c8b02e5383cb0";
     };
     meta = {
-      description = "Android SDK Platform 1.6_r2";
-      url = http://developer.android.com/sdk/android-1.6.html;
+      description = "Android SDK Platform 4";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_5 = buildPlatform {
     name = "android-platform-2.0";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.0_r01-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.0_r01-linux.zip;
       sha1 = "be9be6a99ca32875c96ec7f91160ca9fce7e3c7d";
     };
     meta = {
-      description = "Android SDK Platform 2.0, revision 1";
-      url = http://developer.android.com/sdk/android-2.0.html;
+      description = "Android SDK Platform 5";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_6 = buildPlatform {
     name = "android-platform-2.0.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.0.1_r01-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.0.1_r01-linux.zip;
       sha1 = "ce2c971dce352aa28af06bda92a070116aa5ae1a";
     };
     meta = {
-      description = "Android SDK Platform 2.0.1_r1";
-      url = http://developer.android.com/sdk/android-2.0.1.html;
+      description = "Android SDK Platform 6";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_7 = buildPlatform {
     name = "android-platform-2.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.1_r03-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.1_r03.zip;
       sha1 = "5ce51b023ac19f8738500b1007a1da5de2349a1e";
     };
     meta = {
-      description = "Android SDK Platform 2.1_r3";
+      description = "Android SDK Platform 7";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -91,11 +91,11 @@ in
   platform_8 = buildPlatform {
     name = "android-platform-2.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.2_r03-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.2_r03.zip;
       sha1 = "231262c63eefdff8fd0386e9ccfefeb27a8f9202";
     };
     meta = {
-      description = "Android SDK Platform 2.2_r3";
+      description = "Android SDK Platform 8";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -103,11 +103,11 @@ in
   platform_9 = buildPlatform {
     name = "android-platform-2.3.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.3.1_r02-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.3.1_r02.zip;
       sha1 = "209f8a7a8b2cb093fce858b8b55fed3ba5206773";
     };
     meta = {
-      description = "Android SDK Platform 2.3.1_r2";
+      description = "Android SDK Platform 9";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -115,11 +115,11 @@ in
   platform_10 = buildPlatform {
     name = "android-platform-2.3.3";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.3.3_r02-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.3.3_r02.zip;
       sha1 = "887e37783ec32f541ea33c2c649dda648e8e6fb3";
     };
     meta = {
-      description = "Android SDK Platform 2.3.3._r2";
+      description = "Android SDK Platform 10";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -127,11 +127,11 @@ in
   platform_11 = buildPlatform {
     name = "android-platform-3.0";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-3.0_r02-linux.zip;
+      url = https://dl.google.com/android/repository/android-3.0_r02.zip;
       sha1 = "2c7d4bd13f276e76f6bbd87315fe27aba351dd37";
     };
     meta = {
-      description = "Android SDK Platform 3.0, revision 2";
+      description = "Android SDK Platform 11";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -139,11 +139,11 @@ in
   platform_12 = buildPlatform {
     name = "android-platform-3.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-3.1_r03-linux.zip;
+      url = https://dl.google.com/android/repository/android-3.1_r03.zip;
       sha1 = "4a50a6679cd95bb68bb5fc032e754cd7c5e2b1bf";
     };
     meta = {
-      description = "Android SDK Platform 3.1, revision 3";
+      description = "Android SDK Platform 12";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -151,11 +151,11 @@ in
   platform_13 = buildPlatform {
     name = "android-platform-3.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-3.2_r01-linux.zip;
+      url = https://dl.google.com/android/repository/android-3.2_r01.zip;
       sha1 = "6189a500a8c44ae73a439604363de93591163cd9";
     };
     meta = {
-      description = "Android SDK Platform 3.2, revision 1";
+      description = "Android SDK Platform 13";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -167,8 +167,8 @@ in
       sha1 = "d4f1d8fbca25225b5f0e7a0adf0d39c3d6e60b3c";
     };
     meta = {
-      description = "Android SDK Platform 4.0";
-
+      description = "Android SDK Platform 14";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -179,8 +179,8 @@ in
       sha1 = "69ab4c443b37184b2883af1fd38cc20cbeffd0f3";
     };
     meta = {
-      description = "Android SDK Platform 4.0.3";
-
+      description = "Android SDK Platform 15";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -191,8 +191,8 @@ in
       sha1 = "12a5ce6235a76bc30f62c26bda1b680e336abd07";
     };
     meta = {
-      description = "Android SDK Platform 4.1.2";
-
+      description = "Android SDK Platform 16";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -203,8 +203,8 @@ in
       sha1 = "dbe14101c06e6cdb34e300393e64e64f8c92168a";
     };
     meta = {
-      description = "Android SDK Platform 4.2.2";
-
+      description = "Android SDK Platform 17";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -215,8 +215,8 @@ in
       sha1 = "e6b09b3505754cbbeb4a5622008b907262ee91cb";
     };
     meta = {
-      description = "Android SDK Platform 4.3.1";
-
+      description = "Android SDK Platform 18";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -227,8 +227,8 @@ in
       sha1 = "2ff20d89e68f2f5390981342e009db5a2d456aaa";
     };
     meta = {
-      description = "Android SDK Platform 4.4.2";
-
+      description = "Android SDK Platform 19";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -239,8 +239,8 @@ in
       sha1 = "a9251f8a3f313ab05834a07a963000927637e01d";
     };
     meta = {
-      description = "Android SDK Platform 4.4W.2";
-
+      description = "Android SDK Platform 20";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -251,8 +251,8 @@ in
       sha1 = "53536556059bb29ae82f414fd2e14bc335a4eb4c";
     };
     meta = {
-      description = "Android SDK Platform 5.0.1";
-
+      description = "Android SDK Platform 21";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -263,20 +263,32 @@ in
       sha1 = "5d1bd10fea962b216a0dece1247070164760a9fc";
     };
     meta = {
-      description = "Android SDK Platform 5.1.1";
-
+      description = "Android SDK Platform 22";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_23 = buildPlatform {
     name = "android-platform-6.0";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/android-23_r01.zip;
-      sha1 = "cbccca8d3127e894845556ce999b28281de541bd";
+      url = https://dl.google.com/android/repository/platform-23_r03.zip;
+      sha1 = "027fede3de6aa1649115bbd0bffff30ccd51c9a0";
     };
     meta = {
-      description = "Android SDK Platform 6.0";
+      description = "Android SDK Platform 23";
+      url = http://developer.android.com/sdk/;
+    };
+  };
 
+  platform_24 = buildPlatform {
+    name = "android-platform-7.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/platform-24_r01.zip;
+      sha1 = "27516dab4848f55896e16f7089038c62bbbffea7";
+    };
+    meta = {
+      description = "Android SDK Platform 24";
+      url = http://developer.android.com/sdk/;
     };
   };
 

--- a/pkgs/development/mobile/androidenv/platforms-macosx.nix
+++ b/pkgs/development/mobile/androidenv/platforms-macosx.nix
@@ -19,71 +19,71 @@ in
   platform_2 = buildPlatform {
     name = "android-platform-1.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-1.1_r1-macosx.zip;
+      url = https://dl.google.com/android/repository/android-1.1_r1-macosx.zip;
       sha1 = "e21dbcff45b7356657449ebb3c7e941be2bb5ebe";
     };
     meta = {
-      description = "Android SDK Platform 1.1_r1";
-      url = http://developer.android.com/sdk/android-1.1.html;
+      description = "Android SDK Platform 2";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_3 = buildPlatform {
     name = "android-platform-1.5";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-1.5_r04-macosx.zip;
+      url = https://dl.google.com/android/repository/android-1.5_r04-macosx.zip;
       sha1 = "d3a67c2369afa48b6c3c7624de5031c262018d1e";
     };
     meta = {
-      description = "Android SDK Platform 1.5_r3";
-      url = http://developer.android.com/sdk/android-1.5.html;
+      description = "Android SDK Platform 3";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_4 = buildPlatform {
     name = "android-platform-1.6";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-1.6_r03-macosx.zip;
+      url = https://dl.google.com/android/repository/android-1.6_r03-macosx.zip;
       sha1 = "bdafad44f5df9f127979bdb21a1fdd87ee3cd625";
     };
     meta = {
-      description = "Android SDK Platform 1.6_r2";
-      url = http://developer.android.com/sdk/android-1.6.html;
+      description = "Android SDK Platform 4";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_5 = buildPlatform {
     name = "android-platform-2.0";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.0_r01-macosx.zip;
+      url = https://dl.google.com/android/repository/android-2.0_r01-macosx.zip;
       sha1 = "2a866d0870dbba18e0503cd41e5fae988a21b314";
     };
     meta = {
-      description = "Android SDK Platform 2.0, revision 1";
-      url = http://developer.android.com/sdk/android-2.0.html;
+      description = "Android SDK Platform 5";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_6 = buildPlatform {
     name = "android-platform-2.0.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.0.1_r01-macosx.zip;
+      url = https://dl.google.com/android/repository/android-2.0.1_r01-macosx.zip;
       sha1 = "c3096f80d75a6fc8cb38ef8a18aec920e53d42c0";
     };
     meta = {
-      description = "Android SDK Platform 2.0.1_r1";
-      url = http://developer.android.com/sdk/android-2.0.1.html;
+      description = "Android SDK Platform 6";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_7 = buildPlatform {
     name = "android-platform-2.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.1_r03-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.1_r03.zip;
       sha1 = "5ce51b023ac19f8738500b1007a1da5de2349a1e";
     };
     meta = {
-      description = "Android SDK Platform 2.1_r3";
+      description = "Android SDK Platform 7";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -91,11 +91,11 @@ in
   platform_8 = buildPlatform {
     name = "android-platform-2.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.2_r03-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.2_r03.zip;
       sha1 = "231262c63eefdff8fd0386e9ccfefeb27a8f9202";
     };
     meta = {
-      description = "Android SDK Platform 2.2_r3";
+      description = "Android SDK Platform 8";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -103,11 +103,11 @@ in
   platform_9 = buildPlatform {
     name = "android-platform-2.3.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.3.1_r02-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.3.1_r02.zip;
       sha1 = "209f8a7a8b2cb093fce858b8b55fed3ba5206773";
     };
     meta = {
-      description = "Android SDK Platform 2.3.1_r2";
+      description = "Android SDK Platform 9";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -115,11 +115,11 @@ in
   platform_10 = buildPlatform {
     name = "android-platform-2.3.3";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-2.3.3_r02-linux.zip;
+      url = https://dl.google.com/android/repository/android-2.3.3_r02.zip;
       sha1 = "887e37783ec32f541ea33c2c649dda648e8e6fb3";
     };
     meta = {
-      description = "Android SDK Platform 2.3.3._r2";
+      description = "Android SDK Platform 10";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -127,11 +127,11 @@ in
   platform_11 = buildPlatform {
     name = "android-platform-3.0";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-3.0_r02-linux.zip;
+      url = https://dl.google.com/android/repository/android-3.0_r02.zip;
       sha1 = "2c7d4bd13f276e76f6bbd87315fe27aba351dd37";
     };
     meta = {
-      description = "Android SDK Platform 3.0, revision 2";
+      description = "Android SDK Platform 11";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -139,11 +139,11 @@ in
   platform_12 = buildPlatform {
     name = "android-platform-3.1";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-3.1_r03-linux.zip;
+      url = https://dl.google.com/android/repository/android-3.1_r03.zip;
       sha1 = "4a50a6679cd95bb68bb5fc032e754cd7c5e2b1bf";
     };
     meta = {
-      description = "Android SDK Platform 3.1, revision 3";
+      description = "Android SDK Platform 12";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -151,11 +151,11 @@ in
   platform_13 = buildPlatform {
     name = "android-platform-3.2";
     src = fetchurl {
-      url = https://dl-ssl.google.com/android/repository/android-3.2_r01-linux.zip;
+      url = https://dl.google.com/android/repository/android-3.2_r01.zip;
       sha1 = "6189a500a8c44ae73a439604363de93591163cd9";
     };
     meta = {
-      description = "Android SDK Platform 3.2, revision 1";
+      description = "Android SDK Platform 13";
       url = http://developer.android.com/sdk/;
     };
   };
@@ -167,8 +167,8 @@ in
       sha1 = "d4f1d8fbca25225b5f0e7a0adf0d39c3d6e60b3c";
     };
     meta = {
-      description = "Android SDK Platform 4.0";
-
+      description = "Android SDK Platform 14";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -179,8 +179,8 @@ in
       sha1 = "69ab4c443b37184b2883af1fd38cc20cbeffd0f3";
     };
     meta = {
-      description = "Android SDK Platform 4.0.3";
-
+      description = "Android SDK Platform 15";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -191,8 +191,8 @@ in
       sha1 = "12a5ce6235a76bc30f62c26bda1b680e336abd07";
     };
     meta = {
-      description = "Android SDK Platform 4.1.2";
-
+      description = "Android SDK Platform 16";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -203,8 +203,8 @@ in
       sha1 = "dbe14101c06e6cdb34e300393e64e64f8c92168a";
     };
     meta = {
-      description = "Android SDK Platform 4.2.2";
-
+      description = "Android SDK Platform 17";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -215,8 +215,8 @@ in
       sha1 = "e6b09b3505754cbbeb4a5622008b907262ee91cb";
     };
     meta = {
-      description = "Android SDK Platform 4.3.1";
-
+      description = "Android SDK Platform 18";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -227,8 +227,8 @@ in
       sha1 = "2ff20d89e68f2f5390981342e009db5a2d456aaa";
     };
     meta = {
-      description = "Android SDK Platform 4.4.2";
-
+      description = "Android SDK Platform 19";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -239,8 +239,8 @@ in
       sha1 = "a9251f8a3f313ab05834a07a963000927637e01d";
     };
     meta = {
-      description = "Android SDK Platform 4.4W.2";
-
+      description = "Android SDK Platform 20";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -251,8 +251,8 @@ in
       sha1 = "53536556059bb29ae82f414fd2e14bc335a4eb4c";
     };
     meta = {
-      description = "Android SDK Platform 5.0.1";
-
+      description = "Android SDK Platform 21";
+      url = http://developer.android.com/sdk/;
     };
   };
 
@@ -263,20 +263,32 @@ in
       sha1 = "5d1bd10fea962b216a0dece1247070164760a9fc";
     };
     meta = {
-      description = "Android SDK Platform 5.1.1";
-
+      description = "Android SDK Platform 22";
+      url = http://developer.android.com/sdk/;
     };
   };
 
   platform_23 = buildPlatform {
     name = "android-platform-6.0";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/android-23_r01.zip;
-      sha1 = "cbccca8d3127e894845556ce999b28281de541bd";
+      url = https://dl.google.com/android/repository/platform-23_r03.zip;
+      sha1 = "027fede3de6aa1649115bbd0bffff30ccd51c9a0";
     };
     meta = {
-      description = "Android SDK Platform 6.0";
+      description = "Android SDK Platform 23";
+      url = http://developer.android.com/sdk/;
+    };
+  };
 
+  platform_24 = buildPlatform {
+    name = "android-platform-7.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/platform-24_r01.zip;
+      sha1 = "27516dab4848f55896e16f7089038c62bbbffea7";
+    };
+    meta = {
+      description = "Android SDK Platform 24";
+      url = http://developer.android.com/sdk/;
     };
   };
 

--- a/pkgs/development/mobile/androidenv/repository-11.xml
+++ b/pkgs/development/mobile/androidenv/repository-11.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" ?>
 <!--
  * Copyright (C) 2009 The Android Open Source Project
  *
@@ -15,40 +15,44 @@
  * limitations under the License.
 -->
 <sdk:sdk-repository xmlns:sdk="http://schemas.android.com/sdk/android/repository/11" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<!--Generated on 2016-07-18 18:30:41.214218 with ADRT.-->
+	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
-    <sdk:license id="android-sdk-license" type="text">To get started with the Android SDK, you must agree to the following terms and conditions.
-
-This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
+This is the Android Software Development Kit License Agreement
 
 1. Introduction
 
-1.1 The Android SDK (referred to in the License Agreement as the &quot;SDK&quot; and specifically including the Android system files, packaged APIs, and SDK library files and tools , if and when they are made available) is licensed to you subject to the terms of the License Agreement. The License Agreement forms a legally binding contract between you and Google in relation to your use of the SDK.
+1.1 The Android Software Development Kit (referred to in the License Agreement as the &quot;SDK&quot; and specifically including the Android system files, packaged APIs, and Google APIs add-ons) is licensed to you subject to the terms of the License Agreement. The License Agreement forms a legally binding contract between you and Google in relation to your use of the SDK.
 
 1.2 &quot;Android&quot; means the Android software stack for devices, as made available under the Android Open Source Project, which is located at the following URL: http://source.android.com/, as updated from time to time.
 
-1.3 &quot;Google&quot; means Google Inc., a Delaware corporation with principal place of business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, United States.
+1.3 A &quot;compatible implementation&quot; means any Android device that (i) complies with the Android Compatibility Definition document, which can be found at the Android compatibility website (http://source.android.com/compatibility) and which may be updated from time to time; and (ii) successfully passes the Android Compatibility Test Suite (CTS).
+
+1.4 &quot;Google&quot; means Google Inc., a Delaware corporation with principal place of business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, United States.
+
 
 2. Accepting the License Agreement
 
 2.1 In order to use the SDK, you must first agree to the License Agreement. You may not use the SDK if you do not accept the License Agreement.
 
-2.2 By clicking to accept and/or using the SDK, you hereby agree to the terms of the License Agreement.
+2.2 By clicking to accept, you hereby agree to the terms of the License Agreement.
 
-2.3 You may not use the SDK and may not accept the License Agreement if you are a person barred from receiving the SDK under the laws of the United States or other countries including the country in which you are resident or from which you use the SDK.
+2.3 You may not use the SDK and may not accept the License Agreement if you are a person barred from receiving the SDK under the laws of the United States or other countries, including the country in which you are resident or from which you use the SDK.
 
-2.4 If you will use the SDK internally within your company or organization you agree to be bound by the License Agreement on behalf of your employer or other entity, and you represent and warrant that you have full legal authority to bind your employer or such entity to the License Agreement. If you do not have the requisite authority, you may not accept the License Agreement or use the SDK on behalf of your employer or other entity.
+2.4 If you are agreeing to be bound by the License Agreement on behalf of your employer or other entity, you represent and warrant that you have full legal authority to bind your employer or such entity to the License Agreement. If you do not have the requisite authority, you may not accept the License Agreement or use the SDK on behalf of your employer or other entity.
+
 
 3. SDK License from Google
 
-3.1 Subject to the terms of the License Agreement, Google grants you a royalty-free, non-assignable, non-exclusive, non-sublicensable, limited, revocable license to use the SDK, personally or internally within your company or organization, solely to develop and distribute applications to run on the Android platform.
+3.1 Subject to the terms of the License Agreement, Google grants you a limited, worldwide, royalty-free, non-assignable, non-exclusive, and non-sublicensable license to use the SDK solely to develop applications for compatible implementations of Android.
 
-3.2 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
+3.2 You may not use this SDK to develop applications for other platforms (including non-compatible implementations of Android) or to develop another SDK. You are of course free to develop applications for other platforms, including non-compatible implementations of Android, provided that this SDK is not used for that purpose.
 
-3.3 You may not use the SDK for any purpose not expressly permitted by the License Agreement. Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK; or (b) load any part of the SDK onto a mobile handset or any other hardware device except a personal computer, combine any part of the SDK with other software, or distribute any software or device incorporating a part of the SDK.
+3.3 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
 
-3.4 You agree that you will not take any actions that may cause or result in the fragmentation of Android, including but not limited to distributing, participating in the creation of, or promoting in any way a software development kit derived from the SDK.
+3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement.  Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK; or (b) load any part of the SDK onto a mobile handset or any other hardware device except a personal computer, combine any part of the SDK with other software, or distribute any software or device incorporating a part of the SDK.
 
-3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement. You agree to remain a licensee in good standing in regard to such open source software licenses under all the rights granted and to refrain from any actions that may terminate, suspend, or breach such rights.
+3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement.
 
 3.6 You agree that the form and nature of the SDK that Google provides may change without prior notice to you and that future versions of the SDK may be incompatible with applications developed on previous versions of the SDK. You agree that Google may stop (permanently or temporarily) providing the SDK (or any features within the SDK) to you or to users generally at Google's sole discretion, without prior notice to you.
 
@@ -56,15 +60,16 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 3.8 You agree that you will not remove, obscure, or alter any proprietary rights notices (including copyright and trademark notices) that may be affixed to or contained within the SDK.
 
+
 4. Use of the SDK by You
 
-4.1 Google agrees that nothing in the License Agreement gives Google any right, title or interest from you (or your licensors) under the License Agreement in or to any software applications that you develop using the SDK, including any intellectual property rights that subsist in those applications.
+4.1 Google agrees that it obtains no right, title or interest from you (or your licensors) under the License Agreement in or to any software applications that you develop using the SDK, including any intellectual property rights that subsist in those applications.
 
-4.2 You agree to use the SDK and write applications only for purposes that are permitted by (a) the License Agreement, and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions (including any laws regarding the export of data or software to and from the United States or other relevant countries).
+4.2 You agree to use the SDK and write applications only for purposes that are permitted by (a) the License Agreement and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions (including any laws regarding the export of data or software to and from the United States or other relevant countries).
 
-4.3 You agree that if you use the SDK to develop applications, you will protect the privacy and legal rights of users. If users provide you with user names, passwords, or other login information or personal information, you must make the users aware that the information will be available to your application, and you must provide legally adequate privacy notice and protection for those users. If your application stores personal or sensitive information provided by users, it must do so securely. If users provide you with Google Account information, your application may only use that information to access the user's Google Account when, and for the limited purposes for which, each user has given you permission to do so.
+4.3 You agree that if you use the SDK to develop applications for general public users, you will protect the privacy and legal rights of those users. If the users provide you with user names, passwords, or other login information or personal information, you must make the users aware that the information will be available to your application, and you must provide legally adequate privacy notice and protection for those users. If your application stores personal or sensitive information provided by users, it must do so securely. If the user provides your application with Google Account information, your application may only use that information to access the user's Google Account when, and for the limited purposes for which, the user has given you permission to do so.
 
-4.4 You agree that you will not engage in any activity with the SDK, including the development or distribution of an application, that interferes with, disrupts, damages, or accesses in an unauthorized manner the servers, networks, or other properties or services of Google or any third party.
+4.4 You agree that you will not engage in any activity with the SDK, including the development or distribution of an application, that interferes with, disrupts, damages, or accesses in an unauthorized manner the servers, networks, or other properties or services of any third party including, but not limited to, Google or any mobile communications carrier.
 
 4.5 You agree that you are solely responsible for (and that Google has no responsibility to you or to any third party for) any data, content, or resources that you create, transmit or display through Android and/or applications for Android, and for the consequences of your actions (including any loss or damage which Google may suffer) by doing so.
 
@@ -78,7 +83,8 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 6.1 In order to continually innovate and improve the SDK, Google may collect certain usage statistics from the software including but not limited to a unique identifier, associated IP address, version number of the software, and information on which tools and/or services in the SDK are being used and how they are being used. Before any of this information is collected, the SDK will notify you and seek your consent. If you withhold consent, the information will not be collected.
 
-6.2 The data collected is examined in the aggregate to improve the SDK and is maintained in accordance with Google's Privacy Policy located at http://www.google.com/policies/privacy/.
+6.2 The data collected is examined in the aggregate to improve the SDK and is maintained in accordance with Google's Privacy Policy.
+
 
 7. Third Party Applications
 
@@ -86,15 +92,17 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 7.2 You should be aware the data, content, and resources presented to you through such a third party application may be protected by intellectual property rights which are owned by the providers (or by other persons or companies on their behalf). You may not modify, rent, lease, loan, sell, distribute or create derivative works based on these data, content, or resources (either in whole or in part) unless you have been specifically given permission to do so by the relevant owners.
 
-7.3 You acknowledge that your use of such third party applications, data, content, or resources may be subject to separate terms between you and the relevant third party.
+7.3 You acknowledge that your use of such third party applications, data, content, or resources may be subject to separate terms between you and the relevant third party. In that case, the License Agreement does not affect your legal relationship with these third parties.
 
-8. Using Google APIs
 
-8.1 Google APIs
+8. Using Android APIs
+
+8.1 Google Data APIs
 
 8.1.1 If you use any API to retrieve data from Google, you acknowledge that the data may be protected by intellectual property rights which are owned by Google or those parties that provide the data (or by other persons or companies on their behalf). Your use of any such API may be subject to additional Terms of Service. You may not modify, rent, lease, loan, sell, distribute or create derivative works based on this data (either in whole or in part) unless allowed by the relevant Terms of Service.
 
 8.1.2 If you use any API to retrieve a user's data from Google, you acknowledge and agree that you shall retrieve data only with the user's explicit consent and only when, and for the limited purposes for which, the user has given you permission to do so.
+
 
 9. Terminating the License Agreement
 
@@ -102,31 +110,38 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 9.2 If you want to terminate the License Agreement, you may do so by ceasing your use of the SDK and any relevant developer credentials.
 
-9.3 Google may at any time, terminate the License Agreement, with or without cause, upon notice to you.
+9.3 Google may at any time, terminate the License Agreement with you if:
+(A) you have breached any provision of the License Agreement; or
+(B) Google is required to do so by law; or
+(C) the partner with whom Google offered certain parts of SDK (such as APIs) to you has terminated its relationship with Google or ceased to offer certain parts of the SDK to you; or
+(D) Google decides to no longer provide the SDK or certain parts of the SDK to users in the country in which you are resident or from which you use the service, or the provision of the SDK or certain SDK services to you by Google is, in Google's sole discretion, no longer commercially viable.
 
-9.4 The License Agreement will automatically terminate without notice or other action when Google ceases to provide the SDK or certain parts of the SDK to users in the country in which you are resident or from which you use the service.
+9.4 When the License Agreement comes to an end, all of the legal rights, obligations and liabilities that you and Google have benefited from, been subject to (or which have accrued over time whilst the License Agreement has been in force) or which are expressed to continue indefinitely, shall be unaffected by this cessation, and the provisions of paragraph 14.7 shall continue to apply to such rights, obligations and liabilities indefinitely.
 
-9.5 When the License Agreement is terminated, the license granted to you in the License Agreement will terminate, you will immediately cease all use of the SDK, and the provisions of paragraphs 10, 11, 12 and 14 shall survive indefinitely.
 
-10. DISCLAIMERS
+10. DISCLAIMER OF WARRANTIES
 
 10.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT YOUR USE OF THE SDK IS AT YOUR SOLE RISK AND THAT THE SDK IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTY OF ANY KIND FROM GOOGLE.
 
-10.2 YOUR USE OF THE SDK AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SDK IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH USE. WITHOUT LIMITING THE FOREGOING, YOU UNDERSTAND THAT THE SDK MAY CONTAIN ERRORS, DEFECTS AND SECURITY VULNERABILITIES THAT CAN RESULT IN SIGNIFICANT DAMAGE, INCLUDING THE COMPLETE, IRRECOVERABLE LOSS OF USE OF YOUR COMPUTER SYSTEM OR OTHER DEVICE.
+10.2 YOUR USE OF THE SDK AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SDK IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH USE.
 
 10.3 GOOGLE FURTHER EXPRESSLY DISCLAIMS ALL WARRANTIES AND CONDITIONS OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+
 
 11. LIMITATION OF LIABILITY
 
 11.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT GOOGLE, ITS SUBSIDIARIES AND AFFILIATES, AND ITS LICENSORS SHALL NOT BE LIABLE TO YOU UNDER ANY THEORY OF LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES THAT MAY BE INCURRED BY YOU, INCLUDING ANY LOSS OF DATA, WHETHER OR NOT GOOGLE OR ITS REPRESENTATIVES HAVE BEEN ADVISED OF OR SHOULD HAVE BEEN AWARE OF THE POSSIBILITY OF ANY SUCH LOSSES ARISING.
 
+
 12. Indemnification
 
-12.1 To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless Google, its affiliates and their respective directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees) arising out of or accruing from (a) your use of the SDK, (b) any application you develop on the SDK that infringes any Intellectual Property Rights of any person or defames any person or violates their rights of publicity or privacy, and (c) any non-compliance by you of the License Agreement.
+12.1 To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless Google, its affiliates and their respective directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys fees) arising out of or accruing from (a) your use of the SDK, (b) any application you develop on the SDK that infringes any copyright, trademark, trade secret, trade dress, patent or other intellectual property right of any person or defames any person or violates their rights of publicity or privacy, and (c) any non-compliance by you with the License Agreement.
+
 
 13. Changes to the License Agreement
 
 13.1 Google may make changes to the License Agreement as it distributes new versions of the SDK. When these changes are made, Google will make a new version of the License Agreement available on the website where the SDK is made available.
+
 
 14. General Legal Terms
 
@@ -140,14 +155,13 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 14.5 EXPORT RESTRICTIONS. THE SDK IS SUBJECT TO UNITED STATES EXPORT LAWS AND REGULATIONS. YOU MUST COMPLY WITH ALL DOMESTIC AND INTERNATIONAL EXPORT LAWS AND REGULATIONS THAT APPLY TO THE SDK. THESE LAWS INCLUDE RESTRICTIONS ON DESTINATIONS, END USERS AND END USE.
 
-14.6 The License Agreement may not be assigned or transferred by you without the prior written approval of Google, and any attempted assignment without such approval will be void. You shall not delegate your responsibilities or obligations under the License Agreement without the prior written approval of Google.
+14.6 The rights granted in the License Agreement may not be assigned or transferred by either you or Google without the prior written approval of the other party. Neither you nor Google shall be permitted to delegate their responsibilities or obligations under the License Agreement without the prior written approval of the other party.
 
 14.7 The License Agreement, and your relationship with Google under the License Agreement, shall be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from the License Agreement. Notwithstanding this, you agree that Google shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction.
 
-June 2014.
-    </sdk:license>
 
-    <sdk:license id="android-sdk-preview-license" type="text">To get started with the Android SDK Preview, you must agree to the following terms and conditions.
+November 20, 2015</sdk:license>
+	<sdk:license id="android-sdk-preview-license" type="text">To get started with the Android SDK Preview, you must agree to the following terms and conditions.
 As described below, please note that this is a preview version of the Android SDK, subject to change, that you use at your own risk.  The Android SDK Preview is not a stable release, and may contain errors and defects that can result in serious damage to your computer systems, devices and data.
 
 This is the Android SDK Preview License Agreement (the &quot;License Agreement&quot;).
@@ -280,1798 +294,1703 @@ This is the Android SDK Preview License Agreement (the &quot;License Agreement&q
 
 14.7 The License Agreement, and your relationship with Google under the License Agreement, shall be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from the License Agreement. Notwithstanding this, you agree that Google shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction.
 
-June 2014.
-    </sdk:license>
-
-    <!-- PLATFORMS ........................ -->
-
-    <sdk:ndk>
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android NDK</sdk:description>
-        <sdk:archives>
-            <sdk:archive>
-            <sdk:size>1083342126</sdk:size>
-            <sdk:checksum type="sha1">6be8598e4ed3d9dd42998c8cb666f0ee502b1294</sdk:checksum>
-            <sdk:url>https://dl-ssl.google.com/android/repository/android-ndk-r10e-darwin-x86_64.zip</sdk:url>
-            <sdk:host-os>macosx</sdk:host-os>
-            <sdk:host-bits>64</sdk:host-bits>
-        </sdk:archive>
-            <sdk:archive>
-            <sdk:size>1110915721</sdk:size>
-            <sdk:checksum type="sha1">f692681b007071103277f6edc6f91cb5c5494a32</sdk:checksum>
-            <sdk:url>https://dl-ssl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip</sdk:url>
-            <sdk:host-os>linux</sdk:host-os>
-            <sdk:host-bits>64</sdk:host-bits>
-        </sdk:archive>
-            <sdk:archive>
-            <sdk:size>1113873239</sdk:size>
-            <sdk:checksum type="sha1">d3510a0e298f6d3b13dc0283bfd92951ccd3a281</sdk:checksum>
-            <sdk:url>https://dl-ssl.google.com/android/repository/android-ndk-r10e-linux-x86.zip</sdk:url>
-            <sdk:host-os>linux</sdk:host-os>
-            <sdk:host-bits>32</sdk:host-bits>
-        </sdk:archive>
-            <sdk:archive>
-            <sdk:size>1066110352</sdk:size>
-            <sdk:checksum type="sha1">a29f3ae41fb02b64ca8ad2b0903f74356f953d9f</sdk:checksum>
-            <sdk:url>https://dl-ssl.google.com/android/repository/android-ndk-r10e-windows-x86_64.zip</sdk:url>
-            <sdk:host-os>windows</sdk:host-os>
-            <sdk:host-bits>64</sdk:host-bits>
-        </sdk:archive>
-            <sdk:archive>
-            <sdk:size>1029711228</sdk:size>
-            <sdk:checksum type="sha1">1d0b8f2835be741f3048fb03c0a3e9f71ab7f357</sdk:checksum>
-            <sdk:url>https://dl-ssl.google.com/android/repository/android-ndk-r10e-windows-x86.zip</sdk:url>
-            <sdk:host-os>windows</sdk:host-os>
-            <sdk:host-bits>32</sdk:host-bits>
-        </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:ndk>
-
-    <sdk:platform>
-        <sdk:version>1.1</sdk:version>
-        <sdk:api-level>2</sdk:api-level>
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android SDK Platform 1.1_r1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/android-1.1.html</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>46828615</sdk:size>
-                <sdk:checksum type="sha1">a4060f29ed39fc929c302836d488998c53c3002e</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-1.1_r1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>45584305</sdk:size>
-                <sdk:checksum type="sha1">e21dbcff45b7356657449ebb3c7e941be2bb5ebe</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-1.1_r1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>45476658</sdk:size>
-                <sdk:checksum type="sha1">c054d25c9b4c6251fa49c2f9c54336998679d3fe</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-1.1_r1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated manually from earlier versions -->
-
-    <sdk:platform>
-        <sdk:version>1.5</sdk:version>
-        <sdk:api-level>3</sdk:api-level>
-        <sdk:revision>04</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>6</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 1.5_r3</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/android-1.5.html</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>54624370</sdk:size>
-                <sdk:checksum type="sha1">5bb106d2e40d481edd337b0833093843e15fe49a</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-1.5_r04-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>52440607</sdk:size>
-                <sdk:checksum type="sha1">d3a67c2369afa48b6c3c7624de5031c262018d1e</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-1.5_r04-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>53348669</sdk:size>
-                <sdk:checksum type="sha1">5c134b7df5f4b8bd5b61ba93bdaebada8fa3468c</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-1.5_r04-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <sdk:version>1.6</sdk:version>
-        <sdk:api-level>4</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>03</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>6</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 1.6_r2</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/android-1.6.html</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>63454485</sdk:size>
-                <sdk:checksum type="sha1">483ed088e45bbdf3444baaf9250c8b02e5383cb0</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-1.6_r03-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>62418496</sdk:size>
-                <sdk:checksum type="sha1">bdafad44f5df9f127979bdb21a1fdd87ee3cd625</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-1.6_r03-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>64654625</sdk:size>
-                <sdk:checksum type="sha1">ce0b5e4ffaf12ca4fd07c2da71a8a1ab4a03dc22</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-1.6_r03-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated on Thu Oct 22 10:16:34 PDT 2009 using eclair-sdk 17704: Platform. Addon. Tools. Doc. -->
-
-    <sdk:platform>
-        <sdk:version>2.0</sdk:version>
-        <sdk:api-level>5</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>3</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 2.0, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/android-2.0.html</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>75095268</sdk:size>
-                <sdk:checksum type="sha1">be9be6a99ca32875c96ec7f91160ca9fce7e3c7d</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.0_r01-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>74956356</sdk:size>
-                <sdk:checksum type="sha1">2a866d0870dbba18e0503cd41e5fae988a21b314</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.0_r01-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>76288040</sdk:size>
-                <sdk:checksum type="sha1">aeb623217ff88b87216d6eb7dbc846ed53f68f57</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.0_r01-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated on Mon Nov 23 14:08:02 PST 2009 using eclair-release 20723: Platform. Addon. -->
-
-    <sdk:platform>
-        <sdk:version>2.0.1</sdk:version>
-        <sdk:api-level>6</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>4</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 2.0.1_r1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/android-2.0.1.html</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>79192618</sdk:size>
-                <sdk:checksum type="sha1">ce2c971dce352aa28af06bda92a070116aa5ae1a</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.0.1_r01-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>79035527</sdk:size>
-                <sdk:checksum type="sha1">c3096f80d75a6fc8cb38ef8a18aec920e53d42c0</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.0.1_r01-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>80385601</sdk:size>
-                <sdk:checksum type="sha1">255781ebe4509d9707d0e77edda2815e2bc216e6</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.0.1_r01-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated on Thu May  6 15:57:41 PDT 2010 using eclair 35983: Platform. -->
-
-    <sdk:platform>
-        <sdk:version>2.1</sdk:version>
-        <sdk:api-level>7</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>03</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>8</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 2.1_r3</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>70142829</sdk:size>
-                <sdk:checksum type="sha1">5ce51b023ac19f8738500b1007a1da5de2349a1e</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.1_r03-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated on Wed Jun 30 16:13:06 PDT 2010 using froyo-release 43546: Platform. Addon. -->
-
-    <sdk:platform>
-        <sdk:version>2.2</sdk:version>
-        <sdk:api-level>8</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>03</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>8</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 2.2_r3</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>74652366</sdk:size>
-                <sdk:checksum type="sha1">231262c63eefdff8fd0386e9ccfefeb27a8f9202</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.2_r03-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated on Thu Jan 20 09:40:59 PST 2011 using gingerbread-sdk-release 93351: Platform. -->
-
-    <sdk:platform>
-        <sdk:version>2.3.1</sdk:version>
-        <sdk:api-level>9</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>02</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>8</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 2.3.1_r2</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>78732563</sdk:size>
-                <sdk:checksum type="sha1">209f8a7a8b2cb093fce858b8b55fed3ba5206773</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.3.1_r02-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated on Fri Feb  4 16:41:27 PST 2011 using gingerbread-release 101070: Platform. -->
-
-    <sdk:platform>
-        <sdk:version>2.3.3</sdk:version>
-        <sdk:api-level>10</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>02</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>8</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 2.3.3._r2</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>85470907</sdk:size>
-                <sdk:checksum type="sha1">887e37783ec32f541ea33c2c649dda648e8e6fb3</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-2.3.3_r02-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated on Thu Feb 17 08:41:10 PST 2011 using honeycomb 104254: Platform. -->
-
-    <sdk:platform>
-        <sdk:version>3.0</sdk:version>
-        <sdk:api-level>11</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>02</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>10</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 3.0, revision 2</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>104513908</sdk:size>
-                <sdk:checksum type="sha1">2c7d4bd13f276e76f6bbd87315fe27aba351dd37</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-3.0_r02-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated on Wed May  4 19:39:17 PDT 2011 using honeycomb-mr1 123685: Platform.
-         r2: layoutlib.jar from 3.0 to fix issue with ADT 10.
-    -->
-
-    <sdk:platform>
-        <sdk:version>3.1</sdk:version>
-        <sdk:api-level>12</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>03</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>11</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 3.1, revision 3</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>106472351</sdk:size>
-                <sdk:checksum type="sha1">4a50a6679cd95bb68bb5fc032e754cd7c5e2b1bf</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-3.1_r03-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- Generated on Fri Jul 15 11:50:12 PDT 2011 using honeycomb-mr2-release 140714: Platform. -->
-
-    <sdk:platform>
-        <sdk:version>3.2</sdk:version>
-        <sdk:api-level>13</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:min-tools-rev>
-            <sdk:major>12</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:description>Android SDK Platform 3.2, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>108426536</sdk:size>
-                <sdk:checksum type="sha1">6189a500a8c44ae73a439604363de93591163cd9</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/android-3.2_r01-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:layoutlib>
-            <sdk:api>4</sdk:api>
-        </sdk:layoutlib>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Thu Sep 11 14:16:21 2014 from git_ics-mr0 @ 1406408 -->
-        <sdk:revision>4</sdk:revision>
-        <sdk:description>Android SDK Platform 4.0</sdk:description>
-        <sdk:version>4.0</sdk:version>
-        <sdk:api-level>14</sdk:api-level>
-        <sdk:layoutlib>
-            <sdk:api>12</sdk:api>
-            <sdk:revision>1</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>46038082</sdk:size>
-                <sdk:checksum type="sha1">d4f1d8fbca25225b5f0e7a0adf0d39c3d6e60b3c</sdk:checksum>
-                <sdk:url>android-14_r04.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Thu Sep 11 14:16:02 2014 from git_ics-mr1 @ 1406430 -->
-        <sdk:revision>5</sdk:revision>
-        <sdk:description>Android SDK Platform 4.0.3</sdk:description>
-        <sdk:version>4.0.3</sdk:version>
-        <sdk:api-level>15</sdk:api-level>
-        <sdk:min-tools-rev>
-            <sdk:major>21</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:layoutlib>
-            <sdk:api>12</sdk:api>
-            <sdk:revision>1</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>44533475</sdk:size>
-                <sdk:checksum type="sha1">69ab4c443b37184b2883af1fd38cc20cbeffd0f3</sdk:checksum>
-                <sdk:url>android-15_r05.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Thu Sep 11 14:15:43 2014 from git_jb-dev @ 1425332 -->
-        <sdk:revision>5</sdk:revision>
-        <sdk:description>Android SDK Platform 4.1.2</sdk:description>
-        <sdk:version>4.1.2</sdk:version>
-        <sdk:api-level>16</sdk:api-level>
-        <sdk:min-tools-rev>
-            <sdk:major>21</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:layoutlib>
-            <sdk:api>12</sdk:api>
-            <sdk:revision>1</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>48128695</sdk:size>
-                <sdk:checksum type="sha1">12a5ce6235a76bc30f62c26bda1b680e336abd07</sdk:checksum>
-                <sdk:url>android-16_r05.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Thu Sep 11 14:15:23 2014 from git_jb-mr1.1-dev @ 1425461 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 4.2.2</sdk:description>
-        <sdk:version>4.2.2</sdk:version>
-        <sdk:api-level>17</sdk:api-level>
-        <sdk:min-tools-rev>
-            <sdk:major>21</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:layoutlib>
-            <sdk:api>12</sdk:api>
-            <sdk:revision>1</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>57030216</sdk:size>
-                <sdk:checksum type="sha1">dbe14101c06e6cdb34e300393e64e64f8c92168a</sdk:checksum>
-                <sdk:url>android-17_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Thu Sep 11 14:14:59 2014 from git_jb-mr2-dev @ 1425645 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 4.3.1</sdk:description>
-        <sdk:version>4.3.1</sdk:version>
-        <sdk:api-level>18</sdk:api-level>
-        <sdk:min-tools-rev>
-            <sdk:major>21</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:layoutlib>
-            <sdk:api>12</sdk:api>
-            <sdk:revision>1</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>57771739</sdk:size>
-                <sdk:checksum type="sha1">e6b09b3505754cbbeb4a5622008b907262ee91cb</sdk:checksum>
-                <sdk:url>android-18_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Mon Sep 22 15:22:30 2014 from git_klp-sdk-release @ 1456859 -->
-        <sdk:revision>4</sdk:revision>
-        <sdk:description>Android SDK Platform 4.4.2</sdk:description>
-        <sdk:version>4.4.2</sdk:version>
-        <sdk:api-level>19</sdk:api-level>
-        <sdk:min-tools-rev>
-            <sdk:major>22</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:layoutlib>
-            <sdk:api>12</sdk:api>
-            <sdk:revision>1</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>63871092</sdk:size>
-                <sdk:checksum type="sha1">2ff20d89e68f2f5390981342e009db5a2d456aaa</sdk:checksum>
-                <sdk:url>android-19_r04.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Thu Oct 23 11:39:31 2014 from git_klp-modular-dev @ 1537038 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android SDK Platform 4.4W.2</sdk:description>
-        <sdk:version>4.4W.2</sdk:version>
-        <sdk:api-level>20</sdk:api-level>
-        <sdk:min-tools-rev>
-            <sdk:major>22</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:layoutlib>
-            <sdk:api>12</sdk:api>
-            <sdk:revision>1</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>63567784</sdk:size>
-                <sdk:checksum type="sha1">a9251f8a3f313ab05834a07a963000927637e01d</sdk:checksum>
-                <sdk:url>android-20_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Thu Dec  4 12:23:51 2014 from git_lmp-dev @ 1624448 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android SDK Platform 5.0.1</sdk:description>
-        <sdk:version>5.0.1</sdk:version>
-        <sdk:api-level>21</sdk:api-level>
-        <sdk:min-tools-rev>
-            <sdk:major>22</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:layoutlib>
-            <sdk:api>12</sdk:api>
-            <sdk:revision>2</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>65897960</sdk:size>
-                <sdk:checksum type="sha1">53536556059bb29ae82f414fd2e14bc335a4eb4c</sdk:checksum>
-                <sdk:url>android-21_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Mon Mar 30 10:48:23 2015 from git_lmp-mr1-sdk-release @ 1819727 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android SDK Platform 5.1.1</sdk:description>
-        <sdk:version>5.1.1</sdk:version>
-        <sdk:api-level>22</sdk:api-level>
-        <sdk:min-tools-rev>
-            <sdk:major>22</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:layoutlib>
-            <sdk:api>14</sdk:api>
-            <sdk:revision>2</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>66852371</sdk:size>
-                <sdk:checksum type="sha1">5d1bd10fea962b216a0dece1247070164760a9fc</sdk:checksum>
-                <sdk:url>android-22_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <sdk:platform>
-        <!-- Generated at Fri Aug 14 15:30:35 2015 from git_mnc-release @ 2166767 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android SDK Platform 6.0</sdk:description>
-        <sdk:version>6.0</sdk:version>
-        <sdk:api-level>23</sdk:api-level>
-        <sdk:min-tools-rev>
-            <sdk:major>22</sdk:major>
-        </sdk:min-tools-rev>
-        <sdk:layoutlib>
-            <sdk:api>15</sdk:api>
-            <sdk:revision>1</sdk:revision>
-        </sdk:layoutlib>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>70408061</sdk:size>
-                <sdk:checksum type="sha1">cbccca8d3127e894845556ce999b28281de541bd</sdk:checksum>
-                <sdk:url>android-23_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform>
-
-    <!-- SAMPLES ........................ -->
-
-    <!-- Generated on Mon Feb 22 13:39:38 PST 2010 using eclair 25887: Samples. -->
-
-    <sdk:sample>
-        <sdk:api-level>7</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:description>Android SDK Samples for Android API 7, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>7677831</sdk:size>
-                <sdk:checksum type="sha1">51e4907f60f248ede5c58b54ce7b6ae0b473e0ca</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-2.1_r01-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <!-- Generated on Tue May 11 19:15:20 PDT 2010 using froyo 36658: Samples. -->
-
-    <sdk:sample>
-        <sdk:api-level>8</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:description>Android SDK Samples for Android API 8, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>7969716</sdk:size>
-                <sdk:checksum type="sha1">d16d8bf2dd84cedf73b98b948d66461c8f19d6fb</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-2.2_r01-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <!-- Generated on Tue Nov 30 19:39:34 PST 2010 using gingerbread 79962: Samples. -->
-
-    <sdk:sample>
-        <sdk:api-level>9</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:description>Android SDK Samples for Android API 9, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>8516326</sdk:size>
-                <sdk:checksum type="sha1">36f7dd6c8b5dbb50b3cf3e3ac5209f3fe55db2aa</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-2.3_r01-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <!-- Generated on Tue Feb  8 17:37:15 PST 2011 using gingerbread 102121: Samples. -->
-
-    <sdk:sample>
-        <sdk:api-level>10</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:description>Android SDK Samples for Android API 10, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>8539583</sdk:size>
-                <sdk:checksum type="sha1">93b0c3f3bdf5b07f1f115100b4954f0665297a0d</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-2.3.3_r01-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <!-- Generated on Thu Feb 17 08:45:49 PST 2011 using honeycomb 104254: Samples. -->
-
-    <sdk:sample>
-        <sdk:api-level>11</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:description>Android SDK Samples for Android API 11, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>11976920</sdk:size>
-                <sdk:checksum type="sha1">3749ace584631270268d65bb1d0ad61b0d691682</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-3.0_r01-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <!-- Generated on Wed May  4 19:49:56 PDT 2011 using honeycomb-mr1 123685: Samples. -->
-
-    <sdk:sample>
-        <sdk:api-level>12</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:description>Android SDK Samples for Android API 12, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>12150514</sdk:size>
-                <sdk:checksum type="sha1">df0ace37cbca73373fe94080f94c71557cac73a7</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-3.1_r01-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <!-- Generated on Fri Jul 15 11:52:24 PDT 2011 using honeycomb-mr2 142871: Samples. -->
-
-    <sdk:sample>
-        <sdk:api-level>13</sdk:api-level>
-        <sdk:codename/>
-        <sdk:revision>01</sdk:revision>
-        <sdk:description>Android SDK Samples for Android API 13, revision 1</sdk:description>
-        <sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>12193502</sdk:size>
-                <sdk:checksum type="sha1">078bcf1abc1cb8921f3fa482c252963a782bed60</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-3.2_r01-linux.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Wed Dec  7 13:48:27 2011 from git_ics-mr0 @ 234950 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:api-level>14</sdk:api-level>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>16253619</sdk:size>
-                <sdk:checksum type="sha1">1312c22ab0b650e26835cc3945d4ff8cea183416</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-14_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Fri Mar 16 11:27:52 2012 from ics-mr1 @ 291902 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:api-level>15</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>16366656</sdk:size>
-                <sdk:checksum type="sha1">042f368c5b09eca4d278264e6dbf9c12c5f73d1f</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-15_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Sun Jun 24 14:02:06 2012 from git_jb-release @ 391408 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>16</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>14729945</sdk:size>
-                <sdk:checksum type="sha1">dce3a2d41db50a381ef47ee8bddbe928520e685e</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-16_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Mon Nov 12 17:18:09 2012 from git_jb-mr1-dev @ 526865 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>17</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>14840030</sdk:size>
-                <sdk:checksum type="sha1">12d58cb26503610fc05bd7618c434cc6f983bc41</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-17_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Tue Jul 23 17:17:22 2013 from git_jb-mr2-ub-dev @ 751786 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>18</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>19897793</sdk:size>
-                <sdk:checksum type="sha1">73e879ce46c04a6e63ad1a9107018b4782945007</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/samples-18_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Wed Aug 27 10:42:00 2014 from git_klp-docs @ 1377789 -->
-        <sdk:revision>6</sdk:revision>
-        <sdk:api-level>19</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>31900752</sdk:size>
-                <sdk:checksum type="sha1">19593662771934b0b1e3be56ed18d13e6489bcd4</sdk:checksum>
-                <sdk:url>samples-19_r06.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Mon Nov 17 16:23:46 2014 from git_klp-modular-docs @ 1587091 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:api-level>20</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>50796850</sdk:size>
-                <sdk:checksum type="sha1">8b1290b0b707827808392e8178094a68dfb51a14</sdk:checksum>
-                <sdk:url>samples-20_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Mon Dec 9 17:22:11 2014 from git_lmp-docs @ 1634277 -->
-        <sdk:revision>4</sdk:revision>
-        <sdk:api-level>21</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>95971939</sdk:size>
-                <sdk:checksum type="sha1">3a08d37e97f567f5f629a06a9012f89b05c5ad8a</sdk:checksum>
-                <sdk:url>samples-21_r04.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Tue May 28 14:48:43 2015 from git_lmp-mr1-ub-dev @ 1966220 -->
-        <sdk:revision>6</sdk:revision>
-        <sdk:api-level>22</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>124512215</sdk:size>
-                <sdk:checksum type="sha1">1f6f4a81a8f19a9b9c9bf4adb64a91330a861c7f</sdk:checksum>
-                <sdk:url>samples-22_r06.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <sdk:sample>
-        <!-- Generated at Fri Aug 14 15:30:59 2015 from git_mnc-release @ 2166767 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:api-level>23</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>127582326</sdk:size>
-                <sdk:checksum type="sha1">94d2857476987cfb7b18c8be61755c21b0a6e599</sdk:checksum>
-                <sdk:url>samples-23_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:sample>
-
-    <!-- PLATFORM-TOOLS ........................ -->
-
-    <sdk:platform-tool>
-        <!-- Generated at Wed Sep  9 14:16:45 2015 from git_mnc-sdk-release @ 2240729 -->
-        <sdk:revision>
-            <sdk:major>23</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>1</sdk:micro>
-        </sdk:revision>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>2402978</sdk:size>
-                <sdk:checksum type="sha1">8f32d5f724618ad58e71909cc963ae006d0867b0</sdk:checksum>
-                <sdk:url>platform-tools_r23.0.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>2520021</sdk:size>
-                <sdk:checksum type="sha1">94dcc5072b3d0d74cc69e4101958b6c2e227e738</sdk:checksum>
-                <sdk:url>platform-tools_r23.0.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>2489850</sdk:size>
-                <sdk:checksum type="sha1">c461d66f3ca9fbae8ea0fa1a49c203b3b6fd653f</sdk:checksum>
-                <sdk:url>platform-tools_r23.0.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:platform-tool>
-
-    <sdk:platform-tool>
-        <!-- Generated at Thu Sep 17 09:08:50 2015 from git_stage-aosp-master @ 2261113 -->
-        <sdk:revision>
-            <sdk:major>23</sdk:major>
-            <sdk:minor>1</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-            <sdk:preview>1</sdk:preview>
-        </sdk:revision>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>2594786</sdk:size>
-                <sdk:checksum type="sha1">0467934bfbbb8bd72959f7365e1a3ce2683b68f6</sdk:checksum>
-                <sdk:url>platform-tools_r23.1_rc1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>2873688</sdk:size>
-                <sdk:checksum type="sha1">b04d1dbdfd734b0263fb04182e76ff565447f498</sdk:checksum>
-                <sdk:url>platform-tools_r23.1_rc1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>2752137</sdk:size>
-                <sdk:checksum type="sha1">c92d9fdfdf79e04a69412492d6480d4f937d1bcc</sdk:checksum>
-                <sdk:url>platform-tools_r23.1_rc1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-preview-license"/>
-    </sdk:platform-tool>
-
-    <!-- BUILD-TOOLS ........................ -->
-
-    <sdk:build-tool>
-        <!-- Generated at Tue May 14 16:40:25 2013 from git_jb-mr1.1-dev @ 673949 -->
-        <sdk:revision>
-            <sdk:major>17</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>11004914</sdk:size>
-                <sdk:checksum type="sha1">899897d327b0bad492d3a40d3db4d96119c15bc0</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r17-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>11696007</sdk:size>
-                <sdk:checksum type="sha1">2c2872bc3806aabf16a12e3959c2183ddc866e6d</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r17-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>12208114</sdk:size>
-                <sdk:checksum type="sha1">602ee709be9dbb8f179b1e4075148a57f9419930</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r17-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <!-- Build tools version 18.0.0 was broken for renderscript, so it has been removed -->
-
-    <sdk:build-tool>
-        <!-- Generated at Mon Jul 29 15:14:00 2013 from git_jb-mr2-dev @ 754669 -->
-        <sdk:revision>
-            <sdk:major>18</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>1</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>15413527</sdk:size>
-                <sdk:checksum type="sha1">a6c2afd0b6289d589351956d2f5212b37014ca7d</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r18.0.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>16627330</sdk:size>
-                <sdk:checksum type="sha1">f11618492b0d2270c332325d45d752d3656a9640</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r18.0.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>16633121</sdk:size>
-                <sdk:checksum type="sha1">d84f5692fb44d60fc53e5b2507cebf9f24626902</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r18.0.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Wed Sep 11 17:41:47 2013 from git_jb-mr2-dev @ 819563 -->
-        <sdk:revision>
-            <sdk:major>18</sdk:major>
-            <sdk:minor>1</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>19659547</sdk:size>
-                <sdk:checksum type="sha1">3a9810fc8559ab03c09378f07531e8cae2f1db30</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r18.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>20229298</sdk:size>
-                <sdk:checksum type="sha1">f314a0599e51397f0886fe888b50dd98f2f050d8</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r18.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>20451524</sdk:size>
-                <sdk:checksum type="sha1">16ddb299b8b43063e5bb3387ec17147c5053dfd8</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r18.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Thu Oct 10 14:18:15 2013 from git_jb-mr2-dev @ 867478 -->
-        <sdk:revision>
-            <sdk:major>18</sdk:major>
-            <sdk:minor>1</sdk:minor>
-            <sdk:micro>1</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>19660000</sdk:size>
-                <sdk:checksum type="sha1">c4605066e2f851387ea70bc1442b1968bd7b4a15</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r18.1.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>20229760</sdk:size>
-                <sdk:checksum type="sha1">68c9acbfc0cec2d51b19efaed39831a17055d998</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r18.1.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>20452157</sdk:size>
-                <sdk:checksum type="sha1">a9d9d37f6ddf859e57abc78802a77aaa166e48d4</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r18.1.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Mon Oct 28 23:12:03 2013 from git_klp-release @ 886418 -->
-        <sdk:revision>
-            <sdk:major>19</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>20611447</sdk:size>
-                <sdk:checksum type="sha1">6edf505c20f5ece9c48fa0aff9a90488f9654d52</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21339943</sdk:size>
-                <sdk:checksum type="sha1">55c1a6cf632e7d346f0002b275ec41fd3137fd83</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21441270</sdk:size>
-                <sdk:checksum type="sha1">86ec1c12db1bc446b7bcaefc5cc14eb361044e90</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Thu Dec  5 14:01:45 2013 from git_klp-dev @ 938007 -->
-        <sdk:revision>
-            <sdk:major>19</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>1</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>20500648</sdk:size>
-                <sdk:checksum type="sha1">5ef422bac5b28f4ced108319ed4a6bc7050a6234</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.0.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21229048</sdk:size>
-                <sdk:checksum type="sha1">18d2312dc4368858914213087f4e61445aca4517</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.0.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21450597</sdk:size>
-                <sdk:checksum type="sha1">efaf50fb19a3edb8d03efbff76f89a249ad2920b</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.0.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Wed Feb 12 12:38:29 2014 from git_klp-sdk-release @ 1009316 -->
-        <sdk:revision>
-            <sdk:major>19</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>2</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>20621117</sdk:size>
-                <sdk:checksum type="sha1">af664672d0d709c9ae30937b1062317d3ade7f95</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.0.2-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21352552</sdk:size>
-                <sdk:checksum type="sha1">a03a6bdea0091aea32e1b35b90a7294c9f04e3dd</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.0.2-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21453726</sdk:size>
-                <sdk:checksum type="sha1">145bc43065d45f756d99d87329d899052b9a9288</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.0.2-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Fri Feb 28 17:11:02 2014 from git_klp-sdk-release @ 1035858 -->
-        <sdk:revision>
-            <sdk:major>19</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>3</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>20730715</sdk:size>
-                <sdk:checksum type="sha1">cb46b433b67a0a6910ff00db84be8b527ea3102f</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.0.3-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21462150</sdk:size>
-                <sdk:checksum type="sha1">c2d6055478e9d2d4fba476ee85f99181ddd1160c</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.0.3-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21563992</sdk:size>
-                <sdk:checksum type="sha1">651cf8754373b2d52e7f6aab2c52eabffe4e9ea4</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.0.3-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Tue May  6 14:19:40 2014 from git_klp-sdk-release @ 1153987 -->
-        <sdk:revision>
-            <sdk:major>19</sdk:major>
-            <sdk:minor>1</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>20812533</sdk:size>
-                <sdk:checksum type="sha1">13b367fbdbff8132cb4356f716e8dc8a8df745c5</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21490972</sdk:size>
-                <sdk:checksum type="sha1">1ff20ac15fa47a75d00346ec12f180d531b3ca89</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21590160</sdk:size>
-                <sdk:checksum type="sha1">0d11aae3417de1efb4b9a0e0a7855904a61bcec1</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/build-tools_r19.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Mon Jun 23 19:17:29 2014 from git_klp-modular-release @ 1246132 -->
-        <sdk:revision>
-            <sdk:major>20</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>20828006</sdk:size>
-                <sdk:checksum type="sha1">cf20720e452b642d5eb59dabe05c0c729b36ec75</sdk:checksum>
-                <sdk:url>build-tools_r20-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21445463</sdk:size>
-                <sdk:checksum type="sha1">b688905526a5584d1327a662d871a635ff502758</sdk:checksum>
-                <sdk:url>build-tools_r20-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>21650508</sdk:size>
-                <sdk:checksum type="sha1">1240f629411c108a714c4ddd756937c7fab93f83</sdk:checksum>
-                <sdk:url>build-tools_r20-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Thu Oct 16 16:51:40 2014 from git_lmp-release @ 1521886 -->
-        <sdk:revision>
-            <sdk:major>21</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>22306371</sdk:size>
-                <sdk:checksum type="sha1">5bc8fd399bc0135a9bc91eec78ddc5af4f54bf32</sdk:checksum>
-                <sdk:url>build-tools_r21-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>22153145</sdk:size>
-                <sdk:checksum type="sha1">4933328fdeecbd554a29528f254f4993468e1cf4</sdk:checksum>
-                <sdk:url>build-tools_r21-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>22668456</sdk:size>
-                <sdk:checksum type="sha1">9bef7989b51436bd4e5114d8a0330359f077cbfa</sdk:checksum>
-                <sdk:url>build-tools_r21-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Fri Oct 17 18:37:07 2014 from git_lmp-release @ 1525922 -->
-        <sdk:revision>
-            <sdk:major>21</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>1</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>22306243</sdk:size>
-                <sdk:checksum type="sha1">d68e7e6fd7a48c8759aa41d713c9d4f0e4c1c1df</sdk:checksum>
-                <sdk:url>build-tools_r21.0.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>22153013</sdk:size>
-                <sdk:checksum type="sha1">e573069eea3e5255e7a65bedeb767f4fd0a5f49a</sdk:checksum>
-                <sdk:url>build-tools_r21.0.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>22668616</sdk:size>
-                <sdk:checksum type="sha1">b60c8f9b810c980abafa04896706f3911be1ade7</sdk:checksum>
-                <sdk:url>build-tools_r21.0.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Tue Oct 21 14:50:58 2014 from git_lmp-release @ 1532339 -->
-        <sdk:revision>
-            <sdk:major>21</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>2</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>22306371</sdk:size>
-                <sdk:checksum type="sha1">37496141b23cbe633167927b7abe6e22d9f1a1c1</sdk:checksum>
-                <sdk:url>build-tools_r21.0.2-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>22153122</sdk:size>
-                <sdk:checksum type="sha1">e1236ab8897b62b57414adcf04c132567b2612a5</sdk:checksum>
-                <sdk:url>build-tools_r21.0.2-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>22668597</sdk:size>
-                <sdk:checksum type="sha1">f17471c154058f3734729ef3cc363399b1cd3de1</sdk:checksum>
-                <sdk:url>build-tools_r21.0.2-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Thu Oct 30 13:18:55 2014 from git_lmp-sdk-release @ 1552913 -->
-        <sdk:revision>
-            <sdk:major>21</sdk:major>
-            <sdk:minor>1</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>32797810</sdk:size>
-                <sdk:checksum type="sha1">c79d63ac6b713a1e326ad4dae43f2ee76708a2f4</sdk:checksum>
-                <sdk:url>build-tools_r21.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>32642820</sdk:size>
-                <sdk:checksum type="sha1">b7455e543784d52a8925f960bc880493ed1478cb</sdk:checksum>
-                <sdk:url>build-tools_r21.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>33158159</sdk:size>
-                <sdk:checksum type="sha1">df619356c2359aa5eacdd48699d15b335d9bd246</sdk:checksum>
-                <sdk:url>build-tools_r21.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Mon Nov  3 13:43:11 2014 from git_lmp-sdk-release @ 1559046 -->
-        <sdk:revision>
-            <sdk:major>21</sdk:major>
-            <sdk:minor>1</sdk:minor>
-            <sdk:micro>1</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>32797356</sdk:size>
-                <sdk:checksum type="sha1">53fc4201237f899d5cd92f0b76ad41fb89da188b</sdk:checksum>
-                <sdk:url>build-tools_r21.1.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>32642454</sdk:size>
-                <sdk:checksum type="sha1">1c712ee3a1ba5a8b0548f9c32f17d4a0ddfd727d</sdk:checksum>
-                <sdk:url>build-tools_r21.1.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>33157676</sdk:size>
-                <sdk:checksum type="sha1">836a146eab0504aa9387a5132e986fe7c7381571</sdk:checksum>
-                <sdk:url>build-tools_r21.1.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Tue Dec  9 15:56:55 2014 from git_lmp-sdk-release @ 1635773 -->
-        <sdk:revision>
-            <sdk:major>21</sdk:major>
-            <sdk:minor>1</sdk:minor>
-            <sdk:micro>2</sdk:micro>
-        </sdk:revision>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>32792587</sdk:size>
-                <sdk:checksum type="sha1">1d944759c47f60e634d2b8a1f3a4259be2f8d652</sdk:checksum>
-                <sdk:url>build-tools_r21.1.2-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>32637678</sdk:size>
-                <sdk:checksum type="sha1">5e35259843bf2926113a38368b08458735479658</sdk:checksum>
-                <sdk:url>build-tools_r21.1.2-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>33152878</sdk:size>
-                <sdk:checksum type="sha1">e7c906b4ba0eea93b32ba36c610dbd6b204bff48</sdk:checksum>
-                <sdk:url>build-tools_r21.1.2-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Mon Mar  2 21:35:23 2015 from git_lmp-mr1-sdk-release @ 1764203 -->
-        <sdk:revision>
-            <sdk:major>22</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>33254114</sdk:size>
-                <sdk:checksum type="sha1">08fcca41e81b172bd9f570963b90d3a84929e043</sdk:checksum>
-                <sdk:url>build-tools_r22-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>33104280</sdk:size>
-                <sdk:checksum type="sha1">a8a1619dd090e44fac957bce6842e62abf87965b</sdk:checksum>
-                <sdk:url>build-tools_r22-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>33646090</sdk:size>
-                <sdk:checksum type="sha1">af95429b24088d704bc5db9bd606e34ac1b82c0d</sdk:checksum>
-                <sdk:url>build-tools_r22-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Tue Mar 17 10:54:01 2015 from git_lmp-mr1-sdk-release @ 1793126 -->
-        <sdk:revision>
-            <sdk:major>22</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>1</sdk:micro>
-        </sdk:revision>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>33254137</sdk:size>
-                <sdk:checksum type="sha1">61d8cbe069d9e0a57872a83e5e5abe164b7d52cf</sdk:checksum>
-                <sdk:url>build-tools_r22.0.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>33104577</sdk:size>
-                <sdk:checksum type="sha1">da8b9c5c3ede39298e6cf0283c000c2ee9029646</sdk:checksum>
-                <sdk:url>build-tools_r22.0.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>33646102</sdk:size>
-                <sdk:checksum type="sha1">53dad7f608e01d53b17176ba11165acbfccc5bbf</sdk:checksum>
-                <sdk:url>build-tools_r22.0.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-
-    <sdk:build-tool>
-        <!-- Generated at Fri Aug 14 15:30:27 2015 from git_mnc-release @ 2166767 -->
-        <sdk:revision>
-            <sdk:major>23</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>38570715</sdk:size>
-                <sdk:checksum type="sha1">3874948f35f2f8946597679cc6e9151449f23b5d</sdk:checksum>
-                <sdk:url>build-tools_r23-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>39080519</sdk:size>
-                <sdk:checksum type="sha1">c1d6209212b01469f80fa804e0c1d39a06bc9060</sdk:checksum>
-                <sdk:url>build-tools_r23-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>38070540</sdk:size>
-                <sdk:checksum type="sha1">90ba6e716f7703a236cd44b2e71c5ff430855a03</sdk:checksum>
-                <sdk:url>build-tools_r23-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <sdk:build-tool>
-        <!-- Generated at Tue Aug 25 11:51:16 2015 from git_mnc-sdk-release @ 2201634 -->
-        <sdk:revision>
-            <sdk:major>23</sdk:major>
-            <sdk:minor>0</sdk:minor>
-            <sdk:micro>1</sdk:micro>
-        </sdk:revision>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>38558889</sdk:size>
-                <sdk:checksum type="sha1">cc1d37231d228f7a6f130e1f8d8c940052f0f8ab</sdk:checksum>
-                <sdk:url>build-tools_r23.0.1-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>39069295</sdk:size>
-                <sdk:checksum type="sha1">b6ba7c399d5fa487d95289d8832e4ad943aed556</sdk:checksum>
-                <sdk:url>build-tools_r23.0.1-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>38059328</sdk:size>
-                <sdk:checksum type="sha1">d96ec1522721e9a179ae2c591c99f75d31d39718</sdk:checksum>
-                <sdk:url>build-tools_r23.0.1-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:build-tool>
-
-    <!-- TOOLS ........................ -->
-
-    <sdk:tool>
-        <!-- Generated at Fri Sep 18 12:00:58 2015 from aosp-emu-1.4-release @ 2265294 -->
-        <sdk:revision>
-            <sdk:major>24</sdk:major>
-            <sdk:minor>4</sdk:minor>
-            <sdk:micro>0</sdk:micro>
-        </sdk:revision>
-        <sdk:min-platform-tools-rev>
-            <sdk:major>20</sdk:major>
-        </sdk:min-platform-tools-rev>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>197016004</sdk:size>
-                <sdk:checksum type="sha1">c3b5d466a8f75d86db79d3c9b8724a4b1d287f5a</sdk:checksum>
-                <sdk:url>tools_r24.4-windows.zip</sdk:url>
-                <sdk:host-os>windows</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>320385195</sdk:size>
-                <sdk:checksum type="sha1">f120858b1f7eedb573608d4ebf16a046d8833024</sdk:checksum>
-                <sdk:url>tools_r24.4-linux.zip</sdk:url>
-                <sdk:host-os>linux</sdk:host-os>
-            </sdk:archive>
-            <sdk:archive>
-                <sdk:size>101816531</sdk:size>
-                <sdk:checksum type="sha1">b83ba3875b4e701b978a11d6506e8997907efca1</sdk:checksum>
-                <sdk:url>tools_r24.4-macosx.zip</sdk:url>
-                <sdk:host-os>macosx</sdk:host-os>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:tool>
-
-    <!-- DOCS ........................ -->
-
-    <sdk:doc>
-        <!-- Manually added entry on Fri Aug  14 17:05:00 2015  -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>23</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>332171437</sdk:size>
-                <sdk:checksum type="sha1">060ebab2f74861e1ddd9136df26b837312bc087f</sdk:checksum>
-                <sdk:url>docs-23_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:doc>
-
-    <!-- SOURCES ........................ -->
-
-    <sdk:source>
-        <!-- Generated at Wed Dec  7 13:48:11 2011 from git_ics-mr0 @ 234950 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>14</sdk:api-level>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>16152383</sdk:size>
-                <sdk:checksum type="sha1">eaf4ed7dcac46e68516a1b4aa5b0d9e5a39a7555</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/sources-14_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
-
-    <sdk:source>
-        <!-- Generated at Fri Mar 30 10:43:44 2012 from ics-mr1 @ 302030 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:api-level>15</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>16468746</sdk:size>
-                <sdk:checksum type="sha1">e5992a5747c9590783fbbdd700337bf0c9f6b1fa</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/sources-15_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
-
-    <sdk:source>
-        <!-- Generated at Thu Jul 19 18:39:42 2012 from git_jb-release @ 403059 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:api-level>16</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>17876720</sdk:size>
-                <sdk:checksum type="sha1">0f83c14ed333c45d962279ab5d6bc98a0269ef84</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/sources-16_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
-
-    <sdk:source>
-        <!-- Generated at Mon Nov 12 17:16:08 2012 from git_jb-mr1-dev @ 526865 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>17</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>18976816</sdk:size>
-                <sdk:checksum type="sha1">6f1f18cd2d2b1852d7f6892df9cee3823349d43a</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/sources-17_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
-
-    <sdk:source>
-        <!-- Generated at Tue Jul 23 17:18:30 2013 from git_jb-mr2-release @ 737497 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>18</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>20226735</sdk:size>
-                <sdk:checksum type="sha1">8b49fdf7433f4881a2bfb559b5dd05d8ec65fb78</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/sources-18_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
-
-    <sdk:source>
-        <!-- Generated at Thu Dec  5 14:04:22 2013 from git_klp-dev @ 938007 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:api-level>19</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>21819439</sdk:size>
-                <sdk:checksum type="sha1">433a1d043ef77561571250e94cb7a0ef24a202e7</sdk:checksum>
-                <sdk:url>https://dl-ssl.google.com/android/repository/sources-19_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
-
-    <sdk:source>
-        <!-- Generated at Mon Jun 23 19:18:43 2014 from git_klp-modular-release @ 1246132 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>20</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>23367603</sdk:size>
-                <sdk:checksum type="sha1">8da3e40f2625f9f7ef38b7e403f49f67226c0d76</sdk:checksum>
-                <sdk:url>sources-20_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
-
-    <sdk:source>
-        <!-- Generated at Thu Oct 16 16:53:14 2014 from git_lmp-release @ 1521886 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>21</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>28274751</sdk:size>
-                <sdk:checksum type="sha1">137a5044915d32bea297a8c1552684802bbc2e25</sdk:checksum>
-                <sdk:url>sources-21_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
-
-    <sdk:source>
-        <!-- Generated at Mon Mar  2 16:26:31 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>22</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>28861236</sdk:size>
-                <sdk:checksum type="sha1">98320e13976d11597a4a730a8d203ac9a03ed5a6</sdk:checksum>
-                <sdk:url>sources-22_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
-
-    <sdk:source>
-        <!-- Generated at Fri Aug 14 15:31:06 2015 from git_mnc-release @ 2166767 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:api-level>23</sdk:api-level>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>31771965</sdk:size>
-                <sdk:checksum type="sha1">b0f15da2762b42f543c5e364c2b15b198cc99cc2</sdk:checksum>
-                <sdk:url>sources-23_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:source>
+June 2014.</sdk:license>
+	<sdk:ndk>
+		<!--Generated from bid:2977051, branch:aosp-ndk-r12-release-->
+		<sdk:description>NDK</sdk:description>
+		<sdk:revision>12</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed Jun 15 13:55:11 2016.-->
+				<sdk:size>734135279</sdk:size>
+				<sdk:checksum type="sha1">e257fe12f8947be9f79c10c3fffe87fb9406118a</sdk:checksum>
+				<sdk:url>android-ndk-r12b-darwin-x86_64.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+				<sdk:host-bits>64</sdk:host-bits>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed Jun 15 13:55:32 2016.-->
+				<sdk:size>755551010</sdk:size>
+				<sdk:checksum type="sha1">170a119bfa0f0ce5dc932405eaa3a7cc61b27694</sdk:checksum>
+				<sdk:url>android-ndk-r12b-linux-x86_64.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+				<sdk:host-bits>64</sdk:host-bits>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed Jun 15 13:54:32 2016.-->
+				<sdk:size>706453972</sdk:size>
+				<sdk:checksum type="sha1">8e6eef0091dac2f3c7a1ecbb7070d4fa22212c04</sdk:checksum>
+				<sdk:url>android-ndk-r12b-windows-x86.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+				<sdk:host-bits>32</sdk:host-bits>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed Jun 15 13:54:50 2016.-->
+				<sdk:size>749567353</sdk:size>
+				<sdk:checksum type="sha1">337746d8579a1c65e8a69bf9cbdc9849bcacf7f5</sdk:checksum>
+				<sdk:url>android-ndk-r12b-windows-x86_64.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+				<sdk:host-bits>64</sdk:host-bits>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:ndk>
+	<sdk:platform>
+		<!--Generated from bid:3051502, branch:git_nyc-preview-release-->
+		<sdk:version>7.0</sdk:version>
+		<sdk:api-level>24</sdk:api-level>
+		<sdk:description>Android SDK Platform 24</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 13:51:08 2016.-->
+				<sdk:size>82645675</sdk:size>
+				<sdk:checksum type="sha1">27516dab4848f55896e16f7089038c62bbbffea7</sdk:checksum>
+				<sdk:url>platform-24_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>22</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>16</sdk:api>
+			<sdk:revision>2</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:2704002, branch:git_mnc-sdk-release-->
+		<sdk:version>6.0</sdk:version>
+		<sdk:api-level>23</sdk:api-level>
+		<sdk:description>Android SDK Platform 23</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 22 14:26:20 2016.-->
+				<sdk:size>70433421</sdk:size>
+				<sdk:checksum type="sha1">027fede3de6aa1649115bbd0bffff30ccd51c9a0</sdk:checksum>
+				<sdk:url>platform-23_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>22</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>16</sdk:api>
+			<sdk:revision>3</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1819727, branch:git_lmp-mr1-sdk-release-->
+		<sdk:version>5.1.1</sdk:version>
+		<sdk:api-level>22</sdk:api-level>
+		<sdk:description>Android SDK Platform 22</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:13 2016.-->
+				<sdk:size>66852371</sdk:size>
+				<sdk:checksum type="sha1">5d1bd10fea962b216a0dece1247070164760a9fc</sdk:checksum>
+				<sdk:url>android-22_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>22</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>14</sdk:api>
+			<sdk:revision>2</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1624448, branch:git_lmp-dev-->
+		<sdk:version>5.0.1</sdk:version>
+		<sdk:api-level>21</sdk:api-level>
+		<sdk:description>Android SDK Platform 21</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:12 2016.-->
+				<sdk:size>65897960</sdk:size>
+				<sdk:checksum type="sha1">53536556059bb29ae82f414fd2e14bc335a4eb4c</sdk:checksum>
+				<sdk:url>android-21_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>22</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>12</sdk:api>
+			<sdk:revision>2</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1537038, branch:git_klp-modular-dev-->
+		<sdk:version>4.4W.2</sdk:version>
+		<sdk:api-level>20</sdk:api-level>
+		<sdk:description>Android SDK Platform 20</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:12 2016.-->
+				<sdk:size>63567784</sdk:size>
+				<sdk:checksum type="sha1">a9251f8a3f313ab05834a07a963000927637e01d</sdk:checksum>
+				<sdk:url>android-20_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>22</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>12</sdk:api>
+			<sdk:revision>1</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1456859, branch:git_klp-sdk-release-->
+		<sdk:version>4.4.2</sdk:version>
+		<sdk:api-level>19</sdk:api-level>
+		<sdk:description>Android SDK Platform 19</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:11 2016.-->
+				<sdk:size>63871092</sdk:size>
+				<sdk:checksum type="sha1">2ff20d89e68f2f5390981342e009db5a2d456aaa</sdk:checksum>
+				<sdk:url>android-19_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>22</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>12</sdk:api>
+			<sdk:revision>1</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1425645, branch:git_jb-mr2-dev-->
+		<sdk:version>4.3.1</sdk:version>
+		<sdk:api-level>18</sdk:api-level>
+		<sdk:description>Android SDK Platform 18</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:11 2016.-->
+				<sdk:size>57771739</sdk:size>
+				<sdk:checksum type="sha1">e6b09b3505754cbbeb4a5622008b907262ee91cb</sdk:checksum>
+				<sdk:url>android-18_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>21</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>12</sdk:api>
+			<sdk:revision>1</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1425461, branch:git_jb-mr1.1-dev-->
+		<sdk:version>4.2.2</sdk:version>
+		<sdk:api-level>17</sdk:api-level>
+		<sdk:description>Android SDK Platform 17</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:11 2016.-->
+				<sdk:size>57030216</sdk:size>
+				<sdk:checksum type="sha1">dbe14101c06e6cdb34e300393e64e64f8c92168a</sdk:checksum>
+				<sdk:url>android-17_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>21</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>12</sdk:api>
+			<sdk:revision>1</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1425332, branch:git_jb-dev-->
+		<sdk:version>4.1.2</sdk:version>
+		<sdk:api-level>16</sdk:api-level>
+		<sdk:description>Android SDK Platform 16</sdk:description>
+		<sdk:revision>5</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:10 2016.-->
+				<sdk:size>48128695</sdk:size>
+				<sdk:checksum type="sha1">12a5ce6235a76bc30f62c26bda1b680e336abd07</sdk:checksum>
+				<sdk:url>android-16_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>21</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>12</sdk:api>
+			<sdk:revision>1</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1406430, branch:git_ics-mr1-->
+		<sdk:version>4.0.3</sdk:version>
+		<sdk:api-level>15</sdk:api-level>
+		<sdk:description>Android SDK Platform 15</sdk:description>
+		<sdk:revision>5</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:10 2016.-->
+				<sdk:size>44533475</sdk:size>
+				<sdk:checksum type="sha1">69ab4c443b37184b2883af1fd38cc20cbeffd0f3</sdk:checksum>
+				<sdk:url>android-15_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>21</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>12</sdk:api>
+			<sdk:revision>1</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1406408, branch:git_ics-mr0-->
+		<sdk:version>4.0</sdk:version>
+		<sdk:api-level>14</sdk:api-level>
+		<sdk:description>Android SDK Platform 14</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:09 2016.-->
+				<sdk:size>46038082</sdk:size>
+				<sdk:checksum type="sha1">d4f1d8fbca25225b5f0e7a0adf0d39c3d6e60b3c</sdk:checksum>
+				<sdk:url>android-14_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>12</sdk:api>
+			<sdk:revision>1</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:140714, branch:honeycomb-mr2-release-->
+		<sdk:version>3.2</sdk:version>
+		<sdk:api-level>13</sdk:api-level>
+		<sdk:description>Android SDK Platform 13</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue May 24 11:44:04 2016.-->
+				<sdk:size>108426536</sdk:size>
+				<sdk:checksum type="sha1">6189a500a8c44ae73a439604363de93591163cd9</sdk:checksum>
+				<sdk:url>android-3.2_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>12</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:123685, branch:honeycomb-mr1-->
+		<sdk:version>3.1</sdk:version>
+		<sdk:api-level>12</sdk:api-level>
+		<sdk:description>Android SDK Platform 12</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue May 24 11:45:54 2016.-->
+				<sdk:size>106472351</sdk:size>
+				<sdk:checksum type="sha1">4a50a6679cd95bb68bb5fc032e754cd7c5e2b1bf</sdk:checksum>
+				<sdk:url>android-3.1_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>11</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:104254, branch:honeycomb-->
+		<sdk:version>3.0</sdk:version>
+		<sdk:api-level>11</sdk:api-level>
+		<sdk:description>Android SDK Platform 11</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue May 24 11:45:33 2016.-->
+				<sdk:size>104513908</sdk:size>
+				<sdk:checksum type="sha1">2c7d4bd13f276e76f6bbd87315fe27aba351dd37</sdk:checksum>
+				<sdk:url>android-3.0_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>10</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:101070, branch:gingerbread-release-->
+		<sdk:version>2.3.3</sdk:version>
+		<sdk:api-level>10</sdk:api-level>
+		<sdk:description>Android SDK Platform 10</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue May 24 11:46:21 2016.-->
+				<sdk:size>85470907</sdk:size>
+				<sdk:checksum type="sha1">887e37783ec32f541ea33c2c649dda648e8e6fb3</sdk:checksum>
+				<sdk:url>android-2.3.3_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>4</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:93351, branch:gingerbread-sdk-release-->
+		<sdk:version>2.3.1</sdk:version>
+		<sdk:api-level>9</sdk:api-level>
+		<sdk:description>Android SDK Platform 9</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue May 24 11:47:02 2016.-->
+				<sdk:size>78732563</sdk:size>
+				<sdk:checksum type="sha1">209f8a7a8b2cb093fce858b8b55fed3ba5206773</sdk:checksum>
+				<sdk:url>android-2.3.1_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>4</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:43546, branch:froyo-release-->
+		<sdk:version>2.2</sdk:version>
+		<sdk:api-level>8</sdk:api-level>
+		<sdk:description>Android SDK Platform 8</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<sdk:size>74652366</sdk:size>
+				<sdk:checksum type="sha1">231262c63eefdff8fd0386e9ccfefeb27a8f9202</sdk:checksum>
+				<sdk:url>android-2.2_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>4</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:35983, branch:eclair-->
+		<sdk:version>2.1</sdk:version>
+		<sdk:api-level>7</sdk:api-level>
+		<sdk:description>Android SDK Platform 7</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<sdk:size>70142829</sdk:size>
+				<sdk:checksum type="sha1">5ce51b023ac19f8738500b1007a1da5de2349a1e</sdk:checksum>
+				<sdk:url>android-2.1_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>8</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:20723, branch:unknown-->
+		<sdk:version>2.0.1</sdk:version>
+		<sdk:api-level>6</sdk:api-level>
+		<sdk:description>Android SDK Platform 6</sdk:description>
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:15 2016.-->
+				<sdk:size>79192618</sdk:size>
+				<sdk:checksum type="sha1">ce2c971dce352aa28af06bda92a070116aa5ae1a</sdk:checksum>
+				<sdk:url>android-2.0.1_r01-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:15 2016.-->
+				<sdk:size>79035527</sdk:size>
+				<sdk:checksum type="sha1">c3096f80d75a6fc8cb38ef8a18aec920e53d42c0</sdk:checksum>
+				<sdk:url>android-2.0.1_r01-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:15 2016.-->
+				<sdk:size>80385601</sdk:size>
+				<sdk:checksum type="sha1">255781ebe4509d9707d0e77edda2815e2bc216e6</sdk:checksum>
+				<sdk:url>android-2.0.1_r01-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>4</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:17704, branch:unknown-->
+		<sdk:version>2.0</sdk:version>
+		<sdk:api-level>5</sdk:api-level>
+		<sdk:description>Android SDK Platform 5</sdk:description>
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:13 2016.-->
+				<sdk:size>75095268</sdk:size>
+				<sdk:checksum type="sha1">be9be6a99ca32875c96ec7f91160ca9fce7e3c7d</sdk:checksum>
+				<sdk:url>android-2.0_r01-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:13 2016.-->
+				<sdk:size>74956356</sdk:size>
+				<sdk:checksum type="sha1">2a866d0870dbba18e0503cd41e5fae988a21b314</sdk:checksum>
+				<sdk:url>android-2.0_r01-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:13 2016.-->
+				<sdk:size>76288040</sdk:size>
+				<sdk:checksum type="sha1">aeb623217ff88b87216d6eb7dbc846ed53f68f57</sdk:checksum>
+				<sdk:url>android-2.0_r01-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>3</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:3, branch:unknown-->
+		<sdk:version>1.6</sdk:version>
+		<sdk:api-level>4</sdk:api-level>
+		<sdk:description>Android SDK Platform 4</sdk:description>
+		<sdk:obsolete/>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<sdk:size>63454485</sdk:size>
+				<sdk:checksum type="sha1">483ed088e45bbdf3444baaf9250c8b02e5383cb0</sdk:checksum>
+				<sdk:url>android-1.6_r03-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<sdk:size>62418496</sdk:size>
+				<sdk:checksum type="sha1">bdafad44f5df9f127979bdb21a1fdd87ee3cd625</sdk:checksum>
+				<sdk:url>android-1.6_r03-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<sdk:size>64654625</sdk:size>
+				<sdk:checksum type="sha1">ce0b5e4ffaf12ca4fd07c2da71a8a1ab4a03dc22</sdk:checksum>
+				<sdk:url>android-1.6_r03-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>6</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:2, branch:unknown-->
+		<sdk:version>1.5</sdk:version>
+		<sdk:api-level>3</sdk:api-level>
+		<sdk:description>Android SDK Platform 3</sdk:description>
+		<sdk:obsolete/>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:14 2016.-->
+				<sdk:size>53348669</sdk:size>
+				<sdk:checksum type="sha1">5c134b7df5f4b8bd5b61ba93bdaebada8fa3468c</sdk:checksum>
+				<sdk:url>android-1.5_r04-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:14 2016.-->
+				<sdk:size>52440607</sdk:size>
+				<sdk:checksum type="sha1">d3a67c2369afa48b6c3c7624de5031c262018d1e</sdk:checksum>
+				<sdk:url>android-1.5_r04-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:14 2016.-->
+				<sdk:size>54624370</sdk:size>
+				<sdk:checksum type="sha1">5bb106d2e40d481edd337b0833093843e15fe49a</sdk:checksum>
+				<sdk:url>android-1.5_r04-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>6</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:1, branch:unknown-->
+		<sdk:version>1.1</sdk:version>
+		<sdk:api-level>2</sdk:api-level>
+		<sdk:description>Android SDK Platform 2</sdk:description>
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:08 2016.-->
+				<sdk:size>45476658</sdk:size>
+				<sdk:checksum type="sha1">c054d25c9b4c6251fa49c2f9c54336998679d3fe</sdk:checksum>
+				<sdk:url>android-1.1_r1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:08 2016.-->
+				<sdk:size>45584305</sdk:size>
+				<sdk:checksum type="sha1">e21dbcff45b7356657449ebb3c7e941be2bb5ebe</sdk:checksum>
+				<sdk:url>android-1.1_r1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:08 2016.-->
+				<sdk:size>46828615</sdk:size>
+				<sdk:checksum type="sha1">a4060f29ed39fc929c302836d488998c53c3002e</sdk:checksum>
+				<sdk:url>android-1.1_r1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>6</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>4</sdk:api>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:source>
+		<!--Generated from bid:2166767, branch:git_mnc-release-->
+		<sdk:api-level>23</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:21 2016.-->
+				<sdk:size>31771965</sdk:size>
+				<sdk:checksum type="sha1">b0f15da2762b42f543c5e364c2b15b198cc99cc2</sdk:checksum>
+				<sdk:url>sources-23_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:1737576, branch:git_lmp-mr1-sdk-release-->
+		<sdk:api-level>22</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:21 2016.-->
+				<sdk:size>28861236</sdk:size>
+				<sdk:checksum type="sha1">98320e13976d11597a4a730a8d203ac9a03ed5a6</sdk:checksum>
+				<sdk:url>sources-22_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:1521886, branch:git_lmp-release-->
+		<sdk:api-level>21</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:20 2016.-->
+				<sdk:size>28274751</sdk:size>
+				<sdk:checksum type="sha1">137a5044915d32bea297a8c1552684802bbc2e25</sdk:checksum>
+				<sdk:url>sources-21_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:1246132, branch:git_klp-modular-release-->
+		<sdk:api-level>20</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:20 2016.-->
+				<sdk:size>23367603</sdk:size>
+				<sdk:checksum type="sha1">8da3e40f2625f9f7ef38b7e403f49f67226c0d76</sdk:checksum>
+				<sdk:url>sources-20_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:938007, branch:git_klp-dev-->
+		<sdk:api-level>19</sdk:api-level>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:23 2016.-->
+				<sdk:size>21819439</sdk:size>
+				<sdk:checksum type="sha1">433a1d043ef77561571250e94cb7a0ef24a202e7</sdk:checksum>
+				<sdk:url>sources-19_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:737497, branch:git_jb-mr2-release-->
+		<sdk:api-level>18</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:23 2016.-->
+				<sdk:size>20226735</sdk:size>
+				<sdk:checksum type="sha1">8b49fdf7433f4881a2bfb559b5dd05d8ec65fb78</sdk:checksum>
+				<sdk:url>sources-18_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:526865, branch:git_jb-mr1-dev-->
+		<sdk:api-level>17</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:22 2016.-->
+				<sdk:size>18976816</sdk:size>
+				<sdk:checksum type="sha1">6f1f18cd2d2b1852d7f6892df9cee3823349d43a</sdk:checksum>
+				<sdk:url>sources-17_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:403059, branch:git_jb-release-->
+		<sdk:api-level>16</sdk:api-level>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:22 2016.-->
+				<sdk:size>17876720</sdk:size>
+				<sdk:checksum type="sha1">0f83c14ed333c45d962279ab5d6bc98a0269ef84</sdk:checksum>
+				<sdk:url>sources-16_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:302030, branch:git_ics-mr1-->
+		<sdk:api-level>15</sdk:api-level>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:22 2016.-->
+				<sdk:size>16468746</sdk:size>
+				<sdk:checksum type="sha1">e5992a5747c9590783fbbdd700337bf0c9f6b1fa</sdk:checksum>
+				<sdk:url>sources-15_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:234950, branch:git_ics-mr0-->
+		<sdk:api-level>14</sdk:api-level>
+		<sdk:obsolete/>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:21 2016.-->
+				<sdk:size>16152383</sdk:size>
+				<sdk:checksum type="sha1">eaf4ed7dcac46e68516a1b4aa5b0d9e5a39a7555</sdk:checksum>
+				<sdk:url>sources-14_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:build-tool>
+		<!--Generated from bid:3051502, branch:git_nyc-preview-release-->
+		<sdk:revision>
+			<sdk:major>24</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 13:50:49 2016.-->
+				<sdk:size>48936213</sdk:size>
+				<sdk:checksum type="sha1">d3647db5c349247787d4e124dfb717e72b4304c7</sdk:checksum>
+				<sdk:url>build-tools_r24.0.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 13:50:47 2016.-->
+				<sdk:size>48725466</sdk:size>
+				<sdk:checksum type="sha1">4fb942e52d05ded78719410fc8644e70a62f18d6</sdk:checksum>
+				<sdk:url>build-tools_r24.0.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 13:50:45 2016.-->
+				<sdk:size>49511433</sdk:size>
+				<sdk:checksum type="sha1">f73cc9028bff45689351ac8e093876bbeb80d1f1</sdk:checksum>
+				<sdk:url>build-tools_r24.0.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:2964546, branch:git_nyc-preview-release-->
+		<sdk:revision>
+			<sdk:major>24</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jun 10 15:06:14 2016.-->
+				<sdk:size>48960919</sdk:size>
+				<sdk:checksum type="sha1">c6271c4d78a5612ea6c7150688bcd5b7313de8d1</sdk:checksum>
+				<sdk:url>build-tools_r24-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Fri Jun 10 15:06:11 2016.-->
+				<sdk:size>48747930</sdk:size>
+				<sdk:checksum type="sha1">97fc4ed442f23989cc488d02c1d1de9bdde241de</sdk:checksum>
+				<sdk:url>build-tools_r24-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Fri Jun 10 15:06:10 2016.-->
+				<sdk:size>49535326</sdk:size>
+				<sdk:checksum type="sha1">dc61b9e5b451a0c3ec42ae2b1ce27c4d3c8da9f7</sdk:checksum>
+				<sdk:url>build-tools_r24-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:2355899, branch:git_mnc-dev-->
+		<sdk:revision>
+			<sdk:major>23</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>2</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:56 2016.-->
+				<sdk:size>39071201</sdk:size>
+				<sdk:checksum type="sha1">8a9f2b37f6fcf7a9fa784dc21aeaeb41bbb9f2c3</sdk:checksum>
+				<sdk:url>build-tools_r23.0.2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:56 2016.-->
+				<sdk:size>38060914</sdk:size>
+				<sdk:checksum type="sha1">482c4cbceef8ff58aefd92d8155a38610158fdaf</sdk:checksum>
+				<sdk:url>build-tools_r23.0.2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:56 2016.-->
+				<sdk:size>38217626</sdk:size>
+				<sdk:checksum type="sha1">fc3a92c744d3ba0a16ccb5d2b41eea5974ce0a96</sdk:checksum>
+				<sdk:url>build-tools_r23.0.2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:2679779, branch:git_mnc-dev-->
+		<sdk:revision>
+			<sdk:major>23</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>3</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 15 17:38:51 2016.-->
+				<sdk:size>40733174</sdk:size>
+				<sdk:checksum type="sha1">368f2600feac7e9b511b82f53d1f2240ae4a91a3</sdk:checksum>
+				<sdk:url>build-tools_r23.0.3-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Mar 15 17:38:50 2016.-->
+				<sdk:size>39679533</sdk:size>
+				<sdk:checksum type="sha1">fbc98cd303fd15a31d472de6c03bd707829f00b0</sdk:checksum>
+				<sdk:url>build-tools_r23.0.3-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Mar 15 17:38:48 2016.-->
+				<sdk:size>39869945</sdk:size>
+				<sdk:checksum type="sha1">c6d8266c6a3243c8f1e41b786c0e3cee4c781263</sdk:checksum>
+				<sdk:url>build-tools_r23.0.3-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:2201634, branch:git_mnc-sdk-release-->
+		<sdk:revision>
+			<sdk:major>23</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:55 2016.-->
+				<sdk:size>39069295</sdk:size>
+				<sdk:checksum type="sha1">b6ba7c399d5fa487d95289d8832e4ad943aed556</sdk:checksum>
+				<sdk:url>build-tools_r23.0.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:55 2016.-->
+				<sdk:size>38059328</sdk:size>
+				<sdk:checksum type="sha1">d96ec1522721e9a179ae2c591c99f75d31d39718</sdk:checksum>
+				<sdk:url>build-tools_r23.0.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:55 2016.-->
+				<sdk:size>38558889</sdk:size>
+				<sdk:checksum type="sha1">cc1d37231d228f7a6f130e1f8d8c940052f0f8ab</sdk:checksum>
+				<sdk:url>build-tools_r23.0.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:2166767, branch:git_mnc-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>23</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<sdk:size>39080519</sdk:size>
+				<sdk:checksum type="sha1">c1d6209212b01469f80fa804e0c1d39a06bc9060</sdk:checksum>
+				<sdk:url>build-tools_r23-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<sdk:size>38070540</sdk:size>
+				<sdk:checksum type="sha1">90ba6e716f7703a236cd44b2e71c5ff430855a03</sdk:checksum>
+				<sdk:url>build-tools_r23-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<sdk:size>38570715</sdk:size>
+				<sdk:checksum type="sha1">3874948f35f2f8946597679cc6e9151449f23b5d</sdk:checksum>
+				<sdk:url>build-tools_r23-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1793126, branch:git_lmp-mr1-sdk-release-->
+		<sdk:revision>
+			<sdk:major>22</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:53 2016.-->
+				<sdk:size>33104577</sdk:size>
+				<sdk:checksum type="sha1">da8b9c5c3ede39298e6cf0283c000c2ee9029646</sdk:checksum>
+				<sdk:url>build-tools_r22.0.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<sdk:size>33646102</sdk:size>
+				<sdk:checksum type="sha1">53dad7f608e01d53b17176ba11165acbfccc5bbf</sdk:checksum>
+				<sdk:url>build-tools_r22.0.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<sdk:size>33254137</sdk:size>
+				<sdk:checksum type="sha1">61d8cbe069d9e0a57872a83e5e5abe164b7d52cf</sdk:checksum>
+				<sdk:url>build-tools_r22.0.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1764203, branch:git_lmp-mr1-sdk-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>22</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:53 2016.-->
+				<sdk:size>33104280</sdk:size>
+				<sdk:checksum type="sha1">a8a1619dd090e44fac957bce6842e62abf87965b</sdk:checksum>
+				<sdk:url>build-tools_r22-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:53 2016.-->
+				<sdk:size>33646090</sdk:size>
+				<sdk:checksum type="sha1">af95429b24088d704bc5db9bd606e34ac1b82c0d</sdk:checksum>
+				<sdk:url>build-tools_r22-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:53 2016.-->
+				<sdk:size>33254114</sdk:size>
+				<sdk:checksum type="sha1">08fcca41e81b172bd9f570963b90d3a84929e043</sdk:checksum>
+				<sdk:url>build-tools_r22-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1635773, branch:git_lmp-sdk-release-->
+		<sdk:revision>
+			<sdk:major>21</sdk:major>
+			<sdk:minor>1</sdk:minor>
+			<sdk:micro>2</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<sdk:size>32637678</sdk:size>
+				<sdk:checksum type="sha1">5e35259843bf2926113a38368b08458735479658</sdk:checksum>
+				<sdk:url>build-tools_r21.1.2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<sdk:size>33152878</sdk:size>
+				<sdk:checksum type="sha1">e7c906b4ba0eea93b32ba36c610dbd6b204bff48</sdk:checksum>
+				<sdk:url>build-tools_r21.1.2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<sdk:size>32792587</sdk:size>
+				<sdk:checksum type="sha1">1d944759c47f60e634d2b8a1f3a4259be2f8d652</sdk:checksum>
+				<sdk:url>build-tools_r21.1.2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1559046, branch:git_lmp-sdk-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>21</sdk:major>
+			<sdk:minor>1</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:51 2016.-->
+				<sdk:size>32642454</sdk:size>
+				<sdk:checksum type="sha1">1c712ee3a1ba5a8b0548f9c32f17d4a0ddfd727d</sdk:checksum>
+				<sdk:url>build-tools_r21.1.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<sdk:size>33157676</sdk:size>
+				<sdk:checksum type="sha1">836a146eab0504aa9387a5132e986fe7c7381571</sdk:checksum>
+				<sdk:url>build-tools_r21.1.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<sdk:size>32797356</sdk:size>
+				<sdk:checksum type="sha1">53fc4201237f899d5cd92f0b76ad41fb89da188b</sdk:checksum>
+				<sdk:url>build-tools_r21.1.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1552913, branch:git_lmp-sdk-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>21</sdk:major>
+			<sdk:minor>1</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:51 2016.-->
+				<sdk:size>32642820</sdk:size>
+				<sdk:checksum type="sha1">b7455e543784d52a8925f960bc880493ed1478cb</sdk:checksum>
+				<sdk:url>build-tools_r21.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:51 2016.-->
+				<sdk:size>33158159</sdk:size>
+				<sdk:checksum type="sha1">df619356c2359aa5eacdd48699d15b335d9bd246</sdk:checksum>
+				<sdk:url>build-tools_r21.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:51 2016.-->
+				<sdk:size>32797810</sdk:size>
+				<sdk:checksum type="sha1">c79d63ac6b713a1e326ad4dae43f2ee76708a2f4</sdk:checksum>
+				<sdk:url>build-tools_r21.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1532339, branch:git_lmp-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>21</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>2</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<sdk:size>22153122</sdk:size>
+				<sdk:checksum type="sha1">e1236ab8897b62b57414adcf04c132567b2612a5</sdk:checksum>
+				<sdk:url>build-tools_r21.0.2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<sdk:size>22668597</sdk:size>
+				<sdk:checksum type="sha1">f17471c154058f3734729ef3cc363399b1cd3de1</sdk:checksum>
+				<sdk:url>build-tools_r21.0.2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<sdk:size>22306371</sdk:size>
+				<sdk:checksum type="sha1">37496141b23cbe633167927b7abe6e22d9f1a1c1</sdk:checksum>
+				<sdk:url>build-tools_r21.0.2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1525922, branch:git_lmp-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>21</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:49 2016.-->
+				<sdk:size>22153013</sdk:size>
+				<sdk:checksum type="sha1">e573069eea3e5255e7a65bedeb767f4fd0a5f49a</sdk:checksum>
+				<sdk:url>build-tools_r21.0.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<sdk:size>22668616</sdk:size>
+				<sdk:checksum type="sha1">b60c8f9b810c980abafa04896706f3911be1ade7</sdk:checksum>
+				<sdk:url>build-tools_r21.0.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<sdk:size>22306243</sdk:size>
+				<sdk:checksum type="sha1">d68e7e6fd7a48c8759aa41d713c9d4f0e4c1c1df</sdk:checksum>
+				<sdk:url>build-tools_r21.0.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1521886, branch:git_lmp-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>21</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:49 2016.-->
+				<sdk:size>22153145</sdk:size>
+				<sdk:checksum type="sha1">4933328fdeecbd554a29528f254f4993468e1cf4</sdk:checksum>
+				<sdk:url>build-tools_r21-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:49 2016.-->
+				<sdk:size>22668456</sdk:size>
+				<sdk:checksum type="sha1">9bef7989b51436bd4e5114d8a0330359f077cbfa</sdk:checksum>
+				<sdk:url>build-tools_r21-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:49 2016.-->
+				<sdk:size>22306371</sdk:size>
+				<sdk:checksum type="sha1">5bc8fd399bc0135a9bc91eec78ddc5af4f54bf32</sdk:checksum>
+				<sdk:url>build-tools_r21-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1246132, branch:git_klp-modular-release-->
+		<sdk:revision>
+			<sdk:major>20</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<sdk:size>21445463</sdk:size>
+				<sdk:checksum type="sha1">b688905526a5584d1327a662d871a635ff502758</sdk:checksum>
+				<sdk:url>build-tools_r20-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<sdk:size>21650508</sdk:size>
+				<sdk:checksum type="sha1">1240f629411c108a714c4ddd756937c7fab93f83</sdk:checksum>
+				<sdk:url>build-tools_r20-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<sdk:size>20828006</sdk:size>
+				<sdk:checksum type="sha1">cf20720e452b642d5eb59dabe05c0c729b36ec75</sdk:checksum>
+				<sdk:url>build-tools_r20-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1153987, branch:git_klp-sdk-release-->
+		<sdk:revision>
+			<sdk:major>19</sdk:major>
+			<sdk:minor>1</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:47 2016.-->
+				<sdk:size>21490972</sdk:size>
+				<sdk:checksum type="sha1">1ff20ac15fa47a75d00346ec12f180d531b3ca89</sdk:checksum>
+				<sdk:url>build-tools_r19.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<sdk:size>21590160</sdk:size>
+				<sdk:checksum type="sha1">0d11aae3417de1efb4b9a0e0a7855904a61bcec1</sdk:checksum>
+				<sdk:url>build-tools_r19.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<sdk:size>20812533</sdk:size>
+				<sdk:checksum type="sha1">13b367fbdbff8132cb4356f716e8dc8a8df745c5</sdk:checksum>
+				<sdk:url>build-tools_r19.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1035858, branch:git_klp-sdk-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>19</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>3</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:47 2016.-->
+				<sdk:size>21462150</sdk:size>
+				<sdk:checksum type="sha1">c2d6055478e9d2d4fba476ee85f99181ddd1160c</sdk:checksum>
+				<sdk:url>build-tools_r19.0.3-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:47 2016.-->
+				<sdk:size>21563992</sdk:size>
+				<sdk:checksum type="sha1">651cf8754373b2d52e7f6aab2c52eabffe4e9ea4</sdk:checksum>
+				<sdk:url>build-tools_r19.0.3-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:47 2016.-->
+				<sdk:size>20730715</sdk:size>
+				<sdk:checksum type="sha1">cb46b433b67a0a6910ff00db84be8b527ea3102f</sdk:checksum>
+				<sdk:url>build-tools_r19.0.3-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:1009316, branch:git_klp-sdk-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>19</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>2</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:46 2016.-->
+				<sdk:size>21352552</sdk:size>
+				<sdk:checksum type="sha1">a03a6bdea0091aea32e1b35b90a7294c9f04e3dd</sdk:checksum>
+				<sdk:url>build-tools_r19.0.2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:46 2016.-->
+				<sdk:size>21453726</sdk:size>
+				<sdk:checksum type="sha1">145bc43065d45f756d99d87329d899052b9a9288</sdk:checksum>
+				<sdk:url>build-tools_r19.0.2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:46 2016.-->
+				<sdk:size>20621117</sdk:size>
+				<sdk:checksum type="sha1">af664672d0d709c9ae30937b1062317d3ade7f95</sdk:checksum>
+				<sdk:url>build-tools_r19.0.2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:938007, branch:git_klp-dev-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>19</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<sdk:size>21229048</sdk:size>
+				<sdk:checksum type="sha1">18d2312dc4368858914213087f4e61445aca4517</sdk:checksum>
+				<sdk:url>build-tools_r19.0.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<sdk:size>21450597</sdk:size>
+				<sdk:checksum type="sha1">efaf50fb19a3edb8d03efbff76f89a249ad2920b</sdk:checksum>
+				<sdk:url>build-tools_r19.0.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<sdk:size>20500648</sdk:size>
+				<sdk:checksum type="sha1">5ef422bac5b28f4ced108319ed4a6bc7050a6234</sdk:checksum>
+				<sdk:url>build-tools_r19.0.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:886418, branch:git_klp-release-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>19</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:02 2016.-->
+				<sdk:size>21339943</sdk:size>
+				<sdk:checksum type="sha1">55c1a6cf632e7d346f0002b275ec41fd3137fd83</sdk:checksum>
+				<sdk:url>build-tools_r19-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<sdk:size>21441270</sdk:size>
+				<sdk:checksum type="sha1">86ec1c12db1bc446b7bcaefc5cc14eb361044e90</sdk:checksum>
+				<sdk:url>build-tools_r19-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<sdk:size>20611447</sdk:size>
+				<sdk:checksum type="sha1">6edf505c20f5ece9c48fa0aff9a90488f9654d52</sdk:checksum>
+				<sdk:url>build-tools_r19-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:867478, branch:git_jb-mr2-dev-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>18</sdk:major>
+			<sdk:minor>1</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:02 2016.-->
+				<sdk:size>20229760</sdk:size>
+				<sdk:checksum type="sha1">68c9acbfc0cec2d51b19efaed39831a17055d998</sdk:checksum>
+				<sdk:url>build-tools_r18.1.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:02 2016.-->
+				<sdk:size>20452157</sdk:size>
+				<sdk:checksum type="sha1">a9d9d37f6ddf859e57abc78802a77aaa166e48d4</sdk:checksum>
+				<sdk:url>build-tools_r18.1.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:02 2016.-->
+				<sdk:size>19660000</sdk:size>
+				<sdk:checksum type="sha1">c4605066e2f851387ea70bc1442b1968bd7b4a15</sdk:checksum>
+				<sdk:url>build-tools_r18.1.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:819563, branch:git_jb-mr2-dev-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>18</sdk:major>
+			<sdk:minor>1</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:01 2016.-->
+				<sdk:size>20229298</sdk:size>
+				<sdk:checksum type="sha1">f314a0599e51397f0886fe888b50dd98f2f050d8</sdk:checksum>
+				<sdk:url>build-tools_r18.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:01 2016.-->
+				<sdk:size>20451524</sdk:size>
+				<sdk:checksum type="sha1">16ddb299b8b43063e5bb3387ec17147c5053dfd8</sdk:checksum>
+				<sdk:url>build-tools_r18.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:01 2016.-->
+				<sdk:size>19659547</sdk:size>
+				<sdk:checksum type="sha1">3a9810fc8559ab03c09378f07531e8cae2f1db30</sdk:checksum>
+				<sdk:url>build-tools_r18.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:754669, branch:git_jb-mr2-dev-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>18</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<sdk:size>16627330</sdk:size>
+				<sdk:checksum type="sha1">f11618492b0d2270c332325d45d752d3656a9640</sdk:checksum>
+				<sdk:url>build-tools_r18.0.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<sdk:size>16633121</sdk:size>
+				<sdk:checksum type="sha1">d84f5692fb44d60fc53e5b2507cebf9f24626902</sdk:checksum>
+				<sdk:url>build-tools_r18.0.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<sdk:size>15413527</sdk:size>
+				<sdk:checksum type="sha1">a6c2afd0b6289d589351956d2f5212b37014ca7d</sdk:checksum>
+				<sdk:url>build-tools_r18.0.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:673949, branch:git_jb-mr1.1-dev-->
+		<sdk:obsolete/>
+		<sdk:revision>
+			<sdk:major>17</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:56:59 2016.-->
+				<sdk:size>11696007</sdk:size>
+				<sdk:checksum type="sha1">2c2872bc3806aabf16a12e3959c2183ddc866e6d</sdk:checksum>
+				<sdk:url>build-tools_r17-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<sdk:size>12208114</sdk:size>
+				<sdk:checksum type="sha1">602ee709be9dbb8f179b1e4075148a57f9419930</sdk:checksum>
+				<sdk:url>build-tools_r17-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<sdk:size>11004914</sdk:size>
+				<sdk:checksum type="sha1">899897d327b0bad492d3a40d3db4d96119c15bc0</sdk:checksum>
+				<sdk:url>build-tools_r17-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:platform-tool>
+		<!--Generated from bid:3051502, branch:nyc_preview_release-->
+		<sdk:revision>
+			<sdk:major>24</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 13:50:59 2016.-->
+				<sdk:size>3328487</sdk:size>
+				<sdk:checksum type="sha1">597f626c206dac435b55c64bbfa13e153a7d97c2</sdk:checksum>
+				<sdk:url>platform-tools_r24-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 13:50:58 2016.-->
+				<sdk:size>3143839</sdk:size>
+				<sdk:checksum type="sha1">f089af7906ccb6a43691b9bad9bb197e7104902e</sdk:checksum>
+				<sdk:url>platform-tools_r24-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 13:50:58 2016.-->
+				<sdk:size>2984063</sdk:size>
+				<sdk:checksum type="sha1">f1e2d122544d7beaa6f979e485fe742ba735802e</sdk:checksum>
+				<sdk:url>platform-tools_r24-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:platform-tool>
+	<sdk:tool>
+		<!--Generated from bid:2879327, branch:aosp-emu-2.0-release-->
+		<sdk:revision>
+			<sdk:major>25</sdk:major>
+			<sdk:minor>1</sdk:minor>
+			<sdk:micro>7</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed May 18 11:42:01 2016.-->
+				<sdk:size>234442830</sdk:size>
+				<sdk:checksum type="sha1">36869e6c81cda18f862959a92301761f81bc06b8</sdk:checksum>
+				<sdk:url>tools_r25.1.7-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed May 18 11:41:53 2016.-->
+				<sdk:size>161408907</sdk:size>
+				<sdk:checksum type="sha1">0fc555651bc6c7fc93237316311d3b435747bf3b</sdk:checksum>
+				<sdk:url>tools_r25.1.7-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed May 18 11:41:48 2016.-->
+				<sdk:size>230413711</sdk:size>
+				<sdk:checksum type="sha1">2556ac9a5fa741d44d9b989966c0bbdf15cb6424</sdk:checksum>
+				<sdk:url>tools_r25.1.7-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-platform-tools-rev>
+			<sdk:major>20</sdk:major>
+		</sdk:min-platform-tools-rev>
+	</sdk:tool>
+	<sdk:tool>
+		<!--Generated from bid:3037468, branch:aosp-emu-2.2-release-->
+		<sdk:revision>
+			<sdk:major>25</sdk:major>
+			<sdk:minor>2</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+			<sdk:preview>1</sdk:preview>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Thu Jul  7 09:13:33 2016.-->
+				<sdk:size>277445993</sdk:size>
+				<sdk:checksum type="sha1">084ff93feb2f432f532cb00375e582f46b583ff2</sdk:checksum>
+				<sdk:url>tools_r25.2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Thu Jul  7 09:13:24 2016.-->
+				<sdk:size>195767390</sdk:size>
+				<sdk:checksum type="sha1">e49cc97f6f408fde9181f11ab942dbbea31abce3</sdk:checksum>
+				<sdk:url>tools_r25.2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Thu Jul  7 09:13:18 2016.-->
+				<sdk:size>301550581</sdk:size>
+				<sdk:checksum type="sha1">cc8bcbd7fb5627ab866cc583b041d0bfc18e4441</sdk:checksum>
+				<sdk:url>tools_r25.2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-platform-tools-rev>
+			<sdk:major>20</sdk:major>
+		</sdk:min-platform-tools-rev>
+	</sdk:tool>
+	<sdk:doc>
+		<!--Generated from bid:2166767, branch:git_mnc-release-->
+		<sdk:api-level>23</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Mar 28 00:57:04 2016.-->
+				<sdk:size>332171437</sdk:size>
+				<sdk:checksum type="sha1">060ebab2f74861e1ddd9136df26b837312bc087f</sdk:checksum>
+				<sdk:url>docs-23_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:doc>
 </sdk:sdk-repository>

--- a/pkgs/development/mobile/androidenv/support-repository.nix
+++ b/pkgs/development/mobile/androidenv/support-repository.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "24";
+  version = "33";
   name = "android-support-repository-r${version}";
   src = fetchurl {
     url = "http://dl.google.com/android/repository/android_m2repository_r${version}.zip";
-    sha1 = "5b6d328a572172ec51dc25c3514392760e49bb81";
+    sha1 = "pdg5s78wypnc27fs5n62c8rrjl8gwyv4";
   };
 
   buildCommand = ''

--- a/pkgs/development/mobile/androidenv/support.nix
+++ b/pkgs/development/mobile/androidenv/support.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "23.1";
+  version = "23.2.1";
   name = "android-support-r${version}";
   src = fetchurl {
     url = "https://dl.google.com/android/repository/support_r${version}.zip";
-    sha1 = "c43a56fcd1c2aa620f6178a0ef529623ed77b3c7";
+    sha1 = "azl7hgps1k98kmbhw45wwbrc86y1n4j1";
   };
   
   buildCommand = ''

--- a/pkgs/development/mobile/androidenv/sys-img.xml
+++ b/pkgs/development/mobile/androidenv/sys-img.xml
@@ -1,54 +1,43 @@
-<!--
-* Copyright (C) 2012 The Android Open Source Project
-*
-* Licensed under the Apache License, version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
--->
+<?xml version="1.0" ?>
 <sdk:sdk-sys-img xmlns:sdk="http://schemas.android.com/sdk/android/sys-img/3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<!--Generated on 2016-07-15 21:31:22.867420 with ADRT.-->
+	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
-
-    <sdk:license id="android-sdk-license" type="text">To get started with the Android SDK, you must agree to the following terms and conditions.
-
-This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
+This is the Android Software Development Kit License Agreement
 
 1. Introduction
 
-1.1 The Android SDK (referred to in the License Agreement as the &quot;SDK&quot; and specifically including the Android system files, packaged APIs, and SDK library files and tools , if and when they are made available) is licensed to you subject to the terms of the License Agreement. The License Agreement forms a legally binding contract between you and Google in relation to your use of the SDK.
+1.1 The Android Software Development Kit (referred to in the License Agreement as the &quot;SDK&quot; and specifically including the Android system files, packaged APIs, and Google APIs add-ons) is licensed to you subject to the terms of the License Agreement. The License Agreement forms a legally binding contract between you and Google in relation to your use of the SDK.
 
 1.2 &quot;Android&quot; means the Android software stack for devices, as made available under the Android Open Source Project, which is located at the following URL: http://source.android.com/, as updated from time to time.
 
-1.3 &quot;Google&quot; means Google Inc., a Delaware corporation with principal place of business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, United States.
+1.3 A &quot;compatible implementation&quot; means any Android device that (i) complies with the Android Compatibility Definition document, which can be found at the Android compatibility website (http://source.android.com/compatibility) and which may be updated from time to time; and (ii) successfully passes the Android Compatibility Test Suite (CTS).
+
+1.4 &quot;Google&quot; means Google Inc., a Delaware corporation with principal place of business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, United States.
+
 
 2. Accepting the License Agreement
 
 2.1 In order to use the SDK, you must first agree to the License Agreement. You may not use the SDK if you do not accept the License Agreement.
 
-2.2 By clicking to accept and/or using the SDK, you hereby agree to the terms of the License Agreement.
+2.2 By clicking to accept, you hereby agree to the terms of the License Agreement.
 
-2.3 You may not use the SDK and may not accept the License Agreement if you are a person barred from receiving the SDK under the laws of the United States or other countries including the country in which you are resident or from which you use the SDK.
+2.3 You may not use the SDK and may not accept the License Agreement if you are a person barred from receiving the SDK under the laws of the United States or other countries, including the country in which you are resident or from which you use the SDK.
 
-2.4 If you will use the SDK internally within your company or organization you agree to be bound by the License Agreement on behalf of your employer or other entity, and you represent and warrant that you have full legal authority to bind your employer or such entity to the License Agreement. If you do not have the requisite authority, you may not accept the License Agreement or use the SDK on behalf of your employer or other entity.
+2.4 If you are agreeing to be bound by the License Agreement on behalf of your employer or other entity, you represent and warrant that you have full legal authority to bind your employer or such entity to the License Agreement. If you do not have the requisite authority, you may not accept the License Agreement or use the SDK on behalf of your employer or other entity.
+
 
 3. SDK License from Google
 
-3.1 Subject to the terms of the License Agreement, Google grants you a royalty-free, non-assignable, non-exclusive, non-sublicensable, limited, revocable license to use the SDK, personally or internally within your company or organization, solely to develop and distribute applications to run on the Android platform.
+3.1 Subject to the terms of the License Agreement, Google grants you a limited, worldwide, royalty-free, non-assignable, non-exclusive, and non-sublicensable license to use the SDK solely to develop applications for compatible implementations of Android.
 
-3.2 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
+3.2 You may not use this SDK to develop applications for other platforms (including non-compatible implementations of Android) or to develop another SDK. You are of course free to develop applications for other platforms, including non-compatible implementations of Android, provided that this SDK is not used for that purpose.
 
-3.3 You may not use the SDK for any purpose not expressly permitted by the License Agreement. Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK; or (b) load any part of the SDK onto a mobile handset or any other hardware device except a personal computer, combine any part of the SDK with other software, or distribute any software or device incorporating a part of the SDK.
+3.3 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
 
-3.4 You agree that you will not take any actions that may cause or result in the fragmentation of Android, including but not limited to distributing, participating in the creation of, or promoting in any way a software development kit derived from the SDK.
+3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement.  Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK; or (b) load any part of the SDK onto a mobile handset or any other hardware device except a personal computer, combine any part of the SDK with other software, or distribute any software or device incorporating a part of the SDK.
 
-3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement. You agree to remain a licensee in good standing in regard to such open source software licenses under all the rights granted and to refrain from any actions that may terminate, suspend, or breach such rights.
+3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement.
 
 3.6 You agree that the form and nature of the SDK that Google provides may change without prior notice to you and that future versions of the SDK may be incompatible with applications developed on previous versions of the SDK. You agree that Google may stop (permanently or temporarily) providing the SDK (or any features within the SDK) to you or to users generally at Google's sole discretion, without prior notice to you.
 
@@ -56,15 +45,16 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 3.8 You agree that you will not remove, obscure, or alter any proprietary rights notices (including copyright and trademark notices) that may be affixed to or contained within the SDK.
 
+
 4. Use of the SDK by You
 
-4.1 Google agrees that nothing in the License Agreement gives Google any right, title or interest from you (or your licensors) under the License Agreement in or to any software applications that you develop using the SDK, including any intellectual property rights that subsist in those applications.
+4.1 Google agrees that it obtains no right, title or interest from you (or your licensors) under the License Agreement in or to any software applications that you develop using the SDK, including any intellectual property rights that subsist in those applications.
 
-4.2 You agree to use the SDK and write applications only for purposes that are permitted by (a) the License Agreement, and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions (including any laws regarding the export of data or software to and from the United States or other relevant countries).
+4.2 You agree to use the SDK and write applications only for purposes that are permitted by (a) the License Agreement and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions (including any laws regarding the export of data or software to and from the United States or other relevant countries).
 
-4.3 You agree that if you use the SDK to develop applications, you will protect the privacy and legal rights of users. If users provide you with user names, passwords, or other login information or personal information, you must make the users aware that the information will be available to your application, and you must provide legally adequate privacy notice and protection for those users. If your application stores personal or sensitive information provided by users, it must do so securely. If users provide you with Google Account information, your application may only use that information to access the user's Google Account when, and for the limited purposes for which, each user has given you permission to do so.
+4.3 You agree that if you use the SDK to develop applications for general public users, you will protect the privacy and legal rights of those users. If the users provide you with user names, passwords, or other login information or personal information, you must make the users aware that the information will be available to your application, and you must provide legally adequate privacy notice and protection for those users. If your application stores personal or sensitive information provided by users, it must do so securely. If the user provides your application with Google Account information, your application may only use that information to access the user's Google Account when, and for the limited purposes for which, the user has given you permission to do so.
 
-4.4 You agree that you will not engage in any activity with the SDK, including the development or distribution of an application, that interferes with, disrupts, damages, or accesses in an unauthorized manner the servers, networks, or other properties or services of Google or any third party.
+4.4 You agree that you will not engage in any activity with the SDK, including the development or distribution of an application, that interferes with, disrupts, damages, or accesses in an unauthorized manner the servers, networks, or other properties or services of any third party including, but not limited to, Google or any mobile communications carrier.
 
 4.5 You agree that you are solely responsible for (and that Google has no responsibility to you or to any third party for) any data, content, or resources that you create, transmit or display through Android and/or applications for Android, and for the consequences of your actions (including any loss or damage which Google may suffer) by doing so.
 
@@ -78,7 +68,8 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 6.1 In order to continually innovate and improve the SDK, Google may collect certain usage statistics from the software including but not limited to a unique identifier, associated IP address, version number of the software, and information on which tools and/or services in the SDK are being used and how they are being used. Before any of this information is collected, the SDK will notify you and seek your consent. If you withhold consent, the information will not be collected.
 
-6.2 The data collected is examined in the aggregate to improve the SDK and is maintained in accordance with Google's Privacy Policy located at http://www.google.com/policies/privacy/.
+6.2 The data collected is examined in the aggregate to improve the SDK and is maintained in accordance with Google's Privacy Policy.
+
 
 7. Third Party Applications
 
@@ -86,15 +77,17 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 7.2 You should be aware the data, content, and resources presented to you through such a third party application may be protected by intellectual property rights which are owned by the providers (or by other persons or companies on their behalf). You may not modify, rent, lease, loan, sell, distribute or create derivative works based on these data, content, or resources (either in whole or in part) unless you have been specifically given permission to do so by the relevant owners.
 
-7.3 You acknowledge that your use of such third party applications, data, content, or resources may be subject to separate terms between you and the relevant third party.
+7.3 You acknowledge that your use of such third party applications, data, content, or resources may be subject to separate terms between you and the relevant third party. In that case, the License Agreement does not affect your legal relationship with these third parties.
 
-8. Using Google APIs
 
-8.1 Google APIs
+8. Using Android APIs
+
+8.1 Google Data APIs
 
 8.1.1 If you use any API to retrieve data from Google, you acknowledge that the data may be protected by intellectual property rights which are owned by Google or those parties that provide the data (or by other persons or companies on their behalf). Your use of any such API may be subject to additional Terms of Service. You may not modify, rent, lease, loan, sell, distribute or create derivative works based on this data (either in whole or in part) unless allowed by the relevant Terms of Service.
 
 8.1.2 If you use any API to retrieve a user's data from Google, you acknowledge and agree that you shall retrieve data only with the user's explicit consent and only when, and for the limited purposes for which, the user has given you permission to do so.
+
 
 9. Terminating the License Agreement
 
@@ -102,31 +95,38 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 9.2 If you want to terminate the License Agreement, you may do so by ceasing your use of the SDK and any relevant developer credentials.
 
-9.3 Google may at any time, terminate the License Agreement, with or without cause, upon notice to you.
+9.3 Google may at any time, terminate the License Agreement with you if:
+(A) you have breached any provision of the License Agreement; or
+(B) Google is required to do so by law; or
+(C) the partner with whom Google offered certain parts of SDK (such as APIs) to you has terminated its relationship with Google or ceased to offer certain parts of the SDK to you; or
+(D) Google decides to no longer provide the SDK or certain parts of the SDK to users in the country in which you are resident or from which you use the service, or the provision of the SDK or certain SDK services to you by Google is, in Google's sole discretion, no longer commercially viable.
 
-9.4 The License Agreement will automatically terminate without notice or other action when Google ceases to provide the SDK or certain parts of the SDK to users in the country in which you are resident or from which you use the service.
+9.4 When the License Agreement comes to an end, all of the legal rights, obligations and liabilities that you and Google have benefited from, been subject to (or which have accrued over time whilst the License Agreement has been in force) or which are expressed to continue indefinitely, shall be unaffected by this cessation, and the provisions of paragraph 14.7 shall continue to apply to such rights, obligations and liabilities indefinitely.
 
-9.5 When the License Agreement is terminated, the license granted to you in the License Agreement will terminate, you will immediately cease all use of the SDK, and the provisions of paragraphs 10, 11, 12 and 14 shall survive indefinitely.
 
-10. DISCLAIMERS
+10. DISCLAIMER OF WARRANTIES
 
 10.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT YOUR USE OF THE SDK IS AT YOUR SOLE RISK AND THAT THE SDK IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTY OF ANY KIND FROM GOOGLE.
 
-10.2 YOUR USE OF THE SDK AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SDK IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH USE. WITHOUT LIMITING THE FOREGOING, YOU UNDERSTAND THAT THE SDK MAY CONTAIN ERRORS, DEFECTS AND SECURITY VULNERABILITIES THAT CAN RESULT IN SIGNIFICANT DAMAGE, INCLUDING THE COMPLETE, IRRECOVERABLE LOSS OF USE OF YOUR COMPUTER SYSTEM OR OTHER DEVICE.
+10.2 YOUR USE OF THE SDK AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SDK IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH USE.
 
 10.3 GOOGLE FURTHER EXPRESSLY DISCLAIMS ALL WARRANTIES AND CONDITIONS OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+
 
 11. LIMITATION OF LIABILITY
 
 11.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT GOOGLE, ITS SUBSIDIARIES AND AFFILIATES, AND ITS LICENSORS SHALL NOT BE LIABLE TO YOU UNDER ANY THEORY OF LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES THAT MAY BE INCURRED BY YOU, INCLUDING ANY LOSS OF DATA, WHETHER OR NOT GOOGLE OR ITS REPRESENTATIVES HAVE BEEN ADVISED OF OR SHOULD HAVE BEEN AWARE OF THE POSSIBILITY OF ANY SUCH LOSSES ARISING.
 
+
 12. Indemnification
 
-12.1 To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless Google, its affiliates and their respective directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys’ fees) arising out of or accruing from (a) your use of the SDK, (b) any application you develop on the SDK that infringes any Intellectual Property Rights of any person or defames any person or violates their rights of publicity or privacy, and (c) any non-compliance by you of the License Agreement.
+12.1 To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless Google, its affiliates and their respective directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys fees) arising out of or accruing from (a) your use of the SDK, (b) any application you develop on the SDK that infringes any copyright, trademark, trade secret, trade dress, patent or other intellectual property right of any person or defames any person or violates their rights of publicity or privacy, and (c) any non-compliance by you with the License Agreement.
+
 
 13. Changes to the License Agreement
 
 13.1 Google may make changes to the License Agreement as it distributes new versions of the SDK. When these changes are made, Google will make a new version of the License Agreement available on the website where the SDK is made available.
+
 
 14. General Legal Terms
 
@@ -140,14 +140,13 @@ This is the Android SDK License Agreement (the &quot;License Agreement&quot;).
 
 14.5 EXPORT RESTRICTIONS. THE SDK IS SUBJECT TO UNITED STATES EXPORT LAWS AND REGULATIONS. YOU MUST COMPLY WITH ALL DOMESTIC AND INTERNATIONAL EXPORT LAWS AND REGULATIONS THAT APPLY TO THE SDK. THESE LAWS INCLUDE RESTRICTIONS ON DESTINATIONS, END USERS AND END USE.
 
-14.6 The License Agreement may not be assigned or transferred by you without the prior written approval of Google, and any attempted assignment without such approval will be void. You shall not delegate your responsibilities or obligations under the License Agreement without the prior written approval of Google.
+14.6 The rights granted in the License Agreement may not be assigned or transferred by either you or Google without the prior written approval of the other party. Neither you nor Google shall be permitted to delegate their responsibilities or obligations under the License Agreement without the prior written approval of the other party.
 
 14.7 The License Agreement, and your relationship with Google under the License Agreement, shall be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from the License Agreement. Notwithstanding this, you agree that Google shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction.
 
-June 2014.
-    </sdk:license>
 
-    <sdk:license id="android-sdk-preview-license" type="text">To get started with the Android SDK Preview, you must agree to the following terms and conditions.
+November 20, 2015</sdk:license>
+	<sdk:license id="android-sdk-preview-license" type="text">To get started with the Android SDK Preview, you must agree to the following terms and conditions.
 As described below, please note that this is a preview version of the Android SDK, subject to change, that you use at your own risk.  The Android SDK Preview is not a stable release, and may contain errors and defects that can result in serious damage to your computer systems, devices and data.
 
 This is the Android SDK Preview License Agreement (the &quot;License Agreement&quot;).
@@ -280,18 +279,14 @@ This is the Android SDK Preview License Agreement (the &quot;License Agreement&q
 
 14.7 The License Agreement, and your relationship with Google under the License Agreement, shall be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from the License Agreement. Notwithstanding this, you agree that Google shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction.
 
-June 2014.
-    </sdk:license>
-
-    <sdk:license id="intel-android-sysimage-license" type="text">
-<![CDATA[
-Intel Corporation Internal Evaluation License Agreement for x86 Android* System Images for Android Software Development Kit (SDK)
-This Internal Evaluation License Agreement (this "Agreement") is entered into by and between Intel and you (as an individual developer or a legal entity -- identified below as Recipient). Intel shall provide the Evaluation Software to Recipient as described in accordance with the Internal Evaluation License Terms and Conditions.
+June 2014.</sdk:license>
+	<sdk:license id="intel-android-sysimage-license" type="text">Intel Corporation Internal Evaluation License Agreement for x86 Android* System Images for Android Software Development Kit (SDK)
+This Internal Evaluation License Agreement (this &quot;Agreement&quot;) is entered into by and between Intel and you (as an individual developer or a legal entity -- identified below as Recipient). Intel shall provide the Evaluation Software to Recipient as described in accordance with the Internal Evaluation License Terms and Conditions.
 
 Definitions.
 These terms shall have the following meanings:
 
-"Intel" or "INTEL"
+&quot;Intel&quot; or &quot;INTEL&quot;
 Intel Corporation
 With an Address of:
 2200 Mission College Blvd.
@@ -300,27 +295,27 @@ Office of the General Counsel
 Mail Stop: RNB-4-51
 Attn: Software and Services Group Legal
 
-"Evaluation Software"
+&quot;Evaluation Software&quot;
 The x86 Android* emulator system images for Android  Software Development Kit (SDK), as provided by Intel.
 
 INTERNAL EVALUATION LICENSE TERMS AND CONDITIONS
 
 1. DEFINITIONS.
 
-1.1 Additional Defined Terms. "Agreement", "Evaluation Software",  "Intel", "Non-disclosure Agreement", "Recipient", and "Effective Date" shall have the meanings ascribed to them on the signature page(s) of this Agreement.
+1.1 Additional Defined Terms. &quot;Agreement&quot;, &quot;Evaluation Software&quot;,  &quot;Intel&quot;, &quot;Non-disclosure Agreement&quot;, &quot;Recipient&quot;, and &quot;Effective Date&quot; shall have the meanings ascribed to them on the signature page(s) of this Agreement.
 
 1.2 Evaluation Materials means, collectively, the Evaluation Software (in source and/or object code form) and documentation (including, without limitation, any design documents, specifications and other related materials) related to the Evaluation Software.
 
-1.3 "Open Source Software" means any software that requires as a condition of use, modification and/or distribution of such software that such software or other software incorporated into, derived from or distributed with such software (a) be disclosed or distributed in source code form; or (b) be licensed by the user to third parties for the purpose of making and/or distributing derivative works; or (c) be redistributable at no charge. Open Source Software includes, without limitation, software licensed or distributed under any of the following licenses or distribution models, or licenses or distribution models substantially similar to any of the following: (a) GNUs General Public License (GPL) or Lesser/Library GPL (LGPL), (b) the Artistic License (e.g., PERL), (c) the Mozilla Public License, (d) the Netscape Public License, (e) the Sun Community Source License (SCSL), (f) the Sun Industry Source License (SISL), (g) the Apache Software license and (h) the Common Public License (CPL).
+1.3 &quot;Open Source Software&quot; means any software that requires as a condition of use, modification and/or distribution of such software that such software or other software incorporated into, derived from or distributed with such software (a) be disclosed or distributed in source code form; or (b) be licensed by the user to third parties for the purpose of making and/or distributing derivative works; or (c) be redistributable at no charge. Open Source Software includes, without limitation, software licensed or distributed under any of the following licenses or distribution models, or licenses or distribution models substantially similar to any of the following: (a) GNUs General Public License (GPL) or Lesser/Library GPL (LGPL), (b) the Artistic License (e.g., PERL), (c) the Mozilla Public License, (d) the Netscape Public License, (e) the Sun Community Source License (SCSL), (f) the Sun Industry Source License (SISL), (g) the Apache Software license and (h) the Common Public License (CPL).
 
-1.4 "Pre-Release Materials" means "alpha" or "beta" designated pre-release features, which may not be fully functional, which Intel may substantially modify in producing any production version of the Evaluation Materials and/or is still under development by Intel and/or Intels suppliers.
+1.4 &quot;Pre-Release Materials&quot; means &quot;alpha&quot; or &quot;beta&quot; designated pre-release features, which may not be fully functional, which Intel may substantially modify in producing any production version of the Evaluation Materials and/or is still under development by Intel and/or Intels suppliers.
 
 2. PURPOSE. Intel desires to provide the Evaluation Materials to Recipient solely for Recipient's internal evaluation of the Evaluation Software and other Intel products, to evaluate the desirability of cooperating with Intel in developing products based on the Evaluation Software and/or to advise Intel as to possible modifications to the Evaluation Software. Recipient may not disclose, distribute or make commercial use of the Evaluation Materials or any modifications to the Evaluation Materials.
 THE EVALUATION MATERIALS ARE PROVIDED FOR EVALUATION PURPOSES ONLY AND MAY NOT BE DISTRIBUTED BY RECIPIENT OR INCORPORATED INTO RECIPIENTS PRODUCTS OR SOFTWARE. PLEASE CONTACT AN INTEL SALES REPRESENTATIVE TO LEARN ABOUT THE AVAILABILITY AND COST OF A COMMERICAL VERSION OF THE EVALUATION SOFTWARE.
 
 3. TITLE. Title to the Evaluation Materials remains with Intel or its suppliers. Recipient shall not mortgage, pledge or encumber the Evaluation Materials in any way. Recipient shall return all Evaluation Materials, keeping no copies, upon termination or expiration of this Agreement.
 
-4. LICENSE. Intel grants Recipient a royalty-free, personal, nontransferable, nonexclusive license under its copyrights to use the Evaluation Software only for the purposes described in paragraph 2 above. Unless otherwise communicated in writing by Intel to Recipient, to the extent the Evaluation Software is provided in more than one delivery or release (each, a "Release") the license grant in this Section 4 and the Evaluation Period shall apply to each Release. Recipient may not make modifications to the Evaluation Software. Recipient shall not disassemble, reverse-engineer, or decompile any software not provided to Recipient in source code form.
+4. LICENSE. Intel grants Recipient a royalty-free, personal, nontransferable, nonexclusive license under its copyrights to use the Evaluation Software only for the purposes described in paragraph 2 above. Unless otherwise communicated in writing by Intel to Recipient, to the extent the Evaluation Software is provided in more than one delivery or release (each, a &quot;Release&quot;) the license grant in this Section 4 and the Evaluation Period shall apply to each Release. Recipient may not make modifications to the Evaluation Software. Recipient shall not disassemble, reverse-engineer, or decompile any software not provided to Recipient in source code form.
 EXCEPT AS PROVIDED HEREIN, NO OTHER LICENSE, EXPRESS OR IMPLIED, BY ESTOPPEL OR OTHERWISE, TO ANY OTHER INTELLECTUAL PROPERTY RIGHTS IS GRANTED TO THE RECIPIENT.
 
 5. NO OBLIGATION. Recipient shall have no duty to purchase or license any product from Intel. Intel and its suppliers shall have no obligation to provide support for, or develop a non-evaluation version of, the Evaluation Software or to license any version of it.
@@ -341,22 +336,18 @@ EXCEPT AS PROVIDED HEREIN, NO OTHER LICENSE, EXPRESS OR IMPLIED, BY ESTOPPEL OR 
 
 10.3 Assignment. Recipient may not delegate, assign or transfer this Agreement, the license granted or any of Recipients rights or duties hereunder, expressly, by implication, by operation of law, by way of merger (regardless of whether Recipient is the surviving entity) or acquisition, or otherwise and any attempt to do so, without Intels express prior written consent, shall be null and void. Intel may assign this Agreement, and its rights and obligations hereunder, in its sole discretion.
 
-10.4 Entire Agreement. This Agreement constitutes the entire agreement between Recipient and Intel and supersedes in their entirety any and all oral or written agreements previously existing between Recipient and Intel with respect to the subject matter hereof. This Agreement supersedes any and all "click-to-accept" or shrink-wrapped licenses, in hard-copy or electronic form, embedded in or included with the Evaluation Materials. This Agreement may only be amended or supplemented by a writing that refers explicitly to this Agreement and that is signed by duly authorized representatives of Recipient and Intel. Without limiting the foregoing, terms and conditions on any purchase orders or similar materials submitted by Recipient to Intel, and any terms contained in Intels standard acknowledgment form that are in conflict with these terms, shall be of no force or effect.
+10.4 Entire Agreement. This Agreement constitutes the entire agreement between Recipient and Intel and supersedes in their entirety any and all oral or written agreements previously existing between Recipient and Intel with respect to the subject matter hereof. This Agreement supersedes any and all &quot;click-to-accept&quot; or shrink-wrapped licenses, in hard-copy or electronic form, embedded in or included with the Evaluation Materials. This Agreement may only be amended or supplemented by a writing that refers explicitly to this Agreement and that is signed by duly authorized representatives of Recipient and Intel. Without limiting the foregoing, terms and conditions on any purchase orders or similar materials submitted by Recipient to Intel, and any terms contained in Intels standard acknowledgment form that are in conflict with these terms, shall be of no force or effect.
 
 10.5 Severability. In the event that any provision of this Agreement shall be unenforceable or invalid under any applicable law or be so held by applicable court decision, such unenforceability or invalidity shall not render this Agreement unenforceable or invalid as a whole, and, in such event, such provision shall be changed and interpreted so as to best accomplish the objectives of such unenforceable or invalid provision within the limits of applicable law or applicable court decisions.
 
-10.6 Export Regulations / Export Control. Recipient shall not export, either directly or indirectly, any product, service or technical data or system incorporating the Evaluation Materials without first obtaining any required license or other approval from the U.S. Department of Commerce or any other agency or department of the United States Government. In the event any product is exported from the United States or re-exported from a foreign destination by Recipient, Recipient shall ensure that the distribution and export/re-export or import of the product is in compliance with all laws, regulations, orders, or other restrictions of the U.S. Export Administration Regulations and the appropriate foreign government. Recipient agrees that neither it nor any of its subsidiaries will export/re-export any technical data, process, product, or service, directly or indirectly, to any country for which the United States government or any agency thereof or the foreign government from where it is shipping requires an export license, or other governmental approval, without first obtaining such license or approval. Recipient also agrees to implement measures to ensure that foreign national employees are authorized to receive any information controlled by U.S. export control laws. An export is "deemed" to take place when information is released to a foreign national wherever located.
+10.6 Export Regulations / Export Control. Recipient shall not export, either directly or indirectly, any product, service or technical data or system incorporating the Evaluation Materials without first obtaining any required license or other approval from the U.S. Department of Commerce or any other agency or department of the United States Government. In the event any product is exported from the United States or re-exported from a foreign destination by Recipient, Recipient shall ensure that the distribution and export/re-export or import of the product is in compliance with all laws, regulations, orders, or other restrictions of the U.S. Export Administration Regulations and the appropriate foreign government. Recipient agrees that neither it nor any of its subsidiaries will export/re-export any technical data, process, product, or service, directly or indirectly, to any country for which the United States government or any agency thereof or the foreign government from where it is shipping requires an export license, or other governmental approval, without first obtaining such license or approval. Recipient also agrees to implement measures to ensure that foreign national employees are authorized to receive any information controlled by U.S. export control laws. An export is &quot;deemed&quot; to take place when information is released to a foreign national wherever located.
 
 10.7 Special Terms for Pre-Release Materials. If so indicated in the description of the Evaluation Software, the Evaluation Software may contain Pre-Release Materials. Recipient hereby understands, acknowledges and agrees that: (i) Pre-Release Materials may not be fully tested and may contain bugs or errors; (ii) Pre-Release materials are not suitable for commercial release in their current state; (iii) regulatory approvals for Pre-Release Materials (such as UL or FCC) have not been obtained, and Pre-Release Materials may therefore not be certified for use in certain countries or environments and (iv) Intel can provide no assurance that it will ever produce or make generally available a production version of the Pre-Release Materials . Intel is not under any obligation to develop and/or release or offer for sale or license a final product based upon the Pre-Release Materials and may unilaterally elect to abandon the Pre-Release Materials or any such development platform at any time and without any obligation or liability whatsoever to Recipient or any other person.
 
 10.8 Open Source Software. In the event Open Source software is included with Evaluation Software, such Open Source software is licensed pursuant to the applicable Open Source software license agreement identified in the Open Source software comments in the applicable source code file(s) and/or file header provided with Evaluation Software. Additional detail may be provided (where applicable) in the accompanying on-line documentation. With respect to the Open Source software, nothing in this Agreement limits any rights under, or grants rights that supersede, the terms of any applicable Open Source software license agreement.
-ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED POSSIBLY WITH FAULTS
-]]>
-    </sdk:license>
-    <sdk:license id="mips-android-sysimage-license" type="text">
-<![CDATA[
-MIPS Technologies, Inc. (“MIPS”) Internal Evaluation License Agreement for MIPS Android™ System Images for Android Software Development Kit (SDK):
-This Internal Evaluation License Agreement (this "Agreement") is entered into by and between MIPS and you (as an individual developer or a legal entity -- identified below as “Recipient”). MIPS shall make the Evaluation Software available to Recipient as described in accordance with the terms and conditions set forth below.
+ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED POSSIBLY WITH FAULTS</sdk:license>
+	<sdk:license id="mips-android-sysimage-license" type="text">MIPS Technologies, Inc. (“MIPS”) Internal Evaluation License Agreement for MIPS Android™ System Images for Android Software Development Kit (SDK):
+This Internal Evaluation License Agreement (this &quot;Agreement&quot;) is entered into by and between MIPS and you (as an individual developer or a legal entity -- identified below as “Recipient”). MIPS shall make the Evaluation Software available to Recipient as described in accordance with the terms and conditions set forth below.
 
 By clicking on the “Accept” button, downloading, installing, or otherwise using the Evaluation Materials (defined below), you agree to be bound by the terms of this Agreement effective as of the date you click “Accept” (the “Effective Date”), and if doing so on behalf of an entity, you represent that you are authorized to bind the entity to the terms and conditions of this Agreement. If you do not agree to be bound by the terms and conditions of this Agreement, do not download, install, or use the Evaluation Materials.
 
@@ -366,7 +357,7 @@ By clicking on the “Accept” button, downloading, installing, or otherwise us
 
 1.2 “Evaluation Software” shall mean MIPS Android™ emulator system images for Android Software Development Kit (SDK), as made available to Recipient.
 
-1.3 “Evaluation Materials" means, collectively, the Evaluation Software (in source and/or object code form) and documentation (including, without limitation, any design documents, specifications, reference manuals, and other related materials) related to the Evaluation Software as made available to Recipient.
+1.3 “Evaluation Materials&quot; means, collectively, the Evaluation Software (in source and/or object code form) and documentation (including, without limitation, any design documents, specifications, reference manuals, and other related materials) related to the Evaluation Software as made available to Recipient.
 
 1.4 “Open Source Software” means any software that requires (as a condition of use, modification and/or distribution of such software) that such software or other software incorporated into, derived from or distributed with such software (a) be disclosed or distributed in source code form; or (b) be licensed by the user to third parties for the purpose of making and/or distributing derivative works; or (c) be redistributable at no charge. Open Source Software includes, without limitation, software licensed or distributed under any of the following licenses or distribution models, or licenses or distribution models substantially similar to any of the following: (a) GNU’s General Public License (GPL) or Lesser/Library GPL (LGPL), (b) the Artistic License (e.g., PERL), (c) the Mozilla Public License, (d) the Netscape Public License, (e) the Sun Community Source License (SCSL), (f) the Sun Industry Source License (SISL), (g) the Apache Software license and (h) the Common Public License (CPL).
 
@@ -405,428 +396,471 @@ EXCEPT AS PROVIDED HEREIN, NO OTHER LICENSE, EXPRESS OR IMPLIED, BY ESTOPPEL OR 
 
 10.5 Severability. In the event that any provision of this Agreement is finally adjudicated to be unenforceable or invalid under any applicable law, such unenforceability or invalidity shall not render this Agreement unenforceable or invalid as a whole, and, in such event, such unenforceable or invalid provision shall be interpreted so as to best accomplish the objectives of such provision within the limits of applicable law or applicable court decisions.
 
-10.6 Export Regulations / Export Control. Recipient shall not export, either directly or indirectly, any product, service or technical data or system incorporating the Evaluation Materials without first obtaining any required license or other necessary approval from the U.S. Department of Commerce or any other governing agency or department of the United States Government. In the event any product is exported from the United States or re-exported from a foreign destination by Recipient, Recipient shall ensure that the distribution and export/re-export or import of the product is in compliance with all applicable laws, regulations, orders, or other restrictions of the U.S. Export Administration Regulations and the appropriate foreign government. Recipient agrees that neither it nor any of its subsidiaries will export/re-export any technical data, process, product, or service, directly or indirectly, to any country for which the United States government or any agency thereof or the foreign government from where it is shipping requires an export license, or other governmental approval, without first obtaining such license or approval. Recipient also agrees to implement measures to ensure that foreign national employees are authorized to receive any information controlled by U.S. export control laws. An export is "deemed" to take place when information is released to a foreign national wherever located.
+10.6 Export Regulations / Export Control. Recipient shall not export, either directly or indirectly, any product, service or technical data or system incorporating the Evaluation Materials without first obtaining any required license or other necessary approval from the U.S. Department of Commerce or any other governing agency or department of the United States Government. In the event any product is exported from the United States or re-exported from a foreign destination by Recipient, Recipient shall ensure that the distribution and export/re-export or import of the product is in compliance with all applicable laws, regulations, orders, or other restrictions of the U.S. Export Administration Regulations and the appropriate foreign government. Recipient agrees that neither it nor any of its subsidiaries will export/re-export any technical data, process, product, or service, directly or indirectly, to any country for which the United States government or any agency thereof or the foreign government from where it is shipping requires an export license, or other governmental approval, without first obtaining such license or approval. Recipient also agrees to implement measures to ensure that foreign national employees are authorized to receive any information controlled by U.S. export control laws. An export is &quot;deemed&quot; to take place when information is released to a foreign national wherever located.
 
 10.7 Special Terms for Pre-Release Materials. If so indicated in the description of the Evaluation Software, the Evaluation Software may contain Pre-Release Materials. Recipient hereby understands, acknowledges and agrees that: (i) Pre-Release Materials may not be fully tested and may contain bugs or errors; (ii) Pre-Release materials are not suitable for commercial release in their current state; (iii) regulatory approvals for Pre-Release Materials (such as UL or FCC) have not been obtained, and Pre-Release Materials may therefore not be certified for use in certain countries or environments or may not be suitable for certain applications and (iv) MIPS can provide no assurance that it will ever produce or make generally available a production version of the Pre-Release Materials . MIPS is not under any obligation to develop and/or release or offer for sale or license a final product based upon the Pre-Release Materials and may unilaterally elect to abandon the Pre-Release Materials or any such development platform at any time and without any obligation or liability whatsoever to Recipient or any other person.
 
 ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED “AS IS” AND “AS AVAILABLE”, POSSIBLY WITH FAULTS, AND WITHOUT REPRESENTATION OR WARRANTY OF ANY KIND.
 
 10.8 Open Source Software. In the event Open Source software is included with Evaluation Software, such Open Source software is licensed pursuant to the applicable Open Source software license agreement identified in the Open Source software comments in the applicable source code file(s) and/or file header as indicated in the Evaluation Software. Additional detail may be available (where applicable) in the accompanying on-line documentation. With respect to the Open Source software, nothing in this Agreement limits any rights under, or grants rights that supersede, the terms of any applicable Open Source software license agreement.
-    ]]>
-    </sdk:license>
-
-    <!-- ARM SYSTEM IMAGES ........................ -->
-
-    <sdk:system-image>
-        <!-- Generated at Wed Dec  7 13:47:01 2011 from git_ics-mr0 @ 229537 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android SDK Platform 4.0</sdk:description>
-        <sdk:api-level>14</sdk:api-level>
-        <sdk:abi>armeabi-v7a</sdk:abi>
-        <sdk:obsolete/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>99621822</sdk:size>
-                <sdk:checksum type="sha1">d8991b0c06b18d7d6ed4169d67460ee1add6661b</sdk:checksum>
-                <sdk:url>sysimg_armv7a-14_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Tue Mar 10 10:46:44 2015 from git_ics-mr1 @ 1741834 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 4.0.3</sdk:description>
-        <sdk:api-level>15</sdk:api-level>
-        <sdk:abi>armeabi-v7a</sdk:abi>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>96240395</sdk:size>
-                <sdk:checksum type="sha1">0a47f586e172b1cf3db2ada857a70c2bdec24ef8</sdk:checksum>
-                <sdk:url>sysimg_armv7a-15_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Tue Mar 10 10:30:46 2015 from git_jb-dev @ 1741836 -->
-        <sdk:revision>4</sdk:revision>
-        <sdk:description>Android SDK Platform 4.1.2</sdk:description>
-        <sdk:api-level>16</sdk:api-level>
-        <sdk:abi>armeabi-v7a</sdk:abi>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>112608076</sdk:size>
-                <sdk:checksum type="sha1">39c093ea755098f0ee79f607be7df9e54ba4943f</sdk:checksum>
-                <sdk:url>sysimg_armv7a-16_r04.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Mon Mar  9 18:24:53 2015 from git_jb-mr1.1-dev @ 1742939 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 4.2.2</sdk:description>
-        <sdk:api-level>17</sdk:api-level>
-        <sdk:abi>armeabi-v7a</sdk:abi>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>118663847</sdk:size>
-                <sdk:checksum type="sha1">97cfad22b51c8475e228b207dd36dbef1c18fa38</sdk:checksum>
-                <sdk:url>sysimg_armv7a-17_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Mon Mar  9 17:40:24 2015 from git_jb-mr2-dev @ 1743067 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 4.3.1</sdk:description>
-        <sdk:api-level>18</sdk:api-level>
-        <sdk:abi>armeabi-v7a</sdk:abi>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>125503391</sdk:size>
-                <sdk:checksum type="sha1">2d7d51f4d2742744766511e5d6b491bd49161c51</sdk:checksum>
-                <sdk:url>sysimg_armv7a-18_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Mon Mar  9 16:57:24 2015 from git_klp-dev @ 1743154 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 4.4.4</sdk:description>
-        <sdk:api-level>19</sdk:api-level>
-        <sdk:abi>armeabi-v7a</sdk:abi>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>159399028</sdk:size>
-                <sdk:checksum type="sha1">5daf7718e3ab03d9bd8792b492dd305f386ef12f</sdk:checksum>
-                <sdk:url>sysimg_armv7a-19_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Fri Mar  6 08:10:49 2015 from git_lmp-sdk-release @ 1772600 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 5.0.2</sdk:description>
-        <sdk:api-level>21</sdk:api-level>
-        <sdk:abi>armeabi-v7a</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>186521381</sdk:size>
-                <sdk:checksum type="sha1">0b2e21421d29f48211b5289ca4addfa7f4c7ae5a</sdk:checksum>
-                <sdk:url>sysimg_arm-21_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Mon Mar  2 11:01:02 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android SDK Platform 5.1</sdk:description>
-        <sdk:api-level>22</sdk:api-level>
-        <sdk:abi>armeabi-v7a</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>193687339</sdk:size>
-                <sdk:checksum type="sha1">2aa6a887ee75dcf3ac34627853d561997792fcb8</sdk:checksum>
-                <sdk:url>sysimg_arm-22_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:system-image>
-
-    <!-- X86 SYSTEM IMAGES ........................ -->
-
-    <sdk:system-image>
-        <sdk:description>Android SDK Platform 2.3.7</sdk:description>
-        <sdk:revision>3</sdk:revision>
-        <sdk:api-level>10</sdk:api-level>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:uses-license ref="intel-android-sysimage-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>66997702</sdk:size>
-                <sdk:checksum type="sha1">6b8539eaca9685d2d3289bf8e6d21d366d791326</sdk:checksum>
-                <sdk:url>sysimg_x86-10_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <sdk:description>Android SDK Platform 4.0.4</sdk:description>
-        <sdk:revision>2</sdk:revision>
-        <sdk:api-level>15</sdk:api-level>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:uses-license ref="intel-android-sysimage-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>109019058</sdk:size>
-                <sdk:checksum type="sha1">56b8d4b3d0f6a8876bc78d654da186f3b7b7c44f</sdk:checksum>
-                <sdk:url>sysimg_x86-15_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <sdk:description>Android SDK Platform 4.1.1</sdk:description>
-        <sdk:revision>2</sdk:revision>
-        <sdk:api-level>16</sdk:api-level>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:uses-license ref="intel-android-sysimage-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>135252264</sdk:size>
-                <sdk:checksum type="sha1">36c2a2e394bcb3290583ce09815eae7711d0b2c2</sdk:checksum>
-                <sdk:url>sysimg_x86-16_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Mon Mar  9 18:25:14 2015 from git_jb-mr1.1-dev @ 1742939 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android SDK Platform 4.2.2</sdk:description>
-        <sdk:api-level>17</sdk:api-level>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>136075512</sdk:size>
-                <sdk:checksum type="sha1">bd8c7c5411431af7e051cbe961be430fc31e773d</sdk:checksum>
-                <sdk:url>sysimg_x86-17_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Mon Mar  9 17:40:48 2015 from git_jb-mr2-dev @ 1743067 -->
-        <sdk:revision>2</sdk:revision>
-        <sdk:description>Android SDK Platform 4.3.1</sdk:description>
-        <sdk:api-level>18</sdk:api-level>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>143899902</sdk:size>
-                <sdk:checksum type="sha1">ab3de121a44fca43ac3aa83f7d68cc47fc643ee8</sdk:checksum>
-                <sdk:url>sysimg_x86-18_r02.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Mon Mar  9 16:57:47 2015 from git_klp-dev @ 1743154 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 4.4.4</sdk:description>
-        <sdk:api-level>19</sdk:api-level>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>180245668</sdk:size>
-                <sdk:checksum type="sha1">3782f3ebac5e54b3de454570add401989515ffca</sdk:checksum>
-                <sdk:url>sysimg_x86-19_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Fri Mar  6 08:10:07 2015 from git_lmp-sdk-release @ 1772600 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 5.0.2</sdk:description>
-        <sdk:api-level>21</sdk:api-level>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>201601288</sdk:size>
-                <sdk:checksum type="sha1">a0b510c66769e84fa5e40515531be2d266a4247f</sdk:checksum>
-                <sdk:url>sysimg_x86-21_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Fri Mar  6 08:10:31 2015 from git_lmp-sdk-release @ 1772600 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 5.0.2</sdk:description>
-        <sdk:api-level>21</sdk:api-level>
-        <sdk:abi>x86_64</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>285253158</sdk:size>
-                <sdk:checksum type="sha1">2f205b728695d84488156f4846beb83a353ea64b</sdk:checksum>
-                <sdk:url>sysimg_x86_64-21_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Mon Mar  2 11:00:17 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android SDK Platform 5.1</sdk:description>
-        <sdk:api-level>22</sdk:api-level>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>207436768</sdk:size>
-                <sdk:checksum type="sha1">6c7bb51e41a16099bb1f2a3cc81fdb5aa053fc15</sdk:checksum>
-                <sdk:url>sysimg_x86-22_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Mon Mar  2 11:00:41 2015 from git_lmp-mr1-sdk-release @ 1737576 -->
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android SDK Platform 5.1</sdk:description>
-        <sdk:api-level>22</sdk:api-level>
-        <sdk:abi>x86_64</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>292511941</sdk:size>
-                <sdk:checksum type="sha1">05752813603f9fa03a58dcf7f8f5e779be722aae</sdk:checksum>
-                <sdk:url>sysimg_x86_64-22_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:system-image>
-
-    <!-- MIPS SYSTEM IMAGES ........................ -->
-
-    <sdk:system-image>
-        <sdk:revision>1</sdk:revision>
-        <sdk:description>Android 4.0.4</sdk:description>
-        <sdk:api-level>15</sdk:api-level>
-        <sdk:abi>mips</sdk:abi>
-        <sdk:uses-license ref="mips-android-sysimage-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>117503178</sdk:size>
-                <sdk:checksum type="sha1">a753bb4a6783124dad726c500ce9aec9d2c1b2d9</sdk:checksum>
-                <sdk:url>sysimg_mips-15_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <sdk:revision>4</sdk:revision>
-        <!-- mipsia repo tag qa-dev-mips-jb-20130123,
-             github.com/MIPS branch dev-mips-jb, tag mips-jb-4.1.2_r1m1
-             repo init -u git://github.com/MIPS/manifests.git
-                 -b dev-mips-jb -m mips-jb-4.1.2_r1m1.xml           -->
-        <sdk:description>Android 4.1.2</sdk:description>
-        <sdk:api-level>16</sdk:api-level>
-        <sdk:abi>mips</sdk:abi>
-        <sdk:uses-license ref="mips-android-sysimage-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>122482530</sdk:size>
-                <sdk:checksum type="sha1">67943c54fb3943943ffeb05fdd39c0b753681f6e</sdk:checksum>
-                <sdk:url>sysimg_mips-16_r04.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <sdk:revision>1</sdk:revision>
-        <!-- mipsia repo tag qa-dev-mips-jb-mr1-20121219,
-             github.com/MIPS tag mips-jb-4.2.1_r1 -->
-        <sdk:description>Android 4.2.1</sdk:description>
-        <sdk:api-level>17</sdk:api-level>
-        <sdk:abi>mips</sdk:abi>
-        <sdk:uses-license ref="mips-android-sysimage-license"/>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>131781761</sdk:size>
-                <sdk:checksum type="sha1">f0c6e153bd584c29e51b5c9723cfbf30f996a05d</sdk:checksum>
-                <sdk:url>sysimg_mips-17_r01.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:tag-id>default</sdk:tag-id>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Fri Aug 14 15:40:56 2015 from git_mnc-release @ 2166767 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 6.0</sdk:description>
-        <sdk:api-level>23</sdk:api-level>
-        <sdk:abi>x86</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>240896796</sdk:size>
-                <sdk:checksum type="sha1">3cb2e8efb575c35a558b091eac7e1bc5843f5f12</sdk:checksum>
-                <sdk:url>sysimg_x86-23_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Fri Aug 14 15:41:23 2015 from git_mnc-release @ 2166767 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 6.0</sdk:description>
-        <sdk:api-level>23</sdk:api-level>
-        <sdk:abi>x86_64</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>337897181</sdk:size>
-                <sdk:checksum type="sha1">226510856431bc4a73690540a8d7cbad974bedd3</sdk:checksum>
-                <sdk:url>sysimg_x86_64-23_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:system-image>
-
-    <sdk:system-image>
-        <!-- Generated at Fri Aug 14 15:41:43 2015 from git_mnc-release @ 2166767 -->
-        <sdk:revision>3</sdk:revision>
-        <sdk:description>Android SDK Platform 6.0</sdk:description>
-        <sdk:api-level>23</sdk:api-level>
-        <sdk:abi>armeabi-v7a</sdk:abi>
-        <sdk:tag-id>default</sdk:tag-id>
-        <sdk:archives>
-            <sdk:archive>
-                <sdk:size>226879660</sdk:size>
-                <sdk:checksum type="sha1">7bb8768ec4333500192fd9627d4234f505fa98dc</sdk:checksum>
-                <sdk:url>sysimg_arm-23_r03.zip</sdk:url>
-            </sdk:archive>
-        </sdk:archives>
-        <sdk:uses-license ref="android-sdk-license"/>
-    </sdk:system-image>
+</sdk:license>
+	<sdk:system-image>
+		<!--Generated from bid:229537, branch:git_ics-mr0-->
+		<sdk:api-level>14</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:05 2016.-->
+				<sdk:size>99621822</sdk:size>
+				<sdk:checksum type="sha1">d8991b0c06b18d7d6ed4169d67460ee1add6661b</sdk:checksum>
+				<sdk:url>sysimg_armv7a-14_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1741834, branch:git_ics-mr1-->
+		<sdk:api-level>15</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:24:59 2016.-->
+				<sdk:size>96240395</sdk:size>
+				<sdk:checksum type="sha1">0a47f586e172b1cf3db2ada857a70c2bdec24ef8</sdk:checksum>
+				<sdk:url>sysimg_armv7a-15_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1741836, branch:git_jb-dev-->
+		<sdk:api-level>16</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:24:59 2016.-->
+				<sdk:size>112608076</sdk:size>
+				<sdk:checksum type="sha1">39c093ea755098f0ee79f607be7df9e54ba4943f</sdk:checksum>
+				<sdk:url>sysimg_armv7a-16_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1742939, branch:git_jb-mr1.1-dev-->
+		<sdk:api-level>17</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:00 2016.-->
+				<sdk:size>118663847</sdk:size>
+				<sdk:checksum type="sha1">97cfad22b51c8475e228b207dd36dbef1c18fa38</sdk:checksum>
+				<sdk:url>sysimg_armv7a-17_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1743067, branch:git_jb-mr2-dev-->
+		<sdk:api-level>18</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:01 2016.-->
+				<sdk:size>125503391</sdk:size>
+				<sdk:checksum type="sha1">2d7d51f4d2742744766511e5d6b491bd49161c51</sdk:checksum>
+				<sdk:url>sysimg_armv7a-18_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1743154, branch:git_klp-dev-->
+		<sdk:api-level>19</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:02 2016.-->
+				<sdk:size>159399028</sdk:size>
+				<sdk:checksum type="sha1">5daf7718e3ab03d9bd8792b492dd305f386ef12f</sdk:checksum>
+				<sdk:url>sysimg_armv7a-19_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1772600, branch:git_lmp-sdk-release-->
+		<sdk:api-level>21</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:03 2016.-->
+				<sdk:size>186521381</sdk:size>
+				<sdk:checksum type="sha1">0b2e21421d29f48211b5289ca4addfa7f4c7ae5a</sdk:checksum>
+				<sdk:url>sysimg_arm-21_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1737576, branch:git_lmp-mr1-sdk-release-->
+		<sdk:api-level>22</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:24:58 2016.-->
+				<sdk:size>193687339</sdk:size>
+				<sdk:checksum type="sha1">2aa6a887ee75dcf3ac34627853d561997792fcb8</sdk:checksum>
+				<sdk:url>sysimg_arm-22_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:2166767, branch:git_mnc-release-->
+		<sdk:api-level>23</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:04 2016.-->
+				<sdk:size>226879660</sdk:size>
+				<sdk:checksum type="sha1">7bb8768ec4333500192fd9627d4234f505fa98dc</sdk:checksum>
+				<sdk:url>sysimg_arm-23_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3065232, branch:git_nyc-emu-release-->
+		<sdk:api-level>24</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>5</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 10:08:55 2016.-->
+				<sdk:size>497498007</sdk:size>
+				<sdk:checksum type="sha1">2eb8fb86f7312614a2a0b033d669d67206a618ff</sdk:checksum>
+				<sdk:url>sysimg_armeabi-v7a-24_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1741834, branch:git_ics-mr1-->
+		<sdk:api-level>15</sdk:api-level>
+		<sdk:description>MIPS System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:24:59 2016.-->
+				<sdk:size>117503178</sdk:size>
+				<sdk:checksum type="sha1">a753bb4a6783124dad726c500ce9aec9d2c1b2d9</sdk:checksum>
+				<sdk:url>sysimg_mips-15_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="mips-android-sysimage-license"/>
+		<sdk:abi>mips</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1741836, branch:git_jb-dev-->
+		<sdk:api-level>16</sdk:api-level>
+		<sdk:description>MIPS System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:00 2016.-->
+				<sdk:size>122482530</sdk:size>
+				<sdk:checksum type="sha1">67943c54fb3943943ffeb05fdd39c0b753681f6e</sdk:checksum>
+				<sdk:url>sysimg_mips-16_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="mips-android-sysimage-license"/>
+		<sdk:abi>mips</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1742939, branch:git_jb-mr1.1-dev-->
+		<sdk:api-level>17</sdk:api-level>
+		<sdk:description>MIPS System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:00 2016.-->
+				<sdk:size>131781761</sdk:size>
+				<sdk:checksum type="sha1">f0c6e153bd584c29e51b5c9723cfbf30f996a05d</sdk:checksum>
+				<sdk:url>sysimg_mips-17_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="mips-android-sysimage-license"/>
+		<sdk:abi>mips</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1, branch:-->
+		<sdk:api-level>10</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:24:58 2016.-->
+				<sdk:size>66997702</sdk:size>
+				<sdk:checksum type="sha1">6b8539eaca9685d2d3289bf8e6d21d366d791326</sdk:checksum>
+				<sdk:url>sysimg_x86-10_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:2, branch:-->
+		<sdk:api-level>15</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:04 2016.-->
+				<sdk:size>109019058</sdk:size>
+				<sdk:checksum type="sha1">56b8d4b3d0f6a8876bc78d654da186f3b7b7c44f</sdk:checksum>
+				<sdk:url>sysimg_x86-15_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3, branch:unknown-->
+		<sdk:api-level>16</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:12 2016.-->
+				<sdk:size>135252264</sdk:size>
+				<sdk:checksum type="sha1">36c2a2e394bcb3290583ce09815eae7711d0b2c2</sdk:checksum>
+				<sdk:url>sysimg_x86-16_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1742939, branch:git_jb-mr1.1-dev-->
+		<sdk:api-level>17</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:01 2016.-->
+				<sdk:size>136075512</sdk:size>
+				<sdk:checksum type="sha1">bd8c7c5411431af7e051cbe961be430fc31e773d</sdk:checksum>
+				<sdk:url>sysimg_x86-17_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:1743067, branch:git_jb-mr2-dev-->
+		<sdk:api-level>18</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>2</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Mar 29 18:25:02 2016.-->
+				<sdk:size>143899902</sdk:size>
+				<sdk:checksum type="sha1">ab3de121a44fca43ac3aa83f7d68cc47fc643ee8</sdk:checksum>
+				<sdk:url>sysimg_x86-18_r02.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:2872501, branch:git_klp-emu-release-->
+		<sdk:api-level>19</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>5</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon May 16 16:26:22 2016.-->
+				<sdk:size>183946064</sdk:size>
+				<sdk:checksum type="sha1">c9298a8eafceed3b8fa11071ba63a3d18e17fd8e</sdk:checksum>
+				<sdk:url>sysimg_x86-19_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:2781484, branch:git_lmp-emu-release-->
+		<sdk:api-level>21</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Thu Apr 21 08:05:21 2016.-->
+				<sdk:size>206323409</sdk:size>
+				<sdk:checksum type="sha1">3b78ad294aa1cdefa4be663d4af6c80d920ec49e</sdk:checksum>
+				<sdk:url>sysimg_x86-21_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:2780077, branch:git_lmp-mr1-emu-release-->
+		<sdk:api-level>22</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>5</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed Apr 20 08:41:31 2016.-->
+				<sdk:size>212301282</sdk:size>
+				<sdk:checksum type="sha1">909e0ad91ed43381597e82f65ec93d41f049dd53</sdk:checksum>
+				<sdk:url>sysimg_x86-22_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:2780065, branch:git_mnc-emu-release-->
+		<sdk:api-level>23</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>9</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed Apr 20 08:41:52 2016.-->
+				<sdk:size>252059065</sdk:size>
+				<sdk:checksum type="sha1">0ce9229974818179833899dce93f228a895ec6a2</sdk:checksum>
+				<sdk:url>sysimg_x86-23_r09.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3065232, branch:git_nyc-emu-release-->
+		<sdk:api-level>24</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>5</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 10:09:24 2016.-->
+				<sdk:size>535224957</sdk:size>
+				<sdk:checksum type="sha1">ce6441c4cadaecd28b364c59b36c31ef0904dae0</sdk:checksum>
+				<sdk:url>sysimg_x86-24_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:2781484, branch:git_lmp-emu-release-->
+		<sdk:api-level>21</sdk:api-level>
+		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Thu Apr 21 08:05:44 2016.-->
+				<sdk:size>290590059</sdk:size>
+				<sdk:checksum type="sha1">eb14ba9c14615d5e5a21c854be29aa903d9bb63d</sdk:checksum>
+				<sdk:url>sysimg_x86_64-21_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86_64</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:2780077, branch:git_lmp_mr1-emu-release-->
+		<sdk:api-level>22</sdk:api-level>
+		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
+		<sdk:revision>5</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed Apr 20 08:44:05 2016.-->
+				<sdk:size>297851141</sdk:size>
+				<sdk:checksum type="sha1">8a04ff4fb30f70414e6ec7b3b06285f316e93d08</sdk:checksum>
+				<sdk:url>sysimg_x86_64-22_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86_64</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:2780065, branch:git_mnc-emu-release-->
+		<sdk:api-level>23</sdk:api-level>
+		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
+		<sdk:revision>9</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed Apr 20 08:44:42 2016.-->
+				<sdk:size>349443901</sdk:size>
+				<sdk:checksum type="sha1">571f5078a3d337a9144e2af13bd23ca46845a979</sdk:checksum>
+				<sdk:url>sysimg_x86_64-23_r09.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86_64</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3065232, branch:git_nyc-emu-release-->
+		<sdk:api-level>24</sdk:api-level>
+		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
+		<sdk:revision>5</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jul 15 10:10:10 2016.-->
+				<sdk:size>727226879</sdk:size>
+				<sdk:checksum type="sha1">e1869b32b1dcb2f4d4d18c912166b3e2bee8a841</sdk:checksum>
+				<sdk:url>sysimg_x86_64-24_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:abi>x86_64</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
 </sdk:sdk-sys-img>

--- a/pkgs/development/mobile/androidenv/sysimages.nix
+++ b/pkgs/development/mobile/androidenv/sysimages.nix
@@ -15,6 +15,14 @@ let
 in
 {
 
+  sysimg_x86_10 = buildSystemImage {
+    name = "sysimg-x86-10";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-10_r03.zip;
+      sha1 = "6b8539eaca9685d2d3289bf8e6d21d366d791326";
+    };
+  };
+
   sysimg_armeabi-v7a_14 = buildSystemImage {
     name = "sysimg-armeabi-v7a-14";
     src = fetchurl {
@@ -31,59 +39,11 @@ in
     };
   };
 
-  sysimg_armeabi-v7a_16 = buildSystemImage {
-    name = "sysimg-armeabi-v7a-16";
+  sysimg_mips_15 = buildSystemImage {
+    name = "sysimg-mips-15";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-16_r04.zip;
-      sha1 = "39c093ea755098f0ee79f607be7df9e54ba4943f";
-    };
-  };
-
-  sysimg_armeabi-v7a_17 = buildSystemImage {
-    name = "sysimg-armeabi-v7a-17";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-17_r03.zip;
-      sha1 = "97cfad22b51c8475e228b207dd36dbef1c18fa38";
-    };
-  };
-
-  sysimg_armeabi-v7a_18 = buildSystemImage {
-    name = "sysimg-armeabi-v7a-18";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-18_r03.zip;
-      sha1 = "2d7d51f4d2742744766511e5d6b491bd49161c51";
-    };
-  };
-
-  sysimg_armeabi-v7a_19 = buildSystemImage {
-    name = "sysimg-armeabi-v7a-19";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-19_r03.zip;
-      sha1 = "5daf7718e3ab03d9bd8792b492dd305f386ef12f";
-    };
-  };
-
-  sysimg_armeabi-v7a_21 = buildSystemImage {
-    name = "sysimg-armeabi-v7a-21";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_arm-21_r03.zip;
-      sha1 = "0b2e21421d29f48211b5289ca4addfa7f4c7ae5a";
-    };
-  };
-
-  sysimg_armeabi-v7a_22 = buildSystemImage {
-    name = "sysimg-armeabi-v7a-22";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_arm-22_r01.zip;
-      sha1 = "2aa6a887ee75dcf3ac34627853d561997792fcb8";
-    };
-  };
-
-  sysimg_x86_10 = buildSystemImage {
-    name = "sysimg-x86-10";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-10_r03.zip;
-      sha1 = "6b8539eaca9685d2d3289bf8e6d21d366d791326";
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_mips-15_r01.zip;
+      sha1 = "a753bb4a6783124dad726c500ce9aec9d2c1b2d9";
     };
   };
 
@@ -95,75 +55,11 @@ in
     };
   };
 
-  sysimg_x86_16 = buildSystemImage {
-    name = "sysimg-x86-16";
+  sysimg_armeabi-v7a_16 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-16";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-16_r02.zip;
-      sha1 = "36c2a2e394bcb3290583ce09815eae7711d0b2c2";
-    };
-  };
-
-  sysimg_x86_17 = buildSystemImage {
-    name = "sysimg-x86-17";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-17_r02.zip;
-      sha1 = "bd8c7c5411431af7e051cbe961be430fc31e773d";
-    };
-  };
-
-  sysimg_x86_18 = buildSystemImage {
-    name = "sysimg-x86-18";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-18_r02.zip;
-      sha1 = "ab3de121a44fca43ac3aa83f7d68cc47fc643ee8";
-    };
-  };
-
-  sysimg_x86_19 = buildSystemImage {
-    name = "sysimg-x86-19";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-19_r03.zip;
-      sha1 = "3782f3ebac5e54b3de454570add401989515ffca";
-    };
-  };
-
-  sysimg_x86_21 = buildSystemImage {
-    name = "sysimg-x86-21";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-21_r03.zip;
-      sha1 = "a0b510c66769e84fa5e40515531be2d266a4247f";
-    };
-  };
-
-  sysimg_x86_64_21 = buildSystemImage {
-    name = "sysimg-x86_64-21";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-21_r03.zip;
-      sha1 = "2f205b728695d84488156f4846beb83a353ea64b";
-    };
-  };
-
-  sysimg_x86_22 = buildSystemImage {
-    name = "sysimg-x86-22";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-22_r01.zip;
-      sha1 = "6c7bb51e41a16099bb1f2a3cc81fdb5aa053fc15";
-    };
-  };
-
-  sysimg_x86_64_22 = buildSystemImage {
-    name = "sysimg-x86_64-22";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-22_r01.zip;
-      sha1 = "05752813603f9fa03a58dcf7f8f5e779be722aae";
-    };
-  };
-
-  sysimg_mips_15 = buildSystemImage {
-    name = "sysimg-mips-15";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_mips-15_r01.zip;
-      sha1 = "a753bb4a6783124dad726c500ce9aec9d2c1b2d9";
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-16_r04.zip;
+      sha1 = "39c093ea755098f0ee79f607be7df9e54ba4943f";
     };
   };
 
@@ -175,6 +71,22 @@ in
     };
   };
 
+  sysimg_x86_16 = buildSystemImage {
+    name = "sysimg-x86-16";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-16_r02.zip;
+      sha1 = "36c2a2e394bcb3290583ce09815eae7711d0b2c2";
+    };
+  };
+
+  sysimg_armeabi-v7a_17 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-17";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-17_r03.zip;
+      sha1 = "97cfad22b51c8475e228b207dd36dbef1c18fa38";
+    };
+  };
+
   sysimg_mips_17 = buildSystemImage {
     name = "sysimg-mips-17";
     src = fetchurl {
@@ -183,19 +95,91 @@ in
     };
   };
 
-  sysimg_x86_23 = buildSystemImage {
-    name = "sysimg-x86-23";
+  sysimg_x86_17 = buildSystemImage {
+    name = "sysimg-x86-17";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-23_r03.zip;
-      sha1 = "3cb2e8efb575c35a558b091eac7e1bc5843f5f12";
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-17_r02.zip;
+      sha1 = "bd8c7c5411431af7e051cbe961be430fc31e773d";
     };
   };
 
-  sysimg_x86_64_23 = buildSystemImage {
-    name = "sysimg-x86_64-23";
+  sysimg_armeabi-v7a_18 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-18";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-23_r03.zip;
-      sha1 = "226510856431bc4a73690540a8d7cbad974bedd3";
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-18_r03.zip;
+      sha1 = "2d7d51f4d2742744766511e5d6b491bd49161c51";
+    };
+  };
+
+  sysimg_x86_18 = buildSystemImage {
+    name = "sysimg-x86-18";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-18_r02.zip;
+      sha1 = "ab3de121a44fca43ac3aa83f7d68cc47fc643ee8";
+    };
+  };
+
+  sysimg_armeabi-v7a_19 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-19";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-19_r03.zip;
+      sha1 = "5daf7718e3ab03d9bd8792b492dd305f386ef12f";
+    };
+  };
+
+  sysimg_x86_19 = buildSystemImage {
+    name = "sysimg-x86-19";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-19_r05.zip;
+      sha1 = "c9298a8eafceed3b8fa11071ba63a3d18e17fd8e";
+    };
+  };
+
+  sysimg_armeabi-v7a_21 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-21";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_arm-21_r03.zip;
+      sha1 = "0b2e21421d29f48211b5289ca4addfa7f4c7ae5a";
+    };
+  };
+
+  sysimg_x86_21 = buildSystemImage {
+    name = "sysimg-x86-21";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-21_r04.zip;
+      sha1 = "3b78ad294aa1cdefa4be663d4af6c80d920ec49e";
+    };
+  };
+
+  sysimg_x86_64_21 = buildSystemImage {
+    name = "sysimg-x86_64-21";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-21_r04.zip;
+      sha1 = "eb14ba9c14615d5e5a21c854be29aa903d9bb63d";
+    };
+  };
+
+  sysimg_armeabi-v7a_22 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-22";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_arm-22_r01.zip;
+      sha1 = "2aa6a887ee75dcf3ac34627853d561997792fcb8";
+    };
+  };
+
+  sysimg_x86_22 = buildSystemImage {
+    name = "sysimg-x86-22";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-22_r05.zip;
+      sha1 = "909e0ad91ed43381597e82f65ec93d41f049dd53";
+    };
+  };
+
+  sysimg_x86_64_22 = buildSystemImage {
+    name = "sysimg-x86_64-22";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-22_r05.zip;
+      sha1 = "8a04ff4fb30f70414e6ec7b3b06285f316e93d08";
     };
   };
 
@@ -204,6 +188,46 @@ in
     src = fetchurl {
       url = https://dl.google.com/android/repository/sys-img/android/sysimg_arm-23_r03.zip;
       sha1 = "7bb8768ec4333500192fd9627d4234f505fa98dc";
+    };
+  };
+
+  sysimg_x86_23 = buildSystemImage {
+    name = "sysimg-x86-23";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-23_r09.zip;
+      sha1 = "0ce9229974818179833899dce93f228a895ec6a2";
+    };
+  };
+
+  sysimg_x86_64_23 = buildSystemImage {
+    name = "sysimg-x86_64-23";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-23_r09.zip;
+      sha1 = "571f5078a3d337a9144e2af13bd23ca46845a979";
+    };
+  };
+
+  sysimg_armeabi-v7a_24 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-24";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armeabi-v7a-24_r05.zip;
+      sha1 = "2eb8fb86f7312614a2a0b033d669d67206a618ff";
+    };
+  };
+
+  sysimg_x86_24 = buildSystemImage {
+    name = "sysimg-x86-24";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-24_r05.zip;
+      sha1 = "ce6441c4cadaecd28b364c59b36c31ef0904dae0";
+    };
+  };
+
+  sysimg_x86_64_24 = buildSystemImage {
+    name = "sysimg-x86_64-24";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-24_r05.zip;
+      sha1 = "e1869b32b1dcb2f4d4d18c912166b3e2bee8a841";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

To build, run, and debug a helloworld application on emulators and devices.
See also #16325.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- `adb` is now 64 bit. Linking against 64 bit libraries.
- Added `.lib` or `.out` postfix for 32 bit library packages.
- Some libraries are reside in `lib64` instead of `lib`.
- Other version bumps.
