### PR TITLE
petsc: init at version 3.7 

### DIFF
--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -1,0 +1,105 @@
+{ stdenv, 
+fetchurl, 
+mpi,
+openblas,
+lapack ? null,
+blasName ? "",
+lapackName ? "",
+pkgconfig,
+python 
+}:
+
+# use openblas for both the blas and lapack backend by default
+# provide necessary option if the user want to override to use Intel MKL or other
+
+let
+    blas = openblas;
+    liblapack = if (lapack == null)  then openblas else lapack;
+    blasLibName = if (blasName != "") then blasName else "openblas";
+    liblapackLibName = if(lapackName != "") then lapackName else "openblas";
+	defaultOptFlags = "-g -O2";
+in
+
+stdenv.mkDerivation rec {
+  name = "petsc-${version}";
+  version = "3.7.3";
+
+  src = fetchurl {
+    url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-${version}.tar.gz";
+    sha256 = "06yd8abwfk3sdzfn0aclyw0fqrggjhdvkxd1w30wd2cbkddpyr9m";
+  };
+
+
+  nativeBuildInputs = [ pkgconfig python ];
+
+  buildInputs = [ blas liblapack mpi];
+
+  preConfigure = ''
+        # petsc python configure script want an existing HOME directory
+        # we provide him a fake one
+        export HOME=$(mktemp -d)
+  '';
+
+ 
+  configureFlags = [ "COPTFLAGS='${defaultOptFlags}'"
+                     "CXXOPTFLAGS='${defaultOptFlags}'"
+					 "--with-fc=0"  "--with-mpi-dir=${mpi}"
+                     "--with-blas-lib=${blas}/lib/lib${blasLibName}.a"
+                     "--with-lapack-lib=${liblapack}/lib/lib${liblapackLibName}.a" 
+                    ];
+   
+  doCheck = true;
+
+  crossAttrs = {
+  
+        ## Fix PETSc cross compilation 
+        ##
+        ## Unfortunatly, PETSC need three steps configure phase for cross-compilation
+        ## 1- configure one on frontend to generate script
+        ## 2- run this generated script
+        ## 3- configure again on backend
+        ##
+		## This is not acceptable on Nix nor in any package manager
+        ## We fake this behavior by using an already generated script that we reconfigure manually
+        ##
+        ## Has been tested and validated with a cross-compilation on BlueGene/Q 
+		##
+        preConfigure = ''
+                        export HOME=$(mktemp -d)
+
+                        ## reconfigure script for cross compile
+                        substitute ${./reconfigure-arch-linux2-c-debug.py.in} ./reconfigure-arch-linux2-c-debug.py \
+                        --replace "@mpi_path@" "${mpi.crossDrv}" \
+                        --replace "@liblapack_path@" "${liblapack.crossDrv}" \
+                        --replace "@liblapackLibName@" "${liblapackLibName}" \
+                        --replace "@blas_path@" "${blas.crossDrv}" \
+                        --replace "@blasLibName@" "${blasLibName}" \
+                        --replace "@python_interpreter@" "${python}/bin/python"
+                        
+                        chmod a+x ./reconfigure-arch-linux2-c-debug.py
+                       '';
+
+        configureScript = "./reconfigure-arch-linux2-c-debug.py";
+
+        configureFlags = "";
+
+        dontSetConfigureCross = true;
+  };
+
+
+  # -j not supported by petsc
+  enableParallelBuilding = false;
+
+  meta = with stdenv.lib; {
+    description = "Portable, Extensible Toolkit for Scientific Computation";
+
+    longDescription = ''
+    PETSc, pronounced PET-see (the S is silent), is a suite of data structures and routines for the scalable (parallel) solution of scientific applications modeled by partial differential equations. It supports MPI, and GPUs through CUDA or OpenCL, as well as hybrid MPI-GPU parallelism.  
+    '';
+
+    homepage = https://www.mcs.anl.gov/petsc/index.html;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.adev ];
+    platforms = platforms.unix; 
+  };
+}

--- a/pkgs/development/libraries/science/math/petsc/reconfigure-arch-linux2-c-debug.py.in
+++ b/pkgs/development/libraries/science/math/petsc/reconfigure-arch-linux2-c-debug.py.in
@@ -1,0 +1,39 @@
+#!@python_interpreter@
+
+configure_options = [
+  '--known-level1-dcache-size=32768',
+  '--known-level1-dcache-linesize=32',
+  '--known-level1-dcache-assoc=0',
+  '--known-sizeof-char=1',
+  '--known-sizeof-void-p=8',
+  '--known-sizeof-short=2',
+  '--known-sizeof-int=4',
+  '--known-sizeof-long=8',
+  '--known-sizeof-long-long=8',
+  '--known-sizeof-float=4',
+  '--known-sizeof-double=8',
+  '--known-sizeof-size_t=8',
+  '--known-bits-per-byte=8',
+  '--known-memcmp-ok=1',
+  '--known-sizeof-MPI_Comm=4',
+  '--known-sizeof-MPI_Fint=4',
+  '--known-mpi-long-double=1',
+  '--known-mpi-int64_t=1',
+  '--known-mpi-c-double-complex=1',
+  '--known-sdot-returns-double=0',
+  '--known-snrm2-returns-double=0',
+  '--known-has-attribute-aligned=1',
+  '--prefix=@out@',
+  '--with-fc=0',
+  '--with-mpi-dir=@mpi_path@',
+  '--with-batch',
+  '--known-mpi-shared-libraries=0',
+  '--with-blas-lib=@blas_path@/lib/lib@blasLibName@.a',
+  '--with-lapack-lib=@liblapack_path@/lib/lib@liblapackLibName@.a',
+]
+if __name__ == '__main__':
+  import os
+  import sys
+  sys.path.insert(0, os.path.abspath('config'))
+  import configure
+  configure.petsc_configure(configure_options)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16702,6 +16702,11 @@ in
   suitesparse = suitesparse_4_4;
 
   superlu = callPackage ../development/libraries/science/math/superlu {};
+  
+  petsc = callPackage ../development/libraries/science/math/petsc {
+    mpi = pkgs.openmpi;
+	openblas = openblasCompat;
+  };
 
   ipopt = callPackage ../development/libraries/science/math/ipopt { openblas = openblasCompat; };
 


### PR DESCRIPTION
###### Motivation for this change

new package petsc
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add petsc, distributed solver adapted to large scale systems to nixpkgs
