### PR TITLE
Add cmakeBuildType and dontAddCmakeBuildType variables to be able to make Debug builds.

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -49,7 +49,13 @@ cmakeConfigurePhase() {
 
     # Avoid cmake resetting the rpath of binaries, on make install
     # And build always Release, to ensure optimisation flags
-    cmakeFlags="-DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON $cmakeFlags"
+    cmakeFlags="-DCMAKE_SKIP_BUILD_RPATH=ON $cmakeFlags"
+
+    if [ -n "$cmakeBuildType" ]; then
+        cmakeFlags="-DCMAKE_BUILD_TYPE=$cmakeBuildType $cmakeFlags"
+    elif [ -z "dontAddBuildType" ]; then
+        cmakeFlags="-DCMAKE_BUILD_TYPE=Release $cmakeFlags"
+    fi
 
     echo "cmake flags: $cmakeFlags ${cmakeFlagsArray[@]}"
 


### PR DESCRIPTION
###### Motivation for this change

Current cmake setup-tools.sh only allow us to make release builds, and one cannot just remove the command as it is baked in right before calling cmake.

This pull request add the ability to set `cmakeBuildType` attribute, and default to `Release`.
This change is likely a mass-rebuild, so I am making this pull request against the staging branch.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution with `rr`.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
