### PR TITLE
travis: split build into matrix of 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ matrix:
           osx_image: xcode7.3
           script: ./maintainers/scripts/travis-nox-review-pr.sh pr
 install: ./maintainers/scripts/travis-nox-review-pr.sh install
+git:
+    depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ matrix:
         - os: linux
           sudo: false
           script:
-              - ./maintainers/scripts/travis-nox-review-pr.sh verify
-              - ./maintainers/scripts/travis-nox-review-pr.sh check
-              - ./maintainers/scripts/travis-nox-review-pr.sh tarball
+              - ./maintainers/scripts/travis-nox-review-pr.sh nixpkgs-verify nixpkgs-manual nixpkgs-tarball
+              - ./maintainers/scripts/travis-nox-review-pr.sh nixos-options nixos-manual
         - os: linux
           sudo: required
           dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
+language: nix
 matrix:
     include:
         - os: linux
-          language: generic
-          sudo: required
-          dist: trusty
+          sudo: false
           script:
               - ./maintainers/scripts/travis-nox-review-pr.sh verify
               - ./maintainers/scripts/travis-nox-review-pr.sh check
               - ./maintainers/scripts/travis-nox-review-pr.sh tarball
         - os: linux
-          language: generic
           sudo: required
           dist: trusty
           script: ./maintainers/scripts/travis-nox-review-pr.sh pr
         - os: osx
-          language: generic
           osx_image: xcode7.3
           script: ./maintainers/scripts/travis-nox-review-pr.sh pr
-install: ./maintainers/scripts/travis-nox-review-pr.sh install
 git:
     depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 matrix:
-    allow_failures:
-        - os: osx
     include:
         - os: linux
           language: generic
           sudo: required
           dist: trusty
+          script:
+              - ./maintainers/scripts/travis-nox-review-pr.sh verify
+              - ./maintainers/scripts/travis-nox-review-pr.sh check
+              - ./maintainers/scripts/travis-nox-review-pr.sh tarball
+        - os: linux
+          language: generic
+          sudo: required
+          dist: trusty
+          script: ./maintainers/scripts/travis-nox-review-pr.sh pr
         - os: osx
           language: generic
           osx_image: xcode7.3
-before_install: ./maintainers/scripts/travis-nox-review-pr.sh nix
-install: ./maintainers/scripts/travis-nox-review-pr.sh nox
-script: ./maintainers/scripts/travis-nox-review-pr.sh build
+          script: ./maintainers/scripts/travis-nox-review-pr.sh pr
+install: ./maintainers/scripts/travis-nox-review-pr.sh install

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ matrix:
           script: ./maintainers/scripts/travis-nox-review-pr.sh pr
 git:
     depth: 1
+env:
+    global:
+        - GITHUB_TOKEN=5edaaf1017f691ed34e7f80878f8f5fbd071603f

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -1,37 +1,12 @@
 #! /usr/bin/env bash
 set -e
 
-# This should make Curl silent
-# but download-from-binary-cache doesn't respect
-export NIX_CURL_FLAGS=-sS
-
-if [ -d $HOME/.nix-profile ]; then
-    source $HOME/.nix-profile/etc/profile.d/nix.sh
-fi
-
 while test -n "$1"; do
 
     # tell Travis to use folding
     echo -en "travis_fold:start:$1\r"
 
     case $1 in
-
-        install)
-            echo "=== Installing Nix..."
-
-            curl -sS https://nixos.org/nix/install | sh
-
-            # Make sure we can use hydra's binary cache
-            sudo mkdir /etc/nix
-            echo "build-max-jobs = 4" | sudo tee /etc/nix/nix.conf > /dev/null
-
-            # Make sure we can execute within /tmp in Linux
-            if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-                sudo mount -o remount,exec /run
-                sudo mount -o remount,exec /run/user
-                sudo mount > /dev/null
-            fi
-            ;;
 
         verify)
             echo "=== Verifying that nixpkgs evaluates..."

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -38,6 +38,12 @@ while test -n "$1"; do
             nix-build $TRAVIS_BUILD_DIR/pkgs/top-level/release.nix --attr tarball --show-trace
             ;;
 
+        nixpkgs-lint)
+            echo "=== Checking nixpkgs lint"
+
+            nix-shell --packages nixpkgs-lint --run "nixpkgs-lint -f $TRAVIS_BUILD_DIR"
+            ;;
+
         pr)
             if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
                 echo "=== No pull request found"

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -32,7 +32,12 @@ while test -n "$1"; do
             else
                 echo "=== Building pull request #$TRAVIS_PULL_REQUEST"
 
-                nix-shell --packages nox git --run "nox-review pr $TRAVIS_PULL_REQUEST" -I nixpkgs=$TRAVIS_BUILD_DIR
+                token=""
+                if [ -n "$GITHUB_TOKEN" ]; then
+                    token="--token $GITHUB_TOKEN"
+                fi
+
+                nix-shell --packages nox git --run "nox-review pr --slug $TRAVIS_REPO_SLUG $token $TRAVIS_PULL_REQUEST" -I nixpkgs=$TRAVIS_BUILD_DIR
             fi
             ;;
 

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -1,58 +1,71 @@
 #! /usr/bin/env bash
 set -e
 
+# This should make Curl silent
+# but download-from-binary-cache doesn't respect
 export NIX_CURL_FLAGS=-sS
 
