### PR TITLE
plugin-torture: git 2013-10-03 -> 5

### DIFF
--- a/pkgs/applications/audio/plugin-torture/default.nix
+++ b/pkgs/applications/audio/plugin-torture/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, boost, ladspaH, lilv, lv2, pkgconfig, serd, sord, sratom }:
+{ stdenv, fetchFromGitHub, boost, ladspaH, lilv, lv2, pkgconfig, serd, sord, sratom }:
 
 stdenv.mkDerivation rec {
-  name = "plugin-torture-git-${version}";
-  version = "2013-10-03";
+  name = "plugin-torture-${version}";
+  version = "5";
 
-  src = fetchgit {
-    url = "https://github.com/cth103/plugin-torture";
-    rev = "9ee06016982bdfbaa215cd0468cc6ada6367462a";
-    sha256 = "0ynzfs3z95lbw4l1w276as2a37zxp0cw6pi3lbikr0qk0r7j5j10";
+  src = fetchFromGitHub {
+    owner = "cth103";
+    repo = "plugin-torture";
+    rev = "v${version}";
+    sha256 = "1mlgxjsyaz86wm4k32ll2w5nghjffnsdqlm6kjv02a4dpb2bfrih";
   };
 
   buildInputs = [ boost ladspaH lilv lv2 pkgconfig serd sord sratom ];
@@ -15,7 +16,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp plugin-torture $out/bin/
-    cp README $out/bin/
+    cp find-safe-plugins $out/bin/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

update pkg
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS 16.03
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
