### PR TITLE
arduino: 1.0.6 -> 1.6.9

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -1,57 +1,111 @@
-{ stdenv, fetchFromGitHub, jdk, jre, ant, coreutils, gnugrep, file, libusb
+{ stdenv, lib, fetchFromGitHub, fetchurl, jdk, ant
+, libusb, libusb1, unzip, zlib, ncurses, readline
 , withGui ? false, gtk2 ? null
 }:
 
 assert withGui -> gtk2 != null;
 
+let
+  externalDownloads = import ./downloads.nix {inherit fetchurl;};
+  # Some .so-files are later copied from .jar-s to $HOME, so patch them beforehand
+  patchelfInJars =
+       lib.optional (stdenv.system == "x86_64-linux") {jar = "share/arduino/lib/jssc-2.8.0.jar"; file = "libs/linux/libjSSC-2.8_x86_64.so";}
+    ++ lib.optional (stdenv.system == "i686-linux") {jar = "share/arduino/lib/jssc-2.8.0.jar"; file = "libs/linux/libjSSC-2.8_x86.so";}
+  ;
+  # abiVersion 6 is default, but we need 5 for `avrdude_bin` executable
+  ncurses5 = ncurses.override { abiVersion = "5"; };
+in
 stdenv.mkDerivation rec {
-
-  version = "1.0.6";
+  version = "1.6.9";
   name = "arduino${stdenv.lib.optionalString (withGui == false) "-core"}-${version}";
 
   src = fetchFromGitHub {
     owner = "arduino";
     repo = "Arduino";
     rev = "${version}";
-    sha256 = "0nr5b719qi03rcmx6swbhccv6kihxz3b8b6y46bc2j348rja5332";
+    sha256 = "0ksd6mkcf41114n0h37q80y1bz3a2q3z8kg6m9i11c3wrj8n80np";
   };
 
-  buildInputs = [ jdk ant file ];
+  buildInputs = [ jdk ant libusb libusb1 unzip zlib ncurses5 readline ];
+  downloadSrcList = builtins.attrValues externalDownloads;
+  downloadDstList = builtins.attrNames externalDownloads;
 
   buildPhase = ''
-    cd ./core && ant 
-    cd ../build && ant 
+    # Copy pre-downloaded files to proper locations
+    download_src=($downloadSrcList)
+    download_dst=($downloadDstList)
+    while [[ "''${#download_src[@]}" -ne 0 ]]; do
+      file_src=''${download_src[0]}
+      file_dst=''${download_dst[0]}
+      mkdir -p $(dirname $file_dst)
+      download_src=(''${download_src[@]:1})
+      download_dst=(''${download_dst[@]:1})
+      cp -v $file_src $file_dst
+    done
+
+    # Loop above creates library_index.json.gz, package_index.json.gz and package_index.json.sig in
+    # current directory. And now we can inject them into build process.
+    library_index_url=file://$(pwd)/library_index.json
+    package_index_url=file://$(pwd)/package_index.json
+
+    cd ./arduino-core && ant
+    cd ../build && ant -Dlibrary_index_url=$library_index_url -Dpackage_index_url=$package_index_url
     cd ..
   '';
 
+  # This will be patched into `arduino` wrapper script
+  # Java loads gtk dynamically, so we need to provide it using LD_LIBRARY_PATH
+  dynamicLibraryPath = lib.makeLibraryPath [gtk2];
+  javaPath = lib.makeBinPath [jdk];
+
+  # Everything else will be patched into rpath
+  rpath = (lib.makeLibraryPath [zlib libusb libusb1 readline ncurses5 stdenv.cc.cc]);
+
   installPhase = ''
     mkdir -p $out/share/arduino
-    cp -r ./build/linux/work/* "$out/share/arduino/"
+    cp -r ./build/linux/work/* "$out/share/arduino/" #*/
     echo ${version} > $out/share/arduino/lib/version.txt
 
     ${stdenv.lib.optionalString withGui ''
-      mkdir -p "$out/bin"
-      sed -i -e "s|^java|${jdk}/bin/java|" "$out/share/arduino/arduino"
-      sed -i -e "s|^LD_LIBRARY_PATH=|LD_LIBRARY_PATH=${gtk2}/lib:|" "$out/share/arduino/arduino"
+      mkdir -p $out/bin
+      substituteInPlace $out/share/arduino/arduino \
+        --replace "JAVA=java" "JAVA=$javaPath/java" \
+        --replace "LD_LIBRARY_PATH=" "LD_LIBRARY_PATH=$dynamicLibraryPath:"
       ln -sr "$out/share/arduino/arduino" "$out/bin/arduino"
-    ''}
 
-    # Fixup "/lib64/ld-linux-x86-64.so.2" like references in ELF executables.
-    echo "running patchelf on prebuilt binaries:"
-    find "$out" | while read filepath; do
-        if file "$filepath" | grep -q "ELF.*executable"; then
-            # skip target firmware files
-            if echo "$filepath" | grep -q "\.elf$"; then
-                continue
-            fi
-            echo "setting interpreter $(cat "$NIX_CC"/nix-support/dynamic-linker) in $filepath"
-            patchelf --set-interpreter "$(cat "$NIX_CC"/nix-support/dynamic-linker)" "$filepath"
-            test $? -eq 0 || { echo "patchelf failed to process $filepath"; exit 1; }
-        fi
+      cp -r build/shared/icons $out/share/arduino
+      mkdir -p $out/share/applications
+      cp build/linux/dist/desktop.template $out/share/applications/arduino.desktop
+      substituteInPlace $out/share/applications/arduino.desktop \
+        --replace '<BINARY_LOCATION>' "$out/bin/arduino" \
+        --replace '<ICON_NAME>' "$out/share/arduino/icons/128x128/apps/arduino.png"
+    ''}
+  '';
+
+  # So we don't accidentally mess with firmware files
+  dontStrip = true;
+  dontPatchELF = true;
+
+  preFixup = ''
+    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+        patchelf --set-rpath ${rpath}:$out/lib $file || true
     done
 
-    patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ libusb ]} \
-        "$out/share/arduino/hardware/tools/avrdude"
+    ${lib.concatMapStringsSep "\n"
+        ({jar, file}:
+          ''
+              jar xvf $out/${jar} ${file}
+              patchelf --set-rpath $rpath ${file}
+              jar uvf $out/${jar} ${file}
+              rm -f ${file}
+          ''
+        )
+        patchelfInJars}
+
+    # avrdude_bin is linked against libtinfo.so.5
+    mkdir $out/lib/
+    ln -s ${lib.makeLibraryPath [ncurses5]}/libncursesw.so.5 $out/lib/libtinfo.so.5
   '';
 
   meta = with stdenv.lib; {
@@ -60,5 +114,5 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     platforms = platforms.all;
     maintainers = with maintainers; [ antono robberer bjornfor ];
-  }; 
+  };
 }

