### PR TITLE
wraith: 1.4.6 -> 1.4.7, fixes build

### DIFF
--- a/pkgs/applications/networking/irc/wraith/configure.patch
+++ b/pkgs/applications/networking/irc/wraith/configure.patch
@@ -1,0 +1,58 @@
+--- a/configure
++++ b/configure
+@@ -6029,53 +6029,8 @@
+ #AC_CHECK_HEADERS(zlib.h)
+ #EGG_CHECK_ZLIB
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for path to OpenSSL" >&5
+-$as_echo_n "checking for path to OpenSSL... " >&6; }
+-
+-
+-# Check whether --with-openssl was given.
+-if test "${with_openssl+set}" = set; then :
+-  withval=$with_openssl; with_openssl_path=$withval
+-else
+-  with_openssl_path=auto
+-fi
+-
+-
+-
+-cf_openssl_basedir=""
+-if test "$with_openssl_path" != "auto"; then
+-    cf_openssl_basedir="`echo ${with_openssl_path} | sed 's/\/$//'`"
+-else
+-    for dirs in /usr/local/ssl /usr/pkg /usr/local /usr/local/openssl; do
+-    if test -f "${dirs}/include/openssl/opensslv.h" && test -f "${dirs}/lib/libssl.so"; then
+-      cf_openssl_basedir="${dirs}"
+-      break
+-    fi
+-  done
+-  unset dirs
+-fi
+-if test ! -z "$cf_openssl_basedir"; then
+-  if test -f "${cf_openssl_basedir}/include/openssl/opensslv.h" && test -f "${cf_openssl_basedir}/lib/libssl.so"; then
+-    SSL_INCLUDES="-I${cf_openssl_basedir}/include"
+-    SSL_LIBS="-L${cf_openssl_basedir}/lib"
+-  else
+-        cf_openssl_basedir=""
+-  fi
+-else
+-    if test -f "/usr/include/openssl/opensslv.h" ; then
+-    cf_openssl_basedir="/usr"
+-  fi
+-fi
+-
+-if test ! -z "$cf_openssl_basedir"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $cf_openssl_basedir" >&5
+-$as_echo "$cf_openssl_basedir" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+-$as_echo "not found" >&6; }
+-  as_fn_error 1 "OpenSSL is required." "$LINENO" 5
+-fi
+-unset cf_openssl_basedir
++SSL_INCLUDES="-I@openssl.dev@/include"
++SSL_LIBS="-L@openssl.out@/lib"
+ 
+ save_CXX="$CXX"
+ CXX="$CXX $SSL_INCLUDES"

--- a/pkgs/applications/networking/irc/wraith/default.nix
+++ b/pkgs/applications/networking/irc/wraith/default.nix
@@ -5,18 +5,19 @@ with stdenv.lib;
 
 mkDerivation rec {
   name = "wraith-${version}";
-  version = "1.4.6";
+  version = "1.4.7";
   src = fetchurl {
     url = "mirror://sourceforge/wraithbotpack/wraith-v${version}.tar.gz";
-    sha256 = "0vb2hbjmwh040f5yhxvwcfxvgxa0q9zdy9vvddydn8zn782d7wl8";
+    sha256 = "0h6liac5y7im0jfm2sj18mibvib7d1l727fjs82irsjj1v9kif3j";
   };
   buildInputs = [ openssl ];
-  patches = [ ./dlopen.patch ];
+  patches = [ ./configure.patch ./dlopen.patch ];
   postPatch = ''
-    substituteInPlace src/libssl.cc    --subst-var-by openssl ${openssl}
-    substituteInPlace src/libcrypto.cc --subst-var-by openssl ${openssl}
+    substituteInPlace configure        --subst-var-by openssl.dev ${openssl.dev} \
+                                       --subst-var-by openssl.out ${openssl.out}
+    substituteInPlace src/libssl.cc    --subst-var-by openssl ${openssl.out}
+    substituteInPlace src/libcrypto.cc --subst-var-by openssl ${openssl.out}
   '';
-  configureFlags = "--with-openssl=${openssl.dev}";
   installPhase = ''
     mkdir -p $out/bin
     cp -a wraith $out/bin/wraith


### PR DESCRIPTION
###### Motivation for this change
- update to latest release
- patch ./configure script for openssl multiple-outputs
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
