### PR TITLE
moonlight-embedded: init at 2.2.1

### DIFF
--- a/pkgs/applications/misc/moonlight-embedded/default.nix
+++ b/pkgs/applications/misc/moonlight-embedded/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchgit, cmake, perl
+, alsaLib, libevdev, libopus, libudev, SDL2
+, ffmpeg, pkgconfig, xorg, libvdpau, libpulseaudio, libcec
+, curl, expat, avahi, enet, libuuid
+}:
+
+stdenv.mkDerivation rec {
+  name = "moonlight-embedded-${version}";
+  version = "2.2.1";
+
+  # fetchgit used to ensure submodules are available
+  src = fetchgit {
+    url = "git://github.com/irtimmer/moonlight-embedded";
+    rev = "refs/tags/v${version}";
+    sha256 = "0m1114dsz44rvq402b4v5ib2cwj2vbasir0l8vi0q5iymwmsvxj4";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  nativeBuildInputs = [ cmake perl ];
+  buildInputs = [
+    alsaLib libevdev libopus libudev SDL2
+    ffmpeg pkgconfig xorg.libxcb libvdpau libpulseaudio libcec
+    xorg.libpthreadstubs curl expat avahi enet libuuid
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Open source implementation of NVIDIA's GameStream";
+    homepage = https://github.com/irtimmer/moonlight-embedded;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.globin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13886,6 +13886,8 @@ in
     inherit (gnome) libgnomecanvas glib;
   };
 
+  moonlight-embedded = callPackage ../applications/misc/moonlight-embedded { };
+
   mop = callPackage ../applications/misc/mop { };
 
   mopidy = callPackage ../applications/audio/mopidy { };


### PR DESCRIPTION
Newly packaged moonlight-embedded.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - N/A OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
