### PR TITLE
maia-icon-theme: init at 23235fa

### DIFF
--- a/pkgs/data/icons/maia-icon-theme/default.nix
+++ b/pkgs/data/icons/maia-icon-theme/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  name = "maia-icon-theme";
+
+  src = fetchFromGitHub {
+    owner = "manjaro";
+    repo = "artwork-maia";
+    rev = "23235fa56e6111d30e9f92576030cc855a0facbe";
+    sha256 = "1d5bv13gds1nx88pc6a9gkrz1lb8sji0wcc5h3bf4mjw0q072nfr";
+  };
+
+  dontBuild = true;
+  
+  installPhase = ''
+    install -dm 755 $out/share/icons
+    rm icons/CMakeLists.txt
+    cp -dr --no-preserve='ownership' icons $out/share/icons/Maia
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Icons based on Breeze and Super Flat Remix";
+    homepage = https://github.com/manjaro/artwork-maia;
+    licence = licenses.free;
+    maintainers = [ maintainers.mounium ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12023,6 +12023,8 @@ in
   # lohit-fonts.kashmiri lohit-fonts.konkani lohit-fonts.maithili lohit-fonts.sindhi
   lohit-fonts = recurseIntoAttrs ( callPackages ../data/fonts/lohit-fonts { } );
 
+  maia-icon-theme = callPackage ../data/icons/maia-icon-theme { };
+
   marathi-cursive = callPackage ../data/fonts/marathi-cursive { };
 
   man-pages = callPackage ../data/documentation/man-pages { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
