### PR TITLE
mirrors: add downloads.sourceforge.net

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -10,6 +10,7 @@ rec {
 
   # SourceForge.
   sourceforge = [
+    http://downloads.sourceforge.net/
     http://prdownloads.sourceforge.net/
     http://heanet.dl.sourceforge.net/sourceforge/
     http://surfnet.dl.sourceforge.net/sourceforge/


### PR DESCRIPTION
downloads.sourceforge.net is the official way to download tarballs from
SourceForge.  However, it is reported as unreliable due to SF's weird
load balancing system.

This commit gives the official mirror utmost priority, and will use
other configured mirrors (which may be temporary) as a fallback only
when the official one can't be reached/download fails/hangs.

References: NixOs/nixpkgs#16900
