### PR TITLE
Add a module for Emacs daemon

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -164,6 +164,7 @@
   ./services/desktops/profile-sync-daemon.nix
   ./services/desktops/telepathy.nix
   ./services/development/hoogle.nix
+  ./services/editors/emacs.nix
   ./services/games/factorio.nix
   ./services/games/ghost-one.nix
   ./services/games/minecraft-server.nix

--- a/nixos/modules/services/editors/emacs.nix
+++ b/nixos/modules/services/editors/emacs.nix
@@ -1,0 +1,65 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.emacs;
+
+in {
+
+  options.services.emacs = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to enable a user service for the Emacs daemon. Use <literal>emacsclient</literal> to connect to the
+        daemon. If <literal>true</literal>, <varname>services.emacs.install</varname> is
+        considered <literal>true</literal>, whatever its value.
+      '';
+    };
+
+    install = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to install a user service for the Emacs daemon. Once
+        the service is started, use emacsclient to connect to the
+        daemon.
+
+        The service must be manually started for each user with
+        "systemctl --user start emacs" or globally through
+        <varname>services.emacs.enable</varname>.
+      '';
+    };
+
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.emacs;
+      defaultText = "pkgs.emacs";
+      description = ''
+        emacs derivation to use.
+      '';
+    };
+
+  };
+
+  config = mkIf (cfg.enable || cfg.install) {
+    systemd.user.services.emacs = {
+      description = "Emacs: the extensible, self-documenting text editor";
+
+      serviceConfig = {
+        Type      = "forking";
+        ExecStart = "${pkgs.bash}/bin/bash -c 'source ${config.system.build.setEnvironment}; exec ${cfg.package}/bin/emacs --daemon'";
+        ExecStop  = "${cfg.package}/bin/emacsclient --eval (kill-emacs)";
+        Restart   = "always";
+      };
+    } // optionalAttrs cfg.enable { wantedBy = [ "default.target" ]; };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+
+}

--- a/nixos/tests/emacs-daemon.nix
+++ b/nixos/tests/emacs-daemon.nix
@@ -1,0 +1,45 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "emacs-daemon";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ DamienCassou ];
+  };
+
+  enableOCR = true;
+
+  machine =
+    { config, pkgs, ... }:
+
+    { imports = [ ./common/x11.nix ];
+      services.emacs = {
+        enable = true;
+        defaultEditor = true;
+      };
+
+      # Important to get the systemd service running for root
+      environment.variables.XDG_RUNTIME_DIR = "/run/user/0";
+
+      environment.variables.TEST_SYSTEM_VARIABLE = "system variable";
+    };
+
+  testScript =
+    ''
+      $machine->waitForUnit("multi-user.target");
+
+      # checks that the EDITOR environment variable is set
+      $machine->succeed("test \$(basename \"\$EDITOR\") = emacseditor");
+
+      # waits for the emacs service to be ready
+      $machine->waitUntilSucceeds("systemctl --user status emacs.service | grep 'Active: active'");
+
+      # connects to the daemon
+      $machine->succeed("emacsclient --create-frame \$EDITOR &");
+
+      # checks that Emacs shows the edited filename
+      $machine->waitForText("emacseditor");
+
+      # makes sure environment variables are accessible from Emacs
+      $machine->succeed("emacsclient --eval '(getenv \"TEST_SYSTEM_VARIABLE\")'") =~ /system variable/ or die;
+
+      $machine->screenshot("emacsclient");
+    '';
+})


### PR DESCRIPTION
###### Motivation for this change
- fix #15807 
- Several users are manually adding a systemd user service to their configuration.nix. A NixOS module avoid copy/pasting half-baked definitions.
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @TikhonJelvis @anderspapitto @PierreR @ttuegel @rvl 
