### PR TITLE
nixpkgs doc: add and clean some paragraphs

### DIFF
--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -10,7 +10,7 @@
   </info>
 
   <xi:include href="introduction.xml" />
-  <xi:include href="quick-start.xml" />
+  <xi:include href="packaging-guide.xml" />
   <xi:include href="stdenv.xml" />
   <xi:include href="multiple-output.xml" />
   <xi:include href="configuration.xml" />

--- a/doc/packaging-guide.xml
+++ b/doc/packaging-guide.xml
@@ -1,24 +1,61 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
          xmlns:xlink="http://www.w3.org/1999/xlink"
-         xml:id="chap-quick-start">
+         xml:id="chap-packaging-guide">
 
-<title>Quick Start to Adding a Package</title>
+  <title>Packaging Guide</title>
 
-<para>To add a package to Nixpkgs:
+  <section xml:id="sec-policies">
 
-<orderedlist>
+    <title>Policies</title>
 
-  <listitem>
+    <para>The forum for policy discussion can be found at the <link
+    xlink:href="https://github.com/NixOS/nixpkgs/labels/6.topic%3A%20policy%20discussion">
+    issue tracker, topics are labeled with 'policy
+    discussion'</link>. This section brewed from maintainer
+    opinions. Regard the following paragraphs as drafts.</para>
+
+    <para>Non free packages are allowed but will not be built by
+    Hydra, and not be available in the binary cache. We want all software
+    to build from source. Packaging binaries is allowed. This is
+    considered when the build process is complex or it is not possible to
+    make a package available without including binaries. Patching binaries
+    to use dependencies in nixpkgs is recommended. Downloading from
+    reliable and public sources is recommended. Windows packages are not
+    allowed, exceptions should be discussed.</para>
+
+    <para>Unstable versions of packages are allowed, these are not
+    built by Hydra unless there is a high demand and available
+resources. Older versions are allowed if packages depending on it can
+not be built with a newer version.  </para>
+
+  </section>
+
+  <section xml:id="sec-guide">
+
+    <title>Guide</title>
+
+    <para>Check if the software you want already have been
+    packaged. Keep in the package your are looking for can have a
+    different name. <link
+    xlink:href="https://github.com/ggreer/the_silver_searcher">the_silver_searcher</link>
+    is named silver-searcher in nixpkgs. Your perception may say it
+    is named <emphasis>ag</emphasis> because that is the name of the
+    binary. This may be circumvented with aliases, as in this case we
+    have ag aliased as silver-searcher in nixpkgs. One way to see if
+    certain software have been packaged is to use the<link
+    xlink:href="https://github.com/NixOS/nixpkgs">search
+    function</link> at github.
+    </para>
+
     <para>Checkout the Nixpkgs source tree:
 
-<screen>
-$ git clone git://github.com/NixOS/nixpkgs.git 
-$ cd nixpkgs</screen>
+    <screen>$ git clone git://github.com/NixOS/nixpkgs.git
+$ git remote add channel git://github.com/NixOS/nixpkgs-channels.git</screen>
 
+    The channel remote provides a way to checkout the last successful build
+    from any Hydra channel.
     </para>
-  </listitem>
 
-  <listitem>
     <para>Find a good place in the Nixpkgs tree to add the Nix
     expression for your package.  For instance, a library package
     typically goes into
@@ -26,31 +63,17 @@ $ cd nixpkgs</screen>
     while a web browser goes into
     <filename>pkgs/applications/networking/browsers/<replaceable>pkgname</replaceable></filename>.
     See <xref linkend="sec-organisation" /> for some hints on the tree
-    organisation.  Create a directory for your package, e.g.
-
-<screen>
-$ mkdir pkgs/development/libraries/libfoo</screen>
-  
+    organisation.
     </para>
-  </listitem>
 
-  <listitem>
     <para>In the package directory, create a Nix expression — a piece
     of code that describes how to build the package.  In this case, it
     should be a <emphasis>function</emphasis> that is called with the
     package dependencies as arguments, and returns a build of the
     package in the Nix store.  The expression should usually be called
