### PR TITLE
nodejs-6_x: 6.2.2 -> 6.3.1

### DIFF
--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -1,15 +1,18 @@
 { stdenv, fetchurl, openssl, python, zlib, libuv, v8, utillinux, http-parser
 , pkgconfig, runCommand, which, libtool
 , callPackage
+, darwin ? null
 }@args:
 
-import ./nodejs.nix (args // rec {
-  version = "6.2.2";
-  src = fetchurl {
-    url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-    sha256 = "2dfeeddba750b52a528b38a1c31e35c1fb40b19cf28fbf430c3c8c7a6517005a";
-  };
-  preBuild = stdenv.lib.optionalString (stdenv.system == "x86_64-darwin") ''
+let
+  inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
+
+in import ./nodejs.nix (args // rec {
+  version = "6.3.1";
+  sha256 = "06ran2ccfxkwyk6w4wikd7qws286952lbx93pqaygmbh9f0q9rbg";
+  extraBuildInputs = stdenv.lib.optionals stdenv.isDarwin
+    [ CoreServices ApplicationServices ];
+  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i -e "s|tr1/type_traits|type_traits|g" \
       -e "s|std::tr1|std|" src/util.h
   '';


### PR DESCRIPTION
Upgrade nodejs-6_x from `6.2.2` to `6.3.1`
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [X] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
