### PR TITLE
libmsgpack: 1.1.0 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/libmsgpack/default.nix
+++ b/pkgs/development/libraries/libmsgpack/default.nix
@@ -1,12 +1,12 @@
 { callPackage, fetchFromGitHub, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "1.1.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "msgpack";
     repo = "msgpack-c";
     rev = "cpp-${version}";
-    sha256 = "1hnpnin6gjiilbzfd75871kamfn9grrf53qpbs061sflvz56fddq";
+    sha256 = "189m44pwpcpf7g4yhzfla4djqyp2kl54wxmwfaj94gwgj5s370i7";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

Update libmsgpack to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
