### PR TITLE
ddclient service: use `environment.etc`

### DIFF
--- a/nixos/modules/services/networking/ddclient.nix
+++ b/nixos/modules/services/networking/ddclient.nix
@@ -7,22 +7,8 @@ let
 
   stateDir = "/var/spool/ddclient";
   ddclientUser = "ddclient";
-  ddclientFlags = "-foreground -verbose -noquiet -file ${ddclientCfg}";
+  ddclientFlags = "-foreground -verbose -noquiet -file /etc/ddclient.conf";
   ddclientPIDFile = "${stateDir}/ddclient.pid";
-  ddclientCfg = pkgs.writeText "ddclient.conf" ''
-    daemon=600
-    cache=${stateDir}/ddclient.cache
-    pid=${ddclientPIDFile}
-    use=${config.services.ddclient.use}
-    login=${config.services.ddclient.username}
-    password=${config.services.ddclient.password}
-    protocol=${config.services.ddclient.protocol}
-    server=${config.services.ddclient.server}
-    ssl=${if config.services.ddclient.ssl then "yes" else "no"}
-    wildcard=YES
-    ${config.services.ddclient.domain}
-    ${config.services.ddclient.extraConfig}
-  '';
 
 in
 
@@ -122,10 +108,30 @@ in
       home = stateDir;
     };
 
+    environment.etc."ddclient.conf" = {
+      uid = config.ids.uids.ddclient;
+      mode = "0600";
+      text = ''
+        daemon=600
+        cache=${stateDir}/ddclient.cache
+        pid=${ddclientPIDFile}
+        use=${config.services.ddclient.use}
+        login=${config.services.ddclient.username}
+        password=${config.services.ddclient.password}
+        protocol=${config.services.ddclient.protocol}
+        server=${config.services.ddclient.server}
+        ssl=${if config.services.ddclient.ssl then "yes" else "no"}
+        wildcard=YES
+        ${config.services.ddclient.domain}
+        ${config.services.ddclient.extraConfig}
+      '';
+    };
+
     systemd.services.ddclient = {
       description = "Dynamic DNS Client";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
+      restartTriggers = [ config.environment.etc."ddclient.conf".source ];
 
       serviceConfig = {
         # Uncomment this if too many problems occur:


### PR DESCRIPTION
###### Motivation for this change

To get rid of the

```
WARNING:  file /nix/store/6hbfyxrh0aywhg7lia3x9nfi2pliprlx-ddclient.conf: file /nix/store/6hbfyxrh0aywhg7lia3x9nfi2pliprlx-ddclient.conf must be accessible only by its owner.
```

nagging that ends up in the ddclient log.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The ddclient daemon requires that the configuration file is only
accessible by the ddclient user. This since it typically contains login
information.
