### PR TITLE
dvtm: allow user configuration

### DIFF
--- a/pkgs/tools/misc/dvtm/default.nix
+++ b/pkgs/tools/misc/dvtm/default.nix
@@ -1,19 +1,25 @@
-{ stdenv, fetchurl, ncurses }:
+{ stdenv, fetchurl, ncurses, customConfig ? null }:
 
 stdenv.mkDerivation rec {
+
   name = "dvtm-0.15";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Dynamic virtual terminal manager";
     homepage = http://www.brain-dump.org/projects/dvtm;
-    license = stdenv.lib.licenses.mit;
-    platfroms = stdenv.lib.platforms.linux;
+    license = licenses.mit;
+    platfroms = platforms.linux;
+    maintainers = [ maintainers.vrthra ];
   };
 
   src = fetchurl {
     url = "${meta.homepage}/${name}.tar.gz";
     sha256 = "0475w514b7i3gxk6khy8pfj2gx9l7lv2pwacmq92zn1abv01a84g";
   };
+
+  postPatch = stdenv.lib.optionalString (customConfig != null) ''
+    cp ${builtins.toFile "config.h" customConfig} ./config.h
+  '';
 
   buildInputs = [ ncurses ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1370,7 +1370,11 @@ in
 
   dvgrab = callPackage ../tools/video/dvgrab { };
 
-  dvtm = callPackage ../tools/misc/dvtm { };
+  dvtm = callPackage ../tools/misc/dvtm {
+    # if you prefer a custom config, write the config.h in dvtm.config.h
+    # and enable
+    # customConfig = builtins.readFile ./dvtm.config.h;
+  };
 
   e2tools = callPackage ../tools/filesystems/e2tools { };
 


### PR DESCRIPTION
###### Motivation for this change

`dvtm` suggests users to customize their settings by modifing the `config.h` directly. This patch allows nix users to customize their dvtm by supplying a `config.h`
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
