### PR TITLE
root: add support for x86_64-darwin

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, fetchpatch, cmake, pkgconfig, python
-, libX11, libXpm, libXft, libXext, zlib, lzma, gsl }:
+{ stdenv, fetchurl, fetchpatch, cmake, pcre, pkgconfig, python
+, libX11, libXpm, libXft, libXext, zlib, lzma, gsl, Cocoa }:
 
 stdenv.mkDerivation rec {
   name = "root-${version}";
@@ -10,13 +10,17 @@ stdenv.mkDerivation rec {
     sha256 = "00f3v3l8nimfkcxpn9qpyh3h23na0mi4wkds2y5gwqh8wh3jryq9";
   };
 
-  buildInputs = [ cmake pkgconfig python libX11 libXpm libXft libXext zlib lzma gsl ];
+  buildInputs = [ cmake pcre pkgconfig python zlib lzma gsl ]
+    ++ stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 libXpm libXft libXext ]
+    ++ stdenv.lib.optionals (stdenv.isDarwin) [ Cocoa ]
+    ;
 
   patches = [
     (fetchpatch {
       url = "https://github.com/root-mirror/root/commit/ee9964210c56e7c1868618a4434c5340fef38fe4.patch";
       sha256 = "186i7ni75yvjydy6lpmaplqxfb5z2019bgpbhff1n6zn2qlrff2r";
     })
+    ./sw_vers.patch
   ];
 
   preConfigure = ''
@@ -27,6 +31,33 @@ stdenv.mkDerivation rec {
     "-Drpath=ON"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-Dalien=OFF"
+    "-Dbonjour=OFF"
+    "-Dcastor=OFF"
+    "-Dchirp=OFF"
+    "-Ddavix=OFF"
+    "-Ddcache=OFF"
+    "-Dfftw3=OFF"
+    "-Dfitsio=OFF"
+    "-Dfortran=OFF"
+    "-Dgfal=OFF"
+    "-Dgviz=OFF"
+    "-Dhdfs=OFF"
+    "-Dkrb5=OFF"
+    "-Dldap=OFF"
+    "-Dmonalisa=OFF"
+    "-Dmysql=OFF"
+    "-Dodbc=OFF"
+    "-Dopengl=OFF"
+    "-Doracle=OFF"
+    "-Dpgsql=OFF"
+    "-Dpythia6=OFF"
+    "-Dpythia8=OFF"
+    "-Drfio=OFF"
+    "-Dsqlite=OFF"
+    "-Dssl=OFF"
+    "-Dxml=OFF"
+    "-Dxrootd=OFF"
   ]
   ++ stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.lib.getDev stdenv.cc.libc}/include";
 
@@ -35,6 +66,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://root.cern.ch/";
     description = "A data analysis framework";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/science/misc/root/sw_vers.patch
