### PR TITLE
email: adopt upstream fix for "$cwd undefined in configure"

### DIFF
--- a/pkgs/tools/networking/email/default.nix
+++ b/pkgs/tools/networking/email/default.nix
@@ -2,11 +2,10 @@
 
 let
   eMailSrc = fetchFromGitHub {
-    #awaiting acceptance of https://github.com/deanproxy/eMail/pull/29
-    owner = "jerith666";
+    owner = "deanproxy";
     repo = "eMail";
-    rev = "d9fd259f952b573d320916ee34e807dd3dd24b1f";
-    sha256 = "0q4ly4bhlv6lrlj5kmjs491aah1afmkjyw63i9yqnz4d2k6npvl9";
+    rev = "7d23c8f508a52bd8809e2af4290417829b6bb5ae";
+    sha256 = "1cxxzhm36civ6vjdgrk7mfmlzkih44kdii6l2xgy4r434s8rzcpn";
   };
 
   srcRoot = "eMail-${eMailSrc.rev}-src";


### PR DESCRIPTION
###### Motivation for this change

update to include https://github.com/deanproxy/eMail/pull/35
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
