### PR TITLE
plugin-torture: 5 -> 2016-07-25

### DIFF
--- a/pkgs/applications/audio/plugin-torture/default.nix
+++ b/pkgs/applications/audio/plugin-torture/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "plugin-torture-${version}";
-  version = "5";
+  version = "2016-07-25";
 
   src = fetchFromGitHub {
     owner = "cth103";
     repo = "plugin-torture";
-    rev = "v${version}";
-    sha256 = "1mlgxjsyaz86wm4k32ll2w5nghjffnsdqlm6kjv02a4dpb2bfrih";
+    rev = "8b9c43197dca372da6b9c8212224ec86b5f16b4a";
+    sha256 = "1xyhvhm85d9z0kw716cjllrrzksn4s4bw34layg8hf4m5m31sp2p";
   };
 
   buildInputs = [ boost ladspaH lilv lv2 pkgconfig serd sord sratom ];


### PR DESCRIPTION
###### Motivation for this change

Fixes [an issue I had](https://github.com/cth103/plugin-torture/issues/4)
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
