### PR TITLE
samsung-UnifiedLinuxDriver: fix multi-output cups

### DIFF
--- a/pkgs/misc/cups/drivers/samsung/4.00.39/default.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.00.39/default.nix
@@ -15,7 +15,9 @@
 
 # Do not bump lightly! Visit <http://www.bchemnet.com/suldr/supported.html>
 # to see what will break when upgrading. Consider a new versioned attribute.
-stdenv.mkDerivation rec {
+let
+  cups' = cups.out;
+in stdenv.mkDerivation rec {
   name = "samsung-UnifiedLinuxDriver-${version}";
   version = "4.00.39";
 
@@ -24,9 +26,10 @@ stdenv.mkDerivation rec {
     sha256 = "144b4xggbzjfq7ga5nza7nra2cf6qn63z5ls7ba1jybkx1vm369k";
   };
 
-  buildInputs = [ cups gcc ghostscript glibc patchelf ];
+  buildInputs = [ cups' gcc ghostscript glibc patchelf ];
 
-  inherit cups gcc ghostscript glibc;
+  inherit gcc ghostscript glibc;
+  cups = cups';
 
   builder = ./builder.sh;
 


### PR DESCRIPTION
###### Motivation for this change

multi-output cups broke dynamic linking of filters (e.g. `lib/cups/filter/rastertosamsungspl`) in samsung-UnifiedLinuxDriver throwing errors in cups´ log:
`Samsung: error while loading shared libraries: libcups.so.2: cannot open shared object file: No such file or directory`
##### Things done

We Adress the issue by having patchelf set the binaries rpath to contain `${cups.out}/lib` instead of `${cups}/lib` so `libcups.so.2` can be found
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  
  Breaks due to `pkgs/servers/nosql/apache-jena/fuseki-binary.nix`:
  `error: while evaluating ‘callPackageWith’ at lib/customisation.nix:93:35, called from pkgs/top-level/all-packages.nix:9875:24:
  while evaluating ‘makeOverridable’ at lib/customisation.nix:54:24, called from lib/customisation.nix:97:8:
  syntax error, unexpected $undefined, at pkgs/servers/nosql/apache-jena/fuseki-binary.nix:27:45`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [X] Tested execution of `lib/cups/filter/rastertosamsungspl`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
