### PR TITLE
redis: 3.0.7 -> 3.2.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1609.xml
+++ b/nixos/doc/manual/release-notes/rl-1609.xml
@@ -33,12 +33,19 @@ has the following highlights: </para>
 following incompatible changes:</para>
 
 <itemizedlist>
+
   <listitem>
     <para>Shell aliases for systemd sub-commands
     <link xlink:href="https://github.com/NixOS/nixpkgs/pull/15598">were dropped</link>:
     <command>start</command>, <command>stop</command>,
     <command>restart</command>, <command>status</command>.</para>
   </listitem>
+
+  <listitem>
+    <para>Redis now binds to 127.0.0.1 only instead of listening to all network interfaces. This is the default 
+    behavior of Redis 3.2</para>
+  </listitem>
+
 </itemizedlist>
 
 

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, lua }:
 
 stdenv.mkDerivation rec {
-  version = "3.0.7";
+  version = "3.2.2";
   name = "redis-${version}";
 
   src = fetchurl {
     url = "http://download.redis.io/releases/${name}.tar.gz";
-    sha256 = "08vzfdr67gp3lvk770qpax2c5g2sx8hn6p64jn3jddrvxb2939xj";
+    sha256 = "05cf63502b2248b5d39588962100bfa4fcb47dabd56931a8cb60b301b1d8daea";
   };
 
   buildInputs = [ lua ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  Used: `nix-env --option build-use-sandbox true -f . -iA redis`
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
