### PR TITLE
waf: 1.8.19 -> 1.9.0

### DIFF
--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "waf-${version}";
-  version = "1.8.19";
+  version = "1.9.0";
 
   src = fetchurl {
     url = "https://waf.io/waf-${version}.tar.bz2";
-    sha256 = "e5df90556d1f70aca82bb5c5f46aa68d2377bae16b0db044eaa0559df8668c6f";
+    sha256 = "1sjpqzm2fzm8pxi3fwfinpsbw4z9040qkrzbg3lxik7ppsbjhn58";
   };
 
   buildInputs = [ python2 ];
@@ -21,11 +21,11 @@ stdenv.mkDerivation rec {
     install waf $out
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Meta build system";
     homepage    = "https://waf.io/";
-    license     = lib.licenses.bsd3;
-    platforms   = lib.platforms.all;
-    maintainers = with lib.maintainers; [ ];
+    license     = licenses.bsd3;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ vrthra ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
