### PR TITLE
foo2zjs: remove use of `builderDefsPackage`

### DIFF
--- a/pkgs/misc/drivers/foo2zjs/default.nix
+++ b/pkgs/misc/drivers/foo2zjs/default.nix
@@ -1,51 +1,33 @@
-x@{builderDefsPackage
-  , foomatic_filters, bc, unzip, ghostscript, systemd, vim
-  , ...}:
-builderDefsPackage
-(a :  
-let 
-  helperArgNames = ["stdenv" "fetchurl" "builderDefsPackage"] ++ 
-    [];
+{ stdenv, fetchurl, foomatic_filters, bc, unzip, ghostscript, systemd, vim }:
 
-  buildInputs = map (n: builtins.getAttr n x)
-    (builtins.attrNames (builtins.removeAttrs x helperArgNames));
-  sourceInfo = rec {
-    baseName="foo2zjs";
-    version="20110210";
-    name="${baseName}-${version}";
-    url="http://www.loegria.net/mirrors/foo2zjs/${name}.tar.gz";
-    hash="0vss8gdbbgxr694xw48rys2qflbnb4sp4gdb1v6z4m9ab97hs5yk";
-  };
-in
-rec {
-  src = a.fetchurl {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.hash;
+stdenv.mkDerivation rec {
+  name = "foo2zjs-20110210";
+
+  src = fetchurl {
+    url = "http://www.loegria.net/mirrors/foo2zjs/${name}.tar.gz";
+    sha256 = "0vss8gdbbgxr694xw48rys2qflbnb4sp4gdb1v6z4m9ab97hs5yk";
   };
 
-  inherit (sourceInfo) name version;
-  inherit buildInputs;
-
-  phaseNames = ["doPatch" "fixHardcodedPaths" "doMakeDirs" "doMakeInstall" "deployGetWeb"];
+  buildInputs = [ foomatic_filters bc unzip ghostscript systemd vim ];
 
   patches = [ ./no-hardcode-fw.diff ];
 
   makeFlags = [
-      ''PREFIX=$out''
-      ''APPL=$out/share/applications''
-      ''PIXMAPS=$out/share/pixmaps''
-      ''UDEVBIN=$out/bin''
-      ''UDEVDIR=$out/etc/udev/rules.d''
-      ''UDEVD=${systemd.udev.bin}/sbin/udevd''
-      ''LIBUDEVDIR=$out/lib/udev/rules.d''
-      ''USBDIR=$out/etc/hotplug/usb''
-      ''FOODB=$out/share/foomatic/db/source''
-      ''MODEL=$out/share/cups/model''
+    "PREFIX=$(out)"
+    "APPL=$(out)/share/applications"
+    "PIXMAPS=$(out)/share/pixmaps"
+    "UDEVBIN=$(out)/bin"
+    "UDEVDIR=$(out)/etc/udev/rules.d"
+    "UDEVD=${systemd.udev.bin}/sbin/udevd"
+    "LIBUDEVDIR=$(out)/lib/udev/rules.d"
+    "USBDIR=$(out)/etc/hotplug/usb"
+    "FOODB=$(out)/share/foomatic/db/source"
+    "MODEL=$(out)/share/cups/model"
   ];
 
   installFlags = [ "install-hotplug" ];
 
-  fixHardcodedPaths = a.fullDepEntry ''
+  postPatch = ''
     touch all-test
     sed -e "/BASENAME=/iPATH=$out/bin:$PATH" -i *-wrapper *-wrapper.in
     sed -e "s@PREFIX=/usr@PREFIX=$out@" -i *-wrapper{,.in}
@@ -55,28 +37,25 @@ rec {
     sed -e "s@/etc/hotplug/usb@$out&@" -i *rules*
     sed -e "s@/usr@$out@g" -i hplj1020.desktop
     sed -e "/PRINTERID=/s@=.*@=$out/bin/usb_printerid@" -i hplj1000
-  '' ["doPatch" "minInit"];
+  '';
 
-  doMakeDirs = a.fullDepEntry ''
+  preInstall = ''
     mkdir -pv $out/{etc/udev/rules.d,lib/udev/rules.d,etc/hotplug/usb}
     mkdir -pv $out/share/foomatic/db/source/{opt,printer,driver}
     mkdir -pv $out/share/cups/model
     mkdir -pv $out/share/{applications,pixmaps}
-  '' ["minInit"];
 
-  deployGetWeb = a.fullDepEntry ''
     mkdir -pv "$out/bin"
     cp -v getweb arm2hpdl "$out/bin"
-  '' ["minInit"];
-      
-  meta = {
+  '';
+
+  meta = with stdenv.lib; {
     description = "ZjStream printer drivers";
-    maintainers = with a.lib.maintainers;
+    maintainers = with maintainers;
     [
       raskin urkud
     ];
-    platforms = with a.lib.platforms;
-      linux;
-    license = a.lib.licenses.gpl2Plus;
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
   };
-}) x
+}


### PR DESCRIPTION
###### Motivation for this change

To remove use of `builderDefsPackage`, see #4210. Note, I don't use this package myself, just verified that the result directory more or less correspond to the old result.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
