### PR TITLE
youtube-dl: 2016.06.19.1 -> 2016.06.27

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -12,11 +12,11 @@
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.06.19.1";
+  version = "2016.06.27";
 
   src = fetchurl {
-    url = "http://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "223c496be84dd57ba9f7d6a132a2732b67c79c7e26e64ecae1439472c10d0d45";
+    url = "https://yt-dl.org/downloads/${version}/${name}.tar.gz";
+    sha256 = "1kwv20kmb0xnlpkbnsc27abw9cv0gkzbzwzzp4qw5mg3naqkmjvc";
   };
 
   buildInputs = [ makeWrapper zip pandoc ];


### PR DESCRIPTION
###### Motivation for this change

Update youtube-dl to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
