### PR TITLE
emem: 0.2.24 -> 0.2.25

### DIFF
--- a/pkgs/applications/misc/emem/default.nix
+++ b/pkgs/applications/misc/emem/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "emem";
-  version = "0.2.24";
+  version = "0.2.25";
   name = "${pname}-${version}";
 
   inherit jdk;
 
   src = fetchurl {
     url = "https://github.com/ebzzry/${pname}/releases/download/v${version}/${pname}.jar";
-    sha256 = "0h20vpd4gkg1m5mn3fkgrmjgf9w640b7w2500nn0pswmvqawrhpi";
+    sha256 = "16j3q0yvh5s32z0y515lyyn0g9ci9yw0vw0ka4sha7fgnynngyr6";
   };
 
   buildInputs = [ ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [.] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [.] NixOS
  - [ ] OS X
  - [.] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [.] Tested execution of all binary files (usually in `./result/bin/`)
- [.] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
