### PR TITLE
emacs-htmlize:  fix url -- see http://fly.srk.fer.hr/

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-generated.nix
@@ -30747,7 +30747,7 @@
         pname = "htmlize";
         version = "20130207.1202";
         src = fetchgit {
-          url = "http://fly.srk.fer.hr/~hniksic/emacs/htmlize.git";
+          url = "https://github.com/abo-abo/htmlize/";
           rev = "aa6e2f6dba6fdfa200c7c55efe29ff63380eac8f";
           sha256 = "1vkqxgirc82vc44g7xhhr041arf93yirjin3h144kjyfkgkplnkp";
         };


### PR DESCRIPTION
###### Motivation for this change

The origin for the download was lost, for explanation see http://fly.srk.fer.hr/
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
