### PR TITLE
Fix perl package CatalystXScriptServerStarman (and indirectly, hydra)

### DIFF
--- a/pkgs/development/perl-modules/CatalystXScriptServerStarman-fork-arg.patch
+++ b/pkgs/development/perl-modules/CatalystXScriptServerStarman-fork-arg.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/CatalystX/Script/Server/Starman.pm b/lib/CatalystX/Script/Server/Starman.pm
+index 670bd74..7b3bd2e 100644
+--- a/lib/CatalystX/Script/Server/Starman.pm
++++ b/lib/CatalystX/Script/Server/Starman.pm
+@@ -9,7 +9,7 @@ our $VERSION = '0.02';
+ 
+ extends 'Catalyst::Script::Server';
+ 
+-has '+fork' => ( default => 1, init_arg => undef );
++has '+fork' => ( default => 1 );
+ 
+ has [qw/ keepalive restart restart_delay restart_regex restart_directory/] => ( init_arg => undef, is => 'ro' );
+ 
+@@ -70,7 +70,7 @@ CatalystX::Script::Server::Starman - Replace the development server with Starman
+ 
+        -d --debug           force debug mode
+        -f --fork            handle each request in a new process
+-                            (defaults to false)
++                            (defaults to true)
+        -? --help            display this help and exits
+        -h --host            host (defaults to all)
+        -p --port            port (defaults to 3000)

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1508,6 +1508,10 @@ let self = _self // overrides; _self = with self; {
       url = mirror://cpan/authors/id/A/AB/ABRAXXA/CatalystX-Script-Server-Starman-0.02.tar.gz;
       sha256 = "0h02mpkc4cmi3jpvcd7iw7xyzx55bqvvl1qkf967gqkvpklm0qx5";
     };
+    patches = [
+      # See Nixpkgs issues #16074 and #17624
+      ../development/perl-modules/CatalystXScriptServerStarman-fork-arg.patch
+    ];
     buildInputs = [ TestWWWMechanizeCatalyst ];
     propagatedBuildInputs = [ CatalystRuntime Moose namespaceautoclean Starman ];
     meta = {


### PR DESCRIPTION
###### Motivation for this change

The `hydra` service is not working due to an issue in `CatalystXScriptServerStarman`, which is one of its dependencies. See #16074 and #17624
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #16074 and #17624 

Reported upstream: https://rt.cpan.org/Public/Bug/Display.html?id=116910

If people are happy about this change, can we merge it soon? Otherwise the `hydra` service exported from `<nixpkgst/nixos/modules/services/continuous-integration/hydra/default.nix>` doesn't work as expected (see #16074 and #17624).  

cc @domenkozar 
