### PR TITLE
tcplay: init at 2.0

### DIFF
--- a/pkgs/tools/security/tcplay/default.nix
+++ b/pkgs/tools/security/tcplay/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGithub, cmake, pkgconfig, libgcrypt, libuuid, devicemapper, libudev, openssl, libgpgerror }:
+
+stdenv.mkDerivation rec {
+  name = "tcplay-2.0";
+
+  src = fetchFromGithub {
+    owner = "bwalex";
+    repo = "tc-play";
+    rev = "v2.0";
+    sha256 = "0bg46ijjdzrfy5yv090sh6rf5wyrpdias2xiciip8qp86w7qj5qf";
+  };
+
+  buildInputs = [ cmake pkgconfig libgcrypt libuuid devicemapper libudev openssl libgpgerror ];
+
+  configurePhase = ''
+    mkdir objdir
+    cd objdir
+    cmake -DCMAKE_INSTALL_PREFIX=$out ..
+  '';
+
+  NIX_CFLAGS_COMPILE = "-fPIC";
+
+  meta = {
+    description = "Free and simple TrueCrypt Implementation based on dm-crypt";
+    license = stdenv.lib.licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3507,6 +3507,8 @@ in
 
   tcpflow = callPackage ../tools/networking/tcpflow { };
 
+  tcplay = callPackage ../tools/security/tcplay { };
+
   teamviewer = callPackage ../applications/networking/remote/teamviewer {
     stdenv = stdenv_32bit;
   };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
