### PR TITLE
Use absolute paths in i3lock-fancy

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, coreutils, scrot, imagemagick, gawk
-, i3lock-color
+, i3lock-color, getopt, fontconfig
 }:
 
 stdenv.mkDerivation rec {
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     sed -i -e "s|i3lock -n |${i3lock-color}/bin/i3lock-color -n |" lock
     sed -i -e 's|ICON="$SCRIPTPATH/lockdark.png"|ICON="'$out'/share/i3lock-fancy/lockdark.png"|' lock
     sed -i -e 's|ICON="$SCRIPTPATH/lock.png"|ICON="'$out'/share/i3lock-fancy/lock.png"|' lock
+    sed -i -e "s|getopt |${getopt}/bin/getopt |" lock
+    sed -i -e "s|fc-match |${fontconfig.bin}/bin/fc-match |" lock
   '';
   installPhase = ''
     mkdir -p $out/bin $out/share/i3lock-fancy


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

When it's used from command line or as a i3 shortcut, i3lock-fancy works
without any issues. If you try to pass it as an argument to xss-lock or
xautolock running as a systemd user service, getopt and fc-match are not in
PATH and locking doesn't work as expected. This patch replaces non absolute
paths with stable ones and should fix the issue.
