### PR TITLE
[WIP] systemd-bootchart part 2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -503,6 +503,7 @@
   ./services/x11/xserver.nix
   ./system/activation/activation-script.nix
   ./system/activation/top-level.nix
+  ./system/boot/bootchart.nix
   ./system/boot/coredump.nix
   ./system/boot/emergency-mode.nix
   ./system/boot/initrd-network.nix

--- a/nixos/modules/system/boot/bootchart.nix
+++ b/nixos/modules/system/boot/bootchart.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.boot.bootchart;
+
+in
+
+{
+
+  options = {
+
+    boot.bootchart.enable = mkEnableOption "systemd-bootchart, boot performance analysis tool";
+
+    boot.bootchart.extraConfig = mkOption {
+      default = "";
+      type = types.lines;
+      example = "Samples=500";
+      description = ''
+        Extra config options for systemd-bootchart. See man bootchart.conf
+        for available options.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.packages = [ pkgs.systemd-bootchart ];
+
+    boot.kernelParams = [ "init2=${pkgs.systemd-bootchart}/lib/systemd/systemd-bootchart" ];
+
+    systemd.services.systemd-bootchart.wantedBy = [ "sysinit.target" ];
+
+    environment.etc."systemd/bootchart.conf".text = ''
+      [Bootchart]
+      ${cfg.extraConfig}
+    '';
+
+    system.requiredKernelConfig = [ config.lib.kernelConfig.isYes "SCHEDSTATS" ];
+
+  };
+
+}

--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -2,6 +2,8 @@
 
 systemConfig=@systemConfig@
 
+initDaemon=systemd
+
 export HOME=/root
 
 
@@ -82,6 +84,9 @@ for o in $(cat /proc/cmdline); do
             set -- $(IFS==; echo $o)
             resumeDevice=$2
             ;;
+        init2=*)
+            set -- $(IFS==; echo $o)
+            initDaemon=$2
     esac
 done
 
@@ -209,4 +214,4 @@ echo "starting systemd..."
 PATH=/run/current-system/systemd/lib/systemd \
     MODULE_DIR=/run/booted-system/kernel-modules/lib/modules \
     LOCALE_ARCHIVE=/run/current-system/sw/lib/locale/locale-archive \
-    exec systemd
+    exec $initDaemon

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -39,7 +39,7 @@ with stdenv.lib;
     DEBUG_STACKOVERFLOW n
   ''}
   RCU_TORTURE_TEST n
-  SCHEDSTATS n
+  SCHEDSTATS y
   DETECT_HUNG_TASK y
 
   # Unix domain sockets.

--- a/pkgs/os-specific/linux/systemd/bootchart-fix-height.patch
+++ b/pkgs/os-specific/linux/systemd/bootchart-fix-height.patch
@@ -1,0 +1,22 @@
+diff --git a/src/svg.c b/src/svg.c
+index f2af535..37b9758 100644
+--- a/src/svg.c
++++ b/src/svg.c
+@@ -90,7 +90,7 @@ static void svg_header(FILE *of, struct list_sample_data *head, double graph_sta
+         /* height is variable based on pss, psize, ksize */
+         h = 400.0 + (arg_scale_y * 30.0) /* base graphs and title */
+             + (arg_pss ? (100.0 * arg_scale_y) + (arg_scale_y * 7.0) : 0.0) /* pss estimate */
+-            + psize + ksize + esize + (n_cpus * 15 * arg_scale_y);
++            + psize + ksize + esize + ((n_cpus+1) * 15 * arg_scale_y);
+ 
+         fprintf(of, "<?xml version=\"1.0\" standalone=\"no\"?>\n");
+         fprintf(of, "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" ");
+@@ -1056,6 +1056,8 @@ static void svg_ps_bars(FILE *of,
+                                         ps->parent->pos_x,
+                                         ps->parent->pos_y);
+                         continue;
++                } else {
++                        continue;
+                 }
+ 
+                 endtime = ps->last->sampledata->sampletime;

--- a/pkgs/os-specific/linux/systemd/bootchart-fix-processes-graph.patch
+++ b/pkgs/os-specific/linux/systemd/bootchart-fix-processes-graph.patch
@@ -1,0 +1,95 @@
+diff --git a/src/store.c b/src/store.c
+index 42cb804..e9bd24b 100644
+--- a/src/store.c
++++ b/src/store.c
+@@ -252,48 +252,49 @@ schedstat_next:
+                         ps->sample->runtime = atoll(rt);
+                         ps->sample->waittime = atoll(wt);
+ 
+-                        /* get name, start time */
++                        /* get name, start time; requires CONFIG_SCHED_DEBUG in kernel */
+                         if (ps->sched < 0) {
+                                 sprintf(filename, "%d/sched", pid);
+                                 ps->sched = openat(procfd, filename, O_RDONLY|O_CLOEXEC);
+                                 if (ps->sched < 0)
+-                                        continue;
++                                        goto no_sched;
+                         }
+ 
+                         s = pread(ps->sched, buf, sizeof(buf) - 1, 0);
+                         if (s <= 0) {
+                                 ps->sched = safe_close(ps->sched);
+-                                continue;
++                                goto no_sched;
+                         }
+                         buf[s] = '\0';
+ 
+                         if (!sscanf(buf, "%s %*s %*s", key))
+-                                continue;
++                                goto no_sched;
+ 
+                         strscpy(ps->name, sizeof(ps->name), key);
+ 
+-                        /* cmdline */
+-                        if (arg_show_cmdline)
+-                                pid_cmdline_strscpy(procfd, ps->name, sizeof(ps->name), pid);
+-
+                         /* discard line 2 */
+                         m = bufgetline(buf);
+                         if (!m)
+-                                continue;
++                                goto no_sched;
+ 
+                         m = bufgetline(m);
+                         if (!m)
+-                                continue;
++                                goto no_sched;
+ 
+                         if (!sscanf(m, "%*s %*s %s", t))
+-                                continue;
++                                goto no_sched;
+ 
+                         r = safe_atod(t, &ps->starttime);
+                         if (r < 0)
+-                                continue;
++                                goto no_sched;
+ 
+                         ps->starttime /= 1000.0;
+ 
++no_sched:
++                        /* cmdline */
++                        if (arg_show_cmdline)
++                                pid_cmdline_strscpy(procfd, ps->name, sizeof(ps->name), pid);
++
+                         if (arg_show_cgroup)
+                                 /* if this fails, that's OK */
+                                 cg_pid_get_path(SYSTEMD_CGROUP_CONTROLLER,
+@@ -527,7 +528,7 @@ catch_rename:
+                                 sprintf(filename, "%d/sched", pid);
+                                 ps->sched = openat(procfd, filename, O_RDONLY|O_CLOEXEC);
+                                 if (ps->sched < 0)
+-                                        continue;
++                                        goto no_sched2;
+                         }
+ 
+                         s = pread(ps->sched, buf, sizeof(buf) - 1, 0);
+@@ -535,16 +536,17 @@ catch_rename:
+                                 /* clean up file descriptors */
+                                 ps->sched = safe_close(ps->sched);
+                                 ps->schedstat = safe_close(ps->schedstat);
+-                                continue;
++                                goto no_sched2;
+                         }
+ 
+                         buf[s] = '\0';
+ 
+                         if (!sscanf(buf, "%s %*s %*s", key))
+-                                continue;
++                                goto no_sched2;
+ 
+                         strscpy(ps->name, sizeof(ps->name), key);
+ 
++no_sched2:
+                         /* cmdline */
+                         if (arg_show_cmdline)
+                                 pid_cmdline_strscpy(procfd, ps->name, sizeof(ps->name), pid);

