### PR TITLE
spring: 101.0 -> 102.0

### DIFF
--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -8,11 +8,11 @@
 stdenv.mkDerivation rec {
 
   name = "spring-${version}";
-  version = "101.0";
+  version = "102.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/springrts/spring_${version}_src.tar.lzma";
-    sha256 = "0nr65zhw92k36zgwqgi31vcp129vk7r3v7xzd6l9w7mp1ljvypgi";
+    sha256 = "0gjlpzwl3bdv1ickm8r3xlrbc6dm7m8i968hw3p0an49k6bqa77i";
   };
 
   # The cmake included module correcly finds nix's glew, however


### PR DESCRIPTION
###### Motivation for this change

springLobby not updated because: https://github.com/springlobby/springlobby/blob/master/ChangeLog#L8 and https://github.com/springlobby/springlobby/issues/707
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
