### PR TITLE
ycmd: fix build

### DIFF
--- a/pkgs/development/tools/misc/ycmd/default.nix
+++ b/pkgs/development/tools/misc/ycmd/default.nix
@@ -10,12 +10,13 @@ stdenv.mkDerivation rec {
     sha256 = "1g0hivv3wla7z5dgnkcn3ny38p089pjfj36nx6k29zmprgmjinyr";
   };
 
-  buildInputs = [ python cmake llvmPackages.clang boost makeWrapper ];
+  buildInputs = [ python cmake boost makeWrapper ];
 
   propagatedBuildInputs = with pythonPackages; [ waitress frozendict bottle ];
 
   buildPhase = ''
-    python build.py --clang-completer --system-libclang --system-boost
+    export EXTRA_CMAKE_ARGS=-DPATH_TO_LLVM_ROOT=${llvmPackages.clang-unwrapped}
+    python build.py --clang-completer --system-boost
   '';
 
   configurePhase = ":";


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
