### PR TITLE
Init {fnotify,fork,power,smem}stat kernel tools

### DIFF
--- a/pkgs/os-specific/linux/fnotifystat/default.nix
+++ b/pkgs/os-specific/linux/fnotifystat/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "fnotifystat-${version}";
+  version = "0.01.14";
+  src = fetchurl {
+    url = "http://kernel.ubuntu.com/~cking/tarballs/fnotifystat/fnotifystat-${version}.tar.gz";
+    sha256 = "1cc3w94v8b4nfpkgr33gfzxpwaf43brqyc0fla9p70gk3hxjqzi5";
+  };
+  installFlags = [ "DESTDIR=$(out)" ];
+  postInstall = ''
+    mv $out/usr/* $out
+    rm -r $out/usr
+  '';
+  meta = with lib; {
+    description = "File activity monitoring tool";
+    homepage = http://kernel.ubuntu.com/~cking/fnotifystat/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ womfoo ];
+  };
+}

--- a/pkgs/os-specific/linux/forkstat/default.nix
+++ b/pkgs/os-specific/linux/forkstat/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "forkstat-${version}";
+  version = "0.01.13";
+  src = fetchurl {
+    url = "http://kernel.ubuntu.com/~cking/tarballs/forkstat/forkstat-${version}.tar.gz";
+    sha256 = "12dmqpv0q3x166sya93rhcj7vs4868x7y7lwfwv9l54hhirpamhq";
+  };
+  installFlags = [ "DESTDIR=$(out)" ];
+  postInstall = ''
+    mv $out/usr/* $out
+    rm -r $out/usr
+  '';
+  meta = with lib; {
+    description = "Process fork/exec/exit monitoring tool";
+    homepage = http://kernel.ubuntu.com/~cking/forkstat/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ womfoo ];
+  };
+}

--- a/pkgs/os-specific/linux/powerstat/default.nix
+++ b/pkgs/os-specific/linux/powerstat/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "powerstat-${version}";
+  version = "0.02.10";
+  src = fetchurl {
+    url = "http://kernel.ubuntu.com/~cking/tarballs/powerstat/powerstat-${version}.tar.gz";
+    sha256 = "11n2k20h27j7m8j0l524w23xlkjhapsb3ml1qpx1si7gf0pkglcl";
+  };
+  installFlags = [ "DESTDIR=$(out)" ];
+  postInstall = ''
+    mv $out/usr/* $out
+    rm -r $out/usr
+  '';
+  meta = with lib; {
+    description = "Laptop power measuring tool";
+    homepage = http://kernel.ubuntu.com/~cking/powerstat/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ womfoo ];
+  };
+}

--- a/pkgs/os-specific/linux/smemstat/default.nix
+++ b/pkgs/os-specific/linux/smemstat/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "smemstat-${version}";
+  version = "0.01.14";
+  src = fetchurl {
+    url = "http://kernel.ubuntu.com/~cking/tarballs/smemstat/smemstat-${version}.tar.gz";
+    sha256 = "0qkpbg0n40d8m9jzf3ylpdp65zzs344zbjn8khha4plbwg00ijrw";
+  };
+  installFlags = [ "DESTDIR=$(out)" ];
+  postInstall = ''
+    mv $out/usr/* $out
+    rm -r $out/usr
+  '';
+  meta = with lib; {
+    description = "Memory usage monitoring tool";
+    homepage = http://kernel.ubuntu.com/~cking/smemstat/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ womfoo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10757,6 +10757,8 @@ in
 
   firejail = callPackage ../os-specific/linux/firejail {};
 
+  fnotifystat = callPackage ../os-specific/linux/fnotifystat { };
+
   freefall = callPackage ../os-specific/linux/freefall {
     inherit (linuxPackages) kernel;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10860,6 +10860,8 @@ in
 
   openisns = callPackage ../os-specific/linux/open-isns { };
 
+  powerstat = callPackage ../os-specific/linux/powerstat { };
+
   tgt = callPackage ../tools/networking/tgt { };
 
   # -- Linux kernel expressions ------------------------------------------------

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10759,6 +10759,8 @@ in
 
   fnotifystat = callPackage ../os-specific/linux/fnotifystat { };
 
+  forkstat = callPackage ../os-specific/linux/forkstat { };
+
   freefall = callPackage ../os-specific/linux/freefall {
     inherit (linuxPackages) kernel;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10862,6 +10862,8 @@ in
 
   powerstat = callPackage ../os-specific/linux/powerstat { };
 
+  smemstat = callPackage ../os-specific/linux/smemstat { };
+
   tgt = callPackage ../tools/networking/tgt { };
 
   # -- Linux kernel expressions ------------------------------------------------


### PR DESCRIPTION
###### Motivation for this change

Adding these useful kernel tools by Colin King

Bundling them in a single PR as they sit next to each other in all-packages.nix
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
