### PR TITLE
fontconfig: fix etc priority

### DIFF
--- a/nixos/modules/config/fonts/fontconfig-ultimate.nix
+++ b/nixos/modules/config/fonts/fontconfig-ultimate.nix
@@ -3,6 +3,95 @@
 with lib;
 
 let fcBool = x: if x then "<bool>true</bool>" else "<bool>false</bool>";
+
+    cfg = config.fonts.fontconfig.ultimate;
+
+    latestVersion  = pkgs.fontconfig.configVersion;
+
+    # fontconfig ultimate main configuration file
+    # priority 52
+    fontconfigUltimateConf = pkgs.writeText "fc-52-fontconfig-ultimate.conf" ''
+      <?xml version="1.0"?>
+      <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+      <fontconfig>
+
+        ${optionalString (!cfg.allowBitmaps) ''
+        <!-- Reject bitmap fonts -->
+        <selectfont>
+          <rejectfont>
+            <pattern>
+              <patelt name="scalable"><bool>false</bool></patelt>
+            </pattern>
+          </rejectfont>
+        </selectfont>
+        ''}
+
+        ${optionalString cfg.allowType1 ''
+        <!-- Reject Type 1 fonts -->
+        <selectfont>
+          <rejectfont>
+            <pattern>
+              <patelt name="fontformat">
+                <string>Type 1</string>
+              </patelt>
+            </pattern>
+          </rejectfont>
+        </selectfont>
+        ''}
+
+        <!-- Use embedded bitmaps in fonts like Calibri? -->
+        <match target="font">
+          <edit name="embeddedbitmap" mode="assign">
+            ${fcBool cfg.useEmbeddedBitmaps}
+          </edit>
+        </match>
+
+        <!-- Force autohint always -->
+        <match target="font">
+          <edit name="force_autohint" mode="assign">
+            ${fcBool cfg.forceAutohint}
+          </edit>
+        </match>
+
+        <!-- Render some monospace TTF fonts as bitmaps -->
+        <match target="pattern">
+          <edit name="bitmap_monospace" mode="assign">
+            ${fcBool cfg.renderMonoTTFAsBitmap}
+          </edit>
+        </match>
+
+      </fontconfig>
+    '';
+
+    # The configuration to be included in /etc/font/
+    confPkg = pkgs.runCommand "font-ultimate-conf" {} ''
+      support_folder=$out/etc/fonts/conf.d
+      latest_folder=$out/etc/fonts/${latestVersion}/conf.d
+
+      mkdir -p $support_folder
+      mkdir -p $latest_folder
+
+      # 52-fontconfig-ultimate.conf
+      ln -s ${fontconfigUltimateConf} \
+            $support_folder/52-fontconfig-ultimate.conf
+      ln -s ${fontconfigUltimateConf} \
+            $latest_folder/52-fontconfig-ultimate.conf
+
+      # fontconfig ultimate substitutions
+      ${optionalString (cfg.substitutions != "none") ''
+      ln -s ${pkgs.fontconfig-ultimate.confd}/etc/fonts/presets/${cfg.substitutions}/*.conf \
+            $support_folder
+      ln -s ${pkgs.fontconfig-ultimate.confd}/etc/fonts/presets/${cfg.substitutions}/*.conf \
+            $latest_folder
+      ''}
+
+      # fontconfig ultimate various configuration files
+      ln -s ${pkgs.fontconfig-ultimate.confd}/etc/fonts/conf.d/*.conf \
+            $support_folder
+      ln -s ${pkgs.fontconfig-ultimate.confd}/etc/fonts/conf.d/*.conf \
+            $latest_folder
+    '';
+
 in
 {
 
@@ -114,80 +203,11 @@ in
 
   };
 
+  config = mkIf (config.fonts.fontconfig.enable && cfg.enable) {
 
-  config =
-    let ultimate = config.fonts.fontconfig.ultimate;
-        fontconfigUltimateConf = ''
-          <?xml version="1.0"?>
-          <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
-          <fontconfig>
+    fonts.fontconfig.confPackages = [ confPkg ];
+    environment.variables = cfg.rendering;
 
-            ${optionalString (!ultimate.allowBitmaps) ''
-            <!-- Reject bitmap fonts -->
-            <selectfont>
-              <rejectfont>
-                <pattern>
-                  <patelt name="scalable"><bool>false</bool></patelt>
-                </pattern>
-              </rejectfont>
-            </selectfont>
-            ''}
-
-            ${optionalString ultimate.allowType1 ''
-            <!-- Reject Type 1 fonts -->
-            <selectfont>
-              <rejectfont>
-                <pattern>
-                  <patelt name="fontformat">
-                    <string>Type 1</string>
-                  </patelt>
-                </pattern>
-              </rejectfont>
-            </selectfont>
-            ''}
-
-            <!-- Use embedded bitmaps in fonts like Calibri? -->
-            <match target="font">
-              <edit name="embeddedbitmap" mode="assign">
-                ${fcBool ultimate.useEmbeddedBitmaps}
-              </edit>
-            </match>
-
-            <!-- Force autohint always -->
-            <match target="font">
-              <edit name="force_autohint" mode="assign">
-                ${fcBool ultimate.forceAutohint}
-              </edit>
-            </match>
-
-            <!-- Render some monospace TTF fonts as bitmaps -->
-            <match target="pattern">
-              <edit name="bitmap_monospace" mode="assign">
-                ${fcBool ultimate.renderMonoTTFAsBitmap}
-              </edit>
-            </match>
-
-            ${optionalString (ultimate.substitutions != "none") ''
-            <!-- Type 1 font substitutions -->
-            <include ignore_missing="yes">${pkgs.fontconfig-ultimate.confd}/etc/fonts/presets/${ultimate.substitutions}</include>
-            ''}
-
-            <include ignore_missing="yes">${pkgs.fontconfig-ultimate.confd}/etc/fonts/conf.d</include>
-
-          </fontconfig>
-        '';
-    in mkIf (config.fonts.fontconfig.enable && ultimate.enable) {
-
-      environment.etc."fonts/conf.d/52-fontconfig-ultimate.conf" = {
-        text = fontconfigUltimateConf;
-      };
-
-      environment.etc."fonts/${pkgs.fontconfig.configVersion}/conf.d/52-fontconfig-ultimate.conf" = {
-        text = fontconfigUltimateConf;
-      };
-
-      environment.variables = ultimate.rendering;
-
-    };
+  };
 
 }

--- a/pkgs/development/libraries/fontconfig-ultimate/confd.nix
+++ b/pkgs/development/libraries/fontconfig-ultimate/confd.nix
@@ -32,6 +32,9 @@ stdenv.mkDerivation {
 
     cp fontconfig_patches/fonts-settings/*.conf $out/etc/fonts/conf.d
 
+    # fix font priority issue https://github.com/bohoomil/fontconfig-ultimate/issues/173
+    mv $out/etc/fonts/conf.d/{43,60}-wqy-zenhei-sharp.conf
+
     mkdir -p $out/etc/fonts/presets/{combi,free,ms}
     cp fontconfig_patches/combi/*.conf $out/etc/fonts/presets/combi
     cp fontconfig_patches/free/*.conf $out/etc/fonts/presets/free

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     cd "$out/etc/fonts"
-    rm conf.d/{50-user,51-local}.conf
     "${libxslt.bin}/bin/xsltproc" --stringparam fontDirectories "${fontbhttf}" \
       --stringparam fontconfigConfigVersion "${configVersion}" \
       --path $out/share/xml/fontconfig \

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation rec {
     cd "$out/etc/fonts"
     rm conf.d/{50-user,51-local}.conf
     "${libxslt.bin}/bin/xsltproc" --stringparam fontDirectories "${fontbhttf}" \
-      --stringparam fontconfig "$out" \
       --stringparam fontconfigConfigVersion "${configVersion}" \
       --path $out/share/xml/fontconfig \
       ${./make-fonts-conf.xsl} $out/etc/fonts/fonts.conf \

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.xsl
@@ -28,8 +28,6 @@
       <!-- /var/cache/fontconfig is useful for non-nixos systems -->
       <cachedir>/var/cache/fontconfig</cachedir>
 
-      <!-- fontconfig distribution conf.d -->
-      <include><xsl:value-of select="$fontconfig" />/etc/fonts/conf.d</include>
       <!-- versioned system-wide config -->
       <include ignore_missing="yes">/etc/fonts/<xsl:value-of select="$fontconfigConfigVersion" />/conf.d</include>
 


### PR DESCRIPTION
###### Motivation for this change

Address #16026

---

Current state issues:
- ~~When /etc/fonts is already present, the new `/etc/fonts` will be created as `/etc/fonts.tmp` breaking fontconfig configuration. Issue #16978~~ fixed by #17042
- ~~using `symlinkJoin` for creating the `/etc/font` package make `test.installers.*` fails because `lndir` is not available. Issue #16983~~ fixed by using `buildEnv` instead of `symlinkJoin`

---

This make all the fontconfig related configuration files be symlinked in the correct order in `etc` so fontconfig settings and `fontconfig.defaultFonts` are applied correctly.

This will trigger a rebuild of fontconfig and all related packages, so the PR is made on `staging`.

The change in fontconfig is required in order to have a correct file loading order for `${pkgs.fontconfig.out}/etc/fonts/conf.d/*`. (that are currently linked in `/etc/fonts/{,2.11}/fonts.conf`).

example:

```
$ FC_DEBUG=1024 fc-match serif
FC_DEBUG=1024
    Loading config file /etc/fonts/2.11/fonts.conf
    Scanning config dir /etc/fonts/2.11/conf.d
    Loading config file /etc/fonts/2.11/conf.d/00-nixos.conf
    Loading config file /etc/fonts/2.11/conf.d/10-nixos-rendering.conf
    Loading config file /etc/fonts/2.11/conf.d/10-scale-bitmap-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/20-unhint-small-vera.conf
    Loading config file /etc/fonts/2.11/conf.d/30-liberation-mono.conf
    Loading config file /etc/fonts/2.11/conf.d/30-liberation-sans-narrow.conf
    Loading config file /etc/fonts/2.11/conf.d/30-liberation-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/30-liberation-serif.conf
    Loading config file /etc/fonts/2.11/conf.d/30-metric-aliases-free.conf
    Loading config file /etc/fonts/2.11/conf.d/30-metric-aliases.conf
    Loading config file /etc/fonts/2.11/conf.d/30-nixos-generic-alias.conf
    Loading config file /etc/fonts/2.11/conf.d/30-urw-aliases.conf
    Loading config file /etc/fonts/2.11/conf.d/31-titillium.conf
    Loading config file /etc/fonts/2.11/conf.d/36-repl-missing-glyphs.conf
    Loading config file /etc/fonts/2.11/conf.d/37-repl-global-free.conf
    Loading config file /etc/fonts/2.11/conf.d/37-repl-webfonts.conf
    Loading config file /etc/fonts/2.11/conf.d/40-alef.conf
    Loading config file /etc/fonts/2.11/conf.d/40-amiri.conf
    Loading config file /etc/fonts/2.11/conf.d/40-arphic-ukai.conf
    Loading config file /etc/fonts/2.11/conf.d/40-arphic-uming.conf
    Loading config file /etc/fonts/2.11/conf.d/40-ddc-uchen.conf
    Loading config file /etc/fonts/2.11/conf.d/40-dejavusans-yuanti-condensed.conf
    Loading config file /etc/fonts/2.11/conf.d/40-dejavusans-yuanti-mono.conf
    Loading config file /etc/fonts/2.11/conf.d/40-dejavusans-yuanti.conf
    Loading config file /etc/fonts/2.11/conf.d/40-dzongkha.conf
    Loading config file /etc/fonts/2.11/conf.d/40-faruma.conf
    Loading config file /etc/fonts/2.11/conf.d/40-hannom.conf
    Loading config file /etc/fonts/2.11/conf.d/40-himalaya-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/40-ipafont.conf
    Loading config file /etc/fonts/2.11/conf.d/40-ipamjfont.conf
    Loading config file /etc/fonts/2.11/conf.d/40-khmer-os.conf
    Loading config file /etc/fonts/2.11/conf.d/40-koruri.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lklug.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-assamese.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-bengali.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-devanagari.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-gujarati.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-gurmukhi.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-kannada.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-malayalam.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-marathi.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-nepali.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-odia.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-punjabi.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-tamil.conf
    Loading config file /etc/fonts/2.11/conf.d/40-lohit-telugu.conf
    Loading config file /etc/fonts/2.11/conf.d/40-melthofonts.conf
    Loading config file /etc/fonts/2.11/conf.d/40-mph-2b-damase.conf
    Loading config file /etc/fonts/2.11/conf.d/40-mplus.conf
    Loading config file /etc/fonts/2.11/conf.d/40-myanmar3.conf
    Loading config file /etc/fonts/2.11/conf.d/40-nanum-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/40-nanumgothic-coding.conf
    Loading config file /etc/fonts/2.11/conf.d/40-non-latin-microsoft.conf
    Loading config file /etc/fonts/2.11/conf.d/40-non-latin-misc.conf
    Loading config file /etc/fonts/2.11/conf.d/40-nonlatin.conf
    Loading config file /etc/fonts/2.11/conf.d/40-noto-arabic.conf
    Loading config file /etc/fonts/2.11/conf.d/40-sawarabi.conf
    Loading config file /etc/fonts/2.11/conf.d/40-saweri.conf
    Loading config file /etc/fonts/2.11/conf.d/40-source-han-sans-cn.conf
    Loading config file /etc/fonts/2.11/conf.d/40-source-han-sans-jp.conf
    Loading config file /etc/fonts/2.11/conf.d/40-source-han-sans-kr.conf
    Loading config file /etc/fonts/2.11/conf.d/40-source-han-sans-twhk.conf
    Loading config file /etc/fonts/2.11/conf.d/40-tharlon.conf
    Loading config file /etc/fonts/2.11/conf.d/40-umeplus.conf
    Loading config file /etc/fonts/2.11/conf.d/40-unfonts-core.conf
    Loading config file /etc/fonts/2.11/conf.d/40-vlgothic.conf
    Loading config file /etc/fonts/2.11/conf.d/40-wqy-microhei.conf
    Loading config file /etc/fonts/2.11/conf.d/40-wqy-zenhei.conf
    Loading config file /etc/fonts/2.11/conf.d/43-wqy-zenhei-sharp.conf
    Loading config file /etc/fonts/2.11/conf.d/45-aboriginal-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-aboriginal-serif.conf
    Loading config file /etc/fonts/2.11/conf.d/45-aileron.conf
    Loading config file /etc/fonts/2.11/conf.d/45-alegreya-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-alegreya.conf
    Loading config file /etc/fonts/2.11/conf.d/45-aleo.conf
    Loading config file /etc/fonts/2.11/conf.d/45-amble.conf
    Loading config file /etc/fonts/2.11/conf.d/45-andada.conf
    Loading config file /etc/fonts/2.11/conf.d/45-antonio.conf
    Loading config file /etc/fonts/2.11/conf.d/45-archivo-black.conf
    Loading config file /etc/fonts/2.11/conf.d/45-archivo-narrow.conf
    Loading config file /etc/fonts/2.11/conf.d/45-arev-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-arsenal.conf
    Loading config file /etc/fonts/2.11/conf.d/45-berenis-adf-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/45-bitter.conf
    Loading config file /etc/fonts/2.11/conf.d/45-bravo.conf
    Loading config file /etc/fonts/2.11/conf.d/45-buenard.conf
    Loading config file /etc/fonts/2.11/conf.d/45-caladea.conf
    Loading config file /etc/fonts/2.11/conf.d/45-camingocode.conf
    Loading config file /etc/fonts/2.11/conf.d/45-cantarell.conf
    Loading config file /etc/fonts/2.11/conf.d/45-cantoraone.conf
    Loading config file /etc/fonts/2.11/conf.d/45-carlito.conf
    Loading config file /etc/fonts/2.11/conf.d/45-caviar-dreams.conf
    Loading config file /etc/fonts/2.11/conf.d/45-charis-sil.conf
    Loading config file /etc/fonts/2.11/conf.d/45-clear-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-comme.conf
    Loading config file /etc/fonts/2.11/conf.d/45-consola-mono.conf
    Loading config file /etc/fonts/2.11/conf.d/45-cooper-hewitt.conf
    Loading config file /etc/fonts/2.11/conf.d/45-courier-prime.conf
    Loading config file /etc/fonts/2.11/conf.d/45-crimson-text.conf
    Loading config file /etc/fonts/2.11/conf.d/45-croscore-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/45-dejavu.conf
    Loading config file /etc/fonts/2.11/conf.d/45-droid.conf
    Loading config file /etc/fonts/2.11/conf.d/45-ebgaramond.conf
    Loading config file /etc/fonts/2.11/conf.d/45-enriqueta.conf
    Loading config file /etc/fonts/2.11/conf.d/45-erewhon.conf
    Loading config file /etc/fonts/2.11/conf.d/45-exo2.conf
    Loading config file /etc/fonts/2.11/conf.d/45-fanwood.conf
    Loading config file /etc/fonts/2.11/conf.d/45-fira-mono.conf
    Loading config file /etc/fonts/2.11/conf.d/45-fira-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-gelasio.conf
    Loading config file /etc/fonts/2.11/conf.d/45-gentium.conf
    Loading config file /etc/fonts/2.11/conf.d/45-helvetica-ce-35-thin.conf
    Loading config file /etc/fonts/2.11/conf.d/45-helvetica-ce-55-roman.conf
    Loading config file /etc/fonts/2.11/conf.d/45-helvetica-cy.conf
    Loading config file /etc/fonts/2.11/conf.d/45-helvetica-narrow.conf
    Loading config file /etc/fonts/2.11/conf.d/45-helvetica-neue-lt-com.conf
    Loading config file /etc/fonts/2.11/conf.d/45-helvetica-neue.conf
    Loading config file /etc/fonts/2.11/conf.d/45-helvetica-world.conf
    Loading config file /etc/fonts/2.11/conf.d/45-helvetica.conf
    Loading config file /etc/fonts/2.11/conf.d/45-heuristica.conf
    Loading config file /etc/fonts/2.11/conf.d/45-inconsolata-pwl.conf
    Loading config file /etc/fonts/2.11/conf.d/45-inconsolatazi4.conf
    Loading config file /etc/fonts/2.11/conf.d/45-infini.conf
    Loading config file /etc/fonts/2.11/conf.d/45-inknut-antiqua.conf
    Loading config file /etc/fonts/2.11/conf.d/45-iosevka.conf
    Loading config file /etc/fonts/2.11/conf.d/45-istok.conf
    Loading config file /etc/fonts/2.11/conf.d/45-junicode.conf
    Loading config file /etc/fonts/2.11/conf.d/45-latin-microsoft.conf
    Loading config file /etc/fonts/2.11/conf.d/45-latin-misc.conf
    Loading config file /etc/fonts/2.11/conf.d/45-latin-modern.conf
    Loading config file /etc/fonts/2.11/conf.d/45-latin.conf
    Loading config file /etc/fonts/2.11/conf.d/45-lato.conf
    Loading config file /etc/fonts/2.11/conf.d/45-league-gothic.conf
    Loading config file /etc/fonts/2.11/conf.d/45-lekton.conf
    Loading config file /etc/fonts/2.11/conf.d/45-liberastika.conf
    Loading config file /etc/fonts/2.11/conf.d/45-liberation.conf
    Loading config file /etc/fonts/2.11/conf.d/45-libre-baskerville.conf
    Loading config file /etc/fonts/2.11/conf.d/45-libre-caslon.conf
    Loading config file /etc/fonts/2.11/conf.d/45-linden-hill.conf
    Loading config file /etc/fonts/2.11/conf.d/45-linux-libertine-o.conf
    Loading config file /etc/fonts/2.11/conf.d/45-linux-libertine.conf
    Loading config file /etc/fonts/2.11/conf.d/45-lobster-two.conf
    Loading config file /etc/fonts/2.11/conf.d/45-lora.conf
    Loading config file /etc/fonts/2.11/conf.d/45-luxi.conf
    Loading config file /etc/fonts/2.11/conf.d/45-magra.conf
    Loading config file /etc/fonts/2.11/conf.d/45-merriweather-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-merriweather.conf
    Loading config file /etc/fonts/2.11/conf.d/45-monoid.conf
    Loading config file /etc/fonts/2.11/conf.d/45-montserrat.conf
    Loading config file /etc/fonts/2.11/conf.d/45-noticia-text.conf
    Loading config file /etc/fonts/2.11/conf.d/45-noto-cros.conf
    Loading config file /etc/fonts/2.11/conf.d/45-noto-nonlatin.conf
    Loading config file /etc/fonts/2.11/conf.d/45-noto-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-noto-serif.conf
    Loading config file /etc/fonts/2.11/conf.d/45-opensans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-oswald.conf
    Loading config file /etc/fonts/2.11/conf.d/45-overpass.conf
    Loading config file /etc/fonts/2.11/conf.d/45-oxygen.conf
    Loading config file /etc/fonts/2.11/conf.d/45-paratype.conf
    Loading config file /etc/fonts/2.11/conf.d/45-permian.conf
    Loading config file /etc/fonts/2.11/conf.d/45-pfeffer-mediaeval.conf
    Loading config file /etc/fonts/2.11/conf.d/45-pfennig.conf
    Loading config file /etc/fonts/2.11/conf.d/45-playfair-display.conf
    Loading config file /etc/fonts/2.11/conf.d/45-quintessential.conf
    Loading config file /etc/fonts/2.11/conf.d/45-raleway.conf
    Loading config file /etc/fonts/2.11/conf.d/45-roboto-mono.conf
    Loading config file /etc/fonts/2.11/conf.d/45-roboto.conf
    Loading config file /etc/fonts/2.11/conf.d/45-sansation.conf
    Loading config file /etc/fonts/2.11/conf.d/45-scada.conf
    Loading config file /etc/fonts/2.11/conf.d/45-sen.conf
    Loading config file /etc/fonts/2.11/conf.d/45-signika.conf
    Loading config file /etc/fonts/2.11/conf.d/45-sinkin-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-sorts-mill-goudy.conf
    Loading config file /etc/fonts/2.11/conf.d/45-source-code-pro-pwl.conf
    Loading config file /etc/fonts/2.11/conf.d/45-source-code-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/45-source-sans-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/45-source-serif-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/45-symbola.conf
    Loading config file /etc/fonts/2.11/conf.d/45-tehuti.conf
    Loading config file /etc/fonts/2.11/conf.d/45-tex-gyre.conf
    Loading config file /etc/fonts/2.11/conf.d/45-titillium.conf
    Loading config file /etc/fonts/2.11/conf.d/45-triod-postnaja.conf
    Loading config file /etc/fonts/2.11/conf.d/45-ubuntu.conf
    Loading config file /etc/fonts/2.11/conf.d/45-unb-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/45-urw-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/45-vera-humana-95.conf
    Loading config file /etc/fonts/2.11/conf.d/45-vollkorn.conf
    Loading config file /etc/fonts/2.11/conf.d/45-weblysleek-ui.conf
    Loading config file /etc/fonts/2.11/conf.d/45-work-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/45-yanone-kaffeesatz.conf
    Loading config file /etc/fonts/2.11/conf.d/49-sansserif.conf
    Loading config file /etc/fonts/2.11/conf.d/52-fontconfig-ultimate.conf
    Loading config file /etc/fonts/2.11/conf.d/60-latin-free.conf
    Loading config file /etc/fonts/2.11/conf.d/60-latin.conf
    Loading config file /etc/fonts/2.11/conf.d/65-fonts-persian.conf
    Loading config file /etc/fonts/2.11/conf.d/65-non-latin-free.conf
    Loading config file /etc/fonts/2.11/conf.d/65-nonlatin.conf
    Loading config file /etc/fonts/2.11/conf.d/65-noto-sans-ui.conf
    Loading config file /etc/fonts/2.11/conf.d/65-noto-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/65-noto-serif.conf
    Loading config file /etc/fonts/2.11/conf.d/65-ttf-droid-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/65-ttf-droid-serif.conf
    Loading config file /etc/fonts/2.11/conf.d/65-wqy-zenhei.conf
    Loading config file /etc/fonts/2.11/conf.d/66-aliases-wine-free.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-assamese.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-bengali.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-devanagari.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-gujarati.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-gurmukhi.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-kannada.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-malayalam.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-marathi.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-nepali.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-odia.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-punjabi.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-tamil.conf
    Loading config file /etc/fonts/2.11/conf.d/66-lohit-telugu.conf
    Loading config file /etc/fonts/2.11/conf.d/67-override-aliases.conf
    Loading config file /etc/fonts/2.11/conf.d/68-override.conf
    Loading config file /etc/fonts/2.11/conf.d/69-unifont.conf
    Loading config file /etc/fonts/2.11/conf.d/80-delicious.conf
    Loading config file /etc/fonts/2.11/conf.d/88-forced-synthetic.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-aileron.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-alegreya-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-alegreya.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-aleo.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-andada.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-arsenal.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-berenis-adf-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-bitter.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-bravo.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-buenard.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-cantarell.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-cantoraone.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-cooper-hewitt.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-crimson-text.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-dejavu.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-ebgaramond.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-enriqueta.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-erewhon.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-exo2.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-fanwood.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-fira-mono.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-fira-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-helvetica-neue-lt-com.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-helvetica-neue.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-helvetica.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-heuristica.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-inconsolata-pwl.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-inconsolatazi4.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-infini.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-latin-modern.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-league-gothic.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-libre-baskerville.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-libre-caslon.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-linden-hill.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-linux-libertine.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-lobster-two.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-luxi.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-magra.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-melthofonts.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-montserrat.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-mplus.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-oswald.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-paratype.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-permian.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-pfeffer-mediaeval.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-quintessential.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-raleway.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-sawarabi.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-scada.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-sen.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-signika.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-sinkin-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-sorts-mill-goudy.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-source-code-pro-pwl.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-source-code-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-source-han-sans-cn.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-source-han-sans-jp.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-source-han-sans-kr.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-source-han-sans-twhk.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-source-sans-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-source-serif-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-tehuti.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-tex-gyre.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-titillium.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-unb-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-urw-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-vollkorn.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-work-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-wqy-microhei.conf
    Loading config file /etc/fonts/2.11/conf.d/90-non-tt-yanone-kaffeesatz.conf
    Loading config file /etc/fonts/2.11/conf.d/90-synthetic.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-aboriginal-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-aboriginal-serif.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-alef.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-alegreya-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-alegreya.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-amble.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-amiri.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-andada.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-antonio.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-archivo-black.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-archivo-narrow.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-arev-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-arphic-ukai.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-arphic-uming.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-caladea.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-camingocode.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-cantoraone.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-carlito.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-caviar-dreams.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-charis-sil.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-clear-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-comme.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-consola-mono.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-courier-prime.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-crimson-text.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-croscore-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-ddc-uchen.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-dejavu.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-dejavusans-yuanti-condensed.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-dejavusans-yuanti-mono.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-dejavusans-yuanti.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-droid.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-dzongkha.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-ebgaramond.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-faruma.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-fonts-microsoft.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-fonts-misc.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-gelasio.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-gentium.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-hannom.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-helvetica-ce-35-thin.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-helvetica-ce-55-roman.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-helvetica-cy.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-helvetica-narrow.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-helvetica-neue-lt-com.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-helvetica-neue.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-helvetica-world.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-helvetica.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-heuristica.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-himalaya-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-inknut-antiqua.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-iosevka.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-ipafont.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-ipamjfont.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-istok.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-junicode.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-khmer-os.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-koruri.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lato.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lekton.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-liberastika.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-liberation.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-libre-baskerville.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-libre-caslon.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-linux-libertine.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lklug.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-assamese.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-bengali.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-devanagari.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-gujarati.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-gurmukhi.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-kannada.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-malayalam.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-marathi.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-nepali.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-odia.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-punjabi.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-tamil.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lohit-telugu.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-lora.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-luxi.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-merriweather-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-merriweather.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-meslo.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-monoid.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-mph-2b-damase.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-myanmar3.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-nanum-fonts.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-nanumgothic-coding.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-noticia-text.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-noto-cros.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-noto-nonlatin.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-noto-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-noto-serif.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-opensans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-overpass.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-oxygen.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-paratype.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-pfennig.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-playfair-display.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-raleway.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-roboto-mono.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-roboto.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-sansation.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-saweri.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-signika.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-sinkin-sans.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-sorts-mill-goudy.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-source-code-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-source-sans-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-source-serif-pro.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-symbola.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-tharlon.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-triod-postnaja.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-ubuntu.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-umeplus.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-unfonts-core.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-vera-humana-95.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-vlgothic.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-vollkorn.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-weblysleek-ui.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-wqy-zenhei.conf
    Loading config file /etc/fonts/2.11/conf.d/90-tt-yanone-kaffeesatz.conf
    Loading config file /etc/fonts/2.11/conf.d/92-selective-rendering-microsoft.conf
    Loading config file /etc/fonts/2.11/conf.d/92-selective-rendering-misc.conf
    Loading config file /etc/fonts/2.11/conf.d/93-final-rendering.conf
    Loading config file /etc/fonts/2.11/conf.d/94-no-synthetic.conf
    Loading config file /etc/fonts/2.11/conf.d/95-reject.conf
    Loading config file /etc/fonts/2.11/conf.d/97-selective-rendering-custom.conf
    Loading config file /etc/fonts/2.11/conf.d/99-user.conf
SourceSerifPro-Regular.otf: "Source Serif Pro" "Regular"
```
###### Notes
- When `/etc/fonts` is already present, the new folder will be created as `/etc/fonts.tmp` unless `/etc/fonts` is manually deleted. I suppose it is because current  `/etc/fonts` is a real folder and this PR `/etc/fonts` is a symlink.
- I am not sure about the `/etc/fonts` and `/etc/fonts/2.11` difference, I tried to keep it as close as it was before the PR, but I would appreciate if someone with better fontconfig knowledge could verify everything work as intended.
- it seems that when multiple are set, the order `fontconfig.defaultFonts` is affected by the system locale (verified with asian locales and japanese fonts), as far as I can tell it seems to be a feature of fontconfig to raise locale matching fonts at a higher priority than what they are declared.
- fontconfig documentation being quite vague and still full of mysteries to me, there should room for improvement .

Tests, feedback and improvements are welcome.

cc @vcunat @ttuegel 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
