### PR TITLE
darwin: R: provide gettext and gfortran as buildInputs on Darwin.

### DIFF
--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -13,18 +13,12 @@
 
 stdenv.mkDerivation rec {
   name = "gd-${version}";
-  version = "2.2.2";
+  version = "2.2.3";
 
   src = fetchurl {
     url = "https://github.com/libgd/libgd/releases/download/${name}/libgd-${version}.tar.xz";
-    sha256 = "1311g5mva2xlzqv3rjqjc4jjkn5lzls4skvr395h633zw1n7b7s8";
+    sha256 = "0g3xz8jpz1pl2zzmssglrpa9nxiaa7rmcmvgpbrjz8k9cyynqsvl";
   };
-
-  # Address an incompatibility with Darwin's libtool
-  patches = stdenv.lib.optional stdenv.isDarwin (fetchpatch {
-    url = https://github.com/libgd/libgd/commit/502e4cd873c3b37b307b9f450ef827d40916c3d6.patch;
-    sha256 = "0gawr2c4zr6cljnwzhdlxhz2mkbg0r5vzvr79dv6yf6fcj06awfs";
-  });
 
   # -pthread gets passed to clang, causing warnings
   configureFlags = stdenv.lib.optional stdenv.isDarwin "--enable-werror=no";

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -8,6 +8,7 @@ let
   buildRPackage = pkgs.callPackage ./generic-builder.nix {
     inherit R;
     inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa Foundation;
+    inherit (pkgs) gettext gfortran;
   };
 
   # Generates package templates given per-repository settings

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -1,11 +1,11 @@
-{ stdenv, R, libcxx, xvfb_run, utillinux, Cocoa, Foundation }:
+{ stdenv, R, libcxx, xvfb_run, utillinux, Cocoa, Foundation, gettext, gfortran }:
 
 { name, buildInputs ? [], ... } @ attrs:
 
 stdenv.mkDerivation ({
   buildInputs = buildInputs ++ [R] ++
                 stdenv.lib.optionals attrs.requireX [utillinux xvfb_run] ++
-                stdenv.lib.optionals stdenv.isDarwin [Cocoa Foundation];
+                stdenv.lib.optionals stdenv.isDarwin [Cocoa Foundation gettext gfortran];
 
   NIX_CFLAGS_COMPILE =
     stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";


### PR DESCRIPTION
###### Motivation for this change

As discussed in https://github.com/NixOS/nixpkgs/pull/10623#issuecomment-172375342 and #16240, many R modules fail to build on Darwin without the libraries and compilers provided by these packages. For example:

```
mkdir test; cd test; cat > default.nix <<EOF
{ pkgs ? import <nixpkgs> {} }:
with pkgs; stdenv.mkDerivation {
    name = "foo";
    buildInputs = [
        (rWrapper.override {
            packages = with rPackages; [
                RSQLite
            ];
        })
    ];
}
EOF
nix-shell default.nix
```

produces errors like

```
clang -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/nix/store/8j7am1c7hdidln6amwi0y22kzkgbx1cq-R-3.2.3/lib/R/lib -o KernSmooth.so blkest.o cp.o dgedi.o dgefa.o dgesl.o init.o linbin.o linbin2D.o locpoly.o rlbin.o sdiag.o sstdiag.o -L/nix/store/gq8xdkq2vqp1smcygy1rixxaxzlvmg6b-openblas-0.2.17/lib -lopenblas -L/nix/store/j0hsa3qkivfvl05qhijdb9winvbby1iv-gfortran-5.1.0/lib/gcc/x86_64-apple-darwin15.0.0/5.1.0 -lgfortran -lquadmath -lm -L/nix/store/j0hsa3qkivfvl05qhijdb9winvbby1iv-gfortran-5.1.0/lib/gcc/x86_64-apple-darwin15.0.0/5.1.0 -lgfortran -lquadmath -lm -L/nix/store/8j7am1c7hdidln6amwi0y22kzkgbx1cq-R-3.2.3/lib/R/lib -lR -lintl -Wl,-framework -Wl,CoreFoundation
ld: library not found for -lgfortran
clang-3.7: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [/nix/store/8j7am1c7hdidln6amwi0y22kzkgbx1cq-R-3.2.3/lib/R/share/make/shlib.mk:6: KernSmooth.so] Error 1
ERROR: compilation failed for package 'KernSmooth'
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

As discussed in #10623 and #16240, many R modules fail to build on Darwin without the
libraries and compilers provided by these packages.

For more detail, please see comment:

  https://github.com/NixOS/nixpkgs/pull/10623#issuecomment-172375342
