### PR TITLE
pianobar: 2015.11.22 -> 2016.06.02

### DIFF
--- a/pkgs/applications/audio/pianobar/default.nix
+++ b/pkgs/applications/audio/pianobar/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, pkgconfig, libao, readline, json_c, libgcrypt, libav, curl }:
 
 stdenv.mkDerivation rec {
-  name = "pianobar-2015.11.22";
+  name = "pianobar-2016.06.02";
 
   src = fetchurl {
     url = "http://6xq.net/projects/pianobar/${name}.tar.bz2";
-    sha256 = "0arjvs31d108l1mn2k2hxbpg3mxs47vqzxm0lzdpfcjvypkckyr3";
+    sha256 = "0n9544bfsdp04xqcjm4nhfvp357dx0c3gpys0rjkq09nzv8b1vy6";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
