### PR TITLE
gimp: fix python plugins

### DIFF
--- a/pkgs/applications/graphics/gimp/2.8.nix
+++ b/pkgs/applications/graphics/gimp/2.8.nix
@@ -28,7 +28,12 @@ stdenv.mkDerivation rec {
 
   pythonPath = [ pygtk ];
 
-  postInstall = ''wrapPythonPrograms'';
+  postFixup = ''
+    wrapPythonProgramsIn $out/lib/gimp/2.0/plug-ins/
+    wrapProgram $out/bin/gimp \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+  '';
 
   passthru = { inherit gtk; }; # probably its a good idea to use the same gtk in plugins ?
 


### PR DESCRIPTION
###### Motivation for this change

python scripts were not wrapped correctly / PYTHONPATH was not set
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
