### PR TITLE
libpng: 1.2.55 > 1.2.56

### DIFF
--- a/pkgs/development/libraries/libpng/12.nix
+++ b/pkgs/development/libraries/libpng/12.nix
@@ -3,11 +3,11 @@
 assert !(stdenv ? cross) -> zlib != null;
 
 stdenv.mkDerivation rec {
-  name = "libpng-1.2.55";
+  name = "libpng-1.2.56";
 
   src = fetchurl {
     url = "mirror://sourceforge/libpng/${name}.tar.xz";
-    sha256 = "0zkra0b9lrpk2axassdgkqinmc2ba6b473sm52xbpyknaqs2fljy";
+    sha256 = "1ghd03p353x0vi4dk83n1nlldg11w7vqdk3f99rkgfb82ic59ki4";
   };
 
   outputs = [ "dev" "out" "man" ];


### PR DESCRIPTION
###### Motivation for this change

[CVE-2015-8540](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8540)

Old package. Old bug. Not even sure whose using it anymore but if it's in the tree...
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
