### PR TITLE
keepassx2-http: init at 2.0.2 | second try.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -354,6 +354,7 @@
   ryantm = "Ryan Mulligan <ryan@ryantm.com>";
   rycee = "Robert Helgesson <robert@rycee.net>";
   ryneeverett = "Ryne Everett <ryneeverett@gmail.com>";
+  s1lvester = "Markus Silvester <s1lvester@bockhacker.me>";
   samuelrivas = "Samuel Rivas <samuelrivas@gmail.com>";
   sander = "Sander van der Burg <s.vanderburg@tudelft.nl>";
   schmitthenner = "Fabian Schmitthenner <development@schmitthenner.eu>";

--- a/pkgs/applications/misc/keepassx/2.0-http.nix
+++ b/pkgs/applications/misc/keepassx/2.0-http.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, libgcrypt, qt5, zlib, libmicrohttpd, libXtst }:
+
+stdenv.mkDerivation rec {
+  name = "keepassx2-http-unstable-${version}";
+  version = "2016-05-27";
+
+  src = fetchFromGitHub {
+    owner = "droidmonkey";
+    repo = "keepassx_http";
+    rev = "bb2e1ee8da3a3245c3ca58978a979dd6b5c2472a";
+    sha256 = "1rlbjs0i1kbrkksliisnykhki8f15g09xm3fwqlgcfc2czwbv5sv";
+  };
+
+  buildInputs = [ cmake libgcrypt zlib qt5.full libXtst libmicrohttpd ];
+
+  meta = {
+    description = "Fork of the keepassX password-manager with additional http-interface to allow browser-integration an use with plugins such as PasslFox (https://github.com/pfn/passifox). See also keepassX2.";
+    homepage = http://www.keepassx.org/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ s1lvester ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13056,6 +13056,7 @@ in
 
   keepassx = callPackage ../applications/misc/keepassx { };
   keepassx2 = callPackage ../applications/misc/keepassx/2.0.nix { };
+  keepassx2-http = callPackage ../applications/misc/keepassx/2.0-http.nix { };
 
   inherit (gnome3) evince;
   evolution_data_server = gnome3.evolution_data_server;


### PR DESCRIPTION
###### Motivation for this change

keepassX2 is an qt-based frontend for kdbx-files. Compared with keepass (which offers an http-interface for browser integration via plugin) we don't need to run mono to use keepass2 files.
kepassX2 however doesn't provide broser-integration, so good people like droidmonkey patched the http-plugin into keepassX. So this is basically a derivation of the keepassX-Code with additional functionality.

Unfortunately I lost control over git... So i closed #17778 deleted my remote branches and opened this one.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
