### PR TITLE
nano: 2.6.1 -> 2.6.2

### DIFF
--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -12,10 +12,10 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "nano-${version}";
-  version = "2.6.1";
+  version = "2.6.2";
   src = fetchurl {
     url = "https://nano-editor.org/dist/v2.6/${name}.tar.gz";
-    sha256 = "56f2ba1c532647bee36abd5f87a714400af0be084cf857a65bc8f41a0dc28fe5";
+    sha256 = "11c9iqiah4q7q3ndn7z9192a796vp4fffkg27s6q1dn8avp06dj5";
   };
   nativeBuildInputs = [ texinfo ] ++ optional enableNls gettext;
   buildInputs = [ ncurses ];


### PR DESCRIPTION
###### Motivation for this change

Update nano to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
