### PR TITLE
Add NixOS modules search logic into libkmod

### DIFF
--- a/nixos/modules/config/zram.nix
+++ b/nixos/modules/config/zram.nix
@@ -8,7 +8,7 @@ let
 
   devices = map (nr: "zram${toString nr}") (range 0 (cfg.numDevices - 1));
 
-  modprobe = "${config.system.sbin.modprobe}/sbin/modprobe";
+  modprobe = "${pkgs.kmod}/bin/modprobe";
 
 in
 

--- a/nixos/modules/hardware/video/bumblebee.nix
+++ b/nixos/modules/hardware/video/bumblebee.nix
@@ -75,7 +75,6 @@ in
       serviceConfig = {
         ExecStart = "${bumblebee}/bin/bumblebeed --use-syslog -g ${cfg.group} --driver ${cfg.driver}";
       };
-      environment.MODULE_DIR="/run/current-system/kernel-modules/lib/modules/";
     };
   };
 }

--- a/nixos/modules/hardware/video/webcam/facetimehd.nix
+++ b/nixos/modules/hardware/video/webcam/facetimehd.nix
@@ -36,7 +36,6 @@ in
 
     # and load it back on resume
     powerManagement.resumeCommands = ''
-      export MODULE_DIR=/run/current-system/kernel-modules/lib/modules
       ${pkgs.kmod}/bin/modprobe -v facetimehd
     '';
 

--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -72,8 +72,6 @@ in
           ExecStart = "${tlp}/bin/tlp init start";
           ExecStop = "${tlp}/bin/tlp init stop";
         };
-
-        environment.MODULE_DIR="/run/current-system/kernel-modules/lib/modules/";
       };
 
       tlp-sleep = {
@@ -92,8 +90,6 @@ in
           ExecStart = "${tlp}/bin/tlp suspend";
           ExecStop = "${tlp}/bin/tlp resume";
         };
