### PR TITLE
fasd: 2015-03-29 -> 2016-08-11

### DIFF
--- a/pkgs/tools/misc/fasd/default.nix
+++ b/pkgs/tools/misc/fasd/default.nix
@@ -1,16 +1,14 @@
-{ stdenv, fetchgit } :
+{ stdenv, fetchFromGitHub } :
 
-let
-  rev = "61ce53be996189e1c325916e45a7dc0aa89660e3";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  pname = "fasd";
+  name = "${pname}-unstable-2016-08-11";
 
-  name = "fasd-git-2015-03-29";
-
-  src = fetchgit {
-    url = "https://github.com/clvv/fasd.git";
-    inherit rev;
-    sha256 = "1fd36ff065ae73de2d6b1bae2131c18c8c4dea98ca63d96b0396e8b291072b5e";
+  src = fetchFromGitHub {
+    owner = "clvv";
+    repo = "${pname}";
+    rev = "90b531a5daaa545c74c7d98974b54cbdb92659fc";
+    sha256 = "0i22qmhq3indpvwbxz7c472rdyp8grag55x7iyjz8gmyn8gxjc11";
   };
 
   installPhase = ''
@@ -18,9 +16,9 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = "https://github.com/clvv/fasd";
+    homepage = "https://github.com/clvv/${pname}";
     description = "Quick command-line access to files and directories for POSIX shells";
-    license = stdenv.lib.licenses.free; # https://github.com/clvv/fasd/blob/master/LICENSE
+    license = stdenv.lib.licenses.mit;
 
     longDescription = ''
       Fasd is a command-line productivity booster.


### PR DESCRIPTION
###### Motivation for this change

Changes license to MIT, which is the license that fasd uses. 
- fasd license: https://github.com/clvv/fasd/blob/master/LICENSE
- MIT license: https://opensource.org/licenses/MIT
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)

```
code/nixpkgs > ./result/bin/fasd --version                   
1.0.1
```
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
