### PR TITLE
pythonPackages.asciinema: init at 1.3.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1169,6 +1169,33 @@ in modules // {
     };
   });
 
+  asciinema = buildPythonPackage rec {
+    name = "asciinema-${version}";
+    version = "1.3.0";
+
+    disabled = pythonOlder "3.3";
+
+    buildInputs = with self; [ nose ];
+    propagatedBuildInputs = with self; [ requests2 ];
+
+    src = pkgs.fetchFromGitHub {
+      owner = "asciinema";
+      repo = "asciinema";
+      rev = "v${version}";
+      sha256 = "1hx7xipyy9w72iwlawldlif9qk3f7b8jx8c1wcx114pqbjz5d347";
+    };
+
+    checkPhase = ''
+      nosetests
+    '';
+
+    meta = {
+      description = "Terminal session recorder and the best companion of asciinema.org";
+      homepage = https://asciinema.org/;
+      license = with licenses; [ gpl3 ];
+    };
+  };
+
   astroid = buildPythonPackage rec {
     name = "astroid-1.4.4";
 


### PR DESCRIPTION
###### Motivation for this change

[Asciinema 1.3.0 switched from using Go to Python](http://blog.asciinema.org/post/and-now-for-something-completely-different/).  Moving forward, the Go implementation will no longer be maintained.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
