### PR TITLE
gnunet: Fix build

### DIFF
--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -20,21 +20,13 @@ stdenv.mkDerivation rec {
     # Brute force: since nix-worker chroots don't provide
     # /etc/{resolv.conf,hosts}, replace all references to `localhost'
     # by their IPv4 equivalent.
-    for i in $(find . \( -name \*.c -or -name \*.conf \) \
-                    -exec grep -l '\<localhost\>' {} \;)
-    do
-      echo "$i: substituting \`127.0.0.1' to \`localhost'..."
-      sed -i "$i" -e's/\<localhost\>/127.0.0.1/g'
-    done
+    find . \( -name \*.c -or -name \*.conf \) | \
+      xargs sed -ie 's|\<localhost\>|127.0.0.1|g'
 
     # Make sure the tests don't rely on `/tmp', for the sake of chroot
     # builds.
-    for i in $(find . \( -iname \*test\*.c -or -name \*.conf \) \
-                    -exec grep -l /tmp {} \;)
-    do
-      echo "$i: replacing references to \`/tmp' by \`$TMPDIR'..."
-      substituteInPlace "$i" --replace "/tmp" "$TMPDIR"
-    done
+    find . \( -iname \*test\*.c -or -name \*.conf \) | \
+      xargs sed -ie "s|/tmp|$TMPDIR|g"
 
     # Ensure NSS installation works fine
     configureFlags="$configureFlags --with-nssdir=$out/lib"
@@ -57,7 +49,7 @@ stdenv.mkDerivation rec {
     '';
   */
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "GNU's decentralized anonymous and censorship-resistant P2P framework";
 
     longDescription = ''
@@ -77,9 +69,9 @@ stdenv.mkDerivation rec {
 
     homepage = http://gnunet.org/;
 
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
 
-    maintainers = with stdenv.lib.maintainers; [ viric vrthra ];
-    platforms = stdenv.lib.platforms.gnu;
+    maintainers = with maintainers; [ viric vrthra ];
+    platforms = platforms.gnu;
   };
 }

--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -39,6 +39,10 @@ stdenv.mkDerivation rec {
     # Ensure NSS installation works fine
     configureFlags="$configureFlags --with-nssdir=$out/lib"
     patchShebangs src/gns/nss/install-nss-plugin.sh
+
+    sed -ie 's|@LDFLAGS@|@LDFLAGS@ $(Z_LIBS)|g' \
+      src/regex/Makefile.in \
+      src/fs/Makefile.in
   '';
 
   doCheck = false;
@@ -75,7 +79,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl2Plus;
 
-    maintainers = with stdenv.lib.maintainers; [ viric ];
+    maintainers = with stdenv.lib.maintainers; [ viric vrthra ];
     platforms = stdenv.lib.platforms.gnu;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes #14969, caused due to a missing zlib env
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
