### PR TITLE
uftp: init at 4.9.2

### DIFF
--- a/pkgs/servers/uftp/default.nix
+++ b/pkgs/servers/uftp/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "uftp-${version}";
+  version = "4.9.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/uftp-multicast/source-tar/uftp-${version}.tar.gz";
+    sha256 = "0pra2sm8rdscyqkagi2v99az1vxbcch47wkdnz9wv4qg1x5phpmr";
+  };
+
+  buildInputs = [
+    openssl
+  ];
+
+  outputs = [ "out" "doc" ];
+
+  patchPhase = ''
+    substituteInPlace makefile --replace gcc cc
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $doc/share/man/man1
+    cp {uftp,uftpd,uftp_keymgt,uftpproxyd} $out/bin/
+    cp {uftp.1,uftpd.1,uftp_keymgt.1,uftpproxyd.1} $doc/share/man/man1
+  '';
+
+  meta = {
+    description = "Encrypted UDP based FTP with multicast";
+    homepage = http://uftp-multicast.sourceforge.net/;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.fadenb ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3973,6 +3973,8 @@ in
 
   uemacs = callPackage ../applications/editors/uemacs { };
 
+  uftp = callPackage ../servers/uftp { };
+
   uhttpmock = callPackage ../development/libraries/uhttpmock { };
 
   uim = callPackage ../tools/inputmethods/uim {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
