### PR TITLE
qt56: 5.6.1 -> 5.6.1-1

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.6/srcs.nix
@@ -3,259 +3,259 @@
 
 {
   qtxmlpatterns = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtxmlpatterns-opensource-src-5.6.1.tar.xz";
-      sha256 = "0q412jv3xbg7v05b8pbahifwx17gzlp96s90akh6zwhpm8i6xx34";
-      name = "qtxmlpatterns-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtxmlpatterns-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "1966rrk7f6c55k57j33rffdjs77kk4mawrnnl8yv1ckcirxc3np1";
+      name = "qtxmlpatterns-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtx11extras-opensource-src-5.6.1.tar.xz";
-      sha256 = "0l736qiz8adrnh267xz63hv4sph6nhy90h836qfnnmv3p78ipsz8";
-      name = "qtx11extras-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtx11extras-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0yj5yg2dqkrwbgbicmk2rpqsagmi8dsffkrprpsj0fmkx4awhv5y";
+      name = "qtx11extras-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwinextras-opensource-src-5.6.1.tar.xz";
-      sha256 = "1db3lcrj8af0z8lnh99lfbwz1cq9il7rr27rk9l38dff65qkssm8";
-      name = "qtwinextras-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtwinextras-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "03zkwqrix2nfqkwfn8lsrpgahzx1hv6p1qbvhkqymzakkzjjncgg";
+      name = "qtwinextras-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtwebview = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwebview-opensource-src-5.6.1.tar.xz";
-      sha256 = "0q869wl61vidds551w3z49ysx88xqyn6igbz07zxac7d0gwgwpda";
-      name = "qtwebview-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtwebview-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "19954snfw073flxn0qk5ayxyzk5x6hwhpg4kn4nrl1zygsw3y49l";
+      name = "qtwebview-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwebsockets-opensource-src-5.6.1.tar.xz";
-      sha256 = "0fkj52i4yi6gmq4jfjgdij08cspxspac6mbpf0fknnllimmkl7jm";
-      name = "qtwebsockets-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtwebsockets-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "1fz0x8570zxc00a22skd848svma3p2g3xyxj14jq10559jihqqil";
+      name = "qtwebsockets-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwebengine-opensource-src-5.6.1.tar.xz";
-      sha256 = "0yv0cflgywsyfn84vv2vc9rwpm8j7hin61rxqjqh498nnl2arw5x";
-      name = "qtwebengine-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtwebengine-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0k708a34zwkj6hwx3vv5kdvnv3lfgb0iad44zaim5gdpgcir03n8";
+      name = "qtwebengine-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwebchannel-opensource-src-5.6.1.tar.xz";
-      sha256 = "01q80917a1048hdhaii4v50dqs84h16lc9w3v99r9xvspk8vab7q";
-      name = "qtwebchannel-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtwebchannel-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "10kys3ppjkj60fs1s335fdcpdsbxsjn6ibvm6zph9gqbncabd2l7";
+      name = "qtwebchannel-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtwayland-opensource-src-5.6.1.tar.xz";
-      sha256 = "1jgghjfrg0wwyfzfwgwhagwxz9k936ylv3w2l9bwlpql8rgm8d11";
-      name = "qtwayland-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtwayland-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "1fnvgpi49ilds3ah9iizxj9qhhb5rnwqd9h03bhkwf0ydywv52c4";
+      name = "qtwayland-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qttranslations-opensource-src-5.6.1.tar.xz";
-      sha256 = "008wyk00mqz116pigm0qq78rvg28v6ykjnjxppkjnk0yd6i2vmb9";
-      name = "qttranslations-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qttranslations-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "03sdzci4pgq6lmxwn25v8x0z5x8g7zgpq2as56dqgj7vp6cvhn8m";
+      name = "qttranslations-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qttools = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qttools-opensource-src-5.6.1.tar.xz";
-      sha256 = "0wbzq60d7lkvlb7b5lqcw87qgy6kyjz1npjavz8f4grdxsaqi8vp";
-      name = "qttools-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qttools-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0haic027a2d7p7k8xz83fbvci4a4dln34360rlwgy7hlyy5m4nip";
+      name = "qttools-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtsvg-opensource-src-5.6.1.tar.xz";
-      sha256 = "08ca5g46g75acy27jfnvnalmcias5hxmjp7491v3y4k9y7a4ybpi";
-      name = "qtsvg-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtsvg-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "1w0jvhgaiddafcms2nv8wl1klg07lncmjwm1zhdw3l6rxi9071sw";
+      name = "qtsvg-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtserialport-opensource-src-5.6.1.tar.xz";
-      sha256 = "1hp63cgqhps6y1k041lzhcb2b0rcpcmszabnn293q5ilbvla4x0b";
-      name = "qtserialport-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtserialport-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "135cbgghxk0c6dblmyyrw6znfb9m8sac9hhyc2dm6vq7vzy8id52";
+      name = "qtserialport-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtserialbus-opensource-src-5.6.1.tar.xz";
-      sha256 = "1h683dkvnf2rdgxgisybnp8miqgn2gpi597rgx5zc7qk2k8kyidz";
-      name = "qtserialbus-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtserialbus-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0li4g70s5vfb517ag0d6405ymsknvvny1c8x66w7qs8a8mnk1jq5";
+      name = "qtserialbus-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtsensors-opensource-src-5.6.1.tar.xz";
-      sha256 = "0bll7ll6s5g8w89knyrc0famjwqyfzwpn512m1f96bf6xwacs967";
-      name = "qtsensors-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtsensors-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0kcrvf6vzn6g2v2m70f9r3raalzmfp48rwjlqhss3w84jfz3y04r";
+      name = "qtsensors-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtscript = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtscript-opensource-src-5.6.1.tar.xz";
-      sha256 = "17zp5dlfplrnzlw233lzapj55drjqchvayajd02qsggzms3yzchw";
-      name = "qtscript-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtscript-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "1gini9483flqa9q4a4bl81bh7g5s408bycqykqhgbklmfd29y5lx";
+      name = "qtscript-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtquickcontrols2-opensource-src-5.6.1.tar.xz";
-      sha256 = "13zbiv63b76ifpjalx5616nixfwjk48q977bzb1xxj363b7xv85v";
-      name = "qtquickcontrols2-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtquickcontrols2-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0wfa2xcqsvx3zihd5nb9f9qhq0xn14c03sw1qdymzfsryqwmk4ac";
+      name = "qtquickcontrols2-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtquickcontrols-opensource-src-5.6.1.tar.xz";
-      sha256 = "14d68ryn7r7rs7klpldnavcsccvyyg0xhwqkvjlm5wwplv2acah1";
-      name = "qtquickcontrols-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtquickcontrols-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0cjzf844r7wi32ssc9vbw1a2m9hnr8c0i1p7yyljy962ifplf401";
+      name = "qtquickcontrols-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtmultimedia-opensource-src-5.6.1.tar.xz";
-      sha256 = "058523c2qra3d8fq46ygcndnkrbwlh316zy28s2cr5pjr5gmnjyj";
-      name = "qtmultimedia-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtmultimedia-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0paffx0614ivjbf87lr9klpbqik6r1pzbc14l41np6d9jv3dqa2f";
+      name = "qtmultimedia-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtmacextras-opensource-src-5.6.1.tar.xz";
-      sha256 = "147yhv7fb0yaakrffqiw6xz8ycqdc7qsnxvnpr6j8rarw5xmdc73";
-      name = "qtmacextras-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtmacextras-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "07j26d5g7av4c6alggg5hssqpvdh555zmn1cpr8xrhx1hpbdnaas";
+      name = "qtmacextras-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtlocation-opensource-src-5.6.1.tar.xz";
-      sha256 = "0qahs7a2n3l4h0bl8bnwci9mzy1vra3zncnzr40csic9ys67ddfk";
-      name = "qtlocation-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtlocation-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0my4pbcxa58yzvdh65l5qx99ln03chjr5c3ml5v37wfk7nx23k69";
+      name = "qtlocation-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtimageformats-opensource-src-5.6.1.tar.xz";
-      sha256 = "020v1148433zx4g87z2r8fgff32n0laajxqqsja1l3yzz7jbrwvl";
-      name = "qtimageformats-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtimageformats-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "1p98acvsm3azka2by1ph4gdb31qbnndrr5k5wns4xk2d760y8ifc";
+      name = "qtimageformats-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtgraphicaleffects-opensource-src-5.6.1.tar.xz";
-      sha256 = "1n0i2drfr7fvydgg810dcij8mxnygdpvqcqv7l1a9a1kv9ap3sap";
-      name = "qtgraphicaleffects-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtgraphicaleffects-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0560800fa9sd6dw1vk0ia9vq8ywdrwch2cpsi1vmh4iyxgwfr71b";
+      name = "qtgraphicaleffects-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtenginio = {
     version = "1.6.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtenginio-opensource-src-1.6.1.tar.xz";
-      sha256 = "1iq4lnz3s6mfdgml61b9lsjisky55bbvsdj72kh003j94mzrc3l5";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtenginio-opensource-src-1.6.1.tar.xz";
+      sha256 = "17hsrhzy9zdvpbzja45aac6jr7jzzjl206vma96b9w73rbgxa50f";
       name = "qtenginio-opensource-src-1.6.1.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtdoc-opensource-src-5.6.1.tar.xz";
-      sha256 = "0yg7903vk4w3h6jjyanssfcig0s2s660q11sj14nw6gcjs7kfa5z";
-      name = "qtdoc-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtdoc-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "1yf3g3h72ndrp88h8g21mzgqdz2ixwkvpav03i3jnrgy2pf7nssp";
+      name = "qtdoc-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtdeclarative-render2d = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtdeclarative-render2d-opensource-src-5.6.1.tar.xz";
-      sha256 = "1m08x8x355545r9wgrjl5p26zjhp5q1yh3h25dww8pk25v6cn8dg";
-      name = "qtdeclarative-render2d-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtdeclarative-render2d-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0kqmb3792rg9fx12m64x87ahcrh0g9krg77mv0ssx3g4gvsgcibc";
+      name = "qtdeclarative-render2d-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtdeclarative-opensource-src-5.6.1.tar.xz";
-      sha256 = "1d2217kxk85kpi7ls08b41hqzy26hvch8m4cgzq6km5sqi5zvz0j";
-      name = "qtdeclarative-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtdeclarative-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "094gx5mzqzcga97y7ihf052b6i5iv512lh7m0702m5q94nsn1pqw";
+      name = "qtdeclarative-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtconnectivity-opensource-src-5.6.1.tar.xz";
-      sha256 = "06fr9321f52kf0nda9zjjfzp5694hbnx0y0v315iw28mnpvandas";
-      name = "qtconnectivity-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtconnectivity-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0sr6sxp0q45pacs25knr28139xdrphcjgrwlksdhdpsryfw19mzi";
+      name = "qtconnectivity-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtcanvas3d = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtcanvas3d-opensource-src-5.6.1.tar.xz";
-      sha256 = "0q17hwmj893pk0lhxmibxmgk6h1gy4ksqfi62rkfzcf81bg2q7hr";
-      name = "qtcanvas3d-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtcanvas3d-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "13127xws6xfkkk1x617bgdzl96l66nd0v82dibdnxnpfa702rl44";
+      name = "qtcanvas3d-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtbase = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtbase-opensource-src-5.6.1.tar.xz";
-      sha256 = "0r3jrqymnnxrig4f11xvs33c26f0kzfakbp3kcbdpv795gpc276h";
-      name = "qtbase-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtbase-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0fbwprlhqmdyhh2wb9122fcpq7pbil530iak482b9sy5gqs7i5ij";
+      name = "qtbase-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtandroidextras-opensource-src-5.6.1.tar.xz";
-      sha256 = "0prkpb57j0s8k36sba47k2bhs3ajf01rdwc7qf5gkvhs991rwckc";
-      name = "qtandroidextras-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtandroidextras-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "0xhm4053y9hqnz5y3y4rwycniq0mb1al1rds3jx636211y039xhk";
+      name = "qtandroidextras-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qtactiveqt-opensource-src-5.6.1.tar.xz";
-      sha256 = "0a2p0w03d04hqg71hlihj9mr6aasvb0h8jfa5rnq8b5rkm8haf4f";
-      name = "qtactiveqt-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qtactiveqt-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "00bj9c0x3ax34gpibaap3wpchkv4wapsydiz01fb0xzs1fy94nbf";
+      name = "qtactiveqt-opensource-src-5.6.1-1.tar.xz";
     };
   };
   qt3d = {
-    version = "5.6.1";
+    version = "5.6.1-1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.6/5.6.1/submodules/qt3d-opensource-src-5.6.1.tar.xz";
-      sha256 = "03d81sls30a20yna6940np15112ciwy5024f8n5imaxicm8h34xd";
-      name = "qt3d-opensource-src-5.6.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.6/5.6.1-1/submodules/qt3d-opensource-src-5.6.1-1.tar.xz";
+      sha256 = "1nxpcjsarcp40m4y18kyy9a5md56wnafll03j8c6q19rba9bcwbf";
+      name = "qt3d-opensource-src-5.6.1-1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Urgent bugfix release. Original sources for 5.6.1 are not available any more.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
