### PR TITLE
sift: fix hydra build fail

### DIFF
--- a/pkgs/tools/text/sift/default.nix
+++ b/pkgs/tools/text/sift/default.nix
@@ -21,6 +21,6 @@ buildGoPackage rec {
     homepage = "https://sift-tool.org";
     maintainers = [ maintainers.carlsverre ];
     license = licenses.gpl3;
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

For some reason I haven't been able to figure out, sift does not build on OSX.
I think it is because sift uses cgo for some of its functionality which you can
see here:
https://github.com/svent/sift/blob/master/matching_cgo.go#L23

The error which hydra found (and is reproducible on OSX) can be seen here:
https://hydra.nixos.org/build/37169149

Ideally I would like to get sift building on OSX, however my nix-fu is weak.
Any suggestions are welcome.  In the meantime I would like to get sift into one
of the release channels for Linux where it works fine.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
