### PR TITLE
evemu: 2.0.0 -> 2.4.0

### DIFF
--- a/pkgs/tools/system/evemu/default.nix
+++ b/pkgs/tools/system/evemu/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   name = "evemu-${version}";
-  version = "2.0.0";
+  version = "2.4.0";
 
   # We could have downloaded a release tarball from cgit, but it changes hash
   # each time it is downloaded :/
   src = fetchgit {
     url = git://git.freedesktop.org/git/evemu;
     rev = "refs/tags/v${version}";
-    sha256 = "0qv2ib3rb0wp881sfkzmhpkfc3nbrswdmll3087pmzpwd701g42l";
+    sha256 = "07iha13xrpf4z59rzl9cm2h1zkc5xhyipbd3ajd3c1d4hhpn9w9s";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @fignuts 