-
-        environment.MODULE_DIR="/run/current-system/kernel-modules/lib/modules/";
       };
     };
 

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -58,7 +58,7 @@ let
       # Fix some paths in the standard udev rules.  Hacky.
       for i in $out/*.rules; do
         substituteInPlace $i \
-          --replace \"/sbin/modprobe \"${config.system.sbin.modprobe}/sbin/modprobe \
+          --replace \"/sbin/modprobe \"${pkgs.kmod}/bin/modprobe \
           --replace \"/sbin/mdadm \"${pkgs.mdadm}/sbin/mdadm \
           --replace \"/sbin/blkid \"${pkgs.utillinux}/sbin/blkid \
           --replace \"/bin/mount \"${pkgs.utillinux}/bin/mount \

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -316,8 +316,7 @@ in
       '';
 
     systemd.services.systemd-udevd =
-      { environment.MODULE_DIR = "/run/booted-system/kernel-modules/lib/modules";
-        restartTriggers = cfg.packages;
+      { restartTriggers = cfg.packages;
       };
 
   };

--- a/nixos/modules/services/network-filesystems/openafs-client/default.nix
+++ b/nixos/modules/services/network-filesystems/openafs-client/default.nix
@@ -80,7 +80,7 @@ in
       preStart = ''
         mkdir -p -m 0755 /afs
         mkdir -m 0700 -p ${cfg.cacheDirectory}
-        ${pkgs.kmod}/sbin/insmod ${openafsPkgs}/lib/openafs/libafs-*.ko || true
+        ${pkgs.kmod}/bin/insmod ${openafsPkgs}/lib/openafs/libafs-*.ko || true
         ${openafsPkgs}/sbin/afsd -confdir ${afsConfig} -cachedir ${cfg.cacheDirectory} ${if cfg.sparse then "-dynroot-sparse" else "-dynroot"} -fakestat -afsdb
         ${openafsPkgs}/bin/fs setcrypt ${if cfg.crypt then "on" else "off"}
       '';

--- a/nixos/modules/services/networking/fan.nix
+++ b/nixos/modules/services/networking/fan.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.networking.fan;
-  modprobe = "${config.system.sbin.modprobe}/sbin/modprobe";
+  modprobe = "${pkgs.kmod}/bin/modprobe";
 
 in
 

--- a/nixos/modules/services/networking/strongswan.nix
+++ b/nixos/modules/services/networking/strongswan.nix
@@ -118,7 +118,7 @@ in
     systemd.services.strongswan = {
       description = "strongSwan IPSec Service";
       wantedBy = [ "multi-user.target" ];
-      path = with pkgs; [ config.system.sbin.modprobe iproute iptables utillinux ]; # XXX Linux
+      path = with pkgs; [ kmod iproute iptables utillinux ]; # XXX Linux
       wants = [ "keys.target" ];
       after = [ "network.target" "keys.target" ];
       environment = {

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -228,7 +228,6 @@ in
     systemd.services."systemd-modules-load" =
       { wantedBy = [ "multi-user.target" ];
         restartTriggers = [ kernelModulesConf ];
-        environment.MODULE_DIR = "/run/booted-system/kernel-modules/lib/modules";
         serviceConfig =
           { # Ignore failed module loads.  Typically some of the
             # modules in ‘boot.kernelModules’ are "nice to have but
@@ -236,10 +235,6 @@ in
             # barf on those.
             SuccessExitStatus = "0 1";
           };
-      };
-
-    systemd.services.kmod-static-nodes =
-      { environment.MODULE_DIR = "/run/booted-system/kernel-modules/lib/modules";
       };
 
     lib.kernelConfig = {

--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -8,41 +8,6 @@ with lib;
 
   options = {
 
-    system.sbin.modprobe = mkOption {
-      internal = true;
-      default = pkgs.stdenv.mkDerivation {
-        name = "modprobe";
-        buildCommand = ''
-          mkdir -p $out/bin
-          for i in ${pkgs.kmod}/sbin/*; do
-            name=$(basename $i)
-            echo "$text" > $out/bin/$name
-            echo 'exec '$i' "$@"' >> $out/bin/$name
-            chmod +x $out/bin/$name
-          done
-          ln -s bin $out/sbin
-        '';
-        text =
-          ''
-            #! ${pkgs.stdenv.shell}
-            export MODULE_DIR=/run/current-system/kernel-modules/lib/modules
-
-            # Fall back to the kernel modules used at boot time if the
-            # modules in the current configuration don't match the
-            # running kernel.
-            if [ ! -d "$MODULE_DIR/$(${pkgs.coreutils}/bin/uname -r)" ]; then
-                MODULE_DIR=/run/booted-system/kernel-modules/lib/modules/
-            fi
-
-          '';
-        meta.priority = 4;
-      };
-      description = ''
-        Wrapper around modprobe that sets the path to the modules
-        tree.
-      '';
-    };
-
     boot.blacklistedKernelModules = mkOption {
       type = types.listOf types.str;
       default = [];
@@ -87,7 +52,7 @@ with lib;
       '';
     environment.etc."modprobe.d/debian.conf".source = pkgs.kmod-debian-aliases;
 
-    environment.systemPackages = [ config.system.sbin.modprobe pkgs.kmod ];
+    environment.systemPackages = [ pkgs.kmod ];
 
     system.activationScripts.modprobe =
       ''
@@ -95,7 +60,7 @@ with lib;
         # in the right location in the Nix store for kernel modules).
         # We need this when the kernel (or some module) auto-loads a
         # module.
-        echo ${config.system.sbin.modprobe}/sbin/modprobe > /proc/sys/kernel/modprobe
+        echo ${pkgs.kmod}/bin/modprobe > /proc/sys/kernel/modprobe
       '';
 
     environment.sessionVariables.MODULE_DIR = "/run/current-system/kernel-modules/lib/modules";

--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -63,8 +63,6 @@ with lib;
         echo ${pkgs.kmod}/bin/modprobe > /proc/sys/kernel/modprobe
       '';
 
-    environment.sessionVariables.MODULE_DIR = "/run/current-system/kernel-modules/lib/modules";
-
   };
 
 }

--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -207,6 +207,5 @@ exec {logOutFd}>&- {logErrFd}>&-
 # Start systemd.
 echo "starting systemd..."
 PATH=/run/current-system/systemd/lib/systemd \
-    MODULE_DIR=/run/booted-system/kernel-modules/lib/modules \
     LOCALE_ARCHIVE=/run/current-system/sw/lib/locale/locale-archive \
     exec systemd

--- a/nixos/modules/tasks/cpu-freq.nix
+++ b/nixos/modules/tasks/cpu-freq.nix
@@ -38,7 +38,7 @@ in
       description = "CPU Frequency Governor Setup";
       after = [ "systemd-modules-load.service" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ cpupower config.system.sbin.modprobe ];
+      path = [ cpupower pkgs.kmod ];
       unitConfig.ConditionVirtualization = false;
       serviceConfig = {
         Type = "oneshot";

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -96,7 +96,6 @@ in
         } // proxy_env;
 
         path = [ pkgs.kmod ] ++ (optional (cfg.storageDriver == "zfs") pkgs.zfs);
-        environment.MODULE_DIR = "/run/current-system/kernel-modules/lib/modules";
 
         postStart = if cfg.socketActivation then "" else cfg.postStart;
 

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -95,7 +95,7 @@ in
           LimitNPROC = 1048576;
         } // proxy_env;
 
-        path = [ config.system.sbin.modprobe ] ++ (optional (cfg.storageDriver == "zfs") pkgs.zfs);
+        path = [ pkgs.kmod ] ++ (optional (cfg.storageDriver == "zfs") pkgs.zfs);
         environment.MODULE_DIR = "/run/current-system/kernel-modules/lib/modules";
 
         postStart = if cfg.socketActivation then "" else cfg.postStart;

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -135,13 +135,13 @@ let
         }
         ''
           # Create a /boot EFI partition with 40M
-          ${pkgs.gptfdisk}/sbin/sgdisk -G /dev/vda
-          ${pkgs.gptfdisk}/sbin/sgdisk -a 1 -n 1:34:2047 -c 1:"BIOS Boot Partition" -t 1:ef02 /dev/vda
-          ${pkgs.gptfdisk}/sbin/sgdisk -a 512 -N 2 -c 2:"EFI System" -t 2:ef00 /dev/vda
-          ${pkgs.gptfdisk}/sbin/sgdisk -A 1:set:1 /dev/vda
-          ${pkgs.gptfdisk}/sbin/sgdisk -A 2:set:2 /dev/vda
-          ${pkgs.gptfdisk}/sbin/sgdisk -h 2 /dev/vda
-          ${pkgs.gptfdisk}/sbin/sgdisk -C /dev/vda
+          ${pkgs.gptfdisk}/bin/sgdisk -G /dev/vda
+          ${pkgs.gptfdisk}/bin/sgdisk -a 1 -n 1:34:2047 -c 1:"BIOS Boot Partition" -t 1:ef02 /dev/vda
+          ${pkgs.gptfdisk}/bin/sgdisk -a 512 -N 2 -c 2:"EFI System" -t 2:ef00 /dev/vda
+          ${pkgs.gptfdisk}/bin/sgdisk -A 1:set:1 /dev/vda
+          ${pkgs.gptfdisk}/bin/sgdisk -A 2:set:2 /dev/vda
+          ${pkgs.gptfdisk}/bin/sgdisk -h 2 /dev/vda
+          ${pkgs.gptfdisk}/bin/sgdisk -C /dev/vda
           ${pkgs.utillinux}/bin/sfdisk /dev/vda -A 2
           . /sys/class/block/vda2/uevent
           mknod /dev/vda2 b $MAJOR $MINOR
@@ -151,11 +151,11 @@ let
           ${pkgs.mtools}/bin/mlabel -i /dev/vda2 ::boot
 
           # Mount /boot; load necessary modules first.
-          ${pkgs.kmod}/sbin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_cp437.ko.xz || true
-          ${pkgs.kmod}/sbin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_iso8859-1.ko.xz || true
-          ${pkgs.kmod}/sbin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/fat.ko.xz || true
-          ${pkgs.kmod}/sbin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/vfat.ko.xz || true
-          ${pkgs.kmod}/sbin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/efivarfs/efivarfs.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_cp437.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/nls/nls_iso8859-1.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/fat.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/fat/vfat.ko.xz || true
+          ${pkgs.kmod}/bin/insmod ${pkgs.linux}/lib/modules/*/kernel/fs/efivarfs/efivarfs.ko.xz || true
           mkdir /boot
           mount /dev/vda2 /boot
 
