### PR TITLE
x42-plugins: 2015-07-02 -> 20160619

### DIFF
--- a/pkgs/applications/audio/x42-plugins/default.nix
+++ b/pkgs/applications/audio/x42-plugins/default.nix
@@ -3,12 +3,12 @@
 , lv2, mesa, gtk2, cairo, pango, fftwFloat, zita-convolver }:
 
 stdenv.mkDerivation rec {
-  version = "2015-07-02";
+  version = "20160619";
   name = "x42-plugins-${version}";
 
   src = fetchurl {
-    url = "http://gareus.org/misc/x42-plugins/x42-plugins-20150702.tar.xz";
-    sha256 = "1mq0grabzbl9xsd53v2qajhr8nngk0d4lx9n0n3nwy95y2gmy6sm";
+    url = "http://gareus.org/misc/x42-plugins/${name}.tar.xz";
+    sha256 = "1ald0c5xbfkdq6g5xwyy8wmbi636m3k3gqrq16kbh46g0kld1as9";
   };
 
   buildInputs = [ mesa_glu ftgl freefont_ttf libjack2 libltc libsndfile libsamplerate lv2 mesa gtk2 cairo pango fftwFloat pkgconfig  zita-convolver];


### PR DESCRIPTION
###### Motivation for this change

update
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
