### PR TITLE
diff-so-fancy: 0.10.1 -> 0.11.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/diff-so-fancy/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "diff-so-fancy-${version}";
-  version = "0.10.1";
+  version = "0.11.1";
 
   # perl is needed here so patchShebangs can do its job
   buildInputs = [perl makeWrapper];
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "so-fancy";
     repo = "diff-so-fancy";
     rev = "v${version}";
-    sha256 = "0wp5civn70jzil1gbygx6ccrxfrmc8xx90v7zgf36rqi2yhvv64m";
+    sha256 = "1dw32c5i9mry6zr2a6h1369fhp1qbqimx04qgdmdnmn1imyck1h3";
   };
 
   buildPhase = null;
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     # itself, so we are copying executable to lib, and only symlink it
     # from bin/
     cp diff-so-fancy $out/lib/diff-so-fancy
-    cp -r lib $out/lib/diff-so-fancy
+    cp -r libexec $out/lib/diff-so-fancy
     ln -s $out/lib/diff-so-fancy/diff-so-fancy $out/bin
 
     # ncurses is needed for `tput`


### PR DESCRIPTION
###### Motivation for this change

Update diff-so-fancy to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
