### PR TITLE
lenmus: init at 5.4.1

### DIFF
--- a/pkgs/applications/misc/lenmus/default.nix
+++ b/pkgs/applications/misc/lenmus/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, pkgconfig, fetchFromGitHub
+, cmake, boost
+, portmidi, sqlite
+, freetype, libpng, pngpp, zlib
+, wxGTK30, wxsqlite3
+}:
+
+stdenv.mkDerivation rec {
+  name = "lenmus-${version}";
+  version = "5.4.1";
+
+  src = fetchFromGitHub {
+    owner = "lenmus";
+    repo = "lenmus";
+    rev = "Release_${version}";
+    sha256 = "03xar8x38x20cns2gnv34jp0hw0k16sa62kkfhka9iiiw90wfyrp";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "DESTINATION \"/usr/share" "DESTINATION \"$out/share"
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_INSALL_PREFIX=$out"
+  ];
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    pkgconfig
+    cmake boost
+    portmidi sqlite
+    freetype libpng pngpp zlib
+    wxGTK30 wxsqlite3
+  ];
+
+  meta = with stdenv.lib; {
+    description = "LenMus Phonascus is a program for learning music";
+    longDescription = ''
+      LenMus Phonascus is a free open source program (GPL v3) for learning music.
+      It allows you to focus on specific skills and exercises, on both theory and aural training.
+      The different activities can be customized to meet your needs
+    '';
+    homepage = "http://www.lenmus.org/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers;  [ ramkromberg ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6415,6 +6415,7 @@ in
 
   lemon = callPackage ../development/tools/parsing/lemon { };
 
+  lenmus = callPackage ../applications/misc/lenmus { };
 
   libtool = self.libtool_2;
 


### PR DESCRIPTION
###### Motivation for this change

An educational music theory and sight-reading software.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
