### PR TITLE
acct: only build on linux

### DIFF
--- a/pkgs/tools/system/acct/default.nix
+++ b/pkgs/tools/system/acct/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.gnu.org/software/acct/;
 
     maintainers = with maintainers; [ pSub ];
-    platforms = with platforms; allBut cygwin;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

"acct" doesn't build on Darwin platforms. From what I can tell, it's a Linux-only kernel feature, so I'm setting it to platforms.linux.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
