### PR TITLE
hashcat: 2.0.0 -> 3.0.0

### DIFF
--- a/pkgs/development/libraries/opencl-icd/default.nix
+++ b/pkgs/development/libraries/opencl-icd/default.nix
@@ -1,15 +1,23 @@
-{ stdenv, fetchurl, ruby, opencl-headers }: let
+{ stdenv, fetchurl, ruby, opencl-headers }:
 
+stdenv.mkDerivation rec {
+  name = "opencl-icd-${version}";
   version = "2.2.9";
 
-in stdenv.mkDerivation {
-
-  name = "opencl-icd-${version}";
-  buildInputs = [ ruby opencl-headers ];
-  configureFlags = [ "--enable-official-khronos-headers" ];
   src = fetchurl {
     url = "https://forge.imag.fr/frs/download.php/716/ocl-icd-${version}.tar.gz";
     sha256 = "1rgaixwnxmrq2aq4kcdvs0yx7i6krakarya9vqs7qwsv5hzc32hc";
   };
 
+  buildInputs = [ ruby opencl-headers ];
+
+  configureFlags = [ "--enable-official-khronos-headers" ];
+
+  meta = with stdenv.lib; {
+    description = "This free ICD Loader can load any (free or non free) ICD";
+    homepage = https://forge.imag.fr/projects/ocl-icd/;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zimbatm ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Just a package update.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

OpenCL is now a requirement.

If you see a `ERROR: clGetPlatformIDs() : -1001 : CL_UNKNOWN_ERROR` error it's because `/etc/OpenCL/vendors` is missing.
