### PR TITLE
Revert "xterm: Enable DEC Locator Mode"

### DIFF
--- a/pkgs/applications/misc/xterm/default.nix
+++ b/pkgs/applications/misc/xterm/default.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
     "--enable-doublechars"
     "--enable-luit"
     "--enable-mini-luit"
-    "--enable-dec-locator"
     "--with-tty-group=tty"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

See #17170 and https://github.com/neovim/neovim/issues/5101.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This reverts commit a98ae8e1526055c347409540d3d5c9dd104b81cb.
