### PR TITLE
kdevelop: Init at 5.0

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, cmake, pkgconfig, extra-cmake-modules, qtbase }:
+
+let
+  pname = "kdevelop-pg-qt";
+  version = "2.0";
+  dirVersion = "2.0.0";
+
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/${dirVersion}/src/${name}.tar.xz";
+    sha256 = "2f778d324b7c0962e8bb5f62dd2643bac1a6f3ac971d145b6aace7cd61878993";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig extra-cmake-modules ];
+  
+  buildInputs = [ qtbase ];
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.ambrop72 ];
+    platforms = platforms.linux;
+    description = "Parser-generator from KDevplatform";
+    longDescription = ''
+      KDevelop-PG-Qt is the parser-generator from KDevplatform.
+      It is used for some KDevelop-languagesupport-plugins (Ruby, PHP, CSS...).
+    '';
+    homepage = https://www.kdevelop.org;
+    license = with stdenv.lib.licenses; [ lgpl2Plus ];
+  };
+}

--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchurl, cmake, gettext, pkgconfig, extra-cmake-modules, makeQtWrapper
+, qtquickcontrols, qtwebkit
+, kconfig, kdeclarative, kdoctools, kiconthemes, ki18n, kitemmodels, kitemviews
+, kjobwidgets, kcmutils, kio, knewstuff, knotifyconfig, kparts, ktexteditor
+, threadweaver, kxmlgui, kwindowsystem
+, plasma-framework, krunner, kdevplatform, kdevelop-pg-qt, shared_mime_info
+, libksysguard, llvmPackages
+}:
+
+let
+  pname = "kdevelop";
+  version = "5.0";
+  dirVersion = "5.0.0";
+
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/${dirVersion}/src/${name}.tar.xz";
+    sha256 = "5e034b8670f4ba13ccb2948c28efa0b54df346e85b648078698cca8974ea811c";
+  };
+
+  nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules makeQtWrapper ];
+
+  buildInputs = [
+    qtquickcontrols qtwebkit
+    kconfig kdeclarative kdoctools kiconthemes ki18n kitemmodels kitemviews
+    kjobwidgets kcmutils kio knewstuff knotifyconfig kparts ktexteditor
+    threadweaver kxmlgui kwindowsystem plasma-framework krunner
+    kdevplatform kdevelop-pg-qt shared_mime_info libksysguard
+    llvmPackages.llvm llvmPackages.clang-unwrapped
+  ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/kdevelop"
+  '';
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.ambrop72 ];
+    platforms = platforms.linux;
+    description = "KDE official IDE";
+    longDescription =
+      ''
+        A free, opensource IDE (Integrated Development Environment)
+        for MS Windows, Mac OsX, Linux, Solaris and FreeBSD. It is a
+        feature-full, plugin extendable IDE for C/C++ and other
+        programing languages. It is based on KDevPlatform, KDE and Qt
+        libraries and is under development since 1998.
+      '';
+    homepage = https://www.kdevelop.org;
+    license = with stdenv.lib.licenses; [ gpl2Plus lgpl2Plus ];
+  };
+}

--- a/pkgs/applications/editors/kdevelop5/kdevplatform.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevplatform.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, cmake, gettext, pkgconfig, extra-cmake-modules, makeQtWrapper
+, boost, subversion, apr, aprutil
+, qtscript, qtwebkit, grantlee, karchive, kconfig, kcoreaddons, kguiaddons, kiconthemes, ki18n
+, kitemmodels, kitemviews, kio, kparts, sonnet, kcmutils, knewstuff, knotifications
+, knotifyconfig, ktexteditor, threadweaver, kdeclarative, libkomparediff2 }:
+
+let
+  pname = "kdevplatform";
+  version = "5.0";
+  dirVersion = "5.0.0";
+
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  
+  src = fetchurl {
+    url = "mirror://kde/stable/kdevelop/${dirVersion}/src/${name}.tar.xz";
+    sha256 = "4085b355ab8d599d902afbc11027e1aefb22afe30d63ed54ea5fe02f24edfd10";
+  };
+
+  nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules makeQtWrapper ];
+
+  propagatedBuildInputs = [ ];
+  buildInputs = [
+    boost subversion apr aprutil
+    qtscript qtwebkit grantlee karchive kconfig kcoreaddons kguiaddons kiconthemes
+    ki18n kitemmodels kitemviews kio kparts sonnet kcmutils knewstuff
+    knotifications knotifyconfig ktexteditor threadweaver kdeclarative
+    libkomparediff2
+  ];
+
+  meta = with stdenv.lib; {
+    maintainers = [ maintainers.ambrop72 ];
+    platforms = platforms.linux;
+    description = "KDE libraries for IDE-like programs";
+    longDescription = ''
+      A free, opensource set of libraries that can be used as a foundation for
+      IDE-like programs. It is programing-language independent, and is planned
+      to be used by programs like: KDevelop, Quanta, Kile, KTechLab ... etc."
+    '';
+    homepage = https://www.kdevelop.org;
+    license = with stdenv.lib.licenses; [ gpl2Plus lgpl2Plus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13686,6 +13686,14 @@ in
 
   kdeconnect = qt5.callPackage ../applications/misc/kdeconnect { };
 
+  kdevelop-pg-qt = kde5.callPackage ../applications/editors/kdevelop5/kdevelop-pg-qt.nix {};
+
+  kdevelop = kde5.callPackage ../applications/editors/kdevelop5/kdevelop.nix {
+    llvmPackages = llvmPackages_38;
+  };
+
+  kdevplatform = kde5.callPackage ../applications/editors/kdevelop5/kdevplatform.nix {};
+
   keepnote = callPackage ../applications/office/keepnote {
     pygtk = pyGtkGlade;
   };


### PR DESCRIPTION
###### Motivation for this change

New major release.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Doesn't use Okteta yet.
