### PR TITLE
ZNC: 1.6.2 -> 1.6.3, push 2015-12-07 -> 2016-07-28, module refactor

### DIFF
--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -26,53 +26,35 @@ let
   };
 
   # Keep znc.conf in nix store, then symlink or copy into `dataDir`, depending on `mutable`.
+  notNull = a: ! isNull a;
   mkZncConf = confOpts: ''
-    // Also check http://en.znc.in/wiki/Configuration
-    
-    AnonIPLimit = 10
-    ConnectDelay = 5
-    # Add `LoadModule = x` for each module...
+    Version = 1.6.3
     ${concatMapStrings (n: "LoadModule = ${n}\n") confOpts.modules}
-    MaxBufferSize = 500
-    ProtectWebSessions = true
-    SSLCertFile = ${cfg.dataDir}/znc.pem
-    ServerThrottle = 30
-    Skin = dark-clouds
-    StatusPrefix = *
-    Version = 1.2
 
-    <Listener listener0>
-            AllowIRC = true
-            AllowWeb = true
+    <Listener l>
+            Port = ${toString confOpts.port}
             IPv4 = true
-            IPv6 = false
-            Port = ${if confOpts.useSSL then "+" else ""}${toString confOpts.port}
+            IPv6 = true
             SSL = ${if confOpts.useSSL then "true" else "false"}
     </Listener>
     
     <User ${confOpts.userName}>
-            Admin = true
-            Allow = *
-            AltNick = ${confOpts.nick}_
-            AppendTimestamp = false
-            AutoClearChanBuffer = false
-            Buffer = 150
-            ChanModes = +stn
-            DenyLoadMod = false
-            DenySetBindHost = false
-            Ident = ident
-            JoinTries = 10
-            MaxJoins = 0
-            MaxNetworks = 1
-            MultiClients = true
-            Nick = ${confOpts.nick}
-            PrependTimestamp = true
-            QuitMsg = Quit
-            RealName = ${confOpts.nick}
-            TimestampFormat = [%H:%M:%S]
-            ${concatMapStrings (n: "LoadModule = ${n}\n") confOpts.userModules}
-            
             ${confOpts.passBlock}
+            Admin = true
+            Nick = ${confOpts.nick}
+            AltNick = ${confOpts.nick}_
+            Ident = ${confOpts.nick}
+            RealName = ${confOpts.nick}
+            ${concatMapStrings (n: "LoadModule = ${n}\n") confOpts.userModules}
+
+            ${ lib.concatStringsSep "\n" (lib.mapAttrsToList (name: net: ''
+              <Network ${name}>
+                  ${concatMapStrings (m: "LoadModule = ${m}\n") net.modules}
+                  Server = ${net.server} ${if net.useSSL then "+" else ""}${toString net.port}
+
+                  ${concatMapStrings (c: "<Chan #${c}>\n</Chan>\n") net.channels}
+              </Network>
+              '') confOpts.networks) }
     </User>
     ${confOpts.extraZncConf}
   '';
@@ -82,6 +64,62 @@ let
     text = if cfg.zncConf != ""
       then cfg.zncConf
       else mkZncConf cfg.confOptions;
+  };
+
+  networkOpts = { ... }: {
+    options = {
+      server = mkOption {
+        type = types.str;
+        example = "chat.freenode.net";
+        description = ''
+          IRC server address.
+        '';
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 6697;
+        example = 6697;
+        description = ''
+          IRC server port.
+        '';
+      };
+
+      useSSL = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to use SSL to connect to the IRC server.
+        '';
+      };
+
+      modulePackages = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        example = [ "pkgs.zncModules.push" "pkgs.zncModules.fish" ];
+        description = ''
+          External ZNC modules to build.
+        '';
+      };
+
+      modules = mkOption {
+        type = types.listOf types.str;
+        default = [ "simple_away" ];
+        example = literalExample "[ simple_away sasl ]";
+        description = ''
+          ZNC modules to load.
+        '';
+      };
+
+      channels = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "nixos" ];
+        description = ''
+          IRC channels to join.
+        '';
+      };
+    };
   };
 
 in
@@ -111,6 +149,15 @@ in
         '';
       };
 
