### PR TITLE
habitat: fix naming collision

### DIFF
--- a/pkgs/applications/networking/cluster/habitat/chroot-env.nix
+++ b/pkgs/applications/networking/cluster/habitat/chroot-env.nix
@@ -3,7 +3,7 @@
 { habitat, libsodium, libarchive, openssl, buildFHSUserEnv }:
 
 buildFHSUserEnv {
-    name = "hab";
+    name = "habitat-sh";
     targetPkgs = pkgs: [ habitat libsodium libarchive openssl ];
     runScript = "bash";
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
