### PR TITLE
maphosts: Don't provide bundler anymore

### DIFF
--- a/pkgs/tools/networking/maphosts/default.nix
+++ b/pkgs/tools/networking/maphosts/default.nix
@@ -1,12 +1,22 @@
 { stdenv, lib, bundlerEnv, ruby }:
 
-bundlerEnv {
-  name = "maphosts-1.1.1";
+stdenv.mkDerivation rec {
+  name = "maphosts-${env.gems.maphosts.version}";
 
-  inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  env = bundlerEnv {
+    name = "maphosts-gems";
+    inherit ruby;
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+
+  phases = ["installPhase"];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    ln -s "${env}/bin/maphosts" "$out/bin/maphosts"
+  '';
 
   meta = with lib; {
     description = "Small command line application for keeping your project hostnames in sync with /etc/hosts";


### PR DESCRIPTION
###### Motivation for this change

Currently the `maphosts` package also provides the `bundler` binary. This leads to conflicts when installing other ruby packages which also provide `bundler` (e.g. `jekyll`) because then there're two `bundler`s.

This change wraps the `bundleEnv` to only provide the `maphosts` binary.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
