### PR TITLE
monero: 0.8.8.4 -> 0.9.4, fixes build

### DIFF
--- a/pkgs/applications/misc/monero/default.nix
+++ b/pkgs/applications/misc/monero/default.nix
@@ -1,17 +1,21 @@
-{ stdenv, fetchurl, cmake, boost }:
+{ stdenv, fetchFromGitHub, cmake, boost, miniupnpc, pkgconfig, unbound }:
 
 let
-  version = "0.8.8.4";
+  version = "0.9.4";
 in
 stdenv.mkDerivation {
   name = "monero-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/monero-project/bitmonero/archive/v${version}.tar.gz";
-    sha256 = "0bbhqjjzh922aymjqrnl2hd3r8x6p7x5aa5jidv3l4d77drhlgzy";
+  src = fetchFromGitHub {
+    owner = "monero-project";
+    repo = "bitmonero";
+    rev = "v${version}";
+    sha256 = "1qzpy1mxz0ky6hfk1gf67ybbr9xy6p6irh6zwri35h1gb97sbc3c";
   };
 
-  buildInputs = [ cmake boost ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ boost miniupnpc unbound ];
 
   # these tests take a long time and don't
   # always complete in the build environment
@@ -20,14 +24,17 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = "-Wno-error=cpp";
 
   doCheck = false;
-  checkTarget = "test-release"; # this would be the target
 
   installPhase = ''
     install -Dt "$out/bin/" \
-        src/bitmonerod \
-        src/connectivity_tool \
-        src/simpleminer \
-        src/simplewallet
+        bin/bitmonerod \
+        bin/blockchain_converter \
+        bin/blockchain_dump \
+        bin/blockchain_export \
+        bin/blockchain_import \
+        bin/cn_deserialize \
+        bin/simpleminer \
+        bin/simplewallet
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
