### PR TITLE
zanshin: 0.2.1 -> 0.3.1

### DIFF
--- a/pkgs/applications/office/zanshin/default.nix
+++ b/pkgs/applications/office/zanshin/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchurl, automoc4, cmake, perl, pkgconfig
-, kdelibs, kdepimlibs, boost }:
+, kdelibs, kdepimlibs, boost, baloo }:
 
 stdenv.mkDerivation rec {
-  name = "zanshin-0.2.1";
+  name = "zanshin-0.3.1";
 
   src = fetchurl {
     url = "http://files.kde.org/zanshin/${name}.tar.bz2";
-    sha256 = "155k72vk7kw0p0x9dhlky6q017kanzcbwvp4dpf1hcbr1dsr55fx";
+    sha256 = "1ck2ncz8i816d6d1gcsdrh6agd2zri24swgz3bhn8vzbk4215yzl";
   };
 
   nativeBuildInputs = [ automoc4 cmake perl pkgconfig ];
 
-  buildInputs = [ kdelibs kdepimlibs boost ];
+  buildInputs = [ kdelibs kdepimlibs boost baloo ];
 
   meta = {
     description = "GTD for KDE";


### PR DESCRIPTION
###### Motivation for this change

New release of Zanshin, KDE 4 branch.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is the branch based on KDE 4.
