### PR TITLE
vtun: add debian gcc5 fix

### DIFF
--- a/pkgs/tools/networking/vtun/default.nix
+++ b/pkgs/tools/networking/vtun/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, lzo, zlib, yacc, flex }:
+{ stdenv, fetchurl, fetchpatch, openssl, lzo, zlib, yacc, flex }:
 
 stdenv.mkDerivation rec {
   name = "vtun-3.0.3";
@@ -8,7 +8,13 @@ stdenv.mkDerivation rec {
     sha256 = "1jxrxp3klhc8az54d5qn84cbc0vdafg319jh84dxkrswii7vxp39";
   };
 
-  patchPhase = ''
+  patches = [
+    (fetchpatch { url = http://sources.debian.net/data/main/v/vtun/3.0.3-2.2/debian/patches/08-gcc5-inline.patch;
+                 sha256 = "18sys97v2hx6vac5zp3ld7sa6kz4izv3g9dnkm0lflbaxhym2vs1";
+                })
+  ];
+
+  postPatch = ''
     sed -i -e 's/-m 755//' -e 's/-o root -g 0//' Makefile.in
     sed -i '/strip/d' Makefile.in
   '';


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
