### PR TITLE
flat-plat: init at 3.20.20160404

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -259,6 +259,7 @@
   moretea = "Maarten Hoogendoorn <maarten@moretea.nl>";
   mornfall = "Petr Ročkai <me@mornfall.net>";
   MostAwesomeDude = "Corbin Simpson <cds@corbinsimpson.com>";
+  mounium = "Katona László <muoniurn@gmail.com>";
   MP2E = "Cray Elliott <MP2E@archlinux.us>";
   mpscholten = "Marc Scholten <marc@mpscholten.de>";
   msackman = "Matthew Sackman <matthew@wellquite.org>";

--- a/pkgs/misc/themes/flat-plat/default.nix
+++ b/pkgs/misc/themes/flat-plat/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "flat-plat-gtk-theme-eba3be5";
+
+  src = fetchFromGitHub {
+    owner = "nana-4";
+    repo = "Flat-Plat";
+    rev = "eba3be5eafd1140e1edb8b02411edb2f6c78b0ca";
+    sha256 = "0vfdnrxspdwg4jr025dwjmdcrqnblhlw666v5b7qhkxymibp5j7h";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    rm .gitignore COPYING README.md
+    cp -r . $out/share/themes
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Material Design-like flat theme for GTK3, GTK2, and GNOME Shell";
+    homepage = https://github.com/nana-4/Flat-Plat;
+    licence = licenses.gpl2;
+    maintainers = [ maintainers.mounium ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17050,6 +17050,8 @@ in
 
   fceux = callPackage ../misc/emulators/fceux { };
 
+  flat-plat = callPackage ../misc/themes/flat-plat { };
+
   foldingathome = callPackage ../misc/foldingathome { };
 
   foo2zjs = callPackage ../misc/drivers/foo2zjs {};


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
