### PR TITLE
dropbox: 6.4.14 -> 8.4.19

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -23,11 +23,11 @@
 let
   # NOTE: When updating, please also update in current stable,
   # as older versions stop working
-  version = "6.4.14";
+  version = "8.4.19";
   sha256 =
     {
-      "x86_64-linux" = "0wpdib3jf5bq4k8q5xv9g01fdcfjb4l903xjxn32rjw615s1q8bg";
-      "i686-linux" = "1lgc7ryp2mn230cfsbndn9ss71l378kib0lvs89rkn25d5zfgzn4";
+      "x86_64-linux" = "0pm43cklsm41mg463mz0ypvbladm2mz65s7ar9z4k4hgjrhyh67j";
+      "i686-linux" = "0myz8s2xdl034zb4548fgzz2f5gfvzfr1nwp50fh3f3hmf6frgp3";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
###### Motivation for this change

Works here as daily driver (although it hasn't been a day yet...)
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
