### PR TITLE
Fake wget

### DIFF
--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchhg, fetchurl, fetchzip, gtk, glib, pkgconfig, unzip, ncurses, zip }:
+{ stdenv, fetchhg, fetchurl, fetchzip, fake-wget, gtk, glib, pkgconfig, unzip, ncurses, zip }:
 let
   # Textadept requires a whole bunch of external dependencies.
   # The build system expects to be able to download them with wget.
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
   name = "textadept-${version}";
 
   buildInputs = [
-    gtk glib pkgconfig unzip ncurses zip
+    fake-wget gtk glib pkgconfig unzip ncurses zip
   ];
 
   src = fetchhg {
@@ -123,12 +123,6 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     cd src
-
-    # Make a dummy wget.
-    mkdir wget
-    echo '#! ${stdenv.shell}' > wget/wget
-    chmod a+x wget/wget
-    export PATH="$PATH:$PWD/wget"
 
     ${get_deps}
 

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -16,7 +16,7 @@
 { stdenv, config, fetchurl,
   python, pkgconfig, yasm,
   autoconf, automake, libtool, m4,
-  libass, libsamplerate, fribidi, libxml2, bzip2,
+  fake-wget, libass, libsamplerate, fribidi, libxml2, bzip2,
   libogg, libtheora, libvorbis, libdvdcss, a52dec, fdk_aac,
   lame, faac, ffmpeg, libdvdread, libdvdnav, libbluray,
   mp4v2, mpeg2dec, x264, libmkv,
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ python pkgconfig yasm autoconf automake libtool m4 ];
   buildInputs = [
-    fribidi fontconfig freetype hicolor_icon_theme
+    fake-wget fribidi fontconfig freetype hicolor_icon_theme
     libass libsamplerate libxml2 bzip2
     libogg libtheora libvorbis libdvdcss a52dec libmkv fdk_aac
     lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264
@@ -60,14 +60,6 @@ stdenv.mkDerivation rec {
   patches = stdenv.lib.optional (! allowUnfree) ./disable-unfree.patch;
 
   preConfigure = ''
-    # Fake wget to prevent downloads
-    mkdir wget
-    echo "#!/bin/sh" > wget/wget
-    echo "echo ===== Not fetching \$*" >> wget/wget
-    echo "exit 1" >> wget/wget
-    chmod +x wget/wget
-    export PATH=$PATH:$PWD/wget
-
     # Force using nixpkgs dependencies
     sed -i '/MODULES += contrib/d' make/include/main.defs
     sed -i '/PKG_CONFIG_PATH=/d' gtk/module.rules

--- a/pkgs/tools/networking/fake-wget/default.nix
+++ b/pkgs/tools/networking/fake-wget/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, ... }:
+
+stdenv.mkDerivation rec {
+
+  name = "fake-wget-1.0";
+
+  src = ./fake-wget.sh;
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -v $src $out/bin/wget
+    chmod +x $out/bin/wget
+  '';
+
+  meta = {
+
+    description = "A fake wget implementation that does nothing";
+
+    longDescription = ''
+      Provides an executable called "wget" which prints a message and halts
+      with exit code 1. This is intended for use with builds where the
+      configure phase fails if it can't find wget, but where you want a
+      deterministic build where nothing should actually be fetched from the
+      network.
+    '';
+
+    license = with lib.licenses; [ free ];
+
+    maintainers = with lib.maintainers; [ chris-martin ];
+
+  };
+
+}

--- a/pkgs/tools/networking/fake-wget/fake-wget.sh
+++ b/pkgs/tools/networking/fake-wget/fake-wget.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo "fake-wget is refusing to execute this command:"
+echo ""
+echo "    wget $*"
+echo ""
+
+exit 1

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4062,6 +4062,8 @@ in
     libpsl = null;
   };
 
+  fake-wget = callPackage ../tools/networking/fake-wget {};
+
   which = callPackage ../tools/system/which { };
 
   wicd = callPackage ../tools/networking/wicd { };


### PR DESCRIPTION
###### Motivation for this change

I found myself needing a mock `wget` executable for a new package I'm working on to get its `configure` script working, and I discovered that several ad-hoc solutions for this already exist in the `preConfigure` phases of a few derivations in `nixpkgs`.

Having a package for this removes a bit of duplicated code, but I think more significantly it makes life a little easier for authors of future packages that may find this useful (as I do in the package I'm currently working on), and provides a place to document the technique.
###### Future work

There is a slightly more complex variant of this in `xen` which, instead of just failing, implements `wget` in a mock way that copies files from a local cache. It may be useful to expand this at some point to include a behavior along those lines.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
