### PR TITLE
nvidia-x11: fix driSupport32Bit

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
     [ gtk atk pango glib gdk_pixbuf cairo ] );
   programPath = makeLibraryPath [ xorg.libXv ];
 
-  patches = if versionAtLeast kernel.version "4.7" then [ ./365.35-kernel-4.7.patch ] else [];
+  patches = if (!libsOnly) && (versionAtLeast kernel.dev.version "4.7") then [ ./365.35-kernel-4.7.patch ] else [];
 
   buildInputs = [ perl nukeReferences ];
 


### PR DESCRIPTION
###### Motivation for this change

`driSupport32Bit` was broken by 5d11dac8bb8f10b797467e913d6ebb9ea1eccd29.
