### PR TITLE
wireguard: split module and tools

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchgit, libmnl, kernel }:
+{ stdenv, fetchgit, libmnl, kernel ? null }:
 
-stdenv.mkDerivation rec {
+let
   name = "wireguard-${version}";
+
   version = "20160708";
 
   src = fetchgit {
@@ -10,25 +11,45 @@ stdenv.mkDerivation rec {
     sha256 = "1ciyjpp8c3fv95y1cypk9qyqynp8cqyh2676afq2hd33110d37ni";
   };
 
-  preConfigure = ''
-    cd src
-    sed -i /depmod/d Makefile
-  '';
-  
-  buildInputs = [ libmnl ];
-
-  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
-
-  makeFlags = [ 
-    "DESTDIR=$(out)" 
-    "PREFIX=/"
-    "INSTALL_MOD_PATH=$(out)" 
-  ];
-
   meta = with stdenv.lib; {
     homepage    = https://www.wireguard.io/;
     description = "Fast, modern, secure VPN tunnel";
     license     = licenses.gpl2;
     platforms   = platforms.linux;
   };
-}
+
+  module = stdenv.mkDerivation {
+    inherit src meta name;
+
+    preConfigure = ''
+      cd src
+      sed -i '/depmod/,+1d' Makefile
+    '';
+
+    KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+    INSTALL_MOD_PATH = "\${out}";
+
+    buildPhase = "make module";
+
+  };
+
+  tools = stdenv.mkDerivation {
+    inherit src meta name;
+
+    preConfigure = "cd src";
+
+    buildInputs = [ libmnl ];
+
+    makeFlags = [
+      "DESTDIR=$(out)"
+      "PREFIX=/"
+      "-C" "tools"
+    ];
+
+    buildPhase = "make tools";
+
+  };
+
+in if kernel == null
+   then tools
+   else module

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11107,7 +11107,7 @@ in
 
     virtualboxGuestAdditions = callPackage ../applications/virtualization/virtualbox/guest-additions { };
 
-    wireguard = callPackage ../os-specific/linux/wireguard {};
+    wireguard = callPackage ../os-specific/linux/wireguard { };
 
     x86_energy_perf_policy = callPackage ../os-specific/linux/x86_energy_perf_policy { };
 
@@ -14885,6 +14885,8 @@ in
   winswitch = callPackage ../tools/X11/winswitch { };
 
   wings = callPackage ../applications/graphics/wings { };
+
+  wireguard = callPackage ../os-specific/linux/wireguard { };
 
   wmname = callPackage ../applications/misc/wmname { };
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/16856#issuecomment-231968818

cc @fpletz 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
