### PR TITLE
purple-hangouts: init at hg-2016-07-17

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-hangouts/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-hangouts/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchhg, pidgin, glib, json_glib, protobuf, protobufc }:
+
+stdenv.mkDerivation rec {
+  name = "purple-hangouts-hg-${version}";
+  version = "2016-07-17";
+
+  src = fetchhg {
+    url = "https://bitbucket.org/EionRobb/purple-hangouts/";
+    rev = "2c60a5e";
+    sha256 = "1m8132ywg9982q3yiqgy1hzm61wkgi590425pp8yk1q03yipd6zb";
+  };
+
+  buildInputs = [ pidgin glib json_glib protobuf protobufc ];
+
+  installPhase = ''
+    install -Dm755 -t $out/lib/pidgin/ libhangouts.so
+    for size in 16 22 24 48; do
+      install -TDm644 hangouts$size.png $out/pixmaps/pidgin/protocols/$size/hangouts.png
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://bitbucket.org/EionRobb/purple-hangouts;
+    description = "Native Hangouts support for pidgin";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ralith ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13910,6 +13910,8 @@ in
 
   pidginwindowmerge = callPackage ../applications/networking/instant-messengers/pidgin-plugins/window-merge { };
 
+  purple-hangouts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-hangouts { };
+
   purple-plugin-pack = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-plugin-pack { };
 
   purple-vk-plugin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin { };


### PR DESCRIPTION
###### Motivation for this change

Native Hangouts support for libpurple. Immature, but still a step up from using XMPP with Hangouts.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
