### PR TITLE
alarm-clock-applet: init at 0.3.4

### DIFF
--- a/pkgs/tools/misc/alarm-clock-applet/default.nix
+++ b/pkgs/tools/misc/alarm-clock-applet/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, pkgconfig
+, glib
+, gtk2
+, gst_all_1
+, gnome
+, libnotify
+, libxml2
+, libunique
+, intltool
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.3.4";
+  name = "alarm-clock-applet-${version}";
+
+  src = fetchurl {
+    url = "http://launchpad.net/alarm-clock/trunk/${version}/+download/${name}.tar.gz";
+    sha256 = "1mrrw5cgv0izdmhdg83vprvbj6062yzk77b2nr1nx6hhmk00946r";
+  };
+
+  buildInputs = [
+    pkgconfig
+    glib
+    gtk2
+    gst_all_1.gstreamer
+    gnome.GConf
+    gnome.gnome_icon_theme
+    libnotify
+    libxml2
+    libunique
+    intltool
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://alarm-clock.pseudoberries.com/;
+    description = "A fully-featured alarm clock for your GNOME panel or equivalent";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.rasendubi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3199,6 +3199,8 @@ in
 
   remarkjs = callPackage ../development/web/remarkjs { };
 
+  alarm-clock-applet = callPackage ../tools/misc/alarm-clock-applet { };
+
   remind = callPackage ../tools/misc/remind { };
 
   remmina = callPackage ../applications/networking/remote/remmina {};


### PR DESCRIPTION
###### Motivation for this change

I don't wanna oversleep for work anymore.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There were a couple of issues before the application runs normally.

The first one is GConf error:
https://nixos.org/wiki/Solve_GConf_errors_when_running_GNOME_applications

The second one is absence of gst plugins:
https://github.com/NixOS/nixpkgs/issues/10559
