### PR TITLE
cpp_ethereum: init at 1.2.9

### DIFF
--- a/pkgs/applications/misc/webthree-umbrella/default.nix
+++ b/pkgs/applications/misc/webthree-umbrella/default.nix
@@ -1,0 +1,152 @@
+{ stdenv
+, fetchgit
+, cmake
+, boost
+, gmp
+, jsoncpp
+, leveldb
+, cryptopp
+, libcpuid
+, miniupnpc
+, libjson_rpc_cpp
+, curl
+, libmicrohttpd
+, mesa
+
+, opencl-headers ? null
+
+, withAMD ? false
+, amdappsdk ? null
+
+, withBeignet ? false
+, beignet ? null
+
+, withCUDA ? false
+, nvidia_x11 ? null
+
+, withGUI ? false
+, qtwebengine ? null
+, qtbase ? null
+, qtdeclarative ? null
+
+, withProfiling ? false
+, gperftools ? null
+
+, withEVMJIT ? false
+, llvm ? null
+, zlib ? null
+, ncurses ? null
+
+, extraCmakeFlags ? []
+}:
+
+assert withAMD -> (amdappsdk != null);
+assert withBeignet -> (beignet != null);
+assert withCUDA -> (nvidia_x11 != null);
+assert stdenv.lib.findSingle (x: x) true false [ withAMD withBeignet withCUDA ];
+
+assert withGUI -> (qtwebengine != null) && (qtbase != null) && (qtdeclarative != null);
+assert withProfiling -> (gperftools != null);
+assert withEVMJIT -> (llvm != null) && (zlib != null) && (ncurses != null);
+
+let
+  withOpenCL = (stdenv.lib.any (x: x) [ withAMD withBeignet withCUDA ]);
+in
+
+assert withOpenCL -> (opencl-headers != null);
+
+stdenv.mkDerivation rec {
+  name = "cpp-ethereum-${version}";
+  version = "1.2.9";
+
+  src = fetchgit {
+    url = https://github.com/ethereum/webthree-umbrella.git;
+    rev = "850479b159a0bfa316fd261ab96b0a043acd766c";
+    sha256 = "0k8w8gqzy71x77p0p85r38gfdnzrlzk2yvb3ablml9ppg4qb4ch5";
+  };
+
+  patchPhase = stdenv.lib.optional withBeignet ''
+    sed -i -re 's#NAMES\ (OpenCL.*)#NAMES\ libcl.so\ \1#g' webthree-helpers/cmake/FindOpenCL.cmake
+  '';
+
+  cmakeFlags = with stdenv.lib; concatStringsSep " " (flatten [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DGUI=${toString withGUI}"
+    "-DETHASHCL=${toString withOpenCL}"
+    "-DPROFILING=${toString withProfiling}"
+    "-DEVMJIT=${toString withEVMJIT}"
+    (optional withOpenCL "-DCMAKE_INCLUDE_PATH=${opencl-headers}/include")
+    (optional withAMD "-DCMAKE_LIBRARY_PATH=${amdappsdk}/lib")
+    (optional withBeignet "-DCMAKE_LIBRARY_PATH=${beignet}/lib/beignet")
+    (optional withCUDA "-DCMAKE_LIBRARY_PATH=${nvidia_x11}/lib")
+    (optional withEVMJIT "-DCMAKE_PREFIX_PATH=${llvm}")
+    extraCmakeFlags
+  ]);
+
+  configurePhase = ''
+    export BOOST_INCLUDEDIR=${boost}/include
+    export BOOST_LIBRARYDIR=${boost.out}/lib
+
+    mkdir -p Build/Install
+    pushd Build
+
+    cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/Install $cmakeFlags
+  '';
+
+  buildInputs = with stdenv.lib; [
+    cmake
+    boost
+    gmp
+    jsoncpp
+    leveldb
+    cryptopp
+    libcpuid
+    miniupnpc
+    libjson_rpc_cpp
+    curl
+    libmicrohttpd
+    mesa
+    (optional withOpenCL opencl-headers)
+    (optional withAMD amdappsdk)
+    (optional withBeignet beignet)
+    (optional withCUDA nvidia_x11)
+    (optional withGUI [
+      qtwebengine
+      qtbase
+      qtdeclarative
+    ])
+    (optional withProfiling gperftools)
+    (optional withEVMJIT [
+      llvm
+      zlib
+      ncurses
+    ])
+  ];
+
+  runPath = with stdenv.lib; concatStringsSep ":" (flatten [
+    (makeLibraryPath (flatten [ stdenv.cc.cc buildInputs ]))
+    (optional withBeignet "${beignet}/lib/beignet")
+  ]);
+
+  installPhase = ''
+    make install
+
+    mkdir -p $out
+
+    for f in Install/lib/*.so* $(find Install/bin -executable -type f); do
+      patchelf --set-rpath $runPath:$out/lib $f
+    done
+
+    cp -r Install/* $out
+  '';
+
+  dontStrip = true;
+
+  meta = with stdenv.lib; {
+    decription = "Umbrella project for the Ethereum C++ implementation";
+    homepage = https://github.com/ethereum/webthree-umbrella.git;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ artuuge ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/jsoncpp/1.6.5/default.nix
+++ b/pkgs/development/libraries/jsoncpp/1.6.5/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, cmake, python }:
+
+stdenv.mkDerivation rec {
+  name = "jsoncpp-${version}";
+  version = "1.6.5";
+
+  src = fetchFromGitHub {
+    owner = "open-source-parsers";
+    repo = "jsoncpp";
+    rev = version;
+    sha256 = "08y54n4v3q18ik8iv8zyziava3x130ilzf1l3qli3vjwf6l42fm0";
+  };
+
+  /* During darwin bootstrap, we have a cp that doesn't understand the
+   * --reflink=auto flag, which is used in the default unpackPhase for dirs
+   */
+  unpackPhase = ''
+    cp -a ${src} ${src.name}
+    chmod -R +w ${src.name}
+    export sourceRoot=${src.name}
+  '';
+
+  # Hack to be able to run the test, broken because we use
+  # CMAKE_SKIP_BUILD_RPATH to avoid cmake resetting rpath on install
+  preBuild = ''
+    export LD_LIBRARY_PATH="`pwd`/src/lib_json:$LD_LIBRARY_PATH"
+  '';
+
+  nativeBuildInputs = [ cmake python ];
+
+  CXXFLAGS = "-Wno-shift-negative-value";
+
+  cmakeFlags = [
+    "-DJSONCPP_LIB_BUILD_SHARED=ON"
+    "-DJSONCPP_LIB_BUILD_STATIC=OFF"
+    "-DJSONCPP_WITH_CMAKE_PACKAGE=ON"
+  ];
+
+  meta = {
+    inherit version;
+    homepage = https://github.com/open-source-parsers/jsoncpp;
+    description = "A simple API to manipulate JSON data in C++";
+    maintainers = with stdenv.lib.maintainers; [ ttuegel page ];
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.mit;
+    branch = "1.6";
+  };
+}

