### PR TITLE
cppdb: init at 0.3.1

### DIFF
--- a/pkgs/development/libraries/cppdb/default.nix
+++ b/pkgs/development/libraries/cppdb/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, cmake, sqlite, libmysql, postgresql, unixODBC }:
+
+stdenv.mkDerivation rec {
+  name = "cppdb";
+  version = "0.3.1";
+
+  src = fetchurl {
+      url = "mirror://sourceforge/cppcms/${name}-${version}.tar.bz2";
+      sha256 = "0blr1casmxickic84dxzfmn3lm7wrsl4aa2abvpq93rdfddfy3nn";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ cmake sqlite libmysql postgresql unixODBC ];
+
+  cmakeFlags = [ "--no-warn-unused-cli" ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://cppcms.com/sql/cppdb/";
+    description = "C++ Connectivity library that supports MySQL, PostgreSQL, Sqlite3 databases and generic ODBC drivers";
+    platforms = platforms.linux ;
+    license = licenses.boost;
+    maintainers = [ maintainers.juliendehos ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7074,6 +7074,8 @@ in
 
   ctpl = callPackage ../development/libraries/ctpl { };
 
+  cppdb = callPackage ../development/libraries/cppdb { };
+
   cpp-netlib = callPackage ../development/libraries/cpp-netlib { };
 
   cppunit = callPackage ../development/libraries/cppunit { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
