### PR TITLE
xl2tpd: add up/down scripts for xl2tpd

### DIFF
--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -144,3 +144,10 @@ int execv(const char *path, char *const argv[])
     char buf[PATH_MAX];
     return execv_real(rewrite(path, buf), argv);
 }
+
+int execve(const char *path, char *const argv[], char *const envp[])
+{
+    int (*execve_real) (const char *path, char *const argv[], char *const envp[]) = dlsym(RTLD_NEXT, "execve");
+    char buf[PATH_MAX];
+    return execve_real(rewrite(path, buf), argv, envp);
+}


### PR DESCRIPTION
###### Motivation for this change

xl2tpd: The lack of up/down scripts to update, e.g., `resolv.conf`, and autoStart option like it was done for `openvpn` module.
libredirect: `pppd` uses `execve` and redirecting `execv` is not enough.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
