### PR TITLE
gnupg and libgcrypt updates (for CVE-2016-6316)

### DIFF
--- a/pkgs/development/libraries/libgcrypt/1.5.nix
+++ b/pkgs/development/libraries/libgcrypt/1.5.nix
@@ -3,11 +3,11 @@
 assert enableCapabilities -> stdenv.isLinux;
 
 stdenv.mkDerivation rec {
-  name = "libgcrypt-1.5.4";
+  name = "libgcrypt-1.5.6";
 
   src = fetchurl {
     url = "mirror://gnupg/libgcrypt/${name}.tar.bz2";
-    sha256 = "0czvqxkzd5y872ipy6s010ifwdwv29sqbnqc4pf56sd486gqvy6m";
+    sha256 = "0ydy7bgra5jbq9mxl5x031nif3m6y3balc6ndw2ngj11wnsjc61h";
   };
 
   buildInputs =

--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -4,11 +4,11 @@ assert enableCapabilities -> stdenv.isLinux;
 
 stdenv.mkDerivation rec {
   name = "libgcrypt-${version}";
-  version = "1.7.2";
+  version = "1.7.3";
 
   src = fetchurl {
     url = "mirror://gnupg/libgcrypt/${name}.tar.bz2";
-    sha256 = "17v8nvvxagcwxz46apzz575l8682kfd78pf00i2kbavfdn8dyd9x";
+    sha256 = "0wbh6fq5zi9wg2xcfvfpwh7dv52jihivx1vm4h91c2kx0w8n3b6x";
   };
 
   outputs = [ "dev" "out" "info" ];

--- a/pkgs/tools/security/gnupg/1.nix
+++ b/pkgs/tools/security/gnupg/1.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, readline, bzip2 }:
 
 stdenv.mkDerivation rec {
-  name = "gnupg-1.4.20";
+  name = "gnupg-1.4.21";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${name}.tar.bz2";
-    sha256 = "1k7d6zi0zznqsmcjic0yrgfhqklqz3qgd3yac7wxsa7s6088p604";
+    sha256 = "0xi2mshq8f6zbarb5f61c9w2qzwrdbjm4q8fqsrwlzc51h8a6ivb";
   };
 
   buildInputs = [ readline bzip2 ];


### PR DESCRIPTION
###### Motivation for this change

From the [release announcement](http://lists.gnu.org/archive/html/info-gnu/2016-08/msg00008.html):

```
Felix Dörre and Vladimir Klebanov from the Karlsruhe Institute of
Technology found a bug in the mixing functions of Libgcrypt's random
number generator: An attacker who obtains 4640 bits from the RNG can
trivially predict the next 160 bits of output.  This bug exists since
1998 in all GnuPG and Libgcrypt versions.


Impact
======
All Libgcrypt and GnuPG versions released before 2016-08-17 are affected
on all platforms.

A first analysis on the impact of this bug in GnuPG shows that existing
RSA keys are not weakened.  For DSA and Elgamal keys it is also unlikely
that the private key can be predicted from other public information.
This needs more research and I would suggest _not to_ overhasty revoke
keys.
```

nox-review running locally, I’ll update the PR status as soon as it all succeeds.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