--- a/pkgs/os-specific/linux/systemd/bootchart.nix
+++ b/pkgs/os-specific/linux/systemd/bootchart.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, intltool, pkgconfig, libtool
+, libxslt, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_45, systemd }:
+
+assert stdenv.isLinux;
+
+stdenv.mkDerivation rec {
+  version = "230";
+  name = "systemd-bootchart-${version}";
+
+  src = fetchFromGitHub {
+    owner = "systemd";
+    repo = "systemd-bootchart";
+    rev = "v${version}";
+    sha256 = "1dbscx7hsvn6a5rbjfmpskwnp0n2hpwdb8n85gssnlmxas7cw72f";
+  };
+
+  nativeBuildInputs = [
+    autoconf automake intltool pkgconfig libtool libxslt docbook_xsl
+    docbook_xml_dtd_42 docbook_xml_dtd_45
+  ];
+
+  buildInputs = [ systemd ];
+
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--with-rootprefix=$(out)"
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    ''-UROOTLIBEXECDIR'' ''-DROOTLIBEXECDIR="/run/current-system/systemd/lib/systemd"''
+    ''-USYSTEMD_BINARY_PATH'' ''-DSYSTEMD_BINARY_PATH="/run/current-system/systemd/lib/systemd/systemd"''
+  ];
+
+  installFlags = [
+    "sysconfdir=$(out)/etc"
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.freedesktop.org/wiki/Software/systemd";
+    description = "Boot performance graphing tool";
+    platforms = platforms.linux;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/os-specific/linux/systemd/bootchart.nix
+++ b/pkgs/os-specific/linux/systemd/bootchart.nix
@@ -21,6 +21,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ systemd ];
 
+  patches = [
+    # https://github.com/systemd/systemd-bootchart/pull/10
+    ./bootchart-fix-processes-graph.patch
+    # https://github.com/systemd/systemd-bootchart/pull/11
+    ./bootchart-fix-height.patch
+  ];
+
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11369,6 +11369,8 @@ in
       udev.lib = libudev.out; # ${systemd.udev.lib}/lib/libudev.*
     };
 
+  systemd-bootchart = callPackage ../os-specific/linux/systemd/bootchart.nix { };
+
   # standalone cryptsetup generator for systemd
   systemd-cryptsetup-generator = callPackage ../os-specific/linux/systemd/cryptsetup-generator.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Extend PR #16902 with patches fixing broken rendering of the processes graph in systemd-bootchart.

(I'm OK if my commit is moved to @abbradar's PR and "my" PR then closed; didn't know how to submit the commit otherwise on top of the previous PR.)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
