### PR TITLE
webkitgtk24x: 2.4.9 -> 2.4.11

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.4.nix
+++ b/pkgs/development/libraries/webkitgtk/2.4.nix
@@ -15,7 +15,7 @@ assert stdenv.isDarwin -> !enableCredentialStorage;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "webkitgtk-${version}";
-  version = "2.4.9";
+  version = "2.4.11";
 
   meta = with stdenv.lib; {
     description = "Web content rendering engine, GTK+ port";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://webkitgtk.org/releases/${name}.tar.xz";
-    sha256 = "0r651ar3p0f8zwl7764kyimxk5hy88cwy116pv8cl5l8hbkjkpxg";
+    sha256 = "1xsvnvyvlywwyf6m9ainpsg87jkxjmd37q6zgz9cxb7v3c2ym2jq";
   };
 
   CC = "cc";
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = with stdenv.lib; [
     "--disable-geolocation"
+    "--disable-jit"
     (optionalString enableIntrospection "--enable-introspection")
   ] ++ optional withGtk2 [
     "--with-gtk=2.0"


### PR DESCRIPTION
###### Motivation for this change

Html preview in gnucash26 was broken. I updated the package and added a new configureFlag
to disable JIT (similar to how debian packages webkitgtk). It seems like html preview now works properly in gnucash26!
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Some further testing might be needed to nail down whether disabling jit is really necessary, but I don't really have the resources to recompile webkit everytime.
