### PR TITLE
fzf: 0.13.2 -> 0.13.3

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "fzf-${version}";
-  version = "0.13.2";
+  version = "0.13.3";
   rev = "${version}";
 
   goPackagePath = "github.com/junegunn/fzf";
@@ -11,13 +11,13 @@ buildGoPackage rec {
     inherit rev;
     owner = "junegunn";
     repo = "fzf";
-    sha256 = "12dr0wib2ajs64a8d3l3zmgj2y8rklkc3xrvgscxgiv29lrlmvfz";
+    sha256 = "0mfrlb91akzrj0qpjpaa9bkp6m9z95z56glamry73qy21vbnj58m";
   };
 
   buildInputs = [ ncurses ];
 
   goDeps = ./deps.json;
-  
+
   patchPhase = ''
     sed -i -e "s|expand('<sfile>:h:h').'/bin/fzf'|'$bin/bin/fzf'|" plugin/fzf.vim
     sed -i -e "s|expand('<sfile>:h:h').'/bin/fzf-tmux'|'$bin/bin/fzf-tmux'|" plugin/fzf.vim
@@ -28,4 +28,11 @@ buildGoPackage rec {
     mkdir -p $out/share/vim-plugins
     ln -s $out/share/go/src/github.com/junegunn/fzf $out/share/vim-plugins/${name}
   '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/junegunn/fzf;
+    description = "A command-line fuzzy finder written in Go";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Update fzf to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
