### PR TITLE
metamorphose2: init at 0.9.0beta

### DIFF
--- a/pkgs/applications/misc/metamorphose2/default.nix
+++ b/pkgs/applications/misc/metamorphose2/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchgit, makeWrapper, gettext
+, python27, python2Packages
+}:
+
+stdenv.mkDerivation rec {
+  name    = "metamorphose2-${version}";
+  version = "0.9.0beta";
+
+  # exif-py vendored via submodule
+  # mutagen vendored via copy
+  src = fetchgit {
+    url = "https://github.com/metamorphose/metamorphose2.git";
+    #rev = "refs/tags/v2.${version}"; #for when wxPython3 support is released
+    rev = "d2bdd6a86340b9668e93b35a6a568894c9909d68";
+    sha256 = "0ivcb3c8hidrff0ivl4dnwa2p3ihpqjdbvdig8dhg9mm5phdbabn";
+  };
+
+  postPatch = ''
+    substituteInPlace messages/Makefile \
+      --replace "\$(shell which msgfmt)" "${gettext}/bin/msgfmt"
+  '';
+
+  postInstall = ''
+    rm $out/bin/metamorphose2
+    makeWrapper ${python27}/bin/python $out/bin/metamorphose2 \
+      --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath "$out") \
+      --add-flags "-O $out/share/metamorphose2/metamorphose2.py -w=3"
+  '';
+
+  buildInput = [ gettext python27 ];
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ python2Packages.wxPython python2Packages.pillow ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "a graphical mass renaming program for files and folders";
+    homepage    = "https://github.com/metamorphose/metamorphose2";
+    license     = with licenses; gpl3Plus;
+    maintainer  = with maintainers; [ ramkromberg ];
+    platforms   = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2527,6 +2527,8 @@ in
 
   megatools = callPackage ../tools/networking/megatools { };
 
+  metamorphose2 = callPackage ../applications/misc/metamorphose2 { };
+
   mfcuk = callPackage ../tools/security/mfcuk { };
 
   mfoc = callPackage ../tools/security/mfoc { };


### PR DESCRIPTION
###### Motivation for this change

For renaming stuff fast without needing to look through man pages.

Note: Had to pull from master for wxPython3 support.
Also, Metamorphose2 vendors mutagen and exif-py.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
