### PR TITLE
rcm: 1.2.3 -> 1.3.0

### DIFF
--- a/pkgs/tools/misc/rcm/default.nix
+++ b/pkgs/tools/misc/rcm/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation {
-  name = "rcm-1.2.3";
+  name = "rcm-1.3.0";
 
   src = fetchurl {
-    url = https://thoughtbot.github.io/rcm/dist/rcm-1.2.3.tar.gz;
-    sha256 = "0gwpclbc152jkclj3w83s2snx3dcgljwr75q1z8czl3yar7d8bsh";
+    url = https://thoughtbot.github.io/rcm/dist/rcm-1.3.0.tar.gz;
+    sha256 = "ddcf638b367b0361d8e063c29fd573dbe1712d1b83e8d5b3a868e4aa45ffc847";
   };
  
   patches = [ ./fix-rcmlib-path.patch ];

--- a/pkgs/tools/misc/rcm/fix-rcmlib-path.patch
+++ b/pkgs/tools/misc/rcm/fix-rcmlib-path.patch
@@ -1,68 +1,48 @@
-*** rcm-1.2.3/bin/lsrc.in.orig	2014-05-09 04:57:39.000000000 -0700
---- rcm-1.2.3/bin/lsrc.in	2015-01-24 14:27:48.786595479 -0800
-***************
-*** 1,6 ****
-  #!@SHELL@
-  
-! : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
-  . "$RCM_LIB/rcm.sh"
-  
-  pushdir() {
---- 1,6 ----
-  #!@SHELL@
-  
-! RCM_LIB=@rcm@/share/rcm
-  . "$RCM_LIB/rcm.sh"
-  
-  pushdir() {
-*** rcm-1.2.3/bin/mkrc.in.orig	2014-05-09 04:57:39.000000000 -0700
---- rcm-1.2.3/bin/mkrc.in	2015-01-24 14:27:48.786595479 -0800
-***************
-*** 1,6 ****
-  #!@SHELL@
-  
-! : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
-  . "$RCM_LIB/rcm.sh"
-  
-  destination() {
---- 1,6 ----
-  #!@SHELL@
-  
-! RCM_LIB=@rcm@/share/rcm
-  . "$RCM_LIB/rcm.sh"
-  
-  destination() {
-*** rcm-1.2.3/bin/rcdn.in.orig	2014-05-09 04:57:39.000000000 -0700
---- rcm-1.2.3/bin/rcdn.in	2015-01-24 14:27:48.786595479 -0800
-***************
-*** 1,6 ****
-  #!@SHELL@
-  
-! : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
-  . "$RCM_LIB/rcm.sh"
-  
-  remove_link() {
---- 1,6 ----
-  #!@SHELL@
-  
-! RCM_LIB=@rcm@/share/rcm
-  . "$RCM_LIB/rcm.sh"
-  
-  remove_link() {
-*** rcm-1.2.3/bin/rcup.in.orig	2014-05-09 04:57:39.000000000 -0700
---- rcm-1.2.3/bin/rcup.in	2015-01-24 14:27:48.786595479 -0800
-***************
-*** 1,6 ****
-  #!@SHELL@
-  
-! : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
-  . "$RCM_LIB/rcm.sh"
-  
-  link_or_copy() {
---- 1,6 ----
-  #!@SHELL@
-  
-! RCM_LIB=@rcm@/share/rcm
-  . "$RCM_LIB/rcm.sh"
-  
-  link_or_copy() {
+diff --git a/bin/lsrc.in b/bin/lsrc.in
+index fcf5fbe..119d659 100755
+--- a/bin/lsrc.in
++++ b/bin/lsrc.in
+@@ -1,6 +1,6 @@
+ #!@SHELL@
+ 
+-: ${RCM_LIB:=$(dirname "$0")/../share/rcm}
++RCM_LIB=@rcm@/share/rcm
+ . "$RCM_LIB/rcm.sh"
+ 
+ pushdir() {
+diff --git a/bin/mkrc.in b/bin/mkrc.in
+index da22a63..a6bb0ad 100755
+--- a/bin/mkrc.in
++++ b/bin/mkrc.in
+@@ -1,6 +1,6 @@
+ #!@SHELL@
+ 
+-: ${RCM_LIB:=$(dirname "$0")/../share/rcm}
++RCM_LIB=@rcm@/share/rcm
+ . "$RCM_LIB/rcm.sh"
+ 
+ destination() {
+diff --git a/bin/rcdn.in b/bin/rcdn.in
+index ae7aad8..c210599 100755
+--- a/bin/rcdn.in
++++ b/bin/rcdn.in
+@@ -1,6 +1,6 @@
+ #!@SHELL@
+ 
+-: ${RCM_LIB:=$(dirname "$0")/../share/rcm}
++RCM_LIB=@rcm@/share/rcm
+ . "$RCM_LIB/rcm.sh"
+ 
+ remove_link() {
+diff --git a/bin/rcup.in b/bin/rcup.in
+index bdae664..2076f53 100755
+--- a/bin/rcup.in
++++ b/bin/rcup.in
+@@ -1,6 +1,6 @@
+ #!@SHELL@
+ 
+-: ${RCM_LIB:=$(dirname "$0")/../share/rcm}
++RCM_LIB=@rcm@/share/rcm
+ . "$RCM_LIB/rcm.sh"
+ 
+ print_ln_v() {


### PR DESCRIPTION
###### Motivation for this change

Upstream update.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
