### PR TITLE
mstflint: 3.7.0-1.18 -> 4.4.0-1.12.gd1edd58

### DIFF
--- a/pkgs/tools/misc/mstflint/default.nix
+++ b/pkgs/tools/misc/mstflint/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, zlib, libibmad }:
 
-stdenv.mkDerivation {
-  name = "mstflint-3.7.0-1.18";
+stdenv.mkDerivation rec {
+  name = "mstflint-4.4.0-1.12.gd1edd58";
 
   src = fetchurl {
-    url = "https://www.openfabrics.org/downloads/mstflint/mstflint-3.7.0-1.18.gcdb9f80.tar.gz";
-    sha256 = "10x4l3i58ynnni18i8qq1gfbqd2028r4jd3frshiwrl9yrj7sxn2";
+    url = "https://www.openfabrics.org/downloads/mstflint/${name}.tar.gz";
+    sha256 = "0kg33i5s5zdc7kigww62r0b824zfw06r757fl6jwrq7lj91j0380";
   };
 
   buildInputs = [ zlib libibmad ];


### PR DESCRIPTION
###### Motivation for this change

To fix build under recent GCC versions. Note, I'm not using mstflint myself so I cannot vouch for the functionality. Running the binaries with the `--help` command line argument works fine, though.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
