### PR TITLE
emacs-source-code: init at 1.0.0

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -471,6 +471,30 @@ let
     };
   };
 
+  emacs-source-directory = stdenv.mkDerivation {
+    name = "emacs-source-directory-1.0.0";
+    src = emacs.src;
+
+    # We don't want accidentally start bulding emacs one more time
+    phases = "unpackPhase buildPhase";
+
+    buildPhase = ''
+     mkdir -p $out/share/emacs/site-lisp/elpa/emacs-source-directory
+     cp -a src $out/src
+     (cd $out/src && ${emacs}/bin/etags *.c *.h)
+     cat <<EOF > $out/share/emacs/site-lisp/elpa/emacs-source-directory/emacs-source-directory-autoloads.el
+     (setq source-directory "$out")
+     (setq find-function-C-source-directory (expand-file-name "src" source-directory))
+     EOF
+     cat <<EOF > $out/share/emacs/site-lisp/elpa/emacs-source-directory/emacs-source-directory-pkg.el
+     (define-package "emacs-source-directory" "1.0.0" "Make emacs C source code available inside emacs. To use with emacsWithPackages in NixOS" '())
+     EOF
+    '';
+    meta = {
+      description = "Make emacs C source code available inside emacs. To use with emacsWithPackages in NixOS";
+    };
+  };
+
   engine-mode = melpaBuild rec {
     pname = "engine-mode";
     version = "1.0.0";


### PR DESCRIPTION
###### Motivation for this change

This pseudo-package will help emacs find its own C sources.

When this package is used in `emacsWithPackages`, you will be able to
   reach emacs C sources, e.g. through a link in `describe-function`
    buffer.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
