### PR TITLE
tclx: init at 8.4.1

### DIFF
--- a/pkgs/development/libraries/tclx/default.nix
+++ b/pkgs/development/libraries/tclx/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, tcl }:
+
+stdenv.mkDerivation rec {
+  name = "tclx-${version}.${patch}";
+  version = "8.4";
+  patch = "1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/tclx/tclx${version}.${patch}.tar.bz2";
+    sha256 = "1v2qwzzidz0is58fd1p7wfdbscxm3ip2wlbqkj5jdhf6drh1zd59";
+  };
+
+  passthru = {
+    libPrefix = ""; # Using tclx${version} did not work
+  };
+
+  buildInputs = [ tcl ];
+
+  configureFlags = [ "--with-tcl=${tcl}/lib" "--exec-prefix=\${prefix}" ];
+
+  meta = {
+    homepage = http://tclx.sourceforge.net/;
+    description = "Tcl extensions";
+    license = stdenv.lib.licenses.tcltk;
+    maintainers = with stdenv.lib.maintainers; [ kovirobi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9227,6 +9227,8 @@ in
 
   tcltls = callPackage ../development/libraries/tcltls { };
 
+  tclx = callPackage ../development/libraries/tclx { };
+
   ntdb = callPackage ../development/libraries/ntdb {
     python = python2;
   };


### PR DESCRIPTION
###### Motivation for this change

Adding Tclx, because it is required for emacspeak, but I have no idea about Tcl packages so would suggest a review by someone who knows how these work. In particular, I found I needed to set "libPrefix" to empty string, instead of "tclx${version}"

Required for #17022 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [x] OS X
  - [x] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
