### PR TITLE
Fix documentation typo in lib/strings.nix

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -248,7 +248,7 @@ rec {
   /* Converts an ASCII string to upper-case.
 
      Example:
-       toLower "home"
+       toUpper "home"
        => "HOME"
   */
   toUpper = replaceChars lowerChars upperChars;


### PR DESCRIPTION
Fix documentation typo in lib/strings.nix
