### PR TITLE
urxvt_font_size: Add missing `xlsfonts` dependency

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-font-size/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-font-size/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, xrdb }:
+{ stdenv, fetchFromGitHub, xrdb, xlsfonts }:
 
 stdenv.mkDerivation {
   name = "urxvt-font-size-2015-05-22";
@@ -13,7 +13,8 @@ stdenv.mkDerivation {
 
   installPhase = ''
     substituteInPlace font-size \
-      --replace "xrdb -merge" "${xrdb}/bin/xrdb -merge"
+      --replace "xrdb -merge" "${xrdb}/bin/xrdb -merge" \
+      --replace "xlsfonts" "${xlsfonts}/bin/xlsfonts"
 
     mkdir -p $out/lib/urxvt/perl
     cp font-size $out/lib/urxvt/perl


### PR DESCRIPTION
###### Motivation for this change

Add missing `xlsfonts` dependency
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
