### PR TITLE
yadm: init at 1.04

### DIFF
--- a/pkgs/applications/version-management/yadm/default.nix
+++ b/pkgs/applications/version-management/yadm/default.nix
@@ -1,28 +1,22 @@
-{ stdenv, fetchurl, git, bash }:
+{ stdenv, fetchurl, fetchFromGitHub }:
 
 let version = "1.04"; in
-let link = "https://raw.githubusercontent.com/TheLocehiliosan/yadm/${version}"; in
 stdenv.mkDerivation {
   name = "yadm-${version}";
-  isLibrary = false;
-  isExecutable = true;
 
-  exe = fetchurl {
-    url = "${link}/yadm";
-    sha256 = "c2a7802e45570d5123f9e5760f6f92f1205f340ce155b47b065e1a1844145067";
-  };
-
-  man = fetchurl {
-    url = "${link}/yadm.1";
-    sha256 = "868755b19b9115cceb78202704a83ee204c2921646dd7814f8c25dd237ce09b2";
+  src = fetchFromGitHub {
+    owner  = "TheLocehiliosan";
+    repo   = "yadm";
+    rev    = "${version}";
+    sha256 = "1g5nz4y63ccxlbz67klm78525ps41ynis8683iayakg4907vd898";
   };
 
   buildCommand = ''
     mkdir -p $out/bin
     mkdir -p $out/share/man/man1
-    sed -e 's:/bin/bash:/usr/bin/env bash:' $exe > $out/bin/yadm
+    sed -e 's:/bin/bash:/usr/bin/env bash:' $src/yadm > $out/bin/yadm
     chmod 755 $out/bin/yadm
-    install -m 644 $man $out/share/man/man1/yadm.1
+    install -m 644 $src/yadm.1 $out/share/man/man1/yadm.1
   '';
 
   meta = {
@@ -38,5 +32,3 @@ stdenv.mkDerivation {
     platforms = stdenv.lib.platforms.unix;
   };
 }
-
-

--- a/pkgs/applications/version-management/yadm/default.nix
+++ b/pkgs/applications/version-management/yadm/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, git, bash }:
+
+let version = "1.04"; in
+let link = "https://raw.githubusercontent.com/TheLocehiliosan/yadm/${version}"; in
+stdenv.mkDerivation {
+  name = "yadm-${version}";
+  isLibrary = false;
+  isExecutable = true;
+
+  exe = fetchurl {
+    url = "${link}/yadm";
+    sha256 = "c2a7802e45570d5123f9e5760f6f92f1205f340ce155b47b065e1a1844145067";
+  };
+
+  man = fetchurl {
+    url = "${link}/yadm.1";
+    sha256 = "868755b19b9115cceb78202704a83ee204c2921646dd7814f8c25dd237ce09b2";
+  };
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+    sed -e 's:/bin/bash:/usr/bin/env bash:' $exe > $out/bin/yadm
+    chmod 755 $out/bin/yadm
+    install -m 644 $man $out/share/man/man1/yadm.1
+  '';
+
+  meta = {
+    homepage = "https://github.com/TheLocehiliosan/yadm";
+    description = "Yet Another Dotfiles Manager";
+    longDescription = ''
+    yadm is a dotfile management tool with 3 main features: Manages files across
+    systems using a single Git repository. Provides a way to use alternate files on
+    a specific OS or host. Supplies a method of encrypting confidential data so it
+    can safely be stored in your repository.
+    '';
+    licence = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17478,9 +17478,7 @@ in
     qt = qt4;
   };
 
-  yadm = callPackage ../applications/version-management/yadm {
-    git = gitMinimal;
-  };
+  yadm = callPackage ../applications/version-management/yadm { };
 
   yafc = callPackage ../applications/networking/yafc { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17478,6 +17478,10 @@ in
     qt = qt4;
   };
 
+  yadm = callPackage ../applications/version-management/yadm {
+    git = gitMinimal;
+  };
+
   yafc = callPackage ../applications/networking/yafc { };
 
   yamdi = callPackage ../tools/video/yamdi { };


### PR DESCRIPTION
###### Motivation for this change

Add [yadm](https://github.com/TheLocehiliosan/yadm) to the package list.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
