### PR TITLE
eq10q: 2.0-beta7 -> 2.0

### DIFF
--- a/pkgs/applications/audio/eq10q/default.nix
+++ b/pkgs/applications/audio/eq10q/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, cmake, fftw, gtkmm, libxcb, lv2, pkgconfig, xorg }:
 stdenv.mkDerivation rec {
-  name = "eq10q-2-${version}";
-  version = "beta7.1";
+  name = "eq10q-${version}";
+  version = "2.0";
   src = fetchurl {
     url = "mirror://sourceforge/project/eq10q/${name}.tar.gz";
-    sha256 = "1jmrcx4jlx8kgsy5n4jcxa6qkjqvx7d8l2p7dsmw4hj20s39lgyi";
+    sha256 = "08vlfly0qqrfqiwpn5g5php680icpk97pwnwjadmj5syhgvi0i3h";
   };
 
   buildInputs = [ cmake fftw gtkmm libxcb lv2 pkgconfig xorg.libpthreadstubs xorg.libXdmcp xorg.libxshmfence ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
