### PR TITLE
gocd-agent: 16.5.0-3309 -> 16.6.0-3590

### DIFF
--- a/nixos/modules/services/continuous-integration/gocd-agent/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-agent/default.nix
@@ -36,7 +36,7 @@ in {
       };
 
       packages = mkOption {
-        default = [ pkgs.stdenv pkgs.jre config.programs.ssh.package pkgs.nix ];
+        default = [ pkgs.stdenv pkgs.jre pkgs.git config.programs.ssh.package pkgs.nix ];
         type = types.listOf types.package;
         description = ''
           Packages to add to PATH for the Go.CD agent process.
@@ -80,26 +80,26 @@ in {
         '';
       };
 
-      heapSize = mkOption {
+      initialJavaHeapSize = mkOption {
         default = "128m";
         type = types.str;
         description = ''
-          Specifies the java heap memory size for the Go.CD agent java process.
+          Specifies the initial java heap memory size for the Go.CD agent java process.
         '';
       };
 
-      maxMemory = mkOption {
+      maxJavaHeapMemory = mkOption {
         default = "256m";
         type = types.str;
         description = ''
-          Specifies the java maximum memory size for the Go.CD agent java process.
+          Specifies the java maximum heap memory size for the Go.CD agent java process.
         '';
       };
 
       startupOptions = mkOption {
         default = [
-          "-Xms${cfg.heapSize}"
-          "-Xmx${cfg.maxMemory}"
+          "-Xms${cfg.initialJavaHeapSize}"
+          "-Xmx${cfg.maxJavaHeapMemory}"
           "-Djava.io.tmpdir=/tmp"
           "-Dcruise.console.publish.interval=10"
           "-Djava.security.egd=file:/dev/./urandom"

--- a/nixos/tests/gocd-agent.nix
+++ b/nixos/tests/gocd-agent.nix
@@ -4,10 +4,15 @@
 #   3. GoCD agent is available on GoCD server using GoCD API
 #     3.1. https://api.go.cd/current/#get-all-agents
 
+let
+  serverUrl = "localhost:8153/go/api/agents";
+  header = "Accept: application/vnd./go.cd/v2+json";
+in
+
 import ./make-test.nix ({ pkgs, ...} : {
   name = "gocd-agent";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ swarren83 ];
+    maintainers = [ grahamc swarren83 ];
   };
 
 nodes = {
@@ -29,6 +34,7 @@ nodes = {
     $gocd_agent->waitForUnit("gocd-server");
     $gocd_agent->waitForOpenPort("8153");
     $gocd_agent->waitForUnit("gocd-agent");
-    $gocd_agent->waitUntilSucceeds("curl -s -f localhost:8153/go/api/agents -H 'Accept: application/vnd.go.cd.v2+json'");
+    $gocd_agent->waitUntilSucceeds("curl -s -f ${serverUrl} -H '${header}' | awk -F \" '/\"uuid\":\s\"[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}/ {print $4}'");
+    $gocd_agent->waitUntilSucceeds("curl -s -f ${serverUrl} -H '${header}' | awk -F \" '/\"agent_state\":\s\"Idle\"/'");
   '';
 })

--- a/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
@@ -2,19 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "gocd-agent-${version}-${rev}";
-  version = "16.5.0";
-  rev = "3305";
+  version = "16.6.0";
+  rev = "3590";
 
   src = fetchurl {
     url = "https://download.go.cd/binaries/${version}-${rev}/generic/go-agent-${version}-${rev}.zip";
-    sha256 = "2cb988d36ec747b2917f3be040b430f2a8289c07353a6b6bdc95bf741fa1ed97";
+    sha256 = "ee076c62b388a6ed88d5065f18a4a96cb0d3161f693c16f920d85886d295ff27";
   };
   meta = with stdenv.lib; {
     description = "A continuous delivery server specializing in advanced workflow modeling and visualization";
     homepage = http://www.go.cd;
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ swarren83 ];
+    maintainers = with maintainers; [ grahamc swarren83 ];
   };
 
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

Update version to 16.6.0-3590
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
  - tested with `nix-build`
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

```
[root@nixos:~/nixpkgs]# nix-shell -p nox --run "nox-review wip"
==> We're in a git repo, trying to fetch it
Building in /run/user/0/nox-review-ucu958ej: gocd-agent
these derivations will be built:
  /nix/store/hzfvd8mg4wxhz974pacwrrl91xj3qrjf-go-agent-16.6.0-3590.zip.drv
  /nix/store/5fm8nhkv7380svak0fs4y1a3n8agj24j-gocd-agent-16.6.0-3590.drv
building path(s) ‘/nix/store/d0icfr8n0cbcsydsp8lmmrkxdahg6fvf-go-agent-16.6.0-3590.zip’
/nix/store/j92yglpzzxk2487arlqs76cc81y3gy9j-stdenv/setup: line 494: /run/user/0/nix-build-go-agent-16.6.0-3590.zip.drv-0/env-vars: Permission denied

trying https://download.go.cd/binaries/16.6.0-3590/generic/go-agent-16.6.0-3590.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3487k  100 3487k    0     0  1639k      0  0:00:02  0:00:02 --:--:-- 1696k
building path(s) ‘/nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590’
/nix/store/j92yglpzzxk2487arlqs76cc81y3gy9j-stdenv/setup: line 494: /run/user/0/nix-build-gocd-agent-16.6.0-3590.drv-0/env-vars: Permission denied
Archive:  /nix/store/d0icfr8n0cbcsydsp8lmmrkxdahg6fvf-go-agent-16.6.0-3590.zip
   creating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/LICENSE
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/README.md
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/agent-bootstrapper.jar
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/agent.cmd
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/agent.sh
   creating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/config/
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/config/log4j.properties
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/default.cruise-agent
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/init.cruise-agent
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/start-agent.bat
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/stop-agent.bat
  inflating: /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590/go-agent-16.6.0/stop-agent.sh
/nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590
Result in /run/user/0/nox-review-ucu958ej
total 0
lrwxrwxrwx 1 root root 66 Jul 27 17:20 result -> /nix/store/cyig94hh01ljclrnlhwhfh2nwr801rpp-gocd-agent-16.6.0-3590
```
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Update gocd-agent package version to 16.6.0-3590 including new sha.  Modify heapSize
and maxMemory mkOption to accurately reflect their intended purpose of configuring
initial java heap sizes.
