### PR TITLE
libjpeg-drop: init at 9b

### DIFF
--- a/pkgs/development/libraries/libjpeg-drop/default.nix
+++ b/pkgs/development/libraries/libjpeg-drop/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, static ? true }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "libjpeg-drop-9b";
+
+  srcs = [
+    (fetchurl {
+      url = http://www.ijg.org/files/jpegsrc.v9b.tar.gz;
+      sha256 = "0lnhpahgdwlrkd41lx6cr90r199f8mc6ydlh7jznj5klvacd63r4";
+    })
+    (fetchurl {
+      url = http://jpegclub.org/droppatch.v9b.tar.gz;
+      sha256 = "022bnvpird7w5pwbfqpq7j7pwja5kp6x9k3sdypcy3g2nwwy2wwk";
+    })
+  ];
+
+  postUnpack = ''
+    rm jpegtran
+    mv jpegtran.c jpeg-9b/jpegtran.c
+    mv transupp.c jpeg-9b/transupp.c
+    mv transupp.h jpeg-9b/transupp.h
+  '';
+
+  configureFlags = []
+    ++ optional static [ "--enable-static" "--disable-shared" ];
+
+  outputs = [ "dev" "out" "man" "bin" ];
+
+  meta = {
+    homepage = http://jpegclub.org/jpegtran/;
+    description = "Experimental lossless crop 'n' drop (cut & paste) patches for libjpeg";
+    license = stdenv.lib.licenses.free;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8099,6 +8099,7 @@ in
 
   libjpeg_original = callPackage ../development/libraries/libjpeg { };
   libjpeg_turbo = callPackage ../development/libraries/libjpeg-turbo { };
+  libjpeg_drop = callPackage ../development/libraries/libjpeg-drop { };
   libjpeg = if stdenv.isLinux then self.libjpeg_turbo else self.libjpeg_original; # some problems, both on FreeBSD and Darwin
 
   libjpeg62 = callPackage ../development/libraries/libjpeg/62.nix {


### PR DESCRIPTION
###### Motivation for this change

These patches supplement _jpegtran_ with the _--drop_ flag that allows dropping (pasting) of blocks from one jpeg to the next without re-compression.

Note the patches are supplied by the JPEGclub.org who also maintain the Independent JPEG Group's libjpeg itself. See http://jpegclub.org http://www.ijg.org/ http://jpegclub.org/jpegtran/

Notes on different libjpeg versions and varieties:
- pkgs/development/libraries/libjpeg/default.nix is libjpeg version 8d dating back to 2012.
- pkgs/development/libraries/libjpeg/62.nix is libjpeg version 6n dating back to 2002.
- pkgs/development/libraries/libjpeg-turbo/default.nix is a fork of 8 series libjpeg with ongoing effort on performance (SMID instructions and other improvements) and correctness with respect to the older APIs.
- pkgs/development/libraries/libjpeg-drop/default.nix is a recent libjpeg version 9b dating 2016 with additional experimental drop patches.

(dates from http://www.ijg.org/files/)

Practically speaking, most of the linux ecosystem depends on libjpeg-turbo or the 8 series libjpeg APIs. For this package's purposes, the interest is in the _transjpeg_ binary which is why the package is also set to compile statically by default.

The issue on 8vs9 series is further discussed in http://www.libjpeg-turbo.org/About/Jpeg-9 .
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
