### PR TITLE
mop: init at 0.2.0

### DIFF
--- a/pkgs/applications/misc/mop/default.nix
+++ b/pkgs/applications/misc/mop/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
 
   src = fetchgit {
     inherit rev;
-    url = "https://github.com/michaeldv/mop";
+    url = "https://github.com/mop-tracker/mop";
     sha256 = "0zp51g9i8rw6acs4vnrxclbxa5z1v0a0m1xx27szszp0rphcczkx";
   };
 

--- a/pkgs/applications/misc/mop/default.nix
+++ b/pkgs/applications/misc/mop/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, buildGoPackage, fetchgit }:
+
+buildGoPackage rec {
+  name = "mop-${version}";
+  version = "0.2.0";
+  rev = "bc666ec165d08b43134f7ec0bf29083ad5466243";
+
+  goPackagePath = "github.com/michaeldv/mop";
+  goDeps = ./deps.json;
+
+  preConfigure = ''
+    for i in $(find . -type f);do
+        sed -i $i -e s/"michaeldv\/termbox-go"/"nsf\/termbox-go"/g
+    done
+    sed -i Makefile -e s/"mop\/cmd"/"mop\/mop"/g
+    mv cmd mop
+  '';
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://github.com/michaeldv/mop";
+    sha256 = "0zp51g9i8rw6acs4vnrxclbxa5z1v0a0m1xx27szszp0rphcczkx";
+  };
+
+  meta = {
+    description = "Simple stock tracker implemented in go";
+    homepage =  https://github.com/mop-tracker/mop;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/misc/mop/deps.json
+++ b/pkgs/applications/misc/mop/deps.json
@@ -1,0 +1,8 @@
+[
+  {
+    "include": "../../libs.json",
+    "packages": [
+      "github.com/nsf/termbox-go"
+    ]
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17303,4 +17303,6 @@ in
   maphosts = callPackage ../tools/networking/maphosts {};
 
   zuki-themes = callPackage ../misc/themes/zuki { };
+
+  mop = callPackage ../applications/misc/mop { };
 }


### PR DESCRIPTION
###### Motivation for this change

Added new go-Package mop
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
