### PR TITLE
Haskell generic-builder: clean before configuring.

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -216,6 +216,9 @@ stdenv.mkDerivation ({
   configurePhase = ''
     runHook preConfigure
 
+    # Let's clean first, just in case a dirty build output directory already exists.
+    ${setupCommand} clean
+
     unset GHC_PACKAGE_PATH      # Cabal complains if this variable is set during configure.
 
     echo configureFlags: $configureFlags


### PR DESCRIPTION
###### Motivation for this change

This is particularly useful when the `src` of the Haskell package is a local
directory for a project you are working on, in which there probably is a dirty
`dist` directory created by `Setup.hs` or `Cabal`. By calling `./Setup.hs clean`
before `configure`, we ensure that this directory is cleaned up and that `Cabal`
and `ghc` don't try to pick any build objects from this directory. Calling
`clean` always succeeds, even in projects when there is nothing to clean.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peti 
