### PR TITLE
acbuild: v0.3.0 -> v0.4.0

### DIFF
--- a/pkgs/applications/misc/acbuild/default.nix
+++ b/pkgs/applications/misc/acbuild/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "acbuild-${version}";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "appc";
     repo = "acbuild";
     rev = "v${version}";
-    sha256 = "19f2fybz4m7d5sp1v8zkl26ig4dacr27qan9h5lxyn2v7a5z34rc";
+    sha256 = "0s81xlaw75d05b4cidxml978hnxak8parwpnk9clanwqjbj66c7x";
   };
 
   buildInputs = [ go ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
