### PR TITLE
weighttp: 0.3 -> 0.4

### DIFF
--- a/pkgs/tools/networking/weighttp/default.nix
+++ b/pkgs/tools/networking/weighttp/default.nix
@@ -1,9 +1,12 @@
-{ stdenv, fetchurl, python, libev}:
-stdenv.mkDerivation {
-  name = "weighttp-0.3";
-  src = fetchurl {
-    url = http://cgit.lighttpd.net/weighttp.git/snapshot/weighttp-0.3.tar.gz;
-    sha256 = "0gl83vnip3nj7fdgbwqkmrx7kxp51sri9jfiwd04q9iz8f9bsmz5";
+{ stdenv, fetchgit, python, libev}:
+stdenv.mkDerivation rec {
+  name = "weighttp-${version}";
+  version = "0.4";
+
+  src = fetchgit {
+    url = https://git.lighttpd.net/weighttp.git;
+    rev = "refs/tags/weighttp-${version}";
+    sha256 = "14yjmdx9p8g8c3zlrx5qid8k156lsagfwhl3ny54162nxjf7kzgr";
   };
 
   buildInputs = [ python libev ];


### PR DESCRIPTION
###### Motivation for this change

Fix the sha (https://github.com/NixOS/nixpkgs/pull/17133) but use `fetchgit` so it'll be more stable.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cgit doesn't generate stable archives, so the SHA changed when there
was a commit earlier this year. Using fetchgit in hopes of stabilizing
the checked out sha.
