### PR TITLE
Bring back ncurses5 to fix GHC bootstrapping

### DIFF
--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -1,4 +1,4 @@
-{stdenv, lib, fetchurl, perl, libedit, ncurses, gmp}:
+{stdenv, lib, fetchurl, perl, libedit, ncurses5, gmp}:
 
 stdenv.mkDerivation rec {
   version = "6.10.2";
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     (if stdenv.isLinux then ''
       find . -type f -perm -0100 \
           -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath "${libedit}/lib:${ncurses.out}/lib:${gmp.out}/lib" {} \;
+          --set-rpath "${libedit}/lib:${ncurses5.out}/lib:${gmp.out}/lib" {} \;
       for prog in ld ar gcc strip ranlib; do
         find . -name "setup-config" -exec sed -i "s@/usr/bin/$prog@$(type -p $prog)@g" {} \;
       done

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, perl, ncurses, gmp, libiconv}:
+{stdenv, fetchurl, perl, ncurses5, gmp, libiconv}:
 
 stdenv.mkDerivation rec {
   version = "7.0.4";
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     stdenv.lib.optionalString stdenv.isLinux ''
       find . -type f -perm -0100 \
           -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath "${ncurses.out}/lib:${gmp.out}/lib" {} \;
+          --set-rpath "${ncurses5.out}/lib:${gmp.out}/lib" {} \;
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       for prog in ld ar gcc strip ranlib; do

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, perl, ncurses, gmp, libiconv, makeWrapper}:
+{stdenv, fetchurl, perl, ncurses5, gmp, libiconv, makeWrapper}:
 
 stdenv.mkDerivation rec {
   version = "7.4.2";
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     # find editline/gmp.
     stdenv.lib.optionalString stdenv.isLinux ''
       mkdir -p "$out/lib"
-      ln -sv "${ncurses.out}/lib/libncurses.so" "$out/lib/libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5"
+      ln -sv "${ncurses5.out}/lib/libncurses.so" "$out/lib/libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5"
       find . -type f -perm -0100 \
           -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
           --set-rpath "$out/lib:${gmp.out}/lib" {} \;

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -1,15 +1,14 @@
 { lib, stdenv, fetchurl, pkgconfig
 
+, abiVersion
 , mouseSupport ? false
 , unicode ? true
 
 , gpm
 }:
 let
-  inherit (stdenv) isDarwin;
-  abiVersion = if isDarwin then "5" else "6";
-  version = if isDarwin then "5.9" else "6.0";
-  sha256 = if isDarwin
+  version = if abiVersion == "5" then "5.9" else "6.0";
+  sha256 = if abiVersion == "5"
     then "0fsn7xis81za62afan0vvm38bvgzg5wfmv1m86flqcj0nj7jjilh"
     else "0q3jck7lna77z5r42f13c4xglc7azd19pxfrjrpgp2yf615w4lgm";
 in
@@ -21,7 +20,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  patches = [ ./clang.patch ];
+  patches = [ ./clang.patch ] ++ lib.optional (abiVersion == "5" && stdenv.cc.isGNU) ./gcc-5.patch;
 
   outputs = [ "dev" "out" "man" ];
   setOutputFlags = false; # some aren't supported

--- a/pkgs/development/libraries/ncurses/gcc-5.patch
+++ b/pkgs/development/libraries/ncurses/gcc-5.patch
@@ -1,0 +1,46 @@
+https://bugs.gentoo.org/545114
+
+extracted from the upstream change (which had many unrelated commits in one)
+
+From 97bb4678dc03e753290b39bbff30ba2825df9517 Mon Sep 17 00:00:00 2001
+From: "Thomas E. Dickey" <dickey@invisible-island.net>
+Date: Sun, 7 Dec 2014 03:10:09 +0000
+Subject: [PATCH] ncurses 5.9 - patch 20141206
+
++ modify MKlib_gen.sh to work around change in development version of
+  gcc introduced here:
+	  https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
+	  https://gcc.gnu.org/ml/gcc-patches/2014-07/msg00236.html
+  (reports by Marcus Shawcroft, Maohui Lei).
+
+diff --git a/ncurses/base/MKlib_gen.sh b/ncurses/base/MKlib_gen.sh
+index d8cc3c9..b91398c 100755
+--- a/ncurses/base/MKlib_gen.sh
++++ b/ncurses/base/MKlib_gen.sh
+@@ -474,11 +474,22 @@ sed -n -f $ED1 \
+ 	-e 's/gen_$//' \
+ 	-e 's/  / /g' >>$TMP
+ 
++cat >$ED1 <<EOF
++s/  / /g
++s/^ //
++s/ $//
++s/P_NCURSES_BOOL/NCURSES_BOOL/g
++EOF
++
++# A patch discussed here:
++#	https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
++# introduces spurious #line markers.  Work around that by ignoring the system's
++# attempt to define "bool" and using our own symbol here.
++sed -e 's/bool/P_NCURSES_BOOL/g' $TMP > $ED2
++cat $ED2 >$TMP
++
+ $preprocessor $TMP 2>/dev/null \
+-| sed \
+-	-e 's/  / /g' \
+-	-e 's/^ //' \
+-	-e 's/_Bool/NCURSES_BOOL/g' \
++| sed -f $ED1 \
+ | $AWK -f $AW2 \
+ | sed -f $ED3 \
+ | sed \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8714,7 +8714,9 @@ in
 
   notify-sharp = callPackage ../development/libraries/notify-sharp { };
 
-  ncurses = callPackage ../development/libraries/ncurses { };
+  ncurses5 = callPackage ../development/libraries/ncurses { abiVersion = "5"; };
+  ncurses6 = callPackage ../development/libraries/ncurses { abiVersion = "6"; };
+  ncurses = if stdenv.isDarwin then ncurses5 else ncurses6;
 
   neardal = callPackage ../development/libraries/neardal { };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #17008: GHC bootstrapping broken by ncurses update
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
