### PR TITLE
[WIP] qt57: add darwin support + add new modules

### DIFF
--- a/maintainers/scripts/generate-qt.sh
+++ b/maintainers/scripts/generate-qt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 ./maintainers/scripts/fetch-kde-qt.sh \
-    http://download.qt.io/official_releases/qt/5.7/5.7.0/submodules/ \
+    https://download.qt.io/official_releases/qt/5.7/5.7.0/submodules/ \
     -A '*.tar.xz' \
     >pkgs/development/libraries/qt-5/5.7/srcs.nix

--- a/pkgs/development/libraries/qt-5/5.7/qtbase/xdg-config-dirs.patch
+++ b/pkgs/development/libraries/qt-5/5.7/qtbase/xdg-config-dirs.patch
@@ -1,12 +1,12 @@
-Index: qtbase-opensource-src-5.7.0/src/corelib/io/qsettings.cpp
-===================================================================
---- qtbase-opensource-src-5.7.0.orig/src/corelib/io/qsettings.cpp
-+++ qtbase-opensource-src-5.7.0/src/corelib/io/qsettings.cpp
-@@ -1161,6 +1161,23 @@ QConfFileSettingsPrivate::QConfFileSetti
+diff --git a/src/corelib/io/qsettings.cpp b/src/corelib/io/qsettings.cpp
+index 6e788d2..fabb95f 100644
+--- a/src/corelib/io/qsettings.cpp
++++ b/src/corelib/io/qsettings.cpp
+@@ -1161,6 +1161,23 @@ QConfFileSettingsPrivate::QConfFileSettingsPrivate(QSettings::Format format,
          confFiles[F_System | F_Application].reset(QConfFile::fromName(systemPath + appFile, false));
      confFiles[F_System | F_Organization].reset(QConfFile::fromName(systemPath + orgFile, false));
  
-+#if !defined(Q_OS_WIN)
++#if defined(Q_OS_LINUX)
 +    // Add directories specified in $XDG_CONFIG_DIRS
 +    const QString pathEnv = QString::fromLocal8Bit(getenv("XDG_CONFIG_DIRS"));
 +    if (!pathEnv.isEmpty()) {
@@ -26,16 +26,19 @@ Index: qtbase-opensource-src-5.7.0/src/corelib/io/qsettings.cpp
      for (i = 0; i < NumConfFiles; ++i) {
          if (confFiles[i]) {
              spec = i;
-Index: qtbase-opensource-src-5.7.0/src/corelib/io/qsettings_p.h
-===================================================================
---- qtbase-opensource-src-5.7.0.orig/src/corelib/io/qsettings_p.h
-+++ qtbase-opensource-src-5.7.0/src/corelib/io/qsettings_p.h
-@@ -246,7 +246,7 @@ public:
+diff --git a/src/corelib/io/qsettings_p.h b/src/corelib/io/qsettings_p.h
+index 9d7b667..b6e6433 100644
+--- a/src/corelib/io/qsettings_p.h
++++ b/src/corelib/io/qsettings_p.h
+@@ -246,7 +246,11 @@ public:
          F_Organization = 0x1,
          F_User = 0x0,
          F_System = 0x2,
--        NumConfFiles = 4
++#if defined(Q_OS_LINUX)
 +        NumConfFiles = 40 // HACK: increase NumConfFiles from 4 to 40 in order to accommodate more paths in $XDG_CONFIG_DIRS -- ellis
++#else
+         NumConfFiles = 4
++#endif
      };
  
      QSettings::Format format;

--- a/pkgs/development/libraries/qt-5/5.7/qtconnectivity.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtconnectivity.nix
@@ -1,6 +1,7 @@
-{ qtSubmodule, qtbase, qtdeclarative }:
+{ qtSubmodule, qtbase, qtdeclarative, bluez, stdenv, pkgconfig }:
 
 qtSubmodule {
   name = "qtconnectivity";
   qtInputs = [ qtbase qtdeclarative ];
+  buildInputs = with stdenv; lib.optional isLinux [ bluez pkgconfig ];
 }

--- a/pkgs/development/libraries/qt-5/5.7/qtmacextras.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtmacextras.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase }:
+
+qtSubmodule {
+  name = "qtmacextras";
+  qtInputs = [ qtbase ];
+}

--- a/pkgs/development/libraries/qt-5/5.7/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtmultimedia.nix
@@ -1,12 +1,15 @@
-{ qtSubmodule, qtbase, qtdeclarative, pkgconfig
-, alsaLib, gstreamer, gst-plugins-base, libpulseaudio
+{ qtSubmodule, qtbase, qtdeclarative, pkgconfig, stdenv,
+  alsaLib, gstreamer, gst-plugins-base, libpulseaudio, openal,
+  OpenAL, AVFoundation, CoreMedia, QuartzCore, AppKit, Quartz,
+  AudioUnit, AudioToolbox
 }:
 
 qtSubmodule {
   name = "qtmultimedia";
   qtInputs = [ qtbase qtdeclarative ];
-  buildInputs = [
-    pkgconfig alsaLib gstreamer gst-plugins-base libpulseaudio
-  ];
+  buildInputs = with stdenv; [ pkgconfig gstreamer gst-plugins-base ]
+  ++ lib.optional isLinux [ alsaLib libpulseaudio openal ]
+  ++ lib.optional isDarwin [ OpenAL AVFoundation CoreMedia QuartzCore AppKit Quartz
+    AudioUnit AudioToolbox ];
   qmakeFlags = [ "GST_VERSION=1.0" ];
 }

--- a/pkgs/development/libraries/qt-5/5.7/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtquickcontrols2.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtquickcontrols2";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.7/qtscxml.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtscxml.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtscxml";
+  qtInputs = [ qtbase qtdeclarative ];
+}

--- a/pkgs/development/libraries/qt-5/5.7/qtserialbus.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtserialbus.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtbase, qtserialport }:
+
+qtSubmodule {
+  name = "qtserialbus";
+  qtInputs = [ qtbase qtserialport ];
+}

--- a/pkgs/development/libraries/qt-5/5.7/qtserialport/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtserialport/default.nix
@@ -1,12 +1,12 @@
-{ qtSubmodule, qtbase, substituteAll, libudev }:
+{ qtSubmodule, qtbase, substituteAll, libudev, stdenv }:
 
 qtSubmodule {
   name = "qtserialport";
   qtInputs = [ qtbase ];
-  patches = [
+  patches = if stdenv.isLinux then [
     (substituteAll {
       src = ./0001-dlopen-serialport-udev.patch;
       libudev = libudev.out;
     })
-  ];
+  ] else [];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9160,7 +9160,11 @@ in
     in recurseIntoAttrs (imported.override (super: qt5LibsFun));
 
   qt57 =
-    let imported = import ../development/libraries/qt-5/5.7 { inherit pkgs; };
+    let imported = import ../development/libraries/qt-5/5.7 {
+        inherit pkgs;
+        inherit darwin;
+        inherit fixDarwinDylibNames;
+    };
     in recurseIntoAttrs (imported.override (super: qt5LibsFun));
 
   qt5 = self.qt56;


### PR DESCRIPTION
###### Main changes
- Add support for Mac OS X (currently only Qt4 version 4.8 is available for Darwin).
- Add new Qt modules: QtMacExtras, QtQuickControls2, QtSCXML, QtSerialBus.
- Other minor changes:
  - Modify _maintainers/scripts/generate-qt.sh_ to fetch tarballs using TLS.
  - Change _substituteInPlace_ instances for _grep_ (otherwise it fails building in Darwin).
  - Build QtMultimedia with _openal_ support.
  - Build QtImageFormats with _libmng_, _libwebp_ and _jasper_ support.
  - Build Qt using systems _double-conversion_ library.
  - Build QtConnectivity with bluez support (Linux).
  - Remove line that fixed bison to bison2. It was a workaround to a bug that was fixed with Qt 5.2.0 ([see this](https://bugreports.qt.io/browse/QTBUG-32913)).
###### TO-DO
- [ ] Fix issue causing regression in Nixos.
- [ ] Figure out why some _dylib_s aren't found by _ld_ (Darwin).
- [ ] Figure out why the Travis build failed for Xcode:
  
  `The invocation of "nix-build -A qt57.qtdoc -A qt57.libdbusmenu -A qt57.qca-qt5 -A qt57.full -A qt57.qtconnectivity -A qt57.qtquickcontrols2 -A qt57.qtmacextras -A qt57.poppler -A qt57.qtmultimedia -A qt57.qtscript -A qt57.qtgraphicaleffects -A qt57.libcommuni -A qt57.qtxmlpatterns -A qt57.qtsensors -A qt57.accounts-qt -A qt57.qtscxml -A qt57.qtsvg -A qt57.qtquickcontrols -A qt57.grantlee`
- [ ] ~~Add _qtstyleplugins_ as a library separate from Qt5.~~
- [ ] Check for [#17413](https://github.com/NixOS/nixpkgs/pull/17413). A rebase and a fix may be needed if it is merged before this one.
- [ ] Check for [#16561](https://github.com/NixOS/nixpkgs/pull/16561). It enables building the QtWebEngine module in Qt 5.6.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [X] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
