### PR TITLE
gnutls: make "nettools" optional on non-Linux

### DIFF
--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -35,11 +35,12 @@ stdenv.mkDerivation {
   # for the actual fix.
   enableParallelBuilding = !guileBindings;
 
-  buildInputs = [ lzo lzip nettle libtasn1 libidn p11_kit zlib gmp autogen nettools ]
+  buildInputs = [ lzo lzip nettle libtasn1 libidn p11_kit zlib gmp autogen ]
     ++ lib.optional (stdenv.isFreeBSD || stdenv.isDarwin) libiconv
     ++ lib.optional (tpmSupport && stdenv.isLinux) trousers
     ++ [ unbound ]
-    ++ lib.optional guileBindings guile;
+    ++ lib.optional guileBindings guile
+    ++ lib.optional stdenv.isLinux nettools;
 
   nativeBuildInputs = [ perl pkgconfig ] ++ nativeBuildInputs;
 


### PR DESCRIPTION
###### Motivation for this change

"nettools" does not seem to be needed for gnutls to work on
Darwin. "nettools" is only available on Linux systems, so make it an
"optional" build input for gnutls. This should fix some evaluation
errors in Darwin.

"nettools" was introduced in commit 325dafe82b74cf7d1c4883cd1ba4909741672eb0.

cc @vcunat, @leenaars
