### PR TITLE
solarus-quest-editor: init at 1.4.5

### DIFF
--- a/pkgs/development/tools/solarus-quest-editor/default.nix
+++ b/pkgs/development/tools/solarus-quest-editor/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, cmake, luajit,
+  SDL2, SDL2_image, SDL2_ttf, physfs,
+  openal, libmodplug, libvorbis, solarus,
+  qtbase, qttools }:
+
+stdenv.mkDerivation rec {
+  name = "solarus-quest-editor-${version}";
+  version = "1.4.5";
+    
+  src = fetchFromGitHub {
+    owner = "christopho";
+    repo = "solarus-quest-editor";
+    rev = "61f0fa7a5048994fcd9c9f3a3d1255d0be2967df";
+    sha256 = "1fpq55nvs5k2rxgzgf39c069rmm73vmv4gr5lvmqzgsz07rkh07f";
+  };
+  
+  buildInputs = [ cmake luajit SDL2
+    SDL2_image SDL2_ttf physfs
+    openal libmodplug libvorbis
+    solarus qtbase qttools ];
+    
+  patches = [ ./patches/fix-install.patch ];
+
+  meta = with stdenv.lib; {
+    description = "The editor for the Zelda-like ARPG game engine, Solarus";
+    longDescription = ''
+      Solarus is a game engine for Zelda-like ARPG games written in lua.
+      Many full-fledged games have been writen for the engine.
+      Games can be created easily using the editor.
+    '';
+    homepage = http://www.solarus-games.org;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.Nate-Devv ];
+    platforms = platforms.linux;
+  };
+  
+}

--- a/pkgs/development/tools/solarus-quest-editor/patches/fix-install.patch
+++ b/pkgs/development/tools/solarus-quest-editor/patches/fix-install.patch
@@ -1,0 +1,16 @@
+# Description Fix CMakeLists.txt to install binaries. Fixed in 1.5 upstream.
+# Author "Nathan R. Moore <natedevv@gmail.com>"
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -359,6 +359,11 @@
+   "${MODPLUG_LIBRARY}"
+ )
+ 
++# Set files to install
++install(TARGETS solarus-quest-editor
++    RUNTIME DESTINATION bin
++)
++
+ # Platform specific.
+ 
+ # Windows: disable the console.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15807,6 +15807,8 @@ in
   };
 
   solarus = callPackage ../games/solarus { };
+  
+  solarus-quest-editor = qt5.callPackage ../development/tools/solarus-quest-editor { };
 
   # You still can override by passing more arguments.
   space-orbit = callPackage ../games/space-orbit { };


### PR DESCRIPTION
###### Motivation for this change

The Solarus engine, which has a nixpkg already also has an editor which makes it easier to create quests that utilize it.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
