### PR TITLE
alpine:configure: allow using passfile

### DIFF
--- a/pkgs/applications/networking/mailreaders/alpine/default.nix
+++ b/pkgs/applications/networking/mailreaders/alpine/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation {
   configureFlags = [
     "--with-ssl-include-dir=${openssl.dev}/include/openssl"
     "--with-tcl-lib=${tcl.libPrefix}"
+    "--with-passfile=.pine-passfile"
     ];
   preConfigure = ''
     export NIX_LDFLAGS="$NIX_LDFLAGS -lgcc_s"


### PR DESCRIPTION
###### Motivation for this change

Allow alpine to use passfile for caching passwords.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
