### PR TITLE
gdbm: enable compatibility layer for dbm

### DIFF
--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  configureFlags = [ "--enable-libgdbm-compat" ];
+
   meta = with stdenv.lib; {
     description = "GNU dbm key/value database library";
 


### PR DESCRIPTION
###### Motivation for this change

Some tools (e.g. ocaml `dbm` package) compile against the old `dbm` API. `gdbm` is perfectly suitable for this, but you need to enable its compatibility layer:

http://www.gnu.org.ua/software/gdbm/manual/html_section/gdbm_19.html

Since it's a pretty small shim (a couple headers and a small library), I hope this can be enabled by default. The output size change is small (616kb -> 644kb on my linux machine).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
