### PR TITLE
shc: init at 3.9.3

### DIFF
--- a/pkgs/tools/security/shc/default.nix
+++ b/pkgs/tools/security/shc/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "shc-${version}";
+  version = "3.9.3";
+  rev = "${version}";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "neurobin";
+    repo = "shc";
+    sha256 = "00fqzg4a0f4kp4wr8swhi5zqds3gh3gf7cgi1cipn16av0818xsa";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://neurobin.github.io/shc;
+    description = "Shell Script Compiler";
+    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17322,6 +17322,8 @@ in
 
   sailsd = callPackage ../misc/sailsd { };
 
+  shc = callPackage ../tools/security/shc { };
+
   canon-cups-ufr2 = callPackage ../misc/cups/drivers/canon { };
 
   mfcj470dw = callPackage_i686 ../misc/cups/drivers/mfcj470dw { };


### PR DESCRIPTION
###### Motivation for this change

New package.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
% nix-env --file $NIXPKGS -iA 'shc'
replacing old ‘shc-3.9.3’
installing ‘shc-3.9.3’
building path(s) ‘/nix/store/g50v6z2ixmhkj4ncr94pyndvpcgv3a33-user-environment’
created 906 symlinks in user environment



% shc -h                           
shc Version 3.9.3, Generic Shell Script Compiler
shc GNU GPL Version 3 Jahidul Hamid <jahidulhamid@yahoo.com>
shc Usage: shc [-e date] [-m addr] [-i iopt] [-x cmnd] [-l lopt] [-o outfile] [-rvDUCABh] -f script

    -e %s  Expiration date in dd/mm/yyyy format [none]
    -m %s  Message to display upon expiration ["Please contact your provider"]
    -f %s  File name of the script to compile
    -i %s  Inline option for the shell interpreter i.e: -e
    -x %s  eXec command, as a printf format i.e: exec('%s',@ARGV);
    -l %s  Last shell option i.e: --
    -o %s  output filename
    -r     Relax security. Make a redistributable binary
    -v     Verbose compilation
    -D     Switch ON debug exec calls [OFF]
    -U     Make binary untraceable [no]
    -C     Display license and exit
    -A     Display abstract and exit
    -B     Compile for busybox
    -h     Display help and exit

    Environment variables used:
    Name    Default  Usage
    CC      cc       C compiler command
    CFLAGS  <none>   C compiler flags

    Please consult the shc man page.
```
