### PR TITLE
go: revert default back to go_1_6

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4750,7 +4750,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
   };
 
-  go = self.go_1_7;
+  go = self.go_1_6;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };
 


### PR DESCRIPTION
###### Motivation for this change

The new go package `go_1_7` does not work on darwin, this just reverts the default back to a version that works on all platforms.
###### Things done
- Built on platform(s)
  - [x] ~~No Changes~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
