### PR TITLE
libtelnet: init at 20160426

### DIFF
--- a/pkgs/development/libraries/libtelnet/default.nix
+++ b/pkgs/development/libraries/libtelnet/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "libtelnet-${version}";
+  version = "0.21+45f2d5c";
+
+  src = fetchFromGitHub {
+    owner = "seanmiddleditch";
+    repo = "libtelnet";
+    rev = "45f2d5cfcf383312280e61c85b107285fed260cf";
+    sha256 = "1lp6gdbndsp2w8mhy88c2jknxj2klvnggvq04ln7qjg8407ifpda";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ zlib ];
+
+  meta = {
+    description = "Simple RFC-complient TELNET implementation as a C library";
+    homepage = "https://github.com/seanmiddleditch/libtelnet";
+    license = stdenv.lib.licenses.publicDomain;
+    maintainers = [ stdenv.lib.maintainers.tomberek ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2402,6 +2402,8 @@ in
 
   libtermkey = callPackage ../development/libraries/libtermkey { };
 
+  libtelnet = callPackage ../development/libraries/libtelnet { };
+
   libtirpc = callPackage ../development/libraries/ti-rpc { };
 
   libshout = callPackage ../development/libraries/libshout { };


### PR DESCRIPTION
###### Motivation for this change

Needed for Apache Guacamole
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
