### PR TITLE
wxsqlite3: init at 3.3.1

### DIFF
--- a/pkgs/development/libraries/wxsqlite3/default.nix
+++ b/pkgs/development/libraries/wxsqlite3/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, wxGTK, sqlite }:
+
+stdenv.mkDerivation rec {
+  name = "wxsqlite3-${version}";
+  version = "3.3.1";
+
+  src = fetchFromGitHub {
+    owner = "utelle";
+    repo = "wxsqlite3";
+    rev = "v${version}";
+    sha1 = "bb8p58g88nkdcsj3h4acx7h925n2cy9g";
+  };
+
+  buildInputs = [ wxGTK sqlite ];
+
+  meta = with stdenv.lib; {
+    homepage = http://utelle.github.io/wxsqlite3/ ;
+    description = "A C++ wrapper around the public domain SQLite 3.x for wxWidgets";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ vrthra ];
+    license = [ licenses.lgpl2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17200,6 +17200,10 @@ in
 
   wxmupen64plus = callPackage ../misc/emulators/wxmupen64plus { };
 
+  wxsqlite3 = callPackage ../development/libraries/wxsqlite3 {
+    wxGTK = wxGTK30;
+  };
+
   x2x = callPackage ../tools/X11/x2x { };
 
   xboxdrv = callPackage ../misc/drivers/xboxdrv { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
