### PR TITLE
eventstat: 0.02.02 -> 0.03.02

### DIFF
--- a/pkgs/os-specific/linux/eventstat/default.nix
+++ b/pkgs/os-specific/linux/eventstat/default.nix
@@ -1,12 +1,13 @@
-{ stdenv, lib, fetchzip }:
+{ stdenv, lib, fetchzip, ncurses }:
 
 stdenv.mkDerivation rec {
   name = "eventstat-${version}";
-  version = "0.02.02";
+  version = "0.03.02";
   src = fetchzip {
     url = "http://kernel.ubuntu.com/~cking/tarballs/eventstat/eventstat-${version}.tar.gz";
-    sha256 = "1l1shcj3c0pxv1g6sqc10ka1crbx0cm2gldxbyrzqv2lmlfnmm44";
+    sha256 = "1bwv0m9pk9l0jfibvsfjggc5pp9lyyrsfr10h6jm6kf1v6r6hf5s";
   };
+  buildInputs = [ ncurses ];
   installFlags = [ "DESTDIR=$(out)" ];
   postInstall = ''
     mv $out/usr/* $out


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
