### PR TITLE
Fix #9759 SSMTP sendmail wrapper

### DIFF
--- a/nixos/modules/programs/ssmtp.nix
+++ b/nixos/modules/programs/ssmtp.nix
@@ -129,7 +129,7 @@ in
 
     environment.systemPackages = [pkgs.ssmtp];
     
-    services.mail.sendmailSetuidWrapper = mkIf networking.defaultMailServer.setSendmail {
+    services.mail.sendmailSetuidWrapper = mkIf cfg.setSendmail {
       program = "sendmail";
       source = "${pkgs.ssmtp}/bin/sendmail";
       setuid = false;

--- a/nixos/modules/programs/ssmtp.nix
+++ b/nixos/modules/programs/ssmtp.nix
@@ -100,6 +100,12 @@ in
           Password used for SMTP auth. (STORED PLAIN TEXT, WORLD-READABLE IN NIX STORE)
         '';
       };
+      
+      setSendmail = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to set the system sendmail to ssmtp's.";
+      };
 
     };
 
@@ -122,6 +128,13 @@ in
       '';
 
     environment.systemPackages = [pkgs.ssmtp];
+    
+    services.mail.sendmailSetuidWrapper = mkIf networking.defaultMailServer.setSendmail {
+      program = "sendmail";
+      source = "${pkgs.ssmtp}/bin/sendmail";
+      setuid = false;
+      setgid = false;
+    };
 
   };
 


### PR DESCRIPTION
###### Motivation for this change

Fix #9759 in the same way as `services.postfix.setSendmail`.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
