### PR TITLE
libinput.accelProfile: improve docs & new default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1609.xml
+++ b/nixos/doc/manual/release-notes/rl-1609.xml
@@ -51,6 +51,13 @@ following incompatible changes:</para>
       gitlab-run and gitlab-rake scripts because gitlab-runner is a component of Gitlab CI.</para>
   </listitem>
 
+  <listitem>
+    <para><literal>services.xserver.libinput.accelProfile</literal> default
+    changed from <literal>flat</literal> to <literal>adaptive</literal>,
+    as per <link xlink:href="https://wayland.freedesktop.org/libinput/doc/latest/group__config.html#gad63796972347f318b180e322e35cee79">
+    official documentation</link>.</para>
+  </listitem>
+
 </itemizedlist>
 
 

--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -25,16 +25,21 @@ in {
 
       accelProfile = mkOption {
         type = types.enum [ "flat" "adaptive" ];
-        default = "flat";
-        example = "adaptive";
+        default = "adaptive";
+        example = "flat";
         description =
           ''
-            Sets  the pointer acceleration profile to the given profile. Permitted values are adaptive, flat.
-            Not all devices support this option or all profiles. If a profile is unsupported, the default profile
-            for this is used. For a description on the profiles and their behavior, see the libinput documentation.
+            Sets  the pointer acceleration profile to the given profile.
+            Permitted values are adaptive, flat.
+            Not all devices support this option or all profiles.
+            If a profile is unsupported, the default profile for this is used.
+            <literal>flat</literal>: Pointer motion is accelerated by a constant
+            (device-specific) factor, depending on the current speed.
+            <literal>adaptive</literal>: Pointer acceleration depends on the input speed.
+            This is the default profile for most devices.
           '';
-      };    
-      
+      };
+
       accelSpeed = mkOption {
         type = types.nullOr types.string;
         default = null;
@@ -216,7 +221,7 @@ in {
           Option "LeftHanded" "${xorgBool cfg.leftHanded}"
           Option "MiddleEmulation" "${xorgBool cfg.middleEmulation}"
           Option "NaturalScrolling" "${xorgBool cfg.naturalScrolling}"
-          ${optionalString (cfg.scrollButton != null) ''Option "ScrollButton" "${cfg.scrollButton}"''}
+          ${optionalString (cfg.scrollButton != null) ''Option "ScrollButton" "${toString cfg.scrollButton}"''}
           Option "ScrollMethod" "${cfg.scrollMethod}"
           Option "HorizontalScrolling" "${xorgBool cfg.horizontalScrolling}"
           Option "SendEventsMode" "${cfg.sendEventsMode}"


### PR DESCRIPTION
The link to some (of course non-existing, i.e. freedesktop) “libinput”
documentation is replaced by a piece of the API documentation.

The default is changed since the documentation suggests adaptive should
be it.
https://wayland.freedesktop.org/libinput/doc/latest/group__config.html#gad63796972347f318b180e322e35cee79

Manual builds.
