### PR TITLE
adapta-gtk-theme: 3.21.2 -> 3.21.3.68

### DIFF
--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, autoreconfHook, sass, inkscape, glib, which, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   name = "adapta-gtk-theme-${version}";
-  version = "3.21.2";
+  version = "3.21.3.68";
 
   meta = with stdenv.lib; {
     description = "An adaptive GTK+ theme based on Material Design";
     homepage = "https://github.com/tista500/Adapta";
-    license = licenses.gpl2;
+    license = with licenses; [ gpl2 cc-by-sa-30 ];
     platforms = platforms.linux;
     maintainers = [ maintainers.SShrike ];
   };
@@ -15,13 +15,15 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tista500";
     repo = "Adapta";
-    rev = "c48da995abc46087c22b05d2cdb0975d10774641";
-    sha256 = "17w9nsrwqwgafswyvhc5h8ld2ggi96ix5fjv6yf1hfz3l1ln9qg7";
+    rev = version;
+    sha256 = "0wwsmsyxfdgsc7fj1kn4r9zsgs09prizwkjljmirwrfdm6j3387p";
   };
 
   preferLocalBuild = true;
   buildInputs = [ gtk-engine-murrine ];
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook sass inkscape glib.dev which ];
+
+  postPatch = "patchShebangs .";
 
   configureFlags = "--enable-chrome --disable-unity";
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
