### PR TITLE
mono44: Init at 4.4.1.0

### DIFF
--- a/pkgs/development/compilers/boo/default.nix
+++ b/pkgs/development/compilers/boo/default.nix
@@ -41,5 +41,6 @@ in stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "The Boo Programming Language";
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/development/compilers/mono/4.0.nix
+++ b/pkgs/development/compilers/mono/4.0.nix
@@ -1,0 +1,6 @@
+{ stdenv, callPackage, Foundation, libobjc }:
+callPackage ./generic.nix (rec {
+  inherit Foundation libobjc;
+  version = "4.0.4.1";
+  sha256 = "1ydw9l89apc9p7xr5mdzy0h97g2q6v243g82mxswfc2rrqhfs4gd";
+})

--- a/pkgs/development/compilers/mono/4.4.nix
+++ b/pkgs/development/compilers/mono/4.4.nix
@@ -1,0 +1,7 @@
+{ stdenv, callPackage, Foundation, libobjc }:
+
+callPackage ./generic.nix (rec {
+  inherit Foundation libobjc;
+  version = "4.4.1.0";
+  sha256 = "0jibyvyv2jy8dq5ij0j00iq3v74r0y90dcjc3dkspcfbnn37cphn";
+})

--- a/pkgs/development/compilers/mono/default.nix
+++ b/pkgs/development/compilers/mono/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc }:
+{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc, python }:
 
 let
   llvm     = callPackage ./llvm.nix { };
-  llvmOpts = stdenv.lib.optionalString withLLVM "--enable-llvm --enable-llvmloaded --with-llvm=${llvm}";
+  sha256 = "1ydw9l89apc9p7xr5mdzy0h97g2q6v243g82mxswfc2rrqhfs4gd";
+  version = "4.0.4.1";
 in
 stdenv.mkDerivation rec {
   name = "mono-${version}";
-  version = "4.0.4.1";
+
   src = fetchurl {
+    inherit sha256;
     url = "http://download.mono-project.com/sources/mono/${name}.tar.bz2";
-    sha256 = "1ydw9l89apc9p7xr5mdzy0h97g2q6v243g82mxswfc2rrqhfs4gd";
   };
 
   buildInputs =
-    [ bison pkgconfig glib gettext perl libgdiplus libX11 ncurses zlib
+    [ bison pkgconfig glib gettext perl libgdiplus libX11 ncurses zlib python
     ]
     ++ (stdenv.lib.optionals stdenv.isDarwin [ Foundation libobjc ]);
 
@@ -26,7 +27,16 @@ stdenv.mkDerivation rec {
 
   # In fact I think this line does not help at all to what I
   # wanted to achieve: have mono to find libgdiplus automatically
-  configureFlags = "--x-includes=${libX11.dev}/include --x-libraries=${libX11.out}/lib --with-libgdiplus=${libgdiplus}/lib/libgdiplus.so ${llvmOpts}";
+  configureFlags = [
+    "--x-includes=${libX11.dev}/include"
+    "--x-libraries=${libX11.out}/lib"
+    "--with-libgdiplus=${libgdiplus}/lib/libgdiplus.so"
+  ]
+  ++ stdenv.lib.optionals withLLVM [
+    "--enable-llvm"
+    "--enable-llvmloaded"
+    "--with-llvm=${llvm}"
+  ];
 
   # Attempt to fix this error when running "mcs --version":
   # The file /nix/store/xxx-mono-2.4.2.1/lib/mscorlib.dll is an invalid CIL image
@@ -53,13 +63,12 @@ stdenv.mkDerivation rec {
   # Other items in the DLLMap may need to be pointed to their store locations, I don't think this is exhaustive
   # http://www.mono-project.com/Config_DllMap
   postBuild = ''
-    find . -name 'config' -type f | while read i; do
-        sed -i "s@libX11.so.6@${libX11.out}/lib/libX11.so.6@g" $i
-        sed -i "s@/.*libgdiplus.so@${libgdiplus}/lib/libgdiplus.so@g" $i
-    done
+    find . -name 'config' -type f | xargs \
+    sed -i -e "s@libX11.so.6@${libX11.out}/lib/libX11.so.6@g" \
+           -e "s@/.*libgdiplus.so@${libgdiplus}/lib/libgdiplus.so@g" \
   '';
 
-  # Without this, any Mono application attempting to open an SSL connection will throw with 
+  # Without this, any Mono application attempting to open an SSL connection will throw with
   # The authentication or decryption has failed.
   # ---> Mono.Security.Protocol.Tls.TlsException: Invalid certificate received from server.
   postInstall = ''
@@ -76,7 +85,7 @@ stdenv.mkDerivation rec {
     homepage = http://mono-project.com/;
     description = "Cross platform, open source .NET development framework";
     platforms = with stdenv.lib.platforms; darwin ++ linux;
-    maintainers = with stdenv.lib.maintainers; [ viric thoughtpolice obadz ];
+    maintainers = with stdenv.lib.maintainers; [ viric thoughtpolice obadz vrthra ];
     license = stdenv.lib.licenses.free; # Combination of LGPL/X11/GPL ?
   };
 }

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -1,9 +1,7 @@
-{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc, python }:
+{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc, python, version, sha256 }:
 
 let
   llvm     = callPackage ./llvm.nix { };
-  sha256 = "1ydw9l89apc9p7xr5mdzy0h97g2q6v243g82mxswfc2rrqhfs4gd";
-  version = "4.0.4.1";
 in
 stdenv.mkDerivation rec {
   name = "mono-${version}";

--- a/pkgs/games/ue4/default.nix
+++ b/pkgs/games/ue4/default.nix
@@ -78,5 +78,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.unfree;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.puffnfresh ];
+    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4798,7 +4798,9 @@ in
 
   mlton = callPackage ../development/compilers/mlton { };
 
-  mono = callPackage ../development/compilers/mono {
+  mono = mono40;
+
+  mono40 = callPackage ../development/compilers/mono/4.0.nix {
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4805,6 +4805,11 @@ in
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
 
+  mono44 = lowPrio (callPackage ../development/compilers/mono/4.4.nix {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  });
+
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
   mozart-binary = callPackage ../development/compilers/mozart/binary.nix { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
