### PR TITLE
diff-so-fancy: 0.9.3 -> 0.10.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "diff-so-fancy-${version}";
-  version = "0.9.3";
+  version = "0.10.0";
 
   # perl is needed here so patchShebangs can do its job
   buildInputs = [perl makeWrapper];
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "so-fancy";
     repo = "diff-so-fancy";
     rev = "v${version}";
-    sha256 = "0b5k54h3l4z81p6f7n14g2r5vz7qdyyrbql0z7rwhb7sw7s7zrgx";
+    sha256 = "08dv9xlrsyjr1ylm83lbsv2p5asfia4ib97bwgcacsdxxh5zyqh9";
   };
 
   buildPhase = null;


### PR DESCRIPTION
###### Motivation for this change

Update diff-so-fancy to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
