### PR TITLE
diffutils: 3.3 -> 3.5

### DIFF
--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, xz, coreutils ? null }:
 
 stdenv.mkDerivation rec {
-  name = "diffutils-3.3";
+  name = "diffutils-3.5";
 
   src = fetchurl {
     url = "mirror://gnu/diffutils/${name}.tar.xz";
-    sha256 = "1761vymxbp4wb5rzjvabhdkskk95pghnn67464byvzb5mfl8jpm2";
+    sha256 = "0csmqfz8ks23kdjsq0v2ll1acqiz8lva06dj19mwmymrsp69ilys";
   };
 
   outputs = [ "out" "info" ];


### PR DESCRIPTION
###### Motivation for this change

PR against staging
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Releases announcements:
3.4: http://lists.gnu.org/archive/html/info-gnu/2016-08/msg00004.html
3.5: http://lists.gnu.org/archive/html/info-gnu/2016-08/msg00010.html
