### PR TITLE
Build go package 1.7

### DIFF
--- a/pkgs/development/tools/leaps/default.nix
+++ b/pkgs/development/tools/leaps/default.nix
@@ -21,5 +21,6 @@ buildGoPackage rec {
     license = "MIT";
     maintainers = with stdenv.lib.maintainers; [ qknight ];
     meta.platforms = stdenv.lib.platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10009,7 +10009,11 @@ in
     go = go_1_6;
   };
 
-  buildGoPackage = buildGo16Package;
+  buildGo17Package = callPackage ../development/go-modules/generic {
+    go = go_1_7;
+  };
+
+  buildGoPackage = buildGo17Package;
 
   go2nix = callPackage ../development/tools/go2nix { };
 


### PR DESCRIPTION
###### Motivation for this change

go 1.7 is now the default go compiler but isn't used by the packages using the `buildGoPackage` constructor.

All the packages are compiling successfully except "leaps" which is broken on master already.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
