### PR TITLE
lfe: init at 1.1.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -422,6 +422,7 @@
   wscott = "Wayne Scott <wsc9tt@gmail.com>";
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
   yarr = "Dmitry V. <savraz@gmail.com>";
+  yurrriq = "Eric Bailey <eric@ericb.me>";
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";
   zagy = "Christian Zagrodnick <cz@flyingcircus.io>";
   zef = "Zef Hemel <zef@zef.me>";

--- a/pkgs/development/interpreters/lfe/default.nix
+++ b/pkgs/development/interpreters/lfe/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchFromGitHub, erlang, makeWrapper, coreutils, bash }:
+
+stdenv.mkDerivation rec {
+  name    = "lfe-${version}";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner  = "rvirding";
+    repo   = "lfe";
+    rev    = version;
+    sha256 = "0w1vpjqj8ni43gi84i0mcml4gfaqhmmd9s46di37cngpdw86i3bz";
+  };
+
+  buildInputs = [ erlang makeWrapper ];
+
+  setupHook   = ./setup-hook.sh;
+
+  # These installPhase tricks are based on Elixir's Makefile.
+  # TODO: Make, upload, and apply a patch.
+  installPhase = ''
+    local libdir=$out/lib/lfe
+    local ebindir=$libdir/ebin
+    local bindir=$libdir/bin
+
+    rm -Rf $ebindir
+    install -m755 -d $ebindir
+    install -m644 ebin/* $ebindir
+
+    install -m755 -d $bindir
+    for bin in bin/lfe{,c,doc,script}; do install -m755 $bin $bindir; done
+
+    install -m755 -d $out/bin
+    for file in $bindir/*; do ln -sf $file $out/bin/; done
+  '';
+
+  # Thanks again, Elixir.
+  postFixup = ''
+    # LFE binaries are shell scripts which run erl and lfe.
+    # Add some stuff to PATH so the scripts can run without problems.
+    for f in $out/bin/*; do
+      wrapProgram $f \
+        --prefix PATH ":" "${erlang}/bin:${coreutils}/bin:${bash}/bin:$out/bin"
+      substituteInPlace $f --replace "/usr/bin/env" "${coreutils}/bin/env"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description     = "The best of Erlang and of Lisp; at the same time!";
+    longDescription = ''
+      LFE, Lisp Flavoured Erlang, is a lisp syntax front-end to the Erlang
+      compiler. Code produced with it is compatible with "normal" Erlang
+      code. An LFE evaluator and shell is also included.
+    '';
+
+    homepage     = "http://lfe.io";
+    downloadPage = "https://github.com/rvirding/lfe/releases";
+
+    license      = licenses.asl20;
+    maintainers  = with maintainers; [ yurrriq ];
+    platforms    = platforms.unix;
+  };
+}

--- a/pkgs/development/interpreters/lfe/setup-hook.sh
+++ b/pkgs/development/interpreters/lfe/setup-hook.sh
@@ -1,0 +1,5 @@
+addLfeLibPath() {
+    addToSearchPath ERL_LIBS $1/lib/lfe/lib
+}
+
+envHooks+=(addLfeLibPath)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2366,7 +2366,7 @@ in
   libqmi = callPackage ../development/libraries/libqmi { };
 
   libqrencode = callPackage ../development/libraries/libqrencode { };
-  
+
   libmbim = callPackage ../development/libraries/libmbim { };
 
   libmongo-client = callPackage ../development/libraries/libmongo-client { };
@@ -5650,6 +5650,8 @@ in
   relxExe = callPackage ../development/tools/erlang/relx-exe {};
 
   elixir = callPackage ../development/interpreters/elixir { debugInfo = true; };
+
+  lfe = callPackage ../development/interpreters/lfe { };
 
   groovy = callPackage ../development/interpreters/groovy { };
 


### PR DESCRIPTION
###### Motivation for this change

Add an LFE (Lisp Flavoured Erlang) package.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a first pass at adding an LFE package.

N.B. man pages are ignored for now. Related: rvirding/lfe#250

I can't seem to get `make travis` (`rebar3 do eunit, ct`) to work either, since PropEr is considered unbuildable...
