### PR TITLE
bleachbit: 1.8 -> 1.12

### DIFF
--- a/pkgs/applications/misc/bleachbit/default.nix
+++ b/pkgs/applications/misc/bleachbit/default.nix
@@ -1,13 +1,13 @@
 { stdenv, pythonPackages, fetchurl }:
 pythonPackages.buildPythonApplication rec {
   name = "bleachbit-${version}";
-  version = "1.8";
+  version = "1.12";
 
   namePrefix = "";
 
   src = fetchurl {
-    url = "mirror://sourceforge/bleachbit/bleachbit-1.8.tar.bz2";
-    sha256 = "dbf50fcbf24b8b3dd1c4325cd62352628d089f88a76eab804df5d90c872ee592";
+    url = "mirror://sourceforge/bleachbit/${name}.tar.bz2";
+    sha256 = "1x58n429q1c77nfpf2g3vyh6yq8wha69zfzmxf1rvjvcvvmqs62m";
   };
 
   buildInputs = [  pythonPackages.wrapPython ];


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
