### PR TITLE
evolution: improve out-of-gnome use

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/apps/evolution/default.nix
@@ -1,8 +1,8 @@
 { stdenv, intltool, fetchurl, libxml2, webkitgtk, highlight
 , pkgconfig, gtk3, glib, libnotify, gtkspell3
-, makeWrapper, itstool, shared_mime_info, libical, db, gcr, sqlite
+, wrapGAppsHook, itstool, shared_mime_info, libical, db, gcr, sqlite
 , gnome3, librsvg, gdk_pixbuf, libsecret, nss, nspr, icu, libtool
-, libcanberra_gtk3, bogofilter, gst_all_1, procps, p11_kit }:
+, libcanberra_gtk3, bogofilter, gst_all_1, procps, p11_kit, dconf }:
 
 let
   majVer = gnome3.version;
@@ -11,18 +11,22 @@ in stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
+  propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard
+                            gnome3.evolution_data_server ];
 
   propagatedBuildInputs = [ gnome3.gtkhtml ];
 
-  buildInputs = [ pkgconfig gtk3 glib intltool itstool libxml2 libtool
+  buildInputs = [ gtk3 glib intltool itstool libxml2 libtool
                   gdk_pixbuf gnome3.defaultIconTheme librsvg db icu
                   gnome3.evolution_data_server libsecret libical gcr
                   webkitgtk shared_mime_info gnome3.gnome_desktop gtkspell3
                   libcanberra_gtk3 bogofilter gnome3.libgdata sqlite
                   gst_all_1.gstreamer gst_all_1.gst-plugins-base p11_kit
                   nss nspr libnotify procps highlight gnome3.libgweather
-                  gnome3.gsettings_desktop_schemas makeWrapper ];
+                  gnome3.gsettings_desktop_schemas dconf
+                  gnome3.libgnome_keyring gnome3.glib_networking ];
+
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
 
   configureFlags = [ "--disable-spamassassin" "--disable-pst-import" "--disable-autoar"
                      "--disable-libcryptui" ];
@@ -30,14 +34,6 @@ in stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${nspr.dev}/include/nspr -I${nss}/include/nss -I${glib.dev}/include/gio-unix-2.0";
 
   enableParallelBuilding = true;
-
-  preFixup = ''
-    for f in $out/bin/* $out/libexec/*; do
-      wrapProgram "$f" \
-        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-        --prefix XDG_DATA_DIRS : "${gnome3.gnome_themes_standard}/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
-    done
-  '';
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Evolution;


### PR DESCRIPTION
###### Motivation for this change

Evolution didn't work.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add `evolution_data_server` to `propagatedUserEnvPkgs`. Evolution needs
`${gnome3.evolution_data_server}/libexec/evolution-source-registry` to
be running to be able to find or create any account settings at all, and
it apparently doesn't know to start it if it's not in the user env.

Add `libgnome_keyring` and `dconf` to `buildInputs`, add
`glib_networking` and `dconf` to `GIO_EXTRA_MODULES` in the wrapper
script. `libgnome_keyring` appears to be necessary for evolution to
remember a password even for a single session, even if it doesn't get
added to the keyring permanently. `dconf` is necessary to persist
preferences. `glib_networking` is necessary to connect to mail servers.

Also fix wrapping `libexec` binaries, even though I'm not sure that
improves anything.

---

Closes #12756.
