### PR TITLE
gnome-software: propogated -> propagated

### DIFF
--- a/pkgs/desktops/gnome-3/3.18/misc/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/3.18/misc/gnome-software/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gnome3.gtk packagekit appstream-glib libsoup
                   gnome3.gsettings_desktop_schemas gnome3.gnome_desktop
                   polkit attr acl libyaml ];
-  propogatedBuildInputs = [ isocodes ];
+  propagatedBuildInputs = [ isocodes ];
 
   postInstall = ''
     mkdir -p $out/share/xml/

--- a/pkgs/desktops/gnome-3/3.20/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/gnome-software/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
                   gnome3.gsettings_desktop_schemas gnome3.gnome_desktop
 		  gtkspell3 json_glib
                   polkit attr acl libyaml ];
-  propogatedBuildInputs = [ isocodes ];
+  propagatedBuildInputs = [ isocodes ];
 
   postInstall = ''
     mkdir -p $out/share/xml/


### PR DESCRIPTION
###### Motivation for this change

I think that's a typo.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
