### PR TITLE
emacs25pre: 25.0.95 -> 25.1-rc1

### DIFF
--- a/pkgs/applications/editors/emacs-25/default.nix
+++ b/pkgs/applications/editors/emacs-25/default.nix
@@ -25,13 +25,13 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "emacs-25.0.95";
+  name = "emacs-25.1-rc1";
 
   builder = ./builder.sh;
 
   src = fetchurl {
     url = "ftp://alpha.gnu.org/gnu/emacs/pretest/${name}.tar.xz";
-    sha256 = "0bmvg7cbrwfa9rbryjrqv2qcllgwja92sx9ikirl80r5d09caf0l";
+    sha256 = "0cv1hars9zxlv040h7f3zz50fhn67dqa18ms4hg9sdblckk50360";
   };
 
   patches = lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
