### PR TITLE
Datefudge

### DIFF
--- a/pkgs/tools/system/datefudge/default.nix
+++ b/pkgs/tools/system/datefudge/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation rec {
+  pname = "datefudge";
+  version = "1.2.1";
+  name = "${pname}-${version}";
+
+  src = fetchgit {
+    sha256 = "0l83kn6c3jr3wzs880zfa64rw81cqjjk55gjxz71rjf2balp64ps";
+    url = "git://anonscm.debian.org/users/robert/datefudge.git";
+    rev = "cd141c63bebe9b579109b2232b5e83db18f222c2";
+  };
+
+  patchPhase = ''
+    substituteInPlace Makefile \
+     --replace "/usr" "/" \
+     --replace "-o root -g root" ""
+    substituteInPlace datefudge.sh \
+     --replace "@LIBDIR@" "$out/lib/"
+    '';
+
+  preInstallPhase = "mkdir -P $out/lib/datefudge";
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  postInstall = "chmod +x $out/lib/datefudge/datefudge.so";
+
+  meta = with stdenv.lib; {
+    description = "Fake the system date";
+    longDescription = ''
+      datefudge is a small utility that pretends that the system time is
+      different by pre-loading a small library which modifies the time,
+      gettimeofday and clock_gettime system calls.
+    '';
+    homepage = http://packages.qa.debian.org/d/datefudge.html;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -702,6 +702,8 @@ in
 
   datamash = callPackage ../tools/misc/datamash { };
 
+  datefudge = callPackage ../tools/system/datefudge { };
+
   ddate = callPackage ../tools/misc/ddate { };
 
   deis = callPackage ../development/tools/deis {};


### PR DESCRIPTION
###### Motivation for this change

This pull request is not meant to be merged without further work.

Datefudge is a tool for faking system time used by e.g. recent gnutls for testing what happens at certain times. There is an updated version of gnutls currently in nixpkgs unstable, which breaks due to the absence of datefudge.

Given that it is a simple but useful tool anyway (it is used by other applications like gitlab during tests as well), I'm trying to add it to nixpkgs. Currently the datefudge library gets builds and the application gets installed. It is a small wrapper app written in shell, which calls the compiled library.

Subsequently however one gets a segmentation error when running a test e.g.
something like: 

```
  datefudge "2006-09-23" date -u +%s 
```

The tool is 13 years old, and runs apparently flawlessly on Debian, Arch, etc. 

Currently gnutls, and everything that depends on it, might be broken in unstable without datefudge. Not a happy thought. Is there anyone that would have the good heart to have a look at what could be wrong with the datefudge "recipe"?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
