### PR TITLE
lib: add fileContents function

### DIFF
--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -44,12 +44,12 @@ rec {
             packedRefsName = toString path + "/packed-refs";
         in if lib.pathExists fileName
            then
-             let fileContent = readFile fileName;
+             let fileContent = lib.fileContents fileName;
                  # Sometimes git stores the commitId directly in the file but
                  # sometimes it stores something like: «ref: refs/heads/branch-name»
-                 matchRef    = match "^ref: (.*)\n$" fileContent;
+                 matchRef    = match "^ref: (.*)$" fileContent;
              in if   isNull matchRef
-                then lib.removeSuffix "\n" fileContent
+                then fileContent
                 else readCommitFromFile path (lib.head matchRef)
            # Sometimes, the file isn't there at all and has been packed away in the
            # packed-refs file, so we have to grep through it:

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -479,4 +479,14 @@ rec {
       absolutePaths = builtins.map (path: builtins.toPath (root + "/" + path)) relativePaths;
     in
       absolutePaths;
+
+  /* Read the contents of a file removing the trailing \n
+
+     Example:
+       $ echo "1.0" > ./version
+
+       fileContents ./version
+       => "1.0"
+  */
+  fileContents = file: removeSuffix "\n" (builtins.readFile file);
 }

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -62,11 +62,13 @@ rec {
     isInt add sub lessThan
     seq deepSeq genericClosure;
 
+  inherit (import ./strings.nix) fileContents;
+
   # Return the Nixpkgs version number.
   nixpkgsVersion =
     let suffixFile = ../.version-suffix; in
-    readFile ../.version
-    + (if pathExists suffixFile then readFile suffixFile else "pre-git");
+    fileContents ../.version
+    + (if pathExists suffixFile then fileContents suffixFile else "pre-git");
 
   # Whether we're being called by nix-shell.
   inNixShell = builtins.getEnv "IN_NIX_SHELL" == "1";

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -49,21 +49,21 @@ in
     nixosRelease = mkOption {
       readOnly = true;
       type = types.str;
-      default = readFile releaseFile;
+      default = fileContents releaseFile;
       description = "The NixOS release (e.g. <literal>16.03</literal>).";
     };
 
     nixosVersionSuffix = mkOption {
       internal = true;
       type = types.str;
-      default = if pathExists suffixFile then readFile suffixFile else "pre-git";
+      default = if pathExists suffixFile then fileContents suffixFile else "pre-git";
       description = "The NixOS version suffix (e.g. <literal>1160.f2d4ee1</literal>).";
     };
 
     nixosRevision = mkOption {
       internal = true;
       type = types.str;
-      default = if pathExists revisionFile then readFile revisionFile else "master";
+      default = if pathExists revisionFile then fileContents revisionFile else "master";
       description = "The Git revision from which this NixOS configuration was built.";
     };
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -7,7 +7,7 @@ with import ../lib;
 
 let
 
-  version = builtins.readFile ../.version;
+  version = fileContents ../.version;
   versionSuffix =
     (if stableBranch then "." else "pre") + "${toString nixpkgs.revCount}.${nixpkgs.shortRev}";
 

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -15,7 +15,7 @@ releaseTools.sourceTarball rec {
   src = nixpkgs;
 
   inherit officialRelease;
-  version = builtins.readFile ../../.version;
+  version = pkgs.lib.fileContents ../../.version;
   versionSuffix = "pre${toString nixpkgs.revCount}.${nixpkgs.shortRev}";
 
   buildInputs = [ nix.out jq ];


### PR DESCRIPTION
###### Motivation for this change

The pattern `removeSuffix "\n" (builtins.readFile file)` is very common to read version numbers or passwords from a single line file.

Having the functionality in lib would save some typing and [search](https://www.mail-archive.com/nix-dev@lists.science.uu.nl/msg20298.html).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
