### PR TITLE
fltk: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -1,6 +1,7 @@
 { stdenv, composableDerivation, fetchurl, pkgconfig, xlibsWrapper, inputproto, libXi
 , freeglut, mesa, libjpeg, zlib, libXinerama, libXft, libpng
 , cfg ? {}
+, darwin, libtiff, freetype
 }:
 
 let inherit (composableDerivation) edf; in
@@ -21,7 +22,10 @@ composableDerivation.composableDerivation {} {
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  propagatedBuildInputs = [ xlibsWrapper inputproto libXi freeglut ];
+  propagatedBuildInputs = [ inputproto ]
+    ++ (if stdenv.isDarwin
+        then (with darwin.apple_sdk.frameworks; [Cocoa AGL GLUT freetype libtiff])
+        else [ xlibsWrapper libXi freeglut ]);
 
   enableParallelBuilding = true;
 
@@ -55,9 +59,8 @@ composableDerivation.composableDerivation {} {
   meta = {
     description = "A C++ cross-platform lightweight GUI library";
     homepage = http://www.fltk.org;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     license = stdenv.lib.licenses.gpl2;
   };
 
 }
-


### PR DESCRIPTION
###### Motivation for this change

fltk works great on darwing, the build just needed a bit of darwin-specific plumbing.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Verified that a sample FLTK program compiles and runs.
