### PR TITLE
qtbitcointrader: add {pre,post}Configure to fix build

### DIFF
--- a/pkgs/applications/misc/qtbitcointrader/default.nix
+++ b/pkgs/applications/misc/qtbitcointrader/default.nix
@@ -16,11 +16,13 @@ stdenv.mkDerivation {
   postUnpack = "sourceRoot=\${sourceRoot}/src";
 
   configurePhase = ''
+    runHook preConfigure
     qmake $qmakeFlags \
       PREFIX=$out \
       DESKTOPDIR=$out/share/applications \
       ICONDIR=$out/share/pixmaps \
       QtBitcoinTrader_Desktop.pro
+    runHook postConfigure
   '';
 
   meta = with stdenv.lib;


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
