### PR TITLE
glfw: 3.1.2 -> 3.2

### DIFF
--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.1.2";
+  version = "3.2";
   name = "glfw-${version}";
 
   src = fetchFromGitHub {
     owner = "glfw";
     repo = "GLFW";
     rev = "${version}";
-    sha256 = "1aj1dfyyd0170gpz32j2xlqbvbsxwbg028xiqai3mqc44xfp10kw";
+    sha256 = "0knqf40jij2z1mia091xqyky5r11r4qyh7b8172blrmgm9q23sl9";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
- Built on NixOS with `nix-build -A`.
- Tested library as a dependency of a simple game.
- Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
