### PR TITLE
Add wscat, a tool for accessing web sockets

### DIFF
--- a/pkgs/top-level/node-packages-generated.nix
+++ b/pkgs/top-level/node-packages-generated.nix
@@ -48024,6 +48024,8 @@
   "timezone" = self.by-version."timezone"."1.0.4";
   by-spec."tinycolor"."0.x" =
     self.by-version."tinycolor"."0.0.1";
+  by-spec."tinycolor"."0.0.x" =
+    self.by-version."tinycolor"."0.0.1";
   by-version."tinycolor"."0.0.1" = self.buildNodePackage {
     name = "tinycolor-0.0.1";
     version = "0.0.1";
@@ -52276,6 +52278,8 @@
   };
   by-spec."ws"."0.8.1" =
     self.by-version."ws"."0.8.1";
+  by-spec."ws"."0.8.x" =
+    self.by-version."ws"."0.8.1";
   by-version."ws"."0.8.1" = self.buildNodePackage {
     name = "ws-0.8.1";
     version = "0.8.1";
@@ -52341,6 +52345,29 @@
   };
   by-spec."ws"."^1.0.1" =
     self.by-version."ws"."1.1.0";
+  by-spec."wscat"."*" =
+    self.by-version."wscat"."1.0.1";
+  by-version."wscat"."1.0.1" = self.buildNodePackage {
+    name = "wscat-1.0.1";
+    version = "1.0.1";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/wscat/-/wscat-1.0.1.tgz";
+      name = "wscat-1.0.1.tgz";
+      sha1 = "542b47c1c27334c64ececef9c2db02faf6212964";
+    };
+    deps = {
+      "commander-2.8.1" = self.by-version."commander"."2.8.1";
+      "tinycolor-0.0.1" = self.by-version."tinycolor"."0.0.1";
+      "ws-0.8.1" = self.by-version."ws"."0.8.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "wscat" = self.by-version."wscat"."1.0.1";
   by-spec."wu"."*" =
     self.by-version."wu"."2.1.0";
   by-version."wu"."2.1.0" = self.buildNodePackage {

--- a/pkgs/top-level/node-packages.json
+++ b/pkgs/top-level/node-packages.json
@@ -180,6 +180,7 @@
 , "webdrvr"
 , "webpack"
 , "winston"
+, "wscat"
 , "wu"
 , "x509"
 , { "guifi-earth": "https://github.com/jmendeth/guifi-earth/tarball/f3ee96835fd4fb0e3e12fadbd2cb782770d64854 " }


### PR DESCRIPTION
###### Motivation for this change

wscat is a tool for accessing web sockets, in the spirit of socat, netcat, etc.
Very useful for testing your web sockets.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note that I could not use the npm2nix tool to generate the actual file, because as I understand, that generation functionality is currently broken. I did run it for wscat individually and I have insertion-sorted the dependencies.
