### PR TITLE
edbrowse: 3.5.4.1 -> 3.6.1

### DIFF
--- a/pkgs/applications/editors/edbrowse/default.nix
+++ b/pkgs/applications/editors/edbrowse/default.nix
@@ -1,13 +1,17 @@
-{ stdenv, fetchurl, spidermonkey_24, unzip, curl, pcre, readline, openssl }:
+{ stdenv, fetchurl, spidermonkey_24, unzip, curl, pcre, readline, openssl, perl, html-tidy }:
 stdenv.mkDerivation rec {
   name = "edbrowse-${version}";
-  version = "3.5.4.1";
+  version = "3.6.1";
 
   nativeBuildInputs = [ unzip ];
-  buildInputs = [ curl pcre readline openssl spidermonkey_24 ];
+  buildInputs = [ curl pcre readline openssl spidermonkey_24 perl html-tidy ];
 
   patchPhase = ''
     substituteInPlace src/ebjs.c --replace \"edbrowse-js\" \"$out/bin/edbrowse-js\"
+    for i in ./tools/*.pl
+    do
+      substituteInPlace $i --replace "/usr/bin/perl" "${perl}/bin/perl"
+    done
   '';
 
   NIX_CFLAGS_COMPILE = "-I${spidermonkey_24.dev}/include/mozjs-24";
@@ -15,9 +19,9 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://edbrowse.org/${name}.zip";
-    sha256 = "0fpzaalwvgwbns7yxq4a4i6hpdljmcjfyvx19r1dlb3vdfw0vx5l";
+    sha256 = "1grkn09r31nmvcnm76jkd8aclmd9n5141mpqvb86wndp9pa7gz7q";
   };
-  meta = {
+  meta = with stdenv.lib; {
     description = "Command Line Editor Browser";
     longDescription = ''
       Edbrowse is a combination editor, browser, and mail client that is 100% text based.
@@ -26,8 +30,8 @@ stdenv.mkDerivation rec {
       A batch job, or cron job, can access web pages on the internet, submit forms, and send email, with no human intervention whatsoever.
       edbrowse can also tap into databases through odbc. It was primarily written by Karl Dahlke.
       '';
-    license = stdenv.lib.licenses.gpl1Plus;
+    license = licenses.gpl1Plus;
     homepage = http://edbrowse.org/;
-    maintainers = [ stdenv.lib.maintainers.schmitthenner ];
+    maintainers = [ maintainers.schmitthenner maintainers.vrthra ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
