### PR TITLE
pixie: 1352 -> 1356

### DIFF
--- a/pkgs/development/interpreters/pixie/default.nix
+++ b/pkgs/development/interpreters/pixie/default.nix
@@ -3,7 +3,7 @@
   variant ? "jit", buildWithPypy ? false }:
 
 let
-  commit-count = "1352";
+  commit-count = "1356";
   common-flags = "--thread --gcrootfinder=shadowstack --continuation";
   variants = {
     jit = { flags = "--opt=jit"; target = "target.py"; };
@@ -13,14 +13,14 @@ let
   };
   pixie-src = fetchgit {
     url = "https://github.com/pixie-lang/pixie.git";
-    rev = "dd754fe9f329e9e176eeaedae1095c85cde65028";
-    sha256 = "1jf3nkd1jzvxrw9ql2r74drsirrxfihc125x0wmk45jyl5q24vdd";
+    rev = "d2a4267ea088f711af36a74928e8dfd8360584ad";
+    sha256 = "1asf6yx7zy9cx4bsg8iai57dy3r3m45xcmkmw2vix70xvfy23ryf";
   };
-  pypy-tag = "81254";
+  pypy-tag = "91db1a9";
   pypy-src = fetchurl {
     name = "pypy-src-${pypy-tag}";
     url = "https://bitbucket.org/pypy/pypy/get/${pypy-tag}.tar.bz2";
-    sha256 = "1cs9xqs1rmzdcnwxxkbvy064s5cbp6vvzhn2jmyzh5kg4di1r3bn";
+    sha256 = "0ylbqvhbcp5m09l15i2q2h3a0vjd055x2r37cq71lkhgmmaxrwbq";
   };
   libs = [ libffi libedit libuv boost.dev boost.out zlib ];
   include-path = stdenv.lib.concatStringsSep ":"

--- a/pkgs/development/interpreters/pixie/default.nix
+++ b/pkgs/development/interpreters/pixie/default.nix
@@ -63,11 +63,17 @@ let
       mkdir -p $out/share $out/bin
       cp pixie-src/pixie-vm $out/share/pixie-vm
       cp -R pixie-src/pixie $out/share/pixie
-      makeWrapper $out/share/pixie-vm $out/bin/pxi \
+      makeWrapper $out/share/pixie-vm $out/bin/pixie-vm \
         --prefix LD_LIBRARY_PATH : ${library-path} \
         --prefix C_INCLUDE_PATH : ${include-path} \
         --prefix LIBRARY_PATH : ${library-path} \
         --prefix PATH : ${bin-path}
+      cat > $out/bin/pxi <<EOF
+      #!$shell
+      >&2 echo "[\$\$] WARNING: 'pxi' is a deprecated alias for 'pixie-vm', please update your scripts."
+      exec $out/bin/pixie-vm "\$@"
+      EOF
+      chmod +x $out/bin/pxi
     '';
     meta = {
       description = "A clojure-like lisp, built with the pypy vm toolkit";

--- a/pkgs/development/interpreters/pixie/dust.nix
+++ b/pkgs/development/interpreters/pixie/dust.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ pixie ];
   patches = [ ./make-paths-configurable.patch ];
   configurePhase = ''
-    pixiePath="${pixie}/bin/pxi" \
+    pixiePath="${pixie}/bin/pixie-vm" \
     basePath="$out/share/dust" \
       substituteAll dust.in dust
     chmod +x dust


### PR DESCRIPTION
###### Motivation for this change

Pixie update, rename binary (deprecate old name)
###### Things done
- Built on platform(s)
  - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
