### PR TITLE
kiwix: Fix broken build

### DIFF
--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -1,9 +1,7 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, zip, python
-, zlib, xapian, which , icu, libmicrohttpd , lzma, zimlib
-, ctpp2, aria2, wget , bc, libuuid , glibc, libX11
-, libXext, libXt, libXrender , glib, dbus, dbus_glib, gtk
-, gdk_pixbuf, pango, cairo , freetype, fontconfig, alsaLib
-, atk
+{ stdenv, callPackage, overrideCC, fetchurl, makeWrapper, pkgconfig
+, zip, python, zlib, which, icu, libmicrohttpd, lzma, ctpp2, aria2, wget, bc
+, libuuid, glibc, libX11, libXext, libXt, libXrender, glib, dbus, dbus_glib
+, gtk, gdk_pixbuf, pango, cairo , freetype, fontconfig, alsaLib, atk
 }:
 
 let
@@ -30,6 +28,9 @@ let
     url = http://download.kiwix.org/dev/pugixml-1.2.tar.gz;
     sha256 = "0sqk0vdwjq44jxbbkj1cy8qykrmafs1sickzldb2w2nshsnjshhg";
   };
+
+  xapian = callPackage ../../../development/libraries/xapian { inherit stdenv; };
+  zimlib = callPackage ../../../development/libraries/zimlib { inherit stdenv; };
 
 in
 with stdenv.lib;
@@ -97,7 +98,7 @@ stdenv.mkDerivation rec {
 
     rm $out/bin/kiwix
     makeWrapper $out/lib/kiwix/kiwix-launcher $out/bin/kiwix \
-      --suffix LD_LIBRARY_PATH : `cat ${stdenv.cc}/nix-support/orig-cc`/lib:${makeLibraryPath [libX11 libXext libXt libXrender glib dbus dbus_glib gtk gdk_pixbuf pango cairo freetype fontconfig alsaLib atk]} \
+      --suffix LD_LIBRARY_PATH : ${makeLibraryPath [stdenv.cc.cc libX11 libXext libXt libXrender glib dbus dbus_glib gtk gdk_pixbuf pango cairo freetype fontconfig alsaLib atk]} \
       --suffix PATH : ${aria2}/bin
   '';
 
@@ -106,6 +107,5 @@ stdenv.mkDerivation rec {
     homepage = http://kiwix.org;
     license = licenses.gpl3;
     maintainers = with maintainers; [ robbinch ];
-    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13659,7 +13659,9 @@ in
     ffmpeg = ffmpeg_2;
   };
 
-  kiwix = callPackage ../applications/misc/kiwix { };
+  kiwix = callPackage ../applications/misc/kiwix {
+    stdenv = overrideCC stdenv gcc49;
+  };
 
   koji = callPackage ../tools/package-management/koji { };
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
