### PR TITLE
Vapoursynth

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,56 +1,70 @@
-{ stdenv, fetchurl, fetchFromGitHub, docutils, makeWrapper, perl, pkgconfig
-, python, which, ffmpeg, freefont_ttf, freetype, libass, libpthreadstubs
-, lua, lua5_sockets
-, libuchardet, rubberband
-, x11Support ? true, libX11 ? null, libXext ? null, mesa ? null, libXxf86vm ? null
-, xineramaSupport ? true, libXinerama ? null
-, xvSupport ? true, libXv ? null
-, sdl2Support? true, SDL2 ? null
-, alsaSupport ? true, alsaLib ? null
-, screenSaverSupport ? true, libXScrnSaver ? null
-, vdpauSupport ? true, libvdpau ? null
-, dvdreadSupport? true, libdvdread ? null
-, dvdnavSupport ? true, libdvdnav ? null
-, bluraySupport ? true, libbluray ? null
-, speexSupport ? true, speex ? null
-, theoraSupport ? true, libtheora ? null
-, jackaudioSupport ? false, libjack2 ? null
-, pulseSupport ? true, libpulseaudio ? null
-, bs2bSupport ? true, libbs2b ? null
-# For screenshots
-, libpngSupport ? true, libpng ? null
-# for Youtube support
-, youtubeSupport ? true, youtube-dl ? null
-, cacaSupport ? true, libcaca ? null
-, vaapiSupport ? false, libva ? null
-, waylandSupport ? false, wayland ? null, libxkbcommon ? null
+{ stdenv, fetchurl, fetchFromGitHub, makeWrapper
+, docutils, perl, pkgconfig, python3, which, ffmpeg
+, freefont_ttf, freetype, libass, libpthreadstubs
+, lua, lua5_sockets, libuchardet, rubberband
+
+, x11Support ? true,
+    mesa       ? null,
+    libX11     ? null,
+    libXext    ? null,
+    libXxf86vm ? null
+
+, waylandSupport ? false,
+    wayland      ? null,
+    libxkbcommon ? null
+
+, xineramaSupport    ? true,  libXinerama   ? null
+, xvSupport          ? true,  libXv         ? null
+, sdl2Support        ? true,  SDL2          ? null
+, alsaSupport        ? true,  alsaLib       ? null
+, screenSaverSupport ? true,  libXScrnSaver ? null
+, vdpauSupport       ? true,  libvdpau      ? null
+, dvdreadSupport     ? true,  libdvdread    ? null
+, dvdnavSupport      ? true,  libdvdnav     ? null
+, bluraySupport      ? true,  libbluray     ? null
+, speexSupport       ? true,  speex         ? null
+, theoraSupport      ? true,  libtheora     ? null
+, pulseSupport       ? true,  libpulseaudio ? null
+, bs2bSupport        ? true,  libbs2b       ? null
+, cacaSupport        ? true,  libcaca       ? null
+, libpngSupport      ? true,  libpng        ? null
+, youtubeSupport     ? true,  youtube-dl    ? null
+, vapoursynthSupport ? false, vapoursynth   ? null
+, jackaudioSupport   ? false, libjack2      ? null
+, vaapiSupport       ? false, libva         ? null
+
 # scripts you want to be loaded by default
 , scripts ? []
 }:
 
-assert x11Support -> (libX11 != null && libXext != null && mesa != null && libXxf86vm != null);
-assert xineramaSupport -> (libXinerama != null && x11Support);
-assert xvSupport -> (libXv != null && x11Support);
-assert sdl2Support -> SDL2 != null;
-assert alsaSupport -> alsaLib != null;
-assert screenSaverSupport -> libXScrnSaver != null;
-assert vdpauSupport -> libvdpau != null;
-assert dvdreadSupport -> libdvdread != null;
-assert dvdnavSupport -> libdvdnav != null;
-assert bluraySupport -> libbluray != null;
-assert speexSupport -> speex != null;
-assert theoraSupport -> libtheora != null;
-assert jackaudioSupport -> libjack2 != null;
-assert pulseSupport -> libpulseaudio != null;
-assert bs2bSupport -> libbs2b != null;
-assert libpngSupport -> libpng != null;
-assert youtubeSupport -> youtube-dl != null;
-assert cacaSupport -> libcaca != null;
-assert waylandSupport -> (wayland != null && libxkbcommon != null);
+with stdenv.lib;
+
+let 
+  available = x: x != null;
+in
+assert x11Support         -> all available [mesa libX11 libXext libXxf86vm];
+assert waylandSupport     -> all available [wayland libxkbcommon];
+assert xineramaSupport    -> x11Support && available libXinerama;
+assert xvSupport          -> x11Support && available libXv;
+assert sdl2Support        -> available SDL2;
+assert alsaSupport        -> available alsaLib;
+assert screenSaverSupport -> available libXScrnSaver;
+assert vdpauSupport       -> available libvdpau;
+assert dvdreadSupport     -> available libdvdread;
+assert dvdnavSupport      -> available libdvdnav;
+assert bluraySupport      -> available libbluray;
+assert speexSupport       -> available speex;
+assert theoraSupport      -> available libtheora;
+assert pulseSupport       -> available libpulseaudio;
+assert bs2bSupport        -> available libbs2b;
+assert cacaSupport        -> available libcaca;
+assert libpngSupport      -> available libpng;
+assert youtubeSupport     -> available youtube-dl;
+assert vapoursynthSupport -> available vapoursynth;
+assert jackaudioSupport   -> available libjack2;
+assert vaapiSupport       -> available libva;
 
 let
-  inherit (stdenv.lib) optional optionals optionalString concatStringsSep;
-
   # Purity: Waf is normally downloaded by bootstrap.py, but
   # for purity reasons this behavior should be avoided.
   wafVersion = "1.8.12";
@@ -59,16 +73,14 @@ let
              "http://www.freehackers.org/~tnagy/release/waf-${wafVersion}" ];
     sha256 = "12y9c352zwliw0zk9jm2lhynsjcf5jy0k1qch1c1av8hnbm2pgq1";
   };
