### PR TITLE
kde5: fix extra-cmake-modules hooks

### DIFF
--- a/pkgs/desktops/kde-5/applications/default.nix
+++ b/pkgs/desktops/kde-5/applications/default.nix
@@ -21,9 +21,9 @@ let
   packages = self: with self; {
 
     kdeApp = import ./kde-app.nix {
-      inherit kdeDerivation lib;
+      inherit lib;
       inherit debug srcs;
-      inherit (pkgs) cmake pkgconfig;
+      inherit kdeDerivation;
     };
 
     kdelibs = callPackage ./kdelibs {

--- a/pkgs/desktops/kde-5/applications/kde-app.nix
+++ b/pkgs/desktops/kde-5/applications/kde-app.nix
@@ -1,4 +1,4 @@
-{ kdeDerivation, lib, debug, srcs, cmake, pkgconfig }:
+{ kdeDerivation, lib, debug, srcs }:
 
 args:
 
@@ -15,10 +15,6 @@ kdeDerivation (args // {
     (args.cmakeFlags or [])
     ++ [ "-DBUILD_TESTING=OFF" ]
     ++ lib.optional debug "-DCMAKE_BUILD_TYPE=Debug";
-
-  nativeBuildInputs =
-    (args.nativeBuildInputs or [])
-    ++ [ cmake pkgconfig ];
 
   meta = {
     platforms = lib.platforms.linux;

--- a/pkgs/desktops/kde-5/applications/okular.nix
+++ b/pkgs/desktops/kde-5/applications/okular.nix
@@ -1,11 +1,11 @@
 {
-  stdenv, lib,
+  kdeApp, lib,
   automoc4, cmake, perl, pkgconfig, kdelibs, qimageblitz,
   poppler_qt4, libspectre, libkexiv2, djvulibre, libtiff, freetype,
   ebook_tools
 }:
 
-stdenv.mkDerivation {
+kdeApp {
   name = "okular";
   nativeBuildInputs = [ automoc4 cmake perl pkgconfig ];
   buildInputs = [

--- a/pkgs/desktops/kde-5/plasma/bluedevil.nix
+++ b/pkgs/desktops/kde-5/plasma/bluedevil.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, bluez-qt, kcoreaddons
+{ plasmaPackage, ecm, bluez-qt, kcoreaddons
 , kdbusaddons, kded, ki18n, kiconthemes, kio, knotifications
 , kwidgetsaddons, kwindowsystem, makeQtWrapper, plasma-framework
 , qtdeclarative, shared_mime_info
@@ -7,7 +7,7 @@
 plasmaPackage {
   name = "bluedevil";
   nativeBuildInputs = [
-    extra-cmake-modules makeQtWrapper shared_mime_info
+    ecm makeQtWrapper shared_mime_info
   ];
   propagatedBuildInputs = [
     bluez-qt ki18n kio kwindowsystem plasma-framework qtdeclarative kcoreaddons

--- a/pkgs/desktops/kde-5/plasma/breeze-gtk.nix
+++ b/pkgs/desktops/kde-5/plasma/breeze-gtk.nix
@@ -1,8 +1,8 @@
 { plasmaPackage
-, extra-cmake-modules
+, ecm
 }:
 
 plasmaPackage {
   name = "breeze-gtk";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/desktops/kde-5/plasma/breeze-qt5.nix
+++ b/pkgs/desktops/kde-5/plasma/breeze-qt5.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, frameworkintegration
+{ plasmaPackage, ecm, frameworkintegration
 , kcmutils, kconfigwidgets, kcoreaddons, kdecoration, kguiaddons
 , ki18n, kwindowsystem, makeQtWrapper, plasma-framework, qtx11extras
 }:
@@ -7,7 +7,7 @@ plasmaPackage {
   name = "breeze-qt5";
   sname = "breeze";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     makeQtWrapper
   ];
   propagatedBuildInputs = [

--- a/pkgs/desktops/kde-5/plasma/kactivitymanagerd.nix
+++ b/pkgs/desktops/kde-5/plasma/kactivitymanagerd.nix
@@ -1,12 +1,12 @@
 { plasmaPackage
-, extra-cmake-modules
+, ecm
 , boost, kconfig, kcoreaddons, kdbusaddons, ki18n, kio, kglobalaccel
 , kwindowsystem, kxmlgui
 }:
 
 plasmaPackage {
   name = "kactivitymanagerd";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     boost kconfig kcoreaddons kdbusaddons kglobalaccel ki18n kio kwindowsystem
     kxmlgui

--- a/pkgs/desktops/kde-5/plasma/kde-cli-tools.nix
+++ b/pkgs/desktops/kde-5/plasma/kde-cli-tools.nix
@@ -1,11 +1,11 @@
-{ plasmaPackage, extra-cmake-modules, kcmutils, kconfig
+{ plasmaPackage, ecm, kcmutils, kconfig
 , kdelibs4support, kdesu, kdoctools, ki18n, kiconthemes
 , kwindowsystem, makeQtWrapper, qtsvg, qtx11extras
 }:
 
 plasmaPackage {
   name = "kde-cli-tools";
-  nativeBuildInputs = [ extra-cmake-modules kdoctools makeQtWrapper ];
+  nativeBuildInputs = [ ecm kdoctools makeQtWrapper ];
   propagatedBuildInputs = [
     kdelibs4support ki18n kwindowsystem qtsvg qtx11extras kcmutils kconfig kdesu
     kiconthemes

--- a/pkgs/desktops/kde-5/plasma/kde-gtk-config/default.nix
+++ b/pkgs/desktops/kde-5/plasma/kde-gtk-config/default.nix
@@ -1,5 +1,5 @@
 { plasmaPackage
-, extra-cmake-modules
+, ecm
 , glib
 , gtk2
 , gtk3
@@ -15,7 +15,7 @@
 plasmaPackage {
   name = "kde-gtk-config";
   patches = [ ./0001-follow-symlinks.patch ];
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     ki18n kio glib gtk2 gtk3 karchive kcmutils kconfigwidgets kiconthemes
     knewstuff

--- a/pkgs/desktops/kde-5/plasma/kdecoration.nix
+++ b/pkgs/desktops/kde-5/plasma/kdecoration.nix
@@ -1,6 +1,6 @@
-{ plasmaPackage, extra-cmake-modules }:
+{ plasmaPackage, ecm }:
 
 plasmaPackage {
   name = "kdecoration";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/desktops/kde-5/plasma/kdeplasma-addons.nix
+++ b/pkgs/desktops/kde-5/plasma/kdeplasma-addons.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, kdoctools
+{ plasmaPackage, ecm, kdoctools
 , kconfig, kconfigwidgets, kcoreaddons, kcmutils, kdelibs4support, ki18n
 , kio, knewstuff, kross, krunner, kservice, ksysguard, kunitconversion
 , plasma-framework, plasma-workspace, qtdeclarative, qtx11extras
@@ -8,7 +8,7 @@
 plasmaPackage {
   name = "kdeplasma-addons";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
   ];
   propagatedBuildInputs = [

--- a/pkgs/desktops/kde-5/plasma/kgamma5.nix
+++ b/pkgs/desktops/kde-5/plasma/kgamma5.nix
@@ -1,9 +1,9 @@
-{ plasmaPackage, extra-cmake-modules, kdoctools, kdelibs4support
+{ plasmaPackage, ecm, kdoctools, kdelibs4support
 , qtx11extras
 }:
 
 plasmaPackage {
   name = "kgamma5";
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [ kdelibs4support qtx11extras ];
 }

--- a/pkgs/desktops/kde-5/plasma/khotkeys.nix
+++ b/pkgs/desktops/kde-5/plasma/khotkeys.nix
@@ -1,11 +1,11 @@
-{ plasmaPackage, extra-cmake-modules, kdoctools, kcmutils
+{ plasmaPackage, ecm, kdoctools, kcmutils
 , kdbusaddons, kdelibs4support, kglobalaccel, ki18n, kio, kxmlgui
 , plasma-framework, plasma-workspace, qtx11extras
 }:
 
 plasmaPackage {
   name = "khotkeys";
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kdelibs4support kglobalaccel ki18n kio plasma-framework plasma-workspace
     qtx11extras kcmutils kdbusaddons kxmlgui

--- a/pkgs/desktops/kde-5/plasma/kinfocenter.nix
+++ b/pkgs/desktops/kde-5/plasma/kinfocenter.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, kdoctools, kcmutils
+{ plasmaPackage, ecm, kdoctools, kcmutils
 , kcompletion, kconfig, kconfigwidgets, kcoreaddons, kdbusaddons
 , kdeclarative, kdelibs4support, ki18n, kiconthemes, kio, kpackage
 , kservice, kwidgetsaddons, kxmlgui, libraw1394, makeQtWrapper
@@ -8,7 +8,7 @@
 plasmaPackage {
   name = "kinfocenter";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
     makeQtWrapper
   ];

--- a/pkgs/desktops/kde-5/plasma/kmenuedit.nix
+++ b/pkgs/desktops/kde-5/plasma/kmenuedit.nix
@@ -1,11 +1,11 @@
-{ plasmaPackage, extra-cmake-modules, kdoctools, ki18n, kxmlgui
+{ plasmaPackage, ecm, kdoctools, ki18n, kxmlgui
 , kdbusaddons, kiconthemes, kio, sonnet, kdelibs4support, makeQtWrapper
 }:
 
 plasmaPackage {
   name = "kmenuedit";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
     makeQtWrapper
   ];

--- a/pkgs/desktops/kde-5/plasma/kscreen.nix
+++ b/pkgs/desktops/kde-5/plasma/kscreen.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, kconfig, kconfigwidgets
+{ plasmaPackage, ecm, kconfig, kconfigwidgets
 , kdbusaddons, kglobalaccel, ki18n, kwidgetsaddons, kxmlgui
 , libkscreen, makeQtWrapper, qtdeclarative, qtgraphicaleffects
 }:
@@ -6,7 +6,7 @@
 plasmaPackage {
   name = "kscreen";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     makeQtWrapper
   ];
   propagatedBuildInputs = [

--- a/pkgs/desktops/kde-5/plasma/kscreenlocker.nix
+++ b/pkgs/desktops/kde-5/plasma/kscreenlocker.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, kcmutils, kcrash, kdeclarative
+{ plasmaPackage, ecm, kcmutils, kcrash, kdeclarative
 , kdelibs4support, kdoctools, kglobalaccel, kidletime, kwayland
 , libXcursor, pam, plasma-framework, qtdeclarative, wayland
 }:
@@ -6,7 +6,7 @@
 plasmaPackage {
   name = "kscreenlocker";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
   ];
   propagatedBuildInputs = [

--- a/pkgs/desktops/kde-5/plasma/ksshaskpass.nix
+++ b/pkgs/desktops/kde-5/plasma/ksshaskpass.nix
@@ -1,10 +1,10 @@
-{ plasmaPackage, extra-cmake-modules, kdoctools, kcoreaddons
+{ plasmaPackage, ecm, kdoctools, kcoreaddons
 , ki18n, kwallet, kwidgetsaddons, makeQtWrapper
 }:
 
 plasmaPackage {
   name = "ksshaskpass";
-  nativeBuildInputs = [ extra-cmake-modules kdoctools makeQtWrapper ];
+  nativeBuildInputs = [ ecm kdoctools makeQtWrapper ];
   propagatedBuildInputs = [ kcoreaddons ki18n kwallet kwidgetsaddons ];
   postInstall = ''
     wrapQtProgram "$out/bin/ksshaskpass"

--- a/pkgs/desktops/kde-5/plasma/ksysguard.nix
+++ b/pkgs/desktops/kde-5/plasma/ksysguard.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, kdoctools, kconfig
+{ plasmaPackage, ecm, kdoctools, kconfig
 , kcoreaddons, kdelibs4support, ki18n, kitemviews, knewstuff
 , kiconthemes, libksysguard, makeQtWrapper
 }:
@@ -6,7 +6,7 @@
 plasmaPackage {
   name = "ksysguard";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
     makeQtWrapper
   ];

--- a/pkgs/desktops/kde-5/plasma/kwayland-integration.nix
+++ b/pkgs/desktops/kde-5/plasma/kwayland-integration.nix
@@ -1,5 +1,5 @@
 { plasmaPackage
-, extra-cmake-modules
+, ecm
 , kidletime
 , kwayland
 , kwindowsystem
@@ -8,7 +8,7 @@
 plasmaPackage {
   name = "kwayland-integration";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
   ];
   propagatedBuildInputs = [
     kidletime kwindowsystem kwayland

--- a/pkgs/desktops/kde-5/plasma/kwin/default.nix
+++ b/pkgs/desktops/kde-5/plasma/kwin/default.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, kdoctools, epoxy
+{ plasmaPackage, ecm, kdoctools, epoxy
 , kactivities, kcompletion, kcmutils, kconfig, kconfigwidgets
 , kcoreaddons, kcrash, kdeclarative, kdecoration, kglobalaccel
 , ki18n, kiconthemes, kidletime, kinit, kio, knewstuff, knotifications
@@ -11,7 +11,7 @@
 plasmaPackage {
   name = "kwin";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
     makeQtWrapper
   ];

--- a/pkgs/desktops/kde-5/plasma/kwrited.nix
+++ b/pkgs/desktops/kde-5/plasma/kwrited.nix
@@ -1,9 +1,9 @@
-{ plasmaPackage, extra-cmake-modules, kcoreaddons, ki18n, kpty
+{ plasmaPackage, ecm, kcoreaddons, ki18n, kpty
 , knotifications, kdbusaddons
 }:
 
 plasmaPackage {
   name = "kwrited";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ kcoreaddons ki18n kpty knotifications kdbusaddons ];
 }

--- a/pkgs/desktops/kde-5/plasma/libkscreen.nix
+++ b/pkgs/desktops/kde-5/plasma/libkscreen.nix
@@ -1,5 +1,5 @@
 { plasmaPackage
-, extra-cmake-modules
+, ecm
 , kwayland, libXrandr
 , qtx11extras
 }:
@@ -7,7 +7,7 @@
 plasmaPackage {
   name = "libkscreen";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
   ];
   propagatedBuildInputs = [
     kwayland libXrandr qtx11extras

--- a/pkgs/desktops/kde-5/plasma/libksysguard/default.nix
+++ b/pkgs/desktops/kde-5/plasma/libksysguard/default.nix
@@ -1,4 +1,4 @@
-{ fetchpatch, plasmaPackage, extra-cmake-modules, kauth, kcompletion
+{ fetchpatch, plasmaPackage, ecm, kauth, kcompletion
 , kconfigwidgets, kcoreaddons, kservice, kwidgetsaddons
 , kwindowsystem, plasma-framework, qtscript, qtx11extras
 , kconfig, ki18n, kiconthemes
@@ -10,7 +10,7 @@ plasmaPackage {
     ./0001-qdiriterator-follow-symlinks.patch
   ];
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
   ];
   propagatedBuildInputs = [
     kauth kconfig ki18n kiconthemes kwindowsystem plasma-framework qtx11extras

--- a/pkgs/desktops/kde-5/plasma/milou.nix
+++ b/pkgs/desktops/kde-5/plasma/milou.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, qtscript, qtdeclarative
+{ plasmaPackage, ecm, qtscript, qtdeclarative
 , kcoreaddons, ki18n, kdeclarative, kservice, plasma-framework
 , krunner
 }:
@@ -6,7 +6,7 @@
 plasmaPackage {
   name = "milou";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
   ];
   propagatedBuildInputs = [
     kdeclarative ki18n krunner plasma-framework qtdeclarative qtscript

--- a/pkgs/desktops/kde-5/plasma/oxygen.nix
+++ b/pkgs/desktops/kde-5/plasma/oxygen.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, ki18n, kcmutils, kconfig
+{ plasmaPackage, ecm, ki18n, kcmutils, kconfig
 , kdecoration, kguiaddons, kwidgetsaddons, kservice, kcompletion
 , frameworkintegration, kwindowsystem, makeQtWrapper, qtx11extras
 }:
@@ -6,7 +6,7 @@
 plasmaPackage {
   name = "oxygen";
   nativeBuildInputs = [
-    extra-cmake-modules makeQtWrapper
+    ecm makeQtWrapper
   ];
   propagatedBuildInputs = [
     kcmutils kconfig kdecoration kguiaddons kwidgetsaddons kservice kcompletion

--- a/pkgs/desktops/kde-5/plasma/plasma-desktop/default.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-desktop/default.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, substituteAll, extra-cmake-modules, kdoctools
+{ plasmaPackage, substituteAll, ecm, kdoctools
 , attica, baloo, boost, fontconfig, kactivities, kactivities-stats
 , kauth, kcmutils, kdbusaddons, kdeclarative, kded, kdelibs4support, kemoticons
 , kglobalaccel, ki18n, kitemmodels, knewstuff, knotifications
@@ -13,7 +13,7 @@
 plasmaPackage rec {
   name = "plasma-desktop";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
     makeQtWrapper
   ];

--- a/pkgs/desktops/kde-5/plasma/plasma-integration.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-integration.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules
+{ plasmaPackage, ecm
 , breeze-qt5, kconfig, kconfigwidgets, kiconthemes, kio, kwayland
 , libXcursor
 }:
@@ -8,7 +8,7 @@
 plasmaPackage {
   name = "plasma-integration";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
   ];
   buildInputs = [
     breeze-qt5 kconfig kconfigwidgets kiconthemes kio kwayland

--- a/pkgs/desktops/kde-5/plasma/plasma-mediacenter.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-mediacenter.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, baloo, kactivities, kconfig
+{ plasmaPackage, ecm, baloo, kactivities, kconfig
 , kcoreaddons, kdeclarative, kguiaddons, ki18n, kio, kservice
 , kfilemetadata, plasma-framework, qtdeclarative, qtmultimedia
 , taglib
@@ -7,7 +7,7 @@
 plasmaPackage rec {
   name = "plasma-mediacenter";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
   ];
   propagatedBuildInputs = [
     baloo kactivities kdeclarative kfilemetadata ki18n kio plasma-framework

--- a/pkgs/desktops/kde-5/plasma/plasma-nm/default.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-nm/default.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, substituteAll, extra-cmake-modules, kdoctools
+{ plasmaPackage, substituteAll, ecm, kdoctools
 , kcompletion, kconfigwidgets, kcoreaddons, kdbusaddons, kdeclarative
 , kdelibs4support, ki18n, kiconthemes, kinit, kio, kitemviews
 , knotifications, kservice, kwallet, kwidgetsaddons, kwindowsystem
@@ -16,7 +16,7 @@ plasmaPackage {
     })
   ];
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
     makeQtWrapper
   ];

--- a/pkgs/desktops/kde-5/plasma/plasma-pa.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-pa.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, glib, kdoctools, kconfigwidgets
+{ plasmaPackage, ecm, glib, kdoctools, kconfigwidgets
 , kcoreaddons, kdeclarative, kglobalaccel, ki18n, libpulseaudio
 , plasma-framework
 }:
@@ -6,7 +6,7 @@
 plasmaPackage {
   name = "plasma-pa";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
   ];
   propagatedBuildInputs = [

--- a/pkgs/desktops/kde-5/plasma/plasma-workspace-wallpapers.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-workspace-wallpapers.nix
@@ -1,10 +1,10 @@
 { plasmaPackage
-, extra-cmake-modules
+, ecm
 }:
 
 plasmaPackage {
   name = "plasma-workspace-wallpapers";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
   ];
 }

--- a/pkgs/desktops/kde-5/plasma/plasma-workspace/default.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-workspace/default.nix
@@ -1,7 +1,7 @@
 {
   plasmaPackage, lib, copyPathsToStore,
 
-  extra-cmake-modules, kdoctools,
+  ecm, kdoctools,
 
   baloo, kactivities, kcmutils, kconfig, kcrash, kdbusaddons, kdeclarative,
   kdelibs4support, kdesu, kglobalaccel, kidletime, kjsembed, knewstuff,
@@ -15,7 +15,7 @@ plasmaPackage {
   name = "plasma-workspace";
 
   nativeBuildInputs = [
-    extra-cmake-modules kdoctools
+    ecm kdoctools
   ];
   buildInputs = [
     baloo kactivities kcmutils kconfig kcrash kdbusaddons kdeclarative

--- a/pkgs/desktops/kde-5/plasma/polkit-kde-agent.nix
+++ b/pkgs/desktops/kde-5/plasma/polkit-kde-agent.nix
@@ -1,5 +1,5 @@
 { plasmaPackage
-, extra-cmake-modules
+, ecm
 , ki18n
 , kwindowsystem
 , kdbusaddons
@@ -15,7 +15,7 @@
 plasmaPackage {
   name = "polkit-kde-agent";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
   ];
   propagatedBuildInputs = [
     kdbusaddons kwidgetsaddons kcoreaddons kcrash kconfig ki18n kiconthemes

--- a/pkgs/desktops/kde-5/plasma/powerdevil.nix
+++ b/pkgs/desktops/kde-5/plasma/powerdevil.nix
@@ -1,4 +1,4 @@
-{ plasmaPackage, extra-cmake-modules, kdoctools, bluez-qt, kactivities
+{ plasmaPackage, ecm, kdoctools, bluez-qt, kactivities
 , kauth, kconfig, kdbusaddons, kdelibs4support, kglobalaccel, ki18n
 , kidletime, kio, knotifyconfig, kwayland, libkscreen, networkmanager-qt
 , plasma-workspace, qtx11extras, solid, udev
@@ -7,7 +7,7 @@
 plasmaPackage {
   name = "powerdevil";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
     kdoctools
   ];
   propagatedBuildInputs = [

--- a/pkgs/desktops/kde-5/plasma/systemsettings.nix
+++ b/pkgs/desktops/kde-5/plasma/systemsettings.nix
@@ -1,12 +1,12 @@
 {
-  plasmaPackage, extra-cmake-modules, kdoctools, makeQtWrapper,
+  plasmaPackage, ecm, kdoctools, makeQtWrapper,
   kcmutils, kconfig, kdbusaddons, khtml, ki18n, kiconthemes, kio, kitemviews,
   kservice, kwindowsystem, kxmlgui, qtquickcontrols
 }:
 
 plasmaPackage {
   name = "systemsettings";
-  nativeBuildInputs = [ extra-cmake-modules kdoctools makeQtWrapper ];
+  nativeBuildInputs = [ ecm kdoctools makeQtWrapper ];
   propagatedBuildInputs = [
     kcmutils kconfig kdbusaddons khtml ki18n kiconthemes kio kitemviews kservice
     kwindowsystem kxmlgui qtquickcontrols

--- a/pkgs/development/libraries/kde-frameworks/attica.nix
+++ b/pkgs/development/libraries/kde-frameworks/attica.nix
@@ -1,11 +1,7 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-}:
+{ kdeFramework, lib, ecm }:
 
 kdeFramework {
   name = "attica";
-  nativeBuildInputs = [ extra-cmake-modules ];
-  meta = {
-    maintainers = [ lib.maintainers.ttuegel ];
-  };
+  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/development/libraries/kde-frameworks/baloo.nix
+++ b/pkgs/development/libraries/kde-frameworks/baloo.nix
@@ -1,16 +1,14 @@
-{ kdeFramework, lib, extra-cmake-modules, kauth, kconfig
+{ kdeFramework, lib, ecm, kauth, kconfig
 , kcoreaddons, kcrash, kdbusaddons, kfilemetadata, ki18n, kidletime
 , kio, lmdb, qtbase, solid
 }:
 
 kdeFramework {
   name = "baloo";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kauth kconfig kcoreaddons kcrash kdbusaddons kfilemetadata ki18n kio
     kidletime lmdb qtbase solid
   ];
-  meta = {
-    maintainers = [ lib.maintainers.ttuegel ];
-  };
 }

--- a/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
@@ -1,17 +1,15 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , qtdeclarative
 }:
 
 kdeFramework {
   name = "bluez-qt";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ qtdeclarative ];
   preConfigure = ''
     substituteInPlace CMakeLists.txt \
       --replace /lib/udev/rules.d "$out/lib/udev/rules.d"
   '';
-  meta = {
-    maintainers = [ lib.maintainers.ttuegel ];
-  };
 }

--- a/pkgs/development/libraries/kde-frameworks/breeze-icons.nix
+++ b/pkgs/development/libraries/kde-frameworks/breeze-icons.nix
@@ -1,12 +1,10 @@
-{ kdeFramework
-, extra-cmake-modules
-, qtsvg
-}:
+{ kdeFramework, lib, ecm, qtsvg }:
 
 kdeFramework {
   name = "breeze-icons";
+  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   outputs = [ "out" ];
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ qtsvg ];
   propagatedUserEnvPkgs = [ qtsvg.out ];
 }

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -31,10 +31,6 @@ let
           ++ [ "-DBUILD_TESTING=OFF" ]
           ++ lib.optional debug "-DCMAKE_BUILD_TYPE=Debug";
 
-        nativeBuildInputs =
-          (args.nativeBuildInputs or [])
-          ++ [ pkgs.cmake pkgs.pkgconfig ecm ];
-
       });
 
     kdeFramework = args:
@@ -59,9 +55,9 @@ let
     bluez-qt = callPackage ./bluez-qt.nix {};
     breeze-icons = callPackage ./breeze-icons.nix {};
     ecm =
-      let drv = { qtbase, qttools }:
+      let drv = { cmake, extra-cmake-modules, pkgconfig, qtbase, qttools }:
             makeSetupHook
-            { deps = [ extra-cmake-modules qtbase qttools ]; }
+            { deps = [ cmake extra-cmake-modules pkgconfig qtbase qttools ]; }
             ./setup-hook.sh;
       in callPackage drv {};
     extra-cmake-modules = callPackage ./extra-cmake-modules {

--- a/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
+++ b/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, kbookmarks, kcompletion
+{ kdeFramework, lib, ecm, kbookmarks, kcompletion
 , kconfig, kconfigwidgets, ki18n, kiconthemes, kio, knotifications
 , kwidgetsaddons, libXcursor, qtx11extras
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "frameworkintegration";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kbookmarks kcompletion kconfig kconfigwidgets knotifications ki18n kio
     kiconthemes kwidgetsaddons libXcursor qtx11extras

--- a/pkgs/development/libraries/kde-frameworks/kactivities-stats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kactivities-stats.nix
@@ -1,9 +1,8 @@
-{ kdeFramework, lib, extra-cmake-modules
-, boost, kactivities, kconfig }:
+{ kdeFramework, lib, ecm, boost, kactivities, kconfig }:
 
 kdeFramework {
   name = "kactivities-stats";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ boost kactivities kconfig ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kactivities.nix
+++ b/pkgs/development/libraries/kde-frameworks/kactivities.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, boost, kcmutils, kconfig
+{ kdeFramework, lib, ecm, boost, kcmutils, kconfig
 , kcoreaddons, kdbusaddons, kdeclarative, kglobalaccel, ki18n
 , kio, kservice, kwindowsystem, kxmlgui, qtdeclarative
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "kactivities";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     boost kcmutils kconfig kcoreaddons kdbusaddons kdeclarative kglobalaccel
     ki18n kio kservice kwindowsystem kxmlgui qtdeclarative

--- a/pkgs/development/libraries/kde-frameworks/kapidox.nix
+++ b/pkgs/development/libraries/kde-frameworks/kapidox.nix
@@ -1,10 +1,7 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, python
-}:
+{ kdeFramework, lib, ecm, python }:
 
 kdeFramework {
   name = "kapidox";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules python ];
+  nativeBuildInputs = [ ecm python ];
 }

--- a/pkgs/development/libraries/kde-frameworks/karchive.nix
+++ b/pkgs/development/libraries/kde-frameworks/karchive.nix
@@ -1,9 +1,7 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-}:
+{ kdeFramework, lib, ecm }:
 
 kdeFramework {
   name = "karchive";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kauth/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kauth/default.nix
@@ -1,13 +1,9 @@
-{ kdeFramework, lib, copyPathsToStore
-, extra-cmake-modules
-, kcoreaddons
-, polkit-qt
-}:
+{ kdeFramework, lib, copyPathsToStore, ecm, kcoreaddons, polkit-qt }:
 
 kdeFramework {
   name = "kauth";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ kcoreaddons polkit-qt ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
 }

--- a/pkgs/development/libraries/kde-frameworks/kbookmarks.nix
+++ b/pkgs/development/libraries/kde-frameworks/kbookmarks.nix
@@ -1,17 +1,12 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, kcodecs
-, kconfig
-, kconfigwidgets
-, kcoreaddons
-, kiconthemes
-, kxmlgui
+{
+  kdeFramework, lib, ecm,
+  kcodecs, kconfig, kconfigwidgets, kcoreaddons, kiconthemes, kxmlgui
 }:
 
 kdeFramework {
   name = "kbookmarks";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kcodecs kconfig kconfigwidgets kcoreaddons kiconthemes kxmlgui
   ];

--- a/pkgs/development/libraries/kde-frameworks/kcmutils/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcmutils/default.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, kconfigwidgets
+{ kdeFramework, lib, ecm, kconfigwidgets
 , kcoreaddons, kdeclarative, ki18n, kiconthemes, kitemviews
 , kpackage, kservice, kxmlgui
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "kcmutils";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kconfigwidgets kcoreaddons kdeclarative ki18n kiconthemes kitemviews
     kpackage kservice kxmlgui

--- a/pkgs/development/libraries/kde-frameworks/kcodecs.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcodecs.nix
@@ -1,11 +1,7 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-}:
+{ kdeFramework, lib, ecm }:
 
 kdeFramework {
   name = "kcodecs";
-  nativeBuildInputs = [ extra-cmake-modules ];
-  meta = {
-    maintainers = [ lib.maintainers.ttuegel ];
-  };
+  meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kcompletion.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcompletion.nix
@@ -1,12 +1,8 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, kconfig
-, kwidgetsaddons
-}:
+{ kdeFramework, lib, ecm, kconfig, kwidgetsaddons }:
 
 kdeFramework {
   name = "kcompletion";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ kconfig kwidgetsaddons ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kconfig.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfig.nix
@@ -1,9 +1,7 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-}:
+{ kdeFramework, lib, ecm }:
 
 kdeFramework {
   name = "kconfig";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kconfigwidgets/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfigwidgets/default.nix
@@ -1,12 +1,15 @@
-{ kdeFramework, lib, extra-cmake-modules, kauth, kcodecs, kconfig
-, kdoctools, kguiaddons, ki18n, kwidgetsaddons
+{
+  kdeFramework, lib, ecm,
+  kauth, kcodecs, kconfig, kdoctools, kguiaddons, ki18n, kwidgetsaddons
 }:
 
 kdeFramework {
   name = "kconfigwidgets";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  propagatedBuildInputs = [ kauth kconfig kcodecs kguiaddons ki18n kwidgetsaddons ];
+  nativeBuildInputs = [ ecm kdoctools ];
+  propagatedBuildInputs = [
+    kauth kconfig kcodecs kguiaddons ki18n kwidgetsaddons
+  ];
   patches = [ ./0001-qdiriterator-follow-symlinks.patch ];
   postInstall = ''
     moveToOutput "bin/preparetips5" "$dev"

--- a/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
@@ -1,11 +1,8 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, shared_mime_info
-}:
+{ kdeFramework, lib, ecm, shared_mime_info }:
 
 kdeFramework {
   name = "kcoreaddons";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ shared_mime_info ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kcrash.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcrash.nix
@@ -1,13 +1,8 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, kcoreaddons
-, kwindowsystem
-, qtx11extras
-}:
+{ kdeFramework, lib, ecm, kcoreaddons, kwindowsystem, qtx11extras }:
 
 kdeFramework {
   name = "kcrash";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ kcoreaddons kwindowsystem qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kdbusaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdbusaddons.nix
@@ -1,11 +1,8 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, qtx11extras
-}:
+{ kdeFramework, lib, ecm, qtx11extras }:
 
 kdeFramework {
   name = "kdbusaddons";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kdeclarative.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdeclarative.nix
@@ -1,13 +1,13 @@
-{ kdeFramework, lib, extra-cmake-modules, epoxy, kconfig
-, kglobalaccel, kguiaddons, ki18n, kiconthemes, kio, kpackage
-, kwidgetsaddons, kwindowsystem, pkgconfig
-, qtdeclarative
+{
+  kdeFramework, lib, ecm,
+  epoxy, kconfig, kglobalaccel, kguiaddons, ki18n, kiconthemes, kio, kpackage,
+  kwidgetsaddons, kwindowsystem, pkgconfig, qtdeclarative
 }:
 
 kdeFramework {
   name = "kdeclarative";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     epoxy kconfig kglobalaccel kguiaddons ki18n kiconthemes kio kpackage
     kwidgetsaddons kwindowsystem qtdeclarative

--- a/pkgs/development/libraries/kde-frameworks/kded.nix
+++ b/pkgs/development/libraries/kde-frameworks/kded.nix
@@ -1,17 +1,13 @@
-{ kdeFramework, lib
-, extra-cmake-modules
-, kconfig
-, kcoreaddons
-, kcrash
-, kdbusaddons
-, kdoctools
-, kinit
-, kservice
+{
+  kdeFramework, lib, ecm,
+  kconfig, kcoreaddons, kcrash, kdbusaddons, kdoctools, kinit, kservice
 }:
 
 kdeFramework {
   name = "kded";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  propagatedBuildInputs = [ kconfig kcoreaddons kcrash kdbusaddons kinit kservice ];
+  nativeBuildInputs = [ ecm kdoctools ];
+  propagatedBuildInputs = [
+    kconfig kcoreaddons kcrash kdbusaddons kinit kservice
+  ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kdelibs4support/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdelibs4support/default.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib, copyPathsToStore
-, extra-cmake-modules, docbook_xml_dtd_45, kauth
+, ecm, docbook_xml_dtd_45, kauth
 , karchive, kcompletion, kconfig, kconfigwidgets, kcoreaddons
 , kcrash, kdbusaddons, kded, kdesignerplugin, kdoctools, kemoticons
 , kglobalaccel, kguiaddons, ki18n, kiconthemes, kio, kitemmodels
@@ -13,10 +13,9 @@
 kdeFramework {
   name = "kdelibs4support";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  outputs = [ "dev" "out" ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
   setupHook = ./setup-hook.sh;
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kauth karchive kcompletion kconfig kconfigwidgets kcoreaddons kcrash
     kdbusaddons kded kdesignerplugin kemoticons kglobalaccel kguiaddons ki18n

--- a/pkgs/development/libraries/kde-frameworks/kdesignerplugin.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdesignerplugin.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , kcompletion
 , kconfig
 , kconfigwidgets
@@ -18,7 +18,7 @@
 kdeFramework {
   name = "kdesignerplugin";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kcompletion kconfig kconfigwidgets kcoreaddons kiconthemes kio
     kitemviews kplotting ktextwidgets kwidgetsaddons kxmlgui sonnet

--- a/pkgs/development/libraries/kde-frameworks/kdesu.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdesu.nix
@@ -1,10 +1,10 @@
-{ kdeFramework, lib, extra-cmake-modules, kcoreaddons, ki18n, kpty
+{ kdeFramework, lib, ecm, kcoreaddons, ki18n, kpty
 , kservice
 }:
 
 kdeFramework {
   name = "kdesu";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ kcoreaddons ki18n kpty kservice ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kdnssd.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdnssd.nix
@@ -1,11 +1,11 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , avahi
 }:
 
 kdeFramework {
   name = "kdnssd";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ avahi ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kdoctools/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdoctools/default.nix
@@ -1,11 +1,11 @@
-{ kdeFramework, lib, extra-cmake-modules, docbook_xml_dtd_45
+{ kdeFramework, lib, ecm, docbook_xml_dtd_45
 , docbook5_xsl, karchive, ki18n, perl, perlPackages
 }:
 
 kdeFramework {
   name = "kdoctools";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ karchive ki18n ];
   propagatedNativeBuildInputs = [ perl perlPackages.URI ];
   cmakeFlags = [

--- a/pkgs/development/libraries/kde-frameworks/kemoticons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kemoticons.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , karchive
 , kconfig
 , kcoreaddons
@@ -9,6 +9,6 @@
 kdeFramework {
   name = "kemoticons";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ karchive kconfig kcoreaddons kservice ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, copyPathsToStore, extra-cmake-modules
+{ kdeFramework, lib, copyPathsToStore, ecm
 , attr, ebook_tools, exiv2, ffmpeg, karchive, ki18n, poppler, qtbase, taglib
 }:
 
@@ -6,7 +6,7 @@ kdeFramework {
   name = "kfilemetadata";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     attr ebook_tools exiv2 ffmpeg karchive ki18n poppler qtbase taglib
   ];

--- a/pkgs/development/libraries/kde-frameworks/kglobalaccel.nix
+++ b/pkgs/development/libraries/kde-frameworks/kglobalaccel.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , kconfig
 , kcoreaddons
 , kcrash
@@ -11,7 +11,7 @@
 kdeFramework {
   name = "kglobalaccel";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kconfig kcoreaddons kcrash kdbusaddons kwindowsystem qtx11extras
   ];

--- a/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
@@ -1,11 +1,11 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , qtx11extras
 }:
 
 kdeFramework {
   name = "kguiaddons";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/khtml.nix
+++ b/pkgs/development/libraries/kde-frameworks/khtml.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, giflib, karchive
+{ kdeFramework, lib, ecm, giflib, karchive
 , kcodecs, kglobalaccel, ki18n, kiconthemes, kio, kjs
 , knotifications, kparts, ktextwidgets, kwallet, kwidgetsaddons
 , kwindowsystem, kxmlgui, perl, phonon, qtx11extras, sonnet
@@ -7,7 +7,7 @@
 kdeFramework {
   name = "khtml";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules perl ];
+  nativeBuildInputs = [ ecm perl ];
   propagatedBuildInputs = [
     giflib karchive kcodecs kglobalaccel ki18n kiconthemes kio kjs
     knotifications kparts ktextwidgets kwallet kwidgetsaddons kwindowsystem

--- a/pkgs/development/libraries/kde-frameworks/ki18n.nix
+++ b/pkgs/development/libraries/kde-frameworks/ki18n.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , gettext
 , python
 , qtdeclarative
@@ -9,7 +9,7 @@
 kdeFramework {
   name = "ki18n";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ qtdeclarative qtscript ];
   propagatedNativeBuildInputs = [ gettext python ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kiconthemes/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kiconthemes/default.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib, copyPathsToStore
-, extra-cmake-modules
+, ecm
 , karchive, kconfigwidgets, ki18n, breeze-icons, kitemviews, qtsvg
 }:
 
@@ -7,6 +7,6 @@ kdeFramework {
   name = "kiconthemes";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ breeze-icons kconfigwidgets karchive ki18n kitemviews qtsvg ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kidletime.nix
+++ b/pkgs/development/libraries/kde-frameworks/kidletime.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , qtbase
 , qtx11extras
 }:
@@ -7,6 +7,6 @@
 kdeFramework {
   name = "kidletime";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ qtbase qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kimageformats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kimageformats.nix
@@ -1,11 +1,11 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , ilmbase
 }:
 
 kdeFramework {
   name = "kimageformats";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   NIX_CFLAGS_COMPILE = "-I${ilmbase}/include/OpenEXR";
 }

--- a/pkgs/development/libraries/kde-frameworks/kinit/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kinit/default.nix
@@ -1,13 +1,13 @@
 {
   kdeFramework, lib, copyPathsToStore,
-  extra-cmake-modules, kdoctools,
+  ecm, kdoctools,
   kconfig, kcrash, ki18n, kio, kservice, kwindowsystem
 }:
 
 kdeFramework {
   name = "kinit";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kconfig kcrash ki18n kio kservice kwindowsystem
   ];

--- a/pkgs/development/libraries/kde-frameworks/kio/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kio/default.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib, copyPathsToStore
-, extra-cmake-modules, acl, karchive
+, ecm, acl, karchive
 , kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons
 , kdbusaddons, kdoctools, ki18n, kiconthemes, kitemviews
 , kjobwidgets, knotifications, kservice, ktextwidgets, kwallet
@@ -10,7 +10,7 @@
 kdeFramework {
   name = "kio";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     acl karchive kbookmarks kcompletion kconfig kconfigwidgets kcoreaddons
     kdbusaddons ki18n kiconthemes kitemviews kjobwidgets knotifications kservice

--- a/pkgs/development/libraries/kde-frameworks/kitemmodels.nix
+++ b/pkgs/development/libraries/kde-frameworks/kitemmodels.nix
@@ -1,9 +1,9 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 }:
 
 kdeFramework {
   name = "kitemmodels";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kitemviews.nix
+++ b/pkgs/development/libraries/kde-frameworks/kitemviews.nix
@@ -1,9 +1,9 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 }:
 
 kdeFramework {
   name = "kitemviews";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kjobwidgets.nix
+++ b/pkgs/development/libraries/kde-frameworks/kjobwidgets.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , kcoreaddons
 , kwidgetsaddons
 , qtx11extras
@@ -8,6 +8,6 @@
 kdeFramework {
   name = "kjobwidgets";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ kcoreaddons kwidgetsaddons qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kjs.nix
+++ b/pkgs/development/libraries/kde-frameworks/kjs.nix
@@ -1,10 +1,10 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , kdoctools
 }:
 
 kdeFramework {
   name = "kjs";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kjsembed.nix
+++ b/pkgs/development/libraries/kde-frameworks/kjsembed.nix
@@ -1,10 +1,10 @@
-{ kdeFramework, lib, extra-cmake-modules, kdoctools, ki18n, kjs
+{ kdeFramework, lib, ecm, kdoctools, ki18n, kjs
 , qtsvg
 }:
 
 kdeFramework {
   name = "kjsembed";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [ ki18n kjs qtsvg ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kmediaplayer.nix
+++ b/pkgs/development/libraries/kde-frameworks/kmediaplayer.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , kparts
 , kxmlgui
 }:
@@ -7,6 +7,6 @@
 kdeFramework {
   name = "kmediaplayer";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ kparts kxmlgui ];
 }

--- a/pkgs/development/libraries/kde-frameworks/knewstuff.nix
+++ b/pkgs/development/libraries/kde-frameworks/knewstuff.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, attica, karchive
+{ kdeFramework, lib, ecm, attica, karchive
 , kcompletion, kconfig, kcoreaddons, ki18n, kiconthemes, kio
 , kitemviews, kservice, ktextwidgets, kwidgetsaddons, kxmlgui
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "knewstuff";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     attica karchive kcompletion kconfig kcoreaddons ki18n kiconthemes kio
     kitemviews kservice ktextwidgets kwidgetsaddons kxmlgui

--- a/pkgs/development/libraries/kde-frameworks/knotifications.nix
+++ b/pkgs/development/libraries/kde-frameworks/knotifications.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , kcodecs, kconfig, kcoreaddons, kwindowsystem
 , libdbusmenu
 , phonon
@@ -9,7 +9,7 @@
 kdeFramework {
   name = "knotifications";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kcodecs kconfig kcoreaddons kwindowsystem libdbusmenu phonon qtx11extras
   ];

--- a/pkgs/development/libraries/kde-frameworks/knotifyconfig.nix
+++ b/pkgs/development/libraries/kde-frameworks/knotifyconfig.nix
@@ -1,10 +1,10 @@
-{ kdeFramework, lib, extra-cmake-modules, kcompletion, kconfig
+{ kdeFramework, lib, ecm, kcompletion, kconfig
 , ki18n, kio, phonon
 }:
 
 kdeFramework {
   name = "knotifyconfig";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ kcompletion kconfig ki18n kio phonon ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kpackage/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kpackage/default.nix
@@ -1,5 +1,5 @@
 { kdeFramework, lib, copyPathsToStore
-, extra-cmake-modules
+, ecm
 , karchive
 , kconfig
 , kcoreaddons
@@ -10,7 +10,7 @@
 kdeFramework {
   name = "kpackage";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [ karchive kconfig kcoreaddons ki18n ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
 }

--- a/pkgs/development/libraries/kde-frameworks/kparts.nix
+++ b/pkgs/development/libraries/kde-frameworks/kparts.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, kconfig, kcoreaddons
+{ kdeFramework, lib, ecm, kconfig, kcoreaddons
 , ki18n, kiconthemes, kio, kjobwidgets, knotifications, kservice
 , ktextwidgets, kwidgetsaddons, kxmlgui
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "kparts";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kconfig kcoreaddons ki18n kiconthemes kio kjobwidgets knotifications
     kservice ktextwidgets kwidgetsaddons kxmlgui

--- a/pkgs/development/libraries/kde-frameworks/kpeople.nix
+++ b/pkgs/development/libraries/kde-frameworks/kpeople.nix
@@ -1,11 +1,11 @@
-{ kdeFramework, lib, extra-cmake-modules, kcoreaddons, ki18n
+{ kdeFramework, lib, ecm, kcoreaddons, ki18n
 , kitemviews, kservice, kwidgetsaddons, qtdeclarative
 }:
 
 kdeFramework {
   name = "kpeople";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kcoreaddons ki18n kitemviews kservice kwidgetsaddons qtdeclarative
   ];

--- a/pkgs/development/libraries/kde-frameworks/kplotting.nix
+++ b/pkgs/development/libraries/kde-frameworks/kplotting.nix
@@ -1,9 +1,9 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 }:
 
 kdeFramework {
   name = "kplotting";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kpty.nix
+++ b/pkgs/development/libraries/kde-frameworks/kpty.nix
@@ -1,8 +1,8 @@
-{ kdeFramework, lib, extra-cmake-modules, kcoreaddons, ki18n }:
+{ kdeFramework, lib, ecm, kcoreaddons, ki18n }:
 
 kdeFramework {
   name = "kpty";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ kcoreaddons ki18n ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kross.nix
+++ b/pkgs/development/libraries/kde-frameworks/kross.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, kcompletion, kcoreaddons
+{ kdeFramework, lib, ecm, kcompletion, kcoreaddons
 , kdoctools, ki18n, kiconthemes, kio, kparts, kwidgetsaddons
 , kxmlgui, qtscript
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "kross";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kcompletion kcoreaddons ki18n kiconthemes kio kparts kwidgetsaddons kxmlgui
     qtscript

--- a/pkgs/development/libraries/kde-frameworks/krunner.nix
+++ b/pkgs/development/libraries/kde-frameworks/krunner.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, kconfig, kcoreaddons
+{ kdeFramework, lib, ecm, kconfig, kcoreaddons
 , ki18n, kio, kservice, plasma-framework, solid
 , threadweaver
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "krunner";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kconfig kcoreaddons ki18n kio kservice plasma-framework solid
     threadweaver

--- a/pkgs/development/libraries/kde-frameworks/ktextwidgets.nix
+++ b/pkgs/development/libraries/kde-frameworks/ktextwidgets.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, kcompletion, kconfig
+{ kdeFramework, lib, ecm, kcompletion, kconfig
 , kconfigwidgets, ki18n, kiconthemes, kservice, kwindowsystem
 , sonnet
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "ktextwidgets";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     kcompletion kconfig kconfigwidgets ki18n kiconthemes kservice kwindowsystem
     sonnet

--- a/pkgs/development/libraries/kde-frameworks/kunitconversion.nix
+++ b/pkgs/development/libraries/kde-frameworks/kunitconversion.nix
@@ -1,8 +1,8 @@
-{ kdeFramework, lib, extra-cmake-modules, ki18n }:
+{ kdeFramework, lib, ecm, ki18n }:
 
 kdeFramework {
   name = "kunitconversion";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ ki18n ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kwallet.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwallet.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, kconfig, kconfigwidgets
+{ kdeFramework, lib, ecm, kconfig, kconfigwidgets
 , kcoreaddons , kdbusaddons, kdoctools, ki18n, kiconthemes
 , knotifications , kservice, kwidgetsaddons, kwindowsystem, libgcrypt
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "kwallet";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kconfig kconfigwidgets kcoreaddons kdbusaddons ki18n kiconthemes
     knotifications kservice kwidgetsaddons kwindowsystem libgcrypt

--- a/pkgs/development/libraries/kde-frameworks/kwayland.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwayland.nix
@@ -1,12 +1,12 @@
 { kdeFramework
-, extra-cmake-modules
+, ecm
 , wayland
 }:
 
 kdeFramework {
   name = "kwayland";
   nativeBuildInputs = [
-    extra-cmake-modules
+    ecm
   ];
   propagatedBuildInputs = [
     wayland

--- a/pkgs/development/libraries/kde-frameworks/kwidgetsaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwidgetsaddons.nix
@@ -1,9 +1,9 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 }:
 
 kdeFramework {
   name = "kwidgetsaddons";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kwindowsystem.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwindowsystem.nix
@@ -1,11 +1,11 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , qtx11extras
 }:
 
 kdeFramework {
   name = "kwindowsystem";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kxmlgui.nix
+++ b/pkgs/development/libraries/kde-frameworks/kxmlgui.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, attica, kconfig
+{ kdeFramework, lib, ecm, attica, kconfig
 , kconfigwidgets, kglobalaccel, ki18n, kiconthemes, kitemviews
 , ktextwidgets, kwindowsystem, sonnet
 }:
@@ -6,7 +6,7 @@
 kdeFramework {
   name = "kxmlgui";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
     attica kconfig kconfigwidgets kglobalaccel ki18n kiconthemes kitemviews
     ktextwidgets kwindowsystem sonnet

--- a/pkgs/development/libraries/kde-frameworks/kxmlrpcclient.nix
+++ b/pkgs/development/libraries/kde-frameworks/kxmlrpcclient.nix
@@ -1,8 +1,8 @@
-{ kdeFramework, lib, extra-cmake-modules, ki18n, kio }:
+{ kdeFramework, lib, ecm, ki18n, kio }:
 
 kdeFramework {
   name = "kxmlrpcclient";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ ki18n kio ];
 }

--- a/pkgs/development/libraries/kde-frameworks/modemmanager-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/modemmanager-qt.nix
@@ -1,11 +1,11 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , modemmanager
 }:
 
 kdeFramework {
   name = "modemmanager-qt";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ modemmanager ];
 }

--- a/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
@@ -1,11 +1,11 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , networkmanager
 }:
 
 kdeFramework {
   name = "networkmanager-qt";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ networkmanager ];
 }

--- a/pkgs/development/libraries/kde-frameworks/oxygen-icons5.nix
+++ b/pkgs/development/libraries/kde-frameworks/oxygen-icons5.nix
@@ -1,6 +1,6 @@
 { kdeFramework
 , lib
-, extra-cmake-modules
+, ecm
 }:
 
 kdeFramework {
@@ -10,5 +10,5 @@ kdeFramework {
     maintainers = [ lib.maintainers.ttuegel ];
   };
   outputs = [ "out" ];
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
 }

--- a/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
+++ b/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, extra-cmake-modules, kactivities, karchive
+{ kdeFramework, lib, ecm, kactivities, karchive
 , kconfig, kconfigwidgets, kcoreaddons, kdbusaddons, kdeclarative
 , kdoctools, kglobalaccel, kguiaddons, ki18n, kiconthemes, kio
 , knotifications, kpackage, kservice, kwindowsystem, kxmlgui
@@ -8,7 +8,7 @@
 kdeFramework {
   name = "plasma-framework";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kactivities karchive kconfig kconfigwidgets kcoreaddons kdbusaddons
     kdeclarative kglobalaccel kguiaddons ki18n kiconthemes kio knotifications

--- a/pkgs/development/libraries/kde-frameworks/solid.nix
+++ b/pkgs/development/libraries/kde-frameworks/solid.nix
@@ -1,11 +1,11 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , qtdeclarative
 }:
 
 kdeFramework {
   name = "solid";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [ qtdeclarative ];
 }

--- a/pkgs/development/libraries/kde-frameworks/sonnet.nix
+++ b/pkgs/development/libraries/kde-frameworks/sonnet.nix
@@ -1,11 +1,11 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 , hunspell
 }:
 
 kdeFramework {
   name = "sonnet";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   buildInputs = [ hunspell ];
 }

--- a/pkgs/development/libraries/kde-frameworks/threadweaver.nix
+++ b/pkgs/development/libraries/kde-frameworks/threadweaver.nix
@@ -1,9 +1,9 @@
 { kdeFramework, lib
-, extra-cmake-modules
+, ecm
 }:
 
 kdeFramework {
   name = "threadweaver";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ ecm ];
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
 }


### PR DESCRIPTION
The hooks are broken for a few packages.
