### PR TITLE
[merged] dolphin-emu: 4.0.2 -> 5.0

### DIFF
--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -1,13 +1,17 @@
-{ stdenv, pkgconfig, cmake, bluez, ffmpeg, libao, mesa, gtk2, glib
-, gettext, libpthreadstubs, libXrandr, libXext, readline
-, openal, libXdmcp, portaudio, SDL, wxGTK30, fetchurl
+{ stdenv, gcc5, pkgconfig, cmake, bluez, ffmpeg, libao, mesa, gtk2, glib
+, gettext, git, libpthreadstubs, libXrandr, libXext, readline
+, openal, libXdmcp, portaudio, fetchFromGitHub, libusb, libevdev
 , libpulseaudio ? null }:
 
 stdenv.mkDerivation rec {
-  name = "dolphin-emu-4.0.2";
-  src = fetchurl {
-    url = https://github.com/dolphin-emu/dolphin/archive/4.0.2.tar.gz;
-    sha256 = "0a8ikcxdify9d7lqz8fn2axk2hq4q1nvbcsi1b8vb9z0mdrhzw89";
+  name = "dolphin-emu-${version}";
+  version = "5.0";
+
+  src = fetchFromGitHub {
+    owner  = "dolphin-emu";
+    repo   = "dolphin";
+    rev    = version;
+    sha256 = "07mlfnh0hwvk6xarcg315x7z2j0qbg9g7cm040df9c8psiahc3g6";
   };
 
   cmakeFlags = ''
@@ -20,16 +24,17 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ pkgconfig cmake bluez ffmpeg libao mesa gtk2 glib
+  buildInputs = [ gcc5 pkgconfig cmake bluez ffmpeg libao mesa gtk2 glib
                   gettext libpthreadstubs libXrandr libXext readline openal
-                  libXdmcp portaudio SDL wxGTK30 libpulseaudio ];
+                  libevdev git libXdmcp portaudio libusb libpulseaudio ];
 
   meta = {
     homepage = http://dolphin-emu.org/;
     description = "Gamecube/Wii/Triforce emulator for x86_64 and ARM";
     license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ MP2E ];
-    broken = true;
+    # x86_32 is an unsupported platform.
+    # Enable generic build if you really want a JIT-less binary.
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
