### PR TITLE
erlangR19: init at 19.0.2

### DIFF
--- a/pkgs/development/interpreters/erlang/R19.nix
+++ b/pkgs/development/interpreters/erlang/R19.nix
@@ -1,0 +1,100 @@
+{ stdenv, fetchurl, fetchFromGitHub, perl, gnum4, ncurses, openssl
+, gnused, gawk, autoconf, libxslt, libxml2, makeWrapper
+, Carbon, Cocoa
+, odbcSupport ? false, unixODBC ? null
+, wxSupport ? true, mesa ? null, wxGTK ? null, xorg ? null, wxmac ? null
+, javacSupport ? false, openjdk ? null
+, enableHipe ? true
+, enableDebugInfo ? false
+}:
+
+assert wxSupport -> (if stdenv.isDarwin
+  then wxmac != null
+  else mesa != null && wxGTK != null && xorg != null);
+
+assert odbcSupport -> unixODBC != null;
+assert javacSupport ->  openjdk != null;
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "erlang-" + version + "${optionalString odbcSupport "-odbc"}"
+  + "${optionalString javacSupport "-javac"}";
+  version = "19.0.2";
+
+  # Minor OTP releases are not always released as tarbals at
+  # http://erlang.org/download/ So we have to download from
+  # github. And for the same reason we can't use a prebuilt manpages
+  # tarball and need to build manpages ourselves.
+  src = fetchFromGitHub {
+    owner = "erlang";
+    repo = "otp";
+    rev = "OTP-${version}";
+    sha256 = "1vsykghhzpgmc42jwj48crl11zzzpvrqvh2lk8lxfqbflzflxm6j";
+  };
+
+  buildInputs =
+    [ perl gnum4 ncurses openssl autoconf libxslt libxml2 makeWrapper
+    ] ++ optionals wxSupport (if stdenv.isDarwin then [ wxmac ] else [ mesa wxGTK xorg.libX11 ])
+      ++ optional odbcSupport unixODBC
+      ++ optional javacSupport openjdk
+      ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
+
+  debugInfo = enableDebugInfo;
+
+  envAndCpPatch = fetchurl {
+     url = "https://github.com/binarin/otp/commit/9f9841eb7327c9fe73e84e197fd2965a97b639cf.patch";
+     sha256 = "10h5348p6g279b4q01i5jdqlljww5chcvrx5b4b0dv79pk0p0m9f";
+  };
+
+  patches = [
+    envAndCpPatch
+  ];
+
+  preConfigure = ''
+    ./otp_build autoconf
+  '';
+
+  configureFlags= [
+    "--with-ssl=${openssl.dev}"
+  ] ++ optional enableHipe "--enable-hipe"
+    ++ optional wxSupport "--enable-wx"
+    ++ optional odbcSupport "--with-odbc=${unixODBC}"
+    ++ optional javacSupport "--with-javac"
+    ++ optional stdenv.isDarwin "--enable-darwin-64bit";
+
+  # install-docs will generate and install manpages and html docs
+  # (PDFs are generated only when fop is available).
+  installTargets = "install install-docs";
+
+  postInstall = ''
+    ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
+  '';
+
+  # Some erlang bin/ scripts run sed and awk
+  postFixup = ''
+    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
+    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${gnused}/bin/:${gawk}/bin"
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    homepage = "http://www.erlang.org/";
+    downloadPage = "http://www.erlang.org/download.html";
+    description = "Programming language used for massively scalable soft real-time systems";
+
+    longDescription = ''
+      Erlang is a programming language used to build massively scalable
+      soft real-time systems with requirements on high availability.
+      Some of its uses are in telecoms, banking, e-commerce, computer
+      telephony and instant messaging. Erlang's runtime system has
+      built-in support for concurrency, distribution and fault
+      tolerance.
+    '';
+
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ the-kenny sjmackenzie couchemar ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5657,6 +5657,21 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
     javacSupport = true; odbcSupport = true;
   };
+  erlangR19 = callPackage ../development/interpreters/erlang/R19.nix {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+  };
+  erlangR19_odbc = callPackage ../development/interpreters/erlang/R19.nix {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    odbcSupport = true;
+  };
+  erlangR19_javac = callPackage ../development/interpreters/erlang/R19.nix {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+      javacSupport = true;
+  };
+  erlangR19_odbc_javac = callPackage ../development/interpreters/erlang/R19.nix {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    javacSupport = true; odbcSupport = true;
+  };
   erlang = self.erlangR18;
   erlang_odbc = self.erlangR18_odbc;
   erlang_javac = self.erlangR18_javac;


### PR DESCRIPTION
###### Motivation for this change

Add an Erlang 19.x package.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add R19.nix, based on @binarin's R18.nix.

N.B. erlang/otp#1023 obviated the need for [`rmAndPwdPatch`](https://github.com/binarin/nixpkgs/blob/3f753083f2ceb863bdba43956a115d1b738244ad/pkgs/development/interpreters/erlang/R18.nix#L45-L48) in R19.
