### PR TITLE
nerdfonts: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/data/fonts/nerdfonts/default.nix
+++ b/pkgs/data/fonts/nerdfonts/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchFromGitHub, bash, which }:
+{ stdenv, fetchFromGitHub, bash, which, withFont ? "" }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.0";
+  version = "0.8.0";
   name = "nerdfonts-${version}";
   src = fetchFromGitHub {
     owner = "ryanoasis";
     repo = "nerd-fonts";
     rev = version;
-    sha256 = "0q2h8hpkbid8idi2kvzx5bnhyh65y51k02g7xpv3drjqj08cz7y0";
+    sha256 = "0n7idfk4460j8g0rw73hzz195pdh4c916hpc5r6dxpvgcmvryzc5";
   };
   dontPatchShebangs = true;
   buildInputs = [ which ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
   installPhase = ''
     mkdir -p $out/share/fonts/truetype
-    ./install.sh
+    ./install.sh ${withFont}
   '';
   meta = with stdenv.lib; {
     description = "Nerd Fonts is a project that attempts to patch as many developer targeted and/or used fonts as possible. The patch is to specifically add a high number of additional glyphs from popular 'iconic fonts' such as Font Awesome, Devicons, Octicons, and others.";


### PR DESCRIPTION
###### Motivation for this change

Update nerdfonts to the last version

This version add a parameter to the install for copying only one font so I've done it with a "withFont" variable for overriding the package like this. Without override the variable, all fonts are copied.

  nixpkgs.config.packageOverrides = pkgs : {
    nerdfonts = pkgs.nerdfonts.override { withFont = "Inconsolata"; };
  };
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
