### PR TITLE
vtk: 5.10.1 -> 7.0.0

### DIFF
--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, cmake, vtk }:
 
 stdenv.mkDerivation rec {
-  version = "2.4.6";
+  version = "2.6.4";
   name = "gdcm-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/gdcm/${name}.tar.bz2";
-    sha256 = "0rgqgkjyqgld0hpa311z8cddp42v9ihzidyanwyxqpv3jmcrlsfk";
+    sha256 = "14bysjdldq7xb9k1ayskxijm08dy2n45v9bg379dqrcz1q5xq5mi";
   };
 
   dontUseCmakeBuildDir = true;

--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchzip, cmake, qhull, flann, boost, vtk, eigen, pkgconfig, qt4
+{ stdenv, fetchFromGitHub, cmake, qhull, flann, boost, vtk, eigen, pkgconfig, qt4
 , libusb1, libpcap, libXt, libpng, Cocoa, AGL, cf-private
 }:
 
 stdenv.mkDerivation rec {
-  name = "pcl-1.7.2";
+  name = "pcl-1.8.0";
 
-  src = fetchzip {
-    name = name + "-src";
-    url = "https://github.com/PointCloudLibrary/pcl/archive/${name}.tar.gz";
-    sha256 = "0sm19p6wcls2d9l0vi5fgwqp7l372nh3g7bdin42w31zr8dmz8h8";
+  src = fetchFromGitHub {
+    owner = "PointCloudLibrary";
+    repo = "pcl";
+    rev = name;
+    sha256 = "1pki4y7mc2dryxc8wa7rs4hg74qab80rpy90jnw3j8fzf09kxcll";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -5,23 +5,24 @@ with stdenv.lib;
 
 let
   os = stdenv.lib.optionalString;
-  majorVersion = "5.10";
-  minorVersion = "1";
+  majorVersion = "7.0";
+  minorVersion = "0";
   version = "${majorVersion}.${minorVersion}";
 in
 
 stdenv.mkDerivation rec {
   name = "vtk-${os (qtLib != null) "qvtk-"}${version}";
   src = fetchurl {
-    url = "${meta.homepage}files/release/${majorVersion}/vtk-${version}.tar.gz";
-    sha256 = "1fxxgsa7967gdphkl07lbfr6dcbq9a72z5kynlklxn7hyp0l18pi";
+    url = "${meta.homepage}files/release/${majorVersion}/VTK-${version}.tar.gz";
+    sha256 = "1hrjxkcvs3ap0bdhk90vymz5pgvxmg7q6sz8ab3wsyddbshr1abq";
   };
-
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1138466
-  postPatch = "sed '/^#define GL_GLEXT_LEGACY/d' -i ./Rendering/vtkOpenGL.h";
 
   buildInputs = [ cmake mesa libX11 xproto libXt ]
     ++ optional (qtLib != null) qtLib;
+
+  preBuild = ''
+    export LD_LIBRARY_PATH="$(pwd)/lib";
+  '';
 
   # Shared libraries don't work, because of rpath troubles with the current
   # nixpkgs camke approach. It wants to call a binary at build time, just


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @viric @bbenoist 

**Pay attention:** it doesn't compile. The vtk compilation chain starts by building a library (`libvtksys-7.0.so.1`) and tool (`vtkHashSource`) that depends on this library. Later, the compilation chain uses the tool but this results in an error:

```
[ 47%] Built target vtkIOLegacy
Scanning dependencies of target vtkHashSource
[ 47%] Building CXX object Utilities/HashSource/CMakeFiles/vtkHashSource.dir/vtkHashSource.cxx.o
[ 47%] Linking CXX executable ../../bin/vtkHashSource-7.0
[ 47%] Built target vtkHashSource
[ 47%] Generating vtkSocketCommunicatorHash.h
../../bin/vtkHashSource-7.0: error while loading shared libraries: libvtksys-7.0.so.1: cannot open shared object file: No such file or directory
make[2]: *** [Parallel/Core/CMakeFiles/vtkParallelCore.dir/build.make:63: Parallel/Core/vtkSocketCommunicatorHash.h] Error 127
```

I can see earlier warnings:

```
[  1%] Building CXX object Utilities/KWSys/vtksys/CMakeFiles/vtksys.dir/SystemInformation.cxx.o
[  1%] Linking CXX shared library ../../../lib/libvtksys-7.0.so
[  1%] Built target vtksys
[  1%] Generating vtkUnicodeCaseFoldData.h
[  7%] Linking CXX shared library ../../lib/libvtkCommonMisc-7.0.so
/nix/store/84x0vldsif3v7i7c6i2ckfzp4jyg9bq9-binutils-2.26/bin/ld: warning: libvtksys-7.0.so.1, needed by ../../lib/libvtkCommonCore-7.0.so.1, not found (try using -rpath or -rpath-link)
[  7%] Linking CXX shared library ../../lib/libvtkCommonTransforms-7.0.so
/nix/store/84x0vldsif3v7i7c6i2ckfzp4jyg9bq9-binutils-2.26/bin/ld: warning: libvtksys-7.0.so.1, needed by ../../lib/libvtkCommonCore-7.0.so.1, not found (try using -rpath or -rpath-link)
[  7%] Built target vtkCommonTransforms
```

The vtkHashSource tool has this [CMakeLists.txt](https://gitlab.kitware.com/vtk/vtk/blob/master/Utilities/HashSource/CMakeLists.txt):

```
vtk_module_export_info()

# This executable is only run from the build tree so we do not need a
# launcher for it and should always use the RPATH to find shared libs.
SET(CMAKE_SKIP_RPATH 0)

IF(NOT CMAKE_CROSSCOMPILING)
  ADD_EXECUTABLE(vtkHashSource vtkHashSource.cxx)
  TARGET_LINK_LIBRARIES(vtkHashSource vtksys)
  vtk_compile_tools_target(vtkHashSource)
ENDIF()
```

Can somebody help me please?
