### PR TITLE
iTerm2: 2.1.4 -> 3.0.2 and refactoring

### DIFF
--- a/pkgs/applications/misc/iterm2/default.nix
+++ b/pkgs/applications/misc/iterm2/default.nix
@@ -1,18 +1,21 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   name = "iterm2-${version}";
-  version = "2.1.4";
+  version = "3.0.2";
 
-  src = fetchurl {
-    url = "https://iterm2.com/downloads/stable/iTerm2-2_1_4.zip";
-    sha256 = "1kb4j1p1kxj9dcsd34709bm2870ffzpq6jig6q9ixp08g0zbhqhh";
+  src = fetchFromGitHub {
+    owner = "gnachman";
+    repo = "iTerm2";
+    rev = "v${version}";
+    sha256 = "121g759i814y1g1g1jwhsmxgg4wrzv08vq7a7qwc7b85a17zbd3h";
   };
 
-  buildInputs = [ unzip ];
+  patches = [ ./disable_updates.patch ];
+  makeFlagsArray = ["Deployment"];
   installPhase = ''
     mkdir -p "$out/Applications"
-    mv "$(pwd)" "$out/Applications/iTerm.app"
+    mv "build/Deployment/iTerm2.app" "$out/Applications/iTerm.app"
   '';
 
   meta = {

--- a/pkgs/applications/misc/iterm2/disable_updates.patch
+++ b/pkgs/applications/misc/iterm2/disable_updates.patch
@@ -1,0 +1,11 @@
+--- iTerm2/sources/iTermPreferences.m   2016-06-23 16:55:28.000000000 +0200
++++ iTerm2/sources/iTermPreferences.m   2016-06-23 16:55:42.000000000 +0200
+@@ -189,7 +189,7 @@
+                   kPreferenceKeyInstantReplayMemoryMegabytes: @4,
+                   kPreferenceKeySavePasteAndCommandHistory: @NO,
+                   kPreferenceKeyAddBonjourHostsToProfiles: @NO,
+-                  kPreferenceKeyCheckForUpdatesAutomatically: @YES,
++                  kPreferenceKeyCheckForUpdatesAutomatically: @NO,
+                   kPreferenceKeyCheckForTestReleases: @NO,
+                   kPreferenceKeyLoadPrefsFromCustomFolder: @NO,
+                   kPreferenceKeyNeverRemindPrefsChangesLostForFileHaveSelection: @NO,


### PR DESCRIPTION
###### Motivation for this change

@edolstra pointed out that the current iterm package is not in the spirit of nixpkgs because instead of building the package itself, the binary is downloaded from the iterm website.

This pr now allows iterm to be build from source. It also includes a version bump because v2.1.4 is not available at GitHub. Now that iterm is built from source, I've also included a patch to disable auto updates.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