-    <filename>default.nix</filename>.
-
-<screen>
-$ emacs pkgs/development/libraries/libfoo/default.nix
-$ git add pkgs/development/libraries/libfoo/default.nix</screen>
-
-    </para>
-
-    <para>You can have a look at the existing Nix expressions under
-    <filename>pkgs/</filename> to see how it’s done.  Here are some
-    good ones:
+    <filename>default.nix</filename>. You can have a look at the existing
+    Nix expressions under <filename>pkgs/</filename> to see these are
+    written.  Here are some good ones:
 
       <itemizedlist>
 
@@ -129,95 +152,67 @@ $ git add pkgs/development/libraries/libfoo/default.nix</screen>
 
       </itemizedlist>
 
-    </para>
 
-    <para>Some notes:
+      </para>
 
-      <itemizedlist>
+  <para>The exact syntax and semantics of the Nix expression language,
+  including the built-in function, are described in the Nix manual in
+  the <link
+  xlink:href="http://hydra.nixos.org/job/nix/trunk/tarball/latest/download-by-type/doc/manual/#chap-writing-nix-expressions">chapter
+  on writing Nix expressions</link>.</para>
 
-        <listitem>
-          <para>All <varname linkend="chap-meta">meta</varname>
-          attributes are optional, but it’s still a good idea to
-          provide at least the <varname>description</varname>,
-          <varname>homepage</varname> and <varname
-          linkend="sec-meta-license">license</varname>.</para>
-        </listitem>
+  <para>Add a call to the function defined in the previous
+  step to <link
+  xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/all-packages.nix"><filename>pkgs/top-level/all-packages.nix</filename></link>
+  with some descriptive name for the variable,
+  e.g. <varname>libfoo</varname>.
 
-        <listitem>
-          <para>You can use <command>nix-prefetch-url</command> (or similar nix-prefetch-git, etc)
-          <replaceable>url</replaceable> to get the SHA-256 hash of
-          source distributions. There are similar commands as <command>nix-prefetch-git</command> and
-          <command>nix-prefetch-hg</command> available in <literal>nix-prefetch-scripts</literal> package.</para>
-        </listitem>
+  <screen> $ emacs pkgs/top-level/all-packages.nix</screen>
+  </para>
 
-        <listitem>
-          <para>A list of schemes for <literal>mirror://</literal>
-          URLs can be found in <link
-          xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchurl/mirrors.nix"><filename>pkgs/build-support/fetchurl/mirrors.nix</filename></link>.</para>
-        </listitem>
+<para>The attributes in that file are sorted by category (like
+“Development / Libraries”) that more-or-less correspond to the
+directory structure of Nixpkgs, and then by attribute name.</para>
 
-      </itemizedlist>
+  <para>To test whether the package builds, run the
+  following command from the root of the nixpkgs source tree:
+  <screen> $ nix-build -A libfoo</screen>
+  where <varname>libfoo</varname> should be the variable name defined
+  in the previous step.  You may want to add the flag
+  <option>-K</option> to keep the temporary build directory in case
+  something fails.  If the build succeeds, a symlink
+  <filename>./result</filename> to the package in the Nix store is
+  created.</para>
 
-    </para>
+  <para>If you want to install the package into your
+  profile (optional), do <screen> $ nix-env -f . -iA libfoo</screen>
+  </para>
 
-    <para>The exact syntax and semantics of the Nix expression
-    language, including the built-in function, are described in the
-    Nix manual in the <link
-    xlink:href="http://hydra.nixos.org/job/nix/trunk/tarball/latest/download-by-type/doc/manual/#chap-writing-nix-expressions">chapter
-    on writing Nix expressions</link>.</para>
-    
-  </listitem>
+  <para>Instructions for preparing and submitting patches are
+  described <link xlink:href="#chap-submitting-changes">here</link>.
+  </para>
 
-  <listitem>
-    <para>Add a call to the function defined in the previous step to
-    <link
-    xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/all-packages.nix"><filename>pkgs/top-level/all-packages.nix</filename></link>
-    with some descriptive name for the variable,
-    e.g. <varname>libfoo</varname>.
+  <section xml:id="sec-guide-notes">
 
