### PR TITLE
adapta-gtk-theme: 3.21.2 -> 3.21.3.1

### DIFF
--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -1,4 +1,16 @@
-{ stdenv, fetchgit, autoreconfHook, gtk-engine-murrine }:
+{
+  stdenv,
+  fetchgit,
+  autoreconfHook,
+  pkgconfig,
+  bundler,
+  sass,
+  glib,
+  libxml2,
+  inkscape,
+  gtk,
+  gtk-engine-murrine
+}:
 
 stdenv.mkDerivation rec {
   name = "adapta-gtk-theme-${version}";
@@ -19,8 +31,8 @@ stdenv.mkDerivation rec {
   };
 
   preferLocalBuild = true;
-  buildInputs = [ gtk-engine-murrine ];
-  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ gtk gtk-engine-murrine ];
+  nativeBuildInputs = [ autoreconfHook bundler sass glib libxml2 inkscape ];
 
   configureFlags = "--enable-chrome --disable-unity";
 }

--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, gtk-engine-murrine }:
+{ stdenv, fetchgit, autoreconfHook, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   name = "adapta-gtk-theme-${version}";
-  version = "3.21.2";
+  version = "3.21.3.1";
 
   meta = with stdenv.lib; {
     description = "An adaptive GTK+ theme based on Material Design";
@@ -12,11 +12,10 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.SShrike ];
   };
 
-  src = fetchFromGitHub {
-    owner = "tista500";
-    repo = "Adapta";
-    rev = "c48da995abc46087c22b05d2cdb0975d10774641";
-    sha256 = "17w9nsrwqwgafswyvhc5h8ld2ggi96ix5fjv6yf1hfz3l1ln9qg7";
+  src = fetchgit {
+    url = "https://github.com/tista500/Adapta";
+    rev = "refs/tags/${version}";
+    sha256 = "11xbwg82x9qzk5a2p5fi9mhi3ij220ij6v45id6rzzc8bs51jach";
   };
 
   preferLocalBuild = true;


### PR DESCRIPTION
###### Motivation for this change

New release of package.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X (N/A)
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
