### PR TITLE
hello: Removes doCheck = false

### DIFF
--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -8,8 +8,6 @@ stdenv.mkDerivation rec {
     sha256 = "0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i";
   };
 
-  doCheck = false;
-
   meta = {
     description = "A program that produces a familiar, friendly greeting";
     longDescription = ''


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This package builds fine without this line and there is no comment indicating why it's important.

/cc @edolstra 
