### PR TITLE
nixos/stage-1: fix antiquotation

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -90,7 +90,7 @@ let
           [ ! -f "$out/lib/$(basename $LIB)" ] && cp -pdv $LIB $out/lib
           while [ "$(readlink $LIB)" != "" ]; do
             LINK="$(readlink $LIB)"
-            if [ "${LINK:0:1}" != "/" ]; then
+            if [ "''${LINK:0:1}" != "/" ]; then
               LINK="$(dirname $LIB)/$LINK"
             fi
             LIB="$LINK"


### PR DESCRIPTION
###### Motivation for this change

There is a glaring antiquotation error in the builder for `extra-utils`.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
