### PR TITLE
travis: build stdenv also

### DIFF
--- a/maintainers/scripts/travis-nox-review-pr.sh
+++ b/maintainers/scripts/travis-nox-review-pr.sh
@@ -48,7 +48,7 @@ while test -n "$1"; do
             echo "=== Fetching Nox from binary cache"
 
             # build nox silently so it's not in the log
-            nix-build "<nixpkgs>" -A nox
+            nix-build "<nixpkgs>" -A nox -A stdenv
             ;;
 
         pr)


### PR DESCRIPTION
###### Motivation for this change

This needs to be built ahead of time also to clean up the logs.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
