### PR TITLE
haskellPackages.mono-traversable: fix build inputs for ghc7.10.x

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -115,6 +115,8 @@ self: super: {
     license = pkgs.stdenv.lib.licenses.bsd3;
   }) {};
 
+  mono-traversable = addBuildDepend super.mono-traversable self.semigroups;
+
   # diagrams/monoid-extras#19
   monoid-extras = overrideCabal super.monoid-extras (drv: {
     prePatch = "sed -i 's|4\.8|4.9|' monoid-extras.cabal";


### PR DESCRIPTION
###### Motivation for this change

This fixes #17635
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
