### PR TITLE
[WIP/RFC] Make `cmakeFlags` more ergonomic

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -227,6 +227,19 @@ rec {
   */
   escapeNixString = s: escape ["$"] (builtins.toJSON s);
 
+  /* Takes an array of strings and preps them for eval into a bash array.
+     Each value has double quotes escape, then is wrapped in double quotes;
+     the values are concatenated and wrapped in parentheses.
+
+     Example:
+       escapeBashArray ["one" "two three" "four\"five"]
+       => "(\"one\"\n\"two three\"\n\"four\\\"five\")"
+  */
+  escapeBashArray = xs: let
+    dquote = ''"'';
+    escapeVal = x: dquote + (escape [ dquote ] x) + dquote;
+  in "(" + (concatMapStringsSep "\n" escapeVal xs) + ")";
+
   /* Obsolete - use replaceStrings instead. */
   replaceChars = builtins.replaceStrings or (
     del: new: s:
@@ -446,6 +459,10 @@ rec {
        => "--without-shared"
   */
   withFeatureAs = with_: feat: value: withFeature with_ feat + optionalString with_ "=${value}";
+
+  tabJoin = xs: let
+    escapeTab = escape [ "\t" ];
+  in builtins.concatStringsSep "\t" (builtins.map escapeTab xs);
 
   /* Create a fixed width string with additional prefix to match
      required width.

--- a/pkgs/applications/audio/i-score/default.nix
+++ b/pkgs/applications/audio/i-score/default.nix
@@ -62,12 +62,12 @@ stdenv.mkDerivation rec {
     rtaudio
   ];
 
-  cmakeFlags = [
-    "-GNinja"
-    "-DISCORE_CONFIGURATION=static-release"
-    "-DISCORE_ENABLE_LTO=OFF"
-    "-DISCORE_BUILD_FOR_PACKAGE_MANAGER=True"
-  ];
+  cmakeFlags = {
+    generator = "Ninja";
+    ISCORE_CONFIGURATION = "static-release";
+    ISCORE_ENABLE_LTO = false;
+    ISCORE_BUILD_FOR_PACKAGE_MANAGER = true;
+  };
 
   preConfigure = ''
     export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:$(echo "${jamomacore}/jamoma/share/cmake/Jamoma")"

--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -22,7 +22,10 @@ stdenv.mkDerivation rec {
     id3lib taglib mp4v2 flac libogg libvorbis zlib readline
     qtbase qttools qtmultimedia qtquickcontrols makeWrapper ];
 
-  cmakeFlags = [ "-DWITH_APPS=Qt;CLI" ];
+  cmakeFlags = {
+    WITH_APPS = "Qt;CLI";
+  };
+
   NIX_LDFLAGS = "-lm -lpthread";
 
   preConfigure = ''

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -15,8 +15,9 @@ stdenv.mkDerivation rec {
     sha256 = "00inrw9g8g34g74bhg5gp0rr5nydhjraiyn7vpl7kaqi5yzmhawd";
   };
 
-  cmakeFlags = [
-  ] ++ lib.optional (lib.versionAtLeast freetype.version "2.5.2") "-DUSE_SYSTEM_FREETYPE=ON";
+  cmakeFlags = {
+    USE_SYSTEM_FREETYPE = lib.versionAtLeast freetype.version "2.5.2";
+  };
 
   nativeBuildInputs = [ cmake pkgconfig ];
 

--- a/pkgs/applications/audio/projectm/default.nix
+++ b/pkgs/applications/audio/projectm/default.nix
@@ -37,15 +37,15 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  cmakeFlags = ''
-    -DprojectM_FONT_MENU=${ttf_bitstream_vera}/share/fonts/truetype/VeraMono.ttf
-    -DprojectM_FONT_TITLE=${ttf_bitstream_vera}/share/fonts/truetype/Vera.ttf
-    -DINCLUDE-PROJECTM-TEST=OFF
-    -DINCLUDE-PROJECTM-QT=${if withQt then "ON" else "OFF"}
-    -DINCLUDE-PROJECTM-LIBVISUAL=${if withLibvisual then "ON" else "OFF"}
-    -DINCLUDE-PROJECTM-JACK=${if withJack then "ON" else "OFF"}
-    -DINCLUDE-PROJECTM-PULSEAUDIO=${if withPulseAudio then "ON" else "OFF"}
-  '';
+  cmakeFlags = {
+    projectM_FONT_MENU = "${ttf_bitstream_vera}/share/fonts/truetype/VeraMono.ttf";
+    projectM_FONT_TITLE = "${ttf_bitstream_vera}/share/fonts/truetype/Vera.ttf";
+    INCLUDE-PROJECTM-TEST = false;
+    INCLUDE-PROJECTM-QT = withQt;
+    INCLUDE-PROJECTM-LIBVISUAL = withLibvisual;
+    INCLUDE-PROJECTM-JACK = withJack;
+    INCLUDE-PROJECTM-PULSEAUDIO = withPulseAudio;
+  };
 
   buildInputs = with stdenv.lib;
     [ glew ftgl ]

--- a/pkgs/applications/audio/tomahawk/default.nix
+++ b/pkgs/applications/audio/tomahawk/default.nix
@@ -20,10 +20,10 @@ stdenv.mkDerivation rec {
     sha256 = "0j84h36wkjfjbsd7ybyji7rcc9wpjdbl0f1xdcc1g7h0nz34pc0g";
   };
 
-  cmakeFlags = [
-    "-DLUCENEPP_INCLUDE_DIR=${lucenepp}/include"
-    "-DLUCENEPP_LIBRARY_DIR=${lucenepp}/lib"
-  ];
+  cmakeFlags = {
+    LUCENEPP_INCLUDE_DIR = "${lucenepp}/include";
+    LUCENEPP_LIBRARY_DIR = "${lucenepp}/lib";
+  };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [

--- a/pkgs/applications/audio/yoshimi/default.nix
+++ b/pkgs/applications/audio/yoshimi/default.nix
@@ -27,7 +27,9 @@ stdenv.mkDerivation  rec {
 
   preConfigure = "cd src";
 
-  cmakeFlags = [ "-DFLTK_MATH_LIBRARY=${stdenv.glibc.out}/lib/libm.so" ];
+  cmakeFlags = {
+    FLTK_MATH_LIBRARY = "${stdenv.glibc.out}/lib/libm.so";
+  };
 
   meta = with stdenv.lib; {
     description = "High quality software synthesizer based on ZynAddSubFX";

--- a/pkgs/applications/display-managers/slim/default.nix
+++ b/pkgs/applications/display-managers/slim/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = "substituteInPlace CMakeLists.txt --replace /lib $out/lib";
 
-  cmakeFlags = [ "-DUSE_PAM=1" ];
+  cmakeFlags = { USE_PAM = true; };
 
   NIX_CFLAGS_COMPILE = "-I${freetype.dev}/include/freetype -std=c++11";
 

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -46,10 +46,10 @@ let
 
     lualibs = [ luaPackages.mpack luaPackages.lpeg luaPackages.luabitop ];
 
-    cmakeFlags = [
-      "-DLUA_PRG=${luaPackages.lua}/bin/lua"
-      "-DGPERF_PRG=${gperf}/bin/gperf"
-    ];
+    cmakeFlags = {
+      LUA_PRG = "${luaPackages.lua}/bin/lua";
+      GPERF_PRG = "${gperf}/bin/gperf";
+    };
 
     # triggers on buffer overflow bug while running tests
     hardeningDisable = [ "fortify" ];

--- a/pkgs/applications/editors/neovim/qt.nix
+++ b/pkgs/applications/editors/neovim/qt.nix
@@ -12,10 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "190yg6kkw953h8wajlqr2hvs2fz65y6z0blmywlg1nff724allaq";
   };
 
-  cmakeFlags = [
-    "-DMSGPACK_INCLUDE_DIRS=${libmsgpack}/include"
-    "-DMSGPACK_LIBRARIES=${libmsgpack}/lib/libmsgpackc.so"
-  ];
+  cmakeFlags = {
+    MSGPACK_INCLUDE_DIRS = "${libmsgpack}/include";
+    MSGPACK_LIBRARIES = "${libmsgpack}/lib/libmsgpackc.so";
+  };
 
   buildInputs = with pythonPackages; [
     neovim qtbase libmsgpack

--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -42,13 +42,12 @@ stdenv.mkDerivation rec {
   # QGIS_MACAPP_BUNDLE=0 stops the installer copying the Qt binaries into the
   # installation which causes havoc
   # Building RelWithDebInfo allows QGIS_DEBUG to print debugging information
-  cmakeFlags = stdenv.lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}"
-               ++ stdenv.lib.optional stdenv.isDarwin
-                    (["-DCMAKE_FIND_FRAMEWORK=never"]
-                      ++ ["-DQGIS_MACAPP_BUNDLE=0"]);
-#                     ++ ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"];
-
-
+  cmakeFlags = (stdenv.lib.optionalAttrs withGrass {
+    GRASS_PREFIX7 = "${grass}/${grass.name}";
+  }) // (stdenv.lib.optionalAttrs stdenv.isDarwin {
+    CMAKE_FIND_FRAMEWORK = "never"
+    DQGIS_MACAPP_BUNDLE = false;
+  });
 
   postInstall =
     (stdenv.lib.optionalString stdenv.isLinux ''

--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -24,10 +24,10 @@ stdenv.mkDerivation rec {
     colord colord-gtk libwebp libsecret gnome3.adwaita-icon-theme
     osm-gps-map ocl-icd
   ];
-    
-  cmakeFlags = [
-    "-DBUILD_USERMANUAL=False"
-  ];
+
+  cmakeFlags = {
+    BUILD_USERMANUAL = false;
+  };
 
   # darktable changed its rpath handling in commit
   # 83c70b876af6484506901e6b381304ae0d073d3c and as a result the

--- a/pkgs/applications/graphics/hugin/default.nix
+++ b/pkgs/applications/graphics/hugin/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
 
   # disable installation of the python scripting interface
-  cmakeFlags = [ "-DBUILD_HSI:BOOl=OFF" ];
+  cmakeFlags = { BUILD_HSI = false; };
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -47,11 +47,13 @@ stdenv.mkDerivation rec {
                  quazip
                  gsettings-desktop-schemas];
 
-  cmakeFlags = ["-DENABLE_OPENCV=ON"
-                "-DENABLE_RAW=ON"
-                "-DENABLE_TIFF=ON"
-                "-DENABLE_QUAZIP=ON"
-                "-DUSE_SYSTEM_QUAZIP=ON"];
+  cmakeFlags = {
+    ENABLE_OPENCV = true;
+    ENABLE_QUAZIP = true;
+    ENABLE_RAW = true;
+    ENABLE_TIFF = true;
+    USE_SYSTEM_QUAZIP = true;
+  };
 
   meta = with stdenv.lib; {
     homepage = https://nomacs.org;

--- a/pkgs/applications/graphics/openimageio/default.nix
+++ b/pkgs/applications/graphics/openimageio/default.nix
@@ -22,9 +22,9 @@ stdenv.mkDerivation rec {
     unzip
   ];
 
-  cmakeFlags = [
-    "-DUSE_PYTHON=OFF"
-  ];
+  cmakeFlags = {
+    USE_PYTHON = false;
+  };
 
   preBuild = ''
     makeFlags="ILMBASE_HOME=${ilmbase.dev} OPENEXR_HOME=${openexr.dev} USE_PYTHON=0

--- a/pkgs/applications/graphics/renderdoc/default.nix
+++ b/pkgs/applications/graphics/renderdoc/default.nix
@@ -34,15 +34,15 @@ stdenv.mkDerivation rec {
     patchShebangs swig/autogen.sh
   '';
 
-  cmakeFlags = [
-    "-DBUILD_VERSION_HASH=${src.rev}"
-    "-DBUILD_VERSION_DIST_NAME=NixOS"
-    "-DBUILD_VERSION_DIST_VER=${version}"
-    "-DBUILD_VERSION_DIST_CONTACT=https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/graphics/renderdoc"
-    "-DBUILD_VERSION_STABLE=ON"
+  cmakeFlags = {
+    BUILD_VERSION_HASH = src.rev;
+    BUILD_VERSION_DIST_NAME = "NixOS";
+    BUILD_VERSION_DIST_VER = version;
+    BUILD_VERSION_DIST_CONTACT = "https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/graphics/renderdoc";
+    BUILD_VERSION_DIST_STABLE = true;
     # TODO: add once pyside2 is in nixpkgs
-    #"-DPYSIDE2_PACKAGE_DIR=${python36Packages.pyside2}"
-  ];
+    # PYSIDE2_PACKAGE_DIR = python36Packages.pyside2;
+  };
 
   # Future work: define these in the above array via placeholders
   preConfigure = ''

--- a/pkgs/applications/graphics/screencloud/default.nix
+++ b/pkgs/applications/graphics/screencloud/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   # for tracking usage.
   consumerKey = "23e747012c68601f27ab69c6de129ed70552d55b6";
   consumerSecret = "4701cb00c1bd357bbcae7c3d713dd216";
-  
+
   src = fetchFromGitHub {
     owner = "olav-st";
     repo = "screencloud";
@@ -34,14 +34,14 @@ stdenv.mkDerivation rec {
   # to add the argument for us.
   dontAddPrefix = true;
 
-  cmakeFlags = [
-    "-DQXT_QXTCORE_INCLUDE_DIR=${qxt}/include/QxtCore"
-    "-DQXT_QXTCORE_LIB_RELEASE=${qxt}/lib/libQxtCore.so"
-    "-DQXT_QXTGUI_INCLUDE_DIR=${qxt}/include/QxtGui"
-    "-DQXT_QXTGUI_LIB_RELEASE=${qxt}/lib/libQxtGui.so"
-    "-DCONSUMER_KEY_SCREENCLOUD=${consumerKey}"
-    "-DCONSUMER_SECRET_SCREENCLOUD=${consumerSecret}"
-  ];
+  cmakeFlags = {
+    QXT_QXTCORE_INCLUDE_DIR = "${qxt}/include/QxtCore";
+    QXT_QXTCORE_LIB_RELEASE = "${qxt}/lib/libQxtCore.so";
+    QXT_QXTGUI_INCLUDE_DIR = "${qxt}/include/QxtGui";
+    QXT_QXTGUI_LIB_RELEASE = "${qxt}/lib/libQxtGui.so";
+    CONSUMER_KEY_SCREENCLOUD = "${consumerKey}";
+    CONSUMER_SECRET_SCREENCLOUD = "${consumerSecret}";
+  };
 
   setSourceRoot = ''
     sourceRoot=$(echo */screencloud)
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     # This needs to be set in preConfigure instead of cmakeFlags in order to
     # access the $prefix environment variable.
-    export cmakeFlags="-DCMAKE_INSTALL_PREFIX=$prefix/opt $cmakeFlags"
+    cmakeFlags+=("-DCMAKE_INSTALL_PREFIX=$prefix/opt")
   '';
 
   # There are a number of issues with screencloud's installation. We need to add

--- a/pkgs/applications/graphics/seg3d/default.nix
+++ b/pkgs/applications/graphics/seg3d/default.nix
@@ -12,22 +12,22 @@ stdenv.mkDerivation {
 
   patches = [ ./cstdio.patch ];
 
-  cmakeFlags = [
-    "-DM_LIBRARY=${stdenv.glibc.out}/lib/libm.so"
-    "-DDL_LIBRARY=${stdenv.glibc.out}/lib/libdl.so"
-    "-DBUILD_UTILS=1"
-    "-DBUILD_SEG3D=1"
-    "-DBUILD_DATAFLOW=0"
-    "-DBUILD_SHARED_LIBS=0"
-    "-DWITH_X11=1"
-    "-DBUILD_BIOMESH3D=1"
-    "-DWITH_TETGEN=1"
-    "-DBUILD_TYPE=Release"
-    "-DBUILD_TESTING=0"
-    "-DWITH_WXWIDGETS=ON"
-    "-DITK_DIR=${itk}/lib/InsightToolkit"
-    "-DGDCM_LIBRARY=${itk}/lib/libitkgdcm.a"
-  ];
+  cmakeFlags = {
+    M_LIBRARY = "${stdenv.glibc.out}/lib/libm.so";
+    DL_LIBRARY = "${stdenv.glibc.out}/lib/libdl.so";
+    BUILD_UTILS = true;
+    BUILD_SEG3D = true;
+    BUILD_DATAFLOW = false;
+    BUILD_SHARED_LIBS = false;
+    WITH_X11 = true;
+    BUILD_BIOMESH3D = true;
+    WITH_TETGEN = true;
+    BUILD_TYPE = "Release";
+    BUILD_TESTING = false;
+    WITH_WXWIDGETS = true;
+    ITK_DIR = "${itk}/lib/InsightToolkit";
+    GDCM_LIBRARY = "${itk}/lib/libitkgdcm.a";
+  };
 
 
   makeFlags = "VERBOSE=1";

--- a/pkgs/applications/graphics/smartdeblur/default.nix
+++ b/pkgs/applications/graphics/smartdeblur/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake qt4 fftw ];
 
-  cmakeFlags = "-DUSE_SYSTEM_FFTW=ON";
+  cmakeFlags = { USE_SYSTEM_FFTW = true; };
 
   meta = {
     homepage = https://github.com/Y-Vladimir/SmartDeblur;

--- a/pkgs/applications/misc/bibletime/default.nix
+++ b/pkgs/applications/misc/bibletime/default.nix
@@ -22,7 +22,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake sword qt4 boost clucene_core ];
 
-  cmakeFlags = "-DUSE_QT_WEBKIT=ON -DCMAKE_BUILD_TYPE=Debug";
+  cmakeFlags = {
+    USE_QT_WEBKIT = true;
+    CMAKE_BUILD_TYPE = "Debug";
+  };
 
   meta = {
     description = "A Qt4 Bible study tool";

--- a/pkgs/applications/misc/dfilemanager/default.nix
+++ b/pkgs/applications/misc/dfilemanager/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake qtbase qttools file solid ];
 
-  cmakeFlags = "-DQT5BUILD=true";
+  cmakeFlags = { QT5BUILD = true; };
 
   meta = {
     homepage = http://dfilemanager.sourceforge.net/;

--- a/pkgs/applications/misc/finalterm/default.nix
+++ b/pkgs/applications/misc/finalterm/default.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation {
     substituteInPlace data/org.gnome.finalterm.gschema.xml \
       --replace "/bin/bash" "${bashInteractive}/bin/bash"
 
-    cmakeFlagsArray=(
-      -DMINIMAL_FLAGS=ON
+    cmakeFlags+=(
+      "-DMINIMAL_FLAGS=ON"
     )
   '';
 

--- a/pkgs/applications/misc/j4-dmenu-desktop/default.nix
+++ b/pkgs/applications/misc/j4-dmenu-desktop/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   # tests are fetching an external git repository
-  cmakeFlags = [ "-DNO_TESTS:BOOL=ON" ];
+  cmakeFlags = { NO_TESTS = true; };
 
   meta = with stdenv.lib; {
     description = "A wrapper for dmenu that recognize .desktop files";

--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -56,17 +56,17 @@ in stdenv.mkDerivation rec {
     "-I${glibmm}/lib/giomm-2.4/include"
   ];
 
-  cmakeFlags = [
-    "-DCMAKE_CXX_FLAGS=-std=c++11"
-    "-DMySQL_CONFIG_PATH=${mysql}/bin/mysql_config"
-    "-DCTemplate_INCLUDE_DIR=${libctemplate}/include"
-    "-DCAIRO_INCLUDE_DIRS=${cairo.dev}/include"
-    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk}/lib/gtk-2.0/include"
-    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${gtk.dev}/include"
-    "-DGTK2_GTKMMCONFIG_INCLUDE_DIR=${gtkmm}/lib/gtkmm-2.4/include"
-    "-DGTK2_GDKMMCONFIG_INCLUDE_DIR=${gtkmm}/lib/gdkmm-2.4/include"
-    "-DGTK2_GLIBMMCONFIG_INCLUDE_DIR=${glibmm}/lib/glibmm-2.4/include"
-  ];
+  cmakeFlags = {
+    CMAKE_CXX_FLAGS = "-std=c++11";
+    MySQL_CONFIG_PATH = "${mysql}/bin/mysql_config";
+    CTemplate_INCLUDE_DIR = "${libctemplate}/include";
+    CAIRO_INCLUDE_DIRS = "${cairo.dev}/include";
+    GTK2_GDKCONFIG_INCLUDE_DIR = "${gtk}/lib/gtk-2.0/include";
+    GTK2_GLIBCONFIG_INCLUDE_DIR = "${gtk.dev}/include";
+    GTK2_GTKMMCONFIG_INCLUDE_DIR = "${gtkmm}/lib/gtkmm-2.4/include";
+    GTK2_GDKMMCONFIG_INCLUDE_DIR = "${gtkmm}/lib/gdkmm-2.4/include";
+    GTK2_GLIBMMCONFIG_INCLUDE_DIR = "${glibmm}/lib/glibmm-2.4/include";
+  };
 
   postInstall = ''
     patchShebangs $out/share/mysql-workbench/extras/build_freetds.sh

--- a/pkgs/applications/misc/navit/default.nix
+++ b/pkgs/applications/misc/navit/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-I${SDL.dev}/include/SDL" ];
 
-  cmakeFlags = [ "-DSAMPLE_MAP=n" ];
+  cmakeFlags = { SAMPLE_MAP = false; };
 
   meta = {
     homepage = http://www.navit-project.org/;

--- a/pkgs/applications/misc/opencpn/default.nix
+++ b/pkgs/applications/misc/opencpn/default.nix
@@ -16,10 +16,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake gtk2 wxGTK30 libpulseaudio curl gettext
                   glib portaudio ];
 
-  cmakeFlags = [
-    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
-    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
-  ];
+  cmakeFlags = {
+    GTK2_GDKCONFIG_INCLUDE_DIR = "${gtk2.out}/lib/gtk-2.0/include";
+    GTK2_GLIBCONFIG_INCLUDE_DIR = "${glib.out}/lib/glib-2.0/include";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/networking/browsers/midori/default.nix
+++ b/pkgs/applications/networking/browsers/midori/default.nix
@@ -40,11 +40,11 @@ stdenv.mkDerivation rec {
     zeitgeist
   ];
 
-  cmakeFlags = [
-    "-DUSE_ZEITGEIST=${if zeitgeistSupport then "ON" else "OFF"}"
-    "-DHALF_BRO_INCOM_WEBKIT2=ON"
-    "-DUSE_GTK3=1"
-  ];
+  cmakeFlags = {
+    USE_ZEITGEIST = zeitgeistSupport;
+    HALF_BRO_INCOM_WEBKIT2 = true;
+    USE_GTK3 = true;
+  };
 
   NIX_LDFLAGS="-lX11";
 

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sed -i -e 's|DESTINATION.*PURPLE_PLUGIN_DIR}|DESTINATION lib/purple-2|' CMakeLists.txt
   '';
 
-  cmakeFlags = "-DCMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT=1";
+  cmakeFlags = { CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT = true; };
 
   meta = {
     homepage = https://bitbucket.org/olegoandreev/purple-vk-plugin;

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
     cp -a "${resources}/iconsets" "$sourceRoot"
   '';
 
-  cmakeFlags = [
-    "-DENABLE_PLUGINS=ON"
-  ];
+  cmakeFlags = {
+    ENABLE_PLUGINS = true;
+  };
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -29,7 +29,6 @@ assert client || daemon -> !monolithic;
 assert !buildClient -> !withKDE; # KDE is used by the client only
 
 let
-  edf = flag: feature: [("-D" + feature + (if flag then "=ON" else "=OFF"))];
   source = import ./source.nix { inherit fetchurl; };
 
 in with stdenv; mkDerivation rec {
@@ -52,15 +51,15 @@ in with stdenv; mkDerivation rec {
       kxmlgui
     ];
 
-  cmakeFlags = [
-    "-DEMBED_DATA=OFF"
-    "-DUSE_QT5=ON"
-  ]
-    ++ edf static "STATIC"
-    ++ edf monolithic "WANT_MONO"
-    ++ edf daemon "WANT_CORE"
-    ++ edf client "WANT_QTCLIENT"
-    ++ edf withKDE "WITH_KDE";
+  cmakeFlags = {
+    EMBED_DATA = false;
+    STATIC = static;
+    WANT_CORE = daemon;
+    WITH_KDE = withKDE;
+    WANT_MONO = monolithic;
+    WANT_QTCLIENT = client;
+    USE_QT5 = true;
+  };
 
   preFixup =
     lib.optionalString daemon ''

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -40,13 +40,15 @@ let
       outputs = [ "out" "man" ] ++ map (p: p.name) enabledPlugins;
 
       enableParallelBuilding = true;
-      cmakeFlags = with stdenv.lib; [
-        "-DENABLE_MAN=ON"
-        "-DENABLE_DOC=ON"
-      ]
-        ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib" "-DCMAKE_FIND_FRAMEWORK=LAST"]
-        ++ map (p: "-D${p.cmakeFlag}=" + (if p.enabled then "ON" else "OFF")) plugins
-        ;
+      cmakeFlags = {
+        ENABLE_MAN = true;
+        ENABLE_DOC = true;
+      } // stdenv.lib.optionalAttrs stdenv.isDarwin {
+        ICONV_LIBRARY = "${libiconv}/lib/libiconv.dylib";
+        CMAKE_FIND_FRAMEWORK = "LAST";
+      } // stdenv.lib.foldr (
+        plugin: acc: acc // { ${plugin.cmakeFlag} = plugin.enabled; }
+      ) {} plugins;
 
       buildInputs = with stdenv.lib; [
           ncurses openssl aspell gnutls zlib curl pkgconfig

--- a/pkgs/applications/networking/owncloud-client/default.nix
+++ b/pkgs/applications/networking/owncloud-client/default.nix
@@ -14,9 +14,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [ qtbase qtwebkit qtkeychain sqlite ];
 
-  cmakeFlags = [
-    "-UCMAKE_INSTALL_LIBDIR"
-  ];
+  cmakeFlags = {
+    CMAKE_INSTALL_LIBDIR = null;
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -41,15 +41,15 @@ in stdenv.mkDerivation {
                   libsecret spice-protocol spice-gtk epoxy at-spi2-core
                   openssl hicolor-icon-theme adwaita-icon-theme json-glib ];
 
-  cmakeFlags = [
-    "-DWITH_VTE=OFF"
-    "-DWITH_TELEPATHY=OFF"
-    "-DWITH_AVAHI=OFF"
-    "-DFREERDP_LIBRARY=${freerdp}/lib/libfreerdp2.so"
-    "-DFREERDP_CLIENT_LIBRARY=${freerdp}/lib/libfreerdp-client2.so"
-    "-DFREERDP_WINPR_LIBRARY=${freerdp}/lib/libwinpr2.so"
-    "-DWINPR_INCLUDE_DIR=${freerdp}/include/winpr2"
-  ];
+  cmakeFlags = {
+    FREERDP_CLIENT_LIBRARY = "${freerdp}/lib/libfreerdp-client2.so";
+    FREERDP_LIBRARY = "${freerdp}/lib/libfreerdp2.so";
+    FREERDP_WINPR_LIBRARY = "${freerdp}/lib/libwinpr2.so";
+    WINPR_INCLUDE_DIR = "${freerdp}/include/winpr2";
+    WITH_AVAHI = false;
+    WITH_TELEPATHY = false;
+    WITH_VTE = false;
+  };
 
   preFixup = ''
     gappsWrapperArgs+=(

--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ qtbase qttools seafile-shared ]
     ++ optional withShibboleth qtwebengine;
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ]
+  cmakeFlags = []
     ++ optional withShibboleth "-DBUILD_SHIBBOLETH_SUPPORT=ON";
 
   postInstall = ''

--- a/pkgs/applications/networking/sniffers/ettercap/default.nix
+++ b/pkgs/applications/networking/sniffers/ettercap/default.nix
@@ -36,10 +36,10 @@ stdenv.mkDerivation rec {
                                      --replace /usr \$\{INSTALL_PREFIX\}
   '';
 
-  cmakeFlags = [
-    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
-    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
-  ];
+  cmakeFlags = {
+    GTK2_GLIBCONFIG_INCLUDE_DIR = "${glib.out}/lib/glib-2.0/include";
+    GTK2_GDKCONFIG_INCLUDE_DIR = "${gtk2.out}/lib/gtk-2.0/include";
+  };
 
   meta = with stdenv.lib; {
     description = "Comprehensive suite for man in the middle attacks";

--- a/pkgs/applications/office/ledger/default.nix
+++ b/pkgs/applications/office/ledger/default.nix
@@ -22,7 +22,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  cmakeFlags = [ "-DCMAKE_INSTALL_LIBDIR=lib" (stdenv.lib.optionalString usePython "-DUSE_PYTHON=true") ];
+  cmakeFlags = {
+    CMAKE_INSTALL_LIBDIR = "lib";
+    USE_PYTHON = usePython;
+  }
 
   # Skip byte-compiling of emacs-lisp files because this is currently
   # broken in ledger...

--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -15,10 +15,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ itk vtk ];
 
-  cmakeFlags = [ "-DANTS_SUPERBUILD=FALSE" "-DUSE_VTK=TRUE"
-                 # as cmake otherwise tries to download test data:
-                 "-DBUILD_TESTING=FALSE" ];
-
+  cmakeFlags = {
+    ANTS_SUPERBUILD = false;
+    USE_VTK = true;
+    # as cmake otherwise tries to download test data:
+    BUILD_TESTING = false;
+  };
   enableParallelBuilding = true;
 
   checkPhase = "ctest";

--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libminc libjpeg zlib ];
   propagatedBuildInputs = [ perl TextFormat ];
 
-  cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" ];
+  cmakeFlags = { LIBMINC_DIR = "${libminc}/lib/"; };
 
   checkPhase = "ctest --output-on-failure";  # still some weird test failures though
 

--- a/pkgs/applications/science/machine-learning/torch/torch-distro.nix
+++ b/pkgs/applications/science/machine-learning/torch/torch-distro.nix
@@ -303,8 +303,15 @@ let
       };
 
       preConfigure = ''
-        cmakeFlags="-DLUA_LIBRARY=${lua}/lib/lua/${lua.luaversion} -DINSTALL_CMOD=$out/lib/lua/${lua.luaversion} -DINSTALL_MOD=$out/lib/lua/${lua.luaversion}"
+        cmakeFlags+=(
+            "-DINSTALL_CMOD=$out/lib/lua/${lua.luaversion}"
+            "-DINSTALL_MOD=$out/lib/lua/${lua.luaversion}"
+        )
       '';
+
+      cmakeFlags = {
+        LUA_LIBRARY = "${lua}/lib/lua/${lua.luaversion}";
+      };
 
       buildInputs = [cmake libuuid lua];
       meta = {

--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -18,14 +18,16 @@ stdenv.mkDerivation {
   buildInputs = [cmake fftw]
   ++ (stdenv.lib.optionals mpiEnabled [ openmpi ]);
 
-  cmakeFlags = ''
-    ${if singlePrec then "-DGMX_DOUBLE=OFF" else "-DGMX_DOUBLE=ON -DGMX_DEFAULT_SUFFIX=OFF"}
-    ${if mpiEnabled then "-DGMX_MPI:BOOL=TRUE 
-                          -DGMX_CPU_ACCELERATION:STRING=SSE4.1 
-                          -DGMX_OPENMP:BOOL=TRUE
-                          -DGMX_THREAD_MPI:BOOL=FALSE"
-                     else "-DGMX_MPI:BOOL=FALSE" }
-  '';
+  cmakeFlags = with stdenv.lib; {
+    GMX_DOUBLE = !singlePrec;
+    GMX_MPI = mpiEnabled;
+  } // (optionalAttrs (!singlePrec) {
+    GMX_DEFAULT_SUFFIX = false;
+  }) // (optionalAttrs mpiEnabled {
+    GMX_CPU_ACCELERATION = "SSE4.1";
+    GMX_OPENMP = true;
+    GMX_THREAD_MPI = false;
+  });
 
   meta = with stdenv.lib; {
     homepage    = "http://www.gromacs.org";

--- a/pkgs/applications/science/robotics/gazebo/default.nix
+++ b/pkgs/applications/science/robotics/gazebo/default.nix
@@ -32,12 +32,13 @@ stdenv.mkDerivation rec {
   };
 
   enableParallelBuilding = true; # gazebo needs this so bad
-  cmakeFlags = [
-  "-DCMAKE_INSTALL_LIBDIR:PATH=lib"
-  "-DCMAKE_INSTALL_INCLUDEDIR=include" ]
-    ++ optional withQuickBuild [ "-DENABLE_TESTS_COMPILATION=False" ]
-    ++ optional withLowMemorySupport [ "-DUSE_LOW_MEMORY_TESTS=True" ]
-    ++ optional withHeadless [ "-DENABLE_SCREEN_TESTS=False" ];
+  cmakeFlags = {
+    CMAKE_INSTALL_LIBDIR = "lib";
+    CMAKE_INSTALL_INCLUDEDIR = "include";
+    ENABLE_TESTS_COMPILATION = !withQuickBuild;
+    USE_LOW_MEMORY_TESTS = withLowMemorySupport;
+    ENABLE_SCREEN_TESTS = !withHeadless;
+  };
 
   nativeBuildInputs = [ cmake pkgconfig ];
 

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -66,7 +66,9 @@ in stdenv.mkDerivation rec {
   # obs attempts to dlopen libobs-opengl, it fails unless we make sure
   # DL_OPENGL is an explicit path. Not sure if there's a better way
   # to handle this.
-  cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-DDL_OPENGL=\\\"$(out)/lib/libobs-opengl.so\\\"" ];
+  cmakeFlags = {
+    CMAKE_CXX_FLAGS = "-DDL_OPENGL=\\\"$(out)/lib/libobs-opengl.so\\\"";
+  };
 
   postInstall = ''
       wrapProgram $out/bin/obs \

--- a/pkgs/applications/window-managers/icewm/default.nix
+++ b/pkgs/applications/window-managers/icewm/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    export cmakeFlags="-DPREFIX=$out -DCFGDIR=/etc/icewm"
+    cmakeFlags+=("-DPREFIX=$out" "-DCFGDIR=/etc/icewm")
   '';
 
   patches = [ ./fix-strlcat_strlcpy.patch ] ++

--- a/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
+++ b/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
     chmod +w -R tools/clang
   '';
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DLLVM_TARGETS_TO_BUILD='X86;JSBackend'"
     "-DLLVM_INCLUDE_EXAMPLES=OFF"
     "-DLLVM_INCLUDE_TESTS=ON"

--- a/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
+++ b/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
@@ -26,17 +26,17 @@ stdenv.mkDerivation rec {
     cp -Lr ${srcFL} tools/clang
     chmod +w -R tools/clang
   '';
-  cmakeFlags = [
-    "-DLLVM_TARGETS_TO_BUILD='X86;JSBackend'"
-    "-DLLVM_INCLUDE_EXAMPLES=OFF"
-    "-DLLVM_INCLUDE_TESTS=ON"
-    #"-DLLVM_CONFIG=${llvm}/bin/llvm-config"
-    "-DLLVM_BUILD_TESTS=ON"
-    "-DCLANG_INCLUDE_TESTS=ON"
-  ] ++ (stdenv.lib.optional stdenv.isLinux
+  cmakeFlags = {
+    LLVM_TARGETS_TO_BUILD = "X86;JSBackend";
+    LLVM_INCLUDE_EXAMPLES = false;
+    LLVM_INCLUDE_TESTS = true;
+    # LLVM_CONFIG = "${llvm}/bin/llvm-config";
+    LLVM_BUILD_TESTS = true;
+    CLANG_INCLUDE_TESTS = true;
+  } ++ (stdenv.lib.optionalAttrs stdenv.isLinux {
     # necessary for clang to find crtend.o
-    "-DGCC_INSTALL_PREFIX=${gcc}"
-  );
+    GCC_INSTALL_PREFIX = "${gcc}";
+  });
   enableParallelBuilding = true;
 
   passthru = {

--- a/pkgs/development/compilers/llvm/3.4/lld.nix
+++ b/pkgs/development/compilers/llvm/3.4/lld.nix
@@ -8,15 +8,17 @@ stdenv.mkDerivation {
   preUnpack = ''
     # !!! Hopefully won't be needed for 3.5
     unpackFile ${llvm.src}
-    export cmakeFlags="$cmakeFlags -DLLD_PATH_TO_LLVM_SOURCE="`ls -d $PWD/llvm-*`
+    cmakeFlags+=(
+        "-DLLD_PATH_TO_LLVM_SOURCE="$(ls -d $PWD/llvm-*)
+    )
   '';
 
   buildInputs = [ cmake ncurses zlib python2 ];
 
-  cmakeFlags = [
-    "-DCMAKE_CXX_FLAGS=-std=c++11"
-    "-DLLD_PATH_TO_LLVM_BUILD=${llvm}"
-  ];
+  cmakeFlags = {
+    CMAKE_CXX_FLAGS = "-std=c++11";
+    LLD_PATH_TO_LLVM_BUILD = "${llvm}";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.4/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.4/lldb.nix
@@ -25,12 +25,12 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake python2 which swig ncurses zlib libedit ];
 
-  cmakeFlags = [
-    "-DCMAKE_CXX_FLAGS=-std=c++11"
-    "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
-    "-DLLDB_PATH_TO_CLANG_BUILD=${clang}"
-    "-DLLDB_DISABLE_LIBEDIT=1" # https://llvm.org/bugs/show_bug.cgi?id=28898
-  ];
+  cmakeFlags = {
+    CMAKE_CXX_FLAGS = "-std=c++11";
+    LLDB_PATH_TO_LLVM_BUILD = "${llvm}";
+    LLDB_PATH_TO_CLANG_BUILD = "${clang}";
+    LLDB_DISABLE_LIBEDIT = true; # https://llvm.org/bugs/show_bug.cgi?id=28898
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.4/polly.nix
+++ b/pkgs/development/compilers/llvm/3.4/polly.nix
@@ -9,10 +9,10 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake isl python2 gmp ];
 
-  cmakeFlags = [
-    "-DCMAKE_CXX_FLAGS=-std=c++11"
-    "-DLLVM_INSTALL_ROOT=${llvm}"
-  ];
+  cmakeFlags = {
+    CMAKE_CXX_FLAGS = "-std=c++11";
+    LLVM_INSTALL_ROOT = "${llvm}";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.5/clang.nix
+++ b/pkgs/development/compilers/llvm/3.5/clang.nix
@@ -14,12 +14,14 @@ in stdenv.mkDerivation {
 
   buildInputs = [ cmake libxml2 llvm ];
 
-  cmakeFlags = [
-    "-DCMAKE_CXX_FLAGS=-std=c++11"
-  ] ++
-  # Maybe with compiler-rt this won't be needed?
-  (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
-  (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
+  cmakeFlags = {
+    CMAKE_CXX_FLAGS = "-std=c++11";
+  } // (stdenv.lib.optionalAttrs stdenv.isLinux {
+    # Maybe with compiler-rt this won't be needed?
+    GCC_INSTALL_PREFIX = "${gcc}";
+  }) // (stdenv.lib.optionalAttrs (stdenv.cc.libc != null) {
+    C_INCLUDE_DIRS = "${stdenv.cc.libc}/include";
+  });
 
   patches = [ ./clang-purity.patch ];
 

--- a/pkgs/development/compilers/llvm/3.5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.5/libc++/default.nix
@@ -28,12 +28,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  cmakeFlags = [
-    "-DLIBCXX_LIBCXXABI_INCLUDE_PATHS=${libcxxabi}/include"
-    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
-    "-DLIBCXX_LIBCPPABI_VERSION=2"
-    "-DLIBCXX_CXX_ABI=libcxxabi"
-  ];
+  cmakeFlags = {
+    LIBCXX_CXX_ABI = "libcxxabi";
+    LIBCXX_LIBCXXABI_INCLUDE_PATHS = "${libcxxabi}/include";
+    LIBCXX_LIBCXXABI_LIB_PATH = "${libcxxabi}/lib";
+    LIBCXX_LIBCPPABI_VERSION = "2";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.5/libc++abi/default.nix
+++ b/pkgs/development/compilers/llvm/3.5/libc++abi/default.nix
@@ -23,7 +23,10 @@ in stdenv.mkDerivation {
     echo cp ${cmakeLists} libcxxabi-*/CMakeLists.txt
     cp ${cmakeLists} libcxxabi-*/CMakeLists.txt
     export NIX_CFLAGS_COMPILE+=" -I$PWD/include"
-    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_INCLUDES=$PWD/$(ls -d libcxx-*)/include"
+    cmakeFlags+=(
+        "-DLLVM_PATH=$PWD/"$(ls -d llvm-*)
+        "-DLIBCXXABI_LIBCXX_INCLUDES=$PWD/"$(ls -d libcxx-*)/include
+    )
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '';

--- a/pkgs/development/compilers/llvm/3.5/lld.nix
+++ b/pkgs/development/compilers/llvm/3.5/lld.nix
@@ -8,7 +8,9 @@ stdenv.mkDerivation {
   preUnpack = ''
     # !!! Hopefully won't be needed for 3.5
     unpackFile ${llvm.src}
-    export cmakeFlags="$cmakeFlags -DLLD_PATH_TO_LLVM_SOURCE="`ls -d $PWD/llvm-*`
+    cmakeFlags+=(
+        "-DLLD_PATH_TO_LLVM_SOURCE="$(ls -d $PWD/llvm-*)
+    )
   '';
 
   buildInputs = [ cmake ncurses zlib python ];

--- a/pkgs/development/compilers/llvm/3.5/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.5/lldb.nix
@@ -25,12 +25,12 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake python which swig ncurses zlib libedit ];
 
-  cmakeFlags = [
-    "-DCMAKE_CXX_FLAGS=-std=c++11"
-    "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
-    "-DLLDB_PATH_TO_CLANG_BUILD=${clang}"
-    "-DLLDB_DISABLE_LIBEDIT=1" # https://llvm.org/bugs/show_bug.cgi?id=28898
-  ];
+  cmakeFlags = {
+    CMAKE_CXX_FLAGS = "-std=c++11";
+    LLDB_PATH_TO_LLVM_BUILD = "${llvm}";
+    LLDB_PATH_TO_CLANG_BUILD = "${clang}";
+    LLDB_DISABLE_LIBEDIT = true; # https://llvm.org/bugs/show_bug.cgi?id=28898
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.5/polly.nix
+++ b/pkgs/development/compilers/llvm/3.5/polly.nix
@@ -9,10 +9,10 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake isl python gmp ];
 
-  cmakeFlags = [
-    "-DCMAKE_CXX_FLAGS=-std=c++11"
-    "-DLLVM_INSTALL_ROOT=${llvm}"
-  ];
+  cmakeFlags = {
+    CMAKE_CXX_FLAGS = "-std=c++11";
+    LLVM_INSTALL_ROOT = "${llvm}";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/clang/default.nix
@@ -15,12 +15,14 @@ let
 
     buildInputs = [ cmake libxml2 llvm ];
 
-    cmakeFlags = [
-      "-DCMAKE_CXX_FLAGS=-std=c++11"
-    ] ++
-    # Maybe with compiler-rt this won't be needed?
-    (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
-    (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
+    cmakeFlags = {
+      CMAKE_CXX_FLAGS = "-std=c++11";
+    } // (stdenv.lib.optionalAttrs stdenv.isLinux {
+      # Maybe with compiler-rt this won't be needed?
+      GCC_INSTALL_PREFIX = "${gcc}";
+    }) // (stdenv.lib.optionalAttrs (stdenv.cc.libc != null) {
+      C_INCLUDE_DIRS = "${stdenv.cc.libc}/include";
+    });
 
     patches = [ ./purity.patch ];
 

--- a/pkgs/development/compilers/llvm/3.7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/libc++/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
-    cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$NIX_BUILD_TOP/libcxxabi-${version}.src/include")
+    cmakeFlags+=(
+        "-DLIBCXX_CXX_ABI_INCLUDE_PATHS=$NIX_BUILD_TOP/libcxxabi-${version}.src/include"
+    )
   '';
 
   patches = [

--- a/pkgs/development/compilers/llvm/3.7/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.7/libc++abi.nix
@@ -18,7 +18,10 @@ in stdenv.mkDerivation {
     unpackFile ${libcxx.src}
     unpackFile ${llvm.src}
     export NIX_CFLAGS_COMPILE+=" -I$PWD/include"
-    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_INCLUDES=$PWD/$(ls -d libcxx-*)/include"
+    cmakeFlags+=(
+        "-DLLVM_PATH=$PWD/"$(ls -d llvm-*)
+        "-DLIBCXXABI_LIBCXX_INCLUDES=$PWD/"$(ls -d libcxx-*)/include
+    )
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '';

--- a/pkgs/development/compilers/llvm/3.7/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.7/lldb.nix
@@ -30,13 +30,13 @@ stdenv.mkDerivation {
     export LDFLAGS="-ldl"
   '';
 
-  cmakeFlags = [
-    "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
-    "-DLLDB_PATH_TO_CLANG_BUILD=${clang-unwrapped}"
-    "-DPYTHON_VERSION_MAJOR=2"
-    "-DPYTHON_VERSION_MINOR=7"
-    "-DLLDB_DISABLE_LIBEDIT=1" # https://llvm.org/bugs/show_bug.cgi?id=28898
-  ];
+  cmakeFlags = {
+    LLDB_DISABLE_LIBEDIT = 1; # https://llvm.org/bugs/show_bug.cgi?id=28898
+    LLDB_PATH_TO_CLANG_BUILD = "${clang-unwrapped}";
+    LLDB_PATH_TO_LLVM_BUILD = "${llvm}";
+    PYTHON_VERSION_MAJOR = 2;
+    PYTHON_VERSION_MINOR = 7;
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.7/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.7/llvm.nix
@@ -70,20 +70,20 @@ in stdenv.mkDerivation rec {
     ../fix-llvm-config.patch
   ];
 
-  cmakeFlags = with stdenv; [
-    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
-    "-DLLVM_INSTALL_UTILS=ON"  # Needed by rustc
-    "-DLLVM_BUILD_TESTS=ON"
-    "-DLLVM_ENABLE_FFI=ON"
-    "-DLLVM_ENABLE_RTTI=ON"
-  ] ++ stdenv.lib.optional enableSharedLibraries
-    "-DBUILD_SHARED_LIBS=ON"
-    ++ stdenv.lib.optional (!isDarwin)
-    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
-    ++ stdenv.lib.optionals ( isDarwin) [
-    "-DLLVM_ENABLE_LIBCXX=ON"
-    "-DCAN_TARGET_i386=false"
-  ];
+  cmakeFlags = with stdenv.lib; {
+    CMAKE_BUILD_TYPE = "${if debugVersion then "Debug" else "Release"}";
+    LLVM_INSTALL_UTILS = true; # Needed by rustc
+    LLVM_BUILD_TESTS = true;
+    LLVM_ENABLE_FFI = true;
+    LLVM_ENABLE_RTTI = true;
+  } // (optionalAttrs (enableSharedLibraries) {
+    BUILD_SHARED_LIBS = true;
+  }) // (optionalAttrs (!stdenv.isDarwin) {
+    LLVM_BINUTILS_INCDIR = "${libbfd.dev}/include";
+  }) // (optionalAttrs (stdenv.isDarwin) {
+    LLVM_ENABLE_LIBCXX = true;
+    CAN_TARGET_i386 = false;
+  });
 
   NIX_LDFLAGS = "-lpthread"; # no idea what's the problem
 

--- a/pkgs/development/compilers/llvm/3.8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/clang/default.nix
@@ -16,12 +16,14 @@ let
     nativeBuildInputs = [ cmake ];
     buildInputs = [ libxml2 llvm python ];
 
-    cmakeFlags = [
-      "-DCMAKE_CXX_FLAGS=-std=c++11"
-    ] ++
-    # Maybe with compiler-rt this won't be needed?
-    (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
-    (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
+    cmakeFlags = {
+      CMAKE_CXX_FLAGS = "-std=c++11";
+    } // (stdenv.lib.optionalAttrs stdenv.isLinux {
+      # Maybe with compiler-rt this won't be needed?
+      GCC_INSTALL_PREFIX = "${gcc}";
+    }) // (stdenv.lib.optionalAttrs (stdenv.cc.libc != null) {
+      C_INCLUDE_DIRS = "${stdenv.cc.libc}/include";
+    });
 
     patches = [ ./purity.patch ];
 

--- a/pkgs/development/compilers/llvm/3.8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
-    cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$NIX_BUILD_TOP/libcxxabi-${version}.src/include")
+    cmakeFlags+=(
+        "-DLIBCXX_CXX_ABI_INCLUDE_PATHS=$NIX_BUILD_TOP/libcxxabi-${version}.src/include"
+    )
   '';
 
   patches = [

--- a/pkgs/development/compilers/llvm/3.8/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++abi.nix
@@ -12,7 +12,10 @@ stdenv.mkDerivation {
     unpackFile ${libcxx.src}
     unpackFile ${llvm.src}
     export NIX_CFLAGS_COMPILE+=" -I$PWD/include"
-    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_INCLUDES=$PWD/$(ls -d libcxx-*)/include"
+    cmakeFlags+=(
+        "-DLLVM_PATH=$PWD/"$(ls -d llvm-*)
+        "-DLIBCXXABI_LIBCXX_INCLUDES=$PWD/"$(ls -d libcxx-*)/include
+    )
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''

--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -22,18 +22,19 @@ let
     buildInputs = [ libxml2 llvm ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-    cmakeFlags = [
-      "-DCMAKE_CXX_FLAGS=-std=c++11"
-    ] ++ stdenv.lib.optionals enableManpages [
-      "-DCLANG_INCLUDE_DOCS=ON"
-      "-DLLVM_ENABLE_SPHINX=ON"
-      "-DSPHINX_OUTPUT_MAN=ON"
-      "-DSPHINX_OUTPUT_HTML=OFF"
-      "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-    ]
+    cmakeFlags = {
+      CMAKE_CXX_FLAGS = "-std=c++11";
+    } // (stdenv.lib.optionalAttrs enableManpages {
+      CLANG_INCLUDE_DOCS = true;
+      LLVM_ENABLE_SPHINX = true;
+      SPHINX_OUTPUT_MAN = true;
+      SPHINX_OUTPUT_HTML = false;
+      SPHINX_WARNINGS_AS_ERRORS = false;
+    })
     # Maybe with compiler-rt this won't be needed?
-    ++ stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}"
-    ++ stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include";
+    // (stdenv.lib.optionalAttrs stdenv.isLinux { GCC_INSTALL_PREFIX = "${gcc}"; })
+    // (stdenv.lib.optionalAttrs (stdenv.cc.libc != null) { C_INCLUDE_DIRS = "${stdenv.cc.libc}/include"; })
+    ;
 
     patches = [ ./purity.patch ];
 

--- a/pkgs/development/compilers/llvm/4/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/4/libc++/default.nix
@@ -34,11 +34,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  cmakeFlags = [
-    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
-    "-DLIBCXX_LIBCPPABI_VERSION=2"
-    "-DLIBCXX_CXX_ABI=libcxxabi"
-  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1";
+  cmakeFlags = {
+    LIBCXX_LIBCXXABI_LIB_PATH = "${libcxxabi}/lib";
+    LIBCXX_LIBCPPABI_VERSION = "2";
+    LIBCXX_CXX_ABI = "libcxxabi";
+  } // (stdenv.lib.optionalAttrs stdenv.hostPlatform.isMusl {
+    LIBCXX_HAS_MUSL_LIBC = "1";
+  });
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/4/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/4/libc++abi.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation {
   postUnpack = ''
     unpackFile ${libcxx.src}
     unpackFile ${llvm.src}
-    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*)"
+    export cmakeFlags=(
+      "-DLLVM_PATH=$PWD/$(ls -d llvm-*)"
+      "-DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*)"
+    )
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''

--- a/pkgs/development/compilers/llvm/4/lldb.nix
+++ b/pkgs/development/compilers/llvm/4/lldb.nix
@@ -37,9 +37,9 @@ stdenv.mkDerivation {
   CXXFLAGS = "-fno-rtti";
   hardeningDisable = [ "format" ];
 
-  cmakeFlags = [
-    "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
-  ];
+  cmakeFlags = {
+    LLDB_CODESIGN_IDENTITY = ""; # codesigning makes nondeterministic
+  };
 
   # Add missing include to fix error when using std::bind
   prePatch = ''

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -91,33 +91,31 @@ in stdenv.mkDerivation (rec {
     ln -sv $PWD/lib $out
   '';
 
-  cmakeFlags = with stdenv; [
-    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
-    "-DLLVM_INSTALL_UTILS=ON"  # Needed by rustc
-    "-DLLVM_BUILD_TESTS=ON"
-    "-DLLVM_ENABLE_FFI=ON"
-    "-DLLVM_ENABLE_RTTI=ON"
-    "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
+  cmakeFlags = with stdenv; {
+    CMAKE_BUILD_TYPE = "${if debugVersion then "Debug" else "Release"}";
+    LLVM_INSTALL_UTILS = true;  # Needed by rustc
+    LLVM_BUILD_TESTS = true;
+    LLVM_ENABLE_FFI = true;
+    LLVM_ENABLE_RTTI = true;
+    COMPILER_RT_INCLUDE_TESTS = true; # FIXME: requires clang source code
 
-    "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
-    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
-  ]
-  ++ stdenv.lib.optional enableSharedLibraries
-    "-DLLVM_LINK_LLVM_DYLIB=ON"
-  ++ stdenv.lib.optionals enableManpages [
-    "-DLLVM_BUILD_DOCS=ON"
-    "-DLLVM_ENABLE_SPHINX=ON"
-    "-DSPHINX_OUTPUT_MAN=ON"
-    "-DSPHINX_OUTPUT_HTML=OFF"
-    "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-  ]
-  ++ stdenv.lib.optional (!isDarwin)
-    "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
-  ++ stdenv.lib.optionals (isDarwin) [
-    "-DLLVM_ENABLE_LIBCXX=ON"
-    "-DCAN_TARGET_i386=false"
-  ];
+    LLVM_HOST_TRIPLE = stdenv.hostPlatform.config;
+    LLVM_DEFAULT_TARGET_TRIPLE = stdenv.targetPlatform.config;
+    TARGET_TRIPLE = stdenv.targetPlatform.config;
+  } // (stdenv.lib.optionalAttrs enableSharedLibraries {
+    LLVM_LINK_LLVM_DYLIB = true;
+  }) // (stdenv.lib.optionalAttrs enableManpages {
+    LLVM_BUILD_DOCS = true;
+    LLVM_ENABLE_SPHINX = true;
+    SPHINX_OUTPUT_MAN = true;
+    SPHINX_OUTPUT_HTML = false;
+    SPHINX_WARNINGS_AS_ERRORS = false;
+  }) // (stdenv.lib.optionalAttrs (!isDarwin) {
+    LLVM_BINUTILS_INCDIR = "${libbfd.dev}/include";
+  }) // (stdenv.lib.optionalAttrs isDarwin {
+    LLVM_ENABLE_LIBCXX = true;
+    CAN_TARGET_i386 = false;
+  });
 
   postBuild = ''
     rm -fR $out

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -43,7 +43,9 @@ in stdenv.mkDerivation rec {
   buildInputs = [ cmake python ];
   enableParallelBuilding = true;
 
-  cmakeFlags = [ "-DSHADERC_SKIP_TESTS=ON" ];
+  cmakeFlags = {
+    SHADERC_SKIP_TESTS = true;
+  };
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -19,10 +19,10 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "stackprotector" ];
 
-  cmakeFlags = ''
-    -DSC_WII=OFF
-    -DSC_EL=${if useSCEL then "ON" else "OFF"}
-  '';
+  cmakeFlags = {
+    SC_EL = useSCEL;
+    SC_WII = false;
+  };
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];
 

