### PR TITLE
openrct2: init at 0.0.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -185,6 +185,7 @@
   joamaki = "Jussi Maki <joamaki@gmail.com>";
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
   joelteon = "Joel Taylor <me@joelt.io>";
+  joepie91 = "Sven Slootweg <admin@cryto.net>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
   jraygauthier = "Raymond Gauthier <jraygauthier@gmail.com>";
   juliendehos = "Julien Dehos <dehos@lisic.univ-littoral.fr>";

--- a/pkgs/games/openrct2/default.nix
+++ b/pkgs/games/openrct2/default.nix
@@ -1,0 +1,13 @@
+{ stdenv, fetchurl, cmake, pkgconfig, requireFile, makeWrapper, innoextract
+, SDL2, SDL2_ttf, fontconfig, jansson, speexdsp, openssl, curl }:
+
+rec {
+  openrct2 = import ./gog.nix { inherit
+    stdenv requireFile makeWrapper innoextract openrct2-engine;
+  };
+
+  openrct2-engine = import ./engine.nix { inherit
+    stdenv fetchurl cmake pkgconfig
+    SDL2 SDL2_ttf fontconfig jansson speexdsp openssl curl;
+  };
+}

--- a/pkgs/games/openrct2/engine.nix
+++ b/pkgs/games/openrct2/engine.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, cmake, pkgconfig
+, SDL2, SDL2_ttf, fontconfig, jansson, speexdsp, openssl, curl }:
+
+let
+  originalExecutable = "setup_rollercoaster_tycoon_2.exe";
+in
+  stdenv.mkDerivation rec {
+    name = "openrct2-engine-${version}";
+    version = "0.0.4";
+
+    meta = {
+      description = ''An open source re-implementation of Roller Coaster Tycoon 2'';
+      longDescription = ''
+        OpenRCT2 is an open-source re-implementation of RollerCoaster
+        Tycoon 2 (RCT2). The gameplay revolves around building and
+        maintaining an amusement park containing attractions, shops
+        and facilities. The player must try to make a profit and
+        maintain a good park reputation whilst keeping the guests
+        happy. OpenRCT2 allows for both scenario and sandbox play.
+
+        Scenarios require the player to complete a certain objective
+        in a set time limit whilst sandbox allows the player to build
+        a more flexible park with optionally no restrictions or
+        finance.
+      '';
+      homepage = http://www.openrct2.website/;
+      license = stdenv.lib.licenses.gpl3;
+      platforms = stdenv.lib.platforms.linux;
+      maintainers = with stdenv.lib.maintainers; [ joepie91 ];
+    };
+
+    src = fetchurl {
+      url = "https://github.com/OpenRCT2/OpenRCT2/archive/v${version}.tar.gz";
+      sha256 = "1as0xf6zjxsjawllkjhbfdnaw7r78n8fq22kadl63dycwcfvzjzb";
+    };
+
+    buildInputs = [
+      cmake pkgconfig
+      SDL2 SDL2_ttf fontconfig jansson speexdsp openssl curl
+    ];
+  }

