### PR TITLE
cc-wrapper: handle -nostdinc{++,}

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -22,6 +22,7 @@ dontLink=0
 getVersion=0
 nonFlagArgs=0
 [[ "@prog@" = *++ ]] && isCpp=1 || isCpp=0
+cppInclude=1
 
 params=("$@")
 n=0
@@ -46,6 +47,10 @@ while [ $n -lt ${#params[*]} ]; do
         isCpp=1
     elif [ "$p" = -nostdlib ]; then
         isCpp=-1
+    elif [ "$p" = -nostdinc ]; then
+        cppInclude=0
+    elif [ "$p" = -nostdinc++ ]; then
+        cppInclude=0
     elif [ "${p:0:1}" != - ]; then
         nonFlagArgs=1
     elif [ "$p" = -m32 ]; then
@@ -106,7 +111,9 @@ if [ "$NIX_ENFORCE_NO_NATIVE" = 1 ]; then
 fi
 
 if [[ "$isCpp" = 1 ]]; then
-    NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE ${NIX_CXXSTDLIB_COMPILE-@default_cxx_stdlib_compile@}"
+    if [[ "$cppInclude" = 1 ]]; then
+        NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE ${NIX_CXXSTDLIB_COMPILE-@default_cxx_stdlib_compile@}"
+    fi
     NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK $NIX_CXXSTDLIB_LINK"
 fi
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #17769.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @copumpkin 
