### PR TITLE
documentation: fix start display-manager command

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -22,7 +22,7 @@
   (with empty password).</para></listitem>
 
   <listitem><para>If you downloaded the graphical ISO image, you can
-  run <command>start display-manager</command> to start KDE. If you
+  run <command>systemctl start display-manager</command> to start KDE. If you
   want to continue on the terminal, you can use
   <command>loadkeys</command> to switch to your preferred keyboard layout.
   (We even provide neo2 via <command>loadkeys de neo</command>!)</para></listitem>

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -42,7 +42,7 @@ with lib;
 
         The "root" account has an empty password.  ${
           optionalString config.services.xserver.enable
-            "Type `start display-manager' to\nstart the graphical user interface."}
+            "Type `systemctl start display-manager' to\nstart the graphical user interface."}
       '';
 
     # Allow sshd to be started manually through "start sshd".


### PR DESCRIPTION
###### Motivation for this change

Address #16596
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
