### PR TITLE
stdenv baseHash

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1196,10 +1196,24 @@ echo @foo@
     <term><function>stripHash</function>
     <replaceable>path</replaceable></term>
     <listitem><para>Strips the directory and hash part of a store
-    path, and prints (on standard output) only the name part.  For
-    instance, <literal>stripHash
-    /nix/store/68afga4khv0w...-coreutils-6.12</literal> print
-    <literal>coreutils-6.12</literal>.</para></listitem>
+    path, storing the name part in the environment variable
+    <literal>strippedName</literal>. For example:
+    
+<programlisting>
+stripHash "/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
+# prints coreutils-8.24
+echo $strippedName
+</programlisting>
+
+    If you wish to store the result in another variable, then the
+    following idiom may be useful:
+    
+<programlisting>
+name="/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
+someVar=$(stripHash $name; echo $strippedName)
+</programlisting>
+
+    </para></listitem>
   </varlistentry>
 
   

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1191,31 +1191,34 @@ echo @foo@
     <replaceable>file</replaceable>.</para></listitem>
   </varlistentry>
 
+  <varlistentry xml:id='fun-baseHash'>
+    <term>
+      <function>baseHash</function>
+      <replaceable>path</replaceable>
+      <replaceable>suffix</replaceable>
+    </term>
+    <listitem><para>Strips the directory and hash part of a store
+    path and outputs the result on stdout. If <literal>suffix</literal> is also
+    provided, the suffix will also be removed. For example:</para>
+    
+<programlisting>
+baseHash "/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
+# prints coreutils-8.24
+</programlisting>
+
+<programlisting>
+baseHash "/nix/store/0016702zbydafsr20n9l1dcw7x2bf6jj-arraysugar-0.1.0.gem" .gem
+# prints arraysugar-0.1.0
+</programlisting>
+    </listitem>
+
+  </varlistentry>
 
   <varlistentry xml:id='fun-stripHash'>
     <term><function>stripHash</function>
     <replaceable>path</replaceable></term>
-    <listitem><para>Strips the directory and hash part of a store
-    path, storing the name part in the environment variable
-    <literal>strippedName</literal>. For example:
-    
-<programlisting>
-stripHash "/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
-# prints coreutils-8.24
-echo $strippedName
-</programlisting>
-
-    If you wish to store the result in another variable, then the
-    following idiom may be useful:
-    
-<programlisting>
-name="/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
-someVar=$(stripHash $name; echo $strippedName)
-</programlisting>
-
-    </para></listitem>
+    <listitem><para>Deprecated. Use baseHash instead.</para></listitem>
   </varlistentry>
-
   
 </variablelist>
 

--- a/nixos/modules/services/networking/ircd-hybrid/builder.sh
+++ b/nixos/modules/services/networking/ircd-hybrid/builder.sh
@@ -12,7 +12,7 @@ for i in $scripts; do
     if test "$(echo $i | cut -c1-2)" = "=>"; then
         subDir=$(echo $i | cut -c3-)
     else
-        dst=$out/$subDir/$((stripHash $i; echo $strippedName) | sed 's/\.in//')
+        dst=$out/$subDir/$(baseHash $i | sed 's/\.in//')
         doSub $i $dst
         chmod +x $dst # !!!
     fi
@@ -23,7 +23,7 @@ for i in $substFiles; do
     if test "$(echo $i | cut -c1-2)" = "=>"; then
         subDir=$(echo $i | cut -c3-)
     else
