### PR TITLE
cmus: 2.7.0 -> 2.7.1

### DIFF
--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -93,13 +93,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "cmus-${version}";
-  version = "2.7.0";
+  version = "2.7.1";
 
   src = fetchFromGitHub {
     owner  = "cmus";
     repo   = "cmus";
-    rev    = "0306cc74c5073a85cf8619c61da5b94a3f863eaa";
-    sha256 = "18w9mznb843nzkrcqvshfha51mlpdl92zlvb5wfc5dpgrbf37728";
+    rev    = "v${version}";
+    sha256 = "0xd96py21bl869qlv1353zw7xsgq6v5s8szr0ldr63zj5fgc2ps5";
   };
 
   patches = [ ./option-debugging.patch ];


### PR DESCRIPTION
###### Motivation for this change

Update cmus to the last version
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
