### PR TITLE
arx-libertatis: fix build

### DIFF
--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -18,9 +18,11 @@ stdenv.mkDerivation rec {
     optipng imagemagick
   ];
 
-  preConfigure = ''
-    cmakeFlags="-DDATA_DIR_PREFIXES=$out/share"
-  '';
+  cmakeFlags = [
+    "-DDATA_DIR_PREFIXES=$out/share"
+    "-DImageMagick_convert_EXECUTABLE=${imagemagick.out}/bin/convert"
+    "-DImageMagick_mogrify_EXECUTABLE=${imagemagick.out}/bin/mogrify"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
