### PR TITLE
pkgs.mysql55: update download URL

### DIFF
--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "5.5.48";
 
   src = fetchurl {
-    url = "mirror://mysql/MySQL-5.5/${name}.tar.gz";
+    url = "http://downloads.mysql.com/archives/get/file/${name}.tar.gz";
     sha256 = "10fpzvf6hxvqgaq8paiz8fvhcbbs4qnzqw0svq40bvlyhx2qfgyc";
   };
 


### PR DESCRIPTION
###### Motivation for this change

`pkgs.mysql55` fails on the `release-16.03` channel since the source for mysql-5.5.48 have moved. This simply updates the URL where the source tarball is available.

An alternative could be to have mysql-5.5.50 replace mysql-5.5.48 (last release of the 5.5 branch).
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) _Some binaries tested (client, not server)_
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
