### PR TITLE
libgxps: fix building

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/core/libgxps/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/libgxps/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, cairo, libarchive, freetype, libjpeg, libtiff
-, openssl, bzip2, acl, attr
+, openssl, bzip2, acl, attr, libxml2
 }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1gi0b0x0354jyqc48vspk2hg2q1403cf2p9ibj847nzhkdrh9l9r";
   };
 
-  buildInputs = [ pkgconfig glib cairo freetype libjpeg libtiff acl openssl bzip2 attr];
+  buildInputs = [ pkgconfig glib cairo freetype libjpeg libtiff acl openssl bzip2 attr libxml2 ];
   propagatedBuildInputs = [ libarchive ];
 
   configureFlags = "--without-liblcms2";


### PR DESCRIPTION
###### Motivation for this change

Lack of `libxml2` library.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested locally binaries execution: xpstojpeg,  xpstopdf,  xpstopng,  xpstops,  xpstosvg. All of them correctly convert from xps format.