+      group = mkOption {
+        default = "";
+        example = "users";
+        type = types.string;
+        description = ''
+          Group to own the ZNCserver process.
+        '';
+      };
+
       dataDir = mkOption {
         default = "/var/lib/znc/";
         example = "/home/john/.znc/";
@@ -125,27 +172,16 @@ in
         example = "See: http://wiki.znc.in/Configuration";
         type = types.lines;
         description = ''
-          The contents of the `znc.conf` file to use when creating it.
+          Config file as generated with `znc --makeconf` to use for the whole ZNC configuration.
           If specified, `confOptions` will be ignored, and this value, as-is, will be used.
           If left empty, a conf file with default values will be used.
-          Recommended to generate with `znc --makeconf` command.
         '';
       };
 
-      /* TODO: add to the documentation of the current module:
-
-         Values to use when creating a `znc.conf` file.
-
-           confOptions = {
-             modules = [ "log" ];
-             userName = "john";
-             nick = "johntron";
-           };
-      */
       confOptions = {
         modules = mkOption {
           type = types.listOf types.str;
-          default = [ "partyline" "webadmin" "adminlog" "log" ];
+          default = [ "webadmin" "adminlog" ];
           example = [ "partyline" "webadmin" "adminlog" "log" ];
           description = ''
             A list of modules to include in the `znc.conf` file.
@@ -154,8 +190,8 @@ in
 
         userModules = mkOption {
           type = types.listOf types.str;
-          default = [ ];
-          example = [ "fish" "push" ];
+          default = [ "chansaver" "controlpanel" ];
+          example = [ "chansaver" "controlpanel" "fish" "push" ];
           description = ''
             A list of user modules to include in the `znc.conf` file.
           '';
@@ -166,9 +202,25 @@ in
           example = "johntron";
           type = types.string;
           description = ''
-            The user name to use when generating the `znc.conf` file.
-            This is the user name used by the user logging into the ZNC web admin.
+            The user name used to log in to the ZNC web admin interface.
           '';
+        };
+
+        networks = mkOption {
+          default = { };
+          type = types.loaOf types.optionSet;
+          description = ''
+            IRC networks to connect the user to.
+          '';
+          options = [ networkOpts ];
+          example = {
+            "freenode" = {
+              server = "chat.freenode.net";
+              port = 6697;
+              ssl = true;
+              modules = [ "simple_away" ];
+            };
+          };
         };
 
         nick = mkOption {
@@ -176,19 +228,16 @@ in
           example = "john";
           type = types.string;
           description = ''
-            The IRC nick to use when generating the `znc.conf` file.
+            The IRC nick.
           '';
         };
 
         passBlock = mkOption {
-          default = defaultPassBlock;
-          example = "Must be the block generated by the `znc --makepass` command.";
+          example = defaultPassBlock;
           type = types.string;
           description = ''
-            The pass block to use when generating the `znc.conf` file.
-            This is the password used by the user logging into the ZNC web admin.
-            This is the block generated by the `znc --makepass` command.
-            !!! If not specified, please change this after starting the service. !!!
+            Generate with znc --makepass.
+            This is the password used to log in to the ZNC web admin interface.
           '';
         };
 
@@ -206,7 +255,7 @@ in
           example = true;
           type = types.bool;
           description = ''
-            Indicates whether the ZNC server should use SSL when listening on the specified port.
+            Indicates whether the ZNC server should use SSL when listening on the specified port. A self-signed certificate will be generated.
           '';
         };
 
@@ -214,7 +263,7 @@ in
           default = "";
           type = types.lines;
           description = ''
-            Extra config to `znc.conf` file
+            Extra config to `znc.conf` file.
           '';
         };
       };
