### PR TITLE
python3.5-jupyter: Fix build issue #17902

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation {
 
   prePatch = optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
+    substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
   '';
 
   preConfigure = ''

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -57,6 +57,7 @@ stdenv.mkDerivation {
 
   prePatch = optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
+    substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
   '';
 
   preConfigure = ''

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation {
 
   prePatch = optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
+    substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
   '';
 
   preConfigure = ''

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, mkPythonDerivation, python, pkgconfig, glib, gobjectIntrospection, pycairo, cairo }:
+{ stdenv, fetchurl, mkPythonDerivation, python, pkgconfig, glib, gobjectIntrospection, pycairo, cairo, which, ncurses}:
 
 mkPythonDerivation rec {
   major = "3.20";
@@ -10,12 +10,13 @@ mkPythonDerivation rec {
     sha256 = "0ikzh3l7g1gjh8jj8vg6mdvrb25svp63gxcam4m0i404yh0lgari";
   };
 
-  buildInputs = [ pkgconfig glib gobjectIntrospection ];
+  buildInputs = [ pkgconfig glib gobjectIntrospection ]
+                 ++ stdenv.lib.optionals stdenv.isDarwin [ which ncurses ];
   propagatedBuildInputs = [ pycairo cairo ];
 
   meta = {
     homepage = http://live.gnome.org/PyGObject;
     description = "Python bindings for Glib";
-    platforms = lib.platforms.unix;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/pyqt/4.x.nix
+++ b/pkgs/development/python-modules/pyqt/4.x.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, pythonPackages, qt4, pkgconfig, lndir, dbus_libs, makeWrapper }:
+{ stdenv, fetchurl, pythonPackages, qt4, pkgconfig, lndir, dbus_libs, makeWrapper }:
 
 let
   version = "4.11.3";
@@ -17,9 +17,15 @@ in mkPythonDerivation {
     rm -rf "$out/nix-support"
 
     export PYTHONPATH=$PYTHONPATH:$out/lib/${python.libPrefix}/site-packages
+    ${stdenv.lib.optionalString stdenv.isDarwin ''
+      export QMAKESPEC="unsupported/macx-clang-libc++" # OS X target after bootstrapping phase \
+    ''}
 
     substituteInPlace configure.py \
-      --replace 'install_dir=pydbusmoddir' "install_dir='$out/lib/${python.libPrefix}/site-packages/dbus/mainloop'"
+      --replace 'install_dir=pydbusmoddir' "install_dir='$out/lib/${python.libPrefix}/site-packages/dbus/mainloop'" \
+    ${stdenv.lib.optionalString stdenv.isDarwin ''
+      --replace "qt_macx_spec = 'macx-g++'" "qt_macx_spec = 'unsupported/macx-clang-libc++'" # for bootstrapping phase \
+    ''}
 
     configureFlagsArray=( \
       --confirm-license --bindir $out/bin \
@@ -50,7 +56,7 @@ in mkPythonDerivation {
     description = "Python bindings for Qt";
     license = "GPL";
     homepage = http://www.riverbankcomputing.co.uk;
-    maintainers = [ lib.maintainers.sander ];
-    platforms = lib.platforms.mesaPlatforms;
+    maintainers = [ stdenv.lib.maintainers.sander ];
+    platforms = stdenv.lib.platforms.mesaPlatforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes the python3.5-jupyter build issue #17902. 
###### Details

A few modules needed fixing for this:
- The pygobject3 package needed `which` and `ncurses` on darwin. (On darwin pygobject3 needs to find the libraries python3.5 was built with, in our case `ncurses`).
- The pygobject3 package build script was confused because `python3.5-config --ldflags` contained `-Wl,-stack_size,1000000`, which upstream uses so some deep recursions in their unit tests work. However the `python3.rb` Formula on homebrew ignores this flag and `doCheck` is not set to true anyway, so we follow the same approach and compile python3.5 without the stack_size flag.
- pyqt4 needs the target platform `unsupported/macx-clang-libc++` in two phases: first the bootstrapping phase where qt stuff is found and second the build phase.
###### Things done
- [ ] Tested using sandboxing ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS, or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
