### PR TITLE
lighthouse: init at 2016-01-26

### DIFF
--- a/pkgs/applications/misc/lighthouse/Makefile.patch
+++ b/pkgs/applications/misc/lighthouse/Makefile.patch
@@ -1,0 +1,31 @@
+# Description: Fix lighthouse Makefile
+Index: Makefile
+===================================================================
+--- ./Makefile	1970-01-01 02:00:01.000000000 +0200
++++ ./Makefile	1970-01-01 02:00:01.000000000 +0200
+@@ -19,21 +19,10 @@
+ endif
+ 
+ # Library specific
+-HAS_GDK := $(shell pkg-config --exists gdk-2.0 echo $?)
+-ifdef $(HAS_GDK)
+-	CFLAGS+=`pkg-config --cflags gdk-2.0`
+-	LDFLAGS+=`pkg-config --libs gdk-2.0`
+-else
+-	CFLAGS+=-DNO_GDK
+-endif
+-HAS_PANGO := $(shell pkg-config --exists pango echo $?)
+-ifdef $(HAS_PANGO)
+-	CFLAGS+=`pkg-config --cflags pango`
+-	LDFLAGS+=`pkg-config --libs pango`
+-else
+-	CFLAGS+=-DNO_PANGO
+-endif
+-
++CFLAGS+=$(shell pkg-config --cflags gdk-2.0)
++LDFLAGS+=$(shell pkg-config --libs gdk-2.0)
++CFLAGS+=$(shell pkg-config --cflags pango)
++LDFLAGS+=$(shell pkg-config --libs pango)
+ 
+ all: lighthouse
+ 

--- a/pkgs/applications/misc/lighthouse/default.nix
+++ b/pkgs/applications/misc/lighthouse/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, pkgconfig
+, libX11, libxcb, cairo, gtk, pango, python27, python3
+}:
+
+stdenv.mkDerivation rec {
+  name = "lighthouse-${date}";
+  date = "2016-01-26";
+
+  src = fetchFromGitHub {
+    owner = "emgram769";
+    repo = "lighthouse";
+    rev = "bf11f111572475e855b0329202a14c9e128c7e57";
+    sha256 = "1ppika61vg4sc9mczbkjqy2mhgxqg57xrnsmmq0h2lyvj0yhg3qn";
+   };
+
+  buildInputs = [
+    pkgconfig libX11 libxcb cairo gtk pango python27 python3
+  ];
+
+  patches = [ ./Makefile.patch ];
+
+  lighthouseInstaller = ''
+    #!${stdenv.shell}
+    cp -r $out/share/lighthouse/.config/lighthouse \$HOME/.config
+    chmod -R +w \$HOME/.config/lighthouse
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp lighthouse $out/bin
+    chmod +x config/lighthouse/cmd*
+    chmod +x config/lighthouse/google.py
+    patchShebangs config/lighthouse/
+    patchShebangs config/lighthouse/scripts/
+    mkdir -p $out/share/lighthouse/.config
+    cp -r config/lighthouse $out/share/lighthouse/.config
+    echo "${lighthouseInstaller}" > $out/bin/lighthouse-install
+    chmod +x $out/bin/lighthouse-install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple flexible popup dialog to run on X";
+    homepage = https://github.com/emgram769/lighthouse;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ramkromberg ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13515,6 +13515,8 @@ in
   };
   ledger = self.ledger3;
 
+  lighthouse = callPackage ../applications/misc/lighthouse { };
+
   lighttable = callPackage ../applications/editors/lighttable {};
 
   links2 = callPackage ../applications/networking/browsers/links2 { };


### PR DESCRIPTION
###### Motivation for this change

A nice dmenu alternative: https://github.com/emgram769/lighthouse

<p align="center">
  <img src="http://i.imgur.com/Z6W0Ube.gif" alt="demo"/>
  <br>
</p>


Note some unusual modification were required:
1. Stripped the Makefile from some pkg-config tests that didn't work right.
2. Written a special script called _lighthouse-install_ placed next to _lighthouse_ in _$out/bin_ that deploys the _~/.config/lighthouse_ configuration files. Those normally getget deployed with _make config_.

Overall, the user simply evokes _lighthouse-install_ in the shell before the first run.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
