### PR TITLE
mesos: FIX #16917 Failed to extract tgz

### DIFF
--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -48,6 +48,9 @@ in stdenv.mkDerivation rec {
     substituteInPlace 3rdparty/libprocess/3rdparty/stout/include/stout/posix/os.hpp \
       --replace '"sh"' '"${bash}/bin/bash"'
 
+    substituteInPlace 3rdparty/libprocess/3rdparty/stout/include/stout/os/posix/shell.hpp \
+      --replace '"sh"' '"${bash}/bin/bash"'
+
     substituteInPlace 3rdparty/libprocess/3rdparty/stout/include/stout/os/posix/fork.hpp \
       --replace '"sh"' '"${bash}/bin/bash"'
 


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/16917

https://github.com/apache/mesos/blob/0.28.0/3rdparty/libprocess/3rdparty/stout/include/stout/os/posix/shell.hpp#L109
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
