### PR TITLE
rox-filer: init at 2.11

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -24,6 +24,7 @@
   ak = "Alexander Kjeldaas <ak@formalprivacy.com>";
   akaWolf = "Artjom Vejsel <akawolf0@gmail.com>";
   akc = "Anders Claesson <akc@akc.is>";
+  aklt = "Anders Thøgersen <anders@bladre.dk>";
   algorith = "Dries Van Daele <dries_van_daele@telenet.be>";
   all = "Nix Committers <nix-commits@lists.science.uu.nl>";
   ambrop72 = "Ambroz Bizjak <ambrop7@gmail.com>";

--- a/pkgs/desktops/rox/rox-filer/default.nix
+++ b/pkgs/desktops/rox/rox-filer/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub, autoconf, pkgconfig, gtk, libSM, shared_mime_info,
+  libxml2, libxslt, docbook_xml_dtd_412 }:
+
+stdenv.mkDerivation rec {
+  name = "rox-filer-2.11";
+
+  src = fetchFromGitHub {
+    owner = "rox-desktop";
+    repo = "rox-filer";
+    rev = "2b9737f13900d68a2726cab6812f950157345345";
+    sha256 = "0vl4c05fscpkmp7jbxy7r17jgw9rwcl6alcvljfqcc6qkpq2p6ld";
+  };
+
+  buildInputs = [ pkgconfig gtk autoconf libSM libxml2 shared_mime_info ];
+
+  buildPhase = ''
+    ./ROX-Filer/AppRun --compile
+
+    substituteInPlace ROX-Filer/src/Docs/Makefile \
+      --replace xmllint ${libxml2.bin}/bin/xmllint \
+      --replace xsltproc ${libxslt.bin}/bin/xsltproc
+
+    for xmlFile in ROX-Filer/src/Docs/Manual*.xml; do
+      substituteInPlace  "$xmlFile" \
+        --replace "/usr/share/sgml/docbook/dtd/xml/4.1.2/docbookx.dtd" \
+                  "${docbook_xml_dtd_412}/xml/dtd/docbook/docbookx.dtd"
+    done
+
+    (cd ROX-Filer/src/Docs && make)
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/ROX-Filer,share/Choices/MIME-types,share/man/man1}
+    cp -rp ROX-Filer/{Help,Messages,ROX,images} $out/share/ROX-Filer
+    cp -p rox.1 $out/share/man/man1
+    cp -p ROX-Filer/{AppInfo.xml,AppRun,Options.xml,ROX-Filer,Templates.ui,subclasses,style.css,.DirIcon} \
+          $out/share/ROX-Filer
+    cp -p Choices/MIME-types/* $out/share/Choices/MIME-types
+
+    echo '#!/bin/sh' > $out/bin/rox
+    echo "exec $out/share/ROX-Filer/AppRun \"\$@\"" >> $out/bin/rox
+    chmod 755 $out/bin/rox
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A RISC OS-like filer for X, the file manager at the core of the ROX desktop";
+    homepage = http://rox.sourceforge.net/desktop/ROX-Filer;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.aklt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16478,6 +16478,8 @@ in
 
   xrandr-invert-colors = callPackage ../applications/misc/xrandr-invert-colors { };
 
+  rox-filer = callPackage ../desktops/rox/rox-filer { };
+
   ### SCIENCE
 
   ### SCIENCE/GEOMETRY


### PR DESCRIPTION
###### Motivation for this change

I would like to run ROX-Filer
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jagajaga @domenkozar
