### PR TITLE
ripser: init at 1.0

### DIFF
--- a/pkgs/applications/science/math/ripser/default.nix
+++ b/pkgs/applications/science/math/ripser/default.nix
@@ -1,0 +1,65 @@
+{ stdenv, fetchurl, fetchFromGitHub
+, assembleReductionMatrix ? false
+, useCoefficients ? false
+, indicateProgress ? false
+, useGoogleHashmap ? false, sparsehash ? null
+, fileFormat ? "lowerTriangularCsv"
+}:
+
+with stdenv.lib;
+
+assert elem fileFormat ["lowerTriangularCsv" "upperTriangularCsv" "dipha"];
+assert useGoogleHashmap -> sparsehash != null;
+
+let
+  inherit (stdenv.lib) optional;
+in
+stdenv.mkDerivation {
+  name = "ripser";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "Ripser";
+    repo = "ripser";
+    rev = "f69c6af6ca6883dd518c48faf41cf8901c379598";
+    sha256 = "1mw2898s7l29hgajsaf75bs9bjn2sn4g2mvmh41a602jpwp9r0rz";
+  };
+
+  #Patch from dev branch to make compilation work.
+  #Will be removed when it gets merged into master.
+  patches = [(fetchurl {
+    url = https://github.com/Ripser/ripser/commit/dc78d8ce73ee35f3828f0aad67a4e53620277ebf.patch;
+    sha256 = "1y93aqpqz8fm1cxxrf90dhh67im3ndkr8dnxgbw5y96296n4r924";
+  })];
+
+  buildInputs = optional useGoogleHashmap sparsehash;
+
+  buildFlags = [
+    "-std=c++11"
+    "-Ofast"
+    "-D NDEBUG"
+  ]
+  ++ optional assembleReductionMatrix "-D ASSEMBLE_REDUCTION_MATRIX"
+  ++ optional useCoefficients "-D USE_COEFFICIENTS"
+  ++ optional indicateProgress "-D INDICATE_PROGRESS"
+  ++ optional useGoogleHashmap "-D USE_GOOGLE_HASHMAP"
+  ++ optional (fileFormat == "lowerTriangularCsv") "-D FILE_FORMAT_LOWER_TRIANGULAR_CSV"
+  ++ optional (fileFormat == "upperTriangularCsv") "-D FILE_FORMAT_UPPER_TRIANGULAR_CSV"
+  ++ optional (fileFormat == "dipha") "-D FILE_FORMAT_DIPHA"
+  ;
+
+  buildPhase = "c++ ripser.cpp -o ripser $buildFlags";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ripser $out/bin
+  '';
+
+  meta = {
+    description = "A lean C++ code for the computation of Vietoris–Rips persistence barcodes";
+    homepage = "https://github.com/Ripser/ripser";
+    license = stdenv.lib.licenses.lgpl3;
+    maintainers = with stdenv.lib.maintainers; [erikryb];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14448,6 +14448,8 @@ in
 
   ricochet = qt55.callPackage ../applications/networking/instant-messengers/ricochet { };
 
+  ripser = callPackage ../applications/science/math/ripser { };
+
   rkt = callPackage ../applications/virtualization/rkt { };
 
   rofi = callPackage ../applications/misc/rofi { };


### PR DESCRIPTION
###### Motivation for this change

Add new package for computing persistent homology.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
