### PR TITLE
openmpi: Remove libibverbs on unsupported platforms

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -26,7 +26,8 @@ in stdenv.mkDerivation rec {
   # https://www.open-mpi.org/community/lists/users/2015/11/28030.php
   patches = [ ./nbc_copy.patch ];
 
-  buildInputs = [ gfortran libibverbs ];
+  buildInputs = [ gfortran ]
+    ++ optional (stdenv.isLinux || stdenv.isFreeBSD) libibverbs;
 
   nativeBuildInputs = [ perl ];
 
@@ -46,5 +47,6 @@ in stdenv.mkDerivation rec {
     description = "Open source MPI-2 implementation";
     longDescription = "The Open MPI Project is an open source MPI-2 implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.";
     maintainers = [ stdenv.lib.maintainers.mornfall ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The infiniband library `libibverbs` is only supported on Linux and FreeBSD, but `openmpi` can be used without it on darwin or other platforms. So I remove this dependency on unsupported platforms.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The libibverbs package is only available on Linux and FreeBSD, but
openmpi can be used without it on platforms that don't support it.
