### PR TITLE
neovim: remove unused glib dependency

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, gettext, glib, libmsgpack, libtermkey
+{ stdenv, fetchFromGitHub, cmake, gettext, libmsgpack, libtermkey
 , libtool, libuv, luajit, luaPackages, man, ncurses, perl, pkgconfig
 , unibilium, makeWrapper, vimUtils, xsel
 
@@ -72,7 +72,6 @@ let
     enableParallelBuilding = true;
 
     buildInputs = [
-      glib
       libtermkey
       libuv
       libmsgpack


### PR DESCRIPTION
###### Motivation for this change

As far as I can tell, neovim has never required glib to build.
The neovim libtermkey does include a demo-glib.c example, but that is
optional.

@nckx You added this dependency in https://github.com/NixOS/nixpkgs/commit/af15a201e1884f00f064e4eacf18f1b99b8aa04c, do you remember why?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
