### PR TITLE
nixpkgs-doc: add patches to coding conventions

### DIFF
--- a/doc/coding-conventions.xml
+++ b/doc/coding-conventions.xml
@@ -659,4 +659,22 @@ src = fetchFromGitHub {
     </itemizedlist>
   </para>
 </section>
+
+<section xml:id="sec-patches"><title>Patches</title>
+  <para>Only patches that are unique to <literal>nixpkgs</literal> should be 
+    included in <literal>nixpkgs</literal> source.</para>
+  <para>Patches available online should be retrieved using 
+    <literal>fetchpatch</literal>.</para>
+  <para>
+<programlisting>
+patches = [
+  (fetchpatch {
+    name = "fix-check-for-using-shared-freetype-lib.patch";
+    url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=8f5d285";
+    sha256 = "1f0k043rng7f0rfl9hhb89qzvvksqmkrikmm38p61yfx51l325xr";
+  })
+];
+</programlisting>
+  </para>
+</section>
 </chapter>


### PR DESCRIPTION
###### Motivation for this change

This add a short section about patches in the coding conventions section of nixpkgs manual.

See commit contents for details.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
