### PR TITLE
gentium: 1.504 -> 5.000

### DIFF
--- a/pkgs/data/fonts/gentium/default.nix
+++ b/pkgs/data/fonts/gentium/default.nix
@@ -2,12 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gentium-${version}";
-  version = "1.504";
+  version = "5.000";
 
   src = fetchzip {
-    name = "${name}.zip";
-    url = "http://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=GentiumPlus-${version}.zip&filename=${name}.zip";
-    sha256 = "1xdx80dfal0b8rkrp1janybx2hki7algnvkx4hyghgikpjcjkdh7";
+    url = "http://software.sil.org/downloads/gentium/GentiumPlus-${version}.zip";
+    sha256 = "0g9sx38wh7f0m16gr64g2xggjwak2q6jw9y4zhrvhmp4aq4xfqm6";
   };
 
   phases = [ "unpackPhase" "installPhase" ];
@@ -16,12 +15,28 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/fonts/truetype
     mkdir -p $out/share/doc/${name}
     cp -v *.ttf $out/share/fonts/truetype/
-    cp -v FONTLOG.txt GENTIUM-FAQ.txt README.txt $out/share/doc/${name}
+    cp -vr documentation/ FONTLOG.txt GENTIUM-FAQ.txt README.txt $out/share/doc/${name}
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&item_id=Gentium";
+    homepage = "http://software.sil.org/gentium/";
     description = "A high-quality typeface family for Latin, Cyrillic, and Greek";
+    longDescription = ''
+      Gentium is a typeface family designed to enable the diverse ethnic groups
+      around the world who use the Latin, Cyrillic and Greek scripts to produce
+      readable, high-quality publications. It supports a wide range of Latin and
+      Cyrillic-based alphabets.
+
+      The design is intended to be highly readable, reasonably compact, and
+      visually attractive. The additional ‘extended’ Latin letters are designed
+      to naturally harmonize with the traditional 26 ones. Diacritics are
+      treated with careful thought and attention to their use. Gentium Plus also
+      supports both polytonic and monotonic Greek.
+
+      This package contains the regular and italic styles for the Gentium Plus
+      font family, along with documentation.
+    '';
+    downloadPage = "http://software.sil.org/gentium/download/";
     maintainers = with maintainers; [ raskin rycee ];
     license = licenses.ofl;
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change

Gentium Plus 5.000 was released in 2014.

The archive now contains a documentation folder with information about OpenType features supported by the font, which I have added to the files to copy to usr/share/doc/.

I have also updated and added some metadata.
###### Things done
- [x] Tested by installing the font and using it
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
