### PR TITLE
pyusb: fix hardcoding libusb1 path

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25940,7 +25940,7 @@ in modules // {
     postPatch = ''
       libusb=${pkgs.libusb1.out}/lib/libusb-1.0.so
       test -f $libusb || { echo "ERROR: $libusb doesn't exist, please update/fix this build expression."; exit 1; }
-      sed -i -e "s|libname = .*|libname = \"$libusb\"|" usb/backend/libusb1.py
+      sed -i -e "s|find_library=None|find_library=lambda _:\"$libusb\"|" usb/backend/libusb1.py
     '';
 
     # No tests included


### PR DESCRIPTION
###### Motivation for this change

The pyusb patching that was intended to hardcode the path to libusb1 had stopped working. This fixes it.

Without this change, you get "No backend available" errors from pyusb because it is unable to locate libusb1.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've built it locally on my NixOS machine within a nix-shell environment, and verified that pyusb is able to access the libusb1 backend.

---

The line that was being replaced by the `sed` command has disappeared
from the source file.

The new `sed` script will replace the default find_library function as a
parameter to the get_backend and _load_library functions.  This means
that if a user wants to provide their own find_library implementation,
their chosen implementation will still be used.
