### PR TITLE
chromium: use --disable-setuid-sandbox by default

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -13,6 +13,7 @@
 , cupsSupport ? true
 , pulseSupport ? false
 , hiDPISupport ? false
+, disableSetUIDSandbox ? true
 }:
 
 let
@@ -74,7 +75,8 @@ in stdenv.mkDerivation {
 
     ln -s "${chromium.browser}/share" "$out/share"
     eval makeWrapper "${browserBinary}" "$out/bin/chromium" \
-      ${concatMapStringsSep " " getWrapperFlags chromium.plugins.enabled}
+      ${concatMapStringsSep " " getWrapperFlags chromium.plugins.enabled} \
+      ${optionalString disableSetUIDSandbox "--add-flags --disable-setuid-sandbox"}
 
     ln -s "$out/bin/chromium" "$out/bin/chromium-browser"
     ln -s "${chromium.browser}/share/icons" "$out/share/icons"


### PR DESCRIPTION
###### Motivation for this change

Fix Chromium under grsecurity. See #17460.
###### Things done
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux

---

Closes #17460

When using grsecurity, chromium's setUID sandbox feature prevents
chromium from starting.

According to
https://chromium.googlesource.com/chromium/src/+/master/docs/linux_sandboxing.md#User-namespaces-sandbox
Chrome now uses namespace sandboxes: "The namespace sandbox aims to
replace the setuid sandbox. It has the advantage of not requiring a
setuid binary. It's based on (unprivileged) user namespaces in the Linux
kernel. It generally requires a kernel >= 3.10, although it may work
with 3.8 if certain patches are backported."

According to https://bugs.chromium.org/p/chromium/issues/detail?id=598454
"we should no longer need the setuid binary sandbox on most if not all
supported versions of desktop Linux. However, Chrome still checks for it
on startup and complains if it's not there. We should stop doing that."

According to
https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox.md
"The Linux SUID sandbox is almost but not completely removed."

We conclude that is likely safe to --disable-setuid-sandbox until that
becomes the default in Chromium

FYI: does not trigger a Chromium rebuild

cc @joachifm @aszlig
