### PR TITLE
ghcjs: move list of stage 1 packages into ghcjs derivation

### DIFF
--- a/pkgs/development/compilers/ghcjs/default.nix
+++ b/pkgs/development/compilers/ghcjs/default.nix
@@ -136,6 +136,33 @@ in mkDerivation (rec {
     isGhcjs = true;
     inherit nodejs ghcjsBoot;
     inherit (ghcjsNodePkgs) "socket.io";
+
+    # This is the list of the Stage 1 packages that are built into a booted ghcjs installation
+    # It can be generated with the command:
+    # nix-shell -p haskell.packages.ghcjs.ghc --command "ghcjs-pkg list | sed -n 's/^    \(.*\)-\([0-9.]*\)$/\1_\2/ p' | sed 's/\./_/g' | sed 's/^\([^_]*\)\(.*\)$/      \"\1\"/'"
+    stage1Packages = [
+      "array"
+      "base"
+      "binary"
+      "rts"
+      "bytestring"
+      "containers"
+      "deepseq"
+      "directory"
+      "filepath"
+      "ghc-prim"
+      "ghcjs-prim"
+      "integer-gmp"
+      "old-locale"
+      "pretty"
+      "primitive"
+      "process"
+      "template-haskell"
+      "time"
+      "transformers"
+      "unix"
+    ];
+
     mkStage2 = import ./stage2.nix {
       inherit ghcjsBoot;
     };

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -8,10 +8,14 @@ in
 with import ./lib.nix { inherit pkgs; };
 
 self: super:
-  # The stage 2 packages. Regenerate with ./ghcjs/gen-stage2.rb
-  let stage2 = super.ghc.mkStage2 {
-       inherit (self) callPackage;
-    }; in stage2 // {
+
+  let # The stage 1 packages
+      stage1 = pkgs.lib.genAttrs super.ghc.stage1Packages (pkg: null);
+      # The stage 2 packages. Regenerate with ../compilers/ghcjs/gen-stage2.rb
+      stage2 = super.ghc.mkStage2 {
+        inherit (self) callPackage;
+      };
+  in stage1 // stage2 // {
 
   old-time = overrideCabal stage2.old-time (drv: {
     postPatch = ''
@@ -29,30 +33,6 @@ self: super:
 
   inherit (self.ghc.bootPkgs)
     jailbreak-cabal alex happy gtk2hs-buildtools rehoo hoogle;
-
-  # This is the list of the Stage 1 packages that are built into a booted ghcjs installation
-  # It can be generated with the command:
-  # nix-shell -p haskell.packages.ghcjs.ghc --command "ghcjs-pkg list | sed -n 's/^    \(.*\)-\([0-9.]*\)$/\1_\2/ p' | sed 's/\./_/g' | sed 's/-\(.\)/\U\1/' | sed 's/^\([^_]*\)\(.*\)$/\1 = null;/'"
-  array = null;
-  base = null;
-  binary = null;
-  rts = null;
-  bytestring = null;
-  containers = null;
-  deepseq = null;
-  directory = null;
-  filepath = null;
-  ghc-prim = null;
-  ghcjs-prim = null;
-  integer-gmp = null;
-  old-locale = null;
-  pretty = null;
-  primitive = null;
-  process = null;
-  template-haskell = null;
-  time = null;
-  transformers = null;
-  unix = null;
 
   # Don't set integer-simple to null!
   # GHCJS uses integer-gmp, so any package expression that depends on


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This makes it easier to ensure that the list of stage 1 packages accurately matches the given version of ghcjs, and makes it possible for this list to be overridden
