### PR TITLE
elm: Constrain aeson-pretty to <0.8

### DIFF
--- a/pkgs/development/compilers/elm/packages/elm-compiler.nix
+++ b/pkgs/development/compilers/elm/packages/elm-compiler.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, aeson, aeson-pretty, ansi-terminal, ansi-wl-pprint
+{ mkDerivation, aeson, aeson-pretty_0_7_2, ansi-terminal, ansi-wl-pprint
 , base, binary, bytestring, containers, directory, edit-distance
 , fetchgit, filemanip, filepath, HUnit, indents
 , language-ecmascript, language-glsl, mtl, parsec, pretty, process
@@ -16,7 +16,7 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson aeson-pretty ansi-terminal ansi-wl-pprint base binary
+    aeson aeson-pretty_0_7_2 ansi-terminal ansi-wl-pprint base binary
     bytestring containers directory edit-distance filepath indents
     language-ecmascript language-glsl mtl parsec pretty process text
     union-find
@@ -25,7 +25,7 @@ mkDerivation {
     aeson base binary directory filepath process text
   ];
   testHaskellDepends = [
-    aeson aeson-pretty ansi-terminal ansi-wl-pprint base binary
+    aeson aeson-pretty_0_7_2 ansi-terminal ansi-wl-pprint base binary
     bytestring containers directory edit-distance filemanip filepath
     HUnit indents language-ecmascript language-glsl mtl parsec pretty
     process QuickCheck test-framework test-framework-hunit

--- a/pkgs/development/compilers/elm/packages/elm-package.nix
+++ b/pkgs/development/compilers/elm/packages/elm-package.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, aeson, aeson-pretty, ansi-wl-pprint, base, binary
+{ mkDerivation, aeson, aeson-pretty_0_7_2, ansi-wl-pprint, base, binary
 , bytestring, containers, directory, edit-distance, elm-compiler
 , fetchgit, filepath, HTTP, http-client, http-client-tls
 , http-types, mtl, network, optparse-applicative, parallel-io
@@ -16,13 +16,13 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson aeson-pretty ansi-wl-pprint base binary bytestring containers
+    aeson aeson-pretty_0_7_2 ansi-wl-pprint base binary bytestring containers
     directory edit-distance elm-compiler filepath HTTP http-client
     http-client-tls http-types mtl network parallel-io text time
     unordered-containers vector zip-archive
   ];
   executableHaskellDepends = [
-    aeson aeson-pretty ansi-wl-pprint base binary bytestring containers
+    aeson aeson-pretty_0_7_2 ansi-wl-pprint base binary bytestring containers
     directory edit-distance elm-compiler filepath HTTP http-client
     http-client-tls http-types mtl network optparse-applicative
     parallel-io pretty text time unordered-containers vector


### PR DESCRIPTION
Fixes compilation error in elm 0.17.1 by locking `aeson-pretty` to <0.8. This is [fixed upstream](https://github.com/elm-lang/elm-compiler/commit/eae9303fbed6ec929478315035fbe2e354e865e5) but they have not issued a new release yet.

Fixes #17424.
