### PR TITLE
Backports for stable

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -30,8 +30,7 @@ let
         description = ''
           If this option is set, ‘device’ is interpreted as the
           path of a swapfile that will be created automatically
-          with the indicated size (in megabytes) if it doesn't
-          exist.
+          with the indicated size (in megabytes).
         '';
       };
 
@@ -132,9 +131,13 @@ in
             script =
               ''
                 ${optionalString (sw.size != null) ''
-                  if [ ! -e "${sw.device}" ]; then
+                  currentSize=$(( $(stat -c "%s" "${sw.device}" 2>/dev/null || echo 0) / 1024 / 1024 ))
+                  if [ "${toString sw.size}" != "$currentSize" ]; then
                     fallocate -l ${toString sw.size}M "${sw.device}" ||
                       dd if=/dev/zero of="${sw.device}" bs=1M count=${toString sw.size}
+                    if [ "${toString sw.size}" -lt "$currentSize" ]; then
+                      truncate --size "${toString sw.size}M" "${sw.device}"
+                    fi
                     chmod 0600 ${sw.device}
                     ${optionalString (!sw.randomEncryption) "mkswap ${sw.realDevice}"}
                   fi

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -501,7 +501,7 @@ sub getEfiTarget {
 my @deviceTargets = getDeviceTargets();
 my $efiTarget = getEfiTarget();
 my $prevGrubState = readGrubState();
-my @prevDeviceTargets = split/:/, $prevGrubState->devices;
+my @prevDeviceTargets = split/,/, $prevGrubState->devices;
 
 my $devicesDiffer = scalar (List::Compare->new( '-u', '-a', \@deviceTargets, \@prevDeviceTargets)->get_symmetric_difference());
 my $nameDiffer = get("fullName") ne $prevGrubState->name;
@@ -549,7 +549,7 @@ if ($requireNewInstall != 0) {
     print FILE get("fullName"), "\n" or die;
     print FILE get("fullVersion"), "\n" or die;
     print FILE $efiTarget, "\n" or die;
-    print FILE join( ":", @deviceTargets ), "\n" or die;
+    print FILE join( ",", @deviceTargets ), "\n" or die;
     print FILE $efiSysMountPoint, "\n" or die;
     close FILE or die;
 }

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -747,7 +747,7 @@ in
         { wantedBy = [ "timers.target" ];
           timerConfig.OnCalendar = service.startAt;
         })
-        (filterAttrs (name: service: service.startAt != "") cfg.services);
+        (filterAttrs (name: service: service.enable && service.startAt != "") cfg.services);
 
     # Generate timer units for all services that have a ‘startAt’ value.
     systemd.user.timers =

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -7,11 +7,12 @@
 assert qt4Support -> qt4 != null;
 
 stdenv.mkDerivation rec {
-  name = "avahi-0.6.31";
+  name = "avahi-${version}";
+  version = "0.6.32";
 
   src = fetchurl {
-    url = "${meta.homepage}/download/${name}.tar.gz";
-    sha256 = "0j5b5ld6bjyh3qhd2nw0jb84znq0wqai7fsrdzg7bpg24jdp2wl3";
+    url = "https://github.com/lathiat/avahi/releases/download/v${version}/avahi-${version}.tar.gz";
+    sha256 = "0m5l3ny9i2z1l27y4wm731c0zdkmfn6l1szbajx0ljjiblc92jfm";
   };
 
   patches = [ ./no-mkdir-localstatedir.patch ];

--- a/pkgs/development/libraries/avahi/no-mkdir-localstatedir.patch
+++ b/pkgs/development/libraries/avahi/no-mkdir-localstatedir.patch
@@ -6,7 +6,7 @@ Don't "mkdir $(localstatedir)" since we can't do it (/var).
  	done
  
  install-data-local:
--	test -z "$(localstatedir)/run" || $(mkdir_p) "$(DESTDIR)$(localstatedir)/run"
+-	test -z "$(localstatedir)/run" || $(MKDIR_P) "$(DESTDIR)$(localstatedir)/run"
  
  update-systemd:
  	curl http://cgit.freedesktop.org/systemd/plain/src/sd-daemon.c > sd-daemon.c

--- a/pkgs/development/tools/misc/strace/default.nix
+++ b/pkgs/development/tools/misc/strace/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, perl, libunwind }:
 
 stdenv.mkDerivation rec {
-  name = "strace-4.11";
+  name = "strace-${version}";
+  version = "4.12";
 
   src = fetchurl {
     url = "mirror://sourceforge/strace/${name}.tar.xz";
-    sha256 = "0ll1rpjs441jac2689nga74qb49x1zkg8a2b7rzzchgrv1n5ysp8";
+    sha256 = "51144b78cb9ba22211b95a5aafe0af3694c0d575b25975d80ca9dd4dfd7c1e59";
   };
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
              ++ stdenv.lib.optional enablePython python;
 
   meta = {
-    homepage = http://code.google.com/p/cryptsetup/;
+    homepage = https://gitlab.com/cryptsetup/cryptsetup/;
     description = "LUKS for dm-crypt";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ viric chaoflow ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -12,11 +12,11 @@
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.02.13";
+  version = "2016.04.06";
 
   src = fetchurl {
-    url = "http://yt-dl.org/downloads/${stdenv.lib.getVersion name}/${name}.tar.gz";
-    sha256 = "0d6ml6nas0pnp6is73fn326ayxkdmxvarzyr96qd6gyjm9icpdcb";
+    url = "http://yt-dl.org/downloads/${version}/${name}.tar.gz";
+    sha256 = "1kdrjwrn0x1wmvansvd2222gfqnld4zdihf2jwnz36112r1p8nhi";
   };
 
   buildInputs = [ makeWrapper zip pandoc ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -12,11 +12,11 @@
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.04.19";
+  version = "2016.05.21.2";
 
   src = fetchurl {
     url = "http://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "09ba62900703a1439659a5394d802c7b03fd3a7b35d604e94a256ae9ccd1b6a0";
+    sha256 = "66f94fc97012c4c7a6338dc4df6ec62af66dcfc144c5e8c8cd8b5519756f1a98";
   };
 
   buildInputs = [ makeWrapper zip pandoc ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -12,11 +12,11 @@
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.04.06";
+  version = "2016.04.19";
 
   src = fetchurl {
     url = "http://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "1kdrjwrn0x1wmvansvd2222gfqnld4zdihf2jwnz36112r1p8nhi";
+    sha256 = "09ba62900703a1439659a5394d802c7b03fd3a7b35d604e94a256ae9ccd1b6a0";
   };
 
   buildInputs = [ makeWrapper zip pandoc ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -12,11 +12,11 @@
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.06.19.1";
+  version = "2016.06.27";
 
   src = fetchurl {
-    url = "http://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "223c496be84dd57ba9f7d6a132a2732b67c79c7e26e64ecae1439472c10d0d45";
+    url = "https://yt-dl.org/downloads/${version}/${name}.tar.gz";
+    sha256 = "1kwv20kmb0xnlpkbnsc27abw9cv0gkzbzwzzp4qw5mg3naqkmjvc";
   };
 
   buildInputs = [ makeWrapper zip pandoc ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -12,11 +12,11 @@
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.07.03.1";
+  version = "2016.07.09.2";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "0qyi2g0i2gl04hqn587w0c5x1pnpkn6l07fhnbfpnqq7fyw1hndy";
+    sha256 = "0qs99ss1w22apx3n2173j5mly7h0ngfgkkgz07bn30235saf0fd3";
   };
 
   buildInputs = [ makeWrapper zip pandoc ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -12,11 +12,11 @@
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.06.27";
+  version = "2016.07.03.1";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "1kwv20kmb0xnlpkbnsc27abw9cv0gkzbzwzzp4qw5mg3naqkmjvc";
+    sha256 = "0qyi2g0i2gl04hqn587w0c5x1pnpkn6l07fhnbfpnqq7fyw1hndy";
   };
 
   buildInputs = [ makeWrapper zip pandoc ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -12,11 +12,11 @@
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.05.21.2";
+  version = "2016.06.19.1";
 
   src = fetchurl {
     url = "http://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "66f94fc97012c4c7a6338dc4df6ec62af66dcfc144c5e8c8cd8b5519756f1a98";
+    sha256 = "223c496be84dd57ba9f7d6a132a2732b67c79c7e26e64ecae1439472c10d0d45";
   };
 
   buildInputs = [ makeWrapper zip pandoc ];


### PR DESCRIPTION
###### Motivation for this change

I looked through commits I've been involved with on master and I think these ones should be applied to release-16.03 as well (various improvements).
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm currently testing my system with it, I'll merge in a day (or more, depending on speed of my PC) if I don't see any regressions.
