### PR TITLE
ruby: 2.2.3 -> 2.2.5 and 2.1.7 -> 2.1.10

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -198,14 +198,14 @@ in {
     };
   };
 
-  ruby_2_2_3 = generic {
+  ruby_2_2_5 = generic {
     majorVersion = "2";
     minorVersion = "2";
-    teenyVersion = "3";
+    teenyVersion = "5";
     patchLevel = "0";
     sha256 = {
-      src = "1kpdf7f8pw90n5bckpl2idzggk0nn0240ah92sj4a1w6k4pmyyfz";
-      git = "1ssq3c23ay57ypfis47y2n817hfmb71w0xrdzp57j6bv12jqmgrx";
+      src = "1qrmlcyc0cy9hgafb1wny2h90rjyyh6d72nvr2h4xjm4jwbb7i1h";
+      git = "0k0av6ypyq08c9axm721f0xi2bcp1443l7ydbxv4v8x4vsxdkmq2";
     };
   };
 

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -147,6 +147,7 @@ let
           license = stdenv.lib.licenses.ruby;
           homepage = http://www.ruby-lang.org/en/;
           description = "The Ruby language";
+          maintainers = [ stdenv.lib.maintainers.vrthra ];
           platforms = stdenv.lib.platforms.all;
         };
 
@@ -187,14 +188,14 @@ in {
     };
   };
 
-  ruby_2_1_7 = generic {
+  ruby_2_1_10 = generic {
     majorVersion = "2";
     minorVersion = "1";
-    teenyVersion = "7";
+    teenyVersion = "10";
     patchLevel = "0";
     sha256 = {
-      src = "10fxlqmpbq9407zgsx060q22yj4zq6c3czbf29h7xk1rmjb1b77m";
-      git = "1fmbqd943akqjwsfbj9bg394ac46qmpavm8s0kv2w87rflrjcjfb";
+      src = "086x66w51lg41abjn79xb7f6xsryymkcc3nvakmkjnjyg96labpv";
+      git = "133phd5r5y0np5lc9nqif93l7yb13yd52aspyl6c46z5jhvhyvfi";
     };
   };
 

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -50,13 +50,10 @@ rec {
     "${patchSet}/patches/ruby/2.1.7/railsexpress/08-funny-falcon-method-cache.patch"
     "${patchSet}/patches/ruby/2.1.7/railsexpress/09-heap-dump-support.patch"
   ];
-  "2.2.3" = [
-    ./ssl_v3.patch
-    ./ruby22-rand-egd.patch
-  ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.2.3/railsexpress/01-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.2.3/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.2.3/railsexpress/03-display-more-detailed-stack-trace.patch"
+  "2.2.5" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/2.2.5/railsexpress/01-zero-broken-tests.patch"
+    "${patchSet}/patches/ruby/2.2.5/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.2.5/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
   "2.3.1" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.3/head/railsexpress/01-skip-broken-tests.patch"

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -36,19 +36,19 @@ rec {
     "${patchSet}/patches/ruby/2.0.0/p${patchLevel}/railsexpress/03-display-more-detailed-stack-trace.patch"
     "${patchSet}/patches/ruby/2.0.0/p${patchLevel}/railsexpress/04-show-full-backtrace-on-stack-overflow.patch"
   ];
-  "2.1.7" = [
-    ./ssl_v3.patch
+  "2.1.10" = [
     ./rand-egd.patch
   ] ++ ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.1.7/railsexpress/01-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.1.7/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.1.7/railsexpress/03-display-more-detailed-stack-trace.patch"
-    "${patchSet}/patches/ruby/2.1.7/railsexpress/04-show-full-backtrace-on-stack-overflow.patch"
-    "${patchSet}/patches/ruby/2.1.7/railsexpress/05-funny-falcon-stc-density.patch"
-    "${patchSet}/patches/ruby/2.1.7/railsexpress/06-funny-falcon-stc-pool-allocation.patch"
-    "${patchSet}/patches/ruby/2.1.7/railsexpress/07-aman-opt-aset-aref-str.patch"
-    "${patchSet}/patches/ruby/2.1.7/railsexpress/08-funny-falcon-method-cache.patch"
-    "${patchSet}/patches/ruby/2.1.7/railsexpress/09-heap-dump-support.patch"
+    # 2.1.10 patchsets are not available, but 2.1.8 patchsets apply
+    "${patchSet}/patches/ruby/2.1.8/railsexpress/01-zero-broken-tests.patch"
+    "${patchSet}/patches/ruby/2.1.8/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.1.8/railsexpress/03-display-more-detailed-stack-trace.patch"
+    "${patchSet}/patches/ruby/2.1.8/railsexpress/04-show-full-backtrace-on-stack-overflow.patch"
+    "${patchSet}/patches/ruby/2.1.8/railsexpress/05-funny-falcon-stc-density.patch"
+    "${patchSet}/patches/ruby/2.1.8/railsexpress/06-funny-falcon-stc-pool-allocation.patch"
+    "${patchSet}/patches/ruby/2.1.8/railsexpress/07-aman-opt-aset-aref-str.patch"
+    "${patchSet}/patches/ruby/2.1.8/railsexpress/08-funny-falcon-method-cache.patch"
+    "${patchSet}/patches/ruby/2.1.8/railsexpress/09-heap-dump-support.patch"
   ];
   "2.2.5" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.2.5/railsexpress/01-zero-broken-tests.patch"

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner  = "skaes";
   repo   = "rvm-patchsets";
-  rev    = "84d0634ce5639781c4d8e9396ec20341d6524901";
-  sha256 = "06x2r43i8kpcmk6s5idrc3z49p8vy18b2lsh1jdqla69i5z2vqlf";
+  rev    = "951e47ca1022cd1e41de9177fa87438cfb72d127";
+  sha256 = "18n2frwmn6lcnjywysyjam1zfzfad0r50141xs2h9kifsyak5xcf";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6004,7 +6004,7 @@ in
   inherit (callPackage ../development/interpreters/ruby {})
     ruby_1_9_3
     ruby_2_0_0
-    ruby_2_1_7
+    ruby_2_1_10
     ruby_2_2_5
     ruby_2_3_1;
 
@@ -6012,7 +6012,7 @@ in
   ruby = ruby_2_3;
   ruby_1_9 = ruby_1_9_3;
   ruby_2_0 = ruby_2_0_0;
-  ruby_2_1 = ruby_2_1_7;
+  ruby_2_1 = ruby_2_1_10;
   ruby_2_2 = ruby_2_2_5;
   ruby_2_3 = ruby_2_3_1;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6005,7 +6005,7 @@ in
     ruby_1_9_3
     ruby_2_0_0
     ruby_2_1_7
-    ruby_2_2_3
+    ruby_2_2_5
     ruby_2_3_1;
 
   # Ruby aliases
@@ -6013,7 +6013,7 @@ in
   ruby_1_9 = ruby_1_9_3;
   ruby_2_0 = ruby_2_0_0;
   ruby_2_1 = ruby_2_1_7;
-  ruby_2_2 = ruby_2_2_3;
+  ruby_2_2 = ruby_2_2_5;
   ruby_2_3 = ruby_2_3_1;
 
   scsh = callPackage ../development/interpreters/scsh { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
