### PR TITLE
dpdk: pktgen: odp-dpdk: upgrades

### DIFF
--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -22,8 +22,11 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   outputs = [ "out" "kmod" "examples" ];
 
-  buildPhase = ''
+  configurePhase = ''
     make T=x86_64-native-linuxapp-gcc config
+  '';
+
+  buildPhase = ''
     make T=x86_64-native-linuxapp-gcc install
     make T=x86_64-native-linuxapp-gcc examples
   '';

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -16,20 +16,16 @@ stdenv.mkDerivation rec {
   RTE_KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   RTE_TARGET = "x86_64-native-linuxapp-gcc";
 
-  enableParallelBuilding = true;
-  outputs = [ "out" "kmod" "examples" ];
-
   # we need ssse3 instructions to build
   NIX_CFLAGS_COMPILE = [ "-march=core2" ];
 
-  patchPhase = ''
-    sed -i 's/CONFIG_RTE_BUILD_COMBINE_LIBS=n/CONFIG_RTE_BUILD_COMBINE_LIBS=y/' config/common_linuxapp
-  '';
+  enableParallelBuilding = true;
+  outputs = [ "out" "kmod" "examples" ];
 
   buildPhase = ''
-    make T=x86_64-native-linuxapp-gcc -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES config
-    make T=x86_64-native-linuxapp-gcc -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES install
-    make T=x86_64-native-linuxapp-gcc -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES examples
+    make T=x86_64-native-linuxapp-gcc config
+    make T=x86_64-native-linuxapp-gcc install
+    make T=x86_64-native-linuxapp-gcc examples
   '';
 
   installPhase = ''
@@ -65,6 +61,6 @@ stdenv.mkDerivation rec {
     homepage = http://dpdk.org/;
     license = with licenses; [ lgpl21 gpl2 bsd2 ];
     platforms =  [ "x86_64-linux" ];
-    maintainers = [ maintainers.iElectric ];
+    maintainers = [ maintainers.domenkozar ];
   };
 }

--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit, autoreconfHook, openssl, libpcap, dpdk, bash }:
+
+stdenv.mkDerivation rec {
+  name = "odp-dpdk-${version}";
+  version = "1.10.1.0";
+
+  src = fetchgit {
+    url = "https://git.linaro.org/lng/odp-dpdk.git";
+    rev = "0ed1ced007d98980f90604675083bf30c354e867";
+    sha256 = "1mb98yvqlkg68qkg8k0kd1gl854j9cbdhvxidw5n6fqq8nk37p0v";
+  };
+
+  nativeBuildInputs = [ autoreconfHook bash ];
+  buildInputs = [ stdenv openssl dpdk libpcap ];
+
+  RTE_SDK = "${dpdk}";
+  RTE_TARGET = "x86_64-native-linuxapp-gcc";
+
+  patchPhase = ''
+    substituteInPlace scripts/git_hash.sh --replace /bin/bash /bin/sh
+    substituteInPlace scripts/get_impl_str.sh --replace /bin/bash /bin/sh
+    echo -n ${version} > .scmversion
+  '';
+
+  dontDisableStatic = true;
+
+  configureFlags = [
+    "--with-platform=linux-dpdk"
+    "--disable-shared"
+    "--with-sdk-install-path=${dpdk}/${RTE_TARGET}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Open Data Plane optimized for DPDK";
+    homepage = http://www.opendataplane.org;
+    license = licenses.bsd3;
+    platforms =  [ "x86_64-linux" ];
+    maintainers = [ maintainers.abuibrahim ];
+  };
+}

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, dpdk, libpcap, utillinux }:
+{ stdenv, fetchurl, dpdk, libpcap, utillinux
+, pkgconfig
+, gtk, withGtk ? false
+}:
 
 stdenv.mkDerivation rec {
   name = "pktgen-${version}";
@@ -9,10 +12,15 @@ stdenv.mkDerivation rec {
     sha256 = "0vrmbpl8zaal5zjwyzlx0y3d6jydfxdmf0psdj7ic37h5yh2iv2q";
   };
 
-  buildInputs = [ dpdk libpcap ];
+  nativeBuildInputs = stdenv.lib.optionals withGtk [ pkgconfig ];
+
+  buildInputs =
+    [ dpdk libpcap ]
+    ++ stdenv.lib.optionals withGtk [gtk];
 
   RTE_SDK = "${dpdk}";
   RTE_TARGET = "x86_64-native-linuxapp-gcc";
+  GUI = stdenv.lib.optionalString withGtk "true";
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pktgen-${version}";
-  version = "3.0.00";
+  version = "3.0.04";
 
   src = fetchurl {
     url = "http://dpdk.org/browse/apps/pktgen-dpdk/snapshot/pktgen-${version}.tar.gz";
-    sha256 = "703f8bd615aa4ae3a3085055483f9889dda09d082abb58afd33c1ba7c766ea65";
+    sha256 = "0vrmbpl8zaal5zjwyzlx0y3d6jydfxdmf0psdj7ic37h5yh2iv2q";
   };
 
   buildInputs = [ dpdk libpcap ];
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-march=core2" ];
 
-  patchPhase = ''
-    sed -i -e s:/usr/local:$out:g lib/lua/src/luaconf.h
-    sed -i -e s:/usr/bin/lscpu:${utillinux}/bin/lscpu:g lib/common/wr_lscpu.h
+  postPatch = ''
+    substituteInPlace lib/lua/src/luaconf.h --replace /usr/local $out
+    substituteInPlace lib/common/wr_lscpu.h --replace /usr/bin/lscpu ${utillinux}/bin/lscpu
   '';
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10599,6 +10599,8 @@ let
 
     pktgen = callPackage ../os-specific/linux/pktgen { };
 
+    odp-dpdk = callPackage ../os-specific/linux/odp-dpdk { };
+
     e1000e = callPackage ../os-specific/linux/e1000e {};
 
     v4l2loopback = callPackage ../os-specific/linux/v4l2loopback { };


### PR DESCRIPTION
###### Motivation for this change

Upgrade pktgen and odp-dpdk to the latest. Cosmetic changes to dpdk.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
