### PR TITLE
gocd-agent: 16.7.0 startup fixes + test improvements

### DIFF
--- a/nixos/modules/services/continuous-integration/gocd-agent/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-agent/default.nix
@@ -57,18 +57,10 @@ in {
       };
 
       goServer = mkOption {
-        default = "127.0.0.1";
+        default = "https://127.0.0.1:8154/go";
         type = types.str;
         description = ''
-          Address of GoCD Server to attach the Go.CD Agent to.
-        '';
-      };
-
-      goServerPort = mkOption {
-        default = 8153;
-        type = types.int;
-        description = ''
-          Port that Go.CD Server is Listening on.
+          URL of the GoCD Server to attach the Go.CD Agent to.
         '';
       };
 
@@ -112,8 +104,8 @@ in {
 
       extraOptions = mkOption {
         default = [ ];
-        example = [ 
-          "-X debug" 
+        example = [
+          "-X debug"
           "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5006"
           "-verbose:gc"
           "-Xloggc:go-agent-gc.log"
@@ -170,7 +162,7 @@ in {
               config.environment.sessionVariables;
         in
           selectedSessionVars //
-            { 
+            {
               NIX_REMOTE = "daemon";
               AGENT_WORK_DIR = cfg.workDir;
               AGENT_STARTUP_ARGS = ''${concatStringsSep " "  cfg.startupOptions}'';
@@ -199,13 +191,14 @@ in {
         ${pkgs.jre}/bin/java ${concatStringsSep " " cfg.startupOptions} \
                         ${concatStringsSep " " cfg.extraOptions} \
                               -jar ${pkgs.gocd-agent}/go-agent/agent-bootstrapper.jar \
-                              ${cfg.goServer} \
-                              ${toString cfg.goServerPort}
+                              -serverUrl ${cfg.goServer}
       '';
 
       serviceConfig = {
         User = cfg.user;
         WorkingDirectory = cfg.workDir;
+        RestartSec = 30;
+        Restart = "on-failure";
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change

16.7.0 changed how Go.CD's agent starts. This PR fixes it, and improves the tests we have for it.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Agent now takes a full URL to the Go.CD server
- Instruct the agent to attempt restart every 30s upon failure
- Test's Accept header did not match the server's expectation
- Replace the tests' complex Awk matches with calls to `jq`
