### PR TITLE
kde5.spectacle: use postInstall instead of postFixup

### DIFF
--- a/pkgs/desktops/kde-5/applications/spectacle.nix
+++ b/pkgs/desktops/kde-5/applications/spectacle.nix
@@ -29,7 +29,7 @@ kdeApp {
     kconfig kcoreaddons kdbusaddons kdeclarative ki18n kio knotifications
     kscreen kwidgetsaddons kwindowsystem kxmlgui libkipi xcb-util-cursor
   ];
-  postFixup = ''
+  postInstall = ''
     wrapQtProgram "$out/bin/spectacle"
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

Consistency with other KDE applications.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The other KDE applications run wrapQtProgram in preFixup.
