### PR TITLE
nixos/update-users-groups.pl: print UIDs and GIDs

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -103,7 +103,7 @@ foreach my $g (@{$spec->{groups}}) {
     if (defined $existing) {
         $g->{gid} = $existing->{gid} if !defined $g->{gid};
         if ($g->{gid} != $existing->{gid}) {
-            warn "warning: not applying GID change of group ‘$name’\n";
+            warn "warning: not applying GID change of group ‘$name’ ($existing->{gid} -> $g->{gid})\n";
             $g->{gid} = $existing->{gid};
         }
         $g->{password} = $existing->{password}; # do we want this?
@@ -163,7 +163,7 @@ foreach my $u (@{$spec->{users}}) {
     if (defined $existing) {
         $u->{uid} = $existing->{uid} if !defined $u->{uid};
         if ($u->{uid} != $existing->{uid}) {
-            warn "warning: not applying UID change of user ‘$name’\n";
+            warn "warning: not applying UID change of user ‘$name’ ($existing->{uid} -> $u->{uid})\n";
             $u->{uid} = $existing->{uid};
         }
     } else {


### PR DESCRIPTION
###### Motivation for this change

This makes it possible for users to take action and fixup the UIDs/GIDs
that NixOS won't touch.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Instead of showing this output from "nixos-rebuild switch":

```
  warning: not applying GID change of group ‘munin’
  warning: not applying UID change of user ‘ntp’
```

print this:

```
  warning: not applying GID change of group ‘munin’ (95 -> 102)
  warning: not applying UID change of user ‘ntp’ (3 -> 179)
```

This makes it possible for users to take action and fixup the UIDs/GIDs
that NixOS won't touch.
