### PR TITLE
libui: adds missing pkg-config file and headers

### DIFF
--- a/pkgs/development/libraries/libui/default.nix
+++ b/pkgs/development/libraries/libui/default.nix
@@ -1,25 +1,38 @@
 { stdenv, fetchgit, cmake, pkgconfig, gtk3 }:
 
-stdenv.mkDerivation rec {
-  version = "3.1.a";
-  name = "libui-${version}";
-  src  = fetchgit {
-    url    = "https://github.com/andlabs/libui.git";
-    rev    = "6ebdc96b93273c3cedf81159e7843025caa83058";
-    sha256 = "1lpbfa298c61aarlzgp7vghrmxg1274pzxh1j9isv8x758gk6mfn";
-  };
+let
+  shortName = "libui";
+  version   = "3.1a";
+in
+  stdenv.mkDerivation rec {
+    name = "${shortName}-${version}";
+    src  = fetchgit {
+      url    = "https://github.com/andlabs/libui.git";
+      rev    = "6ebdc96b93273c3cedf81159e7843025caa83058";
+      sha256 = "1lpbfa298c61aarlzgp7vghrmxg1274pzxh1j9isv8x758gk6mfn";
+    };
 
-  buildInputs = [ cmake pkgconfig gtk3 ];
+    buildInputs = [ cmake pkgconfig gtk3 ];
 
-  installPhase = ''
-    mkdir -p $out
-    mv ./out/libui.so.0 $out/libui.so.0
-  '';
+    installPhase = ''
+      mkdir -p $out/{include,lib}
+      mkdir -p $out/lib/pkgconfig
 
-  meta = with stdenv.lib; {
-    description = "Simple and portable (but not inflexible) GUI library in C that uses the native GUI technologies of each platform it supports.";
-    homepage    = https://github.com/andlabs/libui;
-    platforms   = platforms.linux;
-    license     = licenses.mit;
-  };
-}
+      mv ./out/${shortName}.so.0 $out/lib/
+      ln -s $out/lib/${shortName}.so.0 $out/lib/${shortName}.so
+
+      cp $src/ui.h $out/include
+      cp $src/ui_unix.h $out/include
+
+      cp ${./libui.pc} $out/lib/pkgconfig/${shortName}.pc
+      substituteInPlace $out/lib/pkgconfig/${shortName}.pc \
+        --subst-var-by out $out \
+        --subst-var-by version "${version}"
+    '';
+
+    meta = {
+      homepage    = https://github.com/andlabs/libui;
+      description = "Simple and portable (but not inflexible) GUI library in C that uses the native GUI technologies of each platform it supports.";
+      platforms   = stdenv.lib.platforms.linux;
+    };
+  }

--- a/pkgs/development/libraries/libui/libui.pc
+++ b/pkgs/development/libraries/libui/libui.pc
@@ -1,0 +1,11 @@
+prefix=@out@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${exec_prefix}/include
+
+Name: libui
+Description: Simple and portable (but not inflexible) GUI library
+Version: @version@
+
+Libs: -L${libdir} -lui
+Cflags: -I${includedir}


### PR DESCRIPTION
###### Motivation for this change

In my previos PR #17005 I added the libui library. To test that the library not only was built successfully, but also that it was working, I used the test application that was shipped with the library. 

However, the test application build uses a relative path for the shared library and the headers. So building and running the test program worked since it was built in the library's source tree. 

But when you want to use the library as a nixpkg dependency the library dir will only contain the shared library `libui.so.0`:

``` bash
$ tree /nix/store/3bx887yqs7xkyfq29r1a27r9v94phy5r-libui-3.1.a
/nix/store/3bx887yqs7xkyfq29r1a27r9v94phy5r-libui-3.1.a
└── libui.so.0
```

Which means you can't include the headers and there's not a `pkg-config` entry to use, making this library unusable.

This PR adds a pkg-config file and copying of the header files. Which makes the result look like this:

``` bash
$ tree /nix/store/pcahv5nbjlw9llmvbsrbvzj3hq964vdc-libui-3.1a
/nix/store/pcahv5nbjlw9llmvbsrbvzj3hq964vdc-libui-3.1a
├── include
│   ├── ui.h
│   └── ui_unix.h
└── lib
    ├── libui.so -> /nix/store/pcahv5nbjlw9llmvbsrbvzj3hq964vdc-libui-3.1a/lib/libui.so.0
    ├── libui.so.0
    └── pkgconfig
        └── libui.pc
```

To see what files were needed I looked at [the projects issue 116](https://github.com/andlabs/libui/issues/116) and then I built the [controlgallery example](https://github.com/andlabs/libui/blob/6ebdc96b93273c3cedf81159e7843025caa83058/examples/controlgallery/main.c) as a separate nixpkg. I changed all relative header paths in the source file to `#include <ui.h>` and used the following Makefile:

``` make
TARGET = main

CFLAGS=-g -Wall -Wextra $(shell pkg-config --cflags libui)
LDFLAGS=$(shell pkg-config --libs libui)

all: $(TARGET)
```

And built it with the following `default.nix` file: 

``` nix
{ stdenv, lib, makeWrapper, pkgconfig, libui }:

let
  shortName = "libui-test";
  version   = "1.0.0";
in
  stdenv.mkDerivation rec {
    name = "${shortName}-${version}";
    src  = ./src;

    buildInputs = [ makeWrapper pkgconfig libui ];

    installPhase = ''
      mkdir -p $out/bin

      cp main $out/bin/${shortName}

      wrapProgram $out/bin/${shortName} \
        --prefix LD_LIBRARY_PATH ":" "${lib.makeLibraryPath
            [ libui ]
          }"
    '';
  }
```

The resulting executable works and links against libui and gtk:

``` bash
$ ldd result/bin/.libui-test-wrapped | grep libui
        libui.so.0 => /nix/store/7mqskw0dxff96g8x6zg5rxyjvhbxmp65-libui-3.1a/lib/libui.so.0 (0x00007f7d827e8000)

$ ldd result/bin/.libui-test-wrapped | grep gtk
        libgtk-3.so.0 => /nix/store/faxfzshl9qw4677cy4v2yk1ah8g649kh-gtk+3-3.18.5/lib/libgtk-3.so.0 (0x00007feb43ed8000)
        libgdk-3.so.0 => /nix/store/faxfzshl9qw4677cy4v2yk1ah8g649kh-gtk+3-3.18.5/lib/libgdk-3.so.0 (0x00007feb43c18000)
```

Here's a screenshot of the program running:

![image](http://i.imgur.com/kcqPIXa.png)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
