### PR TITLE
btfs: 2.9 -> 2.10

### DIFF
--- a/pkgs/development/libraries/libtorrent-rasterbar/1.09.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/1.09.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic.nix (args // {
+  version = "1.0.9";
+  sha256 = "1kfydlvmx4pgi5lpbhqr4p3jr78p3f61ic32046mkp4yfyydrspl";
+})

--- a/pkgs/os-specific/linux/btfs/default.nix
+++ b/pkgs/os-specific/linux/btfs/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "btfs-${version}";
-  version = "2.9";
+  version = "2.10";
 
   src = fetchFromGitHub {
     owner = "johang";
     repo = "btfs";
-    rev = "3ee6671eca2c0e326ac38d07cab4989ebad3495c";
-    sha256 = "0f7yc7hkfwdj9hixsyswf17yrpcpwxxb0svj5lfqcir8a45kf100";
+    rev = "2eac5e70a1ed22fa0761b6357c54fd90eea02de6";
+    sha256 = "146vgwn79dnbkkn35safga55lkwhvarkmilparmr26hjb56cs1dk";
   };
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -636,7 +636,9 @@ in
     sha256 = "0p2sxrpzd0vsk11zf3kb5h12yl1nq4yypb5mpjrm8ww0cfaijck2";
   };
 
-  btfs = callPackage ../os-specific/linux/btfs { };
+  btfs = callPackage ../os-specific/linux/btfs {
+    libtorrentRasterbar = libtorrentRasterbar_1_09;
+  };
 
   cabal2nix = self.haskellPackages.cabal2nix;
 
@@ -8281,6 +8283,8 @@ in
   libtomcrypt = callPackage ../development/libraries/libtomcrypt { };
 
   libtorrentRasterbar = callPackage ../development/libraries/libtorrent-rasterbar { };
+
+  libtorrentRasterbar_1_09 = callPackage ../development/libraries/libtorrent-rasterbar/1.09.nix { };
 
   libtorrentRasterbar_0_16 = callPackage ../development/libraries/libtorrent-rasterbar/0.16.nix {
     # fix "unrecognized option -arch" error


### PR DESCRIPTION
###### Motivation for this change

libtorrent version 1.1.0 introduced breaking changes and btfs build was failing.
This updates btfs to 2.10 using the latest compatible version of libtorrent (1.0.9)
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files
- [x] Tested compilation of all pkgs that depend on this change using (none)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
