### PR TITLE
lightum: fix build against systemd-230

### DIFF
--- a/pkgs/os-specific/linux/lightum/default.nix
+++ b/pkgs/os-specific/linux/lightum/default.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation {
     systemd
   ];
 
+  patchPhase = ''
+    substituteInPlace Makefile \
+      --replace "libsystemd-login" "libsystemd"
+  '';
+
   installPhase = ''
     make install prefix=$out bindir=$out/bin docdir=$out/share/doc \
       mandir=$out/share/man INSTALL="install -c" INSTALLDATA="install -c -m 644"


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

libsystemd-login is now merged into libsystemd (similar commit at 6f8d2d6)
