### PR TITLE
uemacs: init at 2014-12-08

### DIFF
--- a/pkgs/applications/editors/uemacs/default.nix
+++ b/pkgs/applications/editors/uemacs/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchgit, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "uemacs-${version}";
+  version = "2014-12-08";
+
+  src = fetchgit {
+    url = git://git.kernel.org/pub/scm/editors/uemacs/uemacs.git;
+    rev = "8841922689769960fa074fbb053cb8507f2f3ed9";
+    sha256 = "14yq7kpkax111cg6k7i3mnqk7sq7a65krq6qizzj7vvnm7bsj3sd";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "-lcurses" "-lncurses" \
+      --replace "CFLAGS=-O2" "CFLAGS+=" \
+      --replace "BINDIR=/usr/bin" "BINDIR=$out/bin" \
+      --replace "LIBDIR=/usr/lib" "LIBDIR=$out/share/uemacs"
+    substituteInPlace epath.h \
+      --replace "/usr/global/lib/" "$out/share/uemacs/" \
+      --replace "/usr/local/bin/" "$out/bin/" \
+      --replace "/usr/local/lib/" "$out/share/uemacs/" \
+      --replace "/usr/local/" "$out/bin/" \
+      --replace "/usr/lib/" "$out/share/uemacs/"
+    mkdir -p $out/bin $out/share/uemacs
+  '';
+
+  buildInputs = [ ncurses ];
+
+  meta = with stdenv.lib; {
+    homepage = https://git.kernel.org/cgit/editors/uemacs/uemacs.git;
+    description = "Torvalds Micro-emacs fork";
+    longDescription = ''
+      uEmacs/PK 4.0 is a full screen editor based on MicroEMACS 3.9e
+    '';
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3916,6 +3916,8 @@ in
 
   udunits = callPackage ../development/libraries/udunits { };
 
+  uemacs = callPackage ../applications/editors/uemacs { };
+
   uhttpmock = callPackage ../development/libraries/uhttpmock { };
 
   uim = callPackage ../tools/inputmethods/uim {


### PR DESCRIPTION
###### Motivation for this change

Low on dependencies and quick to compile.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
