### PR TITLE
LiE: init at 2.2.2

### DIFF
--- a/pkgs/applications/science/math/LiE/default.nix
+++ b/pkgs/applications/science/math/LiE/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl
+, bison, readline }:
+
+stdenv.mkDerivation rec {
+  version = "2.2.2";
+     # The current version of LiE is 2.2.2, which is more or less unchanged
+     # since about the year 2000. Minor bugfixes do get applied now and then.
+  name = "LiE-${version}";
+
+  meta = {
+    description = "A Computer algebra package for Lie group computations";
+    homepage = "http://wwwmathlabo.univ-poitiers.fr/~maavl/LiE/";
+    license = stdenv.lib.licenses.lgpl3; # see the website
+
+    longDescription = ''
+      LiE is a computer algebra system that is specialised in computations
+      involving (reductive) Lie groups and their representations. It is
+      publically available for free in source code. For a description of its
+      characteristics, we refer to the following sources of information.
+    ''; # take from the website
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ ]; # this package is probably not going to change anyway
+  };
+
+  src = fetchurl {
+    url = "http://wwwmathlabo.univ-poitiers.fr/~maavl/LiE/conLiE.tar.gz";
+    sha256 = "07lbj75qqr4pq1j1qz8fyfnmrz1gnk92lnsshxycfavxl5zzdmn4";
+  };
+
+  buildInputs = [ bison readline ];
+
+  patchPhase = ''
+    substituteInPlace make_lie \
+      --replace \`/bin/pwd\` $out
+  '';
+
+  installPhase = ''
+    mkdir -vp $out/bin
+
+    cp -v Lie.exe $out
+    cp -v lie $out/bin
+
+    cp -v LEARN LEARN.ind $out
+    cp -v INFO.ind INFO.[0-4] $out
+  '';
+}


### PR DESCRIPTION
###### Motivation for this change

provide a common program for nixos and nix
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
