### PR TITLE
go-ethereum: init at 1.4.7

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -16,6 +16,8 @@ rec {
   dogecoin  = callPackage ./dogecoin.nix { withGui = true; };
   dogecoind = callPackage ./dogecoin.nix { withGui = false; };
 
+  go-ethereum = callPackage ./go-ethereum.nix { };
+
   litecoin  = callPackage ./litecoin.nix { withGui = true; };
   litecoind = callPackage ./litecoin.nix { withGui = false; };
 

--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, go, fetchgit }:
+
+stdenv.mkDerivation rec {
+  name = "go-ethereum-${version}";
+  version = "1.4.7";
+  rev = "refs/tags/v${version}";
+  goPackagePath = "github.com/ethereum/go-ethereum";
+
+  buildInputs = [ go ];
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://${goPackagePath}";
+    sha256 = "19q518kxkvrr44cvsph4wv3lr6ivqsckz1f22r62932s3sq6gyd8";
+  };
+
+  buildPhase = ''
+    export GOROOT=$(mktemp -d --suffix=-goroot)
+    ln -sv ${go}/share/go/* $GOROOT
+    ln -svf ${go}/bin $GOROOT
+    make all
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -v build/bin/* $out/bin
+  '';
+
+  meta = {
+    homepage = "https://ethereum.github.io/go-ethereum/";
+    description = "Official golang implementation of the Ethereum protocol";
+    license = with lib.licenses; [ lgpl3 gpl3 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11991,6 +11991,8 @@ in
   bitcoin = self.altcoins.bitcoin;
   bitcoin-xt = self.altcoins.bitcoin-xt;
 
+  go-ethereum = self.altcoins.go-ethereum;
+
   aumix = callPackage ../applications/audio/aumix {
     gtkGUI = false;
   };


### PR DESCRIPTION
###### Motivation for this change
- #15376 initialized go-ethereum at 1.4.1 in `go-packages`
- 08575ee deleted all go packages, including go-ethereum

So now I'm adding go-ethereum back again (at a slightly higher version this time).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
