### PR TITLE
quick-der library, asn2quickder + hexio tools

### DIFF
--- a/pkgs/development/libraries/quickder/default.nix
+++ b/pkgs/development/libraries/quickder/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, fetchurl, hexio, python, which, asn2quickder, bash }:
+
+stdenv.mkDerivation rec {
+  pname = "quickder";
+  name = "${pname}-${version}";
+  version = "1.0-RC1";
+
+  src = fetchFromGitHub {
+    sha256 = "05gw5dqkw3l8kwwm0044zpxhcp7sxicx9wxbfyr49c91403p870w";
+    rev = "version-${version}";
+    owner = "vanrein";
+    repo = "quick-der";
+  };
+
+  buildInputs = [ which asn2quickder bash ];
+
+  patchPhase = ''
+    substituteInPlace Makefile \
+      --replace 'lib tool test rfc' 'lib test rfc'
+    substituteInPlace ./rfc/Makefile \
+      --replace 'ASN2QUICKDER_CMD = ' 'ASN2QUICKDER_CMD = ${asn2quickder}/bin/asn2quickder #'
+    '';
+
+  installFlags = "ASN2QUICKDER_DIR=${asn2quickder}/bin ASN2QUICKDER_CMD=${asn2quickder}/bin/asn2quickder";
+  installPhase = ''
+    mkdir -p $out/lib $out/man
+    make DESTDIR=$out PREFIX=/ all
+    make DESTDIR=$out PREFIX=/ install
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Quick (and Easy) DER, a Library for parsing ASN.1";
+    homepage = https://github.com/vanrein/quick-der;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/development/tools/asn2quickder/default.nix
+++ b/pkgs/development/tools/asn2quickder/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pythonPackages, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "asn2quickder";
+  name = "${pname}-${version}";
+  version = "0.7-RC1";
+
+  src = fetchFromGitHub {
+    sha256 = "0ynajhbml28m4ipbj5mscjcv6g1a7frvxfimxh813rhgl0w3sgq8";
+    rev = "version-${version}";
+    owner = "vanrein";
+    repo = "${pname}";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ pyparsing makeWrapper ];
+
+  patchPhase = with pythonPackages; ''
+    substituteInPlace Makefile \
+      --replace '..' '..:$(DESTDIR)/${python.sitePackages}:${pythonPackages.pyparsing}/${python.sitePackages}' \
+    '';
+
+  installPhase = ''
+    mkdir -p $out/${pythonPackages.python.sitePackages}/
+    mkdir -p $out/bin $out/lib $out/sbin $out/man
+    make DESTDIR=$out PREFIX=/ all
+    make DESTDIR=$out PREFIX=/ install
+    '';
+
+  meta = with stdenv.lib; {
+    description = "An ASN.1 compiler with a backend for Quick DER";
+    homepage = https://github.com/vanrein/asn2quickder;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/development/tools/hexio/default.nix
+++ b/pkgs/development/tools/hexio/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, fetchurl, python, pcsclite, pth, glibc }:
+
+stdenv.mkDerivation rec {
+  pname = "hexio";
+  name = "${pname}-${version}";
+  version = "201605";
+
+  src = fetchFromGitHub {
+    sha256 = "08jxkdi0gjsi8s793f9kdlad0a58a0xpsaayrsnpn9bpmm5cgihq";
+    rev = "f6f963bd0fcd2808977e0ad82dcb3100691cdd7c";
+    owner = "vanrein";
+    repo = "hexio";
+  };
+
+  buildInputs = [ python pcsclite pth glibc ];
+
+  patchPhase = ''
+    substituteInPlace Makefile \
+      --replace '-I/usr/local/include/PCSC/' '-I${pcsclite}/include/PCSC/' \
+      --replace '-L/usr/local/lib/pth' '-I${pth}/lib/'
+    '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib $out/sbin $out/man
+    make DESTDIR=$out PREFIX=/ all
+    make DESTDIR=$out PREFIX=/ install
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Low-level I/O helpers for hexadecimal, tty/serial devices and so on";
+    homepage = https://github.com/vanrein/hexio;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -869,6 +869,8 @@ in
 
   heatseeker = callPackage ../tools/misc/heatseeker { };
 
+  hexio = callPackage ../development/tools/hexio { };
+
   interlock = callPackage ../servers/interlock {};
 
   kapacitor = callPackage ../servers/monitoring/kapacitor { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5718,6 +5718,8 @@ in
   apacheKafka_0_9 = callPackage ../servers/apache-kafka { majorVersion = "0.9"; };
   apacheKafka_0_10 = callPackage ../servers/apache-kafka { majorVersion = "0.10"; };
 
+  asn2quickder = callPackage ../development/tools/asn2quickder {};
+
   astyle = callPackage ../development/tools/misc/astyle { };
 
   electron = callPackage ../development/tools/electron { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8884,6 +8884,8 @@ in
 
   quesoglc = callPackage ../development/libraries/quesoglc { };
 
+  quickder = callPackage ../development/libraries/quickder {};
+
   quicksynergy = callPackage ../applications/misc/quicksynergy { };
 
   qwt = callPackage ../development/libraries/qwt {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1160,6 +1160,28 @@ in modules // {
     };
   };
 
+ asn1ate = buildPythonPackage rec {
+  pname = "asn1ate";
+  date = "20160810";
+  name = "${pname}-unstable-${date}";
+
+  src = pkgs.fetchFromGitHub {
+    sha256 = "04pddr1mh2v9qq8fg60czwvjny5qwh4nyxszr3qc4bipiiv2xk9w";
+    rev = "c56104e8912400135509b584d84423ee05a5af6b";
+    owner = "kimgr";
+    repo = pname;
+  };
+
+  propagatedBuildInputs = with self; [ pyparsing ];
+
+  meta = with stdenv.lib; {
+    description = "Python library for translating ASN.1 into other forms";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ leenaars ];
+  };
+};
+
   atomiclong = buildPythonPackage rec {
     version = "0.1.1";
     name = "atomiclong-${version}";


### PR DESCRIPTION
###### Motivation for this change

Libraries and tools used in ARPA2 project.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
