### PR TITLE
norwester-font: init at 1.2

### DIFF
--- a/pkgs/data/fonts/norwester/default.nix
+++ b/pkgs/data/fonts/norwester/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  pname = "norwester";
+  version = "1.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://jamiewilson.io/norwester/assets/norwester.zip";
+    sha256 = "0syg8ss7mpli4cbxvh3ld7qrlbhb2dfv3wchm765iw6ndc05g92d";
+  };
+
+  phases = [ "installPhase" ];
+
+  buildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    unzip -D -j $src ${pname}-v${version}/${pname}.otf -d $out/share/fonts/opentype/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://jamiewilson.io/norwester";
+    description = "A condensed geometric sans serif by Jamie Wilson";
+    maintainers = with maintainers; [ leenaars ];
+    license = licenses.ofl;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16755,6 +16755,8 @@ in
 
   nixos-artwork = callPackage ../data/misc/nixos-artwork { };
 
+  norwester-font = callPackage ../data/fonts/norwester  {};
+
   nut = callPackage ../applications/misc/nut { };
 
   solfege = callPackage ../misc/solfege {


### PR DESCRIPTION
###### Motivation for this change

Just a good font.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) -> tested the font works
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
