### PR TITLE
Gofish: Init at 1.2

### DIFF
--- a/pkgs/servers/gopher/gofish/default.nix
+++ b/pkgs/servers/gopher/gofish/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+
+  name = "gofish-${version}";
+  version = "1.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/gofish/gofish/${version}/${name}.tar.gz";
+    sha256 = "0br5nvlna86k4ya4q13gz0i7nlmk225lqmpfiqlkldxkr473kf0s";
+  };
+  	
+  meta = with stdenv.lib; {
+    description = "A lightweight Gopher server";
+    homepage = http://gofish.sourceforge.net/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10003,6 +10003,8 @@ in
 
   glabels = callPackage ../applications/graphics/glabels { };
 
+  gofish = callPackage ../servers/gopher/gofish { };
+
   grafana = (callPackage ../servers/monitoring/grafana { }).bin // { outputs = ["bin"]; };
 
   groovebasin = callPackage ../applications/audio/groovebasin { nodejs = nodejs-0_10; };


### PR DESCRIPTION
###### Motivation for this change

Gofish is a lightweight Gopher server.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

TODO: install the NixOS system-dependent files.
