### PR TITLE
gpxsee: init at 2.16

### DIFF
--- a/pkgs/applications/misc/gpxsee/default.nix
+++ b/pkgs/applications/misc/gpxsee/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, qmakeHook }:
+
+stdenv.mkDerivation rec {
+  name = "gpxsee-${version}";
+  version = "2.16";
+
+  src = fetchFromGitHub {
+    owner = "tumic0";
+    repo = "GPXSee";
+    rev = version;
+    sha256 = "0xqmjh071my9klxlk5afx8r673zlknq84n7ain6mz9i8n9m1gviv";
+  };
+
+  nativeBuildInputs = [ qmakeHook ];
+  
+  patchPhase = ''
+    sed -i '/lang\/gpxsee_cs.qm/d' gpxsee.qrc
+  '';
+
+  preFixup = ''
+    mkdir -p $out/bin
+    cp GPXSee $out/bin
+  '';
+  
+  meta = with stdenv.lib; {
+    homepage = http://tumic.wz.cz/gpxsee;
+    description = "GPX viewer and analyzer";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.womfoo ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12977,6 +12977,8 @@ in
 
   gpsprune = callPackage ../applications/misc/gpsprune { };
 
+  gpxsee = qt5.callPackage ../applications/misc/gpxsee { };
+
   gtk2fontsel = callPackage ../applications/misc/gtk2fontsel {
     inherit (gnome2) gtk;
   };


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
