### PR TITLE
teamspeak_client: specify a custom, nonfree license

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client.nix
@@ -101,7 +101,11 @@ stdenv.mkDerivation rec {
   meta = {
     description = "The TeamSpeak voice communication tool";
     homepage = http://teamspeak.com/;
-    license = "http://www.teamspeak.com/?page=downloads&type=ts3_linux_client_latest";
+    license = {
+      fullName = "Teamspeak client license";
+      url = http://sales.teamspeakusa.com/licensing.php;
+      free = false;
+    };
     maintainers = [ stdenv.lib.maintainers.lhvwb ];
     platforms = stdenv.lib.platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change

It is reasonable to expect that specifying `allowUnfree = false` is sufficient to ensure a system comprising only libre software.  Previously, `teamspeak_client` would happily build even though it is clearly unfree per the usual definition, however.

cc @Jookia raised this issue on IRC.
