### PR TITLE
tntnet: init at 2.2.1

### DIFF
--- a/pkgs/development/libraries/tntnet/default.nix
+++ b/pkgs/development/libraries/tntnet/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, cxxtools, zlib, openssl, zip }:
+
+stdenv.mkDerivation rec {
+  version = "2.2.1";
+  name = "tntnet";
+  src = fetchurl {
+    url = "http://www.tntnet.org/download/tntnet-${version}.tar.gz";
+    sha256 = "08bmak9mpbamwwl3h9p8x5qzwqlm9g3jh70y0ml5hk7hiv870cf8";
+  };
+
+  buildInputs = [ cxxtools zlib openssl zip ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.tntnet.org/tntnet.html";
+    description = "Web server which allows users to develop web applications using C++";
+    platforms = platforms.linux ;
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.juliendehos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9552,6 +9552,8 @@ in
 
   tnt = callPackage ../development/libraries/tnt { };
 
+  tntnet = callPackage ../development/libraries/tntnet { };
+
   kyotocabinet = callPackage ../development/libraries/kyotocabinet { };
 
   tokyocabinet = callPackage ../development/libraries/tokyo-cabinet { };


### PR DESCRIPTION
###### Motivation for this change

This PR aims to add the tntnet framework as discussed here: https://github.com/NixOS/nixpkgs/pull/17777#issuecomment-240212291 .
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
