### PR TITLE
marp: init at 0.0.8

### DIFF
--- a/pkgs/applications/office/marp/default.nix
+++ b/pkgs/applications/office/marp/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, atomEnv, libXScrnSaver }:
+
+stdenv.mkDerivation rec {
+  name = "marp-${version}";
+  version = "0.0.8";
+
+  src = fetchurl {
+    url = "https://github.com/yhatt/marp/releases/download/v${version}/${version}-Marp-linux-x64.tar.gz";
+    sha256 = "0d7vvz34ik2jafwl3qjkdsvcva25gyrgrfg1gz1nk8f5dkl1wjcf";
+  };
+  sourceRoot = ".";
+
+  installPhase = ''
+      mkdir -p $out/lib/marp $out/bin
+      cp -r ./* $out/lib/marp
+      ln -s $out/lib/marp/Marp $out/bin
+  '';
+
+  postFixup = ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${atomEnv.libPath}:${stdenv.lib.makeLibraryPath [ libXScrnSaver ]}:$out/lib/marp" \
+      $out/bin/Marp
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Markdown presentation writer, powered by Electron";
+    homepage = https://yhatt.github.io/marp/;
+    license = licenses.mit;
+    maintainers = [ maintainers.puffnfresh ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13553,6 +13553,8 @@ in
 
   marathon = callPackage ../applications/networking/cluster/marathon { };
 
+  marp = callPackage ../applications/office/marp { };
+
   matchbox = callPackage ../applications/window-managers/matchbox { };
 
   MBdistortion = callPackage ../applications/audio/MBdistortion { };


### PR DESCRIPTION
###### Motivation for this change

https://yhatt.github.io/marp
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
