### PR TITLE
Fix Spidermonkey builds (on ARM)

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/17.0.nix
+++ b/pkgs/development/interpreters/spidermonkey/17.0.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = !stdenv.isArm; # fails on v7 with "Alignment trap: not handling instruction" in kernel log
+  doCheck = true;
   preCheck = ''
     rm jit-test/tests/sunspider/check-date-format-tofte.js    # https://bugzil.la/600522
 

--- a/pkgs/development/interpreters/spidermonkey/185-1.0.0.nix
+++ b/pkgs/development/interpreters/spidermonkey/185-1.0.0.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, nspr, perl, python, zip }:
+{ stdenv, autoconf213, fetchurl, pkgconfig, nspr, perl, python, zip }:
 
 stdenv.mkDerivation rec {
   version = "185-1.0.0";
@@ -12,17 +12,21 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ nspr ];
 
   buildInputs = [ pkgconfig perl python zip ];
+  nativeBuildInputs = if stdenv.isArm then [ autoconf213 ] else [];
 
   postUnpack = "sourceRoot=\${sourceRoot}/js/src";
 
   preConfigure = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${nspr.dev}/include/nspr"
     export LIBXUL_DIST=$out
+    ${if stdenv.isArm then "autoreconf --verbose --force" else ""}
   '';
 
-  # Explained below in configureFlags for ARM
   patches = stdenv.lib.optionals stdenv.isArm [
+    # Explained below in configureFlags for ARM
     ./findvanilla.patch
+    # Fix for hard float flags.
+    ./arm-flags.patch
   ];
 
   patchFlags = "-p3";
