### PR TITLE
caddy service: add option to change ACME certificate authority

### DIFF
--- a/nixos/modules/services/web-servers/caddy.nix
+++ b/nixos/modules/services/web-servers/caddy.nix
@@ -14,10 +14,24 @@ in
       description = "Verbatim Caddyfile to use";
     };
 
+    ca = mkOption {
+      default = "https://acme-v01.api.letsencrypt.org/directory";
+      example = "https://acme-staging.api.letsencrypt.org/directory";
+      type = types.string;
+      description = "Certificate authority ACME server. The default (Let's Encrypt production server) should be fine for most people.";
+    };
+
     email = mkOption {
       default = "";
       type = types.string;
       description = "Email address (for Let's Encrypt certificate)";
+    };
+
+    agree = mkOption {
+      default = false;
+      example = true;
+      type = types.bool;
+      description = "Agree to Let's Encrypt Subscriber Agreement";
     };
 
     dataDir = mkOption {
@@ -33,11 +47,13 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        ExecStart = "${pkgs.caddy.bin}/bin/caddy -conf=${configFile} -email=${cfg.email}";
-	Type = "simple";
-	User = "caddy";
-	Group = "caddy";
-	AmbientCapabilities = "cap_net_bind_service";
+        ExecStart = ''${pkgs.caddy.bin}/bin/caddy -conf=${configFile} \
+          -ca=${cfg.ca} -email=${cfg.email} ${optionalString cfg.agree "-agree"}
+        '';
+        Type = "simple";
+        User = "caddy";
+        Group = "caddy";
+        AmbientCapabilities = "cap_net_bind_service";
       };
     };
 


### PR DESCRIPTION
###### Motivation for this change

i want to set the ca to the staging ca of letsencrypt.

```
  services.caddy = {
    enable = true;
    ca = "https://acme-staging.api.letsencrypt.org/directory";
    email = "me@domain.net";
    config = ''
    import /var/www/domain.net/web/Caddyfile
    '';
  };
```

there might be other ACME CAs in the future.

also "Agree to Let's Encrypt Subscriber Agreement"
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @angus-g
