### PR TITLE
git-up: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6527,14 +6527,12 @@ in modules // {
   };
 
   git-up = buildPythonPackage rec {
-    version = "1.4.0";
+    version = "1.4.1";
     name = "git-up-${version}";
 
-    src = pkgs.fetchFromGitHub {
-      owner = "msiemens";
-      repo = "PyGitUp";
-      rev = "v${version}";
-      sha256 = "1g7sxiqg6vxx2jlgg8pg9fqsk1xgvm80d7mcpw8i3mw7r835q4bi";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/g/git-up/${name}.zip";
+      sha256 = "1nsdzjnla0926fzfsqnwyzg3f7g253n8lk4wgw8nj2rv0awbdmas";
     };
 
     buildInputs = with self; [ pkgs.git nose ];


### PR DESCRIPTION
###### Motivation for this change

We are now fetching from pypi as they include tests - thanks @FRidh 
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
