### PR TITLE
mypy-lang: Add missing lxml dependency

### DIFF
--- a/pkgs/development/tools/mypy-lang/default.nix
+++ b/pkgs/development/tools/mypy-lang/default.nix
@@ -12,6 +12,8 @@ python35Packages.buildPythonApplication rec {
     sha256 = "12vwgzbpv0n403dvzas5ckw0f62slqk5j3024y65hi9n95r34rws";
   };
 
+  propagatedBuildInputs = with python35Packages; [ lxml ];
+
   meta = with stdenv.lib; {
     description = "Optional static typing for Python";
     homepage    = "http://www.mypy-lang.org";


### PR DESCRIPTION
###### Motivation for this change

mypy-lang package was added yesterday, but some `mypy` options (like `--*-report`-options) requires lxml which was not included. This patch adds lxml as a dependency.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
