### PR TITLE
cantarell_fonts: 0.0.24 -> 0.0.25

### DIFF
--- a/pkgs/data/fonts/cantarell-fonts/default.nix
+++ b/pkgs/data/fonts/cantarell-fonts/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   major = "0.0";
-  minor = "24";
+  minor = "25";
   name = "cantarell-fonts-${major}.${minor}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/cantarell-fonts/${major}/${name}.tar.xz";
-    sha256 = "0r4jnc2x9yncf40lixjb1pqgpq8rzbi2fz33pshlqzjgx2d69bcw";
+    sha256 = "0zvkd8cm1cg2919v1js9qmzwa02sjl7qajj3gcvgqvai1fm2i8hl";
   };
 
   meta = {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
