### PR TITLE
kmymoney: 4.7.2 -> 4.8.0

### DIFF
--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -3,11 +3,12 @@
 , doxygen, aqbanking, gwenhywfar }:
 
 stdenv.mkDerivation rec {
-  name = "kmymoney-4.7.2";
+  name = "kmymoney-${version}";
+  version = "4.8.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/kmymoney2/${name}.tar.xz";
-    sha256 = "0g9rakjx7zmw4bf7m5516rrx0n3bl2by3nn24iiz9209yfgw5cmz";
+  url = "mirror://kde/stable/kmymoney/${version}/src/${name}.tar.xz";
+  sha256 = "1hlayhcmdfayma4hchv2bfyg82ry0h74hg4095d959mg19qkb9n2";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
###### Motivation for this change
- Update kmymoney to newest iteration.
- Use proper kde mirrors instead of sourceforge.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
