### PR TITLE
vala: 0.32.0 -> 0.32.1

### DIFF
--- a/pkgs/development/compilers/vala/0.32.nix
+++ b/pkgs/development/compilers/vala/0.32.nix
@@ -4,8 +4,8 @@
 
 let
   major = "0.32";
-  minor = "0";
-  sha256 = "0vpvq403vdd25irvgk7zibz3nw4x4i17m0dgnns8j1q4vr7am8h7";
+  minor = "1";
+  sha256 = "1ab1l44abf9fj1wznzq5956431ia136rl5049cggnk5393jlf3fx";
 in
 stdenv.mkDerivation rec {
   name = "vala-${major}.${minor}";
@@ -27,4 +27,5 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib libiconv ]
     ++ libintlOrEmpty;
+
 }


### PR DESCRIPTION
###### Motivation for this change

maintenance https://wiki.gnome.org/Projects/Vala/Release

Note: The latest vala (0.32) should become the current version instead of the older 0.28 since there were a lot of GNOME\GTK binding updates and general fixes related to other packages that are already part of Nix. ~~However, I'll push that in a separate PR later since hydra is pretty full right now as it is.~~ I opened an issue instead: https://github.com/NixOS/nixpkgs/issues/17869 It's a trivial file & namespace rename operation but a lot of GNOME \ GTK packages will need to be recompiled so I can't just push a PR and hope for the best ;)
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
