### PR TITLE
ympd: init at 1.3.0

### DIFF
--- a/pkgs/applications/audio/ympd/default.nix
+++ b/pkgs/applications/audio/ympd/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, llvmPackages, pkgconfig, mpd_clientlib, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "ympd-${version}";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "notandy";
+    repo = "ympd";
+    rev = "v${version}";
+    sha256 = "1nvb19jd556v2h2bi7w4dcl507p3p8xvjkqfzrcsy7ccy3502brq";
+  };
+
+  preConfigure = ''
+    export LIBMPDCLIENT_LIBS=${mpd_clientlib}/lib/libmpdclient.${if stdenv.isDarwin then mpd_clientlib.majorVersion + ".dylib" else "so." + mpd_clientlib.majorVersion + ".0." + mpd_clientlib.minorVersion}
+    export LIBMPDCLIENT_CFLAGS=${mpd_clientlib}
+
+    export LIBCLANG_CXXFLAGS="-isystem ${llvmPackages.clang.cc}/include $(llvm-config --cxxflags)"
+    export LIBCLANG_LIBDIR="${llvmPackages.clang.cc}/lib"
+  '';
+
+  buildInputs = [ cmake pkgconfig mpd_clientlib openssl ];
+
+  meta = {
+    homepage = "http://www.ympd.org";
+    description = "Standalone MPD Web GUI written in C, utilizing Websockets and Bootstrap/JS";
+    maintainers = [ stdenv.lib.maintainers.siddharthist ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13964,6 +13964,8 @@ in
 
   ncmpcpp = callPackage ../applications/audio/ncmpcpp { };
 
+  ympd = callPackage ../applications/audio/ympd { };
+
   nload = callPackage ../applications/networking/nload { };
 
   normalize = callPackage ../applications/audio/normalize { };


### PR DESCRIPTION
###### Motivation for this change

ympd is a quite popular web interface to mpd.

I've tested this locally by running it with mpd. It works :smile: 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
