### PR TITLE
buildEnv: don't create directory if it already exists

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -182,8 +182,12 @@ foreach my $relName (sort keys %symlinks) {
     my $abs = "$out" . "$extraPrefix" . "/$relName";
     next unless isInPathsToLink $relName;
     if ($target eq "") {
-        #print "creating directory $relName\n";
-        mkpath $abs or die "cannot create directory `$abs': $!";
+        if (!-d $abs) {
+            #print "creating directory $relName\n";
+            mkpath $abs or die "cannot create directory `$abs': $!";
+        } else {
+            #print "$relName exists, skipping\n";
+        }
     } else {
         #print "creating symlink $relName to $target\n";
         symlink $target, $abs ||


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This patch fixes #16614.

The issue was caused by the fact that both `/share` and
`/share/fish/vendor_completions.d` end in the `pathsToLink`. The
`pkgs/build-support/buildenv/builder.pl` creates `/share`, then links
`/share/fish` under `/share` and then tries to create the directory
`/share/fish/vendor_completions.d` and fails because it already exists.

The simplest way to reproduce the issue is to build the next Nix
expression:

``` nix
let pkgs = import <nixpkgs> { };
in pkgs.buildEnv {
  name = "buildenv-issue";

  paths = [
    pkgs.fish
    pkgs.vim
  ];

  pathsToLink = [
    "/share"
    "/share/fish/vendor_completions.d"
  ];
}
```

This patch makes buildEnv check if directory already exists before
trying to create it.
