### PR TITLE
qt3: fix build after multiple-outputs change

### DIFF
--- a/pkgs/development/libraries/qt-3/default.nix
+++ b/pkgs/development/libraries/qt-3/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   setupHook = ./setup-hook.sh;
 
   src = fetchurl {
-    url = ftp://ftp.trolltech.com/qt/source/qt-x11-free-3.3.8.tar.bz2;
+    url = http://download.qt.io/archive/qt/3/qt-x11-free-3.3.8.tar.bz2;
     sha256 = "0jd4g3bwkgk2s4flbmgisyihm7cam964gzb3pawjlkhas01zghz8";
   };
 
@@ -39,14 +39,14 @@ stdenv.mkDerivation {
     -I${xextproto}/include
     ${if openglSupport then "-dlopen-opengl
       -L${mesa}/lib -I${mesa}/include
-      -L${libXmu}/lib -I${libXmu}/include" else ""}
+      -L${libXmu.out}/lib -I${libXmu.dev}/include" else ""}
     ${if threadSupport then "-thread" else "-no-thread"}
-    ${if xrenderSupport then "-xrender -L${libXrender}/lib -I${libXrender}/include" else "-no-xrender"}
+    ${if xrenderSupport then "-xrender -L${libXrender.out}/lib -I${libXrender.dev}/include" else "-no-xrender"}
     ${if xrandrSupport then "-xrandr
-      -L${libXrandr}/lib -I${libXrandr}/include
+      -L${libXrandr.out}/lib -I${libXrandr.dev}/include
       -I${randrproto}/include" else "-no-xrandr"}
-    ${if xineramaSupport then "-xinerama -L${libXinerama}/lib -I${libXinerama}/include" else "-no-xinerama"}
-    ${if cursorSupport then "-L${libXcursor}/lib -I${libXcursor}/include" else ""}
+    ${if xineramaSupport then "-xinerama -L${libXinerama.out}/lib -I${libXinerama.dev}/include" else "-no-xinerama"}
+    ${if cursorSupport then "-L${libXcursor.out}/lib -I${libXcursor.dev}/include" else ""}
     ${if mysqlSupport then "-qt-sql-mysql -L${mysql.lib}/lib/mysql -I${mysql.lib}/include/mysql" else ""}
     ${if xftSupport then "-xft
       -L${libXft.out}/lib -I${libXft.dev}/include


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

nox-review identified 3 more dependencies (lprof, taskjuggler and twinkle) and I could make them compile successfully only when marking taskjuggler with `broken = true`.

Besides that, lprof and twinkle seem to work fine.

Let me know if we should mark taskjuggler as broken.
