### PR TITLE
Add system-wise kbd search path

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -43,7 +43,7 @@ in
 
       consolePackages = mkOption {
         type = types.listOf types.package;
-        default = [];
+        default = with pkgs.kbdKeymaps; [ dvp neo ];
         description = ''
 	  List of additional packages that provide console fonts, keymaps and
           other resources.

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -41,6 +41,15 @@ in
         '';
       };
 
+      consolePackages = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = ''
+	  List of additional packages that provide console fonts, keymaps and
+          other resources.
+        '';
+      };
+
       consoleFont = mkOption {
         type = types.str;
         default = "Lat2-Terminus16";

--- a/nixos/modules/tasks/kbd.nix
+++ b/nixos/modules/tasks/kbd.nix
@@ -52,8 +52,7 @@ in
       environment.systemPackages = [ pkgs.kbd ];
 
       # Let systemd-vconsole-setup.service do the work of setting up the
-      # virtual consoles.  FIXME: trigger a restart of
-      # systemd-vconsole-setup.service if /etc/vconsole.conf changes.
+      # virtual consoles.
       environment.etc = [ {
         target = "vconsole.conf";
         source = vconsoleConf;

--- a/nixos/modules/tasks/kbd.nix
+++ b/nixos/modules/tasks/kbd.nix
@@ -13,6 +13,12 @@ let
     ${colors}
   '';
 
+  kbdEnv = pkgs.buildEnv {
+    name = "kbd-env";
+    paths = [ pkgs.kbd ] ++ config.i18n.consolePackages;
+    pathsToLink = [ "/share/consolefonts" "/share/consoletrans" "/share/keymaps" "/share/unimaps" ];
+  };
+
   setVconsole = !config.boot.isContainer;
 in
 
@@ -53,10 +59,9 @@ in
 
       # Let systemd-vconsole-setup.service do the work of setting up the
       # virtual consoles.
-      environment.etc = [ {
-        target = "vconsole.conf";
-        source = vconsoleConf;
-      } ];
+      environment.etc."vconsole.conf".source = vconsoleConf;
+      # Provide kbd with additional packages.
+      environment.etc."kbd".source = "${kbdEnv}/share";
 
       # This is identical to the systemd-vconsole-setup.service unit
       # shipped with systemd, except that it uses /dev/tty1 instead of
@@ -66,7 +71,7 @@ in
         { wantedBy = [ "multi-user.target" ];
           before = [ "display-manager.service" ];
           after = [ "systemd-udev-settle.service" ];
-          restartTriggers = [ vconsoleConf ];
+          restartTriggers = [ vconsoleConf kbdEnv ];
         };
     })
   ];

--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -9,18 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "0ppv953gn2zylcagr4z6zg5y2x93dxrml29plypg6xgbq3hrv2bs";
   };
 
