### PR TITLE
pitivi: 0.95 -> 0.96 (fixes startup error)

### DIFF
--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -30,18 +30,6 @@ in stdenv.mkDerivation rec {
     sha256 = "115d37mvi32yds8gqj2yidkk6pap7szavhjf2hw0388ynydlc2zs";
   };
 
-  meta = with stdenv.lib; {
-    description = "Non-Linear video editor utilizing the power of GStreamer";
-    homepage    = "http://pitivi.org/";
-    longDescription = ''
-      Pitivi is a video editor built upon the GStreamer Editing Services.
-      It aims to be an intuitive and flexible application
-      that can appeal to newbies and professionals alike.
-    '';
-    license     = licenses.lgpl21Plus;
-    platforms   = platforms.linux;
-  };
-
   nativeBuildInputs = [ pkgconfig intltool itstool wrapGAppsHook ];
 
   buildInputs = [
@@ -57,4 +45,16 @@ in stdenv.mkDerivation rec {
     python pygobject3 gst-python pyxdg numpy pycairo sqlite3 matplotlib
     dbus
   ]);
+
+  meta = with stdenv.lib; {
+    description = "Non-Linear video editor utilizing the power of GStreamer";
+    homepage    = "http://pitivi.org/";
+    longDescription = ''
+      Pitivi is a video editor built upon the GStreamer Editing Services.
+      It aims to be an intuitive and flexible application
+      that can appeal to newbies and professionals alike.
+    '';
+    license     = licenses.lgpl21Plus;
+    platforms   = platforms.linux;
+  };
 }

--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, makeWrapper
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, wrapGAppsHook
 , python3Packages, gst, gtk3, hicolor_icon_theme
 , gobjectIntrospection, librsvg, gnome3, libnotify
 # for gst-transcoder:
@@ -42,7 +42,7 @@ in stdenv.mkDerivation rec {
     platforms   = platforms.linux;
   };
 
-  nativeBuildInputs = [ pkgconfig intltool itstool makeWrapper ];
+  nativeBuildInputs = [ pkgconfig intltool itstool wrapGAppsHook ];
 
   buildInputs = [
     gobjectIntrospection gtk3 librsvg gnome3.gnome_desktop
@@ -57,12 +57,4 @@ in stdenv.mkDerivation rec {
     python pygobject3 gst-python pyxdg numpy pycairo sqlite3 matplotlib
     dbus
   ]);
-
-  preFixup = ''
-    wrapProgram "$out/bin/pitivi" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$out/share:$GSETTINGS_SCHEMAS_PATH"
-  '';
 }

--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -1,16 +1,33 @@
 { stdenv, fetchurl, pkgconfig, intltool, itstool, makeWrapper
 , python3Packages, gst, gtk3, hicolor_icon_theme
 , gobjectIntrospection, librsvg, gnome3, libnotify
+# for gst-transcoder:
+, which, meson, ninja
 }:
 
 let
-  version = "0.95";
+  version = "0.96";
+
+  # gst-transcoder will eventually be merged with gstreamer (according to
+  # gst-transcoder 1.8.0 release notes). For now the only user is pitivi so we
+  # don't bother exposing the package to all of nixpkgs.
+  gst-transcoder = stdenv.mkDerivation rec {
+    name = "gst-transcoder-1.8.0";
+    src = fetchurl {
+      name = "${name}.tar.gz";
+      url = "https://github.com/pitivi/gst-transcoder/archive/1.8.0.tar.gz";
+      sha256 = "0iggr6idmp7cmfsf6pkhfl3jq1bkga37jl5prbcl1zapkzi26fg6";
+    };
+    buildInputs = [ which meson ninja pkgconfig gobjectIntrospection ]
+      ++ (with gst; [ gstreamer gst-plugins-base ]);
+  };
+
 in stdenv.mkDerivation rec {
   name = "pitivi-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/pitivi/${version}/${name}.tar.xz";
-    sha256 = "04ykw619aikhxk5wj7z44pvwl52053d1kamcxpscw0ixrh5j45az";
+    sha256 = "115d37mvi32yds8gqj2yidkk6pap7szavhjf2hw0388ynydlc2zs";
   };
 
   meta = with stdenv.lib; {
@@ -31,12 +48,14 @@ in stdenv.mkDerivation rec {
     gobjectIntrospection gtk3 librsvg gnome3.gnome_desktop
     gnome3.defaultIconTheme
     gnome3.gsettings_desktop_schemas libnotify
+    gst-transcoder
   ] ++ (with gst; [
     gstreamer gst-editing-services
     gst-plugins-base gst-plugins-good
     gst-plugins-bad gst-plugins-ugly gst-libav gst-validate
   ]) ++ (with python3Packages; [
     python pygobject3 gst-python pyxdg numpy pycairo sqlite3 matplotlib
+    dbus
   ]);
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

Fix startup error caused by breaking change in gtk 3.20.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The upgrade of gtk3 to 3.20 broke pitivi. This release fixes that.

New dependencies: gst-transcoder and dbus.
(pitivi imports dbus if it finds the GNOME_DESKTOP_SESSION_ID
environment variable. Without dbus there will be some ugly errors for
GNOME desktop users.)
