### PR TITLE
openpts: fix build

### DIFF
--- a/pkgs/servers/openpts/default.nix
+++ b/pkgs/servers/openpts/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-tss" "--with-aru" "--with-tboot" "--enable-tnc" "--with-aide" ];
 
-  NIX_CFLAGS_COMPILE = "-I${trousers}/include/trousers -I${trousers}/include/tss";
+  NIX_CFLAGS_COMPILE = "-I${trousers}/include/trousers -I${trousers}/include/tss -Wno-deprecated-declarations";
 
   preInstall = ''
     mkdir -p $out
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     description = "TCG Platform Trust Service (PTS)";
     homepage = "ttp://sourceforge.jp/projects/openpts";
     license = stdenv.lib.licenses.cpl10;
-    platforms = stdenv.lib.platforms.unix;
+    platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ tstrobel ];
   };
 }


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
