### PR TITLE
buildStackProject: Fix missing STACK_ROOT causing build errors

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -28,7 +28,10 @@ stdenv.mkDerivation (args // {
 
   preferLocalBuild = true;
 
-  configurePhase = args.configurePhase or "stack setup";
+  configurePhase = args.configurePhase or ''
+    export STACK_ROOT=$NIX_BUILD_TOP/.stack
+    stack setup
+  '';
 
   buildPhase = args.buildPhase or "stack build";
 


### PR DESCRIPTION
###### Motivation for this change

Stack will try to create `$HOME/.stack` if it doesn't already exist, whenever it is invoked. Nix sets `$HOME` to `/homeless-shelter` to avoid impurity. This naturally leads Stack to try to create `/homeless-shelter/.stack` whenever it's used in a Nix build, which fails since `/homeless-shelter` must not exist, and (hopefully) it doesn't have permission to create it. This patch makes it put it in `$NIX_BUILD_TOP/.stack` instead.

See https://github.com/BlocklandGlass/ParseTS-Playground/blob/49b932719ddd2d5879c329c7e15ddc9b968947e0/parsets.nix for a build that fails without (the equivalent of) this change.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
