### PR TITLE
dockerTools: disable compression in tarsum.go

### DIFF
--- a/pkgs/build-support/docker/tarsum.go
+++ b/pkgs/build-support/docker/tarsum.go
@@ -1,24 +1,24 @@
 package main
 
 import (
-    "tarsum"
-    "io"
-    "io/ioutil"
-    "fmt"
-    "os"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"tarsum"
 )
 
 func main() {
-    ts, err := tarsum.NewTarSum(os.Stdin, false, tarsum.Version1)
-    if err != nil {
-        fmt.Println(err)
-        os.Exit(1)
-    }
+	ts, err := tarsum.NewTarSum(os.Stdin, false, tarsum.Version1)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
-    if _, err = io.Copy(ioutil.Discard, ts); err != nil {
-        fmt.Println(err)
-        os.Exit(1)
-    }
+	if _, err = io.Copy(ioutil.Discard, ts); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
-    fmt.Println(ts.Sum(nil))
+	fmt.Println(ts.Sum(nil))
 }

--- a/pkgs/build-support/docker/tarsum.go
+++ b/pkgs/build-support/docker/tarsum.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	ts, err := tarsum.NewTarSum(os.Stdin, false, tarsum.Version1)
+	ts, err := tarsum.NewTarSum(os.Stdin, true, tarsum.Version1)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Previously, tarsum would compress the (discarded) tarball produced.
That's a waste of CPU, and a waste of time.
