### PR TITLE
leatherman: disable curl test to fix build

### DIFF
--- a/pkgs/development/libraries/leatherman/default.nix
+++ b/pkgs/development/libraries/leatherman/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost cmake curl ];
 
+  # curl upgrade to 7.50.0 (#17152) broke the curl mock tests, disabling for now
+  # upstream bug raised https://tickets.puppetlabs.com/browse/LTH-108
+  cmakeFlags = [ "-DLEATHERMAN_MOCK_CURL=OFF" ];
+
   meta = with stdenv.lib; {
     homepage = https://github.com/puppetlabs/leatherman/;  
     description = "A collection of C++ and CMake utility libraries";


### PR DESCRIPTION
- curl upgrade to 7.50.0 (#17152) broke the curl mock tests, disabling for now
- upstream bug raised https://tickets.puppetlabs.com/browse/LTH-108
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
