### PR TITLE
gtk3: 3.20.8 -> 3.20.9

### DIFF
--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -13,7 +13,7 @@ with stdenv.lib;
 
 let
   ver_maj = "3.20";
-  ver_min = "8";
+  ver_min = "9";
   version = "${ver_maj}.${ver_min}";
 in
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk+/${ver_maj}/gtk+-${version}.tar.xz";
-    sha256 = "9841bd9b4d23c045c474b10fdde9da958af904b63783701e796391d55d4396f3";
+    sha256 = "05xcwvy68p7f4hdhi4bgdm3aycvqqr4pr5kkkr8ba91l5yx0k9l3";
   };
 
   outputs = [ "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/GNOME/gtk/commit/10c3a2483635d1c1bd140f5623ec0fee5970535a made me think my mouse was broken :/

The other changes barely register: https://github.com/GNOME/gtk/commits/53e92dcab2d28748409e9248f229496b08263ca5

cc maintainer @vcunat 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
