### PR TITLE
LiE: include forgotten file INFO.a by installation

### DIFF
--- a/pkgs/applications/science/math/LiE/default.nix
+++ b/pkgs/applications/science/math/LiE/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     cp -v Lie.exe $out
     cp -v lie $out/bin
 
-    cp -v LEARN LEARN.ind $out
-    cp -v INFO.ind INFO.[0-4] $out
+    cp -v LEARN* $out
+    cp -v INFO* $out
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

Hello!

Sorry for bringing this up again. During installation phase the file INFO.a was forgotten to be copied to $out. At the moment many builtin functions are not available rigth now. For example start lie
% lie
and then run

> max_sub(B3)
> this should not return an error but a list of sub algebras.

@jagajaga 
Please consider to merge heilkn:lie again.

I'm sorry for the inconvenience.

Kind regards

Konstantin
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
