### PR TITLE
itstool: 1.2.0 -> 2.0.2

### DIFF
--- a/pkgs/development/tools/misc/itstool/default.nix
+++ b/pkgs/development/tools/misc/itstool/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, python, libxml2Python }:
 
 stdenv.mkDerivation rec {
-  name = "itstool-1.2.0";
+  name = "itstool-2.0.2";
 
   src = fetchurl {
     url = "http://files.itstool.org/itstool/${name}.tar.bz2";
-    sha256 = "1akq75aflihm3y7js8biy7b5mw2g11vl8yq90gydnwlwp0zxdzj6";
+    sha256 = "bf909fb59b11a646681a8534d5700fec99be83bb2c57badf8c1844512227033a";
   };
 
-  buildInputs = [ python ];
+  buildInputs = [ python libxml2Python ];
 
   patchPhase =
     ''


### PR DESCRIPTION
###### Motivation for this change

Update itstool to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
