### PR TITLE
Properly fix nixos-version --hash when building from Git

### DIFF
--- a/nixos/modules/installer/tools/get-version-suffix
+++ b/nixos/modules/installer/tools/get-version-suffix
@@ -17,6 +17,6 @@ getVersion() {
 if nixpkgs=$(nix-instantiate --find-file nixpkgs "$@"); then
     getVersion $nixpkgs
     if [ -n "$rev" ]; then
-        echo "$rev"
+        echo ".git.$rev"
     fi
 fi

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -311,10 +311,9 @@ fi
 # nixos-version shows something useful).
 if [ -n "$canRun" ]; then
     if nixpkgs=$(nix-instantiate --find-file nixpkgs "${extraBuildFlags[@]}"); then
-        revision=$($SHELL $nixpkgs/nixos/modules/installer/tools/get-git-revision "${extraBuildFlags[@]}" || true)
-        if [ -n "$revision" ]; then
-            echo -n ".git.$revision" > "$nixpkgs/.version-suffix" || true
-            echo -n "$revision"  > "$nixpkgs/.git-revision" || true
+        suffix=$($SHELL $nixpkgs/nixos/modules/installer/tools/get-version-suffix "${extraBuildFlags[@]}" || true)
+        if [ -n "$suffix" ]; then
+            echo -n "$suffix" > "$nixpkgs/.version-suffix" || true
         fi
     fi
 fi

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -63,7 +63,9 @@ in
     nixosRevision = mkOption {
       internal = true;
       type = types.str;
-      default = if pathExists revisionFile then fileContents revisionFile else "master";
+      default = if pathIsDirectory gitRepo then commitIdFromGitRepo gitRepo
+                else if pathExists revisionFile then fileContents revisionFile
+                else "master";
       description = "The Git revision from which this NixOS configuration was built.";
     };
 


### PR DESCRIPTION
First of all sorry for not reviewing #17218 in the first place.

The changes here IMHO follow a better approach by using the .git directory directly for fetching the hash rather than placing an additional `.git-revision` file beneath it containing the same redundant information.

@bennofs: Can you test whether these changes work for you as well?

Cc: @Profpatsch
