### PR TITLE
timewarrior: 2016-03-29 -> 0.9.5.alpha

### DIFF
--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -1,18 +1,23 @@
-{ stdenv, fetchgit, cmake, libuuid, gnutls }:
+{ stdenv, fetchurl, cmake, libuuid, gnutls }:
 
 stdenv.mkDerivation rec {
   name = "timewarrior-${version}";
-  version = "2016-03-29";
+  version = "0.9.5.alpha";
 
   enableParallelBuilding = true;
 
-  src = fetchgit {
-    url = "https://git.tasktools.org/scm/tm/timew.git";
-    rev = "2175849a81ddd03707dca7b4c9d69d8fa11e35f7";
-    sha256 = "0clhbm6093wnvpq0ypvx95095amvlzab0sz9kiflasw9mgnwisrv";
+  src = fetchurl {
+    url = "https://taskwarrior.org/download/timew-${version}.tar.gz";
+    sha256 = "154d5sgxcmz1b7g401c7s6sf7pkk0hh74dx6rss3vkamsjc4wgl8";
   };
 
   nativeBuildInputs = [ cmake ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp -rv doc/man $out/share/
+    cp src/timew $out/bin/
+  '';
 
   meta = with stdenv.lib; {
     description = "A command-line time tracker";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux (debian)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not sure whether the `installPhase` is overridden correctly. ... `nix-build` worked and executing the `result/bin/timew` worked, so I guess this is fine...
