### PR TITLE
rustc: fix darwin build

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchurl, makeWrapper, cacert, zlib }:
 
 let
+  inherit (stdenv.lib) optionalString;
+
   platform =
     if stdenv.system == "i686-linux"
     then "i686-unknown-linux-gnu"
@@ -46,9 +48,11 @@ rec {
       ./install.sh --prefix=$out \
         --components=rustc,rust-std-${platform},rust-docs
 
-      patchelf \
-        --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-        "$out/bin/rustc"
+      ${optionalString stdenv.isLinux ''
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/rustc"
+       ''}
 
       # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
       # (or similar) here. It causes strange effects where rustc loads
@@ -71,9 +75,11 @@ rec {
       ./install.sh --prefix=$out \
         --components=cargo
 
-      patchelf \
-        --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-        "$out/bin/cargo"
+      ${optionalString stdenv.isLinux ''
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/rustc"
+       ''}
 
       wrapProgram "$out/bin/cargo" \
         --suffix PATH : "${rustc}/bin"

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -13,26 +13,28 @@
 } @ args:
 
 let
-    version = if isRelease then
-        "${shortVersion}"
-      else
-        "${shortVersion}-g${builtins.substring 0 7 srcRev}";
+  inherit (stdenv.lib) optional optionalString;
 
-    name = "rustc-${version}";
+  version = if isRelease then
+      "${shortVersion}"
+    else
+      "${shortVersion}-g${builtins.substring 0 7 srcRev}";
 
-    procps = if stdenv.isDarwin then darwin.ps else args.procps;
+  name = "rustc-${version}";
 
-    llvmShared = llvm.override { enableSharedLibraries = true; };
+  procps = if stdenv.isDarwin then darwin.ps else args.procps;
 
-    target = builtins.replaceStrings [" "] [","] (builtins.toString targets);
+  llvmShared = llvm.override { enableSharedLibraries = true; };
 
-    meta = with stdenv.lib; {
-      homepage = http://www.rust-lang.org/;
-      description = "A safe, concurrent, practical language";
-      maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington retrry ];
-      license = [ licenses.mit licenses.asl20 ];
-      platforms = platforms.linux ++ platforms.darwin;
-    };
+  target = builtins.replaceStrings [" "] [","] (builtins.toString targets);
+
+  meta = with stdenv.lib; {
+    homepage = http://www.rust-lang.org/;
+    description = "A safe, concurrent, practical language";
+    maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington retrry ];
+    license = [ licenses.mit licenses.asl20 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
 in
 
 stdenv.mkDerivation {
@@ -42,7 +44,7 @@ stdenv.mkDerivation {
 
   __impureHostDeps = [ "/usr/lib/libedit.3.dylib" ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-rpath ${llvmShared}/lib";
+  NIX_LDFLAGS = optionalString stdenv.isDarwin "-rpath ${llvmShared}/lib";
 
   src = fetchgit {
     url = https://github.com/rust-lang/rust;
@@ -55,9 +57,9 @@ stdenv.mkDerivation {
                 ++ [ "--enable-local-rust" "--local-rust-root=${rustPlatform.rust.rustc}" "--enable-rpath" ]
                 # ++ [ "--jemalloc-root=${jemalloc}/lib"
                 ++ [ "--default-linker=${stdenv.cc}/bin/cc" "--default-ar=${binutils.out}/bin/ar" ]
-                ++ stdenv.lib.optional (stdenv.cc.cc ? isClang) "--enable-clang"
-                ++ stdenv.lib.optional (targets != []) "--target=${target}"
-                ++ stdenv.lib.optional (!forceBundledLLVM) "--llvm-root=${llvmShared}";
+                ++ optional (stdenv.cc.cc ? isClang) "--enable-clang"
+                ++ optional (targets != []) "--target=${target}"
+                ++ optional (!forceBundledLLVM) "--llvm-root=${llvmShared}";
 
   patches = patches ++ targetPatches;
   passthru.target = target;
@@ -73,7 +75,7 @@ stdenv.mkDerivation {
       --replace "\$\$(subst  /,//," "\$\$(subst /,/,"
 
     # Fix dynamic linking against llvm
-    ${stdenv.lib.optionalString (!forceBundledLLVM) ''sed -i 's/, kind = \\"static\\"//g' src/etc/mklldeps.py''}
+    ${optionalString (!forceBundledLLVM) ''sed -i 's/, kind = \\"static\\"//g' src/etc/mklldeps.py''}
 
     # Fix the configure script to not require curl as we won't use it
     sed -i configure \
@@ -97,7 +99,7 @@ stdenv.mkDerivation {
   # ps is needed for one of the test cases
   nativeBuildInputs = [ file python2 procps rustPlatform.rust.rustc git ];
   buildInputs = [ ncurses ] ++ targetToolchains
-    ++ stdenv.lib.optional (!forceBundledLLVM) llvmShared;
+    ++ optional (!forceBundledLLVM) llvmShared;
 
   # https://github.com/rust-lang/rust/issues/30181
   # enableParallelBuilding = false; # missing files during linking, occasionally
@@ -105,7 +107,10 @@ stdenv.mkDerivation {
   outputs = [ "out" "doc" ];
   setOutputFlags = false;
 
-  preCheck = "export TZDIR=${tzdata}/share/zoneinfo";
+  preCheck = ''
+    export TZDIR=${tzdata}/share/zoneinfo
+    ${optionalString stdenv.isDarwin "export TMPDIR=/tmp"}
+  '';
 
   doCheck = true;
   dontSetConfigureCross = true;


### PR DESCRIPTION
###### Motivation for this change

This should fix rust on darwin.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
