### PR TITLE
ethabi: init at 0.2.1

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -27,6 +27,8 @@ rec {
   namecoin  = callPackage ./namecoin.nix  { inherit namecoind; };
   namecoind = callPackage ./namecoind.nix { };
 
+  ethabi = callPackage ./ethabi.nix { };
+
   primecoin  = callPackage ./primecoin.nix { withGui = true; };
   primecoind = callPackage ./primecoin.nix { withGui = false; };
 

--- a/pkgs/applications/altcoins/ethabi.nix
+++ b/pkgs/applications/altcoins/ethabi.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "ethabi-${version}";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ethcore";
+    repo = "ethabi";
+    rev = "fbed04984cab0db8767e01054ee16271b8e36281";
+    sha256 = "1zgyyg1i5wmz8l1405yg5jmq4ddq530sl7018pkkc7l6cjj3bbhd";
+  };
+
+  depsSha256 = "0srxv0wbhvyflc967lkpd2mx5nk7asx2cbxa0qxvas16wy6vxz52";
+
+  meta = {
+    description = "Ethereum function call encoding (ABI) utility";
+    homepage = https://github.com/ethcore/ethabi/;
+    maintainers = [stdenv.lib.maintainers.dbrock];
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12377,6 +12377,7 @@ in
   bitcoin-xt = self.altcoins.bitcoin-xt;
 
   go-ethereum = self.altcoins.go-ethereum;
+  ethabi = self.altcoins.ethabi;
 
   aumix = callPackage ../applications/audio/aumix {
     gtkGUI = false;


### PR DESCRIPTION
###### Motivation for this change

The `ethabi(1)` utility from Ethcore is a very useful building block for applications that need to interact with the Ethereum blockchain. https://github.com/ethcore/ethabi

Related to but independent of https://github.com/NixOS/nixpkgs/pull/17670
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
