### PR TITLE
zam-plugins: 3.6 -> 3.7

### DIFF
--- a/pkgs/applications/audio/zam-plugins/default.nix
+++ b/pkgs/applications/audio/zam-plugins/default.nix
@@ -2,20 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "zam-plugins-${version}";
-  version = "3.6";
+  version = "3.7";
 
   src = fetchgit {
     url = "https://github.com/zamaudio/zam-plugins.git";
     deepClone = true;
-    rev = "91fe56931a3e57b80f18c740d2dde6b44f962aee";
-    sha256 = "1ldrqh6nk0m1axb553wjp1gfznw8b6b3k0v0z1jdwy425sl6g07d";
+    rev = "932046905a57f698406318765a60807a1f81257d";
+    sha256 = "0zgkmq3jgysrsb6cm6sfbgqpgfpwv8nxlgkqm29zzvb97j56bm7z";
   };
 
   buildInputs = [ boost libX11 mesa liblo libjack2 ladspaH lv2 pkgconfig rubberband libsndfile ];
 
   patchPhase = ''
     patchShebangs ./dpf/utils/generate-ttl.sh
-    substituteInPlace Makefile --replace "ZaMaximX2" "ZaMaximX2 ZamPiano ZamChild670"
   '';
 
   makeFlags = [


### PR DESCRIPTION
###### Motivation for this change

update
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
