### PR TITLE
nix-prefetch-git: include date in standard output

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -20,6 +20,7 @@ http_proxy=${http_proxy:-}
 fullRev=
 humanReadableRev=
 commitDate=
+commitDateStrict8601=
 
 if test -n "$deepClone"; then
     deepClone=true
@@ -287,9 +288,12 @@ _clone_user_rev() {
             fi;;
     esac
 
-    fullRev="$(cd "$dir" && (git rev-parse "$rev" 2> /dev/null || git rev-parse "refs/heads/$branchName") | tail -n1)"
-    humanReadableRev="$(cd "$dir" && (git describe "$fullRev" 2> /dev/null || git describe --tags "$fullRev" 2> /dev/null || echo -- none --))"
-    commitDate="$(cd "$dir" && git show --no-patch --pretty=%ci "$fullRev")"
+    pushd "$dir"
+    fullRev="$((git rev-parse "$rev" 2> /dev/null || git rev-parse "refs/heads/$branchName") | tail -n1)"
+    humanReadableRev="$(git describe "$fullRev" 2> /dev/null || git describe --tags "$fullRev" 2> /dev/null || echo -- none --)"
+    commitDate="$(git show --no-patch --pretty=%ci "$fullRev")"
+    commitDateStrict8601="$(git show --no-patch --pretty=%cI "$fullRev")"
+    popd
 
     # Allow doing additional processing before .git removal
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"
@@ -337,6 +341,7 @@ print_results() {
         echo "{"
         echo "  \"url\": \"$url\","
         echo "  \"rev\": \"$fullRev\","
+        echo "  \"date\": \"$commitDateStrict8601\","
         echo -n "  \"$hashType\": \"$hash\""
         if test -n "$fetchSubmodules"; then
             echo ","


### PR DESCRIPTION
###### Motivation for this change

@expipiplus1 and I are working on a tool for automatically updating the revision and sha256 information in a `fetchgit` Nix expression.  When we are updating that information, we would also like to know the commit date because many packages that use fetchgit also store the commit date in a version attribute for that package.  Those packages are following a rule from the [Nixpkgs manual](https://nixos.org/nixpkgs/manual/):

> If package is fetched from git's commit then the version part of the name must be the date of that (fetched) commit. The date must be in "YYYY-MM-DD" format.

Currently, nix-prefetch-git does output a human-readable commit date on the standard error.  However, it would be useful to have the date be in the standard output of nix-prefetch-git so that we can get it with a standard JSON parser and not worry as much about its format changing.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
