### PR TITLE
Add GlobalPlatform tools

### DIFF
--- a/pkgs/development/libraries/globalplatform/default.nix
+++ b/pkgs/development/libraries/globalplatform/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, pkgconfig, zlib, openssl, pcsclite }:
+
+stdenv.mkDerivation rec {
+  name = "globalplatform-${version}";
+  version  = "6.0.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/globalplatform/${name}.tar.gz";
+    sha256 = "191s9005xbc7i90bzjk4rlw15licd6m0rls9fxli8jyymz2021zy";
+  };
+
+  buildInputs = [ zlib pkgconfig openssl pcsclite ];
+
+  meta = with stdenv.lib; {
+    homepage = https://sourceforge.net/p/globalplatform/wiki/Home/;
+    description = "Library for interacting with smart card devices";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/globalplatform/gppcscconnectionplugin.nix
+++ b/pkgs/development/libraries/globalplatform/gppcscconnectionplugin.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, pkgconfig, globalplatform, openssl, pcsclite }:
+
+stdenv.mkDerivation rec {
+  name = "gppcscconnectionplugin-${version}";
+  version  = "1.1.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/globalplatform/${name}.tar.gz";
+    sha256 = "0d3vcrh9z55rbal0dchmj661pqqrav9c400bx1c46grcl1q022ad";
+  };
+
+  buildInputs = [ pkgconfig globalplatform openssl pcsclite ];
+
+  meta = with stdenv.lib; {
+    homepage = https://sourceforge.net/p/globalplatform/wiki/Home/;
+    description = "GlobalPlatform pcsc connection plugin";
+    license = [ licenses.lgpl3 licenses.gpl3 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/misc/gpshell/default.nix
+++ b/pkgs/development/tools/misc/gpshell/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, pkgconfig, globalplatform, pcsclite }:
+
+stdenv.mkDerivation rec {
+  name = "gpshell-${version}";
+  version = "1.4.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/globalplatform/gpshell-${version}.tar.gz";
+    sha256 = "19a77zvyf2vazbv17185s4pynhylk2ky8vhl4i8pg9zww29sicqi";
+  };
+
+  buildInputs = [ pkgconfig globalplatform pcsclite ];
+
+  meta = with stdenv.lib; {
+    homepage = https://sourceforge.net/p/globalplatform/wiki/Home/;
+    description = "Smartcard management application";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7382,6 +7382,8 @@ in
   glm = callPackage ../development/libraries/glm { };
   glm_0954 = callPackage ../development/libraries/glm/0954.nix { };
 
+  globalplatform = callPackage ../development/libraries/globalplatform { };
+
   glog = callPackage ../development/libraries/glog { };
 
   gloox = callPackage ../development/libraries/gloox { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7506,6 +7506,8 @@ in
 
   gpgstats = callPackage ../tools/security/gpgstats { };
 
+  gpshell = callPackage ../development/tools/misc/gpshell { };
+
   grantlee = callPackage ../development/libraries/grantlee { };
 
   gsasl = callPackage ../development/libraries/gsasl { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7383,6 +7383,8 @@ in
   glm_0954 = callPackage ../development/libraries/glm/0954.nix { };
 
   globalplatform = callPackage ../development/libraries/globalplatform { };
+  gppcscconnectionplugin =
+    callPackage ../development/libraries/globalplatform/gppcscconnectionplugin.nix { };
 
   glog = callPackage ../development/libraries/glog { };
 


### PR DESCRIPTION
###### Motivation for this change

`gpshell` is a low-level tool for interacting with certain smartcard applets (e.g. yubikey developer edition). It requires the other globalplatform libraries to run.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
