### PR TITLE
ratpoison: Inherit patches to allow user customization.

### DIFF
--- a/pkgs/applications/window-managers/ratpoison/default.nix
+++ b/pkgs/applications/window-managers/ratpoison/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
       libX11 inputproto libXt libXpm libXft libXtst xextproto libXi
       fontconfig freetype readline ];
 
+  inherit patches;
+
   meta = with stdenv.lib; {
     homepage = "http://www.nongnu.org/ratpoison/";
     description = "Simple mouse-free tiling window manager";


### PR DESCRIPTION
###### Motivation for this change

I would like to add the ability to add user patches to the ratpoison package.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
