### PR TITLE
xsw: init at 0.1.2

### DIFF
--- a/pkgs/applications/misc/xsw/default.nix
+++ b/pkgs/applications/misc/xsw/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoconf, automake, SDL, SDL_image, SDL_ttf, SDL_gfx, flex, bison }:
+
+stdenv.mkDerivation rec {
+  name = "xsw-${version}";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "andrenho";
+    repo = "xsw";
+    rev = version;
+    sha256 = "092vp61ngd2vscsvyisi7dv6qrk5m1i81gg19hyfl5qvjq5p0p8g";
+  };
+
+  buildInputs = [ pkgconfig autoconf automake SDL SDL_image SDL_ttf SDL_gfx flex bison ];
+
+  patches = [
+    ./parse.patch # Fixes compilation error by avoiding redundant definitions.
+  ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "A slide show presentation tool";
+
+    platforms = platforms.unix;
+    license  = licenses.gpl3;
+    maintainers = [ maintainers.vrthra ];
+  };
+}

--- a/pkgs/applications/misc/xsw/parse.patch
+++ b/pkgs/applications/misc/xsw/parse.patch
@@ -1,0 +1,21 @@
+The `%code` causes Color definition to be added in both parser.h and parser.c
+causing duplicate definitions error. This ensures that once it has been included
+as part of parser.h, it wont be redefined in parser.c
+
+--- xsw-0.1.2-src/src/parser.y	1969-12-31 16:00:01.000000000 -0800
++++ xsw-0.1.2-src/src/parser.y	2016-06-28 13:21:35.707027770 -0700
+@@ -38,7 +38,13 @@
+ 
+ %}
+ 
+-%code requires { typedef struct { unsigned char c; } Color; }
++%code requires
++{
++#ifndef COLORDEF
++#define COLORDEF
++typedef struct { unsigned char c; } Color;
++#endif
++}
+ 
+ %token SLIDE COLON HIFEN TEXT X Y W H IMAGE SIZE SCALE TEMPLATE BACKGROUND FONT
+ %token STYLE ALIGN EXPAND PLUS IMAGE_PATH

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17079,6 +17079,13 @@ in
     libpng = libpng12;
   };
 
+  xsw = callPackage ../applications/misc/xsw {
+   # Enable the next line to use this in terminal.
+   # Note that it requires sixel capable terminals such as mlterm
+   # or xterm -ti 340
+   SDL = SDL_sixel;
+  };
+
   xwiimote = callPackage ../misc/drivers/xwiimote {
     bluez = pkgs.bluez5.override {
       enableWiimote = true;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
