### PR TITLE
fcitx-unikey: init at 0.2.5

### DIFF
--- a/nixos/modules/i18n/input-method/default.xml
+++ b/nixos/modules/i18n/input-method/default.xml
@@ -88,6 +88,8 @@ i18n.inputMethod = {
       methods among Traditional Chinese Unix users.</para></listitem>
   <listitem><para>Hangul (<literal>fcitx-engines.hangul</literal>): Korean input 
       method.</para></listitem>
+  <listitem><para>Unikey (<literal>fcitx-engines.unikey</literal>): Vietnamese input 
+      method.</para></listitem>
   <listitem><para>m17n (<literal>fcitx-engines.m17n</literal>): m17n is an input 
       method that uses input methods and corresponding icons in the m17n 
       database.</para></listitem>

--- a/pkgs/development/compilers/rust/beta.nix
+++ b/pkgs/development/compilers/rust/beta.nix
@@ -19,10 +19,15 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "beta-0.13.0";
-    srcRev = "fb2faf29b26da39bd815b470ca73255dbfe30e42";
-    srcSha = "1r7wd3hp85mvmm7ivj01k65qcgb6qk1mys9mp48ww9k5cdniwcaj";
-    depsSha256 = "0lsf99pgl6wnl1lfk0drp5l4agrx7hzgdbps7hy3rprbf41jd6ai";
+    # TODO: We're temporarily tracking master here as Darwin needs the
+    # `http.cainfo` option from .cargo/config which isn't released
+    # yet.
+
+    version = "beta-2016-07-25";
+    srcRev = "f09ef68cc47956ccc5f99212bdcdd15298c400a0";
+    srcSha = "1r6q9jd0fl6mzhwkvrrcv358q2784hg51dfpy28xgh4n61m7c155";
+    depsSha256 = "055ky0lkrcsi976kmvc4lqyv0sjdpcj3jv36kz9hkqq0gip3crjc";
+
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo
   };

--- a/pkgs/development/compilers/rust/beta.nix
+++ b/pkgs/development/compilers/rust/beta.nix
@@ -3,13 +3,15 @@
 
 rec {
   rustc = callPackage ./rustc.nix {
-    shortVersion = "beta-1.10.0";
+    shortVersion = "beta-1.11.0";
     forceBundledLLVM = false;
+    needsCmake = true;
     configureFlags = [ "--release-channel=beta" ];
-    srcRev = "d18e321abeecc69e4d1bf9cafba4fba53ddf267d";
-    srcSha = "1ck8mbjrq0bzq5xzwgaqdilakwm2ab0xpzqibjycds62ad4yw774";
-    patches = [ ./patches/disable-lockfile-check.patch ]
-      ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
+    srcRev = "9333c420da0da6291740c313d5af3d620b55b8bc";
+    srcSha = "05z6i4s5jjw3c5ypap6kzxk81bg4dib47h51znvsvcvr0svsnkgs";
+    patches = [
+      ./patches/disable-lockfile-check.patch
+    ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
     inherit targets;
     inherit targetPatches;
     inherit targetToolchains;
@@ -17,10 +19,10 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.10.0";
-    srcRev = "refs/tags/${version}";
-    srcSha = "06scvx5qh60mgvlpvri9ig4np2fsnicsfd452fi9w983dkxnz4l2";
-    depsSha256 = "0js4697n7v93wnqnpvamhp446w58llj66za5hkd6wannmc0gsy3b";
+    version = "0.12.0";
+    srcRev = "6c27aa6985c18d644cbf6a13d54c8ae36aeaae12";
+    srcSha = "1piq13aigd0yz0ysff450bfg3z56pw0vzzbzzpcppsnnrnh8zdb2";
+    depsSha256 = "1jrwzm9fd15kf2d5zb17q901hx32h711ivcwdpxpmzwq08sjlcvl";
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo
   };

--- a/pkgs/development/compilers/rust/beta.nix
+++ b/pkgs/development/compilers/rust/beta.nix
@@ -19,10 +19,10 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.12.0";
-    srcRev = "6c27aa6985c18d644cbf6a13d54c8ae36aeaae12";
-    srcSha = "1piq13aigd0yz0ysff450bfg3z56pw0vzzbzzpcppsnnrnh8zdb2";
-    depsSha256 = "1jrwzm9fd15kf2d5zb17q901hx32h711ivcwdpxpmzwq08sjlcvl";
+    version = "beta-0.13.0";
+    srcRev = "fb2faf29b26da39bd815b470ca73255dbfe30e42";
+    srcSha = "1r7wd3hp85mvmm7ivj01k65qcgb6qk1mys9mp48ww9k5cdniwcaj";
+    depsSha256 = "0lsf99pgl6wnl1lfk0drp5l4agrx7hzgdbps7hy3rprbf41jd6ai";
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo
   };

--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchurl, makeWrapper, cacert, zlib }:
 
 let
