### PR TITLE
jwm: 1535 -> 1548

### DIFF
--- a/pkgs/applications/window-managers/jwm/default.nix
+++ b/pkgs/applications/window-managers/jwm/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "jwm-${version}";
-  version = "1535";
+  version = "1548";
   
   src = fetchurl {
      url = "https://github.com/joewing/jwm/archive/s${version}.tar.gz";
-     sha256 = "1v593v1n9p9nvlhz1m9vc94wj21a6rbk7hcja30421h5mwa2b6gb";
+     sha256 = "1ih5y7567vwcbnkjwm3cc9iq4n9rzz818mkh6ryli9ld230hla5r";
   };
 
   nativeBuildInputs = [ pkgconfig automake autoconf libtool gettext which ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
