### PR TITLE
puredata 0.45-4 -> 0.47-1

### DIFF
--- a/pkgs/applications/audio/puredata/default.nix
+++ b/pkgs/applications/audio/puredata/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation  rec {
   name = "puredata-${version}";
-  version = "0.45-4";
+  version = "0.47-1";
 
   src = fetchurl {
     url = "mirror://sourceforge/pure-data/pd-${version}.src.tar.gz";
-    sha256 = "1ls2ap5yi2zxvmr247621g4jx0hhfds4j5704a050bn2n3l0va2p";
+    sha256 = "0k5s949kqd7yw97h3m8z81bjz32bis9m4ih8df1z0ymipnafca67";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
