### PR TITLE
tlp service: add restart on config change

### DIFF
--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -61,6 +61,7 @@ in
         after = [ "multi-user.target" ];
         wantedBy = [ "multi-user.target" ];
         before = [ "shutdown.target" ];
+        restartTriggers = [ confFile ];
 
         serviceConfig = {
           Type = "oneshot";


### PR DESCRIPTION
###### Motivation for this change

TLP service should restart after configuration change.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @abbradar 
