### PR TITLE
haskellPackages.spy: fix for new fsnotify version

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -975,4 +975,7 @@ self: super: {
     '';
   });
 
+  # https://bitbucket.org/ssaasen/spy/pull-requests/3/fsnotify-dropped-system-filepath
+  spy = appendPatch super.spy ./patches/spy.patch;
+
 }

--- a/pkgs/development/haskell-modules/patches/spy.patch
+++ b/pkgs/development/haskell-modules/patches/spy.patch
@@ -1,0 +1,26 @@
+diff --git a/src/Spy/Watcher.hs b/src/Spy/Watcher.hs
+     index 8512613..4df67d4 100644
+--- a/src/Spy/Watcher.hs
++++ b/src/Spy/Watcher.hs
+@@ -50,7 +50,7 @@ plainFormat = Plain
+ spy :: Spy -> IO b -> IO ()
+ spy config after = withManager $ \wm ->
+     runIndefinitely
+-      (watchTree wm (decodeString $ dir config)
++      (watchTree wm (dir config)
+                   (not . skipEvent config . eventPath)
+                   (handleEvent config)) 
+       (const after)
+@@ -106,9 +106,9 @@ eventTime (Modified _ t) = t
+ eventTime (Removed _ t) = t
+ 
+ eventPath :: Event -> FilePath
+-eventPath (Added fp _) = encodeString fp
+-eventPath (Modified fp _) = encodeString fp
+-eventPath (Removed fp _) = encodeString fp
++eventPath (Added fp _) = fp
++eventPath (Modified fp _) = fp
++eventPath (Removed fp _) = fp
+ 
+ eventType :: Event -> FilePath
+ eventType (Added _ _) = "Added"


### PR DESCRIPTION
- Built on platform(s)
  - [x] NixOS

Temporary fix, until it is merged upstream.
