### PR TITLE
Springrts and springlobby update

### DIFF
--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -8,11 +8,11 @@
 stdenv.mkDerivation rec {
 
   name = "spring-${version}";
-  version = "102.0";
+  version = "103.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/springrts/spring_${version}_src.tar.lzma";
-    sha256 = "0gjlpzwl3bdv1ickm8r3xlrbc6dm7m8i968hw3p0an49k6bqa77i";
+    sha256 = "1fmnwk8ig36429pkp1rafzg4hyzp7i6mwy27p7fdxrdj1q4blx9l";
   };
 
   # The cmake included module correcly finds nix's glew, however

--- a/pkgs/games/spring/revert_58b423e.patch
+++ b/pkgs/games/spring/revert_58b423e.patch
@@ -1,0 +1,16 @@
+--- a/src/utils/slpaths.cpp
++++ b/src/utils/slpaths.cpp
+@@ -165,13 +165,10 @@
+ 			usync_paths.push_back(bundle);
+ 		}
+ 		if (!SlPaths::IsPortableMode()) {
+-			/*
+-//FIXME: reenable when #707 is fixed / spring 102.0 is "established"
+ 			LSL::SpringBundle systembundle;
+ 			if (LSL::SpringBundle::LocateSystemInstalledSpring(systembundle)) {
+ 				usync_paths.push_back(systembundle);
+ 			}
+-*/
+ 
+ 			std::vector<std::string> paths;
+ 			PossibleEnginePaths(paths);

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
 
   name = "springlobby-${version}";
-  version = "0.247";
+  version = "0.255";
 
   src = fetchurl {
     url = "http://www.springlobby.info/tarballs/springlobby-${version}.tar.bz2";
-    sha256 = "0sx14k4xsyjkmphhxfn9q341lv32c53g6wl1cbdx2sknzs3qasxs";
+    sha256 = "12iv6h1mz998lzxc2jwkza0m1yvaaq8h05k36i85xyp7g90197jw";
   };
 
   buildInputs = [
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     substituteInPlace tools/test-susynclib.awk --replace "#!/usr/bin/awk" "#!${gawk}/bin/awk"
     substituteInPlace CMakeLists.txt --replace "boost_system-mt" "boost_system"
   '';
+
+  patches = [ ./revert_58b423e.patch ]; # Allows springLobby to continue using system installed spring until #707 is fixed
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I updated springLobby with a patch that reverses https://github.com/springlobby/springlobby/commit/58b423e62dbd7fa2d33d73aa382b01d520133baa. Now there's some bug that requires the lobby to be closed and then opened again for it to properly detect spring.

maintainers @phreedom @qknight @domenkozar
