### PR TITLE
tnef: init at 1.4.12

### DIFF
--- a/pkgs/applications/misc/tnef/default.nix
+++ b/pkgs/applications/misc/tnef/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, lib, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  version = "1.4.12";
+  name = "tnef-${version}";
+
+  src = fetchFromGitHub {
+    owner = "verdammelt";
+    repo = "tnef";
+    rev = "${version}";
+    sha256 = "02hwdaaa3yk0lbzb40fgxlkyhc1wicl6ncajpvfcz888z6yxps2c";
+  };
+
+  doCheck = true;
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "Unpacks MIME attachments of type application/ms-tnef";
+    longDescription = ''
+      TNEF is a program for unpacking MIME attachments of type "application/ms-tnef". This is a Microsoft only attachment.
+
+      Due to the proliferation of Microsoft Outlook and Exchange mail servers, more and more mail is encapsulated into this format.
+
+      The TNEF program allows one to unpack the attachments which were encapsulated into the TNEF attachment. Thus alleviating the need to use Microsoft Outlook to view the attachment.
+    '';
+    homepage = https://github.com/verdammelt/tnef;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.DamienCassou ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/misc/tnef/tnef/default.nix
+++ b/pkgs/applications/misc/tnef/tnef/default.nix
@@ -1,0 +1,30 @@
+{ fetchurl, lib }:
+
+stdenv.mkDerivation rec {
+  version = "1.4.12";
+  name = "tnef-${version}";
+
+  src = fetchFromGitHub {
+    owner = "verdammelt";
+    repo = "tnef";
+    rev = "${version}";
+    sha256 = "0ssi2wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i";
+  };
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Unpacks MIME attachments of type application/ms-tnef";
+    longDescription = ''
+      TNEF is a program for unpacking MIME attachments of type "application/ms-tnef". This is a Microsoft only attachment.
+
+      Due to the proliferation of Microsoft Outlook and Exchange mail servers, more and more mail is encapsulated into this format.
+
+      The TNEF program allows one to unpack the attachments which were encapsulated into the TNEF attachment. Thus alleviating the need to use Microsoft Outlook to view the attachment.
+    '';
+    homepage = https://github.com/verdammelt/tnef;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.DamienCassou ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14419,6 +14419,8 @@ in
     inherit (linuxPackages) x86_energy_perf_policy;
   };
 
+  tnef = callPackage ../applications/misc/tnef { };
+
   todo-txt-cli = callPackage ../applications/office/todo.txt-cli { };
 
   tomahawk = callPackage ../applications/audio/tomahawk {


### PR DESCRIPTION
###### Motivation for this change

I needed it to read an attachment from a company.
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
