### PR TITLE
offlineimap: 7.0.0 -> 7.0.2

### DIFF
--- a/pkgs/tools/networking/offlineimap/default.nix
+++ b/pkgs/tools/networking/offlineimap/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages, sqlite3 }:
 
 pythonPackages.buildPythonApplication rec {
-  version = "7.0.0";
+  version = "7.0.2";
   name = "offlineimap-${version}";
   namePrefix = "";
 
@@ -9,7 +9,7 @@ pythonPackages.buildPythonApplication rec {
     owner = "OfflineIMAP";
     repo = "offlineimap";
     rev = "v${version}";
-    sha256 = "15m0z3y3gxx30b980gym0mnc2icmdy2xy2ckcbmwp97ynm7pmzmp";
+    sha256 = "1xwblb1nvqq6gkxjynzsw31xja07qday58x5jqak8sp3d4lqw2h2";
   };
 
   doCheck = false;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
