### PR TITLE
conky: added double buffer support

### DIFF
--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -17,6 +17,7 @@
 , ncursesSupport      ? true      , ncurses       ? null
 , x11Support          ? true      , xlibsWrapper           ? null
 , xdamageSupport      ? x11Support, libXdamage    ? null
+, doubleBufferSupport ? x11Support
 , imlib2Support       ? x11Support, imlib2        ? null
 
 , luaSupport          ? true      , lua           ? null
@@ -113,6 +114,7 @@ stdenv.mkDerivation rec {
     ++ optional rssSupport          "-DBUILD_RSS=ON"
     ++ optional (!x11Support)       "-DBUILD_X11=OFF"
     ++ optional xdamageSupport      "-DBUILD_XDAMAGE=ON"
+    ++ optional doubleBufferSupport "-DBUILD_XDBE=ON"
     ++ optional weatherMetarSupport "-DBUILD_WEATHER_METAR=ON"
     ++ optional weatherXoapSupport  "-DBUILD_WEATHER_XOAP=ON"
     ++ optional wirelessSupport     "-DBUILD_WLAN=ON"


### PR DESCRIPTION
In my setup (xmonad + compton + conky) I encountered problems with background color and transparency in conky. The background was always black disregarding the color in the config file. And enabling option `own_window_argb_visual` caused the following error:

```
X Error of failed request:  BadMatch (invalid parameter attributes)
  Major opcode of failed request:  62 (X_CopyArea)
  ...
```

I adopted solution found on [the archlinux forum](https://bbs.archlinux.org/viewtopic.php?pid=1540889#p1540889), that simply enables double buffer option. In [the official packages](https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/conky#n35) they do it by default.
