### PR TITLE
conky: 1.10.1 -> 1.10.3

### DIFF
--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, cmake
 
 # dependencies
-, glib
+, glib, libXinerama
 
 # optional features without extra dependencies
 , mpdSupport          ? true
@@ -62,13 +62,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "conky-${version}";
-  version = "1.10.1";
+  version = "1.10.3";
 
   src = fetchFromGitHub {
     owner = "brndnmtthws";
     repo = "conky";
     rev = "v${version}";
-    sha256 = "0k93nqx8mxz2z84zzwpwfp7v7dwxwg1di1a2yb137lk7l157azw6";
+    sha256 = "0sa2jl159jk5p2hr37adwq84m0ynva7v87qrwj1xv0kw8l4qzhjs";
   };
 
   postPatch = ''
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = "-lgcc_s";
 
-  buildInputs = [ pkgconfig glib cmake ]
+  buildInputs = [ pkgconfig glib cmake libXinerama ]
     ++ optionals docsSupport        [ docbook2x libxslt man less ]
     ++ optional  ncursesSupport     ncurses
     ++ optional  x11Support         xlibsWrapper


### PR DESCRIPTION
###### Motivation for this change

Update to latest release
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
