### PR TITLE
wpsoffice: 10.1.0.5503 -> 10.1.0.5672

### DIFF
--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec{
   name = "wpsoffice-${version}";
-  version = "10.1.0.5503";
+  version = "10.1.0.5672";
 
   src = fetchurl {
     name = "${name}.tar.gz";
-    url = "http://kdl.cc.ksosoft.com/wps-community/download/a20/wps-office_10.1.0.5503~a20p2_x86_64.tar.xz";
-    sha256 = "0h9f8s7zkpd056ibrj978mr04imv631sp1wljplh99l5ncns6hws";
+    url = "http://kdl.cc.ksosoft.com/wps-community/download/a21/wps-office_10.1.0.5672~a21_x86_64.tar.xz";
+    sha1 = "7e9b17572ed5cea50af24f01457f726fc558a515";
   };
   
   meta = {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The url of the previous package is broken.
