### PR TITLE
darwin.libsecurity: fix for gnustep makefiles

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_generic/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_generic/default.nix
@@ -29,7 +29,7 @@ name: version: sha256: args: let
         makeFlagsArray=(-j''$NIX_BUILD_CORES)
       '';
       buildInputs = [
-        pkgs.gnustep-make
+        pkgs.gnustep.make
         pkgs.darwin.apple_sdk.frameworks.AppKit
         pkgs.darwin.apple_sdk.frameworks.Foundation
         pkgs.darwin.cf-private
@@ -38,6 +38,7 @@ name: version: sha256: args: let
         "-f${makeFile}"
         "MAKEFILE_NAME=${makeFile}"
         "GNUSTEP_ABSOLUTE_INSTALL_PATHS=yes"
+        "GNUSTEP_MAKEFILES=${pkgs.gnustep.make}/share/GNUstep/Makefiles"
         "LIB_LINK_INSTALL_DIR=\$(out)/lib"
       ];
       installFlags = [

--- a/pkgs/os-specific/darwin/security-tool/default.nix
+++ b/pkgs/os-specific/darwin/security-tool/default.nix
@@ -1,5 +1,5 @@
 { CoreServices, Foundation, PCSC, Security, GSS, Kerberos, makeWrapper, apple_sdk,
-fetchurl, gnustep-make, libobjc, libsecurity_apple_csp, libsecurity_apple_cspdl,
+fetchurl, gnustep, libobjc, libsecurity_apple_csp, libsecurity_apple_cspdl,
 libsecurity_apple_file_dl, libsecurity_apple_x509_cl, libsecurity_apple_x509_tp,
 libsecurity_asn1, libsecurity_cdsa_client, libsecurity_cdsa_plugin,
 libsecurity_cdsa_utilities, libsecurity_cdsa_utils, libsecurity_cssm, libsecurity_filedb,
@@ -39,7 +39,11 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = "-no_dtrace_dof";
 
-  makeFlags = "-f ${./GNUmakefile} MAKEFILE_NAME=${./GNUmakefile}";
+  makeFlags = [
+    "-f ${./GNUmakefile}"
+    "MAKEFILE_NAME=${./GNUmakefile}"
+    "GNUSTEP_MAKEFILES=${gnustep.make}/share/GNUstep/Makefiles"
+  ];
 
   installFlags = [
     "security_INSTALL_DIR=\$(out)/bin"
@@ -50,7 +54,7 @@ stdenv.mkDerivation rec {
   __propagatedImpureHostDeps = [ "/System/Library/Keychains" ];
 
   buildInputs = [
-    gnustep-make
+    gnustep.make
     libsecurity_asn1
     libsecurity_utilities
     libsecurity_cdsa_utilities


### PR DESCRIPTION
###### Motivation for this change

It looks like https://github.com/NixOS/nixpkgs/commit/c3974455ebdc5a61093d236d06d389c3c1eac5df broke `darwin.libsecurity` and `darwin.security_tool`.

cc @matthewbauer
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] OS X
  - [x] ~~Other platforms~~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
