### PR TITLE
jp: init at 0.1.2

### DIFF
--- a/pkgs/development/tools/jmespath/default.nix
+++ b/pkgs/development/tools/jmespath/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "jmespath-${version}";
+  version = "0.2.2";
+  rev = "${version}";
+
+  goPackagePath = "github.com/jmespath/go-jmespath";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "jmespath";
+    repo = "go-jmespath";
+    sha256 = "0f4j0m44limnjd6q5fk152g6jq2a5cshcdms4p3a1br8pl9wp5fb";
+  };
+  meta = with stdenv.lib; {
+    description = "A JMESPath implementation in Go";
+    homepage = "https://github.com/jmespath/go-jmespath";
+    maintainers = with maintainers; [ cransom ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/tools/jp/default.nix
+++ b/pkgs/development/tools/jp/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, jmespath }:
+
+buildGoPackage rec {
+  name = "jp-${version}";
+  version = "0.1.2";
+  rev = "${version}";
+
+  goPackagePath = "github.com/jmespath/jp";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "jmespath";
+    repo = "jp";
+    sha256 = "1i0jl0c062crigkxqx8zpyqliz8j4d37y95cna33jl777kx42r6h";
+  };
+  meta = with stdenv.lib; {
+    description = "A command line interface to the JMESPath expression language for JSON";
+    homepage = "https://github.com/jmespath/jp";
+    maintainers = with maintainers; [ cransom ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2133,6 +2133,8 @@ in
 
   jing = callPackage ../tools/text/xml/jing { };
 
+  jmespath = callPackage ../development/tools/jmespath { };
+
   jmtpfs = callPackage ../tools/filesystems/jmtpfs { };
 
   jnettop = callPackage ../tools/networking/jnettop { };
@@ -2140,6 +2142,8 @@ in
   john = callPackage ../tools/security/john {
     gcc = gcc49; # doesn't build with gcc5
   };
+
+  jp = callPackage ../development/tools/jp { };
 
   jp2a = callPackage ../applications/misc/jp2a { };
 


### PR DESCRIPTION
###### Motivation for this change

It's not that we really need more JSON parsers in the world, but AWS happened to choose an implementation and embedded it in their CLI tools. This is a standalone utility into that library.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

A json parson tool based on the JMESPATH query language.
http://jmespath.org/
