### PR TITLE
syncthing: Allow the user service to be enabled with systemctl

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -9,6 +9,7 @@ let
 
   header = {
     description = "Syncthing service";
+    after = [ "network.target" ];
     environment = {
       STNORESTART = "yes";
       STNOUPGRADE = "yes";
@@ -113,9 +114,8 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    systemd.services = mkIf cfg.systemService {
-      syncthing = header // {
-        after = [ "network.target" ];
+    systemd.services.syncthing = mkIf cfg.systemService
+      header // {
         wantedBy = [ "multi-user.target" ];
         serviceConfig = service // {
           User = cfg.user;
@@ -124,14 +124,14 @@ in
           ExecStart = "${cfg.package}/bin/syncthing -no-browser -home=${cfg.dataDir}";
         };
       };
-    };
 
-    systemd.user.services =  {
-      syncthing = header // {
+    systemd.user.services.syncthing =
+      header // {
+        wantedBy = [ "default.target" ];
         serviceConfig = service // {
           ExecStart = "${cfg.package}/bin/syncthing -no-browser";
         };
       };
-    };
+
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Currently the user service unit has no `wantedB`: it can't be set to auto-start with `systemctl --user enable syncthing`. This change sets the unit to the `default.target`, also adding a network dependency.
###### Things done
- [x] Tested using sandboxing
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
