### PR TITLE
command-not-found.pl: don't rely on Config.pm anymore

### DIFF
--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -4,7 +4,6 @@ use strict;
 use DBI;
 use DBD::SQLite;
 use String::ShellQuote;
-use Config;
 
 my $program = $ARGV[0];
 
@@ -15,7 +14,7 @@ my $dbh = DBI->connect("dbi:SQLite:dbname=$dbPath", "", "")
 $dbh->{RaiseError} = 0;
 $dbh->{PrintError} = 0;
 
-my $system = $ENV{"NIX_SYSTEM"} // $Config{myarchname};
+my $system = $ENV{"NIX_SYSTEM"} // substr `nix-instantiate --eval -E builtins.currentSystem`, 1, -2;
 
 my $res = $dbh->selectall_arrayref(
     "select package from Programs where system = ? and name = ?",


### PR DESCRIPTION
As part of https://github.com/NixOS/nix/issues/341, don't rely on perl Nix modules for command-not-found.

cc @edolstra 
