### PR TITLE
grsecurity module: disable EFI runtime services by default

### DIFF
--- a/nixos/doc/manual/configuration/grsecurity.xml
+++ b/nixos/doc/manual/configuration/grsecurity.xml
@@ -265,6 +265,11 @@
   <sect1 xml:id="sec-grsec-issues"><title>Issues and work-arounds</title>
 
   <itemizedlist>
+    <listitem><para>Access to EFI runtime services is disabled by default:
+    this plugs a potential code injection attack vector; use
+    <option>security.grsecurity.disableEfiRuntimeServices</option> to override
+    this behavior.</para></listitem>
+
     <listitem><para>Virtualization: KVM is the preferred virtualization
     solution. Xen, Virtualbox, and VMWare are
     <emphasis>unsupported</emphasis> and most likely require a custom kernel.

--- a/nixos/modules/security/grsecurity.nix
+++ b/nixos/modules/security/grsecurity.nix
@@ -37,6 +37,18 @@ in
       '';
     };
 
+    disableEfiRuntimeServices = mkOption {
+      type = types.bool;
+      example = false;
+      default = true;
+      description = ''
+        Whether to disable access to EFI runtime services.  Enabling EFI runtime
+        services creates a venue for code injection attacks on the kernel and
+        should be disabled if at all possible.  Changing this option enters into
+        effect upon reboot.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -44,6 +56,8 @@ in
     # Allow the user to select a different package set, subject to the stated
     # required kernel config
     boot.kernelPackages = mkDefault pkgs.linuxPackages_grsec_nixos;
+
+    boot.kernelParams = optional cfg.disableEfiRuntimeServices "noefi";
 
     system.requiredKernelConfig = with config.lib.kernelConfig;
       [ (isEnabled "GRKERNSEC")


### PR DESCRIPTION
Enabling EFI runtime services creates a RWX mapping to kernel land, providing a venue for injecting malicious code into the kernel.

When grsecurity is enabled, we close this by default by disabling access to EFI runtime services, with an optional toggle to enable it if the user really needs it for some reason.
