### PR TITLE
jabref: 3.5 -> 3.6

### DIFF
--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, makeDesktopItem, ant, jdk, jre }:
 
 stdenv.mkDerivation rec {
-  version = "3.5";
+  version = "3.6";
   name = "jabref-${version}";
 
   src = fetchurl {
     url = "https://github.com/JabRef/jabref/releases/download/v${version}/JabRef-${version}.jar";
-    sha256 = "19q86xc8qr6j8zd9rsc6aa3jd4kbblkr6ik1h6h7npq012019adm";
+    sha256 = "140fixwffw463dprgg6kcccsp833dnclzjzvwmqs7dq0f9y2nyc5";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
