### PR TITLE
fehlstart: init at 9f4342d7

### DIFF
--- a/pkgs/applications/misc/fehlstart/default.nix
+++ b/pkgs/applications/misc/fehlstart/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, pkgconfig, gtk2, keybinder, fetchFromGitLab }:
+
+stdenv.mkDerivation {
+  name = "fehlstart-9f4342d7";
+
+  src = fetchFromGitLab {
+    owner = "fehlstart";
+    repo = "fehlstart";
+    rev = "9f4342d75ec5e2a46c13c99c34894bc275798441";
+    sha256 = "1rfzh7w6n2s9waprv7m1bhvqrk36a77ada7w655pqiwkhdj5q95i";
+  };
+
+  patches = [ ./patch ];
+  buildInputs = [ pkgconfig gtk2 keybinder ];
+
+  preConfigure = ''
+    export PREFIX=$out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Small desktop application launcher with reasonable memory footprint";
+    homepage = https://gitlab.com/fehlstart/fehlstart;
+    licence = licenses.gpl3;
+    maintainers = [ maintainers.mounium ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/misc/fehlstart/patch
+++ b/pkgs/applications/misc/fehlstart/patch
@@ -1,0 +1,20 @@
+--- fehlstart-9f4342d75ec5e2a46c13c99c34894bc275798441-src/fehlstart.c	1970-01-01 01:00:01.000000000 +0100
++++ fehlstart.c	2016-08-10 12:21:11.231638418 +0200
+@@ -779,9 +779,14 @@
+     read_settings(setting_file, &settings);
+     update_commands();
+     g_hash_table_foreach(action_map, update_launcher, NULL);
+-    add_launchers(STR_S(APPLICATIONS_DIR_0));
+-    add_launchers(STR_S(APPLICATIONS_DIR_1));
+-    add_launchers(STR_S(USER_APPLICATIONS_DIR));
++    char* nixprofiles = getenv("NIX_PROFILES");
++    char* pch = strtok(nixprofiles, " ");
++    while (pch != NULL)
++    {
++        String nix_dir = str_concat((String) { pch, strlen(pch), false },STR_S("/share/applications"));
++        add_launchers(nix_dir);
++        pch = strtok(NULL, " ");
++    }
+     return NULL;
+ }
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12986,6 +12986,8 @@ in
 
   fbreader = callPackage ../applications/misc/fbreader { };
 
+  fehlstart = callPackage ../applications/misc/fehlstart { };
+
   fetchmail = callPackage ../applications/misc/fetchmail { };
 
   flacon = callPackage ../applications/audio/flacon { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
