### PR TITLE
galen: 2.2.4 -> 2.3.0

### DIFF
--- a/pkgs/development/tools/galen/default.nix
+++ b/pkgs/development/tools/galen/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, jdk, unzip }:
+{ stdenv, fetchurl, jre8, unzip }:
 
 stdenv.mkDerivation rec {
   pname = "galen";
-  version = "2.2.4";
+  version = "2.3.0";
   name = "${pname}-${version}";
 
-  inherit jdk;
+  inherit jre8;
 
   src = fetchurl {
     url = "https://github.com/galenframework/galen/releases/download/galen-${version}/galen-bin-${version}.zip";
-    sha256 = "0qx6pza6aw880ph76wbypcgy983pln8k4ad2indagb5qhiz4zw1d";
+    sha256 = "10z7vh3jiq7kbzzp3j0354swkr4xxz9qimi5c5bddbiy671k6cra";
   };
 
   buildInputs = [ unzip ];
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-  cat galen | sed -e "s,java,$jdk/bin/java," > $out/bin/galen
+  cat galen | sed -e "s,java,$jre8/bin/java," > $out/bin/galen
   chmod +x $out/bin/galen
   cp galen.jar $out/bin
   '';


### PR DESCRIPTION
###### Motivation for this change

This is just a regular minor version update with some new features and bugfixes.
According to the [release notes](http://galenframework.com/post/2016-07-13-version-2.3-is-released/) galen now requires Java 8, so I explicitly set this version.
I’ve also replaced the jdk dependency with jre because jdk is not needed in this case as we are only downloading the pre-build jar file and don’t compile it our self.
###### Things done
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
