### PR TITLE
Cleanup of construo package

### DIFF
--- a/pkgs/games/construo/default.nix
+++ b/pkgs/games/construo/default.nix
@@ -1,29 +1,26 @@
-{ stdenv, fetchurl, builderDefs, libX11, zlib, xproto, mesa ? null, freeglut ? null }:
+{ stdenv, fetchurl, libX11, zlib, xproto, mesa ? null, freeglut ? null }:
 
-	let localDefs = builderDefs.passthru.function {
-		src = /* put a fetchurl here */
-		fetchurl {
-			url = http://savannah.nongnu.org/download/construo/construo-0.2.2.tar.gz;
-			sha256 = "0c661rjasax4ykw77dgqj39jhb4qi48m0bhhdy42vd5a4rfdrcck";
-		};
-
-		buildInputs = [ libX11 zlib xproto ]
-                  ++ stdenv.lib.optional (mesa != null) mesa
-                  ++ stdenv.lib.optional (freeglut != null) freeglut;
-		preConfigure = builderDefs.stringsWithDeps.fullDepEntry (''
-		  sed -e 's/math[.]h/cmath/' -i vector.cxx
-		  sed -e 's/games/bin/' -i Makefile.in
-		  sed -e '1i\#include <stdlib.h>' -i construo_main.cxx -i command_line.cxx -i config.hxx
-		  sed -e '1i\#include <string.h>' -i command_line.cxx -i lisp_reader.cxx -i unix_system.cxx \
-		      -i world.cxx construo_main.cxx
-		'') ["doUnpack" "minInit"];
-	};
-	in with localDefs;
 stdenv.mkDerivation rec {
-	name = "construo-0.2.2";
-	builder = writeScript (name + "-builder")
-		(textClosure localDefs ["preConfigure" "doConfigure" "doMakeInstall" "doForceShare" "doPropagate"]);
-	meta = {
-		description = "Masses and springs simulation game";
-	};
+  name = "construo-0.2.2";
+
+  src = fetchurl {
+    url = http://savannah.nongnu.org/download/construo/construo-0.2.2.tar.gz;
+    sha256 = "0c661rjasax4ykw77dgqj39jhb4qi48m0bhhdy42vd5a4rfdrcck";
+  };
+
+  buildInputs = [ libX11 zlib xproto ]
+    ++ stdenv.lib.optional (mesa != null) mesa
+    ++ stdenv.lib.optional (freeglut != null) freeglut;
+
+  preConfigure = ''
+    sed -e 's/math[.]h/cmath/' -i vector.cxx
+    sed -e 's/games/bin/' -i Makefile.in
+    sed -e '1i\#include <stdlib.h>' -i construo_main.cxx -i command_line.cxx -i config.hxx
+    sed -e '1i\#include <string.h>' -i command_line.cxx -i lisp_reader.cxx -i unix_system.cxx \
+      -i world.cxx construo_main.cxx
+  '';
+
+  meta = {
+    description = "Masses and springs simulation game";
+  };
 }

--- a/pkgs/games/construo/default.nix
+++ b/pkgs/games/construo/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, libX11, zlib, xproto, mesa ? null, freeglut ? null }:
 
 stdenv.mkDerivation rec {
-  name = "construo-0.2.2";
+  name = "construo-${version}";
+  version = "0.2.3";
 
   src = fetchurl {
-    url = http://savannah.nongnu.org/download/construo/construo-0.2.2.tar.gz;
-    sha256 = "0c661rjasax4ykw77dgqj39jhb4qi48m0bhhdy42vd5a4rfdrcck";
+    url = "https://github.com/Construo/construo/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "1wmj527hbj1qv44cdsj6ahfjrnrjwg2dp8gdick8nd07vm062qxa";
   };
 
   buildInputs = [ libX11 zlib xproto ]
@@ -13,14 +14,12 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (freeglut != null) freeglut;
 
   preConfigure = ''
-    sed -e 's/math[.]h/cmath/' -i vector.cxx
-    sed -e 's/games/bin/' -i Makefile.in
-    sed -e '1i\#include <stdlib.h>' -i construo_main.cxx -i command_line.cxx -i config.hxx
-    sed -e '1i\#include <string.h>' -i command_line.cxx -i lisp_reader.cxx -i unix_system.cxx \
-      -i world.cxx construo_main.cxx
+    substituteInPlace src/Makefile.in \
+      --replace games bin
   '';
 
   meta = {
     description = "Masses and springs simulation game";
+    homepage = http://fs.fsf.org/construo/;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

To replace `builderDefsPackage`. I also updated to 0.2.3 in a separate commit to simplify the package further (and to fix the build of the glut version).

See #4210 for further motivation.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
