### PR TITLE
crashplan: Wait for filesystems to be mounted before starting

### DIFF
--- a/nixos/modules/services/backup/crashplan.nix
+++ b/nixos/modules/services/backup/crashplan.nix
@@ -28,7 +28,7 @@ with lib;
       description = "CrashPlan Backup Engine";
 
       wantedBy = [ "multi-user.target" ];
-      after    = [ "network.target" ];
+      after    = [ "network.target" "local-fs.target" ];
 
       preStart = ''
         ensureDir() {


### PR DESCRIPTION
###### Motivation for this change

Without this, there is a race condition between mounting local filesystems and starting Crashplan. If the network is faster than the disks (which is often true), it'll end up getting the /var/lib/crashplan on the root partition, to hilarious effect.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/17728)

<!-- Reviewable:end -->
