### PR TITLE
dpdk: pktgen: odp-dpdk: upgrades

### DIFF
--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   RTE_KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   RTE_TARGET = "x86_64-native-linuxapp-gcc";
 
-  # we need ssse3 instructions to build
+  # we need sse3 instructions to build
   NIX_CFLAGS_COMPILE = [ "-march=core2" ];
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -22,8 +22,11 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   outputs = [ "out" "kmod" "examples" ];
 
-  buildPhase = ''
+  configurePhase = ''
     make T=x86_64-native-linuxapp-gcc config
+  '';
+
+  buildPhase = ''
     make T=x86_64-native-linuxapp-gcc install
     make T=x86_64-native-linuxapp-gcc examples
   '';

--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "odp-dpdk-${version}";
-  version = "1.8.0.0";
+  version = "1.10.1.0";
 
   src = fetchgit {
     url = "https://git.linaro.org/lng/odp-dpdk.git";
-    rev = "438a207a39bad213cdc03929452a8199caef5d8c";
-    sha256 = "0k4g5zbirbfdcgqz0nbn9san66y178qnigyvrr2apj3apzjjy7zv";
+    rev = "0ed1ced007d98980f90604675083bf30c354e867";
+    sha256 = "1kf090bizr0p0cxn525qpmypb5j86imvxrfpmwbl7vqqfh74j5ax";
   };
 
   nativeBuildInputs = [ autoreconfHook bash ];
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     substituteInPlace scripts/git_hash.sh --replace /bin/bash /bin/sh
+    substituteInPlace scripts/get_impl_str.sh --replace /bin/bash /bin/sh
     echo -n ${version} > .scmversion
   '';
 
@@ -26,7 +27,6 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-platform=linux-dpdk"
     "--disable-shared"
-    "--disable-shared-dpdk"
     "--with-sdk-install-path=${dpdk}/${RTE_TARGET}"
   ];
 

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, dpdk, libpcap, utillinux }:
+{ stdenv, fetchurl, dpdk, libpcap, utillinux
+, pkgconfig
+, gtk, withGtk ? false
+}:
 
 stdenv.mkDerivation rec {
   name = "pktgen-${version}";
@@ -9,10 +12,15 @@ stdenv.mkDerivation rec {
     sha256 = "0vrmbpl8zaal5zjwyzlx0y3d6jydfxdmf0psdj7ic37h5yh2iv2q";
   };
 
-  buildInputs = [ dpdk libpcap ];
+  nativeBuildInputs = stdenv.lib.optionals withGtk [ pkgconfig ];
+
+  buildInputs =
+    [ dpdk libpcap ]
+    ++ stdenv.lib.optionals withGtk [gtk];
 
   RTE_SDK = "${dpdk}";
   RTE_TARGET = "x86_64-native-linuxapp-gcc";
+  GUI = stdenv.lib.optionalString withGtk "true";
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pktgen-${version}";
-  version = "3.0.00";
+  version = "3.0.04";
 
   src = fetchurl {
     url = "http://dpdk.org/browse/apps/pktgen-dpdk/snapshot/pktgen-${version}.tar.gz";
-    sha256 = "703f8bd615aa4ae3a3085055483f9889dda09d082abb58afd33c1ba7c766ea65";
+    sha256 = "0vrmbpl8zaal5zjwyzlx0y3d6jydfxdmf0psdj7ic37h5yh2iv2q";
   };
 
   buildInputs = [ dpdk libpcap ];
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-march=core2" ];
 
-  patchPhase = ''
-    sed -i -e s:/usr/local:$out:g lib/lua/src/luaconf.h
-    sed -i -e s:/usr/bin/lscpu:${utillinux}/bin/lscpu:g lib/common/wr_lscpu.h
+  postPatch = ''
+    substituteInPlace lib/lua/src/luaconf.h --replace /usr/local $out
+    substituteInPlace lib/common/wr_lscpu.h --replace /usr/bin/lscpu ${utillinux}/bin/lscpu
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Upgrade pktgen and odp-dpdk to the latest. Cosmetic changes to dpdk.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
