### PR TITLE
Idea: 2016.1.2 -> 2016.2

### DIFF
--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -185,13 +185,13 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2016.1.2";
-    build = "IC-145.971.21";
+    version = "2016.1.3";
+    build = "IC-145.1617.8";
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "15c92wsfw16j48k12x4vw78886yf9yjx7hwwjamgf28lmzvc37iz";
+      sha256 = "0yd1jqz4arywyjsiakszrr48w2xqnik6vnl1a6l0ph2hssgkzkfi";
     };
   };
 
@@ -221,13 +221,13 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2016.1.2";
-    build = "IU-145.971.21";
+    version = "2016.1.3";
+    build = "IU-145.1617.8";
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
-      sha256 = "0dxpx4nx845vgqxl5qz029d3w3kn3hi98wgzympidplxrphgalgy";
+      sha256 = "1zzxwdnw2bbnl86kj7fjk5p8c99d0hdn1ki2alw5xm8wp4k0w7rv";
     };
   };
 

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -185,13 +185,13 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2016.1.3";
-    build = "IC-145.1617.8";
+    version = "2016.2";
+    build = "IC-162.1121";
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "0yd1jqz4arywyjsiakszrr48w2xqnik6vnl1a6l0ph2hssgkzkfi";
+      sha256 = "164x4l0q31zpc1jh3js1xx9y6afrzsshmnkx1mwhmq8qmvzc4w32";
     };
   };
 
@@ -221,13 +221,13 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2016.1.3";
-    build = "IU-145.1617.8";
+    version = "2016.2";
+    build = "IU-162.1121";
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
-      sha256 = "1zzxwdnw2bbnl86kj7fjk5p8c99d0hdn1ki2alw5xm8wp4k0w7rv";
+      sha256 = "10hiqh6ccmai2cnc5p72vqjcz9kzmmcpn0hy5v514h4mq6vs4zk4";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Version of IDEA currently available on `release-16.03` is no longer available on JetBrains' servers, and thus the installation fails. Updating so that installation no longer fails. I've simply cherry-picked commits from `master` branch.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
