### PR TITLE
Allow setting fonts and keymaps early in initrd

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -41,6 +41,15 @@ in
         '';
       };
 
+      consolePackages = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = ''
+	  List of additional packages that provide console fonts, keymaps and
+          other resources.
+        '';
+      };
+
       consoleFont = mkOption {
         type = types.str;
         default = "Lat2-Terminus16";

--- a/nixos/modules/tasks/kbd.nix
+++ b/nixos/modules/tasks/kbd.nix
@@ -52,8 +52,7 @@ in
       environment.systemPackages = [ pkgs.kbd ];
 
       # Let systemd-vconsole-setup.service do the work of setting up the
-      # virtual consoles.  FIXME: trigger a restart of
-      # systemd-vconsole-setup.service if /etc/vconsole.conf changes.
+      # virtual consoles.
       environment.etc = [ {
         target = "vconsole.conf";
         source = vconsoleConf;

--- a/nixos/modules/tasks/kbd.nix
+++ b/nixos/modules/tasks/kbd.nix
@@ -5,19 +5,32 @@ with lib;
 let
 
   makeColor = n: value: "COLOR_${toString n}=${value}";
+  makeColorCS =
+    let positions = [ "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "A" "B" "C" "D" "E" "F" ];
+    in n: value: "\033]P${elemAt position n}${value}";
   colors = concatImapStringsSep "\n" makeColor config.i18n.consoleColors;
-
-  vconsoleConf = pkgs.writeText "vconsole.conf" ''
-    KEYMAP=${config.i18n.consoleKeyMap}
-    FONT=${config.i18n.consoleFont}
-    ${colors}
-  '';
 
   kbdEnv = pkgs.buildEnv {
     name = "kbd-env";
     paths = [ pkgs.kbd ] ++ config.i18n.consolePackages;
     pathsToLink = [ "/share/consolefonts" "/share/consoletrans" "/share/keymaps" "/share/unimaps" ];
   };
+
+  isUnicode = hasSuffix "UTF-8" (toUpper config.i18n.defaultLocale);
+
+  optimizedKeymap = pkgs.runCommand "keymap" {
+    nativeBuildInputs = [ pkgs.kbd ];
+  } ''
+    cd ${kbdEnv}/share/keymaps
+    loadkeys -b ${optionalString isUnicode "-u"} "${config.i18n.consoleKeyMap}" > $out
+  '';
+
+  # Sadly, systemd-vconsole-setup doesn't support binary keymaps.
+  vconsoleConf = pkgs.writeText "vconsole.conf" ''
+    KEYMAP=${config.i18n.consoleKeyMap}
+    FONT=${config.i18n.consoleFont}
+    ${colors}
+  '';
 
   setVconsole = !config.boot.isContainer;
 in
@@ -44,36 +57,73 @@ in
       '';
     };
 
+    boot.earlyVconsoleSetup = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Enable setting font and keymap as early as possible (in initrd).
+      '';
+    };
+
   };
 
 
   ###### implementation
 
   config = mkMerge [
-    (mkIf (!setVconsole) {
+    (mkIf (!setVconsole || (setVconsole && config.boot.earlyVconsoleSetup)) {
       systemd.services."systemd-vconsole-setup".enable = false;
     })
 
-    (mkIf setVconsole {
-      environment.systemPackages = [ pkgs.kbd ];
+    (mkIf setVconsole (mkMerge [
+      { environment.systemPackages = [ pkgs.kbd ];
 
-      # Let systemd-vconsole-setup.service do the work of setting up the
-      # virtual consoles.
-      environment.etc."vconsole.conf".source = vconsoleConf;
-      # Provide kbd with additional packages.
-      environment.etc."kbd".source = "${kbdEnv}/share";
+        # Let systemd-vconsole-setup.service do the work of setting up the
+        # virtual consoles.
+        environment.etc."vconsole.conf".source = vconsoleConf;
+      }
 
-      # This is identical to the systemd-vconsole-setup.service unit
-      # shipped with systemd, except that it uses /dev/tty1 instead of
-      # /dev/tty0 to prevent putting the X server in non-raw mode, and
-      # it has a restart trigger.
-      systemd.services."systemd-vconsole-setup" =
-        { wantedBy = [ "multi-user.target" ];
-          before = [ "display-manager.service" ];
-          after = [ "systemd-udev-settle.service" ];
-          restartTriggers = [ vconsoleConf kbdEnv ];
-        };
-    })
+      (mkIf (!config.boot.earlyVconsoleSetup) {
+        # This is identical to the systemd-vconsole-setup.service unit
+        # shipped with systemd, except that it uses /dev/tty1 instead of
+        # /dev/tty0 to prevent putting the X server in non-raw mode, and
+        # it has a restart trigger.
+        systemd.services."systemd-vconsole-setup" =
+          { wantedBy = [ "sysinit.target" ];
+            before = [ "display-manager.service" ];
+            after = [ "systemd-udev-settle.service" ];
+            restartTriggers = [ vconsoleConf ];
+          };
+      })
+
+      (mkIf config.boot.earlyVconsoleSetup {
+        boot.initrd.extraUtilsCommands = ''
+          mkdir -p $out/share/consolefonts
+          ${if substring 0 1 config.i18n.consoleFont == "/" then ''
+            font="${config.i18n.consoleFont}"
+          '' else ''
+            font="$(echo ${kbdEnv}/share/consolefonts/${config.i18n.consoleFont}.*)"
+          ''}
+          if [[ $font == *.gz ]]; then
+            gzip -cd $font > $out/share/consolefonts/font.psf
+          else
+            cp -L $font $out/share/consolefonts/font.psf
+          fi
+        '';
+
+        boot.initrd.preLVMCommands = mkBefore ''
+          kbd_mode ${if isUnicode then "-u" else "-a"} -C /dev/console
+          printf "\033%%${if isUnicode then "G" else "@"}" >> /dev/console
+          loadkmap < ${optimizedKeymap}
+
+          setfont -C /dev/console $extraUtils/share/consolefonts/font.psf
+
+          ${concatImapStringsSep "\n" (n: color: ''
+            printf "${makeColorCS n color}" >> /dev/console
+          '') config.i18n.consoleColors}
+        '';
+      })
+    ]))
   ];
 
 }

--- a/nixos/modules/tasks/kbd.nix
+++ b/nixos/modules/tasks/kbd.nix
@@ -13,6 +13,12 @@ let
     ${colors}
   '';
 
+  kbdEnv = pkgs.buildEnv {
+    name = "kbd-env";
+    paths = [ pkgs.kbd ] ++ config.i18n.consolePackages;
+    pathsToLink = [ "/share/consolefonts" "/share/consoletrans" "/share/keymaps" "/share/unimaps" ];
+  };
+
   setVconsole = !config.boot.isContainer;
 in
 
@@ -53,10 +59,9 @@ in
 
       # Let systemd-vconsole-setup.service do the work of setting up the
       # virtual consoles.
-      environment.etc = [ {
-        target = "vconsole.conf";
-        source = vconsoleConf;
-      } ];
+      environment.etc."vconsole.conf".source = vconsoleConf;
+      # Provide kbd with additional packages.
+      environment.etc."kbd".source = "${kbdEnv}/share";
 
       # This is identical to the systemd-vconsole-setup.service unit
       # shipped with systemd, except that it uses /dev/tty1 instead of
@@ -66,7 +71,7 @@ in
         { wantedBy = [ "multi-user.target" ];
           before = [ "display-manager.service" ];
           after = [ "systemd-udev-settle.service" ];
-          restartTriggers = [ vconsoleConf ];
+          restartTriggers = [ vconsoleConf kbdEnv ];
         };
     })
   ];

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation rec {
     CONFIG_FEATURE_MOUNT_CIFS n
     CONFIG_FEATURE_MOUNT_HELPERS y
 
+    # Set paths for console fonts.
+    CONFIG_DEFAULT_SETFONT_DIR "/etc/kbd"
+
     ${extraConfig}
     $extraCrossConfig
     EOF


### PR DESCRIPTION
###### Motivation for this change
1. User may want a custom keymap while entering LUKS passphrase;
2. In certain situations, i.e. Plymouth in KMS mode (when display driver module is included in initrd) we can't set those later.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Notice that this uses several commits that are in staging already but not yet in master. They are not mass-rebuildy by theirselves but we should wait till staging is merged to have consistent git history.
