### PR TITLE
qt56.qtwebengine: make it build

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -97,6 +97,7 @@ let
       /* qtwayland = not packaged */
       qtwebchannel = callPackage ./qtwebchannel.nix {};
       qtwebengine = callPackage ./qtwebengine.nix {};
+      qtwebkit = callPackage ./qtwebkit/default.nix {};
       qtwebsockets = callPackage ./qtwebsockets.nix {};
       /* qtwinextras = not packaged */
       qtx11extras = callPackage ./qtx11extras.nix {};

--- a/pkgs/development/libraries/qt-5/5.6/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebengine.nix
@@ -1,6 +1,58 @@
-{ qtSubmodule, qtquickcontrols, qtlocation, qtwebchannel }:
+{ qtSubmodule, qtquickcontrols, qtlocation, qtwebchannel
+
+, xlibs, libXcursor, libXScrnSaver, libXrandr, libXtst
+, fontconfig, freetype, harfbuzz, icu, dbus
+, zlib, libjpeg, libpng, libtiff
+, alsaLib
+, libcap
+, pciutils
+
+, bison, flex, git, which, gperf
+, coreutils
+, pkgconfig, python
+
+}:
 
 qtSubmodule {
   name = "qtwebengine";
   qtInputs = [ qtquickcontrols qtlocation qtwebchannel ];
+  buildInputs = [ bison flex git which gperf ];
+  nativeBuildInputs = [ pkgconfig python coreutils ];
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    export MAKEFLAGS=-j$NIX_BUILD_CORES
+
+    substituteInPlace ./src/3rdparty/chromium/build/common.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/toolchain.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/standalone.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+      
+    configureFlags+="\
+        -plugindir $out/lib/qt5/plugins \
+        -importdir $out/lib/qt5/imports \
+        -qmldir $out/lib/qt5/qml \
+        -docdir $out/share/doc/qt5"
+
+  '';
+  propagatedBuildInputs = [
+    dbus zlib alsaLib
+
+    # Image formats
+    libjpeg libpng libtiff
+
+    # Text rendering
+    fontconfig freetype harfbuzz icu
+
+    # X11 libs
+    xlibs.xrandr libXScrnSaver libXcursor libXrandr xlibs.libpciaccess libXtst
+    xlibs.libXcomposite
+
+    libcap
+    pciutils
+  ];
 }

