### PR TITLE
virtualbox-image: fix config

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -32,7 +32,7 @@ in {
       configFile = pkgs.writeText "configuration.nix"
         ''
           {
-            imports = [ <nixpkgs/nixos/modules/virtualisation/virtualbox-image.nix> ];
+            imports = [ <nixpkgs/nixos/modules/installer/virtualbox-demo.nix> ];
           }
         '';
 


### PR DESCRIPTION
###### Motivation for this change

fix #14970 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
