### PR TITLE
texlive-new: fix wrong xdvi md5.run

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive-new/pkgs.nix
+++ b/pkgs/tools/typesetting/tex/texlive-new/pkgs.nix
@@ -22857,7 +22857,7 @@ tl: { # no indentation
   version = "prot2.5";
 };
 "xdvi" = {
-  md5.run = "ada6dc1ceffd19a5fdd33d0536c8f82a";
+  md5.run = "0d66ffa281d713e3395ee0f5db93c9bd";
   md5.doc = "eda28e06fbd79ed2bb26aff4d4d2fd22";
   hasRunfiles = true;
   version = "22.87";


### PR DESCRIPTION
###### Motivation for this change

Wrong md5 for `xdvi` package of `texlive-new`
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested locally with configuration:

``` nix
texlive.combine { inherit (texlive) scheme-full scheme-gust xdvi; }
```
