### PR TITLE
commandergenius: init at 194beta

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -163,6 +163,7 @@
   guibert = "David Guibert <david.guibert@gmail.com>";
   havvy = "Ryan Scheel <ryan.havvy@gmail.com>";
   hbunke = "Hendrik Bunke <bunke.hendrik@gmail.com>";
+  hce = "Hans-Christian Esperer <hc@hcesperer.org>";
   henrytill = "Henry Till <henrytill@gmail.com>";
   hiberno = "Christian Lask <hiberno@hiberno.net>";
   hinton = "Tom Hinton <t@larkery.com>";

--- a/pkgs/games/commandergenius/default.nix
+++ b/pkgs/games/commandergenius/default.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv, fetchFromGitHub, SDL2, SDL2_image, pkgconfig
+, libvorbis, libogg, mesa, boost, curl, zlib, cmake }:
+
+
+stdenv.mkDerivation rec {
+  name = "commandergenius-${version}";
+  version = "194beta";
+
+  src = fetchFromGitHub {
+    owner = "gerstrong";
+    repo = "Commander-Genius";
+    rev = "v${version}";
+    sha256 = "0qxqzlmadxklrhxilbqj7y94fmbv0byj6vgpl59lb77lgs4y4x47";
+  };
+
+  buildInputs = [ SDL2 SDL2_image pkgconfig libvorbis libogg mesa boost curl zlib cmake ];
+
+  patchPhase = ''
+    cat >> lib/GsKit/CMakeLists.txt <<EOF
+    execute_process(COMMAND sdl2-config --cflags
+      OUTPUT_VARIABLE CFLAGS)
+    string(REGEX REPLACE "^-I" "" CFLAGS2 \''${CFLAGS})
+    string(REGEX REPLACE " .*" "" SDLINC \''${CFLAGS2})
+    INCLUDE_DIRECTORIES(\''${SDLINC})
+    EOF
+  '';
+
+  configurePhase = ''
+    cmake -DUSE_SDL2=yes -DBUILD_TARGET=LINUX -DCMAKE_INSTALL_PREFIX:PATH=$out -DCPACK_PACKAGE_INSTALL_DIRECTORY=$out
+    sed -i 's_/usr/share_$out_g' cmake_install.cmake
+    sed -i 's_/usr/share_$out_g' src/cmake_install.cmake
+  '';
+
+  installTargets = [ ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp src/CGeniusExe $out/bin
+  '';
+
+  meta = {
+    description = "Modern Interpreter for the Commander Keen Games";
+    longdescription = ''
+      Commander Genius is an open-source clone of
+      Commander Keen which allows you to play
+      the games, and some of the mods
+      made for it. All of the original data files
+      are required to do so
+    '';
+    homepage = "https://github.com/gerstrong/Commander-Genius";
+    maintainers = with stdenv.lib.maintainers; [ hce ]; 
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15347,6 +15347,8 @@ in
 
   cockatrice = qt5.callPackage ../games/cockatrice {  };
 
+  commandergenius = callPackage ../games/commandergenius { };
+
   confd = callPackage ../tools/system/confd { };
 
   construoBase = lowPrio (callPackage ../games/construo {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
