### PR TITLE
nixos-artwork: make the standard nixos grub background default

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -212,11 +212,12 @@ in
     ];
 
     services.xserver.displayManager.sddm = {
-      theme = "breeze";
+      theme = "nixos";
       themes = [
         kde5.ecm # for the setup-hook
         kde5.plasma-workspace
         kde5.breeze-icons
+        pkgs.nixos-artwork
         (kde5.oxygen-icons or kde5.oxygen-icons5)
       ];
     };

--- a/pkgs/data/misc/nixos-artwork/default.nix
+++ b/pkgs/data/misc/nixos-artwork/default.nix
@@ -1,21 +1,83 @@
-{ stdenv, fetchurl }:
+{ stdenv, lib, pkgs, fetchurl, writeText }:
 
-stdenv.mkDerivation {
+let
+  sddm_metadata = writeText "sddm_metadata.desktop" ''
+    [SddmGreeterTheme]
+    Name=Breeze
+    Description=NixOS Theme
+    Author=David Edmundson and NixOS
+    Copyright=(c) 2014, David Edmundson and NixOS
+    License=CC-BY-SA
+    Type=sddm-theme
+    Version=0.1
+    Website=https://nixos.org
+    Screenshot=breeze.jpg
+    MainScript=Main.qml
+    ConfigFile=theme.conf
+    TranslationsDirectory=translations
+    Email=davidedmundson@kde.org
+    Theme-Id=nixos
+    Theme-API=2.0
+  '';
+
+  plasma_metadata = writeText "plasma_metadata.desktop" ''
+    [Desktop Entry]
+    Comment=NixOS Breeze Desktop Design Language by the KDE VDG and NixOS
+    Encoding=UTF-8
+    Keywords=Desktop;Workspace;Appearance;Look and Feel;Logout;Lock;Suspend;Shutdown;Hibernate;
+    Name=Breeze_NixOS
+    Type=Service
+
+    X-KDE-ServiceTypes=Plasma/LookAndFeel
+    X-KDE-ParentApp=
+    X-KDE-PluginInfo-Author=KDE Visual Design Group and NixOS
+    X-KDE-PluginInfo-Category=
+    X-KDE-PluginInfo-Email=plasma-devel@kde.org
+    X-KDE-PluginInfo-License=GPLv2+
+    X-KDE-PluginInfo-Name=org.nixos.breeze.desktop
+    X-KDE-PluginInfo-Version=2.0
+    X-KDE-PluginInfo-Website=http://www.nixos.org
+    X-Plasma-MainScript=defaults
+  '';
+
+  pkg_plasma = lib.getBin pkgs.kde5.plasma-workspace;
+
+in stdenv.mkDerivation rec {
   name = "nixos-artwork-2015-02-27";
   # Remember to check the default lightdm wallpaper when updating
+
+  doStrip = false;
+
+  sourceRoot = ./.;
+
+  buildInputs = [ pkg_plasma ];
 
   GnomeDark = fetchurl {
     url = https://raw.githubusercontent.com/NixOS/nixos-artwork/7ece5356398db14b5513392be4b31f8aedbb85a2/gnome/Gnome_Dark.png;
     sha256 = "0c7sl9k4zdjwvdz3nhlm8i4qv4cjr0qagalaa1a438jigixx27l7";
   };
 
-  unpackPhase = "true";
+  phases = [ "installPhase" ];
 
   installPhase = ''
-    mkdir -p $out/share/artwork/gnome
-    ln -s $GnomeDark $out/share/artwork/gnome/Gnome_Dark.png
+    gnome=$out/share/artwork/gnome
+    mkdir -p $gnome
+    ln -s $GnomeDark $gnome/Gnome_Dark.png
+
+    sddm=$out/share/sddm/themes/nixos
+    mkdir -p $sddm
+    cp -r --no-preserve=mode ${pkg_plasma}/share/sddm/themes/breeze/* $sddm/
+    ln -sf $GnomeDark $sddm/components/artwork/background.png
+    ln -sf ${sddm_metadata} $sddm/metadata.desktop
+
+    plasma=$out/share/plasma/look-and-feel/org.nixos.breeze.desktop
+    mkdir -p $plasma
+    cp -r --no-preserve=mode ${pkg_plasma}/share/plasma/look-and-feel/org.kde.breeze.desktop/* $plasma/
+    ln -sf $GnomeDark \
+       $plasma/contents/components/artwork/background.png
+    ln -sf ${plasma_metadata} $plasma/metadata.desktop
   '';
-  
+
   meta = with stdenv.lib; {
     homepage = https://github.com/NixOS/nixos-artwork;
     platforms = platforms.all;

--- a/pkgs/desktops/kde-5/plasma/startkde/startkde.sh
+++ b/pkgs/desktops/kde-5/plasma/startkde/startkde.sh
@@ -75,7 +75,7 @@ mkdir -p "$configDir"
 cat >$configDir/startupconfigkeys <<EOF
 kcminputrc Mouse cursorTheme 'breeze_cursors'
 kcminputrc Mouse cursorSize ''
-ksplashrc KSplash Theme Breeze
+ksplashrc KSplash Theme org.nixos.breeze.desktop
 ksplashrc KSplash Engine KSplashQML
 kdeglobals KScreen ScreenScaleFactors ''
 kcmfonts General forceFontDPI 0


### PR DESCRIPTION
###### Motivation for this change

2 reasons really:

1) the current desktop experience is not particular uniform - grub will show a background with the Nix logo after which sddm will then proceed to show the stock KDE background. In this first iteration, it will be the same image all the way from grub over sddm to KDE splash.

2) I am personally not a fan of the stock KDE look. The feedback on various fora indicates that 
I'm not alone in this.

The package does its work by creating modified versions of Breeze for SDDM and Plasma that has the default grub background image instead of the default KDE backgrounds. We then replace a few names, but otherwise it's same as regular breeze to avoid having to maintain a full theme.

I understand that it can be controversial due to changing a default setting (the SDDM theme), but the changes to the Plasma theme only take effect for a new user/profile.

This is the first step towards a slightly more uniform look.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
