### PR TITLE
zstd: set meta.platforms to unix

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     # The licence of the CLI programme is GPLv2+, that of the library BSD-2.
     license = with licenses; [ gpl2Plus bsd2 ];
 
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ nckx ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The Zstd library is portable.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [X] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