-  /* Get the dvorak programmer keymap (present in X but not in kbd) */
-  dvpSrc = fetchurl {
-    url = "http://kaufmann.no/downloads/linux/dvp-1_2_1.map.gz";
-    sha256 = "0e859211cfe16a18a3b9cbf2ca3e280a23a79b4e40b60d8d01d0fde7336b6d50";
-  };
-
-  neoSrc = fetchurl {
-    name = "neo.map";
-    url = "https://svn.neo-layout.org/linux/console/neo.map?r=2455";
-    sha256 = "1wlgp09wq84hml60hi4ls6d4zna7vhycyg40iipyh1279i91hsx7";
-  };
-
   configureFlags = [
     "--enable-optional-progs"
     "--enable-libkeymap"
@@ -31,12 +19,8 @@ stdenv.mkDerivation rec {
 
   postPatch =
     ''
-      mkdir -p data/keymaps/i386/neo
-      cat "$neoSrc" > data/keymaps/i386/neo/neo.map
+      # Add Neo keymap subdirectory
       sed -i -e 's,^KEYMAPSUBDIRS *= *,&i386/neo ,' data/Makefile.am
-
-      # Add the dvp keyboard in the dvorak folder
-      ${gzip}/bin/gzip -c -d ${dvpSrc} > data/keymaps/i386/dvorak/dvp.map
 
       # Fix the path to gzip/bzip2.
       substituteInPlace src/libkeymap/findfile.c \

--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchurl, autoreconfHook, gzip, bzip2, pkgconfig, check, pam }:
+{ stdenv, fetchurl, autoreconfHook, gzip, bzip2, pkgconfig, flex, check, pam }:
 
 stdenv.mkDerivation rec {
-  name = "kbd-2.0.3";
+  name = "kbd-${version}";
+  version = "2.0.3";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/kbd/${name}.tar.xz";
@@ -26,7 +27,7 @@ stdenv.mkDerivation rec {
     "--disable-nls"
   ];
 
-  patches = [ ./console-fix.patch ];
+  patches = [ ./console-fix.patch ./search-paths.patch ];
 
   postPatch =
     ''
@@ -49,13 +50,15 @@ stdenv.mkDerivation rec {
       ''}
     '';
 
-  buildInputs = [ autoreconfHook pkgconfig check pam ];
+  buildInputs = [ check pam ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig flex ];
 
-  makeFlags = "setowner= ";
+  makeFlags = [ "setowner=" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = ftp://ftp.altlinux.org/pub/people/legion/kbd/;
     description = "Linux keyboard utilities and keyboard maps";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
+    licenses = licenses.gpl2Plus;
   };
 }

--- a/pkgs/os-specific/linux/kbd/keymaps.nix
+++ b/pkgs/os-specific/linux/kbd/keymaps.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchurl, gzip }:
+
+{
+  dvp = stdenv.mkDerivation rec {
+    name = "dvp-${version}";
+    version = "1.2.1";
+
+    src = fetchurl {
+      url = "http://kaufmann.no/downloads/linux/dvp-${lib.replaceStrings ["."] ["_"] version}.map.gz";
+      sha256 = "0e859211cfe16a18a3b9cbf2ca3e280a23a79b4e40b60d8d01d0fde7336b6d50";
+    };
+
+    nativeBuildInputs = [ gzip ];
+
+    buildCommand = ''
+      mkdir -p $out/share/keymaps/i386/dvorak
+      gzip -c -d $src > $out/share/keymaps/i386/dvorak/dvp.map
+    '';
+  };
+
+  neo = stdenv.mkDerivation rec {
+    name = "neo-${version}";
+    version = "2476";
+
+    src = fetchurl {
+      name = "neo.map";
+      url = "https://svn.neo-layout.org/linux/console/neo.map?r=${version}";
+      sha256 = "19mfrd31vzpsjiwc7pshxm0b0sz5dd17xrz6k079cy4im1vf0r4g";
+    };
+
+    buildCommand = ''
+      install -D $src $out/share/keymaps/i386/neo/neo.map
+    '';
+  };
+}

