### PR TITLE
uzbl: Fix wrong python site-package path

### DIFF
--- a/pkgs/applications/networking/browsers/uzbl/default.nix
+++ b/pkgs/applications/networking/browsers/uzbl/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     makeFlags="$makeFlags PREFIX=$out"
     makeFlags="$makeFlags PYINSTALL_EXTRA=--prefix=$out"
-    mkdir -p $out/lib/python3.4/site-packages/
-    export PYTHONPATH=$PYTHONPATH:$out/lib/python3.4/site-packages/
+    mkdir -p $out/lib/${python3}/site-packages/
+    export PYTHONPATH=$PYTHONPATH:$out/lib/${python3}/site-packages/
   '';
 
   preFixup = ''

--- a/pkgs/applications/networking/browsers/uzbl/default.nix
+++ b/pkgs/applications/networking/browsers/uzbl/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     makeFlags="$makeFlags PREFIX=$out"
     makeFlags="$makeFlags PYINSTALL_EXTRA=--prefix=$out"
-    mkdir -p $out/lib/python3.5/site-packages/
-    export PYTHONPATH=$PYTHONPATH:$out/lib/python3.5/site-packages/
+    mkdir -p $out/${python3.sitePackages}
+    export PYTHONPATH=$PYTHONPATH:$out/${python3.sitePackages}
   '';
 
   preFixup = ''

--- a/pkgs/applications/networking/browsers/uzbl/default.nix
+++ b/pkgs/applications/networking/browsers/uzbl/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     makeFlags="$makeFlags PREFIX=$out"
     makeFlags="$makeFlags PYINSTALL_EXTRA=--prefix=$out"
-    mkdir -p $out/lib/${python3}/site-packages/
-    export PYTHONPATH=$PYTHONPATH:$out/lib/${python3}/site-packages/
+    mkdir -p $out/lib/python3.5/site-packages/
+    export PYTHONPATH=$PYTHONPATH:$out/lib/python3.5/site-packages/
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

Uzbl fails to build because of wrong python site-package path ('python3.5' expected vs 'python3.4' as it is now). An alternative fix would be specifying the python version to be used as 3.4.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
