### PR TITLE
[unison] use ocaml 4.02

### DIFF
--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation (rec {
   name = "unison-2.48.4";
   src = fetchurl {
     url = "http://www.seas.upenn.edu/~bcpierce/unison/download/releases/stable/${name}.tar.gz";
-    sha256 = "30aa53cd671d673580104f04be3cf81ac1e20a2e8baaf7274498739d59e99de8";
+    sha256 = "1s4xx5crswwq8hkzgalb5q5f5h8sz0ybw12g2203arqxcz6m7aih";
   };
 
   buildInputs = [ ocaml makeWrapper ncurses ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14879,6 +14879,7 @@ in
   unison = callPackage ../applications/networking/sync/unison {
     inherit (ocamlPackages) lablgtk;
     enableX11 = config.unison.enableX11 or true;
+    ocaml = config.unison.ocaml or pkgs.ocaml_4_02;
   };
 
   unpaper = callPackage ../tools/graphics/unpaper { };


### PR DESCRIPTION
###### Motivation for this change

I see referenced issues. Hopefully this is the last PR :sleepy: 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
