### PR TITLE
Matplotlib tkagg

### DIFF
--- a/pkgs/development/python-modules/matplotlib/basedirlist.patch
+++ b/pkgs/development/python-modules/matplotlib/basedirlist.patch
@@ -1,0 +1,8 @@
+diff --git a/setup.cfg b/setup.cfg
+new file mode 100644
+index 0000000..6f81985
+--- /dev/null
++++ b/setup.cfg
+@@ -0,0 +1,2 @@
++[directories]
++basedirlist = .

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -4,11 +4,17 @@
 , enableGhostscript ? false, ghostscript ? null, gtk3
 , enableGtk2 ? false, pygtk ? null, gobjectIntrospection
 , enableGtk3 ? false, cairo
+, enableTk ? false, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
 , Cocoa, Foundation, CoreData, cf-private, libobjc, libcxx
 }:
 
 assert enableGhostscript -> ghostscript != null;
 assert enableGtk2 -> pygtk != null;
+assert enableTk -> (tcl != null)
+                && (tk != null)
+                && (tkinter != null)
+                && (libX11 != null)
+                ;
 
 buildPythonPackage rec {
   name = "matplotlib-${version}";
@@ -33,11 +39,26 @@ buildPythonPackage rec {
       libpng pkgconfig mock pytz  
     ]
     ++ stdenv.lib.optional enableGtk2 pygtk
-    ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ];
+    ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ]
+    ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ];
 
   patches =
     [ ./basedirlist.patch ] ++
     stdenv.lib.optionals stdenv.isDarwin [ ./darwin-stdenv.patch ];
+
+  # Matplotlib tries to find Tcl/Tk by opening a Tk window and asking the
+  # corresponding interpreter object for its library paths. This fails if
+  # `$DISPLAY` is not set. The fallback option assumes that Tcl/Tk are both
+  # installed under the same path which is not true in Nix.
+  # With the following patch we just hard-code these paths into the install
+  # script.
+  postPatch =
+    let
+      inherit (stdenv.lib.strings) substring;
+      tcl_tk_cache = ''"${tk}/lib", "${tcl}/lib", "${substring 0 3 tk.version}"'';
+    in
+    stdenv.lib.optionalString enableTk
+      "sed -i '/self.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py";
 
   checkPhase = ''
     ${python.interpreter} tests.py

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -35,7 +35,9 @@ buildPythonPackage rec {
     ++ stdenv.lib.optional enableGtk2 pygtk
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ];
 
-  patches = stdenv.lib.optionals stdenv.isDarwin [ ./darwin-stdenv.patch ];
+  patches =
+    [ ./basedirlist.patch ] ++
+    stdenv.lib.optionals stdenv.isDarwin [ ./darwin-stdenv.patch ];
 
   checkPhase = ''
     ${python.interpreter} tests.py


### PR DESCRIPTION
###### Motivation for this change
- Fix #15993 (Add TkAgg backend to matplotlib)
- Be able to build matplotlib on non-NixOS without interference from libraries installed in `/usr`, and `/usr/local`.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (there are none)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
