### PR TITLE
imagemagick: 6.9.3-9 -> 6.9.5-2

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -11,7 +11,7 @@ let
     else throw "ImageMagick is not supported on this platform.";
 
   cfg = {
-    version = "6.9.3-9";
+    version = "6.9.5-2";
     sha256 = "0q19jgn1iv7zqrw8ibxp4z57iihrc9kyb09k2wnspcacs6vrvinf";
     patches = [];
   }
@@ -23,7 +23,7 @@ let
           name = "mingw-build.patch";
           url = "https://raw.githubusercontent.com/Alexpux/MINGW-packages/"
             + "01ca03b2a4ef/mingw-w64-imagemagick/002-build-fixes.patch";
-          sha256 = "1pypszlcx2sf7wfi4p37w1y58ck2r8cd5b2wrrwr9rh87p7fy1c0";
+          sha256 = "09h3rpr1jnzd7ipy5d16r2gi0bwg4hk5khwzv4cyhv1xzs8pk7pj";
         })];
       };
 in

--- a/pkgs/applications/graphics/ImageMagick/imagetragick.patch
+++ b/pkgs/applications/graphics/ImageMagick/imagetragick.patch
@@ -1,15 +1,8 @@
-diff --git a/config/policy.xml b/config/policy.xml
-index ca3b022..b058c05 100644
 --- a/config/policy.xml
 +++ b/config/policy.xml
-@@ -58,4 +58,10 @@
-   <!-- <policy domain="resource" name="time" value="3600"/> -->
-   <!-- <policy domain="system" name="precision" value="6"/> -->
-   <policy domain="cache" name="shared-secret" value="passphrase"/>
-+
-+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
-+  <policy domain="coder" rights="none" pattern="URL" />
-+  <policy domain="coder" rights="none" pattern="HTTPS" />
-+  <policy domain="coder" rights="none" pattern="MVG" />
-+  <policy domain="coder" rights="none" pattern="MSL" />
- </policymap>
+67a68,72
+>   <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+>   <policy domain="coder" rights="none" pattern="URL" />
+>   <policy domain="coder" rights="none" pattern="HTTPS" />
+>   <policy domain="coder" rights="none" pattern="MVG" />
+>   <policy domain="coder" rights="none" pattern="MSL" />


### PR DESCRIPTION
###### Motivation for this change

[CVE-2016-3717](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3717)

There were also a few more issues detailed in the [change logs](http://git.imagemagick.org/repos/ImageMagick/blob/master/ChangeLog) that didn't reach a CVE:

```
2016-05-25  7.0.1-7 Cristy  <quetzlzacatenango@image...>
  * Security improvements to TEXT coder broke it (reference
    https://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=29754).
  * Fix stroke offset problem for -annotate (reference
    https://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=29626).
  * Don't interpret -fx option arguments (reference
    https://www.imagemagick.org/discourse-server/viewtopic.php?f=3&t=29774);
  * Add additional checks to DCM reader to prevent data-driven faults (bug
    report from Hanno Böck).
```

```
2016-05-03  7.0.1-1 Cristy  <quetzlzacatenango@image...>
  * Sanitize input filename for http / https delegates (improved patch).
  * Fix for possible security vulnerabilities (reference
    https://www.imagemagick.org/discourse-server/viewtopic.php?f=4&t=29588).
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

p.s. also fixed up the patch to make it easier to update the package. 
