### PR TITLE
Fix Poppler with Qt >= 5.7

### DIFF
--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, fetchurl, fetchpatch, pkgconfig, libiconv, libintlOrEmpty
 , zlib, curl, cairo, freetype, fontconfig, lcms, libjpeg, openjpeg
-, minimal ? false, qt4Support ? false, qt4 ? null, qt5Support ? false, qtbase ? null
+, minimal ? false
+, qt4Support ? false, qt4 ? null
+, qt5Support ? false, qtbase ? null
 , utils ? false, suffix ? "glib"
 }:
 
@@ -30,6 +32,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig libiconv ] ++ libintlOrEmpty;
 
   NIX_CFLAGS_COMPILE = [ "-DQT_NO_DEBUG" ];
+
+  # Any package depending on Qt >= 5.7 must build using the C++11 standard.
+  CXXFLAGS = lib.optional qt5Support "-std=c++11";
 
   configureFlags = with lib;
     [


### PR DESCRIPTION
###### Motivation for this change

The build is broken.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Packages that depend on Qt >= 5.7 must build using the C++11 standard.
