### PR TITLE
gocd-server: 16.5.0-3309 -> 16.6.0-3590

### DIFF
--- a/nixos/modules/services/continuous-integration/gocd-server/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-server/default.nix
@@ -67,33 +67,33 @@ in {
       };
 
       packages = mkOption {
-        default = [ pkgs.stdenv pkgs.jre config.programs.ssh.package pkgs.nix ];
+        default = [ pkgs.stdenv pkgs.jre pkgs.git config.programs.ssh.package pkgs.nix ];
         type = types.listOf types.package;
         description = ''
           Packages to add to PATH for the Go.CD server's process.
         '';
       };
 
-      heapSize = mkOption {
+      initialJavaHeapSize = mkOption {
         default = "512m";
         type = types.str;
         description = ''
-          Specifies the java heap memory size for the Go.CD server's java process.
+          Specifies the initial java heap memory size for the Go.CD server's java process.
         '';
       };
 
-      maxMemory = mkOption {
+      maxJavaHeapMemory = mkOption {
         default = "1024m";
         type = types.str;
         description = ''
-          Specifies the java maximum memory size for the Go.CD server's java process.
+          Specifies the java maximum heap memory size for the Go.CD server's java process.
         '';
       };
 
       extraOptions = mkOption {
         default = [
-          "-Xms${cfg.heapSize}"
-          "-Xmx${cfg.maxMemory}"
+          "-Xms${cfg.initialJavaHeapSize}"
+          "-Xmx${cfg.maxJavaHeapMemory}"
           "-Dcruise.listen.host=${cfg.listenAddress}"
           "-Duser.language=en"
           "-Djruby.rack.request.size.threshold.bytes=30000000"

--- a/pkgs/development/tools/continuous-integration/gocd-server/default.nix
+++ b/pkgs/development/tools/continuous-integration/gocd-server/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "gocd-server-${version}-${rev}";
-  version = "16.5.0";
-  rev = "3305";
+  version = "16.6.0";
+  rev = "3590";
 
   src = fetchurl {
     url = "https://download.go.cd/binaries/${version}-${rev}/generic/go-server-${version}-${rev}.zip";
-    sha256 = "41139051f419dc340a5c05c76e5de06eeef3516526341f377ac77532511bfa2c";
+    sha256 = "6e737c8b419544deb5089e9a2540892a6faec73c962ee7c4e526a799056acca1";
   };
 
   meta = with stdenv.lib; {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.go.cd;
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ swarren83 ];
+    maintainers = with maintainers; [ grahamc swarren83 ];
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
  - tested using `nix-build`
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  - https://gist.github.com/swarren83/3acfc0e8408a3658a185826b8b291896
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Update gocd-server package version to 16.6.0-3590 including new sha.  Modify heapSize
and maxMemory mkOption to accurately reflect their intended purpose of configuring
initial java heap sizes.
