### PR TITLE
cron: Fix crontab(1) and cron job PATH

### DIFF
--- a/pkgs/tools/system/cron/default.nix
+++ b/pkgs/tools/system/cron/default.nix
@@ -14,9 +14,19 @@ stdenv.mkDerivation {
     makeFlags="DESTROOT=$out"
 
     # We want to ignore the $glibc/include/paths.h definition of
-    # sendmail path
-    echo "#undef _PATH_SENDMAIL" >> pathnames.h
-    echo '#define _PATH_SENDMAIL "${sendmailPath}"' >> pathnames.h
+    # sendmail path.
+    # Also set a usable default PATH (#16518).
+    cat >> pathnames.h <<__EOT__
+    #undef _PATH_SENDMAIL
+    #define _PATH_SENDMAIL "${sendmailPath}"
+
+    #undef _PATH_DEFPATH
+    #define _PATH_DEFPATH "/var/setuid-wrappers:/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:/run/current-system/sw/bin:/run/current-system/sw/sbin:/usr/bin:/bin"
+    __EOT__
+
+    # Implicit saved uids do not work here due to way NixOS uses setuid wrappers
+    # (#16518).
+    echo "#undef HAVE_SAVED_UIDS" >> externs.h
   '';
 
   preInstall = "mkdir -p $out/bin $out/sbin $out/share/man/man1 $out/share/man/man5 $out/share/man/man8";


### PR DESCRIPTION
###### Motivation for this change

Fix bugs with crontab(1) invocation from unprivileged users and PATH during cron job execution.

Re #16518 
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Switch off HAVE_SAVED_UIDS since it activates a code path for temporary
privilege dropping which does not work on NixOS.

Vixie-cron's sources ship with two implementations. Unfortunately, the
one activated by HAVE_SAVED_UIDS (using setuid()) does not work on
NixOS. Saved UIDs work only if the program which is using them has the
setuid bit set on its own executable, not if called from a setuid
wrapper (as we do it in NixOS). The other implementation (using
setreuid()) works without problems.

Quote from
http://stackoverflow.com/questions/8499296/realuid-saved-uid-effective-uid-whats-going-on:

```
If you're euid is root and you change the uid, the privileges gets
dropped permanently.If effective user id is not root then saved user
id is never touched and you can regain the root privilege back
anytime you want in your program.
```

Also run cron jobs with a sane PATH as vixie-cron's default is not
really usable on NixOS.

Re #16518
