### PR TITLE
libcommuni: Fix build (missing deps, configuration)

### DIFF
--- a/pkgs/development/libraries/libcommuni/default.nix
+++ b/pkgs/development/libraries/libcommuni/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     sed -i -e 's|/bin/pwd|pwd|g' configure
   '';
 
+  doCheck = true;
+
   meta = with stdenv.lib; {
     description = "A cross-platform IRC framework written with Qt";
     homepage = https://communi.github.io;

--- a/pkgs/development/libraries/libcommuni/default.nix
+++ b/pkgs/development/libraries/libcommuni/default.nix
@@ -1,4 +1,4 @@
-{ fetchgit, qtbase, qmakeHook, stdenv
+{ fetchgit, qtbase, qmakeHook, which, stdenv
 }:
 
 stdenv.mkDerivation rec {
@@ -12,13 +12,14 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ qtbase ];
-  nativeBuildInputs = [ qmakeHook ];
+  nativeBuildInputs = [ qmakeHook which ];
 
   enableParallelBuild = true;
 
-  configurePhase = ''
+  dontUseQmakeConfigure = true;
+  configureFlags = "-config release";
+  preConfigure = ''
     sed -i -e 's|/bin/pwd|pwd|g' configure
-    ./configure -config release -prefix $out -qmake $QMAKE
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

libcommuni broken on nixpkgs master with missing build dependency on "which", among other things.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
