### PR TITLE
duo-unix: 1.9.11 -> 1.9.19

### DIFF
--- a/pkgs/tools/security/duo-unix/default.nix
+++ b/pkgs/tools/security/duo-unix/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "duo-unix-${version}";
-  version = "1.9.11";
+  version = "1.9.19";
 
   src = fetchurl {
     url    = "https://dl.duosecurity.com/duo_unix-${version}.tar.gz";
-    sha256 = "0747avzmzzz1gaisahgjlpxyxxbrn04w1mip90lfj9wp2x6a9jgm";
+    sha256 = "02hvayknj0kvdik4mqm9j9isqzxk0f992i9v274s27891xqgj8rd";
   };
 
   buildInputs = [ pam openssl zlib ];


### PR DESCRIPTION
Closes NixOs/nixpkgs#17911

Tested with `nix-shell -p nox --run "nox-review wip"` on Ubuntu 16.04.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/17966)

<!-- Reviewable:end -->
