### PR TITLE
disper: repair missing libXrandr and libX11 dependencies

### DIFF
--- a/pkgs/tools/misc/disper/default.nix
+++ b/pkgs/tools/misc/disper/default.nix
@@ -1,12 +1,18 @@
-{stdenv, fetchurl, python}:
+{stdenv, fetchurl, python, xorg, makeWrapper}:
 
 stdenv.mkDerivation rec {
   name = "disper-0.3.1";
 
-  buildInputs = [python];
+  buildInputs = [python makeWrapper];
 
   preConfigure = ''
     export makeFlags="PREFIX=$out"
+  '';
+
+  postInstall = ''
+      wrapProgram $out/bin/disper \
+      --prefix "LD_LIBRARY_PATH" : "${xorg.libXrandr.out}/lib:${xorg.libX11.out}/lib"
+
   '';
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/16438)

<!-- Reviewable:end -->
