### PR TITLE
php: default php56 -> php70

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5864,9 +5864,9 @@ in
 
   inherit (callPackages ../development/interpreters/perl {}) perl perl520 perl522;
 
-  php = php56;
+  php = php70;
 
-  phpPackages = php56Packages;
+  phpPackages = php70Packages;
 
   php56Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
     php = php56;
@@ -6444,7 +6444,7 @@ in
   gnumake = self.gnumake42;
 
   gnustep = recurseIntoAttrs (callPackage ../desktops/gnustep {});
-  
+
   gob2 = callPackage ../development/tools/misc/gob2 { };
 
   gocd-agent = callPackage ../development/tools/continuous-integration/gocd-agent { };
@@ -10486,7 +10486,7 @@ in
 
   influxdb = (callPackage ../servers/nosql/influxdb/v0.nix { }).bin // { outputs = [ "bin" ]; };
 
-  influxdb10 = (callPackage ../servers/nosql/influxdb/v1.nix { }).bin // { outputs = [ "bin" ]; }; 
+  influxdb10 = (callPackage ../servers/nosql/influxdb/v1.nix { }).bin // { outputs = [ "bin" ]; };
 
   hyperdex = callPackage ../servers/nosql/hyperdex { };
 


### PR DESCRIPTION
###### Motivation for this change

PHP 5 loses active support in December of this year, PHP 7 is where we should be defaulting. I did a nox-rebuild wip on this and it all turned out great:

```
[nix-shell:~/projects/nixpkgs]$ nox-review wip
==> We're in a git repo, trying to fetch it

Building in /run/user/1000/nox-review-rxih2djv: limesurvey php56 arcanist drush nagios hhvm php wp-cli yle-dl
/nix/store/0j6n5dwmh52c7k90hwzd2zaism1rzdc9-limesurvey-2.05_plus_141210
/nix/store/jjmypjjgdnd2x637fghr3q3jb32yj1lz-php-5.6.25
/nix/store/qmpmkg4g7392df5igqwa63292v3x8i04-arcanist-20160516
/nix/store/lnv0185sgjni73yyr39i8i42j5izqk8x-drush-6.1.0
/nix/store/3ij73krh6q86msaigffc3blyb8gbj922-nagios-4.0.8
/nix/store/vs5m874gv285i121417v2v6142d8z4bf-hhvm-3.12.1
/nix/store/1agdz5b86ry6why27wpdd62mwcicvan3-php-7.0.10
/nix/store/9zr8ivfspac3ffd6293ixv16vhc3b034-wp-cli-0.23.1
/nix/store/3vgdkzrgjpgq821q4ml4n5qbnqxq1cxp-yle-dl-2.9.1
Result in /run/user/1000/nox-review-rxih2djv
total 0
lrwxrwxrwx 1 grahamc users 71 Aug 26 06:55 result -> /nix/store/0j6n5dwmh52c7k90hwzd2zaism1rzdc9-limesurvey-2.05_plus_141210
lrwxrwxrwx 1 grahamc users 54 Aug 26 06:55 result-2 -> /nix/store/jjmypjjgdnd2x637fghr3q3jb32yj1lz-php-5.6.25
lrwxrwxrwx 1 grahamc users 61 Aug 26 06:55 result-3 -> /nix/store/qmpmkg4g7392df5igqwa63292v3x8i04-arcanist-20160516
lrwxrwxrwx 1 grahamc users 55 Aug 26 06:55 result-4 -> /nix/store/lnv0185sgjni73yyr39i8i42j5izqk8x-drush-6.1.0
lrwxrwxrwx 1 grahamc users 56 Aug 26 06:55 result-5 -> /nix/store/3ij73krh6q86msaigffc3blyb8gbj922-nagios-4.0.8
lrwxrwxrwx 1 grahamc users 55 Aug 26 06:55 result-6 -> /nix/store/vs5m874gv285i121417v2v6142d8z4bf-hhvm-3.12.1
lrwxrwxrwx 1 grahamc users 54 Aug 26 06:55 result-7 -> /nix/store/1agdz5b86ry6why27wpdd62mwcicvan3-php-7.0.10
lrwxrwxrwx 1 grahamc users 57 Aug 26 06:55 result-8 -> /nix/store/9zr8ivfspac3ffd6293ixv16vhc3b034-wp-cli-0.23.1
lrwxrwxrwx 1 grahamc users 56 Aug 26 06:55 result-9 -> /nix/store/3vgdkzrgjpgq821q4ml4n5qbnqxq1cxp-yle-dl-2.9.1
```
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

(plus fixed some whitespace errors)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/18011)

<!-- Reviewable:end -->
