### PR TITLE
Expose nixos-tools (nixos-{generate-config, install, option, rebuild}) into nixpkgs

### DIFF
--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -203,13 +203,10 @@ let
             # need must be included in the VM.
             system.extraDependencies = with pkgs;
               [ sudo
-                libxml2.bin
-                libxslt.bin
-                docbook5
-                docbook5_xsl
                 unionfs-fuse
                 ntp
                 nixos-artwork
+                nixos-manpages
                 perlPackages.XMLLibXML
                 perlPackages.ListCompare
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17188,6 +17188,15 @@ in
 
   nixos-container = callPackage ../tools/virtualization/nixos-container { };
 
+  nixos-default-config = import ../../nixos { inherit system; configuration = { }; };
+
+  inherit (nixos-default-config.config.system.build)
+    nixos-generate-config
+    nixos-install
+    nixos-rebuild;
+
+  nixos-manpages = nixos-default-config.config.system.build.manual.manpages;
+
   norwester-font = callPackage ../data/fonts/norwester  {};
 
   nut = callPackage ../applications/misc/nut { };


### PR DESCRIPTION
###### Motivation for this change

The goal is to make it easier to work on these tools. It's generally easier to work on a script that's in a nixpkgs derivation rather than one that's in a nixos module.

Also, since most users coming to NixOS are likely to have an existing Linux install, this should also enable us to deliver a simple way to install NixOS from their existing Linux distro, without having to write a USB stick or burn a DVD. The workflow would be something like
- `sudo mkdir /nix ; chown …`
- `curl nixos.org… | sh`
- `fdisk; fsck; mount /mnt…`
- `nix-env -iA nixos-generate-config nixos-install`
- `nixos-generate-config; nixos-install…`

(Note: I haven't tested this workflow yet but this PR is a step in that direction)
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @edolstra @shlevy @domenkozar
