### PR TITLE
terraform: 0.6.15 -> 0.6.16

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -2,16 +2,16 @@
 
 buildGoPackage rec {
   name = "terraform-${version}";
-  version = "0.6.15";
+  version = "0.6.16";
   rev = "v${version}";
-  
+
   goPackagePath = "github.com/hashicorp/terraform";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "hashicorp";
     repo = "terraform";
-    sha256 = "1mf98hagb0yp40g2mbar7aw7hmpq01clnil6y9khvykrb33vy0nb";
+    sha256 = "1bg8hn4b31xphyxrc99bpnf7gmq20fxqx1k871nidx132brcsah2";
   };
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

upgrade
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (there were none)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
