### PR TITLE
planner: init at 0.14.6

### DIFF
--- a/pkgs/applications/office/planner/default.nix
+++ b/pkgs/applications/office/planner/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl
+, pkgconfig
+, intltool
+, gnome
+, libxslt
+, python
+}:
+
+let
+  version = "${major}.${minor}.${patch}";
+  major = "0";
+  minor = "14";
+  patch = "6";
+
+in stdenv.mkDerivation {
+  name = "planner-${version}";
+
+  src = fetchurl {
+    url = "http://ftp.gnome.org/pub/GNOME/sources/planner/${major}.${minor}/planner-${version}.tar.xz";
+    sha256 = "15h6ps58giy5r1g66sg1l4xzhjssl362mfny2x09khdqsvk2j38k";
+  };
+
+  buildInputs = [
+    pkgconfig
+    intltool
+    gnome.GConf
+    gnome.gtk
+    gnome.libgnomecanvas
+    gnome.libgnomeui
+    gnome.libglade
+    gnome.scrollkeeper
+    libxslt
+    python
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Apps/Planner/;
+    description = "Project management application for GNOME";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.rasendubi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13863,6 +13863,8 @@ in
 
   pijul = callPackage ../applications/version-management/pijul { };
 
+  planner = callPackage ../applications/office/planner { };
+
   playonlinux = callPackage ../applications/misc/playonlinux {
      stdenv = stdenv_32bit;
   };


### PR DESCRIPTION
###### Motivation for this change

I need to build a gantt chart.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
