### PR TITLE
xmagnify: init at 0.1.0

### DIFF
--- a/pkgs/tools/X11/xmagnify/default.nix
+++ b/pkgs/tools/X11/xmagnify/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitLab, libX11, xproto }:
+
+stdenv.mkDerivation rec {
+  name = "xmagnify-0.1.0";
+
+  src = fetchFromGitLab {
+    owner = "amiloradovsky";
+    repo = "magnify";
+    rev = "0.1.0";  # 56da280173e9d0bd7b3769e07ba485cb4db35869
+    sha256 = "1ngnp5f5zl3v35vhbdyjpymy6mwrs0476fm5nd7dzkba7n841jdh";
+  };
+
+  prePatch = ''substituteInPlace ./Makefile --replace /usr $out'';
+
+  buildInputs = [ libX11 xproto ];
+
+  meta = with stdenv.lib; {
+    description = "Tiny screen magnifier for X11";
+    homepage = https://gitlab.com/amiloradovsky/magnify;
+    license = licenses.mit;  # or GPL2+, optionally
+    maintainers = with maintainers; [ amiloradovsky ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17429,7 +17429,9 @@ in
 
   xhyve = callPackage ../applications/virtualization/xhyve { };
 
-  xinput_calibrator = callPackage ../tools/X11/xinput_calibrator {};
+  xinput_calibrator = callPackage ../tools/X11/xinput_calibrator { };
+
+  xmagnify = callPackage ../tools/X11/xmagnify { };
 
   xosd = callPackage ../misc/xosd { };
 


### PR DESCRIPTION
###### Motivation for this change

To have a lightweight accessibility, or raster graphics editing, tool in the packages.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tiny screen magnifier for X11
