### PR TITLE
weighttp: fix sha256

### DIFF
--- a/pkgs/tools/networking/weighttp/default.nix
+++ b/pkgs/tools/networking/weighttp/default.nix
@@ -3,7 +3,7 @@ stdenv.mkDerivation {
   name = "weighttp-0.3";
   src = fetchurl {
     url = http://cgit.lighttpd.net/weighttp.git/snapshot/weighttp-0.3.tar.gz;
-    sha256 = "0gl83vnip3nj7fdgbwqkmrx7kxp51sri9jfiwd04q9iz8f9bsmz5";
+    sha256 = "09mrpwjnipmxayqzzhs110lipq41nsyk5pwp2rc6wnlj3266g6pi";
   };
 
   buildInputs = [ python libev ];


### PR DESCRIPTION
###### Motivation for this change

`weighttp`'s sha256 checksum is wrong. 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
% nix-prefetch-url http://cgit.lighttpd.net/weighttp.git/snapshot/weighttp-0.3.tar.gz
downloading ‘http://cgit.lighttpd.net/weighttp.git/snapshot/weighttp-0.3.tar.gz’... [35/92 KiB, 23.9 KiB/s]
path is ‘/nix/store/2nxna2dpzxn5kf804zf5yzbi1w27cr0x-weighttp-0.3.tar.gz’
09mrpwjnipmxayqzzhs110lipq41nsyk5pwp2rc6wnlj3266g6pi
```
