### PR TITLE
skrooge2: init at 2.4.0

### DIFF
--- a/pkgs/applications/office/skrooge/2.nix
+++ b/pkgs/applications/office/skrooge/2.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, cmake, ecm, makeQtWrapper, qtwebkit, qtscript, grantlee,
+  kxmlgui, kwallet, kparts, kdoctools, kjobwidgets, kdesignerplugin,
+  kiconthemes, knewstuff, sqlcipher, qca-qt5, kdelibs4support, kactivities,
+  knotifyconfig, krunner, libofx }:
+
+stdenv.mkDerivation rec {
+  name = "skrooge-${version}";
+  version = "2.4.0";
+
+  src = fetchurl {
+    url = "http://download.kde.org/stable/skrooge/${name}.tar.xz";
+    sha256 = "132d022337140f841f51420536c31dfe07c90fa3a38878279026825f5d2526fe";
+  };
+
+  nativeBuildInputs = [ cmake ecm makeQtWrapper ];
+
+  buildInputs = [ qtwebkit qtscript grantlee kxmlgui kwallet kparts kdoctools
+    kjobwidgets kdesignerplugin kiconthemes knewstuff sqlcipher qca-qt5
+    kdelibs4support kactivities knotifyconfig krunner libofx
+  ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/skrooge"
+    wrapQtProgram "$out/bin/skroogeconvert"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A personal finances manager, powered by KDE";
+    license = with licenses; [ gpl3 ];
+    maintainers = with maintainers; [ joko ];
+    homepage = https://skrooge.org/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14714,6 +14714,8 @@ in
     themes = [];  # extra themes, etc.
   };
 
+  skrooge2 = qt5.callPackage ../applications/office/skrooge/2.nix {};
+
   slim = callPackage ../applications/display-managers/slim {
     libpng = libpng12;
   };


### PR DESCRIPTION
###### Motivation for this change

The available skrooge package relies on KDE4. I would like to introduce the new version which relies on Qt5 and Kf5.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
