### PR TITLE
xonsh 0.3.2 -> 0.3.4 and pygment

### DIFF
--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "xonsh-${version}";
-  version = "0.3.2";
+  version = "0.3.4";
 
   src = fetchFromGitHub {
     owner = "scopatz";
     repo = "xonsh";
     rev = version;
-    sha256= "0cqfrpvkgzk0q3dykavqxwfqrx61y8rbzixmwcv8pfa9r2sya24q";
+    sha256= "13inkj0vs8nqdghp3j19dardawfsdmcsfzsp77hlwavmw7sqjxzi";
   };
 
   ## The logo xonsh prints during build contains unicode characters, and this

--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication rec {
     HOME=$TMPDIR nosetests -x
   '';
 
-  buildInputs = with python3Packages; [ glibcLocales nose pygments ];
+  buildInputs = with python3Packages; [ glibcLocales nose ];
   propagatedBuildInputs = with python3Packages; [ ply prompt_toolkit ];
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16891,8 +16891,8 @@ in modules // {
       rm prompt_toolkit/win32_types.py
     '';
 
-    buildInputs = with self; [ jedi ipython pygments ];
-    propagatedBuildInputs = with self; [ docopt six wcwidth ];
+    buildInputs = with self; [ jedi ipython ];
+    propagatedBuildInputs = with self; [ docopt six wcwidth pygments ];
 
     meta = {
       description = "Python library for building powerful interactive command lines";


### PR DESCRIPTION
###### Motivation for this change

Update xonsh and make it start without failing due to missing pygment.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

maintainers @nckx @spwhitt  @garbas 
