### PR TITLE
wsmancli: fix compilation

### DIFF
--- a/pkgs/tools/system/wsmancli/default.nix
+++ b/pkgs/tools/system/wsmancli/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, autoconf, automake, libtool, pkgconfig, openwsman }:
+{ fetchurl, stdenv, autoconf, automake, libtool, pkgconfig, openwsman, openssl }:
 
 stdenv.mkDerivation rec {
   version = "2.6.0";
@@ -9,9 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "03ay6sa4ii8h6rr3l2qiqqml8xl6gplrlg4v2avdh9y6sihfyvvn";
   };
 
-  buildInputs = [ autoconf automake libtool pkgconfig openwsman ];
+  buildInputs = [ autoconf automake libtool pkgconfig openwsman openssl ];
 
-  preConfigure = "./bootstrap";
+  preConfigure = ''
+    ./bootstrap
+
+    configureFlagsArray=(
+      LIBS="-L${openssl}/lib -lssl -lcrypto"
+    )
+  '';
 
   meta = {
     description = "Openwsman command-line client";


### PR DESCRIPTION
###### Motivation for this change

Without this fix the package build fails with a linking error. Fixes #14872.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
