### PR TITLE
DisplayLink driver and module

### DIFF
--- a/nixos/modules/hardware/video/displaylink.nix
+++ b/nixos/modules/hardware/video/displaylink.nix
@@ -1,0 +1,61 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+
+  enabled = elem "displaylink" config.services.xserver.videoDrivers;
+
+  displaylink = config.boot.kernelPackages.displaylink;
+
+in
+
+{
+
+  config = mkIf enabled {
+
+    boot.extraModulePackages = [ displaylink ];
+
+    boot.kernelModules = [ "evdi" ];
+
+    # Those are taken from displaylink-installer.sh and from Arch Linux AUR package.
+
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="17e9", ATTR{bNumInterfaces}=="*5", TAG+="uaccess"
+    '';
+
+    powerManagement.powerDownCommands = ''
+      #flush any bytes in pipe
+      while read -n 1 -t 1 SUSPEND_RESULT < /tmp/PmMessagesPort_out; do : ; done;
+
+      #suspend DisplayLinkManager
+      echo "S" > /tmp/PmMessagesPort_in
+
+      #wait until suspend of DisplayLinkManager finish
+      read -n 1 -t 10 SUSPEND_RESULT < /tmp/PmMessagesPort_out
+    '';
+
+    powerManagement.resumeCommands = ''
+      #resume DisplayLinkManager
+      echo "R" > /tmp/PmMessagesPort_in
+    '';
+
+    systemd.services.displaylink = {
+      description = "DisplayLink Manager Service";
+      after = [ "display-manager.service" ];
+      wantedBy = [ "graphical.target" ];
+
+      serviceConfig = {
+        ExecStart = "${displaylink}/bin/DisplayLinkManager";
+        Restart = "always";
+        RestartSec = 5;
+      };
+
+      preStart = ''
+        mkdir -p /var/log/displaylink
+      '';
+    };
+
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -40,6 +40,7 @@
   ./hardware/video/amdgpu.nix
   ./hardware/video/ati.nix
   ./hardware/video/bumblebee.nix
+  ./hardware/video/displaylink.nix
   ./hardware/video/nvidia.nix
   ./hardware/video/webcam/facetimehd.nix
   ./i18n/input-method/default.nix

--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, lib, fetchurl, fetchFromGitHub, unzip, kernel, utillinux, libdrm, libusb1, makeWrapper }:
+
+let
+  arch =
+    if stdenv.system == "x86_64-linux" then "x64"
+    else if stdenv.system == "i686-linux" then "x86"
+    else throw "Unsupported architecture";
+  libPath = lib.makeLibraryPath [ stdenv.cc.cc utillinux libusb1 ];
+
+in stdenv.mkDerivation rec {
+  name = "displaylink-${version}";
+  version = "1.1.62";
+
+  src = fetchFromGitHub {
+    owner = "DisplayLink";
+    repo = "evdi";
+    rev = "fe779940ff9fc7b512019619e24a5b22e4070f6a";
+    sha256 = "02hw83f6lscms8hssjzf30hl9zly3b28qcxwmxvnqwfhx1q491z9";
+  };
+
+  daemon = fetchurl {
+    name = "displaylink.zip";
+    url = "http://www.displaylink.com/downloads/file?id=607";
+    sha256 = "0jky3xk4dfzbzg386qya9l9952i4m8zhf55fdl06pi9r82k2iijx";
+  };
+
+  nativeBuildInputs = [ unzip makeWrapper ];
+
+  buildInputs = [ kernel libdrm ];
+
+  buildCommand = ''
+    unpackPhase
+    cd $sourceRoot
+    unzip $daemon
+    chmod +x displaylink-driver-${version}.run
+    ./displaylink-driver-${version}.run --target daemon --noexec
+
+    ( cd module
+      export makeFlags="$makeFlags KVER=${kernel.modDirVersion} KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      export hardeningDisable="pic format"
+      buildPhase
+      install -Dm755 evdi.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gpu/drm/evdi/evdi.ko
+    )
+
+    ( cd library
+      buildPhase
+      install -Dm755 libevdi.so $out/lib/libevdi.so
+    )
+
+    fixupPhase
+
+    ( cd daemon
+      install -Dt $out/lib/displaylink *.spkg
+      install -Dm755 ${arch}/DisplayLinkManager $out/bin/DisplayLinkManager
+      patchelf \
+        --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+        --set-rpath $out/lib:${libPath} \
+        $out/bin/DisplayLinkManager
+      wrapProgram $out/bin/DisplayLinkManager \
+        --run "cd $out/lib/displaylink"
+    )
+  '';
+
+  meta = with stdenv.lib; {
+    description = "DisplayLink DL-5xxx, DL-41xx and DL-3x00 Driver for Linux";
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    license = licenses.unfree;
+    homepage = "http://www.displaylink.com/";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11241,6 +11241,8 @@ in
 
     cpupower = callPackage ../os-specific/linux/cpupower { };
 
+    displaylink = callPackage ../os-specific/linux/displaylink { };
+
     dpdk = callPackage ../os-specific/linux/dpdk { };
 
     pktgen = callPackage ../os-specific/linux/pktgen { };


### PR DESCRIPTION
###### Motivation for this change

Fixes #18023 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @chris-martin for testing. I don't have the necessary hardware so I've just packaged the driver and made a module closely following Arch's AUR package. To enable this:

```
  services.xserver.videoDrivers = [ "displaylink" ];
```
