### PR TITLE
camlzip: 1.05 -> 1.06

### DIFF
--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -2,26 +2,39 @@
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "1.05";
+  param =
+    if stdenv.lib.versionAtLeast ocaml_version "4.02"
+    then {
+      version = "1.06";
+      url = "1616";
+      sha256 = "0m6gyjw46w3qnhxfsyqyag42znl5lwargks7w7rfchr9jzwpff68";
+      patch = ./makefile_1_06.patch;
+      installTargets = "install-findlib";
+    } else {
+      version = "1.05";
+      url = "1037";
+      sha256 = "930b70c736ab5a7ed1b05220102310a0a2241564786657abe418e834a538d06b";
+      patch = ./makefile_1_05.patch;
+      installTargets = "install";
+    };
 in
 
 stdenv.mkDerivation {
-  name = "camlzip-${version}";
+  name = "camlzip-${param.version}";
 
   src = fetchurl {
-    url = "http://forge.ocamlcore.org/frs/download.php/1037/" +
-          "camlzip-${version}.tar.gz";
-    sha256 = "930b70c736ab5a7ed1b05220102310a0a2241564786657abe418e834a538d06b";
+    url = "http://forge.ocamlcore.org/frs/download.php/${param.url}/camlzip-${param.version}.tar.gz";
+    inherit (param) sha256;
   };
 
   buildInputs = [zlib ocaml findlib];
 
-  patches = [ ./makefile.patch ];
+  patches = [ param.patch ];
 
   createFindlibDestdir = true;
 
   postPatch = ''
-    substitute ${./META} META --subst-var-by VERSION "${version}"
+    substitute ${./META} META --subst-var-by VERSION "${param.version}"
     substituteInPlace Makefile \
       --subst-var-by ZLIB_LIBDIR "${zlib.out}/lib" \
       --subst-var-by ZLIB_INCLUDE "${zlib.dev}/include"
@@ -29,7 +42,11 @@ stdenv.mkDerivation {
 
   buildFlags = "all allopt";
 
-  installTargets = "install";
+  inherit (param) installTargets;
+
+  postInstall = ''
+    ln -s $out/lib/ocaml/${ocaml_version}/site-lib/{,caml}zip
+  '';
 
   meta = {
     homepage = "http://cristal.inria.fr/~xleroy/software.html#camlzip";

--- a/pkgs/development/ocaml-modules/camlzip/makefile_1_05.patch
+++ b/pkgs/development/ocaml-modules/camlzip/makefile_1_05.patch
@@ -48,7 +48,7 @@ diff -Nuar camlzip-1.04/Makefile camlzip-1.04.nixpkgs/Makefile
 -
 -installopt:
 -	cp zip.cmxa zip.a zip.cmx gzip.cmx $(INSTALLDIR)
-+	$(OCAMLFIND) install camlzip META $(LIBINSTALL_FILES)
++	$(OCAMLFIND) install zip META $(LIBINSTALL_FILES)
  
  depend:
  	gcc -MM -I$(ZLIB_INCLUDE) *.c > .depend

--- a/pkgs/development/ocaml-modules/camlzip/makefile_1_06.patch
+++ b/pkgs/development/ocaml-modules/camlzip/makefile_1_06.patch
@@ -1,0 +1,22 @@
+--- a/Makefile	2016-06-10 14:37:48.000000000 +0200
++++ b/Makefile	2016-06-23 05:10:26.000000000 +0200
+@@ -4,17 +4,13 @@
+ ZLIB_LIB=-lz
+ 
+ # The directory containing the Zlib library (libz.a or libz.so)
+-ZLIB_LIBDIR=/usr/lib
++ZLIB_LIBDIR=@ZLIB_LIBDIR@
+ # ZLIB_LIBDIR=/usr/local/lib
+ 
+ # The directory containing the Zlib header file (zlib.h)
+-ZLIB_INCLUDE=/usr/include
++ZLIB_INCLUDE=@ZLIB_INCLUDE@
+ # ZLIB_INCLUDE=/usr/local/include
+ 
+-# Where to install the library.  By default: sub-directory 'zip' of
+-# OCaml's standard library directory.
+-INSTALLDIR=`$(OCAMLC) -where`/zip
+-
+ ### End of configuration section
+ 
+ OCAMLC=ocamlc -g -safe-string


### PR DESCRIPTION
###### Motivation for this change

Upstream update.
camlzip 1.05 requires OCaml ≤ 4.02
camlzip 1.06 requires OCaml ≥ 4.02

So I keep both versions.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
