### PR TITLE
Qt5: Enable Wayland support

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -92,7 +92,7 @@ let
       qtsvg = callPackage ./qtsvg.nix {};
       qttools = callPackage ./qttools {};
       qttranslations = callPackage ./qttranslations.nix {};
-      /* qtwayland = not packaged */
+      qtwayland = callPackage ./qtwayland.nix {};
       qtwebchannel = callPackage ./qtwebchannel.nix {};
       qtwebengine = callPackage ./qtwebengine.nix {};
       qtwebkit = callPackage ./qtwebkit {};
@@ -105,8 +105,8 @@ let
       full = env "qt-${qtbase.version}" [
         qtconnectivity qtdeclarative qtdoc qtenginio qtgraphicaleffects
         qtimageformats qtlocation qtmultimedia qtquickcontrols qtscript
-        qtsensors qtserialport qtsvg qttools qttranslations qtwebsockets
-        qtx11extras qtxmlpatterns
+        qtsensors qtserialport qtsvg qttools qttranslations qtwayland
+        qtwebsockets qtx11extras qtxmlpatterns
       ];
 
       makeQtWrapper = makeSetupHook { deps = [ makeWrapper ]; } ./make-qt-wrapper.sh;

--- a/pkgs/development/libraries/qt-5/5.6/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtwayland.nix
@@ -1,0 +1,8 @@
+{ qtSubmodule, qtbase, qtquickcontrols, wayland, pkgconfig }:
+
+qtSubmodule {
+  name = "qtwayland";
+  qtInputs = [ qtbase qtquickcontrols ];
+  buildInputs = [ wayland ];
+  nativeBuildInputs = [ pkgconfig ];
+}

--- a/pkgs/development/libraries/qt-5/5.7/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/default.nix
@@ -88,6 +88,7 @@ let
       qtsvg = callPackage ./qtsvg.nix {};
       qttools = callPackage ./qttools {};
       qttranslations = callPackage ./qttranslations.nix {};
+      qtwayland = callPackage ./qtwayland.nix {};
       qtwebchannel = callPackage ./qtwebchannel.nix {};
       qtwebengine = callPackage ./qtwebengine.nix {};
       qtwebkit = callPackage ./qtwebkit {};
@@ -99,8 +100,8 @@ let
       full = env "qt-${qtbase.version}" [
         qtconnectivity qtdeclarative qtdoc qtgraphicaleffects
         qtimageformats qtlocation qtmultimedia qtquickcontrols qtscript
-        qtsensors qtserialport qtsvg qttools qttranslations qtwebsockets
-        qtx11extras qtxmlpatterns
+        qtsensors qtserialport qtsvg qttools qttranslations qtwayland
+        qtwebsockets qtx11extras qtxmlpatterns
       ];
 
       makeQtWrapper =

--- a/pkgs/development/libraries/qt-5/5.7/qtwayland.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtwayland.nix
@@ -1,0 +1,8 @@
+{ qtSubmodule, qtbase, qtquickcontrols, wayland, pkgconfig }:
+
+qtSubmodule {
+  name = "qtwayland";
+  qtInputs = [ qtbase qtquickcontrols ];
+  buildInputs = [ wayland ];
+  nativeBuildInputs = [ pkgconfig ];
+}


### PR DESCRIPTION
###### Motivation for this change

This PR adds the qtwayland package which allows Qt5 apps to be run under Wayland.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
