### PR TITLE
cherrytree: 0.35.9 -> 0.37.1

### DIFF
--- a/pkgs/applications/misc/cherrytree/default.nix
+++ b/pkgs/applications/misc/cherrytree/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "cherrytree-${version}";
-  version = "0.35.9";
+  version = "0.37.1";
 
   src = fetchurl {
     url = "http://www.giuspen.com/software/${name}.tar.xz";
-    sha256 = "14yahp0y13z3xkpwvprm7q9x3rj6jbzi0bryqlsn3bbafdq7wnac";
+    sha256 = "45f1cee4067598cf2ca8ae6f89d03789b86f9e3bf196236119868653420d7cdd";
   };
 
   propagatedBuildInputs = with pythonPackages;
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  meta = { 
+  meta = {
     description = "An hierarchical note taking application";
     longDescription = ''
       Cherrytree is an hierarchical note taking application,
@@ -44,10 +44,10 @@ stdenv.mkDerivation rec {
       documents. All those little bits of information you have scattered
       around your hard drive can be conveniently placed into a
       Cherrytree document where you can easily find it.
-    ''; 
+    '';
     homepage = http://www.giuspen.com/cherrytree;
     license = licenses.gpl3;
-    platforms = platforms.linux; 
-    maintainers = [ maintainers.AndersonTorres ]; 
-  }; 
+    platforms = platforms.linux;
+    maintainers = [ maintainers.AndersonTorres ];
+  };
 }

--- a/pkgs/applications/misc/cherrytree/subprocess.patch
+++ b/pkgs/applications/misc/cherrytree/subprocess.patch
@@ -1,6 +1,6 @@
-diff -Naur cherrytree-0.35.6-orig/setup.py cherrytree-0.35.6/setup.py
---- cherrytree-0.35.6-orig/setup.py     2014-05-30 23:25:11.000000000 +0200
-+++ cherrytree-0.35.6/setup.py  2015-01-29 07:35:32.785904009 +0100
+diff -Naur cherrytree-0.37.1-orig/setup.py cherrytree-0.37.1/setup.py
+--- cherrytree-0.37.1-orig/setup.py	2016-01-08 20:50:50.000000000 +0100
++++ cherrytree-0.37.1/setup.py	2016-07-05 20:30:27.768178682 +0200
 @@ -205,4 +205,9 @@
            },
         distclass=CherryTreeDist
@@ -12,4 +12,3 @@ diff -Naur cherrytree-0.35.6-orig/setup.py cherrytree-0.35.6/setup.py
 +        pass # handle errors in the called executable
 +    except OSError:
 +        pass # executable not found
-


### PR DESCRIPTION
###### Motivation for this change

Update cherrytree to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
