### PR TITLE
Maven: Fix JAVA_HOME in wrapper

### DIFF
--- a/pkgs/development/tools/build-managers/apache-maven/builder.sh
+++ b/pkgs/development/tools/build-managers/apache-maven/builder.sh
@@ -5,7 +5,7 @@ unpackPhase
 mkdir -p $out/maven
 cp -r $name/* $out/maven
 
-makeWrapper $out/maven/bin/mvn $out/bin/mvn --set JAVA_HOME "$jdk"
+makeWrapper $out/maven/bin/mvn $out/bin/mvn --set JAVA_HOME "$jdk/lib/openjdk"
 
 # Add the maven-axis and JIRA plugin by default when using maven 1.x
 if [ -e $out/maven/bin/maven ]


### PR DESCRIPTION
###### Motivation for this change

The JAVA_HOME set in the wrapper does not allow applications to find $JAVA_HOME/lib.
This change fixed the behaviour.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Run against various Java repositories, everything builds fine.

Fixes #17603 
