### PR TITLE
mosquito: add support for websockets

### DIFF
--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, libuuid, cmake }:
+{ stdenv, fetchurl, openssl, libuuid, cmake, libwebsockets }:
 
 stdenv.mkDerivation rec {
   pname = "mosquitto";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1imw5ps0cqda41b574k8hgz9gdr8yy58f76fg8gw14pdnvf3l7sr";
   };
 
-  buildInputs = [ openssl libuuid ]
+  buildInputs = [ openssl libuuid libwebsockets ]
     ++ stdenv.lib.optional stdenv.isDarwin cmake;
 
   makeFlags = [
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
   preBuild = ''
     substituteInPlace config.mk \
       --replace "/usr/local" ""
+    substituteInPlace config.mk \
+      --replace "WITH_WEBSOCKETS:=no" "WITH_WEBSOCKETS:=yes"
+
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Mosquitto has supported websockets for 2 years now.  It would be nice to have this feature in nixos especially before 16.09
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x ] NixOS
  - [ ] OS X
  - [ x Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
