### PR TITLE
Add a default value for services.mopidy.configuration

### DIFF
--- a/nixos/modules/services/audio/mopidy.nix
+++ b/nixos/modules/services/audio/mopidy.nix
@@ -70,6 +70,11 @@ in {
   ###### implementation
 
   config = mkIf cfg.enable {
+    assertions = [
+      { assertion = cfg.configuration != "" && cfg.configuration != null;
+        message = "services.mopidy.configuration must be set";
+      }
+    ];
 
     systemd.services.mopidy = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/audio/mopidy.nix
+++ b/nixos/modules/services/audio/mopidy.nix
@@ -47,6 +47,7 @@ in {
       };
 
       configuration = mkOption {
+        default = "";
         type = types.lines;
         description = ''
           The configuration that Mopidy should use.
@@ -70,11 +71,6 @@ in {
   ###### implementation
 
   config = mkIf cfg.enable {
-    assertions = [
-      { assertion = cfg.configuration != "" && cfg.configuration != null;
-        message = "services.mopidy.configuration must be set";
-      }
-    ];
 
     systemd.services.mopidy = {
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
###### Motivation for this change

See #17381

fixes #17381
###### Things done
- [x] `nixos-rebuild build --nixpkgs=.` (I'm currently doing this, but it takes a while). 
- Built on platform(s)
  - [x] NixOS
- [?] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Is this the right style of commit message for a service?
