### PR TITLE
biber: 2.4 -> 2.5

### DIFF
--- a/pkgs/tools/typesetting/biber/default.nix
+++ b/pkgs/tools/typesetting/biber/default.nix
@@ -1,20 +1,23 @@
-{ stdenv, fetchurl, buildPerlPackage, autovivification, BusinessISBN
+{ stdenv, fetchFromGitHub, buildPerlPackage, autovivification, BusinessISBN
 , BusinessISMN, BusinessISSN, ConfigAutoConf, DataCompare, DataDump, DateSimple
 , EncodeEUCJPASCII, EncodeHanExtra, EncodeJIS2K, ExtUtilsLibBuilder
 , FileSlurp, IPCRun3, Log4Perl, LWPProtocolHttps, ListAllUtils, ListMoreUtils
 , ModuleBuild, MozillaCA, ReadonlyXS, RegexpCommon, TextBibTeX, UnicodeCollate
 , UnicodeLineBreak, URI, XMLLibXMLSimple, XMLLibXSLT, XMLWriter, ClassAccessor
-, TextRoman, DataUniqid }:
+, TextRoman, DataUniqid, TestDifferences, FileWhich, UnicodeNormalize, LinguaTranslit }:
 
 let
-  version = "2.4";
+  version = "2.5";
   pn = "biblatex-biber";
 in
 buildPerlPackage {
   name = "biber-${version}";
-  src = fetchurl {
-    url = "mirror://sourceforge/project/${pn}/${pn}/${version}/${pn}.tar.gz";
-    sha256 = "1gccbs5vzs3fca41d9dwl6nrdljnh29yls8xzfw04hd57yrfn5w4";
+  version = "2.5";
+  src = fetchFromGitHub {
+    owner = "plk";
+    repo = "biber";
+    rev = "v${version}";
+    sha256 = "1ldkszsr2n11nib4nvmpvsxmvp0qd9w3lxijyqlf01cfaryjdzgr";
   };
 
   buildInputs = [
@@ -23,20 +26,23 @@ buildPerlPackage {
     ExtUtilsLibBuilder FileSlurp IPCRun3 Log4Perl LWPProtocolHttps ListAllUtils
     ListMoreUtils ModuleBuild MozillaCA ReadonlyXS RegexpCommon TextBibTeX
     UnicodeCollate UnicodeLineBreak URI XMLLibXMLSimple XMLLibXSLT XMLWriter
-    ClassAccessor TextRoman DataUniqid
+    ClassAccessor TextRoman DataUniqid TestDifferences FileWhich UnicodeNormalize
+    LinguaTranslit
   ];
   preConfigure = "touch Makefile.PL";
   buildPhase = "perl Build.PL --prefix=$out; ./Build build";
-  checkPhase = "./Build test";
+  checkPhase = ''
+    rm t/utils.t # broken
+    ./Build test
+  '';
   installPhase = "./Build install";
 
-  # Tests seem to be broken
-  doCheck = false;
+  doCheck = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Backend for BibLaTeX";
-    license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.ttuegel ];
+    license = with licenses; [ artistic1 gpl1Plus ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ttuegel maintainers.vrthra ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -911,7 +911,7 @@ in
       ExtUtilsLibBuilder FileSlurp IPCRun3 Log4Perl LWPProtocolHttps ListAllUtils
       ListMoreUtils ModuleBuild MozillaCA ReadonlyXS RegexpCommon TextBibTeX
       UnicodeCollate UnicodeLineBreak URI XMLLibXMLSimple XMLLibXSLT XMLWriter
-      ClassAccessor TextRoman DataUniqid;
+      ClassAccessor TextRoman DataUniqid TestDifferences FileWhich UnicodeNormalize LinguaTranslit;
   };
 
   bibtextools = callPackage ../tools/typesetting/bibtex-tools {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12950,15 +12950,16 @@ let self = _self // overrides; _self = with self; {
   };
 
   TextBibTeX = buildPerlModule rec {
-    name = "Text-BibTeX-0.71";
+    name = "Text-BibTeX-0.72";
     buildInputs = [ ConfigAutoConf ExtUtilsLibBuilder ];
     src = fetchurl {
       url = "mirror://cpan/authors/id/A/AM/AMBS/${name}.tar.gz";
-      sha256 = "1jwi4yc4l1sf9pyc6qifcm493lwf8iggdjli7f9a9aqin1swh36d";
+      sha256 = "0vfnj9ygdjympc8hsf38nc4a1lq45qbq7v6z6mrnfgr3k198b6gw";
     };
     meta = {
       description = "Interface to read and parse BibTeX files";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.vrthra ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13795,6 +13795,19 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  LinguaTranslit = buildPerlPackage {
+    name = "Lingua-Translit-1.26";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/A/AL/ALINKE/Lingua-Translit-0.26.tar.gz;
+      sha256 = "161589h08kzliga17i2g0hb0yn4cjmb8rdiyadq5bw97974bac14";
+    };
+    meta = {
+      maintainers = [ maintainers.vrthra ];
+      description = "Transliterates text between writing systems";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   UnicodeNormalize = buildPerlPackage {
     name = "Unicode-Normalize-1.19";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13809,12 +13809,13 @@ let self = _self // overrides; _self = with self; {
   };
 
   UnicodeNormalize = buildPerlPackage {
-    name = "Unicode-Normalize-1.19";
+    name = "Unicode-Normalize-1.25";
     src = fetchurl {
-      url = mirror://cpan/authors/id/S/SA/SADAHIRO/Unicode-Normalize-1.19.tar.gz;
-      sha256 = "ab16467692cb78ced706fb7bee4145ac09d9f14d9eed92be4a305de3172ce6c4";
+      url = mirror://cpan/authors/id/K/KH/KHW/Unicode-Normalize-1.25.tar.gz;
+      sha256 = "0v04bcyjfcfap4kfpc8q3ikq3j7s68nym4ckw3iasmmksdskmcq0";
     };
     meta = {
+      maintainers = [ maintainers.vrthra ];
       description = "Unicode Normalization Forms";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };


### PR DESCRIPTION
###### Motivation for this change

Upgrade biber and its dependencies, and ensure that almost all tests pass.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
