### PR TITLE
cpuminer-multi: 20140723 -> 20160316, limit builds to linux

### DIFF
--- a/pkgs/tools/misc/cpuminer-multi/default.nix
+++ b/pkgs/tools/misc/cpuminer-multi/default.nix
@@ -2,8 +2,8 @@
 , aesni ? true }:
 
 let
-  rev = "977dad27e18627e5b723800f5f4201e385fe0d2e";
-  date = "20140723";
+  rev = "8393e03089c0abde61bd5d72aba8f926c3d6eca4";
+  date = "20160316";
 in
 stdenv.mkDerivation rec {
   name = "cpuminer-multi-${date}-${stdenv.lib.strings.substring 0 7 rev}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     inherit rev;
     url = https://github.com/wolf9466/cpuminer-multi.git;
-    sha256 = "1lzaiwy2wk9awpzpfnp3d6dymnb4bvgw1vg2433plfqhi9jfdrqj";
+    sha256 = "11dg4rra4dgfb9x6q85irn0hrkx2lkwyrdpgdh10pag09s3vhy4v";
   };
 
   buildInputs = [ autoconf automake curl jansson ];
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/wolf9466/cpuminer-multi;
     license = licenses.gpl2;
     maintainers = [ maintainers.ehmry ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
- bump to latest version
- limit builds to linux (failed compiling on osx including previous versions)
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
