### PR TITLE
zerotierone: 1.1.4 -> 1.1.6

### DIFF
--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -3,12 +3,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.1.4";
+  version = "1.1.6";
   name = "zerotierone";
 
   src = fetchurl {
     url = "https://github.com/zerotier/ZeroTierOne/archive/${version}.tar.gz";
-    sha256 = "10aw0dlkmprdvph3aqkqximxqkryf0l4jcnv2bbm7f1qvclqihva";
+    sha256 = "1bl8dppaqydsd1qf9pk3bp16amkwjxyqh1gvm62ys2a0m4c529ks";
   };
 
   preConfigure = ''
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ openssl lzo zlib gcc iproute ];
+
+  buildFlags = [ "one" ]; # TODO: Add support for building and installing manpages as well.
 
   installPhase = ''
     install -Dt "$out/bin/" zerotier-one


### PR DESCRIPTION
###### Motivation for this change

Bump to 1.1.6

There is currently one major breaking issue with 1.1.4 which has since been fixed in 1.1.6:
https://github.com/zerotier/ZeroTierOne/issues/336
this was fixed in this commit:
https://github.com/zerotier/ZeroTierOne/commit/039790cf267cb67a5130fb82caf97998d8b0959e

Building the manpages is a bit more complicated because it would depend on "ronn" or "marked-man", neither of which are currently packaged for nixpkgs.
See https://github.com/zerotier/ZeroTierOne/blob/master/doc/build.sh

CC @sjmackenzie @zimbatm
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
