### PR TITLE
kalibrate-hackrf: init at 2016-08-27

### DIFF
--- a/pkgs/tools/misc/kalibrate-hackrf/default.nix
+++ b/pkgs/tools/misc/kalibrate-hackrf/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, fftw, hackrf, libusb1 }:
+
+stdenv.mkDerivation rec {
+  name = "kalibrate-hackrf-unstable-20160827";
+
+  # There are no tags/releases, so use the latest commit from git master.
+  # Currently, the latest commit is from 2016-07-03.
+  src = fetchFromGitHub {
+    owner = "scateu";
+    repo = "kalibrate-hackrf";
+    rev = "2492c20822ca6a49dce97967caf394b1d4b2c43e";
+    sha256 = "1jvn1qx7csgycxpx1k804sm9gk5a0c65z9gh8ybp9awq3pziv0nx";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ fftw hackrf libusb1 ];
+
+  postInstall = ''
+    mv $out/bin/kal $out/bin/kal-hackrf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Calculate local oscillator frequency offset in hackrf devices";
+    longDescription = ''
+      Kalibrate, or kal, can scan for GSM base stations in a given frequency
+      band and can use those GSM base stations to calculate the local
+      oscillator frequency offset.
+
+      This package is for hackrf devices.
+    '';
+    homepage = https://github.com/scateu/kalibrate-hackrf;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2190,6 +2190,8 @@ in
 
   kalibrate-rtl = callPackage ../tools/misc/kalibrate-rtl { };
 
+  kalibrate-hackrf = callPackage ../tools/misc/kalibrate-hackrf { };
+
   kakoune = callPackage ../applications/editors/kakoune { };
 
   kbdd = callPackage ../applications/window-managers/kbdd { };


### PR DESCRIPTION
###### Motivation for this change

We have the rtl version this is the version for the hackrf.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
