### PR TITLE
fcitx: refactor

### DIFF
--- a/nixos/modules/i18n/input-method/fcitx.nix
+++ b/nixos/modules/i18n/input-method/fcitx.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.i18n.inputMethod.fcitx;
-  fcitxPackage = pkgs.fcitx-with-plugins.override { plugins = cfg.engines; };
+  fcitxPackage = pkgs.fcitx.override { plugins = cfg.engines; };
   fcitxEngine = types.package // {
     name  = "fcitx-engine";
     check = x: (lib.types.package.check x) && (attrByPath ["meta" "isFcitxEngine"] false x);

--- a/pkgs/tools/inputmethods/fcitx/default.nix
+++ b/pkgs/tools/inputmethods/fcitx/default.nix
@@ -1,51 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, cmake, intltool, gettext
-, libxml2, enchant, isocodes, icu, libpthreadstubs
-, pango, cairo, libxkbfile, libXau, libXdmcp, libxkbcommon
-, dbus, gtk2, gtk3, qt4, kde5
-}:
+{ callPackage, plugins ? [] }:
 
-stdenv.mkDerivation rec {
-  name = "fcitx-${version}";
-  version = "4.2.9.1";
-
-  src = fetchurl {
-    url    = "http://download.fcitx-im.org/fcitx/${name}_dict.tar.xz";
-    sha256 = "0xvcmm4yi7kagf55d0yl3ql5ssbkm9410fwbz3kd988pchichdsk";
+let 
+  unwrapped = callPackage ./unwrapped.nix { };
+  wrapped   = callPackage ./wrapper.nix {
+    plugins = plugins;
+    fcitx   = unwrapped;
   };
-
-  postUnpack = ''
-    ln -s ${kde5.extra-cmake-modules}/share/ECM/modules/ECMFindModuleHelpers.cmake \
-      $sourceRoot/cmake/
-  '';
-
-  patches = [ ./fcitx-ecm.patch ];
-
-  postPatch = ''
-    substituteInPlace src/frontend/qt/CMakeLists.txt \
-      --replace $\{QT_PLUGINS_DIR} $out/lib/qt4/plugins
-  '';
-
-  buildInputs = [
-    cmake enchant gettext isocodes pkgconfig intltool icu
-    libpthreadstubs libXau libXdmcp libxkbfile libxkbcommon libxml2
-    dbus cairo gtk2 gtk3 pango qt4
-  ];
-
-  cmakeFlags = ''
-    -DENABLE_QT_IM_MODULE=ON
-    -DENABLE_GTK2_IM_MODULE=ON
-    -DENABLE_GTK3_IM_MODULE=ON
-    -DENABLE_GIR=OFF
-    -DENABLE_OPENCC=OFF
-    -DENABLE_PRESAGE=OFF
-    -DENABLE_XDGAUTOSTART=OFF
-  '';
-
-  meta = with stdenv.lib; {
-    homepage    = "https://github.com/fcitx/fcitx";
-    description = "A Flexible Input Method Framework";
-    license     = licenses.gpl2;
-    platforms   = platforms.linux;
-    maintainers = with maintainers; [ ericsagnes ];
-  };
-}
+in if plugins == [] 
+   then unwrapped
+   else wrapped

--- a/pkgs/tools/inputmethods/fcitx/unwrapped.nix
+++ b/pkgs/tools/inputmethods/fcitx/unwrapped.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchurl, pkgconfig, cmake, intltool, gettext
+, libxml2, enchant, isocodes, icu, libpthreadstubs
+, pango, cairo, libxkbfile, libXau, libXdmcp, libxkbcommon
+, dbus, gtk2, gtk3, qt4, kde5
+}:
+
+stdenv.mkDerivation rec {
+  name = "fcitx-${version}";
+  version = "4.2.9.1";
+
+  src = fetchurl {
+    url    = "http://download.fcitx-im.org/fcitx/${name}_dict.tar.xz";
+    sha256 = "0xvcmm4yi7kagf55d0yl3ql5ssbkm9410fwbz3kd988pchichdsk";
+  };
+
+  postUnpack = ''
+    ln -s ${kde5.extra-cmake-modules}/share/ECM/modules/ECMFindModuleHelpers.cmake \
+      $sourceRoot/cmake/
+  '';
+
+  patches = [ ./fcitx-ecm.patch ];
+
+  postPatch = ''
+    substituteInPlace src/frontend/qt/CMakeLists.txt \
+      --replace $\{QT_PLUGINS_DIR} $out/lib/qt4/plugins
+  '';
+
+  buildInputs = [
+    cmake enchant gettext isocodes pkgconfig intltool icu
+    libpthreadstubs libXau libXdmcp libxkbfile libxkbcommon libxml2
+    dbus cairo gtk2 gtk3 pango qt4
+  ];
+
+  cmakeFlags = ''
+    -DENABLE_QT_IM_MODULE=ON
+    -DENABLE_GTK2_IM_MODULE=ON
+    -DENABLE_GTK3_IM_MODULE=ON
+    -DENABLE_GIR=OFF
+    -DENABLE_OPENCC=OFF
+    -DENABLE_PRESAGE=OFF
+    -DENABLE_XDGAUTOSTART=OFF
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = "https://github.com/fcitx/fcitx";
+    description = "A Flexible Input Method Framework";
+    license     = licenses.gpl2;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ericsagnes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1496,7 +1496,9 @@ in
 
   fatsort = callPackage ../tools/filesystems/fatsort { };
 
-  fcitx = callPackage ../tools/inputmethods/fcitx { };
+  fcitx = callPackage ../tools/inputmethods/fcitx {
+    plugins = [];
+  };
 
   fcitx-engines = recurseIntoAttrs {
 
@@ -1519,10 +1521,6 @@ in
   };
 
   fcitx-configtool = callPackage ../tools/inputmethods/fcitx/fcitx-configtool.nix { };
-
-  fcitx-with-plugins = callPackage ../tools/inputmethods/fcitx/wrapper.nix {
-    plugins = [ ];
-  };
 
   fcppt = callPackage ../development/libraries/fcppt/default.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Inspired by the [pidgin](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/instant-messengers/pidgin/default.nix) package, this merge `fcitx-with-plugins` in `fcitx`.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
