### PR TITLE
sage: fix ncurses compilation error

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     export SAGE_ATLAS_ARCH=fast
     mkdir -p $out/sageHome
     export HOME=$out/sageHome
+    export CPPFLAGS="-P"
   '';
 
   preBuild = "patchShebangs build";
@@ -30,7 +31,6 @@ stdenv.mkDerivation rec {
   installPhase = ''DESTDIR=$out make install'';
 
   meta = {
-    broken = true;
     homepage = "http://www.sagemath.org";
     description = "A free open source mathematics software system";
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -361,7 +361,7 @@ rec {
     http://ftp.ntua.gr/pub/sagemath/src/
 
     # Old versions
-    http://sagemath.org/src-old/
+    http://old.files.sagemath.org/src-old/
   ];
 
   # MySQL mirrors


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See
http://stackoverflow.com/questions/37475222/ncurses-6-0-compilation-error-error-expected-before-int
