### PR TITLE
cpuminer-multi: disable on 686-linux

### DIFF
--- a/pkgs/tools/misc/cpuminer-multi/default.nix
+++ b/pkgs/tools/misc/cpuminer-multi/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/wolf9466/cpuminer-multi;
     license = licenses.gpl2;
     maintainers = [ maintainers.ehmry ];
-    platforms = platforms.linux;
+    # does not build on i686 https://github.com/lucasjones/cpuminer-multi/issues/27
+    platforms = [ "x86_64-linux" ]; 
   };
 }


### PR DESCRIPTION
upstream bug lucasjones/cpuminer-multi#27
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
