### PR TITLE
varnish: Fix compile-time state dir.

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -1,7 +1,10 @@
 { stdenv, fetchurl, pcre, libxslt, groff, ncurses, pkgconfig, readline, python
 , pythonPackages }:
-
-stdenv.mkDerivation rec {
+let
+  # This flag needs to be set during configure *and* build. It's mixed into
+  # another statedir compile-time constant.
+  flags = "localstatedir=/var/spool";
+in stdenv.mkDerivation rec {
   version = "4.0.3";
   name = "varnish-${version}";
 
@@ -13,7 +16,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ pcre libxslt groff ncurses pkgconfig readline python
     pythonPackages.docutils];
 
-  buildFlags = "localstatedir=/var/spool";
+  # Comment out a rule which attempts to write to /var.
+  postPatch = ''
+    substituteInPlace Makefile.in --replace '$(install_sh)' 'true #'
+  '';
+
+  configureFlags = flags;
+  buildFlags = flags;
 
   meta = {
     description = "Web application accelerator also known as a caching HTTP reverse proxy";


### PR DESCRIPTION
###### Motivation for this change

A bevy of Varnish-related tooling, including builtin tools like `varnishhist` and `varnishstat`, as well as the Varnish plugin for collectd, do not work without this change.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Enables other tools like varnishstat.

Tested on my production machines; http://hydra.matador.cloud/ is running this version of Varnish right now.
