### PR TITLE
afl: 2.10b -> 2.23b

### DIFF
--- a/pkgs/tools/security/afl/default.nix
+++ b/pkgs/tools/security/afl/default.nix
@@ -9,11 +9,11 @@ let
 in
 stdenv.mkDerivation rec {
   name    = "afl-${version}";
-  version = "2.10b";
+  version = "2.23b";
 
   src = fetchurl {
     url    = "http://lcamtuf.coredump.cx/afl/releases/${name}.tgz";
-    sha256 = "1qxz3szsdr3ciz496mjb5v2k8p90nilgnlbwwv9csk828qb2jhc1";
+    sha256 = "152pqrc0py6jk1i3pwn2k928bsgax0d4yavpa3ca29bmrbzpnadh";
   };
 
   # Note: libcgroup isn't needed for building, just for the afl-cgroup


### PR DESCRIPTION
Looks like mostly performance enhancements and stability fixes.  The main user facing changes appear to be:
- The -Z option was removed
- A macro named FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION is defined when
  compiling with afl-gcc

Full changelog at http://lcamtuf.coredump.cx/afl/ChangeLog.txt
