### PR TITLE
guile-sdl: fix after multiple-outputs change

### DIFF
--- a/pkgs/development/guile-modules/guile-sdl/default.nix
+++ b/pkgs/development/guile-modules/guile-sdl/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ guile ];
 
   buildInputs = [
-    SDL SDL_image SDL_ttf SDL_mixer
+    SDL.dev SDL_image SDL_ttf SDL_mixer
   ];
 
   GUILE_AUTO_COMPILE = 0;


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
