### PR TITLE
sway: 0.7 -> 0.8

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -3,39 +3,41 @@
 , wayland, wlc, libxkbcommon, pixman, fontconfig, pcre, json_c, dbus_libs
 }:
 
-stdenv.mkDerivation rec {
-  name = "sway-${version}";
-  version = "0.7";
+let
+  version = "0.8";
+in
+  stdenv.mkDerivation rec {
+    name = "sway-${version}";
 
-  src = fetchFromGitHub {
-    owner = "Sircmpwn";
-    repo = "sway";
-    rev = "0.7";
-    sha256 = "05mn68brqz7j3a1sb5xd3pxzzdd8swnhw2g7cc9f7rdjr5dlrjip";
-  };
+    src = fetchFromGitHub {
+      owner = "Sircmpwn";
+      repo = "sway";
+      rev = "${version}";
+      sha256 = "10i62cn1z7fwg0jwkskmzcaha39lprkl4zvkp59jr5wvpjligdq3";
+    };
 
-  nativeBuildInputs = [ makeWrapper cmake pkgconfig asciidoc libxslt docbook_xsl ];
+    nativeBuildInputs = [ makeWrapper cmake pkgconfig asciidoc libxslt docbook_xsl ];
 
-  buildInputs = [ wayland wlc libxkbcommon pixman fontconfig pcre json_c dbus_libs pango cairo libinput ];
+    buildInputs = [ wayland wlc libxkbcommon pixman fontconfig pcre json_c dbus_libs pango cairo libinput ];
 
-  patchPhase = ''
-    sed -i s@/etc/sway@$out/etc/sway@g CMakeLists.txt;
-  '';
+    patchPhase = ''
+      sed -i s@/etc/sway@$out/etc/sway@g CMakeLists.txt;
+    '';
 
-  makeFlags = "PREFIX=$(out)";
-  installPhase = "PREFIX=$out make install";
+    makeFlags = "PREFIX=$(out)";
+    installPhase = "PREFIX=$out make install";
 
-  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath [ wlc dbus_libs ];
-  preFixup = ''
-    wrapProgram $out/bin/sway \
-      --prefix LD_LIBRARY_PATH : "${LD_LIBRARY_PATH}";
-  '';
+    LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath [ wlc dbus_libs ];
+    preFixup = ''
+      wrapProgram $out/bin/sway \
+        --prefix LD_LIBRARY_PATH : "${LD_LIBRARY_PATH}";
+    '';
 
-  meta = with stdenv.lib; {
-    description = "i3-compatible window manager for Wayland";
-    homepage    = "http://swaywm.org";
-    license     = licenses.mit;
-    platforms   = platforms.linux;
-    maintainers = with maintainers; [ ];
-  };
-}
+    meta = with stdenv.lib; {
+      description = "i3-compatible window manager for Wayland";
+      homepage    = "http://swaywm.org";
+      license     = licenses.mit;
+      platforms   = platforms.linux;
+      maintainers = with maintainers; [ ];
+    };
+  }


### PR DESCRIPTION
###### Motivation for this change

upgrade! release notes here: https://github.com/SirCmpwn/sway/releases/tag/0.8
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
