### PR TITLE
pyopenssl: 0.15.1 -> 16.0.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19522,11 +19522,11 @@ in modules // {
 
   pyopenssl = buildPythonPackage rec {
     name = "pyopenssl-${version}";
-    version = "0.15.1";
+    version = "16.0.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/pyOpenSSL/pyOpenSSL-${version}.tar.gz";
-      sha256 = "0wnnq15rhj7fhdcd8ycwiw6r6g3w9f9lcy6cigg8226vsrq618ph";
+      sha256 = "0zfijaxlq4vgi6jz0d4i5xq9ygqnyps6br7lmigjhqnh8gp10g9n";
     };
 
     # 12 tests failing, 26 error out

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26376,7 +26376,8 @@ in modules // {
 
     postPatch = ''
       substituteInPlace requirements.txt \
-        --replace 'certifi==2015.11.20.1' 'certifi==2016.2.28'
+        --replace 'certifi==2015.11.20.1' 'certifi==2016.2.28' \
+        --replace 'pyopenssl==0.15.1' 'pyopenssl==16.0.0'
     '';
 
     propagatedBuildInputs = with self; [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26915,15 +26915,15 @@ in modules // {
 
   service-identity = buildPythonPackage rec {
     name = "service-identity-${version}";
-    version = "14.0.0";
+    version = "16.0.0";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/s/service_identity/service_identity-${version}.tar.gz";
-      sha256 = "0njg9bklkkp4rl2b9vsfh9aasxy3w2dmjkv9cq34jn65lwcs619i";
+      sha256 = "0dih7i7d36nbllcxgfkvbnaj1wlzhwfnpr4b97dz74czylif4c06";
     };
 
     propagatedBuildInputs = with self; [
-      characteristic pyasn1 pyasn1-modules pyopenssl idna
+      characteristic pyasn1 pyasn1-modules pyopenssl idna attrs
     ];
 
     buildInputs = with self; [


### PR DESCRIPTION
###### Motivation for this change

certbot fails with this log:

```
======================================================================
ERROR: test_valid_true (certbot.tests.crypto_util_test.ValidPrivkeyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/nix-build-certbot-0.6.0.drv-0/certbot-v0.6.0-src/certbot/tests/crypto_util_test.py", line 162, in test_valid_true
    self.assertTrue(self._call(RSA256_KEY))
  File "/tmp/nix-build-certbot-0.6.0.drv-0/certbot-v0.6.0-src/certbot/tests/crypto_util_test.py", line 159, in _call
    return valid_privkey(privkey)
  File "/tmp/nix-build-certbot-0.6.0.drv-0/certbot-v0.6.0-src/certbot/crypto_util.py", line 200, in valid_privkey
    OpenSSL.crypto.FILETYPE_PEM, privkey).check()
  File "/...-python2.7-pyopenssl-0.15.1/lib/python2.7/site-packages/OpenSSL/crypto.py", line 243, in check
    if _lib.EVP_PKEY_type(self._pkey.type) != _lib.EVP_PKEY_RSA:
AttributeError: '_cffi_backend.CDataGCP' object has no attribute 'type'
```

http://hydra.nixos.org/build/38387037/nixlog/3

This was fixed in pyca/pyopenssl#406 and pyca/pyopenssl@f8b29ba535b6748941e78eb6eaf504095d14bd12
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This will fix the error in certbot.

http://hydra.nixos.org/build/38387037/nixlog/3
