### PR TITLE
vmtouch: 1.0.2 -> 1.1.0

### DIFF
--- a/pkgs/tools/misc/vmtouch/default.nix
+++ b/pkgs/tools/misc/vmtouch/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vmtouch";
-  version = "1.0.2";
+  version = "1.1.0";
   name = "${pname}-git-${version}";
 
   src = fetchFromGitHub {
     owner = "hoytech";
     repo = "vmtouch";
-    rev = "vmtouch-${version}";
-    sha256 = "0m4s1am1r3qp8si3rnc8j2qc7sbf1k3gxvxr6fnpbf8fcfhh6cay";
+    rev = "v${version}";
+    sha256 = "1cr8bw3favdvc3kc05n1r7f5fibqqv54bn3z2jwj70br8s5g0qx0";
   };
 
   buildInputs = [perl];


### PR DESCRIPTION
###### Motivation for this change

Upstream release
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
