### PR TITLE
git-lfs: 2016-06-7 -> 1.3.1

### DIFF
--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -3,8 +3,8 @@
 buildGoPackage rec {
   name = "git-lfs-${version}";
   # NOTE: use versions after 1.2.1
-  version = "2016-06-07";
-  rev = "12fe249f2eebb56608a825fdb4a68c00f090bc91";
+  version = "1.3.1";
+  rev = "9c9dffb1b5baddfa06f280ef1b5fbf68ecbc90b1";
   
   goPackagePath = "github.com/github/git-lfs";
 
@@ -12,7 +12,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "github";
     repo = "git-lfs";
-    sha256 = "0cj7xbgvj706r1cyxqlcwfvy5zg2d19al04d441sxa6spr6xa4v6";
+    sha256 = "0fg48jxh0gmd0w5yy3avascaasxk85019qayaikzfkym8bdqplb2";
   };
 
   # Tests fail with 'lfstest-gitserver.go:46: main redeclared in this block'


### PR DESCRIPTION
###### Motivation for this change

New git-lfs version.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
