### PR TITLE
openssh: Use the default privilege separation dir (/var/empty)

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -45,6 +45,9 @@ stdenv.mkDerivation rec {
       ./locale_archive.patch
       ./fix-host-key-algorithms-plus.patch
       ./CVE-2015-8325.patch
+
+      # See discussion in https://github.com/NixOS/nixpkgs/pull/16966
+      ./dont_create_privsep_path.patch
     ]
     ++ optional withGssapiPatches gssapiSrc;
 
@@ -65,11 +68,6 @@ stdenv.mkDerivation rec {
     ++ optional withKerberos "--with-kerberos5=${kerberos}"
     ++ optional stdenv.isDarwin "--disable-libutil"
     ++ optional (!linkOpenssl) "--without-openssl";
-
-  preConfigure = ''
-    configureFlagsArray+=("--with-privsep-path=$out/empty")
-    mkdir -p $out/empty
-  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/networking/openssh/dont_create_privsep_path.patch
+++ b/pkgs/tools/networking/openssh/dont_create_privsep_path.patch
@@ -1,0 +1,11 @@
+diff -ur openssh-7.2p2_orig/Makefile.in openssh-7.2p2/Makefile.in
+--- openssh-7.2p2_orig/Makefile.in	2016-03-09 19:04:48.000000000 +0100
++++ openssh-7.2p2/Makefile.in	2016-07-16 09:56:05.643903293 +0200
+@@ -301,7 +301,6 @@
+ 	$(srcdir)/mkinstalldirs $(DESTDIR)$(mandir)/$(mansubdir)5
+ 	$(srcdir)/mkinstalldirs $(DESTDIR)$(mandir)/$(mansubdir)8
+ 	$(srcdir)/mkinstalldirs $(DESTDIR)$(libexecdir)
+-	(umask 022 ; $(srcdir)/mkinstalldirs $(DESTDIR)$(PRIVSEP_PATH))
+ 	$(INSTALL) -m 0755 $(STRIP_OPT) ssh$(EXEEXT) $(DESTDIR)$(bindir)/ssh$(EXEEXT)
+ 	$(INSTALL) -m 0755 $(STRIP_OPT) scp$(EXEEXT) $(DESTDIR)$(bindir)/scp$(EXEEXT)
+ 	$(INSTALL) -m 0755 $(STRIP_OPT) ssh-add$(EXEEXT) $(DESTDIR)$(bindir)/ssh-add$(EXEEXT)


### PR DESCRIPTION
###### Motivation for this change

(This is a rewritten version of the reverted commit
a927709a35cee56f878f0f57a932e1a6e2ebe23b, that disables the creation of
/var/empty during build so that sandboxed builds also works. For more
context, see https://github.com/NixOS/nixpkgs/pull/16966)

If running NixOS inside a container where the host's root-owned files
and directories have been mapped to some other uid (like nobody), the
ssh daemon fails to start, producing this error message:

fatal: /nix/store/...-openssh-7.2p2/empty must be owned by root and not group or world-writable.

The reason for this is that when openssh is built, we explicitly set
`--with-privsep-path=$out/empty`. This commit removes that flag which
causes the default directory /var/empty to be used instead. Since NixOS'
activation script correctly sets up that directory, the ssh daemon now
also works within containers that have a non-root-owned nix store.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