@@ -370,7 +370,7 @@ in
     boot.initrd.extraUtilsCommands =
       ''
         # We need mke2fs in the initrd.
-        copy_bin_and_libs ${pkgs.e2fsprogs}/sbin/mke2fs
+        copy_bin_and_libs ${pkgs.e2fsprogs}/bin/mke2fs
       '';
 
     boot.initrd.postDeviceCommands =

--- a/pkgs/development/tools/misc/lttng-tools/default.nix
+++ b/pkgs/development/tools/misc/lttng-tools/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ popt libuuid liburcu lttng-ust libxml2 ];
 
   prePatch = ''
-    sed -e "s|/sbin/modprobe|${kmod}/sbin/modprobe|g" \
+    sed -e "s|/sbin/modprobe|${kmod}/bin/modprobe|g" \
         -i src/bin/lttng-sessiond/modprobe.c
   '';
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -93,7 +93,7 @@ let
             echo "stripping FHS paths in \`$mf'..."
             sed -i "$mf" -e 's|/usr/bin/||g ; s|/bin/||g ; s|/sbin/||g'
         done
-        sed -i Makefile -e 's|= depmod|= ${kmod}/sbin/depmod|'
+        sed -i Makefile -e 's|= depmod|= ${kmod}/bin/depmod|'
       '';
 
       configurePhase = ''
