### PR TITLE
gd: cherry-pick a temporary patch for darwin

### DIFF
--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -8,6 +8,7 @@
 , libXpm ? null
 , fontconfig
 , freetype
+, fetchpatch, autoreconfHook, perl
 }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +20,17 @@ stdenv.mkDerivation rec {
     sha256 = "1311g5mva2xlzqv3rjqjc4jjkn5lzls4skvr395h633zw1n7b7s8";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  # Address an incompatibility with Darwin's libtool
+  patches = stdenv.lib.optional stdenv.isDarwin (fetchpatch {
+    url = https://github.com/libgd/libgd/commit/502e4cd873c3b37b307b9f450ef827d40916c3d6.patch;
+    sha256 = "0gawr2c4zr6cljnwzhdlxhz2mkbg0r5vzvr79dv6yf6fcj06awfs";
+  });
+
+  # -pthread gets passed to clang, causing warnings
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--enable-werror=no";
+
+  nativeBuildInputs = [ pkgconfig ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ autoreconfHook perl ];
   buildInputs = [ zlib fontconfig freetype ];
   propagatedBuildInputs = [ libpng libjpeg libwebp libtiff libXpm ];
 


### PR DESCRIPTION
###### Motivation for this change

The `gd` library has not built on Darwin for a little while now. The upstream fix is not yet included in a released version, so we pull it in on Darwin here.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
