### PR TITLE
xfsprogs: propagate libuuid

### DIFF
--- a/pkgs/tools/filesystems/xfsprogs/default.nix
+++ b/pkgs/tools/filesystems/xfsprogs/default.nix
@@ -24,7 +24,8 @@ stdenv.mkDerivation rec {
     ./4.3.0-sharedlibs.patch
   ];
 
-  buildInputs = [ gettext libuuid readline ];
+  propagatedBuildInputs = [ libuuid ];
+  buildInputs = [ gettext readline ];
 
   outputs = [ "dev" "out" "bin" ]; # TODO: review xfs
 


### PR DESCRIPTION
###### Motivation for this change

libxfs is broken without access to libuuid. Like from building ceph in http://hydra.nixos.org/build/38385720/nixlog/1.

```
configure: WARNING: xfs/xfs.h: present but cannot be compiled
configure: WARNING: xfs/xfs.h:     check for missing prerequisite headers?
configure: WARNING: xfs/xfs.h: see the Autoconf documentation
configure: WARNING: xfs/xfs.h:     section "Present But Cannot Be Compiled"
configure: WARNING: xfs/xfs.h: proceeding with the compiler's result
configure: WARNING:     ## ----------------------------------------- ##
configure: WARNING:     ## Report this to ceph-devel@vger.kernel.org ##
configure: WARNING:     ## ----------------------------------------- ##
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

see also #17633

---

Before, this would fail because libuuid needed to be available.

```
> echo '#include <xfs/xfs.h>' | cc -E -
```
