### PR TITLE
tntdb: init at 1.3

### DIFF
--- a/pkgs/development/libraries/tntdb/default.nix
+++ b/pkgs/development/libraries/tntdb/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, cxxtools, postgresql, mysql, sqlite, zlib, openssl }:
+
+stdenv.mkDerivation rec {
+  version = "1.3";
+  name = "tntdb";
+  src = fetchurl {
+    url = "http://www.tntnet.org/download/tntdb-${version}.tar.gz";
+    sha256 = "0js79dbvkic30bzw1pf26m64vs2ssw2sbj55w1dc0sy69dlv4fh9";
+  };
+
+  buildInputs = [ cxxtools postgresql mysql sqlite zlib openssl ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.tntnet.org/tntdb.html";
+    description = "C++ library which makes accessing SQL databases easy and robust";
+    platforms = platforms.linux ;
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.juliendehos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9554,6 +9554,8 @@ in
 
   tntnet = callPackage ../development/libraries/tntnet { };
 
+  tntdb = callPackage ../development/libraries/tntdb { };
+
   kyotocabinet = callPackage ../development/libraries/kyotocabinet { };
 
   tokyocabinet = callPackage ../development/libraries/tokyo-cabinet { };


### PR DESCRIPTION
###### Motivation for this change

This PR aims to add the tntnet framework (tntdb) as discussed here: https://github.com/NixOS/nixpkgs/pull/17777#issuecomment-240212291 .
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
