### PR TITLE
elixir: 1.2.6 -> 1.3.0

### DIFF
--- a/pkgs/development/interpreters/elixir/default.nix
+++ b/pkgs/development/interpreters/elixir/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "elixir-${version}";
-  version = "1.2.6";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "elixir-lang";
     repo = "elixir";
     rev = "v${version}";
-    sha256 = "0zrsy0jy33m7krpwf1vymmiirl068sj4hfjji77wkhn8k88awmfb";
+    sha256 = "06y8v239d5r3zr9s9mw19ws99qm7niicz69pqhawvg5qm4qxhvkr";
   };
 
   buildInputs = [ erlang rebar makeWrapper ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing: `nix-env --option build-use-sandbox true -f . -iA elixir`
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip --against master"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
