### PR TITLE
kdevplatform: Fix build.

### DIFF
--- a/pkgs/development/libraries/kdevplatform/default.nix
+++ b/pkgs/development/libraries/kdevplatform/default.nix
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "195134bde11672de38838f4b341ed28c58042374ca12beedacca9d30e6ab4a2b";
   };
 
-  patches = [ ./gettext.patch ];
+  patches = [
+    ./gettext.patch     # build error caused by CMake update
+    ./dependency.patch  # build error: https://phabricator.kde.org/D1160
+  ];
 
   propagatedBuildInputs = [ kdelibs qt4 phonon ];
   buildInputs = [ apr aprutil subversion boost qjson grantlee ];

--- a/pkgs/development/libraries/kdevplatform/dependency.patch
+++ b/pkgs/development/libraries/kdevplatform/dependency.patch
@@ -1,0 +1,12 @@
+diff --git a/plugins/filetemplates/CMakeLists.txt b/plugins/filetemplates/CMakeLists.txt
+--- a/plugins/filetemplates/CMakeLists.txt
++++ b/plugins/filetemplates/CMakeLists.txt
+@@ -81,6 +81,7 @@
+ )
+ 
+ kde4_add_executable(testfiletemplates ${test_srcs})
++add_dependencies(testfiletemplates kdevfiletemplates)
+ 
+ target_link_libraries(testfiletemplates
+     ${KDE4_KDECORE_LIBS}
+


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Build log: https://hydra.nixos.org/build/38445107/nixlog/1
Upstream report and patch: https://phabricator.kde.org/D1160
