### PR TITLE
habitat: build from source

### DIFF
--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -1,37 +1,26 @@
-{ stdenv, lib, fetchurl, fetchzip }:
+{ stdenv, lib, fetchFromGitHub, rustPlatform, pkgconfig
+, libsodium, libarchive, openssl }:
 
-let
+with rustPlatform;
 
+buildRustPackage rec {
+  name = "habitat-${version}";
   version = "0.7.0";
 
-  linux = rec {
-    timestamp = "20160614230104";
-    src = fetchurl {
-      url = "https://dl.bintray.com/habitat/stable/linux/x86_64/hab-${version}-${timestamp}-x86_64-linux.tar.gz";
-      sha256 = "1xaclcswvqxwvrxxjv2kabx6v14bp2pwi514gvrvs90sv5ysxh87";
-    };
+  src = fetchFromGitHub {
+    owner = "habitat-sh";
+    repo = "habitat";
+    rev = version;
+    sha256 = "0pacxcc86w4zdakyd6qbz2rqx30rkv1j5aca1fqa1hf1jqg44vg0";
   };
 
-  darwin = rec {
-    timestamp = "20160614231131";
-    src = fetchzip {
-      url = "https://dl.bintray.com/habitat/stable/darwin/x86_64/hab-${version}-${timestamp}-x86_64-darwin.zip";
-      sha256 = "1v158a38qch7ax6yxsdd1n89z6gb6fsaj776v11y4i8p7yhcc3a9";
-    };
-  };
+  sourceRoot = "habitat-${version}-src/components/hab";
 
-in stdenv.mkDerivation rec {
-  inherit version;
+  depsSha256 = "0bm9f6w7ircji4d1c1fgysna93w0lf8ws7gfkqq80zx92x3lz5z5";
 
-  name = "habitat-${version}";
+  buildInputs = [ libsodium libarchive openssl ];
 
-  src = if stdenv.isDarwin then darwin.src else linux.src;
-
-  installPhase =
-    ''
-      mkdir -p $out/bin
-      cp -v hab $out/bin
-    '';
+  nativeBuildInputs = [ pkgconfig ];
 
   meta = with lib; {
     description = "An application automation framework";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
