### PR TITLE
vp: init at 1.8

### DIFF
--- a/pkgs/applications/misc/vp/default.nix
+++ b/pkgs/applications/misc/vp/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, SDL, SDL_image }:
+
+stdenv.mkDerivation rec {
+  name = "vp-${version}";
+  version = "1.8";
+
+  src = fetchFromGitHub {
+    owner = "erikg";
+    repo = "vp";
+    rev = "v${version}";
+    sha256 = "08q6xrxsyj6vj0sz59nix9isqz84gw3x9hym63lz6v8fpacvykdq";
+  };
+
+  buildInputs = [ SDL autoconf automake SDL_image ];
+
+  preConfigure = ''
+    autoreconf -i
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://brlcad.org/~erik/;
+    description = "SDL based picture viewer/slideshow";
+    platforms = platforms.unix;
+    license  = licenses.gpl3;
+    maintainers = [ maintainers.vrthra ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3744,6 +3744,13 @@ in
 
   vpnc = callPackage ../tools/networking/vpnc { };
 
+  vp = callPackage ../applications/misc/vp {
+    # Enable next line for console graphics. Note that
+    # it requires `sixel` enabled terminals such as mlterm
+    # or xterm -ti 340
+    SDL = SDL_sixel;
+  };
+
   openconnect = openconnect_openssl;
 
   openconnect_openssl = callPackage ../tools/networking/openconnect.nix {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
