### PR TITLE
mpv: fix on darwin

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -192,6 +192,11 @@ let
     patchPhase = ''
       sed -e "s,^LUAPREFIX_linux.*,LUAPREFIX_linux=$out," \
           -i src/makefile
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+      export PLAT=macosx
+      export LUAPREFIX_macosx=$out
+      substituteInPlace src/Makefile --replace gcc cc \
+        --replace 10.3 10.5
     '';
 
     meta = {


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
