### PR TITLE
Add libdynd and dynd-python

### DIFF
--- a/pkgs/development/libraries/libdynd/default.nix
+++ b/pkgs/development/libraries/libdynd/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+let version = "0.7.2"; in
+stdenv.mkDerivation {
+  name = "libdynd-${version}";
+
+  src = fetchFromGitHub {
+    owner = "libdynd";
+    repo = "libdynd";
+    rev = "v${version}";
+    sha256 = "0fkd5rawqni1cq51fmr76iw7ll4fmbahfwv4rglnsabbkylf73pr";
+  };
+
+  cmakeFlags = [
+    "-DDYND_BUILD_BENCHMARKS=OFF"
+  ];
+
+  buildInputs = [ cmake ];
+
+  outputs = [ "dev" "out" ];
+  outputDoc = "dev";
+
+  meta = with stdenv.lib; {
+    description = "C++ dynamic ndarray library, with Python exposure.";
+    homepage = http://libdynd.org;
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1531,7 +1531,7 @@ in
     hangul = callPackage ../tools/inputmethods/fcitx-engines/fcitx-hangul { };
 
     unikey = callPackage ../tools/inputmethods/fcitx-engines/fcitx-unikey { };
-    
+
     m17n = callPackage ../tools/inputmethods/fcitx-engines/fcitx-m17n { };
 
     mozc = callPackage ../tools/inputmethods/fcitx-engines/fcitx-mozc {
@@ -9809,6 +9809,8 @@ in
   zlib = callPackage ../development/libraries/zlib {
     fetchurl = fetchurlBoot;
   };
+
+  libdynd = callPackage ../development/libraries/libdynd { };
 
   zlog = callPackage ../development/libraries/zlog { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14849,6 +14849,39 @@ in modules // {
     };
   };
 
+  dynd = buildPythonPackage rec {
+    version = "0.7.2";
+    name = "dynd-${version}";
+    disabled = isPyPy;
+
+    src = pkgs.fetchFromGitHub {
+      owner = "libdynd";
+      repo = "dynd-python";
+      rev = "v${version}";
+      sha256 = "19igd6ibf9araqhq9bxmzbzdz05vp089zxvddkiik3b5gb7l17nh";
+    };
+
+    # setup.py invokes git on build but we're fetching a tarball, so
+    # can't retrieve git version. We hardcode:
+    preConfigure = ''
+      substituteInPlace setup.py --replace "ver = check_output(['git', 'describe', '--dirty'," "ver = '${version}'"
+      substituteInPlace setup.py --replace "'--always', '--match', 'v*']).decode('ascii').strip('\n')" ""
+    '';
+
+    # Python 3 works but has a broken import test that I couldn't
+    # figure out.
+    doCheck = !isPy3k;
+    buildInputs = with pkgs; [ cmake libdynd.dev self.cython ];
+    propagatedBuildInputs = with self; [ numpy pkgs.libdynd ];
+
+    meta = {
+      homepage = http://libdynd.org;
+      license = licenses.bsd2;
+      description = "Python exposure of dynd";
+      maintainers = with maintainers; [ teh ];
+    };
+  };
+
   livestreamer = buildPythonPackage rec {
     version = "1.12.2";
     name = "livestreamer-${version}";


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
