### PR TITLE
jpegrescan: init at 2016-06-01

### DIFF
--- a/pkgs/applications/graphics/jpegrescan/default.nix
+++ b/pkgs/applications/graphics/jpegrescan/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, makeWrapper, libjpeg_turbo, perl, perlPackages }:
+
+stdenv.mkDerivation rec {
+  pname = "jpegrescan";
+  date = "2016-06-01";
+  name = "${pname}-${date}";
+
+  src = fetchFromGitHub {
+    owner = "kud";
+    repo = pname;
+    rev = "e5e39cd972b48ccfb2cba4da6855c511385c05f9";
+    sha256 = "0jbx1vzkzif6yjx1fnsm7fjsmq166sh7mn22lf01ll7s245nmpdp";
+  };
+
+  patchPhase = ''
+    patchShebangs jpegrescan
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/jpegrescan
+    mv README.md $out/share/jpegrescan/
+    mkdir $out/bin
+    mv jpegrescan $out/bin
+    chmod +x $out/bin/jpegrescan
+
+    wrapProgram $out/bin/jpegrescan --prefix PERL5LIB : $PERL5LIB
+  '';
+
+  propagatedBuildInputs = [ perlPackages.FileSlurp ];
+
+  buildInputs = [
+    perl libjpeg_turbo makeWrapper
+  ];
+
+  meta = with stdenv.lib; {
+    description = "losslessly shrink any JPEG file";
+    homepage = https://github.com/kud/jpegrescan;
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.ramkromberg ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2133,6 +2133,8 @@ in
 
   jpegoptim = callPackage ../applications/graphics/jpegoptim { };
 
+  jpegrescan = callPackage ../applications/graphics/jpegrescan { };
+
   jq = callPackage ../development/tools/jq { };
 
   jo = callPackage ../development/tools/jo { };


### PR DESCRIPTION
###### Motivation for this change

I've encountered jpegs that MozJPEG fails to recognize and process that this script can.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
