### PR TITLE
pulseaudio: 8.0 -> 9.0

### DIFF
--- a/pkgs/development/libraries/webrtc-audio-processing/default.nix
+++ b/pkgs/development/libraries/webrtc-audio-processing/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "webrtc-audio-processing-0.1";
+  name = "webrtc-audio-processing-0.3";
 
   src = fetchurl {
     url = "http://freedesktop.org/software/pulseaudio/webrtc-audio-processing/${name}.tar.xz";
-    sha256 = "1p7yg8n39wwdfr52br2dq3bh8iypfx9md99mh1i9g2v8qbwm4jzd";
+    sha256 = "1yl0187xjh1j2zkb7v9cs9i868zcaj23pzn4a36qhzam9wfjjvkm";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -34,11 +34,11 @@
 
 stdenv.mkDerivation rec {
   name = "${if libOnly then "lib" else ""}pulseaudio-${version}";
-  version = "8.0";
+  version = "9.0";
 
   src = fetchurl {
     url = "http://freedesktop.org/software/pulseaudio/releases/pulseaudio-${version}.tar.xz";
-    sha256 = "128rrlvrgb4ia3pbzipf5mi6nvrpm6zmxn5r3bynqiikhvify3k9";
+    sha256 = "11j682g2mn723sz3bh4i44ggq29z053zcggy0glzn63zh9mxdly3";
   };
 
   patches = [ ./caps-fix.patch ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done

My minimal testing has been rebuilding my system with the changes and confirming that sound works.
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This also updates webrtc-audio-processing from 0.1 -> 0.3 as mentioned
in [1](https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/9.0/).

Release notes can be seen in [1](https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/9.0/).
