### PR TITLE
cgdb: 0.6.7 -> 0.6.8

### DIFF
--- a/pkgs/development/tools/misc/cgdb/default.nix
+++ b/pkgs/development/tools/misc/cgdb/default.nix
@@ -1,26 +1,26 @@
-{ stdenv, fetchurl, ncurses, readline }:
+{ stdenv, fetchurl, ncurses, readline, flex, texinfo, help2man }:
 
 stdenv.mkDerivation rec {
   name = "cgdb-${version}";
-  version = "0.6.7";
+  version = "0.6.8";
 
   src = fetchurl {
     url = "http://cgdb.me/files/${name}.tar.gz";
-    sha256 = "1agxk6a97v6q0n097zw57qqpaza4j79jg36x99bh8yl23qfx6kh7";
+    sha256 = "0hfgyj8jimb7imqlfdpzaln787r6r0yzwzmnk91rfl19pqlkw85y";
   };
 
-  buildInputs = [ ncurses readline ];
+  buildInputs = [ ncurses readline flex texinfo help2man ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A curses interface to gdb";
 
     homepage = https://cgdb.github.io/;
 
     repositories.git = git://github.com/cgdb/cgdb.git;
 
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
 
-    platforms = with stdenv.lib.platforms; linux ++ cygwin;
-    maintainers = with stdenv.lib.maintainers; [ viric ];
+    platforms = with platforms; linux ++ cygwin;
+    maintainers = with maintainers; [ viric vrthra ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
