### PR TITLE
elvish: init at 0.1

### DIFF
--- a/pkgs/development/go-modules/libs.json
+++ b/pkgs/development/go-modules/libs.json
@@ -1,5 +1,14 @@
 [
   {
+    "goPackagePath": "github.com/elves/getopt",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/elves/getopt",
+      "rev": "f91a7bf920995832d55a1182f26657bc975b9c24",
+      "sha256": "0wz5dz0iq1b1c2w30mmcgll9xidsrnlvs2906jw9szy0h67310za"
+    }
+  },
+  {
     "goPackagePath": "golang.org/x/sys",
     "fetch": {
       "type": "git",

--- a/pkgs/shells/elvish/default.nix
+++ b/pkgs/shells/elvish/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "elvish-${version}";
+  version = "0.1";
+
+  goPackagePath = "github.com/elves/elvish";
+
+  src = fetchFromGitHub {
+    repo = "elvish";
+    owner = "elves";
+    rev = "4125c2bb927330b0100b354817dd4ad252118ba6";
+    sha256 = "1xwhjbw0y6j5xy19hz39456l0v6vjg2icd7c1jx4h1cydk3yn39f";
+  };
+
+  goDeps = ./deps.json;
+
+  meta = with stdenv.lib; {
+    description = "A Novel unix shell in go language";
+    homepage = https://github.com/elves/elvish;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ vrthra ];
+  };
+}

--- a/pkgs/shells/elvish/deps.json
+++ b/pkgs/shells/elvish/deps.json
@@ -1,0 +1,9 @@
+[
+  {
+    "include": "../../libs.json",
+    "packages": [
+      "github.com/mattn/go-sqlite3",
+      "github.com/elves/getopt"
+    ]
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -473,6 +473,8 @@ in
 
   djmount = callPackage ../tools/filesystems/djmount { };
 
+  elvish = callPackage ../shells/elvish { };
+
   grc = callPackage ../tools/misc/grc { };
 
   green-pdfviewer = callPackage ../applications/misc/green-pdfviewer {


### PR DESCRIPTION
###### Motivation for this change

A novel shell written in go.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

A novel unix shell written in go language.
