### PR TITLE
releaseTools: add channel function

### DIFF
--- a/pkgs/build-support/release/default.nix
+++ b/pkgs/build-support/release/default.nix
@@ -73,4 +73,56 @@ rec {
         done
       '';
 
+  /* Create a channel job which success depends on the success of all of
+     its contituents. Channel jobs are a special type of jobs that are
+     listed in the channel tab of Hydra and that can be suscribed.
+     A tarball of the src attribute is distributed via the channel.
+     
+     - constituents: a list of derivations on which the channel success depends.
+     - name: the channel name that will be used in the hydra interface.
+     - src: should point to the root folder of the nix-expressions used by the
+            channel, typically a folder containing a `default.nix`.
+
+       channel {
+         constituents = [ foo bar baz ];
+         name = "my-channel";
+         src = ./.;
+       };
+     
+  */
+  channel =
+    { name, src, constituents ? [], meta ? {}, isNixOS ? true, ... }@args:
+    stdenv.mkDerivation ({
+      preferLocalBuild = true;
+      _hydraAggregate = true;
+
+      phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+
+      patchPhase = stdenv.lib.optionalString isNixOS ''
+        touch .update-on-nixos-rebuild
+      '';
+
+      installPhase = ''
+        mkdir -p $out/{tarballs,nix-support}
+
+        tar cJf "$out/tarballs/nixexprs.tar.xz" \
+          --owner=0 --group=0 --mtime="1970-01-01 00:00:00 UTC" \
+          --transform='s!^\.!${name}!' .
+
+        echo "channel - $out/tarballs/nixexprs.tar.xz" > "$out/nix-support/hydra-build-products"
+        echo $constituents > "$out/nix-support/hydra-aggregate-constituents"
+
+        # Propagate build failures.
+        for i in $constituents; do
+          if [ -e "$i/nix-support/failed" ]; then
+            touch "$out/nix-support/failed"
+          fi
+        done
+      '';
+
+      meta = meta // {
+        isHydraChannel = true;
+      };
+    } // removeAttrs args [ "meta" ]);
+
 }


### PR DESCRIPTION
###### Motivation for this change

This add a function to `releaseTools` to generate Hydra channels.

The added coded of the PR is copy pasted from https://github.com/snabblab/snabblab-nixos/blob/customchannel/jobsets/snabblab.nix

Related issue #17356

cc @domenkozar @aszlig 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
