### PR TITLE
redshift: Fix default value of $DISPLAY

### DIFF
--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -108,7 +108,12 @@ in {
         RestartSec = 3;
         Restart = "always";
       };
-      environment = { DISPLAY = ":${toString config.services.xserver.display}"; };
+      environment = {
+        DISPLAY = ":${toString (
+          let display = config.services.xserver.display;
+          in if display != null then display else 0
+        )}";
+      };
     };
   };
 


### PR DESCRIPTION
Before commit 54fa0cfe4eef7e54e23380704af70ee7b65473ce, the `redshift`
service was run with the environment variable `DISPLAY` set to `:0`.

Commit 54fa0cfe4eef7e54e23380704af70ee7b65473ce changed this to
instead use the value of the `services.xserver.display` configuration
option in the value of the `DISPLAY` variable. In so doing, no default
value was provided for the case where `services.xserver.display` is
`null`.

While the default value of `services.xserver.display` is `0`, use of
which by the `redshift` module would result in `DISPLAY` again being
set to `:0`, `services.xserver.display` may also be `null`, to which
value it is set by, e.g., the `lightdm` module.

In the case that `services.xserver.display` is `null`, with the change
made in commit 54fa0cfe4eef7e54e23380704af70ee7b65473ce, the `DISPLAY`
variable in the environment of the `redshift` service would be set to
`:` (a single colon), which, according to my personal experience,
would result in —
- the `redshift` service failing to start; and
- systemd repeatedly attempting to restart the `redshift` service,
  looping indefinitely, while the hapless `redshift` spews error
  messages into the journal.

It can be observed that the malformed value of `DISPLAY` is likely at
fault for this issue by executing the following commands in an
ordinary shell, with a suitable `redshift` executable, and the X11
display not already tinted:
- `redshift -O 2500` — This command should reduce the color
  temperature of the display (making it more reddish).
- `DISPLAY=':' redshift -O 6500` — This command should raise the
  color temperature back up, were it not for the `DISPLAY`
  environment variable being set to `:` for it, which should cause
  it to, instead, fail with several error messages.

This commit attempts to fix this issue by having the `DISPLAY`
environment variable for the `redshift` service default to its old
value of `:0` in the case that `services.xserver.display` is `null`.

I have tested this solution on NixOS, albeit without the benefit of a
system with multiple displays.
