### PR TITLE
ocamlPackages.containers: 0.16 -> 0.18

### DIFF
--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, cppo, gen, sequence, qtest, ounit, ocaml_oasis, result }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, cppo, gen, sequence, qtest, ounit, ocaml_oasis, result
+, qcheck }:
 
 let
 
@@ -6,7 +7,7 @@ let
     let v = stdenv.lib.getVersion ocaml; in
       "${p}/lib/ocaml/${v}/site-lib";
 
-  version = "0.16";
+  version = "0.18";
 
 in
 
@@ -17,10 +18,10 @@ stdenv.mkDerivation {
     owner = "c-cube";
     repo = "ocaml-containers";
     rev = "${version}";
-    sha256 = "1mc33b4nvn9k3r4k56amxr804bg5ndhxv92cmjzg5pf4qh220c2h";
+    sha256 = "169j8vqg8h70wbldjg610jqikfk23ggw8zypmpzv3piym5p1dfiw";
   };
 
-  buildInputs = [ ocaml findlib cppo gen sequence qtest ounit ocaml_oasis ];
+  buildInputs = [ ocaml findlib cppo gen sequence qtest ounit ocaml_oasis qcheck ];
 
   propagatedBuildInputs = [ result ];
 


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
