### PR TITLE
youtube-dl: 2016.07.09.2 -> 2016.07.17

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -12,11 +12,11 @@
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.07.09.2";
+  version = "2016.07.16";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "0qs99ss1w22apx3n2173j5mly7h0ngfgkkgz07bn30235saf0fd3";
+    sha256 = "017x2hqc2bacypjmn9ac9f91y9y6afydl0z7dich5l627494hvfg";
   };
 
   buildInputs = [ makeWrapper zip pandoc ];


### PR DESCRIPTION
Hi -- my first NixOS PR. :wave:
#### Motivation for this change

youtube-dl stopped working. This new version seems to fix it.
#### Things done
- [ ] Tested using sandboxing (nix.useChroot on NixOS, or option build-use-chroot in nix.conf on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in ./result/bin/)
- [x] Fits CONTRIBUTING.md
