### PR TITLE
slic3r: Add LWP for "Send to printer"

### DIFF
--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     EncodeLocale MathClipper ExtUtilsXSpp threads
     MathConvexHullMonotoneChain MathGeometryVoronoi MathPlanePath Moo
     IOStringy ClassXSAccessor Wx GrowlGNTP NetDBus ImportInto XMLSAX
-    ExtUtilsMakeMaker OpenGL WxGLCanvas ModuleBuild
+    ExtUtilsMakeMaker OpenGL WxGLCanvas ModuleBuild LWP
   ];
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Motivation for this change

The current slic3r package does not have a dependency on the LWP module.
###### Things done

This patch adds a dependency on the LWP perl module so that Slic3r can
make HTTP connections to Octoprint and send G-code to a remote printer.
- [X] Tested using sandboxing
  - Built on platform(s)
    - [X] NixOS
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md]
