### PR TITLE
lib.{warn, info}: add simple helpers

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -98,4 +98,19 @@ rec {
   */
   importJSON = path:
     builtins.fromJSON (builtins.readFile path);
+
+  /* See https://github.com/NixOS/nix/issues/749. Eventually we'd like these
+     to expand to Nix builtins that carry metadata so that Nix can filter out
+     the INFO messages without parsing the message string.
+
+     Usage:
+     {
+       foo = lib.warn "foo is deprecated" oldFoo;
+     }
+
+     TODO: figure out a clever way to integrate location information from
+     something like __unsafeGetAttrPos.
+  */
+  warn = msg: builtins.trace "WARNING: ${msg}";
+  info = msg: builtins.trace "INFO: ${msg}";
 }


### PR DESCRIPTION
Add two simple functions, `lib.warn` and `lib.info`, in an attempt to move towards https://github.com/NixOS/nix/issues/749.
