### PR TITLE
plotutils: disable i686 tests

### DIFF
--- a/pkgs/tools/graphics/plotutils/default.nix
+++ b/pkgs/tools/graphics/plotutils/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
 
   configureFlags = "--enable-libplotter"; # required for pstoedit
 
-  doCheck = true;
+  # disable tests on i686 like ubuntu
+  # https://lists.gnu.org/archive/html/bug-plotutils/2016-04/msg00002.html
+  doCheck = if stdenv.isi686 then false else true;
 
   meta = {
     description = "Powerful C/C++ library for exporting 2D vector graphics";


### PR DESCRIPTION
###### Motivation for this change

disable tests on i686 like ubuntu https://lists.gnu.org/archive/html/bug-plotutils/2016-04/msg00002.html
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
