### PR TITLE
clamav: 0.99.1 -> 0.99.2

### DIFF
--- a/pkgs/tools/security/clamav/default.nix
+++ b/pkgs/tools/security/clamav/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "clamav-${version}";
-  version = "0.99.1";
+  version = "0.99.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/clamav/clamav-${version}.tar.gz";
-    sha256 = "12nm4mxzx3qlbm65cadflzncjfkxdfqcp0lch29i5yfk4a8nhi71";
+    url = "https://www.clamav.net/downloads/production/${name}.tar.gz";
+    sha256 = "0yh2q318bnmf2152g2h1yvzgqbswn0wvbzb8p4kf7v057shxcyqn";
   };
 
   buildInputs = [ zlib bzip2 libxml2 openssl ncurses curl libiconv libmilter pcre ];


### PR DESCRIPTION
###### Motivation for this change

Update clamav to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
