### PR TITLE
gnupg: Fix gpgsm linking for gnupg 2.1.14

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     readline libusb gnutls adns openldap zlib bzip2
   ];
 
+  patches = [ ./fix-gpgsm-linking.patch ];
+
   postPatch = stdenv.lib.optionalString stdenv.isLinux ''
     sed -i 's,"libpcsclite\.so[^"]*","${pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
   ''; #" fix Emacs syntax highlighting :-(

--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     readline libusb gnutls adns openldap zlib bzip2
   ];
 
+  # gpgsm-linking is fixed by commit (c49c43d7) in the gnupg master branch;
+  # fix-gpgsm-linking.patch should be dropped after gnupg 2.1.15 is released
   patches = [ ./fix-gpgsm-linking.patch ];
 
   postPatch = stdenv.lib.optionalString stdenv.isLinux ''

--- a/pkgs/tools/security/gnupg/fix-gpgsm-linking.patch
+++ b/pkgs/tools/security/gnupg/fix-gpgsm-linking.patch
@@ -1,0 +1,11 @@
+--- a/tests/gpgscm/Makefile.in
++++ b/tests/gpgscm/Makefile.in
+@@ -457,7 +457,7 @@
+ 	scheme-config.h opdefines.h scheme.c scheme.h scheme-private.h
+ 
+ gpgscm_LDADD = $(LDADD) $(common_libs) \
+-	$(NETLIBS) $(LIBICONV) $(LIBREADLINE) \
++	$(NETLIBS) $(LIBICONV) $(LIBREADLINE) $(LIBINTL) \
+ 	$(LIBGCRYPT_LIBS) $(GPG_ERROR_LIBS)
+ 
+ t_child_SOURCES = t-child.c


### PR DESCRIPTION
###### Motivation for this change

Fix compilation of gnupg 2.1.14 on OS X.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

gnupg 2.1.14 fails to compile under OS X due to a missing -lintl flag [1].
This was fixed in commit c49c43d7 in the gnupg repository [2], which adds
the flag to Makefile.am.

This commit adds the flag to Makefile.in.

[1] https://lists.gnupg.org/pipermail/gnupg-devel/2016-July/031354.html
[2] https://lists.gnupg.org/pipermail/gnupg-devel/2016-July/031362.html

Fixes #17617.
