### PR TITLE
fcitx-engines.table-other: fix build for cmake 3.6

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
@@ -5,11 +5,14 @@ stdenv.mkDerivation rec {
   version = "0.2.3";
 
   src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-table-other/${name}.tar.xz";
+    url    = "http://download.fcitx-im.org/fcitx-table-other/${name}.tar.xz";
     sha256 = "12fqbsjrpx5pndx2jf7fksrlp01a4yxz62h2vpxrbkpk73ljly4v";
   };
 
   buildInputs = [ cmake fcitx gettext ];
+
+  # https://github.com/fcitx/fcitx-table-other/pull/2
+  patches = [ ./make-dir.patch ];
 
   preInstall = ''
    substituteInPlace tables/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/make-dir.patch
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/make-dir.patch
@@ -1,0 +1,16 @@
+diff --git a/tables/CMakeLists.txt b/tables/CMakeLists.txt
+index 1f501ba..68d8c51 100644
+--- a/tables/CMakeLists.txt
++++ b/tables/CMakeLists.txt
+@@ -50,8 +50,11 @@ set(CONF_FILE)
+ foreach(table ${TABLE_NAMES})
+   fcitx_translate_add_apply_source("${table}.conf.in"
+     "${CMAKE_CURRENT_BINARY_DIR}/${table}.conf")
++  get_filename_component(out_dir
++    "${CMAKE_CURRENT_BINARY_DIR}/${table}.mb" PATH)
+   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${table}.mb"
+     DEPENDS "${table}.txt" "${TXT2MB}"
++    COMMAND "${CMAKE_COMMAND}" -E make_directory "${out_dir}"
+     COMMAND "${TXT2MB}" ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${table}.txt"
+     "${CMAKE_CURRENT_BINARY_DIR}/${table}.mb")
+   set(MB_FILE ${MB_FILE} "${CMAKE_CURRENT_BINARY_DIR}/${table}.mb")


### PR DESCRIPTION
###### Motivation for this change

The package broke due to the cmake 3.6 update.
[Hydra build](https://hydra.nixos.org/build/38451512) - [error log](https://hydra.nixos.org/build/38451512/log/tail-reload)
#17721 successor
#17721 failed because upstream patch was amended, making the patch hash to change. Also, after the changes, the amended patch diverged too much so we cannot use it as it is.

This bring a custom patch to fix the build until a new `table-other` version is released.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
