### PR TITLE
nixos-install: add options --closure, --dont-copy-channel and --dont-set-root-password

### DIFF
--- a/nixos/doc/manual/man-nixos-install.xml
+++ b/nixos/doc/manual/man-nixos-install.xml
@@ -26,6 +26,16 @@
       <replaceable>root</replaceable>
     </arg>
     <arg>
+      <arg choice='plain'><option>--closure</option></arg>
+      <replaceable>closure</replaceable>
+    </arg>
+    <arg>
+      <arg choice='plain'><option>--dont-copy-channel</option></arg>
+    </arg>
+    <arg>
+      <arg choice='plain'><option>--dont-set-root-password</option></arg>
+    </arg>
+    <arg>
       <group choice='req'>
         <arg choice='plain'><option>--max-jobs</option></arg>
         <arg choice='plain'><option>-j</option></arg>
@@ -75,8 +85,8 @@ the following steps:
   and generates a GRUB configuration file that boots into the NixOS
   configuration just installed.</para></listitem>
 
-  <listitem><para>It prompts you for a password for the root
-  account.</para></listitem>
+  <listitem><para>It prompts you for a password for the root account
+  (unless <option>--dont-set-root-password</option> is specified).</para></listitem>
 
 </itemizedlist>
 
@@ -99,6 +109,19 @@ it.</para>
     <listitem>
       <para>Defaults to <filename>/mnt</filename>. If this option is given, treat the directory
       <replaceable>root</replaceable> as the root of the NixOS installation.
+      </para>
+    </listitem>
+  </varlistentry>
+
+  <varlistentry>
+    <term><option>--closure</option></term>
+    <listitem>
+      <para>If this option is provided, <command>nixos-install</command> will install the specified closure
+      rather than attempt to build one from <filename>/mnt/etc/nixos/configuration.nix</filename>.</para>
+
+      <para>The closure must be an appropriately configured NixOS system, with boot loader and partition
+      configuration that fits the target host. Such a closure is typically obtained with a command such as
+      <command>nix-build -I nixos-config=./configuration.nix '&lt;nixos&gt;' -A system --no-out-link</command>
       </para>
     </listitem>
   </varlistentry>


### PR DESCRIPTION
###### Motivation for this change

It's sometimes annoying to have to set up configuration inside the chroot when the closure can be fully prepared outside the chroot and then copied in.

This can also be used to "upgrade" bootable USB-keys (without actually booting on them) which is where `--dont-set-root-password` also comes in handy.

Finally I generally don't use channels so I've also added `--dont-copy-channel`.
###### Things done

Tested with `nix-build '<nixos/release.nix>' -A tests.installer.simple` (but needs this patch: https://github.com/NixOS/nixpkgs/issues/16983#issuecomment-234782651 for I think unrelated reasons)
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
