### PR TITLE
gnurl: 7.35 -> 7.48

### DIFF
--- a/pkgs/development/libraries/libgnurl/default.nix
+++ b/pkgs/development/libraries/libgnurl/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
-  version = "7.35.0";
+  version = "7.48.0";
 
   name = "libgnurl-${version}";
 
   src = fetchurl {
-    url = "https://gnunet.org/sites/default/files/gnurl-${version}.tar.bz2";
-    sha256 = "0dzj22f5z6ppjj1aq1bml64iwbzzcd8w1qy3bgpk6gnzqslsxknf";
+    url = "https://gnunet.org/sites/default/files/gnurl-7_48_0.tar.bz2";
+    sha256 = "14gch4rdibrc8qs4mijsczxvl45dsclf234g17dk6c8nc2s4bm0a";
   };
+
+  buildInputs = [ perl ];
 
   preConfigure = ''
     sed -e 's|/usr/bin|/no-such-path|g' -i.bak configure
@@ -17,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A fork of libcurl used by GNUnet";
     homepage    = https://gnunet.org/gnurl;
-    maintainers = with maintainers; [ falsifian ];
+    maintainers = with maintainers; [ falsifian vrthra ];
     hydraPlatforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libgnurl/default.nix
+++ b/pkgs/development/libraries/libgnurl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchurl, perl, zlib, gnutls, gss, openssl, libssh2, libidn, libpsl, openldap }:
 
 stdenv.mkDerivation rec {
   version = "7.48.0";
@@ -10,11 +10,21 @@ stdenv.mkDerivation rec {
     sha256 = "14gch4rdibrc8qs4mijsczxvl45dsclf234g17dk6c8nc2s4bm0a";
   };
 
-  buildInputs = [ perl ];
+  buildInputs = [ perl gnutls gss openssl zlib libidn libssh2 libpsl openldap ];
 
   preConfigure = ''
     sed -e 's|/usr/bin|/no-such-path|g' -i.bak configure
   '';
+
+  configureFlags = [
+    "--with-zlib"
+    "--with-gssapi"
+    "--with-libssh2"
+    "--with-libidn"
+    "--with-libpsl"
+    "--enable-ldap"
+    "--enable-ldaps"
+  ];
 
   meta = with stdenv.lib; {
     description = "A fork of libcurl used by GNUnet";


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
