### PR TITLE
flow: 0.28.0 -> 0.30.0

### DIFF
--- a/pkgs/development/tools/analysis/flow/default.nix
+++ b/pkgs/development/tools/analysis/flow/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchFromGitHub, lib, ocaml, libelf, cf-private, CoreServices, git, mercurial }:
+{ stdenv, fetchFromGitHub, lib, ocaml, libelf, cf-private, CoreServices }:
 
 with lib;
 
 stdenv.mkDerivation rec {
-  version = "0.28.0";
+  version = "0.30.0";
   name = "flow-${version}";
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "flow";
     rev = "v${version}";
-    sha256 = "1xryv1366zc385r82r6n832xkaqcm63zs1baizl02qchfzfa3am2";
+    sha256 = "1s6l3570r53qjyqs8ghqqgb51rb0skijwjgm6av43xi7b7knkd35";
   };
 
   installPhase = ''
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     cp bin/flow $out/bin/
   '';
 
-  buildInputs = [ ocaml libelf git mercurial ] # git and mercurial are necessary because of https://github.com/facebook/flow/issues/1981
+  buildInputs = [ ocaml libelf ]
     ++ optionals stdenv.isDarwin [ cf-private CoreServices ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

I needed an up to date version.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
  **No idea how. It says: `The option 'useChroot' defined in '/etc/nixos/configuration.nix' does not exist.`**
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  **No idea how.**
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  **No idea how. I ran `nix-env -i flow -f .` to build and install it. And `nix-build -A flow`.**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'd be happy to fulfill the other tasks, I just need some guidance.
