### PR TITLE
oxygenfonts: init at 20160825

### DIFF
--- a/pkgs/data/fonts/oxygenfonts/default.nix
+++ b/pkgs/data/fonts/oxygenfonts/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchFromGitHub }:
+
+let
+  pname = "oxygenfonts";
+  version = "20160825";
+in
+
+  stdenv.mkDerivation rec {
+    name = "${pname}-${version}";
+
+    src = fetchFromGitHub {
+      owner = "vernnobile";
+      repo = "oxygenFont";
+      rev = "62db0ebe3488c936406685485071a54e3d18473b";
+      sha256 = "134kx3d0g3zdkw8kl8p6j37fzw3bl163jv2dx4dk1451f3ramcnh";
+    };
+
+    phases = [ "unpackPhase" "installPhase" ];
+
+    installPhase = ''
+      mkdir -p $out/share/fonts/truetype/${pname}
+      cp OxygenSans-version-0.4/*/*.ttf $out/share/fonts/truetype/${pname}
+      cp Oxygen-Monospace/*.ttf $out/share/fonts/truetype/${pname}
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Desktop/gui font for integrated use with the KDE desktop";
+      longDescription =
+      ''
+      Oxygen Font is a font family originally aimed as a desktop/gui
+      font for integrated use with the KDE desktop.
+
+      The basic concept for Oxygen Font was to design a clear,
+      legible, sans serif, that would be rendered with Freetype on
+      Linux-based devices. In addition a bold weight, plus regular and
+      bold italics, and a monospace version will be made.
+
+      Oxygen is constructed closely with the gridfitting aspects of
+      the Freetype font rendering engine. The oxygen fonts are also
+      autohinted with Werner Lemberg's "ttfautohint" library to
+      further the compatibility with the Freetype engine. The aim of
+      this approach is to produce a family of freetype-specific
+      desktop fonts whose appearance will stay uniform under different
+      screen render settings, unlike more traditionally designed
+      'screen fonts' that have tended to be designed for best
+      legibility on the Windows GDI render engine.
+
+      The main creator of Oxygen, Vernon Adams, suffered a heavy
+      traffic accident three months after its last release, causing him severe brain
+      injury. He finally passed away, sans oxygen, on August 25th 2016.
+      See: http://sansoxygen.com/
+      '';
+
+      license = licenses.ofl;
+      platforms = platforms.all;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12102,6 +12102,8 @@ in
 
   orbitron = callPackage ../data/fonts/orbitron { };
 
+  oxygenfonts = callPackage ../data/fonts/oxygenfonts { };
+
   paper-icon-theme = callPackage ../data/icons/paper-icon-theme { };
 
   pecita = callPackage ../data/fonts/pecita {};


### PR DESCRIPTION
###### Motivation for this change

This font is used in the KDE desktop, and the mono font seems to be the default in e.g. Konsole. 
So it should probably be added to those packages as well.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
