### PR TITLE
midori: update to current webkitgtk

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13850,9 +13850,7 @@ in
 
   mid2key = callPackage ../applications/audio/mid2key { };
 
-  midori-unwrapped = callPackage ../applications/networking/browsers/midori {
-    webkitgtk = webkitgtk24x;
-  };
+  midori-unwrapped = callPackage ../applications/networking/browsers/midori { };
   midori = wrapFirefox midori-unwrapped { };
 
   mikmod = callPackage ../applications/audio/mikmod { };


### PR DESCRIPTION
###### Summary
1. Update to current webkitgtk. (https://github.com/NixOS/nixpkgs/issues/12023)
2. Use wrapGAppsHook.
3. Add missing (libxcb...) and implicit (gtk3) dependencies.
4. Use nativeBuildInputs.
5. Optional zeitgeistSupport.
6. Miscellaneous cleanups...

(EDIT) Incidentally, Looking at the travis logs, I don't know why travis is trying to build webkitgtk, but I think webkitgtk is missing pcre.dev  as a build dependency seeing how it can't find _libpcre.pc_.
It shouldn't affect this PR though.
(EDIT) @koral I tried locally to add _pcre.dev_ and the errors are gone. I won't make a PR since it takes me days to build webkitgtk so I can't be sure how it will effect\affect the build, but the changes can be found here: https://github.com/RamKromberg/nixpkgs/commit/7b4d4b192f1cf32c843a3d51bebbbf9d2bc09271 . Again, this isn't related to this PR.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
