### PR TITLE
newpkg: gnuradio-gsm , gnuradio-ais, gnuradio-rds, libosmocore-0.9.0

### DIFF
--- a/pkgs/applications/misc/gnuradio-ais/default.nix
+++ b/pkgs/applications/misc/gnuradio-ais/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
+, makeWrapper, cppunit, gnuradio-osmosdr
+, pythonSupport ? true, python, swig
+}:
+
+assert pythonSupport -> python != null && swig != null;
+
+stdenv.mkDerivation rec {
+  name = "gnuradio-ais-${version}";
+  version = "2016-08-26";
+
+  src = fetchFromGitHub {
+    owner = "bistromath";
+    repo = "gr-ais";
+    rev = "1863d1bf8a7709a8dfedb3ddb8e2b99112e7c872";
+    sha256 = "1vl3kk8xr2mh5lf31zdld7yzmwywqffffah8iblxdzblgsdwxfl6";
+  };
+
+  buildInputs = [
+    cmake pkgconfig boost gnuradio makeWrapper cppunit gnuradio-osmosdr
+  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+
+  postInstall = ''
+    for prog in "$out"/bin/*; do
+        wrapProgram "$prog" --set PYTHONPATH $PYTHONPATH:$(toPythonPath "$out")
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gnuradio block for ais";
+    homepage = https://github.com/bistromath/gr-ais;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mog ];
+  };
+}

--- a/pkgs/applications/misc/gnuradio-gsm/default.nix
+++ b/pkgs/applications/misc/gnuradio-gsm/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
+, makeWrapper, cppunit, libosmocore, gnuradio-osmosdr
+, pythonSupport ? true, python, swig
+}:
+
+assert pythonSupport -> python != null && swig != null;
+
+stdenv.mkDerivation rec {
+  name = "gnuradio-gsm-${version}";
+  version = "2016-08-25";
+
+  src = fetchFromGitHub {
+    owner = "ptrkrysik";
+    repo = "gr-gsm";
+    rev = "3ca05e6914ef29eb536da5dbec323701fbc2050d";
+    sha256 = "13nnq927kpf91iqccr8db9ripy5czjl5jiyivizn6bia0bam2pvx";
+  };
+
+  buildInputs = [
+    cmake pkgconfig boost gnuradio makeWrapper cppunit libosmocore gnuradio-osmosdr
+  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+
+  postInstall = ''
+    for prog in "$out"/bin/*; do
+        wrapProgram "$prog" --set PYTHONPATH $PYTHONPATH:${gnuradio-osmosdr}/lib/${python.libPrefix}/site-packages:$(toPythonPath "$out")
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gnuradio block for gsm";
+    homepage = https://github.com/ptrkrysik/gr-gsm;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mog ];
+  };
+}

--- a/pkgs/applications/misc/gnuradio-rds/default.nix
+++ b/pkgs/applications/misc/gnuradio-rds/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
+, makeWrapper, pythonSupport ? true, python, swig
+}:
+
+assert pythonSupport -> python != null && swig != null;
+
+stdenv.mkDerivation rec {
+  name = "gnuradio-rds-${version}";
+  version = "2016-08-27";
+
+  src = fetchFromGitHub {
+    owner = "bastibl";
+    repo = "gr-rds";
+    rev = "5246b75180808d47f321cb26f6c16d7c7a7af4fc";
+    sha256 = "008284ya464q4h4fd0zvcn6g7bym231p8fl3kdxncz9ks4zsbsxs";
+  };
+
+  buildInputs = [
+    cmake pkgconfig boost gnuradio makeWrapper
+  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+
+  postInstall = ''
+    for prog in "$out"/bin/*; do
+        wrapProgram "$prog" --set PYTHONPATH $PYTHONPATH:$(toPythonPath "$out")
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gnuradio block for radio data system";
+    homepage = https://github.com/bastibl/gr-rds;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mog ];
+  };
+}

--- a/pkgs/applications/misc/libosmocore/default.nix
+++ b/pkgs/applications/misc/libosmocore/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pcsclite, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  name = "libosmocore-${version}";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "osmocom";
+    repo = "libosmocore";
+    rev = "8649d57f507d359c99a89654aac7e19ce22db282";
+    sha256 = "08mcpy9ljwb1i3l4cmlwn024q2psk5gg9f0ylgh99hy1ffx0n7am";
+  };
+
+  buildInputs = [
+    autoreconfHook pcsclite pkgconfig
+  ];
+
+  preConfigure = ''
+    autoreconf -i -f
+  '';
+
+  meta = with stdenv.lib; {
+    description = "libosmocore";
+    homepage = https://github.com/osmocom/libosmocore;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8485,6 +8485,8 @@ in
 
   libosip_3 = callPackage ../development/libraries/osip/3.nix {};
 
+  libosmocore = callPackage ../applications/misc/libosmocore { };
+
   libosmpbf = callPackage ../development/libraries/libosmpbf {};
 
   libotr = callPackage ../development/libraries/libotr { };
@@ -13155,10 +13157,16 @@ in
   };
 
   gnuradio-with-packages = callPackage ../applications/misc/gnuradio/wrapper.nix {
-    extraPackages = [ gnuradio-nacl gnuradio-osmosdr ];
+    extraPackages = [ gnuradio-nacl gnuradio-osmosdr gnuradio-gsm gnuradio-ais gnuradio-rds ];
   };
 
   gnuradio-nacl = callPackage ../applications/misc/gnuradio-nacl { };
+
+  gnuradio-gsm = callPackage ../applications/misc/gnuradio-gsm { };
+
+  gnuradio-ais = callPackage ../applications/misc/gnuradio-ais { };
+
+  gnuradio-rds = callPackage ../applications/misc/gnuradio-rds { };
 
   gnuradio-osmosdr = callPackage ../applications/misc/gnuradio-osmosdr { };
 


### PR DESCRIPTION
###### Motivation for this change

This adds three new blocks to gnuradio and the dependency needed for them.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
