### PR TITLE
doctl: init at 1.3.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -356,7 +356,7 @@
   sheganinans = "Aistis Raulinaitis <sheganinans@gmail.com>";
   shell = "Shell Turner <cam.turn@gmail.com>";
   shlevy = "Shea Levy <shea@shealevy.com>";
-  siddharthist = "Langston Barrett <langston.barrett@gmail.com>"
+  siddharthist = "Langston Barrett <langston.barrett@gmail.com>";
   simonvandel = "Simon Vandel Sillesen <simon.vandel@gmail.com>";
   sjagoe = "Simon Jagoe <simon@simonjagoe.com>";
   sjmackenzie = "Stewart Mackenzie <setori88@gmail.com>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -356,6 +356,7 @@
   sheganinans = "Aistis Raulinaitis <sheganinans@gmail.com>";
   shell = "Shell Turner <cam.turn@gmail.com>";
   shlevy = "Shea Levy <shea@shealevy.com>";
+  siddharthist = "Langston Barrett <langston.barrett@gmail.com>"
   simonvandel = "Simon Vandel Sillesen <simon.vandel@gmail.com>";
   sjagoe = "Simon Jagoe <simon@simonjagoe.com>";
   sjmackenzie = "Stewart Mackenzie <setori88@gmail.com>";

--- a/pkgs/development/tools/doctl/default.nix
+++ b/pkgs/development/tools/doctl/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "doctl-${version}";
+  version = "1.3.1";
+  rev = "a57555c195d06bc7aa5037af77fde0665ad1231f";
+  goPackagePath = "github.com/digitalocean/doctl";
+
+  src = fetchFromGitHub {
+    owner = "digitalocean";
+    repo = "doctl";
+    rev = "${rev}";
+    sha256 = "03z652fw0a628gv666w8vpi05a4sdilvs1j5scjhcbi82zsbkvma";
+  };
+}

--- a/pkgs/development/tools/doctl/default.nix
+++ b/pkgs/development/tools/doctl/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
   meta = {
     description = "A command line tool for DigitalOcean services";
     homepage = "https://github.com/digitalocean/doctl";
-    license = stdenv.lib.licenses.apache2;
+    license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.siddharthist ];
   };

--- a/pkgs/development/tools/doctl/default.nix
+++ b/pkgs/development/tools/doctl/default.nix
@@ -12,4 +12,12 @@ buildGoPackage rec {
     rev = "${rev}";
     sha256 = "03z652fw0a628gv666w8vpi05a4sdilvs1j5scjhcbi82zsbkvma";
   };
+
+  meta = {
+    description = "A command line tool for DigitalOcean services";
+    homepage = "https://github.com/digitalocean/doctl";
+    license = stdenv.lib.licenses.apache2;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.siddharthist ];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6278,6 +6278,8 @@ in
 
   docutils = pythonPackages.docutils;
 
+  doctl = callPackage ../development/tools/doctl { };
+
   dot2tex = pythonPackages.dot2tex;
 
   doxygen = callPackage ../development/tools/documentation/doxygen {


### PR DESCRIPTION
###### Motivation for this change

[DigitalOcean](https://www.digitalocean.com/) is one of the biggest cloud hosting services around, coming in right behind Amazon Web Services and Google Compute Engine. This is the CLI wrapper for their API. 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