-    <screen>
-$ emacs pkgs/top-level/all-packages.nix</screen>
-      
-    </para>
+  <title>Notes</title>
 
-    <para>The attributes in that file are sorted by category (like
-    “Development / Libraries”) that more-or-less correspond to the
-    directory structure of Nixpkgs, and then by attribute name.</para>
-  </listitem>
+  <para>All <varname linkend="chap-meta">meta</varname>
+  attributes are optional, but it’s still a good idea to provide at
+  least the <varname>description</varname>, <varname>homepage</varname>
+  and <varname linkend="sec-meta-license">license</varname>.</para>
 
-  <listitem>
-    <para>To test whether the package builds, run the following command
-    from the root of the nixpkgs source tree:
+  <para>You can use <command>nix-prefetch-url</command>
+  (or similar nix-prefetch-git, etc) <replaceable>url</replaceable> to
+  get the SHA-256 hash of source distributions. There are similar
+  commands as <command>nix-prefetch-git</command> and
+  <command>nix-prefetch-hg</command> available in
+  <literal>nix-prefetch-scripts</literal> package.</para>
 
-    <screen>
-$ nix-build -A libfoo</screen>
+  <para>A list of schemes for
+  <literal>mirror://</literal> URLs can be found in <link
+  xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchurl/mirrors.nix"><filename>pkgs/build-support/fetchurl/mirrors.nix</filename></link>.</para>
 
-    where <varname>libfoo</varname> should be the variable name
-    defined in the previous step.  You may want to add the flag
-    <option>-K</option> to keep the temporary build directory in case
-    something fails.  If the build succeeds, a symlink
-    <filename>./result</filename> to the package in the Nix store is
-    created.</para>
-  </listitem>
-
-  <listitem>
-    <para>If you want to install the package into your profile
-    (optional), do
-
-    <screen>
-$ nix-env -f . -iA libfoo</screen>
-
-    </para>
-  </listitem>
-
-  <listitem>
-    <para>Optionally commit the new package and open a pull request, or send a patch to
-    <literal>nix-dev@cs.uu.nl</literal>.</para>
-  </listitem>
-
-
-</orderedlist>
-
-</para>
+  </section>
+</section>
 
 </chapter>

--- a/doc/submitting-changes.xml
+++ b/doc/submitting-changes.xml
@@ -2,331 +2,164 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          xml:id="chap-submitting-changes">
 
-<title>Submitting changes</title>
+  <title>Submitting changes</title>
 
-<section>
-<title>Making patches</title>
+  <section>
+    <title>Making patches</title>
 
-<itemizedlist>
-<listitem>
-<para>Read <link xlink:href="https://nixos.org/nixpkgs/manual/">Manual (How to write packages for Nix)</link>.</para>
-</listitem>
+    <itemizedlist>
+      <listitem>
+	<para>Read the <link xlink:href="#chap-packaging-guide">Packaging Guide</link>.</para>
+      </listitem>
 
-<listitem>
-<para>Fork the repository on GitHub.</para>
-</listitem>
+      <listitem>
+	<para>Create a branch for your future fix.
 
-<listitem>
-<para>Create a branch for your future fix.
+	<itemizedlist>
+	  <listitem>
+	    <para>You can make branch from a commit of your local
+	    <command>nixos-version</command>. This will help you to avoid
+	    additional local compilations. Because you will receive packages from
+	    binary cache.
 
-<itemizedlist>
-<listitem>
-<para>You can make branch from a commit of your local <command>nixos-version</command>. That will help you to avoid additional local compilations. Because you will receive packages from binary cache.
+	    For example: <command>nixos-version</command> returns
+	    <command>15.05.git.0998212 (Dingo)</command>. So you can do:
 
-<itemizedlist>
-<listitem>
-<para>For example: <command>nixos-version</command> returns <command>15.05.git.0998212 (Dingo)</command>. So you can do:</para>
-</listitem>
-</itemizedlist>
+	    <screen>$ git checkout 0998212
+$ git checkout -b 'fix/pkg-name-update'</screen>
+	    </para>
+	  </listitem>
 
