### PR TITLE
Cherry-pick eCryptfs test & kernel-fix to release-16.03

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -68,6 +68,7 @@ in rec {
         (all nixos.tests.boot.uefiCdrom)
         (all nixos.tests.boot.uefiUsb)
         (all nixos.tests.boot-stage1)
+        (all nixos.tests.ecryptfs)
         (all nixos.tests.ipv6)
         (all nixos.tests.kde4)
         #(all nixos.tests.lightdm)

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -203,6 +203,7 @@ in rec {
   tests.containers = callTest tests/containers.nix {};
   tests.docker = hydraJob (import tests/docker.nix { system = "x86_64-linux"; });
   tests.dockerRegistry = hydraJob (import tests/docker-registry.nix { system = "x86_64-linux"; });
+  tests.ecryptfs = callTest tests/ecryptfs.nix {};
   tests.etcd = hydraJob (import tests/etcd.nix { system = "x86_64-linux"; });
   tests.ec2-nixops = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-nixops;
   tests.ec2-config = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-config;

--- a/nixos/tests/ecryptfs.nix
+++ b/nixos/tests/ecryptfs.nix
@@ -1,0 +1,81 @@
+import ./make-test.nix ({ pkgs, ... }:
+{
+  name = "ecryptfs";
+
+  machine = { config, pkgs, ... }: {
+    imports = [ ./common/user-account.nix ];
+    boot.kernelModules = [ "ecryptfs" ];
+    security.pam.enableEcryptfs = true;
+    environment.systemPackages = with pkgs; [ keyutils ];
+  };
+
+  testScript = ''
+    $machine->waitForUnit("default.target");
+
+    # Set alice up with a password and a home
+    $machine->succeed("(echo foobar; echo foobar) | passwd alice");
+    $machine->succeed("chown -R alice.users ~alice");
+
+    # Migrate alice's home
+    my $out = $machine->succeed("echo foobar | ecryptfs-migrate-home -u alice");
+    $machine->log("ecryptfs-migrate-home said: $out");
+
+    # Log alice in (ecryptfs passwhrase is wrapped during first login)
+    $machine->sleep(2); # urgh: wait for username prompt
+    $machine->sendChars("alice\n");
+    $machine->sleep(1);
+    $machine->sendChars("foobar\n");
+    $machine->sleep(2);
+    $machine->sendChars("logout\n");
+    $machine->sleep(2);
+
+    # Why do I need to do this??
+    $machine->succeed("su alice -c ecryptfs-umount-private");
+    $machine->sleep(1);
+    $machine->fail("mount | grep ecryptfs"); # check that encrypted home is not mounted
+
+    # Show contents of the user keyring
+    my $out = $machine->succeed("su - alice -c 'keyctl list \@u'");
+    $machine->log("keyctl unlink said: " . $out);
+
+    # Log alice again
+    $machine->sendChars("alice\n");
+    $machine->sleep(1);
+    $machine->sendChars("foobar\n");
+    $machine->sleep(2);
+
+    # Create some files in encrypted home
+    $machine->succeed("su alice -c 'touch ~alice/a'");
+    $machine->succeed("su alice -c 'echo c > ~alice/b'");
+
+    # Logout
+    $machine->sendChars("logout\n");
+    $machine->sleep(2);
+
+    # Why do I need to do this??
+    $machine->succeed("su alice -c ecryptfs-umount-private");
+    $machine->sleep(1);
+
+    # Check that the filesystem is not accessible
+    $machine->fail("mount | grep ecryptfs");
+    $machine->succeed("su alice -c 'test \! -f ~alice/a'");
+    $machine->succeed("su alice -c 'test \! -f ~alice/b'");
+
+    # Log alice once more
+    $machine->sendChars("alice\n");
+    $machine->sleep(1);
+    $machine->sendChars("foobar\n");
+    $machine->sleep(2);
+
+    # Check that the files are there
+    $machine->sleep(1);
+    $machine->succeed("su alice -c 'test -f ~alice/a'");
+    $machine->succeed("su alice -c 'test -f ~alice/b'");
+    $machine->succeed(qq%test "\$(cat ~alice/b)" = "c"%);
+
+    # Catch https://github.com/NixOS/nixpkgs/issues/16766
+    $machine->succeed("su alice -c 'ls -lh ~alice/'");
+
+    $machine->sendChars("logout\n");
+  '';
+})

--- a/pkgs/os-specific/linux/kernel/ecryptfs-fix-mmap-bug.patch
+++ b/pkgs/os-specific/linux/kernel/ecryptfs-fix-mmap-bug.patch
@@ -1,0 +1,20 @@
+Signed-off-by: Tyler Hicks <tyhicks@xxxxxxxxxxxxx>
+Tested-by: Tyler Hicks <tyhicks@xxxxxxxxxxxxx> # 4.4.y, 3.18.y
+Cc: <stable@xxxxxxxxxxxxxxx> # 4.5-
+---
+ fs/ecryptfs/kthread.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fs/ecryptfs/kthread.c b/fs/ecryptfs/kthread.c
+index e818f5a..b9faeab 100644
+--- a/fs/ecryptfs/kthread.c
++++ b/fs/ecryptfs/kthread.c
+@@ -171,7 +171,7 @@ int ecryptfs_privileged_open(struct file **lower_file,
+ 		goto out;
+ 	}
+ have_file:
+-	if ((*lower_file)->f_op->mmap == NULL) {
++	if ((*lower_file)->f_op->mmap == NULL && !d_is_dir(lower_dentry)) {
+ 		fput(*lower_file);
+ 		*lower_file = NULL;
+ 		rc = -EMEDIUMTYPE;

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -185,4 +185,8 @@ rec {
         sha256 = "14rm1qr87p7a5prz8g5fwbpxzdp3ighj095x8rvhm8csm20wspyy";
       };
     };
+  ecryptfs_fix_mmap_bug =
+    { name = "ecryptfs_fix_mmap_bug";
+      patch = ./ecryptfs-fix-mmap-bug.patch;
+    };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10429,6 +10429,7 @@ let
       [ kernelPatches.bridge_stp_helper
         kernelPatches.qat_common_Makefile
         kernelPatches.hiddev_CVE_2016_5829
+        kernelPatches.ecryptfs_fix_mmap_bug
       ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu


### PR DESCRIPTION
###### Motivation for this change
#16766 is also affecting `release-16.03` as `4.4.14` was ported to it. This PR adds both the test and the fix to the branch.
###### Things done

Successfully ran `nix-build <nixos/release.nix> -A tests.ecryptfs` locally.
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @pippijn @grahamc
