### PR TITLE
openttd: music support

### DIFF
--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -52,9 +52,12 @@ stdenv.mkDerivation rec {
       cp ${opensfx}/*.{obs,cat} $out/share/games/openttd/data
     ''}
 
+    mkdir $out/share/games/openttd/baseset/openmsx
+
     ${stdenv.lib.optionalString withOpenMSX ''
-      cp ${openmsx}/*.{obm,mid} $out/share/games/openttd/data
+      cp ${openmsx}/*.{obm,mid} $out/share/games/openttd/baseset/openmsx
     ''}
+
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
- fix music path for openmsx
- added wrapper script to play midi files based on https://wiki.archlinux.org/index.php/OpenTTD
- used pulseaudio as the default as I assume this is what most people use
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
