### PR TITLE
cxx-prettyprint: init at 2016-04-30

### DIFF
--- a/pkgs/development/libraries/cxx-prettyprint/default.nix
+++ b/pkgs/development/libraries/cxx-prettyprint/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "cxx-prettyprint-unstable-${version}";
+  version = "2016-04-30";
+  rev = "9ab26d228f2960f50b38ad37fe0159b7381f7533";
+
+  src = fetchFromGitHub {
+    owner = "louisdx";
+    repo = "cxx-prettyprint";
+    inherit rev;
+    sha256 = "1bp25yw8fb0mi432f72ihfxfj887gi36b36fpv677gawm786l7p1";
+  };
+
+  installPhase = ''
+    mkdir -p "$out/include"
+    cp prettyprint.hpp "$out/include"
+  '';
+
+  meta = with stdenv.lib; {
+    description    = "Header only C++ library for pretty printing standard containers";
+    homepage       = https://github.com/louisdx/cxx-prettyprint;
+    license        = stdenv.lib.licenses.boost;
+    platforms      = platforms.all;
+
+    # This is a header-only library, no point in hydra building it:
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7084,6 +7084,8 @@ in
 
   cwiid = callPackage ../development/libraries/cwiid { };
 
+  cxx-prettyprint = callPackage ../development/libraries/cxx-prettyprint { };
+
   cyrus_sasl = callPackage ../development/libraries/cyrus-sasl {
     kerberos = if stdenv.isFreeBSD then libheimdal else kerberos;
   };


### PR DESCRIPTION
###### Motivation for this change

Pretty-printing standard containers is something that should be easy, but [is not in C++](http://stackoverflow.com/questions/4850473/pretty-print-c-stl-containers).
This header only library can be used to do exactly that.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`: There are no dependencies.
- [ ] Tested execution of all binary files: There are none, as it is header only.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
