### PR TITLE
handbrake: depend on hicolor_icon_theme

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -20,7 +20,7 @@
   libogg, libtheora, libvorbis, libdvdcss, a52dec, fdk_aac,
   lame, faac, ffmpeg, libdvdread, libdvdnav, libbluray,
   mp4v2, mpeg2dec, x264, libmkv,
-  fontconfig, freetype,
+  fontconfig, freetype, hicolor_icon_theme,
   glib, gtk, webkitgtk, intltool, libnotify,
   gst_all_1, dbus_glib, udev, libgudev,
   useGtk ? true,
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ python pkgconfig yasm autoconf automake libtool m4 ];
   buildInputs = [
-    fribidi fontconfig freetype
+    fribidi fontconfig freetype hicolor_icon_theme
     libass libsamplerate libxml2 bzip2
     libogg libtheora libvorbis libdvdcss a52dec libmkv fdk_aac
     lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264


### PR DESCRIPTION
###### Motivation for this change

To avoid conflicts on `share/icons/hicolor/icon-theme.cache`.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
