### PR TITLE
nodejs: 6.2.2 -> 6.3.0

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -3,6 +3,7 @@
 , version
 , src
 , preBuild ? ""
+, extraConfigFlags ? []
 , ...
 }:
 
@@ -30,7 +31,7 @@ in stdenv.mkDerivation {
 
   name = "nodejs-${version}";
 
-  configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps) ++ [ "--without-dtrace" ];
+  configureFlags = concatMap sharedConfigureFlags (builtins.attrNames deps) ++ [ "--without-dtrace" ] ++ [ extraConfigFlags ];
   dontDisableStatic = true;
   prePatch = ''
     patchShebangs .

--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -4,12 +4,13 @@
 }@args:
 
 import ./nodejs.nix (args // rec {
-  version = "6.2.2";
+  version = "6.3.0";
   src = fetchurl {
     url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-    sha256 = "2dfeeddba750b52a528b38a1c31e35c1fb40b19cf28fbf430c3c8c7a6517005a";
+    sha256 = "0b7npvxrby203z59r4jnd2v2x54lg8d2gc96c2gj3zyzzrdh3hk6";
   };
-  preBuild = stdenv.lib.optionalString (stdenv.system == "x86_64-darwin") ''
+  extraConfigFlags = stdenv.lib.optionalString (stdenv.isDarwin) [ "--without-inspector" ];
+  preBuild = stdenv.lib.optionalString (stdenv.isDarwin) ''
     sed -i -e "s|tr1/type_traits|type_traits|g" \
       -e "s|std::tr1|std|" src/util.h
   '';


### PR DESCRIPTION
###### Motivation for this change

Updating `nodejs-6_x` from `6.2.2` to `6.3.0` - [Changelog](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#6.3.0)

**Caveat**: I did not manage to get it to compile with the inspector enabled on OSX. I will open a separate issue for this. At the moment I'd rather have the most recent nodejs without inspector than no recent nodejs on OSX at all.
###### Things done
- Built on platform(s)
  - [X] NixOS
  - [X] OS X
  - [ ] Linux
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
