### PR TITLE
traceroute: 2.0.21 -> 2.1.0

### DIFF
--- a/pkgs/tools/networking/traceroute/default.nix
+++ b/pkgs/tools/networking/traceroute/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "traceroute-${version}";
-  version = "2.0.21";
+  version = "2.1.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/traceroute/${name}.tar.gz";
-    sha256 = "1q4n9s42nfcc4fmnwmrsiabvqrcaagiagmmqj9r5hfmi63pr7b7p";
+    sha256 = "3669d22a34d3f38ed50caba18cd525ba55c5c00d5465f2d20d7472e5d81603b6";
   };
 
-  makeFlags = "prefix=$(out)";
+  makeFlags = "prefix=$(out) LDFLAGS=-lm";
 
   preConfigure = ''
     sed -i 's@LIBS := \(.*\) -lm \(.*\)@LIBS := \1 \2@' Make.rules


### PR DESCRIPTION
###### Motivation for this change

Update traceroute to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
