### PR TITLE
jags: 3.4.0 -> 4.1.0

### DIFF
--- a/pkgs/applications/science/math/jags/default.nix
+++ b/pkgs/applications/science/math/jags/default.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl, gfortran, openblas}:
 
 stdenv.mkDerivation rec {
-  name = "JAGS-3.4.0";
+  name = "JAGS-4.1.0";
   src = fetchurl {
     url = "mirror://sourceforge/mcmc-jags/${name}.tar.gz";
-    sha256 = "0ayqsz9kkmbss7mxlwr34ch2z1vsb65lryjzqpprab1ccyiaksib";
+    sha256 = "08pmrnbwibc0brgn5cx860jcl0s2xaw4amw7g45649r1bcdz7v25";
   };
   buildInputs = [gfortran openblas];
   configureFlags = [ "--with-blas=-lopenblas" "--with-lapack=-lopenblas" ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1137,18 +1137,7 @@ let
     "choroplethr" # depends on broken package acs
     "acs" # broken build
     "spray" # depends on broken package partitions
-    "simmr" # depends on broken package rjags
-    "morse" # depends on broken package rjags
-    "gemtc" # depends on broken package rjags
-    "EasyMARK" # depends on broken package rjags
-    "PVAClone" # depends on broken package rjags
-    "sharx" # depends on broken package rjags
-    "dcmle" # depends on broken package rjags
-    "dclone" # depends on broken package rjags
-    "CNVrd2" # depends on broken package rjags
-    "bayescount" # depends on broken package rjags
-    "BANOVA" # depends on broken package rjags
-    "rjags" # broken build
+    "CNVrd2" # broken build
     "proteoQC" # depends on broken package rTANDEM
     "PGA" # depends on broken package rTANDEM
     "MBESS" # depends on broken package OpenMx
@@ -1211,13 +1200,11 @@ let
     "ARTool" # depends on broken package nlopt
     "AssetPricing" # broken build
     "AtelieR" # broken build
-    "auRoc" # depends on broken package rjags
+    "auRoc" # depends on broken package MBESS
     "AutoModel" # depends on broken package car
     "bamdit" # broken build
-    "BANOVA" # broken build
     "bapred" # depends on broken package lme4
     "bartMachine" # depends on broken package nlopt
-    "bayescount" # broken build
     "bayesDem" # depends on broken package nlopt
     "bayesLife" # depends on broken package nlopt
     "BayesMed" # broken build
@@ -1283,7 +1270,6 @@ let
     "covmat" # depends on broken package VIM
     "cplexAPI" # build is broken
     "cquad" # depends on broken package car
-    "crmPack" # depends on broken package rjags
     "CrypticIBDcheck" # depends on broken package nlopt
     "ctsem" # depends on broken package OpenMx
     "cudaBayesreg" # build is broken
@@ -1293,7 +1279,7 @@ let
     "datafsm" # depends on broken package caret
     "dbConnect" # broken build
     "DBKGrad" # depends on broken package rpanel
-    "dcmle" # broken build
+    #"dcmle" # broken build
     "ddst" # broken build
     "Deducer" # depends on broken package nlopt
     "DeducerExtras" # depends on broken package nlopt
@@ -1318,7 +1304,6 @@ let
     "drsmooth" # depends on broken package nlopt
     "dynlm" # depends on broken package nlopt
     "easyanova" # depends on broken package nlopt
-    "EasyMARK" # broken build
     "ecd" # depends on broken package polynom
     "edge" # depends on broken package nlopt
     "eeptools" # depends on broken package nlopt
@@ -1370,7 +1355,6 @@ let
     "gcmr" # depends on broken package nlopt
     "GDAtools" # depends on broken package nlopt
     "gdtools" # broken build
-    "gemtc" # broken build
     "GENE_E" # depends on broken package rhdf5
     "GENESIS" # broken build
     "genridge" # depends on broken package nlopt
@@ -1499,7 +1483,6 @@ let
     "mlVAR" # depends on broken package nlopt
     "MM" # broken build
     "mongolite" # build is broken
-    "morse" # broken build
     "mosaic" # depends on broken package nlopt
     "mpoly" # broken build
     "mRMRe" # broken build
@@ -1577,7 +1560,6 @@ let
     "PSAboot" # depends on broken package nlopt
     "ptw" # depends on broken nloptr
     "PurBayes" # broken build
-    "PVAClone" # broken build
     "pvca" # depends on broken package nlopt
     "PythonInR" # broken build
     "QFRM" # broken build
@@ -1664,7 +1646,6 @@ let
     "Rgnuplot" # broken build
     "rhdf5" # build is broken
     "rjade" # depends on broken package V8
-    "rjags" # broken build
     "rJPSGCS" # build is broken
     "rLindo" # build is broken
     "RLRsim" # depends on broken package lme4
@@ -1724,10 +1705,8 @@ let
     "seqHMM" # depends on broken package nloptr
     "seqTools" # build is broken
     "SharpeR" # broken build
-    "sharx" # broken build
     "shinyTANDEM" # depends on broken package rTANDEM
     "SIBER" # broken build
-    "simmr" # broken build
     "simPop" # depends on broken package VIM
     "simr" # depends on broken package lme4
     "SJava" # broken build


### PR DESCRIPTION
This allows `rPackages.rjags` (currently marked as broken) to compile.

Tested on Linux.
