### PR TITLE
ghc8: apply patches to fix https://ghc.haskell.org/trac/ghc/ticket/12130

### DIFF
--- a/pkgs/development/compilers/ghc/8.0.1.nix
+++ b/pkgs/development/compilers/ghc/8.0.1.nix
@@ -1,10 +1,16 @@
 { stdenv, fetchurl, fetchpatch, bootPkgs, perl, gmp, ncurses, libiconv, binutils, coreutils
-, hscolour
+, hscolour, patchutils
 }:
 
 let
   inherit (bootPkgs) ghc;
 
+  fetchFilteredPatch = args: fetchurl (args // {
+    downloadToTemp = true;
+    postFetch = ''
+      ${patchutils}/bin/filterdiff --clean --strip-match=1 -x 'testsuite/*' "$downloadedFile" > "$out"
+    '';
+  });
 in
 stdenv.mkDerivation rec {
   version = "8.0.1";
@@ -17,6 +23,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./ghc-8.x-dont-pass-linker-flags-via-response-files.patch  # https://github.com/NixOS/nixpkgs/issues/10752
+
+    # Fix https://ghc.haskell.org/trac/ghc/ticket/12130
+    (fetchFilteredPatch { url = https://git.haskell.org/ghc.git/patch/4d71cc89b4e9648f3fbb29c8fcd25d725616e265; sha256 = "0syaxb4y4s2dc440qmrggb4vagvqqhb55m6mx12rip4i9qhxl8k0"; })
+    (fetchFilteredPatch { url = https://git.haskell.org/ghc.git/patch/2f8cd14fe909a377b3e084a4f2ded83a0e6d44dd; sha256 = "06zvlgcf50ab58bw6yw3krn45dsmhg4cmlz4nqff8k4z1f1bj01v"; })
   ];
 
   buildInputs = [ ghc perl hscolour ];


### PR DESCRIPTION
###### Motivation for this change

There was a regression in GHC 8.0.1 described in https://ghc.haskell.org/trac/ghc/ticket/12130 that prevents, among other things, Yesod projects to build.

This patch pulls in the fixes from that issue so that we do not need to wait for 8.0.2. @jezen depends on this to move his project forward and he was previously struggling to get all the required libraries to build on 7.10.3. He has confirmed that the patch works.

Patches pulled in:

https://git.haskell.org/ghc.git/commitdiff/4d71cc89b4e9648f3fbb29c8fcd25d725616e265
https://git.haskell.org/ghc.git/commitdiff/2f8cd14fe909a377b3e084a4f2ded83a0e6d44dd

cc @peti
