### PR TITLE
kdiskfree: init at 16.08.0

### DIFF
--- a/pkgs/desktops/kde-5/applications/default.nix
+++ b/pkgs/desktops/kde-5/applications/default.nix
@@ -47,6 +47,7 @@ let
     kcolorchooser = callPackage ./kcolorchooser.nix {};
     kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
     kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
+    kdf = callPackage ./kdf.nix {};
     kgpg = callPackage ./kgpg.nix { inherit (pkgs.kde4) kdepimlibs; };
     khelpcenter = callPackage ./khelpcenter.nix {};
     kio-extras = callPackage ./kio-extras.nix {};

--- a/pkgs/desktops/kde-5/applications/kdf.nix
+++ b/pkgs/desktops/kde-5/applications/kdf.nix
@@ -1,0 +1,21 @@
+{
+  kdeApp, lib, kdeWrapper,
+  ecm, kdoctools,
+  kcmutils
+}:
+
+let
+  unwrapped =
+    kdeApp {
+      name = "kdf";
+      meta = {
+        license = with lib.licenses; [ gpl2 ];
+        maintainers = [ lib.maintainers.peterhoeg ];
+      };
+      nativeBuildInputs = [ ecm kdoctools ];
+      propagatedBuildInputs = [
+        kcmutils
+      ];
+    };
+in
+kdeWrapper unwrapped { targets = [ "bin/kdf" ]; }


### PR DESCRIPTION
###### Motivation for this change

kdf was ported to kf5 with the release of 16.08
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
