### PR TITLE
Switch sourceforge links to mirror://

### DIFF
--- a/pkgs/applications/backup/areca/default.nix
+++ b/pkgs/applications/backup/areca/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "areca-7.5";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/areca/areca-stable/areca-7.5/areca-7.5-src.tar.gz";
+    url = "mirror://sourceforge/project/areca/areca-stable/areca-7.5/areca-7.5-src.tar.gz";
     sha256 = "1q4ha9s96c1syplxm04bh1v1gvjq16l4pa8w25w95d2ywwvyq1xb";
   };
 

--- a/pkgs/applications/editors/ht/default.nix
+++ b/pkgs/applications/editors/ht/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "ht-${version}";
   version = "2.1.0";
   src = fetchurl {
-    url = "http://sourceforge.net/projects/hte/files/ht-source/ht-${version}.tar.bz2";
+    url = "mirror://sourceforge/project/hte/ht-source/ht-${version}.tar.bz2";
     sha256 = "0w2xnw3z9ws9qrdpb80q55h6ynhh3aziixcfn45x91bzrbifix9i";
   };
   buildInputs = [

--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   version = "1.33.0";
 
   src = fetchurl {
-    url = "http://sourceforge.net/projects/gammu/files/gammu/${version}/gammu-${version}.tar.xz";
+    url = "mirror://sourceforge/project/gammu/gammu/${version}/gammu-${version}.tar.xz";
     sha256 = "18gplx1v9d70k1q86d5i4n4dfpx367g34pj3zscppx126vwhv112";
   };
 

--- a/pkgs/applications/misc/mlterm/default.nix
+++ b/pkgs/applications/misc/mlterm/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3.3.8";
 
   src = fetchurl {
-    url = "https://downloads.sourceforge.net/project/mlterm/01release/${name}/${name}.tar.gz";
+    url = "mirror://sourceforge/project/mlterm/01release/${name}/${name}.tar.gz";
     sha256 = "088pgxynzxxii7wdmjp2fdkxydirx4k05588zkhlzalkb5l8ji1i";
   };
 

--- a/pkgs/applications/misc/xautoclick/default.nix
+++ b/pkgs/applications/misc/xautoclick/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "0.31";
   name = "xautoclick-${version}";
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/project/xautoclick/xautoclick/xautoclick-0.31/xautoclick-0.31.tar.gz";
+    url = "mirror://sourceforge/project/xautoclick/xautoclick/xautoclick-0.31/xautoclick-0.31.tar.gz";
     sha256 = "0h522f12a7v2b89411xm51iwixmjp2mp90rnizjgiakx9ajnmqnm";
   };
   buildInputs = [ xorg.libX11 xorg.libXtst xorg.xinput xorg.libXi xorg.libXext pkgconfig ]

--- a/pkgs/applications/window-managers/windowmaker/dockapps/wmsystemtray.nix
+++ b/pkgs/applications/window-managers/windowmaker/dockapps/wmsystemtray.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "wmsystemtray-1.4";
   src = fetchurl {
-     url = http://sourceforge.net/projects/wmsystemtray/files/wmsystemtray/wmsystemtray-1.4.tar.gz;
+     url = mirror://sourceforge/project/wmsystemtray/wmsystemtray/wmsystemtray-1.4.tar.gz;
      sha256 = "8edef43691e9fff071000e29166c7c1ad420c0956e9068151061e881c8ac97e9";
   };
 

--- a/pkgs/desktops/lxde/core/lxmenu-data.nix
+++ b/pkgs/desktops/lxde/core/lxmenu-data.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.1.5";
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/lxde/${name}.tar.xz";
+    url = "mirror://sourceforge/lxde/${name}.tar.xz";
     sha256 = "9fe3218d2ef50b91190162f4f923d6524c364849f87bcda8b4ed8eb59b80bab8";
   };
 

