### PR TITLE
motif: init at 2.3.6 & nedit: 5.6 -> 5.6a

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -18,6 +18,7 @@ in
     ./i3.nix
     ./jwm.nix
     ./metacity.nix
+    ./mwm.nix
     ./openbox.nix
     ./pekwm.nix
     ./notion.nix

--- a/nixos/modules/services/x11/window-managers/mwm.nix
+++ b/nixos/modules/services/x11/window-managers/mwm.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.mwm;
+in
+{
+  ###### interface
+  options = {
+    services.xserver.windowManager.mwm.enable = mkEnableOption "mwm";
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "mwm";
+      start = ''
+        ${pkgs.motif}/bin/mwm &
+        waitPID=$!
+      '';
+    };
+    environment.systemPackages = [ pkgs.motif ];
+  };
+}

--- a/pkgs/applications/editors/nedit/default.nix
+++ b/pkgs/applications/editors/nedit/default.nix
@@ -3,11 +3,11 @@
 assert stdenv.isLinux;
 
 stdenv.mkDerivation rec {
-  name = "nedit-5.6";
+  name = "nedit-5.6a";
   
   src = fetchurl {
     url = "mirror://sourceforge/nedit/nedit-source/${name}-src.tar.gz";
-    sha256 = "023hwpqc57mnzvg6p7jda6193afgjzxzajlhwhqvk3jq2kdv6zna";
+    sha256 = "1v8y8vwj3kn91crsddqkz843y6csgw7wkjnd3zdcb4bcrf1pjrsk";
   };
 
   buildInputs = [ xlibsWrapper motif libXpm ];

--- a/pkgs/development/libraries/motif/default.nix
+++ b/pkgs/development/libraries/motif/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, pkgconfig, libtool
+, xlibsWrapper, xbitmaps, libXrender, libXmu, libXt
+, expat, libjpeg, libpng, libiconv
+, flex
+, libXp, libXau
+, demoSupport ? false, autoconf, automake
+}:
+# refer to the gentoo package
+
+stdenv.mkDerivation rec {
+  name = "motif-${version}";
+  version = "2.3.6";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/motif/${name}.tar.gz";
+    sha256 = "1ksqbp0bzdw6wcrx8s4hj4ivvxmw54hz85l2xfigb87cxmmhx0gs";
+  };
+
+  buildInputs = [
+    pkgconfig libtool
+    xlibsWrapper xbitmaps libXrender libXmu libXt
+    expat libjpeg libpng libiconv
+  ] ++ stdenv.lib.optionals (!demoSupport) [ autoconf automake ];
+
+  nativeBuildInputs = [ flex ];
+
+  propagatedBuildInputs = [ libXp libXau ];
+
+  makeFlags = [ "CFLAGS=-fno-strict-aliasing" ];
+
+  patchPhase = ''
+    rm lib/Xm/Xm.h
+    echo -e '"The X.Org Foundation"\t\t\t\t\tpc' >>bindings/xmbind.alias
+  '' + stdenv.lib.optionalString (!demoSupport)
+  ''
+    sed -i -e '/^SUBDIRS/{:x;/\\$/{N;bx;};s/[ \t\n\\]*demos//;}' Makefile.am
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://motif.ics.com;
+    description = "Unix standard widget-toolkit and window-manager";
+    platforms = with platforms; linux;
+    license = with licenses; [ lgpl21 ];
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14078,9 +14078,7 @@ in
 
   ne = callPackage ../applications/editors/ne { };
 
-  nedit = callPackage ../applications/editors/nedit {
-    motif = lesstif;
-  };
+  nedit = callPackage ../applications/editors/nedit { };
 
   notmuch = callPackage ../applications/networking/mailreaders/notmuch {
     # No need to build Emacs - notmuch.el works just fine without

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13881,6 +13881,8 @@ in
 
   mopidy-musicbox-webclient = callPackage ../applications/audio/mopidy-musicbox-webclient { };
 
+  motif = callPackage ../development/libraries/motif { };
+
   mozplugger = callPackage ../applications/networking/browsers/mozilla-plugins/mozplugger {};
 
   mozjpeg = callPackage ../applications/graphics/mozjpeg { };


### PR DESCRIPTION
###### Motivation for this change

lessfit was abandoned circa 2012 when motif was released as lgpl. There's a big bright red banner in the site explaining this: http://lesstif.sourceforge.net/

Wanting to test the toolkit against an existing package, I tried using nedit. Unfortunately its tarball was missing so that had to be fixed first.

Finally, I've added the nwm module. It's untested, but at least it serves as a placeholder.

Incidentally, I've also tested xpdf to work but haven't PRed it for now since I can't test the motif package and xpdf on darwin.

p.s. I'm presenting the changes as individual commits instead of 2- 3separate PRs considering the obscurity of the packages in question.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
