### PR TITLE
midori: 0.5.8 -> 0.5.11

### DIFF
--- a/pkgs/applications/networking/browsers/midori/default.nix
+++ b/pkgs/applications/networking/browsers/midori/default.nix
@@ -1,20 +1,20 @@
 { stdenv, fetchurl, cmake, pkgconfig, intltool, vala, makeWrapper
 , gtk3, webkitgtk, librsvg, libnotify, sqlite
-, glib_networking, gsettings_desktop_schemas, libsoup
+, glib_networking, gsettings_desktop_schemas, libsoup, pcre, gnome3
 }:
 
 let
-  version = "0.5.8";
+  version = "0.5.11";
 in
 stdenv.mkDerivation rec {
   name = "midori-${version}";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Lightweight WebKitGTK+ web browser";
     homepage = "http://midori-browser.org";
-    license = stdenv.lib.licenses.lgpl21Plus;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ raskin ];
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ raskin ramkromberg ];
   };
 
   src = fetchurl {
@@ -23,21 +23,21 @@ stdenv.mkDerivation rec {
       "http://mirrors-ru.go-parts.com/blfs/conglomeration/midori/midori_${version}_all_.tar.bz2"
     ];
     name = "midori_${version}_all_.tar.bz2";
-    sha256 = "10ckm98rfqfbwr84b8mc1ssgj84wjgkr4dadvx2l7c64sigi66dg";
+    sha256 = "0gcwqkcyliqz10i33ww3wl02mmfnl7jzl2d493l4l53ipsb1l6cn";
   };
-
-  sourceRoot = ".";
 
   buildInputs = [
     cmake pkgconfig intltool vala makeWrapper
-    webkitgtk librsvg libnotify sqlite gsettings_desktop_schemas
-    (libsoup.override {gnomeSupport = true;})
+    webkitgtk librsvg libnotify sqlite gsettings_desktop_schemas pcre gnome3.gcr
+    (libsoup.override {gnomeSupport = true; valaSupport = true;})
   ];
 
-  cmakeFlags = ''
-    -DHALF_BRO_INCOM_WEBKIT2=ON
-    -DUSE_ZEITGEIST=OFF
-  '';
+  cmakeFlags = [ 
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DUSE_ZEITGEIST=OFF"
+    "-DHALF_BRO_INCOM_WEBKIT2=OFF"
+    "-DUSE_GTK3=1"
+  ];
 
   NIX_LDFLAGS="-lX11";
 


### PR DESCRIPTION
###### Motivation for this change

