### PR TITLE
llvm: 3.8.0 -> 3.9.0

### DIFF
--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src, python }:
+
+let
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  self = stdenv.mkDerivation {
+    name = "clang-${version}";
+
+    unpackPhase = ''
+      unpackFile ${fetch "cfe" "1v4n5j1vdc74v4j4m2zldkcm5aniajc2l8k1qlmvs4yc0cjbn1nb"}
+      mv cfe-${version}.src clang
+      sourceRoot=$PWD/clang
+      unpackFile ${clang-tools-extra_src}
+      mv clang-tools-extra-* $sourceRoot/tools/extra
+    '';
+
+    buildInputs = [ cmake libedit libxml2 llvm python ];
+
+    cmakeFlags = [
+      "-DCMAKE_BUILD_TYPE=Release"
+      "-DCMAKE_CXX_FLAGS=-std=c++11"
+    ] ++
+    # Maybe with compiler-rt this won't be needed?
+    (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
+    (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
+
+    patches = [ ./purity.patch ];
+
+    postPatch = ''
+      sed -i -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/Tools.cpp
+      sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains.cpp
+    '';
+
+    # Clang expects to find LLVMgold in its own prefix
+    # Clang expects to find sanitizer libraries in its own prefix
+    postInstall = ''
+      ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+      ln -sv ${llvm}/lib/clang/3.9.0/lib $out/lib/clang/3.9.0/
+      ln -sv $out/bin/clang $out/bin/cpp
+    '';
+
+    enableParallelBuilding = true;
+
+    passthru = {
+      lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
+      isClang = true;
+    } // stdenv.lib.optionalAttrs stdenv.isLinux {
+      inherit gcc;
+    };
+
+    meta = {
+      description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
+      homepage    = http://llvm.org/;
+      license     = stdenv.lib.licenses.bsd3;
+      platforms   = stdenv.lib.platforms.all;
+    };
+  };
+in self

--- a/pkgs/development/compilers/llvm/3.9/clang/purity.patch
+++ b/pkgs/development/compilers/llvm/3.9/clang/purity.patch
@@ -1,0 +1,16 @@
+--- a/lib/Driver/Tools.cpp	2016-08-25 15:48:05.187553443 +0200
++++ b/lib/Driver/Tools.cpp	2016-08-25 15:48:47.534468882 +0200
+@@ -9420,13 +9420,6 @@
+   if (!Args.hasArg(options::OPT_static)) {
+     if (Args.hasArg(options::OPT_rdynamic))
+       CmdArgs.push_back("-export-dynamic");
+-
+-    if (!Args.hasArg(options::OPT_shared)) {
+-      const std::string Loader =
+-          D.DyldPrefix + ToolChain.getDynamicLinker(Args);
+-      CmdArgs.push_back("-dynamic-linker");
+-      CmdArgs.push_back(Args.MakeArgString(Loader));
+-    }
+   }
+ 
+   CmdArgs.push_back("-o");

--- a/pkgs/development/compilers/llvm/3.9/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/default.nix
@@ -1,0 +1,35 @@
+{ newScope, stdenv, isl, fetchurl, overrideCC, wrapCC }:
+let
+  callPackage = newScope (self // { inherit stdenv isl version fetch; });
+
+  version = "3.9.0rc3";
+
+  fetch = fetch_v version;
+  fetch_v = ver: name: sha256: fetchurl {
+    url = "http://llvm.org/pre-releases/3.9.0/rc3/${name}-${ver}.src.tar.xz";
+    inherit sha256;
+  };
+
+  compiler-rt_src = fetch "compiler-rt" "00ljgkjcds0z2z96zv02x39wryj902q29i895xixg60hd0909qra";
+  clang-tools-extra_src = fetch "clang-tools-extra" "1nvc5f8g93hb76vrfygz2yafqa6kncpqwip7q1xwbw5fnw7rib5d";
+
+  self = {
+    llvm = callPackage ./llvm.nix {
+      inherit compiler-rt_src stdenv;
+    };
+
+    clang-unwrapped = callPackage ./clang {
+      inherit clang-tools-extra_src stdenv;
+    };
+
+    clang = wrapCC self.clang-unwrapped;
+
+    stdenv = overrideCC stdenv self.clang;
+
+    lldb = callPackage ./lldb.nix {};
+
+    libcxx = callPackage ./libc++ {};
+
+    libcxxabi = callPackage ./libc++abi.nix {};
+  };
+in self

--- a/pkgs/development/compilers/llvm/3.9/libc++/darwin.patch
+++ b/pkgs/development/compilers/llvm/3.9/libc++/darwin.patch
@@ -1,0 +1,39 @@
+--- libcxx-3.8.0.src.org/lib/CMakeLists.txt	2015-12-16 15:41:05.000000000 -0800
++++ libcxx-3.8.0.src/lib/CMakeLists.txt	2016-06-17 19:40:00.293394500 -0700
+@@ -94,30 +94,30 @@
+     add_definitions(-D__STRICT_ANSI__)
+     add_link_flags(
+       "-compatibility_version 1"
+       "-current_version 1"
+-      "-install_name /usr/lib/libc++.1.dylib"
+-      "-Wl,-reexport_library,/usr/lib/libc++abi.dylib"
++      "-install_name ${LIBCXX_LIBCXXABI_LIB_PATH}/libc++.1.dylib"
++      "-Wl,-reexport_library,${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib"
+       "-Wl,-unexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++unexp.exp"
+       "/usr/lib/libSystem.B.dylib")
+   else()
+     if ( ${CMAKE_OSX_SYSROOT} )
+       list(FIND ${CMAKE_OSX_ARCHITECTURES} "armv7" OSX_HAS_ARMV7)
+       if (OSX_HAS_ARMV7)
+         set(OSX_RE_EXPORT_LINE
+-          "${CMAKE_OSX_SYSROOT}/usr/lib/libc++abi.dylib"
++          "${CMAKE_OSX_SYSROOT}${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib"
+           "-Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++sjlj-abi.exp")
+       else()
+         set(OSX_RE_EXPORT_LINE
+-          "-Wl,-reexport_library,${CMAKE_OSX_SYSROOT}/usr/lib/libc++abi.dylib")
++          "-Wl,-reexport_library,${CMAKE_OSX_SYSROOT}${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib")
+       endif()
+     else()
+-      set(OSX_RE_EXPORT_LINE "/usr/lib/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
++      set(OSX_RE_EXPORT_LINE "${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
+     endif()
+ 
+     add_link_flags(
+       "-compatibility_version 1"
+-      "-install_name /usr/lib/libc++.1.dylib"
++      "-install_name ${LIBCXX_LIBCXXABI_LIB_PATH}/libc++.1.dylib"
+       "-Wl,-unexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++unexp.exp"
+       "${OSX_RE_EXPORT_LINE}"
+       "-Wl,-force_symbols_not_weak_list,${CMAKE_CURRENT_SOURCE_DIR}/notweak.exp"
+       "-Wl,-force_symbols_weak_list,${CMAKE_CURRENT_SOURCE_DIR}/weak.exp")

--- a/pkgs/development/compilers/llvm/3.9/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/libc++/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetch, cmake, libcxxabi, fixDarwinDylibNames, version }:
+
+stdenv.mkDerivation rec {
+  name = "libc++-${version}";
+
+  src = fetch "libcxx" "13p4wdqai5rbic91n8lfyqzlll319cw5cx786jkh109h7gqvavb6";
+
+  postUnpack = ''
+    unpackFile ${libcxxabi.src}
+  '';
+
+  preConfigure = ''
+    # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
+    cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$NIX_BUILD_TOP/libcxxabi-${version}.src/include")
+  '';
+
+  patches = lib.optional stdenv.isDarwin ./darwin.patch;
+
+  buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+  cmakeFlags =
+    [ "-DCMAKE_BUILD_TYPE=Release"
+      "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+      "-DLIBCXX_LIBCPPABI_VERSION=2"
+      "-DLIBCXX_CXX_ABI=libcxxabi"
+    ];
+
+  enableParallelBuilding = true;
+
+  linkCxxAbi = stdenv.isLinux;
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    homepage = http://libcxx.llvm.org/;
+    description = "A new implementation of the C++ standard library, targeting C++11";
+    license = "BSD";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/3.9/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/3.9/libc++/setup-hook.sh
@@ -1,0 +1,3 @@
+linkCxxAbi="@linkCxxAbi@"
+export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/3.9/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.9/libc++abi.nix
@@ -1,0 +1,47 @@
+{ stdenv, cmake, fetch, libcxx, libunwind, llvm, version }:
+
+stdenv.mkDerivation {
+  name = "libc++abi-${version}";
+
+  src = fetch "libcxxabi" "14bb6441ziq93irz527880g22hpcaznfqxr8y807ajkwy2678yhm";
+
+  buildInputs = [ cmake ] ++ stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
+
+  postUnpack = ''
+    unpackFile ${libcxx.src}
+    unpackFile ${llvm.src}
+    export NIX_CFLAGS_COMPILE+=" -I$PWD/include"
+    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_INCLUDES=$PWD/$(ls -d libcxx-*)/include"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export TRIPLE=x86_64-apple-darwin
+  '';
+
+  installPhase = if stdenv.isDarwin
+    then ''
+      for file in lib/*.dylib; do
+        # this should be done in CMake, but having trouble figuring out
+        # the magic combination of necessary CMake variables
+        # if you fancy a try, take a look at
+        # http://www.cmake.org/Wiki/CMake_RPATH_handling
+        install_name_tool -id $out/$file $file
+      done
+      make install
+      install -d 755 $out/include
+      install -m 644 ../include/*.h $out/include
+    ''
+    else ''
+      install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.so.1.0 $out/lib
+      install -m 644 ../include/cxxabi.h $out/include
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
+    '';
+
+  meta = {
+    homepage = http://libcxxabi.llvm.org/;
+    description = "A new implementation of low level support for a standard C++ library";
+    license = "BSD";
+    maintainers = with stdenv.lib.maintainers; [ vlstill ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/3.9/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.9/lldb.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, ncurses
+, swig
+, which
+, libedit
+, llvm
+, clang-unwrapped
+, python
+, version
+}:
+
+stdenv.mkDerivation {
+  name = "lldb-${version}";
+
+  src = fetch "lldb" "1rhilgdlbbwkmd37jr29015m1jrq0vdplrmzydxg31yzbavmfl6y";
+
+  postUnpack = ''
+    # Hack around broken standalone build as of 3.8
+    unpackFile ${llvm.src}
+    srcDir="$(ls -d lldb-*.src)"
+    mkdir -p "$srcDir/tools/lib/Support"
+    cp "$(ls -d llvm-*.src)/lib/Support/regex_impl.h" "$srcDir/tools/lib/Support/"
+
+    # Fix up various paths that assume llvm and clang are installed in the same place
+    substituteInPlace $srcDir/cmake/modules/LLDBStandalone.cmake \
+      --replace CheckAtomic $(readlink -f llvm-*.src)/cmake/modules/CheckAtomic.cmake
+    sed -i 's,".*ClangConfig.cmake","${clang-unwrapped}/lib/cmake/clang/ClangConfig.cmake",' \
+      $srcDir/cmake/modules/LLDBStandalone.cmake
+    sed -i 's,".*tools/clang/include","${clang-unwrapped}/include",' \
+      $srcDir/cmake/modules/LLDBStandalone.cmake
+    sed -i 's,"$.LLVM_LIBRARY_DIR.",${llvm}/lib ${clang-unwrapped}/lib,' \
+      $srcDir/cmake/modules/LLDBStandalone.cmake
+  '';
+
+  buildInputs = [ cmake python which swig ncurses zlib libedit llvm ];
+
+  CXXFLAGS = "-fno-rtti";
+  hardeningDisable = [ "format" ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DLLVM_MAIN_INCLUDE_DIR=${llvm}/include"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A next-generation high-performance debugger";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.bsd3;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -1,0 +1,89 @@
+{ stdenv
+, fetch
+, perl
+, groff
+, cmake
+, python
+, libffi
+, binutils
+, libxml2
+, valgrind
+, ncurses
+, version
+, zlib
+, compiler-rt_src
+, libcxxabi
+, debugVersion ? false
+, enableSharedLibraries ? true
+}:
+
+let
+  src = fetch "llvm" "10iz9qjxgd05qfzi1zppabn1gb2w1f4ryrydi2mk0z4v18wxhbmm";
+in stdenv.mkDerivation rec {
+  name = "llvm-${version}";
+
+  unpackPhase = ''
+    unpackFile ${src}
+    mv llvm-${version}.src llvm
+    sourceRoot=$PWD/llvm
+    unpackFile ${compiler-rt_src}
+    mv compiler-rt-* $sourceRoot/projects/compiler-rt
+  '';
+
+  buildInputs = [ perl groff cmake libxml2 python libffi ]
+    ++ stdenv.lib.optional stdenv.isDarwin libcxxabi;
+
+  propagatedBuildInputs = [ ncurses zlib ];
+
+  # hacky fix: New LLVM releases require a newer OS X SDK than
+  # 10.9. This is a temporary measure until nixpkgs darwin support is
+  # updated.
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+        sed -i 's/os_trace(\(.*\)");$/printf(\1\\n");/g' ./projects/compiler-rt/lib/sanitizer_common/sanitizer_mac.cc
+  '';
+
+  # hacky fix: created binaries need to be run before installation
+  preBuild = ''
+    mkdir -p $out/
+    ln -sv $PWD/lib $out
+  '';
+
+  cmakeFlags = with stdenv; [
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
+    "-DLLVM_INSTALL_UTILS=ON"  # Needed by rustc
+    "-DLLVM_BUILD_TESTS=ON"
+    "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_ENABLE_RTTI=ON"
+    "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
+  ] ++ stdenv.lib.optional enableSharedLibraries [
+    "-DLLVM_LINK_LLVM_DYLIB=ON"
+  ] ++ stdenv.lib.optional (!isDarwin)
+    "-DLLVM_BINUTILS_INCDIR=${binutils.dev}/include"
+    ++ stdenv.lib.optionals ( isDarwin) [
+    "-DLLVM_ENABLE_LIBCXX=ON"
+    "-DCAN_TARGET_i386=false"
+  ];
+
+  postBuild = ''
+    rm -fR $out
+
+    paxmark m bin/{lli,llvm-rtdyld}
+  '';
+
+  postInstall = stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
+    install_name_tool -id $out/lib/libLLVM.dylib $out/lib/libLLVM.dylib
+    ln -s $out/lib/libLLVM.dylib $out/lib/libLLVM-${version}.dylib
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.src = src;
+
+  meta = {
+    description = "Collection of modular and reusable compiler and toolchain technologies";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4924,6 +4924,10 @@ in
     inherit (stdenvAdapters) overrideCC;
   };
 
+  llvmPackages_39 = callPackage ../development/compilers/llvm/3.9 {
+    inherit (stdenvAdapters) overrideCC;
+  };
+
   manticore = callPackage ../development/compilers/manticore { };
 
   mentorToolchains = recurseIntoAttrs (


### PR DESCRIPTION
###### Motivation for this change

LLVM 3.9 should be released within the next few days, so I've begun packaging the release candidate.  I'd like to switch mesa to the new LLVM version soon in order to support the AMD Polaris graphics card, see #17991.  This PR only adds the new LLVM version, but does not change any existing dependencies.

Status: everything builds and seems to work just fine.

Changes from 3.8:
- I disabled the compiler-rt tests in llvm, these require clang source code.
- I adapted the purity patch for clang, there was some refactoring in `Driver/Tools.cpp`.

lldb requires even more build system patches now than before, ~~and I still get the following build error~~ (I have fixed this now):

```
[100%] Linking CXX executable ../../bin/lldb-server
../../lib/liblldbSymbol.a(ClangASTContext.cpp.o):(.data.rel.ro._ZTI22NullDiagnosticConsumer[_ZTI22NullDiagnosticConsumer]+0x10): undefined reference to `typeinfo for clang::DiagnosticConsumer'
../../lib/liblldbSymbol.a(ClangASTImporter.cpp.o):(.data.rel.ro._ZTIN12lldb_private16ClangASTImporter6MinionE[_ZTIN12lldb_private16ClangASTImporter6MinionE]+0x10): undefined reference to `typeinfo for clang::ASTImporter'
../../lib/liblldbPluginExpressionParserClang.a(ClangModulesDeclVendor.cpp.o):(.data.rel.ro._ZTIN12_GLOBAL__N_125StoringDiagnosticConsumerE+0x10): undefined reference to `typeinfo for clang::DiagnosticConsumer'
../../lib/liblldbPluginExpressionParserClang.a(ASTResultSynthesizer.cpp.o):(.data.rel.ro._ZTIN12lldb_private20ASTResultSynthesizerE[_ZTIN12lldb_private20ASTResultSynthesizerE]+0x10): undefined reference to `typeinfo for clang::SemaConsumer'
../../lib/liblldbPluginExpressionParserClang.a(ASTStructExtractor.cpp.o):(.data.rel.ro._ZTIN12lldb_private18ASTStructExtractorE[_ZTIN12lldb_private18ASTStructExtractorE]+0x10): undefined reference to `typeinfo for clang::SemaConsumer'
../../lib/liblldbPluginExpressionParserClang.a(ClangExpressionParser.cpp.o):(.data.rel.ro._ZTIN12lldb_private21ClangExpressionParser25LLDBPreprocessorCallbacksE[_ZTIN12lldb_private21ClangExpressionParser25LLDBPreprocessorCallbacksE]+0x10): undefined reference to `typeinfo for clang::PPCallbacks'
../../lib/liblldbPluginExpressionParserClang.a(ClangExpressionParser.cpp.o):(.data.rel.ro._ZTI29ClangDiagnosticManagerAdapter[_ZTI29ClangDiagnosticManagerAdapter]+0x10): undefined reference to `typeinfo for clang::DiagnosticConsumer'
../../lib/liblldbPluginExpressionParserClang.a(ClangExpressionParser.cpp.o):(.data.rel.ro._ZTIZN12lldb_private21ClangExpressionParser17RewriteExpressionERNS_17DiagnosticManagerEE16RewritesReceiver+0x10): undefined reference to `typeinfo for clang::edit::EditsReceiver'
../../lib/liblldbSymbol.a(ClangExternalASTSourceCommon.cpp.o):(.data.rel.ro._ZTIN12lldb_private28ClangExternalASTSourceCommonE[_ZTIN12lldb_private28ClangExternalASTSourceCommonE]+0x10): undefined reference to `typeinfo for clang::ExternalASTSource'
collect2: error: ld returned 1 exit status
make[3]: *** [tools/lldb-server/CMakeFiles/lldb-server.dir/build.make:543: bin/lldb-server-3.9.0] Error 1
make[2]: *** [CMakeFiles/Makefile2:6280: tools/lldb-server/CMakeFiles/lldb-server.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:6292: tools/lldb-server/CMakeFiles/lldb-server.dir/rule] Error 2
make: *** [Makefile:1371: lldb-server] Error 2
```

~~Does anybody have ideas for lldb?~~  Can anybody test this on Darwin?

cc maintainers @lovek323 @7c6f434c @viric @vlstill 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