--- a/pkgs/development/arduino/arduino-core/downloads.nix
+++ b/pkgs/development/arduino/arduino-core/downloads.nix
@@ -1,0 +1,92 @@
+{fetchurl}:
+
+{
+  # Following 3 files are snapshots of files that were downloaded from http://download.arduino.cc/
+  # Because original URLs update daily. https://github.com/binarin/arduino-indexes also contains script
+  # for updating those snapshots.
+  "package_index.json.gz" = fetchurl {
+    url = "https://github.com/binarin/arduino-indexes/raw/snapshot-2016-07-18/package_index.json.gz";
+    sha256 = "11y16864bca6h5n03xbk8cw3v9b4xwvjz5mkirkcxslkkf7cx5yg";
+  };
+  "package_index.json.sig" = fetchurl {
+    url = "https://github.com/binarin/arduino-indexes/raw/snapshot-2016-07-18/package_index.json.sig";
+    sha256 = "14ky3qb81mvqswaw9g5cpg5jcjqx6knfm75mzx1si7fbx576amls";
+  };
+  "library_index.json.gz" = fetchurl {
+    url = "https://github.com/binarin/arduino-indexes/raw/snapshot-2016-07-18/library_index.json.gz";
+    sha256 = "19md4yf4m4wh9vnc3aj0gm3jak1qa591z5yhg0x8lsxx5hr2v85z";
+  };
+
+  "build/shared/reference-1.6.6-3.zip" = fetchurl {
+    url = "http://downloads.arduino.cc/reference-1.6.6-3.zip";
+    sha256 = "119nj1idz85l71fy6a6wwsx0mcd8y0ib1wy0l6j9kz88nkwvggy3";
+  };
+  "build/shared/Galileo_help_files-1.6.2.zip" = fetchurl {
+    url = "http://downloads.arduino.cc/Galileo_help_files-1.6.2.zip";
+    sha256 = "0qda0xml353sfhjmx9my4mlcyzbf531k40dcr1cnsa438xp2fw0w";
+  };
+  "build/shared/Edison_help_files-1.6.2.zip" = fetchurl {
+    url = "http://downloads.arduino.cc/Edison_help_files-1.6.2.zip";
+    sha256 = "1x25rivmh0zpa6lr8dafyxvim34wl3wnz3r9msfxg45hnbjqqwan";
+  };
+  "build/Firmata-2.5.2.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Firmata/archive/2.5.2.zip";
+    sha256 = "1r75bxvpr17kwhpks9nxxpm5d5qbw0qnhygakv06whan9s0dc5cz";
+  };
+  "build/Bridge-1.6.2.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Bridge/archive/1.6.2.zip";
+    sha256 = "10v557bsxasq8ya09m9157nlk50cbkb0wlzrm54cznzmwc0gx49a";
+  };
+  "build/Robot_Control-1.0.2.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Robot_Control/archive/1.0.2.zip";
+    sha256 = "1wdpz3ilnza3lfd5a628dryic46j72h4a89y8vp0qkbscvifcvdk";
+  };
+  "build/Robot_Motor-1.0.2.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Robot_Motor/archive/1.0.2.zip";
+    sha256 = "0da21kfzy07kk2qnkprs3lj214fgkcjxlkk3hdp306jfv8ilmvy2";
+  };
+  "build/RobotIRremote-1.0.2.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/RobotIRremote/archive/1.0.2.zip";
+    sha256 = "0wkya7dy4x0xyi7wn5aghmr1gj0d0wszd61pq18zgfdspz1gi6xn";
+  };
+  "build/SpacebrewYun-1.0.0.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/SpacebrewYun/archive/1.0.0.zip";
+    sha256 = "1sklyp92m8i31rfb9b9iw0zvvab1zd7jdmg85fr908xn6k05qhmp";
+  };
+  "build/Temboo-1.1.5.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Temboo/archive/1.1.5.zip";
+    sha256 = "1ak9b2wrd42n3ak7kcqwg28ianq01acsi5jv4cc031wr0kpq4507";
+  };
+  "build/Esplora-1.0.4.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Esplora/archive/1.0.4.zip";
+    sha256 = "1dflfrg38f0312nxn6wkkgq1ql4hx3y9kplalix6mkqmzwrdvna4";
+  };
+  "build/Mouse-1.0.1.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Mouse/archive/1.0.1.zip";
+    sha256 = "106jjqxzpf5lrs9akwvamqsblj5w2fb7vd0wafm9ihsikingiypr";
+  };
+  "build/Keyboard-1.0.1.zip" = fetchurl {
+    url = "https://github.com/arduino-libraries/Keyboard/archive/1.0.1.zip";
+    sha256 = "1spv73zhjbrb0vgpzjnh6wr3bddlbyzv78d21dbn8z2l0aqv2sac";
+  };
+  "build/libastylej-2.05.1-3.zip" = fetchurl {
+    url = "http://downloads.arduino.cc/libastylej-2.05.1-3.zip";
+    sha256 = "0a1xy2cdl0xls5r21vy5d2j1dapn1jsdw0vbimlwnzfx7r84mxa6";
+  };
+  "build/liblistSerials-1.1.0.zip" = fetchurl {
+    url = "http://downloads.arduino.cc/liblistSerials/liblistSerials-1.1.0.zip";
+    sha256 = "12n3y9y3gfi7i3x6llbwvi59jram02v8yyilv2kd38dm7wrqpw16";
+  };
+  "build/arduino-builder-linux64-1.3.18.tar.bz2" = fetchurl {
+    url = "http://downloads.arduino.cc/tools/arduino-builder-linux64-1.3.18.tar.bz2";
+    sha256 = "0xbzcmvfa1h22dlvym8v4s68w4r1vdq8pj086sk1iwlkfiq0y4zq";
+  };
+  "build/linux/avr-gcc-4.8.1-arduino5-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "http://downloads.arduino.cc/tools/avr-gcc-4.8.1-arduino5-x86_64-pc-linux-gnu.tar.bz2";
+    sha256 = "1k793qsv1jdc0m4i9k40l2k7blnarfzy2k3clndl2yirfk0zqm4h";
+  };
+  "build/linux/avrdude-6.0.1-arduino5-x86_64-pc-linux-gnu.tar.bz2" = fetchurl {
+    url = "http://downloads.arduino.cc/tools/avrdude-6.0.1-arduino5-x86_64-pc-linux-gnu.tar.bz2";
+    sha256 = "0xm4hfr4binny9f5affnmyrrq3lhrxr66s6ymplgfq9l72kwq9nq";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -406,7 +406,6 @@ in
 
   arduino-core = callPackage ../development/arduino/arduino-core {
     jdk = jdk;
-    jre = jdk;
     withGui = false;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Yet another arduino PR, now with all download problems fixed.Based on @brodul commit at
https://github.com/brodul/nixpkgs/tree/arduino-update. Desktop file generation is from #13690

All chroot download problems are solved. Package/library lists are changing daily, so I've had to create my own repository with snapshots of those files.

Tested it by uploading simple sketch to Arduino Uno.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
