### PR TITLE
patch-shebangs.sh

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -46,7 +46,8 @@ patchShebangs() {
             args="$arg0 $args"
         fi
 
-        newInterpreterLine="$newPath $args"
+        # Strip trailing whitespace introduced when no arguments are present
+        newInterpreterLine=$(echo "$newPath $args" | sed 's/[[:space:]]*$//')
 
         if [ -n "$oldPath" -a "${oldPath:0:${#NIX_STORE}}" != "$NIX_STORE" ]; then
             if [ -n "$newPath" -a "$newPath" != "$oldPath" ]; then


### PR DESCRIPTION
###### Motivation for this change

Avoid untidy trailing spaces when using patchShebangs.
This has only been tested locally, I would want to do additional checks before merging.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Prior to this commit, trailing whitespace would be introduced when 
modifying '#!' lines with no arguments.  For example (whitespace added):

```
/nix/store/.../foo: interpreter directive changed 
    from "/bin/bash"
      to "/nix/store/...-bash-4.3-p42/bin/bash  "

/nix/store/.../bar: interpreter directive changed 
    from "/bin/baz wef"
      to "/nix/store/...-baz wef "
```

We add a sed command to strip trailing whitespace, so the above commands
would drop the two spaces after "bash", or the one space after "baz wef".
