### PR TITLE
networkmanager: cleanup

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -231,11 +231,6 @@ in {
     users.extraUsers = [{
       name = "nm-openvpn";
       uid = config.ids.uids.nm-openvpn;
-    }
-    {
-      # to enable link-local connections
-      name = "avahi-autoipd";
-      uid = config.ids.uids.avahi-autoipd;
     }];
 
     systemd.packages = cfg.packages;

--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, pkgconfig, libglade, networkmanager, gnome3
-, libnotify, libsecret, dbus_glib, polkit, isocodes
+, libnotify, libsecret, polkit, isocodes
 , mobile_broadband_provider_info, glib_networking, gsettings_desktop_schemas
 , makeWrapper, udev, libgudev, hicolor_icon_theme }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--sysconfdir=/etc" ];
 
   buildInputs = [
-    gnome3.gtk libglade networkmanager libnotify libsecret dbus_glib gsettings_desktop_schemas
+    gnome3.gtk libglade networkmanager libnotify libsecret gsettings_desktop_schemas
     polkit isocodes makeWrapper udev libgudev gnome3.gconf gnome3.libgnome_keyring
   ];
 

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, intltool, wirelesstools, pkgconfig, dbus_glib, xz
 , systemd, libgudev, libnl, libuuid, polkit, gnutls, ppp, dhcp, dhcpcd, iptables
-, libgcrypt, dnsmasq, avahi, bind, perl, bluez5, substituteAll, readline
+, libgcrypt, dnsmasq, bind, perl, bluez5, substituteAll, readline
 , gobjectIntrospection, modemmanager, openresolv, libndp, newt, libsoup
 , ethtool, gnused, coreutils, file, inetutils }:
 
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
       --replace /usr/sbin/ethtool ${ethtool}/sbin/ethtool \
       --replace /bin/sed ${gnused}/bin/sed
     # to enable link-local connections
-    substituteInPlace src/devices/nm-device.c --replace '("avahi-autoipd", NULL, NULL)' '("avahi-autoipd", &"${avahi}/sbin/avahi-autoipd", NULL)'
     configureFlags="$configureFlags --with-udev-dir=$out/lib/udev"
   '';
 

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, intltool, wirelesstools, pkgconfig, dbus_glib, xz
-, systemd, libgudev, libnl, libuuid, polkit, gnutls, ppp, dhcp, dhcpcd, iptables
-, libgcrypt, dnsmasq, bind, perl, bluez5, substituteAll, readline
+{ stdenv, fetchurl, intltool, pkgconfig, dbus_glib
+, systemd, libgudev, libnl, libuuid, polkit, gnutls, ppp, dhcp, iptables
+, libgcrypt, dnsmasq, bluez5, readline
 , gobjectIntrospection, modemmanager, openresolv, libndp, newt, libsoup
 , ethtool, gnused, coreutils, file, inetutils }:
 
@@ -38,7 +38,6 @@ stdenv.mkDerivation rec {
     "--with-dhclient=${dhcp}/bin/dhclient"
     "--with-dnsmasq=${dnsmasq}/bin/dnsmasq"
     # Upstream prefers dhclient, so don't add dhcpcd to the closure
-    #"--with-dhcpcd=${dhcpcd}/sbin/dhcpcd"
     "--with-dhcpcd=no"
     "--with-pppd=${ppp}/bin/pppd"
     "--with-iptables=${iptables}/bin/iptables"
@@ -55,8 +54,8 @@ stdenv.mkDerivation rec {
     "--with-libsoup=yes"
   ];
 
-  buildInputs = [ wirelesstools systemd libgudev libnl libuuid polkit ppp libndp
-                  xz bluez5 dnsmasq gobjectIntrospection modemmanager readline newt libsoup ];
+  buildInputs = [ systemd libgudev libnl libuuid polkit ppp libndp
+                  bluez5 dnsmasq gobjectIntrospection modemmanager readline newt libsoup ];
 
   propagatedBuildInputs = [ dbus_glib gnutls libgcrypt ];
 


### PR DESCRIPTION
###### Motivation for this change

NetworkManager was updated in #16412 . 
- Upstream dropped the dependency on avahi-autoipd
- There were a few unused things in the expression
- Upstream is working on replacing dbus_glib with gio's native dbus support. NM itself (and some plugins) can be built without dbus_glib. But if you want libnm-glib (deprecated) you still need dbus_glib. Since nm-applet still used libnm-glib we have to build the legacy api :disappointed:
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @obadz
