### PR TITLE
xpilot-ng: fix build

### DIFF
--- a/pkgs/games/xpilot/default.nix
+++ b/pkgs/games/xpilot/default.nix
@@ -1,7 +1,7 @@
-{stdenv, fetchurl, libX11, SDL, mesa, expat, SDL_ttf, SDL_image}:
+{stdenv, fetchurl, libX11, libSM, SDL, mesa, expat, SDL_ttf, SDL_image, zlib}:
 let
   buildInputs = [
-    libX11 SDL SDL_ttf SDL_image mesa expat
+    libX11 libSM SDL SDL_ttf SDL_image mesa expat zlib
   ];
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
