### PR TITLE
virtualbox-image module: add virtualBoxImage

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -22,6 +22,8 @@
 , # Shell code executed after the VM has finished.
   postVM ? ""
 
+, outputs ? [ "out" ]
+
 , name ? "nixos-disk-image"
 
 , format ? "raw"
@@ -41,7 +43,7 @@ pkgs.vmTools.runInLinuxVM (
       buildInputs = [ pkgs.utillinux pkgs.perl pkgs.e2fsprogs pkgs.parted ];
       exportReferencesGraph =
         [ "closure" config.system.build.toplevel ];
-      inherit postVM;
+      inherit postVM outputs;
       memSize = 1024;
     }
     ''

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -36,10 +36,14 @@ in {
           }
         '';
 
+      outputs = [ "out" "vdi" ];
+
       postVM =
         ''
+          mkdir -p $vdi
+
           echo "creating VirtualBox disk image..."
-          ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -O vdi $diskImage disk.vdi
+          ${pkgs.vmTools.qemu}/bin/qemu-img convert -f raw -O vdi $diskImage $vdi/disk.vdi
           rm $diskImage
 
           echo "creating VirtualBox VM..."
@@ -57,7 +61,7 @@ in {
             --usb on --mouse usbtablet
           VBoxManage storagectl "$vmName" --name SATA --add sata --portcount 4 --bootable on --hostiocache on
           VBoxManage storageattach "$vmName" --storagectl SATA --port 0 --device 0 --type hdd \
-            --medium disk.vdi
+            --medium $vdi/disk.vdi
 
           echo "exporting VirtualBox VM..."
           mkdir -p $out


### PR DESCRIPTION
###### Motivation for this change

This should help generate virtualbox images for NixOps again.

Related bug report https://github.com/NixOS/nixops/issues/473
NixOps [image generation script](https://github.com/NixOS/nixops/blob/master/maintainers/build-virtualbox-image.sh)

Making a dedicated derivation for the vdi is motivated by https://github.com/NixOS/nixpkgs/commit/5cc7bcda3023b01bd926eccd0c5f095a050c5ab0, so the OVA derivation doesn't reach the hydra-queue-runner's size limit of 2 GiB.

cc @edolstra @domenkozar 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
