### PR TITLE
ycmd: claim mainteinership

### DIFF
--- a/pkgs/development/tools/misc/ycmd/default.nix
+++ b/pkgs/development/tools/misc/ycmd/default.nix
@@ -28,10 +28,11 @@ stdenv.mkDerivation rec {
     ln -s $out/lib/ycmd/ycmd/__main__.py $out/bin/ycmd
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A code-completion and comprehension server";
-    homepage = "https://github.com/Valloric/ycmd";
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.all;
+    homepage = https://github.com/Valloric/ycmd;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ rasendubi ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I've added the package originally.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
