### PR TITLE
lxd: 2.0.0.rc4 -> 2.0.2

### DIFF
--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "lxd-${version}";
-  version = "2.0.0.rc4";
+  version = "2.0.2";
   rev = "lxd-${version}";
 
   goPackagePath = "github.com/lxc/lxd";
@@ -11,17 +11,13 @@ buildGoPackage rec {
     inherit rev;
     owner = "lxc";
     repo = "lxd";
-    sha256 = "1rpyyj6d38d9kmb47dcmy1x41fiacj384yx01yslsrj2l6qxcdjn";
+    sha256 = "1rs9g1snjymg6pjz5bj77zk5wbs0w8xmrfxzqs32w6zr1dxhf9hs";
   };
 
   goDeps = ./deps.json;
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ lxc ];
-
-  postInstall = ''
-    cp go/src/$goPackagePath/scripts/lxd-images $bin/bin
-  '';
 
   meta = with stdenv.lib; {
     description = "Daemon based on liblxc offering a REST API to manage containers";


### PR DESCRIPTION
###### Motivation for this change

2.0.0.rc4 is relatively old
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
