### PR TITLE
ndjbdns: build from latest sources which adds Darwin compatibility

### DIFF
--- a/pkgs/tools/networking/ndjbdns/default.nix
+++ b/pkgs/tools/networking/ndjbdns/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, fetchurl, systemd, pkgconfig }:
+{ stdenv, fetchFromGitHub, autoreconfHook, systemd, pkgconfig }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   version = "1.06";
   name = "ndjbdns-${version}";
 
-  src = fetchurl {
-    url = "http://pjp.dgplug.org/ndjbdns/${name}.tar.gz";
-    sha256 = "09qi5a9abqm08iqmxj74fzzq9x1w5lzr1jlbzj2hl8hz0g2sgraw";
+  src = fetchFromGitHub {
+    owner = "pjps";
+    repo = "ndjbdns";
+    rev = "64d371b6f887621de7bf8bd495be10442b2accd0";
+    sha256 = "0gjyvn8r66kp49gasd6sqfvg2pj0c6v67hnq7cqwl04kj69rfy86";
   };
 
-  buildInputs = [ pkgconfig systemd ];
+  buildInputs = [ autoreconfHook pkgconfig ]
+    ++ optional stdenv.isLinux systemd;
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "A brand new release of the Djbdns";
     longDescription = ''
       Djbdns is a fully‐fledged Domain Name System(DNS), originally written by the eminent author of qmail, Dr. D J Bernstein.
@@ -19,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = http://pjp.dgplug.org/ndjbdns/;
     license = licenses.gpl2;
     maintainers = [ maintainers.msackman ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Build on Darwin platform.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [X] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
