### PR TITLE
glmark2: 2014.03 -> 2015-06-11

### DIFF
--- a/pkgs/tools/graphics/glmark2/default.nix
+++ b/pkgs/tools/graphics/glmark2/default.nix
@@ -1,19 +1,22 @@
-{ stdenv, fetchurl, pkgconfig, libjpeg, libpng12, xorg, libX11, mesa, libdrm, python27 }:
+{ stdenv, fetchFromGitHub, pkgconfig, libjpeg, libpng, xorg, libX11, mesa, libdrm, python27, wayland }:
+
 stdenv.mkDerivation rec {
   name = "glmark2-${version}";
-  version = "2014.03";
+  version = "2015-06-11";
 
-  src = fetchurl {
-    url = "https://launchpad.net/glmark2/trunk/${version}/+download/${name}.tar.gz";
-    sha256 = "1dgn7ln115ivk13d1yagpj06lgllpv2jrr41kcnhdkhqz6m43vdx";
+  src = fetchFromGitHub {
+    owner = "glmark2";
+    repo = "glmark2";
+    rev = "fa71af2dfab711fac87b9504b6fc9862f44bf72a";
+    sha256 = "1razwrmwk94wf8y7rnqpas9520gidixzcwa65pg946n823105znw";
   };
 
   buildInputs = [
-    pkgconfig libjpeg libpng12 xorg.libxcb libX11 mesa libdrm python27
+    pkgconfig libjpeg libpng xorg.libxcb libX11 mesa libdrm python27 wayland
   ];
 
   buildPhase = ''
-    python ./waf configure --prefix=$out --with-flavors x11-gl,x11-glesv2
+    python ./waf configure --prefix=$out --with-flavors x11-gl,x11-glesv2,drm-gl,drm-glesv2,wayland-gl,wayland-glesv2
     python2 ./waf
   '';
 
@@ -23,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "OpenGL (ES) 2.0 benchmark";
-    homepage = https://launchpad.net/glmark2;
+    homepage = https://github.com/glmark2/glmark2;
     license = licenses.gpl3Plus;
     longDescription = ''
       glmark2 is a benchmark for OpenGL (ES) 2.0. It uses only the subset of
@@ -33,4 +36,3 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.wmertens ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

Switched to depend on the newer libpng 1.6 instead of the old 1.2 branch; added wayland support; added drm (direct rendering...) support.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
