### PR TITLE
solarus: init at 1.4.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -264,6 +264,7 @@
   muflax = "Stefan Dorn <mail@muflax.com>";
   myrl = "Myrl Hex <myrl.0xf@gmail.com>";
   nathan-gs = "Nathan Bijnens <nathan@nathan.gs>";
+  Nate-Devv = "Nathan Moore <natedevv@gmail.com>";
   nckx = "Tobias Geerinckx-Rice <tobias.geerinckx.rice@gmail.com>";
   nequissimus = "Tim Steinbach <tim@nequissimus.com>";
   nfjinjing = "Jinjing Wang <nfjinjing@gmail.com>";

--- a/pkgs/games/solarus/default.nix
+++ b/pkgs/games/solarus/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cmake, luajit,
+  SDL2, SDL2_image, SDL2_ttf, physfs,
+  openal, libmodplug, libvorbis}:
+
+stdenv.mkDerivation rec {
+  name = "solarus-${version}";
+  version = "1.4.5";
+    
+  src = fetchFromGitHub {
+    owner = "christopho";
+    repo = "solarus";
+    rev = "d9fdb9fdb4e1b9fc384730a9279d134ae9f2c70e";
+    sha256 = "0xjx789d6crm322wmkqyq9r288vddsha59yavhy78c4r01gs1p5v";
+  };
+  
+  buildInputs = [ cmake luajit SDL2
+    SDL2_image SDL2_ttf physfs
+    openal libmodplug libvorbis ];
+
+  meta = with stdenv.lib; {
+    description = "A Zelda-like ARPG game engine";
+    longDescription = ''
+      Solarus is a game engine for Zelda-like ARPG games written in lua.
+      Many full-fledged games have been writen for the engine.
+    '';
+    homepage = http://www.solarus-games.org;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.Nate-Devv ];
+    platforms = platforms.linux;
+  };
+  
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15581,6 +15581,8 @@ in
   soi = callPackage ../games/soi {
     lua = lua5_1;
   };
+  
+  solarus = callPackage ../games/solarus { };
 
   # You still can override by passing more arguments.
   space-orbit = callPackage ../games/space-orbit { };


### PR DESCRIPTION
###### Motivation for this change

Expanding the distribution scope of the Solarus game engine to NixOS and Nix.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Obviously, the engine does need games, but I didn't know if I needed to create a separate pull request for the existing games I've packaged, or if I could add them here, so I've left them off.
