### PR TITLE
ffmpeg: 3.1.1 -> 3.1.2

### DIFF
--- a/pkgs/development/libraries/ffmpeg/3.1.nix
+++ b/pkgs/development/libraries/ffmpeg/3.1.nix
@@ -5,8 +5,8 @@
 }@args:
 
 callPackage ./generic.nix (args // rec {
-  version = "${branch}.1";
+  version = "${branch}.2";
   branch = "3.1";
-  sha256 = "1d5knh87cgnla5zawy56gkrpb48qhyiq7i0pm8z9hyx3j05abg55";
+  sha256 = "1xvh1c8nlws0wx6b7yl1pvkybgzaj5585h1r6z1gzhck1f0qvsv2";
   darwinFrameworks = [ Cocoa CoreMedia ];
 })


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
