### PR TITLE
Bump leatherman: 0.7.0 -> 0.7.5 and sole dependency facter 3.1.6 -> 3.1.8

### DIFF
--- a/pkgs/development/libraries/leatherman/default.nix
+++ b/pkgs/development/libraries/leatherman/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "leatherman-${version}";
-  version = "0.7.0";
+  version = "0.7.5";
 
   src = fetchFromGitHub {
-    sha256 = "1m37zcr11a2g08wbkpxgav97m2fr14in2zhdhhv5krci5i2grzd7";
+    sha256 = "103qzhjhgw7jh0xcaxag735wfm6q35xprq5wmdimfhhmmrmjr51g";
     rev = version;
     repo = "leatherman";
     owner = "puppetlabs";

--- a/pkgs/tools/system/facter/default.nix
+++ b/pkgs/tools/system/facter/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "facter-${version}";
-  version = "3.1.6";
+  version = "3.1.8";
   src = fetchurl {
     url = "https://downloads.puppetlabs.com/facter/${name}.tar.gz";
-    sha256 = "1kv4k9zqpsiw362kk1rw1a4sixd0pmnh57ghd4k4pffr2dkmdfsv";
+    sha256 = "1fhfjf5bm5kyjiady14fxhpp7hdrkgx56vsvdbqj82km0xqcxpj9";
   };
 
   cmakeFlags = [ "-DFACTER_RUBY=${ruby}/lib/libruby.so" ];


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
