### PR TITLE
libsoup: 2.52.2 -> 2.54.1 & valaSupport

### DIFF
--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -1,33 +1,41 @@
 { stdenv, fetchurl, glib, libxml2, pkgconfig
-, gnomeSupport ? false, libgnome_keyring, sqlite, glib_networking, gobjectIntrospection
+, gnomeSupport ? true, libgnome_keyring, sqlite, glib_networking, gobjectIntrospection
+, valaSupport ? true, vala
 , libintlOrEmpty
 , intltool, python }:
 let
-  majorVersion = "2.52";
-  version = "${majorVersion}.2";
+  majorVersion = "2.54";
+  version = "${majorVersion}.1";
 in
 stdenv.mkDerivation {
   name = "libsoup-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/libsoup/${majorVersion}/libsoup-${version}.tar.xz";
-    sha256 = "1p4k40y2gikr6m8p3hm0vswdzj2pj133dckipd2jk5bxbj5n4mfv";
+    sha256 = "0cyn5pq4xl1gb8413h2p4d5wrn558dc054zhwmk4swrl40ijrd27";
   };
 
-  patchPhase = ''
+  prePatch = ''
     patchShebangs libsoup/
+  '' + stdenv.lib.optionalString valaSupport
+  ''
+     substituteInPlace libsoup/Makefile.in --replace "\$(DESTDIR)\$(vapidir)" "\$(DESTDIR)\$(girdir)/../vala/vapi"
   '';
 
   outputs = [ "dev" "out" ];
 
-  buildInputs = libintlOrEmpty ++ [ intltool python sqlite ];
+  buildInputs = libintlOrEmpty ++ [ intltool python sqlite ]
+    ++ stdenv.lib.optionals valaSupport [ vala ];
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ glib libxml2 gobjectIntrospection ]
     ++ stdenv.lib.optionals gnomeSupport [ libgnome_keyring ];
   passthru.propagatedUserEnvPackages = [ glib_networking.out ];
 
   # glib_networking is a runtime dependency, not a compile-time dependency
-  configureFlags = "--disable-tls-check --enable-vala=no" + stdenv.lib.optionalString (!gnomeSupport) " --without-gnome";
+  configureFlags = "--disable-tls-check"
+    + stdenv.lib.optionalString (!valaSupport) " --enable-vala=no"
+    + stdenv.lib.optionalString (valaSupport) " --enable-vala=yes"
+    + stdenv.lib.optionalString (!gnomeSupport) " --without-gnome";
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 


### PR DESCRIPTION
###### Motivation for this change

I had some libsoup build errors trying to update Midori. ~~I haven't gotten around them yet but~~ I updated this library and enabled the valaSupport with a nifty _Makefile.in_ trick to workaround it trying to write into the vala store directory.

Midori's PR is now ready and available at https://github.com/NixOS/nixpkgs/pull/17142.

Note: The gnome support ( _libgnome_keyring_ as a _buildInput_ ) is now turned on by default. I went over all the libsoup dependent packages and almost all of them are knee deep in gnome anyhow. Besides _gksu_ depends on it so something is bound to drag it along one way or another.

Here's the relevant change-logs:

```
Changes in libsoup from 2.52.1 to 2.53.1:

    * Really fixed build under MinGW for sure this time [Ignacio
          Casal Quinteiro]

        * Fixed SoupServer Web Sockets code so that the
      SoupClientContext passed to a SoupServerWebsocketCallback is
      fully usable (rather than crashing when you try to do most
      things).

Changes in libsoup from 2.53.1 to 2.53.2:

    * Fixed up symbol visibility handling for mingw by copying
          GLib's system [Ignacio Casal Quinteiro, #757146]

    * Finally marked the old SoupSessionAsync and SoupSessionSync
          methods as deprecated [Ignacio Casal Quinteiro, Dan Winship,
          #757146]

    * Added libsoup-2.4.deps for valac [Rico Tzschichholz]

    * Make it possible to build from git without gtk-doc being
          installed [Ignacio Casal Quinteiro]

    * Updated translations:
      Norwegian bokmÃ¥l, Occitan

Changes in libsoup from 2.53.2 to 2.53.90:

    * NUL bytes in headers are now ignored [#760832, Dan Winship]

    * Fixed transfer annotation of soup_form_decode* functions
          [#743966, Lionel Landwerlin]

    * Updated translations:
      Bulgarian, Latvian, Norwegian bokmÃ¥l

Changes in libsoup from 2.53.90 to 2.53.92:

    * libsoup now supports HTTP "Negotiate"/GSSAPI/Kerberos
          authentication. It must be enabled specifically by the
          application and is also subject to certain other
          restrictions, some of which are not yet controllable through
          the API. [#587145, Guido Guenther, Tomas Popela, David
          Woodhouse, Dan Winship]

    * Added support for building under MSVC [#758759, Chun-wei
          Fan]

    * Fixed a problem with the 2.53.90 tarball that caused
          translations to be mis-installed.

    * Updated translations:
      Occitan

Changes in libsoup from 2.53.92 to 2.54.0.1:

    * (2.54.0.1 fixes a build problem with the 2.54.0 tarball,
          which would not build if you configured with
          "--without-gnome". There are no other changes between 2.54.0
          and 2.54.0.1.)

Changes in libsoup from 2.53.92 to 2.54.0:

    * Fixed examples/simple-httpd on Windows [#758759, Chun-wei
          Fan]

Changes in libsoup from 2.54.0.1 to 2.54.1:

    * *** IMPORTANT ***
          Fixed an ABI break in 2.54.0 caused by adding a member to
          SoupAuthClass; 2.54.1 is ABI-compatible with 2.53.92 and
          earlier, but NOT with the anomalous 2.54.0. If you built
          packages against 2.54.0, you will need to rebuild them
          against 2.54.1.

    * Fixed NTLM authentication when ntlm_auth from the latest
          version of Samba is present. [#765106, Milan Crha]

    * Updates to MSVC build, including for GSS-API support
          [Chun-wei Fan]

    * Updated translations:
      Friulian
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
