### PR TITLE
perf: Point tipdir to path in $out  (please backport to 16.03)

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -39,7 +39,11 @@ stdenv.mkDerivation {
     /* I don't want cross-python or cross-perl -
        I don't know if cross-python even works */
     propagatedBuildInputs = [ elfutils.crossDrv newt.crossDrv ];
-    makeFlags = "CROSS_COMPILE=${stdenv.cross.config}-";
+    makeFlags = [
+      "CROSS_COMPILE=${stdenv.cross.config}-"
+      "tipdir=$out/share/doc/perf-tip"
+    ];
+
     elfutils = elfutils.crossDrv;
     inherit (kernel.crossDrv) src patches;
   };


### PR DESCRIPTION
###### Motivation for this change

By default it looks in /share, and then in the build directory.
Updating this corrects an error which periodically shows up:

```
Cannot load tips.txt file, please install perf!
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
