### PR TITLE
darwin: go: make go-1.7 build with clang-3.8.

### DIFF
--- a/pkgs/development/compilers/go/1.7.nix
+++ b/pkgs/development/compilers/go/1.7.nix
@@ -98,6 +98,9 @@ stdenv.mkDerivation rec {
 
     sed -i '/TestDisasmExtld/areturn' src/cmd/objdump/objdump_test.go
 
+    sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
+    sed -i 's/unrecognized/unknown/' src/cmd/go/build.go
+
     touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
 
     sed -i '1 a\exit 0' misc/cgo/errors/test.bash

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4735,9 +4735,11 @@ in
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
   };
 
-  go_1_7 = callPackage ../development/compilers/go/1.7.nix {
+  go_1_7 = callPackage ../development/compilers/go/1.7.nix ({
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
-  };
+  } // stdenv.lib.optionalAttrs stdenv.isDarwin {
+    stdenv = stdenvAdapters.overrideCC pkgs.stdenv pkgs.clang_38;
+  });
 
   go = self.go_1_7;
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #17968 + resolves the build problems on darwin described in https://github.com/NixOS/nixpkgs/pull/17805#issuecomment-241275038.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The darwin stdenv currently provides clang-3.7; however,

  a) go-1.7 currently expects a compiler that supports "-fdebug-prefix-map"
     arguments (which clang-3.8 supports but clang-3.7 does not) and

  b) even with clang-3.8, go-1.7 misinterprets the result of its runtime probes
     for support for the "-no-pie" flag, thereby failing to build runtime/cgo.

This patch resolves (a) by building go-1.7 with clang-3.8 and resolves (b) by
teaching go how to correctly probe "-no-pie" error messages from clang.
