### PR TITLE
sysdig: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -3,10 +3,10 @@ let
   inherit (stdenv.lib) optional optionalString;
   s = rec {
     baseName="sysdig";
-    version = "0.9.0";
+    version = "0.10.0";
     name="${baseName}-${version}";
     url="https://github.com/draios/sysdig/archive/${version}.tar.gz";
-    sha256 = "198x1zmlydvi4i1sfvs8xjh9z5pb47l6xs4phrnkwwak46rhka3j";
+    sha256 = "0hs0r9z9j7padqdcj69bwx52iw6gvdl0w322qwivpv12j3prcpsj";
   };
   buildInputs = [
     cmake zlib luajit ncurses perl jsoncpp libb64 openssl curl


### PR DESCRIPTION
I updated it to `0.10.0`, although there is already `0.11.0`.  The problem is that I could not get the build to work due to a dependency on `jq` and a missing `compile.h` header.

Seems like https://github.com/draios/sysdig/issues/626 is the reason.  If somebody knows how to fix this in the nix build, bumping to `0.11.0` would be even better.
