### PR TITLE
unifont: 8.0.01 -> 9.0.01

### DIFF
--- a/pkgs/data/fonts/unifont/default.nix
+++ b/pkgs/data/fonts/unifont/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "unifont-${version}";
-  version = "8.0.01";
+  version = "9.0.01";
 
   ttf = fetchurl {
     url = "http://fossies.org/linux/unifont/font/precompiled/${name}.ttf";
-    sha256 = "0g4g2n024072cdrs2wjp7xmkr3i9dm52a5g9hiafxjgj5a45c8kl";
+    sha256 = "0n2vdzrp86bjxfyqgmryrqckmjiiz4jvsfz9amgg3dv2p42y0dhd";
   };
 
   pcf = fetchurl {
     url = "http://fossies.org/linux/unifont/font/precompiled/${name}.pcf.gz";
-    sha256 = "0mpdy2k7z9s60x8i6sbv64p9wrihfwgrw81x5yj13rl6x7zzghr8";
+    sha256 = "1n3zff46pk6s2x5y7h76aq7h9wfq2acv77gpmxkhz5iwvbpxgb4z";
   };
 
   buildInputs = [ mkfontscale mkfontdir ];
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
     # Basically GPL2+ with font exception.
     license = http://unifoundry.com/LICENSE.txt;
-    maintainers = [ maintainers.rycee ];
+    maintainers = [ maintainers.rycee maintainers.vrthra ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/data/fonts/unifont_upper/default.nix
+++ b/pkgs/data/fonts/unifont_upper/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "unifont_upper-${version}";
-  version = "8.0.01";
+  version = "9.0.01";
 
   ttf = fetchurl {
-    url = "http://unifoundry.com/pub/unifont-8.0.01/font-builds/${name}.ttf";
-    sha256 = "0ffqm85bk345pnql1x0rbg0z31472y844xibb27njjg4avb21lga";
+    url = "http://unifoundry.com/pub/unifont-9.0.01/font-builds/${name}.ttf";
+    sha256 = "06b7na4vb2fjn0zn14bmarzn6vb3ndkysixc89kmb2cc24kfpix1";
   };
 
   phases = "installPhase";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
     # Basically GPL2+ with font exception.
     license = http://unifoundry.com/LICENSE.txt;
-    maintainers = [ maintainers.mathnerd314 ];
+    maintainers = [ maintainers.mathnerd314 maintainers.vrthra ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