--- a/pkgs/games/openrct2/gog.nix
+++ b/pkgs/games/openrct2/gog.nix
@@ -1,0 +1,73 @@
+{ stdenv, requireFile, makeWrapper, innoextract, openrct2-engine }:
+
+let
+  originalExecutable = "setup_rollercoaster_tycoon_2.exe";
+in
+  stdenv.mkDerivation rec {
+    name = "openrct2-${version}";
+    version = "0.0.4";
+
+    meta = {
+      description = ''An open source re-implementation of Roller Coaster Tycoon 2 (using GOG assets)'';
+      longDescription = ''
+        This package will attempt to install OpenRCT2 using the assets
+        from the GOG installer for RollerCoaster Tycoon 2: Triple Thrill
+        Pack. If you just want to install OpenRCT2 itself and specify the
+        assets manually, install 'openrct2-engine' instead.
+
+        OpenRCT2 is an open-source re-implementation of RollerCoaster
+        Tycoon 2 (RCT2). The gameplay revolves around building and
+        maintaining an amusement park containing attractions, shops
+        and facilities. The player must try to make a profit and
+        maintain a good park reputation whilst keeping the guests
+        happy. OpenRCT2 allows for both scenario and sandbox play.
+
+        Scenarios require the player to complete a certain objective
+        in a set time limit whilst sandbox allows the player to build
+        a more flexible park with optionally no restrictions or
+        finance.
+      '';
+      homepage = http://www.openrct2.website/;
+      license = stdenv.lib.licenses.unfree;
+      platforms = stdenv.lib.platforms.linux;
+      maintainers = with stdenv.lib.maintainers; [ joepie91 ];
+    };
+
+    src = requireFile {
+      message = ''
+        OpenRCT2 requires the assets of the original RollerCoaster Tycoon 2 game to run.
+        To automatically extract these assets, you should provide the GOG installer, using
+        a command that looks something like this:
+
+          nix-prefetch-url file:///path/to/${originalExecutable}
+
+        ... or alternatively, install 'openrct2-engine' instead. The game will then ask you
+            to locate the asset directory when you start it for the first time.
+      '';
+      name = originalExecutable;
+      sha256 = "68c2a43388967dbdf45e716263eab6bd1d9c8fb51e8d89a76a028e97754618da";
+    };
+
+    phases = "unpackPhase installPhase";
+
+    buildInputs = [
+      openrct2-engine makeWrapper
+    ];
+
+    unpackPhase = ''
+      ${innoextract}/bin/innoextract -egd original_assets/ ${src}
+      cd original_assets
+    '';
+
+    installPhase = ''
+      echo "Moving assets..."
+      mkdir -p "$out/assets"
+      mv app/* "$out/assets/"
+
+      # Temporary workaround for OpenRCT2/OpenRCT2#3981
+      # WARNING: this will modify the configuration file in the user's homedir on every launch.
+      echo "Patching in asset path configuration..."
+      makeWrapper "${openrct2-engine}/bin/openrct2" "$out/bin/openrct2" \
+        --run "${openrct2-engine}/bin/openrct2 set-rct2 $out/assets/"
+    '';
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -53,6 +53,8 @@ in
 
   callPackage_i686 = lib.callPackageWith (pkgsi686Linux // pkgsi686Linux.xorg);
 
+  callPackages_i686 = lib.callPackagesWith (pkgsi686Linux // pkgsi686Linux.xorg);
+
   forceNativeDrv = drv : if crossSystem == null then drv else
     (drv // { crossDrv = drv.nativeDrv; });
 
@@ -15429,6 +15431,12 @@ in
   openlierox = callPackage ../games/openlierox { };
 
   openmw = callPackage ../games/openmw { };
+
+  inherit (callPackages_i686 ../games/openrct2 {
+      stdenv = stdenv_32bit;
+    })
+    openrct2
+    openrct2-engine;
 
   openra = callPackage ../games/openra { lua = lua5_1; };
 


### PR DESCRIPTION
###### Motivation for this change

Package is currently missing from nixpkgs, and this fixes that :)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not familiar with either sandboxing or nox-review and didn't find out about their existence until I went to create a PR (nor does anything really seem to explain this), so I haven't done those steps yet.

This PR adds _two_ packages - `openrct2` (marked 'unfree') and `openrct2-engine` (marked GPL3). The reason for this is that OpenRCT2 is an RCT2 clone that is currently in a state where there are no original assets yet.  This means that in the majority of cases, the user will want to install the game using assets from the GOG installer for the original RCT2, and so that is the default.

Both for the purpose of Hydra builds and for users who want to use a different source for their game assets, the `openrct2-engine` package is available, which builds and installs _just_ the OpenRCT2 engine itself. The `openrct2` package will install `openrct2-engine`, extract the assets from the GOG installer (or ask the user for it if they haven't provided it yet), and then use a wrapper to load OpenRCT2 with the installed assets.

The wrapper currently modifies the OpenRCT2 configuration file in the user's home directory; unfortunately, this cannot be resolved until OpenRCT2/OpenRCT2#3981 is fixed.

Note that this package is only available in an i686 variant - this is intentional, as it is not currently possible to build a 64-bit version of OpenRCT2.

EDIT: Forgot to mention, I had to add  a callPackages_i686 to `top_level.nix` as well, as it didn't exist yet.
