### PR TITLE
nixos: Disable audit by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1609.xml
+++ b/nixos/doc/manual/release-notes/rl-1609.xml
@@ -66,6 +66,11 @@ following incompatible changes:</para>
     <literal>environment.variables</literal>.</para>
   </listitem>
 
+  <listitem>
+    <para>The <literal>audit</literal> service is no longer enabled by default.
+    Use <literal>security.audit.enable = true;</literal> to explicitly enable it.
+  </listitem>
+
 </itemizedlist>
 
 

--- a/nixos/modules/security/audit.nix
+++ b/nixos/modules/security/audit.nix
@@ -55,7 +55,7 @@ in {
     security.audit = {
       enable = mkOption {
         type        = types.enum [ false true "lock" ];
-        default     = true; # The kernel seems to enable it by default with no rules anyway
+        default     = false;
         description = ''
           Whether to enable the Linux audit system. The special `lock' value can be used to
           enable auditing and prevent disabling it until a restart. Be careful about locking

--- a/nixos/modules/security/audit.nix
+++ b/nixos/modules/security/audit.nix
@@ -4,12 +4,20 @@ with lib;
 
 let
   cfg = config.security.audit;
+  enabled = cfg.enable == "lock" || cfg.enable;
 
   failureModes = {
     silent = 0;
     printk = 1;
     panic  = 2;
   };
+
+  disableScript = pkgs.writeScript "audit-disable" ''
+    #!${pkgs.stdenv.shell} -eu
+    # Explicitly disable everything, as otherwise journald might start it.
+    auditctl -D
+    auditctl -e 0 -a task,never
+  '';
 
   # TODO: it seems like people like their rules to be somewhat secret, yet they will not be if
   # put in the store like this. At the same time, it doesn't feel like a huge deal and working
@@ -91,7 +99,7 @@ in {
     };
   };
 
-  config = mkIf (cfg.enable == "lock" || cfg.enable) {
+  config = {
     systemd.services.audit = {
       description = "Kernel Auditing";
       wantedBy = [ "basic.target" ];
@@ -103,8 +111,8 @@ in {
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStart = "@${startScript} audit-start";
-        ExecStop  = "@${stopScript}  audit-stop";
+        ExecStart = "@${if enabled then startScript else disableScript} audit-start";
+        ExecStop  = "@${stopScript} audit-stop";
       };
     };
   };

--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0jwrww1vn7yqxmb84n6y4p58z34gga0ic4rs2msvpzc2x1hxrn31";
   };
 
+  outputs = [ "dev" "out" "bin" "man" ];
+
   buildInputs = [ openldap ]
             ++ stdenv.lib.optional enablePython python;
 


### PR DESCRIPTION
Because in its default enabled state it it causes a global performance
hit on all system calls (https://fedorahosted.org/fesco/ticket/1311) and
unwanted spam in dmesg, in particular when using Chromium (#13710).

To actually make audit fully disabled, use the big hammer by putting `audit=0` to the kernel parameters.
That is actually needed because otherwise journald starts it anyway. For some discussion on the usefulness of that:
    - https://fedorahosted.org/fesco/ticket/1311
    - systemd/systemd#959
    - openSUSE/systemd@64f83d3

Finally, split audit to multiple outputs - that prevents the library part of audit (used by systemd for instance) from depending on openldap, which currently brings in 180+ MB of crud
into the closure due to it depending on glibc headers and other stuff. (That one could
really be fixed by https://github.com/NixOS/patchelf/pull/98, FWIW).

cc @edolstra  @copumpkin 
