### PR TITLE
antBuild: run default hooks

### DIFF
--- a/pkgs/build-support/release/ant-build.nix
+++ b/pkgs/build-support/release/ant-build.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (
     postPhases =
       ["generateWrappersPhase" "finalPhase"];
 
-    prePhases = 
+    prePhases =
       ["antSetupPhase"];
 
     antSetupPhase = with stdenv.lib; ''
@@ -41,8 +41,10 @@ stdenv.mkDerivation (
     '';
 
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/share/java
-      ${ if jars == [] then '' 
+      ${ if jars == [] then ''
            find . -name "*.jar" | xargs -I{} cp -v {} $out/share/java
          '' else stdenv.lib.concatMapStrings (j: ''
            cp -v ${j} $out/share/java
@@ -53,13 +55,15 @@ stdenv.mkDerivation (
         canonicalizeJar $j
         echo file jar $j >> $out/nix-support/hydra-build-products
       done
+
+      runHook postInstall
     '';
 
-    generateWrappersPhase = 
-      let 
+    generateWrappersPhase =
+      let
         cp = w: "-cp '${lib.optionalString (w ? classPath) w.classPath}${lib.optionalString (w ? mainClass) ":$out/share/java/*"}'";
       in
-      '' 
+      ''
       header "Generating jar wrappers"
     '' + (stdenv.lib.concatMapStrings (w: ''
 
@@ -75,15 +79,19 @@ stdenv.mkDerivation (
       closeNest
     '';
 
-    buildPhase = if antTargets == [] then ''
+    buildPhase = ''
+      runHook preBuild
+    '' + (if antTargets == [] then ''
       header "Building default ant target"
       ant ${antFlags}
       closeNest
     '' else stdenv.lib.concatMapStrings (t: ''
       header "Building '${t}' target"
-      ant ${antFlags} ${t} 
+      ant ${antFlags} ${t}
       closeNest
-    '') antTargets;
+    '') antTargets) + ''
+      runHook postBuild
+    '';
 
     finalPhase =
       ''
@@ -95,11 +103,11 @@ stdenv.mkDerivation (
       '';
   }
 
-  // removeAttrs args ["antProperties" "buildInputs" "pkgs" "jarWrappers"] // 
+  // removeAttrs args ["antProperties" "buildInputs" "pkgs" "jarWrappers"] //
 
   {
     name = name + (if src ? version then "-" + src.version else "");
-  
+
     buildInputs = [ant jre zip unzip] ++ stdenv.lib.optional (args ? buildInputs) args.buildInputs ;
 
     postHook = ''
@@ -109,6 +117,6 @@ stdenv.mkDerivation (
 
       origSrc=$src
       src=$(findTarball $src)
-    ''; 
+    '';
   }
 )


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/10931.
antBuild overrides buildPhase and installPhase without calling default
hooks.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

NOT TESTED
