### PR TITLE
btfs: 2.10 -> 2.11

### DIFF
--- a/pkgs/os-specific/linux/btfs/default.nix
+++ b/pkgs/os-specific/linux/btfs/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "btfs-${version}";
-  version = "2.10";
+  version = "2.11";
 
   src = fetchFromGitHub {
     owner = "johang";
     repo = "btfs";
-    rev = "2eac5e70a1ed22fa0761b6357c54fd90eea02de6";
-    sha256 = "146vgwn79dnbkkn35safga55lkwhvarkmilparmr26hjb56cs1dk";
+    rev = "fe585ca285690579db50b1624cec81ae76279ba2";
+    sha256 = "1vqya2k8cx5x7jfapl9vmmb002brwbsz4j5xs4417kzv3j2bsms9";
   };
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -646,9 +646,7 @@ in
     sha256 = "0p2sxrpzd0vsk11zf3kb5h12yl1nq4yypb5mpjrm8ww0cfaijck2";
   };
 
-  btfs = callPackage ../os-specific/linux/btfs {
-    libtorrentRasterbar = libtorrentRasterbar_1_09;
-  };
+  btfs = callPackage ../os-specific/linux/btfs { };
 
   cabal2nix = self.haskell.lib.overrideCabal self.haskellPackages.cabal2nix (drv: {
     isLibrary = false;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Should I remove `libtorrentRasterbar_1_09`?
