### PR TITLE
sigil: 0.7.4 > 0.9.6

### DIFF
--- a/pkgs/applications/editors/sigil/default.nix
+++ b/pkgs/applications/editors/sigil/default.nix
@@ -1,67 +1,42 @@
-{ stdenv, fetchurl, unzip, cmake, pkgconfig, makeWrapper
-, hunspell, minizip, boost, xercesc
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, makeWrapper
+, boost, xercesc
 , qtbase, qttools, qtwebkit, qtxmlpatterns
+, python3, python3Packages
 }:
-
-let
-  version = "0.7.4";
-
-in
 
 stdenv.mkDerivation rec {
   name = "sigil-${version}";
+  version = "0.9.6";
 
-  src = fetchurl {
-    url = "https://sigil.googlecode.com/files/Sigil-${version}-Code.zip";
-    sha256 = "68c7ca15ea8611921af0c435369563f55c6afd2ef1fb0945cf6c4a47429b0fb5";
+  src = fetchFromGitHub {
+    sha256 = "0hihd5f3avpdvxwp5j80qdg74zbw7p20y6j9q8cw7wd0bak58h9c";
+    rev = version;
+    repo = "Sigil";
+    owner = "Sigil-Ebook";
   };
 
+  pythonPath = with python3Packages; [ lxml ];
+
+  propagatedBuildInputs = with python3Packages; [ lxml ];
+
   buildInputs = [
-    unzip cmake pkgconfig
-    hunspell minizip boost xercesc qtbase qttools qtwebkit qtxmlpatterns
+    cmake pkgconfig
+    boost xercesc qtbase qttools qtwebkit qtxmlpatterns
+    python3 python3Packages.lxml makeWrapper
   ];
 
-  # XXX: the compiler seems to treat the .h file inappropriately:
-  #
-  #    COMMAND ${CMAKE_CXX_COMPILER} ${compile_flags} \
-  #            ${CMAKE_CURRENT_SOURCE_DIR}/${header_name}.h \
-  #           -o ${header_name}.h.gch
-  #
-  #  but using -c or -x c++-header seems to work:
-  #
-  #    COMMAND ${CMAKE_CXX_COMPILER} ${compile_flags} \
-  #            -c ${CMAKE_CURRENT_SOURCE_DIR}/${header_name}.h \
-  #            -o ${header_name}.h.gch
-  #
-  #    COMMAND ${CMAKE_CXX_COMPILER} ${compile_flags} \
-  #            -x c++-header ${CMAKE_CURRENT_SOURCE_DIR}/${header_name}.h \
-  #            -o ${header_name}.h.gch
-  #
-  # Might be related to:
-  #
-  #   http://permalink.gmane.org/gmane.comp.gcc.bugs/361195
-  buildCommand = ''
-    mkdir -pv $out
-    mkdir -pv ${name}/src ${name}/build ${name}/run
-    cd ${name}/src
-    unzip -n ${src}
-    sed -i \
-        -e 's|\(COMMAND\) \([^ ]\+\) \([^ ]\+\) \(.*\)|\1 \2 \3 -c \4|' \
-        cmake_extras/CustomPCH.cmake
-    cd ../build
-    cmake -G "Unix Makefiles" \
-        -DCMAKE_INSTALL_PREFIX=$out \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_SKIP_BUILD_RPATH=ON \
-        ../src
-    make
-    make install
+  preFixup = ''
+    wrapProgram "$out/bin/sigil" \
+       --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath ${python3Packages.lxml})
   '';
+
+  enableParallelBuilding = true;
 
   meta = {
     description = "Free, open source, multi-platform ebook (ePub) editor";
-    homepage = https://code.google.com/p/sigil/;
+    homepage = https://github.com/Sigil-Ebook/Sigil/;
     license = stdenv.lib.licenses.gpl3;
     inherit version;
+    maintainers = with stdenv.lib.maintainers; [ ramkromberg ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

When I tried installing sigil it downloaded the source code and then failed to build it.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
