### PR TITLE
gradle: 2.13 -> 2.14

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -51,11 +51,11 @@ rec {
   };
 
   gradleLatest = gradleGen rec {
-    name = "gradle-2.13";
+    name = "gradle-2.14";
 
     src = fetchurl {
       url = "http://services.gradle.org/distributions/${name}-bin.zip";
-      sha256 = "0r5nrgrb14fi1p4cx5q5x82nghhrzdd843dsyzx6ay56lp35wrhg";
+      sha256 = "1m98m4cxnvyl5ymkj6z8xb9vpdna47hdh5qrfblqkijjnqrlyfwr";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Update to latest release
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
