### PR TITLE
imlibsetroot: init at 1.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -226,6 +226,7 @@
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
   lowfatcomputing = "Andreas Wagner <andreas.wagner@lowfatcomputing.org>";
   lsix = "Lancelot SIX <lsix@lancelotsix.com>";
+  lucas8 = "Luc Chabassier <luc.linux@mailoo.org>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
   luispedro = "Luis Pedro Coelho <luis@luispedro.org>";
   lukasepple = "Lukas Epple <post@lukasepple.de>";

--- a/pkgs/applications/graphics/imlibsetroot/default.nix
+++ b/pkgs/applications/graphics/imlibsetroot/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, libX11, libXinerama, imlib2 }:
+
+stdenv.mkDerivation rec {
+  name = "imlibsetroot-${version}";
+  version = "1.2";
+  src = fetchurl {
+    url = "http://robotmonkeys.net/wp-content/uploads/2010/03/imlibsetroot-12.tar.gz";
+    sha256 = "8c1b3b7c861e4d865883ec13a96b8e4ab22464a87d4e6c67255b17a88e3cfd1c";
+  };
+
+  buildInputs = [ libX11 imlib2 libXinerama ];
+  buildPhase = ''
+    gcc -g imlibsetroot.c -o imlibsetroot             \
+      `imlib2-config --cflags` `imlib2-config --libs` \
+      -I/include/X11/extensions -lXinerama -lX11
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 755 imlibsetroot $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Xinerama Aware Background Changer";
+    homepage = "http://robotmonkeys.net/2010/03/30/imlibsetroot/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lucas8 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7766,6 +7766,8 @@ in
 
   imlib2 = callPackage ../development/libraries/imlib2 { };
 
+  imlibsetroot = callPackage ../applications/graphics/imlibsetroot { libXinerama = xorg.libXinerama; } ;
+
   ijs = callPackage ../development/libraries/ijs { };
 
   incrtcl = callPackage ../development/libraries/incrtcl { };


### PR DESCRIPTION
###### Motivation for this change

Add imlibsetroot to the package list.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
