### PR TITLE
fcitx-engines.table-other: fix build

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fcitx, gettext }:
+{ stdenv, fetchurl, fetchpatch, cmake, fcitx, gettext }:
 
 stdenv.mkDerivation rec {
   name = "fcitx-table-other-${version}";
@@ -10,6 +10,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ cmake fcitx gettext ];
+
+  patches = [
+    (fetchpatch { url = https://sources.debian.net/data/main/f/fcitx-table-other/0.2.3-3/debian/patches/0001-table-other-fix-build.patch;
+                  sha256 = "06n1df9szfgfjm5al8r1mvp4cib5h0cm601kwngl6k1vqyyjzg1j";
+                })
+  ];
 
   preInstall = ''
    substituteInPlace tables/cmake_install.cmake \


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
