### PR TITLE
apacheKafka: 0.9.0.1 -> 0.10.0.1

### DIFF
--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -11,6 +11,10 @@ let
               scalaVersion = "2.11";
               sha256 = "0ykcjv5dz9i5bws9my2d60pww1g9v2p2nqr67h0i2xrjm7az8a6v";
             };
+    "0.10" = { kafkaVersion = "0.10.0.1";
+               scalaVersion = "2.11";
+               sha256 = "0bdhzbhmm87a47162hyazcjmfibqg9r3ryzfjag7r0nxxmd64wrd";
+             };
   };
 in
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6112,9 +6112,10 @@ in
 
   apacheAnt = callPackage ../development/tools/build-managers/apache-ant { };
 
-  apacheKafka = apacheKafka_0_9;
+  apacheKafka = apacheKafka_0_10;
   apacheKafka_0_8 = callPackage ../servers/apache-kafka { majorVersion = "0.8"; };
   apacheKafka_0_9 = callPackage ../servers/apache-kafka { majorVersion = "0.9"; };
+  apacheKafka_0_10 = callPackage ../servers/apache-kafka { majorVersion = "0.10"; };
 
   astyle = callPackage ../development/tools/misc/astyle { };
 


### PR DESCRIPTION
###### Motivation for this change

Update `apacheKafka` release to 0.10.0.1 which is the latest stable. Retaining prior versions for 0.9.x and 0.8.x. Full release notes for 0.10.0.1:

https://archive.apache.org/dist/kafka/0.10.0.1/RELEASE_NOTES.html
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)

```
$ sudo nixos-option nix.useSandbox
Value:
true

Default:
false

Description:


 If set, Nix will perform builds in a sandboxed environment that it
 will set up automatically for each build. This prevents
 impurities in builds by disallowing access to dependencies
 outside of the Nix store.

Declared by:
  "/nix/store/1n6lx6y3n1vhgan0ia4nds3ncpiafck8-nixos-16.09pre85931.125ffff/nixos/nixpkgs/nixos/modules/services/misc/nix-daemon.nix"

Defined by:
  "/etc/nixos/configuration.nix"
```
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux

```
$ nixos-version
16.09pre85931.125ffff (Flounder)
```
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

```
$ nix-shell -p nox --run "nox-review wip"
==> We're in a git repo, trying to fetch it
Building in /run/user/1000/nox-review-uawa7mox: apacheKafka_0_9 apacheKafka
/nix/store/r43jhxdxkyilyg6hlaqlv9hp0d39b9s4-apache-kafka-2.11-0.9.0.1
/nix/store/0ddrwwa2vhix1k6lh9vfmcwlihjgm8cs-apache-kafka-2.11-0.10.0.1
Result in /run/user/1000/nox-review-uawa7mox
total 0
lrwxrwxrwx 1 spotter users 69 Aug 14 14:59 result -> /nix/store/r43jhxdxkyilyg6hlaqlv9hp0d39b9s4-apache-kafka-2.11-0.9.0.1
lrwxrwxrwx 1 spotter users 70 Aug 14 14:59 result-2 -> /nix/store/0ddrwwa2vhix1k6lh9vfmcwlihjgm8cs-apache-kafka-2.11-0.10.0.1
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)

I tested the newly built Kafka 0.10.0.1 package by starting a broker (server) with a specified server.properties file and running test producer and test consumer and checking outputs. Eventually this can be automated in a NixOS module test but to avoid adding too much complication to a simple update to a package that will be done in a separate PR.

```
# From both results from running nox
# lrwxrwxrwx 1 spotter users 70 Aug 14 15:08 result -> /nix/store/0ddrwwa2vhix1k6lh9vfmcwlihjgm8cs-apache-kafka-2.11-0.10.0.1
# lrwxrwxrwx 1 spotter users 69 Aug 14 15:08 result-2 -> /nix/store/r43jhxdxkyilyg6hlaqlv9hp0d39b9s4-apache-kafka-2.11-0.9.0.1

$ /nix/store/0ddrwwa2vhix1k6lh9vfmcwlihjgm8cs-apache-kafka-2.11-0.10.0.1/bin/kafka-server-start.sh /nix/store/0ddrwwa2vhix1k6lh9vfmcwlihjgm8cs-apache-kafka-2.11-0.10.0.1/config/server.properties
anager)
[2016-08-14 15:28:51,257] INFO Starting log flusher with a default period of 9223372036854775807 ms. (kafka.log.LogManager)
...
        port = 9092
...
[2016-08-14 15:28:51,283] INFO Awaiting socket connections on 0.0.0.0:9092. (kafka.network.Acceptor)

^Z

$ nc -vz localhost 9092
localhost [127.0.0.1] 9092 (XmlIpcRegSvc) open

$ cat messages.txt
A virtuous abstinence from the joys of pederasty comes most easily to those who have no taste for it.

Alas, I am dying beyond my means. (sipping champagne on his deathbed)

As long as war is regarded as wicked, it will always have its fascination. When it is looked upon as vulgar, it will cease to be popular.

Democracy means simply the bludgeoning of the people by the people for the people.

Fashion is a form of ugliness so intolerable that we have to alter it every six months.

The only way to behave to a woman is to make love to her if she is pretty and to someone else if she is plain.

The only way to get rid of a temptation is to yield to it.

There is only one thing in the world worse than being talked about, and that is not being talked about.

Whenever people agree with me I always feel I must be wrong.

Why was I born with such contemporaries?

Young men want to be faithful and are not; old men want to be faithless and cannot.

$ /nix/store/0ddrwwa2vhix1k6lh9vfmcwlihjgm8cs-apache-kafka-2.11-0.10.0.1/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic test < messages.txt

# in broker console
[2016-08-14 15:36:18,024] INFO Topic creation {"version":1,"partitions":{"0":[0]}} (kafka.admin.AdminUtils$)
[2016-08-14 15:36:18,029] INFO [KafkaApi-0] Auto creation of topic test with 1 partitions and replication factor 1 is successful (kafka.server.KafkaApis)

$ /nix/store/0ddrwwa2vhix1k6lh9vfmcwlihjgm8cs-apache-kafka-2.11-0.10.0.1/bin/kafka-console-consumer.sh --zookeeper localhost:2181 --topic test --from-beginning | tee output.txt
A virtuous abstinence from the joys of pederasty comes most easily to those who have no taste for it.

Alas, I am dying beyond my means. (sipping champagne on his deathbed)

As long as war is regarded as wicked, it will always have its fascination. When it is looked upon as vulgar, it will cease to be popular.

Democracy means simply the bludgeoning of the people by the people for the people.

Fashion is a form of ugliness so intolerable that we have to alter it every six months.

The only way to behave to a woman is to make love to her if she is pretty and to someone else if she is plain.

The only way to get rid of a temptation is to yield to it.

There is only one thing in the world worse than being talked about, and that is not being talked about.

Whenever people agree with me I always feel I must be wrong.

Why was I born with such contemporaries?

Young men want to be faithful and are not; old men want to be faithless and cannot.
^CProcessed a total of 21 messages

```
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
commit message conforms to CONTRIBUTING.md 
```
