### PR TITLE
cloc: 1.68 -> 1.70

### DIFF
--- a/pkgs/tools/misc/cloc/default.nix
+++ b/pkgs/tools/misc/cloc/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "cloc-${version}";
-  version = "1.68";
+  version = "1.70";
 
   src = fetchFromGitHub {
     owner = "AlDanial";
     repo = "cloc";
     rev = "v${version}";
-    sha256 = "17n6w7rd17h4q4cnjg4hxcfpx4plp40gd58bdyig9lsfbn6xcjxj";
+    sha256 = "1abkfkjn4fxplq33cwqjmgxabk2x6ij2klqn0w4a0lj82a7xx10x";
   };
 
   sourceRoot = "cloc-v${version}-src/Unix";


### PR DESCRIPTION
###### Motivation for this change

Version bump.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
