### PR TITLE
kobodeluxe: fix build

### DIFF
--- a/pkgs/games/kobodeluxe/default.nix
+++ b/pkgs/games/kobodeluxe/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, SDL, SDL_image} :
+{stdenv, fetchurl, SDL, SDL_image, mesa} :
 
 stdenv.mkDerivation {
   name = "kobodeluxe-0.5.1";
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
     sha256 = "0f7b910a399d985437564af8c5d81d6dcf22b96b26b01488d72baa6a6fdb5c2c";
   };
 
-  buildInputs = [ SDL SDL_image];
+  buildInputs = [ SDL SDL_image mesa ];
 
   prePatch = ''
     sed -e 's/char \*tok/const char \*tok/' -i graphics/window.cpp


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
