### PR TITLE
bookerly: Amazon Kindle font, init at 4.21.0.65

### DIFF
--- a/pkgs/data/fonts/bookerly/default.nix
+++ b/pkgs/data/fonts/bookerly/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, unzip }:
+
+let apk = fetchurl {
+            url = "http://www.apkmirror.com/wp-content/themes/APKMirror/download.php?id=60658";
+            sha256 = "462e9da7d6eb7cf67aa8abb6f66b522104fa1d7465a10f338ca488a187387490";
+          };
+in stdenv.mkDerivation rec {
+  name = "bookerly-${version}";
+  version = "4.21.0.65";
+
+  buildInputs = [ unzip ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  unpackPhase = ''
+    unzip ${apk}
+    sourceRoot=.
+  '';
+
+  installPhase = ''
+    install -Dm644 -t $out/share/fonts/truetype assets/Bookerly*.ttf
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://play.google.com/store/apps/details?id=com.amazon.kindle";
+    description = "Amazon Kindle fonts";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.unfree;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11898,6 +11898,8 @@ in
 
   bgnet = callPackage ../data/documentation/bgnet { };
 
+  bookerly = callPackage ../data/fonts/bookerly { };
+
   cacert = callPackage ../data/misc/cacert { };
 
   caladea = callPackage ../data/fonts/caladea {};


### PR DESCRIPTION
###### Motivation for this change

Bookerly is a great serif font for the Amazon Kindle and now NixOS
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
