### PR TITLE
gnome-3: remove ibus from corePackages

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/default.nix
@@ -17,7 +17,7 @@ let
   maintainers = with pkgs.lib.maintainers; [ lethalman jgeerds DamienCassou ];
 
   corePackages = with gnome3; [
-    pkgs.desktop_file_utils pkgs.ibus
+    pkgs.desktop_file_utils
     pkgs.shared_mime_info # for update-mime-database
     glib # for gsettings
     gtk3 # for gtk-update-icon-cache


### PR DESCRIPTION
###### Motivation for this change

solves #17277

`pkgs.ibus` shouldn't be in `environment.SystemPackages` as it conflicts with `ibus-with-packages` that is installed with the ibus module.

cc @DamienCassou 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
