### PR TITLE
Mattermost service

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -274,6 +274,7 @@
       gocd-agent = 251;
       gocd-server = 252;
       terraria = 253;
+      mattermost = 254;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -518,6 +519,7 @@
       gocd-agent = 251;
       gocd-server = 252;
       terraria = 253;
+      mattermost = 254;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -463,6 +463,7 @@
   ./services/ttys/agetty.nix
   ./services/ttys/gpm.nix
   ./services/ttys/kmscon.nix
+  ./services/web-apps/mattermost.nix
   ./services/web-apps/pump.io.nix
   ./services/web-apps/tt-rss.nix
   ./services/web-servers/apache-httpd/default.nix

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -1,0 +1,228 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.mattermost;
+
+  defaultConfig = builtins.fromJSON (readFile "${pkgs.mattermost}/config/config.json");
+
+  mattermostConf = foldl recursiveUpdate defaultConfig
+    [ { ServiceSettings.SiteURL = cfg.siteUrl;
+        ServiceSettings.ListenAddress = cfg.listenAddress;
+        TeamSettings.SiteName = cfg.siteName;
+        SqlSettings.DriverName = "postgres";
+        SqlSettings.DataSource = "postgres://${cfg.localDatabaseUser}:${cfg.localDatabasePassword}@localhost:5432/${cfg.localDatabaseName}?sslmode=disable&connect_timeout=10";
+      }
+      cfg.extraConfig
+    ];
+
+  mattermostConfJSON = pkgs.writeText "mattermost-config-raw.json" (builtins.toJSON mattermostConf);
+
+in
+
+{
+  options = {
+    services.mattermost = {
+      enable = mkEnableOption "Mattermost chat platform";
+
+      statePath = mkOption {
+        type = types.str;
+        default = "/var/lib/mattermost";
+        description = "Mattermost working directory";
+      };
+
+      siteUrl = mkOption {
+        type = types.str;
+        example = "https://chat.example.com";
+        description = ''
+          URL this Mattermost instance is reachable under, without trailing slash."
+        '';
+      };
+
+      siteName = mkOption {
+        type = types.str;
+        default = "Mattermost";
+        description = "Name of this Mattermost site.";
+      };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = ":8065";
+        example = "[::1]:8065";
+        description = ''
+          Address and port this Mattermost instance listens to.
+        '';
+      };
+
+      mutableConfig = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether the Mattermost config.json is writeable by Mattermost.
+
+          Most of the settings can be edited in the system console of
+          Mattermost if this option is enabled. A template config using
+          the options specified in services.mattermost will be generated
+          but won't be overwritten on changes or rebuilds.
+
+          If this option is disabled, changes in the system console won't
+          be possible (default). If an config.json is present, it will be
+          overwritten!
+        '';
+      };
+
+      extraConfig = mkOption {
+        type = types.attrs;
+        default = { };
+        description = ''
+          Addtional configuration options as Nix attribute set in config.json schema.
+        '';
+      };
+
+      localDatabaseCreate = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Create a local PostgreSQL database for Mattermost automatically.
+        '';
+      };
+
+      localDatabaseName = mkOption {
+        type = types.str;
+        default = "mattermost";
+        description = ''
+          Local Mattermost database name.
+        '';
+      };
+
+      localDatabaseUser = mkOption {
+        type = types.str;
+        default = "mattermost";
+        description = ''
+          Local Mattermost database username.
+        '';
+      };
+
+      localDatabasePassword = mkOption {
+        type = types.str;
+        default = "mmpgsecret";
+        description = ''
+          Password for local Mattermost database user.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "mattermost";
+        description = ''
+          User which runs the Mattermost service.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "mattermost";
+        description = ''
+          Group which runs the Mattermost service.
+        '';
+      };
+
+      matterircd = {
+        enable = mkEnableOption "Mattermost IRC bridge";
+        parameters = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          example = [ "-mmserver chat.example.com" "-bind [::]:6667" ];
+          description = ''
+            Set commandline parameters to pass to matterircd. See
+            https://github.com/42wim/matterircd#usage for more information.
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+      users.extraUsers = optionalAttrs (cfg.user == "mattermost") (singleton {
+        name = "mattermost";
+        group = cfg.group;
+        uid = config.ids.uids.mattermost;
+        home = cfg.statePath;
+      });
+
+      users.extraGroups = optionalAttrs (cfg.group == "mattermost") (singleton {
+        name = "mattermost";
+        gid = config.ids.gids.mattermost;
+      });
+
+      services.postgresql.enable = cfg.localDatabaseCreate;
+
+      # The systemd service will fail to execute the preStart hook
+      # if the WorkingDirectory does not exist
+      system.activationScripts.mattermost = ''
+        mkdir -p ${cfg.statePath}
+      '';
+
+      systemd.services.mattermost = {
+        description = "Mattermost chat platform service";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" "postgresql.service" ];
+
+        preStart = ''
+          mkdir -p ${cfg.statePath}/{data,config,logs}
+          ln -sf ${pkgs.mattermost}/{bin,fonts,i18n,templates,webapp} ${cfg.statePath}
+        '' + lib.optionalString (!cfg.mutableConfig) ''
+          ln -sf ${mattermostConfJSON} ${cfg.statePath}/config/config.json
+        '' + lib.optionalString cfg.mutableConfig ''
+          if ! test -e "${cfg.statePath}/config/.initial-created"; then
+            rm -f ${cfg.statePath}/config/config.json
+            cp ${mattermostConfJSON} ${cfg.statePath}/config/config.json
+            touch ${cfg.statePath}/config/.initial-created
+          fi
+        '' + lib.optionalString cfg.localDatabaseCreate ''
+          if ! test -e "${cfg.statePath}/.db-created"; then
+            ${config.services.postgresql.package}/bin/psql postgres -c \
+              "CREATE ROLE ${cfg.localDatabaseUser} WITH LOGIN NOCREATEDB NOCREATEROLE NOCREATEUSER ENCRYPTED PASSWORD '${cfg.localDatabasePassword}'"
+            ${config.services.postgresql.package}/bin/createdb \
+              --owner ${cfg.localDatabaseUser} ${cfg.localDatabaseName}
+            touch ${cfg.statePath}/.db-created
+          fi
+        '' + ''
+          chown ${cfg.user}:${cfg.group} -R ${cfg.statePath}
+          chmod u+rw,g+r,o-rwx -R ${cfg.statePath}
+        '';
+
+        serviceConfig = {
+          PermissionsStartOnly = true;
+          User = cfg.user;
+          Group = cfg.group;
+          ExecStart = "${pkgs.mattermost}/bin/mattermost-platform";
+          WorkingDirectory = "${cfg.statePath}";
+          PrivateTmp = true;
+          Restart = "always";
+          RestartSec = "10";
+          LimitNOFILE = "49152";
+        };
+      };
+    })
+    (mkIf cfg.matterircd.enable {
+      systemd.services.matterircd = {
+        description = "Mattermost IRC bridge service";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          User = "nobody";
+          Group = "nogroup";
+          ExecStart = "${pkgs.matterircd.bin}/bin/matterircd ${concatStringsSep " " cfg.matterircd.parameters}";
+          WorkingDirectory = "/tmp";
+          PrivateTmp = true;
+          Restart = "always";
+          RestartSec = "5";
+        };
+      };
+    })
+  ];
+}
+

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "mattermost-${version}";
+  version = "3.3.0";
+
+  src = fetchurl {
+    url = "https://releases.mattermost.com/${version}/mattermost-team-${version}-linux-amd64.tar.gz";
+    sha256 = "16mp75hv4lzkj99lj18c5vyqsmk9kqk5r81hirq41fgb6bdqx509";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    mv * $out/
+    ln -s ./platform $out/bin/mattermost-platform
+  '';
+
+  postFixup = ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/platform
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open-Source, self-hosted Slack-alternative";
+    homepage = "https://www.mattermost.org";
+    license = with licenses; [ agpl3 asl20 ];
+    maintainers = with maintainers; [ fpletz ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/servers/mattermost/matterircd.nix
+++ b/pkgs/servers/mattermost/matterircd.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "matterircd-${version}";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "42wim";
+    repo = "matterircd";
+    rev = "v${version}";
+    sha256 = "1sh34vwi8ycmdsgpzqwa7gcjzb0rn46aig6n40hxy6q1lk2l6m3c";
+  };
+
+  goPackagePath = "github.com/42vim/matterircd";
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Minimal IRC server bridge to Mattermost";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fpletz ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10297,6 +10297,8 @@ in
 
   mailman = callPackage ../servers/mail/mailman { };
 
+  mattermost = callPackage ../servers/mattermost { };
+
   mediatomb = callPackage ../servers/mediatomb {
     spidermonkey = spidermonkey_185;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10298,6 +10298,7 @@ in
   mailman = callPackage ../servers/mail/mailman { };
 
   mattermost = callPackage ../servers/mattermost { };
+  matterircd = callPackage ../servers/mattermost/matterircd.nix { };
 
   mediatomb = callPackage ../servers/mediatomb {
     spidermonkey = spidermonkey_185;


### PR DESCRIPTION
###### Motivation for this change

Adds Mattermost package & service and the matterircd bridge.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
