### PR TITLE
wily: init at 0.13.42

### DIFF
--- a/pkgs/applications/editors/wily/default.nix
+++ b/pkgs/applications/editors/wily/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, libX11, libXt } :
+
+stdenv.mkDerivation rec {
+  version = "0.13.42";
+  name = "wily-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/wily/${name}.tar.gz";
+    sha256 = "1jy4czk39sh365b0mjpj4d5wmymj98x163vmwzyx3j183jqrhm2z";
+  };
+
+  buildInputs = [ libX11 libXt ];
+
+  configureFlags = [ "--prefix=$(out)" ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An emulation of ACME";
+    homepage = http://wily.sourceforge.net;
+    license = licenses.artistic1;
+    maintainers = [ maintainers.vrthra ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14824,6 +14824,8 @@ in
 
   windowmaker = callPackage ../applications/window-managers/windowmaker { };
 
+  wily = callPackage ../applications/editors/wily { };
+
   alsamixer.app = callPackage ../applications/window-managers/windowmaker/dockapps/alsamixer.app.nix { };
 
   wmcalclock = callPackage ../applications/window-managers/windowmaker/dockapps/wmcalclock.nix { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