+  inherit (stdenv.lib) optionalString;
+
   platform =
     if stdenv.system == "i686-linux"
     then "i686-unknown-linux-gnu"
@@ -24,7 +26,7 @@ let
     then "d59b5509e69c1cace20a57072e3b3ecefdbfd8c7e95657b0ff2ac10aa1dfebe6"
     else throw "missing boostrap hash for platform ${stdenv.system}";
 
-  needsPatchelf = (stdenv.system == "i686-linux") || (stdenv.system == "x86_64-linux");
+  needsPatchelf = stdenv.isLinux;
 
   src = fetchurl {
      url = "https://static.rust-lang.org/dist/rust-${version}-${platform}.tar.gz";

--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -50,11 +50,11 @@ rec {
       ./install.sh --prefix=$out \
         --components=rustc,rust-std-${platform},rust-docs
 
-      ${if needsPatchelf then ''
+      ${optionalString needsPatchelf ''
         patchelf \
           --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
           "$out/bin/rustc"
-      '' else ""}
+      ''}
 
       # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
       # (or similar) here. It causes strange effects where rustc loads
@@ -77,11 +77,11 @@ rec {
       ./install.sh --prefix=$out \
         --components=cargo
 
-      ${if needsPatchelf then ''
+      ${optionalString needsPatchelf ''
         patchelf \
           --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
           "$out/bin/cargo"
-      '' else ""}
+      ''}
 
       wrapProgram "$out/bin/cargo" \
         --suffix PATH : "${rustc}/bin"

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -23,10 +23,15 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.11.0";
-    srcRev = "refs/tags/${version}";
-    srcSha = "0ic2093bmwiw6vl2l9yhip87ni6dbz7dhrizy9wdx61229k16hc4";
-    depsSha256 = "0690sgn6fcay7sazlmrbbn4jbhnvmznrpz5z3rvkbaifkjrg4w6d";
+    # TODO: We're temporarily tracking master here as Darwin needs the
+    # `http.cainfo` option from .cargo/config which isn't released
+    # yet.
+
+    version = "master-2016-07-25";
+    srcRev = "f09ef68cc47956ccc5f99212bdcdd15298c400a0";
+    srcSha = "1r6q9jd0fl6mzhwkvrrcv358q2784hg51dfpy28xgh4n61m7c155";
+    depsSha256 = "1p1ygabg9k9b0azm0mrx8asjzdi35c5zw53iysba198lli6bhdl4";
+
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo
   };

--- a/pkgs/development/compilers/rust/head.nix
+++ b/pkgs/development/compilers/rust/head.nix
@@ -3,13 +3,14 @@
 
 rec {
   rustc = callPackage ./rustc.nix {
-    shortVersion = "master-1.11.0";
+    shortVersion = "master-1.12.0";
     forceBundledLLVM = false;
-    srcRev = "298730e7032cd55809423773da397cd5c7d827d4";
-    srcSha = "0hyz5j1z75sjkgsifzgxviv3b1lhgaz8wqwvmq80xx5vd78yd0c1";
-    patches = [ ./patches/disable-lockfile-check.patch
-                ./patches/use-rustc-1.9.0.patch ]
-      ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
+    needsCmake = true;
+    srcRev = "c77f8ce7c3284441a00faed6782d08eb5a78296c";
+    srcSha = "11y24bm2rj7bzsf86iyx3v286ygxprch4c804qbl1w477mkhcac7";
+    patches = [
+      ./patches/disable-lockfile-check.patch
+    ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
     inherit targets;
     inherit targetPatches;
     inherit targetToolchains;
@@ -17,10 +18,10 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "2016.06.07";
-    srcRev = "3e70312a2a4ebedace131fc63bb8f27463c5db28";
-    srcSha = "0nibzyfjkiqfnq0c00hhqvs856l5qls8wds252p97q5q92yvp40f";
-    depsSha256 = "1xbb33aqnf5yyws6gjys9w8kznbh9rh6hw8mpg1hhq1ahipc2j1f";
+    version = "master-0.13.0";
+    srcRev = "fb2faf29b26da39bd815b470ca73255dbfe30e42";
+    srcSha = "1r7wd3hp85mvmm7ivj01k65qcgb6qk1mys9mp48ww9k5cdniwcaj";
+    depsSha256 = "0lsf99pgl6wnl1lfk0drp5l4agrx7hzgdbps7hy3rprbf41jd6ai";
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo
   };

--- a/pkgs/development/compilers/rust/head.nix
+++ b/pkgs/development/compilers/rust/head.nix
@@ -22,10 +22,11 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "master-0.13.0";
-    srcRev = "fb2faf29b26da39bd815b470ca73255dbfe30e42";
-    srcSha = "1r7wd3hp85mvmm7ivj01k65qcgb6qk1mys9mp48ww9k5cdniwcaj";
-    depsSha256 = "0lsf99pgl6wnl1lfk0drp5l4agrx7hzgdbps7hy3rprbf41jd6ai";
+    version = "master-2016-07-25";
+    srcRev = "f09ef68cc47956ccc5f99212bdcdd15298c400a0";
+    srcSha = "1r6q9jd0fl6mzhwkvrrcv358q2784hg51dfpy28xgh4n61m7c155";
+    depsSha256 = "1p1ygabg9k9b0azm0mrx8asjzdi35c5zw53iysba198lli6bhdl4";
+
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo
   };

--- a/pkgs/development/compilers/rust/head.nix
+++ b/pkgs/development/compilers/rust/head.nix
@@ -11,6 +11,8 @@ rec {
     srcSha = "07wybqvnw99fljmcy33vb9iwirmp10cwy47n008p396s7pb852hv";
     patches = [
       ./patches/disable-lockfile-check.patch
+      # Drop this patch after
+      # https://github.com/rust-lang/rust/pull/35140 gets merged
       ./patches/tcp-stress-test-run-a-smaller-number-of-threads.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
     inherit targets;

--- a/pkgs/development/compilers/rust/head.nix
+++ b/pkgs/development/compilers/rust/head.nix
@@ -6,10 +6,12 @@ rec {
     shortVersion = "master-1.12.0";
     forceBundledLLVM = false;
     needsCmake = true;
-    srcRev = "c77f8ce7c3284441a00faed6782d08eb5a78296c";
-    srcSha = "11y24bm2rj7bzsf86iyx3v286ygxprch4c804qbl1w477mkhcac7";
+    configureFlags = [ "--release-channel=nightly" ];
+    srcRev = "d9a911d236cbecb47775276ba51a5f9111bdbc9c";
+    srcSha = "07wybqvnw99fljmcy33vb9iwirmp10cwy47n008p396s7pb852hv";
     patches = [
       ./patches/disable-lockfile-check.patch
+      ./patches/tcp-stress-test-run-a-smaller-number-of-threads.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
     inherit targets;
     inherit targetPatches;

--- a/pkgs/development/compilers/rust/patches/tcp-stress-test-run-a-smaller-number-of-threads.patch
+++ b/pkgs/development/compilers/rust/patches/tcp-stress-test-run-a-smaller-number-of-threads.patch
@@ -1,0 +1,44 @@
+From b6202b5d602ca8216febe8ce9078581faa32955e Mon Sep 17 00:00:00 2001
+From: Moritz Ulrich <moritz@tarn-vedra.de>
+Date: Sat, 30 Jul 2016 09:01:13 +0200
+Subject: [PATCH] tcp-stress-test: Run a smaller number of threads.
+
+---
+ src/test/run-pass/tcp-stress.rs | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/test/run-pass/tcp-stress.rs b/src/test/run-pass/tcp-stress.rs
+index dfc8649..df8cdc9 100644
+--- a/src/test/run-pass/tcp-stress.rs
++++ b/src/test/run-pass/tcp-stress.rs
+@@ -21,6 +21,8 @@ use std::sync::mpsc::channel;
+ use std::time::Duration;
+ use std::thread::{self, Builder};
+ 
++const TARGET_CNT: usize = 256;
++
+ fn main() {
+     // This test has a chance to time out, try to not let it time out
+     thread::spawn(move|| -> () {
+@@ -42,8 +44,9 @@ fn main() {
+     });
+ 
+     let (tx, rx) = channel();
++
+     let mut spawned_cnt = 0;
+-    for _ in 0..1000 {
++    for _ in 0..TARGET_CNT {
+         let tx = tx.clone();
+         let res = Builder::new().stack_size(64 * 1024).spawn(move|| {
+             match TcpStream::connect(addr) {
+@@ -66,6 +69,6 @@ fn main() {
+     for _ in 0..spawned_cnt {
+         rx.recv().unwrap();
+     }
+-    assert_eq!(spawned_cnt, 1000);
++    assert_eq!(spawned_cnt, TARGET_CNT);
+     process::exit(0);
+ }
+-- 
+2.9.1
+

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, fetchgit, fetchzip, file, python2, tzdata, procps
-, llvm, jemalloc, ncurses, darwin, binutils, rustPlatform, git
+, llvm, jemalloc, ncurses, darwin, binutils, rustPlatform, git, cmake, curl
 
 , isRelease ? false
+, needsCmake ? false
 , shortVersion
 , forceBundledLLVM ? false
 , srcSha, srcRev
@@ -94,8 +95,15 @@ stdenv.mkDerivation {
     configureFlagsArray+=("--infodir=$out/share/info")
   '';
 
+  # New -beta and -unstable unfortunately need cmake for compiling
+  # llvm-rt but don't use it for the normal build. This disables cmake
+  # in Nix.
+  dontUseCmakeConfigure = needsCmake;
+
   # ps is needed for one of the test cases
-  nativeBuildInputs = [ file python2 procps rustPlatform.rust.rustc git ];
+  nativeBuildInputs = [ file python2 procps rustPlatform.rust.rustc git ]
+    ++ stdenv.lib.optional needsCmake [ cmake curl ];
+
   buildInputs = [ ncurses ] ++ targetToolchains
     ++ stdenv.lib.optional (!forceBundledLLVM) llvmShared;
 

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation {
                 ++ optional (!forceBundledLLVM) "--llvm-root=${llvmShared}";
 
   patches = patches ++ targetPatches;
+
   passthru.target = target;
 
   postPatch = ''
@@ -86,6 +87,9 @@ stdenv.mkDerivation {
     # TODO: reenable if we can figure out how to get our jemalloc to work
     #[ -f src/liballoc_jemalloc/lib.rs ] && sed -i 's,je_,,g' src/liballoc_jemalloc/lib.rs
     #[ -f src/liballoc/heap.rs ] && sed -i 's,je_,,g' src/liballoc/heap.rs # Remove for 1.4.0+
+
+    # Disable fragile linker-output-non-utf8 test
+    rm -vr src/test/run-make/linker-output-non-utf8/
 
     # Useful debugging parameter
     #export VERBOSE=1

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -121,6 +121,6 @@ stdenv.mkDerivation {
   '';
 
   # Disable doCheck on Darwin to work around upstream issue
-  doCheck = !stdenv.isDarwin;
+  doCheck = true;
   dontSetConfigureCross = true;
 }

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -14,26 +14,28 @@
 } @ args:
 
 let
-    version = if isRelease then
-        "${shortVersion}"
-      else
-        "${shortVersion}-g${builtins.substring 0 7 srcRev}";
+  inherit (stdenv.lib) optional optionalString;
 
-    name = "rustc-${version}";
+  version = if isRelease then
+      "${shortVersion}"
+    else
+      "${shortVersion}-g${builtins.substring 0 7 srcRev}";
 
-    procps = if stdenv.isDarwin then darwin.ps else args.procps;
+  name = "rustc-${version}";
 
-    llvmShared = llvm.override { enableSharedLibraries = true; };
+  procps = if stdenv.isDarwin then darwin.ps else args.procps;
 
-    target = builtins.replaceStrings [" "] [","] (builtins.toString targets);
+  llvmShared = llvm.override { enableSharedLibraries = true; };
 
-    meta = with stdenv.lib; {
-      homepage = http://www.rust-lang.org/;
-      description = "A safe, concurrent, practical language";
-      maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington retrry ];
-      license = [ licenses.mit licenses.asl20 ];
-      platforms = platforms.linux ++ platforms.darwin;
-    };
+  target = builtins.replaceStrings [" "] [","] (builtins.toString targets);
+
+  meta = with stdenv.lib; {
+    homepage = http://www.rust-lang.org/;
+    description = "A safe, concurrent, practical language";
+    maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington retrry ];
+    license = [ licenses.mit licenses.asl20 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
 in
 
 stdenv.mkDerivation {
@@ -43,7 +45,7 @@ stdenv.mkDerivation {
 
   __impureHostDeps = [ "/usr/lib/libedit.3.dylib" ];
 
-  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-rpath ${llvmShared}/lib";
+  NIX_LDFLAGS = optionalString stdenv.isDarwin "-rpath ${llvmShared}/lib";
 
   src = fetchgit {
     url = https://github.com/rust-lang/rust;
@@ -56,9 +58,9 @@ stdenv.mkDerivation {
                 ++ [ "--enable-local-rust" "--local-rust-root=${rustPlatform.rust.rustc}" "--enable-rpath" ]
                 # ++ [ "--jemalloc-root=${jemalloc}/lib"
                 ++ [ "--default-linker=${stdenv.cc}/bin/cc" "--default-ar=${binutils.out}/bin/ar" ]
-                ++ stdenv.lib.optional (stdenv.cc.cc ? isClang) "--enable-clang"
-                ++ stdenv.lib.optional (targets != []) "--target=${target}"
-                ++ stdenv.lib.optional (!forceBundledLLVM) "--llvm-root=${llvmShared}";
+                ++ optional (stdenv.cc.cc ? isClang) "--enable-clang"
+                ++ optional (targets != []) "--target=${target}"
+                ++ optional (!forceBundledLLVM) "--llvm-root=${llvmShared}";
 
   patches = patches ++ targetPatches;
   passthru.target = target;
@@ -74,7 +76,7 @@ stdenv.mkDerivation {
       --replace "\$\$(subst  /,//," "\$\$(subst /,/,"
 
     # Fix dynamic linking against llvm
-    ${stdenv.lib.optionalString (!forceBundledLLVM) ''sed -i 's/, kind = \\"static\\"//g' src/etc/mklldeps.py''}
+    ${optionalString (!forceBundledLLVM) ''sed -i 's/, kind = \\"static\\"//g' src/etc/mklldeps.py''}
 
     # Fix the configure script to not require curl as we won't use it
     sed -i configure \
@@ -105,7 +107,7 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optional needsCmake [ cmake curl ];
 
   buildInputs = [ ncurses ] ++ targetToolchains
-    ++ stdenv.lib.optional (!forceBundledLLVM) llvmShared;
+    ++ optional (!forceBundledLLVM) llvmShared;
 
   # https://github.com/rust-lang/rust/issues/30181
   # enableParallelBuilding = false; # missing files during linking, occasionally
@@ -113,7 +115,10 @@ stdenv.mkDerivation {
   outputs = [ "out" "doc" ];
   setOutputFlags = false;
 
-  preCheck = "export TZDIR=${tzdata}/share/zoneinfo";
+  preCheck = ''
+    export TZDIR=${tzdata}/share/zoneinfo
+    ${optionalString stdenv.isDarwin "export TMPDIR=/tmp"}
+  '';
 
   # Disable doCheck on Darwin to work around upstream issue
   doCheck = !stdenv.isDarwin;

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -115,6 +115,7 @@ stdenv.mkDerivation {
 
   preCheck = "export TZDIR=${tzdata}/share/zoneinfo";
 
-  doCheck = true;
+  # Disable doCheck on Darwin to work around upstream issue
+  doCheck = !stdenv.isDarwin;
   dontSetConfigureCross = true;
 }

--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, cmake, zlib, python, libssh2, openssl, http-parser, libiconv }:
+{ stdenv, fetchurl, pkgconfig, cmake, zlib, python, libssh2, openssl, curl, http-parser, libiconv }:
 
 stdenv.mkDerivation (rec {
   version = "0.24.1";
@@ -10,10 +10,20 @@ stdenv.mkDerivation (rec {
     sha256 = "0rw80480dx2f6a2wbb1bwixygg1iwq3r7vwhxdmkkf4lpxd35jhd";
   };
 
+  # TODO: `cargo` (rust's package manager) surfaced a serious bug in
+  # libgit2 when the `Security.framework` transport is used on Darwin.
+  # The upstream issue is tracked at
+  # https://github.com/libgit2/libgit2/issues/3885 - feel free to
+  # remove this patch as soon as it's resolved (i.E. when cargo is
+  # working fine without this patch)
+  patches = stdenv.lib.optionals stdenv.isDarwin [
+    ./disable-security.framework.patch
+  ];
+
   cmakeFlags = "-DTHREADSAFE=ON";
 
   nativeBuildInputs = [ cmake python pkgconfig ];
-  buildInputs = [ zlib libssh2 openssl http-parser ];
+  buildInputs = [ zlib libssh2 openssl http-parser curl ];
 
   meta = {
     description = "The Git linkable library";

--- a/pkgs/development/libraries/git2/disable-security.framework.patch
+++ b/pkgs/development/libraries/git2/disable-security.framework.patch
@@ -1,0 +1,58 @@
+From fbc2ea65406236a740b8734dd41dc5ddbc24f8c9 Mon Sep 17 00:00:00 2001
+From: mulrich <mulrich@entwicklerheld.local>
+Date: Mon, 8 Aug 2016 15:36:07 +0200
+Subject: [PATCH] disable security.framework
+
+---
+ CMakeLists.txt    | 7 +++----
+ src/curl_stream.c | 9 ++++++++-
+ 2 files changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 93a9e47..331e148 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,7 +49,8 @@ ENDIF()
+ 
+ IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+ 	SET( USE_ICONV ON )
+-	FIND_PACKAGE(Security)
++	# FIND_PACKAGE(Security)
++  SET(SECURITY_FOUND "NO")
+ 	FIND_PACKAGE(CoreFoundation REQUIRED)
+ ENDIF()
+ 
+@@ -87,9 +88,7 @@ IF(MSVC)
+ 	OPTION(MSVC_CRTDBG "Enable CRTDBG memory leak reporting" OFF)
+ ENDIF()
+ 
+-IF (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+-	OPTION( USE_OPENSSL                     "Link with and use openssl library"             ON )
+-ENDIF()
++OPTION( USE_OPENSSL                     "Link with and use openssl library"             ON )
+ 
+ CHECK_STRUCT_HAS_MEMBER ("struct stat" st_mtim "sys/types.h;sys/stat.h"
+ 	HAVE_STRUCT_STAT_ST_MTIM LANGUAGE C)
+diff --git a/src/curl_stream.c b/src/curl_stream.c
+index 98de187..a8a9f4c 100644
+--- a/src/curl_stream.c
++++ b/src/curl_stream.c
+@@ -309,7 +309,14 @@ int git_curl_stream_new(git_stream **out, const char *host, const char *port)
+ 	curl_easy_setopt(handle, CURLOPT_HTTPPROXYTUNNEL, 1);
+ 	curl_easy_setopt(handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
+ 
+-	/* curl_easy_setopt(handle, CURLOPT_VERBOSE, 1); */
++  const char* cainfo = getenv("SSL_CERT_FILE");
++  if(cainfo != NULL) {
++    curl_easy_setopt(handle, CURLOPT_CAINFO, cainfo);
++  }
++
++  /*
++	curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
++  */
+ 
+ 	st->parent.version = GIT_STREAM_VERSION;
+ 	st->parent.encrypted = 0; /* we don't encrypt ourselves */
+-- 
+2.3.8 (Apple Git-58)
+

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, cmake, fcitx, gettext, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "fcitx-unikey-${version}";
+  version = "0.2.5";
+
+  src = fetchurl {
+    url = "http://download.fcitx-im.org/fcitx-unikey/${name}.tar.xz";
+    sha256 = "063vc29v7ycaai98v3z4q319sv9sm91my17pmhblw1vifxnw02wf";
+  };
+
+  buildInputs = [ cmake fcitx gettext pkgconfig ];
+
+  preInstall = ''
+    substituteInPlace src/cmake_install.cmake \
+      --replace ${fcitx} $out
+    substituteInPlace data/cmake_install.cmake \
+      --replace ${fcitx} $out
+  '';
+  
+  meta = with stdenv.lib; {
+    isFcitxEngine = true;
+    homepage      = "https://github.com/fcitx/fcitx-unikey";
+    downloadPage  = "http://download.fcitx-im.org/fcitx-table-other/";
+    description   = "Fcitx wrapper for unikey";
+    license       = licenses.gpl3Plus;
+    platforms     = platforms.linux;
+    maintainers   = with maintainers; [ ericsagnes ];
+  };
+
+}

--- a/pkgs/tools/security/thc-hydra/default.nix
+++ b/pkgs/tools/security/thc-hydra/default.nix
@@ -1,29 +1,41 @@
-{ stdenv, fetchurl, pkgconfig, openssl, libidn, ncurses, pcre, libssh, postgresql92 }:
+{ stdenv, lib, fetchurl, zlib, openssl, ncurses, libidn, pcre, libssh, libmysql, postgresql
+, withGUI ? false, makeWrapper, pkgconfig, gtk2 }:
 
-with stdenv.lib;
+let
+  makeDirs = output: subDir: pkgs: lib.concatStringsSep " " (map (path: lib.getOutput output path + "/" + subDir) pkgs);
 
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   name = "thc-hydra-${version}";
-  version = "7.5";
+  version = "8.2";
 
   src = fetchurl {
     url = "http://www.thc.org/releases/hydra-${version}.tar.gz";
-    sha256 = "1dhavbn2mcm6c2c1qw29ipbpmczax3vhhlxzwn49c8cq471yg4vj";
+    sha256 = "1i2a5glmrxdjr80gfppx6wgakflcpj3ksgng212fjzhxr9m4k24y";
   };
 
   preConfigure = ''
-   substituteInPlace configure --replace "\$LIBDIRS" "${openssl.out}/lib ${pcre.out}/lib ${libssh.out}/lib ${postgresql92.lib}/lib"
-   substituteInPlace configure --replace "\$INCDIRS" "${openssl.dev}/include ${pcre.dev}/include ${libssh.dev}/include ${postgresql92}/include"
+    substituteInPlace configure \
+      --replace "\$LIBDIRS" "${makeDirs "lib" "lib" buildInputs}" \
+      --replace "\$INCDIRS" "${makeDirs "dev" "include" buildInputs}" \
+      --replace "/usr/include/math.h" "${stdenv.glibc.dev}/include/math.h" \
+      --replace "libcurses.so" "libncurses.so" \
+      --replace "-lcurses" "-lncurses"
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl libidn ncurses pcre libssh ];
+  nativeBuildInputs = lib.optionals withGUI [ pkgconfig makeWrapper ];
+  buildInputs = [ zlib openssl ncurses libidn pcre libssh libmysql postgresql ]
+                ++ lib.optional withGUI gtk2;
 
-  meta = {
+  postInstall = lib.optionalString withGUI ''
+    wrapProgram $out/bin/xhydra \
+      --add-flags --hydra-path --add-flags "$out/bin/hydra"
+  '';
+
+  meta = with stdenv.lib; {
     description = "A very fast network logon cracker which support many different services";
     license = licenses.agpl3;
     homepage = https://www.thc.org/thc-hydra/;
     maintainers = with maintainers; [offline];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/text/par/default.nix
+++ b/pkgs/tools/text/par/default.nix
@@ -1,0 +1,36 @@
+{stdenv, fetchurl, fetchpatch}:
+
+stdenv.mkDerivation {
+  name = "par-1.52";
+
+  src = fetchurl {
+    url = http://www.nicemice.net/par/Par152.tar.gz;
+    sha256 = "33dcdae905f4b4267b4dc1f3efb032d79705ca8d2122e17efdecfd8162067082";
+  };
+
+  patches = [
+    # A patch by Jérôme Pouiller that adds support for multibyte
+    # charsets (like UTF-8), plus Debian packaging.
+    (fetchpatch {
+      url = "http://sysmic.org/dl/par/par-1.52-i18n.4.patch";
+      sha256 = "0alw44lf511jmr38jnh4j0mpp7vclgy0grkxzqf7q158vzdb6g23";
+    })
+  ];
+
+  buildPhase = ''make -f protoMakefile'';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp par $out/bin
+
+    mkdir -p $out/share/man/man1
+    cp  par.1 $out/share/man/man1
+  '';
+
+
+  meta = {
+    homepage = http://www.nicemice.net/par/;
+    description = "Paragraph reflow for email";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5481,7 +5481,9 @@ in
   rust = rustStable;
   rustStable = callPackage ../development/compilers/rust {};
   rustBeta = lowPrio (callPackage ../development/compilers/rust/beta.nix {});
-  rustUnstable = lowPrio (callPackage ../development/compilers/rust/head.nix {});
+  rustUnstable = lowPrio (callPackage ../development/compilers/rust/head.nix {
+    rustPlatform = recurseIntoAttrs (makeRustPlatform rustBeta);
+  });
 
   cargo = rust.cargo;
   rustc = rust.rustc;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1528,6 +1528,8 @@ in
 
     hangul = callPackage ../tools/inputmethods/fcitx-engines/fcitx-hangul { };
 
+    unikey = callPackage ../tools/inputmethods/fcitx-engines/fcitx-unikey { };
+    
     m17n = callPackage ../tools/inputmethods/fcitx-engines/fcitx-m17n { };
 
     mozc = callPackage ../tools/inputmethods/fcitx-engines/fcitx-mozc {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4223,6 +4223,8 @@ in
 
   zimwriterfs = callPackage ../tools/text/zimwriterfs { };
 
+  par = callPackage ../tools/text/par { };
+
   zip = callPackage ../tools/archivers/zip { };
 
   zkfuse = callPackage ../tools/filesystems/zkfuse { };


### PR DESCRIPTION
###### Motivation for this change

Fcitx Input method Engine for Vietnamese language
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

For code review: This new package is mostly identical to an existing one:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/inputmethods/fcitx-engines/fcitx-hangul/default.nix
