### PR TITLE
ibus: fix #16292

### DIFF
--- a/pkgs/tools/inputmethods/ibus/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus/wrapper.nix
@@ -23,7 +23,7 @@ let
 
     for prog in ibus ibus-daemon ibus-setup; do
         wrapProgram "$out/bin/$prog" \
-          --prefix GDK_PIXBUF_MODULE_FILE : ${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache \
+          --prefix GDK_PIXBUF_MODULEDIR : ${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0 \
           --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH:$out/lib/girepository-1.0" \
           --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules" \
           --set IBUS_COMPONENT_PATH "$out/share/ibus/component/" \


### PR DESCRIPTION
fix for bug #16292 

change environmental variable in wrapper
    GDK_PIXBUF_MODULE_FILE -> GDK_PIXBUF_MODULEDIR
https://developer.gnome.org/gdk-pixbuf/unstable/gdk-pixbuf-query-loaders.html

This patch is only for the ibus package. I think however, this substitution should be done for all packages. The given link specifies GDK_PIXBUF_MODULE_FILE as a write to location. So clearly, GDK_PIXBUF_MODULE_FILE can not point to a file in the nix store.
