### PR TITLE
mypy-lang: init at 0.4.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -232,6 +232,7 @@
   markus1189 = "Markus Hauck <markus1189@gmail.com>";
   markWot = "Markus Wotringer <markus@wotringer.de>";
   martijnvermaat = "Martijn Vermaat <martijn@vermaat.name>";
+  martingms = "Martin Gammelsæter <martin@mg.am>";
   matejc = "Matej Cotman <cotman.matej@gmail.com>";
   mathnerd314 = "Mathnerd314 <mathnerd314.gph+hs@gmail.com>";
   matthiasbeyer = "Matthias Beyer <mail@beyermatthias.de>";

--- a/pkgs/development/tools/mypy-lang/default.nix
+++ b/pkgs/development/tools/mypy-lang/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, python35Packages }:
+
+python35Packages.buildPythonApplication rec {
+  name = "mypy-lang-${version}";
+  version = "0.4.2";
+
+  # Tests not included in pip package.
+  doCheck = false;
+
+  src = fetchurl {
+    url = "mirror://pypi/m/mypy-lang/${name}.tar.gz";
+    sha256 = "12vwgzbpv0n403dvzas5ckw0f62slqk5j3024y65hi9n95r34rws";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Optional static typing for Python";
+    homepage    = "http://www.mypy-lang.org";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ martingms ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6705,6 +6705,8 @@ in
 
   grabserial = callPackage ../development/tools/grabserial { };
 
+  mypy-lang = callPackage ../development/tools/mypy-lang { };
+
 
   ### DEVELOPMENT / LIBRARIES
 


### PR DESCRIPTION
###### Motivation for this change

mypy is a static type checker for Python programs, supporting versions from 2.7 and up.
Description from [http://www.mypy-lang.org](http://www.mypy-lang.org):

>  Mypy is an experimental optional static type checker for Python that aims to combine the benefits of dynamic (or "duck") typing and static typing. Mypy combines the expressive power and convenience of Python with a powerful type system and compile-time type checking. Mypy type checks standard Python programs; run them using any Python VM with basically no runtime overhead.
> 
> Mypy is still in development. Most Python features are supported. 

This package provides `mypy` for static checking, and `stubgen` for generating stubs for modules.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
