### PR TITLE
rspam module: reference to RuntimeDirectory is invalid

### DIFF
--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -45,10 +45,7 @@ in
 
     services.rspamd = {
 
-      enable = mkOption {
-        default = false;
-        description = "Whether to run the rspamd daemon.";
-      };
+      enable = mkEnableOption "Whether to run the rspamd daemon.";
 
       debug = mkOption {
         default = false;
@@ -97,7 +94,6 @@ in
         '';
        };
     };
-
   };
 
 
@@ -128,7 +124,6 @@ in
 
       serviceConfig = {
         ExecStart = "${pkgs.rspamd}/bin/rspamd ${optionalString cfg.debug "-d"} --user=${cfg.user} --group=${cfg.group} --pid=/run/rspamd.pid -c ${rspamdConfFile} -f";
-        RuntimeDirectory = "/var/lib/rspamd";
         PermissionsStartOnly = true;
         Restart = "always";
       };
@@ -137,9 +132,6 @@ in
         ${pkgs.coreutils}/bin/mkdir -p /var/{lib,log}/rspamd
         ${pkgs.coreutils}/bin/chown ${cfg.user}:${cfg.group} /var/lib/rspamd
       '';
-
     };
-
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

As mentioned in #17144, the `RuntimeDirectory` is invalid. Technically this is just being ignored by systemd and the `preStart` script takes care of creating the directory anyway (outside /run), so rspam runs normally. Tested in vm.

Fixes: #17144 
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
