### PR TITLE
matrix-synapse: 0.16.0 -> 0.16.1

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -12,13 +12,13 @@ let
 in
 buildPythonApplication rec {
   name = "matrix-synapse-${version}";
-  version = "0.16.0";
+  version = "0.16.1";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "synapse";
     rev = "v${version}";
-    sha256 = "046lh9s7lpi19akqxfvr361fp8bwcz48w3sqz1vsy2z59iim9xy3";
+    sha256 = "166y1f74wjkrpks88cp67w33rcs02b4dk815yj93lfla1k9ypg6b";
   };
 
   patches = [ ./matrix-synapse.patch ];
@@ -37,9 +37,10 @@ buildPythonApplication rec {
     mock setuptoolsTrial
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://matrix.org;
     description = "Matrix reference homeserver";
-    license = stdenv.lib.licenses.asl20;
+    license = licenses.asl20;
+    maintainers = [ maintainers.ralith ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New bugfix release. Adding myself as a maintainer while I'm at it.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
