### PR TITLE
xf86videoamdgpu: init at 1.1.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1722,6 +1722,18 @@ let
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit fontsproto libpciaccess randrproto renderproto videoproto xextproto xorgserver xproto ;};
 
+  xf86videoamdgpu = (mkDerivation "xf86videoamdgpu" {
+    name = "xf86-video-amdgpu-1.1.0";
+    builder = ./builder.sh;
+    src = fetchurl {
+      url = mirror://xorg/individual/driver/xf86-video-amdgpu-1.1.0.tar.bz2;
+      sha256 = "0cbrqpmi1hgbsi0i93v0yp7lv3wf4s0vbdlrj19cxmglv7gd1xb9";
+    };
+    buildInputs = [pkgconfig fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
+    configureFlags = "--with-xorg-conf-dir=$(out)/share/X11/xorg.conf.d";
+    meta.platforms = stdenv.lib.platforms.unix;
+  }) // {inherit fontsproto libdrm udev libpciaccess randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
+
   xf86videocirrus = (mkDerivation "xf86videocirrus" {
     name = "xf86-video-cirrus-1.5.3";
     builder = ./builder.sh;

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -302,6 +302,7 @@ let
         xf86inputsynaptics = linux;
         xf86videoati = linux;
         xf86videocirrus = linux;
+        xf86videoamdgpu = linux;
         xf86videointel = linux;
         xf86videonv = linux;
         xf86videovesa = linux;


### PR DESCRIPTION
###### Motivation for this change

xf86-video-amdgpu wasn't available, see #17682
###### Things done

Based on ati driver (buildInputs could be wrong?).  Added configureFlags to stop it installing xorg.conf in `pkg-config -sysconfdir xorg-server`.
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested with linux-4.7 + DRM_AMDGPU_CIK on an R9 290