+++ b/pkgs/applications/science/misc/root/sw_vers.patch
@@ -1,0 +1,90 @@
+diff --git a/build/unix/compiledata.sh b/build/unix/compiledata.sh
+--- a/build/unix/compiledata.sh
++++ b/build/unix/compiledata.sh
+@@ -49,7 +49,7 @@ fi
+ 
+ if [ "$ARCH" = "macosx" ] || [ "$ARCH" = "macosx64" ] || \
+    [ "$ARCH" = "macosxicc" ]; then
+-   macosx_minor=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 2`
++   macosx_minor=7
+    SOEXT="so"
+    if [ $macosx_minor -ge 5 ]; then
+       if [ "x`echo $SOFLAGS | grep -- '-install_name'`" != "x" ]; then
+diff --git a/cmake/modules/SetUpMacOS.cmake b/cmake/modules/SetUpMacOS.cmake
+--- a/cmake/modules/SetUpMacOS.cmake
++++ b/cmake/modules/SetUpMacOS.cmake
+@@ -12,25 +12,11 @@ set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} /usr/X11R6)
+ #---------------------------------------------------------------------------------------------------------
+ 
+ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+-  EXECUTE_PROCESS(COMMAND sw_vers "-productVersion"
+-                  COMMAND cut -d . -f 1-2
+-                  OUTPUT_VARIABLE MACOSX_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+-  MESSAGE(STATUS "Found a Mac OS X System ${MACOSX_VERSION}")
+-  EXECUTE_PROCESS(COMMAND sw_vers "-productVersion"
+-                  COMMAND cut -d . -f 2
+-                  OUTPUT_VARIABLE MACOSX_MINOR OUTPUT_STRIP_TRAILING_WHITESPACE)
+-
+-  if(MACOSX_VERSION VERSION_GREATER 10.7 AND ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
+     set(libcxx ON CACHE BOOL "Build using libc++" FORCE)
+-  endif()
+ 
+-  if(${MACOSX_MINOR} GREATER 4)
+     #TODO: check haveconfig and rpath -> set rpath true
+     #TODO: check Thread, define link command
+     #TODO: more stuff check configure script
+-    execute_process(COMMAND /usr/sbin/sysctl machdep.cpu.extfeatures OUTPUT_VARIABLE SYSCTL_OUTPUT)
+-    if(${SYSCTL_OUTPUT} MATCHES 64)
+-       MESSAGE(STATUS "Found a 64bit system")
+        set(ROOT_ARCHITECTURE macosx64)
+        SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+        SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -m64")
+@@ -38,27 +24,6 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
+        SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
+        SET(CMAKE_FORTRAN_FLAGS "${CMAKE_FORTRAN_FLAGS} -m64")
+-    else(${SYSCTL_OUTPUT} MATCHES 64)
+-       MESSAGE(STATUS "Found a 32bit system")
+-       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+-       SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+-       SET(CMAKE_FORTRAN_FLAGS "${CMAKE_FORTRAN_FLAGS} -m32")
+-    endif(${SYSCTL_OUTPUT} MATCHES 64)
+-  endif()
+-
+-  if(MACOSX_VERSION VERSION_GREATER 10.6)
+-    set(MACOSX_SSL_DEPRECATED ON)
+-  endif()
+-  if(MACOSX_VERSION VERSION_GREATER 10.7)
+-    set(MACOSX_ODBC_DEPRECATED ON)
+-  endif()
+-  if(MACOSX_VERSION VERSION_GREATER 10.8)
+-    set(MACOSX_GLU_DEPRECATED ON)
+-    set(MACOSX_KRB5_DEPRECATED ON)
+-  endif()
+-  if(MACOSX_VERSION VERSION_GREATER 10.9)
+-    set(MACOSX_LDAP_DEPRECATED ON)
+-  endif()
+ 
+   if (CMAKE_COMPILER_IS_GNUCXX)
+      message(STATUS "Found GNU compiler collection")
+@@ -135,7 +100,7 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+   endif()
+ 
+   #---Set Linker flags----------------------------------------------------------------------
+-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  -mmacosx-version-min=${MACOSX_VERSION} -Wl,-rpath,@loader_path/../lib")
++  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,@loader_path/../lib")
+ 
+ 
+ else (CMAKE_SYSTEM_NAME MATCHES Darwin)
+diff --git a/config/root-config.in b/config/root-config.in
+--- a/config/root-config.in
++++ b/config/root-config.in
+@@ -304,7 +304,7 @@ macosxicc)
+    ;;
+ macosx64)
+    # MacOS X with gcc (GNU cc v4.x) in 64 bit mode
+-   macosx_minor=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 2`
++   macosx_minor=7
+    # cannot find the one linked to libGraf if relocated after built
+    if [ $macosx_minor -le 4 ]; then
+       rootlibs="$rootlibs -lfreetype"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17022,7 +17022,9 @@ in
 
   megam = callPackage ../applications/science/misc/megam { };
 
-  root = callPackage ../applications/science/misc/root { };
+  root = callPackage ../applications/science/misc/root {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   simgrid = callPackage ../applications/science/misc/simgrid { };
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

also
1) add pcre dependency (for some reason builtin_pcre doesn't work)
2) disable dependencies that are not supported by the expression
(improves purity)
