### PR TITLE
zdoom: Mark it and its forks as nonfree.

### DIFF
--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = https://github.com/coelckers/gzdoom;
     description = "A Doom source port based on ZDoom. It features an OpenGL renderer and lots of new features";
+    license = stdenv.lib.licenses.unfree;
     maintainers = [ stdenv.lib.maintainers.lassulus ];
   };
 }

--- a/pkgs/games/zandronum/default.nix
+++ b/pkgs/games/zandronum/default.nix
@@ -57,7 +57,7 @@ in stdenv.mkDerivation {
     homepage = http://zandronum.com/;
     description = "Multiplayer oriented port, based off Skulltag, for Doom and Doom II by id Software";
     maintainers = with maintainers; [ lassulus ];
+    license = stdenv.lib.licenses.unfree;
     platforms = platforms.linux;
-    license = licenses.bsdOriginal;
   };
 }

--- a/pkgs/games/zdoom/default.nix
+++ b/pkgs/games/zdoom/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://zdoom.org/;
     description = "Enhanced port of the official DOOM source code";
+    license = stdenv.lib.licenses.unfree;
     maintainers = [ stdenv.lib.maintainers.lassulus ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Each of these is built off of zdoom and as such can only be used for noncommercial purposes.
See http://zdoom.org/wiki/License and the source code of each package.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
