### PR TITLE
fftw: 3.3.4 -> 3.3.5

### DIFF
--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -4,14 +4,14 @@ with lib;
 
 assert elem precision [ "single" "double" "long-double" "quad-precision" ];
 
-let version = "3.3.4"; in
+let version = "3.3.5"; in
 
 stdenv.mkDerivation rec {
   name = "fftw-${precision}-${version}";
 
   src = fetchurl {
     url = "ftp://ftp.fftw.org/pub/fftw/fftw-${version}.tar.gz";
-    sha256 = "10h9mzjxnwlsjziah4lri85scc05rlajz39nqf3mbh4vja8dw34g";
+    sha256 = "1kwbx92ps0r7s2mqy7lxbxanslxdzj7dp7r7gmdkzv1j8yqf3kwf";
   };
 
   outputs = [ "dev" "out" "doc" ]; # it's dev-doc only


### PR DESCRIPTION
###### Motivation for this change

There has not been a release since 2014, but at least one important bug
has been fixed:
https://github.com/FFTW/fftw3/issues/16

The submitter of the bug, @x-42, has advised me to upgrade our distro,
as the fftw devs are very conservative so this is not bleeding edge code.
###### Things done
- [x] Tested using sandboxing
  I tested with the pkg [x42-plugins](https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/audio/x42-plugins).
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
