### PR TITLE
Merge container configurations correctly.

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -106,6 +106,20 @@ in
                 A specification of the desired configuration of this
                 container, as a NixOS module.
               '';
+              type = lib.mkOptionType {
+                name = "Toplevel NixOS config";
+                merge = loc: defs: (import ../../lib/eval-config.nix {
+                  inherit system;
+                  modules =
+                    let extraConfig =
+                      { boot.isContainer = true;
+                        networking.hostName = mkDefault name;
+                        networking.useDHCP = false;
+                      };
+                    in [ extraConfig ] ++ (map (x: x.value) defs);
+                  prefix = [ "containers" name ];
+                }).config;
+              };
             };
 
             path = mkOption {
@@ -217,18 +231,9 @@ in
           };
 
           config = mkMerge
-            [ (mkIf options.config.isDefined {
-                path = (import ../../lib/eval-config.nix {
-                  inherit system;
-                  modules =
-                    let extraConfig =
-                      { boot.isContainer = true;
-                        networking.hostName = mkDefault name;
-                        networking.useDHCP = false;
-                      };
-                    in [ extraConfig config.config ];
-                  prefix = [ "containers" name ];
-                }).config.system.build.toplevel;
+            [
+              (mkIf options.config.isDefined {
+                path = config.config.system.build.toplevel;
               })
             ];
         }));


### PR DESCRIPTION
An issue arises with container configuration when one defines multiples times the same sub-option, or tries to merge two configuration sets.

For example, only the second extraHost is taken into account in the following setup:

``` nix
{ lib, ... }:
{
    containers.test-1.config = let
        cfg1 = {
            networking.extraHosts = ''
                10.10.10.10 bla1
            '';
        };
        cfg2 = {
            networking.extraHosts = ''
                11.11.11.11 bla2
            '';
        };
    in lib.mkMerge [
        cfg1
        cfg2
    ];
}
```

```
$ export NIXOS_CONFIG=/above/file.nix
$ nix-instantiate "<nixpkgs/nixos>" -A config.containers.test-1.config.networking.extraHosts --eval
"11.11.11.11 bla2\n"
$ # whoops ;-)
```

This arises because `config.containers.<name>.config` has no type, and the merge defaults to a dumb `//` of the two attributes sets.

This pull request moves eval-config.nix earlier in the evaluation process.
This way, eval-config.nix is used to merge configuration settings according to their expected (top-level) definition.

I would love input from @shlevy and @nbp as it seems related to comments they made in the module architecture.

@danbst, This is both an explanation of why your config did not work and a potential fix for your issue described in http://lists.science.uu.nl/pipermail/nix-dev/2016-July/thread.html#20989