--- a/pkgs/development/libraries/qt-5/5.6/qtwebkit/0001-dlopen-webkit-nsplugin.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebkit/0001-dlopen-webkit-nsplugin.patch
@@ -1,0 +1,53 @@
+From 862ce7d357a3ec32683ac6ec7c0ebdc9346b44ba Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:18:54 -0500
+Subject: [PATCH 1/3] dlopen webkit nsplugin
+
+---
+ Source/WebCore/plugins/qt/PluginPackageQt.cpp                        | 2 +-
+ Source/WebCore/plugins/qt/PluginViewQt.cpp                           | 2 +-
+ Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Source/WebCore/plugins/qt/PluginPackageQt.cpp b/Source/WebCore/plugins/qt/PluginPackageQt.cpp
+index a923d49..2731d05 100644
+--- a/Source/WebCore/plugins/qt/PluginPackageQt.cpp
++++ b/Source/WebCore/plugins/qt/PluginPackageQt.cpp
+@@ -136,7 +136,7 @@ static void initializeGtk(QLibrary* module = 0)
+         }
+     }
+ 
+-    QLibrary library(QLatin1String("libgtk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gtk@/lib/libgtk-x11-2.0"), 0);
+     if (library.load()) {
+         typedef void *(*gtk_init_check_ptr)(int*, char***);
+         gtk_init_check_ptr gtkInitCheck = (gtk_init_check_ptr)library.resolve("gtk_init_check");
+diff --git a/Source/WebCore/plugins/qt/PluginViewQt.cpp b/Source/WebCore/plugins/qt/PluginViewQt.cpp
+index de06a2f..363bde5 100644
+--- a/Source/WebCore/plugins/qt/PluginViewQt.cpp
++++ b/Source/WebCore/plugins/qt/PluginViewQt.cpp
+@@ -697,7 +697,7 @@ static Display *getPluginDisplay()
+     // support gdk based plugins (like flash) that use a different X connection.
+     // The code below has the same effect as this one:
+     // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
+-    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gdk_pixbuf@/lib/libgdk-x11-2.0"), 0);
+     if (!library.load())
+         return 0;
+ 
+diff --git a/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp b/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
+index d734ff6..62a2197 100644
+--- a/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
++++ b/Source/WebKit2/WebProcess/Plugins/Netscape/x11/NetscapePluginX11.cpp
+@@ -64,7 +64,7 @@ static Display* getPluginDisplay()
+     // The code below has the same effect as this one:
+     // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
+ 
+-    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gdk_pixbuf@/libgdk-x11-2.0"), 0);
+     if (!library.load())
+         return 0;
+ 
+-- 
+2.5.0
+

--- a/pkgs/development/libraries/qt-5/5.6/qtwebkit/0002-dlopen-webkit-gtk.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebkit/0002-dlopen-webkit-gtk.patch
@@ -1,0 +1,25 @@
+From 6a407d30357c2551abceac75c82f4a1688e47437 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:19:16 -0500
+Subject: [PATCH 2/3] dlopen webkit gtk
+
+---
+ Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp b/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp
+index 8de6521..0b25748 100644
+--- a/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp
++++ b/Source/WebKit2/PluginProcess/qt/PluginProcessMainQt.cpp
+@@ -53,7 +53,7 @@ static void messageHandler(QtMsgType type, const QMessageLogContext&, const QStr
+ 
+ static bool initializeGtk()
+ {
+-    QLibrary gtkLibrary(QLatin1String("libgtk-x11-2.0"), 0);
++    QLibrary gtkLibrary(QLatin1String("@gtk@/lib/libgtk-x11-2.0"), 0);
+     if (!gtkLibrary.load())
+         return false;
+     typedef void* (*gtk_init_ptr)(void*, void*);
+-- 
+2.5.0
+

--- a/pkgs/development/libraries/qt-5/5.6/qtwebkit/0003-dlopen-webkit-udev.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebkit/0003-dlopen-webkit-udev.patch
@@ -1,0 +1,31 @@
+From 864020dd47c3b6d532d9f26b82185904cf9324f2 Mon Sep 17 00:00:00 2001
+From: Thomas Tuegel <ttuegel@gmail.com>
+Date: Sun, 23 Aug 2015 09:19:29 -0500
+Subject: [PATCH 3/3] dlopen webkit udev
+
+---
+ Source/WebCore/platform/qt/GamepadsQt.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Source/WebCore/platform/qt/GamepadsQt.cpp b/Source/WebCore/platform/qt/GamepadsQt.cpp
+index 60ff317..da8ac69 100644
+--- a/Source/WebCore/platform/qt/GamepadsQt.cpp
++++ b/Source/WebCore/platform/qt/GamepadsQt.cpp
+@@ -111,12 +111,12 @@ private:
+     bool load()
+     {
+         m_libUdev.setLoadHints(QLibrary::ResolveAllSymbolsHint);
+-        m_libUdev.setFileNameAndVersion(QStringLiteral("udev"), 1);
++        m_libUdev.setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 1);
+         m_loaded = m_libUdev.load();
+         if (resolveMethods())
+             return true;
+ 
+-        m_libUdev.setFileNameAndVersion(QStringLiteral("udev"), 0);
++        m_libUdev.setFileNameAndVersion(QStringLiteral("@libudev@/lib/libudev"), 0);
+         m_loaded = m_libUdev.load();
+         return resolveMethods();
+     }
+-- 
+2.5.0
+

--- a/pkgs/development/libraries/qt-5/5.6/qtwebkit/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebkit/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl
+, qtSubmodule, qtdeclarative, qtlocation, qtmultimedia, qtsensors
+, fontconfig, gdk_pixbuf, gtk, libwebp, libxml2, libxslt
+, sqlite, libudev
+, bison2, flex, gdb, gperf, perl, pkgconfig, python, ruby
+, substituteAll
+, flashplayerFix ? false
+}:
+
+with stdenv.lib;
+
+qtSubmodule {
+  name = "qtwebkit";
+  version = "5.6.1-1";
+  src = fetchurl {
+    url = "http://download.qt.io/community_releases/5.6/5.6.1/.5.6.1-1/qtwebkit-opensource-src-5.6.1.tar.xz";
+    sha256 = "f7f2a6c4b371981e6f11b15c8753a6001a79c05a2a6e6c03bbfaf6e4cf6835e6";
+  };
+  qtInputs = [ qtdeclarative qtlocation qtmultimedia qtsensors ];
+  buildInputs = [ fontconfig libwebp libxml2 libxslt sqlite ];
+  nativeBuildInputs = [
+    bison2 flex gdb gperf perl pkgconfig python ruby
+  ];
+  patches =
+    let dlopen-webkit-nsplugin = substituteAll {
+          src = ./0001-dlopen-webkit-nsplugin.patch;
+          gtk = gtk.out;
+          gdk_pixbuf = gdk_pixbuf.out;
+        };
+        dlopen-webkit-gtk = substituteAll {
+          src = ./0002-dlopen-webkit-gtk.patch;
+          gtk = gtk.out;
+        };
+        dlopen-webkit-udev = substituteAll {
+          src = ./0003-dlopen-webkit-udev.patch;
+          libudev = libudev.out;
+        };
+    in optionals flashplayerFix [ dlopen-webkit-nsplugin dlopen-webkit-gtk ]
+    ++ [ dlopen-webkit-udev ];
+}


### PR DESCRIPTION
###### Motivation for this change

Currently qt5.qtwebengine can be installed, but the package is a dud. The build fails with exit code 0.
This patch provides the necessary packages to make qtwebengine build.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
