### PR TITLE
dislocker: init at 0.6.1

### DIFF
--- a/pkgs/tools/filesystems/dislocker/cmake_dirfix.patch
+++ b/pkgs/tools/filesystems/dislocker/cmake_dirfix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 365903a..f126ade 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -149,7 +149,7 @@ if(NOT DEFINED bindir)
+ endif()
+ 
+ string (TOLOWER "${CMAKE_SYSTEM_NAME}" SYSNAME)
+-set (DIS_MAN ../man/${SYSNAME})
++set (DIS_MAN ${PROJECT_SOURCE_DIR}/man/${SYSNAME})
+ 
+ # RPATH handling
+ if(POLICY CMP0042)

--- a/pkgs/tools/filesystems/dislocker/default.nix
+++ b/pkgs/tools/filesystems/dislocker/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub
+, cmake
+, polarssl , fuse
+}:
+with stdenv.lib;
+let
+  version = "0.6.1";
+in
+stdenv.mkDerivation rec {
+  name = "dislocker-${version}";
+
+  src = fetchFromGitHub {
+    owner = "aorimn";
+    repo = "dislocker";
+    rev = "v${version}";
+    sha256 = "1s2pvsf4jgzxk9d9m2ik7v7g81lvj8mhmhh7f53vwy0vmihf9h0d";
+  };
+
+  buildInputs = [ cmake fuse polarssl ];
+
+  patches = [ ./cmake_dirfix.patch ];
+
+  meta = {
+    description = "Read BitLocker encrypted partitions in Linux";
+    homepage    = https://github.com/aorimn/dislocker;
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ elitak ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -735,6 +735,8 @@ in
     asciidoc = asciidoc-full;
   };
 
+  dislocker = callPackage ../tools/filesystems/dislocker { };
+
   ditaa = callPackage ../tools/graphics/ditaa { };
 
   dlx = callPackage ../misc/emulators/dlx { };


### PR DESCRIPTION
###### Motivation for this change

Read access to bitlocker volumes is nice.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
###### A couple questions:

When should I put new packages in `pkgs/os-specific/linux` vs `pkgs/tools/filesystems`?

Should I divide this already tiny package into multiple outputs, or is that for larger projects only?
