### PR TITLE
Add Solidity (Ethereum compiler)

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -99,6 +99,7 @@
   davidak = "David Kleuker <post@davidak.de>";
   davidrusu = "David Rusu <davidrusu.me@gmail.com>";
   dbohdan = "Danyil Bohdan <danyil.bohdan@gmail.com>";
+  dbrock = "Daniel Brockman <daniel@brockman.se>";
   deepfire = "Kosyrev Serge <_deepfire@feelingofgreen.ru>";
   demin-dmitriy = "Dmitriy Demin <demindf@gmail.com>";
   DerGuteMoritz = "Moritz Heidkamp <moritz@twoticketsplease.de>";

--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     longDescription = "This package also includes `lllc', the LLL compiler.";
     homepage = https://github.com/ethereum/solidity;
     license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.dbrock ];
     inherit version;
   };
 }

--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, boost, cmake, jsoncpp }:
+
+stdenv.mkDerivation rec {
+  version = "0.3.6";
+  name = "solc-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "solidity";
+    rev = "v${version}";
+    sha256 = "1cynqwy8wr63l3l4wv9z6shhcy6lq0q8pbsh3nav0dg9qgj9sg57";
+  };
+
+  buildInputs = [ boost cmake jsoncpp ];
+
+  meta = {
+    description = "Compiler for Ethereum smart contract language Solidity";
+    longDescription = "This package also includes `lllc', the LLL compiler.";
+    homepage = https://github.com/ethereum/solidity;
+    license = stdenv.lib.licenses.gpl3;
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5535,6 +5535,8 @@ in
             then callPackage ../development/compilers/smlnj { }
             else callPackage_i686 ../development/compilers/smlnj { };
 
+  solc = callPackage ../development/compilers/solc { };
+
   sqldeveloper = callPackage ../development/tools/database/sqldeveloper { };
 
   squeak = callPackage ../development/compilers/squeak { };


### PR DESCRIPTION
###### Motivation for this change

Add `solc`, the compiler for the popular Ethereum smart contract language Solidity (same package also includes `lllc`, the compiler for the lower-level language LLL). https://github.com/ethereum/solidity
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Moved from #17670.
