### PR TITLE
systemd: make ctrl-alt-del target configurable.

### DIFF
--- a/nixos/modules/system/boot/systemd-lib.nix
+++ b/nixos/modules/system/boot/systemd-lib.nix
@@ -176,7 +176,7 @@ rec {
       ${optionalString (type == "system") ''
         # Stupid misc. symlinks.
         ln -s ${cfg.defaultUnit} $out/default.target
-
+        ln -s ${cfg.ctrlAltDelUnit} $out/ctrl-alt-del.target
         ln -s rescue.target $out/kbrequest.target
 
         mkdir -p $out/getty.target.wants/

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -120,7 +120,6 @@ let
       "systemd-poweroff.service"
       "halt.target"
       "systemd-halt.service"
-      "ctrl-alt-del.target"
       "shutdown.target"
       "umount.target"
       "final.target"
@@ -162,7 +161,6 @@ let
       "systemd-hostnamed.service"
       "systemd-binfmt.service"
     ]
-
     ++ cfg.additionalUpstreamSystemUnits;
 
   upstreamSystemWants =
@@ -483,6 +481,15 @@ in
       default = "multi-user.target";
       type = types.str;
       description = "Default unit started when the system boots.";
+    };
+
+    systemd.ctrlAltDelUnit = mkOption {
+      default = "reboot.target";
+      type = types.str;
+      example = "poweroff.target";
+      description = ''
+        Target that should be started when Ctrl-Alt-Delete is pressed.
+      '';
     };
 
     systemd.globalEnvironment = mkOption {


### PR DESCRIPTION
###### Motivation for this change

We currently only allow upstream's default of "reboot.target" due to the way the symlinks are initialized. I made this configurable similar to the default unit.

See the [original pull request #12612 for a detailed discussion.
###### Things done
- [x] Tested correct behaviour on both a NixOS VM and a physical machine.
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

We currently only allow upstream's default of "reboot.target" due to the
way the symlinks are initialized. I made this configurable similar to the
default unit.
