### PR TITLE
gnupg: change 1compat platform to unix

### DIFF
--- a/pkgs/tools/security/gnupg/1compat.nix
+++ b/pkgs/tools/security/gnupg/1compat.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I've been using leiningen on OS X. It has a dependency on gnupg1compat which has not been buildable on Darwin since 2258b21e4b40d42cbe36fd4b5946c19861a9ff95.

It may have been marked as Linux because of this issue that has since been resolved: https://github.com/NixOS/nixpkgs/issues/17617
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [X] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
