### PR TITLE
newrelic-sysmond: 1.5.1 -> 2.3.0

### DIFF
--- a/pkgs/servers/monitoring/newrelic-sysmond/default.nix
+++ b/pkgs/servers/monitoring/newrelic-sysmond/default.nix
@@ -1,12 +1,11 @@
 { stdenv, fetchurl }:
 
-assert stdenv.system == "x86_64-linux";
-
 stdenv.mkDerivation rec {
-  name = "newrelic-sysmond-2.3.0.132";
+  name = "newrelic-sysmond-${version}";
+  version = "2.3.0.132";
 
   src = fetchurl {
-    url = "http://download.newrelic.com/server_monitor/release/newrelic-sysmond-2.3.0.132-linux.tar.gz";
+    url = "http://download.newrelic.com/server_monitor/archive/${version}/newrelic-sysmond-${version}-linux.tar.gz";
     sha256 = "0cdvffdsadfahfn1779zjfawz6l77awab3g9mw43vsba1568jh4f";
   };
 
@@ -17,11 +16,11 @@ stdenv.mkDerivation rec {
       $out/bin/nrsysmond
   '';
 
-  meta = {
-    homepage = http://newrelic.com/;
-
+  meta = with stdenv.lib; {
     description = "System-wide monitoring for newrelic";
-
-    license = stdenv.lib.licenses.unfree;
+    homepage = http://newrelic.com/;
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lnl7 ];
   };
 }

--- a/pkgs/servers/monitoring/newrelic-sysmond/default.nix
+++ b/pkgs/servers/monitoring/newrelic-sysmond/default.nix
@@ -3,12 +3,11 @@
 assert stdenv.system == "x86_64-linux";
 
 stdenv.mkDerivation rec {
-  name = "newrelic-sysmond-1.5.1.93";
+  name = "newrelic-sysmond-2.3.0.132";
 
   src = fetchurl {
-    url = "http://download.newrelic.com/server_monitor/release/newrelic-sysmond-1.5.1.93-linux.tar.gz";
-
-    sha256 = "1bfwyczcf7pvji8lx566jxgy8dhyf1gmqmi64lj10673a86axnwz";
+    url = "http://download.newrelic.com/server_monitor/release/newrelic-sysmond-2.3.0.132-linux.tar.gz";
+    sha256 = "0cdvffdsadfahfn1779zjfawz6l77awab3g9mw43vsba1568jh4f";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

~~The old package version is no longer available.~~
Uses the archive url to prevent breakage when a new version is released.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
