### PR TITLE
Enable DRM_GMA600 and DRM_GMA3600 support in gma500_gfx kernel module

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -165,6 +165,8 @@ with stdenv.lib;
   # Allow specifying custom EDID on the kernel command line
   DRM_LOAD_EDID_FIRMWARE y
   VGA_SWITCHEROO y # Hybrid graphics support
+  DRM_GMA600 y
+  DRM_GMA3600 y
 
   # Sound.
   SND_DYNAMIC_MINORS y


### PR DESCRIPTION
###### Motivation for this change

Resolves #14727.

Currently, our kernels are built with `gma500_gfx` module, but it doesn’t support the newer GMA600 and GMA3600 VGA controllers.

On the other hand, these controllers are used in slow netbooks, so recompilation on those is not really… pleasant (12+ hours).

Both Debian and ArchLinux set these options to `y`.

Also: I’ve found mentions of these options already in 3.5, so, probably, no version guard is necessary.
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X — n/a
  - [ ] Linux — ?
- [ ] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files — not really all, but the recompiled kernel works on my mother’s netbook — including the GPU
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). — I’m not sure how to go about kernel config?
