### PR TITLE
flashplayer: 11.2.202.626 -> 11.2.202.632 APSB16-25

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
@@ -70,11 +70,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "11.2.202.626";
+  version = "11.2.202.632";
 
   src = fetchurl {
     url = "https://fpdownload.macromedia.com/pub/flashplayer/installers/archive/fp_${version}_archive.zip";
-    sha256 = "1c7ffr1kjmdq5rcx3xzgkd4wg1c8b3zkb1ysmnjiicfm423xr9h7";
+    sha256 = "0nf2d7jn8g6bp9vilkwwkkh6pm05fg3h73njsn4yvx3285k73lpn";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

https://helpx.adobe.com/security/products/flash-player/apsb16-25.html

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4172
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4173
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4174
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4175
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4176
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4177
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4178
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4179
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4180
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4181
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4182
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4183
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4184
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4185
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4186
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4187
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4188
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4189
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4190
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4217
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4218
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4219
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4220
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4221
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4222
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4223
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4224
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4225
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4226
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4227
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4228
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4229
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4230
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4231
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4232
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4233
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4234
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4235
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4236
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4237
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4238
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4239
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4240
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4241
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4242
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4243
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4244
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4245
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4246
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4247
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4248
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4249

lol what a sieve :D
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