--- a/pkgs/development/libraries/allegro/5.nix
+++ b/pkgs/development/libraries/allegro/5.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     sed -e 's@/XInput2.h@/XI2.h@g' -i CMakeLists.txt "src/"*.c
   '';
 
-  cmakeFlags = [ "-DCMAKE_SKIP_RPATH=ON" ];
+  cmakeFlags = { CMAKE_SKIP_RPATH = true; };
 
   meta = with stdenv.lib; {
     description = "A game programming library";

--- a/pkgs/development/libraries/allegro/default.nix
+++ b/pkgs/development/libraries/allegro/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  cmakeFlags = [ "-DCMAKE_SKIP_RPATH=ON" ];
+  cmakeFlags = { CMAKE_SKIP_RPATH = true; };
 
   meta = with stdenv.lib; {
     description = "A game programming library";

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -36,11 +36,14 @@ in stdenv.mkDerivation rec {
                          (builtins.elem "*" apis)))
          (with darwin.apple_sdk.frameworks; [ CoreAudio AudioToolbox ]);
 
-  cmakeFlags =
-    lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "-DENABLE_TESTING=OFF"
-    ++ lib.optional (apis != ["*"])
-      "-DBUILD_ONLY=${lib.concatStringsSep ";" apis}";
+  cmakeFlags = {
+    # TODO(aneeshusa): upstream seems to use this as a string variable instead of a boolean?
+    CUSTOM_MEMORY_MANAGEMENT = if customMemoryManagement then "1" else "0";
+  } // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+    ENABLE_TESTING = false;
+  } // lib.optionalAttrs (apis != [ "*" ]) {
+      BUILD_ONLY = lib.concatStringsSep ";" apis;
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/beignet/default.nix
+++ b/pkgs/development/libraries/beignet/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     patchShebangs src/git_sha1.sh
   '';
 
