### PR TITLE
dnscrypt-proxy service: auto-updated resolver list

### DIFF
--- a/nixos/tests/dnscrypt-proxy.nix
+++ b/nixos/tests/dnscrypt-proxy.nix
@@ -22,8 +22,6 @@ import ./make-test.nix ({ pkgs, ... }: {
   };
 
   testScript = ''
-    $client->start;
-    $client->waitForUnit("sockets.target");
     $client->waitForUnit("dnsmasq");
 
     # The daemon is socket activated; sending a single ping should activate it.


### PR DESCRIPTION
###### Motivation for this change

Updating the resolver list manually is a waste of time.
###### Things done

Tested in a VM. Works as expected.

---

This removes the abillity to specify a resolver list.  Instead, we always use the upstream resolver list.  This list is then updated (and verified) periodically, to ensure that we're always using a valid server list.
