### PR TITLE
awf: init at 1.3.1

### DIFF
--- a/pkgs/development/tools/misc/awf/default.nix
+++ b/pkgs/development/tools/misc/awf/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, gtk2, gtk3, pkgconfig
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "awf-${version}";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "valr";
+    repo = "awf";
+    rev = "v${version}";
+    sha256 = "18dqa2269cwr0hrn67vp0ifwbv8vc2xn6mg145pbnc038hicql8m";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook ];
+
+  buildInputs = [ gtk2 gtk3 ];
+
+  autoreconfPhase = ''
+    patchShebangs ./autogen.sh
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Widget Factory";
+    longDescription = ''
+      A widget factory is a theme preview application for gtk2 and
+      gtk3. It displays the various widget types provided by gtk2/gtk3
+      in a single window allowing to see the visual effect of the
+      applied theme.
+    '';
+    homepage = https://github.com/valr/awf;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ michalrus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6113,6 +6113,8 @@ in
 
   astyle = callPackage ../development/tools/misc/astyle { };
 
+  awf = callPackage ../development/tools/misc/awf { };
+
   electron = callPackage ../development/tools/electron { };
 
   autobuild = callPackage ../development/tools/misc/autobuild { };


### PR DESCRIPTION
###### Motivation for this change

AWF is a cool tool to test your GTK2/3 themes, as it renders all possible widgets. Useful for theme devs.
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change — _none do_
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