-<screen>
-$ git checkout 0998212
-$ git checkout -b 'fix/pkg-name-update'
-</screen>
-</para>
-</listitem>
 
-<listitem>
-<para>Please avoid working directly on the <command>master</command> branch.</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
+	</itemizedlist>
+	</para>
+      </listitem>
 
-<listitem>
-<para>Make commits of logical units.
+      <listitem>
+	<para>Make commits of logical units. If you removed pkgs, made
+	some major NixOS changes etc., write about them in
+	<command>nixos/doc/manual/release-notes/rl-unstable.xml</command>. Write
+	a motivation in the commit message if possible. Simple commits such as
+	updates and initial commits do not need this.  Check for unnecessary
+	whitespace changes with <command>git diff --check</command> before
+	committing.  Squash irrelevant commits such as <command>pkg-name: oh,
+	forgot to insert whitespace</command>. Use <command>git rebase
+	-i</command>.  GitHub will tell you if a pull-request can not be
+	merged automatically. In this case rebase you branch against current
+	<command>master</command>.</para>
+      </listitem>
 
-<itemizedlist>
-<listitem>
-<para>If you removed pkgs, made some major NixOS changes etc., write about them in <command>nixos/doc/manual/release-notes/rl-unstable.xml</command>.</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-
-<listitem>
-<para>Check for unnecessary whitespace with <command>git diff --check</command> before committing.</para>
-</listitem>
-
-<listitem>
-<para>Format the commit in a following way:</para>
-<programlisting>
+      <listitem>
+	<para>Format the commit title in a way that follows:</para>
+	<screen>
 (pkg-name | service-name): (from -> to | init at version | refactor | etc)
-Additional information.
-</programlisting>
+Additional information.</screen>
 
-<itemizedlist>
-<listitem>
-<para>Examples:
+	<para>Examples:
 
-<itemizedlist>
-<listitem>
-<para>
-<command>nginx: init at 2.0.1</command>
-</para>
-</listitem>
+	<itemizedlist>
+	  <listitem>
+	    <para>
+	      <command>nginx: init at 2.0.1</command>
+	    </para>
+	  </listitem>
 
-<listitem>
-<para>
-<command>firefox: 3.0 -> 3.1.1</command>
-</para>
-</listitem>
+	  <listitem>
+	    <para>
+	      <command>firefox: 3.0 -> 3.1.1</command>
+	    </para>
+	  </listitem>
 
-<listitem>
-<para>
-<command>hydra service: add bazBaz option</command>
-</para>
-</listitem>
+	  <listitem>
+	    <para>
+	      <command>hydra service: add bazBaz option</command>
+	    </para>
+	  </listitem>
 
-<listitem>
-<para>
-<command>nginx service: refactor config generation</command>
-</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-</itemizedlist>
-</listitem>
+	  <listitem>
+	    <para>
+	      <command>nginx service: refactor config generation</command>
+	    </para>
+	  </listitem>
+	</itemizedlist>
+	</para>
 
