### PR TITLE
antimony: fix build and 0.8.0b -> 0.9.2

### DIFF
--- a/pkgs/applications/graphics/antimony/default.nix
+++ b/pkgs/applications/graphics/antimony/default.nix
@@ -1,29 +1,25 @@
-{ stdenv, fetchgit, libpng, python3, boost, mesa, qtbase, qmakeHook, ncurses }:
+{ stdenv, fetchFromGitHub, libpng, python3, boost, mesa, qtbase, ncurses, cmake, flex, lemon }:
 
 let
-  gitRev    = "745eca3a2d2657c495d5509e9083c884e021d09c";
+  gitRev    = "e8480c718e8c49ae3cc2d7af10ea93ea4c2fff9a";
   gitBranch = "master";
-  gitTag    = "0.8.0b";
+  gitTag    = "0.9.2";
 in 
   stdenv.mkDerivation rec {
     name    = "antimony-${version}";
     version = gitTag;
 
-    src  = fetchgit {
-      url         = "git://github.com/mkeeter/antimony.git";
-      rev         = gitRev;
-      sha256      = "0azjdkbixz2pyk2yy7a0ya5xk60xgw3l2pd4pj4ijyqxx5jmh0sy";
+    src = fetchFromGitHub {
+      owner = "mkeeter";
+      repo = "antimony";
+      rev = gitTag;
+      sha256 = "0fpgy5cb4knz2z9q078206k8wzxfs8b9g76mf4bz1ic77931ykjz";
     };
 
     patches = [ ./paths-fix.patch ];
-    # fix build with glibc-2.23
+
     postPatch = ''
-      sed 's/\<isinf(/std::isinf(/g' -i \
-        src/export/export_heightmap.cpp \
-        src/fab/types/bounds.cpp \
-        src/graph/hooks/meta.cpp \
-        src/ui/dialogs/resolution_dialog.cpp \
-        src/render/render_task.cpp
+       sed -i "s,/usr/local,$out,g" app/CMakeLists.txt app/app/app.cpp app/app/main.cpp
     '';
 
     buildInputs = [
@@ -31,15 +27,13 @@ in
       mesa qtbase ncurses
     ];
 
-    nativeBuildHooks = [ qmakeHook ];
+    nativeBuildInputs = [ cmake flex lemon ];
 
-    preConfigure = ''
-      export GITREV=${gitRev}
-      export GITBRANCH=${gitBranch}
-      export GITTAG=${gitTag}
-
-      cd qt
-    '';
+    cmakeFlags= [
+      "-DGITREV=${gitRev}"
+      "-DGITTAG=${gitTag}"
+      "-DGITBRANCH=${gitBranch}"
+    ];
 
     enableParallelBuilding = true;
 
@@ -48,6 +42,5 @@ in
       homepage    = "https://github.com/mkeeter/antimony";
       license     = licenses.mit;
       platforms   = platforms.linux;
-      broken = true;
     };
   }

