### PR TITLE
Use new early kbd-setting code in initrd and fix layouts from external packages

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -172,10 +172,6 @@ udevadm trigger --action=add
 udevadm settle
 
 
-# Load boot-time keymap before any LVM/LUKS initialization
-@extraUtils@/bin/busybox loadkmap < "@busyboxKeymap@"
-
-
 # XXX: Use case usb->lvm will still fail, usb->luks->lvm is covered
 @preLVMCommands@
 

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -185,15 +185,6 @@ let
   };
 
 
-  # The binary keymap for busybox to load at boot.
-  busyboxKeymap = pkgs.runCommand "boottime-keymap"
-    { preferLocalBuild = true; }
-    ''
-      ${pkgs.kbd}/bin/loadkeys -qb "${config.i18n.consoleKeyMap}" > $out ||
-        ${pkgs.kbd}/bin/loadkeys -qbu "${config.i18n.consoleKeyMap}" > $out
-    '';
-
-
   # The init script of boot stage 1 (loading kernel modules for
   # mounting the root FS).
   bootStage1 = pkgs.substituteAll {
@@ -203,7 +194,7 @@ let
 
     isExecutable = true;
 
-    inherit udevRules extraUtils modulesClosure busyboxKeymap;
+    inherit udevRules extraUtils modulesClosure;
 
     inherit (config.boot) resumeDevice devSize runSize;
 

--- a/nixos/modules/tasks/kbd.nix
+++ b/nixos/modules/tasks/kbd.nix
@@ -14,8 +14,8 @@ let
 
   optimizedKeymap = pkgs.runCommand "keymap" {
     nativeBuildInputs = [ pkgs.kbd ];
+    LOADKEYS_KEYMAP_PATH = "${kbdEnv}/share/keymaps/**";
   } ''
-    cd ${kbdEnv}/share/keymaps
     loadkeys -b ${optionalString isUnicode "-u"} "${config.i18n.consoleKeyMap}" > $out
   '';
 


### PR DESCRIPTION
###### Motivation for this change

@Profpatsch  reported a bug in my patch https://github.com/NixOS/nixpkgs/pull/16642. Rather than fixing it in the old code, I moved us to the new code from https://github.com/NixOS/nixpkgs/pull/16801 instead and fixed the same problem there. Along with fixing the reported bug, this gives us several advantages over the old code:
- Console is now set only if it really needs to (i.e. it's not a container);
- We support Unicode keymaps in initrd and set console properly;
- We also set colors, if they were specified;
- More modularity.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

My test plan:
1. Build a VM with this configuration:

```
  i18n.consoleKeyMap = "neo";
  i18n.consoleFont = "ter-v16n";
  i18n.consolePackages = [ pkgs.terminus_font pkgs.kbdKeymaps.neo pkgs.kbdKeymaps.dvp ];
  boot.initrd.kernelModules = [ "fbcon" ];
  boot.earlyVconsoleSetup = true;
```
1. Run it with `QEMU_KERNEL_PARAMS=boot.debug1devices result/bin/run-nixos-vm`;
2. Observe that layout is unconditionally set up;
3. Observe that (if layout supports that) I can change the input language;
4. Observe that font is set up iff `earlyVconsoleSetup` is enabled.

I've run it with following changes:
- `consoleKeyMap`: `neo`, `dvp`, `ruwin_cplk-UTF-8`, not set;
- `earlyVconsoleSetup`: on and off

@Profpatsch, it would be cool to get additional testing from a real user of a layout from an external package! Notice that by default `consolePackages` is set to `with pkgs.kbdKeymaps; [ neo dvp ]` -- that is, if you don't change it you get those layouts installed like before.
