### PR TITLE
networkmanager_l2tp: fixup

### DIFF
--- a/pkgs/tools/networking/network-manager/l2tp.nix
+++ b/pkgs/tools/networking/network-manager/l2tp.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, automake, autoconf, libtool, intltool, pkgconfig
-, networkmanager, networkmanagerapplet, ppp, xl2tpd, strongswan, libsecret
-, withGnome ? true, gnome3 }:
+, networkmanager, ppp, xl2tpd, strongswan, libsecret
+, withGnome ? true, gnome3, networkmanagerapplet }:
 
 stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "01f39ghc37vw4n4i7whyikgqz8vzxf41q9fsv2gfw1g501cny1j2";
   };
 
-  buildInputs = [ networkmanager ppp networkmanagerapplet libsecret ]
-    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring ];
+  buildInputs = [ networkmanager ppp libsecret ]
+    ++ stdenv.lib.optionals withGnome [ gnome3.gtk gnome3.libgnome_keyring networkmanagerapplet ];
 
   nativeBuildInputs = [ automake autoconf libtool intltool pkgconfig ];
 


### PR DESCRIPTION
`network-manager-applet` (and it's GNOME-dependencies) will be installed
disregarding `withGnome` option when `networking.networkmanager.enabled = true`.
This patch fixes it.

To check the things, a minimal config example is [here](https://gist.github.com/zohl/6b8f8f2af727f13327d3799e75706f2a).

```
NIXOS_CONFIG=$(pwd)/configuration.nix nixos-rebuild dry-build 2>&1 | grep -i gnome

# before:
  /nix/store/j7nl7ilzfhywcpv617nsjrqgk2a38402-gnome-keyring-3.20.0
  /nix/store/w9zm0m0wbwip5znjz81wa41snajmip3m-gnome-backgrounds-3.20

# after:
  (Nothing)
```
