### PR TITLE
emacs: add versatile "emacsWrapper"

### DIFF
--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -36,7 +36,10 @@ in customEmacsPackages.emacsWithPackages (epkgs: [ epkgs.evil epkgs.magit ])
 
 with lib; let inherit (self) emacs; in
 
-packagesFun: # packages explicitly requested by the user
+{
+  packagesFun ? [], # packages explicitly requested by the user
+  extraStart ? ""
+}:
 
 let
   explicitRequires =
@@ -53,7 +56,7 @@ stdenv.mkDerivation {
   # Store all paths we want to add to emacs here, so that we only need to add
   # one path to the load lists
   deps = runCommand "emacs-packages-deps"
-   { inherit explicitRequires lndir emacs; }
+   { inherit explicitRequires lndir emacs extraStart; }
    ''
      mkdir -p $out/bin
      mkdir -p $out/share/emacs/site-lisp
@@ -96,6 +99,7 @@ stdenv.mkDerivation {
 (load-file "$emacs/share/emacs/site-lisp/site-start.el")
 (add-to-list 'load-path "$out/share/emacs/site-lisp")
 (add-to-list 'exec-path "$out/bin")
+$extraStart
 EOF
 
      # Byte-compiling improves start-up time only slightly, but costs nothing.

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -63,7 +63,7 @@ let
     inherit fetchurl lib stdenv texinfo;
   };
 
-  emacsWithPackages = import ../build-support/emacs/wrapper.nix {
+  emacsWrapper = import ../build-support/emacs/wrapper.nix {
     inherit lib lndir makeWrapper stdenv runCommand;
   };
 
@@ -71,7 +71,9 @@ let
 
   inherit emacs melpaBuild trivialBuild;
 
-  emacsWithPackages = emacsWithPackages self;
+  emacsWrapper = emacsWrapper self;
+
+  emacsWithPackages = packagesFun: emacsWrapper { inherit packagesFun; };
 
   ## START HERE
 


### PR DESCRIPTION
###### Motivation for this change

"emacsWrapper" replaces emacsWithPackages. In addition to "packagesFun",
emacsWrapper has an optional variable called "execStart". execStart can
be used to append elisp to the default site-start.el script. This is
useful for providing a way to load a user's .emacs.d/init.el
file. "emacsWithPackages" is implemented with emacsWrapper for
convenience and compatability.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
