### PR TITLE
pdf2odt: init at 2014-12-17

### DIFF
--- a/pkgs/tools/typesetting/pdf2odt/default.nix
+++ b/pkgs/tools/typesetting/pdf2odt/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, lib, makeWrapper, fetchFromGitHub
+, bc, coreutils, file, gawk, ghostscript, gnused, imagemagick, zip }:
+
+stdenv.mkDerivation rec {
+  version = "2014-12-17";
+  name = "pdf2odt-${version}";
+
+  src = fetchFromGitHub {
+    owner = "gutschke";
+    repo = "pdf2odt";
+    rev = "master";
+    sha256 = "14f9r5f0g6jzanl54jv86ls0frvspka1p9c8dy3fnriqpm584j0r";
+  };
+
+  dontStrip = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  path = lib.makeBinPath [
+    bc
+    coreutils
+    file
+    gawk
+    ghostscript
+    gnused
+    imagemagick
+    zip
+  ];
+
+  patches = [ ./use_mktemp.patch ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/doc
+
+    install -m0755 pdf2odt $out/bin/pdf2odt
+    ln -rs $out/bin/pdf2odt $out/bin/pdf2ods
+
+    install -m0644 README.md LICENSE -t $out/share/doc
+
+    wrapProgram $out/bin/pdf2odt --prefix PATH : ${path}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PDF to ODT format converter";
+    homepage = http://github.com/gutschke/pdf2odt;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ peterhoeg ];
+    inherit version;
+  };
+}

--- a/pkgs/tools/typesetting/pdf2odt/use_mktemp.patch
+++ b/pkgs/tools/typesetting/pdf2odt/use_mktemp.patch
@@ -1,0 +1,19 @@
+diff --git a/pdf2odt b/pdf2odt
+index d38bb07..e1ddf05 100755
+--- a/pdf2odt
++++ b/pdf2odt
+@@ -173,13 +173,7 @@ if [ -e "${out}" ] &&
+ fi
+ 
+ # Set up temporary staging directory
+-TMPDIR="/tmp/pdf2odt.$$"
+-[ \! -e "${TMPDIR}" ] || {
+-  echo "Staging directory ${TMPDIR} already exists" >&2
+-  exit 1
+-}
+-trap 'rm -rf "${TMPDIR}"' EXIT INT TERM QUIT HUP
+-mkdir -p "${TMPDIR}"
++TMPDIR=$(mktemp -d)
+ 
+ # Adjust DPI so that the image fits on a letter- or a4-sized page.
+ function scale() {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3011,6 +3011,8 @@ in
 
   pdf2djvu = callPackage ../tools/typesetting/pdf2djvu { };
 
+  pdf2odt = callPackage ../tools/typesetting/pdf2odt { };
+
   pdf2svg = callPackage ../tools/graphics/pdf2svg { };
 
   pdfjam = callPackage ../tools/typesetting/pdfjam { };


### PR DESCRIPTION
###### Motivation for this change

It's not the most elegant solution, but I had a need for this script, so might as well package it...
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
