### PR TITLE
Plymouth splash screen

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -522,6 +522,7 @@
   ./system/boot/luksroot.nix
   ./system/boot/modprobe.nix
   ./system/boot/networkd.nix
+  ./system/boot/plymouth.nix
   ./system/boot/resolved.nix
   ./system/boot/shutdown.nix
   ./system/boot/stage-1.nix

--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -100,9 +100,6 @@ in
     '';
 
     boot.initrd.network.postCommands = ''
-      mkdir /dev/pts
-      mount -t devpts devpts /dev/pts
-
       echo '${cfg.shell}' > /etc/shells
       echo 'root:x:0:0:root:/root:${cfg.shell}' > /etc/passwd
       echo 'passwd: files' > /etc/nsswitch.conf

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -1,0 +1,129 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  inherit (pkgs) plymouth;
+
+  cfg = config.boot.plymouth;
+
+  themesEnv = pkgs.buildEnv {
+    name = "plymouth-themes";
+    paths = [ plymouth ] ++ cfg.themePackages;
+  };
+
+  configFile = pkgs.writeText "plymouthd.conf" ''
+    [Daemon]
+    ShowDelay=0
+    Theme=${cfg.theme}
+  '';
+
+in
+
+{
+
+  options = {
+
+    boot.plymouth = {
+
+      enable = mkEnableOption "Plymouth boot splash screen";
+
+      themePackages = mkOption {
+        default = [];
+        type = types.listOf types.package;
+        description = ''
+          Extra theme packages for plymouth.
+        '';
+      };
+
+      theme = mkOption {
+        default = "fade-in";
+        type = types.str;
+        description = ''
+          Splash screen theme.
+        '';
+      };
+
+      logo = mkOption {
+        type = types.path;
+        default = pkgs.fetchurl {
+          url = "https://nixos.org/logo/nixos-hires.png";
+          sha256 = "1ivzgd7iz0i06y36p8m5w48fd8pjqwxhdaavc0pxs7w1g7mcy5si";
+        };
+        description = ''
+          Logo which is displayed on the splash screen.
+        '';
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    boot.kernelParams = [ "splash" ];
+
+    # To be discoverable by systemd.
+    environment.systemPackages = [ plymouth ];
+
+    environment.etc."plymouth/plymouthd.conf".source = configFile;
+    environment.etc."plymouth/plymouthd.defaults".source = "${plymouth}/share/plymouth/plymouth.defaults";
+    environment.etc."plymouth/logo.png".source = cfg.logo;
+    environment.etc."plymouth/themes".source = "${themesEnv}/share/plymouth/themes";
+    # XXX: Needed because we supply a different set of plugins in initrd.
+    environment.etc."plymouth/plugins".source = "${plymouth}/lib/plymouth";
+
+    systemd.packages = [ plymouth ];
+
+    systemd.services.plymouth-kexec.wantedBy = [ "kexec.target" ];
+    systemd.services.plymouth-halt.wantedBy = [ "halt.target" ];
+    systemd.services.plymouth-quit = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "display-manager.service" "multi-user.target" ];
+    };
+    systemd.services.plymouth-poweroff.wantedBy = [ "poweroff.target" ];
+    systemd.services.plymouth-reboot.wantedBy = [ "reboot.target" ];
+    systemd.services.plymouth-read-write.wantedBy = [ "sysinit.target" ];
+
+    boot.initrd.extraUtilsCommands = ''
+      copy_bin_and_libs ${pkgs.plymouth}/bin/plymouthd
+      copy_bin_and_libs ${pkgs.plymouth}/bin/plymouth
+
+      moduleName="$(sed -n 's,ModuleName *= *,,p' ${themesEnv}/share/plymouth/themes/${cfg.theme}/${cfg.theme}.plymouth)"
+
+      mkdir -p $out/lib/plymouth/renderers
+      cp ${plymouth}/lib/plymouth/{text,details,$moduleName}.so $out/lib/plymouth
+      cp ${plymouth}/lib/plymouth/renderers/{drm,frame-buffer}.so $out/lib/plymouth/renderers
+
+      mkdir -p $out/share/plymouth/themes
+      cp ${plymouth}/share/plymouth/plymouthd.defaults $out/share/plymouth
+      cp -r ${themesEnv}/share/plymouth/themes/{text,details,${cfg.theme}} $out/share/plymouth/themes
+      cp ${cfg.logo} $out/share/plymouth/logo.png
+    '';
+
+    boot.initrd.extraUtilsCommandsTest = ''
+      $out/bin/plymouthd --help >/dev/null
+      $out/bin/plymouth --help >/dev/null
+    '';
+
+    boot.initrd.extraUdevRulesCommands = ''
+      cp ${config.systemd.package}/lib/udev/rules.d/{70-uaccess,71-seat}.rules $out
+      sed -i '/loginctl/d' $out/71-seat.rules
+    '';
+
+    boot.initrd.preLVMCommands = mkAfter ''
+      mkdir -p /etc/plymouth
+      ln -s ${configFile} /etc/plymouth/plymouthd.conf
+      ln -s $extraUtils/share/plymouth/plymouthd.defaults /etc/plymouth/plymouthd.defaults
+      ln -s $extraUtils/share/plymouth/logo.png /etc/plymouth/logo.png
+      ln -s $extraUtils/share/plymouth/themes /etc/plymouth/themes
+      ln -s $extraUtils/lib/plymouth /etc/plymouth/plugins
+
+      plymouthd --mode=boot --pid-file=/run/plymouth/pid --attach-to-session
+      plymouth --show-splash
+    '';
+
+  };
+
+}

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -70,6 +70,8 @@ mount -t sysfs sysfs /sys
 mount -t devtmpfs -o "size=@devSize@" devtmpfs /dev
 mkdir -p /run
 mount -t tmpfs -o "mode=0755,size=@runSize@" tmpfs /run
