### PR TITLE
vifm: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/applications/misc/vifm/default.nix
+++ b/pkgs/applications/misc/vifm/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "vifm-${version}";
-  version = "0.8.1";
+  version = "0.8.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/vifm/vifm/${name}.tar.bz2";
-    sha256 = "0yf3xc4czdrcbvmhq7d4xkck5phrmxwybmnv1zdb56qg56baq64r";
+    sha256 = "07r15kq7kjl3a41sd11ncpsii866xxps4f90zh3lv8jqcrv6silb";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update vifm to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
