### PR TITLE
Gtk : Enable wayland support on Linux

### DIFF
--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, gettext, perl
 , expat, glib, cairo, pango, gdk_pixbuf, atk, at_spi2_atk, gobjectIntrospection
-, xorg, wayland, epoxy, json_glib, libxkbcommon, gmp
+, xorg, epoxy, json_glib, libxkbcommon, gmp
+, waylandSupport ? stdenv.isLinux, wayland, wayland-protocols
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? stdenv.isLinux, cups ? null
 , darwin
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = with xorg; with stdenv.lib;
     [ expat glib cairo pango gdk_pixbuf atk at_spi2_atk
       libXrandr libXrender libXcomposite libXi libXcursor libSM libICE ]
-    ++ optionals stdenv.isLinux [ wayland ]
+    ++ optionals waylandSupport [ wayland wayland-protocols ]
     ++ optional stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ AppKit Cocoa ])
     ++ optional xineramaSupport libXinerama
     ++ optional cupsSupport cups;
@@ -53,6 +54,10 @@ stdenv.mkDerivation rec {
     "--disable-glibtest"
     "--with-gdktarget=quartz"
     "--enable-quartz-backend"
+  ] ++ optional stdenv.isLinux [
+    "--enable-x11-backend"
+  ] ++ optional waylandSupport [
+    "--enable-wayland-backend"
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Gtk3 is currently compiled without wayland support.
This pr enables it by default on Linux, (as it is already done in most other distributions).

I haven't tested it much, except on the packages I use, because I don't have the build power to rebuild the whole dependency closure of gtk3 (but I hope this won't bring much trouble, as the wayland backend is only supposed to be active if the `GDK_BACKEND` env var is set to `wayland`).

Note: This triggers quite a huge rebuild, should I submit the pull request to staging instead ?
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
