### PR TITLE
postgresql: Fix use with extensions

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -11,12 +11,14 @@ let
     if cfg.extraPlugins == [] then pg
     else pkgs.buildEnv {
       name = "postgresql-and-plugins-${(builtins.parseDrvName pg.name).version}";
-      paths = [ pg ] ++ cfg.extraPlugins;
+      paths = [ pg pg.lib ] ++ cfg.extraPlugins;
+      buildInputs = [ pkgs.makeWrapper ];
       postBuild =
         ''
           mkdir -p $out/bin
           rm $out/bin/{pg_config,postgres,pg_ctl}
           cp --target-directory=$out/bin ${pg}/bin/{postgres,pg_config,pg_ctl}
+          wrapProgram $out/bin/postgres --set NIX_PGLIBDIR $out/lib
         '';
     };
 

--- a/nixos/tests/postgis.nix
+++ b/nixos/tests/postgis.nix
@@ -1,0 +1,30 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "postgis";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ lsix ];
+  };
+
+  nodes = {
+    master =
+      { pkgs, config, ... }:
+
+      {
+        services.postgresql = let mypg = pkgs.postgresql95; in {
+            enable = true;
+            package = mypg;
+            extraPlugins = [ (pkgs.postgis.override { postgresql = mypg; }).v_2_2_1 ];
+            initialScript =  pkgs.writeText "postgresql-init.sql"
+          ''
+          CREATE ROLE postgres WITH superuser login createdb;
+          '';
+          };
+      };
+  };
+
+  testScript = ''
+    startAll;
+    $master->waitForUnit("postgresql");
+    $master->sleep(10); # Hopefully this is long enough!!
+    $master->succeed("sudo -u postgres psql -c 'CREATE EXTENSION postgis;'");
+  '';
+})

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -33,6 +33,7 @@ let
       [ (if lib.versionAtLeast version "9.4" then ./disable-resolve_symlinks-94.patch else ./disable-resolve_symlinks.patch)
         ./less-is-more.patch
         ./hardcode-pgxs-path.patch
+        ./specify_pkglibdir_at_runtime.patch
       ];
 
     installTargets = [ "install-world" ];

--- a/pkgs/servers/sql/postgresql/specify_pkglibdir_at_runtime.patch
+++ b/pkgs/servers/sql/postgresql/specify_pkglibdir_at_runtime.patch
@@ -1,0 +1,29 @@
+diff -ur postgresql-9.5.3-orig/src/port/path.c postgresql-9.5.3/src/port/path.c
+--- postgresql-9.5.3-orig/src/port/path.c	2016-05-09 22:50:23.000000000 +0200
++++ postgresql-9.5.3/src/port/path.c	2016-08-29 22:44:10.507377613 +0200
+@@ -714,7 +714,11 @@
+ void
+ get_lib_path(const char *my_exec_path, char *ret_path)
+ {
+-	make_relative_path(ret_path, LIBDIR, PGBINDIR, my_exec_path);
++	char const * const nix_pglibdir = getenv("NIX_PGLIBDIR");
++	if(nix_pglibdir == NULL)
++		make_relative_path(ret_path, LIBDIR, PGBINDIR, my_exec_path);
++	else
++		make_relative_path(ret_path, nix_pglibdir, PGBINDIR, my_exec_path);
+ }
+ 
+ /*
+@@ -723,7 +727,11 @@
+ void
+ get_pkglib_path(const char *my_exec_path, char *ret_path)
+ {
+-	make_relative_path(ret_path, PKGLIBDIR, PGBINDIR, my_exec_path);
++	char const * const nix_pglibdir = getenv("NIX_PGLIBDIR");
++	if(nix_pglibdir == NULL)
++		make_relative_path(ret_path, PKGLIBDIR, PGBINDIR, my_exec_path);
++	else
++		make_relative_path(ret_path, nix_pglibdir, PGBINDIR, my_exec_path);
+ }
+ 
+ /*


### PR DESCRIPTION
###### Motivation for this change

Postgresql extension mechanism is broken in master as reported in #15512 and #16032
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #15512 and #16032
