### PR TITLE
zerotierone: 1.1.6 -> 1.1.12

### DIFF
--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -3,12 +3,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.1.6";
+  version = "1.1.12";
   name = "zerotierone";
 
   src = fetchurl {
     url = "https://github.com/zerotier/ZeroTierOne/archive/${version}.tar.gz";
-    sha256 = "1bl8dppaqydsd1qf9pk3bp16amkwjxyqh1gvm62ys2a0m4c529ks";
+    sha256 = "95258398c81f3515d7bf2a0ba0cce6c10af3dbdde4bbbf6115be6fd9eb325156";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested that `zerotier-one -v` gives `1.1.12`
- [x] Tested that NixOS's zerotierone module works as expected
