### PR TITLE
pfstools: 1.8.5 -> 2.0.5

### DIFF
--- a/pkgs/tools/graphics/pfstools/default.nix
+++ b/pkgs/tools/graphics/pfstools/default.nix
@@ -1,24 +1,31 @@
-{stdenv, fetchurl, libtiff, openexr, imagemagick, libjpeg, qt4, mesa,
-freeglut, bzip2, libX11, libpng, expat, pkgconfig }:
+{ stdenv, fetchurl, cmake, pkgconfig, openexr, ilmbase, zlib, imagemagick, mesa, freeglut, fftwFloat, fftw, gsl, libexif, perl, opencv, qt4 }:
 
 stdenv.mkDerivation rec {
-  name = "pfstools-1.8.5";
+  name = "pfstools";
+  version = "2.0.5";
 
   src = fetchurl {
-    url = "mirror://sourceforge/pfstools/${name}.tar.gz";
-    sha256 = "01kk2r8afrb3vrhm8abfjdhhan97lzpapc4n8w1mpdp3kv9miy9c";
+    url = "mirror://sourceforge/${name}/${version}/${name}-${version}.tgz";
+    sha256 = "1fyc2c7jzr7k797c2dqyyvapzc3szxwcp48r382yxz2yq558xgd9";
   };
 
-  configureFlags = "--with-moc=${qt4}/bin/moc";
+  outputs = [ "out" "doc"];
 
-  buildInputs = [ libtiff openexr imagemagick libjpeg qt4 mesa freeglut
-    bzip2 libX11 libpng expat ];
+  cmakeFlags = ''
+    -DWITH_MATLAB=false 
+  '';
 
-  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openexr zlib imagemagick mesa freeglut fftwFloat fftw gsl libexif perl opencv qt4 ];
 
-  meta = {
-    homepage = http://pfstools.sourceforge.net/;
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  patches = [ ./threads.patch ./pfstools.patch ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://pfstools.sourceforge.net/";
     description = "Toolkit for manipulation of HDR images";
-    license = "GPL";
+    platforms = platforms.linux;
+    license = licenses.lgpl2;
+    maintainers = [ maintainers.juliendehos ];
   };
 }

--- a/pkgs/tools/graphics/pfstools/pfstools.patch
+++ b/pkgs/tools/graphics/pfstools/pfstools.patch
@@ -1,0 +1,21 @@
+--- a/CMakeLists.txt	2016-05-26 11:31:16.000000000 +0200
++++ b/CMakeLists.txt	2016-07-22 19:07:22.074669909 +0200
+@@ -320,12 +320,12 @@
+ 
+ # ======== libexif ==========
+ 
+-find_package(EXIF)
+-if( NOT EXIF_FOUND )
+-    message( "EXIF library (libexif) not found. 'pfsalign' will not be compiled" )
+-else( NOT EXIF_FOUND )
+-    message(STATUS "libexif library found.")  
+-endif( NOT EXIF_FOUND )
++find_package( PkgConfig REQUIRED )
++pkg_check_modules( MYPKG REQUIRED libexif IlmBase )
++if( MYPKG_FOUND )
++    message( STATUS "libexif and IlmBase found." )
++endif( MYPKG_FOUND )
++include_directories( ${MYPKG_INCLUDE_DIRS} )
+ 
+ # ======== Config and sub dirs ===========
+ 

--- a/pkgs/tools/graphics/pfstools/threads.patch
+++ b/pkgs/tools/graphics/pfstools/threads.patch
@@ -1,0 +1,20 @@
+--- a/src/fileformat/CMakeLists.txt	2016-05-26 11:31:23.000000000 +0200
++++ b/src/fileformat/CMakeLists.txt	2016-07-21 23:19:56.510958771 +0200
+@@ -53,13 +53,15 @@
+ if( OPENEXR_FOUND )
+     include_directories("${OPENEXR_INCLUDE_DIR}")
+ 
++    find_package (Threads)
++
+     add_executable(pfsinexr pfsinexr.cpp "${GETOPT_OBJECT}")
+-    target_link_libraries(pfsinexr pfs ${OPENEXR_LIBRARIES})
++    target_link_libraries(pfsinexr pfs ${OPENEXR_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+     install (TARGETS pfsinexr DESTINATION bin)
+     install (FILES pfsinexr.1 DESTINATION ${MAN_DIR})
+ 
+     add_executable(pfsoutexr pfsoutexr.cpp "${GETOPT_OBJECT}")
+-    target_link_libraries(pfsoutexr pfs ${OPENEXR_LIBRARIES})
++    target_link_libraries(pfsoutexr pfs ${OPENEXR_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+     install (TARGETS pfsoutexr DESTINATION bin)
+     install (FILES pfsoutexr.1 DESTINATION ${MAN_DIR})
+  endif( OPENEXR_FOUND )


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
