### PR TITLE
Add Novena platform support

### DIFF
--- a/pkgs/misc/uboot/novena.nix
+++ b/pkgs/misc/uboot/novena.nix
@@ -1,0 +1,46 @@
+{stdenv, fetchurl, unzip}:
+
+# We should enable this check once we have the cross target system information
+# assert stdenv.system == "armv5tel-linux" || crossConfig == "armv5tel-linux";
+
+let
+  version = "v2014.10.r8-novena";
+in stdenv.mkDerivation {
+  name = "uboot-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/xobs/u-boot-novena/archive/${version}.tar.gz";
+    name = "u-boot-novena-${version}.tar.gz";
+    sha256 = "0icdplngdqdk08j0xxmz9zzgnx4h2wg3kiniwx1cpjvm7ynjxslq";
+  };
+
+  configurePhase = ''
+    make novena_config
+  '';
+
+  patchPhase = ''
+    cp include/linux/compiler-gcc{4,5}.h
+  '';
+
+  buildPhase = ''
+    unset src
+    if test -z "$crossConfig"; then
+        make clean all
+    else
+        make clean all ARCH=arm CROSS_COMPILE=$crossConfig-
+    fi
+  '';
+
+  nativeBuildInputs = [ unzip ];
+
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp u-boot.img $out/u-boot.img
+    cp SPL $out/u-boot.spl
+
+    mkdir -p $out/bin
+    cp tools/{mkenvimage,dumpimage,mkimage} $out/bin
+  '';
+}

--- a/pkgs/os-specific/linux/kernel/linux-novena.nix
+++ b/pkgs/os-specific/linux/kernel/linux-novena.nix
@@ -1,0 +1,14 @@
+{ stdenv, fetchurl, perl, buildLinux, ... } @ args:
+
+import ./generic.nix (args // rec {
+  version = "4.4-novena-r9";
+  modDirVersion = "4.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/xobs/novena-linux/archive/v${version}.tar.gz";
+    name = "novena-linux-v${version}.tar.gz";
+    sha256 = "1wcv1y2yxgbcda16v1a2i1dypc1mppslcfdq2if8x0bicn6cb61m";
+  };
+
+  extraMeta.hydraPlatforms = [];
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11792,6 +11792,8 @@ in
 
   ubootGuruplug = callPackage ../misc/uboot/guruplug.nix { };
 
+  ubootNovena = callPackage ../misc/uboot/novena.nix { };
+
   uclibc = callPackage ../os-specific/linux/uclibc { };
 
   uclibcCross = lowPrio (callPackage ../os-specific/linux/uclibc {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11134,6 +11134,8 @@ in
     kernelPatches = [ kernelPatches.bridge_stp_helper ];
   };
 
+  linux_novena = callPackage ../os-specific/linux/kernel/linux-novena.nix { };
+
   linux_3_10 = callPackage ../os-specific/linux/kernel/linux-3.10.nix {
     kernelPatches = with kernelPatches; [ bridge_stp_helper link_lguest link_apm ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
@@ -11381,6 +11383,7 @@ in
   # Build the kernel modules for the some of the kernels.
   linuxPackages_mptcp = self.linuxPackagesFor self.linux_mptcp linuxPackages_mptcp;
   linuxPackages_rpi = self.linuxPackagesFor self.linux_rpi linuxPackages_rpi;
+  linuxPackages_novena = linuxPackagesFor pkgs.linux_novena linuxPackages_novena;
   linuxPackages_3_10 = recurseIntoAttrs (self.linuxPackagesFor self.linux_3_10 linuxPackages_3_10);
   linuxPackages_3_10_tuxonice = self.linuxPackagesFor self.linux_3_10_tuxonice linuxPackages_3_10_tuxonice;
   linuxPackages_3_12 = recurseIntoAttrs (self.linuxPackagesFor self.linux_3_12 linuxPackages_3_12);

--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -394,6 +394,16 @@ rec {
     uboot = null;
   };
 
+  novena = armv7l-hf-multiplatform // {
+    name = "novena";
+    #kernelHeadersBaseConfig = "imx_v6_v7_defconfig";
+    kernelBaseConfig = "imx_v6_v7_defconfig"; # "novena_defconfig";
+    kernelArch = "arm";
+    #uboot = "novena";
+    # Only for uboot = uboot :
+    #ubootConfig = "novena_config";
+  };
+
   armv7l-hf-multiplatform = {
     name = "armv7l-hf-multiplatform";
     kernelMajor = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.

--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -396,9 +396,8 @@ rec {
 
   novena = armv7l-hf-multiplatform // {
     name = "novena";
-    #kernelHeadersBaseConfig = "imx_v6_v7_defconfig";
-    kernelBaseConfig = "imx_v6_v7_defconfig"; # "novena_defconfig";
-    kernelArch = "arm";
+    kernelHeadersBaseConfig = "imx_v6_v7_defconfig";
+    kernelBaseConfig = "novena_defconfig"; # Requires Novena kernel.
     #uboot = "novena";
     # Only for uboot = uboot :
     #ubootConfig = "novena_config";

--- a/pkgs/top-level/platforms.nix
+++ b/pkgs/top-level/platforms.nix
@@ -396,9 +396,8 @@ rec {
 
   novena = armv7l-hf-multiplatform // {
     name = "novena";
-    kernelHeadersBaseConfig = "imx_v6_v7_defconfig";
     kernelBaseConfig = "novena_defconfig"; # Requires Novena kernel.
-    #uboot = "novena";
+    uboot = "novena";
     # Only for uboot = uboot :
     #ubootConfig = "novena_config";
   };


### PR DESCRIPTION
###### Motivation for this change

This set of patches adds the 'novena' platform, the 'novena' variant and 'novena' u-boot package. With this you can now run NixOS on your Novena! At least as a terminal, there's still a lot more to be done.

Pinging @viric for possible review on this since I've spoken about this before
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Sent from my Novena. ;)
