### PR TITLE
s3cmd: Fix file library path for darwin

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12417,7 +12417,7 @@ in modules // {
     propagatedBuildInputs = with self; [ pkgs.file ];
 
     patchPhase = ''
-      substituteInPlace magic.py --replace "ctypes.util.find_library('magic')" "'${pkgs.file}/lib/libmagic.so'"
+      substituteInPlace magic.py --replace "ctypes.util.find_library('magic')" "'${pkgs.file}/lib/libmagic.${if stdenv.isDarwin then "dylib" else "so"}'"
     '';
 
     doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Was not able to use s3cmd on Darwin, got this error message:

```
Invoked as: s3cmd
Problem: OSError: dlopen(/nix/store/xwhv8l2h6wk8yb7rdy3m26hw7klcbbnj-file-5.28/lib/libmagic.so, 6): image not found
S3cmd:   1.6.1
python:   2.7.11 (default, Jun 25 2016, 16:48:38) 
[GCC 4.2.1 Compatible Clang 3.7.1 (tags/RELEASE_371/final)]
environment LANG=en_US.UTF-8

Traceback (most recent call last):
  File "/nix/store/6i2d3l0zks4l1wfv21dryf3q52j2bdsn-s3cmd-1.6.1/bin/.s3cmd-wrapped", line 2901, in <module>
    from S3.S3 import S3
  File "/nix/store/6i2d3l0zks4l1wfv21dryf3q52j2bdsn-s3cmd-1.6.1/lib/python2.7/site-packages/S3/S3.py", line 39, in <module>
    import magic
  File "/nix/store/9mjxckk0ak9yjim9nxp9gqcwggi5cc9f-python2.7-python-magic-0.4.10/lib/python2.7/site-packages/magic.py", line 150, in <module>
    libmagic = ctypes.CDLL(dll)
  File "/nix/store/hxibgs3ndm009wqk20qm852cdhi06jxx-python-2.7.11/lib/python2.7/ctypes/__init__.py", line 365, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(/nix/store/xwhv8l2h6wk8yb7rdy3m26hw7klcbbnj-file-5.28/lib/libmagic.so, 6): image not found
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
