### PR TITLE
rc: init at 1.7.4

### DIFF
--- a/pkgs/shells/rc/default.nix
+++ b/pkgs/shells/rc/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, autoreconfHook
+, ncurses #acinclude.m4 wants headers for tgetent().
+, historySupport ? false
+, readline ? null
+}:
+
+stdenv.mkDerivation rec {
+  name = "rc-${version}";
+  version = "1.7.4";
+
+  src = fetchurl {
+    url = "http://static.tobold.org/rc/rc-${version}.tar.gz";
+    sha256 = "1n5zz6d6z4z6s3fwa0pscqqawy561k4xfnmi91i626hcvls67ljy";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ ncurses ]
+    ++ stdenv.lib.optionals (readline != null) [ readline ];
+
+  configureFlags = [
+    "--enable-def-interp=${stdenv.shell}" #183
+    ] ++ stdenv.lib.optionals historySupport [ "--with-history" ]
+    ++ stdenv.lib.optionals (readline != null) [ "--with-edit=readline" ];
+
+  prePatch = ''
+    substituteInPlace configure.ac \
+      --replace "date -I" "echo 2015-05-13" #reproducible-build
+  '';
+
+  passthru = {
+    shellPath = "/bin/rc";
+  };
+
+  meta = with stdenv.lib; {
+    description = "The Plan 9 shell";
+    longDescription = "Byron Rakitzis' UNIX reimplementation of Tom Duff's Plan 9 shell.";
+    homepage = http://tobold.org/article/rc;
+    license = with licenses; zlib;
+    maintainers = with maintainers; [ ramkromberg ];
+    platforms = with platforms; all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3279,6 +3279,8 @@ in
 
   rawdog = callPackage ../applications/networking/feedreaders/rawdog { };
 
+  rc = callPackage ../shells/rc { };
+
   read-edid = callPackage ../os-specific/linux/read-edid { };
 
   redir = callPackage ../tools/networking/redir { };


### PR DESCRIPTION
###### Motivation for this change

rc shell. For _*.rc_ files.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
