### PR TITLE
galen: fix on nixos

### DIFF
--- a/pkgs/development/tools/galen/default.nix
+++ b/pkgs/development/tools/galen/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ unzip ];
-  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
 
   buildPhase = ''
   mkdir -p $out/bin


### PR DESCRIPTION
This fixes galen on NixOS. Since the phases were limited to exclude `configure` shebangs were not patched and thus the wrapper script from galen still had `/bin/bash` in it.
###### Things done
- Built on platform(s)
  - [X] NixOS
  - [X] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
