### PR TITLE
rust: bump registry and racerd

### DIFF
--- a/pkgs/development/tools/rust/racerd/default.nix
+++ b/pkgs/development/tools/rust/racerd/default.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "racerd-${version}";
-  version = "0.1.1";
+  version = "2016-08-23";
   src = fetchgit {
     url = "git://github.com/jwilm/racerd.git";
-    rev = "dcbb7885e84eb5e2fbb2072e185701ad1abbd93a";
-    sha256 = "0qm0hpvxba632av355mj1wqd616zjvi0qy045np7mi746m0bbqwh";
+    rev = "5d685ed26ba812a1afe892a8c0d12eb6abbeeb3d";
+    sha256 = "1ww96nc00l8p28rnln31n92x0mp2p5jnaqh2nwc8xi3r559p1y5i";
   };
 
   doCheck = false;
 
-  depsSha256 = "0ca0lc8mm8kczll5m03n5fwsr0540c2xbfi4nn9ksn0s4sap50yn";
+  depsSha256 = "13vkabr6bbl2nairxpn3lhqxcr3larasjk03r4hzrn7ff7sy40h2";
 
   buildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -6,7 +6,7 @@ buildRustPackage rec {
   name = "exa-${version}";
   version = "2016-04-20";
 
-  depsSha256 = "0nyrdl57nhr3lxqs3gaij3mdmlrm0z52qv6mznvgw0ziwqmlq5w1";
+  depsSha256 = "0qsqkgc1wxigvskhaamgfp5pyc2kprsikhcfccysgs07w44nxkd0";
 
   src = fetchFromGitHub {
     owner = "ogham";

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2016-08-10";
-  rev = "fe018be71eeed9c1dc441a16e6a0f32eb6a46bce";
-  sha256 = "0d8rvhndkz8sz7zn79lrk5vlkpljfilrk52cb2pr5rx83cm89vmi";
+  version = "2016-08-23";
+  rev = "e98ce679ed90bb5b8a64ad9f5bd82f87fd6b641f";
+  sha256 = "0dpl071ic3ddknsy98dxm99mznlblhmgjqi9ha6rlbldbjp3gf8j";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Should fix #17942.
