### PR TITLE
evilwm: init at 1.1.1 (#17104)

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -432,4 +432,5 @@
   zimbatm = "zimbatm <zimbatm@zimbatm.com>";
   zohl = "Al Zohali <zohl@fmap.me>";
   zoomulator = "Kim Simmons <zoomulator@gmail.com>";
+  amiloradovsky = "Andrew Miloradovsky <miloradovsky@gmail.com>";
 }

--- a/pkgs/applications/window-managers/evilwm/default.nix
+++ b/pkgs/applications/window-managers/evilwm/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl,  libX11, libXext, libXrandr, libXrender,
+  xproto, xextproto, randrproto, renderproto, kbproto,  patches ? [] }:
+
+stdenv.mkDerivation rec {
+  name = "evilwm-1.1.1";
+
+  src = fetchurl {
+    url = "http://www.6809.org.uk/evilwm/${name}.tar.gz";
+    sha256 = "79589c296a5915ee0bae1d231e8912601fc794d9f0a9cacb6b648ff9a5f2602a";
+  };
+
+  buildInputs = [ libX11 libXext libXrandr libXrender
+                  xproto xextproto randrproto renderproto kbproto ];
+
+  prePatch = ''substituteInPlace ./Makefile --replace /usr $out \
+                                            --replace "CC = gcc" "#CC = gcc"'';
+
+  # Allow users set their own list of patches
+  inherit patches;
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.6809.org.uk/evilwm/";
+    description = "Minimalist window manager for the X Window System";
+
+    license = {
+      shortName = "evilwm";
+      fullName = "Custom, inherited from aewm and 9wm";
+      url = http://www.6809.org.uk/evilwm/;
+      free = true;
+    };  # like BSD/MIT, but Share-Alike'y; See README.
+
+    maintainers = with maintainers; [ amiloradovsky ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12562,6 +12562,10 @@ in
     patches = config.dwm.patches or [];
   };
 
+  evilwm = callPackage ../applications/window-managers/evilwm {
+    patches = config.evilwm.patches or [];
+  };
+
   dzen2 = callPackage ../applications/window-managers/dzen2 { };
 
   eaglemode = callPackage ../applications/misc/eaglemode { };


### PR DESCRIPTION
###### Motivation for this change

To have a nice window manager in the packages.
It has no decorations, is fully keyboard-driven, and yet doesn't pretend to be tiling.
Just a simple tool to easily move windows around, without unnecessary complications.

(This is a resubmit of an earlier pull request, #17104, which was very flawed.)
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Minimalist window manager for the X Window System
