### PR TITLE
xserver: fix #16641 again, undoing part of 07fc652

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -13,6 +13,7 @@ let
 
   # Map video driver names to driver packages. FIXME: move into card-specific modules.
   knownVideoDrivers = {
+    modesetting = { modules = []; };
     virtualbox = { modules = [ kernelPackages.virtualboxGuestAdditions ]; driverName = "vboxvideo"; };
   };
 


### PR DESCRIPTION
###### Motivation for this change

If someone could double-check this for me, using NixOS in a virtualbox guest, slim as the display manager, my X server crashes with the vboxmouse error message in commits following 07fc652.
