### PR TITLE
influxdb: parametrize default.nix to prepare packaging of 1.0

### DIFF
--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -1,19 +1,13 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoPackage, fetchFromGitHub, src, version }:
 
 buildGoPackage rec {
   name = "influxdb-${version}";
-  version = "0.13.0";
 
   goPackagePath = "github.com/influxdata/influxdb";
 
-  src = fetchFromGitHub {
-    owner = "influxdata";
-    repo = "influxdb";
-    rev = "v${version}";
-    sha256 = "0f7af5jb1f65qnslhc7zccml1qvk6xx5naczqfsf4s1zc556fdi4";
-  };
-
   excludedPackages = "test";
+  
+  inherit src;
 
   # Generated with the `gdm2nix.rb` script and the `Godeps` file from the
   # influxdb repo root.

--- a/pkgs/servers/nosql/influxdb/v0.nix
+++ b/pkgs/servers/nosql/influxdb/v0.nix
@@ -1,0 +1,13 @@
+{ lib, buildGoPackage, fetchFromGitHub }@args:
+
+import ./default.nix (args // rec {
+  
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "influxdata";
+    repo = "influxdb";
+    rev = "v${version}";
+    sha256 = "0f7af5jb1f65qnslhc7zccml1qvk6xx5naczqfsf4s1zc556fdi4";
+  };
+}) 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10342,7 +10342,7 @@ in
 
   riak = callPackage ../servers/nosql/riak/2.1.1.nix { };
 
-  influxdb = (callPackage ../servers/nosql/influxdb { }).bin // { outputs = [ "bin" ]; };
+  influxdb = (callPackage ../servers/nosql/influxdb/v0.nix { }).bin // { outputs = [ "bin" ]; };
 
   hyperdex = callPackage ../servers/nosql/hyperdex { };
 


### PR DESCRIPTION
###### Motivation for this change

Parametrize default.nix as preparation for adding a package for 1.0.0-beta3
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
