### PR TITLE
mosh: 1.2.5 -> 1.2.6

### DIFF
--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -2,30 +2,21 @@
 , makeWrapper, perl, openssl, autoreconfHook, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  name = "mosh-1.2.5";
+  name = "mosh-1.2.6";
 
   src = fetchurl {
-    url = "http://mosh.mit.edu/${name}.tar.gz";
-    sha256 = "1qsb0y882yfgwnpy6f98pi5xqm6kykdsrxzvaal37hs7szjhky0s";
+    url = "https://mosh.org/${name}.tar.gz";
+    sha256 = "118fhpm754wpklf1blnlq5xbvrxqml6rdfs3b07wg666zkxvg0ky";
   };
 
   buildInputs = [ autoreconfHook protobuf ncurses zlib pkgconfig IOTty makeWrapper perl openssl ];
-
-  patches = [
-    # remove automake detection macro patch on next release as it is already on mosh master
-    (fetchpatch {
-      name = "fix_automake_detection_macro.patch";
-      url = "https://github.com/mobile-shell/mosh/commit/a47917b97606a03f6bbf0cafd1fcd495b0229790.patch";
-      sha256 = "0ib200ffvbnns125xd58947fyxdx31m06rmnzqmxpxcnjza7k404";
-    })
-  ];
 
   postInstall = ''
       wrapProgram $out/bin/mosh --prefix PERL5LIB : $PERL5LIB
   '';
 
   meta = {
-    homepage = http://mosh.mit.edu/;
+    homepage = https://mosh.org/;
     description = "Mobile shell (ssh replacement)";
     longDescription = ''
       Remote terminal application that allows roaming, supports intermittent


### PR DESCRIPTION
I'm on vacation and can't test this.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
