### PR TITLE
gpsd: 3.10 -> 3.16, fix python dependencies

### DIFF
--- a/pkgs/servers/gpsd/0001-Import-LD_LIBRARY_PATH-to-allow-running-scons-check-.patch
+++ b/pkgs/servers/gpsd/0001-Import-LD_LIBRARY_PATH-to-allow-running-scons-check-.patch
@@ -1,4 +1,4 @@
-From d7e56abcae8bcb85dc935e94418a2f0e9956941b Mon Sep 17 00:00:00 2001
+From e08583ddb8445241c38c88d828271be908d52f9f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Bj=C3=B8rn=20Forsman?= <bjorn.forsman@gmail.com>
 Date: Mon, 17 Feb 2014 20:52:50 +0000
 Subject: [PATCH 1/2] Import LD_LIBRARY_PATH to allow running 'scons check'
@@ -9,17 +9,17 @@ Subject: [PATCH 1/2] Import LD_LIBRARY_PATH to allow running 'scons check'
  1 file changed, 1 insertion(+)
 
 diff --git a/SConstruct b/SConstruct
-index 14e2f59..86b94bc 100644
+index fe444a2..f73c87e 100644
 --- a/SConstruct
 +++ b/SConstruct
-@@ -215,6 +215,7 @@ import_env = (
-     'PKG_CONFIG_LIBDIR',      # Pass more environment variables to pkg-config (required for crossbuilds)
+@@ -220,6 +220,7 @@ import_env = (
      'STAGING_DIR',     # Required by the OpenWRT and CeroWrt builds.
      'STAGING_PREFIX',  # Required by the OpenWRT and CeroWrt builds.
+     'WRITE_PAD',       # So we can test WRITE_PAD values on the fly.
 +    'LD_LIBRARY_PATH', # Allows running 'scons check' without 'chrpath'
      )
  envs = {}
  for var in import_env:
 -- 
-1.9.0
+2.9.0
 

--- a/pkgs/servers/gpsd/0001-Use-pkgconfig-for-dbus-library.patch
+++ b/pkgs/servers/gpsd/0001-Use-pkgconfig-for-dbus-library.patch
@@ -1,0 +1,31 @@
+From b4ed6e9e89e3b7d57e5de9f2c1987a489bb5628c Mon Sep 17 00:00:00 2001
+From: Alexey Shmalko <rasen.dubi@gmail.com>
+Date: Sat, 9 Jul 2016 20:54:05 +0300
+Subject: [PATCH] Use pkgconfig for dbus library
+
+Without this, gcc can't find library path for the dbus.
+
+This is already fixed upstream, so the patch shouldn't be necessary with
+the next version of gpsd.
+---
+ SConstruct | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/SConstruct b/SConstruct
+index 0d4b29d..d8624b0 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -586,8 +586,8 @@ else:
+ 
+     if env['dbus_export'] and config.CheckPKG('dbus-1'):
+         confdefs.append("#define HAVE_DBUS 1\n")
+-        dbusflags = ["-ldbus-1"]
+-        env.MergeFlags(pkg_config("dbus-1"))
++        dbusflags = pkg_config("dbus-1")
++        env.MergeFlags(dbusflags)
+     else:
+         confdefs.append("/* #undef HAVE_DBUS */\n")
+         dbusflags = []
+-- 
+2.9.0
+

--- a/pkgs/servers/gpsd/0002-Import-XML_CATALOG_FILES-to-be-able-to-validate-the-.patch
+++ b/pkgs/servers/gpsd/0002-Import-XML_CATALOG_FILES-to-be-able-to-validate-the-.patch
@@ -1,4 +1,4 @@
-From aed93b6ada5b9b76b85d11d9bad732ca005295af Mon Sep 17 00:00:00 2001
+From 21e5295a633c8c450629106c4603b78b2de7d786 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Bj=C3=B8rn=20Forsman?= <bjorn.forsman@gmail.com>
 Date: Sat, 15 Mar 2014 15:08:01 +0100
 Subject: [PATCH 2/2] Import XML_CATALOG_FILES to be able to validate the
@@ -12,17 +12,17 @@ download DTD's and builders don't have network access...
  1 file changed, 1 insertion(+)
 
 diff --git a/SConstruct b/SConstruct
-index 86b94bc..a0b3d25 100644
+index f73c87e..0d4b29d 100644
 --- a/SConstruct
 +++ b/SConstruct
-@@ -216,6 +216,7 @@ import_env = (
-     'STAGING_DIR',     # Required by the OpenWRT and CeroWrt builds.
+@@ -221,6 +221,7 @@ import_env = (
      'STAGING_PREFIX',  # Required by the OpenWRT and CeroWrt builds.
+     'WRITE_PAD',       # So we can test WRITE_PAD values on the fly.
      'LD_LIBRARY_PATH', # Allows running 'scons check' without 'chrpath'
 +    'XML_CATALOG_FILES', # Enables validating the manual with 'xmlto' using nix build system
      )
  envs = {}
  for var in import_env:
 -- 
-1.9.0
+2.9.0
 

--- a/pkgs/servers/gpsd/default.nix
+++ b/pkgs/servers/gpsd/default.nix
@@ -8,11 +8,11 @@
 # TODO: put the X11 deps behind a guiSupport parameter for headless support
 
 stdenv.mkDerivation rec {
-  name = "gpsd-3.10";
+  name = "gpsd-3.16";
 
   src = fetchurl {
     url = "http://download-mirror.savannah.gnu.org/releases/gpsd/${name}.tar.gz";
-    sha256 = "0823hl5zgwnbgm0fq3i4z34lv76cpj0k6m0zjiygiyrxrz0w4vvh";
+    sha256 = "0a90ph4qrlz5kkcz2mwkfk3cmwy9fmglp94znz2y0gsd7bqrlmq3";
   };
 
   nativeBuildInputs = [
@@ -34,18 +34,19 @@ stdenv.mkDerivation rec {
   patches = [
     ./0001-Import-LD_LIBRARY_PATH-to-allow-running-scons-check-.patch
     ./0002-Import-XML_CATALOG_FILES-to-be-able-to-validate-the-.patch
+
+    # TODO: remove the patch with the next release
+    ./0001-Use-pkgconfig-for-dbus-library.patch
   ];
 
   # - leapfetch=no disables going online at build time to fetch leap-seconds
   #   info. See <gpsd-src>/build.txt for more info.
-  # - chrpath=no stops the build from using 'chrpath' (which we don't have).
-  #   'chrpath' is used to be able to run the tests from the source tree, but
-  #   we use $LD_LIBRARY_PATH instead.
   buildPhase = ''
     patchShebangs .
-    sed -e "s|python_lib_dir = .*|python_lib_dir = \"$out/lib/${pythonPackages.python.libPrefix}/site-packages\"|" -i SConstruct
+    sed -e "s|systemd_dir = .*|systemd_dir = '$out/lib/systemd/system'|" -i SConstruct
     scons prefix="$out" leapfetch=no gpsd_user=${gpsdUser} gpsd_group=${gpsdGroup} \
-        systemd=yes udevdir="$out/lib/udev" chrpath=no
+        systemd=yes udevdir="$out/lib/udev" \
+        python_libdir="$out/lib/${pythonPackages.python.libPrefix}/site-packages"
   '';
 
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

This fixes xgps and xgpsspeed executables.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
