### PR TITLE
hoppy, qtah: add myself as maintainer

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -90,6 +90,14 @@ package-maintainers:
   khumba:
     - goatee
     - goatee-gtk
+    - hoppy-docs
+    - hoppy-generator
+    - hoppy-runtime
+    - hoppy-std
+    - qtah-cpp-qt5
+    - qtah-examples
+    - qtah-generator
+    - qtah-qt5
   psibi:
     - path-pieces
     - persistent


### PR DESCRIPTION
###### Motivation for this change

I am upstream, and NixOS is awesome to develop with.

I've tested the `qtah-generator` binary, and this effectively tests Hoppy, but the rest of the Qtah packages don't build right now (they need system deps); I'm fixing that separately.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
