### PR TITLE
shotwell: 0.23.4 -> 0.23.5

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, m4, glibc, gtk3, libexif, libgphoto2, libsoup, libxml2, vala, sqlite
 , webkitgtk, pkgconfig, gnome3, gst_all_1, which, udev, libgudev, libraw, glib, json_glib
-, gettext, desktop_file_utils, lcms2, gdk_pixbuf, librsvg, makeWrapper
+, gettext, desktop_file_utils, lcms2, gdk_pixbuf, librsvg, wrapGAppsHook
 , gnome_doc_utils, hicolor_icon_theme, itstool }:
 
 # for dependencies see http://www.yorba.org/projects/shotwell/install/
@@ -8,12 +8,12 @@
 stdenv.mkDerivation rec {
   version = "${major}.${minor}";
   major = "0.23";
-  minor = "4";
+  minor = "5";
   name = "shotwell-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/shotwell/${major}/${name}.tar.xz";
-    sha256 = "1hnl0lxibklmr1cy95ij1b3jgvdsw4zlcja53ngfxvlsi2r2bbxi";
+    sha256 = "0fgs1rgvkmy79bmpxrsvm5w8rvqml4l1vnwma0xqx5zzm02p8a07";
   };
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/glib-2.0 -I${glib.out}/lib/glib-2.0/include";
@@ -24,19 +24,11 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  preFixup = ''
-    wrapProgram "$out/bin/shotwell" \
-     --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-     --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3.out}/share:$out/share:$GSETTINGS_SCHEMAS_PATH" \
-     --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
-  '';
-
-
   buildInputs = [ m4 glibc gtk3 libexif libgphoto2 libsoup libxml2 vala sqlite webkitgtk
                   pkgconfig gst_all_1.gstreamer gst_all_1.gst-plugins-base gnome3.libgee
                   which udev libgudev gnome3.gexiv2 hicolor_icon_theme
                   libraw json_glib gettext desktop_file_utils glib lcms2 gdk_pixbuf librsvg
-                  makeWrapper gnome_doc_utils gnome3.rest
+                  wrapGAppsHook gnome_doc_utils gnome3.rest
                   gnome3.defaultIconTheme itstool ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update shotwell to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
