### PR TITLE
nox: update to 0.0.4

### DIFF
--- a/pkgs/tools/package-management/nox/default.nix
+++ b/pkgs/tools/package-management/nox/default.nix
@@ -2,12 +2,12 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "nox-${version}";
-  version = "0.0.3";
+  version = "0.0.4";
   namePrefix = "";
 
   src = fetchurl {
     url = "mirror://pypi/n/nix-nox/nix-nox-${version}.tar.gz";
-    sha256 = "0bbd8nyvxwwz56qp82h3bln960bmpy2lczxr00h2jva1gpz5a964";
+    sha256 = "11f6css8rnh7qz55z7i81cnb5h9ys98fqxq3fps3hsh64zlydj52";
   };
 
   buildInputs = [ pythonPackages.pbr ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