--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -1,48 +1,34 @@
-{ stdenv, fetchFromGitHub, cmake, python }:
-
+{ stdenv
+, fetchgit
+, cmake
+, python
+}:
 stdenv.mkDerivation rec {
   name = "jsoncpp-${version}";
-  version = "1.6.5";
+  version = "1.7.2";
 
-  src = fetchFromGitHub {
-    owner = "open-source-parsers";
-    repo = "jsoncpp";
-    rev = version;
-    sha256 = "08y54n4v3q18ik8iv8zyziava3x130ilzf1l3qli3vjwf6l42fm0";
+  src = fetchgit {
+    url = https://github.com/open-source-parsers/jsoncpp.git;
+    sha256 = "04w4cfmvyv52rpqhc370ln8rhlsrr515778bixhgafqbp3p4x34k";
+    rev = "c8054483f82afc3b4db7efe4e5dc034721649ec8";
   };
 
-  /* During darwin bootstrap, we have a cp that doesn't understand the
-   * --reflink=auto flag, which is used in the default unpackPhase for dirs
-   */
-  unpackPhase = ''
-    cp -a ${src} ${src.name}
-    chmod -R +w ${src.name}
-    export sourceRoot=${src.name}
-  '';
+  configurePhase = ''
+    mkdir -p Build
+    pushd Build
 
-  # Hack to be able to run the test, broken because we use
-  # CMAKE_SKIP_BUILD_RPATH to avoid cmake resetting rpath on install
-  preBuild = ''
-    export LD_LIBRARY_PATH="`pwd`/src/lib_json:$LD_LIBRARY_PATH"
-  '';
+    mkdir -p $out
+    cmake .. -DCMAKE_INSTALL_PREFIX=$out \
+             -DBUILD_SHARED_LIBS=ON \
+             -DCMAKE_BUILD_TYPE=Release
+  ''; 
 
-  nativeBuildInputs = [ cmake python ];
+  buildInputs = [ cmake python ];
 
-  CXXFLAGS = "-Wno-shift-negative-value";
-
-  cmakeFlags = [
-    "-DJSONCPP_LIB_BUILD_SHARED=ON"
-    "-DJSONCPP_LIB_BUILD_STATIC=OFF"
-    "-DJSONCPP_WITH_CMAKE_PACKAGE=ON"
-  ];
-
-  meta = {
-    inherit version;
+  meta = with stdenv.lib; {
     homepage = https://github.com/open-source-parsers/jsoncpp;
-    description = "A simple API to manipulate JSON data in C++";
-    maintainers = with stdenv.lib.maintainers; [ ttuegel page ];
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.mit;
-    branch = "1.6";
+    description = "A C++ library for interacting with JSON.";
+    license = licenses.mit;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libjson-rpc-cpp/0.2.1/default.nix
+++ b/pkgs/development/libraries/libjson-rpc-cpp/0.2.1/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, cmake, curl }:
+
+let
+  basename = "libjson-rpc-cpp";
+  version = "0.2.1";
+in
+
+stdenv.mkDerivation {
+  name = "${basename}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/cinemast/${basename}/archive/${version}.tar.gz";
+    sha256 = "1pc9nn4968qkda8vr4f9dijn2fcldm8i0ymwmql29h4cl5ghdnpw";
+  };
+
+  buildInputs = [ cmake curl ];
+
+  NIX_LDFLAGS = "-lpthread";
+  enableParallelBuilding = true;
+  doCheck = true;
+
+  checkPhase = "LD_LIBRARY_PATH=out/ ctest";
+
+  meta = {
+    description = "C++ framework for json-rpc (json remote procedure call)";
+    homepage = https://github.com/cinemast/libjson-rpc-cpp;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libjson-rpc-cpp/default.nix
+++ b/pkgs/development/libraries/libjson-rpc-cpp/default.nix
@@ -1,30 +1,69 @@
-{ stdenv, fetchurl, cmake, curl }:
+{ stdenv
+, fetchgit
+, cmake
+, jsoncpp
+, argtable
+, curl
+, libmicrohttpd
+, doxygen
+, catch
+}:
+stdenv.mkDerivation rec {
+  name = "libjson-rpc-cpp-${version}";
+  version = "0.6.0";
 
-let
-  basename = "libjson-rpc-cpp";
-  version = "0.2.1";
-in
-
-stdenv.mkDerivation {
-  name = "${basename}-${version}";
-
-  src = fetchurl {
-    url = "https://github.com/cinemast/${basename}/archive/${version}.tar.gz";
-    sha256 = "1pc9nn4968qkda8vr4f9dijn2fcldm8i0ymwmql29h4cl5ghdnpw";
+  src = fetchgit {
+    url = https://github.com/cinemast/libjson-rpc-cpp.git;
+    sha256 = "00fxxisg89zgg1wq047n8r8ws48jx35x3s6bbym4kg7dkxv9vv9f";
+    rev = "c6e3d7195060774bf95afc6df9c9588922076d3e";
   };
 
-  buildInputs = [ cmake curl ];
+  patchPhase = ''
+    for f in cmake/FindArgtable.cmake \
+             src/stubgenerator/stubgenerator.cpp \
+             src/stubgenerator/stubgeneratorfactory.cpp
+    do
+      sed -i -re 's/argtable2/argtable3/g' $f
+    done
 
-  NIX_LDFLAGS = "-lpthread";
-  enableParallelBuilding = true;
-  doCheck = true;
+    sed -i -re 's#MATCHES "jsoncpp"#MATCHES ".*/jsoncpp/json$"#g' cmake/FindJsoncpp.cmake
+  '';
 
-  checkPhase = "LD_LIBRARY_PATH=out/ ctest";
+  configurePhase = ''
+    mkdir -p Build/Install
+    pushd Build
 
-  meta = {
+    cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/Install \
+             -DCMAKE_BUILD_TYPE=Release
+  '';
+ 
+  installPhase = '' 
+    mkdir -p $out
+
+    function fixRunPath {
+      p=$(patchelf --print-rpath $1)
+      q="$p:${stdenv.lib.makeLibraryPath [ stdenv.cc.cc jsoncpp argtable libmicrohttpd curl ]}:$out/lib"
+      patchelf --set-rpath $q $1
+    }
+
+    make install
+
+    sed -i -re "s#-([LI]).*/Build/Install(.*)#-\1$out\2#g" Install/lib/pkgconfig/*.pc
+    for f in Install/lib/*.so* $(find Install/bin -executable -type f); do
+      fixRunPath $f
+    done
+ 
+    cp -r Install/* $out
+  '';
+
+  dontStrip = true;
+
+  buildInputs = [ cmake jsoncpp argtable curl libmicrohttpd doxygen catch ];
+
+  meta = with stdenv.lib; {
     description = "C++ framework for json-rpc (json remote procedure call)";
     homepage = https://github.com/cinemast/libjson-rpc-cpp;
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.mit;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/argtable/default.nix
+++ b/pkgs/tools/misc/argtable/default.nix
@@ -1,0 +1,41 @@
+{ stdenv 
+, fetchgit
+}:
+stdenv.mkDerivation rec {
+  name = "argtable-${version}";
+  version = "3.0.1";
+
+  src = fetchgit {
+    url = https://github.com/argtable/argtable3.git;
+    rev = "de93cfd85f755250285b337cba053a709a270721";
+    sha256 = "0fbvk78s3dwryrzgafdra0lb8w7lb873c6xgldl94ps9828x85i3";
+  };
+
+  buildPhase = ''
+    gcc -shared -o libargtable3.so -fPIC argtable3.c
+
+    pushd tests
+    make
+    popd
+  '';
+
+  installPhase = ''
+    mkdir -p $out/include
+    cp argtable3.h $out/include
+
+    mkdir -p $out/lib
+    cp libargtable3.so $out/lib
+
+    mkdir -p $out/src
+    cp argtable3.c $out/src
+    cp -r examples $out/src
+    ln -s $out/include/argtable3.h $out/src/argtable3.h
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.argtable.org/;
+    description = "A Cross-Platform, Single-File, ANSI C Command-Line Parsing Library";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ artuuge ];
+  };
+}

--- a/pkgs/tools/misc/libcpuid/default.nix
+++ b/pkgs/tools/misc/libcpuid/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, fetchgit
+, libtool
+, automake
+, autoconf
+, python
+}:
+stdenv.mkDerivation rec {
+  name = "libcpuid-${version}";
+  version = "0.2.2";
+
+  src = fetchgit {
+    url = https://github.com/anrieff/libcpuid.git;
+    rev = "535ec64dd9d8df4c5a8d34b985280b58a5396fcf";
+    sha256 = "1j9pg7fyvqhr859k5yh8ccl9jjx65c7rrsddji83qmqyg0vp1k1a";
+  };
+
+  patchPhase = ''
+    libtoolize
+    autoreconf --install
+ '';
+
+  configurePhase = ''
+    mkdir -p Install
+    ./configure --prefix=$(pwd)/Install
+    substituteInPlace Makefile --replace "/usr/local" "$out"
+  '';
+
+  buildPhase = ''
+    make all
+  '';
+
+  postInstall = ''
+    pushd Install
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/lib ${python.interpreter} ../tests/run_tests.py ./bin/cpuid_tool ../tests/
+    popd
+
+    function fixRunPath {
+      p0=$(patchelf --print-rpath $1)
+      p1=$(echo $p0 | sed -re 's#.*Install/lib:##g')
+      patchelf --set-rpath $p1 $1
+    }
+
+    fixRunPath Install/bin/cpuid_tool
+
+    mkdir -p $out
+    sed -i -re "s#(prefix=).*Install#\1$out#g" Install/lib/pkgconfig/libcpuid.pc
+ 
+    cp -r Install/* $out
+    cp -r tests $out
+  '';
+
+  buildInputs = [
+    libtool
+    automake
+    autoconf
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://libcpuid.sourceforge.net/;
+    description = "a small C library for x86 CPU detection and feature extraction";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ artuuge ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -412,6 +412,8 @@ in
 
   apitrace = qt55.callPackage ../applications/graphics/apitrace {};
 
+  argtable = callPackage ../tools/misc/argtable {};
+
   argyllcms = callPackage ../tools/graphics/argyllcms {};
 
   arp-scan = callPackage ../tools/misc/arp-scan { };
@@ -2155,6 +2157,8 @@ in
   leocad = callPackage ../applications/graphics/leocad { };
 
   less = callPackage ../tools/misc/less { };
+
+  libcpuid = callPackage ../tools/misc/libcpuid { };
 
   lesspipe = callPackage ../tools/misc/lesspipe { };
 
@@ -7550,6 +7554,8 @@ in
 
   jsoncpp = callPackage ../development/libraries/jsoncpp { };
 
+  jsoncpp_1_6_5 = callPackage ../development/libraries/jsoncpp/1.6.5 { };
+
   jsonnet = callPackage ../development/compilers/jsonnet { };
 
   libjson = callPackage ../development/libraries/libjson { };
@@ -8079,6 +8085,8 @@ in
   libjreen = callPackage ../development/libraries/libjreen { };
 
   libjson_rpc_cpp = callPackage ../development/libraries/libjson-rpc-cpp { };
+
+  libjson_rpc_cpp_0_2_1 = callPackage ../development/libraries/libjson-rpc-cpp/0.2.1 { };
 
   libkate = callPackage ../development/libraries/libkate { };
 
@@ -12241,6 +12249,17 @@ in
 
   conkeror-unwrapped = callPackage ../applications/networking/browsers/conkeror { };
   conkeror = self.wrapFirefox conkeror-unwrapped { };
+
+  cpp_ethereum = callPackage ../applications/misc/webthree-umbrella {
+    # withCUDA = true;
+    # inherit (linuxPackages) nvidia_x11;
+
+    # withEVMJIT = true;
+    # inherit (pkgs.llvmPackages_38) llvm;
+
+    # withGUI = true;
+    # inherit (pkgs.qt5) qtwebengine qtbase qtdeclarative;
+  };
 
   csdp = callPackage ../applications/science/math/csdp {
     liblapack = liblapackWithoutAtlas;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12251,8 +12251,7 @@ in
   conkeror = self.wrapFirefox conkeror-unwrapped { };
 
   cpp_ethereum = callPackage ../applications/misc/webthree-umbrella {
-    # withCUDA = true;
-    # inherit (linuxPackages) nvidia_x11;
+    withOpenCL = true;
 
     # withEVMJIT = true;
     # inherit (pkgs.llvmPackages_38) llvm;


### PR DESCRIPTION
###### Motivation for this change

This package corresponds to a C++ implementation of `Ethereum` from the Umbrella project. The GUI support is disabled by default, but it is possible to build the binaries overriding the `null` values for `qtwebengine`, `qtbase`, and `qtdeclarative`, making use of #16561.    

The present PR includes several other packages which are required as dependencies for `cpp_ethereum-1.2.9`. The existing packages `jsoncpp` and `libjson_rpc_cpp` are upgraded to versions `1.7.2` and `0.6.0`, respectively, and the packages `argtable` and `libcpuid` are initialized. The original script for `libjson_rpc_cpp` is expecting `argtable2`, but the more recent `argtable3` seems to work fine. The package `jsoncpp` needs to be build with `-DBUILD_SHARED_LIBS=ON` flag passed to `cmake`.  

The packages `cudatoolkit` and `nvidia_x11` are taken by default as a reasonable choice to have an OpenCL implementation, but one should adjust this for non-CUDA architectures. 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
