### PR TITLE
bitwig-studio: init at 1.3.12

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/default.nix
+++ b/pkgs/applications/audio/bitwig-studio/default.nix
@@ -1,0 +1,97 @@
+{ stdenv, fetchurl, alsaLib, bzip2, cairo, dpkg, freetype, gdk_pixbuf
+, glib, gtk, harfbuzz, jdk, lib, libX11, libXau, libXcursor, libXdmcp
+, libXext, libXfixes, libXrender, libbsd, libjack2, libpng, libxcb
+, libxkbcommon, libxkbfile, makeWrapper, pixman, xcbutil, xcbutilwm
+, xdg_utils, zenity, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "bitwig-studio-${version}";
+  version = "1.3.12";
+
+  src = fetchurl {
+    url = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
+    sha256 = "01z6yia4a6lfsf3rqq379l7xzqfbpz27mf1mr8sx9z1a8rzzyhld";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  unpackCmd = "mkdir root ; dpkg-deb -x $curSrc root";
+
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+
+  libPath = lib.makeLibraryPath [
+    alsaLib bzip2.out cairo freetype gdk_pixbuf glib gtk harfbuzz
+    libX11 libXau libXcursor libXdmcp libXext libXfixes libXrender
+    libbsd libjack2 libpng libxcb libxkbfile pixman xcbutil xcbutilwm
+    zlib
+  ];
+
+  binPath = lib.makeBinPath [
+    xdg_utils zenity
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r opt/bitwig-studio $out/libexec
+
+    # Use NixOS versions of these libs instead of the bundled ones.
+    (
+      cd $out/libexec/lib/bitwig-studio
+      rm libbz2.so* libxkbfile.so* libXcursor.so* libXau.so* \
+         libXdmcp.so* libpng16.so* libxcb*.so* libharfbuzz.so* \
+         libcairo.so* libfreetype.so*
+      ln -s ${bzip2.out}/lib/libbz2.so.1.0.6 libbz2.so.1.0
+    )
+
+    # Use our OpenJDK instead of Bitwig’s bundled—and commercial!—one.
+    rm -rf $out/libexec/lib/jre
+    ln -s ${jdk.home}/jre $out/libexec/lib/jre
+
+    # Bitwig’s `libx11-windowing-system.so` has several problems:
+    #
+    #   • has some old version of libxkbcommon linked statically (ಠ_ಠ),
+    #
+    #   • hardcodes path to `/usr/share/X11/xkb`,
+    #
+    #   • even if we redirected it with libredirect (after adding
+    #     `eaccess()` to libredirect!), their version of libxkbcommon
+    #     is unable to parse our xkeyboardconfig. Been there, done that.
+    #
+    # However, it suffices to override theirs with our libxkbcommon
+    # in LD_PRELOAD. :-)
+
+    find $out -type f -executable \
+      -not -name '*.so.*' \
+      -not -name '*.so' \
+      -not -path '*/resources/*' | \
+    while IFS= read -r f ; do
+      patchelf \
+        --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+        $f && \
+      wrapProgram $f \
+        --prefix PATH : "${binPath}" \
+        --prefix LD_LIBRARY_PATH : "${libPath}" \
+        --set LD_PRELOAD "${libxkbcommon.out}/lib/libxkbcommon.so" || true
+    done
+
+    mkdir -p $out/bin
+    ln -s $out/libexec/bitwig-studio $out/bin/bitwig-studio
+
+    cp -r usr/share $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A digital audio workstation";
+    longDescription = ''
+      Bitwig Studio is a multi-platform music-creation system for
+      production, performance and DJing, with a focus on flexible
+      editing tools and a super-fast workflow.
+    '';
+    homepage = http://www.bitwig.com/;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ michalrus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12400,6 +12400,10 @@ in
 
   bitmeter = callPackage ../applications/audio/bitmeter { };
 
+  bitwig-studio =  callPackage ../applications/audio/bitwig-studio {
+    inherit (gnome2) zenity;
+  };
+
   bleachbit = callPackage ../applications/misc/bleachbit { };
 
   blender = callPackage  ../applications/misc/blender {


### PR DESCRIPTION
###### Motivation for this change

It’s a nice DAW. However, proprietary.
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change — _none do_
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - `libexec/bin32/BitwigPluginHost32` does not launch, but that is expected, as we don’t have multilib.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
