### PR TITLE
dropbox: 4.4.29 -> 6.4.14

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -3,7 +3,7 @@
 , libdrm, libffi, libICE, libSM
 , libX11, libXcomposite, libXext, libXmu, libXrender, libxcb
 , libxml2, libxslt, ncurses, zlib
-, qtbase, qtdeclarative, qtquick1, qtwebkit
+, qtbase, qtdeclarative, qtwebkit
 }:
 
 # this package contains the daemon version of dropbox
@@ -23,11 +23,11 @@
 let
   # NOTE: When updating, please also update in current stable,
   # as older versions stop working
-  version = "4.4.29";
+  version = "6.4.14";
   sha256 =
     {
-      "x86_64-linux" = "1ff01vqi9jiwhkqm81rh321bsz4brl11xal2xzm9gll7s2m8lz06";
-      "i686-linux" = "0lwvvyxy5xyxh0b2g8a9bdy0y2hgpbak4n6q6b30167fvpj1ad1i";
+      "x86_64-linux" = "0wpdib3jf5bq4k8q5xv9g01fdcfjb4l903xjxn32rjw615s1q8bg";
+      "i686-linux" = "1lgc7ryp2mn230cfsbndn9ss71l378kib0lvs89rkn25d5zfgzn4";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =
@@ -45,7 +45,7 @@ let
       libX11 libXcomposite libXext libXmu libXrender libxcb libxml2 libxslt
       ncurses zlib
 
-      qtbase qtdeclarative qtquick1 qtwebkit
+      qtbase qtdeclarative qtwebkit
     ];
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Motivation for this change
1. New version
2. I also dropped the reference to qtquick1 which threw a compilation error and dropbox seems to work fine without
3. I have only tested the 64 bit version, but it's running fine here.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
