### PR TITLE
fix typo

### DIFF
--- a/pkgs/games/vessel/default.nix
+++ b/pkgs/games/vessel/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
       message = goBuyItNow;
       name = "${name}-bin";
       sha256 = "1vpwcrjiln2mx43h7ib3jnccyr3chk7a5x2bw9kb4lw8ycygvg96";
-    } else throw "unsupported platform ${stdenv.s:ystem} only i686-linux supported for now.";
+    } else throw "unsupported platform ${stdenv.system} only i686-linux supported for now.";
 
   phases = "installPhase";
   ld_preload = ./isatty.c;


### PR DESCRIPTION
###### Motivation for this change

this is clearly a typo. see also NixOS/nix#1017 and NixOS/nix#836  for why this even compiles.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
