### PR TITLE
wolfssl: 3.9.0 -> 3.9.6, split package

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -2,16 +2,26 @@
 
 stdenv.mkDerivation rec {
   name = "wolfssl-${version}";
-  version = "3.9.0";
+  version = "3.9.6";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
     rev = "v${version}";
-    sha256 = "0j4la9936jcy2fam1x5wplbslqa4zjnrk4wyipkbwz9m8cxg0n6v";
+    sha256 = "19k3pqd567jfxyps4i6mk7sblwzaj1rixmsdwscw63pdgcgf260g";
   };
 
+  outputs = [ "dev" "out" "doc" "lib" ];
+
   nativeBuildInputs = [ autoreconfHook ];
+
+  postInstall = ''
+     # fix recursive cycle:
+     # wolfssl-config points to dev, dev propagates bin
+     moveToOutput bin/wolfssl-config "$dev"
+     # moveToOutput also removes "$out" so recreate it
+     mkdir -p "$out"
+  '';
 
   meta = with stdenv.lib; {
     description = "A small, fast, portable implementation of TLS/SSL for embedded devices";


### PR DESCRIPTION
###### Motivation for this change
1. Update wolfssl.
2. Split package similar to openssl so it can be used as a drop-in replacement for openssl.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note that no package immediately depends on wolfssl, so for testing I've built curl with wolfssl as a replacement for openssl using the following nix shell script:

``` nix
with import <nixpkgs> {};
let
  curlwolfssl = (curl.override {
    openssl = wolfssl;
  }).overrideDerivation (oldAttrs: {
    configureFlags = oldAttrs.configureFlags ++ [
      "--with-cyassl=${wolfssl}"
    ];
  });
in
{
  my-env = stdenv.mkDerivation {
    name = "my-env";
    buildInputs = [
      curlwolfssl
    ];
  };
}
```

The resulting curl binary was tested with

```
curl https://nixos.org/
curl --sslv2 https://nixos.org/
```

which work as expected (the latter command gives `curl: (35) CyaSSL does not support SSLv2` confirming that it indeed uses wolfssl).

Note that I had to break a dependency cycle. I did this simply by removing the "wolfssl-config" binary. The dev package comes with a pkg-config .pc file anyway, so I hope this is an acceptable solution. If there is a more standard solution for this problem, I'd be happy to be pointed to it and to fix it accordingly.
