### PR TITLE
reintroduce qmake .pro files after qmake4Hook changes

### DIFF
--- a/pkgs/applications/misc/multimon-ng/default.nix
+++ b/pkgs/applications/misc/multimon-ng/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ qmake4Hook ];
 
+  qmakeFlags = [ "multimon-ng.pro" ];
+
   installPhase = ''
     mkdir -p $out/bin
     cp multimon-ng $out/bin

--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -9,8 +9,18 @@ stdenv.mkDerivation rec {
     sha256 = "181qnknq1j5x075icpw2qk0sc4wcj9f2hym533vs936is0wxp2gk";
   };
 
+  unpackPhase = ''
+    tar xjf ${src}
+  '';
+
   buildInputs = [ qtbase qtsvg boost qmakeHook ];
 
+  qmakeFlags = [ "phoenix.pro" ];
+
+  preConfigure = ''
+    cd fritzing-${version}.source
+  '';
+  
   meta = {
     description = "An open source prototyping tool for Arduino-based projects";
     homepage = http://fritzing.org/;

--- a/pkgs/applications/version-management/guitone/default.nix
+++ b/pkgs/applications/version-management/guitone/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qt4 qmake4Hook pkgconfig graphviz ];
 
+  qmakeFlags = [ "guitone.pro" ];
+
   meta = {
     description = "Qt4 based GUI for monotone";
     homepage = http://guitone.thomaskeller.biz;

--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec{
   buildInputs = [ zlib libpng pkgconfig qt4 qmake4Hook ]
                 ++ (if withGamepads then [ SDL ] else [ ]);
 
+  qmakeFlags = [ "PPSSPPQt.pro" ];
+
   preConfigure = "cd Qt";
   installPhase = "mkdir -p $out/bin && cp ppsspp $out/bin";
 


### PR DESCRIPTION
fritzing, guitone, multimon-ng and ppsspp fail on hydra when not passed their .pro files

I've added the related hashes from #14770 in each commit description

cc @abbradar 
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
