### PR TITLE
root: 6.04.16 -> 6.04.18

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -1,16 +1,23 @@
 { stdenv, fetchurl, fetchpatch, cmake, pkgconfig, python
-, libX11, libXpm, libXft, libXext, zlib, lzma }:
+, libX11, libXpm, libXft, libXext, zlib, lzma, gsl }:
 
 stdenv.mkDerivation rec {
   name = "root-${version}";
-  version = "6.04.16";
+  version = "6.04.18";
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${version}.source.tar.gz";
-    sha256 = "0f58dg83aqhggkxmimsfkd1qyni2vhmykq4qa89cz6jr9p73i1vm";
+    sha256 = "00f3v3l8nimfkcxpn9qpyh3h23na0mi4wkds2y5gwqh8wh3jryq9";
   };
 
-  buildInputs = [ cmake pkgconfig python libX11 libXpm libXft libXext zlib lzma ];
+  buildInputs = [ cmake pkgconfig python libX11 libXpm libXft libXext zlib lzma gsl ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/root-mirror/root/commit/ee9964210c56e7c1868618a4434c5340fef38fe4.patch";
+      sha256 = "186i7ni75yvjydy6lpmaplqxfb5z2019bgpbhff1n6zn2qlrff2r";
+    })
+  ];
 
   preConfigure = ''
     patchShebangs build/unix/
@@ -22,6 +29,8 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
   ]
   ++ stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include";
+
+  enableParallelBuilding = true;
 
   meta = {
     homepage = "https://root.cern.ch/";


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

root: compile against external gsl

Revert "Revert "root: enable parallel building""

This reverts commit ee1a10ee6b4b0a1a22e3e0dbbcf96a2d667d0685.

ROOT has no problems with parallel build. The problems that caused the
original commit were not related to parallel building.
