### PR TITLE
yelp: refactor build inputs

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/core/yelp/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/yelp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, intltool, fetchurl, webkitgtk, pkgconfig, gtk3, glib
-, file, librsvg, gnome3, gdk_pixbuf, sqlite
+, file, librsvg, gnome3, gdk_pixbuf, sqlite, groff
 , bash, makeWrapper, itstool, libxml2, libxslt, icu, gst_all_1
 , wrapGAppsHook }:
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig gtk3 glib webkitgtk intltool itstool sqlite
                   libxml2 libxslt icu file makeWrapper gnome3.yelp_xsl
-                  librsvg gdk_pixbuf gnome3.defaultIconTheme
+                  librsvg gdk_pixbuf gnome3.defaultIconTheme groff
                   gnome3.gsettings_desktop_schemas wrapGAppsHook
                   gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good ];
 


### PR DESCRIPTION
###### Motivation for this change

`yelp` needs `groff` in order to read man pages. Otherwise it will complain:

```
man: can't execute groff: No such file or directory
man: command exited with status 255: /nix/store/cs79m7g52zj8wckk0i6m47n6h3ig3x0n-man-db-2.7.5/libexec/man-db/zsoelim | /nix/store/cs79m7g52zj8wckk0i6m47n6h3ig3x0n-man-db-2.7.5/libexec/man-db/manconv -f UTF-8:ISO-8859-1 -t ISO-8859-1//IGNORE | /nix/store/iz15ap0a194gz28p0ry0lfbkjnjzqmrd-groff-1.22.3/bin/tbl | groff -mandoc -Z -rLL=100n -rLT=100n -Tutf8
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
