### PR TITLE
python: add file encoding to run_setup.py

### DIFF
--- a/pkgs/development/python-modules/generic/run_setup.py
+++ b/pkgs/development/python-modules/generic/run_setup.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import setuptools
 import tokenize
 


### PR DESCRIPTION
###### Motivation for this change

Newer 'mutagen' versions have a test suite that trips over missing
encoding in this file. This file is copied to source trees with the name
nix_run_setup.py.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

WARNING: Untested. Posted for review and seeing how much Travis will build before timing out.
