### PR TITLE
bviplus: fix build

### DIFF
--- a/pkgs/applications/editors/bviplus/default.nix
+++ b/pkgs/applications/editors/bviplus/default.nix
@@ -11,9 +11,11 @@ stdenv.mkDerivation rec {
     ncurses
   ];
   makeFlags = "PREFIX=$(out)";
+  buildFlags = [ "CFLAGS=-fgnu89-inline" ];
+
   meta = with lib; {
-    description = "ncurses based hex editor with a vim-like interface";
-    homepage = "http://bviplus.sourceforge.net";
+    description = "Ncurses based hex editor with a vim-like interface";
+    homepage = http://bviplus.sourceforge.net;
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];


### PR DESCRIPTION
###### Motivation for this change

Issue #15270
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
