### PR TITLE
pwsafe: fix build and 0.95 -> 0.99

### DIFF
--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl, wxGTK, libuuid, xercesc, zip , libXt, libXtst
+{ stdenv, fetchFromGitHub, wxGTK, libuuid, xercesc, zip , libXt, libXtst
 , libXi, xextproto, gettext, perl, pkgconfig, libyubikey, ykpers
 }:
 
 stdenv.mkDerivation rec {
   name = "pwsafe-${version}";
-  version = "0.95";
+  version = "0.99";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/passwordsafe/pwsafe-${version}BETA-src.tgz";
-    sha256 = "f0b081bc358fee97fce20f352e360960d2813989023b837102b90ba6ed787d46";
+  src = fetchFromGitHub {
+    owner = "pwsafe";
+    repo = "pwsafe";
+    rev = "${version}BETA";
+    sha256 = "1bkimz4g9v9kfjkqr3dqddh4jps7anzc1hgmirmmhwpac0xdp60g";
   };
 
   makefile = "Makefile.linux";
@@ -30,6 +32,9 @@ stdenv.mkDerivation rec {
       substituteInPlace $f --replace /usr/share/ $out/share/
     done
 
+    # Fix hard coded zip path.
+    substituteInPlace help/Makefile.linux --replace /usr/bin/zip ${zip}/bin/zip
+
     for f in `grep -Rl /usr/bin/ .`; do
       substituteInPlace $f --replace /usr/bin/ ""
     done
@@ -45,7 +50,7 @@ stdenv.mkDerivation rec {
              $out/share/locale
 
     (cd help && make -f Makefile.linux)
-    cp help/help.zip $out/share/doc/passwordsafe/help
+    cp help/help*.zip $out/share/doc/passwordsafe/help
 
     (cd src/ui/wxWidgets/I18N && make mos)
     cp -dr src/ui/wxWidgets/I18N/mos/* $out/share/locale/


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
