### PR TITLE
zexy: don't patchShebangs, breaks build

### DIFF
--- a/pkgs/applications/audio/pd-plugins/zexy/default.nix
+++ b/pkgs/applications/audio/pd-plugins/zexy/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
     for i in ${puredata}/include/pd/*; do
       ln -s $i .
     done
-    patchShebangs
     ./bootstrap.sh
     ./configure --enable-lpt=no --prefix=$out
   '';


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
