### PR TITLE
gst-python: 1.8.1 -> 1.8.2

### DIFF
--- a/pkgs/development/libraries/gstreamer/python/default.nix
+++ b/pkgs/development/libraries/gstreamer/python/default.nix
@@ -4,14 +4,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-python-1.8.1";
+  name = "gst-python-1.8.2";
 
   src = fetchurl {
     urls = [
       "${meta.homepage}/src/gst-python/${name}.tar.xz"
       "mirror://gentoo/distfiles/${name}.tar.xz"
       ];
-    sha256 = "160ah5rpy4n8p1mhbf545rcv7rbq0i17xl7q5hmivf4w5yvvz8vn";
+    sha256 = "15sdfa6lq5pswvi09vk51cs30yf8wr2rlm9myhb4q0c2jhiial2g";
   };
 
   patches = [ ./different-path-with-pygobject.patch ];


### PR DESCRIPTION
###### Motivation for this change

Aligns version numbers with the rest of GStreamer in nixpkgs.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Letting travis do some build testing :-)
