### PR TITLE
curl: 7.50.0 -> 7.50.1

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -18,11 +18,11 @@ assert scpSupport -> libssh2 != null;
 assert c-aresSupport -> c-ares != null;
 
 stdenv.mkDerivation rec {
-  name = "curl-7.50.0";
+  name = "curl-7.50.1";
 
   src = fetchurl {
     url = "http://curl.haxx.se/download/${name}.tar.bz2";
-    sha256 = "16psxjcl25i7v5x71193nkq2anm5mj8pfziq5iwxnj3znwnzx3b0";
+    sha256 = "0mjidq4q0hikhis2d35kzkhx6xfcgl875mk5ph5d98fa9kswa4iw";
   };
 
   outputs = [ "dev" "out" "bin" "man" "docdev" ];


### PR DESCRIPTION
###### Motivation for this change
- the curl upgrade to 7.50.0 (#17152) broke several packages
- latest release includes a fix (curl/curl#926) to not break most apps
- too many packages for nox-review to build locally
- but I was able to build kodi, quvi, warmux

```
$ nix-build -A curl -A kodi -A quvi -A warmux
/nix/store/6airsa06qmgy746s9bv90fbkzgcyw9yr-curl-7.50.1-dev
/nix/store/n1cflbvnzx7bhywdvbqj5y5820xm4gh1-kodi-16.1
/nix/store/hkwxys3h8sf5sjvix57qsppd0zcw6cgd-quvi-0.9.5
/nix/store/99y4mais03m3y40lnr1zlzfhq6r91sch-warmux-11.04.1
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
