### PR TITLE
docker: Expose completions for fish

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     patchShebangs .
     export AUTO_GOPATH=1
-    export DOCKER_GITCOMMIT="a34a1d59"
+    export DOCKER_GITCOMMIT="20f81dde"
     ./hack/make.sh dynbinary
   '';
 
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
 
     # completion
     install -Dm644 ./contrib/completion/bash/docker $out/share/bash-completion/completions/docker
+    install -Dm644 ./contrib/completion/fish/docker.fish $out/share/fish/vendor_completions.d/docker.fish
     install -Dm644 ./contrib/completion/zsh/_docker $out/share/zsh/site-functions/_docker
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Also set correct DOCKER_GITCOMMIT.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
