### PR TITLE
[WIP]libsoup: 2.54.1 -> 2.55.90 & vala_0_23 -> vala_0_32

### DIFF
--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchurl, glib, libxml2, pkgconfig
 , gnomeSupport ? true, libgnome_keyring, sqlite, glib_networking, gobjectIntrospection
-, valaSupport ? true, vala_0_23
+, valaSupport ? true, vala_0_32
 , libintlOrEmpty
 , intltool, python }:
 let
-  majorVersion = "2.54";
-  version = "${majorVersion}.1";
+  majorVersion = "2.55";
+  version = "${majorVersion}.90";
 in
 stdenv.mkDerivation {
   name = "libsoup-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/libsoup/${majorVersion}/libsoup-${version}.tar.xz";
-    sha256 = "0cyn5pq4xl1gb8413h2p4d5wrn558dc054zhwmk4swrl40ijrd27";
+    sha256 = "14xp0vfjdgd7y1r2xclfvd4mgcwbwnflw8ycm2ii5a8y4dgsmabb";
   };
 
   prePatch = ''
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   outputs = [ "dev" "out" ];
 
   buildInputs = libintlOrEmpty ++ [ intltool python sqlite ]
-    ++ stdenv.lib.optionals valaSupport [ vala_0_23 ];
+    ++ stdenv.lib.optionals valaSupport [ vala_0_32 ];
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ glib libxml2 gobjectIntrospection ]
     ++ stdenv.lib.optionals gnomeSupport [ libgnome_keyring ];
@@ -33,8 +33,7 @@ stdenv.mkDerivation {
 
   # glib_networking is a runtime dependency, not a compile-time dependency
   configureFlags = "--disable-tls-check"
-    + stdenv.lib.optionalString (!valaSupport) " --enable-vala=no"
-    + stdenv.lib.optionalString (valaSupport) " --enable-vala=yes"
+    + " --enable-vala=${if valaSupport then "yes" else "no"}"
     + stdenv.lib.optionalString (!gnomeSupport) " --without-gnome";
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-lintl";


### PR DESCRIPTION
###### Motivation for this change

maintenance ( https://github.com/GNOME/libsoup/commits/master nothing changed in the APIs)
vala_0_23 -> vala_0_32
miscellaneous cleanup

Note: Builds fine. But I couldn't test it. I tried building both midori and surf against the commit but they kept trying to rebuild webkitgtk...

I'm not seeing any reason to rush an update without testing but I'll leave it to the reviewer to decide whether to merge or wait until unstable updates.
