### PR TITLE
opam, aspcud: init packages for external solver

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -162,6 +162,7 @@
   grahamc = "Graham Christensen <graham@grahamc.com>";
   gridaphobe = "Eric Seidel <eric@seidel.io>";
   guibert = "David Guibert <david.guibert@gmail.com>";
+  hakuch = "Jesse Haber-Kucharsky <hakuch@gmail.com>";
   havvy = "Ryan Scheel <ryan.havvy@gmail.com>";
   hbunke = "Hendrik Bunke <bunke.hendrik@gmail.com>";
   hce = "Hans-Christian Esperer <hc@hcesperer.org>";

--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchgit, fetchurl, ocaml, unzip, ncurses, curl }:
+{ stdenv, fetchgit, fetchurl, makeWrapper,
+  ocaml, unzip, ncurses, curl,
+  aspcudSupport ? !stdenv.isDarwin, aspcud
+}:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12.1";
 
@@ -45,7 +48,7 @@ in stdenv.mkDerivation rec {
   name = "opam-${version}";
   version = "1.2.2";
 
-  buildInputs = [ unzip curl ncurses ocaml ];
+  buildInputs = [ unzip curl ncurses ocaml makeWrapper];
 
   src = srcs.opam;
 
@@ -68,6 +71,13 @@ in stdenv.mkDerivation rec {
 
   # Dirty, but apparently ocp-build requires a TERM
   makeFlags = ["TERM=screen"];
+
+  postInstall =
+    if aspcudSupport then ''
+      wrapProgram $out/bin/opam \
+        --suffix PATH : ${aspcud}/bin
+    ''
+    else "";
 
   doCheck = false;
 

--- a/pkgs/tools/misc/aspcud/default.nix
+++ b/pkgs/tools/misc/aspcud/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl,
+  boost, clasp, cmake, gringo, re2c
+}:
+
+let
+  version = "1.9.0";
+in
+
+stdenv.mkDerivation rec {
+  name = "aspcud-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/potassco/aspcud/${version}/aspcud-${version}-source.tar.gz";
+    sha256 = "029035vcdk527ssf126i8ipi5zs73gqpbrg019pvm9r24rf0m373";
+  };
+
+  buildInputs = [ boost clasp cmake gringo re2c ];
+
+  buildPhase = ''
+    cmake -DCMAKE_BUILD_TYPE=Release \
+      -DGRINGO_LOC=${gringo}/bin/gringo \
+      -DCLASP_LOC=${clasp}/bin/clasp \
+      -DENCODING_LOC=$out/share/aspcud/specification.lp \
+      .
+
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/{aspcud,cudf2lp,lemon} $out/bin
+
+    mkdir -p $out/share/aspcud
+    cp ../share/aspcud/specification.lp $out/share/aspcud
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Solver for package problems in CUDF format using ASP";
+    homepage = http://potasssco.sourceforge.net/;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.hakuch ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/tools/misc/clasp/default.nix
+++ b/pkgs/tools/misc/clasp/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl }:
+
+let
+  version = "3.1.4";
+in
+
+stdenv.mkDerivation {
+  name = "clasp-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/potassco/clasp/${version}/clasp-${version}-source.tar.gz";
+    sha256 = "1zkjqc4gp4n9p2kf3k3z8x82g42any4p3shhhivny89z1jlxi9zn";
+  };
+
+  preConfigure = "patchShebangs ./configure.sh";
+  configureScript = "./configure.sh";
+
+  preBuild = "cd build/release";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/clasp $out/bin/clasp
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Answer set solver for (extended) normal and disjunctive logic programs";
+    homepage = http://potassco.sourceforge.net/;
+    platforms = platforms.all;
+    maintainers = [ maintainers.hakuch ];
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/tools/misc/gringo/default.nix
+++ b/pkgs/tools/misc/gringo/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl,
+  bison, re2c, scons
+}:
+
+let
+  version = "4.5.4";
+in
+
+stdenv.mkDerivation rec {
+  name = "gringo-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/potassco/gringo/${version}/gringo-${version}-source.tar.gz";
+    sha256 = "16k4pkwyr2mh5w8j91vhxh9aff7f4y31npwf09w6f8q63fxvpy41";
+  };
+
+  buildInputs = [ bison re2c scons ];
+
+  patches = [
+    ./gringo-4.5.4-cmath.patch
+  ];
+
+  buildPhase = ''
+    scons --build-dir=release
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp build/release/gringo $out/bin/gringo
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Converts input programs with first-order variables to equivalent ground programs";
+    homepage = http://potassco.sourceforge.net/;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.hakuch ];
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/tools/misc/gringo/gringo-4.5.4-cmath.patch
+++ b/pkgs/tools/misc/gringo/gringo-4.5.4-cmath.patch
@@ -1,0 +1,11 @@
+--- gringo/libgringo/src/term.cc~	2016-07-12 23:56:10.593577749 -0400
++++ gringo/libgringo/src/term.cc	2016-07-12 23:52:35.169968338 -0400
+@@ -22,6 +22,8 @@
+ #include "gringo/logger.hh"
+ #include "gringo/graph.hh"
+ 
++#include <cmath>
++
+ namespace Gringo {
+ 
+ // {{{ definition of Defines

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -524,6 +524,10 @@ in
   };
   aria = self.aria2;
 
+  aspcud = callPackage ../tools/misc/aspcud {
+    boost = boost155;
+  };
+
   at = callPackage ../tools/system/at { };
 
   atftp = callPackage ../tools/networking/atftp { };
@@ -690,6 +694,8 @@ in
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };
 
+  clasp = callPackage ../tools/misc/clasp { };
+
   cli53 = callPackage ../tools/admin/cli53 { };
 
   cli-visualizer = callPackage ../applications/misc/cli-visualizer { };
@@ -814,6 +820,8 @@ in
   glide = callPackage ../development/tools/glide { };
 
   gmic = callPackage ../tools/graphics/gmic { };
+
+  gringo = callPackage ../tools/misc/gringo { };
 
   gti = callPackage ../tools/misc/gti { };
 


### PR DESCRIPTION
###### Motivation for this change

The [opam](https://opam.ocaml.org/) package manager depends on external solvers to solve packaging constraints.

While in theory opam can attempt to satisfy constraints with its internal solver, in practice, even having a small handful of packages installed can lead to time-outs.

Aspcud is the best supported and most popular external solver for opam, but, unlike opam, was not packaged with nixpkgs.

Aspcud depends on two complementary package: clasp, and gringo.

The patch to gringo was necessary to get it to compile (the code used `std::pow` without including `<cmath>`). Likewise, aspcud needs to be compiled with an older version of Boost.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
