### PR TITLE
KDE - systemsettings fails to show "Workspace theme" due to missing QTQuickControls dependency

### DIFF
--- a/pkgs/desktops/kde-5/plasma/systemsettings.nix
+++ b/pkgs/desktops/kde-5/plasma/systemsettings.nix
@@ -1,6 +1,6 @@
 { plasmaPackage, extra-cmake-modules, kdoctools, kitemviews
 , kcmutils, ki18n, kio, kservice, kiconthemes, kwindowsystem
-, kxmlgui, kdbusaddons, kconfig, khtml, makeQtWrapper
+, kxmlgui, kdbusaddons, kconfig, khtml, makeQtWrapper, qt5
 }:
 
 plasmaPackage {
@@ -14,7 +14,7 @@ plasmaPackage {
   ];
   propagatedBuildInputs = [
     khtml ki18n kio kwindowsystem kitemviews kcmutils kservice kiconthemes
-    kxmlgui kdbusaddons kconfig
+    kxmlgui kdbusaddons kconfig qt5.qtquickcontrols
   ];
   postInstall = ''
     wrapQtProgram "$out/bin/systemsettings5"


### PR DESCRIPTION
Several parts of the KDE system settings are broken due to a missing dependency on qtquickcontrols.

The Workspace Theme panels are basically empty and systemsettings5 throws this error (I've added newlines for readability):

```
peter@mildred:~ $ kcmshell5 kcm_desktoptheme
org.kde.kcoreaddons: Error loading plugin "kcm_desktoptheme" "The shared library was not found."
Plugin search paths are (
"/run/current-system/sw/lib/qt5/plugins",
"/nix/var/nix/profiles/default/lib/qt5/plugins",
"/home/peter/.nix-profile/lib/qt5/plugins",
"/nix/store/d0n3cxm8qndkpdfxy8da682qzhkbakrr-qtbase-5.6.1-1/lib/qt5/plugins",
"/nix/store/3c09yz9awdi2zpzr64lj87g8g1jdgfiq-qtsvg-5.6.1-1/lib/qt5/plugins",
"/nix/store/q29dw847wm8jpm3vlw0brkv8v9qdyp8m-qtdeclarative-5.6.1-1/lib/qt5/plugins",
"/nix/store/v7rx7qba6ngq9q950g1kd14hgrbg97n0-qttools-5.6.1-1/lib/qt5/plugins",
"/nix/store/mzhrs84cs9isxyd52jgcz0l254jjvcrp-ki18n-5.24.0/lib/qt5/plugins",
"/nix/store/4v1anq04jd0d8i11gdj20017lnfn9igw-kauth-5.24.0/lib/qt5/plugins",
"/nix/store/gqn9z910asa41drpfjz5i2alcidmqnii-kwindowsystem-5.24.0/lib/qt5/plugins",
"/nix/store/zqx7k99l8qgx7hj9qdqk0v4paamp1b6k-kglobalaccel-5.24.0/lib/qt5/plugins",
"/nix/store/wcndc277y617q62qmdfi5lqc7z7kmrg6-sonnet-5.24.0/lib/qt5/plugins",
"/nix/store/k4js37kwwfi4qaq77m3gvxs21y5dwsf4-phonon-qt5-4.9.0/lib/qt5/plugins",
"/nix/store/jkh4pnbvx9vg4dwbxa3vgkzpsd4fmhi7-kio-5.24.0/lib/qt5/plugins",
"/nix/store/6n15iaaals485yhbrvkrwiiv766jl68y-kdesignerplugin-5.24.0/lib/qt5/plugins",
"/nix/store/53g7jv9jfymxdfs8mjxgn8zphddzp2cp-kemoticons-5.24.0/lib/qt5/plugins",
"/nix/store/b3rcls9p0xdykhyxql8hh45k7yihrvvv-kdelibs4support-5.24.0/lib/qt5/plugins",
"/nix/store/akj3dbxw36k6n8199ywc5mgdp3ccnjv7-kde-cli-tools-5.7.1/lib/qt5/plugins",
"/nix/store/akj3dbxw36k6n8199ywc5mgdp3ccnjv7-kde-cli-tools-5.7.1/bin")

The environment variable QT_PLUGIN_PATH might be not correctly set
"file:///nix/store/wgb0bhnlwmgzqn9qqpz8faibi07dzyd1-plasma-desktop-5.7.1/share/kpackage/kcms/kcm_desktoptheme/contents/ui/main.qml"
 "Error loading QML file.
24: module \"QtQuick.Controls\" is not installed
21: module \"QtQuick.Layouts\" is not installed
23: module \"QtQuick.Controls.Private\" is not installed
22: module \"QtQuick.Dialogs\" is not installed
24: module \"QtQuick.Controls\" is not installed
21: module \"QtQuick.Layouts\" is not installed
23: module \"QtQuick.Controls.Private\" is not installed
22: module \"QtQuick.Dialogs\" is not installed
24: module \"QtQuick.Controls\" is not installed
21: module \"QtQuick.Layouts\" is not installed
23: module \"QtQuick.Controls.Private\" is not installed
22: module \"QtQuick.Dialogs\" is not installed
24: module \"QtQuick.Controls\" is not installed
21: module \"QtQuick.Layouts\" is not installed
23: module \"QtQuick.Controls.Private\" is not installed
22: module \"QtQuick.Dialogs\" is not installed
"
```

This patch fixes that although I'm almost certain that it is not the right way to go about it, but hopefully this is helpful to someone who is intimately familiar with KDE, such as @ttuegel.

I just realized that this is only a partial fix, as it handles `systemsettings5` but if you are using `kcmshell5 kcm_desktoptheme` is still doesn't work as that wrapper is generated separately.
