### PR TITLE
mbuffer: Disable build on Mac OS X and 20151002 -> 20160613

### DIFF
--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -3,12 +3,12 @@
  } :
 
 stdenv.mkDerivation rec {
-  version = "20151002";
+  version = "20160613";
   name = "mbuffer-${version}";
 
   src = fetchurl {
     url = "http://www.maier-komor.de/software/mbuffer/mbuffer-${version}.tgz";
-    sha256 = "04pz70jr7fkdyax7b67g9jr0msl6ff2i8s6fl8zginqz5rrxckqk";
+    sha256 = "1za9yqfn23axnp4zymdsrjkqcci3wxywqw3bv4dxms57q1ljiab7";
   };
 
   buildInputs = [ openssl ];

--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     description  = "mbuffer is a tool for buffering data streams with a large set of unique features";
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ tokudan ];
-    platforms =  with stdenv.lib.platforms; allBut darwin;
+    platforms = with stdenv.lib.platforms; allBut darwin;
   };
 }

--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
     description  = "mbuffer is a tool for buffering data streams with a large set of unique features";
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ tokudan ];
-    platforms = with stdenv.lib.platforms; all;
+    platforms =  with stdenv.lib.platforms; allBut darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

mbuffer does not support Mac OS X, it was blocked by another lib before.
update to newer version with a couple of bug fixes:

Changelog 20160613:
- fix: fix potential assertion triggered by interrupted system call
- enhancement: ignore EINTR for I/O syscalls
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
