### PR TITLE
kronometer: init at 2.1.0

### DIFF
--- a/pkgs/tools/misc/kronometer/default.nix
+++ b/pkgs/tools/misc/kronometer/default.nix
@@ -1,0 +1,28 @@
+{
+  kdeDerivation, kdeWrapper, fetchurl, lib,
+  ecm, kdoctools,
+  kconfig, kinit
+}:
+
+let
+  pname = "kronometer";
+  version = "2.1.0";
+  unwrapped = kdeDerivation rec {
+    name = "${pname}-${version}";
+
+    src = fetchurl {
+      url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
+      sha256 = "1nh7y4c13rscy55f5n8s2v8jij27b55rwkxh9g8r0p7mdwmw8vri";
+    };
+
+    meta = with lib; {
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ peterhoeg ];
+    };
+    nativeBuildInputs = [ ecm kdoctools ];
+    propagatedBuildInputs = [ kconfig kinit ];
+  };
+in
+kdeWrapper unwrapped {
+  targets = [ "bin/kronometer" ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15854,7 +15854,7 @@ in
   };
 
   solarus = callPackage ../games/solarus { };
-  
+
   solarus-quest-editor = qt5.callPackage ../development/tools/solarus-quest-editor { };
 
   # You still can override by passing more arguments.
@@ -16344,6 +16344,8 @@ in
     kile = callPackage ../applications/editors/kile/frameworks.nix { };
 
     konversation = callPackage ../applications/networking/irc/konversation/1.6.nix { };
+
+    kronometer = callPackage ../tools/misc/kronometer { };
 
     krita = callPackage ../applications/graphics/krita {
       vc = vc_0_7;


### PR DESCRIPTION
###### Motivation for this change

Refer to #17467 
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
