### PR TITLE
pekwm: init at 0.1.17

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -19,6 +19,7 @@ in
     ./jwm.nix
     ./metacity.nix
     ./openbox.nix
+    ./pekwm.nix
     ./notion.nix
     ./ratpoison.nix
     ./sawfish.nix

--- a/nixos/modules/services/x11/window-managers/pekwm.nix
+++ b/nixos/modules/services/x11/window-managers/pekwm.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.pekwm;
+in
+{
+  ###### interface
+  options = {
+    services.xserver.windowManager.pekwm.enable = mkEnableOption "pekwm";
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "pekwm";
+      start = ''
+        ${pkgs.pekwm}/bin/pekwm &
+        waitPID=$!
+      '';
+    };
+    environment.systemPackages = [ pkgs.pekwm ];
+  };
+}

--- a/pkgs/applications/window-managers/pekwm/default.nix
+++ b/pkgs/applications/window-managers/pekwm/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, pkgconfig
+, libpng, libjpeg
+, libXext, libXft, libXpm, libXrandr, libXinerama }:
+
+stdenv.mkDerivation rec {
+
+  name = "pekwm-${version}";
+  version = "0.1.17";
+
+  src = fetchurl {
+    url = "https://www.pekwm.org/projects/pekwm/files/${name}.tar.bz2";
+    sha256 = "003x6bxj1lb2ljxz3v414bn0rdl6z68c0r185fxwgs1qkyzx67wa";
+  };
+
+  buildInputs = [ pkgconfig libpng libjpeg
+  libXext libXft libXpm libXrandr libXinerama ];
+
+  meta = with stdenv.lib; {
+    description = "A lightweight window manager";
+    longDescription = ''
+      pekwm is a window manager that once upon a time was based on the
+      aewm++ window manager, but it has evolved enough that it no
+      longer resembles aewm++ at all. It has a much expanded
+      feature-set, including window grouping (similar to ion, pwm, or
+      fluxbox), autoproperties, xinerama, keygrabber that supports
+      keychains, and much more.      
+      - Lightweight and Unobtrusive, a window manager shouldn't be
+        noticed.
+      - Very configurable, we all work and think in different ways.
+      - Automatic properties, for all the lazy people, make things
+        appear as they should when starting applications.
+      - Chainable Keygrabber, usability for everyone.
+    '';
+      homepage = https://www.pekwm.org;
+      license = licenses.gpl2;
+      maintainers = [ maintainers.AndersonTorres ];
+      platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13969,6 +13969,8 @@ in
 
   pcsx2 = callPackage_i686 ../misc/emulators/pcsx2 { };
 
+  pekwm = callPackage ../applications/window-managers/pekwm { };
+
   pencil = callPackage ../applications/graphics/pencil {
     xulrunner = firefox-unwrapped;
   };


### PR DESCRIPTION
###### Motivation for this change

Insertion of pekwm, a lightweight window manager.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
