### PR TITLE
Add django 1 10

### DIFF
--- a/pkgs/development/python-modules/django/1.10-gis-libs.template.patch
+++ b/pkgs/development/python-modules/django/1.10-gis-libs.template.patch
@@ -13,12 +13,12 @@ diff --git a/django/contrib/gis/gdal/libgdal.py b/django/contrib/gis/gdal/libgda
 diff --git a/django/contrib/gis/geos/libgeos.py b/django/contrib/gis/geos/libgeos.py
 --- a/django/contrib/gis/geos/libgeos.py
 +++ b/django/contrib/gis/geos/libgeos.py
-@@ -23,7 +23,7 @@ try:
-     lib_path = settings.GEOS_LIBRARY_PATH
- except (AttributeError, EnvironmentError,
-         ImportError, ImproperlyConfigured):
--    lib_path = None
-+    lib_path = "@geos@/lib/libgeos_c.so"
+@@ -26,7 +26,7 @@ try:
+         lib_path = settings.GEOS_LIBRARY_PATH
+     except (AttributeError, EnvironmentError,
+             ImportError, ImproperlyConfigured):
+-        lib_path = None
++        lib_path = "@geos@/lib/libgeos_c.so"
  
- # Setting the appropriate names for the GEOS-C library.
- if lib_path:
+     # Setting the appropriate names for the GEOS-C library.
+     if lib_path:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8903,6 +8903,30 @@ in modules // {
     ];
   };
 
+  django_1_10 = buildPythonPackage rec {
+    name = "Django-${version}";
+    version = "1.10";
+    disabled = pythonOlder "2.7";
+
+    src = pkgs.fetchurl {
+      url = "http://www.djangoproject.com/m/releases/1.10/${name}.tar.gz";
+      sha256 = "01bh5yra6zyxcpqacahbwfbn0y4ivw07j2jsw3crvmjzivb6if26";
+    };
+
+    # patch only $out/bin to avoid problems with starter templates (see #3134)
+    postFixup = ''
+      wrapPythonProgramsIn $out/bin "$out $pythonPath"
+    '';
+
+    # too complicated to setup
+    doCheck = false;
+
+    meta = {
+      description = "A high-level Python Web framework";
+      homepage = https://www.djangoproject.com/;
+    };
+  };
+
   django_1_9 = buildPythonPackage rec {
     name = "Django-${version}";
     version = "1.9.5";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8891,12 +8891,12 @@ in modules // {
     };
   };
 
-  django = self.django_1_9;
+  django = self.django_1_10;
 
   django_gis = self.django.override rec {
     patches = [
       (pkgs.substituteAll {
-        src = ../development/python-modules/django/1.7.7-gis-libs.template.patch;
+        src = ../development/python-modules/django/1.10-gis-libs.template.patch;
         geos = pkgs.geos;
         gdal = pkgs.gdal;
       })
@@ -9202,7 +9202,14 @@ in modules // {
       sha256 = "0rpi1bkfx74xfbb2nk874kfdra1jcqp2vzky1r3z7zidlc9kah04";
     };
 
-    propagatedBuildInputs = with self; [ django django_compat ];
+    # TODO improve the that multi-override necessity (the fixpoint based python
+    # packages work can be the solution)
+    propagatedBuildInputs = with self; [ django_1_9 (django_compat.override {
+      buildInputs = with self; [ (django_nose.override {
+        propagatedBuildInputs = with self; [ django_1_9 nose ];
+      }) ];
+      propagatedBuildInputs = with self; [ django_1_9 six ];
+    }) ];
 
     meta = {
       description = "Allows superusers to hijack (=login as) and work on behalf of another user";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9114,21 +9114,21 @@ in modules // {
 
   django_compat = buildPythonPackage rec {
     name = "django-compat-${version}";
-    version = "1.0.8";
+    version = "1.0.13";
 
     # build process attempts to access a missing README.rst
     disabled = isPy35;
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/d/django-compat/${name}.tar.gz";
-      sha256 = "195dgr55vzpw1fbjvbw2h35k9bfhvm5zchh2p7nzbq57xmwb3sra";
+      sha256 = "0s0z7cx0vv1kjsyzk24sg256hfnd09ssilc9rakhxrzr3firgx80";
     };
 
     buildInputs = with self; [ django_nose ];
     propagatedBuildInputs = with self; [ django six ];
 
     meta = {
-      description = "Forward and backwards compatibility layer for Django 1.4, 1.7, 1.8, and 1.9";
+      description = "Forward and backwards compatibility layer for Django 1.4, 1.7, 1.8, 1.9 and 1.10";
       homepage = https://github.com/arteria/django-compat;
       license = licenses.mit;
     };


### PR DESCRIPTION
###### Motivation for this change

Django 1.10 is [out](https://www.djangoproject.com/weblog/2016/aug/01/django-110-released/), this PR uses it as default django version.

Some packages fail `nox-review wip`, but they were broken before this PR. Those are:
- python27Packages.natsort
- python27Packages.searx
- python35Packages.natsort
- python27Packages.python-etcd
- python35Packages.filebrowser_safe
- python35Packages.mezzanine
- python35Packages.detox
- python35Packages.gpsoauth
- python35Packages.python-etcd
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
