### PR TITLE
objconv: 1.0 -> 2.16

### DIFF
--- a/pkgs/development/tools/misc/objconv/default.nix
+++ b/pkgs/development/tools/misc/objconv/default.nix
@@ -1,16 +1,25 @@
 { stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation {
-  name = "objconv-1.0";
+stdenv.mkDerivation rec {
+  name = "objconv-${version}";
+  version = "2.16";
 
   src = fetchFromGitHub {
     owner  = "vertis";
     repo   = "objconv";
-    rev    = "01da9219e684360fd04011599805ee3e699bae96";
+    rev    = "${version}";
     sha256 = "1by2bbrampwv0qy8vn4hhs49rykczyj7q8g373ym38da3c95bym2";
   };
 
   buildPhase = "c++ -o objconv -O2 src/*.cpp";
 
   installPhase = "mkdir -p $out/bin && mv objconv $out/bin";
+
+  meta = with stdenv.lib; {
+    description = "Used for converting object files between COFF/PE, OMF, ELF and Mach-O formats for all 32-bit and 64-bit x86 platforms.";
+    homepage = http://www.agner.org/optimize/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ vrthra ];
+  };
+
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
