### PR TITLE
Argus + Argus-clients: init at 3.0.8.2

### DIFF
--- a/pkgs/tools/networking/argus-clients/default.nix
+++ b/pkgs/tools/networking/argus-clients/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, libpcap, bison, flex, cyrus_sasl, tcp_wrappers, pkgconfig, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "argus-clients";
+  version = "3.0.8.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://qosient.com/argus/src/${name}.tar.gz";
+    sha256 = "1c9vj6ma00gqq9h92fg71sxcsjzz912166sdg90ahvnmvmh3l1rj";
+  };
+
+  patchPhase = ''
+    for file in ./examples/*/*.pl; do
+      substituteInPlace $file \
+        --subst-var-by PERLBIN ${perl}/bin/perl
+    done
+    '';
+
+  configureFlags = "--with-perl=${perl}/bin/perl";
+
+  buildInputs = [ libpcap pkgconfig bison cyrus_sasl tcp_wrappers flex ];
+
+  meta = with stdenv.lib; {
+    description = "Clients for ARGUS";
+    longDescription = ''Clients for Audit Record Generation and
+    Utilization System (ARGUS). The Argus Project is focused on developing all
+    aspects of large scale network situtational awareness derived from
+    network activity audit. Argus, itself, is next-generation network
+    flow technology, processing packets, either on the wire or in
+    captures, into advanced network flow data. The data, its models,
+    formats, and attributes are designed to support Network
+    Operations, Performance and Security Management. If you need to
+    know what is going on in your network, right now or historically,
+    you will find Argus a useful tool. '';
+    homepage = http://qosient.com/argus;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/argus/default.nix
+++ b/pkgs/tools/networking/argus/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, libpcap, bison, flex, cyrus_sasl, tcp_wrappers,
+  pkgconfig, procps, which, wget, lsof, net_snmp, bash, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "argus";
+  version = "3.0.8.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://qosient.com/argus/src/${name}.tar.gz";
+    sha256 = "1zzf688dbbcb5z2r9v1p28rddns6znzx35nc05ygza6lp7aknkna";
+  };
+
+  buildInputs = [ libpcap pkgconfig bison cyrus_sasl tcp_wrappers flex ];
+  propagatedBuildInputs = [ procps which wget lsof net_snmp ];
+
+  patchPhase = ''
+     substituteInPlace events/argus-extip.pl \
+       --subst-var-by PERLBIN ${perl}/bin/perl
+    substituteInPlace events/argus-lsof.pl \
+      --replace "\`which lsof\`" "\"${lsof}/bin/lsof\"" \
+      --subst-var-by PERLBIN ${perl}/bin/perl
+    substituteInPlace events/argus-vmstat.sh \
+      --replace vm_stat ${procps}/bin/vmstat
+    substituteInPlace events/argus-snmp.sh \
+      --replace /usr/bin/snmpget ${net_snmp}/bin/snmpget \
+      --replace /usr/bin/snmpwalk ${net_snmp}/bin/snmpwalk
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Audit Record Generation and Utilization System for networks";
+    longDescription = ''The Argus Project is focused on developing all
+    aspects of large scale network situtational awareness derived from
+    network activity audit. Argus, itself, is next-generation network
+    flow technology, processing packets, either on the wire or in
+    captures, into advanced network flow data. The data, its models,
+    formats, and attributes are designed to support Network
+    Operations, Performance and Security Management. If you need to
+    know what is going on in your network, right now or historically,
+    you will find Argus a useful tool. '';
+    homepage = http://qosient.com/argus;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -420,6 +420,8 @@ in
 
   apitrace = qt55.callPackage ../applications/graphics/apitrace {};
 
+  argus = callPackage ../tools/networking/argus {};
+
   argtable = callPackage ../tools/misc/argtable {};
 
   argyllcms = callPackage ../tools/graphics/argyllcms {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -422,6 +422,8 @@ in
 
   argus = callPackage ../tools/networking/argus {};
 
+  argus-clients = callPackage ../tools/networking/argus-clients {};
+
   argtable = callPackage ../tools/misc/argtable {};
 
   argyllcms = callPackage ../tools/graphics/argyllcms {};


### PR DESCRIPTION
###### Motivation for this change

"Argus is used by many sites to generate network activity reports for every network transaction on their networks. The network audit data that Argus generates is great for security, operations and performance management. The data is used for network forensics, non-repudiation, network asset and service inventory, behavioral baselining of server and client relationships, detecting covert channels, and analyzing Zero day events."
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
