### PR TITLE
Remove redundant -DCMAKE_BUILD_TYPE=Release flags

### DIFF
--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     phonon automoc4 chromaprint id3lib taglib mp4v2 flac libogg libvorbis
     qt zlib readline makeWrapper ];
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" "-DWITH_APPS=Qt;CLI" ];
+  cmakeFlags = [ "-DWITH_APPS=Qt;CLI" ];
   NIX_LDFLAGS = "-lm -lpthread";
 
   preConfigure = ''

--- a/pkgs/applications/misc/doomseeker/default.nix
+++ b/pkgs/applications/misc/doomseeker/default.nix
@@ -8,8 +8,6 @@ stdenv.mkDerivation rec {
     sha256 = "172ybxg720r64hp6aah0hqvxklqv1cf8v7kwx0ng5ap0h20jydbw";
   };
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
-
   buildInputs = [ qt4 zlib bzip2 ];
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/applications/misc/webthree-umbrella/default.nix
+++ b/pkgs/applications/misc/webthree-umbrella/default.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation rec {
   };
 
   cmakeFlags = with stdenv.lib; concatStringsSep " " (flatten [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DGUI=${toString withGUI}"
     "-DETHASHCL=${toString withOpenCL}"
     "-DPROFILING=${toString withProfiling}"

--- a/pkgs/applications/networking/browsers/midori/default.nix
+++ b/pkgs/applications/networking/browsers/midori/default.nix
@@ -41,8 +41,7 @@ stdenv.mkDerivation rec {
     zeitgeist
   ];
 
-  cmakeFlags = [ 
-    "-DCMAKE_BUILD_TYPE=Release"
+  cmakeFlags = [
     "-DUSE_ZEITGEIST=${if zeitgeistSupport then "ON" else "OFF"}"
     "-DHALF_BRO_INCOM_WEBKIT2=ON"
     "-DUSE_GTK3=1"

--- a/pkgs/applications/networking/instant-messengers/kadu/default.nix
+++ b/pkgs/applications/networking/instant-messengers/kadu/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${phonon}/lib64/pkgconfig:${phonon}/lib32/pkgconfig"
   '';
 
-  cmakeFlags = "-DENABLE_AUTODOWNLOAD=OFF -DBUILD_DESCRIPTION='NixOS' -DCMAKE_BUILD_TYPE=Release";
+  cmakeFlags = "-DENABLE_AUTODOWNLOAD=OFF -DBUILD_DESCRIPTION='NixOS'";
 
   prePatch = ''
     patchShebangs .

--- a/pkgs/applications/science/electronics/caneda/default.nix
+++ b/pkgs/applications/science/electronics/caneda/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
     sha256 = "dfbcac97f5a1b41ad9a63392394f37fb294cbf78c576673c9bc4a5370957b2c8";
   };
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
-
   buildInputs = [ cmake qt4 libxml2 libxslt ];
 
   postInstall = ''

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -21,11 +21,10 @@ stdenv.mkDerivation rec {
       sha256 = "0vrzykgxx423iwgz6186bi8724kmbi5wfl92gfwb3r6mqammgwpg";
     })
   ];
-  
+
   sourceRoot = "kicad-${version}";
 
   cmakeFlags = ''
-    -DCMAKE_BUILD_TYPE=Release
     -DKICAD_SKIP_BOOST=ON
     -DKICAD_BUILD_VERSION=${version}
     -DKICAD_REPO_NAME=stable
@@ -43,7 +42,7 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     pushd $(pwd)
-  '';  
+  '';
 
   postInstall = ''
     popd
@@ -53,7 +52,7 @@ stdenv.mkDerivation rec {
     make $MAKE_FLAGS
     make install
     popd
-   
+
     pushd kicad-footprints-*
     mkdir -p $out/share/kicad/modules
     cp -R *.pretty $out/share/kicad/modules/

--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
     cd src
   '';
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
-
   postInstall = ''
     wrapProgram $out/bin/linja --prefix PATH : $out/bin:${ninja}/bin
   '';

--- a/pkgs/development/compilers/hhvm/default.nix
+++ b/pkgs/development/compilers/hhvm/default.nix
@@ -46,8 +46,6 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
-
   meta = {
     description = "High-performance JIT compiler for PHP/Hack";
     homepage    = "http://hhvm.com";

--- a/pkgs/development/compilers/llvm/3.4/clang.nix
+++ b/pkgs/development/compilers/llvm/3.4/clang.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation {
   buildInputs = [ cmake libedit libxml2 zlib ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
     "-DCLANG_PATH_TO_LLVM_BUILD=${llvm}"
   ] ++

--- a/pkgs/development/compilers/llvm/3.4/lld.nix
+++ b/pkgs/development/compilers/llvm/3.4/lld.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation {
   buildInputs = [ cmake ncurses zlib python ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
     "-DLLD_PATH_TO_LLVM_BUILD=${llvm}"
   ];

--- a/pkgs/development/compilers/llvm/3.4/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.4/lldb.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation {
   buildInputs = [ cmake python which swig ncurses zlib libedit ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
     "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
     "-DLLDB_PATH_TO_CLANG_BUILD=${clang}"

--- a/pkgs/development/compilers/llvm/3.4/polly.nix
+++ b/pkgs/development/compilers/llvm/3.4/polly.nix
@@ -10,7 +10,6 @@ stdenv.mkDerivation {
   buildInputs = [ cmake isl python gmp ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
     "-DLLVM_INSTALL_ROOT=${llvm}"
   ];

--- a/pkgs/development/compilers/llvm/3.5/clang.nix
+++ b/pkgs/development/compilers/llvm/3.5/clang.nix
@@ -15,7 +15,6 @@ in stdenv.mkDerivation {
   buildInputs = [ cmake libedit libxml2 llvm ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
   ] ++
   # Maybe with compiler-rt this won't be needed?

--- a/pkgs/development/compilers/llvm/3.5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.5/libc++/default.nix
@@ -24,13 +24,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  cmakeFlags =
-    [ "-DCMAKE_BUILD_TYPE=Release"
-      "-DLIBCXX_LIBCXXABI_INCLUDE_PATHS=${libcxxabi}/include"
-      "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
-      "-DLIBCXX_LIBCPPABI_VERSION=2"
-      "-DLIBCXX_CXX_ABI=libcxxabi"
-    ];
+  cmakeFlags = [
+    "-DLIBCXX_LIBCXXABI_INCLUDE_PATHS=${libcxxabi}/include"
+    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+    "-DLIBCXX_LIBCPPABI_VERSION=2"
+    "-DLIBCXX_CXX_ABI=libcxxabi"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.5/lld.nix
+++ b/pkgs/development/compilers/llvm/3.5/lld.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation {
   buildInputs = [ cmake ncurses zlib python ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
     "-DLLD_PATH_TO_LLVM_BUILD=${llvm}"
   ];

--- a/pkgs/development/compilers/llvm/3.5/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.5/lldb.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation {
   buildInputs = [ cmake python which swig ncurses zlib libedit ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
     "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
     "-DLLDB_PATH_TO_CLANG_BUILD=${clang}"

--- a/pkgs/development/compilers/llvm/3.5/polly.nix
+++ b/pkgs/development/compilers/llvm/3.5/polly.nix
@@ -10,7 +10,6 @@ stdenv.mkDerivation {
   buildInputs = [ cmake isl python gmp ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
     "-DLLVM_INSTALL_ROOT=${llvm}"
   ];

--- a/pkgs/development/compilers/llvm/3.6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.6/clang/default.nix
@@ -16,7 +16,6 @@ let
     buildInputs = [ cmake libedit libxml2 llvm ];
 
     cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
       "-DCMAKE_CXX_FLAGS=-std=c++11"
     ] ++
     # Maybe with compiler-rt this won't be needed?

--- a/pkgs/development/compilers/llvm/3.6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.6/libc++/default.nix
@@ -19,13 +19,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  cmakeFlags =
-    [ "-DCMAKE_BUILD_TYPE=Release"
-      "-DLIBCXX_LIBCXXABI_INCLUDE_PATHS=${libcxxabi}/include"
-      "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
-      "-DLIBCXX_LIBCPPABI_VERSION=2"
-      "-DLIBCXX_CXX_ABI=libcxxabi"
-    ];
+  cmakeFlags = [
+    "-DLIBCXX_LIBCXXABI_INCLUDE_PATHS=${libcxxabi}/include"
+    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+    "-DLIBCXX_LIBCPPABI_VERSION=2"
+    "-DLIBCXX_CXX_ABI=libcxxabi"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.6/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.6/lldb.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation {
   buildInputs = [ cmake python which swig ncurses zlib libedit ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
     "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
     "-DLLDB_PATH_TO_CLANG_BUILD=${clang-unwrapped}"

--- a/pkgs/development/compilers/llvm/3.7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/clang/default.nix
@@ -16,7 +16,6 @@ let
     buildInputs = [ cmake libedit libxml2 llvm ];
 
     cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
       "-DCMAKE_CXX_FLAGS=-std=c++11"
     ] ++
     # Maybe with compiler-rt this won't be needed?

--- a/pkgs/development/compilers/llvm/3.7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/libc++/default.nix
@@ -18,12 +18,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  cmakeFlags =
-    [ "-DCMAKE_BUILD_TYPE=Release"
-      "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
-      "-DLIBCXX_LIBCPPABI_VERSION=2"
-      "-DLIBCXX_CXX_ABI=libcxxabi"
-    ];
+  cmakeFlags = [
+    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+    "-DLIBCXX_LIBCPPABI_VERSION=2"
+    "-DLIBCXX_CXX_ABI=libcxxabi"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.7/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.7/lldb.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation {
   '';
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
     "-DLLDB_PATH_TO_CLANG_BUILD=${clang-unwrapped}"
     "-DPYTHON_VERSION_MAJOR=2"

--- a/pkgs/development/compilers/llvm/3.8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/clang/default.nix
@@ -16,7 +16,6 @@ let
     buildInputs = [ cmake libedit libxml2 llvm python ];
 
     cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
       "-DCMAKE_CXX_FLAGS=-std=c++11"
     ] ++
     # Maybe with compiler-rt this won't be needed?

--- a/pkgs/development/compilers/llvm/3.8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++/default.nix
@@ -18,12 +18,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  cmakeFlags =
-    [ "-DCMAKE_BUILD_TYPE=Release"
-      "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
-      "-DLIBCXX_LIBCPPABI_VERSION=2"
-      "-DLIBCXX_CXX_ABI=libcxxabi"
-    ];
+  cmakeFlags = [
+    "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+    "-DLIBCXX_LIBCPPABI_VERSION=2"
+    "-DLIBCXX_CXX_ABI=libcxxabi"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/3.8/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.8/lldb.nix
@@ -33,7 +33,6 @@ stdenv.mkDerivation {
   '';
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DLLDB_PATH_TO_LLVM_BUILD=${llvm}"
     "-DLLVM_MAIN_INCLUDE_DIR=${llvm}/include"
     "-DLLDB_PATH_TO_CLANG_BUILD=${clang-unwrapped}"

--- a/pkgs/development/compilers/mono/llvm.nix
+++ b/pkgs/development/compilers/mono/llvm.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
   postBuild = "rm -fR $out";
 
   cmakeFlags = with stdenv; [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_BINUTILS_INCDIR=${binutils.dev}/include"
     "-DCMAKE_CXX_FLAGS=-std=c++11"

--- a/pkgs/development/libraries/cpp-netlib/default.nix
+++ b/pkgs/development/libraries/cpp-netlib/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DCPP-NETLIB_BUILD_SHARED_LIBS=ON"
-    "-DCMAKE_BUILD_TYPE=RELEASE"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/openbr/default.nix
+++ b/pkgs/development/libraries/openbr/default.nix
@@ -18,10 +18,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
-  ];
-
   meta = {
     description = "Open Source Biometric Recognition";
     homepage = http://openbiometrics.org/;

--- a/pkgs/development/libraries/stxxl/default.nix
+++ b/pkgs/development/libraries/stxxl/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
     "-DBUILD_STATIC_LIBS=OFF"
-    "-DCMAKE_BUILD_TYPE=Release"
     (mkFlag parallel "USE_GNU_PARALLEL")
   ];
 

--- a/pkgs/games/eternity-engine/default.nix
+++ b/pkgs/games/eternity-engine/default.nix
@@ -7,10 +7,6 @@ stdenv.mkDerivation rec {
     sha256 = "0jq8q0agw7lgab9q2h8wcaakvg913l9j3a6ss0hn9661plkw2yb4";
   };
 
-  cmakeFlags = ''
-    -DCMAKE_BUILD_TYPE=Release
-  '';
-
   buildInputs = [ stdenv cmake mesa SDL SDL_mixer SDL_net ];
 
   enableParallelBuilding = true;

--- a/pkgs/games/odamex/default.nix
+++ b/pkgs/games/odamex/default.nix
@@ -7,10 +7,6 @@ stdenv.mkDerivation rec {
     sha256 = "0cb6p58yv55kdyfj7s9n9xcwpvxrj8nyc6brw9jvwlc5n4y3cd5a";
   };
 
-  cmakeFlags = ''
-    -DCMAKE_BUILD_TYPE=Release
-  '';
-
   buildInputs = [ cmake pkgconfig SDL SDL_mixer SDL_net ];
 
   enableParallelBuilding = true;

--- a/pkgs/games/openspades/default.nix
+++ b/pkgs/games/openspades/default.nix
@@ -23,11 +23,14 @@ stdenv.mkDerivation rec {
     sed '1i#include <math.h>' -i Sources/Draw/SWFeatureLevel.h
   '';
 
-  nativeBuildInputs = 
+  nativeBuildInputs =
     [ cmake curl glew makeWrapper mesa SDL2 SDL2_image unzip wget zlib ]
     ++ lib.optional withOpenal openal;
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" "-DOPENSPADES_INSTALL_BINARY=bin" "-DOPENSPADES_RESOURCES=NO" ];
+  cmakeFlags = [
+    "-DOPENSPADES_INSTALL_BINARY=bin"
+    "-DOPENSPADES_RESOURCES=NO"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/games/openspades/git.nix
+++ b/pkgs/games/openspades/git.nix
@@ -16,12 +16,15 @@ stdenv.mkDerivation rec {
 
   postPatch = "sed '1i#include <cmath>' -i Sources/Client/{,Client}Player.cpp";
 
-  nativeBuildInputs = 
+  nativeBuildInputs =
     with stdenv.lib;
     [ cmake curl glew makeWrapper mesa SDL2 SDL2_image unzip wget zlib ]
     ++ lib.optional withOpenal openal;
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" "-DOPENSPADES_INSTALL_BINARY=bin" "-DOPENSPADES_RESOURCES=NO" ];
+  cmakeFlags = [
+    "-DOPENSPADES_INSTALL_BINARY=bin"
+    "-DOPENSPADES_RESOURCES=NO"
+  ];
 
   #enableParallelBuilding = true;
 

--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
     -DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include
     -DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include
     -DGTK2_INCLUDE_DIRS=${gtk2.dev}/include/gtk-2.0
-    -DCMAKE_BUILD_TYPE=Release
     -DENABLE_LTO=True
   '';
 

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
     -DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include
     -DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include
     -DGTK2_INCLUDE_DIRS=${gtk2.dev}/include/gtk-2.0
-    -DCMAKE_BUILD_TYPE=Release
     -DENABLE_LTO=True
   '';
 

--- a/pkgs/misc/screensavers/xss-lock/default.nix
+++ b/pkgs/misc/screensavers/xss-lock/default.nix
@@ -13,10 +13,6 @@ stdenv.mkDerivation {
   buildInputs = [ cmake pkgconfig docutils glib libpthreadstubs libXau
                   libXdmcp xcbutil ];
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
-  ];
-
   meta = with stdenv.lib; {
     description = "Use external locker (such as i3lock) as X screen saver";
     license = licenses.mit;

--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
     ++ optional  weatherXoapSupport libxml2
     ;
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ]
+  cmakeFlags = []
     ++ optional docsSupport         "-DMAINTAINER_MODE=ON"
     ++ optional curlSupport         "-DBUILD_CURL=ON"
     ++ optional (!ibmSupport)       "-DBUILD_IBM=OFF"

--- a/pkgs/tools/filesystems/darling-dmg/default.nix
+++ b/pkgs/tools/filesystems/darling-dmg/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake fuse openssl zlib bzip2 libxml2 icu ];
 
-  cmakeConfigureFlagFlags = ["-DCMAKE_BUILD_TYPE=RELEASE"];
-
   meta = {
     homepage = http://www.darlinghq.org/;
     description = "Darling lets you open OS X dmgs on Linux";


### PR DESCRIPTION
###### Motivation for this change

Cleanup I noticed while working on #17886.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Haven't built or tested yet.
