### PR TITLE
habitat: add an option to run in an FHS chroot

### DIFF
--- a/pkgs/applications/networking/cluster/habitat/chroot-env.nix
+++ b/pkgs/applications/networking/cluster/habitat/chroot-env.nix
@@ -1,0 +1,9 @@
+# TODO: Drop once https://github.com/habitat-sh/habitat/issues/994
+#       is resolved.
+{ habitat, libsodium, libarchive, openssl, buildFHSUserEnv }:
+
+buildFHSUserEnv {
+    name = "hab";
+    targetPkgs = pkgs: [ habitat libsodium libarchive openssl ];
+    runScript = "bash";
+}

--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -5,18 +5,18 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "habitat-${version}";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "habitat-sh";
     repo = "habitat";
     rev = version;
-    sha256 = "0pacxcc86w4zdakyd6qbz2rqx30rkv1j5aca1fqa1hf1jqg44vg0";
+    sha256 = "1h9wv2v4hcv79jkkjf8j96lzxni9d51755zfflfr5s3ayaip7rzj";
   };
 
   sourceRoot = "habitat-${version}-src/components/hab";
 
-  depsSha256 = "0bm9f6w7ircji4d1c1fgysna93w0lf8ws7gfkqq80zx92x3lz5z5";
+  depsSha256 = "1612jaw3zdrgrb56r755bb18l8szdmf1wi7p9lpv3d2gklqcb7l1";
 
   buildInputs = [ libsodium libarchive openssl ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1940,6 +1940,7 @@ in
   haveged = callPackage ../tools/security/haveged { };
 
   habitat = callPackage ../applications/networking/cluster/habitat { };
+  habitat-sh = callPackage ../applications/networking/cluster/habitat/chroot-env.nix { };
 
   hardlink = callPackage ../tools/system/hardlink { };
 


### PR DESCRIPTION
###### Motivation for this change

`hab studio enter` as well as other `hab` commands that make use
of the studio assume an FHS system when creating a chroot.

See https://github.com/habitat-sh/habitat/issues/994
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
