### PR TITLE
Unifi controller fixes

### DIFF
--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -46,6 +46,18 @@ in
       '';
     };
 
+    services.unifi.openPorts = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether or not to open the minimum required ports on the firewall.
+
+        This is necessary to allow firmware upgrades and device discovery to
+        work. For remote login, you should additionally open (or forward) port
+        8443.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -54,6 +66,19 @@ in
       uid = config.ids.uids.unifi;
       description = "UniFi controller daemon user";
       home = "${stateDir}";
+    };
+
+    networking.firewall = mkIf cfg.openPorts {
+      # https://help.ubnt.com/hc/en-us/articles/204910084-UniFi-Change-Default-Ports-for-Controller-and-UAPs
+      allowedTCPPorts = [
+        8080  # Port for UAP to inform controller.
+        8880  # Port for HTTP portal redirect, if guest portal is enabled.
+        8843  # Port for HTTPS portal redirect, ditto.
+      ];
+      allowedUDPPorts = [
+        3478  # UDP port used for STUN.
+        10001 # UDP port used for device discovery.
+      ];
     };
 
     # We must create the binary directories as bind mounts instead of symlinks
@@ -80,8 +105,8 @@ in
 
       preStart = ''
         # Ensure privacy of state and data.
-        chown unifi "${stateDir}" "${dataDir}"
-        chmod 0700 "${stateDir}" "${dataDir}"
+        chown unifi "${stateDir}" "${stateDir}/data"
+        chmod 0700 "${stateDir}" "${stateDir}/data"
 
         # Create the volatile webapps
         rm -rf "${stateDir}/webapps"

--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -79,9 +79,9 @@ in
       environment.LD_LIBRARY_PATH = with pkgs.stdenv; "${cc.cc.lib}/lib";
 
       preStart = ''
-        # Ensure privacy of state
-        chown unifi "${stateDir}"
-        chmod 0700 "${stateDir}"
+        # Ensure privacy of state and data.
+        chown unifi "${stateDir}" "${dataDir}"
+        chmod 0700 "${stateDir}" "${dataDir}"
 
         # Create the volatile webapps
         rm -rf "${stateDir}/webapps"


### PR DESCRIPTION
###### Motivation for this change

I like things to work by default.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/17782)

<!-- Reviewable:end -->
