### PR TITLE
xterm: Make dec-locator support optional

### DIFF
--- a/pkgs/applications/misc/xterm/default.nix
+++ b/pkgs/applications/misc/xterm/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, xorg, ncurses, freetype, fontconfig, pkgconfig }:
+{ stdenv, fetchurl, xorg, ncurses, freetype, fontconfig, pkgconfig
+, enableDecLocator ? true
+}:
 
 stdenv.mkDerivation rec {
   name = "xterm-325";
@@ -27,9 +29,8 @@ stdenv.mkDerivation rec {
     "--enable-doublechars"
     "--enable-luit"
     "--enable-mini-luit"
-    "--enable-dec-locator"
     "--with-tty-group=tty"
-  ];
+  ] ++ stdenv.lib.optional enableDecLocator "--enable-dec-locator";
 
   # Work around broken "plink.sh".
   NIX_LDFLAGS = "-lXmu -lXt -lICE -lX11 -lfontconfig";


### PR DESCRIPTION
###### Motivation for this change

As discussed in https://github.com/NixOS/nixpkgs/pull/17234, 
Closes #17170 at least as far as I can tell.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
