### PR TITLE
prosody: Revert 4a7d31a

### DIFF
--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -46,12 +46,12 @@ stdenv.mkDerivation rec {
   postInstall = ''
       cp $communityModules/mod_websocket/mod_websocket.lua $out/lib/prosody/modules/
       wrapProgram $out/bin/prosody \
-        --set LUA_PATH '${luaPath};' \
-        --set LUA_CPATH '${luaCPath};'
+        --set LUA_PATH '"${luaPath};"' \
+        --set LUA_CPATH '"${luaCPath};"'
       wrapProgram $out/bin/prosodyctl \
         --add-flags '--config "/etc/prosody/prosody.cfg.lua"' \
-        --set LUA_PATH '${luaPath};' \
-        --set LUA_CPATH '${luaCPath};'
+        --set LUA_PATH '"${luaPath};"' \
+        --set LUA_CPATH '"${luaCPath};"'
     '';
 
   meta = {

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -46,12 +46,12 @@ stdenv.mkDerivation rec {
   postInstall = ''
       cp $communityModules/mod_websocket/mod_websocket.lua $out/lib/prosody/modules/
       wrapProgram $out/bin/prosody \
-        --set LUA_PATH '"${luaPath};"' \
-        --set LUA_CPATH '"${luaCPath};"'
+        --set LUA_PATH "'${luaPath};'" \
+        --set LUA_CPATH "'${luaCPath};'"
       wrapProgram $out/bin/prosodyctl \
         --add-flags '--config "/etc/prosody/prosody.cfg.lua"' \
-        --set LUA_PATH '"${luaPath};"' \
-        --set LUA_CPATH '"${luaCPath};"'
+        --set LUA_PATH "'${luaPath};'" \
+        --set LUA_CPATH "'${luaCPath};'"
     '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

4a7d31a392d78a8afc4a2d78d73dc5c789a602e8 broke `prosodyctl` due to unquoted `?` in the filenames (used as a placeholder by lua) get interpreted as glob-patterns
###### Things done

This commit reverts 4a7d31a392d78a8afc4a2d78d73dc5c789a602e8 on `pkgs/servers/xmpp/prosody/default.nix` to address this
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
