### PR TITLE
trojita: init at 0.7

### DIFF
--- a/pkgs/applications/networking/mailreaders/trojita/default.nix
+++ b/pkgs/applications/networking/mailreaders/trojita/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, fetchgit
+, cmake
+, qtbase
+, qtwebkit
+, makeQtWrapper
+}:
+
+stdenv.mkDerivation rec {
+  name = "trojita-${version}";
+  version = "0.7";
+
+  src = fetchgit {
+    url = "https://anongit.kde.org/trojita.git";
+    rev = "065d527c63e8e4a3ca0df73994f848b52e14ed58";
+    sha256 = "1zlwhir33hha2p3l08wnb4njnfdg69j88ycf1fa4q3x86qm3r7hw";
+  };
+
+  buildInputs = [
+    cmake
+    qtbase
+    qtwebkit
+  ];
+
+  nativeBuildInputs = [
+    makeQtWrapper
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/trojita"
+  '';
+
+
+  meta = {
+    description = "A Qt IMAP e-mail client";
+    homepage = http://trojita.flaska.net/;
+    license = with lib.licenses; [ gpl2 gpl3 ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15829,6 +15829,9 @@ in
 
   numix-gtk-theme = callPackage ../misc/themes/numix-gtk-theme { };
 
+  # We need QtWebkit which was deprecated in Qt 5.6 although it can still be build
+  trojita = with qt55; callPackage ../applications/networking/mailreaders/trojita { };
+
   kde5PackagesFun = self: with self; {
 
     calamares = callPackage ../tools/misc/calamares rec {


### PR DESCRIPTION
###### Motivation for this change

A Qt mail client. 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
