### PR TITLE
byzanz: Let it find gstreamer plugins

### DIFF
--- a/pkgs/applications/video/byzanz/default.nix
+++ b/pkgs/applications/video/byzanz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, which, gnome3, glib, intltool, pkgconfig, libtool, cairo, gtk3, gst_all_1 }:
+{ stdenv, fetchgit, wrapGAppsHook, which, gnome3, glib, intltool, pkgconfig, libtool, cairo, gtk3, gst_all_1, xorg }:
 
 stdenv.mkDerivation rec {
   version = "0.2.3.alpha";
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
-  buildInputs = [ which gnome3.gnome_common glib intltool pkgconfig libtool cairo gtk3 gst_all_1.gstreamer gst_all_1.gst-plugins-base ];
+  buildInputs = [ which gnome3.gnome_common glib intltool pkgconfig libtool cairo gtk3 xorg.xwininfo ]
+  ++ (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-bad gst-plugins-good gst-plugins-ugly gst-libav wrapGAppsHook ]);
 
   meta = with stdenv.lib; {
     description = "Tool to record a running X desktop to an animation suitable for presentation in a web browser";


### PR DESCRIPTION
###### Motivation for this change

Fix for #17599 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @MasseGuillaume @rvl @domenkozar @pSub 
