### PR TITLE
keybase-go: init at 1.0.16

### DIFF
--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "keybase-${version}";
+  version = "1.0.16";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/keybase/client";
+  subPackages = [ "go/keybase" ];
+
+  dontRenameImports = true;
+
+  src = fetchFromGitHub {
+    owner = "keybase";
+    repo = "client";
+    inherit rev;
+    sha256 = "0p62cqpfgx9b5kfnviqpig27i20yv9bg5mq61am5xrmkp68jk35b";
+  };
+
+  buildFlags = [ "-tags production" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://www.keybase.io/;
+    description = "The Keybase official command-line utility and service.";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ carlsverre ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2172,6 +2172,8 @@ in
 
   keybase = callPackage ../applications/misc/keybase { };
 
+  keybase-go = callPackage ../tools/security/keybase { };
+
   keychain = callPackage ../tools/misc/keychain { };
 
   keyfuzz = callPackage ../tools/inputmethods/keyfuzz { };


### PR DESCRIPTION
###### Motivation for this change

I think that Keybase is a great tool/service for starting out with encryption on any platform.  I also am planning on creating a nix port of the newly released fuse Keybase File System (https://github.com/keybase/kbfs) which will require this package to work.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Build the official keybase go client from source.  The client includes both a
CLI for performing keybase operations and a service which will start
automatically when needed.

Keybase is a service which combines social proof with encryption.  Learn more at
their site: http://keybase.io
