### PR TITLE
mosh: remove boost dependency

### DIFF
--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, boost, protobuf, ncurses, pkgconfig, IOTty
+{ stdenv, fetchurl, zlib, protobuf, ncurses, pkgconfig, IOTty
 , makeWrapper, perl, openssl, autoreconfHook, fetchpatch }:
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1qsb0y882yfgwnpy6f98pi5xqm6kykdsrxzvaal37hs7szjhky0s";
   };
 
-  buildInputs = [ autoreconfHook boost protobuf ncurses zlib pkgconfig IOTty makeWrapper perl openssl ];
+  buildInputs = [ autoreconfHook protobuf ncurses zlib pkgconfig IOTty makeWrapper perl openssl ];
 
   patches = [
     # remove automake detection macro patch on next release as it is already on mosh master


### PR DESCRIPTION
###### Motivation for this change

boost was removed from the mosh dependency requirements in 2012.
(It was only used from February and April 2012.)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
