### PR TITLE
nixos/gnome-desktop: fix adding printers with GNOME Control Center

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -119,6 +119,7 @@ in {
     services.telepathy.enable = mkDefault true;
     networking.networkmanager.enable = mkDefault true;
     services.upower.enable = config.powerManagement.enable;
+    services.dbus.packages = mkIf config.services.printing.enable [ pkgs.system-config-printer ];
     hardware.bluetooth.enable = mkDefault true;
 
     fonts.fonts = [ pkgs.dejavu_fonts pkgs.cantarell_fonts ];


### PR DESCRIPTION
###### Motivation for this change

I want to fix adding printers with GNOME Control Center.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

...by adding system-config-printer to services.dbus.packages (if
services.printing.enable is true).

Without this patch, trying to add a printer will result in a little dialog
saying "Failed to add new printer" and gnome-control-center will print this to
the terminal (line wrapped):

```
(gnome-control-center:3546): printers-cc-panel-WARNING **: \
  GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: \
  The name org.fedoraproject.Config.Printing was not provided by any .service files
```

system-config-printer supplies the "org.fedoraproject.Config.Printing" dbus
service, thus fixing the problem.

CC @lethalman 
