### PR TITLE
zgv: init at 5.9

### DIFF
--- a/pkgs/applications/graphics/zgv/default.nix
+++ b/pkgs/applications/graphics/zgv/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, fetchpatch, pkgconfig, SDL, SDL_image, libjpeg, libpng, libtiff }:
+
+stdenv.mkDerivation rec {
+  name = "zgv-${version}";
+  version = "5.9";
+  src = fetchurl {
+    url = "http://www.svgalib.org/rus/zgv/${name}.tar.gz";
+    sha256 = "1fk4i9x0cpnpn3llam0zy2pkmhlr2hy3iaxhxg07v9sizd4dircj";
+  };
+
+  buildInputs = [ SDL SDL_image pkgconfig libjpeg libpng libtiff ];
+
+  makeFlags = [
+    "BACKEND=SDL"
+  ];
+
+  patches = [
+    (fetchpatch {
+    url = https://foss.aueb.gr/mirrors/linux/gentoo/media-gfx/zgv/files/zgv-5.9-libpng15.patch;
+    sha256 = "1blw9n04c28bnwcmcn64si4f5zpg42s8yn345js88fyzi9zm19xw";
+    })
+    ./switch.patch
+  ];
+
+  patchFlags = "-p0";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp src/zgv $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.svgalib.org/rus/zgv/;
+    description = "Picture viewer with a thumbnail-based selector";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/graphics/zgv/switch.patch
+++ b/pkgs/applications/graphics/zgv/switch.patch
@@ -1,0 +1,14 @@
+GCC complains
+
+diff -ur src/zgv_io.c src/zgv_io.c
+--- src/zgv_io.c	2005-01-20 15:07:46.000000000 -0800
++++ src/zgv_io.c	2016-06-29 10:19:40.169897611 -0700
+@@ -645,7 +645,7 @@
+         case SDLK_INSERT:	return(RK_INSERT);
+         case SDLK_DELETE:	return(RK_DELETE);
+         case SDLK_RETURN:	return(RK_ENTER);
+-        default:
++        default: ;
+           /* stop complaints */
+         }
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15062,6 +15062,13 @@ in
 
   zgrviewer = callPackage ../applications/graphics/zgrviewer {};
 
+  zgv = callPackage ../applications/graphics/zgv {
+   # Enable the below line for terminal display. Note
+   # that it requires sixel graphics compatible terminals like mlterm
+   # or xterm -ti 340
+   SDL = SDL_sixel;
+  };
+
   zim = callPackage ../applications/office/zim {
     pygtk = pyGtkGlade;
   };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
