### PR TITLE
tint2: 0.12.11 -> 0.12.12

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -1,27 +1,27 @@
-{ stdenv, fetchFromGitLab, pkgconfig, cmake, gettext, pango, cairo, glib
-, pcre , imlib2, libXinerama , libXrender, libXcomposite, libXdamage, libX11
-, libXrandr, gtk, libpthreadstubs , libXdmcp, librsvg
-, libstartup_notification, hicolor_icon_theme, wrapGAppsHook
+{ stdenv, fetchFromGitLab, pkgconfig, cmake, gettext, cairo, pango, pcre
+, glib , imlib2, gtk, libXinerama , libXrender, libXcomposite, libXdamage
+, libX11 , libXrandr, librsvg, libpthreadstubs , libXdmcp
+, libstartup_notification , hicolor_icon_theme, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
   name = "tint2-${version}";
-  version = "0.12.11";
+  version = "0.12.12";
 
   src = fetchFromGitLab {
     owner = "o9000";
     repo = "tint2";
     rev = version;
-    sha256 = "0gfxbxslc8h95q7cq84a69yd7qdhyks978l3rmk48jhwwixdp0hr";
+    sha256 = "0zgcdancsna95sjxslack9lh8f6qnj8d5wm02891mshn2jhgins3";
   };
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ pkgconfig cmake gettext wrapGAppsHook ];
 
-  buildInputs = [ pango cairo glib pcre imlib2 libXinerama libXrender
-    libXcomposite libXdamage libX11 libXrandr gtk libpthreadstubs libXdmcp
-    librsvg libstartup_notification hicolor_icon_theme ];
+  buildInputs = [ cairo pango pcre glib imlib2 gtk libXinerama libXrender
+    libXcomposite libXdamage libX11 libXrandr librsvg libpthreadstubs
+    libXdmcp libstartup_notification hicolor_icon_theme ];
 
   preConfigure = ''
     substituteInPlace CMakeLists.txt --replace /etc $out/etc


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
