### PR TITLE
Included darwin in supported platforms for lessc compiler.

### DIFF
--- a/pkgs/development/compilers/lessc/default.nix
+++ b/pkgs/development/compilers/lessc/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "LESS to CSS compiler";
     homepage = http://lesscss.org/;
     license = licenses.asl20;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ pSub ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Needed to use lessc in a project and saw that the original expression only suppored linux. The expression works just fine for darwin as well though.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
