### PR TITLE
Separate fix-point from config importing hacks and other impurities

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,4 +6,4 @@ if ! builtins ? nixVersion || builtins.compareVersions requiredVersion builtins.
 
 else
 
-  import ./pkgs/top-level
+  import ./pkgs/top-level/impure.nix

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -6,7 +6,7 @@
 
 
 { # The system (e.g., `i686-linux') for which to build the packages.
-  system ? builtins.currentSystem
+  system
 
 , # The standard environment to use.  Only used for bootstrapping.  If
   # null, the default standard environment is used.
@@ -19,21 +19,8 @@
                && system != "x86_64-solaris"
                && system != "x86_64-kfreebsd-gnu")
 
-, # Allow a configuration attribute set to be passed in as an
-  # argument.  Otherwise, it's read from $NIXPKGS_CONFIG or
-  # ~/.nixpkgs/config.nix.
-  #
-  # [For NixOS (nixos-rebuild), use nixpkgs.config option to set.]
-  config ? let
-      inherit (builtins) getEnv pathExists;
-
-      configFile = getEnv "NIXPKGS_CONFIG";
-      homeDir = getEnv "HOME";
-      configFile2 = homeDir + "/.nixpkgs/config.nix";
-    in
-      if configFile != "" && pathExists configFile then import configFile
-      else if homeDir != "" && pathExists configFile2 then import configFile2
-      else {}
+, # Allow a configuration attribute set to be passed in as an argument.
+  config ? {}
 
 , crossSystem ? null
 , platform ? null

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -1,0 +1,24 @@
+/* Impure default args for `pkgs/top-level/default.nix`. See that file
+   for the meaning of each argument. */
+
+{ # Fallback: Assume we are building packages for the current (host, in GNU
+  # Autotools parlance) system.
+  system ? builtins.currentSystem
+
+, # Fallback: The contents of the configuration file found at $NIXPKGS_CONFIG or
+  # $HOME/.nixpkgs/config.nix.
+  config ? let
+      inherit (builtins) getEnv pathExists;
+
+      configFile = getEnv "NIXPKGS_CONFIG";
+      homeDir = getEnv "HOME";
+      configFile2 = homeDir + "/.nixpkgs/config.nix";
+    in
+      if configFile != "" && pathExists configFile then import configFile
+      else if homeDir != "" && pathExists configFile2 then import configFile2
+      else {}
+
+, ...
+} @ args:
+
+import ./. (args // { inherit system config; })


### PR DESCRIPTION
Extracted from https://github.com/NixOS/nixpkgs/pull/15043 .

@Mathnerd314 had the idea of just putting `impure.nix` in `/default.nix` (not `/pkgs/top-level/default.nix`), which should be considered.
