### PR TITLE
pythonPackages.nipy: add matplotlib as a dependency

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13631,6 +13631,7 @@ in modules // {
     buildInputs = stdenv.lib.optional doCheck [ self.nose ];
 
     propagatedBuildInputs = with self; [
+      matplotlib
       nibabel
       numpy
       scipy


### PR DESCRIPTION
While Matplotlib is listed as an "optional" dependency, it's imported in a number of places, often without any error handling, so it seems better to make it required.
