### PR TITLE
emem: 0.2.15 -> 0.2.16

### DIFF
--- a/pkgs/applications/misc/emem/default.nix
+++ b/pkgs/applications/misc/emem/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "emem";
-  version = "0.2.15";
+  version = "0.2.16";
   name = "${pname}-${version}";
 
   inherit jdk;
 
   src = fetchurl {
     url = "https://github.com/ebzzry/${pname}/releases/download/v${version}/${pname}.jar";
-    sha256 = "0jj990syd9biq2awnjydi4x3p4hivigc522ds59hdf5wg4y2gg6c";
+    sha256 = "1j6i40mcfwcx85zv0pxpwrqj0zy9s5qd7j63zdqf0lckkjvyrih9";
   };
 
   buildInputs = [ ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [.] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [.] Tested execution of all binary files (usually in `./result/bin/`)
- [.] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
