### PR TITLE
gnustep-make: 2.6.7 -> 2.6.8

### DIFF
--- a/pkgs/development/tools/build-managers/gnustep/make/default.nix
+++ b/pkgs/development/tools/build-managers/gnustep/make/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
-let version = "2.6.7"; in
+let version = "2.6.8"; in
 stdenv.mkDerivation rec {
   name = "gnustep-make-${version}";
 
   src = fetchurl {
     url = "http://ftpmain.gnustep.org/pub/gnustep/core/${name}.tar.gz";
-    sha256 = "1r2is23xdg4qirckb6bd4lynfwnnw5d9522wib3ndk1xgirmfaqi";
+    sha256 = "0r00439f7vrggdwv60n8p626gnyymhq968i5x9ad2i4v6g8x4gk0";
   };
 
   patchPhase = ''
@@ -16,19 +16,41 @@ stdenv.mkDerivation rec {
       --replace 'makedir = $(DESTDIR)' 'makedir = ' \
       --replace 'mandir  = $(DESTDIR)' 'mandir  = '
 
+    substituteInPlace configure \
+      --replace /Library/GNUstep "$out"
+
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+
     substituteInPlace FilesystemLayouts/apple \
       --replace /usr/local ""
 
-    substituteInPlace configure \
-      --replace /Library/GNUstep "$out"
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+
+    substituteInPlace FilesystemLayouts/fhs \
+      --replace /usr/local "."
+
   '';
 
   installFlags = "DESTDIR=$(out)";
 
+  configureFlags =
+    if stdenv.isLinux then [ "--with-layout=fhs" ]
+    else [ "--with-layout=apple" ];
+
   postInstall = ''
     mkdir -p $out/nix-support
+
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+
     cat >$out/nix-support/setup-hook <<EOF
       . $out/Library/GNUstep/Makefiles/GNUstep.sh
     EOF
+
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+
+    cat >$out/nix-support/setup-hook <<EOF
+      . $out/share/GNUstep/Makefiles/GNUstep.sh
+    EOF
+
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

First step for https://github.com/NixOS/nixpkgs/issues/16868.

I've fixed up the linux end of things and updated to 2.6.8 while I was at it. I haven't touched the OSX bits but it would still be best if an OSX user could test it out at some point ;)
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
