### PR TITLE
haskellPackages.cereal: fix for pre-GHC8

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -946,9 +946,4 @@ self: super: {
     url = "https://github.com/commercialhaskell/stack/commit/7f7f1a5f67f4ecdd1f3009495f1ff101dd38047e.patch";
     sha256 = "1yh2g45mkfpwxq0vyzcbc4nbxh6wmb2xpp0k7r5byd8jicgvli29";
   });
-
-  # Glob depends conditionally on semigroups for GHC < 8
-  Glob = if pkgs.lib.versionAtLeast self.ghc.version "8.0"
-    then super.Glob
-    else addBuildDepend super.Glob self.semigroups;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -181,8 +181,6 @@ self: super: {
   # lens-family-th >= 0.5.0.0 is GHC 8.0 only
   lens-family-th = self.lens-family-th_0_4_1_0;
 
-  # cereal must have `fail` in pre-ghc-8.0.x versions
-  cereal = addBuildDepend super.cereal self.fail;
 
   # The tests in vty-ui do not build, but vty-ui itself builds.
   vty-ui = enableCabalFlag super.vty-ui "no-tests";
@@ -210,6 +208,10 @@ self: super: {
   intervals = addBuildDepends super.intervals (with self; [doctest QuickCheck]);
   Glob_0_7_9 = addBuildDepends super.Glob_0_7_9 (with self; [semigroups]);
   Glob = addBuildDepends super.Glob (with self; [semigroups]);
+  # cereal must have `fail` in pre-ghc-8.0.x versions
+  # also tests require bytestring>=0.10.8.1
+  cereal = dontCheck (addBuildDepend super.cereal self.fail);
+  cereal_0_5_2_0 = dontCheck (addBuildDepend super.cereal_0_5_2_0 self.fail);
 
   # Moved out from common as no longer the case for GHC8
   ghc-mod = super.ghc-mod.override { cabal-helper = self.cabal-helper_0_6_3_1; };


### PR DESCRIPTION
See commit message.
Should fix git-annex.

Next step would be to move all packages that deal with this kind of issue from 7.10 overrides to common.
Next step would be to make cabal2nix recognize conditionals.

cc @peti 
