### PR TITLE
zoom-us: fix url

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
     version = "2.0.52458.0531";
     src = fetchurl {
-      url = "https://zoom.us/client/latest/zoom_${version}_x86_64.tar.xz";
+      url = "https://zoom.us/client/${version}/zoom_${version}_x86_64.tar.xz";
       sha256 = "16d64pn9j27v3fnh4c9i32vpkr10q1yr26w14964n0af1mv5jf7a";
     };
 


### PR DESCRIPTION
###### Motivation for this change

Source URL changed.

See issue #17524 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This just fixes the URL to the current version, it doesn't bump the version of the package as that requires more work as described in #17524 (which I plan to do, but not today).
