### PR TITLE
i3blocks-gaps: init at 1.4

### DIFF
--- a/pkgs/applications/window-managers/i3/blocks-gaps.nix
+++ b/pkgs/applications/window-managers/i3/blocks-gaps.nix
@@ -1,0 +1,24 @@
+{ fetchFromGitHub, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "i3blocks-gaps-${version}";
+  version = "1.4";
+
+  src = fetchFromGitHub {
+    owner = "Airblader";
+    repo = "i3blocks-gaps";
+    rev = "4cfdf93c75f729a2c96d471004d31734e923812f";
+    sha256 = "0v9307ij8xzwdaxay3r75sd2cp453s3qb6q7dy9fks2p6wwqpazi";
+  };
+
+  makeFlags = "all";
+  installFlags = "PREFIX=\${out} VERSION=${version}";
+
+  meta = with stdenv.lib; {
+    description = "A flexible scheduler for your i3bar blocks -- this is a fork to use with i3-gaps";
+    homepage = https://github.com/Airblader/i3blocks-gaps;
+    license = licenses.gpl3;
+    maintainers = [ "carlsverre" ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13350,6 +13350,8 @@ in
 
   i3blocks = callPackage ../applications/window-managers/i3/blocks.nix { };
 
+  i3blocks-gaps = callPackage ../applications/window-managers/i3/blocks-gaps.nix { };
+
   i3cat = callPackage ../tools/misc/i3cat { };
 
   i3lock = callPackage ../applications/window-managers/i3/lock.nix {


### PR DESCRIPTION
###### Motivation for this change

I want to use a working version of i3blocks along with i3-gaps.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fork of i3blocks which supports adding borders to work with i3-gaps
