### PR TITLE
coreutils: don't use shell wrapper for env binary, this breaks shebangs

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -3,7 +3,7 @@
 , selinuxSupport? false, libselinux ? null, libsepol ? null
 , autoconf, automake114x, texinfo
 , withPrefix ? false
-, singleBinary ? true # you can also pass "symlinks", for example
+, singleBinary ? "symlinks" # you can also pass "shebangs" or false
 }:
 
 assert aclSupport -> acl != null;


### PR DESCRIPTION
###### Motivation for this change

The changes introduced by #16406 caused the `env` executable to break when used in a shebang line. This change makes sure that the `env` executable is always a binary.

Example: script will fail with `./foo: line 2: print: command not found.`

```
#!/nix/store/4g28y97ma9zm431y61b0czf4lrphgh1w-coreutils-8.25/bin/env python
print 'foo'
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
