### PR TITLE
virtualbox: 5.0.20 -> 5.0.24

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -18,7 +18,7 @@ let
   # revision/hash as well. See
   # http://download.virtualbox.org/virtualbox/${version}/SHA256SUMS
   # for hashes.
-  version = "5.0.20";
+  version = "5.0.24";
 
   forEachModule = action: ''
     for mod in \
@@ -44,7 +44,7 @@ let
     name = "Oracle_VM_VirtualBox_Extension_Pack-${version}-${extpackRevision}.vbox-extpack";
     # IMPORTANT: Hash must be base16 encoded because it's used as an input to
     # VBoxExtPackHelperApp!
-    sha256 = "11f40842a56ebb17da1bbc82a21543e66108a5330ebd54ded68038a990aa071b";
+    sha256 = "aeee163c3d1bea8d3de9647d2ce6771fbf0e873bd20de6b39f84ef9d2de4b0c9 ";
     message = ''
       In order to use the extension pack, you need to comply with the VirtualBox Personal Use
       and Evaluation License (PUEL) available at:
@@ -63,7 +63,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}.tar.bz2";
-    sha256 = "0asc5n9an2dzvrd4isjz3vac2h0sm6dbzvrc36hn8ag2ma3hg75g";
+    sha256 = "11zs7bkzwsri0hay5lmzaqdx4q7znxdan2ihw8s3b8hwl96b0d4i";
   };
 
   buildInputs =

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "1rh1dw0fqz1zhdbpnwxclh1bfj889xh27dm2m23v5wg54bymkfvg";
+    sha256 = "0426mm3xd4vlszv67abns0k71xiczsmjwvwa0xjcgdjk4f0whxid";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/*/build";


### PR DESCRIPTION
## Motivation

Issue #16641 seems to come from updates to VirtualBox. Hopefully, this will resolve some of these issues.

Basically, the version of the Virtualbox Guest Additions in the 16.03 channel is broken. For now, I'd say f9e2b4c, 76ebea5, and b984ab1 should be reverted on the 16.03 channel until we can verify that 5.0.24 completely fixes the problem.
## Virtualbox Changelog
### VirtualBox 5.0.24 (released 2016-06-28)

This is a maintenance release. The following items were fixed and/or added:
- VMM: reverted to the old I/O-APIC code for now to fix certain regressions with 5.0.22 (bug 15529). This means that the networking performance with certain guests will drop to the 5.0.20 level (bug 15295). One workaround is to disable GRO for Linux guests.
- Main: when taking a screenshot, don't save garbage for blanked screens
- NAT: correctly parse resolv.conf file with multiple separators (5.0.22 regression)
- Storage: fixed a possible corruption of stream optimized VMDK images from VMware when opened in read/write mode for the first time
- Audio: imlemented dynamic re-attaching of input/output devices on Mac OS X hosts
- ACPI: notify the guest when the battery / AC state changes instead of relying on guest polling
- Linux hosts: fixed VERR_VMM_SET_JMP_ABORTED_RESUME Guru Meditations on hosts with Linux 4.6 or later (bug 15439)
- Solaris hosts: make the GUI work on Solaris 10 again (bug 15549)
### VirtualBox 5.0.22 (released 2016-06-16)

This is a maintenance release. The following items were fixed and/or added:
- VMM: fixes for certain Intel Atom hosts (bug 14915)
- VMM: properly restore the complete FPU state for 32-bit guests on 64-bit hosts on Intel Sandy Bridge and Ivy Bridge CPUs
- VMM: new I/O-APIC implementation fixing several bugs and improving the performance under certain conditions (bug 15295 and others)
- VMM: fixed a potential Linux guest panic on AMD hosts
- VMM: fixed a potential hang with 32-bit EFI guests on Intel CPUs (VT-x without unrestricted guest execution)
- GUI: don't allow to start subsequent separate VM instances
- GUI: raised upper limit for video capture screen resolution (bug 15432)
- GUI: warn if the VM has less than 128MB VRAM configured and 3D enabled
- Main: when monitoring DNS configuration changes on Windows hosts avoid false positives from competing DHCP renewals. This should fix NAT link flaps when host has multiple DHCP configured interfaces, in particular when the host uses OpnVPN.
- Main: properly display an error message if the VRDE server cannot be enabled at runtime, for example because another service is using the same port
- NAT: Initialize guest address guess for wildcard port-forwarding rules with default guest address (bug 15412)
- VGA: fix for a problem which made certain legacy guests crash under certain conditions (bug 14811)
- OVF: fixed import problems for some appliances using an AHCI controller created by 3rd party applications
- SDK: reduced memory usage in the webservice Java bindings
- Windows hosts: fixed performance regresson with SMP guests (5.0 regression)
- Windows hosts: fixes for the shared clipboard
- Windows hosts: Windows hardening fix
- Windows Additions: fixes to retain the guest display layout when resizing or disabling the guest monitors
- Linux hosts: EL 6.8 fix (bug 15411)
- Linux hosts: Linux 4.7 fix (bug 15459)
- Linux Additions: Linux 4.7 fixes (bug 15444)
- Linux Additions: fix for certain 32-bit guests (5.0.18 regression; bug 15320)
- Linux Additions: fixed mouse pointer offset (5.0.18 regression; bug 15324)
- Linux Additions: made old X.Org releases work again with kernels 3.11 and later (5.0.18 regression; bug 15319)
- Linux Additions: fixed X.Org crash after hard guest reset (5.0.18 regression; bug 15354)
- Linux Additions: don't stop the X11 setup if loading the shared folders module fails (5.0.18 regression)
- Linux Additions: don't complain if the Drag and Drop service is not available on the host
- Solaris Additions: added support for X.org 1.18
