### PR TITLE
purple-matrix: init at 2016-07-11

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit, pkgconfig, pidgin, json_glib, glib, http-parser } :
+
+let
+  version = "2016-07-11";
+in
+stdenv.mkDerivation rec {
+  name = "purple-matrix-unstable-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/matrix-org/purple-matrix";
+    rev = "f9d36198a57de1cd1740a3ae11c2ad59b03b724a";
+    sha256 = "1mmyvc70gslniphmcpk8sfl6ylik6dnprqghx4n47gsj1sb1cy00";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ pidgin json_glib glib http-parser ];
+
+  installPhase = ''
+    install -Dm755 -t $out/lib/pidgin/ libmatrix.so
+    for size in 16 22 48; do
+      install -TDm644 matrix-"$size"px.png $out/pixmaps/pidgin/protocols/$size/matrix.png
+    done
+  '';
+
+  meta = {
+    homepage = https://github.com/matrix-org/purple-matrix;
+    description = "Matrix support for Pidgin / libpurple";
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14277,6 +14277,8 @@ in
 
   purple-hangouts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-hangouts { };
 
+  purple-matrix = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-matrix { };
+
   purple-plugin-pack = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-plugin-pack { };
 
   purple-vk-plugin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin { };


### PR DESCRIPTION
###### Motivation for this change

This Pidgin plugin is needed to connect directly to a Matrix homeserver without using an XMPP bridge or other protocol bridge.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` **Nothing depends on this package**
- [x] Tested execution of all binary files (usually in `./result/bin/`) **Shared library successfully loaded by Pidgin**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
