### PR TITLE
Emacspeak add at 44

### DIFF
--- a/pkgs/applications/editors/emacs-modes/emacspeak/default.nix
+++ b/pkgs/applications/editors/emacs-modes/emacspeak/default.nix
@@ -1,0 +1,87 @@
+{ stdenv, fetchurl, makeWrapper, emacs, texinfo, tcl, tk, tclx
+, espeakTTS ? true, espeak ? null
+, outLoudTTS ? false, glibc_multi ? null, alsaLib ? null
+, decTalkTTS ? false}:
+
+assert espeakTTS -> espeak != null;
+
+assert outLoudTTS -> glibc_multi != null;
+assert outLoudTTS -> alsaLib != null;
+assert outLoudTTS -> false; # Could not get it to work
+
+assert decTalkTTS -> false; # Could not get it to work
+
+stdenv.mkDerivation rec {
+  name = "emacspeak-${version}";
+  version = "44.0";
+
+  src = fetchurl {
+    url = "https://github.com/tvraman/emacspeak/releases/download/44.0/${name}.tar.bz2";
+    sha256 = "1mbgfcd2hk8xya85cx7zwd4k5zn2lqqqqmqpc35860ljsm58zspq";
+  };
+
+  tclLibraries = [ tclx tk ];
+  tclLibPaths = stdenv.lib.concatStringsSep " "
+    (map (p: "${p}/lib/${p.libPrefix}") tclLibraries);
+
+  buildInputs = [ makeWrapper emacs texinfo
+                  espeak glibc_multi alsaLib
+                  tcl ] ++ tclLibraries;
+
+  configurePhase = ''
+    make config
+
+    ${if espeakTTS then "" else
+      "sed '/INSTALL.*ESPEAK/d' -i Makefile"}
+    ${if outLoudTTS then "" else
+      "sed '/INSTALL.*OUTLOUD/d' -i Makefile"}
+    ${if decTalkTTS then "" else
+      "sed '/INSTALL.*DTKTTS/d' -i Makefile"}
+  '';
+
+  buildPhase = ''
+    make
+
+    ${if espeakTTS then
+      "(cd servers/linux-espeak;
+        make)"
+    else ""}
+    ${if outLoudTTS then
+      "(cd servers/linux-outloud;
+        make)"
+    else ""}
+    ${if decTalkTTS then
+      "(cd servers/software-dtk;
+        make)"
+    else ""}
+  '';
+
+  installPhase = ''
+    make prefix=$out SRC=$out/share/emacs/site-lisp/emacspeak install
+
+    ${if espeakTTS then
+      "(cd servers/linux-espeak;
+        make PREFIX=$out install)"
+    else ""}
+    ${if outLoudTTS then
+      "(cd servers/linux-outloud;
+        make PREFIX=$out install)"
+    else ""}
+    ${if decTalkTTS then
+      "(cd servers/software-dtk;
+        make PREFIX=$out install)"
+    else ""}
+
+    for prog in `grep -rl '^#!/usr/bin/tclsh' $out`; do
+      wrapProgram "$prog" --set TCLLIBPATH '"${tclLibPaths}"'
+    done
+  '';
+
+  meta = {
+    description = "Speech mode for Emacs";
+    homepage = http://emacspeak.sourceforge.net;
+    license     = stdenv.lib.licenses.gpl2Plus;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ kovirobi ];
+  };
+}

--- a/pkgs/development/libraries/tclx/default.nix
+++ b/pkgs/development/libraries/tclx/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, tcl }:
+
+stdenv.mkDerivation rec {
+  name = "tclx-${version}.${patch}";
+  version = "8.4";
+  patch = "1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/tclx/tclx${version}.${patch}.tar.bz2";
+    sha256 = "1v2qwzzidz0is58fd1p7wfdbscxm3ip2wlbqkj5jdhf6drh1zd59";
+  };
+
+  passthru = {
+    libPrefix = ""; # Using tclx${version} did not work
+  };
+
+  buildInputs = [ tcl ];
+
+  configureFlags = [ "--with-tcl=${tcl}/lib" "--exec-prefix=\${prefix}" ];
+
+  meta = {
+    homepage = http://tclx.sourceforge.net/;
+    description = "Tcl extensions";
+    license = stdenv.lib.licenses.tcltk;
+    maintainers = with stdenv.lib.maintainers; [ kovirobi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12632,6 +12632,8 @@ in
 
     emacsSessionManagement = callPackage ../applications/editors/emacs-modes/session-management-for-emacs { };
 
+    emacspeak = callPackage ../applications/editors/emacs-modes/emacspeak { };
+
     emacsw3m = callPackage ../applications/editors/emacs-modes/emacs-w3m { };
 
     emms = callPackage ../applications/editors/emacs-modes/emms { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9368,6 +9368,8 @@ in
 
   tcltls = callPackage ../development/libraries/tcltls { };
 
+  tclx = callPackage ../development/libraries/tclx { };
+
   ntdb = callPackage ../development/libraries/ntdb {
     python = python2;
   };


### PR DESCRIPTION
###### Motivation for this change

Adding emacspeak because I wanted to try it out. I have no idea about emacs packages, so someone who knows how those work should review it. Not sure if it is a package, or a standalone executable, as it creakes an "emacspeak" script that calls emacs loading emacs-setup.el

Also could not get either software-dtk working, or linux-outloud, so just have a false assertion

Requires #17021, henced the 2 'commits'
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
