### PR TITLE
lzfse: init at 2016-06-21

### DIFF
--- a/pkgs/tools/compression/lzfse/default.nix
+++ b/pkgs/tools/compression/lzfse/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "lzfse-${version}";
+  version = "2016-06-21";
+
+  src = fetchFromGitHub {
+    owner = "lzfse";
+    repo = "lzfse";
+    rev = "45912281e3945a09c6ebfa8c6629f6906a99fc29";
+    sha256 = "1wbh3x874fjn548g1hw4bm7lkk60vlvy8ph0wsjkzcx8873hwj7h";
+  };
+
+  makeFlags = [ "INSTALL_PREFIX=$(out)" ];
+
+  enableParallelBuilding = false; #bug
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/lzfse/lzfse;
+    description = "a reference C implementation of the LZFSE compressor";
+    longDescription = ''
+      This is a reference C implementation of the LZFSE compressor introduced in the Compression library with OS X 10.11 and iOS 9.
+      LZFSE is a Lempel-Ziv style data compression algorithm using Finite State Entropy coding.
+      It targets similar compression rates at higher compression and decompression speed compared to deflate using zlib.
+    '';
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2424,6 +2424,8 @@ in
   lxc = callPackage ../os-specific/linux/lxc { };
   lxd = callPackage ../tools/admin/lxd { };
 
+  lzfse = callPackage ../tools/compression/lzfse { };
+
   lzip = callPackage ../tools/compression/lzip { };
 
   lzma = xz;


### PR DESCRIPTION
###### Motivation for this change

I wanted to try it out. Only takes a second to compile on my toaster so I figured there's no harm.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
