### PR TITLE
unar: init at 1.10.1

### DIFF
--- a/pkgs/tools/archivers/unar/default.nix
+++ b/pkgs/tools/archivers/unar/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchurl, gnustep, unzip, bzip2, zlib, icu, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "unar";
+  version = "1.10.1";
+
+  src = fetchurl {
+    url = "http://unarchiver.c3.cx/downloads/${pname}${version}_src.zip";
+    sha256 = "0aq9zlar5vzr5qxphws8dm7ax60bsfsw77f4ciwa5dq5lla715j0";
+  };
+
+  buildInputs = [
+    gnustep.make unzip gnustep.base bzip2.dev
+    zlib.dev icu.dev openssl.dev
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile.linux \
+      --replace "CC = gcc" "CC=cc" \
+      --replace "CXX = g++" "CXX=c++" \
+      --replace "OBJCC = gcc" "OBJCC=cc" \
+      --replace "OBJCXX = g++" "OBJCXX=c++"
+
+    substituteInPlace ../UniversalDetector/Makefile.linux \
+      --replace "CC = gcc" "CC=cc" \
+      --replace "CXX = g++" "CXX=c++" \
+      --replace "OBJCC = gcc" "OBJCC=c" \
+      --replace "OBJCXX = g++" "OBJCXX=c++"
+  '';
+
+  makefile = "Makefile.linux";
+
+  sourceRoot = "./The Unarchiver/XADMaster";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp lsar $out/bin
+    cp unar $out/bin
+
+    mkdir -p $out/share/man/man1
+    cp ../Extra/lsar.1 $out/share/man/man1
+    cp ../Extra/unar.1 $out/share/man/man1
+
+    mkdir -p $out/etc/bash_completion.d
+    cp ../Extra/lsar.bash_completion $out/etc/bash_completion.d/lsar
+    cp ../Extra/unar.bash_completion $out/etc/bash_completion.d/unar
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://unarchiver.c3.cx/unarchiver;
+    description = "An archive unpacker program";
+    longDescription = ''
+      The Unarchiver is an archive unpacker program with support for the popular \
+      zip, RAR, 7z, tar, gzip, bzip2, LZMA, XZ, CAB, MSI, NSIS, EXE, ISO, BIN, \
+      and split file formats, as well as the old Stuffit, Stuffit X, DiskDouble, \
+      Compact Pro, Packit, cpio, compress (.Z), ARJ, ARC, PAK, ACE, ZOO, LZH, \
+      ADF, DMS, LZX, PowerPacker, LBR, Squeeze, Crunch, and other old formats. 
+    '';
+    license = with licenses; [ lgpl21Plus ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4016,6 +4016,8 @@ in
 
   ugarit-manifest-maker = callPackage ../tools/backup/ugarit-manifest-maker { };
 
+  unar = callPackage ../tools/archivers/unar { stdenv = clangStdenv; };
+
   unarj = callPackage ../tools/archivers/unarj { };
 
   unshield = callPackage ../tools/archivers/unshield { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/16868

Thanks to @matthewbauer for https://github.com/NixOS/nixpkgs/pull/16762
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
