### PR TITLE
zap: 2.4.3 -> 2.5.0

### DIFF
--- a/pkgs/tools/networking/zap/default.nix
+++ b/pkgs/tools/networking/zap/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "zap-${version}";
-  version = "2.4.3";
+  version = "2.5.0";
   src = fetchFromGitHub {
     owner = "zaproxy";
     repo = "zaproxy";
     rev ="${version}";
-    sha256 = "1np9jxy09j8wzqcxw3c71x9hwrrbkjlz7qw903kv43wr74mv2snd";
+    sha256 = "12bd0f2zrs7cvcyy2xj31m3szxrr2ifdjyd24z047qm465z3hj33";
   };
 
   buildInputs = [ jdk ant ];
@@ -19,10 +19,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p "$out/share"
-    tar xvf  "ZAP_${version}_Linux.tar.gz" -C "$out/share/"
+    tar xvf  "ZAP_Dev Build_Linux.tar.gz" -C "$out/share/"
     mkdir -p "$out/bin"
     echo "#!/bin/sh" > "$out/bin/zap"
-    echo \"$out/share/ZAP_${version}/zap.sh\" >> "$out/bin/zap"
+    echo \"$out/share/ZAP_Dev\ Build/zap.sh\" >> "$out/bin/zap"
     chmod +x "$out/bin/zap"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

New version. Note that the naming scheme for files was changed upstream, which required changes to the unpack and wrapper script.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