-        dst=$out/$subDir/$((stripHash $i; echo $strippedName) | sed 's/\.in//')
+        dst=$out/$subDir/$(baseHash $i | sed 's/\.in//')
         doSub $i $dst
     fi
 done

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -531,8 +531,7 @@ rec {
 
       # Hacky: RPM looks for <basename>.spec inside the tarball, so
       # strip off the hash.
-      stripHash "$src"
-      srcName="$strippedName"
+      srcName=$(baseHash "$src")
       cp "$src" "$srcName" # `ln' doesn't work always work: RPM requires that the file is owned by root
 
       export HOME=/tmp/home

--- a/pkgs/data/fonts/droid/default.nix
+++ b/pkgs/data/fonts/droid/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   sourceRoot = "./";
 
   unpackCmd = ''
-    ttfName=$(basename $(stripHash $curSrc; echo $strippedName))
+    ttfName=$(baseHash $curSrc)
     cp $curSrc ./$ttfName
   '';
 

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook-ebnf/builder.sh
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook-ebnf/builder.sh
@@ -3,5 +3,4 @@ source $stdenv/setup
 mkdir -p $out/xml/dtd/docbook-ebnf
 cd $out/xml/dtd/docbook-ebnf
 cp -p $dtd dbebnf.dtd
-stripHash $catalog
-cp -p $catalog $strippedName
+cp -p $catalog $(baseHash $catalog)

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -484,8 +484,7 @@ dumpVars() {
 }
 
 
-# Utility function: return the base name of the given path, with the
-# prefix `HASH-' removed, if present.
+# DEPRECATED, use baseHash - 2016-06-23
 stripHash() {
     strippedName=$(basename $1);
     if echo "$strippedName" | grep -q '^[a-z0-9]\{32\}-'; then
@@ -493,6 +492,14 @@ stripHash() {
     fi
 }
 
+# Print NAME with any leading directory components and hash removed. 
+# If specified, also remove a trailing SUFFIX.
+#
+# Usage: baseHash NAME [SUFFIX]
+# Usage: baseName -a [-s SUFFIX] NAME...
+baseHash() {
+  basename "$@" | sed -s 's/^[a-z0-9]\{32\}-//g'
+}
 
 unpackCmdHooks+=(_defaultUnpack)
 _defaultUnpack() {

--- a/pkgs/tools/typesetting/tex/nix/animatedot.sh
+++ b/pkgs/tools/typesetting/tex/nix/animatedot.sh
@@ -4,6 +4,6 @@ mkdir -p $out
 
 for ((i = 1; i <= $nrFrames; i++)); do
     echo "producing frame $i...";
-    targetName=$out/$(basename $(stripHash $dotGraph; echo $strippedName) .dot)-f-$i.dot
+    targetName=$out/$(baseHash $dotGraph .dot)-f-$i.dot
     cpp -DFRAME=$i < $dotGraph > $targetName
 done

--- a/pkgs/tools/typesetting/tex/nix/default.nix
+++ b/pkgs/tools/typesetting/tex/nix/default.nix
@@ -185,7 +185,7 @@ rec {
         if test -d $postscript; then
           input=$(ls $postscript/*.ps)
         else
-          input=$(stripHash $postscript; echo $strippedName)
+          input=$(baseHash $postscript)
           ln -s $postscript $input
         fi
 

--- a/pkgs/tools/typesetting/tex/nix/dot2pdf.sh
+++ b/pkgs/tools/typesetting/tex/nix/dot2pdf.sh
@@ -4,7 +4,7 @@ mkdir -p $out
 
 dot2pdf() {
     sourceFile=$1
-    targetName=$out/$(basename $(stripHash $sourceFile; echo $strippedName) .dot).pdf
+    targetName=$out/$(baseHash $sourceFile .dot).pdf
     echo "converting $sourceFile to $targetName..."
     export FONTCONFIG_FILE=$fontsConf
     dot -Tpdf $sourceFile > $targetName

--- a/pkgs/tools/typesetting/tex/nix/dot2ps.sh
+++ b/pkgs/tools/typesetting/tex/nix/dot2ps.sh
@@ -4,7 +4,7 @@ mkdir -p $out
 
 dot2ps() {
     sourceFile=$1
-    targetName=$out/$(basename $(stripHash $sourceFile; echo $strippedName) .dot).ps
+    targetName=$out/$(baseHash $sourceFile .dot).ps
     echo "converting $sourceFile to $targetName..."
     dot -Tps $sourceFile > $targetName
 }

--- a/pkgs/tools/typesetting/tex/nix/lhs2tex.sh
+++ b/pkgs/tools/typesetting/tex/nix/lhs2tex.sh
@@ -10,7 +10,7 @@ cd $startDir
 
 lhstex() {
     sourceFile=$1
-    targetName=$out/$(basename $(stripHash $sourceFile; echo $strippedName) .lhs).tex
+    targetName=$out/$(baseHash $sourceFile .lhs).tex
     echo "converting $sourceFile to $targetName..."
     lhs2TeX -o "$targetName" $flags "$sourceFile"
 }

--- a/pkgs/tools/typesetting/tex/nix/run-latex.sh
+++ b/pkgs/tools/typesetting/tex/nix/run-latex.sh
@@ -16,11 +16,11 @@ for i in $extraFiles; do
     if test -d $i; then
         ln -s $i/* .
     else
-        ln -s $i $(stripHash $i; echo $strippedName)
+        ln -s $i $(baseHash $i)
     fi
 done
 
-rootName=$(basename $(stripHash "$rootFile"; echo $strippedName))
+rootName=$(baseHash "$rootFile")
 
 rootNameBase=$(echo "$rootName" | sed 's/\..*//')
 


### PR DESCRIPTION
###### Motivation for this change

It provides a better implementation to stripHash which leaks into the global namespace. Initiated by the discussion at https://github.com/NixOS/nixpkgs/pull/16398
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
