### PR TITLE
tini: fix build

### DIFF
--- a/pkgs/applications/virtualization/tini/default.nix
+++ b/pkgs/applications/virtualization/tini/default.nix
@@ -7,14 +7,12 @@ stdenv.mkDerivation rec {
     url = "https://github.com/krallin/tini/archive/v0.8.3.tar.gz";
     sha256 ="1w7rj4crrcyv25idmh4asbp2sxzwyihy5mbpw384bzxjzaxn9xpa";
   };
+  patchPhase = "sed -i /tini-static/d CMakeLists.txt";
   NIX_CFLAGS_COMPILE = [
     "-DPR_SET_CHILD_SUBREAPER=36"
     "-DPR_GET_CHILD_SUBREAPER=37"
   ];
   buildInputs = [ cmake ];
-  postInstall = ''
-    rm $out/bin/tini-static
-  '';
   meta = with stdenv.lib; {
     description = "A tiny but valid init for containers";
     homepage = https://github.com/krallin/tini;


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
