### PR TITLE
nodePackages.rollup: init at 0.31.2

### DIFF
--- a/pkgs/top-level/node-packages-generated.nix
+++ b/pkgs/top-level/node-packages-generated.nix
@@ -42094,6 +42094,27 @@
     os = [ ];
     cpu = [ ];
   };
+  by-spec."rollup"."*" =
+    self.by-version."rollup"."0.31.2";
+  by-version."rollup"."0.31.2" = self.buildNodePackage {
+    name = "rollup-0.31.2";
+    version = "0.31.2";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/rollup/-/rollup-0.31.2.tgz";
+      name = "rollup-0.31.2.tgz";
+      sha1 = "b479fe0a5faf7c310b8cc963da4dd0eb0a6174d0";
+    };
+    deps = {
+      "source-map-support-0.4.0" = self.by-version."source-map-support"."0.4.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "rollup" = self.by-version."rollup"."0.31.2";
   by-spec."root"."^2.0.0" =
     self.by-version."root"."2.0.0";
   by-version."root"."2.0.0" = self.buildNodePackage {
@@ -45386,6 +45407,24 @@
       url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz";
       name = "source-map-support-0.3.2.tgz";
       sha1 = "737d5c901e0b78fdb53aca713d24f23ccbb10be1";
+    };
+    deps = {
+      "source-map-0.1.32" = self.by-version."source-map"."0.1.32";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-version."source-map-support"."0.4.0" = self.buildNodePackage {
+    name = "source-map-support-0.4.0";
+    version = "0.4.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.0.tgz";
+      name = "source-map-support-0.4.0.tgz";
+      sha1 = "cb92292bc05455ce48691de545ac2690bb1cc976";
     };
     deps = {
       "source-map-0.1.32" = self.by-version."source-map"."0.1.32";

--- a/pkgs/top-level/node-packages.json
+++ b/pkgs/top-level/node-packages.json
@@ -150,6 +150,7 @@
 , "react-tools"
 , "redis"
 , "rethinkdb"
+, "rollup"
 , "s3http"
 , "selenium-webdriver"
 , "semver"


### PR DESCRIPTION
###### Motivation for this change

Just an npm package.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
