### PR TITLE
cross-compilation: fixes for powerpc-linux-uclibc

### DIFF
--- a/pkgs/build-support/gcc-cross-wrapper/builder.sh
+++ b/pkgs/build-support/gcc-cross-wrapper/builder.sh
@@ -7,7 +7,7 @@ mkdir $out/nix-support
 # Force gcc to use ld-wrapper.sh when calling ld.
 cflagsCompile="-B$out/bin/"
 
-if test -z "$nativeLibc"; then
+if test -z "$nativeLibc" -a -n "$libc"; then
     cflagsCompile="$cflagsCompile -B$gccLibs/lib -B$libc/lib/ -isystem $libc/include"
     ldflags="$ldflags -L$libc/lib"
     # Get the proper dynamic linker for glibc and uclibc. 

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -189,6 +189,9 @@ let version = "4.9.3";
             # To keep ABI compatibility with upstream mingw-w64
             " --enable-fully-dynamic-string"
             else (if cross.libc == "uclibc" then
+              # libsanitizer requires netrom/netrom.h which is not
+              # available in uclibc.
+              " --disable-libsanitizer" +
               # In uclibc cases, libgomp needs an additional '-ldl'
               # and as I don't know how to pass it, I disable libgomp.
               " --disable-libgomp" else "") +

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -189,6 +189,9 @@ let version = "5.4.0";
             # To keep ABI compatibility with upstream mingw-w64
             " --enable-fully-dynamic-string"
             else (if cross.libc == "uclibc" then
+              # libsanitizer requires netrom/netrom.h which is not
+              # available in uclibc.
+              " --disable-libsanitizer" +
               # In uclibc cases, libgomp needs an additional '-ldl'
               # and as I don't know how to pass it, I disable libgomp.
               " --disable-libgomp" else "") +

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -188,6 +188,9 @@ let version = "6.1.0";
             # To keep ABI compatibility with upstream mingw-w64
             " --enable-fully-dynamic-string"
             else (if cross.libc == "uclibc" then
+              # libsanitizer requires netrom/netrom.h which is not
+              # available in uclibc.
+              " --disable-libsanitizer" +
               # In uclibc cases, libgomp needs an additional '-ldl'
               # and as I don't know how to pass it, I disable libgomp.
               " --disable-libgomp" else "") +

--- a/pkgs/os-specific/linux/uclibc/default.nix
+++ b/pkgs/os-specific/linux/uclibc/default.nix
@@ -104,6 +104,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://www.uclibc.org/;
     description = "A small implementation of the C library";
+    maintainers = with stdenv.lib.maintainers; [ rasendubi ];
     license = stdenv.lib.licenses.lgpl2;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This is needed to get my custom powerpc-linux-uclibc working.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
