### PR TITLE
scummvm: fix build

### DIFF
--- a/pkgs/games/scummvm/default.nix
+++ b/pkgs/games/scummvm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL, zlib, libmpeg2, libmad, libogg, libvorbis, flac, alsaLib }:
+{ stdenv, fetchurl, SDL, zlib, libmpeg2, libmad, libogg, libvorbis, flac, alsaLib, mesa }:
 
 stdenv.mkDerivation rec {
   name = "scummvm-1.8.0";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0f3zgvz886lk9ps0v333aq74vx6grlx68hg14gfaxcvj55g73v01";
   };
   
-  buildInputs = [ SDL zlib libmpeg2 libmad libogg libvorbis flac alsaLib ];
+  buildInputs = [ SDL zlib libmpeg2 libmad libogg libvorbis flac alsaLib mesa ];
 
   crossAttrs = {
     preConfigure = ''


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
