### PR TITLE
Openclonk

### DIFF
--- a/pkgs/games/openclonk/5.4.nix
+++ b/pkgs/games/openclonk/5.4.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, cmake, gnome, boost155, pcre, freetype, mesa, glew, glib, gtk2, libjpeg, libpng, SDL, SDL_mixer, libupnp, xorg, zlib, pkgconfig, gtest, libxml2}:
+
+stdenv.mkDerivation rec {
+  version = "5.4.1";
+  name = "openclonk-${version}";
+
+  src = fetchurl {
+    url = "http://archive.ubuntu.com/ubuntu/pool/universe/o/openclonk/openclonk_${version}.orig.tar.xz";
+    sha256 = "12cq3y7djbiv7rzjspqyb053cj5vg3s5pallycip93y1m1w7i9bz";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    cmake boost155 gnome.gtksourceview pcre freetype mesa glew glib gtk2 libjpeg
+    libpng SDL SDL_mixer libupnp xorg.libX11 xorg.libXrandr xorg.libpthreadstubs
+    xorg.libXdmcp libxml2 zlib pkgconfig gtest
+  ];
+
+  postInstall = "mv -v $out/games/openclonk $out/bin/";
+
+  meta = with stdenv.lib; {
+    description = "Free multiplayer action game in which you control clonks, small but witty and nimble humanoid beings";
+    homepage = "http://openclonk.org";
+    license = licenses.isc;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/games/openclonk/default.nix
+++ b/pkgs/games/openclonk/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, cmake, gnome3, pcre, freetype, glew, gtk3, libjpeg, libpng,
+  SDL, SDL_mixer, libupnp, xorg, pkgconfig, gtest, tinyxml, gmock, readline,
+  libxkbcommon, epoxy, at_spi2_core, dbus, libxml2,
+  enableSoundtrack ? false # Enable the "Open Clonk Soundtrack - Explorers Journey" by David Oerther
+}:
+
+let
+  soundtrack_src = fetchurl {
+    url = "http://www.openclonk.org/download/Music.ocg";
+    sha256 = "1ckj0dlpp5zsnkbb5qxxfxpkiq76jj2fgj91fyf3ll7n0gbwcgw5";
+  };
+in stdenv.mkDerivation rec {
+  version = "7.0";
+  name = "openclonk-${version}";
+
+  src = fetchurl {
+    url = "http://www.openclonk.org/builds/release/7.0/openclonk-${version}-src.tar.bz2";
+    sha256 = "0ch71dqaaalg744pc1gvg6sj2yp2kgvy2m4yh6l7ljkpf8fj66mw";
+  };
+
+  postInstall = ''
+    mv -v $out/games/openclonk $out/bin/
+  '' + stdenv.lib.optionalString enableSoundtrack ''
+    cp -v ${soundtrack_src} $out/share/games/openclonk/Music.ocg
+  '';
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    cmake gnome3.gtksourceview pcre freetype glew gtk3 libjpeg libpng SDL
+    SDL_mixer libupnp tinyxml xorg.libpthreadstubs libxkbcommon xorg.libXdmcp
+    pkgconfig gtest gmock readline epoxy at_spi2_core dbus libxml2
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Free multiplayer action game in which you control clonks, small but witty and nimble humanoid beings";
+    homepage = "http://openclonk.org";
+    license = if enableSoundtrack then licenses.unfreeRedistributable else licenses.isc;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15839,6 +15839,7 @@ in
 
   openlierox = callPackage ../games/openlierox { };
 
+  openclonk54 = callPackage ../games/openclonk/5.4.nix { boost155 = boost155.override { enableStatic = true; }; };
   openclonk = callPackage ../games/openclonk { };
 
   openmw = callPackage ../games/openmw { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15839,6 +15839,8 @@ in
 
   openlierox = callPackage ../games/openlierox { };
 
+  openclonk = callPackage ../games/openclonk { };
+
   openmw = callPackage ../games/openmw { };
 
   openra = callPackage ../games/openra { lua = lua5_1; };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I believe the following counts as unfree?

> by David Oerther <A9> Copyright 2015
> All rights reserved, note that the soundtrack does not use the creative common or similar licenses.
> 
> The game Open Clonk ( http://www.openclonk.org/ ) may use and distribute the soundtrack, as long as credit is given. This explicitly includes packaged distributions of the
> game. In-game videos of Open Clonk and game modifications and extensions based on the Open Clonk file-types (.ocd, .ocs and .ocf) don't require credits.
> 
> For all other usage please contact: david.oerther@directbox.com
