### PR TITLE
ocaml-magick: fix darwin build

### DIFF
--- a/pkgs/development/ocaml-modules/magick/default.nix
+++ b/pkgs/development/ocaml-modules/magick/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation {
 
   createFindlibDestdir = true;
 
+  preConfigure = "substituteInPlace Makefile --replace gcc $CC";
+
   installTargets = [ "find_install" ];
 
   meta = {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
