### PR TITLE
hipchat: 4.0.1641 -> 4.26.0.1655

### DIFF
--- a/pkgs/applications/networking/instant-messengers/hipchat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/hipchat/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "4.0.1641";
+  version = "4.26.0.1655";
 
   rpath = stdenv.lib.makeLibraryPath [
     xdg_utils
@@ -43,7 +43,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://atlassian.artifactoryonline.com/atlassian/hipchat-apt-client/pool/HipChat4-${version}-Linux.deb";
-        sha256 = "15xy89qmldp1zs3f809b8sayvawc7sz24l0718iib83g5jzvivsm";
+        sha256 = "1y484cp77kz984z9zdsy6c4669fmwv2knc287c1v24s81p5pqygg";
       }
     else
       throw "HipChat is not supported on ${stdenv.system}";


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
