### PR TITLE
flat-plat: init at 3.20.20160404

### DIFF
--- a/pkgs/misc/themes/flat-plat/default.nix
+++ b/pkgs/misc/themes/flat-plat/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, pkgs }:
+
+stdenv.mkDerivation rec {
+  name = "flat-plat-gtk-theme-${version}";
+  version = "3.20.20160404";
+
+  src = fetchurl {
+    url = "https://github.com/nana-4/Flat-Plat/releases/download/${version}/Flat-Plat-${version}.tar.gz";
+    md5 = "32716d645a2d4524dffba78c10b7d294";
+  };
+
+  buildInputs = [ pkgs.gnome3.gnome_themes_standard ];
+
+  preferLocalBuild = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    cp -r .. $out/share/themes
+  '';
+
+  meta = {
+    description = "A Material Design-like flat theme for GTK3, GTK2, and GNOME Shell";
+    homepage = https://github.com/nana-4/Flat-Plat;
+    licence = stdenv.lib.licences.gpl2;
+    maintainers = [ "Mounium <muoniurn@gmail.com>" ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}
+

--- a/pkgs/misc/themes/flat-plat/default.nix
+++ b/pkgs/misc/themes/flat-plat/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, pkgs }:
+
+stdenv.mkDerivation rec {
+  name = "flat-plat-gtk-theme-${version}";
+  version = "3.20.20160404";
+
+  src = fetchurl {
+    url = "https://github.com/nana-4/Flat-Plat/releases/download/${version}/Flat-Plat-${version}.tar.gz";
+    md5 = "32716d645a2d4524dffba78c10b7d294";
+  };
+
+  buildInputs = [ pkgs.gnome3.gnome_themes_standard ];
+
+  preferLocalBuild = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    cp -r .. $out/share/themes
+  '';
+
+  meta = {
+    description = "A Material Design-like flat theme for GTK3, GTK2, and GNOME Shell";
+    homepage = https://github.com/nana-4/Flat-Plat;
+    licence = stdenv.lib.licenses.gpl2;
+    maintainers = [ "Mounium <muoniurn@gmail.com>" ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -795,6 +795,8 @@ in
 
   filebench = callPackage ../tools/misc/filebench { };
 
+  flat-plat = callPackage ../misc/themes/flat-plat { };
+
   fop = callPackage ../tools/typesetting/fop { };
 
   fondu = callPackage ../tools/misc/fondu { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
