### PR TITLE
zuki-themes: init at 2016-07-01

### DIFF
--- a/pkgs/misc/themes/zuki/default.nix
+++ b/pkgs/misc/themes/zuki/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, gnome3, gdk_pixbuf, gtk_engines, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "zuki-themes-${version}";
+  version = "${gnome3.version}.${date}";
+  date = {
+    "3.18" = "2016-06-21";
+    "3.20" = "2016-07-01";
+  }."${gnome3.version}";
+
+  src = fetchFromGitHub {
+    owner = "lassekongo83";
+    repo = "zuki-themes";
+    rev = {
+      "3.18" = "5c83a847ad8fab0fe0b82ed2a7db429655ac9c10";
+      "3.20" = "dda1726ac7b556df2ef9696e530f8c2eaa0aed37";
+    }."${gnome3.version}";
+    sha256 = {
+      "3.18" = "1x9zrx5dqq8kivhqj5kjwhy4vwr899pri6jvwxbff5hibvyc7ipy";
+      "3.20" = "0p7db8a2ni494vwp3b7av7d214fnynf6gr976qma6h9x4ck3phiz";
+    }."${gnome3.version}";
+  };
+
+  buildInputs = [ gdk_pixbuf gtk_engines gtk-engine-murrine ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -dm 755 $out/share/themes
+    cp -va Zuki* $out/share/themes/
+  '';
+
+  meta = {
+    description = "A selection of themes for GTK3, gnome-shell and more";
+    homepage = "https://github.com/lassekongo83/zuki-themes";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17241,4 +17241,6 @@ in
   sequelpro = callPackage ../applications/misc/sequelpro {};
 
   maphosts = callPackage ../tools/networking/maphosts {};
+
+  zuki-themes = callPackage ../misc/themes/zuki { };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
