### PR TITLE
libxfce4ui_gtk3: 4.12.1 -> 4.13.0

### DIFF
--- a/pkgs/desktops/xfce/core/libxfce4ui.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui.nix
@@ -4,8 +4,8 @@
 }:
 let
   p_name  = "libxfce4ui";
-  ver_maj = "4.12";
-  ver_min = "1";
+  ver_maj = if withGtk3 then "4.13" else "4.12";
+  ver_min = if withGtk3 then "0" else "1";
   inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation rec {
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://xfce/src/xfce/${p_name}/${ver_maj}/${name}.tar.bz2";
-    sha256 = "3d619811bfbe7478bb984c16543d980cadd08586365a7bc25e59e3ca6384ff43";
+    sha256 =
+      if withGtk3
+      then "22f0b66a33945f347952249589f71618418f1e47ca847850eb0ee1bdb0c353d4"
+      else "3d619811bfbe7478bb984c16543d980cadd08586365a7bc25e59e3ca6384ff43";
   };
 
   outputs = [ "dev" "out" "docdev" ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
