### PR TITLE
rhythmbox: init at 3.2.1

### DIFF
--- a/pkgs/applications/audio/rhythmbox/default.nix
+++ b/pkgs/applications/audio/rhythmbox/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchurl, pkgconfig
+, python3
+, perl
+, perlPackages
+, gtk3
+, intltool
+, libsoup
+, gnome3
+, tdb
+, json_glib
+, itstool
+, wrapGAppsHook
+, gst_all_1
+, gst_plugins ? with gst_all_1; [ gst-plugins-good gst-plugins-ugly ]
+}:
+let
+  version = "${major}.${minor}";
+  major = "3.2";
+  minor = "1";
+
+in stdenv.mkDerivation rec {
+  name = "rhythmbox-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/rhythmbox/${major}/${name}.tar.xz";
+    sha256 = "0f3radhlji7rxl760yl2vm49fvfslympxrpm8497acbmbd7wlhxz";
+  };
+
+  buildInputs = [
+    pkgconfig
+
+    python3
+    perl
+    perlPackages.XMLParser
+
+    intltool
+    libsoup
+    tdb
+    json_glib
+    itstool
+
+    gtk3
+    gnome3.libpeas
+    gnome3.totem-pl-parser
+    gnome3.defaultIconTheme
+
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+
+    wrapGAppsHook
+  ] ++ gst_plugins;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Apps/Rhythmbox;
+    description = "A music playing application for GNOME";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.rasendubi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12934,6 +12934,8 @@ in
 
   photivo = callPackage ../applications/graphics/photivo { };
 
+  rhythmbox = callPackage ../applications/audio/rhythmbox { };
+
   wavesurfer = callPackage ../applications/misc/audio/wavesurfer { };
 
   wireshark-cli = callPackage ../applications/networking/sniffers/wireshark {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
