### PR TITLE
Fix and version bump Stellarium

### DIFF
--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "stellarium-0.14.2";
+  name = "stellarium-0.14.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/stellarium/${name}.tar.gz";
-    sha256 = "1xxil0rv61zc08znfv83cpsc47y1gjl2f3njhz0pn5zd8jpaa15a";
+    sha256 = "1919wzlvhfxdxficbwhp31xlhm0571grgcmsfdp5y36z9yqwahfy";
   };
 
   nativeBuildInputs = [ makeQtWrapper ];

--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, freetype, libpng, mesa, gettext, openssl, perl, libiconv
-, qtscript, qtserialport, qttools
+, qtscript, qtserialport, qttools, makeQtWrapper
 }:
 
 stdenv.mkDerivation rec {
@@ -10,12 +10,18 @@ stdenv.mkDerivation rec {
     sha256 = "1xxil0rv61zc08znfv83cpsc47y1gjl2f3njhz0pn5zd8jpaa15a";
   };
 
+  nativeBuildInputs = [ makeQtWrapper ];
+
   buildInputs = [
     cmake freetype libpng mesa gettext openssl perl libiconv qtscript
     qtserialport qttools
   ];
 
   enableParallelBuilding = true;
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/stellarium"
+  '';
 
   meta = {
     description = "Free open-source planetarium";


### PR DESCRIPTION
###### Motivation for this change

To make Stellarium run without segfaulting.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