-  cmakeFlags = [ "-DCLANG_LIBRARY_DIR=${clang-unwrapped}/lib" ];
+  cmakeFlags = { CLANG_LIBRARY_DIR = "${clang-unwrapped}/lib"; };
 
   buildInputs = [
     llvm

--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -17,7 +17,10 @@ stdenv.mkDerivation rec {
     unzip cmake libGLU_combined freeglut libX11 xproto inputproto libXi
   ];
 
-  cmakeFlags = [ "-DBOX2D_INSTALL=ON" "-DBOX2D_BUILD_SHARED=ON" ];
+  cmakeFlags = {
+    BOX2D_BUILD_SHARED = true;
+    BOX2D_INSTALL = true;
+  };
 
   prePatch = ''
     substituteInPlace Box2D/Common/b2Settings.h \

--- a/pkgs/development/libraries/bullet/default.nix
+++ b/pkgs/development/libraries/bullet/default.nix
@@ -23,18 +23,18 @@ stdenv.mkDerivation rec {
     sed -i 's/FIND_LIBRARY(COCOA_LIBRARY Cocoa)//' CMakeLists.txt
   '';
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_CPU_DEMOS=OFF"
-    "-DINSTALL_EXTRA_LIBS=ON"
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    "-DMACOSX_DEPLOYMENT_TARGET=\"10.9\""
-    "-DOPENGL_FOUND=true"
-    "-DOPENGL_LIBRARIES=${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework"
-    "-DOPENGL_INCLUDE_DIR=${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework"
-    "-DOPENGL_gl_LIBRARY=${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework"
-    "-DCOCOA_LIBRARY=${darwin.apple_sdk.frameworks.Cocoa}/Library/Frameworks/Cocoa.framework"
-  ];
+  cmakeFlags = {
+    BUILD_CPU_DEMOS = false;
+    BUILD_SHARED_LIBS = true;
+    INSTALL_EXTRA_LIBS = true;
+  } // (stdenv.lib.optionalAttrs stdenv.isDarwin {
+    COCOA_LIBRARY = "${darwin.apple_sdk.frameworks.Cocoa}/Library/Frameworks/Cocoa.framework";
+    MACOSX_DEPLOYMENT_TARGET = "10.9";
+    OPENGL_FOUND = true;
+    OPENGL_gl_LIBRARY = "${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework";
+    OPENGL_INCLUDE_DIR = "${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework";
+    OPENGL_LIBRARIES = "${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework";
+  });
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost ffmpeg ];
 
