### PR TITLE
coreutils: single binary build

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -30,7 +30,8 @@ let
     outputs = [ "out" "info" ];
 
     nativeBuildInputs = [ perl xz.bin ];
-    configureFlags = optionalString stdenv.isSunOS "ac_cv_func_inotify_init=no";
+    configureFlags = [ "--enable-single-binary" ]
+      ++ optional stdenv.isSunOS "ac_cv_func_inotify_init=no";
 
     buildInputs = [ gmp ]
       ++ optional aclSupport acl


### PR DESCRIPTION
###### Motivation for this change

This brings down the coreutils install size from 10-16MB to 2.6MB (on Darwin):

```
$ du -ks /nix/store/*8.25
16368   /nix/store/95wmyhk0y60r09b98l6v4vswv5m7xm4q-coreutils-8.25
2644    /nix/store/c50vsbnq4kw3gfp8yxyggy0yyr5i7gbl-coreutils-8.25
10668   /nix/store/clqq5iva8aylmr3k08lpp68ai7g6wz2r-coreutils-8.25
9812    /nix/store/kshydzblaqjxqdmx61hpm2xl811raknb-coreutils-8.25
2644    /nix/store/rwqm8czcxx31jgvxqqwy8wdfq35rkjp1-coreutils-8.25
```

It does this by creating a single binary and a bunch of scripts that call it:

```
$ ll /nix/store/c50vsbnq4kw3gfp8yxyggy0yyr5i7gbl-coreutils-8.25/bin/
total 2216
-r-xr-xr-x 1 wmertens     102 Jan  1  1970 [*
[...]
-r-xr-xr-x 1 wmertens     106 Jan  1  1970 cksum*
-r-xr-xr-x 1 wmertens     105 Jan  1  1970 comm*
-r-xr-xr-x 1 wmertens 1840300 Jan  1  1970 coreutils*
-r-xr-xr-x 1 wmertens     103 Jan  1  1970 cp*
[...]
$ cat /nix/store/c50vsbnq4kw3gfp8yxyggy0yyr5i7gbl-coreutils-8.25/bin/tty 
#!/nix/store/c50vsbnq4kw3gfp8yxyggy0yyr5i7gbl-coreutils-8.25/bin/coreutils --coreutils-prog-shebang=tty
```

See also https://lists.gnu.org/archive/html/coreutils/2014-06/msg00036.html for the initial patch and https://lists.gnu.org/archive/html/coreutils/2014-06/msg00071.html for the reasoning about the shebang thing.

This gets used in ChromeOS, and I can't think of a reason not to have it in NixOS.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
