### PR TITLE
gmic: 1.6.5 -> 1.7.4

### DIFF
--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gmic-${version}";
-  version = "1.6.5.0";
+  version = "1.7.4";
 
   src = fetchurl {
     url = "http://gmic.eu/files/source/gmic_${version}.tar.gz";
-    sha256 = "1vb6zm5zpqfnzxjvb9yfvczaqacm55rf010ib0yk9f28b17qrjgb";
+    sha256 = "1k4swqi1adq479b6zdpvy5kdpkvjkfihkj9iwgw9mgi0xdqikjry";
   };
 
   buildInputs = [ fftw zlib libjpeg libtiff libpng ];


### PR DESCRIPTION
###### Motivation for this change

Update gmic to the latest upstream version
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
