### PR TITLE
vino: fix dependencies again

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/core/vino/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/vino/default.nix
@@ -1,14 +1,28 @@
-{ stdenv, intltool, fetchurl, gtk3, glib, libsoup, pkgconfig, makeWrapper
-, gnome3, libnotify, file, telepathy_glib, dbus_glib }:
+{ stdenv, fetchurl, lib, makeWrapper
+, pkgconfig, gnome3, gtk3, glib, intltool, libXtst, libnotify, libsoup
+, telepathySupport ? false, dbus_glib ? null, telepathy_glib ? null
+, libsecret ? null, gnutls ? null, libgcrypt ? null, avahi ? null
+, zlib ? null, libjpeg ? null
+, libXdamage ? null, libXfixes ? null, libXext ? null
+, gnomeKeyringSupport ? false, libgnome_keyring3 ? null
+, networkmanager ? null }:
+
+with lib;
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
   doCheck = true;
 
-  buildInputs = [ gtk3 intltool glib libsoup pkgconfig libnotify
-                  gnome3.defaultIconTheme dbus_glib telepathy_glib file
-                  makeWrapper ];
+  buildInputs = [
+    makeWrapper
+    pkgconfig gnome3.defaultIconTheme gtk3 glib intltool libXtst libnotify libsoup
+  ] ++ optionals telepathySupport [ dbus_glib telepathy_glib ]
+    ++ optional gnomeKeyringSupport libgnome_keyring3
+    ++ filter (p: p != null) [
+      libsecret gnutls libgcrypt avahi zlib libjpeg
+      libXdamage libXfixes libXext networkmanager
+    ];
 
   preFixup = ''
     wrapProgram "$out/libexec/vino-server" \

--- a/pkgs/desktops/gnome-3/3.20/core/vino/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/vino/default.nix
@@ -1,14 +1,28 @@
-{ stdenv, intltool, fetchurl, gtk3, glib, libsoup, pkgconfig, makeWrapper
-, gnome3, libnotify, file, telepathy_glib, dbus_glib }:
+{ stdenv, fetchurl, lib, makeWrapper
+, pkgconfig, gnome3, gtk3, glib, intltool, libXtst, libnotify, libsoup
+, telepathySupport ? false, dbus_glib ? null, telepathy_glib ? null
+, libsecret ? null, gnutls ? null, libgcrypt ? null, avahi ? null
+, zlib ? null, libjpeg ? null
+, libXdamage ? null, libXfixes ? null, libXext ? null
+, gnomeKeyringSupport ? false, libgnome_keyring3 ? null
+, networkmanager ? null }:
+
+with lib;
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
 
   doCheck = true;
 
-  buildInputs = [ gtk3 intltool glib libsoup pkgconfig libnotify
-                  gnome3.defaultIconTheme dbus_glib telepathy_glib file
-                  makeWrapper ];
+  buildInputs = [
+    makeWrapper
+    pkgconfig gnome3.defaultIconTheme gtk3 glib intltool libXtst libnotify libsoup
+  ] ++ optionals telepathySupport [ dbus_glib telepathy_glib ]
+    ++ optional gnomeKeyringSupport libgnome_keyring3
+    ++ filter (p: p != null) [
+      libsecret gnutls libgcrypt avahi zlib libjpeg
+      libXdamage libXfixes libXext networkmanager
+    ];
 
   preFixup = ''
     wrapProgram "$out/libexec/vino-server" \


### PR DESCRIPTION
###### Motivation for this change

My previous pull request was for release-15.09,
and as such has not been reapplied in master (and thus release-16.09).

Previous message:
The libXtst dependency was missing, which was required to enable remote control.
The other dependencies have been updated as well to reflect the dependencies stated at:
https://wiki.gnome.org/Projects/Vino
https://git.gnome.org/browse/vino/tree/configure.ac
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
