### PR TITLE
gthumb: init at 3.4.3

### DIFF
--- a/pkgs/applications/graphics/gthumb/default.nix
+++ b/pkgs/applications/graphics/gthumb/default.nix
@@ -1,0 +1,31 @@
+{ stdenv,  fetchurl, gnome3, itstool, libxml2, pkgconfig, intltool,
+  exiv2, libjpeg, libtiff, gstreamer, libraw, libsoup, libsecret,
+  libchamplain, librsvg, libwebp, json_glib, webkit, lcms2, bison,
+  flex, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "gthumb";
+  version = "${major}.3";
+  major = "3.4";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${major}/${name}.tar.xz";
+    sha256 = "0pc2xl6kwhi5l3d0dj6nzdcj2vpihs7y1s3l1hwir8zy7cpx23y1";
+  };
+
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+
+  buildInputs = with gnome3;
+    [ itstool libxml2 intltool glib gtk gsettings_desktop_schemas dconf
+      exiv2 libjpeg libtiff gstreamer libraw libsoup libsecret libchamplain
+      librsvg libwebp json_glib webkit lcms2 bison flex ];
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Apps/gthumb;
+    description = "Image browser and viewer for GNOME";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.mimadrid ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13083,6 +13083,8 @@ in
 
   gsimplecal = callPackage ../applications/misc/gsimplecal { };
 
+  gthumb = callPackage ../applications/graphics/gthumb { };
+
   gtimelog = pythonPackages.gtimelog;
 
   inherit (gnome3) gucharmap;


### PR DESCRIPTION
###### Motivation for this change

Add gThumb to NixOS.

I've added it to applications/graphics perhaps inside of gnome desktop folder is better, I don't really know.

Any kind of comment or suggestion is welcome.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
