### PR TITLE
Python plover fix

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13957,7 +13957,6 @@ in modules // {
       description = "OpenSteno Plover stenography software";
       maintainers = with maintainers; [ twey kovirobi ];
       license = licenses.gpl2;
-      broken = true;
     };
 
     src = pkgs.fetchurl {
@@ -13965,8 +13964,14 @@ in modules // {
       sha256 = "1jja37nhiypdx1z6cazp8ffsf0z3yqmpdbprpdzf668lcb422rl0";
     };
 
-    buildInputs = with self; [ pytest ];
-    propagatedBuildInputs = with self; [ wxPython pyserial hidapi xlib appdirs pkgs.wmctrl mock ];
+    # This is a fix for https://github.com/pypa/pip/issues/3624 causing regression https://github.com/pypa/pip/issues/3781
+    postPatch = ''
+     substituteInPlace setup.py --replace " in sys_platform" " == sys_platform"
+    '';
+
+    buildInputs = with self; [ pytest mock ];
+    propagatedBuildInputs = with self; [ six setuptools pyserial appdirs hidapi
+                                         wxPython xlib pkgs.wmctrl ];
   };
 
   pygal = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Fixes broken build (the added `patchPhase`) and updates it. Update relies on #18044 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
