### PR TITLE
faust: remove double quotes around NIX_CFLAGS_COMPILE and NIX_LDFLAGS

### DIFF
--- a/pkgs/applications/audio/faust/faust1.nix
+++ b/pkgs/applications/audio/faust/faust1.nix
@@ -170,8 +170,8 @@ let
             --set FAUST_LIB_PATH "${faust}/lib/faust" \
             --prefix PATH : "$PATH" \
             --prefix PKG_CONFIG_PATH : "$PKG_CONFIG_PATH" \
-            --set NIX_CFLAGS_COMPILE "\"$NIX_CFLAGS_COMPILE\"" \
-            --set NIX_LDFLAGS "\"$NIX_LDFLAGS\""
+            --set NIX_CFLAGS_COMPILE "$NIX_CFLAGS_COMPILE" \
+            --set NIX_LDFLAGS "$NIX_LDFLAGS"
         done
       '';
     });

--- a/pkgs/applications/audio/faust/faust1git.nix
+++ b/pkgs/applications/audio/faust/faust1git.nix
@@ -175,8 +175,8 @@ let
             --set FAUSTINC "${faust}/include/faust" \
             --prefix PATH : "$PATH" \
             --prefix PKG_CONFIG_PATH : "$PKG_CONFIG_PATH" \
-            --set NIX_CFLAGS_COMPILE "\"$NIX_CFLAGS_COMPILE\"" \
-            --set NIX_LDFLAGS "\"$NIX_LDFLAGS\""
+            --set NIX_CFLAGS_COMPILE "$NIX_CFLAGS_COMPILE" \
+            --set NIX_LDFLAGS "$NIX_LDFLAGS"
         done
       '';
     });

--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -196,8 +196,8 @@ let
             --set FAUST_LIB_PATH "${faust}/lib/faust" \
             --prefix PATH : "$PATH" \
             --prefix PKG_CONFIG_PATH : "$PKG_CONFIG_PATH" \
-            --set NIX_CFLAGS_COMPILE "\"$NIX_CFLAGS_COMPILE\"" \
-            --set NIX_LDFLAGS "\"$NIX_LDFLAGS\""
+            --set NIX_CFLAGS_COMPILE "$NIX_CFLAGS_COMPILE" \
+            --set NIX_LDFLAGS "$NIX_LDFLAGS"
         done
       '';
     });


### PR DESCRIPTION
###### Motivation for this change

Fixes [this build error](https://travis-ci.org/NixOS/nixpkgs/jobs/147556297#L2705)
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
