### PR TITLE
armadillo: Correct dependencies

### DIFF
--- a/pkgs/development/libraries/armadillo/default.nix
+++ b/pkgs/development/libraries/armadillo/default.nix
@@ -1,23 +1,26 @@
-{stdenv, fetchurl, cmake, pkgconfig, atlas, blas, openblas}:
+{ stdenv, fetchurl, cmake, openblasCompat, superlu, hdf5 }:
 
 stdenv.mkDerivation rec {
-  version = "7.200.1b";
+  version = "7.200.2";
   name = "armadillo-${version}";
-  
+
   src = fetchurl {
-    url = "http://sourceforge.net/projects/arma/files/armadillo-${version}.tar.xz";
-    sha256 = "00s8xrywc4aipipq1zpd6q9gzqmsiv8cwd25zvb1csrpninmidvc";
+    url = "mirror://sourceforge/arma/armadillo-${version}.tar.xz";
+    sha256 = "1yvx75caks477jqwx5gspi6946jialddk00wdvg6dnh5wdi2xasm";
   };
 
-  unpackCmd = [ "tar -xf ${src}" ];
-  
-  nativeBuildInputs = [ cmake atlas blas openblas ];
+  buildInputs = [ cmake openblasCompat superlu hdf5 ];
+
+  cmakeFlags = [ "-DDETECT_HDF5=ON" ];
+
+  patches = [ ./use-unix-config-on-OS-X.patch
+              ./use-OpenBLAS-as-LAPACK.patch ];
   
   meta = with stdenv.lib; {
     description = "C++ linear algebra library";
-    homepage = "http://arma.sourceforge.net" ;
+    homepage = http://arma.sourceforge.net;
     license = licenses.mpl20;
-    platforms = stdenv.lib.platforms.linux ;
-    maintainers = [ stdenv.lib.maintainers.juliendehos ];
+    platforms = platforms.unix;
+    maintainers = [ maintainers.juliendehos ];
   };
 }

--- a/pkgs/development/libraries/armadillo/use-OpenBLAS-as-LAPACK.patch
+++ b/pkgs/development/libraries/armadillo/use-OpenBLAS-as-LAPACK.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake_aux/Modules/ARMA_FindLAPACK.cmake b/cmake_aux/Modules/ARMA_FindLAPACK.cmake
+index 5395afb..a203c93 100644
+--- a/cmake_aux/Modules/ARMA_FindLAPACK.cmake
++++ b/cmake_aux/Modules/ARMA_FindLAPACK.cmake
+@@ -5,7 +5,7 @@
+ # also defined, but not for general use are
+ #  LAPACK_LIBRARY, where to find the LAPACK library.
+ 
+-SET(LAPACK_NAMES ${LAPACK_NAMES} lapack)
++SET(LAPACK_NAMES ${LAPACK_NAMES} openblas)
+ FIND_LIBRARY(LAPACK_LIBRARY
+   NAMES ${LAPACK_NAMES}
+   PATHS /usr/lib64/atlas /usr/lib/atlas /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib
+

--- a/pkgs/development/libraries/armadillo/use-unix-config-on-OS-X.patch
+++ b/pkgs/development/libraries/armadillo/use-unix-config-on-OS-X.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,7 +84,7 @@ message(STATUS "DETECT_HDF5                = ${DETECT_HDF5}"               )
+ ##
+ ## Find LAPACK and BLAS libraries, or their optimised versions
+ ##
+-
++set(APPLE false)
+ if(APPLE)
+   
+   set(ARMA_OS macos)

--- a/pkgs/development/libraries/science/math/superlu/add-superlu-lib-as-dependency-for-the-unit-tests.patch
+++ b/pkgs/development/libraries/science/math/superlu/add-superlu-lib-as-dependency-for-the-unit-tests.patch
@@ -1,0 +1,7 @@
+--- a/TESTING/MATGEN/CMakeLists.txt
++++ b/TESTING/MATGEN/CMakeLists.txt
+@@ -97,3 +97,4 @@ if(enable_complex16)
+ endif()
+ 
+ add_library(matgen ${sources})
++target_link_libraries(matgen superlu)

--- a/pkgs/development/libraries/science/math/superlu/default.nix
+++ b/pkgs/development/libraries/science/math/superlu/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, cmake,
+  gfortran, openblasCompat}:
+
+stdenv.mkDerivation rec {
+  version = "5.2.1";
+  name = "superlu-${version}";
+
+  src = fetchurl {
+    url = "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_${version}.tar.gz";
+    sha256 = "0qzlb7cd608q62kyppd0a8c65l03vrwqql6gsm465rky23b6dyr8";
+  };
+
+  buildInputs = [ cmake gfortran ];
+
+  propagatedBuildInputs = [ openblasCompat ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=true"
+    "-DUSE_XSDK_DEFAULTS=true"
+  ];
+
+  patches = [
+    ./find-openblas-library.patch
+    ./add-superlu-lib-as-dependency-for-the-unit-tests.patch
+  ];
+
+  doCheck = true;
+  checkTarget = "test";
+
+  meta = {
+    homepage = http://crd-legacy.lbl.gov/~xiaoye/SuperLU/;
+    license = http://crd-legacy.lbl.gov/~xiaoye/SuperLU/License.txt;
+    description = "A library for the solution of large, sparse, nonsymmetric systems of linear equations";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/science/math/superlu/find-openblas-library.patch
+++ b/pkgs/development/libraries/science/math/superlu/find-openblas-library.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -75,6 +75,8 @@ set(CMAKE_C_FLAGS_RELEASE "-O3" CACHE STRING "")
+ ######################################################################
+ #
+ #--------------------- BLAS ---------------------
++find_package(OpenBLAS)
++set(TPL_BLAS_LIBRARIES ${OpenBLAS_LIBRARIES})
+ if(NOT enable_blaslib)
+   if (TPL_BLAS_LIBRARIES)
+     set(BLAS_FOUND TRUE)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16382,6 +16382,8 @@ in
   suitesparse_4_4 = callPackage ../development/libraries/science/math/suitesparse {};
   suitesparse = suitesparse_4_4;
 
+  superlu = callPackage ../development/libraries/science/math/superlu {};
+
   ipopt = callPackage ../development/libraries/science/math/ipopt { openblas = openblasCompat; };
 
   gmsh = callPackage ../applications/science/math/gmsh { };


### PR DESCRIPTION
###### Motivation for this change
- The armadillo package was missing the `superlu` dependency for sparse matrices and the `hdf5` library for HDF5 I/O support.
- There were unnecessary dependencies on `atlas` and `blas`, which `openblas` already covers.
- Darwin support was missing from the package.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
