### PR TITLE
geany-with-vte: fix desktop shortcut and man pages

### DIFF
--- a/pkgs/applications/editors/geany/with-vte.nix
+++ b/pkgs/applications/editors/geany/with-vte.nix
@@ -2,5 +2,7 @@
 let name = builtins.replaceStrings ["geany-"] ["geany-with-vte-"] geany.name;
 in
 runCommand "${name}" { nativeBuildInputs = [ makeWrapper ]; } "
+   mkdir -p $out
+   ln -s ${geany}/share $out
    makeWrapper ${geany}/bin/geany $out/bin/geany --prefix LD_LIBRARY_PATH : ${gnome.vte}/lib
 "


### PR DESCRIPTION
###### Motivation for this change

geany-with-vte lacked geany.desktop, share/icons/, the man pages, etc...
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
