### PR TITLE
ocamlPackage.ppx_blob: init at 0.2

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_blob/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_blob/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildOcaml, fetchurl, ppx_tools }:
+
+buildOcaml rec {
+  name = "ppx_blob";
+  version = "0.2";
+
+  src = fetchurl {
+    url = "https://github.com/johnwhitington/ppx_blob/archive/v${version}.tar.gz";
+    sha256 = "0kvqfm47f4xbgz0cl7ayz29myyb24xskm35svqrgakjq12nkpsss";
+  };
+
+  buildInputs = [ ppx_tools ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/johnwhitington/ppx_blob";
+    description = "OCaml ppx to include binary data from a file as a string";
+    license = licenses.unlicense;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5323,6 +5323,11 @@ in
 
     pprint = callPackage ../development/ocaml-modules/pprint { };
 
+    ppx_blob =
+      if lib.versionAtLeast ocaml_version "4.02"
+      then callPackage ../development/ocaml-modules/ppx_blob {}
+      else null;
+
     ppx_tools =
       if lib.versionAtLeast ocaml_version "4.02"
       then callPackage ../development/ocaml-modules/ppx_tools {}


### PR DESCRIPTION
###### Motivation for this change

OCaml ppx to include binary data from a file as a string.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
