### PR TITLE
wmii-hg: refactor to fetchurl as fetchhg broke

### DIFF
--- a/pkgs/applications/window-managers/wmii-hg/default.nix
+++ b/pkgs/applications/window-managers/wmii-hg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchhg, pkgconfig, libixp_hg, txt2tags, dash, python, which
+{ stdenv, fetchurl, unzip, pkgconfig, libixp_hg, txt2tags, dash, python, which
 , libX11 , libXrender, libXext, libXinerama, libXrandr, libXft }:
 
 stdenv.mkDerivation rec {
@@ -6,15 +6,14 @@ stdenv.mkDerivation rec {
   version = "hg-2012-12-09";
   name = "wmii-${version}";
 
-  src = fetchhg {
-    url = https://code.google.com/p/wmii/;
-    sha256 = "1wqw41jb2fhq902a04ixfzmx0lia1pawahm1ymyrs3is6mm32r51";
-    inherit rev;
+  src = fetchurl {
+    url = https://storage.googleapis.com/google-code-archive-source/v2/code.google.com/wmii/source-archive.zip;
+    sha256 = "1wmkq14zvmfrmydl8752xz852cy7agrx3qp4fy2cc5asb2r9abaz";
   };
 
   # for dlopen-ing
   patchPhase = ''
-    substituteInPlace lib/libstuff/x11/xft.c --replace "libXft.so" "${libXft}/lib/libXft.so"
+    substituteInPlace lib/libstuff/x11/xft.c --replace "libXft.so" "$(pkg-config --variable=libdir xft)/libXft.so.2"
     substituteInPlace cmd/wmii.sh.sh --replace "\$(which which)" "${which}/bin/which"
   '';
 
@@ -30,14 +29,14 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
-  buildInputs = [ pkgconfig libixp_hg txt2tags dash python which
+  buildInputs = [ unzip pkgconfig libixp_hg txt2tags dash python which
                   libX11 libXrender libXext libXinerama libXrandr libXft ];
 
   # For some reason including mercurial in buildInputs did not help
   makeFlags = "WMII_HGVERSION=hg${rev}";
 
   meta = {
-    homepage = "https://code.google.com/p/wmii/";
+    homepage = "https://code.google.com/archive/p/wmii/";
     description = "A small window manager controlled by a 9P filesystem";
     maintainers = with stdenv.lib.maintainers; [ kovirobi ];
     license = stdenv.lib.licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

Fetchhg broke (presumably due to code.google.com shutting down), archive seems to work
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: see #17155 
