### PR TITLE
sagemath: update mirrors, fix TeX Live dependency

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, m4, perl, gfortran, texLive, ffmpeg, tk
+{ stdenv, fetchurl, m4, perl, gfortran, texlive, ffmpeg, tk
 , imagemagick, liblapack, python, openssl, libpng
 , which
 }:
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "102mrzzi215g1xn5zgcv501x9sghwg758jagx2jixvg1rj2jijj9";
   };
 
-  buildInputs = [ m4 perl gfortran texLive ffmpeg tk imagemagick liblapack
+  buildInputs = [ m4 perl gfortran texlive.combined.scheme-basic ffmpeg tk imagemagick liblapack
                   python openssl libpng which];
 
   patches = [ ./spkg-singular.patch ./spkg-python.patch ./spkg-git.patch ];
@@ -25,9 +25,12 @@ stdenv.mkDerivation rec {
     export HOME=$out/sageHome
   '';
 
+  preBuild = "patchShebangs build";
+
   installPhase = ''DESTDIR=$out make install'';
 
   meta = {
+    broken = true;
     homepage = "http://www.sagemath.org";
     description = "A free open source mathematics software system";
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -290,34 +290,49 @@ rec {
 
   # Sage mirrors (http://www.sagemath.org/mirrors.html)
   sagemath = [
-    http://boxen.math.washington.edu/home/sagemath/sage-mirror/src/
-    http://echidna.maths.usyd.edu.au/sage/src/
-    http://ftp.iitm.ac.in/sage/src/
+    # Africa
+    http://sagemath.polytechnic.edu.na/src/
+    ftp://ftp.sun.ac.za/pub/mirrors/www.sagemath.org/src/
+    http://sagemath.mirror.ac.za/src/
+    https://ftp.leg.uct.ac.za/pub/packages/sage/src/
+    http://mirror.ufs.ac.za/sagemath/src/
+
+    # America, North
+    http://mirrors-usa.go-parts.com/sage/sagemath/src/
+    http://mirrors.mit.edu/sage/src/
+    http://www.cecm.sfu.ca/sage/src/
+    http://files.sagemath.org/src/
+    http://mirror.clibre.uqam.ca/sage/src/
+    https://mirrors.xmission.com/sage/src/
+
+    # America, South
+    http://sagemath.c3sl.ufpr.br/src/
+    http://linorg.usp.br/sage/
+
+    # Asia
+    http://sage.asis.io/src/
+    http://mirror.hust.edu.cn/sagemath/src/
+    https://ftp.iitm.ac.in/sage/src/
     http://ftp.kaist.ac.kr/sage/src/
     http://ftp.riken.jp/sagemath/src/
+    https://mirrors.tuna.tsinghua.edu.cn/sagemath/src/
+    https://mirrors.ustc.edu.cn/sagemath/src/
     http://ftp.tsukuba.wide.ad.jp/software/sage/src/
-    http://jambu.spms.ntu.edu.sg/sage/src/
-    http://linorg.usp.br/sage/src/
-    http://mirror.aarnet.edu.au/pub/sage/src/
-    http://mirror.clibre.uqam.ca/sage/src/
-    http://mirror.hust.edu.cn/sagemath/src/
-    http://mirror.switch.ch/mirror/sagemath/src/
-    http://mirror.yandex.ru/mirrors/sage.math.washington.edu/src/
-    http://mirrors.fe.up.pt/pub/sage/src/
-    http://mirrors.hustunique.com/sagemath/src/
-    http://mirrors.ustc.edu.cn/sagemath/src/
-    http://mirrors.xmission.com/sage/src/
-    http://sage.asis.io/src/
+    http://ftp.yz.yamagata-u.ac.jp/pub/math/sage/src/
+    https://mirror.yandex.ru/mirrors/sage.math.washington.edu/src/
+
+    # Australia
+    http://echidna.maths.usyd.edu.au/sage/src/
+
+    # Europe
     http://sage.mirror.garr.it/mirrors/sage/src/
-    http://sage.yasar.edu.tr/src/
-    http://sagemath.c3sl.ufpr.br/src/
-    http://sagemath.polytechnic.edu.na/src/
     http://sunsite.rediris.es/mirror/sagemath/src/
+    http://mirror.switch.ch/mirror/sagemath/src/
+    http://mirrors.fe.up.pt/pub/sage/src/
     http://www-ftp.lip6.fr/pub/math/sagemath/src/
-    http://www.mirrorservice.org/sites/www.sagemath.org/src/
+    http://ftp.ntua.gr/pub/sagemath/src/
 
     # Old versions
-    http://www.cecm.sfu.ca/sage/src/
     http://sagemath.org/src-old/
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Many mirrors are missing from the current list of mirrors, and many are down.

The Sage derivation has `texLive` as an input, but `texLive` is marked as broken and was superseded by `texlive.combine`. Even once the derivation does not have a broken package as an input, it is still unable to build because of a problem while building ncurses, so I mark it as broken.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
