### PR TITLE
spacefm: sudo and gksu fixes #15758 and license update

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -76,6 +76,7 @@
   ./programs/screen.nix
   ./programs/shadow.nix
   ./programs/shell.nix
+  ./programs/spacefm.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
   ./programs/tmux.nix

--- a/nixos/modules/programs/spacefm.nix
+++ b/nixos/modules/programs/spacefm.nix
@@ -1,0 +1,55 @@
+# Global configuration for spacefm.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.spacefm;
+
+in
+{
+  ###### interface
+
+  options = {
+
+    programs.spacefm = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to install SpaceFM and create <filename>/etc/spacefm/spacefm.conf<filename>.
+        '';
+      };
+
+      settings = mkOption {
+        type = types.attrs;
+        default = {
+          tmp_dir = "/tmp";
+          terminal_su = "${pkgs.sudo}/bin/sudo";
+          graphical_su = "${pkgs.gksu}/bin/gksu";
+        };
+        example = literalExample ''{
+          tmp_dir = "/tmp";
+          terminal_su = "''${pkgs.sudo}/bin/sudo";
+          graphical_su = "''${pkgs.gksu}/bin/gksu";
+        }'';
+        description = ''
+          The system-wide spacefm configuration.
+          Parameters to be written to <filename>/etc/spacefm/spacefm.conf</filename>.
+          Refer to the <link xlink:href="https://ignorantguru.github.io/spacefm/spacefm-manual-en.html#programfiles-etc">relevant entry</link> in the SpaceFM manual.
+        '';
+      };
+
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.spaceFM ];
+
+    environment.etc."spacefm/spacefm.conf".text =
+      concatStrings (mapAttrsToList (n: v: "${n}=${toString v}\n") cfg.settings);
+  };
+}

--- a/pkgs/applications/misc/spacefm/default.nix
+++ b/pkgs/applications/misc/spacefm/default.nix
@@ -1,6 +1,6 @@
-{ pkgs, fetchFromGitHub, stdenv, gtk3, udev, desktop_file_utils, shared_mime_info
-, intltool, pkgconfig, wrapGAppsHook, ffmpegthumbnailer, jmtpfs, ifuse, lsof, udisks
-, hicolor_icon_theme, adwaita-icon-theme }:
+{ pkgs, fetchFromGitHub, stdenv, gtk3, udev, desktop_file_utils
+, shared_mime_info, intltool, pkgconfig, wrapGAppsHook, ffmpegthumbnailer
+, jmtpfs, ifuse, lsof, udisks, hicolor_icon_theme, adwaita-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "spacefm-${version}";
@@ -15,14 +15,21 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-bash-path=${pkgs.bash}/bin/bash"
-    "--with-preferable-sudo=${pkgs.sudo}/bin/sudo"
   ];
 
   preConfigure = ''
     configureFlags="$configureFlags --sysconfdir=$out/etc"
   '';
 
-  buildInputs = [ gtk3 udev desktop_file_utils shared_mime_info intltool pkgconfig wrapGAppsHook ffmpegthumbnailer jmtpfs ifuse lsof udisks ];
+  postInstall = ''
+    rm -f $out/etc/spacefm/spacefm.conf
+    ln -s /etc/spacefm/spacefm.conf $out/etc/spacefm/spacefm.conf 
+  '';
+
+  buildInputs = [
+    gtk3 udev desktop_file_utils shared_mime_info intltool pkgconfig
+    wrapGAppsHook ffmpegthumbnailer jmtpfs ifuse lsof udisks
+  ];
 
   meta = with stdenv.lib;  {
     description = "A multi-panel tabbed file manager";
@@ -33,7 +40,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://ignorantguru.github.io/spacefm/;
     platforms = platforms.linux;
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jagajaga obadz ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/15758
and license change from GPL3 to GPL3+ ( https://github.com/IgnorantGuru/spacefm/blob/master/COPYING )

~~https://github.com/NixOS/nixpkgs/issues/183~~ doesn't apply here. SpaceFM depends on real bash features.

I've also added a module to install _SpaceFM_ and modify _spacefm.conf_ by adding the following in _configuration.nix_:

```
  programs.spacefm.enable = true;
```

Additionally, the default settings can be overridden with:

```
  programs.spacefm.settings = {
    tmp_dir = "/tmp";
    terminal_su = "${pkgs.sudo}/bin/sudo";
    graphical_su = "${pkgs.gksu}/bin/gksu";
  };
```

It borrows common declarations from other modules. It relieves the _SpaceFM_ package from it's dependencies on sudo and gksu as discussed in the https://github.com/NixOS/nixpkgs/issues/15758 while allowing their replacement in the module without recompilation.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
