### PR TITLE
Theano-cuda: init at 0.8.2

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/7.5-5.0/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/7.5-5.0/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, requireFile
+, cudatoolkit
+}:
+
+stdenv.mkDerivation rec {
+  version = "5.0";
+  cudatoolkit_version = "7.5";
+
+  name = "cudatoolkit-${cudatoolkit_version}-cudnn-${version}";
+
+  src = requireFile rec {
+    name = "cudnn-${cudatoolkit_version}-linux-x64-v${version}-ga.tgz";
+    message = ''
+      This nix expression requires that ${name} is already part of the store.
+      Register yourself to NVIDIA Accelerated Computing Developer Program, retrieve the cuDNN library
+      at https://developer.nvidia.com/cudnn, and run the following command in the download directory:
+      nix-prefetch-url file://${name}
+    '';
+    sha256 = "c4739a00608c3b66a004a74fc8e721848f9112c5cb15f730c1be4964b3a23b3a";
+  };
+
+  phases = "unpackPhase installPhase fixupPhase";
+
+  installPhase = ''
+    function fixRunPath {
+      p=$(patchelf --print-rpath $1)
+      patchelf --set-rpath "$p:${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}" $1
+    }
+    fixRunPath lib64/libcudnn.so
+
+    mkdir -p $out
+    cp -a include $out/include
+    cp -a lib64 $out/lib64
+  '';
+
+  propagatedBuildInputs = [
+    cudatoolkit
+  ];
+
+  meta = {
+    description = "NVIDIA CUDA Deep Neural Network library (cuDNN)";
+    homepage = "https://developer.nvidia.com/cudnn";
+    license = stdenv.lib.licenses.unfree;
+  };
+}

--- a/pkgs/development/python-modules/theano/cuda/default.nix
+++ b/pkgs/development/python-modules/theano/cuda/default.nix
@@ -1,0 +1,62 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, blas
+, numpy
+, six
+, scipy
+, nose
+, nose-parameterized
+, pydot_ng
+, sphinx
+, pygments
+, libgpuarray
+, python
+, pycuda
+, cudatoolkit
+, cudnn
+, stdenv
+}:
+
+buildPythonPackage rec {
+  name = "Theano-cuda-${version}";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "Theano";
+    repo = "Theano";
+    rev = "46fbfeb628220b5e42bf8277a5955c52d153e874";
+    sha256 = "1sl91gli3jaw5gpjqqab4fiq4x6282spqciaid1s65pjsf3k55sc";
+  };
+
+  doCheck = false;
+
+  patchPhase = ''
+    pushd theano/sandbox/gpuarray
+    sed -i -re '2s/^/from builtins import bytes\n/g' subtensor.py
+    sed -i -re "s/(b'2')/int(bytes(\1))/g" subtensor.py
+    sed -i -re "s/(ctx.bin_id\[\-2\])/int(\1)/g" subtensor.py
+
+    sed -i -re '2s/^/from builtins import bytes\n/g' dnn.py
+    sed -i -re "s/(b'30')/int(bytes(\1))/g" dnn.py
+    sed -i -re "s/(ctx.bin_id\[\-2:\])/int(\1)/g" dnn.py
+    popd
+  '';
+
+  dontStrip = true;
+
+  propagatedBuildInputs = [
+    blas
+    numpy
+    six
+    scipy
+    nose
+    nose-parameterized
+    pydot_ng
+    sphinx
+    pygments
+    pycuda
+    cudatoolkit
+    libgpuarray
+  ] ++ (stdenv.lib.optional (cudnn != null) [ cudnn ]);
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1192,6 +1192,10 @@ in
 
   cudnn = callPackage ../development/libraries/science/math/cudnn/default.nix {};
 
+  cudnn5_cudatoolkit75 = callPackage ../development/libraries/science/math/cudnn/7.5-5.0 {
+    cudatoolkit = self.cudatoolkit75;
+  };
+
   curlFull = self.curl.override {
     idnSupport = true;
     ldapSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21029,6 +21029,21 @@ in modules // {
     };
   };
 
+  Theano-cuda = callPackage ../development/python-modules/theano/cuda (
+  let
+    boost = pkgs.boost159.override {
+      inherit (self) python numpy scipy;
+    };
+  in rec {
+    cudatoolkit = pkgs.cudatoolkit75;
+    cudnn = pkgs.cudnn5_cudatoolkit75;
+    inherit (self) numpy scipy;
+    pycuda = self.pycuda.override { inherit boost; };
+    libgpuarray = self.libgpuarray-cuda.override {
+      clblas = pkgs.clblas-cuda.override { inherit boost; };
+    };
+  });
+
   tidylib = buildPythonPackage rec {
     version = "0.2.4";
     name = "pytidylib-${version}";


### PR DESCRIPTION
###### Motivation for this change

This is an extension of the existing python package `Theano-0.8.1` to add a functionality of running the code on an NVIDIA GPU. The minor upgrade to version 0.8.2 is required to provide compatibility with `libgpuarray--9998.0`. The `libgpuarray` package has a dependency on `clblas` which requires OpenCL 1.2. For this reason one needs to use `cudatoolkit-7.5` in place of `cudatoolkit-7.0`. 

The package builds fine with `python-3.5`, but many unit tests on GPU encounter a `Cannot allocate memory problem` error. The tests if one installs the package as `python34Pacakges.Theano-cuda` pass successfully:

``` bash
nix-shell -p pkgs.python34Packages.Theano-cuda
rm -rf ~/.theano
theano-test
```

Note that the `cuDNN` part of the tests requires a GPU of compute capability >= 3.0. 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
