### PR TITLE
exrtools: init at 0.4

### DIFF
--- a/pkgs/applications/graphics/exrtools/default.nix
+++ b/pkgs/applications/graphics/exrtools/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, pkgconfig, openexr, libpng12, libjpeg }:
+
+stdenv.mkDerivation rec {
+  name = "exrtools";
+  version = "0.4";
+
+  src = fetchurl {
+    url =  "http://scanline.ca/exrtools/${name}-${version}.tar.gz";
+    sha256 = "0jpkskqs1yjiighab4s91jy0c0qxcscwadfn94xy2mm2bx2qwp4z";
+  };
+
+  buildInputs = [ stdenv pkgconfig openexr libpng12 libjpeg ];
+
+  meta = with stdenv.lib; {
+    description = "Collection of utilities for manipulating OpenEXR images";
+    homepage = "http://scanline.ca/exrtools";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = [ maintainers.juliendehos ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12855,6 +12855,8 @@ in
 
   exrdisplay = callPackage ../applications/graphics/exrdisplay { };
 
+  exrtools = callPackage ../applications/graphics/exrtools { };
+
   fbpanel = callPackage ../applications/window-managers/fbpanel { };
 
   fbreader = callPackage ../applications/misc/fbreader { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
