### PR TITLE
prometheus: Bump all to newest

### DIFF
--- a/pkgs/servers/monitoring/prometheus/alertmanager.nix
+++ b/pkgs/servers/monitoring/prometheus/alertmanager.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "alertmanager-${version}";
-  version = "0.1.0";
+  version = "0.2.1";
   rev = "${version}";
 
   goPackagePath = "github.com/prometheus/alertmanager";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "alertmanager";
-    sha256 = "1ya465bns6cj2lqbipmfm13wz8kxii5h9mm7lc0ba1xv26xx5zs7";
+    sha256 = "11gas19k4m483rvnfhzmcbkzzs7cfrn9cw7n7aa0g9yxdk91a1cx";
   };
 
   # Tests exist, but seem to clash with the firewall.

--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "prometheus-${version}";
-  version = "0.17.0";
+  version = "0.20.0";
   rev = "${version}";
 
   goPackagePath = "github.com/prometheus/prometheus";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "prometheus";
-    sha256 = "176198krna2i37dfhwsqi7m36sqn175yiny6n52vj27mc9s8ggzx";
+    sha256 = "1w3249kvh0ps8hlxw93q4bmn2g76hvl0ynlra2pzkw2drk34xd06";
   };
 
   docheck = true;

--- a/pkgs/servers/monitoring/prometheus/haproxy-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/haproxy-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "haproxy_exporter-${version}";
-  version = "0.4.0";
+  version = "0.7.0";
   rev = version;
 
   goPackagePath = "github.com/prometheus/haproxy_exporter";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "haproxy_exporter";
-    sha256 = "0cwls1d4hmzjkwc50mjkxjb4sa4q6yq581wlc5sg9mdvl6g91zxr";
+    sha256 = "1jkijdawmnj5yps0yaj47nyfmcah0krwmqsjvicm3sl0dhwmac4w";
   };
 
   goDeps = ./haproxy-exporter_deps.json;

--- a/pkgs/servers/monitoring/prometheus/mysqld-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mysqld-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "mysqld_exporter-${version}";
-  version = "0.1.0";
+  version = "0.8.1";
   rev = version;
 
   goPackagePath = "github.com/prometheus/mysqld_exporter";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "mysqld_exporter";
-    sha256 = "10xnyxyb6saz8pq3ijp424hxy59cvm1b5c9zcbw7ddzzkh1f6jd9";
+    sha256 = "0pwf2vii9n9zgad1lxgw28c2743yc9c3qc03516fiwvlqc1cpddr";
   };
 
   goDeps = ./mysqld-exporter_deps.json;

--- a/pkgs/servers/monitoring/prometheus/node-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/node-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "node_exporter-${version}";
-  version = "0.11.0";
+  version = "0.12.0";
   rev = version;
   
   goPackagePath = "github.com/prometheus/node_exporter";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "node_exporter";
-    sha256 = "149fs9yxnbiyd4ww7bxsv730mcskblpzb3cs4v12jnq2v84a4kk4";
+    sha256 = "0ih8w9ji0fw1smsi45jgvrpqfzm3f5bvk9q3nwrl0my5xkksnr8g";
   };
 
   goDeps = ./node-exporter_deps.json;

--- a/pkgs/servers/monitoring/prometheus/pushgateway.nix
+++ b/pkgs/servers/monitoring/prometheus/pushgateway.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "pushgateway-${version}";
-  version = "0.1.1";
+  version = "0.3.0";
   rev = version;
   
   goPackagePath = "github.com/prometheus/pushgateway";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "pushgateway";
-    sha256 = "17q5z9msip46wh3vxcsq9lvvhbxg75akjjcr2b29zrky8bp2m230";
+    sha256 = "1bj0s4s3gbcnlp2z2yx7jf3jx14cdg2v4pr0yciai0g6jwwg63hd";
   };
 
   goDeps = ./pushgateway_deps.json;

--- a/pkgs/servers/monitoring/prometheus/statsd-bridge.nix
+++ b/pkgs/servers/monitoring/prometheus/statsd-bridge.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "statsd_bridge-${version}";
-  version = "0.1.0";
+  version = "0.3.0";
   rev = version;
   
   goPackagePath = "github.com/prometheus/statsd_bridge";
@@ -10,8 +10,8 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     inherit rev;
     owner = "prometheus";
-    repo = "statsd_bridge";
-    sha256 = "1fndpmd1k0a3ar6f7zpisijzc60f2dng5399nld1i1cbmd8jybjr";
+    repo = "statsd_exporter";
+    sha256 = "1gg9v224n05khcwy27637w3rwh0cymm7hx6bginfxd7730rmpp2r";
   };
 
   goDeps = ./statsd-bridge_deps.json;


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Do you want me to split these into individual commits? FWIW, the various Prometheus repositories are co-developed and interdependent, so bumping just one would make little sense.

Note that the statsd_bridge repository has changed name.

I have tested execution of Prometheus, node_exporter and alertmanager. I don't have a functional setup for the others.
