### PR TITLE
viber: 4.2.2.6 -> 6.0.1.5

### DIFF
--- a/pkgs/applications/networking/instant-messengers/viber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/default.nix
@@ -1,20 +1,20 @@
-{ fetchurl, stdenv, dpkg, makeWrapper, xorg, qt5Full, gstreamer, zlib, sqlite, libxslt }:
+{fetchurl, stdenv, dpkg, makeWrapper,
+ alsaLib, cups, curl, dbus, expat, fontconfig, freetype, glib, gst_all_1, harfbuzz, libcap,
+ libpulseaudio, mesa, nspr, nss, libudev, wayland, xorg, zlib, ...
+}:
 
 assert stdenv.system == "x86_64-linux";
 
-# BUG: viber tries to access contacts list and that causes segfault
-# FIX: you have to do `chmod 444 ~/.ViberPC/<your mobile phone number>/Avatars`
-# BUG: viber tries to it's downloads and that causes segfault
-# FIX: you have to do `chmod 444 ~/Documents/ViberDownloads`
-# TODO: fix bugs
+# BUG: Viber requires running tray application, segfaulting if it's missing
+# FIX: Start something like `stalonetray` if you DE doesn't provide tray
 
 stdenv.mkDerivation rec {
   name = "viber-${version}";
-  version = "4.2.2.6";
+  version = "6.0.1.5";
 
   src = fetchurl {
     url = "http://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
-    sha256 = "1fv269z9sni21lc1ka25jnxr9w8zfg1gfn2c7fnd8cdd5fm57d26";
+    sha256 = "026vp2pv66b2dlwi5w5wk4yjnnmnsqapdww98p7xdnz8n0hnsbbi";
   };
 
   buildInputs = [ dpkg makeWrapper ];
@@ -22,36 +22,74 @@ stdenv.mkDerivation rec {
   unpackPhase = "true";
 
   libPath = stdenv.lib.makeLibraryPath [
-      qt5Full
-      xorg.libX11
-      gstreamer
-      zlib
-      sqlite
-      xorg.libXrender
-      libxslt
+      alsaLib
+      cups
+      curl
+      dbus
+      expat
+      fontconfig
+      freetype
+      glib
+      gst_all_1.gst-plugins-base
+      gst_all_1.gstreamer
+      harfbuzz
+      libcap
+      libpulseaudio
+      mesa
+      nspr
+      nss
       stdenv.cc.cc
-      xorg.libXScrnSaver
+      libudev
+      wayland
+      zlib
+
+      xorg.libICE
+      xorg.libSM
+      xorg.libX11
+      xorg.libxcb
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
       xorg.libXext
-  ];
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXScrnSaver
+      xorg.libXtst
+      xorg.xcbutilimage
+      xorg.xcbutilkeysyms
+      xorg.xcbutilrenderutil
+      xorg.xcbutilwm
+  ]
+  ;
 
   installPhase = ''
     dpkg-deb -x $src $out
     mkdir -p $out/bin
-    mv $out/opt/viber/{Sound,icons,libqfacebook.so} $out
-    mv $out/opt/viber/Viber $out/viber
-    rm -rf $out/opt
-    ln -s $out/viber $out/bin/viber
-    mkdir -p usr/lib/mozilla/plugins
 
-    patchelf \
-      --set-rpath $libPath \
-      $out/libqfacebook.so
-    patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath $libPath:$out \
-      $out/viber
+    # Soothe nix-build "suspicions"
+    chmod -R g-w $out
 
-    wrapProgram $out/viber --prefix LD_LIBRARY_PATH : $libPath:$out
+    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath $libPath:$out/opt/viber/lib $file || true
+    done
+
+    # qt.conf is not working, so override everything using environment variables
+    wrapProgram $out/opt/viber/Viber \
+      --set QT_PLUGIN_PATH "$out/opt/viber/plugins" \
+      --set QT_XKB_CONFIG_ROOT "${xorg.xkeyboardconfig}/share/X11/xkb" \
+      --set QTCOMPOSE "${xorg.libX11}/share/X11/locale"
+    ln -s $out/opt/viber/Viber $out/bin/viber
+
+    mv $out/usr/share $out/share
+    rm -rf $out/usr
+
+    # Fix the desktop link
+    substituteInPlace $out/share/applications/viber.desktop \
+      --replace /opt/viber/Viber $out/opt/viber/Viber \
+      --replace /usr/share/ $out/share/
   '';
 
   dontStrip = true;
@@ -63,7 +101,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.unfree;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ jagajaga ];
-    broken = true;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
- Upgrade
- Use Qt provided by viber itself -> no longer broken
- Remove notes about obsolete bugs
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
