### PR TITLE
Netsurf: init at 3.5

### DIFF
--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -1,0 +1,78 @@
+{ stdenv, fetchurl, pkgconfig, libpng, openssl, curl, gtk2, check
+, libxml2, libidn, perl, nettools, perlPackages
+, libXcursor, libXrandr, makeWrapper
+, buildsystem
+, nsgenbind
+, libnsfb
+, libwapcaplet
+, libparserutils
+, libcss
+, libhubbub
+, libdom
+, libnsbmp
+, libnsgif
+, libnsutils
+, libutf8proc
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${version}";
+  version = "3.5";
+
+  # UIS incldue Framebuffer, and gtk, but
+  # Framebuffer is buggy. To enable, make sure
+  # to also build netsurf-libnsfb with ui=framebuffer
+  # and switch the ui here to framebuffer
+  ui = "gtk";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/netsurf/releases/source/netsurf-${version}-src.tar.gz";
+    sha256 = "1k0x8mzgavfy7q9kywl6kzsc084g1xlymcnsxi5v6jp279nsdwwq";
+  };
+
+  buildInputs = [ pkgconfig libpng openssl curl gtk2 check libxml2 libidn perl
+    nettools perlPackages.HTMLParser libXcursor libXrandr makeWrapper
+    buildsystem
+    nsgenbind
+    libnsfb
+    libwapcaplet
+    libparserutils
+    libcss
+    libhubbub
+    libdom
+    libnsbmp
+    libnsgif
+    libnsutils
+    libutf8proc
+ ];
+
+  preConfigure = ''
+    cat <<EOF > Makefile.conf
+    override NETSURF_GTK_RESOURCES := $out/share/Netsurf/${ui}/res
+    override NETSURF_USE_GRESOURCE := YES
+    EOF
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+    "TARGET=${ui}"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/Netsurf/${ui}
+    cmd=$(case "${ui}" in framebuffer) echo nsfb;; gtk) echo nsgtk;; esac)
+    cp $cmd $out/bin/netsurf
+    wrapProgram $out/bin/netsurf --set NETSURFRES $out/share/Netsurf/${ui}/res
+    tar -hcf - ${ui}/res | (cd $out/share/Netsurf/ && tar -xvpf -)
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "Free opensource web browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/buildsystem/default.nix
+++ b/pkgs/applications/misc/netsurf/buildsystem/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-buildsystem-${version}";
+  version = "1.5";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/buildsystem-${version}.tar.gz";
+    sha256 = "0wdgvasrjik1dgvvpqbppbpyfzkqd1v45x3g9rq7p67n773azinv";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "Build system for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libcss/default.nix
+++ b/pkgs/applications/misc/netsurf/libcss/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, pkgconfig, perl
+, buildsystem
+, libwapcaplet
+, libparserutils
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libcss";
+  version = "0.6.0";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "0qp4p1q1dwgdra4pkrzd081zjzisxkgwx650ijx323j8bj725daf";
+  };
+
+  buildInputs = [ pkgconfig perl
+    buildsystem
+    libwapcaplet
+    libparserutils
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "Cascading Style Sheets library for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libdom/default.nix
+++ b/pkgs/applications/misc/netsurf/libdom/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, pkgconfig, expat
+, buildsystem
+, libparserutils
+, libwapcaplet
+, libhubbub
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libdom";
+  version = "0.3.0";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "1kk6qbqagx5ypiy9kf0059iqdzyz8fqaw336vzhb5gnrzjw3wv4a";
+  };
+
+  buildInputs = [ pkgconfig expat
+    buildsystem
+    libparserutils
+    libwapcaplet
+    libhubbub
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "Document Object Model library for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libhubbub/default.nix
+++ b/pkgs/applications/misc/netsurf/libhubbub/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, pkgconfig, perl
+, buildsystem
+, libparserutils
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libhubbub";
+  version = "0.3.3";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "101781iw32p47386fxqr01nrkywi12w17ajh02k2vlga4z8zyv86";
+  };
+
+  buildInputs = [ pkgconfig perl
+    buildsystem
+    libparserutils
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "HTML5 parser library for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libnsbmp/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsbmp/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, pkgconfig
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libnsbmp";
+  version = "0.1.3";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "0gmvzw1whh7553d6s98vr4ri2whjwrgggcq1z5b160gwjw20mzyy";
+  };
+
+  buildInputs = [ pkgconfig
+    buildsystem
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "BMP Decoder for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libnsfb/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsfb/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, pkgconfig, ui? "gtk"
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libnsfb";
+  version = "0.1.4";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "176f8why9gzbaca9nnxjqasl02qzc6g507z5w3dzkcjifnkz4mzl";
+  };
+
+  buildInputs = [ pkgconfig buildsystem ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+    "TARGET=${ui}"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "CSS parser and selection library for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libnsgif/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsgif/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, pkgconfig
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libnsgif";
+  version = "0.1.3";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "1a4z45gh0fw4iybf34fig725av25h31ffk0azi0snzh4130cklnk";
+  };
+
+  buildInputs = [ buildsystem pkgconfig];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "GIF Decoder for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libnsutils/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsutils/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, pkgconfig
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libnsutils";
+  version = "0.0.2";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "03p4xmd08yhj70nyj7acjccmmshs59lv4n4zsqpsn5lgkwa23lzy";
+  };
+
+  buildInputs = [ buildsystem pkgconfig];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "Generalised utility library for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libparserutils/default.nix
+++ b/pkgs/applications/misc/netsurf/libparserutils/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, perl
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libparserutils";
+  version = "0.2.3";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "01gzlsabgl6x0icd8758d9jqs8rrf9574bdkjainn04w3fs3znf5";
+  };
+
+  buildInputs = [ buildsystem perl ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "Parser building library for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libutf8proc/default.nix
+++ b/pkgs/applications/misc/netsurf/libutf8proc/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, pkgconfig
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libutf8proc";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "0xf659y3c6ikjnip47r30wv796a34d71p6qhc4xjs64iqszm1sbq";
+  };
+
+  buildInputs = [ buildsystem pkgconfig];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "UTF8 Processing library for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
+++ b/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libwapcaplet";
+  version = "0.3.0";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "0cs1dd2afjgc3wf5gqg434hv6jdabrp9qvlpl4dp53nhkyfywna3";
+  };
+
+  buildInputs = [ buildsystem ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "String internment library for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/nsgenbind/default.nix
+++ b/pkgs/applications/misc/netsurf/nsgenbind/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl
+, flex, bison
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-nsgenbind-${version}";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/nsgenbind-${version}-src.tar.gz";
+    sha256 = "16xsazly7gxwywmlkf2xix9b924sj3skhgdak7218l0nc62a08gg";
+  };
+
+  buildInputs = [ buildsystem flex bison ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.netsurf-browser.org/";
+    description = "Generator for JavaScript bindings for netsurf browser";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2230,6 +2230,8 @@ in
 
     libcss = callPackage ../applications/misc/netsurf/libcss { };
 
+    libhubbub = callPackage ../applications/misc/netsurf/libhubbub { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2224,6 +2224,8 @@ in
 
     libwapcaplet = callPackage ../applications/misc/netsurf/libwapcaplet { };
 
+    nsgenbind = callPackage ../applications/misc/netsurf/nsgenbind { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2242,6 +2242,8 @@ in
 
     libnsutils = callPackage ../applications/misc/netsurf/libnsutils { };
 
+    libutf8proc = callPackage ../applications/misc/netsurf/libutf8proc { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2218,6 +2218,12 @@ in
 
   netdata = callPackage ../tools/system/netdata { };
 
+  netsurf = recurseIntoAttrs (let callPackage = newScope pkgs.netsurf; in rec {
+
+    buildsystem = callPackage ../applications/misc/netsurf/buildsystem { };
+
+  });
+
   netperf = callPackage ../applications/networking/netperf { };
 
   netsniff-ng = callPackage ../tools/networking/netsniff-ng { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2244,6 +2244,8 @@ in
 
     libutf8proc = callPackage ../applications/misc/netsurf/libutf8proc { };
 
+    browser = callPackage ../applications/misc/netsurf/browser { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2234,6 +2234,8 @@ in
 
     libdom = callPackage ../applications/misc/netsurf/libdom { };
 
+    libnsbmp = callPackage ../applications/misc/netsurf/libnsbmp { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2236,6 +2236,8 @@ in
 
     libnsbmp = callPackage ../applications/misc/netsurf/libnsbmp { };
 
+    libnsgif = callPackage ../applications/misc/netsurf/libnsgif { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2232,6 +2232,8 @@ in
 
     libhubbub = callPackage ../applications/misc/netsurf/libhubbub { };
 
+    libdom = callPackage ../applications/misc/netsurf/libdom { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2240,6 +2240,8 @@ in
 
     libnsfb = callPackage ../applications/misc/netsurf/libnsfb { };
 
+    libnsutils = callPackage ../applications/misc/netsurf/libnsutils { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2226,6 +2226,8 @@ in
 
     nsgenbind = callPackage ../applications/misc/netsurf/nsgenbind { };
 
+    libparserutils = callPackage ../applications/misc/netsurf/libparserutils { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2222,6 +2222,8 @@ in
 
     buildsystem = callPackage ../applications/misc/netsurf/buildsystem { };
 
+    libwapcaplet = callPackage ../applications/misc/netsurf/libwapcaplet { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2228,6 +2228,8 @@ in
 
     libparserutils = callPackage ../applications/misc/netsurf/libparserutils { };
 
+    libcss = callPackage ../applications/misc/netsurf/libcss { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2238,6 +2238,8 @@ in
 
     libnsgif = callPackage ../applications/misc/netsurf/libnsgif { };
 
+    libnsfb = callPackage ../applications/misc/netsurf/libnsfb { };
+
   });
 
   netperf = callPackage ../applications/networking/netperf { };


### PR DESCRIPTION
###### Motivation for this change

A free opensource browser, along with the supporting libraries.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
