### PR TITLE
emem: 0.2.19 -> 0.2.20

### DIFF
--- a/pkgs/applications/misc/emem/default.nix
+++ b/pkgs/applications/misc/emem/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "emem";
-  version = "0.2.19";
+  version = "0.2.20";
   name = "${pname}-${version}";
 
   inherit jdk;
 
   src = fetchurl {
     url = "https://github.com/ebzzry/${pname}/releases/download/v${version}/${pname}.jar";
-    sha256 = "1lrdfkw5bn9b5d4ggw3amnf31xxwpxccs2spgrrxggf8win6y50j";
+    sha256 = "05lpgcgznqrcsipv989a7ywr2kld7wbz5jv6d2wvbqs74ryrmn66";
   };
 
   buildInputs = [ ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [✔] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [✔] NixOS
  - [ ] OS X
  - [✔] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [✔] Tested execution of all binary files (usually in `./result/bin/`)
- [✔] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
