### PR TITLE
unison: 2.48.3 -> 2.48.4

### DIFF
--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -3,10 +3,10 @@
 
 stdenv.mkDerivation (rec {
 
-  name = "unison-2.48.3";
+  name = "unison-2.48.4";
   src = fetchurl {
     url = "http://www.seas.upenn.edu/~bcpierce/unison/download/releases/stable/${name}.tar.gz";
-    sha256 = "10sln52rnnsj213jy3166m0q97qpwnrwl6mm529xfy10x3xkq3gl";
+    sha256 = "30aa53cd671d673580104f04be3cf81ac1e20a2e8baaf7274498739d59e99de8";
   };
 
   buildInputs = [ ocaml makeWrapper ncurses ];


### PR DESCRIPTION
###### Motivation for this change

New version available

_Hint_: One should declare/use ocaml 4.02 to compile it to be compatible with most other
distributions as ocaml's object serializer format changed with 4.01->4.02.
More information: https://bugs.archlinux.org/task/43241

This can be achieved by setting this option in your `.nixpkgs/config.nix`

```
{
  packageOverrides = pkgs: rec {
    unison = pkgs.unison.override {
      ocaml = pkgs.ocaml_4_02;
    };
  };
}
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Signed-off-by: Maximilian Güntner code@maschinenpsychologe.de
