### PR TITLE
Update gtkspell3 and gtkspellmm

### DIFF
--- a/pkgs/development/libraries/gtkspell/3.nix
+++ b/pkgs/development/libraries/gtkspell/3.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gtkspell-${version}";
-  version = "3.0.7";
+  version = "3.0.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/gtkspell/gtkspell3-${version}.tar.gz";
-    sha256 = "1hiwzajf18v9ik4nai3s7frps4ccn9s20nggad1c4k2mwb9ydwhk";
+    sha256 = "1zrz5pz4ryvcssk898liynmy2wyxgj95ak7mp2jv7x62yzihq6h1";
   };
 
   buildInputs = [ aspell pkgconfig gtk3 enchant intltool ];

--- a/pkgs/development/libraries/gtkspellmm/default.nix
+++ b/pkgs/development/libraries/gtkspellmm/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "3.0.3";
+  version = "3.0.4";
 
 in
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "mirror://sourceforge/project/gtkspell/gtkspellmm/" +
           "${name}.tar.gz";
-    sha256 = "f9dcc0991621c08e7a972f33487afd6b37491468f0b654f50c741a7e6d810624";
+    sha256 = "0x6zx928dl62f0c0x6b2s32i06lvn18wx7crrgs1j9yjgkim4k4k";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
