### PR TITLE
microcode-intel: 20150121 -> 20160714

### DIFF
--- a/pkgs/os-specific/linux/microcode/intel.nix
+++ b/pkgs/os-specific/linux/microcode/intel.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "microcode-intel-${version}";
-  version = "20150121";
+  version = "20160714";
 
   src = fetchurl {
-    url = "http://downloadmirror.intel.com/24661/eng/microcode-${version}.tgz";
-    sha256 = "1cznv3f25cxkwxdc930ab0ifvq0c76fryppadi4p26a2pf9knd93";
+    url = "http://downloadmirror.intel.com/26156/eng/microcode-${version}.tgz";
+    sha256 = "03l4pkymrgbd5y9m5ys7kq85zvckmjbw7xr6pkzg2nr7jgycdagk";
   };
 
   buildInputs = [ libarchive ];


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

tested on my i7-4870HQ by adding `hardware.cpu.intel.updateMicrocode = true;` in `configuration.nix`

before:

```
$ dmesg | grep -i micro
[    0.000000] microcode: microcode updated early to revision 0x12, date = 2014-07-03
[    0.779255] microcode: CPU0 sig=0x40661, pf=0x20, revision=0x12
[    0.779283] microcode: CPU1 sig=0x40661, pf=0x20, revision=0x12
[    0.779310] microcode: CPU2 sig=0x40661, pf=0x20, revision=0x12
[    0.779316] microcode: CPU3 sig=0x40661, pf=0x20, revision=0x12
[    0.779343] microcode: CPU4 sig=0x40661, pf=0x20, revision=0x12
[    0.779367] microcode: CPU5 sig=0x40661, pf=0x20, revision=0x12
[    0.779395] microcode: CPU6 sig=0x40661, pf=0x20, revision=0x12
[    0.779407] microcode: CPU7 sig=0x40661, pf=0x20, revision=0x12
[    0.779524] microcode: Microcode Update Driver: v2.01 <tigran@aivazian.fsnet.co.uk>, Peter Oruba
```

after:

```
$ dmesg | grep -i micro
[    0.000000] microcode: microcode updated early to revision 0x16, date = 2016-04-01
[    1.524754] microcode: CPU0 sig=0x40661, pf=0x20, revision=0x16
[    1.524807] microcode: CPU1 sig=0x40661, pf=0x20, revision=0x16
[    1.524858] microcode: CPU2 sig=0x40661, pf=0x20, revision=0x16
[    1.524875] microcode: CPU3 sig=0x40661, pf=0x20, revision=0x16
[    1.524932] microcode: CPU4 sig=0x40661, pf=0x20, revision=0x16
[    1.524980] microcode: CPU5 sig=0x40661, pf=0x20, revision=0x16
[    1.525033] microcode: CPU6 sig=0x40661, pf=0x20, revision=0x16
[    1.525058] microcode: CPU7 sig=0x40661, pf=0x20, revision=0x16
[    1.525231] microcode: Microcode Update Driver: v2.01 <tigran@aivazian.fsnet.co.uk>, Peter Oruba
```
