### PR TITLE
reckon: csv to ledger command line application

### DIFF
--- a/pkgs/tools/text/reckon/Gemfile
+++ b/pkgs/tools/text/reckon/Gemfile
@@ -1,2 +1,2 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 gem 'reckon'

--- a/pkgs/tools/text/reckon/Gemfile
+++ b/pkgs/tools/text/reckon/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gem 'reckon'

--- a/pkgs/tools/text/reckon/Gemfile.lock
+++ b/pkgs/tools/text/reckon/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    chronic (0.10.2)
+    fastercsv (1.5.5)
+    highline (1.7.8)
+    reckon (0.4.4)
+      chronic (>= 0.3.0)
+      fastercsv (>= 1.5.1)
+      highline (>= 1.5.2)
+      terminal-table (>= 1.4.2)
+    terminal-table (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  reckon
+
+BUNDLED WITH
+   1.12.5

--- a/pkgs/tools/text/reckon/default.nix
+++ b/pkgs/tools/text/reckon/default.nix
@@ -1,0 +1,16 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv {
+  name = "reckon";
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+ 
+  meta = with lib; {
+    description = "Flexibly import bank account CSV files into Ledger for command line accounting";
+    license = licenses.mit;
+    maintainers = "mckean.kylej@gmail.com";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/text/reckon/default.nix
+++ b/pkgs/tools/text/reckon/default.nix
@@ -1,12 +1,26 @@
-{ lib, bundlerEnv, ruby }:
+{ stdenv, lib, bundlerEnv, makeWrapper }:
 
-bundlerEnv {
-  name = "reckon";
-  inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
- 
+stdenv.mkDerivation rec {
+  name = "reckon-${version}";
+  version = "0.4.4";
+
+  env = bundlerEnv {
+    name = "${name}-gems";
+
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+
+  phases = [ "installPhase" ];
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${env}/bin/reckon $out/bin/cide
+  '';
+
   meta = with lib; {
     description = "Flexibly import bank account CSV files into Ledger for command line accounting";
     license = licenses.mit;

--- a/pkgs/tools/text/reckon/default.nix
+++ b/pkgs/tools/text/reckon/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    makeWrapper ${env}/bin/reckon $out/bin/cide
+    makeWrapper ${env}/bin/reckon $out/bin/reckon
   '';
 
   meta = with lib; {

--- a/pkgs/tools/text/reckon/gemset.nix
+++ b/pkgs/tools/text/reckon/gemset.nix
@@ -1,12 +1,42 @@
 {
   chronic = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hrdkn4g8x7dlzxwb1rfgr8kw3bp4ywg5l4y4i9c2g5cwv62yvvn";
+      type = "gem";
+    };
+    version = "0.10.2";
   };
   fastercsv = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1df3vfgw5wg0s405z0pj0rfcvnl9q6wak7ka8gn0xqg4cag1k66h";
+      type = "gem";
+    };
+    version = "1.5.5";
   };
   highline = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nf5lgdn6ni2lpfdn4gk3gi47fmnca2bdirabbjbz1fk9w4p8lkr";
+      type = "gem";
+    };
+    version = "1.7.8";
   };
   reckon = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1p6w8w7vpl8fq4yfggrxbv6ph76psg7l5b4q29a8zvfbzzx6a0xw";
+      type = "gem";
+    };
+    version = "0.4.4";
   };
   terminal-table = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hbmzfr17ji5ws5x5z3kypmb5irwwss7q7kkad0gs005ibqrxv0a";
+      type = "gem";
+    };
+    version = "1.6.0";
   };
 }

--- a/pkgs/tools/text/reckon/gemset.nix
+++ b/pkgs/tools/text/reckon/gemset.nix
@@ -1,0 +1,12 @@
+{
+  chronic = {
+  };
+  fastercsv = {
+  };
+  highline = {
+  };
+  reckon = {
+  };
+  terminal-table = {
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3309,6 +3309,8 @@ in
 
   replace = callPackage ../tools/text/replace { };
 
+  reckon = callPackage ../tools/text/reckon { };
+
   reposurgeon = callPackage ../applications/version-management/reposurgeon { };
 
   reptyr = callPackage ../os-specific/linux/reptyr {};


### PR DESCRIPTION
###### Motivation for this change

Adds a ruby script that can transform CSV files into ledger files.
###### I need help

I dont program in ruby and so I just followed the nixpkg manual on how to build ruby applications.
When I run `nix-build -A reckon` I get the following error:

``` sh
error: attribute ‘source’ missing, at /home/kyle/packages/pkgs/development/ruby-modules/bundler-env/default.nix:35:53
```

Can anyone help me complete this pr?
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
