### PR TITLE
dxx_rebirth: Mark license as nonfree.

### DIFF
--- a/pkgs/games/d1x-rebirth/default.nix
+++ b/pkgs/games/d1x-rebirth/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.dxx-rebirth.com/;
     description = "Source Port of the Descent 1 engine";
-    license = stdenv.lib.licenses.mit;
+    license = stdenv.lib.licenses.unfree;
     platforms = with stdenv.lib.platforms; linux;
     maintainers = with stdenv.lib.maintainers; [viric];
   };

--- a/pkgs/games/d2x-rebirth/default.nix
+++ b/pkgs/games/d2x-rebirth/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.dxx-rebirth.com/;
     description = "Source Port of the Descent 2 engine";
-    license = stdenv.lib.licenses.mit;
+    license = stdenv.lib.licenses.unfree;
     platforms = with stdenv.lib.platforms; linux;
     maintainers = with stdenv.lib.maintainers; [viric];
   };


### PR DESCRIPTION
###### Motivation for this change

The actual license prohibits noncommercial use.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
