### PR TITLE
concatMap: reimplement using foldl'

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -76,7 +76,7 @@ rec {
        concatMap (x: [x] ++ ["z"]) ["a" "b"]
        => [ "a" "z" "b" "z" ]
   */
-  concatMap = f: list: concatLists (map f list);
+  concatMap = f: list: foldl' (a: b: a ++ (f b)) [] list;
 
   /* Flatten the argument into a single list; that is, nested lists are
      spliced into the top-level lists.


### PR DESCRIPTION
Using the following example:

```
$ cat benchconcatmap.nix
with (import <nixpkgs/lib>);

flatten (
     concatMap (a:
       concatMap (b:
         concatMap (c:
           concatMap (d:
             [d]
           ) (range 1 40)
         ) (range 1 40)
       ) (range 1 20)
     ) (range 1 8))
```

Previous implementation of concatMap took ~70s and ~400MB of ram
to evaluate on my machine.

Now it takes ~0.5s and ~350MB of ram.

That's a very nice improvement to CPU usage, apprently previous
implementation was O(n^2). I have no idea why Nix takes 350MB of ram
for 244k integers though.

Note: new implementation doesn't flatten the list if it's nested more than once. I think current implementation is more correct and aligned with what one might expect.

cc @edolstra @nbp 
