### PR TITLE
wolfssl: 3.9.6 -> 3.9.8

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "wolfssl-${version}";
-  version = "3.9.6";
+  version = "3.9.8";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
     rev = "v${version}";
-    sha256 = "19k3pqd567jfxyps4i6mk7sblwzaj1rixmsdwscw63pdgcgf260g";
+    sha256 = "0b1a9rmzpzjblj0gsrzas2aljivd0gfimcsj8gjl80ng25zgmaxr";
   };
 
   outputs = [ "dev" "out" "doc" "lib" ];


### PR DESCRIPTION
###### Motivation for this change

Keeping track of latest upstream version.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file).
    on non-NixOS) Note: I used `nix-shell --option build-use-chroot true`
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux (Fedora 24)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (see note below)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note that no package immediately depends on wolfssl, so for testing I've built curl with wolfssl as a replacement for openssl using the following nix shell script:

``` .nix
with import <nixpkgs> {};
let
  curlwolfssl = (curl.override {
    openssl = wolfssl;
  }).overrideDerivation (oldAttrs: {
    configureFlags = oldAttrs.configureFlags ++ [
      "--with-cyassl=${wolfssl}"
    ];
  });
in
{
  my-env = stdenv.mkDerivation {
    name = "my-env";
    buildInputs = [
      curlwolfssl
    ];
  };
}
```

The resulting curl binary was tested with

```
curl https://nixos.org/
curl --sslv2 https://nixos.org/
```

which work as expected (the latter command gives curl: `(35) CyaSSL does not support SSLv2` confirming that it indeed uses wolfssl).
