### PR TITLE
openssh: Use the default privilege separation dir (/var/empty)

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -66,11 +66,6 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin "--disable-libutil"
     ++ optional (!linkOpenssl) "--without-openssl";
 
-  preConfigure = ''
-    configureFlagsArray+=("--with-privsep-path=$out/empty")
-    mkdir -p $out/empty
-  '';
-
   enableParallelBuilding = true;
 
   postInstall = ''


### PR DESCRIPTION
If running NixOS inside a container where the host's root-owned files
and directories have been mapped to some other uid (like nobody), the
ssh daemon fails to start, producing this error message:

```
fatal: /nix/store/...-openssh-7.2p2/empty must be owned by root and not group or world-writable.
```

The reason for this is that when openssh is built, we explicitly set
`--with-privsep-path=$out/empty`. This commit removes that flag which
causes the default directory `/var/empty` to be used instead. Since NixOS'
activation script correctly sets up that directory, the ssh daemon now
also works within containers that have a non-root-owned nix store.

@edolstra I realise it's almost ten years ago now, but do you remember the reason for adding `--with-privsep-path=$out/empty` in https://github.com/NixOS/nixpkgs/commit/e09f8061b78ba4276de1b5f07825b44ac70fda3f#diff-7549192c447e957daffa20c6382448e8R29?
