### PR TITLE
build-support: Add fetchfossil function.

### DIFF
--- a/pkgs/build-support/fetchfossil/builder.sh
+++ b/pkgs/build-support/fetchfossil/builder.sh
@@ -3,7 +3,8 @@ header "Cloning Fossil $url into $out"
 
 # Fossil, bless its adorable little heart, wants to write global configuration
 # to $HOME/.fossil. AFAICT, there is no way to disable this functionality.
-export HOME=.
+# Instead, we'll let it write to the build directory.
+export HOME=$(pwd)
 
 # We must explicitly set the admin user for the clone to something reasonable.
 fossil clone -A nobody "$url" fossil-clone.fossil

--- a/pkgs/build-support/fetchfossil/builder.sh
+++ b/pkgs/build-support/fetchfossil/builder.sh
@@ -1,5 +1,5 @@
 source $stdenv/setup
-header "Cloning Fossil $url into $out"
+header "Cloning Fossil $url [$rev] into $out"
 
 # Fossil, bless its adorable little heart, wants to write global configuration
 # to $HOME/.fossil. AFAICT, there is no way to disable this functionality.
@@ -13,7 +13,7 @@ mkdir fossil-clone
 WORKDIR=$(pwd)
 mkdir $out
 pushd $out
-fossil open "$WORKDIR/fossil-clone.fossil"
+fossil open "$WORKDIR/fossil-clone.fossil" "$rev"
 popd
 
 # Just nuke the checkout file.

--- a/pkgs/build-support/fetchfossil/builder.sh
+++ b/pkgs/build-support/fetchfossil/builder.sh
@@ -1,0 +1,21 @@
+source $stdenv/setup
+header "Cloning Fossil $url into $out"
+
+# Fossil, bless its adorable little heart, wants to write global configuration
+# to $HOME/.fossil. AFAICT, there is no way to disable this functionality.
+export HOME=.
+
+# We must explicitly set the admin user for the clone to something reasonable.
+fossil clone -A nobody "$url" fossil-clone.fossil
+
+mkdir fossil-clone
+WORKDIR=$(pwd)
+mkdir $out
+pushd $out
+fossil open "$WORKDIR/fossil-clone.fossil"
+popd
+
+# Just nuke the checkout file.
+rm $out/.fslckout
+
+stopNest

--- a/pkgs/build-support/fetchfossil/default.nix
+++ b/pkgs/build-support/fetchfossil/default.nix
@@ -1,0 +1,21 @@
+{stdenv, fossil}:
+
+{name ? null, url, rev ? null, md5 ? null, sha256 ? null}:
+
+# TODO: statically check if mercurial as the https support if the url starts woth https.
+stdenv.mkDerivation {
+  name = "fossil-archive" + (if name != null then "-${name}" else "");
+  builder = ./builder.sh;
+  buildInputs = [fossil];
+
+  impureEnvVars = [
+    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
+  ];
+
+  outputHashAlgo = if md5 != null then "md5" else "sha256";
+  outputHashMode = "recursive";
+  outputHash = if md5 != null then md5 else sha256;
+
+  inherit url rev;
+  preferLocalBuild = true;
+}

--- a/pkgs/build-support/fetchfossil/default.nix
+++ b/pkgs/build-support/fetchfossil/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fossil}:
 
-{name ? null, url, rev, md5 ? null, sha256 ? null}:
+{name ? null, url, rev, sha256}:
 
 stdenv.mkDerivation {
   name = "fossil-archive" + (if name != null then "-${name}" else "");
@@ -11,9 +11,9 @@ stdenv.mkDerivation {
   # https://www.fossil-scm.org/index.html/doc/trunk/www/env-opts.md
   impureEnvVars = [ "http_proxy" ];
 
-  outputHashAlgo = if md5 != null then "md5" else "sha256";
+  outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = if md5 != null then md5 else sha256;
+  outputHash = sha256;
 
   inherit url rev;
   preferLocalBuild = true;

--- a/pkgs/build-support/fetchfossil/default.nix
+++ b/pkgs/build-support/fetchfossil/default.nix
@@ -2,15 +2,14 @@
 
 {name ? null, url, rev ? null, md5 ? null, sha256 ? null}:
 
-# TODO: statically check if mercurial as the https support if the url starts woth https.
 stdenv.mkDerivation {
   name = "fossil-archive" + (if name != null then "-${name}" else "");
   builder = ./builder.sh;
   buildInputs = [fossil];
 
-  impureEnvVars = [
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-  ];
+  # Envvar docs are hard to find. A link for the future:
+  # https://www.fossil-scm.org/index.html/doc/trunk/www/env-opts.md
+  impureEnvVars = [ "http_proxy" ];
 
   outputHashAlgo = if md5 != null then "md5" else "sha256";
   outputHashMode = "recursive";

--- a/pkgs/build-support/fetchfossil/default.nix
+++ b/pkgs/build-support/fetchfossil/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fossil}:
 
-{name ? null, url, rev ? null, md5 ? null, sha256 ? null}:
+{name ? null, url, rev, md5 ? null, sha256 ? null}:
 
 stdenv.mkDerivation {
   name = "fossil-archive" + (if name != null then "-${name}" else "");

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -162,6 +162,8 @@ in
 
   fetchdarcs = callPackage ../build-support/fetchdarcs { };
 
+  fetchfossil = callPackage ../build-support/fetchfossil { };
+
   fetchgit = callPackage ../build-support/fetchgit {
     git = gitMinimal;
   };


### PR DESCRIPTION
###### Motivation for this change

I have a Fossil repository that I want to reference from Nix.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a dead-simple fetcher which clones a Fossil repository, opens it directly into $out, and then nicks out the single Fossil checkout marker.

For some reason, my Let's Encrypt certificates don't work when fetching over HTTPS. I don't know why. It's not a dealbreaker for me, though.
