### PR TITLE
vimPlugins: fix youcompleteme on darwin

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1,7 +1,7 @@
 # TODO check that no license information gets lost
 { fetchurl, bash, stdenv, python, go, cmake, vim, vimUtils, perl, ruby, unzip
 , which, fetchgit, fetchFromGitHub, fetchhg, fetchzip, llvmPackages, zip
-, vim_configurable, vimPlugins, xkb_switch, git, rustracerd, fzf
+, vim_configurable, vimPlugins, xkb_switch, git, rustracerd ? null, fzf
 , Cocoa ? null
 }:
 
@@ -1126,8 +1126,11 @@ rec {
       llvmPackages.llvm
     ] ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
 
-    propogatedBuildInputs = [
-      rustracerd
+    propagatedBuildInputs = [] ++ stdenv.lib.optional (!stdenv.isDarwin) rustracerd;
+
+    patches = [
+      ./patches/youcompleteme/1-top-cmake.patch
+      ./patches/youcompleteme/2-ycm-cmake.patch
     ];
 
     buildPhase = ''

--- a/pkgs/misc/vim-plugins/patches/youcompleteme/1-top-cmake.patch
+++ b/pkgs/misc/vim-plugins/patches/youcompleteme/1-top-cmake.patch
@@ -1,0 +1,14 @@
+
+--- ./third_party/ycmd/cpp/CMakeLists.txt
++++ ./third_party/ycmd/cpp/CMakeLists.txt
+@@ -121,8 +121,8 @@
+     set( CPP11_AVAILABLE true )
+   endif()
+ elseif( COMPILER_IS_CLANG )
+-  set( CPP11_AVAILABLE true )
+-  set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11" )
++  #set( CPP11_AVAILABLE true )
++  #  set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11" )
+   set( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++" )
+ endif()
+ 

--- a/pkgs/misc/vim-plugins/patches/youcompleteme/2-ycm-cmake.patch
+++ b/pkgs/misc/vim-plugins/patches/youcompleteme/2-ycm-cmake.patch
@@ -1,0 +1,36 @@
+--- ./third_party/ycmd/cpp/ycm/CMakeLists.txt
++++ ./third_party/ycmd/cpp/ycm/CMakeLists.txt
+@@ -335,7 +335,7 @@
+       COMMAND ${CMAKE_COMMAND} -E copy "${LIBCLANG_TARGET}" "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+     )
+ 
+-    if( APPLE )
++  #if( APPLE )
+       # In OS X El Capitan, Apple introduced System Integrity Protection.
+       # Amongst other things, this introduces features to the dynamic loader
+       # (dyld) which cause it to "sanitise" (and complain about) embedded
+@@ -354,15 +354,15 @@
+       # simply strip the rpath entry from the dylib.  There's no way any
+       # @executable_path that python might have could be in any way useful to
+       # libclang.dylib, so this seems perfectly safe.
+-      get_filename_component( LIBCLANG_TAIL ${LIBCLANG_TARGET} NAME )
+-      add_custom_command( TARGET ${PROJECT_NAME}
+-                          POST_BUILD
+-                          COMMAND install_name_tool
+-                          "-delete_rpath"
+-                          "@executable_path/../lib"
+-                          "$<TARGET_FILE_DIR:${PROJECT_NAME}>/${LIBCLANG_TAIL}"
+-                        )
+-    endif()
++      #    get_filename_component( LIBCLANG_TAIL ${LIBCLANG_TARGET} NAME )
++      #add_custom_command( TARGET ${PROJECT_NAME}
++      #                    POST_BUILD
++      #                    COMMAND install_name_tool
++      #                    "-delete_rpath"
++      #                    "@executable_path/../lib"
++      #                    "$<TARGET_FILE_DIR:${PROJECT_NAME}>/${LIBCLANG_TAIL}"
++      #                  )
++      # endif()
+   endif()
+ endif()
+ 

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/youcompleteme
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/youcompleteme
@@ -4,8 +4,13 @@
       llvmPackages.llvm
     ] ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
 
-    propogatedBuildInputs = [
+    propagatedBuildInputs = [
       rustracerd
+    ];
+
+    patches = [
+      ./patches/youcompleteme/1-top-cmake.patch
+      ./patches/youcompleteme/2-ycm-cmake.patch
     ];
 
     buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Youcompleteme on Darwin didn't build due to a bug with Boost, libc++, and c++11. See #16212 
I added a few patches to turn off C++11 during the build, and it works.

I also disabled Rust autocomplete support on Darwin for now (it's still enabled elsewhere)

NixOS support did not break.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
