### PR TITLE
wireguard: 20160708 -> unstable-2016-07-22

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchgit, libmnl, kernel ? null }:
 
 let
-  name = "wireguard-${version}";
+  name = "wireguard-unstable-${version}";
 
-  version = "20160708";
+  version = "2016-07-22";
 
   src = fetchgit {
     url    = "https://git.zx2c4.com/WireGuard";
-    rev    = "dcc2583fe0618931e51aedaeeddde356d123acb2";
-    sha256 = "1ciyjpp8c3fv95y1cypk9qyqynp8cqyh2676afq2hd33110d37ni";
+    rev    = "8e8bf6f848c324603827c0e57f0856d5866ac32d";
+    sha256 = "11qrf9fxm6mkwjnjq7dgbisdric5w22cyfkqc6zx9fla2dz99mxk";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

package name fix and version update.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
