### PR TITLE
haskellPackages.hfsevents: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -206,7 +206,12 @@ self: super: {
 
   # hfsevents needs CoreServices in scope
   hfsevents = if pkgs.stdenv.isDarwin
-    then with pkgs.darwin.apple_sdk.frameworks; addBuildTool (addBuildDepends super.hfsevents [Cocoa]) CoreServices
+    then overrideCabal
+           (with pkgs.darwin.apple_sdk.frameworks;
+            addBuildTool (addBuildDepends super.hfsevents [Cocoa])
+                         CoreServices)
+           (_: { isLibrary = true;
+                 libraryHaskellDepends = with self; [ base cereal mtl text ]; })
     else super.hfsevents;
 
   # FSEvents API is very buggy and tests are unreliable. See


### PR DESCRIPTION
###### Motivation for this change

Allow `stack` to build on Darwin.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The generated expression for this Darwin-only library prevents it from
actually building on Darwin. It is a requirement for building `stack`.
