### PR TITLE
ffmpeg: add extra darwin framework for 3.1

### DIFF
--- a/pkgs/development/libraries/ffmpeg/3.1.nix
+++ b/pkgs/development/libraries/ffmpeg/3.1.nix
@@ -1,7 +1,12 @@
-{ callPackage, ... } @ args:
+{ callPackage
+# Darwin frameworks
+, Cocoa, CoreMedia
+, ...
+}@args:
 
 callPackage ./generic.nix (args // rec {
   version = "${branch}.1";
   branch = "3.1";
   sha256 = "1d5knh87cgnla5zawy56gkrpb48qhyiq7i0pm8z9hyx3j05abg55";
+  darwinFrameworks = [ Cocoa CoreMedia ];
 })

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -13,7 +13,7 @@
 , optimizationsDeveloper ? true
 , extraWarningsDeveloper ? false
 # Darwin frameworks
-, Cocoa
+, Cocoa, darwinFrameworks ? [ Cocoa ]
 # Inherit generics
 , branch, sha256, version, patches ? [], ...
 }:
@@ -153,7 +153,7 @@ stdenv.mkDerivation rec {
     ++ optionals (!isDarwin && !isArm) [ libvpx libpulseaudio ] # Need to be fixed on Darwin and ARM
     ++ optional ((isLinux || isFreeBSD) && !isArm) libva
     ++ optional isLinux alsaLib
-    ++ optional isDarwin Cocoa
+    ++ optionals isDarwin darwinFrameworks
     ++ optional vdpauSupport libvdpau
     ++ optional sdlSupport SDL;
 

--- a/pkgs/development/libraries/libmikmod/default.nix
+++ b/pkgs/development/libraries/libmikmod/default.nix
@@ -1,6 +1,9 @@
-{ stdenv, fetchurl, texinfo, alsaLib, libpulseaudio }:
+{ stdenv, fetchurl, texinfo, alsaLib, libpulseaudio, CoreAudio }:
 
-stdenv.mkDerivation rec {
+let
+  inherit (stdenv.lib) optional optionals optionalString;
+
+in stdenv.mkDerivation rec {
   name = "libmikmod-3.3.7";
   src = fetchurl {
     url = "mirror://sourceforge/mikmod/${name}.tar.gz";
@@ -8,11 +11,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ texinfo ]
-    ++ stdenv.lib.optional stdenv.isLinux [ alsaLib libpulseaudio ];
+    ++ optionals stdenv.isLinux [ alsaLib libpulseaudio ]
+    ++ optional stdenv.isDarwin CoreAudio;
   propagatedBuildInputs =
-    stdenv.lib.optional stdenv.isLinux libpulseaudio;
+    optional stdenv.isLinux libpulseaudio;
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lasound";
+  NIX_LDFLAGS = optionalString stdenv.isLinux "-lasound";
 
   meta = with stdenv.lib; {
     description = "A library for playing tracker music module files";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7172,7 +7172,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
   ffmpeg_3_1 = callPackage ../development/libraries/ffmpeg/3.1.nix {
-    inherit (darwin.apple_sdk.frameworks) Cocoa;
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreMedia;
   };
   # Aliases
   ffmpeg_0 = self.ffmpeg_0_10;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8292,7 +8292,9 @@ in
 
   libmicrohttpd = callPackage ../development/libraries/libmicrohttpd { };
 
-  libmikmod = callPackage ../development/libraries/libmikmod { };
+  libmikmod = callPackage ../development/libraries/libmikmod {
+    inherit (darwin.apple_sdk.frameworks) CoreAudio;
+  };
 
   libmilter = callPackage ../development/libraries/libmilter { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8203,7 +8203,9 @@ in
 
   librevisa = callPackage ../development/libraries/librevisa { };
 
-  libsamplerate = callPackage ../development/libraries/libsamplerate { };
+  libsamplerate = callPackage ../development/libraries/libsamplerate {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon CoreServices;
+  };
 
   libsieve = callPackage ../development/libraries/libsieve { };
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] OS X
  - [x] No rebuilds for other platforms
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