@@ -188,7 +188,7 @@ let
         find -empty -type d -delete
 
         # Remove reference to kmod
-        sed -i Makefile -e 's|= ${kmod}/sbin/depmod|= depmod|'
+        sed -i Makefile -e 's|= ${kmod}/bin/depmod|= depmod|'
       '' else optionalString installsFirmware ''
         make firmware_install $makeFlags "''${makeFlagsArray[@]}" \
           $installFlags "''${installFlagsArray[@]}"

--- a/pkgs/os-specific/linux/kmod/aggregator.nix
+++ b/pkgs/os-specific/linux/kmod/aggregator.nix
@@ -21,7 +21,7 @@ buildEnv {
       # kernel version number, otherwise depmod will use `uname -r'.
       if test -w $out/lib/modules/$kernelVersion; then
           rm -f $out/lib/modules/$kernelVersion/modules.*
-          ${kmod}/sbin/depmod -b $out -a $kernelVersion
+          ${kmod}/bin/depmod -b $out -a $kernelVersion
       fi
     '';
 }

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -1,25 +1,37 @@
-{ stdenv, fetchurl, xz, zlib, pkgconfig, libxslt }:
+{ stdenv, lib, fetchurl, autoreconfHook, xz, zlib, pkgconfig, libxslt }:
 
-stdenv.mkDerivation rec {
-  name = "kmod-22";
+let
+  systems = [ "current-system" "booted-system" ];
+  modulesDirs = lib.concatMapStringsSep ":" (x: "/run/${x}/kernel-modules/lib/modules") systems;
+
+in stdenv.mkDerivation rec {
+  name = "kmod-${version}";
+  version = "22";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/kernel/kmod/${name}.tar.xz";
     sha256 = "10lzfkmnpq6a43a3gkx7x633njh216w0bjwz31rv8a1jlgg1sfxs";
   };
 
-  buildInputs = [ pkgconfig libxslt xz /* zlib */ ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig libxslt ];
+  buildInputs = [ xz /* zlib */ ];
 
-  configureFlags = [ "--sysconfdir=/etc" "--with-xz" /* "--with-zlib" */ ];
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--with-xz"
+    "--with-modulesdirs=${modulesDirs}"
+    # "--with-zlib"
+  ];
 
   patches = [ ./module-dir.patch ];
 
   postInstall = ''
