### PR TITLE
netsurf: init at 3.5 (WIP)

### DIFF
--- a/pkgs/applications/misc/netsurf/default.nix
+++ b/pkgs/applications/misc/netsurf/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchurl, SDL, perl, curl, libpng, libjpeg, fetchgit, pkgconfig
+, expat, gperf, bison, flex, openssl, perlPackages, coreutils, which
+, libidn, spidermonkey_185, gtk2, makeWrapper, check, nspr, nettools
+, libxml2, ui }:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${version}";
+  version = "3.5";
+
+  src = fetchgit {
+    url = "http://git.netsurf-browser.org/netsurf-all.git";
+    rev = "06c2a483a718573d3db65ae7b107772915c753bc";
+    sha256 = "15hal3lj3lrs71aranl6rmp9xq45dv3mn3mwqk682xs7kf521f3h";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ SDL perl curl libpng pkgconfig expat gperf bison flex
+    openssl libjpeg perlPackages.HTMLParser coreutils which libidn gtk2
+    makeWrapper check nspr nettools libxml2 ];
+
+  preConfigure = ''
+    export PKG_CONFIG_PATH=$out/lib/pkgconfig:$PKG_CONFIG_PATH
+    ( echo NETSURF_USE_DUKTAPE := NO;
+      echo override NETSURF_GTK_RESOURCES := $out/share/res;
+    # Disable experimental Javascript.
+      echo override NETSURF_USE_MOZJS := NO )> netsurf/Makefile.config
+  '';
+
+  buildPhase = ''
+    # ui can be any of : gtk framebuffer.
+    # framebuffer can use sdl, but is buggy currently.
+    export TARGET=${ui}
+    export PREFIX=$out
+    export PATH=$out/bin:$PATH
+    for i in buildsystem \
+      nsgenbind \
+      libnsfb libwapcaplet libparserutils libcss libhubbub libdom \
+      libnsbmp libnsgif librosprite libnsutils libutf8proc
+    do
+      (cd $i && make install )
+    done
+    # the actual browser
+    (cd netsurf && make)
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share
+    case "${ui}" in
+      framebuffer) cp netsurf/nsfb $out/bin/netsurf ;;
+      gtk) cp netsurf/nsgtk $out/bin/netsurf ;;
+    esac
+    cp -r netsurf/$TARGET/res $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "Free opensource web browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2207,6 +2207,10 @@ in
 
   netdata = callPackage ../tools/system/netdata { };
 
+  netsurf = callPackage ../applications/misc/netsurf {
+    ui = "gtk";
+  };
+
   netperf = callPackage ../applications/networking/netperf { };
 
   netsniff-ng = callPackage ../tools/networking/netsniff-ng { };


### PR DESCRIPTION
###### Motivation for this change

Netsurf is a browser that supports GTK, and framebuffer
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
