### PR TITLE
gfxtablet: git-2013-10-21 -> 1.4

### DIFF
--- a/pkgs/os-specific/linux/gfxtablet/default.nix
+++ b/pkgs/os-specific/linux/gfxtablet/default.nix
@@ -1,32 +1,30 @@
-{stdenv, fetchgit, linuxHeaders}:
-let
-  s = # Generated upstream information
-  rec {
-    version="git-2013-10-21";
-    name = "gfxtablet-uinput-driver-${version}";
-    rev = "c4e337ae0b53a8ccdfe11b904ff129714bd25ec4";
-    sha256 = "14ll9rls2mamllmpwjiv2dc6165plazv7ny9cliylafrwgb55l7p";
-    url = "https://github.com/rfc2822/GfxTablet.git";
-  };
+{stdenv, fetchFromGitHub, linuxHeaders}:
+
+stdenv.mkDerivation rec {
+  version = "1.4";
+  name = "gfxtablet-uinput-driver-${version}";
+
   buildInputs = [
     linuxHeaders
   ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
-  src = fetchgit {
-    inherit (s) url sha256 rev;
+
+  src = fetchFromGitHub {
+    owner = "rfc2822";
+    repo = "GfxTablet";
+    rev = "android-app-${version}";
+    sha256 = "1i2m98yypfa9phshlmvjlgw7axfisxmldzrvnbzm5spvv5s4kvvb";
   };
+
   preBuild = ''cd driver-uinput'';
+
   installPhase = ''
     mkdir -p "$out/bin"
     cp networktablet "$out/bin"
     mkdir -p "$out/share/doc/gfxtablet/"
     cp ../*.md "$out/share/doc/gfxtablet/"
   '';
+
   meta = {
-    inherit (s) version;
     description = ''Uinput driver for Android GfxTablet tablet-as-input-device app'';
     license = stdenv.lib.licenses.mit ;
     maintainers = [stdenv.lib.maintainers.raskin];


### PR DESCRIPTION
###### Motivation for this change

Old git revision replaced with latest released version on github.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
