### PR TITLE
rdup: init at 1.1.15

### DIFF
--- a/pkgs/tools/backup/rdup/default.nix
+++ b/pkgs/tools/backup/rdup/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, glib, pcre }:
+
+stdenv.mkDerivation rec {
+  name = "rdup-${version}";
+  version = "1.1.15";
+
+  src = fetchFromGitHub {
+    owner = "miekg";
+    repo = "rdup";
+    rev = "d66e4320cd0bbcc83253baddafe87f9e0e83caa6";
+    sha256 = "0bzyv6qmnivxnv9nw7lnfn46k0m1dlxcjj53zcva6v8y8084l1iw";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ glib pcre ];
+
+  meta = {
+    description = "The only backup program that doesn't make backups";
+    homepage    = "https://github.com/miekg/rdup";
+    license    = stdenv.lib.licenses.gpl3;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ lukasepple ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14430,6 +14430,8 @@ in
 
   rdesktop = callPackage ../applications/networking/remote/rdesktop { };
 
+  rdup = callPackage ../tools/backup/rdup { };
+
   recode = callPackage ../tools/text/recode { };
 
   remotebox = callPackage ../applications/virtualization/remotebox { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
