### PR TITLE
libsecret: add vala dependency

### DIFF
--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, pkgconfig, intltool, libxslt, docbook_xsl, gtk_doc
-, libgcrypt, gobjectIntrospection }:
+, libgcrypt, gobjectIntrospection, vala_0_32 }:
 let
   version = "0.18.5";
 in
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib ];
   nativeBuildInputs = [ pkgconfig intltool libxslt docbook_xsl ];
-  buildInputs = [ libgcrypt gobjectIntrospection ];
+  buildInputs = [ libgcrypt gobjectIntrospection vala_0_32 ];
   # optional: build docs with gtk-doc? (probably needs a flag as well)
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/17844#issuecomment-241198806

I tested compilation against vala 32 and vala 28. The /share/vala bindings are produced correctly. 

Note the current vala package is 0.28 which isn't current or stable so there will be some run time hiccups until the default is updated to 32. But it's separate from this PR (https://github.com/NixOS/nixpkgs/issues/17869).
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
