### PR TITLE
nasty: add large file support

### DIFF
--- a/pkgs/tools/security/nasty/default.nix
+++ b/pkgs/tools/security/nasty/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1dznlxr728k1pgy1kwmlm7ivyl3j3rlvkmq34qpwbwbj8rnja1vn";
   };
 
+  # does not apply cleanly with patchPhase/fetchpatch
+  # https://sources.debian.net/src/nasty/0.6-3/debian/patches/02_add_largefile_support.patch
+  CFLAGS = "-D_FILE_OFFSET_BITS=64";
+
   buildInputs = [ gpgme ];
 
   installPhase = ''


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

also fixes i686 build as a side-effect
