### PR TITLE
tk: propagate dependency on tcl & libXft

### DIFF
--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -17,8 +17,10 @@ stdenv.mkDerivation {
     "--with-tcl=${tcl}/lib"
   ];
 
-  buildInputs = [ pkgconfig tcl libXft ]
+  buildInputs = [ pkgconfig ]
     ++ stdenv.lib.optional stdenv.isDarwin fontconfig;
+
+  propagatedBuildInputs = [ tcl libXft ];
 
   NIX_CFLAGS_LINK = if stdenv.isDarwin then "-lfontconfig" else null;
 


### PR DESCRIPTION
###### Motivation for this change

I believe it should be possible to build against tk without having to depend on its own dependencies (namely tcl + xlib). Currently this is not possible:

main.c:

```
#include <tk.h>
int main() {
  return 0;
}
```

```
$ nix-shell -p tk --run 'gcc -o /dev/null ~/Desktop/tktest/main.c'
In file included from /home/tim/Desktop/tktest/main.c:1:0:
/nix/store/zxwzr9v1phx8ak0kc0wcvk3jga12xxs7-tk-8.6.4/include/tk.h:19:17: fatal error: tcl.h: No such file or directory
compilation terminated.

$ nix-shell -p tk -p tcl --run 'gcc -o /dev/null ~/Desktop/tktest/main.c'
In file included from /home/tim/Desktop/tktest/main.c:1:0:
/nix/store/zxwzr9v1phx8ak0kc0wcvk3jga12xxs7-tk-8.6.4/include/tk.h:96:25: fatal error: X11/Xlib.h: No such file or directory
compilation terminated.

$ nix-shell -p tk -p tcl -p xorg.libXft --run 'gcc -o /dev/null ~/Desktop/tktest/main.c'
# (ok)
```
### Now, with these changes:

```
env NIX_PATH=nixpkgs=$HOME/dev/nix/nixpkgs/ nix-shell -p tk --run 'gcc -o /dev/null ~/Desktop/tktest/main.c'
# (ok)
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @lovek323 @wkennington 
