### PR TITLE
octave: add arpack, libwebp, and darwin compat

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, gfortran, readline, ncurses, perl, flex, texinfo, qhull
 , libsndfile, libX11, graphicsmagick, pcre, pkgconfig, mesa, fltk
-, fftw, fftwSinglePrec, zlib, curl, qrupdate, openblas
+, fftw, fftwSinglePrec, zlib, curl, qrupdate, openblas, arpack, libwebp
 , qt ? null, qscintilla ? null, ghostscript ? null, llvm ? null, hdf5 ? null,glpk ? null
 , suitesparse ? null, gnuplot ? null, jdk ? null, python ? null
 }:
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gfortran readline ncurses perl flex texinfo qhull libX11
     graphicsmagick pcre pkgconfig mesa fltk zlib curl openblas libsndfile
-    fftw fftwSinglePrec qrupdate ]
+    fftw fftwSinglePrec qrupdate arpack libwebp ]
     ++ (stdenv.lib.optional (qt != null) qt)
     ++ (stdenv.lib.optional (qscintilla != null) qscintilla)
     ++ (stdenv.lib.optional (ghostscript != null) ghostscript)
@@ -38,9 +38,10 @@ stdenv.mkDerivation rec {
     ++ (stdenv.lib.optional (jdk != null) jdk)
     ++ (stdenv.lib.optional (gnuplot != null) gnuplot)
     ++ (stdenv.lib.optional (python != null) python)
+    ++ (stdenv.lib.optionals (!stdenv.isDarwin) [mesa libX11])
     ;
 
-  doCheck = true;
+  doCheck = !stdenv.isDarwin;
 
   enableParallelBuilding = true;
 
@@ -50,7 +51,9 @@ stdenv.mkDerivation rec {
       "--with-blas=openblas"
       "--with-lapack=openblas"
     ]
-    ++ stdenv.lib.optional openblas.blas64 "--enable-64";
+    ++ stdenv.lib.optional openblas.blas64 "--enable-64"
+    ++ stdenv.lib.optionals stdenv.isDarwin ["--with-x=no"]
+    ;
 
   # Keep a copy of the octave tests detailed results in the output
   # derivation, because someone may care
@@ -67,6 +70,6 @@ stdenv.mkDerivation rec {
     homepage = http://octave.org/;
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [viric raskin];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This follows on from PR #16965 for `qrupdate` and PR #16968 for `fltk`.

WIth these, the added explicit dependencies on arpack (to support
the octave `eigs` function) and `libwebp`, and not pulling X11 things on darwin,
octave works properly on darwin.
