### PR TITLE
cppcms: init at 1.0.5

### DIFF
--- a/pkgs/development/libraries/cppcms/default.nix
+++ b/pkgs/development/libraries/cppcms/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, cmake, pcre, zlib, python, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "cppcms";
+  version = "1.0.5";
+
+  src = fetchurl {
+      url = "mirror://sourceforge/cppcms/${name}-${version}.tar.bz2";
+      sha256 = "0r8qyp102sq4lw8xhrjhan0dnslhsmxj4zs9jzlw75yagfbqbdl4";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ cmake pcre zlib python openssl ];
+
+  cmakeFlags = [
+    "--no-warn-unused-cli"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://cppcms.com";
+    description = "High Performance C++ Web Framework";
+    platforms = platforms.linux ;
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.juliendehos ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7076,6 +7076,8 @@ in
 
   cpp-netlib = callPackage ../development/libraries/cpp-netlib { };
 
+  cppcms = callPackage ../development/libraries/cppcms { };
+
   cppunit = callPackage ../development/libraries/cppunit { };
 
   cpputest = callPackage ../development/libraries/cpputest { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
