### PR TITLE
gocd-agent: 16.6.0-3590 -> 16.7.0-3819

### DIFF
--- a/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "gocd-agent-${version}-${rev}";
-  version = "16.6.0";
-  rev = "3590";
+  version = "16.7.0";
+  rev = "3819";
 
   src = fetchurl {
     url = "https://download.go.cd/binaries/${version}-${rev}/generic/go-agent-${version}-${rev}.zip";
-    sha256 = "ee076c62b388a6ed88d5065f18a4a96cb0d3161f693c16f920d85886d295ff27";
+    sha256 = "24cc47099d2e9cc1d3983e1ab65957316770f791632e572189b1e6c0183403b7";
   };
   meta = with stdenv.lib; {
     description = "A continuous delivery server specializing in advanced workflow modeling and visualization";


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Bump gocd-agent version to 16.7.0-3819 and update sha256 checksum.
