### PR TITLE
performous: 1.0 -> 1.1, fixes build

### DIFF
--- a/pkgs/games/performous/default.nix
+++ b/pkgs/games/performous/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, gettext
 , glibmm, libxmlxx, pango, librsvg
-, SDL2, glew, boost, libav, portaudio
+, SDL2, glew, boost, libav, portaudio, epoxy
 }:
 
-stdenv.mkDerivation {
-  name = "performous-1.0";
+stdenv.mkDerivation rec {
+  name = "performous-${version}";
+  version = "1.1";
 
   meta = with stdenv.lib; {
     description = "Karaoke, band and dancing game";
@@ -16,14 +17,14 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "performous";
     repo = "performous";
-    rev = "1.0";
-    sha256 = "1wgydwnhadrjkj3mjzrhppfmphrxnqfljs361206imirmvs7s15l";
+    rev = version;
+    sha256 = "08j0qhr65l7qnd5vxl4l07523qpvdwi31h4vzl3lfiinx1zcgr4x";
   };
 
   nativeBuildInputs = [ cmake pkgconfig gettext ];
 
   buildInputs = [
     glibmm libxmlxx pango librsvg
-    SDL2 glew boost libav portaudio
+    SDL2 glew boost libav portaudio epoxy
   ];
 }


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
