### PR TITLE
netsurf: enable sixel display

### DIFF
--- a/pkgs/applications/misc/netsurf/libnsfb/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsfb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, ui? "gtk"
+{ stdenv, fetchurl, pkgconfig, uilib? "framebuffer", SDL
 , buildsystem
 }:
 
@@ -13,12 +13,12 @@ stdenv.mkDerivation rec {
     sha256 = "176f8why9gzbaca9nnxjqasl02qzc6g507z5w3dzkcjifnkz4mzl";
   };
 
-  buildInputs = [ pkgconfig buildsystem ];
+  buildInputs = [ pkgconfig buildsystem SDL ];
 
   makeFlags = [
     "PREFIX=$(out)"
     "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
-    "TARGET=${ui}"
+    "TARGET=${uilib}"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2207,6 +2207,14 @@ in
   netdata = callPackage ../tools/system/netdata { };
 
   netsurf = recurseIntoAttrs (let callPackage = newScope pkgs.netsurf; in rec {
+    # ui could be gtk, sixel or framebuffer. Note that console display (sixel)
+    # requires a terminal that supports `sixel` capabilities such as mlterm
+    # or xterm -ti 340
+    ui = "sixel";
+
+    uilib = if ui == "gtk" then "gtk" else "framebuffer";
+
+    SDL = if ui == "gtk" then null else if ui == "sixel" then SDL_sixel else SDL;
 
     buildsystem = callPackage ../applications/misc/netsurf/buildsystem { };
 


### PR DESCRIPTION
###### Motivation for this change

Previously, we had disabled `framebuffer` because it caused an assert failure on assessing mouse location. However, on further investigation, the failure is caused by not having the `dec-locator-mode` enabled in xterm (#16604), which provides pixel based mouse location to applications under sixel. Hence, enabling the target for netsurf.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
