### PR TITLE
syncthing-inotify: init at 0.8.3

### DIFF
--- a/pkgs/applications/networking/syncthing/inotify-deps.json
+++ b/pkgs/applications/networking/syncthing/inotify-deps.json
@@ -1,0 +1,38 @@
+[
+  {
+    "goPackagePath": "github.com/cenkalti/backoff",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/cenkalti/backoff",
+      "rev": "cdf48bbc1eb78d1349cbda326a4a037f7ba565c6",
+      "sha256": "0dg7hvpv0a1db8qriygz1jqgp16v8k505b197x9902z7z6lldgbh"
+    }
+  },
+  {
+    "goPackagePath": "github.com/gobwas/glob",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/gobwas/glob",
+      "rev": "ce6abff51712df5da11095fb41dd4b0353559797",
+      "sha256": "1gxv4nnn3f9hw1ncdmhsr8fbfdma2h713ima7b4k28gxydfa8i9m"
+    }
+  },
+  {
+    "goPackagePath": "github.com/syncthing/syncthing",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/syncthing/syncthing",
+      "rev": "66a506e72b9dcc749d09a03cb120ba86bbf3d7f8",
+      "sha256": "0is4f1r3im2bbmbca9fafzxffikxaf86vd6f851831fk5wi4pzw9"
+    }
+  },
+  {
+    "goPackagePath": "github.com/zillode/notify",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/zillode/notify",
+      "rev": "2da5cc9881e8f16bab76b63129c7781898f97d16",
+      "sha256": "0qwsj730p5mivp2xw9zr5vq8xr7rr9cxjmi564wgmsn7dcvqnr40"
+    }
+  }
+]

--- a/pkgs/applications/networking/syncthing/inotify.nix
+++ b/pkgs/applications/networking/syncthing/inotify.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "syncthing-inotify-${version}";
+  version = "0.8.3";
+
+  goPackagePath = "github.com/syncthing/syncthing-inotify";
+
+  src = fetchFromGitHub {
+    owner = "syncthing";
+    repo = "syncthing-inotify";
+    rev = "v${version}";
+    sha256 = "194pbz9zzxaz0vri93czpbsxl85znlba2gy61mjgyr0dm2h4s6yw";
+  };
+
+  goDeps = ./inotify-deps.json;
+
+  meta = {
+    homepage = https://github.com/syncthing/syncthing-inotify;
+    description = "File watcher intended for use with Syncthing";
+    license = stdenv.lib.licenses.mpl20;
+    maintainers = with stdenv.lib.maintainers; [ joko ];
+    platforms = with stdenv.lib.platforms; linux ++ freebsd ++ openbsd ++ netbsd;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14735,6 +14735,8 @@ in
 
   syncthing013 = callPackage ../applications/networking/syncthing013 { };
 
+  syncthing-inotify = callPackage ../applications/networking/syncthing/inotify.nix { };
+
   # linux only by now
   synergy = callPackage ../applications/misc/synergy { };
 


### PR DESCRIPTION
###### Motivation for this change

This PR introduces the `syncthing-inotify` package. In #17320 we shall hopefully settle on the service definitions.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
