### PR TITLE
vips: 8.2.2 -> 8.3.1 and dependency nip2: 8.0 -> 8.3.0

### DIFF
--- a/pkgs/tools/graphics/nip2/default.nix
+++ b/pkgs/tools/graphics/nip2/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchurl, pkgconfig, glib, libxml2, flex, bison, vips, gnome,
-fftw, gsl, goffice_0_8, libgsf }:
+fftw, gsl, goffice, libgsf }:
 
 stdenv.mkDerivation rec {
-  name = "nip2-8.0";
+  name = "nip2-8.3.0";
 
   src = fetchurl {
     url = "http://www.vips.ecs.soton.ac.uk/supported/current/${name}.tar.gz";
-    sha256 = "10ybac0qrz63x1yk1d0gpv9z1vzpadyii2qhrai6lllplzw6jqx7";
+    sha256 = "0vr12gyfvhxx2a28y74lzfg379d1fk0g9isc69k0vdgpn4y1i8aa";
   };
 
   buildInputs =
   [ pkgconfig glib libxml2 flex bison vips
-    gnome.gtk fftw gsl goffice_0_8 libgsf
+    gnome.gtk fftw gsl goffice libgsf
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -4,11 +4,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "vips-8.2.2";
+  name = "vips-8.3.1";
 
   src = fetchurl {
     url = "http://www.vips.ecs.soton.ac.uk/supported/current/${name}.tar.gz";
-    sha256 = "12b319aicr129cpi5sixwd3q91y97vwwva6b044zy54px4s8ls0g";
+    sha256 = "01hh1baar2r474kny24fcq6ddshcvq104207mqxnkis0as6pzjq9";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change
- update to latest release
- move away from goffice_0_8
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
