### PR TITLE
kube-aws: init at 0.8.1

### DIFF
--- a/pkgs/development/tools/kube-aws/default.nix
+++ b/pkgs/development/tools/kube-aws/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchFromGitHub, buildGoPackage }:
+
+with lib;
+
+buildGoPackage rec {
+  name = "kube-aws-${version}";
+  version = "0.8.1";
+
+  goPackagePath = "github.com/coreos/coreos-kubernetes";
+
+  src = fetchFromGitHub {
+    owner = "coreos";
+    repo = "coreos-kubernetes";
+    rev = "v${version}";
+    sha256 = "067nc525km0f37w5km44fs5pr22a6zz3lkdwwg2akb4hhg6f45c2";
+  };
+
+  preBuild = ''
+    (cd go/src/github.com/coreos/coreos-kubernetes
+     go generate multi-node/aws/pkg/config/config.go)
+  '';
+
+  meta = {
+    description = "Tool for deploying kubernetes on aws using coreos";
+    license = licenses.asl20;
+    homepage = https://github.com/coreos/coreos-kubernetes;
+    maintainers = with maintainers; [offline];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6513,6 +6513,8 @@ in
 
   kcov = callPackage ../development/tools/analysis/kcov { };
 
+  kube-aws = callPackage ../development/tools/kube-aws { };
+
   lcov = callPackage ../development/tools/analysis/lcov { };
 
   leiningen = callPackage ../development/tools/build-managers/leiningen { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
