### PR TITLE
with: init at 0.0.1

### DIFF
--- a/pkgs/applications/misc/with-shell/default.nix
+++ b/pkgs/applications/misc/with-shell/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation {
+  name = "with-2016-08-20";
+  src = fetchFromGitHub {
+    owner = "mchav";
+    repo = "With";
+    rev = "cc2828bddd92297147d4365765f4ef36385f050a";
+    sha256 = "10m2xv6icrdp6lfprw3a9hsrzb3bip19ipkbmscap0niddqgcl9b";
+  };
+  installPhase = ''
+    mkdir -p $out/bin
+    cp with $out/bin/with
+  '';
+  meta = {
+    homepage = "https://github.com/mchav/With";
+    description = "Command prefixing for continuous workflow using a single tool";
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17519,6 +17519,8 @@ in
     inherit (gnome2) zenity;
   };
 
+  with-shell = callPackage ../applications/misc/with-shell { };
+
   wmutils-core = callPackage ../tools/X11/wmutils-core { };
 
   wraith = callPackage ../applications/networking/irc/wraith { };


### PR DESCRIPTION
###### Motivation for this change

Adds the "with" shell helper application.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
