### PR TITLE
nixos-container: add 'terminate' command which 'destroy' now uses

### DIFF
--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -22,7 +22,7 @@ Usage: nixos-container list
        nixos-container destroy <container-name>
        nixos-container start <container-name>
        nixos-container stop <container-name>
-       nixos-container kill <container-name> [--signal <signal-specifier>]
+       nixos-container terminate <container-name>
        nixos-container status <container-name>
        nixos-container update <container-name> [--config <string>]
        nixos-container login <container-name>
@@ -189,12 +189,9 @@ sub isContainerRunning {
     return $status =~ /ActiveState=active/;
 }
 
-sub killContainer {
-    my @args = ();
-    push(@args, ("--signal", $signal)) if ($signal ne "");
-
-    system("machinectl", "kill", $containerName, @args) == 0
-        or die "$0: failed to kill container\n";
+sub terminateContainer {
+    system("machinectl", "terminate", $containerName) == 0
+        or die "$0: failed to terminate container\n";
 }
 
 sub stopContainer {
@@ -239,8 +236,7 @@ if ($action eq "destroy") {
     die "$0: cannot destroy declarative container (remove it from your configuration.nix instead)\n"
         unless POSIX::access($confFile, &POSIX::W_OK);
 
-    $signal = "SIGKILL";
-    killContainer if (isContainerRunning);
+    terminateContainer if (isContainerRunning);
 
     safeRemoveTree($profileDir) if -e $profileDir;
     safeRemoveTree($gcRootsDir) if -e $gcRootsDir;
@@ -257,8 +253,8 @@ elsif ($action eq "stop") {
     stopContainer;
 }
 
-elsif ($action eq "kill") {
-    killContainer;
+elsif ($action eq "terminate") {
+    terminateContainer;
 }
 
 elsif ($action eq "status") {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

My earlier commit to have `nixos-container destroy` use `kill` broke
the `container-imperative` test, see[1]. As suggested by @aszlig,
`machinectl terminate` doesn't have that problem, and is the command
that should have been used to begin with rather then `kill`.

1| https://github.com/NixOS/nixpkgs/commit/60c6c7bc9a0d564cf86af4b1711b33db48cf0d07#commitcomment-18478032
