### PR TITLE
emby: 3.0.6000 -> 3.0.6020

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.0.6000";
+  version = "3.0.6020";
 
   src = fetchurl {
     url = "https://github.com/MediaBrowser/Emby/archive/${version}.tar.gz";
-    sha256 = "1q1l6gl8k3rxklmw52vcpp4r6iwyhydv61zjbz5v66zpvi64w8is";
+    sha256 = "1hpzprhvwwrxjx3qijwvcnjprvx9g58idqnms7d9qql53a20scaq";
   };
 
   propagatedBuildInputs = with pkgs; [


### PR DESCRIPTION
###### Motivation for this change

New upstream release available: https://github.com/MediaBrowser/Emby/releases/tag/3.0.6020
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