@@ -33,12 +37,15 @@ stdenv.mkDerivation rec {
   # of polkit, which is what matters most, it does not override the allocator
   # so the failure of that test does not matter much.
   configureFlags = [ "--enable-threadsafe" "--with-system-nspr" ] ++
-    stdenv.lib.optionals stdenv.isArm [
+    stdenv.lib.optionals (stdenv.system == "armv5tel-linux") [
         "--with-cpu-arch=armv5t" 
         "--disable-tracejit" ];
 
   # hack around a make problem, see https://github.com/NixOS/nixpkgs/issues/1279#issuecomment-29547393
-  preBuild = "touch -- {.,shell,jsapi-tests}/{-lpthread,-ldl}";
+  preBuild = ''
+    touch -- {.,shell,jsapi-tests}/{-lpthread,-ldl}
+    ${if stdenv.isArm then "rm -r jit-test/tests/jaeger/bug563000" else ""}
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/interpreters/spidermonkey/31.5.nix
+++ b/pkgs/development/interpreters/spidermonkey/31.5.nix
@@ -27,9 +27,6 @@ stdenv.mkDerivation rec {
     "--with-system-ffi"
     "--enable-readline"
 
-    # there is at least one unfixed issue building the tests, so I didn't bother
-    "--disable-tests"
-
     # enabling these because they're wanted by 0ad. They may or may
     # not be good defaults for other uses.
     "--enable-gcgenerational"
@@ -43,9 +40,6 @@ stdenv.mkDerivation rec {
   # This addresses some build system bug. It's quite likely to be safe
   # to re-enable parallel builds if the source revision changes.
   enableParallelBuilding = false;
-
-  # see comment by --disable-tests
-  doCheck = false;
 
   postFixup = ''
     # The headers are symlinks to a directory that doesn't get put

--- a/pkgs/development/interpreters/spidermonkey/31.5.nix
+++ b/pkgs/development/interpreters/spidermonkey/31.5.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   postUnpack = "sourceRoot=\${sourceRoot}/js/src";
 
   preConfigure = ''
+    export CXXFLAGS="-fpermissive"
     export LIBXUL_DIST=$out
   '';
 

--- a/pkgs/development/interpreters/spidermonkey/arm-flags.patch
+++ b/pkgs/development/interpreters/spidermonkey/arm-flags.patch
@@ -1,0 +1,342 @@
+From: Mike Hommey <mh@glandium.org>
+Date: Wed, 27 Apr 2011 08:58:01 +0200
+Subject: Bug 626035 - Modify the way arm compiler flags are set in configure
+
+---
+ configure.in        |  292 ++++++++++++++++++++++++++++++++-------------------
+ js/src/configure.in |  284 ++++++++++++++++++++++++++++++++-----------------
+ 2 files changed, 372 insertions(+), 204 deletions(-)
+
+Index: mozjs-1.8.5-1.0.0+dfsg/js/src/configure.in
+===================================================================
+--- mozjs-1.8.5-1.0.0+dfsg.orig/js/src/configure.in	2012-01-21 15:57:37.507703219 +0100
++++ mozjs-1.8.5-1.0.0+dfsg/js/src/configure.in	2012-01-21 15:58:04.951703302 +0100
+@@ -3535,34 +3535,6 @@
+     AC_CHECK_LIB(socket, socket)
+ esac
+ 
+-AC_MSG_CHECKING(for ARM SIMD support in compiler)
+-AC_TRY_COMPILE([],
+-               [asm("uqadd8 r1, r1, r2");],
+-               result="yes", result="no")
+-AC_MSG_RESULT("$result")
+-if test "$result" = "yes"; then
+-    AC_DEFINE(HAVE_ARM_SIMD)
+-    HAVE_ARM_SIMD=1
+-fi
+-AC_SUBST(HAVE_ARM_SIMD)
+-
+-AC_MSG_CHECKING(for ARM NEON support in compiler)
+-_SAVE_CFLAGS="$CFLAGS"
+-if test "$GNU_CC"; then
+-  # gcc needs -mfpu=neon to recognize NEON instructions
+-  CFLAGS="$CFLAGS -mfpu=neon -mfloat-abi=softfp"
+-fi
+-AC_TRY_COMPILE([],
+-               [asm("vadd.i8 d0, d0, d0");],
+-               result="yes", result="no")
+-AC_MSG_RESULT("$result")
+-if test "$result" = "yes"; then
+-    AC_DEFINE(HAVE_ARM_NEON)
+-    HAVE_ARM_NEON=1
+-fi
+-CFLAGS="$_SAVE_CFLAGS"
+-AC_SUBST(HAVE_ARM_NEON)
+-
+ dnl ========================================================
+ dnl = pthread support
+ dnl = Start by checking whether the system support pthreads
+@@ -4614,13 +4586,11 @@
+ BUILD_STATIC_LIBS=
+ ENABLE_TESTS=1
+ 
+-MOZ_THUMB2=
+ USE_ARM_KUSER=
+ 
+ case "${target}" in
+     arm-android-eabi)
+         USE_ARM_KUSER=1
+-        MOZ_THUMB2=1
+         ;;
+ esac
+ 
+@@ -4666,80 +4636,204 @@
+ dnl ========================================================
+ MOZ_ARG_HEADER(Individual module options)
+ 
+-dnl Setup default CPU arch for arm target
+-case "$target_cpu" in
+-  arm*)
+-    MOZ_ARM_ARCH=armv7
+-  ;;
+-esac
+ dnl ========================================================
+-dnl = Enable building the Thumb2 instruction set
++dnl = ARM toolchain tweaks
+ dnl ========================================================
+-MOZ_ARG_ENABLE_BOOL(thumb2,
+- [  --enable-thumb2         Enable Thumb2 instruction set (implies ARMv7)],
+-    MOZ_THUMB2=1,
+-    MOZ_THUMB2=)
+-if test -n "$MOZ_THUMB2"; then
+-  MOZ_ARM_ARCH=armv7
++
++dnl Defaults
++case "${target}" in
++arm-android-eabi)
++    MOZ_THUMB=yes
++    MOZ_ARCH=armv7-a
++    MOZ_FPU=vfp
++    MOZ_FLOAT_ABI=softfp
++    ;;
++arm*-*)
++    if test -n "$MOZ_PLATFORM_MAEMO"; then
++        MOZ_THUMB=no
++        MOZ_ARCH=armv7-a
++        MOZ_FLOAT_ABI=softfp
++    fi
++    if test "$MOZ_PLATFORM_MAEMO" = 6; then
++        MOZ_THUMB=yes
++    fi
++    ;;
++esac
++
++dnl Kept for compatibility with some buildbot mozconfig
++MOZ_ARG_DISABLE_BOOL(thumb2, [], MOZ_THUMB=no, MOZ_THUMB=yes)
++
++MOZ_ARG_WITH_STRING(thumb,
++[  --with-thumb[[=yes|no|toolchain]]]
++[                          Use Thumb instruction set (-mthumb)],
++    if test -z "$GNU_CC"; then
++        AC_MSG_ERROR([--with-thumb is not supported on non-GNU toolchains])
++    fi
++    MOZ_THUMB=$withval)
++
++MOZ_ARG_WITH_STRING(thumb-interwork,
++[  --with-thumb-interwork[[=yes|no|toolchain]]
++                           Use Thumb/ARM instuctions interwork (-mthumb-interwork)],
++    if test -z "$GNU_CC"; then
++        AC_MSG_ERROR([--with-thumb-interwork is not supported on non-GNU toolchains])
++    fi
++    MOZ_THUMB_INTERWORK=$withval)
++
++MOZ_ARG_WITH_STRING(arch,
++[  --with-arch=[[type|toolchain]]
++                           Use specific CPU features (-march=type)],
++    if test -z "$GNU_CC"; then
++        AC_MSG_ERROR([--with-arch is not supported on non-GNU toolchains])
++    fi
++    MOZ_ARCH=$withval)
++
++MOZ_ARG_WITH_STRING(fpu,
++[  --with-fpu=[[type|toolchain]]
++                           Use specific FPU type (-mfpu=type)],
++    if test -z "$GNU_CC"; then
++        AC_MSG_ERROR([--with-fpu is not supported on non-GNU toolchains])
++    fi
++    MOZ_FPU=$withval)
++
++MOZ_ARG_WITH_STRING(float-abi,
++[  --with-float-abi=[[type|toolchain]]
++                           Use specific arm float ABI (-mfloat-abi=type)],
++    if test -z "$GNU_CC"; then
++        AC_MSG_ERROR([--with-float-abi is not supported on non-GNU toolchains])
++    fi
++    MOZ_FLOAT_ABI=$withval)
++
++MOZ_ARG_WITH_STRING(soft-float,
++[  --with-soft-float[[=yes|no|toolchain]]
++                           Use soft float library (-msoft-float)],
++    if test -z "$GNU_CC"; then
++        AC_MSG_ERROR([--with-soft-float is not supported on non-GNU toolchains])
++    fi
++    MOZ_SOFT_FLOAT=$withval)
++
++case "$MOZ_ARCH" in
++toolchain|"")
++    arch_flag=""
++    ;;
++*)
++    arch_flag="-march=$MOZ_ARCH"
++    ;;
++esac
++
++case "$MOZ_THUMB" in
++yes)
++    MOZ_THUMB2=1
++    thumb_flag="-mthumb"
++    ;;
++no)
++    MOZ_THUMB2=
++    thumb_flag="-marm"
++    ;;
++*)
++    _SAVE_CFLAGS="$CFLAGS"
++    CFLAGS="$arch_flag"
++    AC_TRY_COMPILE([],[return sizeof(__thumb2__);],
++        MOZ_THUMB2=1,
++        MOZ_THUMB2=)
++    CFLAGS="$_SAVE_CFLAGS"
++    thumb_flag=""
++    ;;
++esac
++
++if test "$MOZ_THUMB2" = 1; then
++    AC_DEFINE(MOZ_THUMB2)
+ fi
+ 
+-dnl ========================================================
+-dnl = Enable building for ARM specific CPU features
+-dnl ========================================================
+-MOZ_ARG_WITH_STRING(cpu-arch,
+-[  --with-cpu-arch=arch      Use specific arm architecture CPU features, default armv7],
+-    MOZ_ARM_ARCH=$withval)
++case "$MOZ_THUMB_INTERWORK" in
++yes)
++    thumb_interwork_flag="-mthumb-interwork"
++    ;;
++no)
++    thumb_interwork_flag="-mno-thumb-interwork"
++    ;;
++*) # toolchain
++    thumb_interwork_flag=""
++    ;;
++esac
+ 
+-if test -n "$MOZ_THUMB2"; then
+-  case "$target_cpu" in
+-    arm*)
+-      if test "$MOZ_ARM_ARCH" != "armv7"; then
+-        AC_MSG_ERROR([--enable-thumb2 is not compatible with cpu-arch=$MOZ_ARM_ARCH])
+-      fi
+-      if test "$GNU_CC"; then
+-        AC_DEFINE(MOZ_THUMB2)
+-        AC_DEFINE(MOZ_ARM_ARCH)
+-        CFLAGS="$CFLAGS -march=armv7-a -mthumb -mfloat-abi=softfp $MOZ_ARM_VFP_FLAGS"
+-        CXXFLAGS="$CXXFLAGS -march=armv7-a -mthumb -mfloat-abi=softfp $MOZ_ARM_VFP_FLAGS"
+-        ASFLAGS="$ASFLAGS -march=armv7-a -mthumb -mfloat-abi=softfp $MOZ_ARM_VFP_FLAGS"
+-      else
+-        AC_MSG_ERROR([--enable-thumb2 is not supported for non-GNU toolchains])
+-      fi
++case "$MOZ_FPU" in
++toolchain|"")
++    fpu_flag=""
+     ;;
+-    *)
+-      AC_MSG_ERROR([--enable-thumb2 is not supported for non-ARM CPU architectures])
++*)
++    fpu_flag="-mfpu=$MOZ_FPU"
+     ;;
+-  esac
+-elif test "$MOZ_ARM_ARCH" = "armv7"; then
+-  case "$target_cpu" in
+-    arm*)
+-      if test "$GNU_CC"; then
+-        AC_DEFINE(MOZ_ARM_ARCH)
+-        CFLAGS="$CFLAGS -march=armv7-a -marm -mfloat-abi=softfp $MOZ_ARM_VFP_FLAGS"
+-        CXXFLAGS="$CXXFLAGS -march=armv7-a -marm -mfloat-abi=softfp $MOZ_ARM_VFP_FLAGS"
+-        ASFLAGS="$ASFLAGS -march=armv7-a -marm -mfloat-abi=softfp $MOZ_ARM_VFP_FLAGS"
+-      else
+-        AC_MSG_ERROR([--with-cpu-arch=armv7 is not supported for non-GNU toolchains])
+-      fi
++esac
++
++case "$MOZ_FLOAT_ABI" in
++toolchain|"")
++    float_abi_flag=""
+     ;;
+-    *)
+-      AC_MSG_ERROR([--with-cpu-arch=armv7 is not supported for non-ARM CPU architectures])
++*)
++    float_abi_flag="-mfloat-abi=$MOZ_FLOAT_ABI"
+     ;;
+-  esac
+-else
+-  case "$target_cpu" in
+-    arm*)
+-      if test "$GNU_CC"; then
+-        CFLAGS="$CFLAGS -march=armv5te -mthumb-interwork -msoft-float"
+-        CXXFLAGS="$CXXFLAGS -march=armv5te -mthumb-interwork -msoft-float"
+-        ASFLAGS="$ASFLAGS -march=armv5te -mthumb-interwork -msoft-float"
+-      fi
+-      ;;
+-  esac
++esac
++
++case "$MOZ_SOFT_FLOAT" in
++yes)
++    soft_float_flag="-msoft-float"
++    ;;
++no)
++    soft_float_flag="-mno-soft-float"
++    ;;
++*) # toolchain
++    soft_float_flag=""
++    ;;
++esac
++
++dnl Use echo to avoid accumulating space characters
++all_flags=`echo $arch_flag $thumb_flag $thumb_interwork_flag $fpu_flag $float_abi_flag $soft_float_flag`
++if test -n "$all_flags"; then
++    _SAVE_CFLAGS="$CFLAGS"
++    CFLAGS="$all_flags"
++    AC_MSG_CHECKING(whether the chosen combination of compiler flags ($all_flags) works)
++    AC_TRY_COMPILE([],[return 0;],
++        AC_MSG_RESULT([yes]),
++        AC_MSG_ERROR([no]))
++
++    CFLAGS="$_SAVE_CFLAGS $all_flags"
++    CXXFLAGS="$CXXFLAGS $all_flags"
++    ASFLAGS="$ASFLAGS $all_flags"
++    if test -n "$thumb_flag"; then
++        LDFLAGS="$LDFLAGS $thumb_flag"
++    fi
+ fi
+ 
+ AC_SUBST(MOZ_THUMB2)
+-AC_SUBST(MOZ_ARM_ARCH)
++
++if test "$CPU_ARCH" = "arm"; then
++  AC_MSG_CHECKING(for ARM SIMD support in compiler)
++  # We try to link so that this also fails when
++  # building with LTO.
++  AC_TRY_LINK([],
++                 [asm("uqadd8 r1, r1, r2");],
++                 result="yes", result="no")
++  AC_MSG_RESULT("$result")
++  if test "$result" = "yes"; then
++      AC_DEFINE(HAVE_ARM_SIMD)
++      HAVE_ARM_SIMD=1
++  fi
++
++  AC_MSG_CHECKING(for ARM NEON support in compiler)
++  # We try to link so that this also fails when
++  # building with LTO.
++  AC_TRY_LINK([],
++                 [asm(".fpu neon\n vadd.i8 d0, d0, d0");],
++                 result="yes", result="no")
++  AC_MSG_RESULT("$result")
++  if test "$result" = "yes"; then
++      AC_DEFINE(HAVE_ARM_NEON)
++      HAVE_ARM_NEON=1
++  fi
++fi # CPU_ARCH = arm
++
++AC_SUBST(HAVE_ARM_SIMD)
++AC_SUBST(HAVE_ARM_NEON)
+ 
+ dnl ========================================================
+ dnl =
+@@ -6147,12 +6241,6 @@
+   if test "$OS_ARCH" = "OS2"; then
+     ac_configure_args="$ac_configure_args CFLAGS=-Zomf AR=emxomfar"
+   fi
+-  if test -n "$MOZ_THUMB2"; then
+-    ac_configure_args="$ac_configure_args --enable-thumb2"
+-  fi
+-  if test -n "$MOZ_ARM_ARCH"; then
+-    ac_configure_args="$ac_configure_args --with-cpu-arch=$MOZ_ARM_ARCH"
+-  fi
+ 
+   # Use a separate cache file for libffi, since it does things differently
+   # from our configure.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5895,10 +5895,10 @@ in
 
   spark = callPackage ../applications/networking/cluster/spark { };
 
-  spidermonkey = callPackage ../development/interpreters/spidermonkey { };
+  spidermonkey = callPackage ../development/interpreters/spidermonkey { stdenv = overrideCC stdenv gcc49; };
   spidermonkey_1_8_0rc1 = callPackage ../development/interpreters/spidermonkey/1.8.0-rc1.nix { };
   spidermonkey_185 = callPackage ../development/interpreters/spidermonkey/185-1.0.0.nix { };
-  spidermonkey_17 = callPackage ../development/interpreters/spidermonkey/17.0.nix { };
+  spidermonkey_17 = callPackage ../development/interpreters/spidermonkey/17.0.nix { stdenv = overrideCC stdenv gcc49; };
   spidermonkey_24 = callPackage ../development/interpreters/spidermonkey/24.2.nix { };
   spidermonkey_31 = callPackage ../development/interpreters/spidermonkey/31.5.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

This fixes all Spidermonkey builds on ARM. It's a bit controversial in that it uses GCC 4.9 for Spidermonkey 1.7 which stops MethodJIT from breaking. This bug was found in master a few days ago and the tests were disabled, which I suspect means we just have a broken Spidermonkey MethodJIT on ARM. Short of disabling it, this is the only way I could fix it.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
