### PR TITLE
ocproxy: init at 1.50

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -186,6 +186,7 @@
   joamaki = "Jussi Maki <joamaki@gmail.com>";
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
   joelteon = "Joel Taylor <me@joelt.io>";
+  joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
   jraygauthier = "Raymond Gauthier <jraygauthier@gmail.com>";
   juliendehos = "Julien Dehos <dehos@lisic.univ-littoral.fr>";

--- a/pkgs/tools/networking/ocproxy/default.nix
+++ b/pkgs/tools/networking/ocproxy/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libevent }:
+
+stdenv.mkDerivation rec {
+  version = "1.50";
+  name = "ocproxy-${version}";
+
+  src = fetchFromGitHub {
+    owner = "cernekee";
+    repo = "ocproxy";
+    rev = "v${version}";
+    sha256 = "136vlk2svgls5paf17xi1zahcahgcnmi2p55khh7zpqaar4lzw6s";
+  };
+
+  buildInputs = [ autoconf automake libevent ];
+
+  preConfigure = ''
+    patchShebangs autogen.sh
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OpenConnect proxy";
+    longdescription = ''
+      ocproxy is a user-level SOCKS and port forwarding proxy for OpenConnect
+      based on lwIP.
+    '';
+    homepage = https://github.com/cernekee/ocproxy;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.joko ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2780,6 +2780,8 @@ in
 
   obexd = callPackage ../tools/bluetooth/obexd { };
 
+  ocproxy = callPackage ../tools/networking/ocproxy { };
+
   openfortivpn = callPackage ../tools/networking/openfortivpn { };
 
   obexfs = callPackage ../tools/bluetooth/obexfs { };


### PR DESCRIPTION
###### Motivation for this change

This package can be combined with `openconnect` and act as a proxy, so that only specific network activity is forwarded to openconnect.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
