### PR TITLE
rofi: 1.1.0 -> 1.2.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -240,7 +240,7 @@
   mathnerd314 = "Mathnerd314 <mathnerd314.gph+hs@gmail.com>";
   matthiasbeyer = "Matthias Beyer <mail@beyermatthias.de>";
   maurer = "Matthew Maurer <matthew.r.maurer+nix@gmail.com>";
-  mbakke = "Marius Bakke <ymse@tuta.io>";
+  mbakke = "Marius Bakke <mbakke@fastmail.com>";
   matthewbauer = "Matthew Bauer <mjbauer95@gmail.com>";
   mbe = "Brandon Edens <brandonedens@gmail.com>";
   mboes = "Mathieu Boespflug <mboes@tweag.net>";

--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -1,15 +1,14 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, libX11, libxkbcommon, pango
-, cairo, glib, libxcb, xcbutil, xcbutilwm, libstartup_notification
-, i3Support ? false, i3
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libxkbcommon, pango
+, cairo, glib, libxcb, xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.0";
+  version = "1.2.0";
   name = "rofi-${version}";
 
   src = fetchurl {
     url = "https://github.com/DaveDavenport/rofi/releases/download/${version}/${name}.tar.xz";
-    sha256 = "1l8vl0mh7i0b1ycifqpg6392f5i4qxlv003m126skfk6fnlfq8hn";
+    sha256 = "0xxx0xpxhrhlhi2axq9867zqrhwqavc1qrr833k1xr0pvm5m0aqc";
   };
 
   preConfigure = ''
@@ -18,9 +17,10 @@ stdenv.mkDerivation rec {
     sed -i 's/~root/~nobody/g' test/helper-expand.c
   '';
 
-  buildInputs = [ autoreconfHook pkgconfig libX11 libxkbcommon pango
-    cairo libstartup_notification libxcb xcbutil xcbutilwm
-  ] ++ stdenv.lib.optional i3Support i3;
+  buildInputs = [ autoreconfHook pkgconfig libxkbcommon pango cairo
+    libstartup_notification libxcb xcbutil xcbutilwm xcbutilxrm
+  ];
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Window switcher, run dialog and dmenu replacement";

--- a/pkgs/servers/x11/xorg/xcb-util-xrm.nix
+++ b/pkgs/servers/x11/xorg/xcb-util-xrm.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, pkgconfig, m4, libxcb, xcbutil, libX11 }:
+
+stdenv.mkDerivation rec {
+  version = "1.0";
+  name = "xcb-util-xrm-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/Airblader/xcb-util-xrm/releases/download/v${version}/${name}.tar.bz2";
+    sha256 = "1h5vxwpd37dqfw9yj1l4zd9c5dj30r3g0szgysr6kd7xrqgaq04l";
+  };
+
+  buildInputs = [ pkgconfig m4 libxcb xcbutil ]
+    ++ stdenv.lib.optional doCheck [ libX11 ];
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "XCB utility functions for the X resource manager";
+    homepage = https://github.com/Airblader/xcb-util-xrm;
+    license = licenses.mit; # X11 variant
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9755,6 +9755,8 @@ in
   xcb-util-cursor = xorg.xcbutilcursor;
   xcb-util-cursor-HEAD = callPackage ../development/libraries/xcb-util-cursor/HEAD.nix { };
 
+  xcbutilxrm = callPackage ../servers/x11/xorg/xcb-util-xrm.nix { };
+
   xdo = callPackage ../tools/misc/xdo { };
 
   xineLib = callPackage ../development/libraries/xine-lib {


### PR DESCRIPTION
###### Motivation for this change

Update to latest version.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

i3Support flag no longer needed; libX11 dependency dropped; new xcb-util-xrm dependency added. Also enabled tests.

Full changelog here: https://github.com/DaveDavenport/rofi/releases/tag/1.2.0

`xcb-util-xrm`, doesn't (yet?) have an official entry on https://xcb.freedesktop.org, so added it in a separate file.

CC @garbas 
