### PR TITLE
zandronum: fix build

### DIFF
--- a/pkgs/games/zandronum/default.nix
+++ b/pkgs/games/zandronum/default.nix
@@ -24,6 +24,8 @@ in stdenv.mkDerivation {
 
   preConfigure = ''
     ln -s ${sqlite-amalgamation}/* sqlite/
+    sed -ie 's| restrict| _restrict|g' dumb/include/dumb.h \
+                                       dumb/src/it/*.c
   '';
 
   cmakeFlags =


### PR DESCRIPTION
###### Motivation for this change

Fixes #15994 by changing `restrict` variable
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #15994
