### PR TITLE
fish: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -8,13 +8,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "fish-${version}";
-  version = "2.3.0";
+  version = "2.3.1";
 
   patches = [ ./etc_config.patch ];
 
   src = fetchurl {
     url = "http://fishshell.com/files/${version}/${name}.tar.gz";
-    sha256 = "1ralmp7lavdl0plc09ppm232aqsn0crxx6m3hgaa06ibam3sqawi";
+    sha256 = "0r46p64lg6da3v6chsa4gisvl04kd3rpy60yih8r870kbp9wm2ij";
   };
 
   buildInputs = [ ncurses libiconv pcre2 ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
[nix-shell:~/git/nixpkgs]$ fish


        　　(＾ヽ--△<＾)
        　 /　　　　　~▽
        　士　0　o　0 士
        　 メ ＿＿＿ メ
        　　　/ へ\`-L、
           (~(　し′｜ ）
             かわいい


~/g/nixpkgs $ 


[nix-shell:~/git/nixpkgs]$ fish --version
fish, version 2.3.1
```
