### PR TITLE
pick: init at 1.4.0

### DIFF
--- a/pkgs/tools/misc/pick/default.nix
+++ b/pkgs/tools/misc/pick/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "pick-${version}";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "thoughtbot";
+    repo = "pick";
+    rev = "v${version}";
+    sha256 = "113if0jh7svwrwrxhrsbi7h1whfr5707v2ny4dc9kk2sjbv6b9pg";
+  };
+
+  buildInputs = [ ncurses ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Fuzzy text selection utility";
+    license = licenses.mit;
+    maintainers = [ maintainers.womfoo ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2839,6 +2839,8 @@ in
 
   pell = callPackage ../applications/misc/pell { };
 
+  pick = callPackage ../tools/misc/pick { };
+
   pitivi = callPackage ../applications/video/pitivi {
     gst = gst_all_1 //
       { gst-plugins-bad = gst_all_1.gst-plugins-bad.overrideDerivation


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
