### PR TITLE
davmail: 4.7.1 -> 4.7.2

### DIFF
--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -1,10 +1,10 @@
 { fetchurl, stdenv, jre, glib, libXtst, gtk, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "davmail-4.7.1";
+  name = "davmail-4.7.2";
   src = fetchurl {
     url = "mirror://sourceforge/davmail/4.7.1/davmail-linux-x86_64-4.7.1-2416.tgz";
-    sha256 = "c3bf1a3a94f35586a3a8d2d28cdaf8c9514a8cf904a51fd74961e93909c9d2a4";
+    sha256 = "196jr44kksb197biz984z664llf9z3d8rlnjm2iqcmgkjhx1mgy3";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

bugfix release
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Bugfix release, detect Exchange throttling to temporarily block requests and a few Carddav fixes.

EWS:
- EWS: handle Exchange throttling, suspend all requests according to server provided delay
- EWS: send DavMailException instead of authentication exception on EWS not available error

Enhancements:
- 128x128 DavMail icon
- Add a new davmail.httpMaxRedirects setting
- DAV: add a hidden davmail.disableNTLM setting

Carddav:
- Carddav: fix another regression on contact create with empty field
- Carddav: remove email over EWS unit test
- Carddav: fix email address removal over EWS
