### PR TITLE
Move nix upgrading instruction to nixpkgs manual

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ let requiredVersion = import ./lib/minver.nix; in
 
 if ! builtins ? nixVersion || builtins.compareVersions requiredVersion builtins.nixVersion == 1 then
 
-  abort "This version of Nixpkgs requires Nix >= ${requiredVersion}, please upgrade! See https://nixos.org/wiki/How_to_update_when_Nix_is_too_old_to_evaluate_Nixpkgs"
+  abort "This version of Nixpkgs requires Nix >= ${requiredVersion}, please upgrade! See https://nixos.org/nixpkgs/manual/#upgrading-nix"
 
 else
 

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -21,5 +21,6 @@
   <xi:include href="coding-conventions.xml" />
   <xi:include href="submitting-changes.xml" />
   <xi:include href="contributing.xml" />
+  <xi:include href="troubleshooting.xml" />
 
 </book>

--- a/doc/troubleshooting.xml
+++ b/doc/troubleshooting.xml
@@ -1,0 +1,20 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="chap-troubleshooting">
+
+<title>Troubleshooting</title>
+
+<section xml:id="upgrading-nix">
+  <title>Upgrading Nix</title>
+  <para>
+    Nixpkgs having a requirement on Nix version, it can happen that Nix is too 
+    old to evaluate Nixpkgs.
+  </para>
+  <para>
+    In that case, it is possible to upgrade Nix to the latest version using 
+    pre-compiled packages: <link 
+      xlink:href="https://hydra.nixos.org/release/nix/nix-1.11.2">Nix 
+      1.11.2</link>.
+  </para>
+</section>
+</chapter>


### PR DESCRIPTION
###### Motivation for this change

Address #13186
ML thread: [How to upgrade when Nix is too old to evaluate nixpkgs](http://thread.gmane.org/gmane.linux.distributions.nixos/20811)

As the wiki is read only and its information is outdated, nixpkgs manual seemed a natural alternative.

Improvements and feedback are welcome.

cc @garbas 
