### PR TITLE
nixos/stage-1: add mechanism which lustrates all impurities from /

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -131,9 +131,16 @@ let
   # The initrd only has to mount / or any FS marked as necessary for
   # booting (such as the FS containing /nix/store, or an FS needed for
   # mounting /, like / on a loopback).
-  fileSystems = filter
-    (fs: fs.neededForBoot || elem fs.mountPoint [ "/" "/nix" "/nix/store" "/var" "/var/log" "/var/lib" "/etc" ])
-    (attrValues config.fileSystems);
+  #
+  # We need to guarantee that / is the first filesystem in the list so
+  # that if and when lustrateRoot is invoked, nothing else is mounted
+  fileSystems = let
+    filterNeeded = filter
+      (fs: fs.mountPoint != "/" && (fs.neededForBoot || elem fs.mountPoint [ "/nix" "/nix/store" "/var" "/var/log" "/var/lib" "/etc" ]));
+    filterRoot = filter
+      (fs: fs.mountPoint == "/");
+    allFileSystems = attrValues config.fileSystems;
+  in (filterRoot allFileSystems) ++ (filterNeeded allFileSystems);
 
 
   udevRules = pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
###### Motivation for this change

This mechanism can be used for either:
- Return an existing NixOS install to its "first boot" state; or
- Turn a non-NixOS install into a NixOS system (see below)

> lustrate /ˈlʌstreɪt/ verb:
> "purify by expiatory sacrifice, ceremonial washing, or some other ritual action."
- `sudo touch /etc/NIXOS_LUSTRATE`
  ⇒ on next reboot, during stage 1, everything but `/nix` and `/boot`
  is moved to `/old-root`
- `echo "etc/passwd" | sudo tee -a /etc/NIXOS_LUSTRATE`
  ⇒ on next reboot, during stage 1, everything but `/nix` and `/boot`
  is moved to `/old-root`; _except_ `/etc/passwd` which is copied back.

Useful for installing NixOS in place on another distro. For instance:

```
$ nix-env -iE '_: with import <nixpkgs/nixos> { configuration = {}; }; with config.system.build; [ nixos-generate-config manual.manpages ]'
$ sudo mkdir /etc/nixos
$ sudo `which nixos-generate-config`
```

… edit the configuration files in `/etc/nixos` using `man configuration.nix`  if needed

  maybe add: `users.extraUsers.root.initialHashedPassword = ""` ?

… Build the entire NixOS system and link it to the system profile:

```
$ nix-env -p /nix/var/nix/profiles/system -f '<nixpkgs/nixos>' -iA system
```

… If you were using a single user install:

```
$ sudo chown -R 0.0 /nix
```

… NixOS is about to take over

```
$ sudo touch /etc/NIXOS
$ sudo touch /etc/NIXOS_LUSTRATE
```

… Let's keep the configuration files we just created

```
$ echo etc/nixos | sudo tee -a /etc/NIXOS_LUSTRATE
```

```
$ sudo mv -v /boot /boot.bak &&
  sudo /nix/var/nix/profiles/system/bin/switch-to-configuration boot
$ sudo reboot
```

… NixOS boots, Stage 1 moves all the old distro stuff in `/old-root`.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @edolstra @domenkozar @aszlig @cleverca22 @grahamc
