### PR TITLE
varnish: fix localstatedir for varnish* tools

### DIFF
--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -28,7 +28,7 @@ with lib;
       };
 
       stateDir = mkOption {
-        default = "/var/spool/varnish";
+        default = "/var/spool/varnish/${config.networking.hostName}";
         description = "
           Directory holding all state for Varnish to run.
         ";
@@ -45,6 +45,9 @@ with lib;
       preStart = ''
         mkdir -p ${cfg.stateDir}
         chown -R varnish:varnish ${cfg.stateDir}
+      '';
+      postStop = ''
+        rm -rf ${cfg.stateDir}
       '';
       path = [ pkgs.gcc ];
       serviceConfig.ExecStart = "${pkgs.varnish}/sbin/varnishd -a ${cfg.http_address} -f ${pkgs.writeText "default.vcl" cfg.config} -n ${cfg.stateDir} -u varnish";

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ pcre libxslt groff ncurses pkgconfig readline python
     pythonPackages.docutils];
 
+  buildFlags = "localstatedir=/var/spool";
+
   meta = {
     description = "Web application accelerator also known as a caching HTTP reverse proxy";
     homepage = "https://www.varnish-cache.org";


### PR DESCRIPTION
###### Motivation for this change

Fix the problem stated in #7495 - varnish\* tools are not able to access a running varnish server in the default configuration. Although it is possible to specify the path to the statedir on the command line on each invocation, users expect that tools just work when sticking to the defaults.

Updated both package and options defaults so that they match.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The varnish tools (varnishstat, varnishlog, ...) tried to load the VSM
file from a spurious var directory in the Nix store. Fix the default so
the tools "just work" when also keeping services.varnish.stateDir at the
default.

Notes:
- The tools use $localstatedir/$HOSTNAME so I've adapted the default for
  stateDir as well to contain hostName.
- Added postStop action to remove the localstatedir. There is no point
  in keeping it around when varnish does not run, as it regenerates it
  on startup anyway.

Fixes #7495
