### PR TITLE
haskell-hoogle: adapt to GHC docs split

### DIFF
--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation {
     }
 
     echo importing builtin packages
-    for docdir in ${ghc}/${docLibGlob}/*; do
+    for docdir in ${ghc.doc}/${docLibGlob}/*; do
       name="$(basename $docdir)"
       ${opts isGhcjs ''docdir="$docdir/html"''}
       if [[ -d $docdir ]]; then


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The docs were split at #16167 and broke google support. @peti fixed
build, however, hoogle still didn't see packages shipped with GHC. This
patch fixes the location of the libraries shipped with GHC.
