### PR TITLE
android-studio: repackage in an FHS environment

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -1,0 +1,82 @@
+{ bash
+, buildFHSUserEnv
+, coreutils
+, fetchurl
+, findutils
+, git
+, gnugrep
+, gnutar
+, gzip
+, jdk
+, libXrandr
+, makeWrapper
+, pkgsi686Linux
+, stdenv
+, unzip
+, which
+, writeTextFile
+, zlib
+}:
+
+let
+
+  version = "2.1.2.0";
+  build = "143.2915827";
+
+  androidStudio = stdenv.mkDerivation {
+    name = "android-studio";
+    buildInputs = [
+      makeWrapper
+      unzip
+    ];
+    installPhase = ''
+      cp -r . $out
+      wrapProgram $out/bin/studio.sh --set PATH "${stdenv.lib.makeBinPath [
+
+        # Checked in studio.sh
+        coreutils
+        findutils
+        gnugrep
+        jdk
+        which
+
+        # Used during setup wizard
+        gnutar
+        gzip
+
+        # Runtime stuff
+        git
+
+      ]}" --set LD_LIBRARY_PATH "${stdenv.lib.makeLibraryPath [
+        # Gradle wants libstdc++.so.6
+        stdenv.cc.cc.lib
+        # mksdcard wants 32 bit libstdc++.so.6
+        pkgsi686Linux.stdenv.cc.cc.lib
+        # aapt wants libz.so.1
+        zlib
+        # Support multiple monitors
+        libXrandr
+      ]}"
+    '';
+    src = fetchurl {
+      url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
+      sha256 = "0q61m8yln77valg7y6lyxlml53z387zh6fyfgc22sm3br5ahbams";
+    };
+  };
+
+  # Android Studio downloads prebuilt binaries as part of the SDK. These tools
+  # (e.g. `mksdcard`) have `/lib/ld-linux.so.2` set as the interpreter. An FHS
+  # environment is used as a work around for that.
+  fhsEnv = buildFHSUserEnv {
+    name = "android-studio-fhs-env";
+  };
+
+in writeTextFile {
+  name = "android-studio-${version}";
+  destination = "/bin/android-studio";
+  executable = true;
+  text = ''
+    #!${bash}/bin/bash
+    ${fhsEnv}/bin/android-studio-fhs-env ${androidStudio}/bin/studio.sh
+  '';
+}

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -10,33 +10,6 @@ let
   bnumber = with stdenv.lib; build: last (splitString "-" build);
   mkIdeaProduct = callPackage ./common.nix { };
 
-  buildAndroidStudio = { name, version, build, src, license, description, wmClass }:
-    let drv = (mkIdeaProduct rec {
-      inherit name version build src wmClass jdk;
-      product = "Studio";
-      meta = with stdenv.lib; {
-        homepage = https://developer.android.com/sdk/installing/studio.html;
-        inherit description license;
-        longDescription = ''
-          Android development environment based on IntelliJ
-          IDEA providing new features and improvements over
-          Eclipse ADT and will be the official Android IDE
-          once it's ready.
-        '';
-        platforms = platforms.linux;
-        hydraPlatforms = []; # Depends on androidsdk, which hits Hydra's output limits
-        maintainers = with maintainers; [ edwtjo ];
-      };
-    });
-    in stdenv.lib.overrideDerivation drv (x : {
-      buildInputs = x.buildInputs ++ [ makeWrapper ];
-      installPhase = x.installPhase +  ''
-        wrapProgram "$out/bin/android-studio" \
-          --set ANDROID_HOME "${androidsdk}/libexec/" \
-          --set LD_LIBRARY_PATH "${stdenv.cc.cc.lib}/lib" # Gradle installs libnative-platform.so in ~/.gradle, that requires libstdc++.so.6
-      '';
-    });
-
   buildClion = { name, version, build, src, license, description, wmClass }:
     (mkIdeaProduct rec {
       inherit name version build src wmClass jdk;
@@ -147,20 +120,6 @@ let
 in
 
 {
-
-  android-studio = let buildNumber = "143.2915827"; in buildAndroidStudio rec {
-    name = "android-studio-${version}";
-    version = "2.1.2.0";
-    build = "AI-${buildNumber}";
-    description = "Android development environment based on IntelliJ IDEA";
-    license = stdenv.lib.licenses.asl20;
-    src = fetchurl {
-      url = "https://dl.google.com/dl/android/studio/ide-zips/${version}" +
-            "/android-studio-ide-${buildNumber}-linux.zip";
-      sha256 = "0q61m8yln77valg7y6lyxlml53z387zh6fyfgc22sm3br5ahbams";
-    };
-    wmClass = "jetbrains-studio";
-  };
 
   clion = buildClion rec {
     name = "clion-${version}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12263,6 +12263,19 @@ in
 
   amsn = callPackage ../applications/networking/instant-messengers/amsn { };
 
+  # Oracle JDK is recommended upstream, but unfree and requires a manual
+  # download. OpenJDK is straightforward, but may suffer from compatibility
+  # problems e.g. https://code.google.com/p/android/issues/detail?id=174496.
+  # To use Oracle JDK add an override to ~/.nixpkgs/config.nix:
+  # {
+  #   packageOverrides = pkgs: {
+  #     android-studio = pkgs.android-studio.override {
+  #       jdk = pkgs.oraclejdk8;
+  #     };
+  #   };
+  # }
+  android-studio = callPackage ../applications/editors/android-studio { };
+
   antimony = qt5.callPackage ../applications/graphics/antimony {};
 
   antiword = callPackage ../applications/office/antiword {};


### PR DESCRIPTION
###### Motivation for this change

Android (studio) can and wants to manage  its own packages. The [current packaging approach](https://github.com/NixOS/nixpkgs/blob/e945646be3a045948801ff7262bec11a7b9315b3/pkgs/applications/editors/idea/default.nix#L13) doesn't allow such management. As a result the package is unusable (see https://github.com/NixOS/nixpkgs/issues/8650 and https://github.com/NixOS/nixpkgs/issues/14903).

@jagajaga has a [nix-shell configuration](https://github.com/NixOS/nixpkgs/issues/14903#issuecomment-213591942), which I have adapted into a package. The quality is pretty much "work for me", but hey, it works :)

Oracle JDK is a nuisance to install (unfree and requires a manual download), but I got an [exception](https://gist.github.com/phunehehe/42c99feba91035103ae6ba14d4e0ed4d) with Open JDK and I have little clue how to continue that way.

Would this be nearly good enough to replace the current package?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
