### PR TITLE
supercollider: 3.6.6 -> 3.7.2

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,33 +1,21 @@
 { stdenv, fetchurl, cmake, pkgconfig
 , libjack2, libsndfile, fftw, curl, gcc
-, libXt, qt, readline
+, libXt, qt55, readline
 , useSCEL ? false, emacs
 }:
 
 let optional = stdenv.lib.optional;
-ljack2 = libjack2.override { gcc = gcc; };
 in
 
 stdenv.mkDerivation rec {
-  name = "supercollider-3.6.6";
+  name = "supercollider-${version}";
+  version = "3.7.2";
 
-  meta = {
-    description = "Programming language for real time audio synthesis";
-    homepage = "http://supercollider.sourceforge.net/";
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.linux;
-  };
 
   src = fetchurl {
-    url = "mirror://sourceforge/supercollider/Source/3.6/SuperCollider-3.6.6-Source.tar.bz2";
-    sha256 = "11khrv6jchs0vv0lv43am8lp0x1rr3h6l2xj9dmwrxcpdayfbalr";
+    url = "https://github.com/supercollider/supercollider/releases/download/Version-${version}/SuperCollider-${version}-Source-linux.tar.bz2";
+    sha256 = "1mybxcnl7flliz74kdfnvh18v5dwd9zbdsw2kc7wpl4idcly1n0s";
   };
-
-  # QGtkStyle unavailable
-  patchPhase = ''
-    substituteInPlace editors/sc-ide/widgets/code_editor/autocompleter.cpp \
-      --replace Q_WS_X11 Q_GTK_STYLE
-  '';
 
   cmakeFlags = ''
     -DSC_WII=OFF
@@ -37,6 +25,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-    gcc ljack2 libsndfile fftw curl libXt qt readline ]
+    gcc libjack2 libsndfile fftw curl libXt qt55.qtwebkit qt55.qttools readline ]
     ++ optional useSCEL emacs;
+
+  meta = {
+    description = "Programming language for real time audio synthesis";
+    homepage = "http://supercollider.sourceforge.net/";
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.linux;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5988,8 +5988,6 @@ in
   spidermonkey_31 = callPackage ../development/interpreters/spidermonkey/31.5.nix { };
 
   supercollider = callPackage ../development/interpreters/supercollider {
-    gcc = gcc48; # doesn't build with gcc49
-    qt = qt4;
     fftw = fftwSinglePrec;
   };
 
@@ -15839,7 +15837,7 @@ in
   };
 
   solarus = callPackage ../games/solarus { };
-  
+
   solarus-quest-editor = qt5.callPackage ../development/tools/solarus-quest-editor { };
 
   # You still can override by passing more arguments.


### PR DESCRIPTION
###### Motivation for this change

update
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
