### PR TITLE
sift: init at 0.8.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -70,6 +70,7 @@
   c0dehero = "CodeHero <codehero@nerdpol.ch>";
   calrama = "Moritz Maxeiner <moritz@ucworks.org>";
   campadrenalin = "Philip Horger <campadrenalin@gmail.com>";
+  carlsverre = "Carl Sverre <accounts@carlsverre.com>";
   cdepillabout = "Dennis Gosnell <cdep.illabout@gmail.com>";
   cfouche = "Chaddaï Fouché <chaddai.fouche@gmail.com>";
   chaoflow = "Florian Friesdorf <flo@chaoflow.net>";

--- a/pkgs/development/go-modules/libs.json
+++ b/pkgs/development/go-modules/libs.json
@@ -1546,5 +1546,23 @@
       "rev": "772320464101e904cd51198160eb4d489be9cc49",
       "sha256": "1a8hnh2k3vc3prjhnz4rjbiwhqq6r3mi18h9cdb6fc6s6yzjc19j"
     }
+  },
+  {
+    "goPackagePath": "github.com/svent/go-flags",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/svent/go-flags",
+      "rev": "4bcbad344f0318adaf7aabc16929701459009aa3",
+      "sha256": "1gb416fgxl9gq4q6wsv3i2grq1mzbi7lvfvmfdqbxqbv9vizzh34"
+    }
+  },
+  {
+    "goPackagePath": "github.com/svent/go-nbreader",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/svent/go-nbreader",
+      "rev": "7cef48da76dca6a496faa7fe63e39ed665cbd219",
+      "sha256": "0hw11jj5r3f6qwydg41nc3c6aadlbkhc1qpxra2609lis0qa9h4r"
+    }
   }
 ]

--- a/pkgs/tools/text/sift/default.nix
+++ b/pkgs/tools/text/sift/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "sift-${version}";
+  version = "0.8.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/svent/sift";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "svent";
+    repo = "sift";
+    sha256 = "1nb042k420xr6000ipwhqn41vg8jfp6ghq4z7y1sjnndkrhclzm1";
+  };
+
+  goDeps = ./deps.json;
+
+  meta = with lib; {
+    description = "sift is a fast and powerful alternative to grep";
+    homepage = "https://sift-tool.org";
+    maintainers = [ maintainers.carlsverre ];
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/text/sift/deps.json
+++ b/pkgs/tools/text/sift/deps.json
@@ -1,0 +1,10 @@
+[
+  {
+    "include": "../../libs.json",
+    "packages": [
+        "github.com/svent/go-flags",
+        "github.com/svent/go-nbreader",
+        "golang.org/x/crypto"
+    ]
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16827,6 +16827,8 @@ in
 
   spectrojack = callPackage ../applications/audio/spectrojack { };
 
+  sift = callPackage ../tools/text/sift { };
+
   xlockmore = callPackage ../misc/screensavers/xlockmore { };
 
   xtrlock-pam = callPackage ../misc/screensavers/xtrlock-pam { };


### PR DESCRIPTION
###### Motivation for this change

I use sift as my primary search tool.  Personally, it is a joy to use and I find it as fast or faster than `git grep` in a lot of cases.  It also supports tons of features like easy file-type listings and so on.  Learn more at the site: https://sift-tool.org/
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

sift is a fast and powerful alternative to grep.

https://sift-tool.org
