### PR TITLE
maphosts: init at 1.1.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -255,6 +255,7 @@
   mornfall = "Petr Ročkai <me@mornfall.net>";
   MostAwesomeDude = "Corbin Simpson <cds@corbinsimpson.com>";
   MP2E = "Cray Elliott <MP2E@archlinux.us>";
+  mpscholten = "Marc Scholten <marc@mpscholten.de>";
   msackman = "Matthew Sackman <matthew@wellquite.org>";
   mschristiansen = "Mikkel Christiansen <mikkel@rheosystems.com>";
   msteen = "Matthijs Steen <emailmatthijs@gmail.com>";

--- a/pkgs/tools/networking/maphosts/Gemfile
+++ b/pkgs/tools/networking/maphosts/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'maphosts'

--- a/pkgs/tools/networking/maphosts/Gemfile.lock
+++ b/pkgs/tools/networking/maphosts/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorize (0.8.0)
+    hosts (0.1.1)
+      linebreak (~> 2.0.1)
+    linebreak (2.0.1)
+    maphosts (1.1.1)
+      colorize (~> 0.7)
+      hosts (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  maphosts
+
+BUNDLED WITH
+   1.12.5

--- a/pkgs/tools/networking/maphosts/default.nix
+++ b/pkgs/tools/networking/maphosts/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, lib, bundlerEnv, ruby }:
+
+bundlerEnv {
+  name = "maphosts-1.1.1";
+
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  meta = with lib; {
+    description = "Small command line application for keeping your project hostnames in sync with /etc/hosts";
+    homepage    = https://github.com/mpscholten/maphosts;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ mpscholten ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/tools/networking/maphosts/gemset.nix
+++ b/pkgs/tools/networking/maphosts/gemset.nix
@@ -1,0 +1,34 @@
+{
+  colorize = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mmi9wr55gb84jfpyhpx975d2c8dhdsjjys88kc6f2r66brxmh23";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  hosts = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0s1mbn73ig5dy69dr8461574kq1ig6rdz89r1w5f8i7gvx9g9z9v";
+      type = "gem";
+    };
+    version = "0.1.1";
+  };
+  linebreak = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0362jhjhjcf0yr3k7bfqk4ai9yybm4985x7h1rwq4b7kvzk77pqj";
+      type = "gem";
+    };
+    version = "2.0.1";
+  };
+  maphosts = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bb7wa4vr3lkaywh4hvl74j2w5n52870zh4ypwl9cr43fdrj4nkw";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17158,4 +17158,6 @@ in
   iterm2 = callPackage ../applications/misc/iterm2 {};
 
   sequelpro = callPackage ../applications/misc/sequelpro {};
+
+  maphosts = callPackage ../tools/networking/maphosts {};
 }


### PR DESCRIPTION
###### Motivation for this change

Adds the [maphosts package](https://github.com/mpscholten/maphosts).

Open question:
- I was following the wiki page on how to bundle a ruby gem. The issue is that when installing the `maphosts` package, it will also provide a `bundler` binary. E.g. `jekyll` does the same. So when installing `jekyll` and `maphosts` you will have a conflict because both packages provide bundler. So how should this be handled? IMO no ruby package should provide the `bundler` binary by default.
- Is it ok if  I add myself as a maintainer of the package? Did not found any documentation on this :)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
