### PR TITLE
gcc-arm-embedded: 5.2 -> 5.4

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/default.nix
@@ -22,11 +22,11 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ bzip2 patchelf ];
- 
+
   dontPatchELF = true;
-  
+
   phases = "unpackPhase patchPhase installPhase";
-  
+
   installPhase = ''
     mkdir -pv $out
     cp -r ./* $out
@@ -42,8 +42,9 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors (Cortex-M0/M0+/M3/M4, Cortex-R4/R5/R7)";
-    homepage = "https://launchpad.net/gcc-arm-embedded";
-    license = licenses.gpl3;
+    homepage = https://launchpad.net/gcc-arm-embedded;
+    license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = [ maintainers.rasendubi ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4635,7 +4635,7 @@ in
     releaseType = "update";
     sha256 = "1r0rqbnw7rf94f5bsa3gi8bick4xb7qnp1dkvdjfbvqjvysvc44r";
   };
-  gcc-arm-embedded = self.gcc-arm-embedded-4_9;
+  gcc-arm-embedded = self.gcc-arm-embedded-5;
 
   gforth = callPackage ../development/compilers/gforth {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4628,12 +4628,12 @@ in
     releaseType = "update";
     sha256 = "c5e0025b065750bbd76b5357b4fc8606d88afbac9ff55b8a82927b4b96178154";
   };
-  gcc-arm-embedded-5_2 = pkgs.callPackage_i686 ../development/compilers/gcc-arm-embedded {
+  gcc-arm-embedded-5 = pkgs.callPackage_i686 ../development/compilers/gcc-arm-embedded {
     dirName = "5.0";
-    subdirName = "5-2015-q4-major";
-    version = "5.2-2015q4-20151219";
-    releaseType = "major";
-    sha256 = "12mbwl9iwbw7h6gwwkvyvfmrsz7vgjz27jh2cz9z006ihzigi50y";
+    subdirName = "5-2016-q2-update";
+    version = "5.4-2016q2-20160622";
+    releaseType = "update";
+    sha256 = "1r0rqbnw7rf94f5bsa3gi8bick4xb7qnp1dkvdjfbvqjvysvc44r";
   };
   gcc-arm-embedded = self.gcc-arm-embedded-4_9;
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
