### PR TITLE
libxcomp: update libpng dependency from 1.2 to 1.6 branch

### DIFF
--- a/pkgs/development/libraries/libxcomp/default.nix
+++ b/pkgs/development/libraries/libxcomp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, libjpeg, libpng12, libX11, zlib }:
+{ stdenv, fetchurl, autoreconfHook, libjpeg, libpng, libX11, zlib }:
 
 stdenv.mkDerivation rec {
   name = "libxcomp-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     url = "http://code.x2go.org/releases/source/nx-libs/nx-libs-${version}-lite.tar.gz";
   };
 
-  buildInputs = [ libjpeg libpng12 libX11 zlib ];
+  buildInputs = [ libjpeg libpng libX11 zlib ];
   nativeBuildInputs = [ autoreconfHook ];
 
   preAutoreconf = ''


### PR DESCRIPTION
###### Motivation for this change

update libpng dependency from 1.2 to 1.6 branch.

The library compiled fine but there were no binaries to test.  I verified that the arch package (https://www.archlinux.org/packages/extra/x86_64/libxcomp/) and the debian package (http://packages.x2go.org/debian/dists/testing/main/binary-amd64/Packages) both used libpng 1.6.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
