### PR TITLE
[WIP] python: add alpha release of 3.6

### DIFF
--- a/pkgs/development/interpreters/python/3.6/default.nix
+++ b/pkgs/development/interpreters/python/3.6/default.nix
@@ -1,0 +1,138 @@
+{ stdenv, fetchurl
+, glibc
+, bzip2
+, db
+, gdbm
+, libX11, xproto
+, lzma
+, ncurses
+, openssl
+, readline
+, sqlite
+, tcl, tk
+, zlib
+, callPackage
+, self
+, python35Packages
+
+, CF, configd
+}:
+
+assert readline != null -> ncurses != null;
+
+with stdenv.lib;
+
+let
+  majorVersion = "3.6";
+  pythonVersion = majorVersion;
+  version = "${majorVersion}.0a3";
+  fullVersion = "${version}";
+
+  buildInputs = filter (p: p != null) [
+    glibc
+    zlib
+    bzip2
+    lzma
+    gdbm
+    sqlite
+    db
+    readline
+    ncurses
+    openssl
+    tcl
+    tk
+    libX11
+    xproto
+  ] ++ optionals stdenv.isDarwin [ CF configd ];
+in
+stdenv.mkDerivation {
+  name = "python3-${fullVersion}";
+  pythonVersion = majorVersion;
+  inherit majorVersion version;
+
+  inherit buildInputs;
+
+  src = fetchurl {
+    url = "https://www.python.org/ftp/python/${majorVersion}.0/Python-${fullVersion}.tar.xz";
+    sha256 = "08c3598bwihibwca9lwxq923sjq9shvgv3wxv4vkga2n6hf63l1c";
+  };
+
+  NIX_LDFLAGS = optionalString stdenv.isLinux "-lgcc_s";
+
+  prePatch = optionalString stdenv.isDarwin ''
+    substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
+  '';
+
+  preConfigure = ''
+    for i in /usr /sw /opt /pkg; do	# improve purity
+      substituteInPlace ./setup.py --replace $i /no-such-path
+    done
+    ${optionalString stdenv.isDarwin ''
+       export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -msse2"
+       export MACOSX_DEPLOYMENT_TARGET=10.6
+     ''}
+
+    substituteInPlace ./Lib/plat-generic/regen --replace "/usr/include" ${glibc}/include
+
+    configureFlagsArray=( --enable-shared --with-threads
+                          CPPFLAGS="${concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs)}"
+                          LDFLAGS="${concatStringsSep " " (map (p: "-L${getLib p}/lib") buildInputs)}"
+                          LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}"
+                        )
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  postInstall = ''
+    # needed for some packages, especially packages that backport functionality
+    # to 2.x from 3.x
+    for item in $out/lib/python${majorVersion}/test/*; do
+      if [[ "$item" != */test_support.py* ]]; then
+        rm -rf "$item"
+      else
+        echo $item
+      fi
+    done
+    touch $out/lib/python${majorVersion}/test/__init__.py
+
+    ln -s "$out/include/python${majorVersion}m" "$out/include/python${majorVersion}"
+    paxmark E $out/bin/python${majorVersion}
+  '';
+
+  passthru = rec {
+    zlibSupport = zlib != null;
+    sqliteSupport = sqlite != null;
+    dbSupport = db != null;
+    readlineSupport = readline != null;
+    opensslSupport = openssl != null;
+    tkSupport = (tk != null) && (tcl != null) && (libX11 != null) && (xproto != null);
+    libPrefix = "python${majorVersion}";
+    executable = "python${majorVersion}m";
+    buildEnv = callPackage ../wrapper.nix { python = self; };
+    withPackages = import ../with-packages.nix { inherit buildEnv; pythonPackages = python36Packages; };
+    isPy3 = true;
+    isPy35 = true;
+    is_py3k = true;  # deprecated
+    sitePackages = "lib/${libPrefix}/site-packages";
+    interpreter = "${self}/bin/${executable}";
+  };
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = http://python.org;
+    description = "A high-level dynamically-typed programming language";
+    longDescription = ''
+      Python is a remarkably powerful dynamic programming language that
+      is used in a wide variety of application domains. Some of its key
+      distinguishing features include: clear, readable syntax; strong
+      introspection capabilities; intuitive object orientation; natural
+      expression of procedural code; full modularity, supporting
+      hierarchical packages; exception-based error handling; and very
+      high level dynamic data types.
+    '';
+    license = licenses.psfl;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ chaoflow domenkozar cstrahan kragniz ];
+  };
+}

--- a/pkgs/development/interpreters/python/3.6/setup-hook.sh
+++ b/pkgs/development/interpreters/python/3.6/setup-hook.sh
@@ -1,0 +1,15 @@
+addPythonPath() {
+    addToSearchPathWithCustomDelimiter : PYTHONPATH $1/lib/python3.6/site-packages
+}
+
+toPythonPath() {
+    local paths="$1"
+    local result=
+    for i in $paths; do
+        p="$i/lib/python3.6/site-packages"
+        result="${result}${result:+:}$p"
+    done
+    echo $result
+}
+
+envHooks+=(addPythonPath)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5842,6 +5842,10 @@ in
     inherit (darwin) CF configd;
     self = python35;
   });
+  python36 = (callPackage ../development/interpreters/python/3.6 {
+    inherit (darwin) CF configd;
+    self = python36;
+  });
   pypy = callPackage ../development/interpreters/pypy {
     self = pypy;
   };
@@ -9883,6 +9887,11 @@ in
   python35Packages = recurseIntoAttrs (callPackage ./python-packages.nix {
     python = python35;
     self = python35Packages;
+  });
+
+  python36Packages = (callPackage ./python-packages.nix {
+    python = python36;
+    self = python36Packages;
   });
 
   pypyPackages = callPackage ./python-packages.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10,6 +10,7 @@ let
   isPy33 = python.majorVersion == "3.3";
   isPy34 = python.majorVersion == "3.4";
   isPy35 = python.majorVersion == "3.5";
+  isPy36 = python.majorVersion == "3.6";
   isPyPy = python.executable == "pypy";
   isPy3k = strings.substring 0 1 python.majorVersion == "3";
 
@@ -30,6 +31,7 @@ let
     if isPy33 then "python33" else
     if isPy34 then "python34" else
     if isPy35 then "python35" else
+    if isPy36 then "python36" else
     if isPyPy then "pypy" else "";
 
   modules = python.modules or {
@@ -42,7 +44,7 @@ let
 
 in modules // {
 
-  inherit python bootstrapped-pip isPy26 isPy27 isPy33 isPy34 isPy35 isPyPy isPy3k pythonName buildPythonPackage buildPythonApplication;
+  inherit python bootstrapped-pip isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k pythonName buildPythonPackage buildPythonApplication;
 
   # helpers
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This might be jumping the gun a little, but I needed to use 3.6 locally
and thought I may as well push it upstream.
