### PR TITLE
nlohmann_json: init at 2.0.2

### DIFF
--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "nlohmann_json-${version}";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "nlohmann";
+    repo = "json";
+    rev = "v${version}";
+    sha256 = "10sk8d23vh0c7b3qafjz2n8r5jv8vc275bl069ikhqnx1zxv6hwp";
+  };
+
+  buildInputs = [ cmake ];
+
+  doCheck = true;
+  checkTarget = "test";
+
+  meta = with stdenv.lib; {
+    description = "Header only C++ library for the JSON file format";
+    homepage = https://github.com/nlohmann/json;
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8829,6 +8829,8 @@ in
     nix = pkgs.nixUnstable;
   };
 
+  nlohmann_json = callPackage ../development/libraries/nlohmann_json { };
+
   nntp-proxy = callPackage ../applications/networking/nntp-proxy { };
 
   non = callPackage ../applications/audio/non { };


### PR DESCRIPTION
###### Motivation for this change

nlohmann_json is a great header only JSON library for modern C++.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`): Tested the unit test binary, the rest is header only.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
