### PR TITLE
emby: 3.0.6030 -> 3.0.6060

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.0.6030";
+  version = "3.0.6060";
 
   src = fetchurl {
     url = "https://github.com/MediaBrowser/Emby/archive/${version}.tar.gz";
-    sha256 = "14fmgb8pwj11n57c1rm002ylwqapdqywbpsv7z6skairbaf6ny09";
+    sha256 = "1s895198x3kiqfznhp56vj67wld9fgh2wd7k8hw69mrasby0kmp3";
   };
 
   propagatedBuildInputs = with pkgs; [


### PR DESCRIPTION
###### Motivation for this change

New release available (new features + bugfixes)
https://github.com/MediaBrowser/Emby/releases/tag/3.0.6050
https://github.com/MediaBrowser/Emby/releases/tag/3.0.6060
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
