### PR TITLE
curl: Add GnuTLS as an alternative to openSSL

### DIFF
--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
   # systemkey-args.h.
   enableParallelBuilding = false;
 
-  buildInputs = [ lzo lzip nettle libtasn1 libidn p11_kit zlib gmp autogen ]
+  buildInputs = [ lzo lzip libtasn1 libidn p11_kit zlib gmp autogen ]
     ++ lib.optional doCheck nettools
     ++ lib.optional (stdenv.isFreeBSD || stdenv.isDarwin) libiconv
     ++ lib.optional (tpmSupport && stdenv.isLinux) trousers
@@ -48,6 +48,8 @@ stdenv.mkDerivation {
     ++ lib.optional guileBindings guile;
 
   nativeBuildInputs = [ perl pkgconfig ] ++ nativeBuildInputs;
+
+  propagatedBuildInputs = [ nettle ];
 
   inherit doCheck;
 

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -4,6 +4,7 @@
 , ldapSupport ? false, openldap ? null
 , zlibSupport ? false, zlib ? null
 , sslSupport ? false, openssl ? null
+, gnutlsSupport ? false, gnutls ? null
 , scpSupport ? false, libssh2 ? null
 , gssSupport ? false, gss ? null
 , c-aresSupport ? false, c-ares ? null
@@ -14,6 +15,8 @@ assert idnSupport -> libidn != null;
 assert ldapSupport -> openldap != null;
 assert zlibSupport -> zlib != null;
 assert sslSupport -> openssl != null;
+assert gnutlsSupport -> !sslSupport;
+assert gnutlsSupport -> gnutls != null;
 assert scpSupport -> libssh2 != null;
 assert c-aresSupport -> c-ares != null;
 
@@ -40,6 +43,7 @@ stdenv.mkDerivation rec {
     optional gssSupport gss ++
     optional c-aresSupport c-ares ++
     optional sslSupport openssl ++
+    optional gnutlsSupport gnutls ++
     optional scpSupport libssh2;
 
   # for the second line see http://curl.haxx.se/mail/tracker-2014-03/0087.html
@@ -52,6 +56,7 @@ stdenv.mkDerivation rec {
       "--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt"
       "--disable-manual"
       ( if sslSupport then "--with-ssl=${openssl.dev}" else "--without-ssl" )
+      ( if gnutlsSupport then "--with-gnutls=${gnutls.dev}" else "--without-gnutls" )
       ( if scpSupport then "--with-libssh2=${libssh2.dev}" else "--without-libssh2" )
       ( if ldapSupport then "--enable-ldap" else "--disable-ldap" )
       ( if ldapSupport then "--enable-ldaps" else "--disable-ldaps" )
@@ -66,6 +71,10 @@ stdenv.mkDerivation rec {
   postInstall = ''
     moveToOutput bin/curl-config "$dev"
     sed '/^dependency_libs/s|${libssh2.dev}|${libssh2.out}|' -i "$out"/lib/*.la
+  '' + stdenv.lib.optionalString gnutlsSupport ''
+    ln $out/lib/libcurl.so $out/lib/libcurl-gnutls.so
+    ln $out/lib/libcurl.so $out/lib/libcurl-gnutls.so.4
+    ln $out/lib/libcurl.so $out/lib/libcurl-gnutls.so.4.4.0
   '';
 
   crossAttrs = {
@@ -73,6 +82,7 @@ stdenv.mkDerivation rec {
     # For the 'urandom', maybe it should be a cross-system option
     configureFlags = [
         ( if sslSupport then "--with-ssl=${openssl.crossDrv}" else "--without-ssl" )
+        ( if gnutlsSupport then "--with-gnutls=${gnutls.crossDrv}" else "--without-gnutls" )
         "--with-random /dev/urandom"
       ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1227,11 +1227,26 @@ in
     gssSupport = true;
   };
 
+  curlFullGnuTLS = lowPrio (self.curlFull.override {
+    sslSupport = false;
+    openssl = null;
+    gnutlsSupport = true;
+    gnutls = gnutls;
+  });
+
+  curlGnuTLS = lowPrio (self.curl.override {
+    sslSupport = false;
+    openssl = null;
+    gnutlsSupport = true;
+    gnutls = gnutls;
+  });
+
   curl = callPackage ../tools/networking/curl rec {
     fetchurl = fetchurlBoot;
     http2Support = !stdenv.isDarwin;
     zlibSupport = true;
     sslSupport = zlibSupport;
+    gnutls = null;
     scpSupport = zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1227,26 +1227,11 @@ in
     gssSupport = true;
   };
 
-  curlFullGnuTLS = lowPrio (self.curlFull.override {
-    sslSupport = false;
-    openssl = null;
-    gnutlsSupport = true;
-    gnutls = gnutls;
-  });
-
-  curlGnuTLS = lowPrio (self.curl.override {
-    sslSupport = false;
-    openssl = null;
-    gnutlsSupport = true;
-    gnutls = gnutls;
-  });
-
   curl = callPackage ../tools/networking/curl rec {
     fetchurl = fetchurlBoot;
     http2Support = !stdenv.isDarwin;
     zlibSupport = true;
     sslSupport = zlibSupport;
-    gnutls = null;
     scpSupport = zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Added this option, as the game "Dont Starve" running in fhsUserEnv needs libcurl-gnutls.so.4, which we didn't have.
Also i find that having more choice regarding crypto(-libraries) is better.

It can be pulled even though it's marked WIP, but maybe we could/should add other libraries as well (libreSSL/...)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
