### PR TITLE
manuskript: init at 0.3.0

### DIFF
--- a/pkgs/applications/editors/manuskript/default.nix
+++ b/pkgs/applications/editors/manuskript/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, zlib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  name = "manuskript";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    repo = name;
+    owner = "olivierkes";
+    rev = version;
+    sha256 = "0bqxc4a8kyi6xz1zs0dp85wxl9h4v8lzc6073bbcsn1zg4y59ys7";
+  };
+
+  propagatedBuildInputs = [
+    python3Packages.pyqt5
+    python3Packages.lxml
+    zlib
+  ];
+
+  buildPhase = '''';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -av * $out/
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "A open-source tool for writers";
+    homepage = http://www.theologeek.ch/manuskript;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.steveej ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13295,6 +13295,8 @@ in
 
   linssid = qt5.callPackage ../applications/networking/linssid { };
 
+  manuskript = callPackage ../applications/editors/manuskript { };
+
   mi2ly = callPackage ../applications/audio/mi2ly {};
 
   praat = callPackage ../applications/audio/praat { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
