### PR TITLE
ssh module: ignore exit code when socket activated

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -263,6 +263,7 @@ in
 
             serviceConfig =
               { ExecStart =
+                  (optionalString cfg.startWhenNeeded "-") +
                   "${cfgc.package}/bin/sshd " + (optionalString cfg.startWhenNeeded "-i ") +
                   "-f ${pkgs.writeText "sshd_config" cfg.extraConfig}";
                 KillMode = "process";


### PR DESCRIPTION
###### Motivation for this change

Fixes #3279.

I have been running with this patch applied for months.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

sshd will at times fail when exiting. When socket activated, this will
leave a number of sshd@ service instances in the failed state, so we
simply ignore the error code if we are running socket activated.

Recommended by upstream:
http://systemd-devel.freedesktop.narkive.com/d0eapMCG/socket-activated-sshd-service-showing-up-as-a-failure-when-the-client-connection-fails

Fixes: #3279
