### PR TITLE
Create package for libqrencode

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -15,6 +15,7 @@
   adev = "Adrien Devresse <adev@adev.name>";
   Adjective-Object = "Maxwell Huang-Hobbs <mhuan13@gmail.com>";
   adnelson = "Allen Nelson <ithinkican@gmail.com>";
+  adolfogc = "Adolfo E. García Castro <adolfo.garcia.cr@gmail.com>";
   aespinosa = "Allan Espinosa <allan.espinosa@outlook.com>";
   aflatter = "Alexander Flatter <flatter@fastmail.fm>";
   aforemny = "Alexander Foremny <alexanderforemny@googlemail.com>";

--- a/pkgs/development/libraries/libqrencode/default.nix
+++ b/pkgs/development/libraries/libqrencode/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, autoconf, automake, pkgconfig,
+  libtool, SDL2, libpng }:
+
+stdenv.mkDerivation rec {
+  name = "libqrencode-${version}";
+  version = "3.4.4";
+
+  src = fetchurl {
+    url = "https://fukuchi.org/works/qrencode/qrencode-${version}.tar.gz";
+    sha1 = "644054a76c8b593acb66a8c8b7dcf1b987c3d0b2";
+    sha256 = "0wiagx7i8p9zal53smf5abrnh9lr31mv0p36wg017401jrmf5577";
+  };
+
+  buildInputs = [ autoconf automake pkgconfig libtool SDL2 libpng ];
+
+  propagatedBuildInputs = [ SDL2 libpng ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "http://fukuchi.org/works/qrencode/";
+    description = "A C library for encoding data in a QR Code symbol";
+
+    longDescription = ''
+      Libqrencode is a C library for encoding data in a QR Code symbol,
+      a kind of 2D symbology that can be scanned by handy terminals
+      such as a mobile phone with CCD.
+    '';
+
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libqrencode/default.nix
+++ b/pkgs/development/libraries/libqrencode/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     '';
 
     license = licenses.gpl2Plus;
+    maintainers = [ maintainers.adolfogc ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2367,6 +2367,8 @@ in
 
   libqmi = callPackage ../development/libraries/libqmi { };
 
+  libqrencode = callPackage ../development/libraries/libqrencode { };
+  
   libmbim = callPackage ../development/libraries/libmbim { };
 
   libmongo-client = callPackage ../development/libraries/libmongo-client { };
@@ -15603,7 +15605,7 @@ in
   soi = callPackage ../games/soi {
     lua = lua5_1;
   };
-  
+
   solarus = callPackage ../games/solarus { };
 
   # You still can override by passing more arguments.


### PR DESCRIPTION
###### Motivation for this change

Create package for libqrencode, a library written in C for encoding data in QR Code symbols. See more information about this library at: https://fukuchi.org/works/qrencode/
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [X] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
