### PR TITLE
ffmpeg: additional package fixes

### DIFF
--- a/pkgs/desktops/kde-5/applications-16.04/default.nix
+++ b/pkgs/desktops/kde-5/applications-16.04/default.nix
@@ -35,7 +35,9 @@ let
     baloo-widgets = callPackage ./baloo-widgets.nix {};
     dolphin = callPackage ./dolphin.nix {};
     dolphin-plugins = callPackage ./dolphin-plugins.nix {};
-    ffmpegthumbs = callPackage ./ffmpegthumbs.nix {};
+    ffmpegthumbs = callPackage ./ffmpegthumbs.nix {
+      ffmpeg = pkgs.ffmpeg_2;
+    };
     filelight = callPackage ./filelight.nix {};
     gpgmepp = callPackage ./gpgmepp.nix {};
     gwenview = callPackage ./gwenview.nix {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8997,6 +8997,7 @@ in
     vlc = lowPrio (callPackage ../applications/video/vlc {
       qt4 = null;
       withQt5 = true;
+      ffmpeg = ffmpeg_2;
     });
 
   };


### PR DESCRIPTION
Some KDE packages still failed after #16632.
