### PR TITLE
fcitx-engines.table-other: fix build for cmake 3.6

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fcitx, gettext }:
+{ stdenv, fetchurl, fetchpatch, cmake, fcitx, gettext }:
 
 stdenv.mkDerivation rec {
   name = "fcitx-table-other-${version}";
@@ -10,6 +10,13 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ cmake fcitx gettext ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/fcitx/fcitx-table-other/pull/2.diff";
+      sha256 = "1ai2zw4c0k5rr3xjhf4z7kcml9v8hvsbwdshwpmz2ybly2ncf5y7";
+    })
+  ];
 
   preInstall = ''
    substituteInPlace tables/cmake_install.cmake \


### PR DESCRIPTION
###### Motivation for this change

The package broke due to the cmake 3.6 update.
[Hydra build](https://hydra.nixos.org/build/38451512) - [error log](https://hydra.nixos.org/build/38451512/log/tail-reload)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
