### PR TITLE
cuyo: fix build

### DIFF
--- a/pkgs/games/cuyo/default.nix
+++ b/pkgs/games/cuyo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL, SDL_mixer }:
+{ stdenv, fetchurl, SDL, SDL_mixer, zlib }:
 
 stdenv.mkDerivation rec {
   name = "cuyo-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
      sha256 = "17yqv924x7yvwix7yz9jdhgyar8lzdhqvmpvv0any8rdkajhj23c";
      };
 
- buildInputs = [ SDL SDL_mixer];
+  buildInputs = [ SDL SDL_mixer zlib ];
      
   meta = {
      homepage = http://karimmi.de/cuyo;


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
