### PR TITLE
Hash-slinger: init at  2.7.0

### DIFF
--- a/pkgs/tools/networking/unbound/python.nix
+++ b/pkgs/tools/networking/unbound/python.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchurl, openssl, expat, libevent, swig, python, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  pname = "pyunbound";
+  name = "${pname}-${version}";
+  version = "1.5.9";
+
+  src = fetchurl {
+    url = "http://unbound.net/downloads/unbound-${version}.tar.gz";
+    sha256 = "01328cfac99ab5b8c47115151896a244979e442e284eb962c0ea84b7782b6990";
+  };
+
+  buildInputs = [ openssl expat libevent swig python ];
+
+  patchPhase = ''substituteInPlace Makefile.in \
+    --replace "\$(DESTDIR)\$(PYTHON_SITE_PKG)" "$out/${python.sitePackages}" \
+    --replace "\$(LIBTOOL) --mode=install cp _unbound.la" "cp _unbound.la"
+    '';
+
+  preConfigure = "export PYTHON_VERSION=${python.majorVersion}";
+
+  configureFlags = [
+    "--with-ssl=${openssl.dev}"
+    "--with-libexpat=${expat.dev}"
+    "--with-libevent=${libevent.dev}"
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "--sbindir=\${out}/bin"
+    "--enable-pie"
+    "--enable-relro-now"
+    "--with-pyunbound"
+    "DESTDIR=$out PREFIX="
+  ];
+
+  preInstall = ''
+    mkdir -p $out/${python.sitePackages} $out/etc/${pname}
+    cp .libs/_unbound.so .libs/libunbound.so* $out/${python.sitePackages}
+    substituteInPlace _unbound.la \
+      --replace "-L.libs $PWD/libunbound.la" "-L$out/${python.sitePackages}" \
+      --replace "libdir=\'$PWD/${python.sitePackages}\'" "libdir=\'$out/${python.sitePackages}\'"
+    '';
+
+  installFlags = [ "configfile=\${out}/etc/unbound/unbound.conf pyunbound-install lib" ];
+
+  # All we want is the Unbound Python module
+  postInstall = ''
+    # Generate the built in root anchor and root key and store these in a logical place 
+    # to be used by tools depending only on the Python module
+    $out/bin/unbound-anchor -l | head -1 > $out/etc/${pname}/root.anchor
+    $out/bin/unbound-anchor -l | tail --lines=+2 - > $out/etc/${pname}/root.key
+    # We don't need anything else
+    rm -fR $out/bin $out/share $out/include $out/etc/unbound
+    patchelf --replace-needed libunbound.so.2 $out/${python.sitePackages}/libunbound.so.2 $out/${python.sitePackages}/_unbound.so 
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Python library for Unbound, the validating, recursive, and caching DNS resolver";
+    license = licenses.bsd3;
+    homepage = http://www.unbound.net;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/tools/security/hash-slinger/default.nix
+++ b/pkgs/tools/security/hash-slinger/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitHub, pythonPackages, openssh, gnupg, unbound, libreswan }:
+
+stdenv.mkDerivation rec {
+  pname    = "hash-slinger";
+  name    = "${pname}-${version}";
+  version = "2.7";
+
+  src = fetchFromGitHub {
+    owner = "letoams";
+    repo = "${pname}";
+    rev = "${version}";
+    sha256 = "05wn744ydclpnpyah6yfjqlfjlasrrhzj48lqmm5a91nyps5yqyn";
+  };
+
+  pythonPath = with pythonPackages; [ dns m2crypto ipaddr python-gnupg
+                                      pyunbound ];
+
+  buildInputs = [ pythonPackages.wrapPython ];
+  propagatedBuildInputs = [ unbound libreswan ] ++ pythonPath;
+  propagatedUserEnvPkgs = [ unbound libreswan ];
+
+  patchPhase = ''
+    substituteInPlace Makefile \
+      --replace "$(DESTDIR)/usr" "$out"
+    substituteInPlace ipseckey \
+      --replace "/usr/sbin/ipsec" "${libreswan}/sbin/ipsec"
+    substituteInPlace tlsa \
+      --replace "/var/lib/unbound/root" "${pythonPackages.pyunbound}/etc/pyunbound/root"
+    patchShebangs *
+    '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/man $out/${python.sitePackages}/
+    make install
+    wrapPythonPrograms
+   '';
+
+   meta = {
+    description = "Various tools to generate special DNS records";
+    homepage    = "https://github.com/letoams/hash-slinger";
+    license     = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [ stdenv.lib.maintainers.leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1947,6 +1947,8 @@ in
 
   hashcat = callPackage ../tools/security/hashcat { };
 
+  hash-slinger = callPackage ../tools/security/hash-slinger { };
+
   hal-flash = callPackage ../os-specific/linux/hal-flash { };
 
   halibut = callPackage ../tools/typesetting/halibut { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -327,6 +327,8 @@ in modules // {
     hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; };
   };
 
+  pyunbound = callPackage ../tools/networking/unbound/python.nix { };
+
   # packages defined here
 
   aafigure = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Hash-slinger is a very useful tool by Paul Wouters et al to create special DNS records. 
The Unbound Python module is a dependency which may be of use itself, but it was not yet available - unlike Unbound/libunbound itself.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
