### PR TITLE
iio-sensor-proxy: init at 2.2 and nixos module

### DIFF
--- a/nixos/modules/hardware/sensor/iio.nix
+++ b/nixos/modules/hardware/sensor/iio.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+
+  options = {
+    hardware.sensor.iio = {
+      enable = mkOption {
+        description = "Enable this option to support IIO sensors.";
+        type = types.bool;
+        default = false;
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf config.hardware.sensor.iio.enable {
+
+    boot.initrd.availableKernelModules = [ "hid-sensor-hub" ];
+
+    environment.systemPackages = with pkgs; [ iio-sensor-proxy ];
+
+    services.dbus.packages = with pkgs; [ iio-sensor-proxy ];
+    services.udev.packages = with pkgs; [ iio-sensor-proxy ];
+    systemd.packages = with pkgs; [ iio-sensor-proxy ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -29,6 +29,7 @@
   ./hardware/ckb.nix
   ./hardware/cpu/amd-microcode.nix
   ./hardware/cpu/intel-microcode.nix
+  ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
   ./hardware/network/b43.nix
   ./hardware/network/intel-2100bg.nix

--- a/pkgs/os-specific/linux/iio-sensor-proxy/default.nix
+++ b/pkgs/os-specific/linux/iio-sensor-proxy/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, autoconf-archive, gettext, libtool, intltool, autoconf, automake
+, glib, gtk3, gtk_doc, libgudev, pkgconfig, systemd }:
+
+stdenv.mkDerivation rec {
+  name = "iio-sensor-proxy-${version}";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner  = "hadess";
+    repo   = "iio-sensor-proxy";
+    rev    = version;
+    sha256 = "1x0whwm2r9g50hq5px0bgsrigy8naihqgi6qm0x5q87jz5lkhrnv";
+  };
+
+  configurePhase = ''
+    ./autogen.sh --prefix=$out \
+      --with-udevrulesdir=$out/lib/udev/rules.d \
+      --with-systemdsystemunitdir=$out/lib/systemd/system
+  '';
+
+  buildInputs = [
+    glib
+    gtk3
+    gtk_doc
+    libgudev
+    systemd
+  ];
+
+  nativeBuildInputs = [
+    autoconf
+    autoconf-archive
+    automake
+    gettext
+    intltool
+    libtool
+    pkgconfig
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Proxy for sending IIO sensor data to D-Bus";
+    homepage = https://github.com/hadess/iio-sensor-proxy;
+    license = licenses.gpl3 ;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.linux;
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -932,6 +932,8 @@ with pkgs;
 
   long-shebang = callPackage ../misc/long-shebang {};
 
+  iio-sensor-proxy = callPackage ../os-specific/linux/iio-sensor-proxy { };
+
   mathics = pythonPackages.mathics;
 
   meson = callPackage ../development/tools/build-managers/meson { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds support for `iio-sensor-proxy` used by GNOME v3 and others for reading data from the accelerometer, gps, compass and similar sensors built into some relatively recent laptops.

This allows the computer to automatically rotate the screen, turn the brightness up/down in response to ambient light and so on.

Additionally, there is a NixOS module exposed via `hardware.sensor.iio` for enabling services, udev rules and dbus services.

Now, while everything installs, can be configured and runs, ~~no events are actually being sent, so that needs to be sorted before this is merged, but I really wanted to see if this is the correct way of doing something like this. Specifically with regards to creating a new namespace under `hardware.sensor`~~, but due to kernel issues in 4.9.x some hardware requires a suspend/resume cycle before events are being sent.

On kernel 4.10 everything is fine!

###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
