### PR TITLE
geant4: Add geant4 license to licenses.nix

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -195,6 +195,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Unspecified free software license";
   };
 
+  g4sl = {
+    fullName = "Geant4 Software License";
+    url = https://geant4.web.cern.ch/geant4/license/LICENSE.html;
+  };
+
   gpl1 = spdx {
     spdxId = "GPL-1.0";
     fullName = "GNU General Public License v1.0 only";


### PR DESCRIPTION
###### Motivation for this change

Building `geant4` did fail because of the missing g4sl license attribute in licenses.nix.
###### Things done

Added license to `licenses.nix`.
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This license was left out during the geant4 pull request:
https://github.com/NixOS/nixpkgs/pull/3963
