### PR TITLE
texmaker: 4.4.1 -> 4.5

### DIFF
--- a/pkgs/applications/editors/texmaker/default.nix
+++ b/pkgs/applications/editors/texmaker/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "texmaker";
-  version = "4.4.1";
+  version = "4.5";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "http://www.xm1math.net/texmaker/${name}.tar.bz2";
-    sha256 = "1d5lb4sibdhvzgfr0zi48j92b4acvvvdy2biqi3jzjdnzy9r94w0";
+    sha256 = "056njk6j8wma23mlp7xa3rgfaxx0q8ynwx8wkmj7iy0b85p9ds9c";
   };
 
   buildInputs = [ qt4 poppler_qt4 zlib ];


### PR DESCRIPTION
###### Motivation for this change

Update texmaker to the last version
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