-in
-
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   name = "mpv-${version}";
   version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "mpv-player";
-    repo = "mpv";
-    rev = "v${version}";
+    repo  = "mpv";
+    rev    = "v${version}";
     sha256 = "14rbglrcplhkf16ik4fbcv7k27lz6h4glfayr12ylh98srmsscqa";
   };
 
@@ -80,60 +92,65 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-libmpv-shared"
+    "--enable-manpage-build"
+    "--enable-zsh-comp"
     "--disable-libmpv-static"
     "--disable-static-build"
-    "--enable-manpage-build"
     "--disable-build-date" # Purity
-    "--enable-zsh-comp"
-  ] ++ optional vaapiSupport "--enable-vaapi"
-  ++ optional waylandSupport "--enable-wayland";
+    (enableFeature vaapiSupport "vaapi")
+    (enableFeature waylandSupport "wayland")
+  ];
 
   configurePhase = ''
-    python ${waf} configure --prefix=$out $configureFlags
+    python3 ${waf} configure --prefix=$out $configureFlags
   '';
 
-  nativeBuildInputs = [ docutils makeWrapper perl pkgconfig python which ];
+  nativeBuildInputs = [ docutils makeWrapper perl pkgconfig python3 which ];
 
   buildInputs = [
-    ffmpeg freetype libass libpthreadstubs lua lua5_sockets libuchardet rubberband
-  ] ++ optionals x11Support [ libX11 libXext mesa libXxf86vm ]
-    ++ optional alsaSupport alsaLib
-    ++ optional xvSupport libXv
-    ++ optional theoraSupport libtheora
-    ++ optional xineramaSupport libXinerama
-    ++ optional dvdreadSupport libdvdread
-    ++ optionals dvdnavSupport [ libdvdnav libdvdnav.libdvdread ]
-    ++ optional bluraySupport libbluray
-    ++ optional jackaudioSupport libjack2
-    ++ optional pulseSupport libpulseaudio
+    ffmpeg freetype libass libpthreadstubs
+    lua lua5_sockets libuchardet rubberband
+  ] ++ optional alsaSupport        alsaLib
+    ++ optional xvSupport          libXv
+    ++ optional theoraSupport      libtheora
+    ++ optional xineramaSupport    libXinerama
+    ++ optional dvdreadSupport     libdvdread
+    ++ optional bluraySupport      libbluray
+    ++ optional jackaudioSupport   libjack2
+    ++ optional pulseSupport       libpulseaudio
     ++ optional screenSaverSupport libXScrnSaver
-    ++ optional vdpauSupport libvdpau
-    ++ optional speexSupport speex
-    ++ optional bs2bSupport libbs2b
-    ++ optional libpngSupport libpng
-    ++ optional youtubeSupport youtube-dl
-    ++ optional sdl2Support SDL2
-    ++ optional cacaSupport libcaca
-    ++ optional vaapiSupport libva
-    ++ optionals waylandSupport [ wayland libxkbcommon ];
+    ++ optional vdpauSupport       libvdpau
+    ++ optional speexSupport       speex
+    ++ optional bs2bSupport        libbs2b
+    ++ optional libpngSupport      libpng
+    ++ optional youtubeSupport     youtube-dl
+    ++ optional sdl2Support        SDL2
+    ++ optional cacaSupport        libcaca
+    ++ optional vaapiSupport       libva
+    ++ optional vapoursynthSupport vapoursynth
+    ++ optionals dvdnavSupport     [ libdvdnav libdvdnav.libdvdread ]
+    ++ optionals x11Support        [ libX11 libXext mesa libXxf86vm ]
+    ++ optionals waylandSupport    [ wayland libxkbcommon ];
 
   enableParallelBuilding = true;
 
   buildPhase = ''
-    python ${waf} build
+    python3 ${waf} build
   '';
 
   installPhase = ''
