### PR TITLE
fio: 2.9 -> 2.12

### DIFF
--- a/pkgs/tools/system/fio/default.nix
+++ b/pkgs/tools/system/fio/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, libaio, python, zlib }:
 
 let
-  version = "2.9";
-  sha256 = "10x5b1f1pdsh33kqzc8yf2v4mijlmkh72lmh9za6kz7hb3hp1nvi";
+  version = "2.12";
+  sha256 = "1m0fx0x1v2375vyxhd2i12b9w1qy4yh75f6qhwlcr78himcsmpp9";
 in
 
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change

Update fio to the last version
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
