### PR TITLE
bird: 1.5.0 -> 1.6.0, add IPv6 build

### DIFF
--- a/pkgs/servers/bird/default.nix
+++ b/pkgs/servers/bird/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, flex, bison, readline }:
+{ stdenv, fetchurl, flex, bison, readline
+, enableIPv6 ? false }:
 
 stdenv.mkDerivation rec {
   name = "bird-1.6.0";
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--localstatedir /var"
-  ];
+  ] ++ stdenv.lib.optional enableIPv6 "--enable-ipv6";
 
   meta = {
     description = "BIRD Internet Routing Daemon";

--- a/pkgs/servers/bird/default.nix
+++ b/pkgs/servers/bird/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, flex, bison, readline }:
 
 stdenv.mkDerivation rec {
-  name = "bird-1.5.0";
+  name = "bird-1.6.0";
 
   src = fetchurl {
     url = "ftp://bird.network.cz/pub/bird/${name}.tar.gz";
-    sha256 = "0pbvq6rx4ww46vcdslpiplb5fwq3mqma83434q38kx959qjw9mbr";
+    sha256 = "04qf07cb04xdjnq0qxj6y8iqwyszk1vyark9gn5v6wxcvqvzwgfv";
   };
 
   buildInputs = [ flex bison readline ];
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     description = "BIRD Internet Routing Daemon";
     homepage = http://bird.network.cz;
     license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [ viric fpletz ];
     platforms  = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9871,6 +9871,7 @@ in
   bind = callPackage ../servers/dns/bind { };
 
   bird = callPackage ../servers/bird { };
+  bird6 = bird.override { enableIPv6 = true; };
 
   bosun = (callPackage ../servers/monitoring/bosun { }).bin // { outputs = [ "bin" ]; };
   scollector = bosun;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
