### PR TITLE
iterm2: 3.0.2 -> 3.0.4

### DIFF
--- a/pkgs/applications/misc/iterm2/default.nix
+++ b/pkgs/applications/misc/iterm2/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "iterm2-${version}";
-  version = "3.0.2";
+  version = "3.0.4";
 
   src = fetchFromGitHub {
     owner = "gnachman";
     repo = "iTerm2";
     rev = "v${version}";
-    sha256 = "121g759i814y1g1g1jwhsmxgg4wrzv08vq7a7qwc7b85a17zbd3h";
+    sha256 = "0ffg9l2jvv503h13nd5rjkn5xrahswcqqwmm052qzd6d0lmqjm93";
   };
 
   patches = [ ./disable_updates.patch ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