--- a/pkgs/development/compilers/fpc/binary.nix
+++ b/pkgs/development/compilers/fpc/binary.nix
@@ -6,12 +6,12 @@ stdenv.mkDerivation {
   src =
     if stdenv.system == "i686-linux" then
       fetchurl {
-        url = "http://sourceforge.net/projects/freepascal/files/Linux/2.6.0/fpc-2.6.0.i386-linux.tar";
+        url = "mirror://sourceforge/project/freepascal/Linux/2.6.0/fpc-2.6.0.i386-linux.tar";
         sha256 = "08yklvrfxvk59bxsd4rh1i6s3cjn0q06dzjs94h9fbq3n1qd5zdf";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
-        url = "http://sourceforge.net/projects/freepascal/files/Linux/2.6.0/fpc-2.6.0.x86_64-linux.tar";
+        url = "mirror://sourceforge/project/freepascal/Linux/2.6.0/fpc-2.6.0.x86_64-linux.tar";
         sha256 = "0k9vi75k39y735fng4jc2vppdywp82j4qhzn7x4r6qjkad64d8lx";
       }
     else throw "Not supported on ${stdenv.system}.";

--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -15,22 +15,22 @@ stdenv.mkDerivation rec {
 
   binSrc =
     if stdenv.system == "i686-linux" then (fetchurl {
-      url = "http://sourceforge.net/projects/mlton/files/mlton/${version}/${name}-1.x86-linux.tgz";
+      url = "mirror://sourceforge/project/mlton/mlton/${version}/${name}-1.x86-linux.tgz";
       sha256 = "1kxjjmnw4xk2d9hpvz43w9dvyhb3025k4zvjx785c33nrwkrdn4j";
     })
     else if stdenv.system == "x86_64-linux" then (fetchurl {
-        url = "http://sourceforge.net/projects/mlton/files/mlton/${version}/${name}-1.amd64-linux.tgz";
+        url = "mirror://sourceforge/project/mlton/mlton/${version}/${name}-1.amd64-linux.tgz";
         sha256 = "0fyhwxb4nmpirjbjcvk9f6w67gmn2gkz7xcgz0xbfih9kc015ygn";
     })
     else if stdenv.system == "x86_64-darwin" then (fetchurl {
-        url = "http://sourceforge.net/projects/mlton/files/mlton/${version}/${name}-1.amd64-darwin.gmp-macports.tgz";
+        url = "mirror://sourceforge/project/mlton/mlton/${version}/${name}-1.amd64-darwin.gmp-macports.tgz";
         sha256 = "044wnh9hhg6if886xy805683k0as347xd37r0r1yi4x7qlxzzgx9";
     })
     else throw "Architecture not supported";
 
   codeSrc =
     fetchurl {
-      url = "http://sourceforge.net/projects/mlton/files/mlton/${version}/${name}.src.tgz";
+      url = "mirror://sourceforge/project/mlton/mlton/${version}/${name}.src.tgz";
       sha256 = "0v1x2hrh9hiqkvnbq11kf34v4i5a2x0ffxbzqaa8skyl26nmfn11";
     };
 

--- a/pkgs/development/compilers/mozart/binary.nix
+++ b/pkgs/development/compilers/mozart/binary.nix
@@ -10,7 +10,7 @@ in stdenv.mkDerivation {
   name = "mozart-binary-${version}";
 
   src = fetchurl {
-    url = "http://sourceforge.net/projects/mozart-oz/files/v${version}-alpha.0/mozart2-${version}-alpha.0+build.4105.5c06ced-x86_64-linux.tar.gz";
+    url = "mirror://sourceforge/project/mozart-oz/v${version}-alpha.0/mozart2-${version}-alpha.0+build.4105.5c06ced-x86_64-linux.tar.gz";
     sha256 = "0rsfrjimjxqbwprpzzlmydl3z3aiwg5qkb052jixdxjyad7gyh5z";
   };
 

--- a/pkgs/development/tools/omniorb/default.nix
+++ b/pkgs/development/tools/omniorb/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "4.2.0";
 
   src = fetchurl rec {
-    url = "http://sourceforge.net/projects/omniorb/files/omniORB/omniORB-${version}/omniORB-${version}.tar.bz2";
+    url = "mirror://sourceforge/project/omniorb/omniORB/omniORB-${version}/omniORB-${version}.tar.bz2";
     sha256 = "1g58xcw4641wyisp9wscrkzaqrz0vf123dgy52qq2a3wk7y77hkl";
   };
 

--- a/pkgs/tools/filesystems/fuseiso/default.nix
+++ b/pkgs/tools/filesystems/fuseiso/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "fuseiso-20070708";
 
   src = fetchurl {
-    url = "http://sourceforge.net/projects/fuseiso/files/fuseiso/20070708/fuseiso-20070708.tar.bz2";
+    url = "mirror://sourceforge/project/fuseiso/fuseiso/20070708/fuseiso-20070708.tar.bz2";
     sha1 = "fe142556ad35dd7e5dc31a16183232a6e2da7692";  
   };
 

--- a/pkgs/tools/networking/srelay/default.nix
+++ b/pkgs/tools/networking/srelay/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "srelay-0.4.8b6";
 
   src = fetchurl {
-    url = "https://sourceforge.net/projects/socks-relay/files/socks-relay/srelay-0.4.8/srelay-0.4.8b6.tar.gz";
+    url = "mirror://sourceforge/project/socks-relay/socks-relay/srelay-0.4.8/srelay-0.4.8b6.tar.gz";
     sha256 = "1az9ds10hpmpw6bqk7fcd1w70001kz0mm48v3vgg2z6vrbmgn0qj";
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3308,7 +3308,7 @@ in modules // {
     disabled = isPy3k;
 
     src = pkgs.fetchurl {
-      url = "http://downloads.sourceforge.net/project/cgkit/cgkit/cgkit-${version}/cgkit-${version}-py2k.tar.gz";
+      url = "mirror://sourceforge/project/cgkit/cgkit/cgkit-${version}/cgkit-${version}-py2k.tar.gz";
       sha256 = "0vvllc42mdyma3c7yqhahs4bfxymm2kvmc4va7dxqr5x0rzh6rd6";
     };
 


### PR DESCRIPTION
This is the proper version of my previous botched PR, #16980. I've requested a revert on it because it hasn't been verified fully and some urls were ending up at sourceforge.net/publish after a few redirects.

I've checked file hashes and made sure that they are working with multiple mirrors properly, this time.

Sorry for the mess that was made, my carelessness has been immortalised in the project history now. :/
