### PR TITLE
rkt: 1.8.0 -> 1.9.1; remove host stage1

### DIFF
--- a/pkgs/applications/virtualization/rkt/default.nix
+++ b/pkgs/applications/virtualization/rkt/default.nix
@@ -4,14 +4,14 @@
 let
   # Always get the information from 
   # https://github.com/coreos/rkt/blob/v${VERSION}/stage1/usr_from_coreos/coreos-common.mk
-  coreosImageRelease = "1032.0.0";
+  coreosImageRelease = "1068.0.0";
   coreosImageSystemdVersion = "229";
 
   # TODO: track https://github.com/coreos/rkt/issues/1758 to allow "host" flavor.
   stage1Flavours = [ "coreos" "fly" "host" ];
 
 in stdenv.mkDerivation rec {
-  version = "1.8.0";
+  version = "1.9.0";
   name = "rkt-${version}";
   BUILDDIR="build-${name}";
 
@@ -19,12 +19,12 @@ in stdenv.mkDerivation rec {
       rev = "v${version}";
       owner = "coreos";
       repo = "rkt";
-      sha256 = "0n4xjvvvkqk83npiqz13cv82lmnsqpzzyjc03lyz6svw2pdszmhd";
+      sha256 = "0vcvy98ch3lf28wk2kfmmr1rdlnikq7h7mx79n6vkplgjl4d7qf7";
   };
 
   stage1BaseImage = fetchurl {
     url = "http://alpha.release.core-os.net/amd64-usr/${coreosImageRelease}/coreos_production_pxe_image.cpio.gz";
-    sha256 = "1lmyhncvw5cby4nbpw6ryiki05wra90fsr6xnsdgi9yqqs6v2d1f";
+    sha256 = "06jawmjkhrrw9hsk98w5j6pxci17d46mvzbj52pslakacw60pbpp";
   };
 
   buildInputs = [

--- a/pkgs/applications/virtualization/rkt/default.nix
+++ b/pkgs/applications/virtualization/rkt/default.nix
@@ -11,7 +11,7 @@ let
   stage1Flavours = [ "coreos" "fly" "host" ];
 
 in stdenv.mkDerivation rec {
-  version = "1.9.0";
+  version = "1.9.1";
   name = "rkt-${version}";
   BUILDDIR="build-${name}";
 
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
       rev = "v${version}";
       owner = "coreos";
       repo = "rkt";
-      sha256 = "0vcvy98ch3lf28wk2kfmmr1rdlnikq7h7mx79n6vkplgjl4d7qf7";
+      sha256 = "094pqxcn91g1s3f0ly3z2lb11s4q3dn99h8cr7lqalkd0gj9l4xg";
   };
 
   stage1BaseImage = fetchurl {

--- a/pkgs/applications/virtualization/rkt/default.nix
+++ b/pkgs/applications/virtualization/rkt/default.nix
@@ -8,7 +8,7 @@ let
   coreosImageSystemdVersion = "229";
 
   # TODO: track https://github.com/coreos/rkt/issues/1758 to allow "host" flavor.
-  stage1Flavours = [ "coreos" "fly" "host" ];
+  stage1Flavours = [ "coreos" "fly" ];
 
 in stdenv.mkDerivation rec {
   version = "1.9.1";


### PR DESCRIPTION
###### Motivation for this change

New release!
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
