### PR TITLE
buildEnv: build the whole tree of directories to pathsToLink

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -31,9 +31,23 @@ sub isInPathsToLink {
 
 my %symlinks;
 
+# Add all pathsToLink and all parent directories.
+#
+# For "/a/b/c" that will include
+# [ "", "/a", "/a/b", "/a/b/c" ]
+#
+# That ensures the whole directory tree needed by pathsToLink is
+# created as directories and not symlinks.
+$symlinks{""} = ["", 0];
 for my $p (@pathsToLink) {
-    $p = "" if $p eq "/";
-    $symlinks{$p} = ["", 0];
+    my @parts = split '/', $p;
+
+    my $cur = "";
+    for my $x (@parts) {
+        $cur = $cur . "/$x";
+        $cur = "" if $cur eq "/";
+        $symlinks{$cur} = ["", 0];
+    }
 }
 
 sub findFiles;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This patch fixes #16614 and #16741.

The first issue was caused by the fact that both `/share` and
`/share/fish/vendor_completions.d` end in the `pathsToLink`. The
`pkgs/build-support/buildenv/builder.pl` creates `/share`, then links
`/share/fish` under `/share` and then tries to create the directory
`/share/fish/vendor_completions.d` and fails because it already exists.

The simplest way to reproduce the issue is to build the next Nix
expression:

``` nix
let pkgs = import <nixpkgs> { };
in pkgs.buildEnv {
  name = "buildenv-issue";

  paths = [
    pkgs.fish
    pkgs.vim
  ];

  pathsToLink = [
    "/share"
    "/share/fish/vendor_completions.d"
  ];
}
```

The second issue is more critical and was caused by the fact findFiles
doesn't recurse deep enough. It stops at first unique directory for the
package (e.g., "/share" or even "/") and later the scripts decides it
shouldn't link it as it doesn't match pathsToLink (e.g., "/share/fish"),
so the result is empty.

The test:

``` nix
let pkgs = import <nixpkgs> { };
in pkgs.buildEnv {
  name = "buildenv-issue";

  paths = [
    pkgs.fish
    pkgs.vim
  ];

  pathsToLink = [
    "/share/fish/functions"
  ];
}
```

or

``` nix
let pkgs = import <nixpkgs> { };
in pkgs.buildEnv {
  name = "buildenv-issue";

  paths = [
    pkgs.vim
  ];

  pathsToLink = [
    "/share"
  ];
}
```
