### PR TITLE
mate-themes: 3.20.8 -> 3.20.10

### DIFF
--- a/pkgs/desktops/mate/mate-themes/default.nix
+++ b/pkgs/desktops/mate/mate-themes/default.nix
@@ -1,27 +1,27 @@
 { stdenv, fetchurl, pkgconfig, intltool, mate, gnome3, gtk2, gtk_engines,
-gtk-engine-murrine, gdk_pixbuf, librsvg }:
+  gtk-engine-murrine, gdk_pixbuf, librsvg }:
 
 stdenv.mkDerivation rec {
   name = "mate-themes-${version}";
   version = "${major-ver}.${minor-ver}";
   major-ver = gnome3.version;
   minor-ver = {
-    "3.18" = "2";
-    "3.20" = "8";
+    "3.18" = "3";
+    "3.20" = "10";
   }."${major-ver}";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/themes/${major-ver}/${name}.tar.xz";
     sha256 = {
-      "3.18" = "1yy22nk450wsx0mlsvdalkyj41mijlvy8s6kifh98d4dnk8dvgfj";
-      "3.20" = "14jl3mbhzm7k2ilp8nmdwy9wrbmc7mbg2i0arf479xs2h7dz06f6";
+      "3.18" = "09vglvjnjnm95wxw5b7pn6rf5xrr3nfyqs5c3y1c72z4p3w8qqn5";
+      "3.20" = "0bhhidip8qbsq69a9n0dmxfryhvzngiy59vnms6xhya9n7y19hci";
     }."${major-ver}";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];
 
   buildInputs = [ mate.mate-icon-theme gtk2 gtk_engines gtk-engine-murrine
-  gdk_pixbuf librsvg ];
+    gdk_pixbuf librsvg ];
 
   meta = {
     description = "A set of themes from MATE";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
