### PR TITLE
matrix-synapse: Only run StartPre script when data folder doesn't exist

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -332,6 +332,7 @@
   robberer = "Longrin Wischnewski <robberer@freakmail.de>";
   robbinch = "Robbin C. <robbinch33@gmail.com>";
   robgssp = "Rob Glossop <robgssp@gmail.com>";
+  roblabla = "Robin Lambertz <robinlambertz+dev@gmail.com>";
   roconnor = "Russell O'Connor <roconnor@theorem.ca>";
   romildo = "José Romildo Malaquias <malaquias@gmail.com>";
   rszibele = "Richard Szibele <richard_szibele@hotmail.com>";

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -522,10 +522,12 @@ in {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''
-        mkdir -p /var/lib/matrix-synapse
-        chmod 700 /var/lib/matrix-synapse
-        chown -R matrix-synapse:matrix-synapse /var/lib/matrix-synapse
-        ${cfg.package}/bin/homeserver --config-path ${configFile} --keys-directory /var/lib/matrix-synapse/ --generate-keys
+        if ! test -e /var/lib/matrix-synapse; then
+          mkdir -p /var/lib/matrix-synapse
+          chmod 700 /var/lib/matrix-synapse
+          chown -R matrix-synapse:matrix-synapse /var/lib/matrix-synapse
+          ${cfg.package}/bin/homeserver --config-path ${configFile} --keys-directory /var/lib/matrix-synapse/ --generate-keys
+        fi
       '';
       serviceConfig = {
         Type = "simple";

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -41,6 +41,6 @@ buildPythonApplication rec {
     homepage = https://matrix.org;
     description = "Matrix reference homeserver";
     license = licenses.asl20;
-    maintainers = [ maintainers.ralith ];
+    maintainers = [ maintainers.ralith maintainers.roblabla ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The startPre script of Synapse is only necessary on first run, and gets absurdly slow due to the recursive chown when Synapse has a lot of data in its data dir. It recently got to the point that matrix-synapse refuses to start on my machine because the startPre scripts times out.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
