### PR TITLE
tzdata: 2016e -> 2016f

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "tzdata-${version}";
-  version = "2016e";
+  version = "2016f";
 
   srcs =
     [ (fetchurl {
         url = "http://www.iana.org/time-zones/repository/releases/tzdata${version}.tar.gz";
-        sha256 = "10dxnv6mwpm1rbv0dp7fhih4jd7lvqgmw7x2gy6h9i4dy6czh05s";
+        sha256 = "1c024mg4gy572vgdj9rk4dqnb33iap06zs8ibasisbyi1089b37d";
       })
       (fetchurl {
         url = "http://www.iana.org/time-zones/repository/releases/tzcode${version}.tar.gz";
-        sha256 = "17j5z894cfnid3dhh8y934hn86pvxz2ym672s1bhdag8spyc9n2p";
+        sha256 = "1vb6n29ik7dzhffzzcnskbhmn6h1dxzan3zanbp118wh8hw5yckj";
       })
     ];
 


### PR DESCRIPTION
###### Motivation for this change

I live in Novosibirsk, Russia. And recently our government switched Asia/Novosibirsk from +06 to +07. And this is available only in tzdata 2016f: http://mm.icann.org/pipermail/tz-announce/2016-July/000040.html
###### Things done

Not sure about those things below though. Don't know how to properly execute them. Probably need some help here. I just updated the version and hashes which I've got through `nix-prefetch-url` command. Is that good?
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Thanks!
