### PR TITLE
pulseaudio module: add extraClientConf option

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -27,6 +27,7 @@ let
   clientConf = writeText "client.conf" ''
     autospawn=${if nonSystemWide then "yes" else "no"}
     ${optionalString nonSystemWide "daemon-binary=${cfg.package.out}/bin/pulseaudio"}
+    ${cfg.extraClientConf}
   '';
 
   # Write an /etc/asound.conf that causes all ALSA applications to
@@ -93,6 +94,14 @@ in {
           The path to the configuration the PulseAudio server
           should use. By default, the "default.pa" configuration
           from the PulseAudio distribution is used.
+        '';
+      };
+
+      extraClientConf = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Extra configuration appended to pulse/client.conf file.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

Currently there is no way to modify `/etc/pulse/client.conf` via nix configuration. This PR adds a configuration option to append arbitrary text to this file.

Modification to `client.conf` are required for example to solve compatibility issues of `firejail` with `pulseaudio` (see https://firejail.wordpress.com/support/known-problems/#pulseaudio).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
