### PR TITLE
Revert "audit: 2.4.4 -> 2.6.6"

### DIFF
--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -5,11 +5,11 @@
 assert enablePython -> python != null;
 
 stdenv.mkDerivation rec {
-  name = "audit-2.6.6";
+  name = "audit-2.4.4";
 
   src = fetchurl {
     url = "http://people.redhat.com/sgrubb/audit/${name}.tar.gz";
-    sha256 = "0jwrww1vn7yqxmb84n6y4p58z34gga0ic4rs2msvpzc2x1hxrn31";
+    sha256 = "08sfcx8ykcn5jsryil15q8yqm0a8czymyqbb2sqxfc1jbx37zx95";
   };
 
   buildInputs = [ openldap ]


### PR DESCRIPTION
###### Motivation for this change

There's an display-manager black screen prolong halt (well over 10 minutes) followed by a stuck login. The issue has been replicated in two vms on two different machines with the following settings: https://gist.github.com/RamKromberg/1145eafc7a92a7515bfb63fca0fadf87

The discussion can be found over at the IRC logs (preceding 2016-08-27 01:30 for a few hours; Users: RamiK clever abbradar)

Notes: Disabling the networking doesn't work. It simply expedites the boot to tty.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This reverts commit 29ec1c6b09bbde3b874e839ec89d79b11c6865a9.
