### PR TITLE
system-config-printer: update hash to really upgrade to 1.5.7

### DIFF
--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, udev, intltool, pkgconfig, glib, xmlto
-, makeWrapper, pygobject, pygtk, docbook_xml_dtd_412, docbook_xsl
-, pythonDBus, libxml2, desktop_file_utils, libusb1, cups, pycups
+, makeWrapper, gtk3, docbook_xml_dtd_412, docbook_xsl
+, libxml2, desktop_file_utils, libusb1, cups, gdk_pixbuf, pango, atk, libnotify
 , pythonPackages
 , withGUI ? true
 }:
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://cyberelk.net/tim/data/system-config-printer/${majorVersion}/${name}.tar.xz";
-    sha256 = "1cg9n75rg5l9vr1925n2g771kga33imikyl0mf70lww2sfgvs18r";
+    sha256 = "1vxczk22f58nbikvj47s2x1gzh6q4mbgwnf091p00h3b6nxppdgn";
   };
 
   propagatedBuildInputs = [ pythonPackages.pycurl ];
@@ -25,18 +25,21 @@ in stdenv.mkDerivation rec {
       pythonPackages.python pythonPackages.wrapPython
     ];
 
-  pythonPath =
-    [ pythonDBus pycups pygobject pythonPackages.pycurl ]
-    ++ stdenv.lib.optionals withGUI [ pygtk pythonPackages.notify ];
+  pythonPath = with pythonPackages;
+    [ pycups pycurl dbus pygobject3 requests2 ];
 
   configureFlags =
     [ "--with-udev-rules"
+      "--with-udevdir=$(out)/etc/udev"
       "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     ];
 
   postInstall =
+    let
+      giTypelibPath = stdenv.lib.makeSearchPath "lib/girepository-1.0" [ gdk_pixbuf.out gtk3.out pango.out atk.out libnotify.out ];
+    in
     ''
-      export makeWrapperArgs="--set prefix $out"
+      export makeWrapperArgs="--set prefix $out --set GI_TYPELIB_PATH ${giTypelibPath}"
       wrapPythonPrograms
       # The program imports itself, so we need to move shell wrappers to a proper place.
       fixupWrapper() {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3512,6 +3512,7 @@ in
 
   system-config-printer = callPackage ../tools/misc/system-config-printer {
     libxml2 = libxml2Python;
+    pythonPackages = python3Packages;
    };
 
   sitecopy = callPackage ../tools/networking/sitecopy { };


### PR DESCRIPTION
###### Motivation for this change

Complete earlier unsuccessful update of system-config-printer and make its version number correct (not a lie).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Commit 03353ce6ff738acce3d ("system-config-printer: 1.3.12 -> 1 5.7")
forgot to update the hash. So since that commit we actually continued to
use the old version (1.3.12) because of the NixOS tarball cache...

Implementation details:
- The new version needs python3.
- 'notify' depends on a pygtk version which is incompatible with
  python3, we disable that for now.
- A new --with-udevdir configure option is used to prevent the
  installer from trying to install stuff to "/rules.d" (yes, the root).
- Get pycups from the passed pythonPackages set (fixes loading of
  python cups module).
- Use pygobject3 instead of pygobject, as needed.
- Use dbus from the passed pythonPackages attrset instead of
  pythonDBus, so we get a python3 compatible module that loads
  successfully.

The new version prints some warnings on startup:

  /nix/store/HASH-system-config-printer-1.5.7/share/system-config-printer/system-config-printer.py:32: \
    PyGIWarning: Polkit was imported without specifying a version first. \
    Use gi.require_version('Polkit', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import Polkit

...and similar errors for GdkPixbuf, Gdk, Gtk and Notify. But the thing
works (I didn't see anything break).
