### PR TITLE
add qtwebchannel and qtwebengine

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -96,7 +96,7 @@ let
       qttranslations = callPackage ./qttranslations.nix {};
       /* qtwayland = not packaged */
       qtwebchannel = callPackage ./qtwebchannel.nix {};
-      /* qtwebengine = not packaged */
+      qtwebengine = callPackage ./qtwebengine.nix {};
       qtwebsockets = callPackage ./qtwebsockets.nix {};
       /* qtwinextras = not packaged */
       qtx11extras = callPackage ./qtx11extras.nix {};

--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -95,7 +95,7 @@ let
       qttools = callPackage ./qttools.nix {};
       qttranslations = callPackage ./qttranslations.nix {};
       /* qtwayland = not packaged */
-      /* qtwebchannel = not packaged */
+      qtwebchannel = callPackage ./qtwebchannel.nix {};
       /* qtwebengine = not packaged */
       qtwebsockets = callPackage ./qtwebsockets.nix {};
       /* qtwinextras = not packaged */

--- a/pkgs/development/libraries/qt-5/5.6/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebchannel.nix
@@ -1,0 +1,7 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtwebchannel";
+  qtInputs = [ qtbase qtdeclarative ];
+}
+

--- a/pkgs/development/libraries/qt-5/5.6/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebengine.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtquickcontrols, qtlocation, qtwebchannel }:
+
+qtSubmodule {
+  name = "qtwebengine";
+  qtInputs = [ qtquickcontrols qtlocation qtwebchannel ];
+}


### PR DESCRIPTION
###### Motivation for this change

needed for kdepim and generally useful
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
