### PR TITLE
pidgin-osd: init at 0.1.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pidgin, xosd
-, autoconf, automake, libtool } :
+, autoreconfHook } :
 
 stdenv.mkDerivation rec {
   name = "pidgin-osd-0.1.0";
@@ -8,16 +8,19 @@ stdenv.mkDerivation rec {
     sha256 = "11hqfifhxa9gijbnp9kq85k37hvr36spdd79cj9bkkvw4kyrdp3j";
   };
 
-  preConfigure = "./autogen.sh";
-
   makeFlags = "PIDGIN_LIBDIR=$(out)";
+
+  # autoreconf is run such that it *really* wants all the files, and there's no
+  # default ChangeLog.  So make it happy.
+  preAutoreconf = "touch ChangeLog";
 
   postInstall = ''
     mkdir -p $out/lib/pidgin
     ln -s $out/pidgin $out/lib/pidgin
   '';
 
-  buildInputs = [ xosd pidgin autoconf automake libtool ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ xosd pidgin ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/mbroemme/pidgin-osd;

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pidgin, xosd
+, autoconf, automake, libtool } :
+
+stdenv.mkDerivation rec {
+  name = "pidgin-osd-0.1.0";
+  src = fetchurl {
+    url = https://github.com/mbroemme/pidgin-osd/archive/pidgin-osd-0.1.0.tar.gz;
+    sha256 = "11hqfifhxa9gijbnp9kq85k37hvr36spdd79cj9bkkvw4kyrdp3j";
+  };
+
+  preConfigure = "./autogen.sh";
+
+  makeFlags = "PIDGIN_LIBDIR=$(out)";
+
+  postInstall = ''
+    mkdir -p $out/lib/pidgin
+    ln -s $out/pidgin $out/lib/pidgin
+  '';
+
+  buildInputs = [ xosd pidgin autoconf automake libtool ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mbroemme/pidgin-osd;
+    description = "Plugin for Pidgin which implements on-screen display via libxosd";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13906,6 +13906,8 @@ in
 
   pidginotr = callPackage ../applications/networking/instant-messengers/pidgin-plugins/otr { };
 
+  pidginosd = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-osd { };
+
   pidginsipe = callPackage ../applications/networking/instant-messengers/pidgin-plugins/sipe { };
 
   pidginwindowmerge = callPackage ../applications/networking/instant-messengers/pidgin-plugins/window-merge { };


### PR DESCRIPTION
###### Motivation for this change

This is a straightforward pidgin plugin; not sure how popular it is, but it's cheap to add.  I hand-rolled this plugin on Gentoo; might as well do it properly on Nix.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS) - **I believe I did this correctly**; I set this (well, nix.useSandbox) in /etc/nixos/configuration.nix, ran nixos-rebuild switch, and then compiled it.
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` - **No dependencies** on this new package
- [x] Tested execution of all binary files (usually in `./result/bin/`) - **more or less** - I built a pidgin-with-plugins using it, and it works for me.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).  **To the best of my ability** without spending too long agonizing.

---

A straightforward pidgin plugin; kind of ancient, but still works fine.
