### PR TITLE
nixos-install: cleanups & improvements to run on non-NixOS systems

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -24,7 +24,6 @@ fi
 # Parse the command line for the -I flag
 extraBuildFlags=()
 chrootCommand=(/run/current-system/sw/bin/bash)
-bootLoader=1
 
 while [ "$#" -gt 0 ]; do
     i="$1"; shift 1
@@ -51,7 +50,7 @@ while [ "$#" -gt 0 ]; do
             noRootPasswd=1
             ;;
         --no-bootloader)
-            bootLoader=0
+            noBootLoader=1
             ;;
         --show-trace)
             extraBuildFlags+=("$i")
@@ -142,7 +141,7 @@ mkdir -m 0755 -p \
     $mountPoint/nix/var/log/nix/drvs
 
 mkdir -m 1775 -p $mountPoint/nix/store
-chown root:nixbld $mountPoint/nix/store
+chown root:@nixbld_gid@ $mountPoint/nix/store
 
 
 # There is no daemon in the chroot.
@@ -155,14 +154,14 @@ export LC_ALL=
 export LC_TIME=
 
 
-# Create a temporary Nix config file that causes the nixbld users to
-# be used.
-echo "build-users-group = nixbld" > $mountPoint/tmp/nix.conf # FIXME: remove in Nix 1.8
-binary_caches=$(@perl@/bin/perl -I @nix@/lib/perl5/site_perl/*/* -e 'use Nix::Config; Nix::Config::readConfig; print $Nix::Config::config{"binary-caches"};')
-if test -n "$binary_caches"; then
-    echo "binary-caches = $binary_caches" >> $mountPoint/tmp/nix.conf
-fi
-export NIX_CONF_DIR=/tmp
+# Builds will use users that are members of this group
+extraBuildFlags+=(--option "build-users-group" "nixbld")
+
+
+# Inherit binary caches from the host
+binary_caches="$(@perl@/bin/perl -I @nix@/lib/perl5/site_perl/*/* -e 'use Nix::Config; Nix::Config::readConfig; print $Nix::Config::config{"binary-caches"};')"
+extraBuildFlags+=(--option "binary-caches" "$binary_caches")
+
 
 touch $mountPoint/etc/passwd $mountPoint/etc/group
 mount --bind -o ro /etc/passwd $mountPoint/etc/passwd
@@ -263,16 +262,17 @@ touch $mountPoint/etc/NIXOS
 # a menu default pointing at the kernel/initrd/etc of the new
 # configuration.
 echo "finalising the installation..."
-NIXOS_INSTALL_GRUB="$bootLoader" chroot $mountPoint \
-    /nix/var/nix/profiles/system/bin/switch-to-configuration boot
-
+if [ -z "$noBootLoader" ]; then
+  NIXOS_INSTALL_GRUB=1 chroot $mountPoint \
+      /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+fi
 
 # Run the activation script.
 chroot $mountPoint /nix/var/nix/profiles/system/activate
 
 
 # Ask the user to set a root password.
-if [ -z "$noRootPasswd" ] && [ "$(chroot $mountPoint /run/current-system/sw/bin/sh -l -c "nix-instantiate --eval '<nixpkgs/nixos>' -A config.users.mutableUsers")" = true ] && [ -t 0 ] ; then
+if [ -z "$noRootPasswd" ] && [ -x $mountPoint/var/setuid-wrappers/passwd ] && [ -t 0 ]; then
     echo "setting root password..."
     chroot $mountPoint /var/setuid-wrappers/passwd
 fi

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -24,6 +24,7 @@ let
     inherit (pkgs) perl pathsFromGraph rsync;
     nix = config.nix.package.out;
     cacert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+    nixbld_gid = config.ids.gids.nixbld;
 
     nixClosure = pkgs.runCommand "closure"
       { exportReferencesGraph = ["refs" config.nix.package.out]; }


### PR DESCRIPTION
###### Motivation for this change
- Fix `--no-bootloader` which didn't do what it advertised
- Hardcode `nixbld` GID so that systems which do not have a `nixbld` group
  can still run `nixos-install` (only with `--closure` since they can't
  build anything)
- Cleanup: get rid of `NIX_CONF_DIR`(`=/tmp`)`/nix.conf` and pass arguments instead
- Cleanup: don't assume that the target system has `'<nixpkgs/nixos>'` or
  `'<nixos-config>'` to see if `config.users.mutableUsers`. Instead check if
  `/var/setuid-wrappers/passwd` is there

Installing NixOS now works from a Ubuntu host (using --closure).
###### Things done

`nix-build -A tests.installer.simple '<nixpkgs/nixos/release.nix>'` succeeds ✓
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @edolstra @domenkozar 

Will merge in a couple of days if I don't hear any objections.
