### PR TITLE
gradle: 2.14.1 -> 3.0, keep 2.14.1

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -51,7 +51,16 @@ rec {
     };
   };
 
-  gradleLatest = gradleGen rec {
+  gradle_latest = gradleGen rec {
+    name = "gradle-3.0";
+
+    src = fetchurl {
+      url = "http://services.gradle.org/distributions/${name}-bin.zip";
+      sha256 = "103z2nzlpc6x3mav0mqardd84rj1si718f6wpnpl8i273aa0dj9r";
+    };
+  };
+
+  gradle_2_14 = gradleGen rec {
     name = "gradle-2.14.1";
 
     src = fetchurl {
@@ -60,7 +69,7 @@ rec {
     };
   };
 
-  gradle25 = gradleGen rec {
+  gradle_2_5 = gradleGen rec {
     name = "gradle-2.5";
 
     src = fetchurl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6453,8 +6453,9 @@ in
   gotty = callPackage ../servers/gotty { };
 
   gradleGen = callPackage ../development/tools/build-managers/gradle { };
-  gradle = self.gradleGen.gradleLatest;
-  gradle25 = self.gradleGen.gradle25;
+  gradle = self.gradleGen.gradle_latest;
+  gradle_2_14 = self.gradleGen.gradle_2_14;
+  gradle_2_5 = self.gradleGen.gradle_2_5;
 
   gperf = callPackage ../development/tools/misc/gperf { };
 


### PR DESCRIPTION
###### Motivation for this change

Gradle 3.0 release (https://docs.gradle.org/3.0/release-notes)

I kept 2.14.1 since there are a number of removals and deprecations in 3.0, which may break Gradle for projects depending on old features.

I did, however, change the package versioning scheme to be more explicit (gradle_2_5 over gradle25)
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
