### PR TITLE
sct: Updated sha256 in default.nix

### DIFF
--- a/pkgs/tools/X11/sct/default.nix
+++ b/pkgs/tools/X11/sct/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   buildInputs = [libX11 libXrandr];
   src = fetchurl {
     url = http://www.tedunangst.com/flak/files/sct.c;
-    sha256 = "0dda697ec3f4129d793f8896743d82be09934883f5aeda05c4a2193d7ab3c305";
+    sha256 = "1321ajd1ph0hyj6pi76ylfcb1csj100lqflrb7n44ni5ybxmy3j2";
   };
   phases = ["patchPhase" "buildPhase" "installPhase"];
   patchPhase = ''

--- a/pkgs/tools/X11/sct/default.nix
+++ b/pkgs/tools/X11/sct/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   buildInputs = [libX11 libXrandr];
   src = fetchurl {
     url = http://www.tedunangst.com/flak/files/sct.c;
-    sha256 = "1bivy0sl5v1jsq4jbq6p9hplz6cvw4nx9rc96p2kxsg506rqllc5";
+    sha256 = "0dda697ec3f4129d793f8896743d82be09934883f5aeda05c4a2193d7ab3c305";
   };
   phases = ["patchPhase" "buildPhase" "installPhase"];
   patchPhase = ''

--- a/pkgs/tools/X11/sct/default.nix
+++ b/pkgs/tools/X11/sct/default.nix
@@ -5,6 +5,14 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = http://www.tedunangst.com/flak/files/sct.c;
     sha256 = "1321ajd1ph0hyj6pi76ylfcb1csj100lqflrb7n44ni5ybxmy3j2";
+    
+    # Discussion regarding the checksum and the source code can be found in issue #17163 
+    # The code seems unmaintained, yet an unknown (probably small change) in the code caused 
+    # failed builds as the checksum had changed.
+    # The checksum is updated for now, however, this is unpractical and potentially unsafe 
+    # so any future changes might warrant a fork of the (feature complete) project. 
+    # The code is under public domain.
+    
   };
   phases = ["patchPhase" "buildPhase" "installPhase"];
   patchPhase = ''

--- a/pkgs/tools/X11/sct/default.nix
+++ b/pkgs/tools/X11/sct/default.nix
@@ -1,10 +1,11 @@
-{stdenv, fetchurl, libX11, libXrandr}:
+{stdenv, fetchgit, libX11, libXrandr}:
 stdenv.mkDerivation rec {
   name = "sct";
   buildInputs = [libX11 libXrandr];
-  src = fetchurl {
-    url = http://www.tedunangst.com/flak/files/sct.c;
-    sha256 = "1321ajd1ph0hyj6pi76ylfcb1csj100lqflrb7n44ni5ybxmy3j2";
+  src = fetchgit {
+    url = git://github.com/wmapp/sct.git;
+    rev = "be00d189f491b9100233b3a623b026bbffccb18e";
+    sha256 = "1bivy0sl5v1jsq4jbq6p9hplz6cvw4nx9rc96p2kxsg506rqllc5";
     
     # Discussion regarding the checksum and the source code can be found in issue #17163 
     # The code seems unmaintained, yet an unknown (probably small change) in the code caused 

--- a/pkgs/tools/X11/sct/default.nix
+++ b/pkgs/tools/X11/sct/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   buildInputs = [libX11 libXrandr];
   src = fetchurl {
     url = http://www.tedunangst.com/flak/files/sct.c;
-    sha256 = "1321ajd1ph0hyj6pi76ylfcb1csj100lqflrb7n44ni5ybxmy3j2";
+    sha256 = "01f3ndx3s6d2qh2xmbpmhd4962dyh8yp95l87xwrs4plqdz6knhd";
     
     # Discussion regarding the checksum and the source code can be found in issue #17163 
     # The code seems unmaintained, yet an unknown (probably small change) in the code caused 

--- a/pkgs/tools/X11/sct/default.nix
+++ b/pkgs/tools/X11/sct/default.nix
@@ -1,11 +1,10 @@
-{stdenv, fetchgit, libX11, libXrandr}:
+{stdenv, fetchurl, libX11, libXrandr}:
 stdenv.mkDerivation rec {
   name = "sct";
   buildInputs = [libX11 libXrandr];
-  src = fetchgit {
-    url = git://github.com/wmapp/sct.git;
-    rev = "be00d189f491b9100233b3a623b026bbffccb18e";
-    sha256 = "1bivy0sl5v1jsq4jbq6p9hplz6cvw4nx9rc96p2kxsg506rqllc5";
+  src = fetchurl {
+    url = http://www.tedunangst.com/flak/files/sct.c;
+    sha256 = "1321ajd1ph0hyj6pi76ylfcb1csj100lqflrb7n44ni5ybxmy3j2";
     
     # Discussion regarding the checksum and the source code can be found in issue #17163 
     # The code seems unmaintained, yet an unknown (probably small change) in the code caused 


### PR DESCRIPTION
###### Motivation for this change

I found that the utility 'sct' was unable to install due to a changed checksum.
My guess is that programmer cleaned up the code or something like that which caused a change in checksum. 
###### Things done

The sha256 sum was updated from the following
1bivy0sl5v1jsq4jbq6p9hplz6cvw4nx9rc96p2kxsg506rqllc5
to the newer value
0dda697ec3f4129d793f8896743d82be09934883f5aeda05c4a2193d7ab3c305.
