### PR TITLE
xtreemfs: fix build

### DIFF
--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
 
     export BOOST_INCLUDEDIR=${boost.dev}/include
     export BOOST_LIBRARYDIR=${boost.out}/lib
-    export OPENSSL_ROOT_DIR=${openssl.dev}
+    export CMAKE_INCLUDE_PATH=${openssl.dev}/include
+    export CMAKE_LIBRARY_PATH=${openssl.out}/lib
 
     substituteInPlace cpp/cmake/FindValgrind.cmake \
       --replace "/usr/local" "${valgrind}"


### PR DESCRIPTION
###### Motivation for this change

passing the OPENSSL_ROOT_DIR no longer works as the include and lib dirs are now separate.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
