### PR TITLE
Revert "nginx: Verify that configuration is syntactically correct"

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -5,7 +5,7 @@ with lib;
 let
   cfg = config.services.nginx;
   nginx = cfg.package;
-  configFileText = ''
+  configFile = pkgs.writeText "nginx.conf" ''
     user ${cfg.user} ${cfg.group};
     daemon off;
 
@@ -19,17 +19,6 @@ let
     ''}
     ${cfg.appendConfig}
   '';
-  configFile = pkgs.runCommand "nginx.conf" {
-    text = configFileText;
-    passAsFile = ["text"];
-    preferLocalBuild = true;
-    allowSubstitutes = false;
-  } ''
-    mkdir -p "$(dirname "$out")"
-    mv "$textPath" "$out"
-    (${nginx}/bin/nginx -t -c "$out" -p ${cfg.stateDir} || true) 2>&1 | grep -q 'syntax is ok'
-  '';
-
 in
 
 {
@@ -102,6 +91,8 @@ in
   };
 
   config = mkIf cfg.enable {
+    # TODO: test user supplied config file pases syntax test
+
     systemd.services.nginx = {
       description = "Nginx Web Server";
       after = [ "network.target" ];


### PR DESCRIPTION
###### Motivation for this change

This breaks on nixops deployments:

```
2016/07/28 11:49:46 [emerg] 13847#0: open() "/srv/www/nixos.mayflower.de/channels/.redirects.conf" failed (2: No such file or directory) in /nix/store/p5iz8y608jp78r00fbq03c42mxpbjigc-nginx.conf:1266
nginx: configuration file /nix/store/p5iz8y608jp78r00fbq03c42mxpbjigc-nginx.conf test failed
```

The path /srv/www/nixos.mayflower.de/ obviously does not exist on the machine I deploy from. I'd strongly prefer reverting this.

(Copied from comment in original PR https://github.com/NixOS/nixpkgs/pull/17208#issuecomment-235873567)