@@ -265,6 +314,7 @@ in
       after = [ "network.service" ];
       serviceConfig = {
         User = cfg.user;
+        Group = cfg.group;
         Restart = "always";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         ExecStop   = "${pkgs.coreutils}/bin/kill -INT $MAINPID";

--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -7,11 +7,11 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "znc-1.6.2";
+  name = "znc-1.6.3";
 
   src = fetchurl {
     url = "http://znc.in/releases/${name}.tar.gz";
-    sha256 = "14q5dyr5zg99hm6j6g1gilcn1zf7dskhxfpz3bnkyhy6q0kpgwgf";
+    sha256 = "09xqi5fs40x6nj9gq99bnw1a7saq96bvqxknxx0ilq7yfvg4c733";
   };
 
   buildInputs = [ openssl pkgconfig ]
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Advanced IRC bouncer";
     homepage = http://wiki.znc.in/ZNC;
-    maintainers = with maintainers; [ viric ];
+    maintainers = with maintainers; [ viric schneefux ];
     license = licenses.asl20;
     platforms = platforms.unix;
   };

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -95,13 +95,13 @@ in rec {
 
   push = zncDerivation rec {
     name = "znc-push-${version}";
-    version = "git-2015-12-07";
+    version = "git-2016-07-28";
     module_name = "push";
 
     src = fetchgit {
       url = "https://github.com/jreese/znc-push.git";
-      rev = "717a2b1741eee75456b0862ef76dbb5af906e936";
-      sha256 = "1ih1hf11mqgi0cfh6v70v3b93xrw83xcb80psmijcqxi7kwjn404";
+      rev = "ca11c9b10062a7399a7f2a1b9653c9cc15854bb8";
+      sha256 = "0qk2qzjawy89p7s0cac2sjdbf8wmks592xc5c3i5gj10l0iyri5w";
     };
 
     meta = {
@@ -109,7 +109,7 @@ in rec {
       homepage = https://github.com/jreese/znc-push;
       repositories.git = https://github.com/jreese/znc-push.git;
       license = stdenv.lib.licenses.mit;
-      maintainers = [ stdenv.lib.maintainers.offline ];
+      maintainers = with stdenv.lib.maintainers; [ offline schneefux ];
     };
   };
 

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -95,14 +95,14 @@ in rec {
 
   push = zncDerivation rec {
     name = "znc-push-${version}";
-    version = "git-2016-07-28";
+    version = "git-2016-10-12";
     module_name = "push";
 
     src = fetchFromGitHub {
       owner = "jreese";
       repo = "znc-push";
-      rev = "ca11c9b10062a7399a7f2a1b9653c9cc15854bb8";
-      sha256 = "0qk2qzjawy89p7s0cac2sjdbf8wmks592xc5c3i5gj10l0iyri5w";
+      rev = "cf08b9e0f483f03c28d72dd78df932cbef141f10";
+      sha256 = "0xpwjw8csyrg736g1jc1n8d6804x6kbdkrvldzhk9ldj4iwqz7ay";
     };
 
     meta = {

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchgit, znc }:
+{ stdenv, fetchurl, fetchFromGitHub, znc }:
 
 let
   zncDerivation = a@{
@@ -20,8 +20,9 @@ in rec {
     version = "git-2015-08-27";
     module_name = "clientbuffer";
 
-    src = fetchgit {
-      url = meta.repositories.git;
+    src = fetchFromGitHub {
+      owner = "jpnurmi";
+      repo = "znc-clientbuffer";
       rev = "fe0f368e1fcab2b89d5c94209822d9b616cea840";
       sha256 = "1s8bqqlwy9kmcpmavil558rd2b0wigjlzp2lpqpcqrd1cg25g4a7";
     };
@@ -29,7 +30,6 @@ in rec {
     meta = with stdenv.lib; {
       description = "ZNC module for client specific buffers";
       homepage = https://github.com/jpnurmi/znc-clientbuffer;
-      repositories.git = https://github.com/jpnurmi/znc-clientbuffer.git;
       license = licenses.asl20;
       maintainers = with maintainers; [ hrdinka ];
     };
@@ -40,8 +40,10 @@ in rec {
     version = "git-2014-10-10";
     module_name = "fish";
 
-    src = fetchgit {
-      url = meta.repositories.git;
+    src = fetchFromGitHub {
+      # this fork works with ZNC 1.6
+      owner = "jarrydpage";
+      repo = "znc-fish";
       rev = "9c580e018a1a08374e814fc06f551281cff827de";
       sha256 = "0yvs0jkwwp18qxqvw1dvir91ggczz56ka00k0zlsb81csdi8xfvl";
     };
@@ -49,8 +51,6 @@ in rec {
     meta = {
       description = "ZNC FiSH module";
       homepage = https://github.com/dctrwatson/znc-fish;
-      # this fork works with ZNC 1.6
-      repositories.git = https://github.com/jarrydpage/znc-fish.git;
       maintainers = [ stdenv.lib.maintainers.offline ];
     };
   };
@@ -60,8 +60,9 @@ in rec {
     version = "git-2015-08-04";
     module_name = "playback";
 
-    src = fetchgit {
-      url = meta.repositories.git;
+    src = fetchFromGitHub {
+      owner = "jpnurmi";
+      repo = "znc-playback";
       rev = "8691abf75becc1f3d7b5bb5ad68dad17cd21863b";
       sha256 = "0mgfajljy035051b2sx70i8xrb51zw9q2z64kf85zw1lynihzyh4";
     };
@@ -69,7 +70,6 @@ in rec {
     meta = with stdenv.lib; {
       description = "An advanced playback module for ZNC";
       homepage = https://github.com/jpnurmi/znc-playback;
-      repositories.git = https://github.com/jpnurmi/znc-playback.git;
       license = licenses.asl20;
       maintainers = with maintainers; [ hrdinka ];
     };
@@ -80,8 +80,9 @@ in rec {
     version = "git-2015-02-22";
     module_name = "privmsg";
 
-    src = fetchgit {
-      url = meta.repositories.git;
+    src = fetchFromGitHub {
+      owner = "kylef";
+      repo = "znc-contrib";
       rev = "9f1f98db56cbbea96d83e6628f657e0d62cd9517";
       sha256 = "0n82z87gdxxragcaixjc80z8bw4bmfwbk0jrf9zs8kk42phlkkc2";
     };
@@ -89,7 +90,6 @@ in rec {
     meta = {
       description = "ZNC privmsg module";
       homepage = https://github.com/kylef/znc-contrib;
-      repositories.git = https://github.com/kylef/znc-contrib.git;
     };
   };
 
@@ -98,8 +98,9 @@ in rec {
     version = "git-2016-07-28";
     module_name = "push";
 
-    src = fetchgit {
-      url = "https://github.com/jreese/znc-push.git";
+    src = fetchFromGitHub {
+      owner = "jreese";
+      repo = "znc-push";
       rev = "ca11c9b10062a7399a7f2a1b9653c9cc15854bb8";
       sha256 = "0qk2qzjawy89p7s0cac2sjdbf8wmks592xc5c3i5gj10l0iyri5w";
     };
@@ -107,7 +108,6 @@ in rec {
     meta = {
       description = "Push notification service module for ZNC";
       homepage = https://github.com/jreese/znc-push;
-      repositories.git = https://github.com/jreese/znc-push.git;
       license = stdenv.lib.licenses.mit;
       maintainers = with stdenv.lib.maintainers; [ offline schneefux ];
     };


### PR DESCRIPTION
Updated ZNC to 1.6.3, changed release URL to Git repository because only the latest release is published on the release page, which regularly breaks the build.
Also see #17427 to add better SSL support required for Let's Encrypt.

The module now builds a minimal configuration. The module allows to specify networks to be set up. Added an option to run ZNC under a specific group. Clarified and reworded some descriptions. Removed `defaultPassBlock` so that a user is forced to generate a password and does not use the hardcoded one.

Usage example:

``` nix
   services.znc = {
     enable = true;
     user = "znc";
     group = "letsencrypt";
     mutable = false;
     modulePackages = [ pkgs.zncModules.push ];
     confOptions = {
       userName = "user";
       passBlock = "Pass = …";
       modules = [ "adminlog" ];
       userModules = [ "block_motd" "bouncedcc" "ctcpflood" "flooddetach" "log" "push" ];
       networks = {
         "freenode" = {
           server = "chat.freenode.net";
           port = 6697;
           useSSL = true;
           channels = [ "nixos" ];
           modules = [ "simple_away" "sasl" ];
         };
         "efnet" = {
           server = "efnet.port80.se";
           port = 6667;
           useSSL = false;
           channels = [ "test" ];
           modules = [ "simple_away" "keepnick" ];
         };
       };
       nick = "nick";
       port = 5000;
       useSSL = true;
     };
   };
```

cc @offlinehacker @chexxor @viric 
###### Things done
- [ ] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files
