### PR TITLE
libixp-hg: refactor to fetchurl as fetchg broke

### DIFF
--- a/pkgs/development/libraries/libixp-hg/default.nix
+++ b/pkgs/development/libraries/libixp-hg/default.nix
@@ -1,24 +1,23 @@
-{ stdenv, fetchhg, txt2tags }:
+{ stdenv, fetchurl, unzip, txt2tags }:
 
 stdenv.mkDerivation rec {
   rev = "148";
   version = "hg-2012-12-02";
   name = "libixp-${version}";
 
-  src = fetchhg {
-    url = https://code.google.com/p/libixp/;
-    sha256 = "1nbnh2ff18fsrs28mx4bfgncq1d1nw5dd6iwhwvv5x2g9w7q5vvj";
-    inherit rev;
+  src = fetchurl {
+    url = https://storage.googleapis.com/google-code-archive-source/v2/code.google.com/libixp/source-archive.zip;
+    sha256 = "0kcdvdcrkw6q39v563ncis6d7ini64xbgn5fd3b4aa95fp9sj3is";
   };
 
   configurePhase = ''
    sed -i -e "s|^PREFIX.*=.*$|PREFIX = $out|" config.mk
   '';
 
-  buildInputs = [ txt2tags ];
+  buildInputs = [ unzip txt2tags ];
 
   meta = {
-    homepage = https://code.google.com/p/libixp/;
+    homepage = https://code.google.com/archive/p/libixp/;
     description = "Portable, simple C-language 9P client and server libary";
     maintainers = with stdenv.lib.maintainers; [ kovirobi ];
     license = stdenv.lib.licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

Fetchhg broke (presumably due to code.google.com shutting down), archive seems to work
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: tested with wmii-hg, see #17156 
