### PR TITLE
qt5ct: init at 0.24

### DIFF
--- a/pkgs/tools/misc/qt5ct/default.nix
+++ b/pkgs/tools/misc/qt5ct/default.nix
@@ -1,0 +1,30 @@
+{stdenv, fetchurl, qtbase, qtsvg, qttools, qmakeHook, makeQtWrapper}:
+
+stdenv.mkDerivation rec {
+  name = "qt5ct-${version}";
+  version = "0.24";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/qt5ct/qt5ct-${version}.tar.bz2";
+    sha256 = "0k62nd945pbgkshycijzrgdyrwj5kcswk33slaj7hr7d6r7bmb6p";
+  };
+
+  buildInputs = [ qtbase qtsvg ];
+  nativeBuildInputs = [ makeQtWrapper qmakeHook qttools ];
+
+  preConfigure = ''
+    qmakeFlags="$qmakeFlags PLUGINDIR=$out/lib/qt5/plugins/platformthemes/"
+  '';
+
+  preFixup = ''
+    wrapQtProgram $out/bin/qt5ct
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Qt5 Configuration Tool";
+    homepage = https://www.opendesktop.org/content/show.php?content=168066;
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ralith ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8903,6 +8903,8 @@ in
 
   qt5 = self.qt56;
 
+  qt5ct = qt5.callPackage ../tools/misc/qt5ct { };
+
   qt5LibsFun = self: with self; {
 
     accounts-qt = callPackage ../development/libraries/accounts-qt { };


### PR DESCRIPTION
###### Motivation for this change

This tool allows for qt5 styling to be configured outside of a standard desktop environment.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
