### PR TITLE
gnupg: make optional dependencies optional

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -3,9 +3,9 @@
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
-, pinentry ? null, x11Support ? true
-, adns ? null, gnutls ? null, libusb ? null, openldap ? null
-, readline ? null, zlib ? null, bzip2 ? null
+, pinentry ? null, adns ? null, gnutls ? null, libusb ? null
+, openldap ? null, readline ? null, zlib ? null, bzip2 ? null
+, x11Support ? true
 }:
 
 with stdenv.lib;
@@ -23,9 +23,14 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgconfig libgcrypt libassuan libksba libiconv npth gettext texinfo
-    readline libusb gnutls adns openldap zlib bzip2
-  ];
+    pkgconfig libgcrypt libassuan libksba libiconv npth gettext texinfo ]
+      ++ optional (adns     != null) adns
+      ++ optional (bzip2    != null) bzip2
+      ++ optional (gnutls   != null) gnutls
+      ++ optional (libusb   != null) libusb
+      ++ optional (openldap != null) openldap
+      ++ optional (readline != null) readline
+      ++ optional (zlib     != null) zlib;
 
   postPatch = stdenv.lib.optionalString stdenv.isLinux ''
     sed -i 's,"libpcsclite\.so[^"]*","${pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c


### PR DESCRIPTION
###### Motivation for this change

gnupg currently pulls in all optional dependencies (which is significant), even if for instance someone only needs a small tool. This patch makes the dependencies configurable, and makes optional dependencies really optional.

I've left the defaults as is. Let me know if this is how this should be done, or if there is another best practise to follow.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
