### PR TITLE
supertuxkart: fix build

### DIFF
--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -1,6 +1,6 @@
 { fetchgit, fetchsvn, cmake, stdenv, plib, SDL, openal, freealut, mesa
 , libvorbis, libogg, gettext, libXxf86vm, curl, pkgconfig
-, fribidi, autoconf, automake, libtool, bluez, libjpeg }:
+, fribidi, autoconf, automake, libtool, bluez, libjpeg, libpng }:
 
 stdenv.mkDerivation rec {
   name = "supertuxkart-${version}";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   
   buildInputs = [
     plib SDL openal freealut mesa libvorbis libogg gettext
-    libXxf86vm curl pkgconfig fribidi autoconf automake libtool cmake bluez libjpeg
+    libXxf86vm curl pkgconfig fribidi autoconf automake libtool cmake bluez libjpeg libpng
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
