### PR TITLE
simpleTpmPk11: git-20140925 -> git-20160712

### DIFF
--- a/pkgs/tools/security/simple-tpm-pk11/default.nix
+++ b/pkgs/tools/security/simple-tpm-pk11/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchgit, trousers, openssl, opencryptoki, automake, autoconf, libtool }:
 
 stdenv.mkDerivation rec {
-  name = "simple-tpm-pk11-2014-09-25";
+  name = "simple-tpm-pk11-2016-07-12";
 
   src = fetchgit {
     url = "https://github.com/ThomasHabets/simple-tpm-pk11";
-    rev = "f26f10e11344560ff6e1479e6795dc0e5dc49a26";
-    sha256 = "0546lhxssngpkrhg5kmrvn4bm1s2kyd20kvhz3rfavfrvr72cs9k";
+    rev = "6f1f7a6b96ac82965e977cfecb88d930f1d70243";
+    sha256 = "06vf3djp29slh7hrh4hlh3npyl277fy7d77jv9mxa1sk1idjklxc";
   };
 
   buildInputs = [ trousers openssl opencryptoki automake autoconf libtool ];


### PR DESCRIPTION
###### Motivation for this change

Last updated 2 years ago ...
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
