### PR TITLE
nixos/lib/make-disk-image: refactor to use nixos-install

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -67,40 +67,24 @@ pkgs.vmTools.runInLinuxVM (
       mkdir /mnt
       mount $rootDisk /mnt
 
-      # The initrd expects these directories to exist.
-      mkdir /mnt/dev /mnt/proc /mnt/sys
-
-      mount -o bind /proc /mnt/proc
-      mount -o bind /dev /mnt/dev
-      mount -o bind /sys /mnt/sys
-
-      # Copy all paths in the closure to the filesystem.
-      storePaths=$(perl ${pkgs.pathsFromGraph} /tmp/xchg/closure)
-
-      mkdir -p /mnt/nix/store
-      echo "copying everything (will take a while)..."
-      set -f
-      cp -prd $storePaths /mnt/nix/store/
-
       # Register the paths in the Nix database.
       printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
-          chroot /mnt ${config.nix.package.out}/bin/nix-store --load-db --option build-users-group ""
+          ${config.nix.package.out}/bin/nix-store --load-db --option build-users-group ""
 
       # Add missing size/hash fields to the database. FIXME:
       # exportReferencesGraph should provide these directly.
-      chroot /mnt ${config.nix.package.out}/bin/nix-store --verify --check-contents
+      ${config.nix.package.out}/bin/nix-store --verify --check-contents --option build-users-group ""
 
-      # Create the system profile to allow nixos-rebuild to work.
-      chroot /mnt ${config.nix.package.out}/bin/nix-env --option build-users-group "" \
-          -p /nix/var/nix/profiles/system --set ${config.system.build.toplevel}
+      # In case the bootloader tries to write to /dev/sda…
+      ln -s vda /dev/xvda
+      ln -s vda /dev/sda
 
-      # `nixos-rebuild' requires an /etc/NIXOS.
-      mkdir -p /mnt/etc
-      touch /mnt/etc/NIXOS
-
-      # `switch-to-configuration' requires a /bin/sh
-      mkdir -p /mnt/bin
-      ln -s ${config.system.build.binsh}/bin/sh /mnt/bin/sh
+      # Install the closure onto the image
+      USER=root ${config.system.build.nixos-install}/bin/nixos-install \
+        --closure ${config.system.build.toplevel} \
+        --no-channel-copy \
+        --no-root-passwd \
+        ${optionalString (!installBootLoader) "--no-bootloader"}
 
       # Install a configuration.nix.
       mkdir -p /mnt/etc/nixos
@@ -108,12 +92,9 @@ pkgs.vmTools.runInLinuxVM (
         cp ${configFile} /mnt/etc/nixos/configuration.nix
       ''}
 
-      # Generate the GRUB menu.
-      ln -s vda /dev/xvda
-      ln -s vda /dev/sda
-      ${optionalString installBootLoader "chroot /mnt ${config.system.build.toplevel}/bin/switch-to-configuration boot"}
+      # Remove /etc/machine-id so that each machine cloning this image will get its own id
+      rm -f /mnt/etc/machine-id
 
-      umount /mnt/proc /mnt/dev /mnt/sys
       umount /mnt
 
       # Do a fsck to make sure resize2fs works.

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -24,6 +24,7 @@ let
     inherit (pkgs) perl pathsFromGraph rsync;
     nix = config.nix.package.out;
     cacert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+    root_uid = config.ids.uids.root;
     nixbld_gid = config.ids.gids.nixbld;
 
     nixClosure = pkgs.runCommand "closure"


### PR DESCRIPTION
###### Motivation for this change
- Replace hand-rolled version of `nixos-install` in `make-disk-image` by an
  actual call to `nixos-install`
- Required a few cleanups of `nixos-install`
- `nixos-install` invokes an activation script which the hand-rolled version
  in `make-disk-image` did not do. We remove `/etc/machine-id` as that's
  a host-specific, impure, output of the activation script
###### Things done

`nix-build '<nixpkgs/nixos/release.nix>' -A tests.installer.simple` passes

Also tried generating an image with:

```
nix-build -E 'let
    pkgs = import <nixpkgs> {};
    lib = pkgs.lib;
    nixos = import <nixpkgs/nixos> {
      configuration = {
        fileSystems."/".device = "/dev/disk/by-label/nixos";
        boot.loader.grub.devices = [ "/dev/sda" ];
        boot.loader.grub.extraEntries = '"''"'
          menuentry "Ubuntu" {
             insmod ext2
             search --set=root --label ubuntu
             configfile /boot/grub/grub.cfg
          }
        '"''"';
      };
    };
  in import <nixpkgs/nixos/lib/make-disk-image.nix> {
    inherit pkgs lib;
    config = nixos.config;
    diskSize = 2000;
    partitioned = false;
    installBootLoader = false;
  }'
```

Then installed the image:

```
$ sudo df if=./result/nixos.img of=/dev/sdaX bs=1M
$ sudo resize2fs /dev/disk/by-label/nixos
$ sudo mount /dev/disk/by-label/nixos /mnt
$ sudo mount --rbind /proc /mnt/proc
$ sudo mount --rbind /dev /mnt/dev
$ sudo chroot /mnt /nix/var/nix/profiles/system/bin/switch-to-configuration boot
```

[ … optionally do something about passwords … ]

and successfully rebooted to that image.

Was doing all this from inside a Ubuntu VM with a single user nix install.
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Follow up to #17236, #17768 

cc @edolstra @domenkozar @shlevy
