### PR TITLE
fix nixos-version --hash when building from git

### DIFF
--- a/nixos/modules/installer/tools/get-git-revision
+++ b/nixos/modules/installer/tools/get-git-revision
@@ -17,6 +17,6 @@ getVersion() {
 if nixpkgs=$(nix-instantiate --find-file nixpkgs "$@"); then
     getVersion $nixpkgs
     if [ -n "$rev" ]; then
-        echo ".git.$rev"
+        echo "$rev"
     fi
 fi

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -311,9 +311,10 @@ fi
 # nixos-version shows something useful).
 if [ -n "$canRun" ]; then
     if nixpkgs=$(nix-instantiate --find-file nixpkgs "${extraBuildFlags[@]}"); then
-        suffix=$($SHELL $nixpkgs/nixos/modules/installer/tools/get-version-suffix "${extraBuildFlags[@]}" || true)
-        if [ -n "$suffix" ]; then
-            echo -n "$suffix" > "$nixpkgs/.version-suffix" || true
+        revision=$($SHELL $nixpkgs/nixos/modules/installer/tools/get-git-revision "${extraBuildFlags[@]}" || true)
+        if [ -n "$revision" ]; then
+            echo -n ".git.$revision" > "$nixpkgs/.version-suffix" || true
+            echo -n "$revision"  > "$nixpkgs/.git-revision" || true
         fi
     fi
 fi


### PR DESCRIPTION
Previously, when building from a git checkout of nixpkgs, `nixos-version --hash` would 
always just print out "master". Now it prints the same git commit as `nixos-version` does, which
already worked correctly before.
