### PR TITLE
brasero: depend on hicolor_icon_theme

### DIFF
--- a/pkgs/tools/cd-dvd/brasero/default.nix
+++ b/pkgs/tools/cd-dvd/brasero/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, pkgconfig, gtk3, itstool, gst_all_1, libxml2, libnotify
 , libcanberra_gtk3, intltool, makeWrapper, dvdauthor, libburn, libisofs
-, vcdimager, wrapGAppsHook }:
+, vcdimager, wrapGAppsHook, hicolor_icon_theme }:
 
 # libdvdcss is "too old" (in fast "too new"), see https://bugs.launchpad.net/ubuntu/+source/brasero/+bug/611590
 
@@ -21,6 +21,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig itstool intltool wrapGAppsHook ];
 
   buildInputs = [ gtk3 libxml2 libnotify libcanberra_gtk3 libburn libisofs
+                  hicolor_icon_theme
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base
                   gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
                   gst_all_1.gst-plugins-ugly gst_all_1.gst-libav ];


### PR DESCRIPTION
###### Motivation for this change

To avoid conflicts on `share/icons/hicolor/icon-theme.cache`.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
