### PR TITLE
universal-ctags: init at 2016-07-06

### DIFF
--- a/pkgs/development/tools/misc/universal-ctags/default.nix
+++ b/pkgs/development/tools/misc/universal-ctags/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, perl }:
+
+stdenv.mkDerivation rec {
+  name = "universal-ctags-${version}";
+  version = "2016-07-06";
+
+  src = fetchFromGitHub {
+    owner = "universal-ctags";
+    repo = "ctags";
+    rev = "44a325a9db23063b231f6f041af9aaf19320d9b9";
+    sha256 = "11vq901h121ckqgw52k9x7way3q38b7jd08vr1n2sjz7kxh0zdd0";
+  };
+
+  buildInputs = [ autoreconfHook pkgconfig ];
+
+  autoreconfPhase = ''
+    ./autogen.sh --tmpdir
+  '';
+
+  postConfigure = ''
+    sed -i 's|/usr/bin/env perl|${perl}/bin/perl|' misc/optlib2c
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A maintained ctags implementation";
+    homepage = "https://ctags.io/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    # universal-ctags is preferred over emacs's ctags
+    priority = 1;
+    maintainers = [ maintainers.mimadrid ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6641,6 +6641,8 @@ in
 
   uncrustify = callPackage ../development/tools/misc/uncrustify { };
 
+  universal-ctags = callPackage ../development/tools/misc/universal-ctags { };
+
   vagrant = callPackage ../development/tools/vagrant {
     ruby = ruby_2_2;
   };


### PR DESCRIPTION
###### Motivation for this change

Add universal-ctags to NixOS
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
