### PR TITLE
lie: fix makefile

### DIFF
--- a/pkgs/applications/science/math/LiE/default.nix
+++ b/pkgs/applications/science/math/LiE/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     substituteInPlace make_lie \
       --replace \`/bin/pwd\` $out
+    substituteInPlace Makefile --replace "CC = gcc" "CC ?= gcc"
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
