### PR TITLE
translate-shell: init at 0.9.4

### DIFF
--- a/pkgs/applications/misc/translate-shell/default.nix
+++ b/pkgs/applications/misc/translate-shell/default.nix
@@ -1,0 +1,101 @@
+{ stdenv, fetchFromGitHub, curl, fribidi, mpv, less, rlwrap, gawk, bash, emacs, groff, ncurses, pandoc }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "translate-shell";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "soimort";
+    repo = "translate-shell";
+    rev = "v" + version;
+    sha256 = "166zhic3k4z37vc8p1fnhc4xx7i7q0j30nr324frmp1mrnwrdib8";
+  };
+
+  phases = [ "buildPhase" "installPhase" "postFixup" ];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share
+    mkdir -p $out/share/man/man1
+  '';
+
+  installPhase = ''
+    cp $src/translate $out/bin/trans
+    cp $src/translate $out/bin/translate
+    cp $src/translate $out/bin/translate-shell
+
+    cp $src/translate.awk $out/share/translate.awk
+    cp $src/build.awk $out/share/build.awk
+    cp $src/metainfo.awk $out/share/metainfo.awk
+    cp $src/test.awk $out/share/test.awk
+
+    cp -r $src/include $out/share
+    cp -r $src/test $out/share
+    cp $src/man/trans.1 $out/share/man/man1
+
+    chmod +x $out/bin/translate
+    chmod +x $out/share/translate.awk
+    chmod +x $out/share/build.awk
+    chmod +x $out/share/metainfo.awk
+    chmod +x $out/share/test.awk
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/bin/trans --replace "/bin/sh" "${bash}/bin/bash"
+    substituteInPlace $out/bin/trans --replace "gawk " "${gawk}/bin/gawk "
+    substituteInPlace $out/bin/trans --replace "translate.awk" "$out/share/translate.awk"
+
+    substituteInPlace $out/bin/translate --replace "/bin/sh" "${bash}/bin/bash"
+    substituteInPlace $out/bin/translate --replace "gawk " "${gawk}/bin/gawk "
+    substituteInPlace $out/bin/translate --replace "translate.awk" "$out/share/translate.awk"
+
+    substituteInPlace $out/bin/translate-shell --replace "/bin/sh" "${bash}/bin/bash"
+    substituteInPlace $out/bin/translate-shell --replace "gawk " "${gawk}/bin/gawk "
+    substituteInPlace $out/bin/translate-shell --replace "translate.awk" "$out/share/translate.awk"
+
+    substituteInPlace $out/share/translate.awk --replace "/usr/bin/gawk" "${gawk}/bin/gawk"
+    substituteInPlace $out/share/translate.awk --replace "metainfo" "$out/share/metainfo"
+    substituteInPlace $out/share/translate.awk --replace "include/" "$out/share/include/"
+
+    substituteInPlace $out/share/build.awk --replace "/usr/bin/gawk" "${gawk}/bin/gawk"
+    substituteInPlace $out/share/build.awk --replace "include/" "$out/share/include/"
+    substituteInPlace $out/share/build.awk --replace "metainfo.awk" "$out/share/metainfo.awk"
+
+    substituteInPlace $out/share/metainfo.awk --replace "translate.awk" "$out/share/translate.awk"
+
+    substituteInPlace $out/share/test.awk --replace "/usr/bin/gawk" "${gawk}/bin/gawk"
+    substituteInPlace $out/share/test.awk --replace "include/" "$out/share/include/"
+    substituteInPlace $out/share/test.awk --replace "test/" "$out/share/test/"
+
+    substituteInPlace $out/share/include/Translators/\*.awk --replace "include/" "$out/share/include/"
+
+    substituteInPlace $out/share/test/Test.awk --replace "test/" "$out/share/test/"
+    substituteInPlace $out/share/test/TestUtils.awk --replace "include/" "$out/share/include/"
+    substituteInPlace $out/share/test/TestParser.awk --replace "include/" "$out/share/include/"
+    substituteInPlace $out/share/test/TestCommons.awk --replace "\"gawk\"" "\"${gawk}/bin/gawk\""
+    substituteInPlace $out/share/test/TestCommons.awk --replace "Commons.awk" "$out/share/include/Commons.awk"
+
+    substituteInPlace $out/share/include/Main.awk --replace "\"tput\"" "\"${ncurses}/bin/tput\""
+    substituteInPlace $out/share/include/Help.awk --replace "\"groff\"" "\"${groff}/bin/groff\""
+    substituteInPlace $out/share/include/Utils.awk --replace "\"fribidi\"" "\"${fribidi}/bin/fribidi\""
+    substituteInPlace $out/share/include/Utils.awk --replace "\"fribidi " "\"${fribidi}/bin/fribidi "
+    substituteInPlace $out/share/include/Utils.awk --replace "\"rlwrap\"" "\"${rlwrap}/bin/rlwrap\""
+    substituteInPlace $out/share/include/Utils.awk --replace "\"emacs\"" "\"${emacs}/bin/emacs\""
+    substituteInPlace $out/share/include/Utils.awk --replace "\"curl\"" "\"${curl}/bin/curl\""
+
+    substituteInPlace $out/share/build.awk --replace "\"pandoc " "\"${pandoc}/bin/pandoc "
+
+    substituteInPlace $out/share/include/Translate.awk --replace "\"mpv " "\"${mpv}/bin/mpv "
+    substituteInPlace $out/share/include/Translate.awk --replace "\"less " "\"${less}/bin/less "
+
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.soimort.org/translate-shell;
+    description = "Command-line translator using Google Translate, Bing Translator, Yandex.Translate, and Apertium";
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.ebzzry ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3764,6 +3764,8 @@ in
 
   tracefilesim = callPackage ../development/tools/analysis/garcosim/tracefilesim { };
 
+  translate-shell = callPackage ../applications/misc/translate-shell { };
+
   trash-cli = callPackage ../tools/misc/trash-cli { };
 
   trickle = callPackage ../tools/networking/trickle {};


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [.] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [.] NixOS
  - [ ] OS X
  - [.] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [.] Tested execution of all binary files (usually in `./result/bin/`)
- [.] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
