### PR TITLE
libxkbcommon: set X11 locale directory

### DIFF
--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, yacc, flex, xkeyboard_config, libxcb }:
+{ stdenv, fetchurl, pkgconfig, yacc, flex, xkeyboard_config, libxcb, libX11 }:
 
 stdenv.mkDerivation rec {
   name = "libxkbcommon-0.6.1";
@@ -12,9 +12,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig yacc flex xkeyboard_config libxcb ];
 
-  configureFlags = ''
-    --with-xkb-config-root=${xkeyboard_config}/etc/X11/xkb
-  '';
+  configureFlags = [
+    "--with-xkb-config-root=${xkeyboard_config}/etc/X11/xkb"
+    "--with-x-locale-root=${libX11.out}/share/X11/locale"
+  ];
 
   preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i 's/,--version-script=.*$//' Makefile


### PR DESCRIPTION
###### Motivation for this change

xkbcommon exposes a Compose(5) API for programs that want to detect e.g. similar letters (i.e. áå matches a) using the libX11 compose map. This fixes the "Failed to get keyboard compose table. Trying to limp on" warning emitted when programs attempt to use this API.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've verified that `rofi` no longer shows the XKB warning. CC @garbas 