-  cmakeFlags = [ "-DBUILD_EXAMPLES=ON" ];
+  cmakeFlags = { BUILD_EXAMPLES = true; };
 
   meta = with stdenv.lib; {
     homepage = https://acoustid.org/chromaprint;

--- a/pkgs/development/libraries/clucene-core/2.x.nix
+++ b/pkgs/development/libraries/clucene-core/2.x.nix
@@ -12,7 +12,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost zlib ];
 
-  cmakeFlags = [ "-DBUILD_CONTRIBS=ON" "-DBUILD_CONTRIBS_LIB=ON" ];
+  cmakeFlags = {
+    BUILD_CONTRIBS = true;
+    BUILD_CONTRIBS_LIB = true;
+  };
 
   patches = # From debian
     [ ./Fix-pkgconfig-file-by-adding-clucene-shared-library.patch

--- a/pkgs/development/libraries/cpp-netlib/default.nix
+++ b/pkgs/development/libraries/cpp-netlib/default.nix
@@ -14,9 +14,9 @@ stdenv.mkDerivation rec {
   # This can be removed when updating to 0.13, see https://github.com/cpp-netlib/cpp-netlib/issues/629
   propagatedBuildInputs = [ asio ];
 
-  cmakeFlags = [
-    "-DCPP-NETLIB_BUILD_SHARED_LIBS=ON"
-  ];
+  cmakeFlags = {
+    CPP-NETLIB_BUILD_SHARED_LIBS = true;
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/cppcms/default.nix
+++ b/pkgs/development/libraries/cppcms/default.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake pcre zlib python openssl ];
 
-  cmakeFlags = [
-    "--no-warn-unused-cli"
-  ];
+  cmakeFlags = {
+    extraFlags = [ "--no-warn-unused-cli" ];
+  };
 
   meta = with stdenv.lib; {
     homepage = http://cppcms.com;

--- a/pkgs/development/libraries/docopt_cpp/default.nix
+++ b/pkgs/development/libraries/docopt_cpp/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake python ];
 
-  cmakeFlags = ["-DWITH_TESTS=ON"];
+  cmakeFlags = { WITH_TESTS = true; };
 
   doCheck = true;
 

--- a/pkgs/development/libraries/double-conversion/default.nix
+++ b/pkgs/development/libraries/double-conversion/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = { BUILD_SHARED_LIBS = true; };
 
   # Case sensitivity issue
   preConfigure = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/fcppt/default.nix
+++ b/pkgs/development/libraries/fcppt/default.nix
@@ -14,7 +14,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost ];
 
-  cmakeFlags = [ "-DENABLE_EXAMPLES=false" "-DENABLE_TEST=false" ];
+  cmakeFlags = {
+    ENABLE_EXAMPLES = false;
+    ENABLE_TEST = false;
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -16,11 +16,11 @@ stdenv.mkDerivation rec {
     cd ../build
   '';
 
-  cmakeFlags = ''
-    -DGDCM_BUILD_APPLICATIONS=ON
-    -DGDCM_BUILD_SHARED_LIBS=ON
-    -DGDCM_USE_VTK=ON
-  '';
+  cmakeFlags = {
+    GDCM_BUILD_APPLICATIONS = true;
+    GDCM_BUILD_SHARED_LIBS = true;
+    GDCM_USE_VTK = true;
+  };
 
   enableParallelBuilding = true;
   buildInputs = [ cmake vtk ];

--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (rec {
     sha256 = "0zrrmfkfhd2xb4879z5khjb6xsdklrm01f1lscrs2ks68v25fk78";
   };
 
-  cmakeFlags = [ "-DTHREADSAFE=ON" ];
+  cmakeFlags = { THREADSAFE = true; };
 
   nativeBuildInputs = [ cmake python pkgconfig ];
 

--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     libX11 libXrandr libXinerama libXcursor
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa Kernel fixDarwinDylibNames ]);
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = { BUILD_SHARED_LIBS = true; };
 
   meta = with stdenv.lib; {
     description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time";

--- a/pkgs/development/libraries/google-gflags/default.nix
+++ b/pkgs/development/libraries/google-gflags/default.nix
@@ -16,11 +16,11 @@ stdenv.mkDerivation rec {
   # This isn't used by the build and breaks the CMake build on case-insensitive filesystems (e.g., on Darwin)
   preConfigure = "rm BUILD";
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_STATIC_LIBS=ON"
-    "-DBUILD_TESTING=${if doCheck then "ON" else "OFF"}"
-  ];
+  cmakeFlags = {
+    BUILD_SHARED_LIBS = true;
+    BUILD_STATIC_LIBS = true;
+    BUILD_TESTING = doCheck;
+  };
 
   doCheck = false;
 

--- a/pkgs/development/libraries/gstreamer/legacy/qt-gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/qt-gstreamer/default.nix
@@ -14,7 +14,10 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ boost155 ];
   nativeBuildInputs = [ cmake automoc4 flex bison pkgconfig ];
 
-  cmakeFlags = "-DUSE_QT_PLUGIN_DIR=OFF -DUSE_GST_PLUGIN_DIR=OFF";
+  cmakeFlags = {
+    USE_GST_PLUGIN_DIR = false;
+    USE_QT_PLUGIN_DIR = false;
+  };
 
   patches = [ ./boost1.48.patch ];
 }

--- a/pkgs/development/libraries/gstreamer/qt-gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/qt-gstreamer/default.nix
@@ -23,7 +23,10 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ boost ];
   nativeBuildInputs = [ cmake automoc4 flex bison pkgconfig ];
 
