### PR TITLE
fcitx-unikey: init at 0.2.5

### DIFF
--- a/nixos/modules/i18n/input-method/default.xml
+++ b/nixos/modules/i18n/input-method/default.xml
@@ -88,6 +88,8 @@ i18n.inputMethod = {
       methods among Traditional Chinese Unix users.</para></listitem>
   <listitem><para>Hangul (<literal>fcitx-engines.hangul</literal>): Korean input 
       method.</para></listitem>
+  <listitem><para>Unikey (<literal>fcitx-engines.unikey</literal>): Vietnamese input 
+      method.</para></listitem>
   <listitem><para>m17n (<literal>fcitx-engines.m17n</literal>): m17n is an input 
       method that uses input methods and corresponding icons in the m17n 
       database.</para></listitem>

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, cmake, fcitx, gettext, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "fcitx-unikey-${version}";
+  version = "0.2.5";
+
+  src = fetchurl {
+    url = "http://download.fcitx-im.org/fcitx-unikey/${name}.tar.xz";
+    sha256 = "063vc29v7ycaai98v3z4q319sv9sm91my17pmhblw1vifxnw02wf";
+  };
+
+  buildInputs = [ cmake fcitx gettext pkgconfig ];
+
+  preInstall = ''
+    substituteInPlace src/cmake_install.cmake \
+      --replace ${fcitx} $out
+    substituteInPlace data/cmake_install.cmake \
+      --replace ${fcitx} $out
+  '';
+  
+  meta = with stdenv.lib; {
+    isFcitxEngine = true;
+    homepage      = "https://github.com/fcitx/fcitx-unikey";
+    downloadPage  = "http://download.fcitx-im.org/fcitx-table-other/";
+    description   = "Fcitx wrapper for unikey";
+    license       = licenses.gpl3Plus;
+    platforms     = platforms.linux;
+    maintainers   = with maintainers; [ ericsagnes ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1528,6 +1528,8 @@ in
 
     hangul = callPackage ../tools/inputmethods/fcitx-engines/fcitx-hangul { };
 
+    unikey = callPackage ../tools/inputmethods/fcitx-engines/fcitx-unikey { };
+    
     m17n = callPackage ../tools/inputmethods/fcitx-engines/fcitx-m17n { };
 
     mozc = callPackage ../tools/inputmethods/fcitx-engines/fcitx-mozc {


### PR DESCRIPTION
###### Motivation for this change

Fcitx Input method Engine for Vietnamese language
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

For code review: This new package is mostly identical to an existing one:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/inputmethods/fcitx-engines/fcitx-hangul/default.nix
