### PR TITLE
linux_mptcp: 0.90.1 -> 0.91 (kernel 3.18 -> 4.1)

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,19 +1,21 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  mptcpVersion = "0.90.1";
-  modDirVersion = "3.18.25";
+  mptcpVersion = "0.91";
+  modDirVersion = "4.1.26";
   version = "${modDirVersion}-mptcp_v${mptcpVersion}";
 
   extraMeta = {
-    branch = "3.18";
+    branch = "4.1";
     maintainers = stdenv.lib.maintainers.layus;
   };
 
   src = fetchurl {
     url = "https://github.com/multipath-tcp/mptcp/archive/v${mptcpVersion}.tar.gz";
-    sha256 = "088cpxl960xzrsz7x2lkq28ksa4gzjb1hp5yf8hxshihyhdaspwl";
+    sha256 = "0rbvgz89j5wk781y201qdxy2kz4gmlamb72wdbxj8mxv92x56lh3";
   };
+
+  kernelPatches = args.kernelPatches;
 
   extraConfig = ''
     IPV6 y

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11068,7 +11068,10 @@ in
   klibcShrunk = lowPrio (callPackage ../os-specific/linux/klibc/shrunk.nix { });
 
   linux_mptcp = callPackage ../os-specific/linux/kernel/linux-mptcp.nix {
-    kernelPatches = [ kernelPatches.bridge_stp_helper ]
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.hiddev_CVE_2016_5829
+      ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
         kernelPatches.mips_fpu_sigill


### PR DESCRIPTION
- [x] Tested on NixOS.
