### PR TITLE
stdenv substitute: fail on non-existant input file

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -389,6 +389,11 @@ substitute() {
     local input="$1"
     local output="$2"
 
+    if [ ! -f "$input" ]; then
+      echo "substitute: File \"$input\" does not exist"
+      return 1
+    fi
+
     local -a params=("$@")
 
     local n p pattern replacement varName content


### PR DESCRIPTION
Citing @edolstra in #9744:

> For example, the upower expression has:
> 
> ```
>   substituteInPlace src/notify-upower.sh \
>     --replace /usr/bin/dbus-send ${dbus_tools}/bin/dbus-send
> ```
> 
> but src/notify-upower.sh doesn't exist. The builder just prints
> 
> cat: src/notify-upower.sh: No such file or directory
> 
> and continues.

fixes #9744

This makes this a hard error, we've had this enabled for a few weeks on our master branch and fixed some errors, and pushed them to nixos/nixpkgs master already, but there probably are more cases, these are very simple to fix by simply removing the invocation and checking if another file needs substituting in its place. Could warrant its own jobset on hydra, but I'd be inclined to push it to staging directly.
