### PR TITLE
inkscape: fix on darwin (fixes #15768)

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, perl, perlXMLParser, gtk, libXft
+{ stdenv, fetchurl, fetchpatch, pkgconfig, perl, perlXMLParser, gtk, libXft
 , libpng, zlib, popt, boehmgc, libxml2, libxslt, glib, gtkmm
 , glibmm, libsigcxx, lcms, boost, gettext, makeWrapper, intltool
 , gsl, python, numpy, pyxml, lxml, poppler, imagemagick, libwpg, librevenge
-, libvisio, libcdr, libexif, unzip
+, libvisio, libcdr, libexif, unzip, automake114x, autoconf
 , boxMakerPlugin ? false # boxmaker plugin
 }:
 
@@ -12,6 +12,11 @@ boxmaker = fetchurl {
   # http://www.inkscapeforum.com/viewtopic.php?f=11&t=10403
   url = "http://www.keppel.demon.co.uk/111000/files/BoxMaker0.91.zip";
   sha256 = "5c5697f43dc3a95468f61f479cb50b7e2b93379a1729abf19e4040ac9f43a1a8";
+};
+
+stdcxx-patch = fetchpatch {
+  url = http://bazaar.launchpad.net/~inkscape.dev/inkscape/trunk/diff/14542?context=3;
+  sha256 = "15h831lsh61ichgdygkdkbdm1dlb9mhprldq27hkx2472lcnyx6y";
 };
 
 in
@@ -28,6 +33,7 @@ stdenv.mkDerivation rec {
   patches = [ ./deprecated-scopedptr.patch ];
 
   postPatch = ''
+    patch -i ${stdcxx-patch} -p 0
     patchShebangs share/extensions
   ''
   # Clang gets misdetected, so hardcode the right answer
@@ -46,7 +52,7 @@ stdenv.mkDerivation rec {
     pkgconfig perl perlXMLParser gtk libXft libpng zlib popt boehmgc
     libxml2 libxslt glib gtkmm glibmm libsigcxx lcms boost gettext
     makeWrapper intltool gsl poppler imagemagick libwpg librevenge
-    libvisio libcdr libexif
+    libvisio libcdr libexif automake114x autoconf
   ] ++ stdenv.lib.optional boxMakerPlugin unzip;
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/cairomm/default.nix
+++ b/pkgs/development/libraries/cairomm/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, cairo, xlibsWrapper, fontconfig, freetype, libsigcxx }:
+{ fetchurl, stdenv, pkgconfig, darwin, cairo, xlibsWrapper, fontconfig, freetype, libsigcxx }:
 let
   ver_maj = "1.12";
   ver_min = "0";
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ cairo libsigcxx ];
-  buildInputs = [ fontconfig freetype ];
+  buildInputs = [ fontconfig freetype ]
+  ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    ApplicationServices
+  ]);
 
   doCheck = true;
 
@@ -35,6 +38,6 @@ stdenv.mkDerivation rec {
     homepage = http://cairographics.org/;
 
     license = with licenses; [ lgpl2Plus mpl10 ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Currently, building inkscape on darwin results in an error:

> error: invalid argument '-std=c++11' not allowed with 'C/ObjC'

This issue has been addressed upstream but the fix is not part of the current released version (0.91). Therefore this PR applies the relevant patch to the released sources.

Tested on OSX and on a virtualized NixOS: builds and runs fine in both cases.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
