### PR TITLE
openssl: fix CVE-2016-2177

### DIFF
--- a/pkgs/development/libraries/openssl/1.0.1-CVE-2016-2177.diff
+++ b/pkgs/development/libraries/openssl/1.0.1-CVE-2016-2177.diff
@@ -1,0 +1,256 @@
+From 6f35f6deb5ca7daebe289f86477e061ce3ee5f46 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Thu, 5 May 2016 11:10:26 +0100
+Subject: [PATCH] Avoid some undefined pointer arithmetic
+
+A common idiom in the codebase is:
+
+if (p + len > limit)
+{
+    return; /* Too long */
+}
+
+Where "p" points to some malloc'd data of SIZE bytes and
+limit == p + SIZE
+
+"len" here could be from some externally supplied data (e.g. from a TLS
+message).
+
+The rules of C pointer arithmetic are such that "p + len" is only well
+defined where len <= SIZE. Therefore the above idiom is actually
+undefined behaviour.
+
+For example this could cause problems if some malloc implementation
+provides an address for "p" such that "p + len" actually overflows for
+values of len that are too big and therefore p + len < limit!
+
+Issue reported by Guido Vranken.
+
+CVE-2016-2177
+
+Reviewed-by: Rich Salz <rsalz@openssl.org>
+---
+ ssl/s3_srvr.c  | 14 +++++++-------
+ ssl/ssl_sess.c |  2 +-
+ ssl/t1_lib.c   | 48 ++++++++++++++++++++++++++----------------------
+ 3 files changed, 34 insertions(+), 30 deletions(-)
+
+diff --git a/ssl/s3_srvr.c b/ssl/s3_srvr.c
+index 04cf93a..6c74caa 100644
+--- a/ssl/s3_srvr.c
++++ b/ssl/s3_srvr.c
+@@ -1040,7 +1040,7 @@ int ssl3_get_client_hello(SSL *s)
+ 
+         session_length = *(p + SSL3_RANDOM_SIZE);
+ 
+-        if (p + SSL3_RANDOM_SIZE + session_length + 1 >= d + n) {
++        if (SSL3_RANDOM_SIZE + session_length + 1 >= (d + n) - p) {
+             al = SSL_AD_DECODE_ERROR;
+             SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+             goto f_err;
+@@ -1058,7 +1058,7 @@ int ssl3_get_client_hello(SSL *s)
+     /* get the session-id */
+     j = *(p++);
+ 
+-    if (p + j > d + n) {
++    if ((d + n) - p < j) {
+         al = SSL_AD_DECODE_ERROR;
+         SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+         goto f_err;
+@@ -1114,14 +1114,14 @@ int ssl3_get_client_hello(SSL *s)
+ 
+     if (s->version == DTLS1_VERSION || s->version == DTLS1_BAD_VER) {
+         /* cookie stuff */
+-        if (p + 1 > d + n) {
++        if ((d + n) - p < 1) {
+             al = SSL_AD_DECODE_ERROR;
+             SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+             goto f_err;
+         }
+         cookie_len = *(p++);
+ 
+-        if (p + cookie_len > d + n) {
++        if ((d + n ) - p < cookie_len) {
+             al = SSL_AD_DECODE_ERROR;
+             SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+             goto f_err;
+@@ -1166,7 +1166,7 @@ int ssl3_get_client_hello(SSL *s)
+         p += cookie_len;
+     }
+ 
+-    if (p + 2 > d + n) {
++    if ((d + n ) - p < 2) {
+         al = SSL_AD_DECODE_ERROR;
+         SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+         goto f_err;
+@@ -1180,7 +1180,7 @@ int ssl3_get_client_hello(SSL *s)
+     }
+ 
+     /* i bytes of cipher data + 1 byte for compression length later */
+-    if ((p + i + 1) > (d + n)) {
++    if ((d + n) - p < i + 1) {
+         /* not enough data */
+         al = SSL_AD_DECODE_ERROR;
+         SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_MISMATCH);
+@@ -1246,7 +1246,7 @@ int ssl3_get_client_hello(SSL *s)
+ 
+     /* compression */
+     i = *(p++);
+-    if ((p + i) > (d + n)) {
++    if ((d + n) - p < i) {
+         /* not enough data */
+         al = SSL_AD_DECODE_ERROR;
+         SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_MISMATCH);
+diff --git a/ssl/ssl_sess.c b/ssl/ssl_sess.c
+index 48fc451..a97d060 100644
+--- a/ssl/ssl_sess.c
++++ b/ssl/ssl_sess.c
+@@ -602,7 +602,7 @@ int ssl_get_prev_session(SSL *s, unsigned char *session_id, int len,
+     int r;
+ #endif
+ 
+-    if (session_id + len > limit) {
++    if (limit - session_id < len) {
+         fatal = 1;
+         goto err;
+     }
+diff --git a/ssl/t1_lib.c b/ssl/t1_lib.c
+index 0bdb77d..8ed1793 100644
+--- a/ssl/t1_lib.c
++++ b/ssl/t1_lib.c
+@@ -942,11 +942,11 @@ static void ssl_check_for_safari(SSL *s, const unsigned char *data,
+         0x02, 0x03,             /* SHA-1/ECDSA */
+     };
+ 
+-    if (data >= (limit - 2))
++    if (limit - data <= 2)
+         return;
+     data += 2;
+ 
+-    if (data > (limit - 4))
++    if (limit - data < 4)
+         return;
+     n2s(data, type);
+     n2s(data, size);
+@@ -954,7 +954,7 @@ static void ssl_check_for_safari(SSL *s, const unsigned char *data,
+     if (type != TLSEXT_TYPE_server_name)
+         return;
+ 
+-    if (data + size > limit)
++    if (limit - data < size)
+         return;
+     data += size;
+ 
+@@ -962,7 +962,7 @@ static void ssl_check_for_safari(SSL *s, const unsigned char *data,
+         const size_t len1 = sizeof(kSafariExtensionsBlock);
+         const size_t len2 = sizeof(kSafariTLS12ExtensionsBlock);
+ 
+-        if (data + len1 + len2 != limit)
++        if (limit - data != (int)(len1 + len2))
+             return;
+         if (memcmp(data, kSafariExtensionsBlock, len1) != 0)
+             return;
+@@ -971,7 +971,7 @@ static void ssl_check_for_safari(SSL *s, const unsigned char *data,
+     } else {
+         const size_t len = sizeof(kSafariExtensionsBlock);
+ 
+-        if (data + len != limit)
++        if (limit - data != (int)(len))
+             return;
+         if (memcmp(data, kSafariExtensionsBlock, len) != 0)
+             return;
+@@ -1019,19 +1019,19 @@ int ssl_parse_clienthello_tlsext(SSL *s, unsigned char **p,
+     if (data == limit)
+         goto ri_check;
+ 
+-    if (data > (limit - 2))
++    if (limit - data < 2)
+         goto err;
+ 
+     n2s(data, len);
+ 
+-    if (data + len != limit)
++    if (limit - data != len)
+         goto err;
+ 
+-    while (data <= (limit - 4)) {
++    while (limit - data >= 4) {
+         n2s(data, type);
+         n2s(data, size);
+ 
+-        if (data + size > (limit))
++        if (limit - data < size)
+             goto err;
+ # if 0
+         fprintf(stderr, "Received extension type %d size %d\n", type, size);
+@@ -1460,20 +1460,20 @@ int ssl_parse_serverhello_tlsext(SSL *s, unsigned char **p, unsigned char *d,
+                              SSL_TLSEXT_HB_DONT_SEND_REQUESTS);
+ # endif
+ 
+-    if (data >= (d + n - 2))
++    if ((d + n) - data <= 2)
+         goto ri_check;
+ 
+     n2s(data, length);
+-    if (data + length != d + n) {
++    if ((d + n) - data != length) {
+         *al = SSL_AD_DECODE_ERROR;
+         return 0;
+     }
+ 
+-    while (data <= (d + n - 4)) {
++    while ((d + n) - data >= 4) {
+         n2s(data, type);
+         n2s(data, size);
+ 
+-        if (data + size > (d + n))
++        if ((d + n) - data < size)
+             goto ri_check;
+ 
+         if (s->tlsext_debug_cb)
+@@ -2179,29 +2179,33 @@ int tls1_process_ticket(SSL *s, unsigned char *session_id, int len,
+     /* Skip past DTLS cookie */
+     if (s->version == DTLS1_VERSION || s->version == DTLS1_BAD_VER) {
+         i = *(p++);
+-        p += i;
+-        if (p >= limit)
++
++        if (limit - p <= i)
+             return -1;
++
++        p += i;
+     }
+     /* Skip past cipher list */
+     n2s(p, i);
+-    p += i;
+-    if (p >= limit)
++    if (limit - p <= i)
+         return -1;
++    p += i;
++
+     /* Skip past compression algorithm list */
+     i = *(p++);
+-    p += i;
+-    if (p > limit)
++    if (limit - p < i)
+         return -1;
++    p += i;
++
+     /* Now at start of extensions */
+-    if ((p + 2) >= limit)
++    if (limit - p <= 2)
+         return 0;
+     n2s(p, i);
+-    while ((p + 4) <= limit) {
++    while (limit - p >= 4) {
+         unsigned short type, size;
+         n2s(p, type);
+         n2s(p, size);
+-        if (p + size > limit)
++        if (limit - p < size)
+             return 0;
+         if (type == TLSEXT_TYPE_session_ticket) {
+             int r;
+-- 
+1.9.1
+

--- a/pkgs/development/libraries/openssl/1.0.2-CVE-2016-2177.diff
+++ b/pkgs/development/libraries/openssl/1.0.2-CVE-2016-2177.diff
@@ -1,0 +1,279 @@
+From a004e72b95835136d3f1ea90517f706c24c03da7 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Thu, 5 May 2016 11:10:26 +0100
+Subject: [PATCH] Avoid some undefined pointer arithmetic
+
+A common idiom in the codebase is:
+
+if (p + len > limit)
+{
+    return; /* Too long */
+}
+
+Where "p" points to some malloc'd data of SIZE bytes and
+limit == p + SIZE
+
+"len" here could be from some externally supplied data (e.g. from a TLS
+message).
+
+The rules of C pointer arithmetic are such that "p + len" is only well
+defined where len <= SIZE. Therefore the above idiom is actually
+undefined behaviour.
+
+For example this could cause problems if some malloc implementation
+provides an address for "p" such that "p + len" actually overflows for
+values of len that are too big and therefore p + len < limit!
+
+Issue reported by Guido Vranken.
+
+CVE-2016-2177
+
+Reviewed-by: Rich Salz <rsalz@openssl.org>
+---
+ ssl/s3_srvr.c  | 14 +++++++-------
+ ssl/ssl_sess.c |  2 +-
+ ssl/t1_lib.c   | 56 ++++++++++++++++++++++++++++++--------------------------
+ 3 files changed, 38 insertions(+), 34 deletions(-)
+
+diff --git a/ssl/s3_srvr.c b/ssl/s3_srvr.c
+index ab28702..ab7f690 100644
+--- a/ssl/s3_srvr.c
++++ b/ssl/s3_srvr.c
+@@ -980,7 +980,7 @@ int ssl3_get_client_hello(SSL *s)
+ 
+         session_length = *(p + SSL3_RANDOM_SIZE);
+ 
+-        if (p + SSL3_RANDOM_SIZE + session_length + 1 >= d + n) {
++        if (SSL3_RANDOM_SIZE + session_length + 1 >= (d + n) - p) {
+             al = SSL_AD_DECODE_ERROR;
+             SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+             goto f_err;
+@@ -998,7 +998,7 @@ int ssl3_get_client_hello(SSL *s)
+     /* get the session-id */
+     j = *(p++);
+ 
+-    if (p + j > d + n) {
++    if ((d + n) - p < j) {
+         al = SSL_AD_DECODE_ERROR;
+         SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+         goto f_err;
+@@ -1054,14 +1054,14 @@ int ssl3_get_client_hello(SSL *s)
+ 
+     if (SSL_IS_DTLS(s)) {
+         /* cookie stuff */
+-        if (p + 1 > d + n) {
++        if ((d + n) - p < 1) {
+             al = SSL_AD_DECODE_ERROR;
+             SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+             goto f_err;
+         }
+         cookie_len = *(p++);
+ 
+-        if (p + cookie_len > d + n) {
++        if ((d + n ) - p < cookie_len) {
+             al = SSL_AD_DECODE_ERROR;
+             SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+             goto f_err;
+@@ -1131,7 +1131,7 @@ int ssl3_get_client_hello(SSL *s)
+         }
+     }
+ 
+-    if (p + 2 > d + n) {
++    if ((d + n ) - p < 2) {
+         al = SSL_AD_DECODE_ERROR;
+         SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_TOO_SHORT);
+         goto f_err;
+@@ -1145,7 +1145,7 @@ int ssl3_get_client_hello(SSL *s)
+     }
+ 
+     /* i bytes of cipher data + 1 byte for compression length later */
+-    if ((p + i + 1) > (d + n)) {
++    if ((d + n) - p < i + 1) {
+         /* not enough data */
+         al = SSL_AD_DECODE_ERROR;
+         SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_MISMATCH);
+@@ -1211,7 +1211,7 @@ int ssl3_get_client_hello(SSL *s)
+ 
+     /* compression */
+     i = *(p++);
+-    if ((p + i) > (d + n)) {
++    if ((d + n) - p < i) {
+         /* not enough data */
+         al = SSL_AD_DECODE_ERROR;
+         SSLerr(SSL_F_SSL3_GET_CLIENT_HELLO, SSL_R_LENGTH_MISMATCH);
+diff --git a/ssl/ssl_sess.c b/ssl/ssl_sess.c
+index b182998..54ee783 100644
+--- a/ssl/ssl_sess.c
++++ b/ssl/ssl_sess.c
+@@ -573,7 +573,7 @@ int ssl_get_prev_session(SSL *s, unsigned char *session_id, int len,
+     int r;
+ #endif
+ 
+-    if (session_id + len > limit) {
++    if (limit - session_id < len) {
+         fatal = 1;
+         goto err;
+     }
+diff --git a/ssl/t1_lib.c b/ssl/t1_lib.c
+index fb64607..cdac011 100644
+--- a/ssl/t1_lib.c
++++ b/ssl/t1_lib.c
+@@ -1867,11 +1867,11 @@ static void ssl_check_for_safari(SSL *s, const unsigned char *data,
+         0x02, 0x03,             /* SHA-1/ECDSA */
+     };
+ 
+-    if (data >= (limit - 2))
++    if (limit - data <= 2)
+         return;
+     data += 2;
+ 
+-    if (data > (limit - 4))
++    if (limit - data < 4)
+         return;
+     n2s(data, type);
+     n2s(data, size);
+@@ -1879,7 +1879,7 @@ static void ssl_check_for_safari(SSL *s, const unsigned char *data,
+     if (type != TLSEXT_TYPE_server_name)
+         return;
+ 
+-    if (data + size > limit)
++    if (limit - data < size)
+         return;
+     data += size;
+ 
+@@ -1887,7 +1887,7 @@ static void ssl_check_for_safari(SSL *s, const unsigned char *data,
+         const size_t len1 = sizeof(kSafariExtensionsBlock);
+         const size_t len2 = sizeof(kSafariTLS12ExtensionsBlock);
+ 
+-        if (data + len1 + len2 != limit)
++        if (limit - data != (int)(len1 + len2))
+             return;
+         if (memcmp(data, kSafariExtensionsBlock, len1) != 0)
+             return;
+@@ -1896,7 +1896,7 @@ static void ssl_check_for_safari(SSL *s, const unsigned char *data,
+     } else {
+         const size_t len = sizeof(kSafariExtensionsBlock);
+ 
+-        if (data + len != limit)
++        if (limit - data != (int)(len))
+             return;
+         if (memcmp(data, kSafariExtensionsBlock, len) != 0)
+             return;
+@@ -2053,19 +2053,19 @@ static int ssl_scan_clienthello_tlsext(SSL *s, unsigned char **p,
+     if (data == limit)
+         goto ri_check;
+ 
+-    if (data > (limit - 2))
++    if (limit - data < 2)
+         goto err;
+ 
+     n2s(data, len);
+ 
+-    if (data + len != limit)
++    if (limit - data != len)
+         goto err;
+ 
+-    while (data <= (limit - 4)) {
++    while (limit - data >= 4) {
+         n2s(data, type);
+         n2s(data, size);
+ 
+-        if (data + size > (limit))
++        if (limit - data < size)
+             goto err;
+ # if 0
+         fprintf(stderr, "Received extension type %d size %d\n", type, size);
+@@ -2472,18 +2472,18 @@ static int ssl_scan_clienthello_custom_tlsext(SSL *s,
+     if (s->hit || s->cert->srv_ext.meths_count == 0)
+         return 1;
+ 
+-    if (data >= limit - 2)
++    if (limit - data <= 2)
+         return 1;
+     n2s(data, len);
+ 
+-    if (data > limit - len)
++    if (limit - data < len)
+         return 1;
+ 
+-    while (data <= limit - 4) {
++    while (limit - data >= 4) {
+         n2s(data, type);
+         n2s(data, size);
+ 
+-        if (data + size > limit)
++        if (limit - data < size)
+             return 1;
+         if (custom_ext_parse(s, 1 /* server */ , type, data, size, al) <= 0)
+             return 0;
+@@ -2569,20 +2569,20 @@ static int ssl_scan_serverhello_tlsext(SSL *s, unsigned char **p,
+                              SSL_TLSEXT_HB_DONT_SEND_REQUESTS);
+ # endif
+ 
+-    if (data >= (d + n - 2))
++    if ((d + n) - data <= 2)
+         goto ri_check;
+ 
+     n2s(data, length);
+-    if (data + length != d + n) {
++    if ((d + n) - data != length) {
+         *al = SSL_AD_DECODE_ERROR;
+         return 0;
+     }
+ 
+-    while (data <= (d + n - 4)) {
++    while ((d + n) - data >= 4) {
+         n2s(data, type);
+         n2s(data, size);
+ 
+-        if (data + size > (d + n))
++        if ((d + n) - data < size)
+             goto ri_check;
+ 
+         if (s->tlsext_debug_cb)
+@@ -3307,29 +3307,33 @@ int tls1_process_ticket(SSL *s, unsigned char *session_id, int len,
+     /* Skip past DTLS cookie */
+     if (SSL_IS_DTLS(s)) {
+         i = *(p++);
+-        p += i;
+-        if (p >= limit)
++
++        if (limit - p <= i)
+             return -1;
++
++        p += i;
+     }
+     /* Skip past cipher list */
+     n2s(p, i);
+-    p += i;
+-    if (p >= limit)
++    if (limit - p <= i)
+         return -1;
++    p += i;
++
+     /* Skip past compression algorithm list */
+     i = *(p++);
+-    p += i;
+-    if (p > limit)
++    if (limit - p < i)
+         return -1;
++    p += i;
++
+     /* Now at start of extensions */
+-    if ((p + 2) >= limit)
++    if (limit - p <= 2)
+         return 0;
+     n2s(p, i);
+-    while ((p + 4) <= limit) {
++    while (limit - p >= 4) {
+         unsigned short type, size;
+         n2s(p, type);
+         n2s(p, size);
+-        if (p + size > limit)
++        if (limit - p < size)
+             return 0;
+         if (type == TLSEXT_TYPE_session_ticket) {
+             int r;
+-- 
+1.9.1
+

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -8,7 +8,7 @@ let
   opensslCrossSystem = stdenv.cross.openssl.system or
     (throw "openssl needs its platform name cross building");
 
-  common = { version, sha256 }: stdenv.mkDerivation rec {
+  common = args@{ version, sha256, patches ? [] }: stdenv.mkDerivation rec {
     name = "openssl-${version}";
 
     src = fetchurl {
@@ -17,7 +17,8 @@ let
     };
 
     patches =
-      [ ./use-etc-ssl-certs.patch ]
+      args.patches
+      ++ [ ./use-etc-ssl-certs.patch ]
       ++ optional stdenv.isCygwin ./1.0.1-cygwin64.patch
       ++ optional
            (versionOlder version "1.0.2" && (stdenv.isDarwin || (stdenv ? cross && stdenv.cross.libc == "libSystem")))
@@ -107,11 +108,19 @@ in {
   openssl_1_0_1 = common {
     version = "1.0.1t";
     sha256 = "4a6ee491a2fdb22e519c76fdc2a628bb3cec12762cd456861d207996c8a07088";
+    patches = [
+      # https://git.openssl.org/?p=openssl.git;a=commit;h=6f35f6deb5ca7daebe289f86477e061ce3ee5f46
+      ./1.0.1-CVE-2016-2177.diff
+    ];
   };
 
   openssl_1_0_2 = common {
     version = "1.0.2h";
     sha256 = "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919";
+    patches = [
+      # https://git.openssl.org/?p=openssl.git;a=commit;h=a004e72b95835136d3f1ea90517f706c24c03da7
+      ./1.0.2-CVE-2016-2177.diff
+    ];
   };
 
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note we can't use `fetchpatch` because that leads to cyclic dependency.
