### PR TITLE
togglesg-download: 2016-02-08 -> 2016-05-31

### DIFF
--- a/pkgs/tools/misc/togglesg-download/default.nix
+++ b/pkgs/tools/misc/togglesg-download/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchFromGitHub, buildPythonApplication, makeWrapper, ffmpeg }:
+{ stdenv, lib, fetchFromGitHub, buildPythonApplication, makeWrapper, ffmpeg_3 }:
 
 buildPythonApplication rec {
 
   name = "togglesg-download-git-${version}";
-  version = "2016-02-08";
+  version = "2016-05-31";
 
   src = fetchFromGitHub {
     owner = "0x776b7364";
     repo = "toggle.sg-download";
-    rev = "5cac3ec039d67ad29240b2fa850a8db595264e3d";
-    sha256 = "0pqw73aa5b18d5ws4zj6gcmzap6ag526jrylqq80m0yyh9yxw5hs";
+    rev = "7d7c5f4d549360f95e248accd9771949abd94ad2";
+    sha256 = "0xj42khvacwmhbiy2p8rxk7lqg7pvya4zdc2c34lnr3avdp49fjn";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -20,11 +20,10 @@ buildPythonApplication rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    install -m755 download_toggle_video2.py $out/bin/download_toggle_video2.py
+    substitute $src/download_toggle_video2.py $out/bin/download_toggle_video2.py \
+      --replace "ffmpeg_download_cmd = 'ffmpeg" "ffmpeg_download_cmd = '${lib.getBin ffmpeg_3}/bin/ffmpeg"
+    chmod 0755 $out/bin/download_toggle_video2.py
   '';
-
-  postInstall = stdenv.lib.optionalString (ffmpeg != null)
-    ''wrapProgram $out/bin/download_toggle_video2.py --prefix PATH : "${ffmpeg}/bin"'';
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/0x776b7364/toggle.sg-download";


### PR DESCRIPTION
###### Motivation for this change

New version.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
