### PR TITLE
units: 2.12 -> 2.13

### DIFF
--- a/pkgs/tools/misc/units/default.nix
+++ b/pkgs/tools/misc/units/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "units-${version}";
-  version = "2.12";
+  version = "2.13";
 
   src = fetchurl {
     url = "mirror://gnu/units/${name}.tar.gz";
-    sha256 = "1jxvjknz2jhq773jrwx9gc1df3gfy73yqmkjkygqxzpi318yls3q";
+    sha256 = "1awhjw9zjlfb8s5g3yyx63f7ddfcr1sanlbxpqifmrgq24ql198b";
   };
 
   buildInputs = [ readline ];
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     description = "Unit conversion tool";
     homepage = https://www.gnu.org/software/units/;
     license = [ licenses.gpl3Plus ];
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
+    maintainers = [ maintainers.vrthra ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
