### PR TITLE
Revert "http-parser: Broken on Pure Darwin"

### DIFF
--- a/pkgs/development/libraries/http-parser/default.nix
+++ b/pkgs/development/libraries/http-parser/default.nix
@@ -16,8 +16,7 @@ in stdenv.mkDerivation {
 
   buildFlags = [ "BUILDTYPE=Release" ];
 
-  buildInputs =
-    [ gyp ]
+  buildInputs = [ gyp ]
     ++ stdenv.lib.optional stdenv.isLinux utillinux
     ++ stdenv.lib.optionals stdenv.isDarwin [ python fixDarwinDylibNames ];
 
@@ -38,10 +37,10 @@ in stdenv.mkDerivation {
 
   meta = {
     description = "An HTTP message parser written in C";
-
     homepage = https://github.com/joyent/http-parser;
-
     license = stdenv.lib.licenses.mit;
+
     platforms = stdenv.lib.platforms.unix;
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/libraries/http-parser/default.nix
+++ b/pkgs/development/libraries/http-parser/default.nix
@@ -42,6 +42,6 @@ in stdenv.mkDerivation {
     homepage = https://github.com/joyent/http-parser;
 
     license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux; # Broken on pure-darwin, wants xcode
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The reverted commit prevents evaluation of `http-parser` on Darwin because it doesn't work on `pure-darwin`. While it looks like a good idea to disable this, it prevents the whole `node` as well as the whole `rust` infrastructure from evaluating on Darwin, even if people don't use `pure-darwin`.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
