### PR TITLE
alarm-clock-applet: use default method for propagating gstreamer

### DIFF
--- a/pkgs/tools/misc/alarm-clock-applet/default.nix
+++ b/pkgs/tools/misc/alarm-clock-applet/default.nix
@@ -8,6 +8,7 @@
 , libunique
 , intltool
 , gst_plugins ? with gst_all_1; [ gst-plugins-base gst-plugins-good gst-plugins-ugly ]
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -35,16 +36,12 @@ stdenv.mkDerivation rec {
     libxml2
     libunique
     intltool
+    wrapGAppsHook
   ];
 
   propagatedUserEnvPkgs = [ gnome.GConf.out ];
 
   enableParallelBuilding = true;
-
-  preFixup = ''
-    wrapProgram $out/bin/alarm-clock-applet \
-      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
-  '';
 
   meta = with stdenv.lib; {
     homepage = http://alarm-clock.pseudoberries.com/;


### PR DESCRIPTION
###### Motivation for this change

I've found a cleaner way to propagate gstreamer's plugins.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
