### PR TITLE
cwebbin: ensure binaries go to the right destddir

### DIFF
--- a/pkgs/development/tools/misc/cwebbin/default.nix
+++ b/pkgs/development/tools/misc/cwebbin/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "MACROSDIR=$(out)/share/texmf/tex/generic/cweb"
     "CWEBINPUTS=$(out)/lib/cweb"
-    "DESTDIR=$(out)/bin"
+    "DESTDIR=$(out)/bin/"
     "MANDIR=$(out)/share/man/man1"
     "EMACSDIR=$(out)/share/emacs/site-lisp"
     "CP=cp"


### PR DESCRIPTION
###### Motivation for this change

The previous version missed the ending '/' in the destdir, and caused the binaries to end up with names `binctangle` and `bincweave`. I had the package under another name previously installed while testing, which caused the `ctangle` and `cweave` to be present, and caused me to not catch the error.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
