### PR TITLE
geeqie: 1.2.3 -> 1.3

### DIFF
--- a/pkgs/applications/graphics/geeqie/default.nix
+++ b/pkgs/applications/graphics/geeqie/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "geeqie-${version}";
-  version = "1.2.3";
+  version = "1.3";
 
   src = fetchurl {
     url = "http://geeqie.org/${name}.tar.xz";
-    sha256 = "2629bf33a9070fad4804b1ef051c3bf8a8fdad3bba4e6188dc20588185003248";
+    sha256 = "0gzc82sy66pbsmq7lnmq4y37zqad1zfwfls3ik3dmfm8s5nmcvsb";
   };
 
   preConfigure = "./autogen.sh";


### PR DESCRIPTION
###### Motivation for this change

Bring geeqie up to the most current version released by upstream. On my system, the problems listed https://github.com/NixOS/nixpkgs/pull/14715 (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=762257 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=765437) seem to be fixed for me. 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
