### PR TITLE
lib: add findFirstIndex

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -131,6 +131,22 @@ rec {
     let found = filter pred list;
     in if found == [] then default else head found;
 
+  /* Find the index of the first element in the list matching the specified
+     predicate or returns null if no such element exists.
+
+     Example:
+       findFirstIndex (x: x > 3) [ 1 6 4 ]
+       => 1
+  */
+  findFirstIndex = pred: list:
+    # Poor man's Either via a list.
+    let searchFun = old: curr:
+          if isList old then old
+            else if pred curr then [old]
+            else old + 1;
+        res = foldl searchFun 0 list;
+    in if isList res then elemAt res 0 else null;
+
   /* Return true iff function `pred' returns true for at least element
      of `list'.
 

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -9,24 +9,8 @@
 }:
 
 let
-  /* Find the index of the first element in the list matching the specified
-     predicate or returns null if no such element exists.
-
-     Example:
-       findFirstIndex (x: x > 3) [ 1 6 4 ]
-       => 1
-  */
-  findFirstIndex = pred: list:
-    # Poor man's Either via a list.
-    let searchFun = old: curr:
-          if lib.isList old then old
-            else if pred curr then [old]
-            else old + 1;
-        res = lib.foldl searchFun 0 list;
-    in if lib.isList res then lib.elemAt res 0 else null;
-
   extractVersion = ver:
-    let suffix = findFirstIndex (x: x == "-") (lib.stringToCharacters ver);
+    let suffix = lib.findFirstIndex (x: x == "-") (lib.stringToCharacters ver);
     in if suffix == null then ver else lib.substring 0 suffix ver;
 
   system-x86_64 = lib.elem stdenv.system lib.platforms.x86_64;


### PR DESCRIPTION
###### Motivation for this change

Can be useful (see tdesktop).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
