### PR TITLE
nixos/grub: change state file device separator from ':' to ','

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -501,7 +501,7 @@ sub getEfiTarget {
 my @deviceTargets = getDeviceTargets();
 my $efiTarget = getEfiTarget();
 my $prevGrubState = readGrubState();
-my @prevDeviceTargets = split/:/, $prevGrubState->devices;
+my @prevDeviceTargets = split/,/, $prevGrubState->devices;
 
 my $devicesDiffer = scalar (List::Compare->new( '-u', '-a', \@deviceTargets, \@prevDeviceTargets)->get_symmetric_difference());
 my $nameDiffer = get("fullName") ne $prevGrubState->name;
@@ -549,7 +549,7 @@ if ($requireNewInstall != 0) {
     print FILE get("fullName"), "\n" or die;
     print FILE get("fullVersion"), "\n" or die;
     print FILE $efiTarget, "\n" or die;
-    print FILE join( ":", @deviceTargets ), "\n" or die;
+    print FILE join( ",", @deviceTargets ), "\n" or die;
     print FILE $efiSysMountPoint, "\n" or die;
     close FILE or die;
 }


### PR DESCRIPTION
###### Motivation for this change

':' is currently used as separator in /boot/grub/state for the list of
devices GRUB should be installed to. The problem is that ':' itself may
appear in a device path:

```
  /dev/disk/by-id/usb-SanDisk_Cruzer_20043512300546C0B317-0:0
```

With such a path, NixOS will install GRUB _every_ time, because it
thinks the configuration differs from the state file (due to the wrong
list split). This fixes it by using ',' as separator.

For existing systems with GRUB installed on multiple devices, this
change means that GRUB will be installed one extra time.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
