### PR TITLE
gpg-mpd: init at 0.7.4

### DIFF
--- a/pkgs/applications/misc/gpg-mdp/default.nix
+++ b/pkgs/applications/misc/gpg-mdp/default.nix
@@ -1,0 +1,34 @@
+{ fetchurl, stdenv, ncurses, gnupg }:
+
+let version = "0.7.4";
+in stdenv.mkDerivation {
+  # mdp renamed to gpg-mdp because there is a mdp package already.
+  name = "gpg-mdp-${version}";
+  meta = {
+    homepage = https://tamentis.com/projects/mdp/;
+    license = [stdenv.lib.licenses.isc];
+    description = "Manage your passwords with GnuPG and a text editor";
+  };
+  src = fetchurl {
+    url = "https://tamentis.com/projects/mdp/files/mdp-${version}.tar.gz";
+    sha256 = "04mdnx4ccpxf9m2myy9nvpl9ma4jgzmv9bkrzv2b9affzss3r34g";
+  };
+  buildInputs = [ ncurses ];
+  prePatch = ''
+    substituteInPlace ./configure \
+      --replace "alias echo=/bin/echo" ""
+
+    substituteInPlace ./src/config.c \
+      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg2" \
+      --replace "/usr/bin/vi" "vi"
+
+    substituteInPlace ./mdp.1 \
+      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg2"
+  '';
+  # we add symlinks to the binary and man page with the name 'gpg-mdp', in case
+  # the completely unrelated program also named 'mdp' is already installed.
+  postFixup = ''
+    ln -s $out/bin/mdp $out/bin/gpg-mdp
+    ln -s $out/share/man/man1/mdp.1.gz $out/share/man/man1/gpg-mdp.1.gz
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12629,6 +12629,8 @@ in
 
   evopedia = callPackage ../applications/misc/evopedia { };
 
+  gpg-mdp = callPackage ../applications/misc/gpg-mdp { };
+
   keepassx = callPackage ../applications/misc/keepassx { };
   keepassx2 = callPackage ../applications/misc/keepassx/2.0.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Adding the `mdp` program from https://tamentis.com/projects/mdp/

Notice that even though the upstream program is called `mdp`, I called this package `gpg-mdp` because there is a completely unrelated package named `mdp` in `nixpkgs`.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
