### PR TITLE
smbldaptools: 0.9.10 -> 0.9.11

### DIFF
--- a/pkgs/tools/networking/smbldaptools/default.nix
+++ b/pkgs/tools/networking/smbldaptools/default.nix
@@ -1,13 +1,13 @@
 {stdenv, fetchurl, perl, NetLDAP, makeWrapper, CryptSmbHash, DigestSHA1}:
 
 let
-  version = "0.9.10";
+  version = "0.9.11";
 in
 stdenv.mkDerivation {
   name = "smbldap-tools-${version}";
   src = fetchurl {
     url = "http://download.gna.org/smbldap-tools/sources/${version}/smbldap-tools-${version}.tar.gz";
-    sha256 = "19hsvslfs61pk9nhyqdkd68gc95z26kpkmsj10b8zvzlhqmwdvy4";
+    sha256 = "1xcxmpz74r82vjp731axyac3cyksfiarz9jk5g5m2bzfdixkq9mz";
   };
 
   buildInputs = [ perl NetLDAP makeWrapper CryptSmbHash DigestSHA1 ];
@@ -27,7 +27,5 @@ stdenv.mkDerivation {
     homepage = http://gna.org/projects/smbldap-tools/;
     description = "SAMBA LDAP tools";
     license = stdenv.lib.licenses.gpl2Plus;
-    # pod2man: unable to format smbldap-config.cmd
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Issue has been [fixed](https://gna.org/support/?3013) in the latest upstream release
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
