### PR TITLE
pdfmod: unbreak after multiple-outputs change

### DIFF
--- a/pkgs/applications/misc/pdfmod/default.nix
+++ b/pkgs/applications/misc/pdfmod/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, gnome_doc_utils, intltool
+{ stdenv, fetchurl, fetchpatch, pkgconfig, gnome_doc_utils, intltool, lib
 , mono, gtk-sharp, gnome-sharp, hyena
 , which, makeWrapper, glib, gnome3, poppler, wrapGAppsHook
 }:
@@ -33,12 +33,7 @@ stdenv.mkDerivation rec {
       --add-flags "$out/lib/pdfmod/PdfMod.exe" \
       --prefix MONO_GAC_PREFIX : ${gtk-sharp} \
       --prefix MONO_GAC_PREFIX : ${gnome-sharp} \
-      --prefix LD_LIBRARY_PATH : ${glib}/lib \
-      --prefix LD_LIBRARY_PATH : ${gtk-sharp}/lib \
-      --prefix LD_LIBRARY_PATH : ${gnome-sharp}/lib \
-      --prefix LD_LIBRARY_PATH : ${gtk-sharp.gtk}/lib \
-      --prefix LD_LIBRARY_PATH : ${gnome3.gconf}/lib \
-      --prefix LD_LIBRARY_PATH : ${poppler.out}/lib
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ glib gnome-sharp gnome3.gconf gtk-sharp gtk-sharp.gtk poppler ]}
   '';
 
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change

fixes #16777 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
