### PR TITLE
Truecrypt: fix source url

### DIFF
--- a/pkgs/applications/misc/truecrypt/default.nix
+++ b/pkgs/applications/misc/truecrypt/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
   builder = ./builder.sh;
 
   src = fetchurl {
-    url = http://fossies.org/unix/misc/TrueCrypt-7.1a-Source.tar.gz;
+    url = https://fossies.org/linux/misc/old/TrueCrypt-7.1a-Source.tar.gz;
     sha1 = "d43e0dbe05c04e316447d87413c4f74c68f5de24";
   };
 

--- a/pkgs/applications/misc/truecrypt/default.nix
+++ b/pkgs/applications/misc/truecrypt/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = https://fossies.org/linux/misc/old/TrueCrypt-7.1a-Source.tar.gz;
-    sha1 = "d43e0dbe05c04e316447d87413c4f74c68f5de24";
+    sha256 = "e6214e911d0bbededba274a2f8f8d7b3f6f6951e20f1c3a598fc7a23af81c8dc";
   };
 
   pkcs11h = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

The current URL for truecrypt is a 404. The first commit updates to a working URL. The file contents are identical.

The second commit just changes the hash from sha1 to sha256. Both hashes are listed at the bottom of https://fossies.org/linux/misc/old/TrueCrypt-7.1a-Source.tar.gz/
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
