### PR TITLE
ibus: fix #16292

### DIFF
--- a/pkgs/tools/inputmethods/ibus/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus/wrapper.nix
@@ -23,7 +23,7 @@ let
 
     for prog in ibus ibus-daemon ibus-setup; do
         wrapProgram "$out/bin/$prog" \
-          --prefix GDK_PIXBUF_MODULE_FILE : ${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache \
+          --set GDK_PIXBUF_MODULE_FILE ${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache \
           --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH:$out/lib/girepository-1.0" \
           --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules" \
           --set IBUS_COMPONENT_PATH "$out/share/ibus/component/" \


### PR DESCRIPTION
set GDK_PIXBUF_MODULE_FILE instead of prefixing it

> I think that would be fine for now. Technically, we need a way to merge loaders.cache files because the dependencies can change at runtime. (For example, if you use a theme with SVG icons, librsvg must be included in loaders.cache.)

I think librsvg is currently the only package from which loaders.cache is being used. The problem is that it's included twice. Once in the wrapper and once from the environmental variable set in

```
nixos/modules/services/x11/desktop-managers/kde5.nix
```

Also, usually GDK_PIXBUF_MODULE_FILE is set like this

```
--set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
```

In the ibus wrapper package this doesn't seem to work (probably because it uses runCommand not mkDerivation). That's probably why the path is given more explicitly.

Thanks for looking into it.

@ttuegel
