### PR TITLE
wine: 1.9.11 -> 1.9.13

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -6,9 +6,9 @@ let fetchurl = args@{url, sha256, ...}:
 in rec {
 
   stable = fetchurl rec {
-    version = "1.8.2";
+    version = "1.8.3";
     url = "mirror://sourceforge/wine/wine-${version}.tar.bz2";
-    sha256 = "0vsswlnaa9ndg1pais63c39xks519r9fhz0yq3q8fphly2nlyqji";
+    sha256 = "0v3sq5zzj3z5pw1aicn7i03pgf41cr9fr0vg1sazwfxrmbvwvknp";
 
     ## see http://wiki.winehq.org/Gecko
     gecko32 = fetchurl rec {

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -30,9 +30,9 @@ in rec {
   };
 
   unstable = fetchurl rec {
-    version = "1.9.11";
+    version = "1.9.13";
     url = "mirror://sourceforge/wine/wine-${version}.tar.bz2";
-    sha256 = "15mbrnx4zqsdsxz7rwkb1pp58bcyfqnm8f2fh7cbbdgwh117k3vj";
+    sha256 = "1nf06xgnda7y5ngnf8v14zaa0lnxzi1hxx7pf3jz2a0zswcq0rwv";
     inherit (stable) mono;
     gecko32 = fetchurl rec {
       version = "2.44";
@@ -48,7 +48,7 @@ in rec {
 
   staging = fetchFromGitHub rec {
     inherit (unstable) version;
-    sha256 = "0q990d26wsik16w1yya2z8nwxnhnaiiy85igdnan1ib2b00z861m";
+    sha256 = "0iw14dwl91i5nd6wfr5i2vvii2w6j0sh95syc46z6yjgvxd14waq";
     owner = "wine-compholio";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
###### Motivation for this change

Update wineUnstable and complementing  wineStaging to recent version
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Onlly 32bit wine was really tested.
