### PR TITLE
gnumake: Allow guile extension language as an optional feature

### DIFF
--- a/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, guileSupport ? false, pkgconfig ? null , guile ? null }:
+
+assert guileSupport -> ( pkgconfig != null && guile != null );
 
 let
   version = "4.2";
@@ -19,12 +21,16 @@ stdenv.mkDerivation {
     ./impure-dirs.patch
   ];
 
+  buildInputs = stdenv.lib.optional guileSupport [ guile pkgconfig ];
+
+  configureFlags = stdenv.lib.optional guileSupport [ "--with-guile" ];
+
   outputs = [ "out" "doc" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.gnu.org/software/make/;
     description = "A tool to control the generation of non-source files from sources";
-    license = stdenv.lib.licenses.gpl3Plus;
+    license = licenses.gpl3Plus;
 
     longDescription = ''
       Make is a tool which controls the generation of executables and
@@ -37,6 +43,7 @@ stdenv.mkDerivation {
       to build and install the program.
     '';
 
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
+    maintainers = [ maintainers.vrthra ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Gmake has supported guile from 4.0 onwards. It allows one to extend make with custom functions.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