--- a/pkgs/applications/graphics/antimony/paths-fix.patch
+++ b/pkgs/applications/graphics/antimony/paths-fix.patch
@@ -1,99 +1,21 @@
-diff --git a/qt/antimony.pro b/qt/antimony.pro
-index 9d586f4..b055a6d 100644
---- a/qt/antimony.pro
-+++ b/qt/antimony.pro
-@@ -12,14 +12,9 @@ QMAKE_CXXFLAGS_RELEASE += -O3
+diff --git a/app/CMakeLists.txt b/app/CMakeLists.txt
+index ddc5c9b..d80728a 100644
+--- a/app/CMakeLists.txt
++++ b/app/CMakeLists.txt
+@@ -158,16 +158,6 @@ target_link_libraries(${ANTIMONY_APP}
  
- QMAKE_CXXFLAGS += -Werror=switch
+ ################################################################################
  
--GITREV = $$system(git log --pretty=format:'%h' -n 1)
--GITDIFF = $$system(git diff --quiet --exit-code || echo "+")
--GITTAG = $$system(git describe --exact-match --tags 2> /dev/null)
--GITBRANCH = $$system(git rev-parse --abbrev-ref HEAD)
+-execute_process(COMMAND git log --pretty=format:'%h' -n 1
+-                OUTPUT_VARIABLE GITREV)
+-execute_process(COMMAND bash -c "git diff --quiet --exit-code || echo +"
+-                OUTPUT_VARIABLE GITDIFF)
+-execute_process(COMMAND git describe --exact-match --tags
+-                OUTPUT_VARIABLE GITTAG
+-                ERROR_QUIET)
+-execute_process(COMMAND git rev-parse --abbrev-ref HEAD
+-                OUTPUT_VARIABLE GITBRANCH)
 -
--QMAKE_CXXFLAGS += "-D'GITREV=\"$${GITREV}$${GITDIFF}\"'"
--QMAKE_CXXFLAGS += "-D'GITTAG=\"$${GITTAG}\"'"
--QMAKE_CXXFLAGS += "-D'GITBRANCH=\"$${GITBRANCH}\"'"
-+QMAKE_CXXFLAGS += "-D'GITREV=\"$$(GITREV)\"'"
-+QMAKE_CXXFLAGS += "-D'GITTAG=\"$$(GITTAG)\"'"
-+QMAKE_CXXFLAGS += "-D'GITBRANCH=\"$$(GITBRANCH)\"'"
- 
- OLD_GL_SET = $$(OLD_GL)
- equals(OLD_GL_SET, "true") {
-@@ -125,11 +120,11 @@ macx {
- }
- 
- linux {
--    executable.path = /usr/local/bin
-+    executable.path = $$(out)/bin
-     executable.files = antimony
--    nodes_folder.path = /usr/local/bin/sb/nodes
-+    nodes_folder.path = $$(out)/bin/sb/nodes
-     nodes_folder.files = ../py/nodes/*
--    fab_folder.path = /usr/local/bin/sb/fab
-+    fab_folder.path = $$(out)/bin/sb/fab
-     fab_folder.files = ../py/fab/*
-     INSTALLS += executable nodes_folder fab_folder
- }
-diff --git a/qt/fab.pri b/qt/fab.pri
-index a54813b..b500536 100644
---- a/qt/fab.pri
-+++ b/qt/fab.pri
-@@ -54,7 +54,7 @@ DEFINES += '_STATIC_= '
- 
- linux {
-     QMAKE_CFLAGS += -std=gnu99
--    QMAKE_CXXFLAGS += $$system(/usr/bin/python3-config --includes)
-+    QMAKE_CXXFLAGS += $$system(python3-config --includes)
-     LIBS += -lpng
- }
- 
-diff --git a/qt/shared.pri b/qt/shared.pri
-index e7d0e3a..026eae3 100644
---- a/qt/shared.pri
-+++ b/qt/shared.pri
-@@ -39,41 +39,11 @@ macx {
- }
- 
- linux {
--    QMAKE_CXXFLAGS += $$system(/usr/bin/python3-config --includes)
--    QMAKE_LFLAGS   += $$system(/usr/bin/python3-config --ldflags)
-+    QMAKE_CXXFLAGS += $$system(python3-config --includes)
-+    QMAKE_LFLAGS   += $$system(python3-config --ldflags)
- 
-     # Even though this is in QMAKE_LFLAGS, the linker is picky about
-     # library ordering (so it needs to be here too).
-     LIBS += -lpython3.4m
--
--    # ldconfig is being used to find libboost_python, but it's in a different
--    # place in different distros (and is not in the default $PATH on Debian).
--    # First, check to see if it's on the default $PATH.
--    system(which ldconfig > /dev/null) {
--        LDCONFIG_BIN = "ldconfig"
--    }
--    # If that failed, then search for it in its usual places.
--    isEmpty(LDCONFIG_BIN) {
--        for(p, $$list(/sbin/ldconfig /usr/bin/ldconfig)) {
--            exists($$p): LDCONFIG_BIN = $$p
--        }
--    }
--    # If that search failed too, then exit with an error.
--    isEmpty(LDCONFIG_BIN) {
--        error("Could not find ldconfig!")
--    }
--
--    # Check for different boost::python naming schemes
--    LDCONFIG_OUT = $$system($$LDCONFIG_BIN -p|grep python)
--    for (b, $$list(boost_python-py34 boost_python3)) {
--        contains(LDCONFIG_OUT, "lib$${b}.so") {
--            LIBS += "-l$$b"
--            GOT_BOOST_PYTHON = True
--        }
--    }
--
--    # If we couldn't find boost::python, exit with an error.
--    isEmpty(GOT_BOOST_PYTHON) {
--        error("Could not find boost::python3")
--    }
-+    LIBS += -lboost_python3
- }
+ add_definitions(-D'GITREV="${GITREV}${GITDIFF}"'
+                 -D'GITTAG="${GITTAG}"'
+                 -D'GITBRANCH="${GITBRANCH}"')


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
