### PR TITLE
groonga: init at 6.0.7

### DIFF
--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, mecab, kytea, libedit, pkgconfig
+, suggestSupport ? false, zeromq, libevent, libmsgpack
+, lz4Support ? false, lz4
+, zlibSupport ? false, zlib
+}:
+
+stdenv.mkDerivation rec {
+
+  name    = "groonga-${version}";
+  version = "6.0.7";
+
+  src = fetchurl {
+    url    = "http://packages.groonga.org/source/groonga/groonga-6.0.7.tar.gz";
+    sha256 = "19vpjjq3mqaqy9idlmqg2agrz9dc48a9id8j7nx158pkwjvpj7jf";
+  };
+
+  buildInputs = with stdenv.lib; [ pkgconfig mecab kytea libedit ] ++
+    optional lz4Support lz4 ++
+    optional zlibSupport zlib ++
+    optional suggestSupport [ zeromq libevent libmsgpack ];
+
+  configureFlags = with stdenv.lib; ''
+    ${optionalString zlibSupport "--with-zlib"}
+    ${optionalString lz4Support "--with-lz4"}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://groonga.org/;
+    description = "An open-source fulltext search engine and column store";
+
+    longDescription = ''
+      Groonga is an open-source fulltext search engine and column store. 
+      It lets you write high-performance applications that requires fulltext search.
+    '';
+
+    license = licenses.lgpl21;
+
+    maintainers = [ maintainers.ericsagnes ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/tools/text/kytea/default.nix
+++ b/pkgs/tools/text/kytea/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+
+  name    = "kytea-${version}";
+  version = "0.4.7";
+
+  src = fetchurl {
+    url    = "http://www.phontron.com/kytea/download/kytea-0.4.6.tar.gz";
+    sha256 = "0n6d88j0qda4dmy6mcj0cyin46n05m5phvjiah9i4ip54h8vs9s3";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://www.phontron.com/kytea/;
+    description = "General toolkit developed for analyzing text";
+
+    longDescription = ''
+      A general toolkit developed for analyzing text, with a focus on Japanese, 
+      Chinese and other languages requiring word or morpheme segmentation.
+    '';
+
+    license = licenses.asl20;
+
+    maintainers = [ maintainers.ericsagnes ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2224,6 +2224,8 @@ in
 
   kst = qt5.callPackage ../tools/graphics/kst { gsl = gsl_1; };
 
+  kytea = callPackage ../tools/text/kytea { };
+
   leocad = callPackage ../applications/graphics/leocad { };
 
   less = callPackage ../tools/misc/less { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1869,6 +1869,8 @@ in
     ghostscript = null;
   };
 
+  groonga = callPackage ../servers/search/groonga { };
+
   grub = callPackage_i686 ../tools/misc/grub {
     buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
   };


### PR DESCRIPTION
###### Motivation for this change

Add the [Groonga](http://groonga.org/) search engine and one of its dependency.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
