### PR TITLE
mc: 4.8.16 -> 4.8.17

### DIFF
--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -2,11 +2,12 @@
 , libX11, libICE, perl, zip, unzip, gettext, slang}:
 
 stdenv.mkDerivation rec {
-  name = "mc-4.8.16";
+  name = "mc-${version}";
+  version = "4.8.17";
   
   src = fetchurl {
-    url = http://www.midnight-commander.org/downloads/mc-4.8.16.tar.bz2;
-    sha256 = "1y5apnp6sc9sn13m6816hlrr0dis1z7wsnffldsx7xlkvyas8zn3";
+    url = "http://www.midnight-commander.org/downloads/${name}.tar.bz2";
+    sha256 = "0fvqzffppj0aja9hi0k1xdjg5m6s99immlla1y9yzn5fp8vwpl36";    
   };
   
   buildInputs = [ pkgconfig perl glib gpm slang zip unzip file gettext libX11 libICE e2fsprogs ];


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
