### PR TITLE
cxxtest: init at 4.4

### DIFF
--- a/pkgs/development/libraries/cxxtest/default.nix
+++ b/pkgs/development/libraries/cxxtest/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, pythonPackages}:
+
+stdenv.mkDerivation rec {
+  version = "4.4";
+  name = "cxxtest";
+
+  src = fetchFromGitHub {
+    owner = "CxxTest";
+    repo = name;
+    rev = version;
+    sha256 = "19w92kipfhp5wvs47l0qpibn3x49sbmvkk91yxw6nwk6fafcdl17";
+  };
+
+  buildInputs = with pythonPackages; [ python wrapPython ];
+
+  installPhase = ''
+    cd python
+    python setup.py install --prefix=$out
+    cd ..
+
+    mkdir -p $out/include
+    cp -R cxxtest $out/include/
+
+    wrapPythonProgramsIn $out/bin "$out $pythonPath"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://cxxtest.com";
+    description = "Unit testing framework for C++";
+    platforms = platforms.unix ;
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.juliendehos ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7075,6 +7075,8 @@ in
 
   cxx-prettyprint = callPackage ../development/libraries/cxx-prettyprint { };
 
+  cxxtest = callPackage ../development/libraries/cxxtest { };
+
   cyrus_sasl = callPackage ../development/libraries/cyrus-sasl {
     kerberos = if stdenv.isFreeBSD then libheimdal else kerberos;
   };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

NB: wrapPython changes the interpreter (from python to sh) for the main script (cxxtestgen), so I had to update the cmake module too.

---
