### PR TITLE
indent: fix on darwin

### DIFF
--- a/pkgs/development/tools/misc/indent/default.nix
+++ b/pkgs/development/tools/misc/indent/default.nix
@@ -7,11 +7,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/indent/${name}.tar.gz";
     sha256 = "0f9655vqdvfwbxvs1gpa7py8k1z71aqh8hp73f65vazwbfz436wa";
   };
-    
+
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i 's|#include <malloc.h>|#include <malloc/malloc.h>|' ./man/texinfo2man.c
+  '';
+
   meta = {
     homepage = https://www.gnu.org/software/indent/;
     description = "A source code reformatter";
     license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
