### PR TITLE
cpuminer: fix darwin build and 2.4.4 -> 2.4.5

### DIFF
--- a/pkgs/tools/misc/cpuminer/default.nix
+++ b/pkgs/tools/misc/cpuminer/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "cpuminer-${version}";
-  version = "2.4.4";
+  version = "2.4.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/cpuminer/pooler-${name}.tar.gz";
-    sha256 = "0xdgz5qlx1yr3mw2h4bwlbj94y6v2ygjy334cnc87xgzxf1wgann";
+    sha256 = "130ab6vcbm9azl9w8n97fzjnjbakm0k2n3wc1bcgy5y5c8s0220h";
   };
 
   patchPhase = if stdenv.cc.isClang then "${perl}/bin/perl ./nomacro.pl" else null;

--- a/pkgs/tools/misc/cpuminer/default.nix
+++ b/pkgs/tools/misc/cpuminer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, curl, jansson }:
+{ stdenv, fetchurl, curl, jansson, perl }:
 
 stdenv.mkDerivation rec {
   name = "cpuminer-${version}";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/cpuminer/pooler-${name}.tar.gz";
     sha256 = "0xdgz5qlx1yr3mw2h4bwlbj94y6v2ygjy334cnc87xgzxf1wgann";
   };
+
+  patchPhase = if stdenv.cc.isClang then "${perl}/bin/perl ./nomacro.pl" else null;
 
   buildInputs = [ curl jansson ];
 


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
