### PR TITLE
libsidplayfp: init at 1.8.6

### DIFF
--- a/pkgs/development/libraries/libsidplayfp/default.nix
+++ b/pkgs/development/libraries/libsidplayfp/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, autoconf, automake, pkgconfig, libtool
+, docSupport ? true, doxygen ? null, graphviz ? null }:
+
+assert docSupport -> doxygen != null && graphviz != null;
+
+stdenv.mkDerivation rec {
+  pname = "libsidplayfp";
+  major = "1";
+  minor = "8";
+  level = "6";
+  version = "${major}.${minor}.${level}";
+  name = "${pname}-${major}.${minor}.${level}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/sidplay-residfp/${pname}/${major}.${minor}/${pname}-${major}.${minor}.${level}.tar.gz";
+    sha256 = "0lzivfdq0crmfr01c6f5h883yr7wvagq198xkk3srdmvshhxmwnw";
+  };
+
+  buildInputs = [ autoconf automake libtool pkgconfig ]
+    ++ stdenv.lib.optionals docSupport [ doxygen graphviz ];
+
+  installTargets = [ "install" ]
+    ++ stdenv.lib.optionals docSupport [ "doc" ];
+
+  outputs = [ "out" ] ++ stdenv.lib.optionals docSupport [ "doc" ];
+
+  postInstall = stdenv.lib.optionalString docSupport ''
+    mkdir -p $doc/share/doc/libsidplayfp
+    mv docs/html $doc/share/doc/libsidplayfp/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A library to play Commodore 64 music derived from libsidplay2";
+    homepage = https://sourceforge.net/projects/sidplay-residfp/;
+    license = with licenses; [ gpl2Plus ];
+    maintainers = with maintainers; [ ramkromberg ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2384,6 +2384,8 @@ in
 
   liboauth = callPackage ../development/libraries/liboauth { };
 
+  libsidplayfp = callPackage ../development/libraries/libsidplayfp { };
+
   libsrs2 = callPackage ../development/libraries/libsrs2 { };
 
   libtermkey = callPackage ../development/libraries/libtermkey { };


### PR DESCRIPTION
###### Motivation for this change

audacious uses it to play old commodore 64 files (https://github.com/NixOS/nixpkgs/pull/17543).
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
