### PR TITLE
urxvt-theme-switch: Add description and homepage

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-theme-switch/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-theme-switch/default.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "";
-    homepage = "";
+    description = "urxvt plugin that allows to switch color themes during runtime";
+    homepage = "https://github.com/felixr/urxvt-theme-switch";
     license = "CCBYNC";
     maintainers = with maintainers; [ garbas ];
     platforms = with platforms; unix;


### PR DESCRIPTION
The urxvt-theme-switch had an empty description and homepage string.  I used the info from the GitHub page to fill those
