### PR TITLE
syncthing:  0.12.25 -> 0.14.3  (backport to 16.03)

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -253,6 +253,7 @@
   palo = "Ingolf Wanger <palipalo9@googlemail.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   pesterhazy = "Paulus Esterhazy <pesterhazy@gmail.com>";
+  peterhoeg = "Peter Hoeg <peter@hoeg.com>";
   philandstuff = "Philip Potter <philip.g.potter@gmail.com>";
   phile314 = "Philipp Hausmann <nix@314.ch>";
   Phlogistique = "Noé Rubinstein <noe.rubinstein@gmail.com>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -166,6 +166,7 @@
   joamaki = "Jussi Maki <joamaki@gmail.com>";
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
   joelteon = "Joel Taylor <me@joelt.io>";
+  joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
   jraygauthier = "Raymond Gauthier <jraygauthier@gmail.com>";
   jwiegley = "John Wiegley <johnw@newartisans.com>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -269,6 +269,7 @@
   prikhi = "Pavan Rikhi <pavan.rikhi@gmail.com>";
   profpatsch = "Profpatsch <mail@profpatsch.de>";
   proglodyte = "Proglodyte <proglodyte23@gmail.com>";
+  pshendry = "Paul Hendry <paul@pshendry.com>";
   psibi = "Sibi <sibi@psibi.in>";
   pSub = "Pascal Wittmann <mail@pascal-wittmann.de>";
   puffnfresh = "Brian McKenna <brian@brianmckenna.org>";

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, go }:
+{ stdenv, fetchFromGitHub, go }:
 
 stdenv.mkDerivation rec {
-  version = "0.14.0";
+  version = "0.14.2";
   name = "syncthing-${version}";
 
-  src = fetchgit {
-    url = https://github.com/syncthing/syncthing;
-    rev = "refs/tags/v${version}";
-    sha256 = "15l3q3r6i3q95i474winswx4y149b5ic7xhpnj52s78fxd4va2q2";
+  src = fetchFromGitHub {
+    owner = "syncthing";
+    repo = "syncthing";
+    rev = "v${version}";
+    sha256 = "0is4f1r3im2bbmbca9fafzxffikxaf86vd6f851831fk5wi4pzw9";
   };
 
   buildInputs = [ go ];
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage = https://www.syncthing.net/;
     description = "Open Source Continuous File Synchronization";
     license = stdenv.lib.licenses.mpl20;
-    maintainers = with stdenv.lib.maintainers; [pshendry];
+    maintainers = with stdenv.lib.maintainers; [ pshendry joko ];
     platforms = with stdenv.lib.platforms; linux ++ freebsd ++ openbsd ++ netbsd;
   };
 }

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchgit, go }:
 
 stdenv.mkDerivation rec {
-  version = "0.13.7";
+  version = "0.13.9";
   name = "syncthing-${version}";
 
   src = fetchgit {
     url = https://github.com/syncthing/syncthing;
     rev = "refs/tags/v${version}";
-    sha256 = "0n1yqaaag4l30i6zqb74z6f800xjvj9zvprb12nl9xlm5swrwrkz";
+    sha256 = "1ah3a86rjfqlx4mqyvn8j3r806i65mzhs5xnfg4aakzmwpr5zpx0";
   };
 
   buildInputs = [ go ];

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, go }:
 
 stdenv.mkDerivation rec {
-  version = "0.14.2";
+  version = "0.14.3";
   name = "syncthing-${version}";
 
   src = fetchFromGitHub {
     owner = "syncthing";
     repo = "syncthing";
     rev = "v${version}";
-    sha256 = "0is4f1r3im2bbmbca9fafzxffikxaf86vd6f851831fk5wi4pzw9";
+    sha256 = "114i0911h3q6dn3j9x2qcm5lzpqclvrpf5vk87qpqp9qy62jp3az";
   };
 
   buildInputs = [ go ];
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage = https://www.syncthing.net/;
     description = "Open Source Continuous File Synchronization";
     license = stdenv.lib.licenses.mpl20;
-    maintainers = with stdenv.lib.maintainers; [ pshendry joko ];
+    maintainers = with stdenv.lib.maintainers; [ pshendry joko peterhoeg ];
     platforms = with stdenv.lib.platforms; linux ++ freebsd ++ openbsd ++ netbsd;
   };
 }

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchgit, go }:
 
 stdenv.mkDerivation rec {
-  version = "0.13.9";
+  version = "0.13.10";
   name = "syncthing-${version}";
 
   src = fetchgit {
     url = https://github.com/syncthing/syncthing;
     rev = "refs/tags/v${version}";
-    sha256 = "1ah3a86rjfqlx4mqyvn8j3r806i65mzhs5xnfg4aakzmwpr5zpx0";
+    sha256 = "07q3j6mnrza719rnvbkdsmvlkyr2pch5sj2l204m5iy5mxaghpx7";
   };
 
   buildInputs = [ go ];

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchgit, go }:
 
 stdenv.mkDerivation rec {
-  version = "0.13.4";
+  version = "0.13.7";
   name = "syncthing-${version}";
 
   src = fetchgit {
     url = https://github.com/syncthing/syncthing;
     rev = "refs/tags/v${version}";
-    sha256 = "0aa0nqi0gmka5r5dzph4g51jlsy7w5q4ri8f4gy3qnma4pgp7pg2";
+    sha256 = "0n1yqaaag4l30i6zqb74z6f800xjvj9zvprb12nl9xlm5swrwrkz";
   };
 
   buildInputs = [ go ];

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit, go }:
+
+stdenv.mkDerivation rec {
+  version = "0.13.4";
+  name = "syncthing-${version}";
+
+  src = fetchgit {
+    url = https://github.com/syncthing/syncthing;
+    rev = "refs/tags/v${version}";
+    sha256 = "0aa0nqi0gmka5r5dzph4g51jlsy7w5q4ri8f4gy3qnma4pgp7pg2";
+  };
+
+  buildInputs = [ go ];
+
+  buildPhase = ''
+    mkdir -p src/github.com/syncthing
+    ln -s $(pwd) src/github.com/syncthing/syncthing
+    export GOPATH=$(pwd)
+    # Required for Go 1.5, can be removed for Go 1.6+
+    export GO15VENDOREXPERIMENT=1
+
+    # Syncthing's build.go script expects this working directory
+    cd src/github.com/syncthing/syncthing
+
+    go run build.go -no-upgrade -version v${version} install all
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/* $out/bin
+  '';
+
+  meta = {
+    homepage = https://www.syncthing.net/;
+    description = "Open Source Continuous File Synchronization";
+    license = stdenv.lib.licenses.mpl20;
+    maintainers = with stdenv.lib.maintainers; [pshendry];
+    platforms = with stdenv.lib.platforms; linux ++ freebsd ++ openbsd ++ netbsd;
+  };
+}

--- a/pkgs/applications/networking/syncthing013/default.nix
+++ b/pkgs/applications/networking/syncthing013/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchgit, go }:
 
 stdenv.mkDerivation rec {
-  version = "0.14.0";
+  version = "0.13.10";
   name = "syncthing-${version}";
 
   src = fetchgit {
     url = https://github.com/syncthing/syncthing;
     rev = "refs/tags/v${version}";
-    sha256 = "15l3q3r6i3q95i474winswx4y149b5ic7xhpnj52s78fxd4va2q2";
+    sha256 = "07q3j6mnrza719rnvbkdsmvlkyr2pch5sj2l204m5iy5mxaghpx7";
   };
 
   buildInputs = [ go ];
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     mkdir -p src/github.com/syncthing
     ln -s $(pwd) src/github.com/syncthing/syncthing
     export GOPATH=$(pwd)
-    # Required for Go 1.5, can be removed for Go 1.6+
-    export GO15VENDOREXPERIMENT=1
 
     # Syncthing's build.go script expects this working directory
     cd src/github.com/syncthing/syncthing

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13870,6 +13870,8 @@ let
 
   syncthing012 = go15Packages.syncthing012.bin // { outputs = [ "bin" ]; };
 
+  syncthing013 = callPackage ../applications/networking/syncthing013 { };
+
   # linux only by now
   synergy = callPackage ../applications/misc/synergy { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13866,8 +13866,9 @@ let
 
   symlinks = callPackage ../tools/system/symlinks { };
 
-  syncthing = go15Packages.syncthing.bin // { outputs = [ "bin" ]; };
-  syncthing011 = go15Packages.syncthing011.bin // { outputs = [ "bin" ]; };
+  syncthing = callPackage ../applications/networking/syncthing { };
+
+  syncthing012 = go15Packages.syncthing012.bin // { outputs = [ "bin" ]; };
 
   # linux only by now
   synergy = callPackage ../applications/misc/synergy { };

--- a/pkgs/top-level/go-packages.nix
+++ b/pkgs/top-level/go-packages.nix
@@ -3378,7 +3378,7 @@ let
     sha256 = "094ksr2nlxhvxr58nbnzzk0prjskb21r86jmxqjr3rwg4rkwn6d4";
   };
 
-  syncthing = buildFromGitHub rec {
+  syncthing012 = buildFromGitHub rec {
     version = "0.12.25";
     rev = "v${version}";
     owner = "syncthing";
@@ -3396,30 +3396,14 @@ let
     '';
   };
 
-  syncthing011 = buildFromGitHub rec {
-    version = "0.11.26";
-    rev = "v${version}";
-    owner = "syncthing";
-    repo = "syncthing";
-    sha256 = "0c0dcvxrvjc84dvrsv90790aawkmavsj9bwp8c6cd6wrwj3cp9lq";
-    buildInputs = [
-      go-lz4 du luhn xdr snappy ratelimit osext syncthing-protocol011
-      goleveldb suture qart crypto net text
-    ];
-    postPatch = ''
-      # Mostly a cosmetic change
-      sed -i 's,unknown-dev,${version},g' cmd/syncthing/main.go
-    '';
-  };
-
   syncthing-lib = buildFromGitHub {
-    inherit (syncthing) rev owner repo sha256;
+    inherit (syncthing012) rev owner repo sha256;
     subPackages = [ "lib/sync" ];
-    propagatedBuildInputs = syncthing.buildInputs;
+    propagatedBuildInputs = syncthing012.buildInputs;
   };
 
   syncthing-protocol = buildFromGitHub {
-    inherit (syncthing) rev owner repo sha256;
+    inherit (syncthing012) rev owner repo sha256;
     subPackages = [ "lib/protocol" ];
     propagatedBuildInputs = [
       go-lz4
@@ -3427,15 +3411,6 @@ let
       luhn
       xdr
       text ];
-  };
-
-  syncthing-protocol011 = buildFromGitHub {
-    rev = "84365882de255d2204d0eeda8dee288082a27f98";
-    date = "2015-08-28";
-    owner = "syncthing";
-    repo = "protocol";
-    sha256 = "07xjs43lpd51pc339f8x487yhs39riysj3ifbjxsx329kljbflwx";
-    propagatedBuildInputs = [ go-lz4 logger luhn xdr text ];
   };
 
   tablewriter = buildFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

Closes #17509

As discussed in #17509, newer versions of Syncthing have been released which render the client in release-16.03 (0.12.25) incompatible with them. This PR cherry-picks the necessary commits to ensure the client interoperability.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
