### PR TITLE
Warn for conflict between synaptics and libinput

### DIFF
--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -227,6 +227,14 @@ in {
         EndSection
       '';
 
+    assertions = [
+      # already present in synaptics.nix
+      /* {
+        assertion = !config.services.xserver.synaptics.enable;
+        message = "Synaptics and libinput are incompatible, you cannot enable both (in services.xserver).";
+      } */
+    ];
+
   };
 
 }

--- a/nixos/modules/services/x11/hardware/synaptics.nix
+++ b/nixos/modules/services/x11/hardware/synaptics.nix
@@ -205,6 +205,13 @@ in {
         EndSection
       '';
 
+    assertions = [
+      {
+        assertion = !config.services.xserver.libinput.enable;
+        message = "Synaptics and libinput are incompatible, you cannot enable both (in services.xserver).";
+      }
+    ];
+
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Libinput is incompatible with synaptics as they conflict for the trackpads/touchpads.
###### Things done

Tested with both options enabled, the assert is fired :-).
Tested with one option enabled, no assert is fired :-D.

---

Libinput takes precedence over synaptics, so your synaptics config gets ignored.
This happened to me when updating my config, because gnome3 now enables libinput by default.
Enabled by lethalman in 4b8c31d981c0bf35c860bf44df04bcdbb5865685.

@lethalman It seems that libinput is required by gnome, right ? Maybe we should improve the error message, add an assert in gnome or warn that synaptics is deprecated ?
