### PR TITLE
firefox-bin: Add libxcb to build inputs

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -17,6 +17,7 @@
 , gtk3
 , libX11
 , libXScrnSaver
+, libxcb
 , libXcomposite
 , libXdamage
 , libXext
@@ -90,6 +91,7 @@ stdenv.mkDerivation {
       libX11
       libXScrnSaver
       libXcomposite
+      libxcb
       libXdamage
       libXext
       libXfixes


### PR DESCRIPTION
###### Motivation for this change

This is needed for future versions of Firefox, and makes external packaging of prerelease versions of Firefox much easier.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