-    ln -s kmod $out/bin/lsmod
-    mkdir -p $out/sbin
-    for prog in rmmod insmod modinfo modprobe depmod; do
-      ln -sv $out/bin/kmod $out/sbin/$prog
+    for prog in rmmod insmod lsmod modinfo modprobe depmod; do
+      ln -sv $out/bin/kmod $out/bin/$prog
     done
+
+    # Backwards compatibility
+    ln -s bin $out/sbin
   '';
 
   meta = {

--- a/pkgs/os-specific/linux/kmod/module-dir.patch
+++ b/pkgs/os-specific/linux/kmod/module-dir.patch
@@ -1,7 +1,46 @@
-diff -ru -x '*~' kmod-17-orig/libkmod/libkmod.c kmod-17/libkmod/libkmod.c
---- kmod-17-orig/libkmod/libkmod.c	2014-04-01 12:40:37.161940089 +0200
-+++ kmod-17/libkmod/libkmod.c	2014-04-17 13:47:15.871441987 +0200
-@@ -201,7 +201,7 @@
+diff --git a/Makefile.am b/Makefile.am
+index d4eeb7e..5c9f603 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -19,6 +19,7 @@ AM_CPPFLAGS = \
+ 	-include $(top_builddir)/config.h \
+ 	-I$(top_srcdir) \
+ 	-DSYSCONFDIR=\""$(sysconfdir)"\" \
++	-DMODULESDIRS=\""$(shell echo $(modulesdirs) | $(SED) 's|:|\\",\\"|g')"\" \
+ 	${zlib_CFLAGS}
+ 
+ AM_CFLAGS = $(OUR_CFLAGS)
+diff --git a/configure.ac b/configure.ac
+index 23510c8..66490cf 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -202,6 +202,12 @@ GTK_DOC_CHECK([1.14],[--flavour no-tmpl-flat])
+ ], [
+ AM_CONDITIONAL([ENABLE_GTK_DOC], false)])
+ 
++AC_ARG_WITH([modulesdirs],
++	AS_HELP_STRING([--with-modulesdirs=DIRS], [Kernel modules directories, separated by :]),
++	[],
++	[with_modulesdirs=/lib/modules])
++AC_SUBST([modulesdirs], [$with_modulesdirs])
++
+ 
+ #####################################################################
+ # Default CFLAGS and LDFLAGS
+diff --git a/libkmod/libkmod.c b/libkmod/libkmod.c
+index 69fe431..d37da32 100644
+--- a/libkmod/libkmod.c
++++ b/libkmod/libkmod.c
+@@ -206,12 +206,15 @@ static int log_priority(const char *priority)
+ 	return 0;
+ }
+ 
+-static const char *dirname_default_prefix = "/lib/modules";
++static const char *dirname_default_prefixes[] = {
++	MODULESDIRS,
++	NULL
++};
+ 
  static char *get_kernel_release(const char *dirname)
  {
  	struct utsname u;
@@ -10,51 +49,109 @@ diff -ru -x '*~' kmod-17-orig/libkmod/libkmod.c kmod-17/libkmod/libkmod.c
  
  	if (dirname != NULL)
  		return path_make_absolute_cwd(dirname);
-@@ -209,7 +209,10 @@
+@@ -219,8 +222,42 @@ static char *get_kernel_release(const char *dirname)
  	if (uname(&u) < 0)
  		return NULL;
  
 -	if (asprintf(&p, "%s/%s", dirname_default_prefix, u.release) < 0)
-+	if ((dirname_prefix = getenv("MODULE_DIR")) == NULL)
-+		dirname_prefix = dirname_default_prefix;
+-		return NULL;
++	if ((dirname_prefix = getenv("MODULE_DIR")) != NULL) {
++		if(asprintf(&p, "%s/%s", dirname_prefix, u.release) < 0)
++			return NULL;
++	} else {
++		size_t i;
++		char buf[PATH_MAX];
 +
-+	if (asprintf(&p, "%s/%s", dirname_prefix, u.release) < 0)
- 		return NULL;
++		for (i = 0; dirname_default_prefixes[i] != NULL; i++) {
++			int plen;
++			struct stat dirstat;
++
++			plen = snprintf(buf, sizeof(buf), "%s/%s", dirname_default_prefixes[i], u.release);
++			if (plen < 0)
++				return NULL;
++			else if (plen >= PATH_MAX)
++				continue;
++
++			if (dirname_default_prefixes[i + 1] != NULL) {
++				if (stat(buf, &dirstat) < 0) {
++					if (errno == ENOENT)
++						continue;
++					else
++						return NULL;
++				}
++
++				if (!S_ISDIR(dirstat.st_mode))
++					continue;
++			}
++
++			p = malloc(plen + 1);
++			if (p == NULL)
++				return NULL;
++			memcpy(p, buf, plen + 1);
++			break;
++		}
++	}
  
  	return p;
-diff -ru -x '*~' kmod-17-orig/tools/static-nodes.c kmod-17/tools/static-nodes.c
---- kmod-17-orig/tools/static-nodes.c	2013-12-17 22:05:42.159047316 +0100
-+++ kmod-17/tools/static-nodes.c	2014-04-17 13:51:17.945974320 +0200
-@@ -159,6 +159,7 @@
+ }
+diff --git a/tools/static-nodes.c b/tools/static-nodes.c
+index 8d2356d..2ed306d 100644
+--- a/tools/static-nodes.c
++++ b/tools/static-nodes.c
+@@ -29,10 +29,11 @@
+ #include <unistd.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+-#include <sys/utsname.h>
+ 
+ #include <shared/util.h>
+ 
++#include <libkmod/libkmod.h>
++
+ #include "kmod.h"
+ 
+ struct static_nodes_format {
+@@ -154,8 +155,8 @@ static void help(void)
+ 
+ static int do_static_nodes(int argc, char *argv[])
+ {
+-	struct utsname kernel;
+ 	char modules[PATH_MAX], buf[4096];
++	struct kmod_ctx *ctx;
+ 	const char *output = "/dev/stdout";
  	FILE *in = NULL, *out = NULL;
  	const struct static_nodes_format *format = &static_nodes_format_human;
- 	int r, ret = EXIT_SUCCESS;
-+	char *dirname_prefix;
- 
- 	for (;;) {
- 		int c, idx = 0, valid;
-@@ -211,16 +212,19 @@
- 		goto finish;
+@@ -206,22 +207,25 @@ static int do_static_nodes(int argc, char *argv[])
+ 		}
  	}
  
+-	if (uname(&kernel) < 0) {
+-		fputs("Error: uname failed!\n", stderr);
++	ctx = kmod_new(NULL, NULL);
++	if (ctx == NULL) {
++		fprintf(stderr, "Error: failed to create kmod context\n");
+ 		ret = EXIT_FAILURE;
+ 		goto finish;
+ 	}
+-
 -	snprintf(modules, sizeof(modules), "/lib/modules/%s/modules.devname", kernel.release);
-+	if ((dirname_prefix = getenv("MODULE_DIR")) == NULL)
-+		dirname_prefix = "/lib/modules";
-+
-+	snprintf(modules, sizeof(modules), "%s/%s/modules.devname", dirname_prefix, kernel.release);
++	if (snprintf(modules, sizeof(modules), "%s/modules.devname", kmod_get_dirname(ctx)) < 0) {
++		fprintf(stderr, "Error: path to modules.devname is too long\n");
++		ret = EXIT_FAILURE;
++		goto finish;
++	}
++	kmod_unref(ctx);
  	in = fopen(modules, "re");
  	if (in == NULL) {
  		if (errno == ENOENT) {
 -			fprintf(stderr, "Warning: /lib/modules/%s/modules.devname not found - ignoring\n",
 -				kernel.release);
-+			fprintf(stderr, "Warning: %s/%s/modules.devname not found - ignoring\n",
-+				dirname_prefix, kernel.release);
++			fprintf(stderr, "Warning: %s not found - ignoring\n", modules);
  			ret = EXIT_SUCCESS;
  		} else {
 -			fprintf(stderr, "Error: could not open /lib/modules/%s/modules.devname - %m\n",
 -				kernel.release);
-+			fprintf(stderr, "Error: could not open %s/%s/modules.devname - %m\n",
-+				dirname_prefix, kernel.release);
++			fprintf(stderr, "Error: could not open %s - %m\n", modules);
  			ret = EXIT_FAILURE;
  		}
  		goto finish;

--- a/pkgs/tools/networking/network-manager/0.9.8/default.nix
+++ b/pkgs/tools/networking/network-manager/0.9.8/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, intltool, pkgconfig, dbus_glib
 , udev, libnl, libuuid, gnutls, dhcp
-, libgcrypt, perl, libgudev }:
+, libgcrypt, perl, libgudev, avahi, ppp, kmod }:
 
 stdenv.mkDerivation rec {
   name = "network-manager-${version}";
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace tools/glib-mkenums --replace /usr/bin/perl ${perl}/bin/perl
+    substituteInPlace src/nm-device.c \
+      --replace @avahi@ ${avahi} \
+      --replace @kmod@ ${kmod}
+    substituteInPlace src/ppp-manager/nm-ppp-manager.c \
+      --replace @ppp@ ${ppp} \
+      --replace @kmod@ ${kmod}
   '';
 
   # Right now we hardcode quite a few paths at build time. Probably we should

--- a/pkgs/tools/networking/network-manager/0.9.8/nixos-purity.patch
+++ b/pkgs/tools/networking/network-manager/0.9.8/nixos-purity.patch
@@ -47,7 +47,7 @@ index 1dc94ee..e60f3c8 100644
  
  	for (iter = modules; *iter; iter++) {
 -		char *argv[3] = { "/sbin/modprobe", *iter, NULL };
-+		char *argv[3] = { "/var/run/current-system/sw/bin/modprobe", *iter, NULL };
++		char *argv[3] = { "@kmod@/bin/modprobe", *iter, NULL };
  		char *envp[1] = { NULL };
  		GError *error = NULL;
  
@@ -71,7 +71,7 @@ index 59698c3..7dba0f7 100644
  	/* Make sure /dev/ppp exists (bgo #533064) */
  	if (stat ("/dev/ppp", &st) || !S_ISCHR (st.st_mode))
 -		ignored = system ("/sbin/modprobe ppp_generic");
-+		ignored = system ("/var/run/current-system/sw/bin/modprobe ppp_generic");
++		ignored = system ("@kmod@/bin/modprobe ppp_generic");
  
  	connection = nm_act_request_get_connection (req);
  	g_assert (connection);

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace /usr/bin/uname ${coreutils}/bin/uname
     substituteInPlace configure --replace /usr/bin/file ${file}/bin/file
     substituteInPlace src/devices/nm-device.c --replace /usr/bin/ping ${inetutils}/bin/ping
-    substituteInPlace src/NetworkManagerUtils.c --replace /sbin/modprobe /run/current-system/sw/sbin/modprobe
+    substituteInPlace src/NetworkManagerUtils.c --replace /sbin/modprobe /run/current-system/sw/bin/modprobe
     substituteInPlace data/84-nm-drivers.rules \
       --replace /bin/sh ${stdenv.shell}
     substituteInPlace data/85-nm-unmanaged.rules \

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -2,7 +2,7 @@
 , systemd, libgudev, libnl, libuuid, polkit, gnutls, ppp, dhcp, iptables
 , libgcrypt, dnsmasq, bluez5, readline
 , gobjectIntrospection, modemmanager, openresolv, libndp, newt, libsoup
-, ethtool, gnused, coreutils, file, inetutils }:
+, ethtool, gnused, coreutils, file, inetutils, kmod }:
 
 stdenv.mkDerivation rec {
   name    = "network-manager-${version}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace /usr/bin/uname ${coreutils}/bin/uname
     substituteInPlace configure --replace /usr/bin/file ${file}/bin/file
     substituteInPlace src/devices/nm-device.c --replace /usr/bin/ping ${inetutils}/bin/ping
-    substituteInPlace src/NetworkManagerUtils.c --replace /sbin/modprobe /run/current-system/sw/bin/modprobe
+    substituteInPlace src/NetworkManagerUtils.c --replace /sbin/modprobe ${kmod}/bin/modprobe
     substituteInPlace data/84-nm-drivers.rules \
       --replace /bin/sh ${stdenv.shell}
     substituteInPlace data/85-nm-unmanaged.rules \

--- a/pkgs/tools/networking/network-manager/openconnect.nix
+++ b/pkgs/tools/networking/network-manager/openconnect.nix
@@ -23,10 +23,10 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
      substituteInPlace "configure" \
-       --replace "/sbin/sysctl" "${procps}/sbin/sysctl"
+       --replace "/sbin/sysctl" "${procps}/bin/sysctl"
      substituteInPlace "src/nm-openconnect-service.c" \
-       --replace "/usr/sbin/openconnect" "${openconnect}/sbin/openconnect" \
-       --replace "/sbin/modprobe" "${kmod}/sbin/modprobe"
+       --replace "/usr/sbin/openconnect" "${openconnect}/bin/openconnect" \
+       --replace "/sbin/modprobe" "${kmod}/bin/modprobe"
   '';
 
   meta = {

--- a/pkgs/tools/networking/network-manager/openvpn.nix
+++ b/pkgs/tools/networking/network-manager/openvpn.nix
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
      substituteInPlace "configure" \
        --replace "/sbin/sysctl" "${procps}/sbin/sysctl"
      substituteInPlace "src/nm-openvpn-service.c" \
-       --replace "/sbin/openvpn" "${openvpn}/sbin/openvpn" \
-       --replace "/sbin/modprobe" "${kmod}/sbin/modprobe"
+       --replace "/sbin/openvpn" "${openvpn}/bin/openvpn" \
+       --replace "/sbin/modprobe" "${kmod}/bin/modprobe"
      substituteInPlace "properties/auth-helpers.c" \
-       --replace "/sbin/openvpn" "${openvpn}/sbin/openvpn"
+       --replace "/sbin/openvpn" "${openvpn}/bin/openvpn"
   '';
 
   meta = {

--- a/pkgs/tools/networking/network-manager/vpnc.nix
+++ b/pkgs/tools/networking/network-manager/vpnc.nix
@@ -24,10 +24,10 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
      substituteInPlace "configure" \
-       --replace "/sbin/sysctl" "${procps}/sbin/sysctl"
+       --replace "/sbin/sysctl" "${procps}/bin/sysctl"
      substituteInPlace "src/nm-vpnc-service.c" \
-       --replace "/sbin/vpnc" "${vpnc}/sbin/vpnc" \
-       --replace "/sbin/modprobe" "${kmod}/sbin/modprobe"
+       --replace "/sbin/vpnc" "${vpnc}/bin/vpnc" \
+       --replace "/sbin/modprobe" "${kmod}/bin/modprobe"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

NixOS needs special logic to search for kernel modules. We first want to check `/run/current-system/kernel-modules` and, if there are no modules for our kernel version there, fall back to `/run/booted-system/kernel-modules`. This way we both allow to enable new kernel packages without a reboot and make the system run consistently after a kernel update before new kernel was loaded.

Unfortunately, this logic previously has been implemented as a wrapper on top of `kmod`, namely `system.sbin.modprobe`. Therefore it was required that either it is inserted into `PATH` of an application which wants to use `modprobe` et all, or, if an application links to `libkmod` and uses it directly (or if we can't hijack `PATH`), to set `MODULE_DIR` to `/run/current-system/kernel-modules` or the other one. In this situation one can have either system consistency or ability to add new kernel packages, but not both.

This set of patches moves this logic into `kmod` itself. Therefore, we don't need `MODULE_DIR` nor `system.sbin.modprobe` at all anymore -- `kmod` and all applications using it would get all the nice things automatically.

As a side improvement, I've replaced `sbin` by `bin` in several places (this was done while I studied how `kmod` is used treewide).

As an example of nice user-side improvement, `bumblebee` now works correctly after a switch to a new kernel.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
