### PR TITLE
wasm: init at 0.0.1

### DIFF
--- a/pkgs/development/interpreters/wasm/default.nix
+++ b/pkgs/development/interpreters/wasm/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchFromGitHub, cmake, clang, python, v8_static, coreutils }:
+
+let
+  sexpr_wasm_prototype = stdenv.mkDerivation {
+    name = "sexpr_wasm_prototype";
+    src = fetchFromGitHub {
+      owner = "WebAssembly";
+      repo = "sexpr-wasm-prototype";
+      rev = "1347a367c34876bfe92562f244a8c8b770372479";
+      sha256 = "1v1mph5fp1rffhvh8bbx937gpjqjrdgm7yhffdxzdn4pih9d0grn";
+    };
+
+    configurePhase = ''
+      # set this to nonempty string to disable default cmake configure
+    '';
+
+    buildInputs = [ cmake clang python ];
+
+    buildPhase = "make clang-debug-no-tests";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp out/clang/Debug/no-tests/sexpr-wasm $out/bin
+    '';
+  };
+
+in
+
+stdenv.mkDerivation {
+  name = "wasm-0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "proglodyte";
+    repo = "wasm";
+    rev = "650188eecaaf4b64f12b341986b4e89e5fdb3bbe";
+    sha256 = "1f5mdl0l2448lx7h36b4bdr541a4q1wapn1kdwrd4z7s94n7a5gq";
+  };
+
+  configurePhase = ''
+    sed -i -e "s|sudo ||g" Makefile
+  '';
+
+  installPhase = ''
+    export DESTDIR=$out
+    export MKTEMPDIR=${coreutils}/bin
+    export D8DIR=${v8_static}/bin
+    export SWDIR=${sexpr_wasm_prototype}/bin
+    make install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "wasm runs WebAssembly from the command line";
+    maintainers = with maintainers; [ proglodyte ];
+    platforms = platforms.linux;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9554,6 +9554,8 @@ in
     inherit (pythonPackages) gyp;
   };
 
+  v8_static = lowPrio (self.v8.override { static = true; });
+
   vaapiIntel = callPackage ../development/libraries/vaapi-intel {
     libva = libva-full; # also wants libva-{x11,drm,wayland}
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5995,6 +5995,8 @@ in
   tcl-8_5 = callPackage ../development/interpreters/tcl/8.5.nix { };
   tcl-8_6 = callPackage ../development/interpreters/tcl/8.6.nix { };
 
+  wasm = callPackage ../development/interpreters/wasm { };
+
   xulrunner = callPackage ../development/interpreters/xulrunner {
     inherit (gnome) libIDL;
     inherit (pythonPackages) pysqlite;


### PR DESCRIPTION
###### Motivation for this change

To make it easy to run WebAssembly from the command line
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Run WebAssembly from the command line with v8 backend
