### PR TITLE
osx-private-sdk: Fix hash

### DIFF
--- a/pkgs/os-specific/darwin/osx-private-sdk/default.nix
+++ b/pkgs/os-specific/darwin/osx-private-sdk/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchgit }:
+{ stdenv, fetchFromGitHub }:
 
-fetchgit {
-  url = "https://github.com/samdmarshall/OSXPrivateSDK.git";
+fetchFromGitHub {
+  owner = "samdmarshall";
+  repo = "OSXPrivateSDK";
   rev = "f4d52b60e86b496abfaffa119a7d299562d99783";
-  sha256 = "0v1l11fqpqnzd5l2vq5c63jm1vrba56r06zpqnag87j5p1gic8lp";
+  sha256 = "0bv0884yxpvk2ishxj8gdy1w6wb0gwfq55q5qjp0s8z0z7f63zqh";
 }


### PR DESCRIPTION
Verified with `nix-build --check -K -A darwin.osx_private_sdk`