+mkdir /dev/pts
+mount -t devpts devpts /dev/pts
 
 # Log the script output to /dev/kmsg or /run/log/stage-1-init.log.
 mkdir -p /tmp

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -14,6 +14,9 @@ export LVM_SUPPRESS_FD_WARNINGS=true
 fail() {
     if [ -n "$panicOnFail" ]; then exit 1; fi
 
+    # If we have a splash screen started, quit it.
+    command -v plymouth >/dev/null 2>&1 && plymouth quit
+
     # If starting stage 2 failed, allow the user to repair the problem
     # in an interactive shell.
     cat <<EOF

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -3,6 +3,7 @@
 targetRoot=/mnt-root
 console=tty1
 
+extraUtils="@extraUtils@"
 export LD_LIBRARY_PATH=@extraUtils@/lib
 export PATH=@extraUtils@/bin
 ln -s @extraUtils@/bin /bin

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -165,7 +165,8 @@ let
             --replace /sbin/mdadm ${extraUtils}/bin/mdadm \
             --replace /bin/sh ${extraUtils}/bin/sh \
             --replace /usr/bin/readlink ${extraUtils}/bin/readlink \
-            --replace /usr/bin/basename ${extraUtils}/bin/basename
+            --replace /usr/bin/basename ${extraUtils}/bin/basename \
+            --replace ${udev}/bin/udevadm ${extraUtils}/bin/udevadm
       done
 
       # Work around a bug in QEMU, which doesn't implement the "READ

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -142,6 +142,7 @@ let
 
   udevRules = pkgs.stdenv.mkDerivation {
     name = "udev-rules";
+    allowedReferences = [ extraUtils ];
     buildCommand = ''
       mkdir -p $out
 

--- a/pkgs/desktops/gnome-3/3.18/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/core/gdm/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, glib, itstool, libxml2, xorg, dbus
 , intltool, accountsservice, libX11, gnome3, systemd, gnome_session, autoreconfHook
-, gtk, libcanberra_gtk3, pam, libtool, gobjectIntrospection }:
+, gtk, libcanberra_gtk3, pam, libtool, gobjectIntrospection, plymouth }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -13,12 +13,13 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--sysconfdir=/etc"
                      "--localstatedir=/var"
                      "--with-systemd=yes"
+                     "--with-plymouth=yes"
                      "--with-systemdsystemunitdir=$(out)/etc/systemd/system" ];
 
   buildInputs = [ pkgconfig glib itstool libxml2 intltool autoreconfHook
                   accountsservice gnome3.dconf systemd
                   gobjectIntrospection libX11 gtk
-                  libcanberra_gtk3 pam libtool ];
+                  libcanberra_gtk3 pam libtool plymouth ];
 
   #enableParallelBuilding = true; # problems compiling
 

--- a/pkgs/desktops/gnome-3/3.20/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/gdm/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, glib, itstool, libxml2, xorg, dbus
 , intltool, accountsservice, libX11, gnome3, systemd, gnome_session, autoreconfHook
