### PR TITLE
dmenu: Fix scripts to run commands by store paths

### DIFF
--- a/pkgs/applications/misc/dmenu/default.nix
+++ b/pkgs/applications/misc/dmenu/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
   inherit patches;
 
   postPatch = ''
-    sed -ri -e 's!\<(dmenu|stest)\>!'"$out/bin"'/&!g' dmenu_run
+    sed -ri -e 's!\<(dmenu|dmenu_path|stest)\>!'"$out/bin"'/&!g' dmenu_run
+    sed -ri -e 's!\<stest\>!'"$out/bin"'/&!g' dmenu_path
   '';
 
   preConfigure = ''


### PR DESCRIPTION
The `dmenu` package includes two binary programs, `dmenu` and `stest`,
and two shell scripts, `dmenu_run` and `dmenu_path`. `dmenu_run`
invokes `dmenu` and `dmenu_path`, and `dmenu_path` invokes `stest`.

`dmenu_run`'s invocation of `dmenu` was patched to run it by its full
store path, but its invocation of `dmenu_path` and `dmenu_path`'s
invocation of `stest` were not.

If `dmenu_path` and `stest` were not in the set of system packages or
otherwise in the `PATH`, this situation would result in `dmenu_run`
opening a dmenu instance with no menu entries (which would normally be
generated by `dmenu_path`, which `dmenu_run` couldn't find, as it was
running it by `PATH` lookup).

This commit fixes the package to also patch the invocation of
`dmenu_path` in `dmenu_run` and the invocations of `stest` in
`dmenu_path` to invoke those programs by their full store paths.

I have tested this change on NixOS.
