### PR TITLE
audacious: 3.5.2 -> 3.7.2

### DIFF
--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -1,69 +1,79 @@
-{ stdenv, fetchurl, pkgconfig, glib, gtk3, libmowgli, libmcs
-, gettext, dbus_glib, libxml2, libmad, xorg, alsaLib, libogg
-, libvorbis, libcdio, libcddb, flac, ffmpeg, makeWrapper
-, mpg123, neon, faad2, gnome3
+{ stdenv, fetchurl, pkgconfig, autoconf, makeWrapper, gettext
+, glib, gtk3, libmowgli, libmcs, dbus_glib, libxml2, xorg, gnome3
+, alsaLib, libpulseaudio, libjack2, fluidsynth
+, libmad, libogg, libvorbis, libcdio082, libcddb, flac, ffmpeg, mpg123
+, libcue, libmms, libbs2b, libsndfile, libmodplug, libsamplerate
+, soxr, lirc, curl, wavpack, neon, faad2, lame, libnotify, libsidplayfp
 }:
 
-let version = "3.5.2"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "audacious-${version}";
+  version = "3.7.2";
 
   src = fetchurl {
-    url = "http://distfiles.audacious-media-player.org/audacious-${version}.tar.bz2";
-    sha256 = "0mhrdj76h0g6q197wgp8rxk6gqsrirrw49hfidcb5b7q5rlvj59r";
+    url = "http://distfiles.audacious-media-player.org/audacious-${version}-gtk3.tar.bz2";
+    sha256 = "1pvyxi8niy70nv13kc16g2vaywwahmg2650fa7v4rlbmykifk75z";
   };
 
   pluginsSrc = fetchurl {
-    url = "http://distfiles.audacious-media-player.org/audacious-plugins-${version}.tar.bz2";
-    sha256 = "1nacd8n46q3pqnwavq3i2ayls609gvxfcp3qqpcsfcdfz3bh15hp";
+    url = "http://distfiles.audacious-media-player.org/audacious-plugins-${version}-gtk3.tar.bz2";
+    sha256 = "0gxka0lp9a35k2xgq8bx69wyv83dvrqnpwcsqliy3h3yz6v1fv2v";
   };
 
-  buildInputs =
-    [ gettext pkgconfig glib gtk3 libmowgli libmcs libxml2 dbus_glib
-      libmad xorg.libXcomposite libogg libvorbis flac alsaLib libcdio
-      libcddb ffmpeg makeWrapper mpg123 neon faad2 gnome3.defaultIconTheme
-    ];
+  buildInputs = [
+    pkgconfig autoconf makeWrapper gettext glib gtk3 libmowgli
+    libmcs dbus_glib libxml2 xorg.libXcomposite gnome3.defaultIconTheme
+    alsaLib libjack2 libpulseaudio fluidsynth
+    libmad libogg libvorbis libcdio082 libcddb flac ffmpeg mpg123
+    libcue libmms libbs2b libsndfile libmodplug libsamplerate
+    soxr lirc curl wavpack neon faad2 lame libnotify libsidplayfp.out
+  ];
 
-  # Here we build bouth audacious and audacious-plugins in one
+  configureFlags = [ "--enable-statusicon" ];
+
+  # Here we build both audacious and audacious-plugins in one
   # derivations, since they really expect to be in the same prefix.
   # This is slighly tricky.
-  builder = builtins.toFile "builder.sh"
-    ''
-      # First build audacious.
-      (
-        source $stdenv/setup
-        genericBuild
-      )
+  builder = builtins.toFile "builder.sh" ''
+    # First build audacious.
+    (
+      source $stdenv/setup
+      genericBuild
+    )
 
-      # Then build the plugins.
-      (
-        nativeBuildInputs="$out $nativeBuildInputs" # to find audacious
-        source $stdenv/setup
-        rm -rfv audacious-*
-        src=$pluginsSrc
-        genericBuild
-      )
+    # Then build the plugins.
+    (
+      nativeBuildInputs="$out $nativeBuildInputs" # to find audacious
+      source $stdenv/setup
+      rm -rfv audacious-*
+      src=$pluginsSrc
+      genericBuild
+    )
 
-      (
-        source $stdenv/setup
-        # gsettings schemas for file dialogues
-        # XDG_ICON_DIRS is set by hook for gnome3.defaultIconTheme
-        for file in "$out/bin/"*; do
-          wrapProgram "$file" \
-            --prefix XDG_DATA_DIRS : "$XDG_ADD:$GSETTINGS_SCHEMAS_PATH" \
-            --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
-        done
-      )
-    '';
+    (
+      source $stdenv/setup
+      # gsettings schemas for file dialogues
+      # XDG_ICON_DIRS is set by hook for gnome3.defaultIconTheme
+      for file in "$out/bin/"*; do
+        wrapProgram "$file" \
+          --prefix XDG_DATA_DIRS : "$XDG_ADD:$GSETTINGS_SCHEMAS_PATH" \
+          --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
+      done
+    )
+  '';
+
   XDG_ADD = gtk3 + "/share";
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Audio player";
     homepage = http://audacious-media-player.org/;
-    maintainers = with stdenv.lib.maintainers; [ eelco ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ eelco ramkromberg ];
+    platforms = with platforms; linux;
+    license = with licenses; [
+      bsd2 bsd3 #https://github.com/audacious-media-player/audacious/blob/master/COPYING
+      gpl2 gpl3 lgpl2Plus #http://redmine.audacious-media-player.org/issues/46
+    ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

was missing a lot of the plugins and features.
#### Depends on https://github.com/NixOS/nixpkgs/pull/17542 ~~& https://github.com/NixOS/nixpkgs/pull/17526 (merged)~~.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
