### PR TITLE
nixos/gnome-desktop: add missing dbus service for color configuration

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -120,6 +120,7 @@ in {
     networking.networkmanager.enable = mkDefault true;
     services.upower.enable = config.powerManagement.enable;
     services.dbus.packages = mkIf config.services.printing.enable [ pkgs.system-config-printer ];
+    services.colord.enable = mkDefault true;
     hardware.bluetooth.enable = mkDefault true;
 
     fonts.fonts = [ pkgs.dejavu_fonts pkgs.cantarell_fonts ];


### PR DESCRIPTION
###### Motivation for this change

Make the color configuration part of the GNOME Control Center work.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Specifically, add "colord" to services.dbus.packages and
systemd.packages (yes, we also have to add the .service file).

Fixes this (line wrapped):

```
  $ gnome-control-center
  [... click on the "Color" item ...]
  (gnome-control-center:3977): color-cc-panel-WARNING **: \
    The name org.freedesktop.ColorManager was not provided by any .service files
```

With this patch applied, the above warnings are not printed and the GUI
shows some devices that can be managed (my printer). Without this patch
the GUI is empty.

(cups will also complain in the journal with a similar message when
doing print jobs, without this patch.)
