### PR TITLE
igv: init at 2.3.77

### DIFF
--- a/pkgs/applications/science/biology/igv/default.nix
+++ b/pkgs/applications/science/biology/igv/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, unzip, jre }:
+
+stdenv.mkDerivation rec {
+  name = "igv-${version}";
+  version = "2.3.77";
+
+  src = fetchurl {
+    url = "http://data.broadinstitute.org/igv/projects/downloads/IGV_${version}.zip";
+    sha256 = "9d8c622649f9f02026e92fa44006bb57e897baad4359c8708ca9cdbb71f94bb5";
+  };
+
+  buildInputs = [ unzip jre ];
+
+  installPhase = ''
+    mkdir -pv $out/{share,bin}
+    cp -Rv * $out/share/
+
+    sed -i "s#prefix=.*#prefix=$out/share#g" $out/share/igv.sh
+    sed -i 's#java#${jre}/bin/java#g' $out/share/igv.sh
+
+    ln -s $out/share/igv.sh $out/bin/igv
+
+    chmod +x $out/bin/igv
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.broadinstitute.org/igv/";
+    description = "A visualization tool for interactive exploration of genomic datasets";
+    license = licenses.lgpl21;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.mimadrid ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16035,6 +16035,8 @@ in
 
   htslib = callPackage ../development/libraries/science/biology/htslib { };
 
+  igv = callPackage ../applications/science/biology/igv { };
+
   neuron = callPackage ../applications/science/biology/neuron { };
 
   neuron-mpi = appendToName "mpi" (neuron.override {


### PR DESCRIPTION
###### Motivation for this change

Add Integrative Genomics Viewer (IGV) to NixOS
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
