### PR TITLE
clib: 1.4.2 -> 1.7.0

### DIFF
--- a/pkgs/tools/package-management/clib/default.nix
+++ b/pkgs/tools/package-management/clib/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchzip, curl  }:
+{ stdenv, fetchFromGitHub, curl  }:
 
 stdenv.mkDerivation rec {
-  version = "1.4.2";
+  version = "1.7.0";
   name = "clib-${version}";
 
-  src = fetchzip {
-    url = "https://github.com/clibs/clib/archive/${version}.zip";
-    sha256 = "0hbi5hf4w0iim96h89j7krxv61x92ffxjbldxp3zk92m5sgpldnm";
+  src = fetchFromGitHub {
+    rev    = version;
+    owner  = "clibs";
+    repo   = "clib";
+    sha256 = "08n2i3dyh5vnrb74a6wlqqn67c9nwkq0v0v651zzha495mqbciq7";
   };
 
   makeFlags = "PREFIX=$(out)";


### PR DESCRIPTION
###### Motivation for this change

Adds some handy functionality since 1.4.2, such as `clib install --save`
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
