### PR TITLE
catclock: init at 2015-10-04

### DIFF
--- a/pkgs/applications/misc/catclock/default.nix
+++ b/pkgs/applications/misc/catclock/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, xlibsWrapper, motif }:
+
+stdenv.mkDerivation rec {
+  name = "catclock-2015-10-04";
+
+  src = fetchFromGitHub {
+    owner = "BarkyTheDog";
+    repo = "catclock";
+    rev = "d20b8825b38477a144e8a2a4bbd4779adb3620ac";
+    sha256 = "0fiv9rj8p8mifv24cxljdrrmh357q70zmzdci9bpbxnhs1gdpr63";
+  };
+
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+    cp xclock.man $out/share/man/man1/xclock.1
+  '';
+
+  makeFlags = [
+    "DESTINATION=$(out)/bin/"
+  ];
+
+  buildInputs = [ xlibsWrapper motif ];
+
+  meta = with stdenv.lib; {
+    homepage = http://codefromabove.com/2014/05/catclock/;
+    license = with licenses; mit;
+    maintainers = with maintainers; [ ramkromberg ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -672,6 +672,8 @@ in
 
   catdoc = callPackage ../tools/text/catdoc { };
 
+  catclock = callPackage ../applications/misc/catclock { };
+
   cdemu-daemon = callPackage ../misc/emulators/cdemu/daemon.nix { };
 
   cdemu-client = callPackage ../misc/emulators/cdemu/client.nix { };


### PR DESCRIPTION
###### Motivation for this change

Mission critical.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
