### PR TITLE
elvish: disable darwin

### DIFF
--- a/pkgs/shells/elvish/default.nix
+++ b/pkgs/shells/elvish/default.nix
@@ -20,5 +20,6 @@ buildGoPackage rec {
     homepage = https://github.com/elves/elvish;
     license = licenses.bsd2;
     maintainers = with maintainers; [ vrthra ];
+    platforms = with platforms; [ linux ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Disable elvish on darwin due to its failing in [hydra](https://hydra.nixos.org/build/37167906). I see cycle detected on post installation check, but I see no reason for the cycle. Disabling elvish on darwin until this can be figured out.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
