### PR TITLE
mysql: 5.5.49 -> 5.5.50 for CVEs

### DIFF
--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "mysql-${version}";
-  version = "5.5.49";
+  version = "5.5.50";
 
   src = fetchurl {
     url = "mirror://mysql/MySQL-5.5/${name}.tar.gz";
-    sha256 = "07wy1qbxf3fxgi04v6cqs4ymi9hgsgabk218bxiwlsx706ds976d";
+    sha256 = "0lgr6badwnwbrzm6sbll4a25m02xfy85v4q6q0rq5cdjn745bb2y";
   };
 
   patches = if stdenv.isCygwin then [


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Problems include buffer overflows, null pointer dereferences, and
other bugfixes.
- CVE-2016-3477
- CVE-2016-3521
- CVE-2016-3615
- CVE-2016-5440

Details:
https://dev.mysql.com/doc/relnotes/mysql/5.5/en/news-5-5-50.html
