### PR TITLE
sooperlooper: git version fixes build.

### DIFF
--- a/pkgs/applications/audio/sooperlooper/default.nix
+++ b/pkgs/applications/audio/sooperlooper/default.nix
@@ -1,18 +1,21 @@
-{ stdenv, fetchurl, liblo, libxml2, libjack2, libsndfile, wxGTK, libsigcxx
-,libsamplerate, rubberband, pkgconfig, ncurses
+{ stdenv, fetchFromGitHub , liblo, libxml2, libjack2, libsndfile, wxGTK, libsigcxx
+  ,libsamplerate, rubberband, pkgconfig, autoconf, automake, libtool, gettext, ncurses, which
 }:
 
 stdenv.mkDerivation rec {
-  name = "sooperlooper-${version}";
-  version = "1.7.3";
-  src = fetchurl {
-    url = "http://essej.net/sooperlooper/${name}.tar.gz";
-    sha256 = "0n2gdxw1fx8nxxnpzf4sj0kp6k6zi1yq59cbz6qqzcnsnpnvszbs";
+  name = "sooperlooper-git-${version}";
+  version = "19-07-2016";
+
+  src = fetchFromGitHub {
+    owner = "essej";
+    repo = "sooperlooper";
+    rev = "3bdfe184cd59b51c757b8048536abc1146fb0de4";
+    sha256 = "0qz25h4idv79m97ici2kzx72fwzks3lysyksk3p3rx72lsijhf3g";
   };
 
   buildInputs = [
-   liblo libxml2 libjack2 libsndfile wxGTK libsigcxx
-   libsamplerate rubberband pkgconfig ncurses
+    liblo libxml2 libjack2 libsndfile wxGTK libsigcxx
+    libsamplerate rubberband pkgconfig autoconf automake libtool gettext ncurses which
   ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

fixes build, see: https://github.com/essej/sooperlooper/pull/6
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
