### PR TITLE
gtk-gnutella: fix build and 1.1.5 -> 1.1.9

### DIFF
--- a/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
+++ b/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
@@ -1,30 +1,26 @@
 { stdenv, fetchurl, bison, pkgconfig
-, glib, gtk, libxml2, gettext, zlib }:
+, glib, gtk, libxml2, gettext, zlib, binutils, gnutls }:
 
 let
   name = "gtk-gnutella";
-  version = "1.1.5";
+  version = "1.1.9";
 in
 stdenv.mkDerivation {
   name = "${name}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/${name}/${name}-${version}.tar.bz2";
-    sha256 = "19d8mmyxrdwdafcjq1hvs9zn40yrcj1127163a2058svi0x08cn3";
+    sha256 = "1zvadgsskmpm82id9mbj24a2lyq38qv768ixv7nmfjl3d4wr2biv";
   };
 
-  nativeBuildInputs = [ bison pkgconfig ];
-  buildInputs = [ glib gtk libxml2 gettext zlib ];
+  nativeBuildInputs = [ bison binutils gettext pkgconfig ];
+  buildInputs = [ glib gnutls gtk libxml2 zlib ];
 
-  NIX_LDFLAGS = "-rpath ${zlib.out}/lib";
-  configureScript = "./Configure";
-  dontAddPrefix = true;
-  configureFlags = "-d -e -D prefix=$out -D gtkversion=2 -D official=true";
+  configureScript = "./build.sh --configure-only";
 
   meta = with stdenv.lib; {
     homepage = http://gtk-gnutella.sourceforge.net/;
     description = "Server/client for Gnutella";
     license = licenses.gpl2;
-    broken = true;
   };
 }


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