-  cmakeFlags = "-DUSE_QT_PLUGIN_DIR=OFF -DUSE_GST_PLUGIN_DIR=OFF";
+  cmakeFlags = {
+    USE_GST_PLUGIN_DIR = false;
+    USE_QT_PLUGIN_DIR = false;
+  };
 
   meta = {
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/itk/default.nix
+++ b/pkgs/development/libraries/itk/default.nix
@@ -8,16 +8,16 @@ stdenv.mkDerivation rec {
     sha256 = "09d1gmqx3wbdfgwf7r91r12m2vknviv0i8wxwh2q9w1vrpizrczy";
   };
 
-  cmakeFlags = [
-    "-DBUILD_TESTING=OFF"
-    "-DBUILD_EXAMPLES=OFF"
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DModule_ITKMINC=ON"
-    "-DModule_ITKIOMINC=ON"
-    "-DModule_ITKIOTransformMINC=ON"
-    "-DModule_ITKVtkGlue=ON"
-    "-DModule_ITKReview=ON"
-  ];
+  cmakeFlags = {
+    BUILD_EXAMPLES = false;
+    BUILD_SHARED_LIBS = true;
+    BUILD_TESTING = false;
+    Module_ITKIOMINC = true;
+    Module_ITKIOTransformMINC = true;
+    Module_ITKMINC = true;
+    Module_ITKReview = true;
+    Module_ITKVtkGlue = true;
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -33,10 +33,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake python ];
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_STATIC_LIBS=OFF"
-  ];
+  cmakeFlags = {
+    BUILD_SHARED_LIBS = true;
+    BUILD_STATIC_LIBS = false;
+  };
 
   meta = with stdenv.lib; {
     inherit version;

--- a/pkgs/development/libraries/kinetic-cpp-client/default.nix
+++ b/pkgs/development/libraries/kinetic-cpp-client/default.nix
@@ -30,9 +30,9 @@ stdenv.mkDerivation rec {
   # The headers and library include from these and there is no provided pc file
   propagatedBuildInputs = [ protobuf openssl ];
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=true"
-  ];
+  cmakeFlags = {
+    BUILD_SHARED_LIBS = true;
+  };
 
   preCheck = ''
     # The checks cannot find libkinetic_client.so otherwise

--- a/pkgs/development/libraries/libbladeRF/default.nix
+++ b/pkgs/development/libraries/libbladeRF/default.nix
@@ -26,12 +26,12 @@ stdenv.mkDerivation rec {
     sed -i 's/$(hostname)/hostname/' host/utilities/bladeRF-cli/src/cmd/doc/generate.bash
   '';
 
-  cmakeFlags = [
-    "-DBUILD_DOCUMENTATION=ON"
-  ] ++ lib.optionals stdenv.isLinux [
-    "-DUDEV_RULES_PATH=etc/udev/rules.d"
-    "-DINSTALL_UDEV_RULES=ON"
-  ];
+  cmakeFlags = {
+    BUILD_DOCUMENTATION = true;
+  } // (stdenv.lib.optionalAttrs stdenv.isLinux {
+    INSTALL_UDEV_RULES = true;
+    UDEV_RULES_PATH = "etc/udev/rules.d";
+  });
 
   hardeningDisable = [ "fortify" ];
 

--- a/pkgs/development/libraries/libcec/default.nix
+++ b/pkgs/development/libraries/libcec/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cmake udev libcec_platform ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=1" ];
+  cmakeFlags = { BUILD_SHARED_LIBS = true; };
 
   # Fix dlopen path
   patchPhase = ''

--- a/pkgs/development/libraries/libcouchbase/default.nix
+++ b/pkgs/development/libraries/libcouchbase/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ca3jp1nr5dk2w35wwyhsf96pblbw6n6n7a3ja264ivc9nhpkz4z";
   };
 
-  cmakeFlags = "-DLCB_NO_MOCK=ON";
+  cmakeFlags = { LCB_NO_MOCK = true; };
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ libevent openssl ];

--- a/pkgs/development/libraries/libdbusmenu-qt/default.nix
+++ b/pkgs/development/libraries/libdbusmenu-qt/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   buildInputs = [ qt4 ];
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = "-DWITH_DOC=OFF";
+  cmakeFlags = { WITH_DOC = false; };
 
   meta = with stdenv.lib; {
     description = "Provides a Qt implementation of the DBusMenu spec";

--- a/pkgs/development/libraries/libdbusmenu-qt/qt-5.5.nix
+++ b/pkgs/development/libraries/libdbusmenu-qt/qt-5.5.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   buildInputs = [ qtbase ];
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = "-DWITH_DOC=OFF";
+  cmakeFlags = { WITH_DOC = false; };
 
   meta = with stdenv.lib; {
     homepage = https://launchpad.net/libdbusmenu-qt;

--- a/pkgs/development/libraries/libdynd/default.nix
+++ b/pkgs/development/libraries/libdynd/default.nix
@@ -11,9 +11,9 @@ stdenv.mkDerivation {
     sha256 = "0fkd5rawqni1cq51fmr76iw7ll4fmbahfwv4rglnsabbkylf73pr";
   };
 
-  cmakeFlags = [
-    "-DDYND_BUILD_BENCHMARKS=OFF"
-  ];
+  cmakeFlags = {
+    DYND_BUILD_BENCHMARKS = false;
+  };
 
   # added to fix build with gcc7
   NIX_CFLAGS_COMPILE = [

--- a/pkgs/development/libraries/libminc/default.nix
+++ b/pkgs/development/libraries/libminc/default.nix
@@ -17,11 +17,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib netcdf nifticlib hdf5 ];
 
-  cmakeFlags = [ "-DBUILD_TESTING=${if doCheck then "TRUE" else "FALSE"}"
-                 "-DLIBMINC_MINC1_SUPPORT=TRUE"
-                 "-DLIBMINC_BUILD_SHARED_LIBS=TRUE"
-                 "-DLIBMINC_USE_SYSTEM_NIFTI=TRUE" ];
-
+  cmakeFlags = {
+    BUILD_TESTING = doCheck;
+    LIBMINC_MINC1_SUPPORT = true;
+    LIBMINC_BUILD_SHARED_LIBS = true;
+    LIBMINC_USE_SYSTEM_NIFTI = true;
+  };
 
   checkPhase = ''
     export LD_LIBRARY_PATH="$(pwd)"  # see #22060

--- a/pkgs/development/libraries/libmsgpack/generic.nix
+++ b/pkgs/development/libraries/libmsgpack/generic.nix
@@ -13,12 +13,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  cmakeFlags = []
-    ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
-                           "-DMSGPACK_BUILD_EXAMPLES=OFF"
-    ++ stdenv.lib.optional (hostPlatform.libc == "msvcrt")
-                           "-DCMAKE_SYSTEM_NAME=Windows"
-    ;
+  cmakeFlags = {}
+    // stdenv.lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
+    MSGPACK_BUILD_EXAMPLES = false;
+  } // stdenv.lib.optionalAttrs (hostPlatform.libc == "msvcrt") {
+    CMAKE_SYSTEM_NAME = "Windows";
+  };
 
   meta = with stdenv.lib; {
     description = "MessagePack implementation for C and C++";

--- a/pkgs/development/libraries/libmysqlconnectorcpp/default.nix
+++ b/pkgs/development/libraries/libmysqlconnectorcpp/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake boost mysql ];
 
-  cmakeFlags = [ "-DMYSQL_LIB_DIR=${mysql}/lib" ];
+  cmakeFlags = { MYSQL_LIB_DIR = "${mysql}/lib"; };
 
   meta = {
     homepage = https://dev.mysql.com/downloads/connector/cpp/;

--- a/pkgs/development/libraries/libsolv/default.nix
+++ b/pkgs/development/libraries/libsolv/default.nix
@@ -11,13 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "1knr48dilg8kscbmpjvd7m2krvgcdq0f9vpbqcgmxxa969mzrcy7";
   };
 
-  cmakeFlags = [
-    "-DENABLE_COMPLEX_DEPS=true"
-    "-DENABLE_RPMMD=true"
-    "-DENABLE_RPMDB=true"
-    "-DENABLE_PUBKEY=true"
-    "-DENABLE_RPMDB_BYRPMHEADER=true"
-  ];
+  cmakeFlags = {
+    ENABLE_COMPLEX_DEPS = true;
+    ENABLE_RPMMD = true;
+    ENABLE_RPMDB = true;
+    ENABLE_PUBKEY = true;
+    ENABLE_RPMDB_BYRPMHEADER = true;
+  };
 
   nativeBuildInputs = [ cmake ninja ];
   buildInputs = [ zlib expat rpm db ];

--- a/pkgs/development/libraries/libtcod/default.nix
+++ b/pkgs/development/libraries/libtcod/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     echo 'INSTALL(DIRECTORY include DESTINATION .)' >> CMakeLists.txt
   '';
 
-  cmakeFlags="-DLIBTCOD_SAMPLES=OFF";
+  cmakeFlags = { LIBTCOD_SAMPLES = false; };
 
   buildInputs = [ cmake SDL libGLU_combined upx zlib ];
 

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -13,11 +13,11 @@ let
       inherit sha256;
     };
 
