### PR TITLE
eclipse-sdk: 4.5.1 -> 4.5.2 -> 4.6

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -311,6 +311,21 @@ rec {
     };
   };
   eclipse_sdk_451 = eclipse-sdk-451; # backward compatibility, added 2016-01-30
+  
+  eclipse-sdk-452 = buildEclipse {
+    name = "eclipse-sdk-4.5.2";
+    description = "Eclipse Mars Classic";
+    sources = {
+      "x86_64-linux" = fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz;
+          sha256 = "87f82b0c13c245ee20928557dbc4435657d1e029f72d9135683c8d585c69ba8d";
+        };
+      "i686-linux" = fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk.tar.gz;
+          sha256 = "78f7e537b34333401fc782fbd1260087c586ff93b17b88da5b177642f3aa5a02";
+        };
+    };
+  };
 
   eclipse-platform = eclipse-platform-46;
 

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -326,6 +326,21 @@ rec {
         };
     };
   };
+  
+  eclipse-sdk-46 = buildEclipse {
+    name = "eclipse-sdk-4.6";
+    description = "Eclipse Neon Classic";
+    sources = {
+      "x86_64-linux" = fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk-x86_64.tar.gz;
+          sha256 = "4d7a39ce4e04ba1f5179f6a72926eb86ed506d97842a3bf4247814491c508e0a";
+        };
+      "i686-linux" = fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk.tar.gz;
+          sha256 = "d9e1d390cac504a17a65d4a22ebb8da6a592bcc54491912cbc29577990d77014";
+        };
+    };
+  };
 
   eclipse-platform = eclipse-platform-46;
 


### PR DESCRIPTION
###### Motivation for this change

Added eclipse-sdk 4.5.2 and 4.6
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
