### PR TITLE
[WIP] caddy: 0.8.3 -> 0.9

### DIFF
--- a/pkgs/development/go-modules/libs.json
+++ b/pkgs/development/go-modules/libs.json
@@ -1,5 +1,41 @@
 [
   {
+    "goPackagePath": "github.com/lucas-clemente/aes12",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/lucas-clemente/aes12",
+      "rev": "5a3c52721c1e81aa8162601ac2342486525156d5",
+      "sha256": "16z4h752na2d4sskjvbgi9bpwx874lpnzn6i13n33xjz599nps4y"
+    }
+  },
+  {
+    "goPackagePath": "github.com/lucas-clemente/fnv128a",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/lucas-clemente/fnv128a",
+      "rev": "393af48d391698c6ae4219566bfbdfef67269997",
+      "sha256": "1cvq0p0k86p668yz9rb3z98fz3f9phvbvqp6ilbasiy4y2x5w184"
+    }
+  },
+  {
+    "goPackagePath": "github.com/lucas-clemente/quic-go-certificates",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/lucas-clemente/quic-go-certificates",
+      "rev": "9bb36d3159787cca26dcfa15e23049615e307ef8",
+      "sha256": "146674p0rg0m4j8p33r5idn5j5k4a277fz1yzf87v5m8wf4694q5"
+    }
+  },
+  {
+    "goPackagePath": "github.com/lucas-clemente/quic-go",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/lucas-clemente/quic-go",
+      "rev": "e3fc73683ce37b762232c46adc0cd7a66b4a230d",
+      "sha256": "0azcci7c63h4yxpdc6ki18pdw6zgcwxfwalmq4xwbdgkfl9qsfxm"
+    }
+  },
+  {
     "goPackagePath": "github.com/elves/getopt",
     "fetch": {
       "type": "git",
@@ -94,8 +130,8 @@
     "fetch": {
       "type": "git",
       "url": "https://go.googlesource.com/net",
-      "rev": "62ac18b461605b4be188bbc7300e9aa2bc836cd4",
-      "sha256": "0lwwvbbwbf3yshxkfhn6z20gd45dkvnmw2ms36diiy34krgy402p"
+      "rev": "07b51741c1d6423d4a6abab1c49940ec09cb1aaf",
+      "sha256": "12lvdj0k2gww4hw5f79qb9yswqpy4i3bgv1likmf3mllgdxfm20w"
     }
   },
   {
@@ -463,8 +499,8 @@
     "fetch": {
       "type": "git",
       "url": "https://github.com/miekg/dns",
-      "rev": "7e024ce8ce18b21b475ac6baf8fa3c42536bf2fa",
-      "sha256": "0hlwb52lnnj3c6papjk9i5w5cjdw6r7c891v4xksnfvk1f9cy9kl"
+      "rev": "db96a2b759cdef4f11a34506a42eb8d1290c598e",
+      "sha256": "0h5n4psd0p7q55jadgsgz2a1aj791yanrfj76avalh6aawvdpcm6"
     }
   },
   {
@@ -1120,8 +1156,8 @@
     "fetch": {
       "type": "git",
       "url": "https://github.com/xenolf/lego",
-      "rev": "ca19a90028e242e878585941c2a27c8f3b3efc25",
-      "sha256": "1zkcsbdzbmfzk3kqmcj9l13li8sz228xhrw2wj3ab4a0w6drbw3x"
+      "rev": "aa216e03991034aadd00c6b94b5ebec0cbf25983",
+      "sha256": "03p71ykwyar3j703ld4a76n0jf7833xq2fcbvij3m5lcyiiali8q"
     }
   },
   {

--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -2,17 +2,24 @@
 
 buildGoPackage rec {
   name = "caddy-${version}";
-  version = "0.8.3";
-  rev = "e2234497b79603388b58ba226abb157aa4aaf065";
+  version = "0.9";
+  rev = "f28af637327a4f12ae745284c519cfdeca5502ef";
 
   goPackagePath = "github.com/mholt/caddy";
+
+  subPackages = [ "caddy" ];
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "mholt";
     repo = "caddy";
-    sha256 = "1snijkbz02yr7wij7bcmrj4257709sbklb3nhb5qmy95b9ssffm6";
+    sha256 = "1s7z0xbcw516i37pyj1wgxd9diqrifdghf97vs31ilbqs6z0nyls";
   };
+
+  buildFlagsArray = ''
+    -ldflags=
+      -X github.com/mholt/caddy/caddy/caddymain.gitTag=${version}
+  '';
 
   goDeps = ./deps.json;
 }

--- a/pkgs/servers/caddy/deps.json
+++ b/pkgs/servers/caddy/deps.json
@@ -2,6 +2,10 @@
   {
     "include": "../../libs.json",
     "packages": [
+      "github.com/lucas-clemente/quic-go",
+      "github.com/lucas-clemente/quic-go-certificates",
+      "github.com/lucas-clemente/aes12",
+      "github.com/lucas-clemente/fnv128a",
       "github.com/BurntSushi/toml",
       "github.com/flynn/go-shlex",
       "github.com/hashicorp/go-syslog",


### PR DESCRIPTION
###### Motivation for this change

https://caddyserver.com/blog/caddy-0_9-released
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @angus-g
