### PR TITLE
llvm-3.8: build shared library on darwin

### DIFF
--- a/pkgs/development/compilers/llvm/3.8/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.8/llvm.nix
@@ -14,7 +14,7 @@
 , compiler-rt_src
 , libcxxabi
 , debugVersion ? false
-, enableSharedLibraries ? !stdenv.isDarwin
+, enableSharedLibraries ? true
 }:
 
 let
@@ -67,6 +67,11 @@ in stdenv.mkDerivation rec {
     rm -fR $out
 
     paxmark m bin/{lli,llvm-rtdyld}
+  '';
+
+  postInstall = stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
+    install_name_tool -id $out/lib/libLLVM.dylib $out/lib/libLLVM.dylib
+    ln -s $out/lib/libLLVM.dylib $out/lib/libLLVM-${version}.dylib
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Support dynamically linking LLVM as a library on darwin.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Enable the shared library build on darwin by default to match other
  platforms.
- Fix the dylib file's name in the store
- Symlink a versioned name as some tooling expects this.
