### PR TITLE
autorandr: 4f5e2401ef -> 59f6aec0b

### DIFF
--- a/pkgs/tools/misc/autorandr/default.nix
+++ b/pkgs/tools/misc/autorandr/default.nix
@@ -1,22 +1,26 @@
 { fetchgit
 , stdenv
 , enableXRandr ? true, xrandr ? null
-, enableDisper ? false, disper ? null
+, enableDisper ? true, disper ? null
 , xdpyinfo }:
 
 assert enableXRandr -> xrandr != null;
 assert enableDisper -> disper != null;
 
 let
-  rev = "4f5e2401ef";
+  # Revision and date taken from the legacy tree, which still
+  # supports disper:
+  # https://github.com/phillipberndt/autorandr/tree/legacy
+  rev = "59f6aec0bb72e26751ce285d079e085b7178e45d";
+  date = "20150127";
 in
   stdenv.mkDerivation {
-    name = "autorandr-${rev}";
+    name = "autorandr-${date}";
 
     src = fetchgit {
       inherit rev;
-      url = "https://github.com/wertarbyte/autorandr.git";
-      sha256 = "1x8agg6mf5jr0imw7dznr8kxyw970bf252bda9q7b0z4yksya2zd"; 
+      url = "https://github.com/phillipberndt/autorandr.git";
+      sha256 = "0mnggsp42477kbzwwn65gi8y0rydk10my9iahikvs6n43lphfa1f";
     };
 
     patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

wertarbyte has allowed his project to languish, and phillipberdt
has taken it over and is merging pull requests
