### PR TITLE
libebml: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/development/libraries/libebml/default.nix
+++ b/pkgs/development/libraries/libebml/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libebml-1.3.3";
+  name = "libebml-1.3.4";
 
   src = fetchurl {
     url = "http://dl.matroska.org/downloads/libebml/${name}.tar.bz2";
-    sha256 = "16alhwd1yz5bv3765xfn5azwk37805lg1f61195gjq8rlkd49yrm";
+    sha256 = "11zka6z9ncywyjr1gfm5cnii33ln7y3w6s86kiacchip2g7kw3f5";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

This version is required in the latest mkvtoolnix
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change (this took a long while)
- [x] Tested execution of all binary files (none)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
