### PR TITLE
nixos-version: fix syntax error and add -h

### DIFF
--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -1,7 +1,7 @@
 #! @shell@
 
 case "$1" in
-  --help)
+  -h|--help)
     exec man nixos-version
     exit 1
     ;;

--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -4,6 +4,7 @@ case "$1" in
   --help)
     exec man nixos-version
     exit 1
+    ;;
   --hash|--revision)
     echo "@nixosRevision@"
     ;;


### PR DESCRIPTION
###### Motivation for this change

error while creating other issue
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
