### PR TITLE
swig: 3.0.7 -> 3.0.10

### DIFF
--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "swig-${version}";
-  version = "3.0.7";
+  version = "3.0.10";
 
   src = fetchFromGitHub {
     owner = "swig";
     repo = "swig";
     rev = "rel-${version}";
-    sha256 = "18zp9546d5xfq88nyykk5v3hh0iyp8r59i2ridbavxn3z914mhyv";
+    sha256 = "049rj883r9mf2bgabj3b03p7cnmqgl5939lmh8v5nnia24zb51jg";
   };
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
@@ -23,12 +23,12 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
     homepage = http://swig.org/;
-    # Licensing is a mess: http://www.swig.org/Release/LICENSE .
-    license = "BSD-style";
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = [ lib.maintainers.urkud lib.maintainers.wkennington ];
+    # Different types of licenses available: http://www.swig.org/Release/LICENSE .
+    license = licenses.gpl3Plus;
+    platforms = with platforms; [ linux darwin ];
+    maintainers = with maintainers; [ urkud wkennington ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
