### PR TITLE
cxxtools: init at 2.2.1

### DIFF
--- a/pkgs/development/libraries/cxxtools/default.nix
+++ b/pkgs/development/libraries/cxxtools/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "2.2.1";
+  name = "cxxtools";
+
+  src = fetchurl {
+    url = "http://www.tntnet.org/download/${name}-${version}.tar.gz";
+    sha256 = "0hp3qkyhidxkdf8qgkwrnqq5bpahink55mf0yz23rjd7rpbbdswc";
+  };
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "http://www.tntnet.org/cxxtools.html";
+    description = "Comprehensive C++ class library for Unix and Linux";
+    platforms = stdenv.lib.platforms.linux ;
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ stdenv.lib.maintainers.juliendehos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7083,6 +7083,8 @@ in
 
   cutee = callPackage ../development/libraries/cutee { };
 
+  cxxtools = callPackage ../development/libraries/cxxtools { };
+
   cwiid = callPackage ../development/libraries/cwiid { };
 
   cyrus_sasl = callPackage ../development/libraries/cyrus-sasl {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
