### PR TITLE
tinc: add Restart in systemd serviceConfig

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -157,6 +157,7 @@ in
         serviceConfig = {
           Type = "simple";
           PIDFile = "/run/tinc.${network}.pid";
+          Restart = "on-failure";
         };
         preStart = ''
           mkdir -p /etc/tinc/${network}/hosts


### PR DESCRIPTION
###### Motivation for this change

We had some tinc segfaults. This change is intended to automatically restart them on-failure in order to reduce downtimes.
###### Things done
- [x] Tested on several hosts
