### PR TITLE
ssh-ident: init at 2016-04-21

### DIFF
--- a/pkgs/tools/networking/ssh-ident/default.nix
+++ b/pkgs/tools/networking/ssh-ident/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, makeWrapper, python }:
+
+stdenv.mkDerivation rec {
+  name = "ssh-ident-${version}";
+  version = "2016-04-21";
+  src = fetchFromGitHub  {
+    owner = "ccontavalli";
+    repo = "ssh-ident";
+    rev = "ebf8282728211dc4448d50f7e16e546ed03c22d2";
+    sha256 = "1jf19lz1gwn7cyp57j8d4zs5bq13iw3kw31m8nvr8h6sib2pf815";
+  };
+
+  buildInputs = [ makeWrapper ];
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 755 ssh-ident $out/bin/ssh-ident
+    wrapProgram $out/bin/ssh-ident \
+      --prefix PATH : "${python}/bin/python"
+  '';
+
+  meta = {
+    homepage = https://github.com/ccontavalli/ssh-ident;
+    description = "Start and use ssh-agent and load identities as necessary";
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = with stdenv.lib.maintainers; [ telotortium ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3416,6 +3416,8 @@ in
 
   ssdeep = callPackage ../tools/security/ssdeep { };
 
+  ssh-ident = callPackage ../tools/networking/ssh-ident { };
+
   sshpass = callPackage ../tools/networking/sshpass { };
 
   sslscan = callPackage ../tools/security/sslscan { };


### PR DESCRIPTION
###### Motivation for this change

Add ssh-ident package from its GitHub repo. Since there are no version
tags on GitHub, I'm using the date of its most recent commit.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
