### PR TITLE
go: install go binary to pwd/bin, then copy to out/bin

### DIFF
--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -107,10 +107,12 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin"
     export GOROOT="$(pwd)/"
-    export GOBIN="$out/bin"
+    export GOBIN="$(pwd)/bin"
     export PATH="$GOBIN:$PATH"
     cd ./src
     ./all.bash
+    cd ../
+    cp $(pwd)/bin/* "$out/bin"
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/development/compilers/go/1.5.nix
+++ b/pkgs/development/compilers/go/1.5.nix
@@ -115,11 +115,13 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin"
     export GOROOT="$(pwd)/"
-    export GOBIN="$out/bin"
+    export GOBIN="$(pwd)/bin"
     export PATH="$GOBIN:$PATH"
     cd ./src
     echo Building
     ./all.bash
+    cd ../
+    cp $(pwd)/bin/* "$out/bin"
   '';
 
   preFixup = ''

--- a/pkgs/development/compilers/go/1.6.nix
+++ b/pkgs/development/compilers/go/1.6.nix
@@ -128,11 +128,13 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin"
     export GOROOT="$(pwd)/"
-    export GOBIN="$out/bin"
+    export GOBIN="$(pwd)/bin"
     export PATH="$GOBIN:$PATH"
     cd ./src
     echo Building
     ./all.bash
+    cd ../
+    cp $(pwd)/bin/* "$out/bin"
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes #16387 . Issues with GOROOT not matching expectations (bin/go not existing, namely)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
