### PR TITLE
timewarrior: 0.9.5.alpha -> 1.0.0.beta1

### DIFF
--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "timewarrior-${version}";
-  version = "0.9.5.alpha";
+  version = "1.0.0.beta1";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
     url = "https://taskwarrior.org/download/timew-${version}.tar.gz";
-    sha256 = "154d5sgxcmz1b7g401c7s6sf7pkk0hh74dx6rss3vkamsjc4wgl8";
+    sha256 = "1gkh07mw8hiqslw8ps35r9lp5jbdy93s0sdrcbp34dd5h99qx587";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

timewarrior got into 1.0.0 beta 1 today.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
