### PR TITLE
cmake: add support for cxxtest

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
         --subst-var-by glibc_bin ${getBin glibc} \
         --subst-var-by glibc_dev ${getDev glibc} \
         --subst-var-by glibc_lib ${getLib glibc}
+      substituteInPlace Modules/FindCxxTest.cmake \
+        --replace "$""{PYTHON_EXECUTABLE}" ${stdenv.shell}
     '';
   configureFlags =
     [ "--docdir=share/doc/${name}"


### PR DESCRIPTION
###### Motivation for this change

Cmake uses the python interpreter to call cxxtest. In the Nix package, cxxtest is wrapped in a shell script (#17416). This PR patches the cmake config for using the shell interpreter to call the wrapped cxxtest.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
