### PR TITLE
tmux module: do not override keys by default in VI mode

### DIFF
--- a/nixos/modules/programs/tmux.nix
+++ b/nixos/modules/programs/tmux.nix
@@ -27,7 +27,7 @@ let
     set -g status-keys ${cfg.keyMode}
     set -g mode-keys   ${cfg.keyMode}
 
-    ${if cfg.keyMode == "vi" then ''
+    ${if cfg.keyMode == "vi" && cfg.customPaneNavigationAndResize then ''
     bind h select-pane -L
     bind j select-pane -D
     bind k select-pane -U
@@ -84,6 +84,13 @@ in {
         example = true;
         type = types.bool;
         description = "Use 24 hour clock.";
+      };
+
+      customPaneNavigationAndResize = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = "Override the hjkl and HJKL bindings for pane navigation and resizing in VI mode.";
       };
 
       escapeTime = mkOption {


### PR DESCRIPTION
###### Motivation for this change

We want to stick to upstream defaults as much as possible.

As pointed out by @8573 in #16999, this was not the case.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
