### PR TITLE
bcftools: init at 1.3.1

### DIFF
--- a/pkgs/applications/science/biology/bcftools/default.nix
+++ b/pkgs/applications/science/biology/bcftools/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, zlib, htslib }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "bcftools";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "https://github.com/samtools/${pname}/releases/download/${version}/${name}.tar.bz2";
+    sha256 = "095ry68vmz9q5s1scjsa698dhgyvgw5aicz24c19iwfbai07mhqj";
+  };
+
+  buildInputs = [ zlib ];
+
+  preBuild = ''
+    makeFlagsArray=("HSTDIR=${htslib}" "prefix=$out")
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tools for manipulating BCF2/VCF/gVCF format, SNP and short indel sequence variants";
+    license = licenses.mit;
+    homepage = http://www.htslib.org/;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.mimadrid ];
+  };
+}

--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -1,19 +1,25 @@
-{ stdenv, fetchurl, zlib, ncurses }:
+{ stdenv, fetchurl, zlib, htslib,  ncurses ? null }:
 
 stdenv.mkDerivation rec {
-  name = "samtools-${version}";
+  name = "${pname}-${version}";
+  pname = "samtools";
   version = "1.3.1";
 
   src = fetchurl {
-    url = "https://github.com/samtools/samtools/releases/download/${version}/${name}.tar.bz2";
+    url = "https://github.com/samtools/${pname}/releases/download/${version}/${name}.tar.bz2";
     sha256 = "0znnnxc467jbf1as2dpskrjhfh8mbll760j6w6rdkwlwbqsp8gbc";
   };
 
-  buildInputs = [ zlib ncurses ];
+  buildInputs = [ zlib ncurses htslib ];
+
+  configureFlags = [ "--with-htslib=${htslib}" ]
+    ++ stdenv.lib.optional (ncurses == null) "--without-curses";
 
   meta = with stdenv.lib; {
-    description = "Tools (written in C using htslib) for manipulating next-generation sequencing data";
+    description = "Tools for manipulating SAM/BAM/CRAM format";
     license = licenses.mit;
     homepage = http://www.htslib.org/;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.mimadrid ];
   };
 }

--- a/pkgs/development/libraries/science/biology/htslib/default.nix
+++ b/pkgs/development/libraries/science/biology/htslib/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "htslib";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "https://github.com/samtools/${pname}/releases/download/${version}/${name}.tar.bz2";
+    sha256 = "49d53a2395b8cef7d1d11270a09de888df8ba06f70fe68282e8235ee04124ae6";
+  };
+
+  buildInputs = [ zlib ];
+
+  meta = with stdenv.lib; {
+    description = "A C library for reading/writing high-throughput sequencing data";
+    license = licenses.mit;
+    homepage = http://www.htslib.org/;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.mimadrid ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15885,6 +15885,8 @@ in
 
   emboss = callPackage ../applications/science/biology/emboss { };
 
+  htslib = callPackage ../development/libraries/science/biology/htslib { };
+
   neuron = callPackage ../applications/science/biology/neuron { };
 
   neuron-mpi = appendToName "mpi" (neuron.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15883,6 +15883,8 @@ in
     stdenv = overrideCC stdenv gcc49;
   };
 
+  bcftools = callPackage ../applications/science/biology/bcftools { };
+
   emboss = callPackage ../applications/science/biology/emboss { };
 
   htslib = callPackage ../development/libraries/science/biology/htslib { };


### PR DESCRIPTION
###### Motivation for this change

Add bcftools to NixOS
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
