### PR TITLE
travis: remount for larger tmp dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
         - os: linux
           sudo: required
           dist: trusty
+          before_script:
+              - sudo mount -o remount,exec,size=2G /run/user
           script: ./maintainers/scripts/travis-nox-review-pr.sh pr
         - os: osx
           osx_image: xcode7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
           sudo: required
           dist: trusty
           before_script:
-              - sudo mount -o remount,exec,size=2G /run/user
+              - sudo mount -o remount,exec,size=2G,mode=755 /run/user
           script: ./maintainers/scripts/travis-nox-review-pr.sh pr
         - os: osx
           osx_image: xcode7.3

--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -55,7 +55,7 @@ while test -n "$1"; do
                     token="--token $GITHUB_TOKEN"
                 fi
 
-                nix-shell --packages nox git --run "nox-review pr --slug $TRAVIS_REPO_SLUG $token $TRAVIS_PULL_REQUEST" -I nixpkgs=$TRAVIS_BUILD_DIR
+                nix-shell --packages nox git --run "nox-review pr --slug $TRAVIS_REPO_SLUG $token $TRAVIS_PULL_REQUEST"
             fi
             ;;
 


### PR DESCRIPTION
This seems to be making a difference in some of [my testing](https://travis-ci.org/NixOS/nixpkgs/jobs/145655354) of Travis building. Basically, we're not getting enough space in the tmp dir, so we can remount it to help out. Currently, [Travis has /run/user to be 100MB](https://travis-ci.org/NixOS/nixpkgs/jobs/144693925), this ups it to 2GB.