```
v0.5.11
 Add fake theme for built-in icons
 * Don't truncate long speed dial titles if there's room to display them
 Fix warnings for -Wformat-security
 Ensure vala knows the prototypes of functions it calls, fixing pointer truncation in tests
 Add unit test to check appmenu/menubar visibility
 Fix last known GTK2 entry placeholder text bugs
 Make sure that only one of appmenu and menubar are visible *initially* as well as when changed
 Move adblock icons to hicolor
 Limit bookmarks panel callbacks to the lifetime of the panel to fix a crash
 Fix fallout (broken bookmarks and history panel search) from tweaks to GTK2 entry placeholder
 fix property binding to ensure that exactly one of appmenu button and menubar is always visible
 Skip open-with codepath with abp links, they are internal
 Use find_file to locate execinfo.h
 Fix middle/ctrl/normal clicking bookmarks (not folders) in the bookmarkbar.
 Add copright header to sanitize_bar.sh
 Adblock fixup: Escape . in filter with \
 Don't shadow variable uri in midori_browser_save_uri
 Switch Adblock icons to 24px color
 Always include app menu in toolbar
 Fix various mis[sing ]annotations and style issues in GIR
 Compile typelib from gir
 Fix assert when resetting webapp state after inactivity reset
 clean up handling of double-valued db column in Tabby
 Add a comment to explain MidoriBrowser popup callback
 fix warnings printed when right-clicking resize grip between location and search entries
 Win32: Use Dr. MinGW if present to preserve crash info
 Fix menubar warning caused by direct cast instead of `as`
 Helper script for setting up bzr with some usefull plugins and settings
 Stop using Gtk.Entry.max_width_chars
 avoid deprecated SoupServer API with libsoup 2.48
 Use unowned in foreach loops in Midori.Window
 Use unowned in foreach loops in Midori.Completion
 Use unowned with Adblock.Subscription and Element in foreach loops
 Use unowned strings in foreach loops
 Enable openWith in app mode and make it work with view-new
 Implement Midori.Window class with toolbar/ headerbar
 Drop support for libsoup-gnome-2.4 < 2.37.1
 Make search icons for engines work correctly
 Move to WebKit2 4.0 which broke ABI
 Port to zeitgeist-2.0
 win32: Bump shipped GrayBird theme version to fix some rendering issues
 avoid deprecated GtkDialog API with GTK+2 >= 2.22
 Title case for "Export Certificate" button
 fix incorrect type of MAX(sorting) in Tabby

v0.5.10
 use exit instead of return in license script
 Fix HAVE_GCR guards after GtkPopover port
 Remove example app and .desktop before creating it in the unit test
 Fix cache dir path in Adblock and always mkdir tmp
 Port location action from Granite.PopOver to Gtk.Popover
 Match https site when user-style is using domain syntax
 Always disable developer tools on Win32
 Reimplement Midori.URI.unescape and add various tests
 Make the inspector resizable with GTK3 by packing into a GtkScrolledWindow
 Don't build tabs2one in release builds
 Don't assume GNotification works on Win32
 update copyright date in About dialog
 Don't entity-escape history and bookmark results in location completion
 Only set tabs' error state if errors come from the main frame
 Implement Paste and Proceed as an action
 No Gcr on Win for the moment
 Yet another Speed Dial CSS update:
 Port bookmark popover from Granite to Gtk.Popover
 Make application choosers resizable with a sane default size
 Use GNotification >= 2.40 and use Midori.App API in webmedia
 Rework mouse button handling in KatzeArrayAction
 Don't bind :day in HistoryDatabase.query
 Make GCR mandatory for all builds
 Update coub support in mediaHerald
 history-list: Fix gtk+3 build caused by dropping "using Gtk;"
 Drop all remaining usages of "using *;"
 Don't open search engines menu when clearing search action
 Only remove apps in the sidepanel when left-clicking the delete icon
 Improve robustness of GTK3-compatibility placeholder text fallback
 Clean up vapi dependency
 tls_flags from webkit_web_view_get_tls_info need to be 0
 Don't add failed pages to history
 Throw error for wrong paramter in Statement.bind
 Replace NoJS "allow all pages" setting with "allow local pages"
 Avoid bugs due to race condition in addons delete dialog
 Calculate transfer progress at regular intervals to fix 0B/s bug and recalcitrant progess bars
 Fix warnings occurring with EXTRA_WARNINGS
 Escape parentheses in adblock_fixup_regexp()
 Use File.query_exist() on win32 when checking for db to attach
 Handle _NEW_WINDOW_ACTION explicitly to make _blank targets work
 Fix undefined behavior uint in mouse gestures
 fix JavaScript keyup event by calling inherited key-release-event handler in MidoriBrowser
 Inline renaming of speed dials
 Handle current_size and last_size of Download being equal
 Add proper copyright headers to element_hider and autosuggestcontrol
 Add X-GNOME-UsesNotifications to indicate the use of notifications
 Fix typo in Bookmarks menu UI definition

v0.5.9
 Remove dead code from browser and preferences
 Build-fix: Make PanedAction's Child.widget public
 fixes tab history undo
 Set a placeholder text on the URL entry
 Add "Add Bookmark" to menu
 Show search menu upon left icon click in location bar
 Fix crash when saving with associated resources
 Fix webkit2 downloads based on older branch
 don't hide window decorations for Midori-Granite
 Connect bookmarks-db singleton correctly to fix menus
 Fix some symbol names and transfer annotations in doc comments
 Use correct signature for window-state-event handler
 Do not overescape page titles in view completion
 Make adblock skip non-standard last update metadata strings
 Drop deprecated Granite LightWindow used for the Clear Private Data dialog
 Keep storing the last web media tab played.
 Allocate CookiePermissionManagerModalInfobar correctly
 Make middle clicking reload button duplicate the current tab, similar to other browsers
 Use network-changed of GNetworkMonitor to reload all tabs if network becomes available
 Show different messages based on network connectivity.
 Fix crash when activating the edit menu
 Fix "open all in tabs" for bookmarks
 Fix a few simple leaks
 Don't focus the locationaction when leaving blank pages
 Fix leaks of two references to the MidoriApp in Tabby
 Compile with valac 0.16 again
 Never display about:new in the urlbar
 fix crash right-clicking forms on local pages
 Share 'youtube, vimeo, dailymotion' that you are playing in Midori using org.midori.mediaHerald
 Give the SoupURI a path when checking cookie relevance
 Resolve ellipsis and title stripping in completion
 Add www. and .com/.country_domain and proceed with Ctrl+Enter/Shift+Enter with (readable code)
 Clean up browser tab/ uri/ title notify
 Drop pseudo Granite distinction in completion layout
 Fix visibility of SpeedDial, Toolbar, Bookmarkbar context menu items
 Distinguish between desc file missing and other parsing issues
 Use dependencies to clear test folders before execution
 win32: Drop dropbox usage from win release script, rename resulting output files
```

http://midori-browser.org/changelog/

Note this PR depends on https://github.com/NixOS/nixpkgs/pull/16897 and can't compile without it.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
