### PR TITLE
amarok: set MY_BASEDIR_VERSION to avoid DEFAULT_MYSQL_HOME /not/a/rea…

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -2,7 +2,7 @@
 , qtscriptgenerator, gettext, curl , libxml2, mysql, taglib
 , taglib_extras, loudmouth , kdelibs , qca2, libmtp, liblastfm, libgpod
 , phonon , strigi, soprano, qjson, ffmpeg, libofa, nepomuk_core ? null
-, lz4, lzo, snappy, libaio, pcre
+, lz4, lzo, snappy, libaio, pcre, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     qtscriptgenerator stdenv.cc.libc gettext curl libxml2 mysql.lib
     taglib taglib_extras loudmouth kdelibs phonon strigi soprano qca2
     libmtp liblastfm libgpod qjson ffmpeg libofa nepomuk_core
-    lz4 lzo snappy libaio pcre
+    lz4 lzo snappy libaio pcre makeWrapper
   ];
 
   # This is already fixed upstream, will be release in 2.9
@@ -33,6 +33,13 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = "-DKDE4_BUILD_TESTS=OFF";
+
+  #this avoids the error
+  #MySQLe query failed! (2000) Can't find messagefile '/not/a/real/dir/share/mysql/errmsg.sys' on init
+  #due to mariadb/default.nix setting DEFAULT_MYSQL_HOME
+  postInstall = ''
+    wrapProgram $out/bin/amarok --set MY_BASEDIR_VERSION ${mysql.out}
+  '';
 
   propagatedUserEnvPkgs = [ qtscriptgenerator ];
 


### PR DESCRIPTION
###### Motivation for this change

This fixes #15264.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
