### PR TITLE
firefox-developer-bin: fix hashes

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -42,12 +42,9 @@ assert stdenv.isLinux;
 
 let
 
-  generated = if channel == "stable" then (import ./sources.nix)
-         else if channel == "beta"   then (import ./beta_sources.nix)
-         else if channel == "developer"   then { version = "49.0a2"; sources = [
-            { locale = "en-US"; arch = "linux-i686"; sha512 = "45dad182bf7a4e753c1be6b8f966393a06531e7b5530238d20cb67b26324e8f5d0eeec983a0855418f31187d3ae508c28810ab86269848b4e48ab2ca3b5d21e7"; }
-            { locale = "en-US"; arch = "linux-x86_64"; sha512 = "cfcbfc633b51612a62267c8a1afc25af212eb832d1fa876a1ffd82421e9378f96b3ac1488446f804518290abd99c21c9f10e4d0e0f699432aeb74b63305d7edc"; }
-          ]; }
+  generated = if channel == "stable"    then (import ./sources.nix)
+         else if channel == "beta"      then (import ./beta_sources.nix)
+         else if channel == "developer" then (import ./dev_sources.nix)
          else builtins.abort "Wrong channel! Channel must be one of `stable`, `beta` or `developer`";
 
   inherit (generated) version sources;

--- a/pkgs/applications/networking/browsers/firefox-bin/dev_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/dev_sources.nix
@@ -1,0 +1,12 @@
+# This file is generated from generate_sources_dev.rb. DO NOT EDIT.
+# Execute the following command to update the file.
+#
+# ruby generate_sources_dev.rb 49.0a2 > dev_sources.nix
+
+{
+  version = "49.0a2";
+  sources = [
+    { locale = "en-US"; arch = "linux-i686"; sha512 = "85c4289e561d2246f96a05e3b8df011337984b9f176670826a705c2cd68a1284056ba507e4b6e4887595bf37f25386d9f7b28a20bc1f125865b9fd7b8be17eaa"; }
+    { locale = "en-US"; arch = "linux-x86_64"; sha512 = "2bf9518dbfbb48348f74929c19d03e8daf51020bf9ba6db577a202b6e98ad7ffb9e9a0b4ca92af010cd3f864ae84940b65438f4230e6de3165f72e4e7280086d"; }
+  ];
+}

--- a/pkgs/applications/networking/browsers/firefox-bin/generate_sources_dev.rb
+++ b/pkgs/applications/networking/browsers/firefox-bin/generate_sources_dev.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+require "open-uri"
+
+version =
+  if ARGV.empty?
+    $stderr.puts("Usage: ruby generate_sources_dev.rb <version> > dev_sources.nix")
+    exit(-1)
+  else
+    ARGV[0]
+  end
+
+base_url = "http://download-installer.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-aurora"
+
+arches = ["linux-i686", "linux-x86_64"]
+locales = ["en-US"]
+sources = []
+
+Source = Struct.new(:hash, :arch, :locale, :filename)
+
+locales.each do |locale|
+  arches.each do |arch|
+    basename = "firefox-#{version}.#{locale}.#{arch}"
+    filename = basename + ".tar.bz2"
+    sha512 = open("#{base_url}/#{basename}.checksums").each_line
+      .find(filename).first
+      .split(" ").first
+    sources << Source.new(sha512, arch, locale, filename)
+  end
+end
+
+sources = sources.sort_by do |source|
+  [source.locale, source.arch]
+end
+
+puts(<<"EOH")
+# This file is generated from generate_sources_dev.rb. DO NOT EDIT.
+# Execute the following command to update the file.
+#
+# ruby generate_sources_dev.rb 49.0a2 > dev_sources.nix
+
+{
+  version = "#{version}";
+  sources = [
+EOH
+
+sources.each do |source|
+  puts(%Q|    { locale = "#{source.locale}"; arch = "#{source.arch}"; sha512 = "#{source.hash}"; }|)
+end
+
+puts(<<'EOF')
+  ];
+}
+EOF


### PR DESCRIPTION
###### Motivation for this change

Hashes where broken
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

the nightly tend to get replaced in-place on the FTP and so benefit from
an update script as well
