### PR TITLE
Merge nixpkgs.config.perlPackageOverrides

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -21,6 +21,11 @@ let
       packageOverrides = pkgs:
         optCall lhs.packageOverrides pkgs //
         optCall (attrByPath ["packageOverrides"] ({}) rhs) pkgs;
+    } //
+    optionalAttrs (lhs ? perlPackageOverrides) {
+      perlPackageOverrides = pkgs:
+        optCall lhs.perlPackageOverrides pkgs //
+        optCall (attrByPath ["perlPackageOverrides"] ({}) rhs) pkgs;
     };
 
   configType = mkOptionType {


### PR DESCRIPTION
We can define `nixpkgs.config.packageOverrides` in multiple modules, and those overrides will be merged. While this does not work for `perlPackageOverrides` - it gets replaced by the latest module imported.

If this is the right thing, we might want to do similar things for other package sets. I'm not sure about haskell, because it's override function gets two arguments.
