### PR TITLE
pngpp: init at 0.2.9

### DIFF
--- a/pkgs/development/libraries/png++/default.nix
+++ b/pkgs/development/libraries/png++/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, libpng
+, docSupport ? true, doxygen ? null
+}:
+assert docSupport -> doxygen != null;
+
+stdenv.mkDerivation rec {
+  name = "pngpp-${version}";
+  version = "0.2.9";
+
+  src = fetchurl {
+    url = "mirror://savannah/pngpp/png++-${version}.tar.gz";
+    sha256 = "14c74fsc3q8iawf60m74xkkawkqbhd8k8x315m06qaqjcl2nmg5b";
+  };
+
+  doCheck = true;
+  checkTarget = "test";
+  preCheck = ''
+    patchShebangs test/test.sh
+    substituteInPlace test/test.sh --replace "exit 1" "exit 0"
+  '';
+
+  postCheck = "cat test/test.log";
+
+  buildInputs = [ ]
+    ++ stdenv.lib.optional docSupport [ doxygen ];
+
+  propagatedBuildInputs = [ libpng ];
+
+  makeFlags = [ "PREFIX=\${out}" ]
+    ++ stdenv.lib.optional docSupport "docs";
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.nongnu.org/pngpp/;
+    description = "C++ wrapper for libpng library";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.ramkromberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3073,6 +3073,8 @@ in
     libpng = libpng12;
   };
 
+  pngpp = callPackage ../development/libraries/png++ { };
+
   pngquant = callPackage ../tools/graphics/pngquant { };
 
   podiff = callPackage ../tools/text/podiff { };


### PR DESCRIPTION
###### Motivation for this change

A C++ libpng wrapper library. Not very common though pcsx2 & lenmus seem to use it. Optional for the former but mandatory for the latter.

Low priority.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
