### PR TITLE
Fix clang 3.5

### DIFF
--- a/pkgs/development/compilers/llvm/3.5/clang.nix
+++ b/pkgs/development/compilers/llvm/3.5/clang.nix
@@ -50,6 +50,5 @@ in stdenv.mkDerivation {
     homepage    = http://llvm.org/;
     license     = stdenv.lib.licenses.bsd3;
     platforms   = stdenv.lib.platforms.all;
-    broken      = true;
   };
 }

--- a/pkgs/development/compilers/llvm/3.5/fix-15974.patch
+++ b/pkgs/development/compilers/llvm/3.5/fix-15974.patch
@@ -1,0 +1,15 @@
+diff --git a/include/llvm/ADT/IntrusiveRefCntPtr.h b/include/llvm/ADT/IntrusiveRefCntPtr.h
+index f9df378..9d860ec 100644
+--- a/include/llvm/ADT/IntrusiveRefCntPtr.h
++++ b/include/llvm/ADT/IntrusiveRefCntPtr.h
+@@ -134,9 +134,9 @@ public:
+ //===----------------------------------------------------------------------===//
+   template <typename T>
+   class IntrusiveRefCntPtr {
++  public:
+     T* Obj;
+ 
+-  public:
+     typedef T element_type;
+ 
+     explicit IntrusiveRefCntPtr() : Obj(nullptr) {}

--- a/pkgs/development/compilers/llvm/3.5/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.5/llvm.nix
@@ -53,6 +53,8 @@ in stdenv.mkDerivation rec {
     "-DCAN_TARGET_i386=false"
   ];
 
+  patches = [ ./fix-15974.patch ];
+
   postBuild = ''
     rm -fR $out
 
@@ -75,3 +77,4 @@ in stdenv.mkDerivation rec {
     platforms   = stdenv.lib.platforms.all;
   };
 }
+


### PR DESCRIPTION
###### Motivation for this change

Clang 3.5 is currently broken

See https://github.com/NixOS/nixpkgs/issues/15974
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This fixes NixOs/nixpkgs#15974

It's not a nice fix, as it's really clang's problem. The proper fix
should modify clang's usage of IntrusiveRefCntPtr.
