### PR TITLE
gmp: 6.1.0 -> 6.1.1

### DIFF
--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -3,11 +3,11 @@
 with { inherit (stdenv.lib) optional optionalString; };
 
 let self = stdenv.mkDerivation rec {
-  name = "gmp-6.1.0";
+  name = "gmp-6.1.1";
 
   src = fetchurl { # we need to use bz2, others aren't in bootstrapping stdenv
     urls = [ "mirror://gnu/gmp/${name}.tar.bz2" "ftp://ftp.gmplib.org/pub/${name}/${name}.tar.bz2" ];
-    sha256 = "1s3kddydvngqrpc6i1vbz39raya2jdcl042wi0ksbszgjjllk129";
+    sha256 = "1mpzprdzkgfpdc1v2lf4dxlxps4x8bvmzvd8n1ri6gw9y9jrh458";
   };
 
   #outputs TODO: split $cxx due to libstdc++ dependency; maybe port to gmp5;
@@ -73,7 +73,7 @@ let self = stdenv.mkDerivation rec {
       '';
 
     platforms = platforms.all;
-    maintainers = [ maintainers.peti ];
+    maintainers = [ maintainers.peti maintainers.vrthra ];
   };
 };
   in self


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
