### PR TITLE
darwin: temporary fix for elixir

### DIFF
--- a/pkgs/development/interpreters/elixir/default.nix
+++ b/pkgs/development/interpreters/elixir/default.nix
@@ -48,8 +48,9 @@ stdenv.mkDerivation rec {
         --set CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
     done
 
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     substituteInPlace $out/bin/mix \
-          --replace "/usr/bin/env elixir" "${coreutils}/bin/env elixir"
+      --replace "/usr/bin/env elixir" "${coreutils}/bin/env elixir"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

There seems to be an issue with the env binary from coreutils (#16406), causing the `mix` command to break, nothing should change for other platforms.
This is just a temporary fix, but fixing the actual issue probably requires a mass rebuild.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
