### PR TITLE
kindlegen: init at 2.9

### DIFF
--- a/pkgs/tools/typesetting/kindlegen/default.nix
+++ b/pkgs/tools/typesetting/kindlegen/default.nix
@@ -1,0 +1,48 @@
+{ fetchurl, stdenv }:
+
+let
+  version = "2.9";
+  fileVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
+
+  sha256 = {
+    "x86_64-linux"  = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
+    "i686-linux"    = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
+    "x86_64-darwin" = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
+    "i686-darwin"   = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
+    "x86_64-cygwin" = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
+    "i686-cygwin"   = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
+  }."${stdenv.system}" or (throw "system #{stdenv.system.} is not supported");
+
+  url = {
+    "x86_64-linux"  = "http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
+    "i686-linux"    = "http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
+    "x86_64-darwin" = "http://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v${fileVersion}.zip";
+    "i686-darwin"   = "http://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v${fileVersion}.zip";
+    "x86_64-cygwin" = "http://kindlegen.s3.amazonaws.com/kindlegen_win32_v${fileVersion}.zip";
+    "i686-cygwin"   = "http://kindlegen.s3.amazonaws.com/kindlegen_win32_v${fileVersion}.zip";
+  }."${stdenv.system}" or (throw "system #{stdenv.system.} is not supported");
+
+in stdenv.mkDerivation rec {
+  name = "kindlegen-${version}";
+
+  src = fetchurl {
+    inherit url;
+    inherit sha256;
+  };
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/kindlegen/doc
+    install -m755 kindlegen $out/bin/kindlegen
+    cp -r *.txt *.html docs/* $out/share/kindlegen/doc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Convert documents to .mobi for use with Amazon Kindle";
+    homepage = https://www.amazon.com/gp/feature.html?docId=1000765211;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "i686-darwin" "x86_64-cygwin" "i686-cygwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2376,6 +2376,8 @@ in
 
   npm2nix = nodePackages.npm2nix;
 
+  kindlegen = callPackage ../tools/typesetting/kindlegen { };
+
   ldapvi = callPackage ../tools/misc/ldapvi { };
 
   ldns = callPackage ../development/libraries/ldns { };
@@ -6444,7 +6446,7 @@ in
   gnumake = self.gnumake42;
 
   gnustep = recurseIntoAttrs (callPackage ../desktops/gnustep {});
-  
+
   gob2 = callPackage ../development/tools/misc/gob2 { };
 
   gocd-agent = callPackage ../development/tools/continuous-integration/gocd-agent { };
@@ -10486,7 +10488,7 @@ in
 
   influxdb = (callPackage ../servers/nosql/influxdb/v0.nix { }).bin // { outputs = [ "bin" ]; };
 
-  influxdb10 = (callPackage ../servers/nosql/influxdb/v1.nix { }).bin // { outputs = [ "bin" ]; }; 
+  influxdb10 = (callPackage ../servers/nosql/influxdb/v1.nix { }).bin // { outputs = [ "bin" ]; };
 
   hyperdex = callPackage ../servers/nosql/hyperdex { };
 


### PR DESCRIPTION
###### Motivation for this change
1. It was missing.
2. I needed it.
3. So I added it.

I haven't tried it on macOS/Windows, so I have no clue if those work.

The Linux binary is a statically compiled behemoth and as the mac/win versions are smaller _maybe_ the are compiled differently and have runtime dependencies. 

Turns out there are some trailing space cleanups too. Those were unintentional and a consequence of `before-save-hook` in emacs.
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
