### PR TITLE
drumstick: init at 1.0.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -358,6 +358,7 @@
   skrzyp = "Jakub Skrzypnik <jot.skrzyp@gmail.com>";
   sleexyz = "Sean Lee <freshdried@gmail.com>";
   smironov = "Sergey Mironov <ierton@gmail.com>";
+  solson = "Scott Olson <scott@solson.me>";
   spacefrogg = "Michael Raitza <spacefrogg-nixos@meterriblecrew.net>";
   spencerjanssen = "Spencer Janssen <spencerjanssen@gmail.com>";
   spinus = "Tomasz Czyż <tomasz.czyz@gmail.com>";

--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, alsaLib, cmake, docbook_xsl, docbook_xml_dtd_45, doxygen
+, fluidsynth, pkgconfig, qt5
+}:
+
+stdenv.mkDerivation rec {
+  name = "drumstick-${version}";
+  version = "1.0.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/drumstick/${version}/${name}.tar.bz2";
+    sha256 = "0l47gy9yywrc860db5g3wdqg8yc8qdb2lqq6wvw1dfim5j0vbail";
+  };
+
+  outputs = [ "out" "dev" "man" ];
+
+  enableParallelBuilding = true;
+
+  # Prevent the manpage builds from attempting to access the Internet.
+  prePatch = ''
+    substituteInPlace cmake_admin/CreateManpages.cmake --replace \
+      http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl \
+      ${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl
+
+    for xml in doc/*.xml.in; do
+      substituteInPlace "$xml" --replace \
+        http://www.docbook.org/xml/4.5/docbookx.dtd \
+        ${docbook_xml_dtd_45}/xml/dtd/docbook/docbookx.dtd
+    done
+  '';
+
+  buildInputs = [
+    alsaLib cmake doxygen fluidsynth pkgconfig qt5.qtbase qt5.qtsvg
+  ];
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ solson ];
+    description = "MIDI libraries for Qt5/C++";
+    homepage = http://drumstick.sourceforge.net/;
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4257,6 +4257,8 @@ in
 
   devpi-client = callPackage ../development/tools/devpi-client {};
 
+  drumstick = callPackage ../development/libraries/drumstick { };
+
   ecl = callPackage ../development/compilers/ecl { };
 
   eql = callPackage ../development/compilers/eql {};


### PR DESCRIPTION
###### Motivation for this change

I started trying to package the new KDE [Minuet](https://minuet.kde.org/) program and I ran into this as a missing dependency. [Drumstick's website](http://drumstick.sourceforge.net/) points out that it has official packages in some popular distros, so it seems fine to include this in Nixpkgs.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first Nix package, so please do not refrain from nitpicking - I need to learn! 😃 
