### PR TITLE
json-glib: add libintl for darwin

### DIFF
--- a/pkgs/development/libraries/json-glib/default.nix
+++ b/pkgs/development/libraries/json-glib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, pkgconfig, gobjectIntrospection, dbus }:
+{ stdenv, fetchurl, glib, pkgconfig, gobjectIntrospection, dbus, libintlOrEmpty }:
 
 stdenv.mkDerivation rec {
   name = "json-glib-${minVer}.0";
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib gobjectIntrospection ];
   nativeBuildInputs = [ pkgconfig ];
+  buildInputs = libintlOrEmpty;
+
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   meta = with stdenv.lib; {
     homepage = http://live.gnome.org/JsonGlib;


### PR DESCRIPTION
###### Motivation for this change

This fixes json-glib building on Darwin.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
