### PR TITLE
meld: 3.16.1 -> 3.16.2

### DIFF
--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, itstool, buildPythonApplication, python27, intltool, makeWrapper
-, libxml2, pygobject3, gobjectIntrospection, gtk3, gnome3, pycairo, cairo
+{ stdenv, fetchurl, itstool, buildPythonApplication, python27, intltool, wrapGAppsHook
+, libxml2, pygobject3, gobjectIntrospection, gtk3, gnome3, pycairo, cairo, file
 }:
 
 
 let
   minor = "3.16";
-  version = "${minor}.1";
+  version = "${minor}.2";
 in
 
 buildPythonApplication rec {
@@ -14,13 +14,13 @@ buildPythonApplication rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/meld/${minor}/meld-${version}.tar.xz";
-    sha256 = "1bec697aa1ababa315ca8241ade65dc68ea87f0d316632f590975afcf967cfab";
+    sha256 = "2dd3f58b95444bf721e0c912668c29cf8f47a402440b772ea12c4b9a0c94966f";
   };
 
   buildInputs = [
-    python27 intltool makeWrapper itstool libxml2
+    python27 intltool wrapGAppsHook itstool libxml2
     gnome3.gtksourceview gnome3.gsettings_desktop_schemas pycairo cairo
-    gnome3.defaultIconTheme
+    gnome3.defaultIconTheme gnome3.dconf file
   ];
   propagatedBuildInputs = [ gobjectIntrospection pygobject3 gtk3 ];
 
@@ -35,13 +35,6 @@ buildPythonApplication rec {
 
     mkdir -p $out/share/gsettings-schemas/$name
     mv $out/share/glib-2.0 $out/share/gsettings-schemas/$name/
-  '';
-
-  preFixup = ''
-    wrapProgram $out/bin/meld \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:$out/share" \
-      --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
   '';
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update meld to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
