### PR TITLE
Add package for BitKeeper-7.3

### DIFF
--- a/pkgs/applications/version-management/bitkeeper/default.nix
+++ b/pkgs/applications/version-management/bitkeeper/default.nix
@@ -2,14 +2,14 @@
  pkgconfig, libXft, fontconfig, pcre, libtomcrypt, libtommath, lz4, zlib}:
 
 stdenv.mkDerivation rec {
-  name = "bitkeeper-7.3ce";
-  base = "bk-7.3ce";
+  version = "7.3ce";
+  name = "bitkeeper-${version}";
   enableParallelBuilding = true;
   src = fetchurl {
-    url = "https://www.bitkeeper.org/downloads/7.3ce/${base}.tar.gz";
+    url = "https://www.bitkeeper.org/downloads/${version}/bk-${version}.tar.gz";
     sha256 = "13249636f4b5b39f1d64b9f6bf682ee2dce53db17cdd8aa4cd9019e65252cabb";
   };
-  sourceRoot = "${base}/src";
+  sourceRoot = "bk-${version}/src";
 
   buildInputs = [ perl gperf bison groff libXft pkgconfig
 	      pcre libtomcrypt libtommath lz4];
@@ -34,9 +34,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "BitKeeper";
+    description = "A distributed version control system";
     longDescription = ''
-BitKeeper is a fast, enterprise-ready, distributed SCM that scales up to very large projects and down to tiny ones.
+	BitKeeper is a fast, enterprise-ready, distributed SCM that scales up to very large projects and down to tiny ones.
     '';
     homepage = http://www.bitkeeper.org/;
     license = stdenv.lib.licenses.asl20;

--- a/pkgs/applications/version-management/bitkeeper/default.nix
+++ b/pkgs/applications/version-management/bitkeeper/default.nix
@@ -1,0 +1,48 @@
+{stdenv, fetchurl, perl, gperf, bison, groff,
+ pkgconfig, libXft, fontconfig, pcre, libtomcrypt, libtommath, lz4, zlib}:
+
+stdenv.mkDerivation rec {
+  name = "bitkeeper-7.3ce";
+  base = "bk-7.3ce";
+  enableParallelBuilding = true;
+  src = fetchurl {
+    url = "https://www.bitkeeper.org/downloads/7.3ce/${base}.tar.gz";
+    sha256 = "13249636f4b5b39f1d64b9f6bf682ee2dce53db17cdd8aa4cd9019e65252cabb";
+  };
+  sourceRoot = "${base}/src";
+
+  buildInputs = [ perl gperf bison groff libXft pkgconfig
+	      pcre libtomcrypt libtommath lz4];
+
+  postPatch = ''
+	substituteInPlace port/unix_platform.sh \
+		--replace /bin/rm rm
+	substituteInPlace ./undo.c \
+		--replace /bin/cat cat
+  '';
+
+  buildPhase = ''
+    make -j6 V=1 p
+    make image
+  '';
+
+  installPhase = ''
+    ./utils/bk-* $out/bitkeeper
+    mkdir -p $out/bin
+    $out/bitkeeper/bk links $out/bin
+    chmod g-w $out
+  '';
+
+  meta = {
+    description = "BitKeeper";
+    longDescription = ''
+BitKeeper is a fast, enterprise-ready, distributed SCM that scales up to very large projects and down to tiny ones.
+    '';
+    homepage = http://www.bitkeeper.org/;
+    license = stdenv.lib.licenses.asl20;
+    platforms = with stdenv.lib.platforms; all;
+    maintainers = [
+      stdenv.lib.maintainers.wscott
+    ];
+  };
+}

--- a/pkgs/development/libraries/libtomcrypt/default.nix
+++ b/pkgs/development/libraries/libtomcrypt/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "libtomcrypt-1.17";
 
   src = fetchurl {
-    url = "http://libtom.org/files/crypt-1.17.tar.bz2";
+    url = "https://github.com/libtom/libtomcrypt/releases/download/1.17/crypt-1.17.tar.bz2";
     sha256 = "e33b47d77a495091c8703175a25c8228aff043140b2554c08a3c3cd71f79d116";
   };
 

--- a/pkgs/development/libraries/libtommath/default.nix
+++ b/pkgs/development/libraries/libtommath/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, libtool}:
 
 stdenv.mkDerivation {
-  name = "libtommath-0.39";
+  name = "libtommath-1.0";
   
   src = fetchurl {
-    url = http://math.libtomcrypt.com/files/ltm-0.39.tar.bz2;
-    sha256 = "1kjx8rrw62nanzc5qp8fj6r3ybhw8ca60ahkyb70f10aiij49zs2";
+    url = https://github.com/libtom/libtommath/releases/download/v1.0/ltm-1.0.tar.xz;
+    sha256 = "0v5mpd8zqjfs2hr900w1mxifz23xylyjdqyx1i1wl7q9xvwpsflr";
   };
 
   buildInputs = [libtool];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12206,6 +12206,8 @@ in
 
   bibletime = callPackage ../applications/misc/bibletime { };
 
+  bitkeeper = callPackage ../applications/version-management/bitkeeper { };
+
   bitlbee = callPackage ../applications/networking/instant-messengers/bitlbee { };
   bitlbee-plugins = callPackage ../applications/networking/instant-messengers/bitlbee/plugins.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Easier access to BitKeeper for nixpkg users.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Needed to update URLs for tomcrypt and tommath libraries.
Updated tommath to a more recent version, but the one other
package in nixpkgs that uses it still works fine.
