### PR TITLE
puddletag: init at 1.1.1

### DIFF
--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, lib, fetchFromGitHub, pythonPackages, makeWrapper, chromaprint }:
+
+with lib;
+with pythonPackages;
+
+buildPythonApplication rec {
+  version = "1.1.1";
+  name = "puddletag-${version}";
+  namePrefix = "";
+
+  src = fetchFromGitHub {
+    owner = "keithgg";
+    repo = "puddletag";
+    rev = "1.1.1";
+    sha256 = "0zmhc01qg64fb825b3kj0mb0r0d9hms30nqvhdks0qnv7ahahqrx";
+  };
+
+  sourceRoot = "${name}-src/source";
+
+  disabled = isPy3k;
+
+  outputs = [ "out" ];
+
+  propagatedBuildInputs = [
+    chromaprint
+    configobj
+    mutagen
+    pyparsing
+    pyqt4
+  ];
+
+  doCheck = false;   # there are no tests
+  dontStrip = true;  # we are not generating any binaries
+
+  installPhase = ''
+    siteDir=$(toPythonPath $out)
+    mkdir -p $siteDir
+    PYTHONPATH=$PYTHONPATH:$siteDir
+    ${python.interpreter} setup.py install --prefix $out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://puddletag.net;
+    description = "An audio tag editor similar to the Windows program, Mp3tag";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13078,6 +13078,8 @@ in
 
   rhythmbox = callPackage ../applications/audio/rhythmbox { };
 
+  puddletag = callPackage ../applications/audio/puddletag { };
+
   wavesurfer = callPackage ../applications/misc/audio/wavesurfer { };
 
   wireshark-cli = callPackage ../applications/networking/sniffers/wireshark {


### PR DESCRIPTION
I'm not sure if using `propagatedBuildInputs` is correct instead of just using `buildInputs`. If `PYTHONPATH` is set correctly in the wrapped "binary", it shouldn't be necessary, right?
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
