### PR TITLE
gocd-agent / gocd-server: Reduce test memory requirements so Hydra builds

### DIFF
--- a/nixos/tests/gocd-agent.nix
+++ b/nixos/tests/gocd-agent.nix
@@ -19,7 +19,7 @@ import ./make-test.nix ({ pkgs, ...} : {
     gocd_agent =
       { config, pkgs, ... }:
       {
-        virtualisation.memorySize = 2048;
+        virtualisation.memorySize = 2046;
         services.gocd-agent = {
           enable = true;
         };

--- a/nixos/tests/gocd-server.nix
+++ b/nixos/tests/gocd-server.nix
@@ -2,7 +2,7 @@
 #   1. GoCD server starts
 #   2. GoCD server responds
 
-import ./make-test.nix ({ pkgs, ...} : 
+import ./make-test.nix ({ pkgs, ...} :
 
 {
   name = "gocd-server";
@@ -13,8 +13,8 @@ import ./make-test.nix ({ pkgs, ...} :
 nodes = {
   gocd_server =
     { config, pkgs, ... }:
-    { 
-      virtualisation.memorySize = 2048;
+    {
+      virtualisation.memorySize = 2046;
       services.gocd-server.enable = true;
     };
 };


### PR DESCRIPTION
###### Motivation for this change

fix this  error http://hydra.nixos.org/build/38384040/log:

```
gocd_agent# qemu-system-i386: at most 2047 MB RAM can be simulated

```
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
