### PR TITLE
Remove gccWith* arguments which are unused

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1,5 +1,4 @@
-{ system, bootStdenv, noSysDirs, gccWithCC, gccWithProfiling
-, config, crossSystem, platform, lib
+{ system, bootStdenv, noSysDirs, config, crossSystem, platform, lib
 , pkgsWithOverrides
 , ... }:
 self: pkgs:
@@ -46,8 +45,7 @@ in
   forceSystem = system: kernel: (import ./../..) {
     inherit system;
     platform = platform // { kernelArch = kernel; };
-    inherit bootStdenv noSysDirs gccWithCC gccWithProfiling config
-      crossSystem;
+    inherit bootStdenv noSysDirs config crossSystem;
   };
 
   # Used by wine, firefox with debugging version of Flash, ...
@@ -3946,7 +3944,7 @@ in
       let
         pkgsCross = (import ./../..) {
           inherit system;
-          inherit bootStdenv noSysDirs gccWithCC gccWithProfiling config;
+          inherit bootStdenv noSysDirs config;
           # Ben Nanonote system
           crossSystem = {
             config = "mipsel-unknown-linux";

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -19,10 +19,6 @@
                && system != "x86_64-solaris"
                && system != "x86_64-kfreebsd-gnu")
 
-  # More flags for the bootstrapping of stdenv.
-, gccWithCC ? true
-, gccWithProfiling ? true
-
 , # Allow a configuration attribute set to be passed in as an
   # argument.  Otherwise, it's read from $NIXPKGS_CONFIG or
   # ~/.nixpkgs/config.nix.
@@ -81,8 +77,7 @@ let
     else config.platform or platformAuto;
 
   topLevelArguments = {
-    inherit system bootStdenv noSysDirs gccWithCC gccWithProfiling config
-      crossSystem platform lib;
+    inherit system bootStdenv noSysDirs config crossSystem platform lib;
   };
 
   # Allow packages to be overridden globally via the `packageOverrides'


### PR DESCRIPTION
Tested by grepping for `gccWith`