--- a/pkgs/os-specific/linux/kbd/search-paths.patch
+++ b/pkgs/os-specific/linux/kbd/search-paths.patch
@@ -1,0 +1,77 @@
+diff -ru3 kbd-2.0.3-old/src/libkeymap/analyze.l kbd-2.0.3/src/libkeymap/analyze.l
+--- kbd-2.0.3-old/src/libkeymap/analyze.l	2016-07-03 02:31:28.258958092 +0300
++++ kbd-2.0.3/src/libkeymap/analyze.l	2016-07-03 02:44:53.042592223 +0300
+@@ -99,6 +99,9 @@
+ static const char *const include_dirpath0[] = { "", 0 };
+ static const char *const include_dirpath1[] = { "", "../include/", "../../include/", 0 };
+ static const char *const include_dirpath3[] = {
++	"/etc/kbd/" KEYMAPDIR "/include/",
++	"/etc/kbd/" KEYMAPDIR "/i386/include/",
++	"/etc/kbd/" KEYMAPDIR "/mac/include/",
+ 	DATADIR "/" KEYMAPDIR "/include/",
+ 	DATADIR "/" KEYMAPDIR "/i386/include/",
+ 	DATADIR "/" KEYMAPDIR "/mac/include/", 0
+diff -ru3 kbd-2.0.3-old/src/loadkeys.c kbd-2.0.3/src/loadkeys.c
+--- kbd-2.0.3-old/src/loadkeys.c	2016-07-03 02:31:28.260958091 +0300
++++ kbd-2.0.3/src/loadkeys.c	2016-07-03 02:34:34.123871103 +0300
+@@ -26,7 +26,7 @@
+ #include "keymap.h"
+ 
+ static const char *progname = NULL;
+-static const char *const dirpath1[] = { "", DATADIR "/" KEYMAPDIR "/**", KERNDIR "/", 0 };
++static const char *const dirpath1[] = { "", "/etc/kbd/" KEYMAPDIR "/**", DATADIR "/" KEYMAPDIR "/**", 0 };
+ static const char *const suffixes[] = { "", ".kmap", ".map", 0 };
+ 
+ static void __attribute__ ((noreturn))
+diff -ru3 kbd-2.0.3-old/src/loadunimap.c kbd-2.0.3/src/loadunimap.c
+--- kbd-2.0.3-old/src/loadunimap.c	2016-07-03 02:31:28.259958091 +0300
++++ kbd-2.0.3/src/loadunimap.c	2016-07-03 02:33:06.803911971 +0300
+@@ -28,7 +28,7 @@
+ extern char *progname;
+ extern int force;
+ 
+-static const char *const unidirpath[] = { "", DATADIR "/" UNIMAPDIR "/", 0 };
++static const char *const unidirpath[] = { "", "/etc/kbd/" UNIMAPDIR "/", DATADIR "/" UNIMAPDIR "/", 0 };
+ static const char *const unisuffixes[] = { "", ".uni", ".sfm", 0 };
+ 
+ #ifdef MAIN
+diff -ru3 kbd-2.0.3-old/src/mapscrn.c kbd-2.0.3/src/mapscrn.c
+--- kbd-2.0.3-old/src/mapscrn.c	2016-07-03 02:31:28.260958091 +0300
++++ kbd-2.0.3/src/mapscrn.c	2016-07-03 02:33:21.119905270 +0300
+@@ -25,7 +25,7 @@
+ static int ctoi (char *);
+ 
+ /* search for the map file in these directories (with trailing /) */
+-static const char *const mapdirpath[] = { "", DATADIR "/" TRANSDIR "/", 0 };
++static const char *const mapdirpath[] = { "", "/etc/kbd/" TRANSDIR "/", DATADIR "/" TRANSDIR "/", 0 };
+ static const char *const mapsuffixes[] = { "", ".trans", "_to_uni.trans", ".acm", 0 };
+ 
+ #ifdef MAIN
+diff -ru3 kbd-2.0.3-old/src/resizecons.c kbd-2.0.3/src/resizecons.c
+--- kbd-2.0.3-old/src/resizecons.c	2016-07-03 02:31:28.260958091 +0300
++++ kbd-2.0.3/src/resizecons.c	2016-07-03 02:33:32.253900060 +0300
+@@ -100,7 +100,7 @@
+ static void vga_set_cursor(int, int);
+ static void vga_set_verticaldisplayend_lowbyte(int);
+ 
+-const char *const dirpath[] = { "", DATADIR "/" VIDEOMODEDIR "/", 0};
++const char *const dirpath[] = { "", "/etc/kbd/" VIDEOMODEDIR "/", DATADIR "/" VIDEOMODEDIR "/", 0};
+ const char *const suffixes[] = { "", 0 };
+ 
+ int
+diff -ru3 kbd-2.0.3-old/src/setfont.c kbd-2.0.3/src/setfont.c
+--- kbd-2.0.3-old/src/setfont.c	2016-07-03 02:31:28.260958091 +0300
++++ kbd-2.0.3/src/setfont.c	2016-07-03 02:33:54.315889734 +0300
+@@ -51,10 +51,10 @@
+ int debug = 0;
+ 
+ /* search for the font in these directories (with trailing /) */
+-const char *const fontdirpath[] = { "", DATADIR "/" FONTDIR "/", 0 };
++const char *const fontdirpath[] = { "", "/etc/kbd/" FONTDIR "/", DATADIR "/" FONTDIR "/", 0 };
+ const char *const fontsuffixes[] = { "", ".psfu", ".psf", ".cp", ".fnt", 0 };
+ /* hide partial fonts a bit - loading a single one is a bad idea */
+-const char *const partfontdirpath[] = { "", DATADIR "/" FONTDIR "/" PARTIALDIR "/", 0 };
++const char *const partfontdirpath[] = { "", "/etc/kbd/" FONTDIR "/" PARTIALDIR "/", DATADIR "/" FONTDIR "/" PARTIALDIR "/", 0 };
+ const char *const partfontsuffixes[] = { "", 0 };
+ 
+ static inline int

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10723,6 +10723,8 @@ in
 
   kbd = callPackage ../os-specific/linux/kbd { };
 
+  kbdKeymaps = callPackage ../os-specific/linux/kbd/keymaps.nix { };
+
   kbdlight = callPackage ../os-specific/linux/kbdlight { };
 
   kmscon = callPackage ../os-specific/linux/kmscon { };


### PR DESCRIPTION
###### Motivation for this change

This improves usability of custom console fonts, keymaps etc. -- things that are set by `kbd` package. We now add `/run/current-system/sw/share` to search path for all its resources -- which means that instead of patching new keymaps into `kbd` or specifying a console font like this:

```
i18n.consoleFont = "${pkgs.terminus_font}/share/consolefonts/ter-v16n.psf.gz";
```

You can do it like this:

```
environment.systemPackages = [ pkgs.terminus_font ];
i18n.consoleFont = "ter-v16n";
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
