### PR TITLE
rofi: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libX11, libxkbcommon, pango
-, cairo, glib, libxcb, xcbutil, xcbutilwm, which, git, libstartup_notification
+, cairo, glib, libxcb, xcbutil, xcbutilwm, libstartup_notification
 , i3Support ? false, i3
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.1";
+  version = "1.1.0";
   name = "rofi-${version}";
 
   src = fetchurl {
     url = "https://github.com/DaveDavenport/rofi/releases/download/${version}/${name}.tar.xz";
-    sha256 = "01jxml9vk4cw7pngpan7dipmb98s6ibh6f0023lw3hbgxy650637";
+    sha256 = "1l8vl0mh7i0b1ycifqpg6392f5i4qxlv003m126skfk6fnlfq8hn";
   };
 
   preConfigure = ''
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ autoreconfHook pkgconfig libX11 libxkbcommon pango
-    cairo libstartup_notification libxcb xcbutil xcbutilwm which git
+    cairo libstartup_notification libxcb xcbutil xcbutilwm
   ] ++ stdenv.lib.optional i3Support i3;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
