### PR TITLE
android-sdk: 24.4.1 -> 25.1.7

### DIFF
--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -31,7 +31,7 @@ let
       buildInputs = x.buildInputs ++ [ makeWrapper ];
       installPhase = x.installPhase +  ''
         wrapProgram "$out/bin/android-studio" \
-          --set ANDROID_HOME "${androidsdk}/libexec/android-sdk-linux/" \
+          --set ANDROID_HOME "${androidsdk}/libexec/" \
           --set LD_LIBRARY_PATH "${stdenv.cc.cc.lib}/lib" # Gradle installs libnative-platform.so in ~/.gradle, that requires libstdc++.so.6
       '';
     });

--- a/pkgs/development/mobile/androidenv/addon.xml
+++ b/pkgs/development/mobile/androidenv/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdk:sdk-addon xmlns:sdk="http://schemas.android.com/sdk/android/addon/7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2016-07-15 21:31:36.580145 with ADRT.-->
+	<!--Generated on 2016-07-21 16:22:25.601902 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -1229,18 +1229,18 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:libs/>
 	</sdk:add-on>
 	<sdk:extra>
-		<!--Generated from bid:3063959, branch:git_nyc-dev-->
+		<!--Generated from bid:3078275, branch:git_nyc-dev-->
 		<sdk:revision>
-			<sdk:major>34</sdk:major>
+			<sdk:major>35</sdk:major>
 			<sdk:minor>0</sdk:minor>
 			<sdk:micro>0</sdk:micro>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 16:41:11 2016.-->
-				<sdk:size>244424374</sdk:size>
-				<sdk:checksum type="sha1">103e1f1001589986c93e04a691bcce0908b16c65</sdk:checksum>
-				<sdk:url>android_m2repository_r34.zip</sdk:url>
+				<!--Built on: Thu Jul 21 12:00:22 2016.-->
+				<sdk:size>251973915</sdk:size>
+				<sdk:checksum type="sha1">7a201334775d78bf185ffcce686b1b168d152217</sdk:checksum>
+				<sdk:url>android_m2repository_r35.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -40,20 +40,12 @@ rec {
 
   androidsdk = import ./androidsdk.nix {
     inherit (pkgs) stdenv fetchurl unzip makeWrapper;
-    inherit (pkgs) freetype fontconfig glib gtk atk mesa file alsaLib jdk coreutils;
-    inherit (pkgs.xorg) libX11 libXext libXrender libxcb libXau libXdmcp libXtst;
+    inherit (pkgs) zlib glxinfo freetype fontconfig glib gtk atk mesa file alsaLib jdk coreutils libpulseaudio;
+    inherit (pkgs.xorg) libX11 libXext libXrender libxcb libXau libXdmcp libXtst xkeyboardconfig;
     
     inherit platformTools buildTools support supportRepository platforms sysimages addons;
     
     stdenv_32bit = pkgs_i686.stdenv;
-    zlib_32bit = pkgs_i686.zlib;
-    libX11_32bit = pkgs_i686.xorg.libX11;
-    libxcb_32bit = pkgs_i686.xorg.libxcb;
-    libXau_32bit = pkgs_i686.xorg.libXau;
-    libXdmcp_32bit = pkgs_i686.xorg.libXdmcp;
-    libXext_32bit = pkgs_i686.xorg.libXext;
-    mesa_32bit = pkgs_i686.mesa;
-    alsaLib_32bit = pkgs_i686.alsaLib;
   };
   
   androidsdk_2_1 = androidsdk {

--- a/pkgs/development/mobile/androidenv/repository-11.xml
+++ b/pkgs/development/mobile/androidenv/repository-11.xml
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 <sdk:sdk-repository xmlns:sdk="http://schemas.android.com/sdk/android/repository/11" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2016-07-18 18:30:41.214218 with ADRT.-->
+	<!--Generated on 2016-07-22 11:17:21.550545 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement

--- a/pkgs/development/mobile/androidenv/support-repository.nix
+++ b/pkgs/development/mobile/androidenv/support-repository.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "33";
+  version = "35";
   name = "android-support-repository-r${version}";
   src = fetchurl {
     url = "http://dl.google.com/android/repository/android_m2repository_r${version}.zip";
-    sha1 = "pdg5s78wypnc27fs5n62c8rrjl8gwyv4";
+    sha1 = "2wi1b38n3dmnikpwbwcbyy2xfws1683s";
   };
 
   buildCommand = ''


### PR DESCRIPTION
###### Motivation for this change

Updates to latest Android SDK.
- Path changed:  `/libexec/android-sdk-linux/tools` → `/libexec/tools`
- Emulator is significantly updated
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
