### PR TITLE
bluejeans: 2.160.49.8 -> 2.160.63.8

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
@@ -17,11 +17,11 @@ in
 stdenv.mkDerivation rec {
   name = "bluejeans-${version}";
 
-  version = "2.160.49.8";
+  version = "2.160.63.8";
 
   src = fetchurl {
     url = "https://swdl.bluejeans.com/skinny/bjnplugin_${version}-1_amd64.deb";
-    sha256 = "1hf4jx0d1wiv622rwck0mm8cckm121yszviw47jsw0mjnp91hqch";
+    sha256 = "1sfz9xvvrbw7gg7fxxwg9wmgbxgv3fa14p7i4m85mg10l3qxaqfc";
   };
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