-, gtk, libcanberra_gtk3, pam, libtool, gobjectIntrospection }:
+, gtk, libcanberra_gtk3, pam, libtool, gobjectIntrospection, plymouth }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -13,12 +13,13 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--sysconfdir=/etc"
                      "--localstatedir=/var"
                      "--with-systemd=yes"
+                     "--with-plymouth=yes"
                      "--with-systemdsystemunitdir=$(out)/etc/systemd/system" ];
 
   buildInputs = [ pkgconfig glib itstool libxml2 intltool autoreconfHook
                   accountsservice gnome3.dconf systemd
                   gobjectIntrospection libX11 gtk
-                  libcanberra_gtk3 pam libtool ];
+                  libcanberra_gtk3 pam libtool plymouth ];
 
   #enableParallelBuilding = true; # problems compiling
 

--- a/pkgs/os-specific/linux/plymouth/default.nix
+++ b/pkgs/os-specific/linux/plymouth/default.nix
@@ -1,27 +1,32 @@
-{ stdenv, fetchurl, autoreconfHook, cairo, docbook_xsl, gtk
-, libdrm, libpng, libxslt, makeWrapper, pango, pkgconfig, udev
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libxslt, docbook_xsl
+, gtk3, udev, systemd
 }:
 
 stdenv.mkDerivation rec {
   name = "plymouth-${version}";
-  version = "0.9.0";
+  version = "0.9.2";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/plymouth/releases/${name}.tar.bz2";
-    sha256 = "0kfdwv179brg390ma003pmdqfvqlbybqiyp9fxrxx0wa19sjxqnk";
+    sha256 = "0zympsgy5bbfl2ag5nc1jxlshpx8r1s1yyjisanpx76g88hfh31g";
   };
 
-  buildInputs = [
-    autoreconfHook cairo docbook_xsl gtk libdrm libpng
-    libxslt makeWrapper pango pkgconfig udev
+  nativeBuildInputs = [
+    autoreconfHook pkgconfig libxslt docbook_xsl
   ];
 
-  prePatch = ''
-    sed -e "s#\$(\$PKG_CONFIG --variable=systemdsystemunitdir systemd)#$out/etc/systemd/system#g" \
-      -i configure.ac
-  '';
+  buildInputs = [
+    gtk3 udev systemd
+  ];
 
   postPatch = ''
+    sed -i \
+      -e "s#\$(\$PKG_CONFIG --variable=systemdsystemunitdir systemd)#$out/etc/systemd/system#g" \
+      -e "s#plymouthplugindir=.*#plymouthplugindir=/etc/plymouth/plugins/#" \
+      -e "s#plymouththemedir=.*#plymouththemedir=/etc/plymouth/themes#" \
+      -e "s#plymouthpolicydir=.*#plymouthpolicydir=/etc/plymouth/#" \
+      configure.ac
+
     configureFlags="
       --prefix=$out
       --bindir=$out/bin
@@ -29,15 +34,24 @@ stdenv.mkDerivation rec {
       --exec-prefix=$out
       --libdir=$out/lib
       --libexecdir=$out/lib
-      --sysconfdir=$out/etc
+      --sysconfdir=/etc
       --localstatedir=/var
-      --with-log-viewer
+      --with-logo=/etc/plymouth/logo.png
+      --with-background-color=0x000000
+      --with-background-start-color-stop=0x000000
+      --with-background-end-color-stop=0x000000
+      --with-release-file=/etc/os-release
       --without-system-root-install
       --without-rhgb-compat-link
       --enable-tracing
       --enable-systemd-integration
       --enable-pango
+      --enable-gdm-transition
       --enable-gtk"
+
+    installFlags="
+      plymouthd_defaultsdir=$out/share/plymouth
+      plymouthd_confdir=$out/etc/plymouth"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Because we can and it looks nice. Enable with `boot.plymouth.enable = true`.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
###### TODO:
- [x] Test on various configurations. Notice that it's recommended to add your video driver module to `boot.initrd.kernelModules` -- for example `i915` for Intel;
- [ ] Make GDM smoothly appear after it (there is support but I haven't tried to enable it or test);
- [x] Test with LUKS (implemented password query but not tested, YubiKey too);
- [x] Better style (I've added our logo but haven't tweaked its size, colors etc.);
- [x] Test most likely broken emergency mode -- we patch out `plymouth quit` before it in our `systemd`;
- [x] Investigate if it's possible to show systemd service failures properly;
- [x] Fix stage-1 `fail`.
###### Implementation details:

This links various resources, including binary Plymouth plugins, to `/etc`. I've done this because we want to have trimmed resources package for including in initrd -- so in it not all plugins, themes etc are available.
