### PR TITLE
meld: 3.16.0 -> 3.16.1

### DIFF
--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -5,7 +5,7 @@
 
 let
   minor = "3.16";
-  version = "${minor}.0";
+  version = "${minor}.1";
 in
 
 buildPythonApplication rec {
@@ -14,7 +14,7 @@ buildPythonApplication rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/meld/${minor}/meld-${version}.tar.xz";
-    sha256 = "02kcnlavlxlk8df456zppmin9xzdvgkw151nskb6f0bwmi9zs6rl";
+    sha256 = "1bec697aa1ababa315ca8241ade65dc68ea87f0d316632f590975afcf967cfab";
   };
 
   buildInputs = [
@@ -55,5 +55,6 @@ buildPythonApplication rec {
     homepage = http://meldmerge.org/;
     license = stdenv.lib.licenses.gpl2;
     platforms = platforms.linux ++ stdenv.lib.platforms.darwin;
+    maintainers = [ maintainers.mimadrid ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update meld to the last version
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
