### PR TITLE
darwin: WWWCurl: fix CURL_DID_MEMORY_FUNC_TYPEDEFS build error

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14116,6 +14116,7 @@ let self = _self // overrides; _self = with self; {
     preConfigure =
       ''
         substituteInPlace Makefile.PL --replace '"cpp"' '"gcc -E"'
+        substituteInPlace Makefile.PL --replace '_LASTENTRY\z' '_LASTENTRY\z|CURL_DID_MEMORY_FUNC_TYPEDEFS\z'
       '';
     doCheck = false; # performs network access
   };


### PR DESCRIPTION
###### Motivation for this change

Building nixUnstable on Darwin currently fails with error:

```
./curlopt-constants.c:19:58: error: non-void function 'constant' should return a value [-Wreturn-type]
            if (strEQ(name, "DID_MEMORY_FUNC_TYPEDEFS")) return CURL_DID_MEMORY_FUNC_TYPEDEFS;
```

which can be worked around as described in https://github.com/szbalint/WWW--Curl/issues/16#issuecomment-222556096
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Apply the patch from

  https://github.com/szbalint/WWW--Curl/issues/16#issuecomment-222556096
