### PR TITLE
cataclysm-dda-git: init at 2017-07-12

### DIFF
--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -1,0 +1,67 @@
+{ fetchFromGitHub, stdenv, makeWrapper, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
+SDL2_mixer, freetype, gettext }:
+
+stdenv.mkDerivation rec {
+  version = "2017-07-12";
+  name = "cataclysm-dda-git-${version}";
+
+  src = fetchFromGitHub {
+    owner = "CleverRaven";
+    repo = "Cataclysm-DDA";
+    rev = "2d7aa8c";
+    sha256 = "0xx7si4k5ivyb5gv98fzlcghrg3w0dfblri547x7x4is7fj5ffjd";
+  };
+
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
+
+  buildInputs = [ ncurses lua SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype gettext ];
+
+  postPatch = ''
+    patchShebangs .
+    sed -i Makefile \
+      -e 's,-Werror,,g' \
+      -e 's,\(DATA_PREFIX=$(PREFIX)/share/\)cataclysm-dda/,\1,g'
+
+    sed '1i#include <cmath>' \
+      -i src/{crafting,skill,weather_data,melee,vehicle,overmap,iuse_actor}.cpp
+  '';
+
+  makeFlags = "PREFIX=$(out) LUA=1 TILES=1 SOUND=1 RELEASE=1 USE_HOME_DIR=1";
+
+  postInstall = ''
+    wrapProgram $out/bin/cataclysm-tiles \
+      --add-flags "--datadir $out/share/cataclysm-dda/"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A free, post apocalyptic, zombie infested rogue-like";
+    longDescription = ''
+      Cataclysm: Dark Days Ahead is a roguelike set in a post-apocalyptic world.
+      Surviving is difficult: you have been thrown, ill-equipped, into a
+      landscape now riddled with monstrosities of which flesh eating zombies are
+      neither the strangest nor the deadliest.
+
+      Yet with care and a little luck, many things are possible. You may try to
+      eke out an existence in the forests silently executing threats and
+      providing sustenance with your longbow. You can ride into town in a
+      jerry-rigged vehicle, all guns blazing, to settle matters in a fug of
+      smoke from your molotovs. You could take a more measured approach and
+      construct an impregnable fortress, surrounded by traps to protect you from
+      the horrors without. The longer you survive, the more skilled and adapted
+      you will get and the better equipped and armed to deal with the threats
+      you are presented with.
+
+      In the course of your ordeal there will be opportunities and temptations
+      to improve or change your very nature. There are tales of survivors fitted
+      with extraordinary cybernetics giving great power and stories too of
+      gravely mutated survivors who, warped by their ingestion of exotic
+      substances or radiation, now more closely resemble insects, birds or fish
+      than their original form.
+    '';
+    homepage = http://en.cataclysmdda.com/;
+    license = licenses.cc-by-sa-30;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16951,6 +16951,8 @@ with pkgs;
 
   cataclysm-dda = callPackage ../games/cataclysm-dda { };
 
+  cataclysm-dda-git = callPackage ../games/cataclysm-dda/git.nix { };
+
   chessdb = callPackage ../games/chessdb { };
 
   chessx = libsForQt5.callPackage ../games/chessx { };


### PR DESCRIPTION
###### Motivation for this change

Cataclysm dda hasn't done a release in like a billion years and I want a up to date game.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is very similar to the current default.nix (differences are enabling parallel building and changing the wrapper datadir path), so maybe a single file with a version argument might be better here? Not sure what's the recommended way to do it.

Should we use LTO? https://github.com/CleverRaven/Cataclysm-DDA/blob/master/COMPILING.md