-    cmakeFlags = [
-      "-DBUILD_NTOX=ON"
-      "-DDHT_BOOTSTRAP=ON"
-      "-DBOOTSTRAP_DAEMON=ON"
-    ];
+    cmakeFlags = {
+      BOOTSTRAP_DAEMON = true;
+      BUILD_NTOX = true;
+      DHT_BOOTSTRAP = true;
+    };
 
     buildInputs = [
       libsodium libmsgpack ncurses libconfig

--- a/pkgs/development/libraries/lucene++/default.nix
+++ b/pkgs/development/libraries/lucene++/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
            CMakeLists.txt
   '';
 
-  cmakeFlags = [ "-DGTEST_INCLUDE_DIR=${gtest}/include" ];
+  cmakeFlags = { GTEST_INCLUDE_DIR = "${gtest}/include"; };
   buildInputs = [ cmake boost gtest ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/mailcore2/default.nix
+++ b/pkgs/development/libraries/mailcore2/default.nix
@@ -30,9 +30,9 @@ stdenv.mkDerivation rec {
       --replace buffio.h tidybuffio.h
   '';
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-  ];
+  cmakeFlags = {
+    BUILD_SHARED_LIBS = true;
+  };
 
   installPhase = ''
     mkdir $out

--- a/pkgs/development/libraries/mygui/default.nix
+++ b/pkgs/development/libraries/mygui/default.nix
@@ -20,7 +20,11 @@ in stdenv.mkDerivation rec {
   buildInputs = [ libX11 unzip cmake ois freetype libuuid boost (if withOgre then ogre else libGLU_combined) ];
 
   # Tools are disabled due to compilation failures.
-  cmakeFlags = [ "-DMYGUI_BUILD_TOOLS=OFF" "-DMYGUI_BUILD_DEMOS=OFF" "-DMYGUI_RENDERSYSTEM=${renderSystem}" ];
+  cmakeFlags = {
+    MYGUI_BUILD_DEMOS = false;
+    MYGUI_BUILD_TOOLS = false;
+    MYGUI_RENDERSYSTEM = renderSystem;
+  };
 
   meta = with stdenv.lib; {
     homepage = http://mygui.info/;

--- a/pkgs/development/libraries/nvidia-texture-tools/default.nix
+++ b/pkgs/development/libraries/nvidia-texture-tools/default.nix
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
     sed -i 's/virtual void endImage() = 0;/virtual void endImage() {}/' src/nvtt/nvtt.h
   '';
 
-  cmakeFlags = [
-    "-DNVTT_SHARED=TRUE"
-  ];
+  cmakeFlags = {
+    NVTT_SHARED = true;
+  };
 
   postInstall = ''
     moveToOutput include "$dev"

--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -16,10 +16,13 @@ stdenv.mkDerivation {
      sha256 = "1zwvlx5dz9nwjazhnrhzb0w8ilpa84r0hrxrmmy69pgr1p1yif5a";
   };
 
-  cmakeFlags = [ "-DOGRE_BUILD_SAMPLES=${toString withSamples}" ]
-    ++ map (x: "-DOGRE_BUILD_PLUGIN_${x}=on")
-           ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")
-    ++ map (x: "-DOGRE_BUILD_RENDERSYSTEM_${x}=on") [ "GL" ];
+  cmakeFlags = {
+    OGRE_BUILD_RENDERSYSTEM_GL = true;
+    OGRE_BUILD_SAMPLES = withSamples;
+  } // (builtins.listToAttrs (builtins.map
+      (x: { name = "OGRE_BUILD_PLUGIN_${x}"; value = true; })
+      ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")
+  ));
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/ogrepaged/default.nix
+++ b/pkgs/development/libraries/ogrepaged/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ois ogre libX11 boost ];
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  cmakeFlags = [ "-DPAGEDGEOMETRY_BUILD_SAMPLES=OFF" ];
+  cmakeFlags = { PAGEDGEOMETRY_BUILD_SAMPLES = false; };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -13,11 +13,6 @@
 , darwin
 }:
 
-let
-  opencvFlag = name: enabled: "-DWITH_${name}=${if enabled then "ON" else "OFF"}";
-
-in
-
 stdenv.mkDerivation rec {
   name = "opencv-${version}";
   version = "2.4.13";
@@ -63,14 +58,14 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = lib.optional enableEXR "-I${ilmbase.dev}/include/OpenEXR";
 
-  cmakeFlags = [
-    (opencvFlag "TIFF" enableTIFF)
-    (opencvFlag "JASPER" enableJPEG2K)
-    (opencvFlag "JPEG" enableJPEG)
-    (opencvFlag "PNG" enablePNG)
-    (opencvFlag "OPENEXR" enableEXR)
-    (opencvFlag "GSTREAMER" enableGStreamer)
-  ];
+  cmakeFlags = {
+    WITH_JASPER = enableJPEG2K;
+    WITH_JPEG = enableJPEG;
+    WIHT_OPENEXR = enableEXR;
+    WITH_PNG = enablePNG;
+    WITH_TIFF = enableTIFF;
+    WITH_GSTREAMER = enableGStreamer;
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/openjpeg/generic.nix
+++ b/pkgs/development/libraries/openjpeg/generic.nix
@@ -20,7 +20,6 @@ assert (openjpegJarSupport || jpipLibSupport) -> jdk != null;
 
 let
   inherit (stdenv.lib) optional optionals;
-  mkFlag = optSet: flag: "-D${flag}=${if optSet then "ON" else "OFF"}";
 in
 
 stdenv.mkDerivation rec {
@@ -37,21 +36,20 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  cmakeFlags = [
-    "-DCMAKE_INSTALL_NAME_DIR=\${CMAKE_INSTALL_PREFIX}/lib"
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_CODEC=ON"
-    (mkFlag mj2Support "BUILD_MJ2")
-    (mkFlag jpwlLibSupport "BUILD_JPWL")
-    (mkFlag jpipLibSupport "BUILD_JPIP")
-    (mkFlag jpipServerSupport "BUILD_JPIP_SERVER")
-    #(mkFlag opjViewerSupport "BUILD_VIEWER")
-    "-DBUILD_VIEWER=OFF"
-    (mkFlag openjpegJarSupport "BUILD_JAVA")
-    (mkFlag jp3dSupport "BUILD_JP3D")
-    (mkFlag thirdPartySupport "BUILD_THIRDPARTY")
-    (mkFlag testsSupport "BUILD_TESTING")
-  ];
+  cmakeFlags = {
+    CMAKE_INSTALL_NAME_DIR = "$CMAKE_INSTALL_PREFIX/lib";
+    BUILD_SHARED_LIBS = true;
+    BUILD_CODEC = true;
+    BUILD_MJ2 = mj2Support;
+    BUILD_JPWL = jpwlLibSupport;
+    BUILD_JPIP = jpipLibSupport;
+    BUILD_JPIP_SERVER = jpipServerSupport;
+    BUILD_VIEWER = false;
+    BUILD_JAVA = openjpegJarSupport;
+    BUILD_JP3D = jp3dSupport;
+    BUILD_THIRDPARTY = thirdPartySupport;
+    BUILD_TESTING = testsSupport;
+  };
 
   nativeBuildInputs = [ cmake pkgconfig ];
 

--- a/pkgs/development/libraries/openwsman/default.nix
+++ b/pkgs/development/libraries/openwsman/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    cmakeFlags="$cmakeFlags -DPACKAGE_ARCHITECTURE=$(uname -m)";
+    cmakeFlags+=("-DPACKAGE_ARCHITECTURE=$(uname -m)")
   '';
 
   configureFlags = "--disable-more-warnings";

--- a/pkgs/development/libraries/physics/hepmc/default.nix
+++ b/pkgs/development/libraries/physics/hepmc/default.nix
@@ -12,10 +12,10 @@ stdenv.mkDerivation rec {
   patches = [ ./in_source.patch ];
   buildInputs = [ cmake ];
 
-  cmakeFlags = [
-    "-Dmomentum:STRING=GEV"
-    "-Dlength:STRING=MM"
-  ];
+  cmakeFlags = {
+    length = "MM";
+    momentum = "GEV";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/poppler/0.61.nix
+++ b/pkgs/development/libraries/poppler/0.61.nix
@@ -7,11 +7,8 @@
 , minimal ? false, suffix ? "glib"
 }:
 
-let
-  version = "0.61.0";
-  mkFlag = optset: flag: "-DENABLE_${flag}=${if optset then "on" else "off"}";
-in
 stdenv.mkDerivation rec {
+  version = "0.61.0";
   name = "poppler-${suffix}-${version}";
 
   src = fetchurl {
@@ -35,14 +32,14 @@ stdenv.mkDerivation rec {
   # Not sure when and how to pass it.  It seems an upstream bug anyway.
   CXXFLAGS = stdenv.lib.optionalString stdenv.cc.isClang "-std=c++11";
 
-  cmakeFlags = [
-    (mkFlag true "XPDF_HEADERS")
-    (mkFlag (!minimal) "GLIB")
-    (mkFlag (!minimal) "CPP")
-    (mkFlag (!minimal) "LIBCURL")
-    (mkFlag utils "UTILS")
-    (mkFlag qt5Support "QT5")
-  ];
+  cmakeFlags = {
+    XPDF_HEADERS = true;
+    GLIB = !minimal;
+    CPP = !minimal;
+    LIBCURL = !minimal;
+    UTILS = utils;
+    QT5 = qt5Support;
+  };
 
   meta = with lib; {
     homepage = https://poppler.freedesktop.org/;

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -7,12 +7,10 @@
 , minimal ? false, suffix ? "glib"
 }:
 
-let # beware: updates often break cups-filters build
-  version = "0.67.0";
-  mkFlag = optset: flag: "-DENABLE_${flag}=${if optset then "on" else "off"}";
-in
 stdenv.mkDerivation rec {
   name = "poppler-${suffix}-${version}";
+  # beware: updates often break cups-filters build
+  version = "0.67.0";
 
   src = fetchurl {
     url = "${meta.homepage}/poppler-${version}.tar.xz";
@@ -36,14 +34,14 @@ stdenv.mkDerivation rec {
   # Not sure when and how to pass it.  It seems an upstream bug anyway.
   CXXFLAGS = stdenv.lib.optionalString stdenv.cc.isClang "-std=c++11";
 
-  cmakeFlags = [
-    (mkFlag true "XPDF_HEADERS")
-    (mkFlag (!minimal) "GLIB")
-    (mkFlag (!minimal) "CPP")
-    (mkFlag (!minimal) "LIBCURL")
-    (mkFlag utils "UTILS")
-    (mkFlag qt5Support "QT5")
-  ];
+  cmakeFlags = {
+    XPDF_HEADERS = true;
+    GLIB = !minimal;
+    CPP = !minimal;
+    LIBCURL = !minimal;
+    UTILS = utils;
+    QT5 = qt5Support;
+  };
 
   meta = with lib; {
     homepage = https://poppler.freedesktop.org/;

--- a/pkgs/development/libraries/pugixml/default.nix
+++ b/pkgs/development/libraries/pugixml/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if shared then "ON" else "OFF"}" ];
+  cmakeFlags = {
+    BUILD_SHARED_LIBS = shared;
+  };
 
   preConfigure = ''
     # Enable long long support (required for filezilla)

--- a/pkgs/development/libraries/qhull/default.nix
+++ b/pkgs/development/libraries/qhull/default.nix
@@ -10,7 +10,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = "-DMAN_INSTALL_DIR=share/man/man1 -DDOC_INSTALL_DIR=share/doc/qhull";
+  cmakeFlags = {
+    DOC_INSTALL_DIR = "share/doc/qhull";
+    MAN_INSTALL_DIR = "share/man/man1";
+  };
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -18,13 +18,13 @@ stdenv.mkDerivation rec {
     sha256 = "1r6qp9l2lp5jpc6ciklbg1swvvzcpc37rg9py46hk0wxy6klnm0b"; # v0.8.0
   };
 
-  cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ]
-    ++ stdenv.lib.optional stdenv.isDarwin [
+  cmakeFlags = {
+    QT_TRANSLATIONS_DIR = "share/qt/translations";
+  } // stdenv.lib.optionalAttrs stdenv.isDarwin {
        # correctly detect the compiler
        # for details see cmake --help-policy CMP0025
-       "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
-       ]
-   ;
+       CMAKE_POLICY_DEFAULT_CMP0025 = "NEW";
+  };
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -26,19 +26,18 @@ stdenv.mkDerivation rec {
   buildInputs = [ gfortran cmake ];
   nativeBuildInputs = [ python2 ];
 
-  cmakeFlags = [
-    "-DUSE_OPTIMIZED_BLAS=ON"
-    "-DCMAKE_Fortran_FLAGS=-fPIC"
-  ]
-  ++ (optionals (atlas != null) [
-    "-DBLAS_ATLAS_f77blas_LIBRARY=${atlasMaybeShared}/lib/libf77blas${usedLibExtension}"
-    "-DBLAS_ATLAS_atlas_LIBRARY=${atlasMaybeShared}/lib/libatlas${usedLibExtension}"
-  ])
-  ++ (optional shared "-DBUILD_SHARED_LIBS=ON")
-  # If we're on darwin, CMake will automatically detect impure paths. This switch
-  # prevents that.
-  ++ (optional stdenv.isDarwin "-DCMAKE_OSX_SYSROOT:PATH=''")
-  ;
+  cmakeFlags = {
+    BUILD_SHARED_LIBS = shared;
+    CMAKE_Fortran_FLAGS = "-fPIC";
+    USE_OPTIMIZED_BLAS = true;
+  } // (optionalAttrs (atlas != null) {
+    BLAS_ATLAS_atlas_LIBRARY = "${atlasMaybeShared}/lib/libatlas${usedLibExtension}";
+    BLAS_ATLAS_f77blas_LIBRARY = "${atlasMaybeShared}/lib/libf77blas${usedLibExtension}";
+  }) // (optionalAttrs stdenv.isDarwin {
+    # If we're on darwin, CMake will automatically detect impure paths. This switch
+    # prevents that.
+    CMAKE_OSX_SYSROOT = "";
+  });
 
   doCheck = ! shared;
 

--- a/pkgs/development/libraries/science/math/metis/default.nix
+++ b/pkgs/development/libraries/science/math/metis/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1cjxgh41r8k6j029yxs8msp3z6lcnpm16g5pvckk35kc7zhfpykn";
   };
 
-  cmakeFlags = [ "-DGKLIB_PATH=../GKlib" ];
+  cmakeFlags = { GKLIB_PATH = "../GKlib"; };
   buildInputs = [ unzip cmake ];
 
   meta = {

--- a/pkgs/development/libraries/science/math/superlu/default.nix
+++ b/pkgs/development/libraries/science/math/superlu/default.nix
@@ -14,10 +14,10 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ openblasCompat ];
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=true"
-    "-DUSE_XSDK_DEFAULTS=true"
-  ];
+  cmakeFlags = {
+    BUILD_SHARED_LIBS = true;
+    USE_XSDK_DEFAULTS = true;
+  };
 
   patches = [
     ./find-openblas-library.patch

--- a/pkgs/development/libraries/sfml/default.nix
+++ b/pkgs/development/libraries/sfml/default.nix
@@ -17,10 +17,14 @@ stdenv.mkDerivation rec {
                   libXrandr libXrender xcbutilimage
                 ] ++ stdenv.lib.optional stdenv.isLinux udev
                   ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit Foundation AppKit OpenAL ];
-  cmakeFlags = [ "-DSFML_INSTALL_PKGCONFIG_FILES=yes"
-                 "-DSFML_MISC_INSTALL_PREFIX=share/SFML"
-                 "-DSFML_BUILD_FRAMEWORKS=no"
-                 "-DSFML_USE_SYSTEM_DEPS=yes" ];
+
+  cmakeFlags = {
+    SFML_INSTALL_PKGCONFIG_FILES = true;
+    SFML_MISC_INSTALL_PREFIX = "share/SFML";
+    SFML_BUILD_FRAMEWORKS = false;
+    SFML_USE_SYSTEM_DEPS = true;
+  }
+
   meta = with stdenv.lib; {
     homepage = http://www.sfml-dev.org/;
     description = "Simple and fast multimedia library";

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  # cmakeFlags = [ "-DSPDLOG_BUILD_EXAMPLES=ON" ];
+  # cmakeFlags = { SPDLOG_BUILD_EXAMPLES = true; };
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/libraries/stxxl/default.nix
+++ b/pkgs/development/libraries/stxxl/default.nix
@@ -2,10 +2,6 @@
 , parallel ? true
 }:
 
-let
-  mkFlag = optset: flag: if optset then "-D${flag}=ON" else "-D${flag}=OFF";
-in
-
 stdenv.mkDerivation rec {
   name = "stxxl-${version}";
   version = "1.4.1";
@@ -17,11 +13,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_STATIC_LIBS=OFF"
-    (mkFlag parallel "USE_GNU_PARALLEL")
-  ];
+  cmakeFlags = {
+    BUILD_SHARED_LIBS = true;
+    BUILD_STATIC_LIBS = false;
+    USE_GNU_PARALLEL = parallel;
+  };
 
   passthru = {
     inherit parallel;

--- a/pkgs/development/libraries/uri/default.nix
+++ b/pkgs/development/libraries/uri/default.nix
@@ -12,9 +12,11 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake doxygen ];
 
-  cmakeFlags = [
-    "-DUri_BUILD_TESTS=OFF" "-DUri_BUILD_DOCS=ON" "-DBUILD_SHARED_LIBS=ON"
-  ];
+  cmakeFlags = {
+    BUILD_SHARED_LIBS = true;
+    Uri_BUILD_DOCS = true;
+    Uri_BUILD_TESTS = false;
+  };
 
   postBuild = "make doc";
 

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -38,12 +38,16 @@ stdenv.mkDerivation rec {
   # built and requiring one of the shared objects.
   # At least, we use -fPIC for other packages to be able to use this in shared
   # objects.
-  cmakeFlags = [ "-DCMAKE_C_FLAGS=-fPIC" "-DCMAKE_CXX_FLAGS=-fPIC" ]
-    ++ optional (qtLib != null) [ "-DVTK_USE_QT:BOOL=ON" ]
-    ++ optional stdenv.isDarwin [ "-DBUILD_TESTING:BOOL=OFF"
-                                  "-DCMAKE_OSX_SYSROOT="
-                                  "-DCMAKE_OSX_DEPLOYMENT_TARGET="
-                                  "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks" ];
+  cmakeFlags = {
+    CMAKE_C_FLAGS = "-fPIC";
+    CMAKE_CXX_FLAGS = "-fPIC";
+    VTK_USE_QT = qtLib != null;
+  } // (optionalAttrs stdenv.isDarwin {
+    BUILD_TESTING = false;
+    CMAKE_OSX_SYSROOT = "";
+    CMAKE_OSX_DEPLOYMENT_TARGET = "";
+    OPENGL_INCLUDE_DIR = "${OpenGL}/Library/Frameworks";
+  });
 
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i 's|COMMAND vtkHashSource|COMMAND "DYLD_LIBRARY_PATH=''${VTK_BINARY_DIR}/lib" ''${VTK_BINARY_DIR}/bin/vtkHashSource-7.0|' ./Parallel/Core/CMakeLists.txt

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -17,10 +17,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake python3 xlibsWrapper libxcb libXrandr libXext wayland ];
   enableParallelBuilding = true;
 
-  cmakeFlags = [
-    "-DFALLBACK_DATA_DIRS=${libGL_driver.driverLink}/share:/usr/local/share:/usr/share"
-    "-DVULKAN_HEADERS_INSTALL_DIR=${vulkan-headers}"
-  ];
+  cmakeFlags = {
+    FALLBACK_DATA_DIRS = "${libGL_driver.driverLink}/share:/usr/local/share:/usr/share";
+    VULKAN_HEADERS_INSTALL_DIR = vulkan-headers;
+  };
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/libraries/vxl/default.nix
+++ b/pkgs/development/libraries/vxl/default.nix
@@ -11,14 +11,18 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake unzip libtiff expat zlib libpng libjpeg ];
 
