### PR TITLE
yubikey-neo-manager: init at 1.4.0

### DIFF
--- a/pkgs/tools/misc/yubikey-neo-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-neo-manager/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, makeWrapper, python27Packages
+, libykneomgr, yubikey-personalization, libu2f-host }:
+
+python27Packages.buildPythonPackage rec {
+  namePrefix = "";
+  name = "yubikey-neo-manager-${version}";
+  version = "1.4.0";
+  src = fetchurl {
+    url = "https://developers.yubico.com/yubikey-neo-manager/Releases/${name}.tar.gz";
+    sha256 = "1isxvx27hk0avxwgwcwys2z8ickfs816ii1aklvmi09ak1rgrf1g";
+  };
+
+  propagatedBuildInputs = with python27Packages; [ pyside pycrypto ];
+  patches = [ ./fix-pyside-requirement.diff ];
+
+  # aid ctypes load_libary()
+  makeWrapperArgs = [
+    "--set LD_PRELOAD '${libykneomgr}/lib/libykneomgr.so ${yubikey-personalization}/lib/libykpers-1.so ${libu2f-host}/lib/libu2f-host.so'"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://developers.yubico.com/yubikey-neo-manager;
+    description = "Cross platform personalization tool for the YubiKey NEO";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ mbakke ];
+  };
+}

--- a/pkgs/tools/misc/yubikey-neo-manager/fix-pyside-requirement.diff
+++ b/pkgs/tools/misc/yubikey-neo-manager/fix-pyside-requirement.diff
@@ -1,0 +1,17 @@
+Description: Remove PySide requirement, since python-pyside does not register itself correctly
+Author: Dain Nilsson <dain@yubico.com>
+Forwarded: no
+--- a/setup.py
++++ b/setup.py
+@@ -44,8 +44,9 @@
+     entry_points={
+         'gui_scripts': ['neoman=neoman.__main__:main']
+     },
+-    install_requires=['PySide', 'pycrypto'],
+-    yc_requires=['ctypes', 'qt'],
++    install_requires=['pycrypto'],
++    yc_requires=['ctypes'],
++    packages=['neoman', 'neoman.model', 'neoman.view', 'neoman.yubicommon', 'neoman.yubicommon.setup', 'neoman.yubicommon.ctypes', 'neoman.yubicommon.qt'],
+     cmdclass={'executable': executable, 'qt_resources': qt_resources('neoman')},
+     classifiers=[
+         'License :: OSI Approved :: BSD License',

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9478,6 +9478,8 @@ in
 
   yubico-piv-tool = callPackage ../tools/misc/yubico-piv-tool { };
 
+  yubikey-neo-manager = callPackage ../tools/misc/yubikey-neo-manager { };
+
   yubikey-personalization = callPackage ../tools/misc/yubikey-personalization {
     libusb = libusb1;
   };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is the package that sparked #14753. Cheers.
