### PR TITLE
wxsqliteplus: init at 0.3.6

### DIFF
--- a/pkgs/development/libraries/wxsqliteplus/default.nix
+++ b/pkgs/development/libraries/wxsqliteplus/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, wxGTK, wxsqlite3, sqlite }:
+
+stdenv.mkDerivation rec {
+  name = "wxsqliteplus-${version}";
+  version = "0.3.6";
+
+  src = fetchFromGitHub {
+    owner = "guanlisheng";
+    repo = "wxsqliteplus";
+    rev = "v${version}";
+    sha1 = "yr9ysviv4hbrxn900z1wz8j32frimvx1";
+  };
+
+  buildInputs = [ wxGTK wxsqlite3 sqlite ];
+
+  makeFlags = [
+    "LDFLAGS=-L${wxsqlite3}/lib"
+  ];
+
+  preBuild = ''
+    sed -ie 's|all: $(LIBPREFIX)wxsqlite$(LIBEXT)|all: |g' Makefile
+    sed -ie 's|wxsqliteplus$(EXEEXT): $(WXSQLITEPLUS_OBJECTS) $(LIBPREFIX)wxsqlite$(LIBEXT)|wxsqliteplus$(EXEEXT):  $(WXSQLITEPLUS_OBJECTS) |g' Makefile
+    sed -ie 's|-lwxsqlite |-lwxcode_gtk2u_wxsqlite3-3.0 |g' Makefile
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp wxsqliteplus $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://guanlisheng.com/;
+    description = "A simple SQLite database browser built with wxWidgets";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ vrthra ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17204,6 +17204,10 @@ in
     wxGTK = wxGTK30;
   };
 
+  wxsqliteplus = callPackage ../development/libraries/wxsqliteplus {
+    wxGTK = wxGTK30;
+  };
+
   x2x = callPackage ../tools/X11/x2x { };
 
   xboxdrv = callPackage ../misc/drivers/xboxdrv { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
