### PR TITLE
ghcjs: refactor stage2 handling

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -136,6 +136,9 @@ in mkDerivation (rec {
     isGhcjs = true;
     inherit nodejs ghcjsBoot;
     inherit (ghcjsNodePkgs) "socket.io";
+    mkStage2 = import ./stage2.nix {
+      inherit ghcjsBoot;
+    };
   };
 
   homepage = "https://github.com/ghcjs/ghcjs";

--- a/pkgs/development/compilers/ghcjs/gen-stage2.rb
+++ b/pkgs/development/compilers/ghcjs/gen-stage2.rb
@@ -26,10 +26,10 @@ stage2_packages = [
 ]
 
 nixpkgs = File.expand_path("../../../../..", __FILE__)
-boot = `nix-build #{nixpkgs} -A haskell.packages.ghcjs.ghc.ghcjsBoot`.chomp
+boot = ARGV[0] || `nix-build #{nixpkgs} -A haskell.packages.ghcjs.ghc.ghcjsBoot`.chomp
 
 out = "".dup
-out << "{ ghcjsBoot, callPackage }:\n"
+out << "{ ghcjsBoot }: { callPackage }:\n"
 out << "\n"
 out << "{\n"
 
@@ -37,6 +37,7 @@ stage2_packages.each do |package|
   name = Pathname.new(package).basename
   nix = `cabal2nix file://#{boot}/#{package}  --jailbreak`
   nix.sub!(/src =.*?$/, "src = \"${ghcjsBoot}/#{package}\";")
+  nix.sub!("  doCheck = false;\n", "")
   nix.sub!("libraryHaskellDepends", "doCheck = false;\n  libraryHaskellDepends")
   # cabal2nix somehow generates the deps for 'text' as if it had selected flag
   # 'integer-simple' (despite not passing the flag within the generated

--- a/pkgs/development/compilers/ghcjs/stage2.nix
+++ b/pkgs/development/compilers/ghcjs/stage2.nix
@@ -1,4 +1,4 @@
-{ ghcjsBoot, callPackage }:
+{ ghcjsBoot }: { callPackage }:
 
 {
   async = callPackage

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -9,11 +9,9 @@ with import ./lib.nix { inherit pkgs; };
 
 self: super:
   # The stage 2 packages. Regenerate with ./ghcjs/gen-stage2.rb
-  let stage2 =
-    (import ./ghcjs/stage2.nix {
+  let stage2 = super.ghc.mkStage2 {
        inherit (self) callPackage;
-       inherit (self.ghc) ghcjsBoot;
-    }); in stage2 // {
+    }; in stage2 // {
 
   old-time = overrideCabal stage2.old-time (drv: {
     postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Previously, the stage2 information was stored in haskell-modules, and imported directly from there.  However, the correct stage2 information is determined by the version of ghcjs-boot repository.  This commit makes the stage2 information part of the ghcjs derivation, which improves organization and makes it possible to override stage2 when overriding ghcjs.
