### PR TITLE
motif: Add support for darwin

### DIFF
--- a/pkgs/applications/editors/nedit/default.nix
+++ b/pkgs/applications/editors/nedit/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, xlibsWrapper, motif, libXpm }:
 
-assert stdenv.isLinux;
-
 stdenv.mkDerivation rec {
   name = "nedit-5.6a";
   
@@ -12,7 +10,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ xlibsWrapper motif libXpm ];
 
-  buildFlags = if stdenv.isLinux then "linux" else "";
+  buildFlags = if stdenv.isLinux then "linux" else
+               # the linux config works fine on darwin too!
+               if stdenv.isDarwin then "linux" else "";
 
   NIX_CFLAGS_COMPILE="-DBUILD_UNTESTED_NEDIT -L${motif}/lib";
 
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
     cp -p source/nedit source/nc $out/bin
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.nedit.org;
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/catclock/default.nix
+++ b/pkgs/applications/misc/catclock/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     homepage = http://codefromabove.com/2014/05/catclock/;
     license = with licenses; mit;
     maintainers = with maintainers; [ ramkromberg ];
-    platforms = with platforms; linux;
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/libraries/motif/Add-X.Org-to-bindings-file.patch
+++ b/pkgs/development/libraries/motif/Add-X.Org-to-bindings-file.patch
@@ -1,0 +1,7 @@
+--- a/bindings/xmbind.alias
++++ b/bindings/xmbind.alias
+@@ -62,3 +62,4 @@
+ "Sun Microsystems, Inc."				sun
+ ! "Sun Microsystems, Inc."				sun_at
+ "Tektronix, Inc."					tek
++"The X.Org Foundation"				tpc

--- a/pkgs/development/libraries/motif/Do-not-compile-demos.patch
+++ b/pkgs/development/libraries/motif/Do-not-compile-demos.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -27,7 +27,6 @@ SUBDIRS   = bindings bitmaps \
+              include \
+              tools \
+              clients \
+-             doc \
+-             demos
++             doc
+ AUTOMAKE_OPTIONS = 1.4
+ ACLOCAL_AMFLAGS = -I .

--- a/pkgs/development/libraries/motif/Remove-unsupported-weak-refs-on-darwin.patch
+++ b/pkgs/development/libraries/motif/Remove-unsupported-weak-refs-on-darwin.patch
@@ -1,0 +1,12 @@
+--- a/lib/Xm/XmP.h
++++ b/lib/Xm/XmP.h
+@@ -1437,7 +1437,7 @@ extern void _XmDestroyParentCallback(
+ 
+ #endif /* NO_XM_1_2_BC */
+ 
+-#if __GNUC__
++#if __GNUC__ && ! __APPLE__
+ #  define XM_DEPRECATED  __attribute__((__deprecated__))
+ #  define XM_ALIAS(sym)  __attribute__((__weak__,alias(#sym)))
+ #else
+

--- a/pkgs/development/libraries/motif/Use-correct-header-for-malloc.patch
+++ b/pkgs/development/libraries/motif/Use-correct-header-for-malloc.patch
@@ -1,0 +1,19 @@
+--- a/demos/programs/workspace/xrmLib.c
++++ b/demos/programs/workspace/xrmLib.c
+@@ -30,7 +30,14 @@ static char rcsid[] = "$XConsortium: xrmLib.c /main/6 1995/07/14 10:01:41 drk $"
+ #endif
+ 
+ #include <stdio.h>
+-#include <malloc.h>
++#if defined(__cplusplus) || defined(__STDC__) || defined(__EXTENSIONS__)
++#  include <stdlib.h>
++#  if defined(HAVE_MALLOC_H)
++#  include <malloc.h>
++#  elif defined(HAVE_SYS_MALLOC_H)
++#  include <sys/malloc.h>
++#  endif
++#endif
+ #include <Xm/Xm.h>
+ #include "wsm.h"
+ #include "wsmDebug.h"
+

--- a/pkgs/development/libraries/motif/default.nix
+++ b/pkgs/development/libraries/motif/default.nix
@@ -17,29 +17,29 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgconfig libtool
+    libtool
     xlibsWrapper xbitmaps libXrender libXmu libXt
     expat libjpeg libpng libiconv
-  ] ++ stdenv.lib.optionals (!demoSupport) [ autoconf automake ];
+  ];
 
-  nativeBuildInputs = [ flex ];
+  nativeBuildInputs = [ pkgconfig flex ] ++ stdenv.lib.optionals (!demoSupport) [ autoconf automake ];
 
   propagatedBuildInputs = [ libXp libXau ];
 
   makeFlags = [ "CFLAGS=-fno-strict-aliasing" ];
 
-  patchPhase = ''
-    rm lib/Xm/Xm.h
-    echo -e '"The X.Org Foundation"\t\t\t\t\tpc' >>bindings/xmbind.alias
-  '' + stdenv.lib.optionalString (!demoSupport)
-  ''
-    sed -i -e '/^SUBDIRS/{:x;/\\$/{N;bx;};s/[ \t\n\\]*demos//;}' Makefile.am
-  '';
+  prePatch = ''rm lib/Xm/Xm.h'';
+
+  patches = [ ./Remove-unsupported-weak-refs-on-darwin.patch
+              ./Use-correct-header-for-malloc.patch
+              ./Add-X.Org-to-bindings-file.patch
+            ]
+            ++ stdenv.lib.optional (!demoSupport) ./Do-not-compile-demos.patch;
 
   meta = with stdenv.lib; {
     homepage = http://motif.ics.com;
     description = "Unix standard widget-toolkit and window-manager";
-    platforms = with platforms; linux;
+    platforms = with platforms; linux ++ darwin;
     license = with licenses; [ lgpl21 ];
     maintainers = with maintainers; [ ];
   };


### PR DESCRIPTION
###### Motivation for this change

This is the first step for closing https://github.com/NixOS/nixpkgs/issues/17359 to deprecate lesstif in favor of motif.
###### Things done
- Added darwin support for `motif`
- Checked if `motif` works correctly by porting `catclock` and `nedit` to darwin.
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
