### PR TITLE
xorriso: 1.4.2 -> 1.4.4

### DIFF
--- a/pkgs/development/libraries/libburn/default.nix
+++ b/pkgs/development/libraries/libburn/default.nix
@@ -2,17 +2,17 @@
 
 stdenv.mkDerivation rec {
   name = "libburn-${version}";
-  version = "1.4.2.pl01";
+  version = "1.4.4";
 
   src = fetchurl {
     url = "http://files.libburnia-project.org/releases/${name}.tar.gz";
-    sha256 = "1nqfm24dm2csdnhsmpgw9cwcnkwvqlvfzsm9bhr6yg7bbmzwvkrk";
+    sha256 = "053x1sj6r5pj5396g007v6l0s7942cy2mh5fd3caqx0jdw6h9xqv";
   };
 
   meta = with stdenv.lib; {
     homepage = http://libburnia-project.org/;
     description = "A library by which preformatted data get onto optical media: CD, DVD, BD (Blu-Ray)";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar vrthra ];
   };
 }

--- a/pkgs/development/libraries/libisoburn/default.nix
+++ b/pkgs/development/libraries/libisoburn/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, acl, attr, zlib, libburn, libisofs }:
+
+stdenv.mkDerivation rec {
+  name = "libisoburn-${version}";
+  version = "1.4.4";
+
+  src = fetchurl {
+    url = "http://files.libburnia-project.org/releases/${name}.tar.gz";
+    sha256 = "1mn2dwkwdrdcjnd59czxali7r5nlxdx92clyxnsfpmw20f9s20kv";
+  };
+
+  buildInputs = [ attr zlib libburn libisofs ];
+  propagatedBuildInputs = [ acl ];
+
+  meta = with stdenv.lib; {
+    homepage = http://libburnia-project.org/;
+    description = "Enables creation and expansion of ISO-9660 filesystems on CD/DVD/BD ";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ vrthra ];
+  };
+}

--- a/pkgs/development/libraries/libisofs/default.nix
+++ b/pkgs/development/libraries/libisofs/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libisofs-${version}";
-  version = "1.4.2";
+  version = "1.4.4";
 
   src = fetchurl {
     url = "http://files.libburnia-project.org/releases/${name}.tar.gz";
-    sha256 = "1axk1ykv8ibrlrd2f3allidviimi4ya6k7wpvr6r4y1sc7mg7rym";
+    sha256 = "1zdx56k847c80ds5yf40hh0a26lkqrc0v11r589dqlm6xvzg0614";
   };
 
   buildInputs = [ attr zlib ];
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
     homepage = http://libburnia-project.org/;
     description = "A library to create an ISO-9660 filesystem with extensions like RockRidge or Joliet";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar vrthra ];
   };
 }

--- a/pkgs/tools/cd-dvd/xorriso/default.nix
+++ b/pkgs/tools/cd-dvd/xorriso/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, libcdio, zlib, bzip2, readline, acl, attr }:
 
 stdenv.mkDerivation rec {
-  name = "xorriso-1.4.2";
+  name = "xorriso-1.4.4";
 
   src = fetchurl {
     url = "mirror://gnu/xorriso/${name}.tar.gz";
-    sha256 = "1cq4a0904lnz6nygbgarnlq49cz4qnfdyvz90s3nfk5as7gbwhr8";
+    sha256 = "1izv8dvwacyh432vv1rm6lyjrq0v205kyakfra6iwa146c9m9fgr";
   };
 
   doCheck = true;
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libcdio zlib bzip2 readline attr ]
     ++ stdenv.lib.optional stdenv.isLinux acl;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "ISO 9660 Rock Ridge file system manipulator";
 
     longDescription =
@@ -26,11 +26,11 @@ stdenv.mkDerivation rec {
          filesystems.
       '';
 
-    license = stdenv.lib.licenses.gpl3Plus;
+    license = licenses.gpl3Plus;
 
     homepage = http://www.gnu.org/software/xorriso/;
 
-    maintainers = [ ];
-    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8095,6 +8095,8 @@ in
 
   libisofs = callPackage ../development/libraries/libisofs { };
 
+  libisoburn = callPackage ../development/libraries/libisoburn { };
+
   libiptcdata = callPackage ../development/libraries/libiptcdata { };
 
   libjpeg_original = callPackage ../development/libraries/libjpeg { };


### PR DESCRIPTION
###### Motivation for this change

Xorriso, supporting and associated libraries.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
