### PR TITLE
Fix issue #17914 : Add python bindings to neuron derivation and minor…

### DIFF
--- a/pkgs/applications/science/biology/neuron/default.nix
+++ b/pkgs/applications/science/biology/neuron/default.nix
@@ -1,33 +1,65 @@
 { stdenv 
 , fetchurl 
-, pkgconfig 
-, ncurses 
+, pkgconfig
+, automake
+, autoconf
+, libtool
+, ncurses
+, readline
+, which
+, python ? null 
 , mpi ? null
 }:
 
 stdenv.mkDerivation rec {
-  name = "neuron-7.4";
-  buildInputs = [ stdenv pkgconfig ncurses mpi ];
+  name = "neuron-${version}";
+  version = "7.4";
+  
+  nativeBuildInputs = [ which pkgconfig automake autoconf libtool ];
+  buildInputs = [ ncurses readline python mpi  ];
 
   src = fetchurl {
-    url = "http://www.neuron.yale.edu/ftp/neuron/versions/v7.4/nrn-7.4.tar.gz";
+    url = "http://www.neuron.yale.edu/ftp/neuron/versions/v${version}/nrn-${version}.tar.gz";
     sha256 = "1rid8cmv5mca0vqkgwahm0prkwkbdvchgw2bdwvx4adkn8bbl0ql";
   };
 
+  patches = (stdenv.lib.optional (stdenv.isDarwin) [ ./neuron-carbon-disable.patch ]);
 
   enableParallelBuilding = true;
 
-  configureFlags = [ "--without-x"
-		     "${if mpi != null then "--with-mpi" else "--without-mpi"}" ];
+  ## neuron install by default everything under prefix/${host_arch}/*
+  ## override this to support nix standard file hierarchy 
+  ## without issues: install everything under prefix/
+  preConfigure = ''
+    ./build.sh
+    export prefix="''${prefix} --exec-prefix=''${out}" 
+  '';
+
+  configureFlags = with stdenv.lib; 
+				   [ "--without-x" "--with-readline=${readline}" ]
+                    ++  optionals (python != null)  [ "--with-nrnpython=${python.interpreter}" ]
+                    ++ (if mpi != null then ["--with-mpi" "--with-paranrn"] 
+                        else ["--without-mpi"]);
+                        
+                        
+  postInstall = stdenv.lib.optionals (python != null) [ ''
+    ## standardise python neuron install dir if any
+    if [[ -d $out/lib/python ]]; then
+        mkdir -p ''${out}/${python.sitePackages}
+        mv ''${out}/lib/python  ''${out}/${python.sitePackages}
+    fi
+  ''];
+  
+  propagatedBuildInputs = [ readline ncurses which libtool ];  
 
   meta = with stdenv.lib; {
     description = "Simulation environment for empirically-based simulations of neurons and networks of neurons";
 
     longDescription = "NEURON is a simulation environment for developing and exercising models of 
-		neurons and networks of neurons. It is particularly well-suited to problems where 
-		cable properties of cells play an important role, possibly including extracellular 
-		potential close to the membrane), and where cell membrane properties are complex, 
-		involving many ion-specific channels, ion accumulation, and second messengers";
+                neurons and networks of neurons. It is particularly well-suited to problems where 
+                cable properties of cells play an important role, possibly including extracellular 
+                potential close to the membrane), and where cell membrane properties are complex, 
+                involving many ion-specific channels, ion accumulation, and second messengers";
 
     license     = licenses.bsd3;
     homepage    = http://www.neuron.yale.edu/neuron;

--- a/pkgs/applications/science/biology/neuron/neuron-carbon-disable.patch
+++ b/pkgs/applications/science/biology/neuron/neuron-carbon-disable.patch
@@ -1,0 +1,21 @@
+--- nrn-7.4/src/mac/Makefile.am	2015-11-12 21:42:45.000000000 +0100
++++ nrn-7.4.new/src/mac/Makefile.am	2016-08-24 17:43:39.000000000 +0200
+@@ -15,18 +15,8 @@
+ host_cpu = @host_cpu@
+ 
+ if MAC_DARWIN
+-carbon = @enable_carbon@
+ bin_SCRIPTS = $(launch_scripts)
+ install: install-am
+-if UniversalMacBinary
+-	$(CC) -arch ppc -o aoutppc -Dcpu="\"$(host_cpu)\"" -I. $(srcdir)/launch.c $(srcdir)/mac2uxarg.c -framework Carbon
+-	$(CC) -arch i386 -o aouti386 -Dcpu="\"$(host_cpu)\"" -I. $(srcdir)/launch.c $(srcdir)/mac2uxarg.c -framework Carbon
+-	lipo aouti386 aoutppc -create -output a.out
+-else
+-	gcc -g -arch i386 -Dncpu="\"$(host_cpu)\"" -I. $(srcdir)/launch.c $(srcdir)/mac2uxarg.c -framework Carbon
+-
+-endif
+-	carbon=$(carbon) sh $(srcdir)/launch_inst.sh "$(host_cpu)" "$(DESTDIR)$(prefix)" "$(srcdir)"
+ 	for i in $(S) ; do \
+ 		sed "s/^CPU.*/CPU=\"$(host_cpu)\"/" < $(DESTDIR)$(bindir)/$$i > temp; \
+ 		mv temp $(DESTDIR)$(bindir)/$$i; \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16453,7 +16453,9 @@ in
 
   igv = callPackage ../applications/science/biology/igv { };
 
-  neuron = callPackage ../applications/science/biology/neuron { };
+  neuron = callPackage ../applications/science/biology/neuron { 
+	python = null;	
+  };
 
   neuron-mpi = appendToName "mpi" (neuron.override {
     mpi = pkgs.openmpi;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -241,6 +241,14 @@ in modules // {
     mpi = pkgs.openmpi;
   };
 
+  neuron = pkgs.neuron.override {
+	inherit python; 
+  };
+
+  neuron-mpi = pkgs.neuron-mpi.override {
+	inherit python;
+  };
+
   nixpart = callPackage ../tools/filesystems/nixpart { };
 
   # This is used for NixOps to make sure we won't break it with the next major


### PR DESCRIPTION
###### Motivation for this change

 Solve  issue #17914
- add python bindings support
- normalize prefix / path following nix conventions
- minor fixes 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

… fixes
- Add support for python bindings
- make neuron respect standard pythonpath prefix
- force exec_prefix == prefix to respect standard nix file hierarchy
- normalize indentation
- propagate dependencies necessary for nrniv_makefile usage
