### PR TITLE
wkhtmltopdf: fix openssl bug (#15443)

### DIFF
--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -95,7 +95,6 @@ stdenv.mkDerivation rec {
         -no-xshape
         -no-xsync
         -opensource
-        -openssl
         -release
         -static
         -system-libjpeg


### PR DESCRIPTION
###### Motivation for this change

Fixes issue where wkhtmltopdf can't render a pdf from an https url. This is already fixed on master, this PR is for those who are running into this issue on 16.03.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

(cherry picked from commit cac460f6c4c95b7fa678373e6b4088c48f0b2a91)
