### PR TITLE
Python: use buildEnv for application, remove PYTHONPATH wrapper

### DIFF
--- a/pkgs/development/interpreters/python/build-application.nix
+++ b/pkgs/development/interpreters/python/build-application.nix
@@ -1,0 +1,32 @@
+{stdenv}:
+
+{ package
+}:
+
+let
+  # Create Python environment with our package
+  env = package.python.withPackages ( ps: with ps; [ package ]);
+
+in stdenv.mkDerivation rec {
+  name = package.name;
+
+  unpackPhase = "true";
+
+  propagatedBuildInputs = [ env ];
+
+  # Create symbolic links to the scripts provided our package
+  # However, we link to wrapped symbolic links in our environment
+  installPhase = ''
+    mkdir -p "$out/bin"
+    if [ -d ${package}/bin ]; then
+      for prg in ${package}/bin/*; do
+        if [ -f "$prg" ]; then
+          echo ${env}/bin/$(basename $prg)
+          ln -t $out/bin -s ${env}/bin/$(basename $prg)
+        fi
+      done
+    fi
+  '';
+}
+
+

--- a/pkgs/development/python-modules/generic/default.nix
+++ b/pkgs/development/python-modules/generic/default.nix
@@ -129,6 +129,11 @@ python.stdenv.mkDerivation (builtins.removeAttrs attrs ["disabled" "doCheck"] //
   # Python packages don't have a checkPhase, only an installCheckPhase
   doCheck = false;
 
+  passthru = {
+      name = name;
+      python = python;
+  };
+
   installPhase = attrs.installPhase or ''
     runHook preInstall
 
@@ -143,7 +148,7 @@ python.stdenv.mkDerivation (builtins.removeAttrs attrs ["disabled" "doCheck"] //
   '';
 
   postFixup = attrs.postFixup or ''
-    wrapPythonPrograms
+#wrapPythonPrograms
   '' + lib.optionalString catchConflicts ''
     # check if we have two packages with the same name in closure and fail
     # this shouldn't happen, something went wrong with dependencies specs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5728,6 +5728,11 @@ in
   python2Packages = python27Packages;
   python3Packages = python35Packages;
 
+  buildApplication = callPackage ../development/interpreters/python/build-application.nix {};
+
+  tox = buildApplication { package = pythonPackages.tox; };
+  ipython = buildApplication { package = pythonPackages.ipython; };
+
   python26 = callPackage ../development/interpreters/python/2.6 {
     db = db47;
     self = python26;


### PR DESCRIPTION
###### Motivation for this change

I got the following idea to make Python applications work, without wrapping all scripts with a wrapper that sets PYTHONPATH. In this PR I introduce a function that builds a `python.buildEnv` for the chosen Python application, and then another derivation that symlinks only the scripts of the application, but then via the `buildEnv`. This works because `python.buildEnv` sets `PYTHONHOME`.

Eventually, I will want to put this function in the `passthru` of the interpreter.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@RonnyPfannschmidt this might be of interest to you.
