### PR TITLE
symbola: fix hash mismatch due to new upstream release

### DIFF
--- a/pkgs/data/fonts/gdouros/default.nix
+++ b/pkgs/data/fonts/gdouros/default.nix
@@ -5,7 +5,7 @@ let
                description = "Scripts and symbols of the Aegean world"; };
     textfonts = { version = "6.00"; file = "Textfonts.zip"; sha256 = "06igp3hdql0yfaj9h2ahh5n7yvj2ni7rj2jdmz534f9618l8qi6r";
                   description = "Fonts based on early Greek editions"; };
-    symbola = { version = "8.00"; file = "Symbola.zip"; sha256 = "1lfs2j816332ysvpb5ibj2gwpmyqyispqdl7skkshf2gra18hmhd";
+    symbola = { version = "9.00"; file = "Symbola.zip"; sha256 = "0d9zrlvzh8inhr17p99banr0dmrvkwxbk3q7zhqqx2z4gf2yavc5";
                 description = "Basic Latin, Greek, Cyrillic and many Symbol blocks of Unicode"; };
     aegyptus = { version = "6.00"; file = "Aegyptus.zip"; sha256 = "10mr54ja9b169fhqfkrw510jybghrpjx7a8a7m38k5v39ck8wz6v";
                  description = "Egyptian Hieroglyphs, Coptic, Meroitic"; };


### PR DESCRIPTION
###### Motivation for this change

Hash sum mismatches when installing the Symbola font package
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Upstream releases are made in-place, ie they update the same URL
rather than creating a new one.

Needs to be backported to 16.03 as well

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/16775)

<!-- Reviewable:end -->
