### PR TITLE
Add missing Konsole kpart to various KDE applications

### DIFF
--- a/pkgs/applications/editors/kile/frameworks.nix
+++ b/pkgs/applications/editors/kile/frameworks.nix
@@ -1,9 +1,9 @@
-{ stdenv
+{ kdeDerivation
 , lib
 , fetchgit
-, extra-cmake-modules
+, ecm
 , kdoctools
-, makeQtWrapper
+, kdeWrapper
 , qtscript
 , kconfig
 , kcrash
@@ -13,54 +13,55 @@
 , kiconthemes
 , kinit
 , khtml
+, konsole
 , kparts
 , ktexteditor
 , kwindowsystem
 , poppler
 }:
 
-stdenv.mkDerivation rec {
-  name = "kile-${version}";
-  version = "2016-07-02";
+let
+  unwrapped =
+    kdeDerivation rec {
+      name = "kile-${version}";
+      version = "2016-07-02";
 
-  src = fetchgit {
-    url = git://anongit.kde.org/kile.git;
-    rev = "d38bc7069667119cc891b351188484ca6fb88973";
-    sha256 = "1nha71i16fs7nq2812b5565nbmbsbs3ak5czas6xg1dg5bsvdqh8";
+      src = fetchgit {
+        url = git://anongit.kde.org/kile.git;
+        rev = "d38bc7069667119cc891b351188484ca6fb88973";
+        sha256 = "1nha71i16fs7nq2812b5565nbmbsbs3ak5czas6xg1dg5bsvdqh8";
 
-  };
+      };
 
-  nativeBuildInputs = [
-    extra-cmake-modules
-    kdoctools
-    makeQtWrapper
-  ];
+      nativeBuildInputs = [ ecm kdoctools ];
 
-  buildInputs = [
-    qtscript
-    kconfig
-    kcrash
-    kdbusaddons
-    kdelibs4support
-    kdoctools
-    kguiaddons
-    kiconthemes
-    kinit
-    khtml
-    kparts
-    ktexteditor
-    kwindowsystem
-    poppler
-  ];
+      buildInputs = [
+        kconfig
+        kcrash
+        kdbusaddons
+        kdelibs4support
+        kdoctools
+        kguiaddons
+        kiconthemes
+        kinit
+        khtml
+        kparts
+        ktexteditor
+        kwindowsystem
+        poppler
+        qtscript
+      ];
 
-  postInstall = ''
-    wrapQtProgram "$out/bin/kile"
-  '';
-
-  meta = {
-    description = "Kile is a user friendly TeX/LaTeX authoring tool for the KDE desktop environment";
-    homepage = https://www.kde.org/applications/office/kile/;
-    maintainers = with lib.maintainers; [ fridh ];
-    license = lib.licenses.gpl2Plus;
-  };
+      meta = {
+        description = "Kile is a user friendly TeX/LaTeX authoring tool for the KDE desktop environment";
+        homepage = https://www.kde.org/applications/office/kile/;
+        maintainers = with lib.maintainers; [ fridh ];
+        license = lib.licenses.gpl2Plus;
+      };
+    };
+in
+kdeWrapper unwrapped
+{
+  targets = [ "bin/kile" ];
+  paths = [ konsole.unwrapped ];
 }

--- a/pkgs/desktops/kde-5/applications/dolphin.nix
+++ b/pkgs/desktops/kde-5/applications/dolphin.nix
@@ -4,7 +4,7 @@
   baloo, baloo-widgets, dolphin-plugins, kactivities, kbookmarks, kcmutils,
   kcompletion, kconfig, kcoreaddons, kdelibs4support, kdbusaddons,
   kfilemetadata, ki18n, kiconthemes, kinit, kio, knewstuff, knotifications,
-  kparts, ktexteditor, kwindowsystem, phonon, solid
+  konsole, kparts, ktexteditor, kwindowsystem, phonon, solid
 }:
 
 let
@@ -27,5 +27,5 @@ in
 kdeWrapper unwrapped
 {
   targets = [ "bin/dolphin" ];
-  paths = [ dolphin-plugins ];
+  paths = [ dolphin-plugins konsole.unwrapped ];
 }

--- a/pkgs/desktops/kde-5/applications/kate.nix
+++ b/pkgs/desktops/kde-5/applications/kate.nix
@@ -1,10 +1,10 @@
 {
   kdeApp, lib, kdeWrapper,
   ecm, kdoctools,
-  kactivities, kconfig, kcrash, kguiaddons, kiconthemes, ki18n, kinit,
-  kjobwidgets, kio, kparts, ktexteditor, kwindowsystem, kxmlgui, kdbusaddons,
-  kwallet, plasma-framework, kitemmodels, knotifications, qtscript,
-  threadweaver, knewstuff, libgit2
+  kactivities, kconfig, kcrash, kdbusaddons, kguiaddons, kiconthemes, ki18n,
+  kinit, kio, kitemmodels, kjobwidgets, knewstuff, knotifications, konsole,
+  kparts, ktexteditor, kwindowsystem, kwallet, kxmlgui, libgit2,
+  plasma-framework, qtscript, threadweaver
 }:
 
 let
@@ -24,4 +24,8 @@ let
       ];
     };
 in
-kdeWrapper unwrapped { targets = [ "bin/kate" "bin/kwrite" ]; }
+kdeWrapper unwrapped
+{
+  targets = [ "bin/kate" "bin/kwrite" ];
+  paths = [ konsole.unwrapped ];
+}


### PR DESCRIPTION
###### Motivation for this change

I missed a few runtime Konsole dependencies in the wrapper updates! Fixes #17419.

@FRidh As the Kile maintainer, could you check that it works with the new wrapper?
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
