### PR TITLE
v8: fix 4.5.107 build

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -312,6 +312,7 @@
   pmiddend = "Philipp Middendorf <pmidden@secure.mailbox.org>";
   prikhi = "Pavan Rikhi <pavan.rikhi@gmail.com>";
   profpatsch = "Profpatsch <mail@profpatsch.de>";
+  proglodyte = "Proglodyte <proglodyte23@gmail.com>";
   pshendry = "Paul Hendry <paul@pshendry.com>";
   psibi = "Sibi <sibi@psibi.in>";
   pSub = "Pascal Wittmann <mail@pascal-wittmann.de>";

--- a/pkgs/development/libraries/v8/4.5.nix
+++ b/pkgs/development/libraries/v8/4.5.nix
@@ -83,6 +83,7 @@ stdenv.mkDerivation rec {
     sed -i 's,#!/usr/bin/env python,#!${python}/bin/python,' build/gyp_v8
     sed -i 's,/bin/echo,${coreutils}/bin/echo,' build/standalone.gypi
     sed -i '/CR_CLANG_REVISION/ d' build/standalone.gypi
+    sed -i 's/-Wno-format-pedantic//g' build/standalone.gypi
   '';
 
   configurePhase = ''
@@ -103,6 +104,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ which ];
   buildInputs = [ readline python icu patchelf ];
+
+  NIX_CFLAGS_COMPILE = "-Wno-error=strict-overflow";
 
   buildFlags = [
     "LINK=g++"
@@ -135,7 +138,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Google's open source JavaScript engine";
-    maintainers = with maintainers; [ cstrahan ];
+    maintainers = with maintainers; [ cstrahan proglodyte ];
     platforms = platforms.linux;
     license = licenses.bsd3;
   };


### PR DESCRIPTION
###### Motivation for this change

Fix v8-4.5.107 build
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Similar to #14272, but fixes 4.5 build rather than generic.
- Ignores errors due to strict-overflow warnings
- Strips clang-only '-Wno-format-pedantic' flag out since this build
  uses gcc
