### PR TITLE
mailutils: fix build break

### DIFF
--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -1,7 +1,6 @@
 { fetchurl, stdenv, gettext, gdbm, libtool, pam, readline
-, ncurses, gnutls, mysql, guile, texinfo, gnum4, dejagnu, sendmailPath ? "/var/setuid-wrappers/sendmail" }:
-
-/* TODO: Add GNU SASL, GNU GSSAPI, and FreeBidi.  */
+, ncurses, gnutls, sasl, fribidi, gss , mysql, guile, texinfo,
+  gnum4, dejagnu, nettools }:
 
 stdenv.mkDerivation rec {
   name = "mailutils-2.2";
@@ -11,17 +10,19 @@ stdenv.mkDerivation rec {
     sha256 = "0szbqa12zqzldqyw97lxqax3ja2adis83i7brdfsxmrfw68iaf65";
   };
 
-  patches = [ ./path-to-cat.patch ./no-gets.patch ];
+  patches = [ ./path-to-cat.patch ./no-gets.patch ./scm_c_string.patch ];
 
-  configureFlags = "--with-path-sendmail=${sendmailPath}";
+  configureFlags = [
+    "--with-gsasl"
+    "--with-gssapi=${gss}"
+  ];
 
   buildInputs =
    [ gettext gdbm libtool pam readline ncurses
-     gnutls mysql.lib guile texinfo gnum4 ]
+     gnutls mysql.lib guile texinfo gnum4 sasl fribidi gss nettools ]
    ++ stdenv.lib.optional doCheck dejagnu;
 
-  # Tests fail since gcc 4.8
-  doCheck = false;
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Rich and powerful protocol-independent mail framework";
@@ -51,7 +52,7 @@ stdenv.mkDerivation rec {
       gpl3Plus /* tools */
     ];
 
-    maintainers = [ ];
+    maintainers = with maintainers; [ vrthra ];
 
     homepage = http://www.gnu.org/software/mailutils/;
 

--- a/pkgs/tools/networking/mailutils/scm_c_string.patch
+++ b/pkgs/tools/networking/mailutils/scm_c_string.patch
@@ -1,0 +1,15 @@
+See https://lists.gnu.org/archive/html/bug-mailutils/2010-10/msg00005.html
+
+diff -u mailutils-2.2/libmu_scm/mu_message.c mailutils-2.2.new/libmu_scm/mu_message.c
+--- mailutils-2.2/libmu_scm/mu_message.c	2010-04-18 10:29:07.000000000 -0700
++++ mailutils-2.2.new/libmu_scm/mu_message.c	2016-07-03 21:18:53.746185547 -0700
+@@ -510,8 +510,8 @@
+     {
+       SCM car = SCM_CAR (lst);
+       if (scm_is_string (car)
+ 	  && mu_c_strncasecmp (scm_i_string_chars (car), name,
+-			       scm_i_string_length (car)) == 0)
++			       scm_c_string_length (car)) == 0)
+ 	return 1;
+     }
+   return 0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2420,7 +2420,7 @@ in
   mailpile = callPackage ../applications/networking/mailreaders/mailpile { };
 
   mailutils = callPackage ../tools/networking/mailutils {
-    guile = guile_1_8;
+    sasl = gsasl;
   };
 
   email = callPackage ../tools/networking/email { };


### PR DESCRIPTION
###### Motivation for this change

Fixes #14606 
mailutils no longer allows to set the path to sendmail as a configuration option. Instead it is taken from "path.h"
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See #14606 for the breakage. It is fixed by using default guile
Also addes support for fribidi, sasl, and gssapi
