### PR TITLE
pflogsumm: init at 1.1.3

### DIFF
--- a/pkgs/servers/mail/postfix/pflogsumm.nix
+++ b/pkgs/servers/mail/postfix/pflogsumm.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, buildPerlPackage, perlPackages
+}:
+
+buildPerlPackage rec {
+  name = "pflogsumm-${version}";
+  version = "1.1.3";
+
+  src = fetchurl {
+    url = "http://jimsun.linxnet.com/downloads/${name}.tar.gz";
+    sha256 = "0hkim9s5f1yg5sfs5048jydhy3sbxafls496wcjk0cggxb113py4";
+  };
+
+  outputs = [ "out" "man" ];
+  buildInputs = [ perlPackages.DateCalc ];
+
+  preConfigure = ''
+    touch Makefile.PL
+  '';
+  doCheck = false;
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mv "pflogsumm.pl" "$out/bin/pflogsumm"
+
+    mkdir -p "$out/share/man/man1"
+    mv "pflogsumm.1" "$out/share/man/man1"
+  '';
+
+  meta = {
+    homepage = "http://jimsun.linxnet.com/postfix_contrib.html";
+    description = "Postfix activity overview";
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10420,6 +10420,7 @@ in
   rspamd = callPackage ../servers/mail/rspamd { };
 
   pfixtools = callPackage ../servers/mail/postfix/pfixtools.nix { };
+  pflogsumm = callPackage ../servers/mail/postfix/pflogsumm.nix { };
 
   pshs = callPackage ../servers/http/pshs { };
 


### PR DESCRIPTION
###### Motivation for this change

Added the pflogsumm postfix log analyzer.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