-if [[ $1 == nix ]]; then
-    echo "=== Installing Nix..."
-    # Install Nix
-    bash <(curl -sS https://nixos.org/nix/install)
+if [ -d $HOME/.nix-profile ]; then
     source $HOME/.nix-profile/etc/profile.d/nix.sh
-
-    # Make sure we can use hydra's binary cache
-    sudo mkdir /etc/nix
-    sudo sh -c 'echo "build-max-jobs = 4" > /etc/nix/nix.conf'
-
-    # Verify evaluation
-    echo "=== Verifying that nixpkgs evaluates..."
-    nix-env -f. -qa --json >/dev/null
-elif [[ $1 == nox ]]; then
-    source $HOME/.nix-profile/etc/profile.d/nix.sh
-    echo "=== Installing nox..."
-    nix-build -A nox '<nixpkgs>' --show-trace
-elif [[ $1 == build ]]; then
-    source $HOME/.nix-profile/etc/profile.d/nix.sh
-
-    if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-        echo "Skipping NixOS things on darwin"
-    else
-        # Nix builds in /tmp and we need exec support
-        sudo mount -o remount,exec /run
-        sudo mount -o remount,exec /run/user
-        sudo mount
-
-        echo "=== Checking NixOS options"
-        nix-build nixos/release.nix -A options --show-trace
-
-        echo "=== Checking tarball creation"
-        nix-build pkgs/top-level/release.nix -A tarball --show-trace
-    fi
-
-    if [[ $TRAVIS_PULL_REQUEST == false ]]; then
-        echo "=== Not a pull request"
-    else
-        echo "=== Checking PR"
-
-        if ! nix-shell -p nox --run "nox-review pr ${TRAVIS_PULL_REQUEST}"; then
-            if sudo dmesg | egrep 'Out of memory|Killed process' > /tmp/oom-log; then
-                echo "=== The build failed due to running out of memory:"
-                cat /tmp/oom-log
-                echo "=== Please disregard the result of this Travis build."
-            fi
-            exit 1
-        fi
-    fi
-else
-    echo "$0: Unknown option $1" >&2
-    false
 fi
+
+while test -n "$1"; do
+
+    # tell Travis to use folding
+    echo -en "travis_fold:start:$1\r"
+
+    case $1 in
+
+        install)
+            echo "=== Installing Nix..."
+
+            curl -sS https://nixos.org/nix/install | sh
+
+            # Make sure we can use hydra's binary cache
+            sudo mkdir /etc/nix
+            echo "build-max-jobs = 4" | sudo tee /etc/nix/nix.conf > /dev/null
+
+            # Make sure we can execute within /tmp in Linux
+            if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+                sudo mount -o remount,exec /run
+                sudo mount -o remount,exec /run/user
+                sudo mount > /dev/null
+            fi
+            ;;
+
+        verify)
+            echo "=== Verifying that nixpkgs evaluates..."
+
+            nix-env --file $TRAVIS_BUILD_DIR --query --available --json > /dev/null
+            ;;
+
+        check)
+            echo "=== Checking NixOS options"
+
+            nix-build $TRAVIS_BUILD_DIR/nixos/release.nix --attr options --show-trace
+            ;;
+
+	tarball)
+            echo "=== Checking tarball creation"
+
+            nix-build $TRAVIS_BUILD_DIR/pkgs/top-level/release.nix --attr tarball --show-trace
+            ;;
+
+        pr)
+            if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+                echo "=== No pull request found"
+            else
+                echo "=== Building pull request #$TRAVIS_PULL_REQUEST"
+
+                nix-shell --packages nox git --run "nox-review pr $TRAVIS_PULL_REQUEST" -I nixpkgs=$TRAVIS_BUILD_DIR
+            fi
+            ;;
+
+        *)
+            echo "Skipping unknown option $1"
+            ;;
+    esac
+
+    echo -en "travis_fold:end:$1\r"
+    shift
+done

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -8,20 +8,32 @@ while test -n "$1"; do
 
     case $1 in
 
-        verify)
+        nixpkgs-verify)
             echo "=== Verifying that nixpkgs evaluates..."
 
             nix-env --file $TRAVIS_BUILD_DIR --query --available --json > /dev/null
             ;;
 
-        check)
+        nixos-options)
             echo "=== Checking NixOS options"
 
             nix-build $TRAVIS_BUILD_DIR/nixos/release.nix --attr options --show-trace
             ;;
 
-	tarball)
-            echo "=== Checking tarball creation"
+        nixos-manual)
+            echo "=== Checking NixOS manuals"
+
+            nix-build $TRAVIS_BUILD_DIR/nixos/release.nix --attr manual --show-trace
+            ;;
+
+        nixpkgs-manual)
+            echo "=== Checking nixpkgs manuals"
+
+            nix-build $TRAVIS_BUILD_DIR/pkgs/top-level/release.nix --attr manpages --show-trace
+            ;;
+
+        nixpkgs-tarball)
+            echo "=== Checking nixpkgs tarball creation"
 
             nix-build $TRAVIS_BUILD_DIR/pkgs/top-level/release.nix --attr tarball --show-trace
             ;;


### PR DESCRIPTION
###### Motivation for this change

Once "language: nix" is available, this can be used for builds on Travis CI.
###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This adds a 3rd matrix to be built by Travis. The new matrix "checks"
the NixPkgs evaluation so the other 2 can save their resources for
building. Hopefully, this will lead to less "out of space" errors that
seem to be happening with Travis.
