### PR TITLE
faust1git: 2016-04-27 -> 2016-07-19

### DIFF
--- a/pkgs/applications/audio/faust/faust1git.nix
+++ b/pkgs/applications/audio/faust/faust1git.nix
@@ -9,12 +9,12 @@ with stdenv.lib.strings;
 
 let
 
-  version = "2016-04-27";
+  version = "2016-07-19";
 
   src = fetchgit {
     url = "git://git.code.sf.net/p/faudiostream/code";
-    rev = "931fca3e649f99ef09025d37bd6a7dc70a03e6f6";
-    sha256 = "1h2qfwxqf9406v0w6kqyxlzn88zw3xmwgxg9f01n4jvd72zxll78";
+    rev = "16c22dc0193c10521b1dc16f98443d9c206bb5dd";
+    sha256 = "01rbcjfhpd5casi72ffi1j95f65ji60l629sgav93pvs0kpdacz5";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes a faust compilation issue I was having.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
