### PR TITLE
badPath: resolve path before check

### DIFF
--- a/pkgs/build-support/cc-wrapper/utils.sh
+++ b/pkgs/build-support/cc-wrapper/utils.sh
@@ -14,6 +14,9 @@ badPath() {
     # the temporary build directory).
     if [ "${p:0:1}" != / ]; then return 1; fi
 
+    # realpath fails if path to the file does not exist
+    p=$(realpath -q "$p" || echo "$p")
+
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \

--- a/pkgs/build-support/gcc-cross-wrapper/utils.sh
+++ b/pkgs/build-support/gcc-cross-wrapper/utils.sh
@@ -9,11 +9,14 @@ skip () {
 # `/nix/store/.../lib/foo.so' isn't.
 badPath() {
     local p=$1
-    
+
     # Relative paths are okay (since they're presumably relative to
     # the temporary build directory).
     if test "${p:0:1}" != "/"; then return 1; fi
-    
+
+    # realpath fails if path to the file does not exist
+    p=$(realpath -q "$p" || echo "$p")
+
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).
     test \

--- a/pkgs/build-support/gcc-wrapper-old/utils.sh
+++ b/pkgs/build-support/gcc-wrapper-old/utils.sh
@@ -9,12 +9,15 @@ skip () {
 # `/nix/store/.../lib/foo.so' isn't.
 badPath() {
     local p=$1
-    
+
     # Relative paths are okay (since they're presumably relative to
     # the temporary build directory).
     if test "${p:0:1}" != "/"; then return 1; fi
-    
+
     @extraPathTests@
+
+    # realpath fails if path to the file does not exist
+    p=$(realpath -q "$p" || echo "$p")
 
     # Otherwise, the path should refer to the store or some temporary
     # directory (including the build directory).


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The issue was raised at https://github.com/NixOS/nixpkgs/issues/8676:
paths like `//tmp/...` are reported as bad and paths like
`/tmp/../bin/` are reported as good.

Note that I have implemented the simplest solution and haven't thought much.
