### PR TITLE
pash: 2015-11-06 -> 2016-07-06

### DIFF
--- a/pkgs/shells/pash/default.nix
+++ b/pkgs/shells/pash/default.nix
@@ -2,13 +2,13 @@
 
 buildDotnetPackage rec {
   baseName = "pash";
-  version = "git-2015-11-06";
+  version = "git-2016-07-06";
   
   src = fetchFromGitHub {
     owner = "Pash-Project";
     repo = "Pash";
-    rev = "50695a28eaf6c8cbfdc8ecddd91923c64e07b618";
-    sha256 = "17hs1f6ayk9qyyh1xsydk46n6na7flh2kbd36dynk86bnda5d3bn";
+    rev = "8d6a48f5ed70d64f9b49e6849b3ee35b887dc254";
+    sha256 = "0c4wa8qi1zs01p9ck171jkw0n1rsymsrhpsb42gl7warwhpmv59f";
   };
 
   preConfigure = "rm -rvf $src/Source/PashConsole/bin/*";
@@ -18,7 +18,7 @@ buildDotnetPackage rec {
   meta = with stdenv.lib; {
     description = "An open source implementation of Windows PowerShell";
     homepage = https://github.com/Pash-Project/Pash;
-    maintainers = [ maintainers.fornever ];
+    maintainers = [ maintainers.fornever maintainers.vrthra ];
     platforms = platforms.all;
     license = with licenses; [ bsd3 gpl3 ];
   };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
