### PR TITLE
mkvtoolnix: 8.9.0 -> 9.2.0

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, autoconf, automake
+{ stdenv, fetchFromGitHub, pkgconfig, autoconf, automake
 , ruby, file, xdg_utils, gettext, expat, qt5, boost
 , libebml, zlib, libmatroska, libogg, libvorbis, flac
 , withGUI ? true
@@ -10,18 +10,19 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "mkvtoolnix-${version}";
-  version = "8.9.0";
+  version = "9.2.0";
 
-  src = fetchgit {
-    url = "https://github.com/mbunkus/mkvtoolnix.git";
-    rev = "54e6b52b3dde07f89da4542997ef059e18802128";
-    sha256 = "1gipydk1xisqy110rr38dgjzpxl8zxbm12kf7b2f4xh4iw17j0k2";
+  src = fetchFromGitHub {
+    owner = "mbunkus";
+    repo = "mkvtoolnix";
+    rev = "release-${version}";
+    sha256 = "02w3161iqaijs3bz5w2wily9nz55xnhq1bdm2s5qi8v3sbcqd6df";
   };
 
-  nativeBuildInputs = [ gettext ruby ];
+  nativeBuildInputs = [ pkgconfig autoconf automake gettext ruby ];
 
   buildInputs = [
-    pkgconfig autoconf automake expat
+    expat
     file xdg_utils boost libebml zlib
     libmatroska libogg libvorbis flac
     (optional withGUI qt5.qtbase)


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
