### PR TITLE
atom: 1.8.0 -> 1.9.0

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "atom-${version}";
-  version = "1.8.0";
+  version = "1.9.0";
 
   src = fetchurl {
     url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
-    sha256 = "0x73n64y3jfwbwg6s9pmsajryrjrrx1a0dzf3ff6dbi5gvv950xi";
+    sha256 = "0hhv1yfs2h5x86pjbkbdg1mn15afdd3baddwpf3p0fl8x2gv9z7m";
     name = "${name}.deb";
   };
 


### PR DESCRIPTION
###### Motivation for this change

I needed an up to date version.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
  **No idea how. It says: `The option 'useChroot' defined in '/etc/nixos/configuration.nix' does not exist.`**
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  **No idea how.**
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  **No idea how. I run `nix-env -i atom -f .` to build and install it. And `nix-build -A atom`.**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'd be happy to fulfill the other tasks, I just need some guidance.
