### PR TITLE
[WIP] flashtool: 0.9.14.0 -> 0.9.22.3

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1519,7 +1519,7 @@ in
 
   flamerobin = callPackage ../applications/misc/flamerobin { };
 
-  flashtool = callPackage_i686 ../development/mobile/flashtool {
+  flashtool = callPackage ../development/mobile/flashtool {
     platformTools = androidenv.platformTools;
   };
 


### PR DESCRIPTION
###### Motivation for this change
- update to support newer phones
- make the package more NixOS-like:
  - [ ] replace the original FlashTool shellscript and use makeWrapper to recreate its functionality
  - [ ] replace the bundled utilities by ones provided by NixOS, where applicable
  - [ ] add new packages to NixOS (eg. unyaffs, XperiFirm,...) and use those, whenever possible
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
