### PR TITLE
libinput: Use absolute paths in udev rules.

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -3,6 +3,7 @@
 , documentationSupport ? false, doxygen ? null, graphviz ? null # Documentation
 , eventGUISupport ? false, cairo ? null, glib ? null, gtk3 ? null # GUI event viewer support
 , testsSupport ? false, check ? null, valgrind ? null
+, autoconf, automake
 }:
 
 assert documentationSupport -> doxygen != null && graphviz != null;
@@ -32,12 +33,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ libevdev mtdev libwacom ]
+  buildInputs = [ libevdev mtdev libwacom autoconf automake ]
     ++ optionals eventGUISupport [ cairo glib gtk3 ]
     ++ optionals documentationSupport [ doxygen graphviz ]
     ++ optionals testsSupport [ check valgrind ];
 
   propagatedBuildInputs = [ udev ];
+
+  patches = [ ./udev-absolute-path.patch ];
+  patchFlags = [ "-p0" ];
 
   meta = {
     description = "Handles input devices in Wayland compositors and provides a generic X.Org input driver";

--- a/pkgs/development/libraries/libinput/udev-absolute-path.patch
+++ b/pkgs/development/libraries/libinput/udev-absolute-path.patch
@@ -1,0 +1,12 @@
+--- configure.ac	2016-05-27 14:00:25.248388226 +0200
++++ configure.ac	2016-05-27 14:01:28.228943416 +0200
+@@ -214,7 +214,8 @@ AM_CONDITIONAL(BUILD_DOCS, [test "x$buil
+ # Used by the udev rules so we can use callouts during testing without
+ # installing everything first. Default is the empty string so the installed
+ # rule will use udev's default path. Override is in udev/Makefile.am
+-AC_SUBST(UDEV_TEST_PATH, "")
++UDEV_TEST_PATH="${UDEV_DIR}/"
++AC_SUBST(UDEV_TEST_PATH)
+ AC_PATH_PROG(SED, [sed])
+ 
+ AC_CONFIG_FILES([Makefile


### PR DESCRIPTION
###### Motivation for this change

I wanted to use libinput for my synaptics touchpad, but it didn't load the necessary udev rules included in the package.  This is because udev can't find the executable libinput-model-quirks referenced in /etc/udev/rules.d/90-libinput-model-quirks.rules.  I am now successfully using:

```
  services.xserver.libinput = {
    enable = true;
  };
  services.udev.packages = with pkgs; [libinput];
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
