### PR TITLE
cask: 0.7.3 -> 0.7.4

### DIFF
--- a/pkgs/applications/editors/emacs-modes/cask/default.nix
+++ b/pkgs/applications/editors/emacs-modes/cask/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchgit, emacs, python }:
+{ stdenv, fetchFromGitHub, emacs, python }:
 
 stdenv.mkDerivation rec {
-  name = "cask-0.7.3";
+  version = "0.7.4";
+  name = "cask-${version}";
 
-  src = fetchgit {
-    url = "https://github.com/cask/cask.git";
-    rev = "717b64a9ba7640ec366e8573da0c01f9c4d57b0c";
-    sha256 = "0bq24hac1z77g1bybwlk991dcc3pss2gjpwq0a6vvrqg5hw02lsf";
+  src = fetchFromGitHub {
+    owner = "cask";
+    repo = "cask";
+    rev = "v${version}";
+    sha256 = "1hvm6r6a8rgjwnn2mcamwqrmhz424vlr4mbvbri3wmn0ikbk510l";
   };
 
   buildInputs = [ emacs python ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I now the existence of `emacsPackagesNgGen`, but this package is still useful for the `cask` binary.

/cc @jgeerds 
