### PR TITLE
nix-prefetch-git: remove extraneous output from JSON

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -288,12 +288,12 @@ _clone_user_rev() {
             fi;;
     esac
 
-    pushd "$dir"
+    pushd "$dir" 1>&2
     fullRev=$( (git rev-parse "$rev" 2>/dev/null || git rev-parse "refs/heads/$branchName") | tail -n1)
     humanReadableRev=$(git describe "$fullRev" 2> /dev/null || git describe --tags "$fullRev" 2> /dev/null || echo -- none --)
     commitDate=$(git show --no-patch --pretty=%ci "$fullRev")
     commitDateStrict8601=$(git show --no-patch --pretty=%cI "$fullRev")
-    popd
+    popd 1>&2
 
     # Allow doing additional processing before .git removal
     eval "$NIX_PREFETCH_GIT_CHECKOUT_HOOK"


### PR DESCRIPTION
###### Motivation for this change

It was breaking the `emacs2nix` use of this tool.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
## \- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Without this change, the JSON output from `nix-prefetch-git` is
corrupted by the pushd/popd output:

```
mdorman@aching:~$ nix-prefetch-git --fetch-submodules --url http://repo.or.cz/r/anything-config.git --rev 2d7e0450e13ab04b20f4dff08f32936e78677e58 2>/dev/null
/tmp/git-checkout-tmp-MKaDNZ03/anything-config-2d7e045 /home/mdorman
/home/mdorman
{
  "url": "http://repo.or.cz/r/anything-config.git",
  "rev": "2d7e0450e13ab04b20f4dff08f32936e78677e58",
  "date": "2015-10-19T11:03:43+09:00",
  "sha256": "077gdqd6vhnfryf21mbgs2bdp8k7bdgaiajdw72rq4rlcg4xpjv9",
  "fetchSubmodules": true
}
```

By redirecting the output of pushd/popd to stderr, we can preserve it in
STDERR (just after 'Switched to a new branch'):

```
mdorman@aching:~$ ~/src/nixpkgs/pkgs/build-support/fetchgit/nix-prefetch-git --fetch-submodules --url http://repo.or.cz/r/anything-config.git --rev 2d7e0450e13ab04b20f4dff08f32936e78677e58
Initialized empty Git repository in /tmp/git-checkout-tmp-6EK8ZHTC/anything-config-2d7e045/.git/
remote: Counting objects: 30, done.
remote: Compressing objects: 100% (28/28), done.
remote: Total 30 (delta 0), reused 16 (delta 0)
Unpacking objects: 100% (30/30), done.
From http://repo.or.cz/r/anything-config
 * branch            HEAD       -> FETCH_HEAD
Switched to a new branch 'fetchgit'
/tmp/git-checkout-tmp-6EK8ZHTC/anything-config-2d7e045 ~
~
removing `.git'...

git revision is 2d7e0450e13ab04b20f4dff08f32936e78677e58
path is /nix/store/5b3acbmxpwhp7i54zw3kh0zm0s0i50zy-anything-config-2d7e045
git human-readable version is -- none --
Commit date is 2015-10-19 11:03:43 +0900
hash is 077gdqd6vhnfryf21mbgs2bdp8k7bdgaiajdw72rq4rlcg4xpjv9
{
  "url": "http://repo.or.cz/r/anything-config.git",
  "rev": "2d7e0450e13ab04b20f4dff08f32936e78677e58",
  "date": "2015-10-19T11:03:43+09:00",
  "sha256": "077gdqd6vhnfryf21mbgs2bdp8k7bdgaiajdw72rq4rlcg4xpjv9",
  "fetchSubmodules": true
}
```

But it does not appear in the JSON output on STDOUT:

```
mdorman@aching:~$ ~/src/nixpkgs/pkgs/build-support/fetchgit/nix-prefetch-git --fetch-submodules --url http://repo.or.cz/r/anything-config.git --rev 2d7e0450e13ab04b20f4dff08f32936e78677e58 2>/dev/null
{
  "url": "http://repo.or.cz/r/anything-config.git",
  "rev": "2d7e0450e13ab04b20f4dff08f32936e78677e58",
  "date": "2015-10-19T11:03:43+09:00",
  "sha256": "077gdqd6vhnfryf21mbgs2bdp8k7bdgaiajdw72rq4rlcg4xpjv9",
  "fetchSubmodules": true
}
```

I noticed this problem when all non-github git pulls for emacs2nix were
failing, so this is not a theoretical problem.