+  # BUILD_BRL fails to find open()
   # BUILD_OUL wants old linux headers for videodev.h, not available
   # in stdenv linux headers
-  # BUILD_BRL fails to find open()
-  cmakeFlags = "-DBUILD_TESTING=OFF -DBUILD_OUL=OFF -DBUILD_BRL=OFF -DBUILD_CONTRIB=OFF "
-    + (if stdenv.system == "x86_64-linux" then
-      "-DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_C_FLAGS=-fPIC"
-    else
-      "");
+  cmakeFlags = {
+    BUILD_BRL = false;
+    BUILD_CONTRIB = false;
+    BUILD_OUL = false;
+    BUILD_TESTING = false;
+  } // (stdenv.lib.optionalAttrs (stdenv.system == "x86_64-linux") {
+    CMAKE_C_FLAGS = "-fPIC";
+    CMAKE_CXX_FLAGS = "-fPIC";
+  });
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -10,7 +10,6 @@
 }:
 
 let
-  mkFlag = optSet: flag: if optSet then "-D${flag}=ON" else "-D${flag}=OFF";
   inherit (stdenv) is64bit;
 in
 
@@ -32,18 +31,18 @@ stdenv.mkDerivation rec {
     sed -i 's/unknown/${version}/g' source/cmake/version.cmake
   '';
 
-  cmakeFlags = [
-    (mkFlag debugSupport "CHECKED_BUILD")
-    "-DSTATIC_LINK_CRT=OFF"
-    (mkFlag (highbitdepthSupport && is64bit) "HIGH_BIT_DEPTH")
-    (mkFlag werrorSupport "WARNINGS_AS_ERRORS")
-    (mkFlag ppaSupport "ENABLE_PPA")
-    (mkFlag vtuneSupport "ENABLE_VTUNE")
-    (mkFlag custatsSupport "DETAILED_CU_STATS")
-    "-DENABLE_SHARED=ON"
-    (mkFlag cliSupport "ENABLE_CLI")
-    (mkFlag unittestsSupport "ENABLE_TESTS")
-  ];
+  cmakeFlags = {
+    CHECKED_BUILD = debugSupport;
+    STATIC_LINK_CRT = false;
+    HIGH_BIT_DEPTH = highbitdepthSupport && is64bit;
+    WARNINGS_AS_ERRORS = werrorSupport;
+    ENABLE_PPA = ppaSupport;
+    ENABLE_VTUNE = vtuneSupport;
+    DETAILED_CU_STATS = custatsSupport;
+    ENABLE_SHARED = true;
+    ENABLE_CLI = cliSupport;
+    ENABLE_TESTS = unittestsSupport;
+  };
 
   preConfigure = ''
     cd source

--- a/pkgs/development/mobile/xpwn/default.nix
+++ b/pkgs/development/mobile/xpwn/default.nix
@@ -20,9 +20,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ cmake zlib libpng bzip2 libusb openssl ];
 
-  cmakeFlags = [
-    "-DCMAKE_OSX_DEPLOYMENT_TARGET="
-  ];
+  cmakeFlags = {
+    CMAKE_OSX_DEPLOYMENT_TARGET = "";
+  };
 
   meta = with stdenv.lib; {
     homepage    = "http://planetbeing.lighthouseapp.com/projects/15246-xpwn";

--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     sha256 = "1fcc6ylfiw1npdhx7mrsj7h0dx7cym7i9664kpr76zqazb52ikm9";
   })];
 
-  cmakeFlags = [ "-DLLVM_OCAML_OUT_OF_TREE=TRUE" ];
+  cmakeFlags = { LLVM_OCAML_OUT_OF_TREE = true; };
 
   buildFlags = "ocaml_all";
 

--- a/pkgs/development/tools/analysis/include-what-you-use/default.nix
+++ b/pkgs/development/tools/analysis/include-what-you-use/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = with llvmPackages; [ clang-unwrapped llvm ];
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DIWYU_LLVM_ROOT_PATH=${llvmPackages.clang-unwrapped}" ];
+  cmakeFlags = { IWYU_LLVM_ROOT_PATH = "${llvmPackages.clang-unwrapped}"; };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/analysis/rr/default.nix
+++ b/pkgs/development/tools/analysis/rr/default.nix
@@ -17,15 +17,15 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
-    cmake libpfm zlib python2Packages.python python2Packages.pexpect which procps gdb capnproto
+    libpfm zlib python2Packages.python python2Packages.pexpect which procps gdb capnproto
   ];
-  cmakeFlags = [
-    "-DCMAKE_C_FLAGS_RELEASE:STRING="
-    "-DCMAKE_CXX_FLAGS_RELEASE:STRING="
-    "-Ddisable32bit=ON"
-  ];
+  cmakeFlags = {
+    CMAKE_C_FLAGS_RELEASE = "";
+    CMAKE_CXX_FLAGS_RELEASE = "";
+    disable32bit = true;
+  };
 
   # we turn on additional warnings due to hardening
   NIX_CFLAGS_COMPILE = "-Wno-error";

--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -35,8 +35,11 @@ in stdenv.mkDerivation {
   # ABI differences GCC 7.1
   # /nix/store/wd6r25miqbk9ia53pp669gn4wrg9n9cj-gcc-7.3.0/include/c++/7.3.0/bits/vector.tcc:394:7: note: parameter passing for argument of type 'std::vector<uhd::range_t>::iterator {aka __gnu_cxx::__normal_iterator<uhd::range_t*, std::vector<uhd::range_t> >}' changed in GCC 7.1
 
-  cmakeFlags = [ "-DLIBUSB_INCLUDE_DIRS=${libusb1.dev}/include/libusb-1.0"] ++
-               [ (stdenv.lib.optionalString stdenv.isAarch32 "-DCMAKE_CXX_FLAGS=-Wno-psabi") ];
+  cmakeFlags = {
+    LIBUSB_INCLUDE_DIRS = "${libusb1.dev}/include/libusb-1.0";
+  } // (stdenv.lib.optionalAttrs stdenv.isAarch32 {
+    CMAKE_CXX_FLAGS = "-Wno-psabi";
+  });
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ python pythonPackages.pyramid_mako orc libusb1 boost ];

