### PR TITLE
systemd-bootchart

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -503,6 +503,7 @@
   ./services/x11/xserver.nix
   ./system/activation/activation-script.nix
   ./system/activation/top-level.nix
+  ./system/boot/bootchart.nix
   ./system/boot/coredump.nix
   ./system/boot/emergency-mode.nix
   ./system/boot/initrd-network.nix

--- a/nixos/modules/system/boot/bootchart.nix
+++ b/nixos/modules/system/boot/bootchart.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.boot.bootchart;
+
+in
+
+{
+
+  options = {
+
+    boot.bootchart.enable = mkEnableOption "systemd-bootchart, boot performance analysis tool";
+
+    boot.bootchart.extraConfig = mkOption {
+      default = "";
+      type = types.lines;
+      example = "Samples=500";
+      description = ''
+        Extra config options for systemd-bootchart. See man bootchart.conf
+        for available options.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    boot.stage2Init = "${pkgs.systemd-bootchart}/lib/systemd/systemd-bootchart";
+
+    environment.etc."systemd/bootchart.conf".text = ''
+      [Bootchart]
+      ${cfg.extraConfig}
+    '';
+
+    system.requiredKernelConfig = map config.lib.kernelConfig.isYes [ "SCHEDSTATS" "SCHED_DEBUG" ];
+
+  };
+
+}

--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -206,7 +206,6 @@ exec {logOutFd}>&- {logErrFd}>&-
 
 # Start systemd.
 echo "starting systemd..."
-PATH=/run/current-system/systemd/lib/systemd \
-    MODULE_DIR=/run/booted-system/kernel-modules/lib/modules \
+MODULE_DIR=/run/booted-system/kernel-modules/lib/modules \
     LOCALE_ARCHIVE=/run/current-system/sw/lib/locale/locale-archive \
-    exec systemd
+    exec @stage2Init@

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -20,7 +20,7 @@ let
     src = ./stage-2-init.sh;
     shellDebug = "${pkgs.bashInteractive}/bin/bash";
     isExecutable = true;
-    inherit (config.boot) devShmSize runSize;
+    inherit (config.boot) devShmSize runSize stage2Init;
     inherit (config.nix) readOnlyStore;
     inherit (config.networking) useHostResolvConf;
     ttyGid = config.ids.gids.tty;
@@ -79,6 +79,15 @@ in
         description = ''
           Size limit for the /run tmpfs. Look at mount(8), tmpfs size option,
           for the accepted syntax.
+        '';
+      };
+
+      stage2Init = mkOption {
+        default = "/run/current-system/systemd/lib/systemd/systemd";
+        type = types.str;
+        internal = true;
+        description = ''
+          Init daemon which is executed at the end of stage 2 init.
         '';
       };
 

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -39,7 +39,8 @@ with stdenv.lib;
     DEBUG_STACKOVERFLOW n
   ''}
   RCU_TORTURE_TEST n
-  SCHEDSTATS n
+  SCHEDSTATS y
+  SCHED_DEBUG y
   DETECT_HUNG_TASK y
 
   # Unix domain sockets.

--- a/pkgs/os-specific/linux/systemd/bootchart.nix
+++ b/pkgs/os-specific/linux/systemd/bootchart.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, intltool, pkgconfig, libtool
+, libxslt, docbook_xsl, docbook_xml_dtd_45, systemd }:
+
+assert stdenv.isLinux;
+
+stdenv.mkDerivation rec {
+  version = "230";
+  name = "systemd-bootchart-${version}";
+
+  src = fetchFromGitHub {
+    owner = "systemd";
+    repo = "systemd-bootchart";
+    rev = "v${version}";
+    sha256 = "1dbscx7hsvn6a5rbjfmpskwnp0n2hpwdb8n85gssnlmxas7cw72f";
+  };
+
+  nativeBuildInputs = [
+    autoconf automake intltool pkgconfig libtool libxslt docbook_xsl
+    docbook_xml_dtd_45
+  ];
+
+  buildInputs = [ systemd ];
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--with-rootprefix=$(out)"
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    ''-UROOTLIBEXECDIR'' ''-DROOTLIBEXECDIR="/run/current-system/systemd/lib/systemd"''
+    ''-USYSTEMD_BINARY_PATH'' ''-DSYSTEMD_BINARY_PATH="/run/current-system/systemd/lib/systemd/systemd"''
+  ];
+
+  installFlags = [
+    "sysconfdir=$(out)/etc"
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/systemd/systemd-bootchart";
+    description = "Boot performance graphing tool";
+    platforms = platforms.linux;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11369,6 +11369,8 @@ in
       udev.lib = libudev.out; # ${systemd.udev.lib}/lib/libudev.*
     };
 
+  systemd-bootchart = callPackage ../os-specific/linux/systemd/bootchart.nix { };
+
   # standalone cryptsetup generator for systemd
   systemd-cryptsetup-generator = callPackage ../os-specific/linux/systemd/cryptsetup-generator.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

I was looking at possibility of implementing this as per [mailing list question](http://thread.gmane.org/gmane.linux.distributions.nixos/20984), became motivated, this and that and I ended up implementing most of the thing ~_^.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

TODO:
- [x] Testing that it produces desired results (returned SVG seems suspicious to me because it shows no processes);
- [ ] Ensuring that kernel config change is okay; let's ping Eelco once we've made sure that this actually works. FWIW, `SCHEDSTATS` is already enabled in Ubuntu (tested first-hand), Fedora (as per [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=1013225)) and Arch ([config](https://git.archlinux.org/svntogit/packages.git/tree/trunk/config.x86_64?h=packages/linux)). People at Fedora's bugtracker suggest that there's no visible performance impact, and this generally seems useful.