-    python ${waf} install
+    python3 ${waf} install
 
     # Use a standard font
     mkdir -p $out/share/mpv
     ln -s ${freefont_ttf}/share/fonts/truetype/FreeSans.ttf $out/share/mpv/subfont.ttf
-  '' + optionalString youtubeSupport ''
     # Ensure youtube-dl is available in $PATH for MPV
     wrapProgram $out/bin/mpv \
+      --add-flags "--script=${concatStringsSep "," scripts}" \
+  '' + optionalString youtubeSupport ''
       --prefix PATH : "${youtube-dl}/bin" \
-      --add-flags "--script=${concatStringsSep "," scripts}"
+  '' + optionalString vapoursynthSupport ''
+      --prefix PYTHONPATH : "$(toPythonPath ${vapoursynth}):$PYTHONPATH"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/vapoursynth-mvtools/default.nix
+++ b/pkgs/development/libraries/vapoursynth-mvtools/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook,
+  vapoursynth, yasm, fftwFloat
+}:
+
+stdenv.mkDerivation rec {
+  name = "vapoursynth-mvtools-${version}";
+  version = "16";
+
+  src = fetchFromGitHub {
+    owner = "dubhater";
+    repo  = "vapoursynth-mvtools";
+    rev    = "48959b868c18fa8066502f957734cbd5fb9762a0";
+    sha256 = "15xpqvfzhv0kcf3gyghni4flazi1mmj2iy6zw5834phqr52yg07z";
+  };
+
+  buildInputs = [
+    pkgconfig autoreconfHook
+    yasm vapoursynth fftwFloat
+  ];
+
+  configureFlags = "--libdir=$(out)/lib/vapoursynth";
+
+  meta = with stdenv.lib; {
+    description = "A set of filters for motion estimation and compensation";
+    homepage = https://github.com/dubhater/vapoursynth-mvtools;
+    license  = licenses.gpl2;
+    maintainers = with maintainers; [ rnhmjoj ];
+  };
+}

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook,
+  glibc, zimg, imagemagick, libass, tesseract, yasm,
+  python3
+}:
+
+stdenv.mkDerivation rec {
+  name = "vapoursynth-${version}";
+  version = "R33.1";
+
+  src = fetchFromGitHub {
+    owner = "vapoursynth";
+    repo  = "vapoursynth";
+    rev    = "0d69d29abb3c4ba9e806958bf9c539bd6eff6852";
+    sha256 = "1dbz81vgqfsb306d7891p8y25y7632y32ii3l64shr0jsq64vgsm";
+  };
+
+  buildInputs = [
+    pkgconfig autoreconfHook
+    zimg imagemagick libass glibc tesseract yasm
+    (python3.withPackages (ps: with ps; [ sphinx cython ]))
+  ];
+
+  configureFlags = [
+    "--enable-imwri"
+    "--disable-static"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A video processing framework with the future in mind";
+    homepage = http://www.vapoursynth.com/;
+    license   = licenses.lgpl21;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ rnhmjoj ];
+  };
+
+}

--- a/pkgs/development/libraries/zimg/default.nix
+++ b/pkgs/development/libraries/zimg/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec{
+  name = "zimg-${version}";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "sekrit-twc";
+    repo  = "zimg";
+    rev    = "e88b156fdd6d5ae647bfc68a30e86d14f214764d";
+    sha256 = "1hb35pm9ykdyhg71drd59yy29d154m2r1mr8ikyzpi3knanjn23a";
+  };
+
+  buildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    description = "Scaling, colorspace conversion and dithering library";
+    homepage = https://github.com/sekrit-twc/zimg;
+    license  = licenses.wtfpl;
+    platform = platforms.linux; # check upstream issue #52
+    maintainers = with maintainers; [ rnhmjoj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16098,6 +16098,8 @@ in
 
   vapor = callPackage ../games/vapor { love = love_0_8; };
 
+  vapoursynth = callPackage ../development/libraries/vapoursynth { };
+
   vassal = callPackage ../games/vassal { };
 
   vdrift = callPackage ../games/vdrift { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17679,6 +17679,8 @@ in
 
   maphosts = callPackage ../tools/networking/maphosts {};
 
+  zimg = callPackage ../development/libraries/zimg { };
+
   zuki-themes = callPackage ../misc/themes/zuki { };
 
   zoom-us = qt55.callPackage ../applications/networking/instant-messengers/zoom-us {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16100,6 +16100,8 @@ in
 
   vapoursynth = callPackage ../development/libraries/vapoursynth { };
 
+  vapoursynth-mvtools = callPackage ../development/libraries/vapoursynth-mvtools { };
+
   vassal = callPackage ../games/vassal { };
 
   vdrift = callPackage ../games/vdrift { };


### PR DESCRIPTION
###### Motivation for this change

Add packages for vapoursynth and other dependencies and enable vapoursynth scripting support in mpv. The true motivation is having 24Hz -> 60Hz motion frame interpolation.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
