### PR TITLE
freetype: 2.6.2 -> 2.6.5

### DIFF
--- a/nixos/modules/config/fonts/fontconfig-ultimate.nix
+++ b/nixos/modules/config/fonts/fontconfig-ultimate.nix
@@ -15,7 +15,7 @@ in
         ultimate = {
           enable = mkOption {
             type = types.bool;
-            default = true;
+            default = false;
             description = ''
               Enable fontconfig-ultimate settings (formerly known as
               Infinality). Besides the customizable settings in this NixOS

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -87,16 +87,44 @@ rec {
   ];
 
   savannah = [
-    ftp://mirror.csclub.uwaterloo.ca/nongnu/
-    ftp://mirror.publicns.net/pub/nongnu/
-    ftp://savannah.c3sl.ufpr.br/
-    http://download.savannah.gnu.org/releases/
-    http://ftp.cc.uoc.gr/mirrors/nongnu.org/
-    http://ftp.twaren.net/Unix/NonGNU/
-    http://mirror.csclub.uwaterloo.ca/nongnu/
-    http://nongnu.askapache.com/
+    # Mirrors from https://download-mirror.savannah.gnu.org/releases/00_MIRRORS.html
+    http://mirror.easyname.at/nongnu/
+    http://mirror2.klaus-uwe.me/nongnu/
     http://savannah.c3sl.ufpr.br/
-    http://www.centervenus.com/mirrors/nongnu/
+    http://mirror.csclub.uwaterloo.ca/nongnu/
+    http://mirror.cedia.org.ec/nongnu/
+    http://ftp.igh.cnrs.fr/pub/nongnu/
+    http://mirror6.layerjet.com/nongnu
+    http://mirror.netcologne.de/savannah/
+    http://ftp.cc.uoc.gr/mirrors/nongnu.org/
+    http://nongnu.uib.no/
+    http://mirrors.fe.up.pt/pub/nongnu/
+    http://mirror.lihnidos.org/GNU/savannah/
+    http://savannah.mirror.si/
+    http://ftp.acc.umu.se/mirror/gnu.org/savannah/
+    http://ftp.twaren.net/Unix/NonGNU/
+    http://ftp.yzu.edu.tw/pub/nongnu/
+    http://mirror.rackdc.com/savannah/
+    http://savannah-nongnu-org.ip-connect.vn.ua/
+    http://www.mirrorservice.org/sites/download.savannah.gnu.org/releases/
+    http://savannah.spinellicreations.com/
+    http://gnu.mirrors.pair.com/savannah/savannah/
+    ftp://mirror.easyname.at/nongnu/
+    ftp://mirror2.klaus-uwe.me/nongnu/
+    ftp://savannah.c3sl.ufpr.br/savannah-nongnu/
+    ftp://mirror.csclub.uwaterloo.ca/nongnu/
+    ftp://mirror.cedia.org.ec/nongnu
+    ftp://ftp.igh.cnrs.fr/pub/nongnu/
+    ftp://mirror6.layerjet.com/nongnu/
+    ftp://mirror.netcologne.de/savannah/
+    ftp://nongnu.uib.no/pub/nongnu/
+    ftp://mirrors.fe.up.pt/pub/nongnu/
+    ftp://savannah.mirror.si/savannah/
+    ftp://ftp.twaren.net/Unix/NonGNU/
+    ftp://ftp.yzu.edu.tw/pub/nongnu/
+    ftp://savannah-nongnu-org.ip-connect.vn.ua/mirror/savannah.nongnu.org/
+    ftp://ftp.mirrorservice.org/sites/download.savannah.gnu.org/releases/
+    ftp://spinellicreations.com/gnu_dot_org_savannah_mirror/
   ];
 
   samba = [

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -2,7 +2,7 @@
 , alsaLib, bootjdk, cacert, perl, liberation_ttf, fontconfig, zlib
 , setJavaClassPath
 , minimal ? false
-, enableInfinality ? true # font rendering patch
+, enableInfinality ? false # font rendering patch
 }:
 
 let

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -46,8 +46,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--disable-static --bindir=$(dev)/bin";
 
-  # from Gentoo, see https://bugzilla.redhat.com/show_bug.cgi?id=506840
-  NIX_CFLAGS_COMPILE = "-fno-strict-aliasing";
   # The asm for armel is written with the 'asm' keyword.
   CFLAGS = optionalString stdenv.isArm "-std=gnu99";
 

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -64,7 +64,14 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A font rendering engine";
-    homepage = http://www.freetype.org/;
+    longDescription = ''
+      FreeType is a portable and efficient library for rendering fonts. It
+      supports TrueType, Type 1, CFF fonts, and WOFF, PCF, FNT, BDF and PFR
+      fonts. It has a bytecode interpreter and has an automatic hinter called
+      autofit which can be used instead of hinting instructions included in
+      fonts.
+    '';
+    homepage = https://www.freetype.org/;
     license = licenses.gpl2Plus; # or the FreeType License (BSD + advertising clause)
     #ToDo: encumbered = useEncumberedCode;
     platforms = platforms.all;

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -8,33 +8,33 @@
 }:
 
 let
-  version = "2.6.2";
-
-  # Don't use fetchpatch. It mangles them. That's an hour I'll never get back.
-  fetchbohoomil = name: sha256: fetchurl {
-    url = https://raw.githubusercontent.com/bohoomil/fontconfig-ultimate/254b688f96d4a37f78fb594303a43160fc15c7cd/freetype/ + name;
-    inherit sha256;
-  };
+  version = "2.6.5";
 in
 with { inherit (stdenv.lib) optional optionals optionalString; };
 stdenv.mkDerivation rec {
   name = "freetype-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/freetype/${name}.tar.bz2";
-    sha256 = "14mqrfgl18q2by1yzv6vcxi97zjy4kppcgsqf312mhfwgkpvvxms";
+    url = "mirror://savannah/freetype/${name}.tar.bz2";
+    sha256 = "1w5c87s4rpx9af5b3mk5cjd1yny3c4dq5p9iv3ixb3vr00a6w2p2";
   };
 
-  patches = []
-    # mingw: these patches use `strcasestr` which isn't available on windows
-    ++ optionals (useEncumberedCode && stdenv.cross.libc or null != "msvcrt" ) [
-      (fetchbohoomil "01-freetype-2.6.2-enable-valid.patch"
-        "1szq0zha7n41f4pq179wgfkam034mp2xn0xc36sdl5sjp9s9hv08")
-      (fetchbohoomil "02-upstream-2015.12.05.patch"
-        "0781r9n35kpn8db8nma0l47cpkzh0hbp84ziii5sald90dnrqdj4")
-      (fetchbohoomil "03-infinality-2.6.2-2015.12.05.patch"
-        "0wcjf9hiymplgqm3szla633i417pb57vpzzs2dyl1dnmcxgqa2y8")
-    ];
+  patches = [
+    # Patch for validation of OpenType and GX/AAT tables.
+    (fetchurl {
+      name = "freetype-2.2.1-enable-valid.patch";
+      url = "http://pkgs.fedoraproject.org/cgit/rpms/freetype.git/plain/freetype-2.2.1-enable-valid.patch?id=9a81147af83b1166a5f301e379f85927cc610990";
+      sha256 = "0zkgqhws2s0j8ywksclf391iijhidb1a406zszd7xbdjn28kmj2l";
+    })
+  ] ++ optionals (useEncumberedCode) [
+    # Patch to enable subpixel rendering.
+    # See https://www.freetype.org/freetype2/docs/reference/ft2-lcd_filtering.html.
+    (fetchurl {
+      name = "freetype-2.3.0-enable-spr.patch";
+      url = http://pkgs.fedoraproject.org/cgit/rpms/freetype.git/plain/freetype-2.3.0-enable-spr.patch?id=9a81147af83b1166a5f301e379f85927cc610990;
+      sha256 = "13ni9n5q3nla38wjmxd4f8cy29gp62kjx2l6y6nqhdyiqp8fz8nd";
+    })
+  ];
 
   outputs = [ "dev" "out" ];
 


### PR DESCRIPTION
###### Motivation for this change

This updates FreeType to the latest release. Since a large number of packages depend on FreeType, this might count as requiring a mass rebuild so I opened the pull request against the staging branch.
###### Things done
- [x] Tested using sandboxing (nix.useSandbox)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
