### PR TITLE
Update marathon to v1.1.1

### DIFF
--- a/pkgs/applications/networking/cluster/marathon/default.nix
+++ b/pkgs/applications/networking/cluster/marathon/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "marathon-${version}";
-  version = "0.15.3";
+  version = "1.1.1";
 
   src = fetchurl {
-    url = "https://downloads.mesosphere.io/marathon/v${version}/marathon-${version}.tgz";
-    sha256 = "1br4k596sjp4cf5l2nyaqhlsfdr443n08fvdyf4kilhr803x2rjq";
+    url = "https://downloads.mesosphere.com/marathon/v${version}/marathon-${version}.tgz";
+    sha256 = "35a80401383f6551c45c676beed30b3c1af6d3ad027f44735c208abe8eaca93d";
   };
 
   buildInputs = [ makeWrapper jdk mesos ];


### PR DESCRIPTION
###### Motivation for this change

version update.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
