### PR TITLE
webkitgtk: 2.10.4 -> 2.10.9

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.10.nix
+++ b/pkgs/development/libraries/webkitgtk/2.10.nix
@@ -13,7 +13,7 @@ assert stdenv.isDarwin -> !enableCredentialStorage;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "webkitgtk-${version}";
-  version = "2.10.4";
+  version = "2.10.9";
 
   meta = {
     description = "Web content rendering engine, GTK+ port";
@@ -28,17 +28,11 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://webkitgtk.org/releases/${name}.tar.xz";
-    sha256 = "0mghsbfnmmf6nsf7cb3ah76s77aigkzf3k6kw96wgh6all6jdy6v";
+    sha256 = "0sg935wpkgyd5ypd5fj25vd7ri8s6sbrmssb53xbgcc02xs8vcdv";
   };
 
   patches = [
     ./finding-harfbuzz-icu.patch
-    (fetchpatch {
-      name = "glibc-isnan.patch";
-      url = "http://trac.webkit.org/changeset/194518/trunk/Source/JavaScriptCore"
-        + "/runtime/Options.cpp?format=diff&new=194518";
-      sha256 = "0pzdv1zmlym751n9d310cx3yp752yzsc49cysbvgnrib4dh68nbm";
-    })
   ] ++ optional stdenv.isDarwin ./adding-libintl.patch;
 
   cmakeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9643,10 +9643,7 @@ in
 
   wcslib = callPackage ../development/libraries/wcslib { };
 
-  webkitgtk = callPackage ../development/libraries/webkitgtk {
-    harfbuzz = harfbuzz-icu;
-    gst-plugins-base = gst_all_1.gst-plugins-base;
-  };
+  webkitgtk = webkitgtk212x;
 
   webkitgtk24x = callPackage ../development/libraries/webkitgtk/2.4.nix {
     harfbuzz = harfbuzz-icu;
@@ -9655,6 +9652,11 @@ in
   };
 
   webkitgtk212x = callPackage ../development/libraries/webkitgtk/2.12.nix {
+    harfbuzz = harfbuzz-icu;
+    gst-plugins-base = gst_all_1.gst-plugins-base;
+  };
+
+  webkitgtk210x = callPackage ../development/libraries/webkitgtk/2.10.nix {
     harfbuzz = harfbuzz-icu;
     gst-plugins-base = gst_all_1.gst-plugins-base;
   };


### PR DESCRIPTION
###### Motivation for this change

Solve #17308: upgrade webkitgtk 2.10 branch, and set default branch to 2.12 (transparent since no derivation was pointing to `webkitgtk`)
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested compilation of modified pkg
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Cc @RamKromberg 
