### PR TITLE
gnome-keyring: remove unused configure flag

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/gnome-keyring/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool docbook_xsl_ns docbook_xsl ];
 
   configureFlags = [
-    "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt" # NixOS hardcoded path
     "--with-pkcs11-config=$$out/etc/pkcs11/" # installation directories
     "--with-pkcs11-modules=$$out/lib/pkcs11/"
   ];


### PR DESCRIPTION
###### Motivation for this change

I was noodling around with this package and noticed a warning that the `--with-ca-certificates` flag is ignored.  See below for details.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The --with-ca-certificates flag seems to have been removed in
[this commit](https://git.gnome.org/browse/gnome-keyring/commit/?id=7afaae43f205c059163c3670169af302f1ba6de3) from March 2013.  The configure script now just warns
about an unknown option.
