### PR TITLE
php: add meta.platforms

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -283,8 +283,9 @@ let
       meta = with stdenv.lib; {
         description = "An HTML-embedded scripting language";
         homepage = http://www.php.net/;
-        license = stdenv.lib.licenses.php301;
+        license = licenses.php301;
         maintainers = with maintainers; [ globin ];
+        platforms = platforms.all;
       };
 
       patches = if !php7 then [ ./fix-paths.patch ] else [ ./fix-paths-php7.patch ];


### PR DESCRIPTION
###### Motivation for this change

Fix #16068.
Hydra is not building php packages because they have no platform set.
This add a `meta.platforms` so php can have binary substitutes.
###### Extra Information

For some reason, the default `php` that is just an alias to `php56` is catched but not `php56`.

From `all-packages.nix`:

```
  php = php56;

  inherit (callPackages ../development/interpreters/php { })
    php55
    php56
    php70;
```

`nix-repl` session:

```
nix-repl> :l ./nixos/release-combined.nix
Added 3 variables.

nix-repl> nixpkgs.php
{ i686-linux = «derivation /nix/store/jnh3rdr9bxp0yi1kcsi9pcd2cga43njb-php-5.6.22.drv»; x86_64-linux = «derivation /nix/store/11bxnw1bkfmzjwrjhccr2g39bdy8xjaq-php-5.6.22.drv»; }

nix-repl> nixpkgs.php56
{ }
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @globin 
