### PR TITLE
liberationsansnarrow: init at 1.07.3

### DIFF
--- a/pkgs/data/fonts/liberationsansnarrow/binary.nix
+++ b/pkgs/data/fonts/liberationsansnarrow/binary.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, liberationsansnarrow }:
+
+stdenv.mkDerivation rec {
+  version = "1.07.3";
+  name = "liberationsansnarrow-${version}";
+  src = fetchurl {
+    url = "https://fedorahosted.org/releases/l/i/liberation-fonts/liberation-fonts-ttf-${version}.tar.gz";
+    sha256 = "0qkr7n97jmj4q85jr20nsf6n5b48j118l9hr88vijn22ikad4wsp";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -v $(find . -name '*Narrow*.ttf') $out/share/fonts/truetype
+
+    mkdir -p "$out/doc/${name}"
+    cp -v AUTHORS ChangeLog COPYING License.txt README "$out/doc/${name}" || true
+  '';
+
+  inherit (liberationsansnarrow) meta;
+}

--- a/pkgs/data/fonts/liberationsansnarrow/default.nix
+++ b/pkgs/data/fonts/liberationsansnarrow/default.nix
@@ -1,0 +1,39 @@
+{stdenv, fetchurl, fontforge, pythonPackages, python}:
+
+stdenv.mkDerivation rec {
+  pname = "liberationsansnarrow";
+  version = "1.07.3";
+  name = "${pname}";
+
+  src = fetchurl {
+    url = "https://fedorahosted.org/releases/l/i/liberation-fonts/liberation-fonts-ttf-${version}.tar.gz";
+    sha256 = "0qkr7n97jmj4q85jr20nsf6n5b48j118l9hr88vijn22ikad4wsp";
+  };
+
+  buildInputs = [ fontforge pythonPackages.fonttools python ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -v $(find . -name '*Narrow*.ttf') $out/share/fonts/truetype
+
+    mkdir -p "$out/doc/${name}"
+    cp -v AUTHORS ChangeLog COPYING License.txt README "$out/doc/${name}" || true
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Liberation Sans Narrow Font Family is a replacement for Arial Narrow";
+    longDescription = ''
+      Liberation Sans Narrow is a font originally created by Ascender
+      Inc and licensed to Oracle Corporation under a GPLv2 license. It is
+      metrically compatible with the commonly used Arial Narrow fonts
+      on Microsoft systems. It is no longer distributed with the
+      latest versions of the Liberation Fonts, as Red Hat has changed the
+      license to the Open Font License.
+    '';
+
+    license = licenses.gpl2;
+    homepage = https://fedorahosted.org/liberation-fonts/;
+    maintainers = [ maintainers.leenaars
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11839,6 +11839,9 @@ in
   liberation_ttf_binary = callPackage ../data/fonts/redhat-liberation-fonts/binary.nix { };
   liberation_ttf = self.liberation_ttf_binary;
 
+  liberationsansnarrow = callPackage ../data/fonts/liberationsansnarrow { };
+  liberationsansnarrow_binary = callPackage ../data/fonts/liberationsansnarrow/binary.nix { };
+
   libertine = callPackage ../data/fonts/libertine { };
 
   lmmath = callPackage ../data/fonts/lmodern/lmmath.nix {};


### PR DESCRIPTION
###### Motivation for this change

Font was formerly included in NixOS as part of the Liberation Fonts, but license changes of the rest of the Liberation fonts) made this excellent font be dropped by Red Hat in the most recent versions. However, there are many documents still out there which reference this GPLv2 licensed font as it was installed by default on many Linux distro's for years - hence the packaging.

I've mirrored the way in which the Liberation fonts are included, by having two install methods: one through source and one binary.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
