### PR TITLE
transgui: init at 5.0.1-svn-r986

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -313,6 +313,7 @@
   qknight = "Joachim Schiele <js@lastlog.de>";
   ragge = "Ragnar Dahlen <r.dahlen@gmail.com>";
   ralith = "Benjamin Saunders <ben.e.saunders@gmail.com>";
+  ramkromberg = "Ram Kromberg <ramkromberg@mail.com>";
   rardiol = "Ricardo Ardissone <ricardo.ardissone@gmail.com>";
   rasendubi = "Alexey Shmalko <rasen.dubi@gmail.com>";
   raskin = "Michael Raskin <7c6f434c@mail.ru>";

--- a/pkgs/applications/networking/p2p/transgui/default.nix
+++ b/pkgs/applications/networking/p2p/transgui/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, fetchsvn, pkgconfig, makeDesktopItem, unzip, fpc, lazarus,
+libX11, glib, gtk, gdk_pixbuf, pango, atk, cairo, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "transgui-5.0.1-svn-r${revision}";
+  revision = "986";
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/transgui/code/trunk/";
+    rev = revision;
+    sha256 = "0z83hvlhllm6p1z4gkcfi1x3akgn2xkssnfhwp74qynb0n5362pi";
+  };
+
+  buildInputs = [
+    pkgconfig unzip fpc lazarus stdenv.cc
+    libX11 glib gtk gdk_pixbuf pango atk cairo openssl
+  ];
+
+  NIX_LDFLAGS = "
+    -L${stdenv.cc.cc.lib}/lib
+    -lX11 -lglib-2.0 -lgtk-x11-2.0 -lgdk-x11-2.0
+    -lgdk_pixbuf-2.0 -lpango-1.0 -latk-1.0 -lcairo -lc -lcrypto
+  ";
+
+  prePatch = ''
+    substituteInPlace restranslator.pas --replace /usr/ $out/
+  '';
+
+  makeFlags = [
+    "FPC=fpc"
+    "PP=fpc"
+    "INSTALL_PREFIX=$(out)"
+  ];
+
+  LCL_PLATFORM = "gtk2"; 
+
+  desktopItem = makeDesktopItem rec {
+    name = "transgui";
+    exec = name + " %U";
+    icon = name;
+    type = "Application";
+    comment = meta.description;
+    desktopName = "Transmission Remote GUI";
+    genericName = "BitTorrent Client";
+    categories = stdenv.lib.concatStringsSep ";" [
+      "Application" "Network" "FileTransfer" "P2P" "GTK"
+    ];
+    startupNotify = "true";
+    mimeType = stdenv.lib.concatStringsSep ";" [
+      "application/x-bittorrent" "x-scheme-handler/magnet"
+    ];
+  };
+
+  postInstall = ''
+    mkdir -p "$out/share/applications"
+    cp $desktopItem/share/applications/* $out/share/applications
+    mkdir -p "$out/share/icons/hicolor/48x48/apps"
+    cp transgui.png "$out/share/icons/hicolor/48x48/apps"
+    mkdir -p "$out/share/transgui"
+    cp -r "./lang" "$out/share/transgui" 
+  '';
+
+  meta = { 
+    description = "A cross platform front-end for the Transmission Bit-Torrent client";
+    homepage = https://sourceforge.net/p/transgui;
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = with stdenv.lib.maintainers; [ ramkromberg ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14525,6 +14525,8 @@ in
   transmission-remote-cli = callPackage ../applications/networking/p2p/transmission-remote-cli {};
   transmission_remote_gtk = callPackage ../applications/networking/p2p/transmission-remote-gtk {};
 
+  transgui = callPackage ../applications/networking/p2p/transgui { };
+
   trayer = callPackage ../applications/window-managers/trayer { };
 
   tree = callPackage ../tools/system/tree {};


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/16567
https://www.reddit.com/r/NixOS/comments/4owwga/transmission_remote_gui_transgui_package/
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
