### PR TITLE
vagrant: cleanup FIX plugin install from #17614

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, dpkg, curl, libarchive, openssl, ruby, buildRubyGem, libiconv
-, libxml2, libxslt, coreutils, makeWrapper }:
+, libxml2, libxslt, makeWrapper }:
 
 assert stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux";
 
@@ -77,6 +77,10 @@ stdenv.mkDerivation rec {
     ln -s ${ruby}/bin/ri opt/vagrant/embedded/bin
     ln -s ${ruby}/bin/ruby opt/vagrant/embedded/bin
 
+    # ruby libs
+    rm -rf opt/vagrant/embedded/lib
+    ln -s ${ruby}/lib opt/vagrant/embedded/lib
+
     # libiconv: iconv
     rm opt/vagrant/embedded/bin/iconv
     ln -s ${libiconv}/bin/iconv opt/vagrant/embedded/bin
@@ -96,11 +100,6 @@ stdenv.mkDerivation rec {
     cp -r opt "$out"
     cp -r usr/bin "$out"
     wrapProgram "$out/bin/vagrant" --prefix LD_LIBRARY_PATH : "$out/opt/vagrant/embedded/lib"
-
-    substituteInPlace $out/opt/vagrant/embedded/lib/ruby/2.2.0/x86_64-linux/rbconfig.rb \
-      --replace '"/bin/mkdir' '"${coreutils}/bin/mkdir'
-    substituteInPlace $out/opt/vagrant/embedded/lib/ruby/2.2.0/x86_64-linux/rbconfig.rb \
-      --replace "'/usr/bin/install" "'${coreutils}/bin/install"
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/17614#issuecomment-238590116
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @aneeshusa 
