### PR TITLE
xautolock: fix compilation

### DIFF
--- a/pkgs/misc/screensavers/xautolock/default.nix
+++ b/pkgs/misc/screensavers/xautolock/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
       url = "https://gist.githubusercontent.com/miekg/9430422/raw/f00965cd63c497d320f028a9972d1185b0dae039/14-add-lockaftersleep-patch";
       sha256 = "042lc5yyyl3zszll2l930apysd0lip26w0d0f0gjkl7sbhshgk8v";
     })
+    ./processwait.patch
   ];
   makeFlags="BINDIR=\${out}/bin MANPATH=\${out}/man";
   preBuild = "xmkmf";

--- a/pkgs/misc/screensavers/xautolock/processwait.patch
+++ b/pkgs/misc/screensavers/xautolock/processwait.patch
@@ -1,0 +1,11 @@
+--- xautolock-2.2.orig/src/engine.c	2016-08-28 09:49:39.013009496 +0200
++++ xautolock-2.2/src/engine.c	2016-08-28 10:24:24.486255036 +0200
+@@ -210,7 +210,7 @@
+ #else /* VMS */
+   if (lockerPid)
+   {
+-#if !defined (UTEKV) && !defined (SYSV) && !defined (SVR4)
++#if !defined (UTEKV) && !defined (SYSV) && !defined (SVR4) && !defined(__GLIBC__)
+     union wait  status;      /* childs process status */
+ #else /* !UTEKV && !SYSV && !SVR4 */
+     int         status = 0;  /* childs process status */


### PR DESCRIPTION
###### Motivation for this change

fix compiler error, because storage size of status argument was unknown.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
