### PR TITLE
xarchiver: 0.5.4 -> 0.5.4.6

### DIFF
--- a/pkgs/tools/archivers/xarchiver/default.nix
+++ b/pkgs/tools/archivers/xarchiver/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchurl, gtk2, pkgconfig, intltool }:
+{ stdenv, fetchFromGitHub, gtk, pkgconfig, intltool }:
 
 stdenv.mkDerivation rec {
-  version = "0.5.4";
+  version = "0.5.4.6";
   name = "xarchiver-${version}";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/xarchiver/${name}.tar.bz2";
-    sha256 = "1x1f8m71cvv2p1364rz99iqs2caxj7yrb46aikz6xigwg4wsfgz6";
+  src = fetchFromGitHub {
+    owner = "ib";
+    repo = "xarchiver";
+    rev = "${name}";
+    sha256 = "1w6b4cchd4prswrn981a7bkq44ad51xm2qiwlpzy43ynql14q877";
   };
 
-  buildInputs = [ gtk2 pkgconfig intltool ];
+  buildInputs = [ gtk pkgconfig intltool ];
 
   meta = {
-    description = "GTK+2 only frontend to 7z,zip,rar,tar,bzip2, gzip,arj, lha, rpm and deb (open and extract only)";
+    description = "GTK+ frontend to 7z,zip,rar,tar,bzip2, gzip,arj, lha, rpm and deb (open and extract only)";
     homepage = http://sourceforge.net/projects/xarchiver/;
     maintainers = [ stdenv.lib.maintainers.domenkozar ];
     license = stdenv.lib.licenses.gpl2;


### PR DESCRIPTION
###### Motivation for this change

Update xarchiver to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
