### PR TITLE
notmuch-mutt: init at 0.22

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -5,10 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "notmuch-0.22";
+  version = "0.22";
+  name = "notmuch-${version}";
 
   passthru = {
     pythonSourceRoot = "${name}/bindings/python";
+    inherit version;
   };
 
   src = fetchurl {

--- a/pkgs/applications/networking/mailreaders/notmuch/mutt.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/mutt.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, fetchurl, perl, buildPerlPackage, perlPackages, makeWrapper, coreutils
+, notmuch }:
+
+stdenv.mkDerivation rec {
+  name = "notmuch-mutt-${version}";
+  version = notmuch.version;
+
+  outputs = [ "out" ];
+
+  dontStrip = true;
+
+  buildInputs = [
+    perl
+    makeWrapper
+  ] ++ (with perlPackages; [
+    FileRemove
+    DigestSHA1
+    Later
+    MailBox
+    MailMaildir
+    MailTools
+    StringShellQuote
+    TermReadLineGnu
+  ]);
+
+  src = notmuch.src;
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    ${coreutils}/bin/install -Dm755 \
+      ./contrib/notmuch-mutt/notmuch-mutt \
+      $out/bin/notmuch-mutt
+
+    wrapProgram $out/bin/notmuch-mutt \
+      --prefix PERL5LIB : $PERL5LIB
+  '';
+
+  meta = with lib; {
+    inherit version;
+    description = "Mutt support for notmuch";
+    homepage    = http://notmuchmua.org/;
+    license     = with licenses; mit;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14122,6 +14122,8 @@ in
     sphinx = pythonPackages.sphinx;
   };
 
+  notmuch-mutt = callPackage ../applications/networking/mailreaders/notmuch/mutt.nix { };
+
   # Open Stack
   nova = callPackage ../applications/virtualization/openstack/nova.nix { };
   keystone = callPackage ../applications/virtualization/openstack/keystone.nix { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6956,6 +6956,15 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  Later = buildPerlPackage rec {
+    version = "0.19";
+    name = "Object-Realize-Later-${version}";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/${name}.tar.gz";
+      sha256 = "0ka0qar51kk5wlvd2s3yis3w9qc14h0ngn0ds0v6c8ssmjvfcgbz";
+    };
+  };
+
   lib_ = buildPerlPackage {
     name = "lib-0.63";
     src = fetchurl {
@@ -7599,6 +7608,36 @@ let self = _self // overrides; _self = with self; {
 
   maatkit = import ../development/perl-modules/maatkit {
     inherit fetchurl buildPerlPackage stdenv DBDmysql;
+  };
+
+  MailMaildir = buildPerlPackage rec {
+    version = "1.0.0";
+    name = "Mail-Maildir-${version}";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/Z/ZE/ZEROALTI/Mail-Maildir-100/${name}.tar.bz2";
+      sha256 = "1krkqfps6q3ifrhi9450l5gm9199qyfcm6vidllr0dv65kdaqpj4";
+    };
+  };
+
+  MailBox = buildPerlPackage rec {
+    version = "2.118";
+    name = "Mail-Box-${version}";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/${name}.tar.gz";
+      sha256 = "1ixi7xpvj8kn2y0l8rxkvdnnl7x5wqg7mi2av0viwdh5l828dcfc";
+    };
+
+    doCheck = false;
+
+    propagatedBuildInputs = [
+      Later
+
+      DevelGlobalDestruction
+      FileRemove
+      IOStringy
+      MailTools
+      MIMETypes
+    ];
   };
 
   MailMboxMessageParser = buildPerlPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Has been my daily driver for ages but outside the nixpkgs repo. Might as well upstream it in case others need it.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
