### PR TITLE
grafana: 3.0.1 -> 3.1.0

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -1,7 +1,8 @@
 { lib, buildGoPackage, fetchurl, fetchFromGitHub }:
 
 buildGoPackage rec {
-  version = "3.0.1";
+  version = "3.1.0";
+  ts = "1468321182";
   name = "grafana-v${version}";
   goPackagePath = "github.com/grafana/grafana";
 
@@ -9,12 +10,12 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "1zykgf8xq7m040d4yljcbz23gh8ppaqnxj50ncj1cjyi5k88i3i9";
+    sha256 = "1p3qp3p4wsb7m2lvdcrc1wz5mxqwqsj5xfqp28hkbfdqh3lblh42";
   };
 
   srcStatic = fetchurl {
-    url = "https://grafanarel.s3.amazonaws.com/builds/grafana-${version}-.linux-x64.tar.gz";
-    sha256 = "14wq2cbf4djnwbbyfbhnwmwqpfh5g4yp1dckg5zzf2109ymkjrqd";
+    url = "https://grafanarel.s3.amazonaws.com/builds/grafana-${version}-${ts}.linux-x64.tar.gz";
+    sha256 = "174w0bx5cqriy77dyk9xsnmdskykzmgbyjczwb5kkp6j8vp7b0fs";
   };
 
   preBuild = "export GOPATH=$GOPATH:$NIX_BUILD_TOP/go/src/${goPackagePath}/Godeps/_workspace";


### PR DESCRIPTION
###### Motivation for this change

Update to current stable grafana.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've been working with this change with the NixOS module (services.grafana.*) and it's been working as advertised.
