### PR TITLE
libyamlcpp: 0.5.1 -> 0.5.3

### DIFF
--- a/pkgs/development/libraries/libyaml-cpp/default.nix
+++ b/pkgs/development/libraries/libyaml-cpp/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchurl, cmake, boost, makePIC ? false }:
+{ stdenv, fetchFromGitHub, cmake, boost, makePIC ? false }:
 
-stdenv.mkDerivation {
-  name = "libyaml-cpp-0.5.1";
+stdenv.mkDerivation rec {
+  name = "libyaml-cpp-${version}";
+  version = "0.5.3";
 
-  src = fetchurl {
-    url = http://yaml-cpp.googlecode.com/files/yaml-cpp-0.5.1.tar.gz;
-    sha256 = "01kg0h8ksp162kdhyzn67vnlxpj5zjbks84sh50pv61xni990z1y";
+  src = fetchFromGitHub {
+    owner = "jbeder";
+    repo = "yaml-cpp";
+    rev = "release-${version}";
+    sha256 = "0qr286q8mwbr4cxz0y0rf045zc071qh3cb804by6w1ydlqciih8a";
   };
 
   buildInputs = [ cmake boost ];
@@ -13,7 +16,7 @@ stdenv.mkDerivation {
   cmakeFlags = stdenv.lib.optionals makePIC [ "-DCMAKE_C_FLAGS=-fPIC" "-DCMAKE_CXX_FLAGS=-fPIC" ];
 
   meta = with stdenv.lib; {
-    homepage = http://code.google.com/p/yaml-cpp/;
+    inherit (src.meta) homepage;
     description = "A YAML parser and emitter for C++";
     license = licenses.mit;
     platforms = platforms.unix;


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
