### PR TITLE
vagrant: FIX #16837 vagrant plugin install

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, dpkg, curl, libarchive, openssl, ruby, buildRubyGem, libiconv
-, libxml2, libxslt, makeWrapper }:
+, libxml2, libxslt, coreutils, makeWrapper }:
 
 assert stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux";
 
@@ -96,6 +96,11 @@ stdenv.mkDerivation rec {
     cp -r opt "$out"
     cp -r usr/bin "$out"
     wrapProgram "$out/bin/vagrant" --prefix LD_LIBRARY_PATH : "$out/opt/vagrant/embedded/lib"
+
+    substituteInPlace $out/opt/vagrant/embedded/lib/ruby/2.2.0/x86_64-linux/rbconfig.rb \
+      --replace '"/bin/mkdir' '"${coreutils}/bin/mkdir'
+    substituteInPlace $out/opt/vagrant/embedded/lib/ruby/2.2.0/x86_64-linux/rbconfig.rb \
+      --replace "'/usr/bin/install" "'${coreutils}/bin/install"
   '';
 
   preFixup = ''


### PR DESCRIPTION
This fixed https://github.com/NixOS/nixpkgs/issues/16837 for me.
There are few more things to patch there, like `grep` and `bash` but I didn't encounter any problems with them while installing `vagrant-hostmanager`.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
