### PR TITLE
alliance: 5.0 -> 5.1.1

### DIFF
--- a/pkgs/applications/science/electronics/alliance/default.nix
+++ b/pkgs/applications/science/electronics/alliance/default.nix
@@ -1,23 +1,74 @@
-{stdenv, fetchurl, xproto, motif, libX11, libXt, libXpm, bison, flex}:
+{ stdenv, fetchurl
+, xproto, motif, libX11, libXt, libXpm, bison
+, flex, automake, autoconf, libtool
+}:
 
-stdenv.mkDerivation {
-  name = "alliance-5.0-20070718";
+stdenv.mkDerivation rec {
+  name = "alliance-${version}";
+  version = "5.1.1";
 
   src = fetchurl {
-    url = http://www-asim.lip6.fr/pub/alliance/distribution/5.0/alliance-5.0-20070718.tar.gz;
-    sha256 = "4e17c8f9f4d344061166856d47e58527c6ae870fda0c73b5ba0200967d23af9f";
+    url = "http://www-asim.lip6.fr/pub/alliance/distribution/5.0/${name}.tar.bz2";
+    sha256 = "046c9qwl1vbww0ljm4xyxf5jpz9nq62b2q0wdz9xjimgh4c207w1";
   };
 
-  buildInputs = [ xproto motif xproto libX11 libXt libXpm bison flex];
 
-  patchPhase = ''
-    sed -i -e \
-      "s/private: static void  operator delete/public: static void  operator delete/" \
-      nero/src/ADefs.h
+  nativeBuildInputs = [ libtool automake autoconf flex ];
+  buildInputs = [ xproto motif xproto libX11 libXt libXpm bison ];
+
+  sourceRoot = "alliance/src/";
+
+  configureFlags = [
+    "--prefix=$(out)"
+    "--disable-static"
+  ];
+
+  preConfigure = ''
+    mkdir -p $out/etc
+
+    #texlive for docs seems extreme
+    mkdir -p $out/share/alliance
+    mv ./documentation $out/share/alliance
+    substituteInPlace autostuff \
+      --replace "$newdirs documentation" "$newdirs" \
+      --replace documentation Solaris
+
+    substituteInPlace sea/src/DEF_grammar_lex.l \
+      --replace "ifndef FLEX_BETA" "if (YY_FLEX_MAJOR_VERSION <= 2) && (YY_FLEX_MINOR_VERSION < 6)"
+    ./autostuff
   '';
 
-  meta = {
-      description = "Complete set of free CAD tools and portable libraries for VLSI design";
-      homepage = http://www-asim.lip6.fr/recherche/alliance/;
+  allianceInstaller = ''
+    #!${stdenv.shell}
+    cp -v -r -n --no-preserve=mode  $out/etc/* /etc/ > /etc/alliance-install.log
+  '';
+
+  allianceUnInstaller = ''
+    #!${stdenv.shell}
+    awk '{print \$3}' /etc/alliance-install.log | xargs rm
+    awk '{print \$3}' /etc/alliance-install.log | xargs rmdir
+    rm /etc/alliance-install.log
+  '';
+
+  postInstall = ''
+    sed -i "s|ALLIANCE_TOP|$out|" distrib/*.desktop
+    mkdir -p $out/share/applications
+    cp -p distrib/*.desktop $out/share/applications/
+    mkdir -p $out/icons/hicolor/48x48/apps/
+    cp -p distrib/*.png $out/icons/hicolor/48x48/apps/
+
+    echo "${allianceInstaller}" > $out/bin/alliance-install
+    chmod +x $out/bin/alliance-install
+
+    echo "${allianceUnInstaller}" > $out/bin/alliance-uninstall
+    chmod +x $out/bin/alliance-uninstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Complete set of free CAD tools and portable libraries for VLSI design";
+    homepage = http://www-asim.lip6.fr/recherche/alliance/;
+    license = with licenses; gpl2Plus;
+    maintainers = with maintainers; [ ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16407,9 +16407,7 @@ in
 
   ### SCIENCE/BIOLOGY
 
-  alliance = callPackage ../applications/science/electronics/alliance {
-    motif = lesstif;
-  };
+  alliance = callPackage ../applications/science/electronics/alliance { };
 
   archimedes = callPackage ../applications/science/electronics/archimedes {
     stdenv = overrideCC stdenv gcc49;


### PR DESCRIPTION
###### Motivation for this change

@fpletz noticed it was broken in https://github.com/NixOS/nixpkgs/pull/17322 so I figured I'd fix it.

Note it's pretty much a complete package rewrite with over 7 years in-between tarballs.

The binaries require about a dozen /etc/ files I didn't feel like writing a module for. So, there's now two scripts: _alliance-install_ and _alliance-uninstall_ to handle their deployment (root required).

The documentations are copied as is into $out/share/alliance instead of being compiled with latex.

xgra (graph viewer) doesn't seem to work. Lessfit complained about deprecated X functions while motif failed silently. The other binaries execute fine.

Finally, I switched from lesstif to motif.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
