### PR TITLE
oraclejdk: 8u91, 8u92 -> 8u101, 8u102

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "91";
+  patchVersion = "101";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "0lndni81vfpz2l6zb8zsshaavk0483q5jc8yzj4fdjv6wnshbkay";
-  sha256_x86_64 = "0lkm3fz1vdi69f34sysavvh3abx603j1frc9hxvr08pwvmm536vg";
+  sha256_i686 = "0p9nvaifb1mn7scmprbcyv9a4lyqy8i0mf7rsb59cli30vpi44mi";
+  sha256_x86_64 = "0a0kb3c7xfh81vx5sicw2frgxq0gyv5qp0d725rviwldlcxk4zs6";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "92";
+  patchVersion = "102";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "095j2hh2xas05jajy4qdj9hxq3k460x4m12rcaxkaxw754imj0vj";
-  sha256_x86_64 = "11wrqd3qbkhimbw9n4g9i0635pjhhnijwxyid7lvjv26kdgg58vr";
+  sha256_i686 = "1bsypgf9va8jds0rlpnwp9n9p11hz77gqlmb0b0w2qwfmlmi227d";
+  sha256_x86_64 = "1dq4kqi8k2k11sc28fnbp6cmncfj86jv57iy1gkap94i0fyf1yvw";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4807,7 +4807,7 @@ in
   oraclejdk8distro = installjdk: pluginSupport:
     assert supportsJDK;
     (if pluginSupport then appendToName "with-plugin" else x: x)
-      (callPackage ../development/compilers/oraclejdk/jdk8-linux.nix { inherit installjdk; });
+      (callPackage ../development/compilers/oraclejdk/jdk8cpu-linux.nix { inherit installjdk; });
 
   oraclejdk8psu_distro = installjdk: pluginSupport:
     assert supportsJDK;


### PR DESCRIPTION
###### Motivation for this change

Security fixes and other bug fixes. Maybe, backporting needed.

http://www.oracle.com/technetwork/java/javase/8u101-relnotes-3021761.html
http://www.oracle.com/technetwork/java/javase/8u102-relnotes-3021767.html

This also renames jdk8-linux.nix to jdk8cpu-linux.nix to prevent accidental update from CPU (Critical Patch Update) to PSU (Patch Set Update). #15820
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
