### PR TITLE
hakuneko: 1.3.12 -> 1.4.1

### DIFF
--- a/pkgs/tools/misc/hakuneko/default.nix
+++ b/pkgs/tools/misc/hakuneko/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, wxGTK, openssl, curl }:
+{ stdenv, fetchurl, wxGTK30, openssl, curl }:
 
 stdenv.mkDerivation rec {
   name = "hakuneko-${version}";
-  version = "1.3.12";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/hakuneko/hakuneko_${version}_src.tar.gz";
-    sha256 = "24e7281a7f68b24e5260ee17ecfa1c5a3ffec408c8ea6e0121ae6c161898b698";
+    sha256 = "d7e066e3157445f273ccf14172c05077759da036ffe700a28a409fde862b69a7";
   };
 
   preConfigure = ''
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
        --replace /bin/bash $shell
     '';
 
-  buildInputs = [ wxGTK openssl curl ];
+  buildInputs = [ wxGTK30 openssl curl ];
 
   meta = {
     description = "Manga downloader";


### PR DESCRIPTION
###### Motivation for this change

this version fixes a memory-leak 1.3.12 and 1.4.0 showed.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
