### PR TITLE
GnuTLS: 3.4.11 -> 3.4.13 / GnuTLS35: init -> 3.5.1

### DIFF
--- a/pkgs/development/libraries/gnutls/3.4.nix
+++ b/pkgs/development/libraries/gnutls/3.4.nix
@@ -1,11 +1,11 @@
 { callPackage, fetchurl, autoreconfHook, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "3.4.11";
+  version = "3.4.13";
 
   src = fetchurl {
     url = "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.4/gnutls-${version}.tar.xz";
-    sha256 = "1f4sbb38xab46h67a3pm6kybgrahjx3vbrn66qq3cbc2jngrrvvh";
+    sha256 = "0naqs9g5b577j1j7q55ma1vcn78jl2d98h3zrl5rh997wzl8cczx";
   };
 
   # This fixes some broken parallel dependencies

--- a/pkgs/development/libraries/gnutls/3.5.nix
+++ b/pkgs/development/libraries/gnutls/3.5.nix
@@ -1,0 +1,17 @@
+{ callPackage, fetchurl, autoreconfHook, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "3.5.1";
+
+  src = fetchurl {
+    url = "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-${version}.tar.xz";
+    sha256 = "1gdxr1p1sigigwvangqf3v31i8fda07d6ngawykarhr7ls00yjmw";
+  };
+
+  # This fixes some broken parallel dependencies
+  postPatch = ''
+    sed -i 's,^BUILT_SOURCES =,\0 systemkey-args.h,g' src/Makefile.am
+  '';
+
+  nativeBuildInputs = [ autoreconfHook ];
+})

--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -1,6 +1,6 @@
 { lib, fetchurl, stdenv, zlib, lzo, libtasn1, nettle, pkgconfig, lzip
 , guileBindings, guile, perl, gmp, autogen, libidn, p11_kit, unbound, libiconv
-, tpmSupport ? false, trousers
+, tpmSupport ? false, trousers, nettools, bash
 
 # Version dependent args
 , version, src, patches ? [], postPatch ? "", nativeBuildInputs ? []
@@ -29,13 +29,17 @@ stdenv.mkDerivation {
   # for the actual fix.
   enableParallelBuilding = !guileBindings;
 
-  buildInputs = [ lzo lzip nettle libtasn1 libidn p11_kit zlib gmp autogen ]
+  buildInputs = [ lzo lzip nettle libtasn1 libidn p11_kit zlib gmp autogen nettools bash ]
     ++ lib.optional (stdenv.isFreeBSD || stdenv.isDarwin) libiconv
     ++ lib.optional (tpmSupport && stdenv.isLinux) trousers
     ++ [ unbound ]
     ++ lib.optional guileBindings guile;
 
   nativeBuildInputs = [ perl pkgconfig ] ++ nativeBuildInputs;
+
+  patchPhase = ''
+    patchShebangs .
+    '';
 
   # XXX: Gnulib's `test-select' fails on FreeBSD:
   # http://hydra.nixos.org/build/2962084/nixlog/1/raw .

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7254,6 +7254,10 @@ in
     guileBindings = config.gnutls.guile or false;
   };
 
+  gnutls35 = callPackage ../development/libraries/gnutls/3.5.nix {
+    guileBindings = config.gnutls.guile or false;
+  };
+
   gpac = callPackage ../applications/video/gpac { };
 
   gpgme = callPackage ../development/libraries/gpgme {


### PR DESCRIPTION
###### Motivation for this change

GnuTLS 3.5 is the new stable-next branch, which is appearing as a dependency. GnuTLS 3.4.13 is a bug fix release on the current stable branch, with security advisory GnuTLS-SA-2016-1 attached to it. 

Note that a new test for GnuTLS requires the use of netstat for both, which is part of nettools. Therefore this is added as a dependency on generic.nix.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
