### PR TITLE
sysstat: 11.0.7 -> 11.2.5

### DIFF
--- a/pkgs/os-specific/linux/sysstat/default.nix
+++ b/pkgs/os-specific/linux/sysstat/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, gettext, bzip2 }:
 
 stdenv.mkDerivation rec {
-  name = "sysstat-11.0.7";
+  name = "sysstat-${version}";
+  version = "11.2.5";
 
   src = fetchurl {
     url = "http://perso.orange.fr/sebastien.godard/${name}.tar.xz";
-    sha256 = "12j55rdx1hyhsc5qm0anx9h9siaa58lhh9dchp40q4ag2wxamp1r";
+    sha256 = "4d5c9cd9122aa933ac477f369eb40c66236365a88516577c9655516f6f32e8e4";
   };
 
   buildInputs = [ gettext ];
@@ -17,7 +18,8 @@ stdenv.mkDerivation rec {
     export SYSTEMCTL=systemctl
   '';
 
-  makeFlags = "SYSCONFIG_DIR=$(out)/etc IGNORE_MAN_GROUP=y CHOWN=true";
+  configureFlags = "--disable-file-attr";
+  makeFlags = "SYSCONFIG_DIR=$(out)/etc CHOWN=true";
   installTargets = "install_base install_nls install_man";
 
   patches = [ ./install.patch ];

--- a/pkgs/os-specific/linux/sysstat/install.patch
+++ b/pkgs/os-specific/linux/sysstat/install.patch
@@ -1,13 +1,12 @@
-diff -rc sysstat-11.0.1/Makefile.in sysstat-11.0.1-new/Makefile.in
-*** sysstat-11.0.1/Makefile.in	2014-08-30 15:38:39.000000000 +0200
---- sysstat-11.0.1-new/Makefile.in	2014-12-18 14:40:45.466349009 +0100
-***************
-*** 331,337 ****
-  install_base: all sa1 sa2 sysstat.sysconfig install_man install_nls \
-  	contrib/isag/isag
-  	mkdir -p $(DESTDIR)$(SA_LIB_DIR)
-- 	mkdir -p $(DESTDIR)$(SA_DIR)
-  ifeq ($(CLEAN_SA_DIR),y)
-  	find $(DESTDIR)$(SA_DIR) \( -name 'sar??' -o -name 'sa??' -o -name 'sar??.gz' -o -name 'sa??.gz' \) \
-  		-exec rm -f {} \;
---- 331,336 ----
+diff --git a/Makefile.in b/Makefile-new.in
+index a92f4f5..5d60f1e 100644
+--- a/Makefile.in
++++ b/Makefile-new.in
+@@ -349,7 +349,6 @@ endif
+ install_base: all sa1 sa2 sysstat.sysconfig install_man install_nls \
+ 	contrib/isag/isag
+ 	mkdir -p $(DESTDIR)$(SA_LIB_DIR)
+-	mkdir -p $(DESTDIR)$(SA_DIR)
+ ifeq ($(CLEAN_SA_DIR),y)
+ 	find $(DESTDIR)$(SA_DIR) \( -name 'sar??' -o -name 'sa??' -o -name 'sar??.gz' -o -name 'sa??.gz' \) \
+ 		-exec rm -f {} \;


### PR DESCRIPTION
###### Motivation for this change

Update sysstat to the last stable version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
