### PR TITLE
nixos/systemd: disable timer units with service

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -764,7 +764,7 @@ in
         { wantedBy = [ "timers.target" ];
           timerConfig.OnCalendar = service.startAt;
         })
-        (filterAttrs (name: service: service.startAt != "") cfg.services);
+        (filterAttrs (name: service: service.enable && service.startAt != "") cfg.services);
 
     # Generate timer units for all services that have a ‘startAt’ value.
     systemd.user.timers =


### PR DESCRIPTION
###### Motivation for this change

A disabled systemd service with a "startAt" attribute, like this:

```
  systemd.services.foo-service = {
    enable = false;
    startAt = "*-*-* 05:15:00";
    ...
  };
```

will cause the following errors in the system journal:

  systemd[1]: foo-service.timer: Refusing to start, unit to trigger not loaded.
  systemd[1]: Failed to start foo-service.timer.

Fix it by not generating the corresponding timer unit when the service
is disabled.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
