### PR TITLE
nixos: fix avahi connectivity for shairport-sync module

### DIFF
--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -52,6 +52,8 @@ in
   config = mkIf config.services.shairport-sync.enable {
 
     services.avahi.enable = true;
+    services.avahi.publish.enable = true;
+    services.avahi.publish.userServices = true;
 
     users.extraUsers = singleton
       { name = cfg.user;


### PR DESCRIPTION
The shairport-sync service currently fails to start with the error

`shairport avahi_entry_group_new failed`

This problem seems to have been introduced by cdd7310a503481e3c40266be45b6b8256d95ecbd. After some trial and error I concluded that the attached commit is a minimal fix.
