### PR TITLE
lenmus: 5.4.1 -> 5.4.2

### DIFF
--- a/pkgs/applications/misc/lenmus/default.nix
+++ b/pkgs/applications/misc/lenmus/default.nix
@@ -7,19 +7,14 @@
 
 stdenv.mkDerivation rec {
   name = "lenmus-${version}";
-  version = "5.4.1";
+  version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "lenmus";
     repo = "lenmus";
     rev = "Release_${version}";
-    sha256 = "03xar8x38x20cns2gnv34jp0hw0k16sa62kkfhka9iiiw90wfyrp";
+    sha256 = "1n639xr1qxx6rhqs0c6sjxp3bv8cwkmw1vfk1cji7514gj2a9v3p";
   };
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "DESTINATION \"/usr/share" "DESTINATION \"$out/share"
-  '';
 
   cmakeFlags = [
     "-DCMAKE_INSALL_PREFIX=$out"


### PR DESCRIPTION
###### Motivation for this change

Upstreamed the _CMakeLists.txt_ hack and circumvented a runtime error (https://github.com/lenmus/lenmus/issues/50 and https://github.com/lenmus/lenmus/pull/51).
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
