### PR TITLE
offlineimap's module: change UI to syslog

### DIFF
--- a/nixos/modules/services/networking/offlineimap.nix
+++ b/nixos/modules/services/networking/offlineimap.nix
@@ -54,7 +54,7 @@ in {
       description = "Offlineimap: a software to dispose your mailbox(es) as a local Maildir(s)";
       serviceConfig = {
         Type      = "oneshot";
-        ExecStart = "${cfg.package}/bin/offlineimap -u basic -o -1";
+        ExecStart = "${cfg.package}/bin/offlineimap -u syslog -o -1";
         TimeoutStartSec = cfg.timeoutStartSec;
       };
       path = cfg.path;


### PR DESCRIPTION
###### Motivation for this change

The 'syslog' UI "allows better integration with systemd":
http://www.offlineimap.org/doc/Changelog.html#offlineimap-v660-rc2-2015-10-15
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The 'syslog' UI "allows better integration with systemd":
http://www.offlineimap.org/doc/Changelog.html#offlineimap-v660-rc2-2015-10-15
