### PR TITLE
cweb: init at 22p

### DIFF
--- a/pkgs/development/tools/misc/cwebbin/default.nix
+++ b/pkgs/development/tools/misc/cwebbin/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, fetchurl, tie }:
+
+stdenv.mkDerivation rec {
+  name = "cwebbin-${version}";
+  version = "22p";
+
+  src = fetchFromGitHub {
+    owner = "ascherer";
+    repo = "cwebbin";
+    rev = name;
+    sha256 = "0zf93016hm9i74i2v384rwzcw16y3hg5vc2mibzkx1rzvqa50yfr";
+  };
+
+  cweb = fetchurl {
+    url = https://www.ctan.org/tex-archive/web/c_cpp/cweb/cweb.tar.gz;
+    sha256 = "1hdzxfzaibnjxjzgp6d2zay8nsarnfy9hfq55hz1bxzzl23n35aj";
+  };
+
+  buildInputs = [ tie ];
+
+  makeFlags = [
+    "MACROSDIR=$(out)/share/texmf/tex/generic/cweb"
+    "CWEBINPUTS=$(out)/lib/cweb"
+    "DESTDIR=$(out)/bin"
+    "MANDIR=$(out)/share/man/man1"
+    "EMACSDIR=$(out)/share/emacs/site-lisp"
+    "CP=cp"
+    "RM=rm"
+    "PDFTEX=echo"
+  ];
+
+  buildPhase = ''
+    zcat ${cweb} | tar -xvpf -
+    make -f Makefile.unix boot $makeFlags
+    make -f Makefile.unix cautiously $makeFlags
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/man/man1 $out/share/texmf/tex/generic $out/share/emacs $out/lib
+    make -f Makefile.unix install $makeFlags
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Literate Programming in C/C++";
+    platforms = with platforms; unix;
+    maintainers = with maintainers; [ vrthra ];
+  };
+}

--- a/pkgs/development/tools/misc/tie/default.nix
+++ b/pkgs/development/tools/misc/tie/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "tie-${version}";
+  version = "2.4";
+
+  src = fetchurl {
+    url = "http://mirrors.ctan.org/web/tie/${name}.tar.gz";
+    sha256 = "1m5952kdfffiz33p1jw0wv7dh272mmw28mpxw9v7lkb352zv4xsj";
+  };
+
+  buildPhase = ''
+    gcc tie.c -o tie
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp tie $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.ctan.org/tex-archive/web/tie;
+    description = "Allow multiple web change files";
+    platforms = with platforms; unix;
+    maintainers = with maintainers; [ vrthra ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3598,6 +3598,8 @@ in
 
   tinc = callPackage ../tools/networking/tinc { };
 
+  tie = callPackage ../development/tools/misc/tie { };
+
   tinc_pre = callPackage ../tools/networking/tinc/pre.nix { };
 
   tiny8086 = callPackage ../applications/virtualization/8086tiny { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1220,6 +1220,8 @@ in
 
   cutter = callPackage ../tools/networking/cutter { };
 
+  cwebbin = callPackage ../development/tools/misc/cwebbin { };
+
   cvs_fast_export = callPackage ../applications/version-management/cvs-fast-export { };
 
   dadadodo = callPackage ../tools/text/dadadodo { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
