### PR TITLE
dejavu-fonts: 2.35 -> 2.37, simplify build process

### DIFF
--- a/pkgs/data/fonts/dejavu-fonts/default.nix
+++ b/pkgs/data/fonts/dejavu-fonts/default.nix
@@ -1,6 +1,6 @@
-{fetchurl, stdenv, fontforge, perl, fontconfig, FontTTF}:
+{fetchurl, fetchFromGitHub, stdenv, fontforge, perl, fontconfig, FontTTF}:
 
-let version = "2.35" ; in
+let version = "2.37" ; in
 
 stdenv.mkDerivation rec {
   name = "dejavu-fonts-${version}";
@@ -8,17 +8,19 @@ stdenv.mkDerivation rec {
   buildInputs = [fontforge perl FontTTF];
 
   unicodeData = fetchurl {
-    url = http://www.unicode.org/Public/6.1.0/ucd/UnicodeData.txt ;
-    sha256 = "1bd6zkzvxfnifrn5nh171ywk7q56sgk8gdvdn43z9i53hljjcrih";
+    url = http://www.unicode.org/Public/9.0.0/ucd/UnicodeData.txt ;
+    sha256 = "13zfannnr6sa6s27ggvcvzmh133ndi38pfyxsssvjmw2s8ac9pv8";
   };
   blocks = fetchurl {
-    url = http://www.unicode.org/Public/6.1.0/ucd/Blocks.txt;
-    sha256 = "0w0vkb09nrlc6mrhqyl9npszdi828afgvhvlb1vs5smjv3h8y3dz";
+    url = http://www.unicode.org/Public/9.0.0/ucd/Blocks.txt;
+    sha256 = "04xyws1prlcnqsryq56sm25dlfvr3464lbjjh9fyaclhi3a2f8b1";
   };
 
-  src = fetchurl {
-    url = "mirror://sourceforge/dejavu/dejavu-fonts-${version}.tar.bz2";
-    sha256 = "1xdbi4llrq1qbkd73352ibrfqcbz93dww8hab216qz5szd95yvv4";
+  src = fetchFromGitHub {
+    owner = "dejavu-fonts";
+    repo = "dejavu-fonts";
+    rev = "version_${stdenv.lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "1xknlg2h287dx34v2n5r33bpcl4biqf0cv7nak657rjki7s0k4bk";
   };
 
   buildFlags = "full-ttf";
@@ -41,6 +43,22 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    description = "A typeface family based on the Bitstream Vera fonts";
+    longDescription = ''
+      The DejaVu fonts are TrueType fonts based on the BitStream Vera fonts,
+      providing more styles and with greater coverage of Unicode.
+
+      This package includes DejaVu Sans, DejaVu Serif, DejaVu Sans Mono, and
+      the TeX Gyre DejaVu Math font.
+    '';
+    homepage = http://dejavu-fonts.org/wiki/Main_Page;
+
+    # Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.
+    # Copyright (c) 2006 by Tavmjong Bah. All Rights Reserved.
+    # DejaVu changes are in public domain
+    # See http://dejavu-fonts.org/wiki/License for details
+    license = stdenv.lib.licenses.free;
+
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/data/fonts/dejavu-fonts/default.nix
+++ b/pkgs/data/fonts/dejavu-fonts/default.nix
@@ -1,20 +1,10 @@
-{fetchurl, fetchFromGitHub, stdenv, fontforge, perl, fontconfig, FontTTF}:
+{fetchFromGitHub, stdenv, fontforge, perl, FontTTF}:
 
 let version = "2.37" ; in
 
 stdenv.mkDerivation rec {
   name = "dejavu-fonts-${version}";
-  #fontconfig is needed only for fc-lang (?)
   buildInputs = [fontforge perl FontTTF];
-
-  unicodeData = fetchurl {
-    url = http://www.unicode.org/Public/9.0.0/ucd/UnicodeData.txt ;
-    sha256 = "13zfannnr6sa6s27ggvcvzmh133ndi38pfyxsssvjmw2s8ac9pv8";
-  };
-  blocks = fetchurl {
-    url = http://www.unicode.org/Public/9.0.0/ucd/Blocks.txt;
-    sha256 = "04xyws1prlcnqsryq56sm25dlfvr3464lbjjh9fyaclhi3a2f8b1";
-  };
 
   src = fetchFromGitHub {
     owner = "dejavu-fonts";
@@ -25,15 +15,7 @@ stdenv.mkDerivation rec {
 
   buildFlags = "full-ttf";
 
-  preBuild = ''
-    sed -e s@/usr/bin/env@$(type -tP env)@ -i scripts/*
-    sed -e s@/usr/bin/perl@$(type -tP perl)@ -i scripts/*
-    mkdir resources
-    tar xf ${fontconfig.src} --wildcards '*/fc-lang'
-    ln -s $PWD/fontconfig-*/fc-lang -t resources/
-    ln -s ${unicodeData} resources/UnicodeData.txt
-    ln -s ${blocks} resources/Blocks.txt
-  '';
+  preBuild = "patchShebangs scripts";
 
   installPhase = ''
     mkdir -p $out/share/fonts/truetype


### PR DESCRIPTION
###### Motivation for this change

Release 2.36 adds and fixes a number of glyphes, and adds the Tex Gyre DejaVu Math font, a companion font to DejaVu Serif for typesetting mathematics.

Release 2.37 fixes an issue with condensed typefaces.

Unicode data and fc-lang are only necessary to generate the status files and coverage information, which are not used, or indeed even generated with full-ttf.
###### Things done
- [x] Tested using `nix-build --attr pkgs.dejavu_fonts default.nix`, with nix.useSandbox
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
