### PR TITLE
gitg: use wrapGAppsHook, pull in dconf

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/misc/gitg/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/misc/gitg/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchurl, fetchgit, vala_0_32, intltool, libgit2, pkgconfig, gtk3, glib
-, json_glib, webkitgtk,  makeWrapper, libpeas, bash, gobjectIntrospection
-, gnome3, gtkspell3, shared_mime_info, libgee, libgit2-glib, librsvg, libsecret }:
+, json_glib, webkitgtk, wrapGAppsHook, libpeas, bash, gobjectIntrospection
+, gnome3, gtkspell3, shared_mime_info, libgee, libgit2-glib, librsvg, libsecret
+, dconf}:
+
 
 # TODO: icons and theme still does not work
 # use packaged gnome3.adwaita-icon-theme 
@@ -20,18 +22,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ vala_0_32 intltool libgit2 pkgconfig gtk3 glib json_glib webkitgtk libgee libpeas
                   libgit2-glib gtkspell3 gnome3.gsettings_desktop_schemas gnome3.gtksourceview
-                  librsvg libsecret
-                  gobjectIntrospection makeWrapper gnome3.adwaita-icon-theme ];
+                  librsvg libsecret dconf
+                  gobjectIntrospection gnome3.adwaita-icon-theme ];
+
+  nativeBuildInputs = [ wrapGAppsHook ];
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=758240
   preBuild = ''make -j$NIX_BUILD_CORES Gitg-1.0.gir'';
-
-  preFixup = ''
-    wrapProgram "$out/bin/gitg" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3.out}/share:${gnome3.gnome_themes_standard}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
-  '';
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/action/show/Apps/Gitg;


### PR DESCRIPTION
###### Motivation for this change

I don't wanna resize the window every time I open `gitg`. Also `wrapGAppsHook` seems pretty cool I guess.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Without dconf, gitg doesn't remember preferences such as window size.
