### PR TITLE
pulseaudio: Add support for package configuration files.

### DIFF
--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -66,7 +66,12 @@ stdenv.mkDerivation rec {
       ++ lib.optional zeroconfSupport  avahi
     );
 
-  preConfigure = ''
+  preConfigure = lib.optionalString (!libOnly) ''
+    mixerDir="/etc/pulse/alsa-mixer"
+    sed -i "src/Makefile.am" \
+        -e 's|\(PA.*PATHS.*\)=".*"|\1\\\"'$mixerDir'/paths\\\"|g' \
+        -e 's|\(PA.*PROFILE_SETS.*\).".*"|\1\\\"'$mixerDir'/profile-sets\\\"|g'
+  '' + ''
     # Performs and autoreconf
     export NOCONFIGURE="yes"
     patchShebangs bootstrap.sh


### PR DESCRIPTION
In a fashion like udev's support, this patch allows configurations from packages
to be merged in to directories for PulseAudio to read from. Currently supported
directories are the alsa-mixer mdoule's profile-sets and paths.

This is accomplished by patching PulseAudio to read directories from environment
variables globally defined by NixOS rather from the data path in the Nix store.
Modules that support it (such as the alsa module) can still be configured at
runtime to use specific paths, this just changes the default paths.

The environment variables are only used if they're defined, as such the previous
behaviour can be reverted to if the variables are unset or NixOS isn't running.
