### PR TITLE
zsh-completions: init at version 0.18.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -275,6 +275,7 @@
   odi = "Oliver Dunkl <oliver.dunkl@gmail.com>";
   offline = "Jaka Hudoklin <jakahudoklin@gmail.com>";
   olcai = "Erik Timan <dev@timan.info>";
+  olejorgenb = "Ole Jørgen Brønner <olejorgenb@yahoo.no>";
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";
   osener = "Ozan Sener <ozan@ozansener.com>";
   otwieracz = "Slawomir Gonet <slawek@otwiera.cz>";

--- a/pkgs/shells/zsh-completions/default.nix
+++ b/pkgs/shells/zsh-completions/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub}:
+
+stdenv.mkDerivation rec {
+  name = "zsh-completions-${version}";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "zsh-users";
+    repo = "zsh-completions";
+    rev = "${version}";
+    sha256 = "0iwb1kaidjxaz66kbbdzbydbdlfc6dk21sflzar0zy25jgx1p4xs";
+  };
+
+  installPhase= ''
+    install -D --target-directory=$out/share/zsh/site-functions src/*
+  '';
+
+  meta = {
+    description = "Additional completion definitions for zsh";
+    homepage = "https://github.com/zsh-users/zsh-completions";
+    license = stdenv.lib.licenses.free;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.olejorgenb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4138,6 +4138,8 @@ in
 
   nix-zsh-completions = callPackage ../shells/nix-zsh-completions { };
 
+  zsh-completions = callPackage ../shells/zsh-completions { };
+
   zsh-prezto = callPackage ../shells/zsh-prezto { };
 
   grml-zsh-config = callPackage ../shells/grml-zsh-config { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/zsh-users/zsh-completions provide addition completion functions for zsh.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
