### PR TITLE
nixos copySystemConfiguration: enable by default

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -175,7 +175,7 @@ in
 
     system.copySystemConfiguration = mkOption {
       type = types.bool;
-      default = false;
+      default = true;
       description = ''
         If enabled, copies the NixOS configuration file
         (usually <filename>/etc/nixos/configuration.nix</filename>)


### PR DESCRIPTION
###### Motivation for this change

system.copySystemConfiguration copies /etc/nixos/configuration.nix into the system derivation at build time.  This can be very useful for debugging, but is much more useful if it was enabled before problems were encountered; however, users are not likely to realize they need this feature until it is too late.

Previously, this feature was not enabled by default because [it did not work with chroots](http://lists.science.uu.nl/pipermail/nix-dev/2010-April/004273.html) (see #7974).  That issue was fixed in e1901a1.
