### PR TITLE
icoutils: perl dependencies added #15894

### DIFF
--- a/pkgs/tools/graphics/icoutils/default.nix
+++ b/pkgs/tools/graphics/icoutils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libpng }:
+{ stdenv, fetchurl, libpng, perl, perlPackages, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "icoutils-0.31.0";
@@ -8,11 +8,24 @@ stdenv.mkDerivation rec {
     sha256 = "0wdgyfb1clrn3maq84vi4vkwjydy72p5hzk6kb9nb3a19bbxk5d8";
   };
 
-  buildInputs = [ libpng ];
+  buildInputs = [ makeWrapper libpng perl ];
+  propagatedBuildInputs = [ perlPackages.LWP ];
+
+  patchPhase = ''
+    patchShebangs extresso/extresso
+    patchShebangs extresso/extresso.in
+    patchShebangs extresso/genresscript
+    patchShebangs extresso/genresscript.in
+  '';
+
+  preFixup = ''
+    wrapProgram $out/bin/extresso --prefix PERL5LIB : $PERL5LIB
+    wrapProgram $out/bin/genresscript --prefix PERL5LIB : $PERL5LIB
+  '';
 
   meta = {
     homepage = http://www.nongnu.org/icoutils/;
-    description = "Set of  programs to deal with Microsoft Windows(R) icon and cursor files";
+    description = "Set of programs to deal with Microsoft Windows(R) icon and cursor files";
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = with stdenv.lib.platforms; linux;
   };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/15894
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