-<listitem>
-<para>Test your changes. If you work with
-
-<itemizedlist>
-<listitem>
-<para>nixpkgs:
-
-<itemizedlist>
-<listitem>
-<para>update pkg ->
-
-<itemizedlist>
-<listitem>
-<para>
-<command>nix-env -i pkg-name -f &lt;path to your local nixpkgs folder&gt;</command>
-</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-
-<listitem>
-<para>add pkg ->
-
-<itemizedlist>
-<listitem>
-<para>Make sure it's in <command>pkgs/top-level/all-packages.nix</command>
-</para>
-</listitem>
-
-<listitem>
-<para>
-<command>nix-env -i pkg-name -f &lt;path to your local nixpkgs folder&gt;</command>
-</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-
-<listitem>
-<para>
-<emphasis>If you don't want to install pkg in you profile</emphasis>.
-
-<itemizedlist>
-<listitem>
-<para>
-<command>nix-build -A pkg-attribute-name &lt;path to your local nixpkgs folder&gt;/default.nix</command> and check results in the folder <command>result</command>. It will appear in the same directory where you did <command>nix-build</command>.</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-
-<listitem>
-<para>If you did <command>nix-env -i pkg-name</command> you can do <command>nix-env -e pkg-name</command> to uninstall it from your system.</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-
-<listitem>
-<para>NixOS and its modules:
-
-<itemizedlist>
-<listitem>
-<para>You can add new module to your NixOS configuration file (usually it's <command>/etc/nixos/configuration.nix</command>).
-            And do <command>sudo nixos-rebuild test -I nixpkgs=&lt;path to your local nixpkgs folder&gt; --fast</command>.</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-
-<listitem>
-<para>If you have commits <command>pkg-name: oh, forgot to insert whitespace</command>: squash commits in this case. Use <command>git rebase -i</command>.</para>
-</listitem>
-
-<listitem>
-<para>Rebase you branch against current <command>master</command>.</para>
-</listitem>
-</itemizedlist>
-</section>
-
-<section>
-<title>Submitting changes</title>
-
-<itemizedlist>
-<listitem>
-<para>Push your changes to your fork of nixpkgs.</para>
-</listitem>
-
-<listitem>
-<para>Create pull request:
-
-<itemizedlist>
-<listitem>
-<para>Write the title in format <command>(pkg-name | service): improvement</command>.
-
-<itemizedlist>
-<listitem>
-<para>If you update the pkg, write versions <command>from -> to</command>.</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-
-<listitem>
-<para>Write in comment if you have tested your patch. Do not rely much on <command>TravisCI</command>.</para>
-</listitem>
-
-<listitem>
-<para>If you make an improvement, write about your motivation.</para>
-</listitem>
-
-<listitem>
-<para>Notify maintainers of the package. For example add to the message: <command>cc @jagajaga @domenkozar</command>.</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-</itemizedlist>
-</section>
-
-<section>
-<title>Hotfixing pull requests</title>
-
-<itemizedlist>
-<listitem>
-<para>Make the appropriate changes in you branch.</para>
-</listitem>
-
-<listitem>
-<para>Don't create additional commits, do
-
-<itemizedlist>
-<listitem>
-<para><command>git rebase -i</command></para>
-</listitem>
-<listitem>
-<para>
-<command>git push --force</command> to your branch.</para>
-</listitem>
-</itemizedlist>
-</para>
-</listitem>
-
-</itemizedlist>
-</section>
-
-<section>
-<title>Commit policy</title>
-
-<itemizedlist>
-<listitem>
-<para>Commits must be sufficiently tested before being merged, both for the master and staging branches.</para>
-</listitem>
-
-<listitem>
-<para>Hydra builds for master and staging should not be used as testing platform, it's a build farm for changes that have been already tested.</para>
-</listitem>
-
-<listitem>
-<para>When changing the bootloader installation process, extra care must be taken. Grub installations cannot be rolled back, hence changes may break people's installations forever. For any non-trivial change to the bootloader please file a PR asking for review, especially from @edolstra.</para>
-</listitem>
-</itemizedlist>
-
-<section>
-  <title>Master branch</title>
-
-  <itemizedlist>
-    <listitem>
-      <para>
-        It should only see non-breaking commits that do not cause mass rebuilds.
-      </para>
-    </listitem>
-  </itemizedlist>
-</section>
-
-<section>
-  <title>Staging branch</title>
-
-  <itemizedlist>
-    <listitem>
-      <para>
-        It's only for non-breaking mass-rebuild commits. That means it's not to
-        be used for testing, and changes must have been well tested already.
-        <link xlink:href="http://comments.gmane.org/gmane.linux.distributions.nixos/13447">Read policy here</link>.
-      </para>
-    </listitem>
-    <listitem>
-      <para>
-        If the branch is already in a broken state, please refrain from adding
-        extra new breakages. Stabilize it for a few days, merge into master,
-        then resume development on staging.
-        <link xlink:href="http://hydra.nixos.org/jobset/nixpkgs/staging#tabs-evaluations">Keep an eye on the staging evaluations here</link>.
-        If any fixes for staging happen to be already in master, then master can
-        be merged into staging.
-      </para>
-    </listitem>
-  </itemizedlist>
-</section>
-
-<section>
-  <title>Stable release branches</title>
-
-  <itemizedlist>
-    <listitem>
-      <para>
-        If you're cherry-picking a commit to a stable release branch, always use
-        <command>git cherry-pick -xe</command> and ensure the message contains a
-        clear description about why this needs to be included in the stable
-        branch.
-      </para>
-      <para>An example of a cherry-picked commit would look like this:</para>
-      <screen>
+	<para>
+	  If you're cherry-picking a commit to a stable release branch, always use
+	  <command>git cherry-pick -xe</command> and ensure the message contains a
+	  clear description about why this needs to be included in the stable
+	  branch. An example of a cherry-picked commit would look like
+	  this:
+	  <screen>
 nixos: Refactor the world.
 
 The original commit message describing the reason why the world was torn apart.
 
 (cherry picked from commit abcdef)
 Reason: I just had a gut feeling that this would also be wanted by people from
-the stone age.
-      </screen>
-    </listitem>
-  </itemizedlist>
-</section>
+	  the stone age.</screen>
+	</para>
 
-</section>
+      </listitem>
+
+      <listitem>
+	<para>Test your changes. The <link xlink:href="#chap-packaging-guide">Packaging Guide</link> describes how to build your package,
+	make sure your package builds and runs.
+	</para>
+
+	<para>If your change is related to a NixOS module you can run
+	relevant tests at <filename>nixos/tests/</filename>. Tests are
+	desirable if you are writing a new module. If you do not have
+	tests, add the relevant module and settings to your
+	configuration file (usually it's
+	<filename>/etc/nixos/configuration.nix</filename>). And do <command>sudo nixos-rebuild test -I nixpkgs=&lt;path to your local nixpkgs folder&gt; --fast</command>.
+	</para>
+
+	<para>Pull requests are automatically tested by TravisCI. Do
+	not rely on this, there are lot of false positives.
+	</para>
+      </listitem>
+
+    </itemizedlist>
+  </section>
+
+  <section>
+    <title>Submitting changes</title>
+
+    <para>Push your changes to your fork of nixpkgs and create a
+    pull request. The title should be formatted the same way
+    commits are. Some maintainers will automatically be notified
+    by a bot. Notify additional maintainers by mentions, for example:
+    <command>cc @jagajaga @domenkozar</command>.</para>
+
+    <para>Do not close and open a new pull request if you have to
+    make changes to commits. Instead, rework your branch by rebasing or
+    amending and finally force pushing your branch.
+    </para>
+
+    <para>Commits must be sufficiently tested before being merged,
+    both for the master and staging branches. If your patch cause a huge
+    rebuild, consider basing your patch onto the branch named
+    staging. Patches that break other builds can also be considered to be
+    staged. The main rule for staging is that it should always be
+    mergeable into master. So it should not be used for testing/developing
+    potentially destabilizing features (e.g. updating GCC to 4.9, or a new
+    X.org release). These should instead go into their own feature
+    branches, which can be merged into staging when they are deemed
+    sufficiently stable.  If the branch is already in a broken state,
+    please refrain from adding extra new breakages. Stabilize it for a few
+    days, merge into master, then resume development on staging.  <link
+    xlink:href="http://hydra.nixos.org/jobset/nixpkgs/staging#tabs-evaluations">Keep
+    an eye on the staging evaluations here</link>.  If any fixes for
+    staging happen to be already in master, then master can be merged into
+    staging.</para>
+
+    <para>When changing the bootloader installation process, extra
+    care must be taken. Grub installations cannot be rolled back,
+    hence changes may break people's installations forever. For
+    any non-trivial change to the bootloader please file a PR
+    asking for review, especially from @edolstra.</para>
+
+  </section>
+
 </chapter>
-


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The quickstart chapter is renamed to packaging guide. Paragraphs
regarding same topic in the guide and chapter about submitting changes
have been rewritten. A new section about poilicies have been added. Both
chapters are now indented.
