### PR TITLE
New: drone (drone.io)

### DIFF
--- a/pkgs/development/tools/continuous-integration/drone/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone/default.nix
@@ -2,18 +2,47 @@
 
 buildGoPackage rec {
   name = "drone.io-${version}";
-  version = "0.5-20160813-${stdenv.lib.strings.substring 0 7 revision}";
-  revision = "e82ddd002276deb1741eca5345260ff1c2059abb";
+  version = "0.5-20161104-${stdenv.lib.strings.substring 0 7 revision}";
+  revision = "232df356afeeb4aec5e2959fa54b084dcadb267f";
   goPackagePath = "github.com/drone/drone";
 
+  # These dependencies pulled (in `drone` buildprocess) via Makefile,
+  # so I extracted them here, all revisions pinned by same date, as ${version}
   extraSrcs = [ 
     {
       goPackagePath = "github.com/drone/drone-ui";
       src = fetchFromGitHub {
         owner = "drone";
         repo = "drone-ui";
-        rev = "43bdae89a59c4d26e24f80f65748b9f78f1df0a9";
-        sha256 = "0k0kg07nkk595yk10n1fym3x8wlgn34n3f4mb237gqp8hhlnp5ra";
+        rev = "e66df33b4620917a2e7b59760887cc3eed543664";
+        sha256 = "0d50xdzkh9akpf5c0sqgcgy11v2vz858l36jp5snr94zkrdkv0n1";
+      };
+    }
+    {
+      goPackagePath = "github.com/drone/mq";
+      src = fetchFromGitHub {
+        owner = "drone";
+        repo = "mq";
+        rev = "0f296601feeed952dabd038793864acdbefe6dbe";
+        sha256 = "1k7439c90l4w29g7wyixfmpbkap7bn8yh8zynbjyjf9qjzwsnw97";
+      };
+    }
+    {
+      goPackagePath = "github.com/tidwall/redlog";
+      src = fetchFromGitHub {
+        owner = "tidwall";
+        repo = "redlog";
+        rev = "54086c8553cd23aba652513a87d2b085ea961541";
+        sha256 = "12a7mk6r8figjinzkbisxcaly6sasggy62m8zs4cf35lpq2lhffq";
+      };
+    }
+    {
+      goPackagePath = "golang.org/x/crypto";
+      src = fetchFromGitHub {
+        owner = "golang";
+        repo = "crypto";
+        rev = "9477e0b78b9ac3d0b03822fd95422e2fe07627cd";
+        sha256 = "1qcqai6nf1q50z9ga7r4ljnrh1qz49kwlcqpri4bknx732lqq0v5";
       };
     }
   ];
@@ -24,11 +53,15 @@ buildGoPackage rec {
     go generate github.com/drone/drone/store/datastore/ddl
   '';
 
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -delete_rpath $out/lib -add_rpath $bin $bin/bin/drone
+  '';
+
   src = fetchFromGitHub {
     owner = "drone";
     repo = "drone";
     rev = revision;
-    sha256 = "11ld8dzjn4g7wbfm4xqr3ih2dqaqqa8rdnw7m7d3sd78w7r7s3gs";
+    sha256 = "0xrijcrlv3ag9n2kywkrhdkxyhxc8fs6zqn0hyav6a6jpqnsahg3";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/continuous-integration/drone/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, buildGoPackage, go-bindata, go-bindata-assetfs }:
+
+buildGoPackage rec {
+  name = "drone.io-${version}";
+  version = "0.5-20160813-${stdenv.lib.strings.substring 0 7 revision}";
+  revision = "e82ddd002276deb1741eca5345260ff1c2059abb";
+  goPackagePath = "github.com/drone/drone";
+
+  extraSrcs = [ 
+    {
+      goPackagePath = "github.com/drone/drone-ui";
+      src = fetchFromGitHub {
+        owner = "drone";
+        repo = "drone-ui";
+        rev = "43bdae89a59c4d26e24f80f65748b9f78f1df0a9";
+        sha256 = "0k0kg07nkk595yk10n1fym3x8wlgn34n3f4mb237gqp8hhlnp5ra";
+      };
+    }
+  ];
+  nativeBuildInputs = [ go-bindata go-bindata-assetfs ];
+
+  preBuild = ''
+    go generate github.com/drone/drone/server/template
+    go generate github.com/drone/drone/store/datastore/ddl
+  '';
+
+  src = fetchFromGitHub {
+    owner = "drone";
+    repo = "drone";
+    rev = revision;
+    sha256 = "11ld8dzjn4g7wbfm4xqr3ih2dqaqqa8rdnw7m7d3sd78w7r7s3gs";
+  };
+
+  meta = with stdenv.lib; {
+    maintainer = with maintainers; [ avnik ];
+    license = licenses.asl20;
+    description = "Continuous Integration platform built on container technology";
+  };
+}

--- a/pkgs/development/tools/go-bindata-assetfs/default.nix
+++ b/pkgs/development/tools/go-bindata-assetfs/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "go-bindata-assetfs-${version}";
+  version = "20160814-${rev}";
+  rev = "e1a2a7e";
+  goPackagePath = "github.com/elazarl/go-bindata-assetfs";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "elazarl";
+    repo = "go-bindata-assetfs";
+    sha256 = "0b6q8h9fwpgpkvml1j87wq9174g7px1dmskhm884drpvswda2djk";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Serve embedded files from jteeuwen/go-bindata";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ avnik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11242,6 +11242,8 @@ in
 
   go-bindata = callPackage ../development/tools/go-bindata { };
 
+  go-bindata-assetfs = callPackage ../development/tools/go-bindata-assetfs { };
+
   gocode = callPackage ../development/tools/gocode { };
 
   kgocode = callPackage ../applications/misc/kgocode {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1430,6 +1430,8 @@ in
 
   driftnet = callPackage ../tools/networking/driftnet {};
 
+  drone = callPackage ../development/tools/continuous-integration/drone { };
+
   dropbear = callPackage ../tools/networking/dropbear { };
 
   dtach = callPackage ../tools/misc/dtach { };


### PR DESCRIPTION
###### Motivation for this change

Build drone.io package.
(only cli functionality tested, no server mode)

Also go-bindata-assetfs packaged, as build requirement
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
