### PR TITLE
flat-plat: Made the theme actually discoverable

### DIFF
--- a/pkgs/misc/themes/flat-plat/default.nix
+++ b/pkgs/misc/themes/flat-plat/default.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p $out/share/themes
+    mkdir -p $out/share/themes/Flat-Plat
     rm .gitignore COPYING README.md
-    cp -r . $out/share/themes
+    cp -r . $out/share/themes/Flat-Plat
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Somehow I managed to upload a non-working version and only realized the problem now
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
