### PR TITLE
unclutter-xfixes: init at 1.2

### DIFF
--- a/pkgs/tools/misc/unclutter-xfixes/default.nix
+++ b/pkgs/tools/misc/unclutter-xfixes/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub,
+  xlibsWrapper, libev, libXi, libXfixes,
+  pkgconfig, asciidoc, libxslt, docbook_xsl }:
+
+let version = "1.2"; in
+
+stdenv.mkDerivation {
+  name = "unclutter-xfixes-${version}";
+  version = version;
+  
+  src = fetchFromGitHub {
+    owner = "Airblader";
+    repo = "unclutter-xfixes";
+    rev = "v${version}";
+    sha256 = "1pw567mj7mq5kr8mqnyrvy7jj62qfg6zgqfyzz21nncslddnjzg8";
+  };
+
+  nativeBuildInputs = [pkgconfig];
+  buildInputs = [
+    xlibsWrapper libev libXi libXfixes
+    asciidoc libxslt docbook_xsl
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "CC = gcc" "CC = cc"
+  '';
+
+  preBuild = ''
+    # The Makefile calls git only to discover the package version,
+    # but that doesn't work right in the build environment,
+    # so we fake it.
+    git() { echo v${version}; }
+    export -f git
+  '';
+
+  preInstall = ''
+    export DESTDIR=$out MANDIR=/man/man1
+  '';
+  
+  postInstall = ''
+    mv $out/usr/bin $out/bin
+    mv $out/usr/share/man $out/man
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Rewrite of unclutter using the X11 Xfixes extension";
+    platforms = platforms.unix;
+    license = stdenv.lib.licenses.mit;
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3993,6 +3993,8 @@ in
 
   unclutter = callPackage ../tools/misc/unclutter { };
 
+  unclutter-xfixes = callPackage ../tools/misc/unclutter-xfixes { };
+
   unbound = callPackage ../tools/networking/unbound { };
 
   units = callPackage ../tools/misc/units { };


### PR DESCRIPTION
###### Motivation for this change

This rewrite of `unclutter` (hides X mouse cursor) works better with my `ratpoison`.

From the Arch wiki regarding the old `unclutter`:

> Unclutter is a tool from the early 90s and has not been updated since. It works by creating fake windows or active pointer grabs, both of which often cause problems. By now, the X11 extensions Xinput2 and Xfixes have been released and are commonly found on most user systems. Using those, unclutter-xfixes-git (AUR) can provide the cursor hiding functionality without interfering with any application.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
