### PR TITLE
Update linux-grsecurity.nix

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-grsecurity.nix
+++ b/pkgs/os-specific/linux/kernel/linux-grsecurity.nix
@@ -2,7 +2,7 @@
 
 import ./generic.nix (args // rec {
   version = "4.7";
-  modDirVersion = "4.7.0";
+  modDirVersion = "4.7.0-grsec";
   extraMeta.branch = "4.7";
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fix for #17801