--- a/pkgs/development/tools/tora/default.nix
+++ b/pkgs/development/tools/tora/default.nix
@@ -30,18 +30,18 @@ in mkDerivation rec {
       extlibs/libermodel/dotgraph.cpp
   '';
 
-  cmakeFlags = [
-    "-DWANT_INTERNAL_LOKI=0"
-    "-DWANT_INTERNAL_QSCINTILLA=0"
+  cmakeFlags = {
+    ENABLE_DB2 = false;
+    ENABLE_ORACLE = false;
+    ENABLE_TERADATA = false;
     # cmake/modules/FindQScintilla.cmake looks in qtbase and for the wrong library name
-    "-DQSCINTILLA_INCLUDE_DIR=${qscintillaLib}/include"
-    "-DQSCINTILLA_LIBRARY=${qscintillaLib}/lib/libqscintilla2.so"
-    "-DENABLE_DB2=0"
-    "-DENABLE_ORACLE=0"
-    "-DENABLE_TERADATA=0"
-    "-DQT5_BUILD=1"
-    "-Wno-dev"
-  ];
+    QSCINTILLA_INCLUDE_DIR = "${qscintillaLib}/include";
+    QSCINTILLA_LIBRARY = "${qscintillaLib}/lib/libqscintilla2.so";
+    QT5_BUILD = true;
+    WANT_INTERNAL_LOKI = false;
+    WANT_INTERNAL_QSCINTILLA = false;
+    extraFlags = [ "-Wno-dev" ];
+  };
 
   # these libraries are only searched for at runtime so we need to force-link them
   NIX_LDFLAGS = [

--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -19,11 +19,11 @@ stdenv.mkDerivation rec {
     optipng imagemagick
   ];
 
-  cmakeFlags = [
-    "-DDATA_DIR_PREFIXES=$out/share"
-    "-DImageMagick_convert_EXECUTABLE=${imagemagick.out}/bin/convert"
-    "-DImageMagick_mogrify_EXECUTABLE=${imagemagick.out}/bin/mogrify"
-  ];
+  cmakeFlags = {
+    DATA_DIR_PREFIXES = "$out/share";
+    ImageMagick_convert_EXECUTABLE = "${imagemagick.out}/bin/convert";
+    ImageMagick_mogrify_EXECUTABLE = "${imagemagick.out}/bin/mogrify";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -24,14 +24,14 @@ in stdenv.mkDerivation {
 
   src = sources.src;
 
-  cmakeFlags = [
-    "-DENABLE_FREETYPE=1"
-    "-DENABLE_GETTEXT=1"
-    "-DENABLE_SYSTEM_JSONCPP=1"
-    "-DGETTEXT_INCLUDE_DIR=${gettext}/include/gettext"
-    "-DCURL_INCLUDE_DIR=${curl.dev}/include/curl"
-    "-DIRRLICHT_INCLUDE_DIR=${irrlicht}/include/irrlicht"
-  ];
+  cmakeFlags = {
+    CURL_INCLUDE_DIR = "${curl.dev}/include/curl";
+    ENABLE_FREETYPE = true;
+    ENABLE_GETTEXT = true;
+    ENABLE_SYSTEM_JSONCPP = true;
+    GETTEXT_INCLUDE_DIR = "${gettext}/include/gettext";
+    IRRLICHT_INCLUDE_DIR = "${irrlicht}/include/irrlicht";
+  };
 
   NIX_CFLAGS_COMPILE = [ "-DluaL_reg=luaL_Reg" ]; # needed since luajit-2.1.0-beta3
 

--- a/pkgs/games/openlierox/default.nix
+++ b/pkgs/games/openlierox/default.nix
@@ -12,10 +12,10 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = "-I${libxml2.dev}/include/libxml2 -std=c++98 -Wno-error";
 
   # The breakpad fails to build on x86_64, and it's only to report bugs upstream
-  cmakeFlags = [ "-DBREAKPAD=0" ];
+  cmakeFlags = { BREAKPAD = false; };
 
   preConfigure = ''
-    cmakeFlags="$cmakeFlags -DSYSTEM_DATA_DIR=$out/share"
+    cmakeFlags+=("-DSYSTEM_DATA_DIR=$out/share")
   '';
 
   patchPhase = ''

--- a/pkgs/games/openspades/default.nix
+++ b/pkgs/games/openspades/default.nix
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
     freetype SDL2 SDL2_image libGL zlib curl glew opusfile openal libogg
   ];
 
-  cmakeFlags = [
-    "-DOPENSPADES_INSTALL_BINARY=bin"
-  ];
+  cmakeFlags = {
+    OPENSPADES_INSTALL_BINARY = "bin";
+  };
 
   devPak = fetchurl {
     url = "https://github.com/yvt/openspades-paks/releases/download/r${devPakVersion}/OpenSpadesDevPackage-r${devPakVersion}.zip";

--- a/pkgs/games/soi/default.nix
+++ b/pkgs/games/soi/default.nix
@@ -14,9 +14,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost lua luabind libGLU_combined SDL ];
 
-  cmakeFlags = [
-    "-DEIGEN_INCLUDE_DIR=${eigen2}/include/eigen2"
-  ];
+  cmakeFlags = {
+    EIGEN_INCLUDE_DIR = "${eigen2}/include/eigen2";
+  };
 
   meta = with stdenv.lib; {
     description = "A physics-based puzzle game";

--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -25,9 +25,11 @@ stdenv.mkDerivation rec {
     rm rts/build/cmake/FindGLEW.cmake
   '';
 
-  cmakeFlags = ["-DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON"
-                "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON"
-                "-DPREFER_STATIC_LIBS:BOOL=OFF"];
+  cmakeFlags = {
+    CMAKE_BUILD_WITH_INSTALL_RPATH = true;
+    CMAKE_INSTALL_RPATH_USE_LINK_PATH = true;
+    PREFER_STATIC_LIBS = false;
+  };
 
   buildInputs = [ cmake lzma boost libdevil zlib p7zip openal libvorbis freetype SDL2
     xorg.libX11 xorg.libXcursor libGLU_combined glew asciidoc libxslt docbook_xsl curl makeWrapper

--- a/pkgs/games/stepmania/default.nix
+++ b/pkgs/games/stepmania/default.nix
@@ -21,11 +21,11 @@ stdenv.mkDerivation rec {
     glew libpulseaudio udev
   ];
 
-  cmakeFlags = [
-    "-DWITH_SYSTEM_FFMPEG=1"
-    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
-    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
-  ];
+  cmakeFlags = {
+    GTK2_GDKCONFIG_INCLUDE_DIR = "${gtk2.out}/lib/gtk-2.0/include";
+    GTK2_GLIBCONFIG_INCLUDE_DIR = "${glib.out}/lib/glib-2.0/include";
+    WITH_SYSTEM_FFMPEG = true;
+  };
 
   postInstall = ''
     mkdir -p $out/bin

--- a/pkgs/games/supertux/default.nix
+++ b/pkgs/games/supertux/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL2 SDL2_image curl libogg libvorbis libGLU_combined openal boost glew ];
 
-  cmakeFlags = [ "-DENABLE_BOOST_STATIC_LIBS=OFF" ];
+  cmakeFlags = { ENABLE_BOOST_STATIC_LIBS = false; };
 
   postInstall = ''
     mkdir $out/bin

--- a/pkgs/games/voxelands/default.nix
+++ b/pkgs/games/voxelands/default.nix
@@ -10,11 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "0bims0y0nyviv2f2nxfj37s3258cjbfp9xd97najz0yylnk3qdfw";
   };
 
-  cmakeFlags = [
-    "-DIRRLICHT_INCLUDE_DIR=${irrlicht}/include/irrlicht"
-    "-DCMAKE_C_FLAGS_RELEASE=-DNDEBUG"
-    "-DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG"
-  ];
+  cmakeFlags = {
+    CMAKE_C_FLAGS_RELEASE = "-DNDEBUG";
+    CMAKE_CXX_FLAGS_RELEASE = "-DNDEBUG";
+    IRRLICHT_INCLUDE_DIR = "${irrlicht}/include/irrlicht";
+  };
 
   buildInputs = [
     cmake irrlicht libpng bzip2 libjpeg sqlite

--- a/pkgs/games/wesnoth/default.nix
+++ b/pkgs/games/wesnoth/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
                   libvorbis fribidi dbus libpng pcre openssl icu ]
                 ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa Foundation];
 
-  cmakeFlags = [ "-DENABLE_TOOLS=${if enableTools then "ON" else "OFF"}" ];
+  cmakeFlags = {
+    ENABLE_TOOLS = enableTools;
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/games/widelands/default.nix
+++ b/pkgs/games/widelands/default.nix
@@ -31,11 +31,11 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    cmakeFlags="
-      -DWL_INSTALL_BASEDIR=$out
-      -DWL_INSTALL_DATADIR=$out/share/widelands
-      -DWL_INSTALL_BINARY=$out/bin
-    "
+    cmakeFlags+=(
+        "-DWL_INSTALL_BASEDIR=$out"
+        "-DWL_INSTALL_DATADIR=$out/share/widelands"
+        "-DWL_INSTALL_BINARY=$out/bin"
+    )
   '';
 
   nativeBuildInputs = [ cmake python gettext ];

--- a/pkgs/games/zdoom/default.nix
+++ b/pkgs/games/zdoom/default.nix
@@ -17,11 +17,11 @@ stdenv.mkDerivation rec {
     SDL2 openal fluidsynth bzip2 zlib libjpeg game-music-emu libsndfile mpg123
   ];
 
-  cmakeFlags = [
-    "-DFORCE_INTERNAL_GME=OFF"
-    "-DGME_INCLUDE_DIR=${game-music-emu}/include"
-    "-DGME_LIBRARIES=${game-music-emu}/lib/libgme.so"
-  ];
+  cmakeFlags = {
+    FORCE_INTERNAL_GME = false;
+    GME_INCLUDE_DIR = "${game-music-emu}/include";
+    GME_LIBRARIES = "${game-music-emu}/lib/libgme.so";
+  };
 
   sourceRoot = ".";
 

--- a/pkgs/misc/emulators/hatari/default.nix
+++ b/pkgs/misc/emulators/hatari/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   # For pthread_cancel
-  cmakeFlags = "-DCMAKE_EXE_LINKER_FLAGS=-lgcc_s";
+  cmakeFlags = { CMAKE_EXE_LINKER_FLAGS = "-lgcc_s"; };
 
   buildInputs = [ zlib SDL cmake ];
 

--- a/pkgs/misc/emulators/vbam/default.nix
+++ b/pkgs/misc/emulators/vbam/default.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE='Release'"
     "-DENABLE_FFMPEG='true'"
     #"-DENABLE_LINK='true'" currently broken :/
     "-DSYSCONFDIR=etc"

--- a/pkgs/misc/emulators/vbam/default.nix
+++ b/pkgs/misc/emulators/vbam/default.nix
@@ -41,11 +41,11 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  cmakeFlags = [
-    "-DENABLE_FFMPEG='true'"
-    #"-DENABLE_LINK='true'" currently broken :/
-    "-DSYSCONFDIR=etc"
-  ];
+  cmakeFlags = {
+    ENABLE_FFMPEG = true;
+    #ENABLE_LINK = true; currently broken :/
+    SYSCONFDIR = "etc";
+  };
 
   meta = {
     description = "A merge of the original Visual Boy Advance forks";

--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -18,10 +18,12 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  cmakeFlags = [
-    "-DUSE_BUNDLED_DEPS=OFF"
-    "-DSYSDIG_VERSION=${version}"
-  ] ++ optional (kernel == null) "-DBUILD_DRIVER=OFF";
+  cmakeFlags = {
+    USE_BUNDLED_DEPS = false;
+    SYSDIG_VERSION = "${version}";
+  } // optionalAttrs (kernel == null) {
+    BUILD_DRIVER = false;
+  };
 
   # needed since luajit-2.1.0-beta3
   NIX_CFLAGS_COMPILE = [

--- a/pkgs/servers/mail/postsrsd/default.nix
+++ b/pkgs/servers/mail/postsrsd/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "09yzb0fvnbfy534maqlqk79c41p1yz8r9f73n7bahm5lwd0livk9";
   };
 
-  cmakeFlags = [ "-DGENERATE_SRS_SECRET=OFF" "-DINIT_FLAVOR=systemd" ];
+  cmakeFlags = {
+    GENERATE_SRS_SECRET = false;
+    INIT_FLAVOR = "systemd";
+  };
 
   preConfigure = ''
     sed -i "s,\"/etc\",\"$out/etc\",g" CMakeLists.txt

--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -18,13 +18,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig perl ];
   buildInputs = [ glib gmime libevent libmagic luajit openssl pcre sqlite ragel icu libfann ];
 
-  cmakeFlags = [
-    "-DDEBIAN_BUILD=ON"
-    "-DRUNDIR=/var/run/rspamd"
-    "-DDBDIR=/var/lib/rspamd"
-    "-DLOGDIR=/var/log/rspamd"
-    "-DLOCAL_CONFDIR=/etc/rspamd"
-  ];
+  cmakeFlags = {
+    DBDIR = "/var/lib/rspamd";
+    DEBIAN_BUILD = true;
+    LOCAL_CONFDIR = "/etc/rspamd";
+    LOGDIR = "/var/log/rspamd";
+    RUNDIR = "/var/run/rspamd";
+  };
 
   meta = with stdenv.lib; {
     homepage = https://github.com/vstakhov/rspamd;

--- a/pkgs/servers/uhub/default.nix
+++ b/pkgs/servers/uhub/default.nix
@@ -36,10 +36,10 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  cmakeFlags = ''
-    -DSYSTEMD_SUPPORT=ON
-    ${if tlsSupport then "-DSSL_SUPPORT=ON" else "-DSSL_SUPPORT=OFF"}
-  '';
+  cmakeFlags = {
+    SSL_SUPPORT = tlSupport;
+    SYSTEMD_SUPPORT = true;
+  };
 
   meta = with stdenv.lib; {
     description = "High performance peer-to-peer hub for the ADC network";

--- a/pkgs/tools/X11/virtualgl/lib.nix
+++ b/pkgs/tools/X11/virtualgl/lib.nix
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "0f1jp7r4vajiksbiq08hkxd5bjj0jxlw7dy5750s52djg1v3hhsg";
   };
 
-  cmakeFlags = [ "-DVGL_SYSTEMFLTK=1" "-DTJPEG_LIBRARY=${libjpeg_turbo.out}/lib/libturbojpeg.so" ];
+  cmakeFlags = {
+    TJPEG_LIBRARY = "${libjpeg_turbo.out}/lib/libturbojpeg.so";
+    VGL_SYSTEMFLTK = true;
+  };
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/tools/audio/acoustid-fingerprinter/default.nix
+++ b/pkgs/tools/audio/acoustid-fingerprinter/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cmake qt4 taglib chromaprint ffmpeg ];
 
-  cmakeFlags = [ "-DTAGLIB_MIN_VERSION=${(builtins.parseDrvName taglib.name).version}" ];
+  cmakeFlags = { TAGLIB_MIN_VERSION = (builtins.parseDrvName taglib.name).version; };
 
   patches = [ (fetchpatch {
     url = "https://bitbucket.org/acoustid/acoustid-fingerprinter/commits/632e87969c3a5562a5d4842b03613267ba6236b2/raw";

--- a/pkgs/tools/graphics/kst/default.nix
+++ b/pkgs/tools/graphics/kst/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ qtbase gsl getdata netcdf muparser matio ];
 
-  cmakeFlags = "-Dkst_qt5=1 -Dkst_release=1";
+  cmakeFlags = {
+    kst_qt5 = true;
+    kst_release = true;
+  };
 
   postInstall = ''
     mkdir -p $out

--- a/pkgs/tools/graphics/pfstools/default.nix
+++ b/pkgs/tools/graphics/pfstools/default.nix
@@ -15,9 +15,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "man"];
 
-  cmakeFlags = ''
-    -DWITH_MATLAB=false 
-  '';
+  cmakeFlags = { WITH_MATLAB = false; };
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [

--- a/pkgs/tools/inputmethods/ibus/ibus-qt.nix
+++ b/pkgs/tools/inputmethods/ibus/ibus-qt.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     ibus cmake qt4 icu doxygen
   ];
 
-  cmakeFlags = [ "-DQT_PLUGINS_DIR=lib/qt4/plugins" ];
+  cmakeFlags = { QT_PLUGINS_DIR = "lib/qt4/plugins"; };
 
   meta = with stdenv.lib; {
     homepage    = https://github.com/ibus/ibus-qt/;

--- a/pkgs/tools/networking/badvpn/default.nix
+++ b/pkgs/tools/networking/badvpn/default.nix
@@ -26,7 +26,10 @@ stdenv.mkDerivation {
   preConfigure = ''
     find . -name '*.sh' -exec sed -e 's@#!/bin/sh@${stdenv.shell}@' -i '{}' ';'
     find . -name '*.sh' -exec sed -e 's@#!/bin/bash@${bash}/bin/bash@' -i '{}' ';'
-    cmakeFlagsArray=("-DCMAKE_BUILD_TYPE=" "-DCMAKE_C_FLAGS=${compileFlags}");
+    cmakeFlags+=(
+        "-DCMAKE_BUILD_TYPE="
+        "-DCMAKE_C_FLAGS=${compileFlags}"
+    );
   '';
 
   meta = {

--- a/pkgs/tools/typesetting/pdf2htmlEX/default.nix
+++ b/pkgs/tools/typesetting/pdf2htmlEX/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./add-glib-cmake.patch ];
 
-  cmakeFlags = [ "-DENABLE_SVG=ON" ];
+  cmakeFlags = { ENABLE_SVG = true; };
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Similar to #15799, but with a smaller scope (can change everything at one time so no need for deprecation) and with an even nicer interface.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There are three main parts to this change:
- Support a new `setupHookFunc` in `mkDerivation`
- Using attribute sets for `cmakeFlags` in Nix
- Passing `cmakeFlags` to the builder more smartly

== Introducing `setupHookFunc`

The `setupHook` attribute allows a derivation to register arbitrary
modifications to run in the context of downstream dependents' builds.

To enable similar modifications to be made to the attributes passed
to `mkDerivation`, teach `mkDerivation` a new trick: `setupHookFunc`.
A derivation can set `setupHookFunc` to a Nix function
which will be called for downstream dependencies
(TODO using the same logic as the setupHook inclusion),
and which takes the attribute set which was passed to `mkDerivation`
and returns a new attribute set with any desired changes.

These will stack (TODO: resolution order?) for composability,
and having these live alongside the original derivation
avoids cluttering `mkDerivation` with cmake-specific code
(which was done in an earlier iteration).

TODO: benchmark

== Using Attribute Sets for `cmakeFlags`

Almost all flags passed to `cmakeFlags` are setting CMake cache options
with "-D<name>=<value>" or "-D<name>:<type>=<value>".
Because the CMake cache is essentially a set of keys and values,
model `cmakeFlags` as an attribute set in Nix as well.

The cmake `setupHookFunc` will take a `cmakeFlags` set
and convert each key/value pair to an appropriate "-D" option for cmake.
String values are used as is, while integers are converted to strings
and booleans are converted to `"ON"` and `"OFF"`.
This presents the following benefits:
- Removal of "-D" visual noise everywhere for ease of reading.
- The `=` operater is literal, allowing extra whitespace for more ease
  of reading.
- CMake options are now first class Nix values that can be operated on
  directly with the full strength of the Nix language.
  For example, boolean values can be used directly because the
  serialization logic is consolidated into the cmake `setupHookFunc`,
  getting rid of helpers like `edf`
  and making it easier to re-use feature flags like `pythonSupport`.
- Sets automatically sort options, improving cache re-use.
- An override which updates a CMake flag option will only incur
  (amortized) O(1) cost with a set, as opposed to O(n) cost with an
  (unsorted) list, which would require a full linear search.
  It's also shorter to write: just use `//`.

A few other CMake flag types are supported:
- Setting a value to null will cause its key to be unset via "-U<name>".
- The `generator` key is mapped to the "-G<value>" option.
- The `extraArgs` key is an escape hatch; any flags in this list of
  strings are not pre-processed, but concatenated to the generated list.

Because `setupHookFunc`s are processed during `mkDerivation`,
when overriding `cmakeFlags` `overrideAttrs` should be used instead of
`overrideDerivation` so the cmake `setupHookFunc` has a chance to rerun.

== Passing `cmakeFlags` to the builder more smartly

Nix's regular conversion of lists to an environment variable
simply concatenates the contents with spaces,
which breaks if any of the flags themselves contain spaces.
`cmakeFlagsArray` was added as a way to get around this limitation,
but is unsatisfactory to use because items must be appended via bash
in a preConfigure hook.

Instead, pass the list to the builder in a smarter way:
instead of relying on Nix's conversion to a string,
perform our own conversion by escaping double quotes,
double quoting each item, and passing the flags as a Bash array,
which is hydrated via `eval`.

This handles flags with spaces, newlines and other whitespace,
as well as double quotes, faithfully.

TODO: does it handle eg some_var="$out/blah"
Make the list available during preConfigure as a bash array, so any
dynamic modifications to the CMake flags can be done there.

These changes make also `cmakeFlagsArray` redundant, so it has been
removed and replaced in all cases with `cmakeFlags`.

---

Notes/questions:

- I'd like to know how to document this (as a breaking change). Since we don't have a good strategy for deprecation, I'd like to avoid that entirely.
- I've only updated some of the packages (namely those I've use locally); if this is a desired change than I can figure out the best way to update all the rest of the packages, too. I made these changes by hand and did compile a few, but I'd rather not compile all of these on my laptop. Can this patchset be run on Hydra to catch any inadvertent breakage?
