### PR TITLE
visualvm: init at 1.3.8

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -248,6 +248,7 @@
   meditans = "Carlo Nucera <meditans@gmail.com>";
   meisternu = "Matt Miemiec <meister@krutt.org>";
   michaelpj = "Michael Peyton Jones <michaelpj@gmail.com>";
+  michalrus = "Michal Rus <m@michalrus.com>";
   michelk = "Michel Kuhlmann <michel@kuhlmanns.info>";
   mimadrid = "Miguel Madrid <mimadrid@ucm.es>";
   mingchuan = "Ming Chuan <ming@culpring.com>";

--- a/pkgs/development/tools/java/visualvm/default.nix
+++ b/pkgs/development/tools/java/visualvm/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchzip, lib, makeWrapper, jdk, gtk }:
+
+stdenv.mkDerivation rec {
+  name = "visualvm-1.3.8";
+
+  src = fetchzip {
+    url = "https://java.net/projects/visualvm/downloads/download/release138/visualvm_138.zip";
+    sha256 = "09wsi85z1g7bwyfhb37vw0gy3wl0j1cy35aj59rg7067q262gy1y";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    rm bin/visualvm.exe
+
+    substituteInPlace etc/visualvm.conf \
+      --replace "#visualvm_jdkhome=" "visualvm_jdkhome=" \
+      --replace "/path/to/jdk" "${jdk.home}" \
+      --replace 'visualvm_default_options="' 'visualvm_default_options="--laf com.sun.java.swing.plaf.gtk.GTKLookAndFeel -J-Dawt.useSystemAAFontSettings=lcd -J-Dswing.aatext=true '
+
+    cp -r . $out
+
+    # To get the native LAF, JVM needs to see GTK’s .so-s.
+    wrapProgram $out/bin/visualvm \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A visual interface for viewing information about Java applications";
+    longDescription = ''
+      VisualVM is a visual tool integrating several commandline JDK
+      tools and lightweight profiling capabilities. Designed for both
+      production and development time use, it further enhances the
+      capability of monitoring and performance analysis for the Java
+      SE platform.
+    '';
+    homepage = https://visualvm.java.net/;
+    license = licenses.gpl2ClasspathPlus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ michalrus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6785,6 +6785,8 @@ in
     ocamlPackages = ocamlPackages_4_02;
   });
 
+  visualvm = callPackage ../development/tools/java/visualvm { };
+
   xc3sprog = callPackage ../development/tools/misc/xc3sprog { };
 
   xmlindent = callPackage ../development/web/xmlindent {};


### PR DESCRIPTION
###### Motivation for this change

It’s generally a useful tool and it’s not bundled with our JDKs.
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change — _none do_
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
