### PR TITLE
Fix: Unable to run double nested bundler

### DIFF
--- a/pkgs/development/ruby-modules/bundler/default.nix
+++ b/pkgs/development/ruby-modules/bundler/default.nix
@@ -7,4 +7,8 @@ buildRubyGem rec {
   version = "1.12.5";
   sha256 = "1q84xiwm9j771lpmiply0ls9l2bpvl5axn3jblxjvrldh8di2pkc";
   dontPatchShebangs = true;
+
+  postFixup = ''
+    sed -i -e "s/activate_bin_path/bin_path/g" $out/bin/bundle
+  '';
 }


### PR DESCRIPTION
###### Motivation for this change

This really needs to get in before 16.09.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The combination of bundler 1.12.5 and rubygems 1.6.2 doesn't play well at all when trying to run gems such as foreman where bundler is used to run bundler.

Just upgrading to the latest bundler rc doesn't fix it and changing rubygems causes a massive rebuild.

Issues:
- https://github.com/bundler/bundler/issues/4402
- https://github.com/bundler/bundler/issues/4576
- https://github.com/bundler/bundler/issues/4602
- https://github.com/docker-library/ruby/issues/73

This PR patches bundler to work around the issue as highlighted here and unbreaks everything for me:

https://github.com/bundler/bundler/issues/4602#issuecomment-233619696
