### PR TITLE
syncthing: fix system service

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -114,8 +114,8 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    systemd.services.syncthing = mkIf cfg.systemService
-      header // {
+    systemd.services = mkIf cfg.systemService {
+      syncthing = header // {
         wantedBy = [ "multi-user.target" ];
         serviceConfig = service // {
           User = cfg.user;
@@ -124,6 +124,7 @@ in
           ExecStart = "${cfg.package}/bin/syncthing -no-browser -home=${cfg.dataDir}";
         };
       };
+    };
 
     systemd.user.services.syncthing =
       header // {


### PR DESCRIPTION
###### Motivation for this change

Commit 267e362fbc41dffd0d978ab5c8d91668b5d7d8fc broke the `syncthing` system service. This commit reverts the way the system service is defined.

Fixes #17229
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
