### PR TITLE
blink1-tool: init at 1.98

### DIFF
--- a/pkgs/tools/misc/blink1-tool/default.nix
+++ b/pkgs/tools/misc/blink1-tool/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, libusb1, pkgconfig, ... }:
+
+stdenv.mkDerivation rec {
+  name = "blink1-${version}";
+  version = "v1.98";
+
+  src = fetchurl {
+    url = "https://github.com/todbot/blink1/archive/${version}.tar.gz";
+    sha256 = "05hbnp20cdvyyqf6jr01waz1ycis20qzsd8hn27snmn6qd48igrb";
+  };
+
+  buildInputs = [ libusb1 pkgconfig ];
+
+  configurePhase = ''
+    cd commandline
+  '';
+
+  installPhase = ''
+    PREFIX=$out make install
+  '';
+
+  meta = {
+    description = "Command line client for the blink(1) notification light";
+    homepage = https://blink1.thingm.com/;
+    license = stdenv.lib.licenses.cc-by-sa-30;
+    maintainers = [ stdenv.lib.maintainers.cransom ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -592,6 +592,8 @@ in
     gnutls = gnutls33;
   };
 
+  blink1-tool = callPackage ../tools/misc/blink1-tool { };
+
   blitz = callPackage ../development/libraries/blitz { };
 
   blockdiag = pythonPackages.blockdiag;


### PR DESCRIPTION
###### Motivation for this change

This client has a few more useful options than the one that gets distributed in the Haskell packages.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The command line tool for the blink(1) notification light.
