### PR TITLE
wine: 1.9.13 -> 1.9.14

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -102,6 +102,6 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
     homepage = "http://www.winehq.org/";
     license = "LGPL";
     description = "An Open Source implementation of the Windows API on top of X, OpenGL, and Unix";
-    maintainers = [stdenv.lib.maintainers.raskin];
+    maintainers = with stdenv.lib.maintainers; [ avnik raskin ];
   };
 })

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -30,9 +30,9 @@ in rec {
   };
 
   unstable = fetchurl rec {
-    version = "1.9.13";
+    version = "1.9.14";
     url = "mirror://sourceforge/wine/wine-${version}.tar.bz2";
-    sha256 = "1nf06xgnda7y5ngnf8v14zaa0lnxzi1hxx7pf3jz2a0zswcq0rwv";
+    sha256 = "0b65j8lc2axyc7lpa5rjr7vbjz4y78gkd7hhmvhra78pmwf9dgkz";
     inherit (stable) mono;
     gecko32 = fetchurl rec {
       version = "2.44";
@@ -48,7 +48,7 @@ in rec {
 
   staging = fetchFromGitHub rec {
     inherit (unstable) version;
-    sha256 = "0iw14dwl91i5nd6wfr5i2vvii2w6j0sh95syc46z6yjgvxd14waq";
+    sha256 = "0582ylrvl7racpb0il3wmbivb2d7lh6n3mymh19yw94qzgifwqrw";
     owner = "wine-compholio";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
###### Motivation for this change

Update wine and wineStaging for latest releases.
Basic wine functionality was tested.
Only 32bit version was built and tested
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Update wineUnstable: 1.9.13 -> 1.9.14
- Update staging: 1.9.13 -> 1.9.14
- Add myself as co-maintainer, because I am do regular updates.
