### PR TITLE
kernel: config: enable DRM_AMD_POWERPLAY

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -181,6 +181,9 @@ with stdenv.lib;
   VGA_SWITCHEROO y # Hybrid graphics support
   DRM_GMA600 y
   DRM_GMA3600 y
+  ${optionalString (versionAtLeast version "4.5") ''
+    DRM_AMD_POWERPLAY y # necessary for amdgpu polaris support
+  ''}
 
   # Sound.
   SND_DYNAMIC_MINORS y


### PR DESCRIPTION
###### Motivation for this change

Support for the AMD Polaris graphics card requires DRM_AMD_POWERPLAY=y, see #17991.  This options is also enabled by default at least in [Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=818174).

cc maintainer @thoughtpolice 

If there are no objections, I'll merge this later today.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
