### PR TITLE
opendoas: init at 0.3.2 (WIP)

### DIFF
--- a/nixos/modules/security/opendoas.nix
+++ b/nixos/modules/security/opendoas.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.security.opendoas;
+
+  inherit (pkgs) opendoas;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    security.opendoas.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description =
+        ''
+          Whether to enable the <command>doas</command> command, which
+          allows non-root users to execute commands as root.
+        '';
+    };
+
+    security.opendoas.configFile = mkOption {
+      type = types.lines;
+      # Note: if syntax errors are detected in this file, the NixOS
+      # configuration will fail to build.
+      description =
+        ''
+          This string contains the contents of the
+          <filename>doas.conf</filename> file.
+        '';
+    };
+
+    security.opendoas.extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra configuration text appended to <filename>doas.conf</filename>.
+      '';
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    security.opendoas.configFile =
+      ''
+        # Don't edit this file. Set the NixOS options ‘security.opendoas.configFile’
+        # or ‘security.opendoas.extraConfig’ instead.
+
+        ${cfg.extraConfig}
+      '';
+
+    security.setuidPrograms = [ "doas" ];
+
+    environment.systemPackages = [ opendoas ];
+  };
+
+}

--- a/pkgs/tools/security/opendoas/default.nix
+++ b/pkgs/tools/security/opendoas/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, lib, fetchFromGitHub, coreutils, pamSupport ? "yes", pam , bison, sudo, utillinux }:
+
+stdenv.mkDerivation rec {
+  name = "opendoas-${version}";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "Duncaen";
+    repo = "OpenDoas";
+    rev = "v${version}";
+    sha256 = "1m3w6ky9pq79ha53fnz8fzc2758wnh2s5dcm6dcm0vj7lrr5a65b";
+  };
+
+  buildInputs = [ coreutils bison utillinux ] ++ lib.optionals (pamSupport != null) [ pam ];
+
+  makeFlags = [
+    "BINOWN="
+    "BINGRP="
+    "DESTDIR="
+    "BINDIR=$(out)/bin"
+    "MANDIR=$(out)/share/man"
+    "PAMDIR=$(out)/etc"
+  ];
+
+  configurePhase = "./configure --prefix=$out " + lib.optionalString (pamSupport == null) "--without-pam";
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    grep -lr '/s\?bin/' | xargs sed -i \
+      -e 's|/bin/mount|${utillinux}/bin/mount|' \
+      -e 's|/bin/umount|${utillinux}/bin/umount|' \
+      -e 's|/bin/cp|${coreutils}/bin/cp|' \
+      -e 's|/bin/mv|${coreutils}/bin/mv|' \
+      -e 's|/bin/chown|${coreutils}/bin/chown|' \
+      -e 's|/bin/date|${coreutils}/bin/date|' \
+      -e 's|/usr/bin/sudo|/var/setuid-wrappers/sudo|'
+  '';
+
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "A command to run commands as root";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3444,6 +3444,8 @@ in
 
   sudo = callPackage ../tools/security/sudo { };
 
+  opendoas = callPackage ../tools/security/opendoas { };
+
   suidChroot = callPackage ../tools/system/suid-chroot { };
 
   sundtek = callPackage ../misc/drivers/sundtek { };


### PR DESCRIPTION
###### Motivation for this change

Opendoas is a simpler alternative for sudo;

I was unable to figure out how to get doas under `/var/setuid-wrappers`. The `pkgs/tools/security/sudo` package was not very helpful in figuring it out. Any help would be really appreciated.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
