### PR TITLE
mopidy-musicbox-webclient: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/applications/audio/mopidy-musicbox-webclient/default.nix
+++ b/pkgs/applications/audio/mopidy-musicbox-webclient/default.nix
@@ -3,13 +3,13 @@
 pythonPackages.buildPythonApplication rec {
   name = "mopidy-musicbox-webclient-${version}";
 
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "pimusicbox";
     repo = "mopidy-musicbox-webclient";
     rev = "v${version}";
-    sha256 = "0v09wy40ipl0b0dpgmcdl15c5g732c9jl7zipm4sy4pr8xiy6baa";
+    sha256 = "1jcfrwsi7axiph3jplqzmcqia9pc46xb2yf13d8h6lnh3h49rwvz";
   };
 
   propagatedBuildInputs = [ mopidy ];


### PR DESCRIPTION
###### Motivation for this change

update!
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
