### PR TITLE
libui: init at 3.1a

### DIFF
--- a/pkgs/development/libraries/libui/default.nix
+++ b/pkgs/development/libraries/libui/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchgit, cmake, pkgconfig, gtk3 }:
+
+stdenv.mkDerivation rec {
+  version = "3.1.a";
+  name = "libui-${version}";
+  src  = fetchgit {
+    url    = "https://github.com/andlabs/libui.git";
+    rev    = "6ebdc96b93273c3cedf81159e7843025caa83058";
+    sha256 = "1lpbfa298c61aarlzgp7vghrmxg1274pzxh1j9isv8x758gk6mfn";
+  };
+
+  buildInputs = [ cmake pkgconfig gtk3 ];
+
+  installPhase = ''
+    mkdir -p $out
+    mv ./out/libui.so.0 $out/libui.so.0
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple and portable (but not inflexible) GUI library in C that uses the native GUI technologies of each platform it supports.";
+    homepage    = https://github.com/andlabs/libui;
+    platforms   = platforms.linux;
+    license     = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8424,6 +8424,8 @@ in
 
   libu2f-server = callPackage ../development/libraries/libu2f-server { };
 
+  libui = callPackage ../development/libraries/libui { };
+
   libunity = callPackage ../development/libraries/libunity { };
 
   libunistring = callPackage ../development/libraries/libunistring { };
@@ -14873,7 +14875,7 @@ in
 
   vym = callPackage ../applications/misc/vym { };
 
-  w3m = callPackage ../applications/networking/browsers/w3m { 
+  w3m = callPackage ../applications/networking/browsers/w3m {
     graphicsSupport = !stdenv.isDarwin;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Adds the library for Linux, even though it's supposed to be cross-platform. I'm not sure how to go about when creating a cross-platform package.

I have tested to build the package on NixOS 16.03 and Alpine Linux 3.3 inside a Docker container. The library comes with a test application that I built and ran successfully on NixOS:

![screenshot](http://i.imgur.com/KBtRANi.png)

I used the following Dockerfile for Alpine to run the test:

``` docker
FROM alpine:3.3

RUN apk add --update bzip2 gnupg perl curl sudo bash && \
    rm -rf /var/cache/apk/*

ENV LANG en_US.utf8
RUN adduser -h /home/tester -D -s /bin/bash tester
RUN addgroup sudo
RUN addgroup tester sudo
RUN echo " tester      ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers

WORKDIR /home/tester
USER tester

ENV USER tester

RUN curl https://nixos.org/nix/install | sh

RUN mkdir libui-nix
ADD default.nix libui-nix/default.nix
ADD shell.nix libui-nix/shell.nix
RUN source .nix-profile/etc/profile.d/nix.sh && nix-build libui-nix/shell.nix
```

Just put the Dockerfile in the same dir as `default.nix` and run `docker build -t libui-nix .`
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
