### PR TITLE
avahi: 0.6.31 -> 0.6.32

### DIFF
--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -7,11 +7,12 @@
 assert qt4Support -> qt4 != null;
 
 stdenv.mkDerivation rec {
-  name = "avahi-0.6.31";
+  name = "avahi-${version}";
+  version = "0.6.32";
 
   src = fetchurl {
-    url = "${meta.homepage}/download/${name}.tar.gz";
-    sha256 = "0j5b5ld6bjyh3qhd2nw0jb84znq0wqai7fsrdzg7bpg24jdp2wl3";
+    url = "https://github.com/lathiat/avahi/releases/download/v${version}/avahi-${version}.tar.gz";
+    sha256 = "0m5l3ny9i2z1l27y4wm731c0zdkmfn6l1szbajx0ljjiblc92jfm";
   };
 
   patches = [ ./no-mkdir-localstatedir.patch ];

--- a/pkgs/development/libraries/avahi/no-mkdir-localstatedir.patch
+++ b/pkgs/development/libraries/avahi/no-mkdir-localstatedir.patch
@@ -6,7 +6,7 @@ Don't "mkdir $(localstatedir)" since we can't do it (/var).
  	done
  
  install-data-local:
--	test -z "$(localstatedir)/run" || $(mkdir_p) "$(DESTDIR)$(localstatedir)/run"
+-	test -z "$(localstatedir)/run" || $(MKDIR_P) "$(DESTDIR)$(localstatedir)/run"
  
  update-systemd:
  	curl http://cgit.freedesktop.org/systemd/plain/src/sd-daemon.c > sd-daemon.c


### PR DESCRIPTION
###### Motivation for this change

Bugfix release.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Bugfix release, backwards compatible.
- Update src URL to github (the latest release is only available there).
- Change "$(mkdir_p)" to "$(MKDIR_P)" in the patch to keep it working
  (apply'able).
