### PR TITLE
gd: 2.2.2 -> 2.2.3

### DIFF
--- a/pkgs/development/libraries/gd/default.nix
+++ b/pkgs/development/libraries/gd/default.nix
@@ -13,18 +13,12 @@
 
 stdenv.mkDerivation rec {
   name = "gd-${version}";
-  version = "2.2.2";
+  version = "2.2.3";
 
   src = fetchurl {
     url = "https://github.com/libgd/libgd/releases/download/${name}/libgd-${version}.tar.xz";
-    sha256 = "1311g5mva2xlzqv3rjqjc4jjkn5lzls4skvr395h633zw1n7b7s8";
+    sha256 = "0g3xz8jpz1pl2zzmssglrpa9nxiaa7rmcmvgpbrjz8k9cyynqsvl";
   };
-
-  # Address an incompatibility with Darwin's libtool
-  patches = stdenv.lib.optional stdenv.isDarwin (fetchpatch {
-    url = https://github.com/libgd/libgd/commit/502e4cd873c3b37b307b9f450ef827d40916c3d6.patch;
-    sha256 = "0gawr2c4zr6cljnwzhdlxhz2mkbg0r5vzvr79dv6yf6fcj06awfs";
-  });
 
   # -pthread gets passed to clang, causing warnings
   configureFlags = stdenv.lib.optional stdenv.isDarwin "--enable-werror=no";


### PR DESCRIPTION
###### Motivation for this change

gd-2.2.3 is a security update that also includes Darwin libtool fixes for NixOS, thereby allowing us to drop a patch.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
