### PR TITLE
nixos/swap: support for resizing swapfile

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -30,8 +30,7 @@ let
         description = ''
           If this option is set, ‘device’ is interpreted as the
           path of a swapfile that will be created automatically
-          with the indicated size (in megabytes) if it doesn't
-          exist.
+          with the indicated size (in megabytes).
         '';
       };
 
@@ -132,9 +131,13 @@ in
             script =
               ''
                 ${optionalString (sw.size != null) ''
-                  if [ ! -e "${sw.device}" ]; then
+                  currentSize=$(( $(stat -c "%s" "${sw.device}" 2>/dev/null || echo 0) / 1024 / 1024 ))
+                  if [ "${toString sw.size}" != "$currentSize" ]; then
                     fallocate -l ${toString sw.size}M "${sw.device}" ||
                       dd if=/dev/zero of="${sw.device}" bs=1M count=${toString sw.size}
+                    if [ "${toString sw.size}" -lt "$currentSize" ]; then
+                      truncate --size "${toString sw.size}M" "${sw.device}"
+                    fi
                     chmod 0600 ${sw.device}
                     ${optionalString (!sw.randomEncryption) "mkswap ${sw.realDevice}"}
                   fi


### PR DESCRIPTION
###### Motivation for this change

Currently NixOS creates the swapfile (with the specified size) only if
it doesn't already exist. Changing the swapfile size afterwards will not
have any effect.

This commit changes that so the swapfile will be recreated whenever
swapDevices.*.size is changed, allowing both growing and shrinking the
swapfile.

The service unit has "restartIfChanged = false", so we don't have to
worry about the swapfile being in use at the time this code is run (you
have to reboot for swapfile changes).

fallocate doesn't shrink files, use truncate for that. truncate can also
be used to grow files, but it creates "holes" in the file which doesn't
work with swapfiles.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've tested resizing (shrink/grow), removing the swapfile and watch it be recreated, checking that changing the configured swapfile size and doing "nixos-rebuild switch" doesn't mess up (as expected with "restartIfChanged = false").
