### PR TITLE
pjsip: 2.1 -> 2.5.5

### DIFF
--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -1,14 +1,15 @@
-{stdenv, fetchurl, openssl, libsamplerate}:
+{ stdenv, fetchurl, openssl, libsamplerate, alsaLib }:
 
 stdenv.mkDerivation rec {
-  name = "pjsip-2.1";
+  name = "pjsip-${version}";
+  version = "2.5.5";
 
   src = fetchurl {
-    url = http://www.pjsip.org/release/2.1/pjproject-2.1.tar.bz2;
-    md5 = "310eb63638dac93095f6a1fc8ee1f578";
+    url = "http://www.pjsip.org/release/${version}/pjproject-${version}.tar.bz2";
+    sha256 = "ab39207b761d3485199cd881410afeb2d171dff7c2bf75e8caae91c6dca508f3";
   };
 
-  buildInputs = [ openssl libsamplerate ];
+  buildInputs = [ openssl libsamplerate alsaLib ];
 
   postInstall = ''
     mkdir -p $out/bin
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
 
   meta = {
-    description = "SIP stack and media stack for presence, im, and multimedia communication";
+    description = "A multimedia communication library written in C, implementing standard based protocols such as SIP, SDP, RTP, STUN, TURN, and ICE";
     homepage = http://pjsip.org/;
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [viric];


### PR DESCRIPTION
###### Motivation for this change

Update to newer version.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
