### PR TITLE
wireguard: init at 20160708

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchgit, libmnl, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "wireguard-${version}";
+  version = "20160708";
+
+  src = fetchgit {
+    url    = "https://git.zx2c4.com/WireGuard";
+    rev    = "dcc2583fe0618931e51aedaeeddde356d123acb2";
+    sha256 = "1ciyjpp8c3fv95y1cypk9qyqynp8cqyh2676afq2hd33110d37ni";
+  };
+
+  preConfigure = ''
+    cd src
+    sed -i /depmod/d Makefile
+  '';
+  
+  buildInputs = [ libmnl ];
+
+  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  makeFlags = [ 
+    "DESTDIR=$(out)" 
+    "PREFIX=/"
+    "INSTALL_MOD_PATH=$(out)" 
+  ];
+
+  meta = with stdenv.lib; {
+    homepage    = https://www.wireguard.io/;
+    description = "Fast, modern, secure VPN tunnel";
+    license     = licenses.gpl2;
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11091,6 +11091,8 @@ in
 
     virtualboxGuestAdditions = callPackage ../applications/virtualization/virtualbox/guest-additions { };
 
+    wireguard = callPackage ../os-specific/linux/wireguard {};
+
     x86_energy_perf_policy = callPackage ../os-specific/linux/x86_energy_perf_policy { };
 
     zfs = callPackage ../os-specific/linux/zfs {


### PR DESCRIPTION
###### Motivation for this change

Wireguard sounds like a [promising alternative](https://www.wireguard.io/) to openvpn.

The packaging seems fine but I cannot get the example to work, probably because the kernel module is not loaded.

I got the following error when testing

```
$ ip link add dev wg0 type wireguard                                                                       ~
RTNETLINK answers: Operation not supported
```

I don't really know how to go from there, so any help or feedback is welcomed.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
