### PR TITLE
grsecurity: drop support on 16.03

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -213,7 +213,6 @@ in rec {
   #tests.gitlab = callTest tests/gitlab.nix {};
   tests.gnome3 = callTest tests/gnome3.nix {};
   tests.gnome3-gdm = callTest tests/gnome3-gdm.nix {};
-  tests.grsecurity = callTest tests/grsecurity.nix {};
   tests.i3wm = callTest tests/i3wm.nix {};
   tests.installer = callSubTests tests/installer.nix {};
   tests.influxdb = callTest tests/influxdb.nix {};

--- a/pkgs/os-specific/linux/kernel/linux-grsecurity-4.5.nix
+++ b/pkgs/os-specific/linux/kernel/linux-grsecurity-4.5.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
+throw "grsecurity is unsupported on this release"
+
 import ./generic.nix (args // rec {
   version = "4.5.6";
   extraMeta.branch = "4.5";


### PR DESCRIPTION
I'm unable to provide reasonable support for grsecurity on the 16.03 release branch.  Mark as broken to more accurately reflect the current state of affairs (and to dissuade use of old and potentially vulnerable code).  Also disable the grsecurity test.

If sombody wishes to maintain grsecurity on 16.03, please revert this commit.

Closes #17061
