### PR TITLE
Improvements to Hydra module

### DIFF
--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -166,7 +166,7 @@ in
 
       buildMachinesFiles = mkOption {
         type = types.listOf types.path;
-        default = [];
+        default = [ "/etc/nix/machines" ];
         example = [ "/etc/nix/machines" "/var/lib/hydra/provisioner/machines" ];
         description = "List of files containing build machines.";
       };

--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -193,7 +193,9 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraGroups.hydra = { };
+    users.extraGroups.hydra = {
+      gid = config.ids.gids.hydra;
+    };
 
     users.extraUsers.hydra =
       { description = "Hydra";
@@ -201,6 +203,7 @@ in
         createHome = true;
         home = baseDir;
         useDefaultShell = true;
+        uid = config.ids.uids.hydra;
       };
 
     users.extraUsers.hydra-queue-runner =
@@ -208,12 +211,14 @@ in
         group = "hydra";
         useDefaultShell = true;
         home = "${baseDir}/queue-runner"; # really only to keep SSH happy
+        uid = config.ids.uids.hydra-queue-runner;
       };
 
     users.extraUsers.hydra-www =
       { description = "Hydra web server";
         group = "hydra";
         useDefaultShell = true;
+        uid = config.ids.uids.hydra-www;
       };
 
     nix.trustedUsers = [ "hydra-queue-runner" ];


### PR DESCRIPTION
###### Motivation for this change
## Honor ids

Hydra related users were ignoring `uid` and `gid` defined in `nixos/modules/misc/ids.nix`.
## buildMachinesFiles

Currently `nix.buildMachines` remotes are listed in "Machine Status" and enabled in "Manage machines" but won't be used because `hydra.buildMachinesFiles` is empty by default.

This adds `/etc/nix/machines` in the default `hydra.buildMachinesFiles` so remotes defined in`nix.buildMachines` are used without explicit configuration.

cc @domenkozar 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
