### PR TITLE
Solarus games

### DIFF
--- a/pkgs/games/zelda_roth_se/default.nix
+++ b/pkgs/games/zelda_roth_se/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit, cmake, zip }:
+
+stdenv.mkDerivation rec {
+  name = "zelda_roth_se-${version}";
+  version = "1.0.8";
+  
+  src = fetchgit {
+    url = "https://github.com/christopho/zelda_roth_se.git";
+    rev = "90060af19bb84e391571f31a1f394aa04cc812c3";
+    sha256 = "0217mrw995ccim80bl6yaypbsanhvdns4z1qkxfpfxj7ipf7bjk7";
+  };
+  
+  buildInputs = [ cmake zip ];
+
+  meta = with stdenv.lib; {
+    description = "A solarus quest";
+    longDescription = ''
+      The Legend of Zelda: Return of the Hylian Solarus Edition
+      is a Solarus remake of Vincent Jouillat's fan game of similar
+      name. It is written in lua.
+    '';
+    homepage = http://www.solarus-games.org;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.Nate-Devv ];
+    platforms = platforms.all;
+  };
+  
+}

--- a/pkgs/games/zsdx/default.nix
+++ b/pkgs/games/zsdx/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchgit, cmake, zip }:
+
+stdenv.mkDerivation rec {
+  name = "zsdx-${version}";
+  version = "1.10.3";
+  
+  src = fetchgit {
+    url = "https://github.com/christopho/zsdx.git";
+    rev = "cb4b1b50b03d9e9a0a852e8528e4450ca72ed8f8";
+    sha256 = "18x5cbl27b294ilmdmvijy19da6vl0m32kxwdx51hc67vzzgnwxd";
+  };
+  
+  buildInputs = [ cmake zip ];
+
+  meta = with stdenv.lib; {
+    description = "A solarus quest";
+    longDescription = ''
+      The Legend of Zelda: Mystery of Solarus DX is the
+      first game made with Solarus.  It is written in lua.
+    '';
+    homepage = http://www.solarus-games.org;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.Nate-Devv ];
+    platforms = platforms.all;
+  };
+  
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15768,6 +15768,8 @@ in
   zandronum-bin = hiPrio (callPackage ../games/zandronum/bin.nix { });
 
   zangband = callPackage ../games/zangband { };
+  
+  zelda_roth_se = callPackage ../games/zelda_roth_se { };
 
   zdoom = callPackage ../games/zdoom { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15778,6 +15778,8 @@ in
   keen4 = callPackage ../games/keen4 { };
 
   zeroad = callPackage ../games/0ad { };
+  
+  zsdx = callPackage ../games/zsdx { };
 
   ### DESKTOP ENVIRONMENTS
 


### PR DESCRIPTION
###### Motivation for this change

Adding working games for users of Solarus.
Included is Mystery of Solarus and Return of the Hylian: Solarus Edition.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
