### PR TITLE
qrupdate: fix installation (darwin)

### DIFF
--- a/pkgs/development/libraries/qrupdate/default.nix
+++ b/pkgs/development/libraries/qrupdate/default.nix
@@ -28,7 +28,9 @@ stdenv.mkDerivation {
 
   buildFlags = [ "lib" "solib" ];
 
-  installTargets = "install";
+  installTargets = if stdenv.isDarwin
+                   then ["install-staticlib" "install-shlib"]
+                   else "install";
 
   buildInputs = [ gfortran openblas ];
 }


### PR DESCRIPTION
###### Motivation for this change

`qrupdate` was not detected by `octave`. Investigating revealed that `qrupdate`'s output directory was empty.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The issue is that the library files were not copied to $out with the
existing `installTargets` definition.

I noticed this problem on darwin, but I do not know if it is a
darwin-only problem.
