### PR TITLE
libselinux: fix Python binding

### DIFF
--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libsepol, pcre
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libsepol, pcre
 , enablePython ? true, swig ? null, python ? null
 }:
 
@@ -20,6 +20,15 @@ stdenv.mkDerivation rec {
              ++ optionals enablePython [ swig python ];
 
   NIX_CFLAGS_COMPILE = "-fstack-protector-all -std=gnu89";
+
+  # Unreleased upstream patch that fixes Python package issue arising
+  # from recent SWIG changes.
+  patches = optional enablePython (fetchpatch {
+    name = "fix-python-swig.patch";
+    url = "https://github.com/SELinuxProject/selinux/commit/a9604c30a5e2f71007d31aa6ba41cf7b95d94822.patch";
+    sha256 = "0mjrclh0sd8m7vq0wvl6pg29ss415j3kn0266v8ixy4fprafagfp";
+    stripLen = 1;
+  });
 
   postPatch = optionalString enablePython ''
     sed -i -e 's|\$(LIBDIR)/libsepol.a|${libsepol}/lib/libsepol.a|' src/Makefile


### PR DESCRIPTION
###### Motivation for this change

See issue #17808 "libselinux Python bindings cannot be imported".
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Upstream has this fix but it's not released yet.

Without it, the Python module can't be imported because of a module
path problem.
