### PR TITLE
[security fix] matrix-synapse: 0.16.1 -> 0.16.1-r1

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -12,13 +12,13 @@ let
 in
 buildPythonApplication rec {
   name = "matrix-synapse-${version}";
-  version = "0.16.1";
+  version = "0.16.1-r1";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "synapse";
     rev = "v${version}";
-    sha256 = "166y1f74wjkrpks88cp67w33rcs02b4dk815yj93lfla1k9ypg6b";
+    sha256 = "0flgaa26j9gga9a9h67b0q3yi0mpnbrjik55220cvvzhy9fnvwa9";
   };
 
   patches = [ ./matrix-synapse.patch ];


### PR DESCRIPTION
###### Motivation for this change

Security fix : https://matrix.org/blog/2016/07/08/critical-security-vulnerability-in-synapse-0-12-to-0-16-1-inclusive/

TLDR: There is a vuln in synapse from 0.12 to 0.16.1 inclusive. This PR fixes the hole.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested locally.
