### PR TITLE
ghcjs: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -173,7 +173,7 @@ self: super: {
   hwsl2 = dontCheck super.hwsl2;
 
   # https://github.com/haskell/haddock/issues/427
-  haddock = dontCheck super.haddock;
+  haddock = dontCheck self.haddock_2_16_1;
 
   # haddock-api >= 2.17 is GHC 8.0 only
   haddock-api = self.haddock-api_2_16_1;
@@ -213,5 +213,7 @@ self: super: {
 
   # Moved out from common as no longer the case for GHC8
   ghc-mod = super.ghc-mod.override { cabal-helper = self.cabal-helper_0_6_3_1; };
+
+  generic-deriving = self.generic-deriving_1_10_5;
 
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -44,8 +44,11 @@ extra-packages:
   - control-monad-free < 0.6            # newer versions don't compile with anything but GHC 7.8.x
   - deepseq == 1.3.0.1                  # required to build Cabal with GHC 6.12.3
   - descriptive < 0.1                   # required for structured-haskell-mode-1.0.8
+  - generic-deriving == 1.10.5.*        # new versions don't compile with GHC 7.10.x
   - gloss < 1.9.3                       # new versions don't compile with GHC 7.8.x
-  - haddock-api < 2.16                  # required on GHC 7.8.x
+  - haddock < 2.17                      # required on GHC 7.10.x
+  - haddock-api == 2.15.*               # required on GHC 7.8.x
+  - haddock-api == 2.16.*               # required on GHC 7.10.x
   - haskell-src-exts < 1.16             # required for structured-haskell-mode-1.0.8
   - mtl < 2.2                           # newer versions require transformers > 0.4.x, which we cannot provide in GHC 7.8.x
   - mtl-prelude < 2                     # required for to build postgrest on mtl 2.1.x platforms


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

We need to hold back some packages, now that ghc 8 is out
