### PR TITLE
sequel-pro: init at 1.1.2

### DIFF
--- a/pkgs/applications/misc/sequelpro/default.nix
+++ b/pkgs/applications/misc/sequelpro/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, undmg }:
+
+stdenv.mkDerivation rec {
+  name = "sequel-pro-${version}";
+  version = "1.1.2";
+
+  src = fetchurl {
+    url = "https://github.com/sequelpro/sequelpro/releases/download/release-1.1.2/sequel-pro-1.1.2.dmg";
+    sha256 = "1il7yc3f0yzxkra27bslnmka5ycxzx0q4m3xz2j9r7iyq5izsd3v";
+  };
+
+  buildInputs = [ undmg ];
+  installPhase = ''
+    mkdir -p "$out/Applications/Sequel Pro.app"
+    cp -R . "$out/Applications/Sequel Pro.app"
+    chmod +x "$out/Applications/Sequel Pro.app/Contents/MacOS/Sequel Pro"
+  '';
+
+  meta = {
+    description = "MySQL database management for Mac OS X";
+    homepage = http://www.sequelpro.com/;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17044,4 +17044,6 @@ in
   imatix_gsl = callPackage ../development/tools/imatix_gsl {};
 
   iterm2 = callPackage ../applications/misc/iterm2 {};
+
+  sequelpro = callPackage ../applications/misc/sequelpro {};
 }


### PR DESCRIPTION
###### Motivation for this change

Adds the sequel pro OS X app :)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
