### PR TITLE
Darwin fixes

### DIFF
--- a/pkgs/applications/graphics/qscreenshot/default.nix
+++ b/pkgs/applications/graphics/qscreenshot/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, dos2unix, which, qt }:
+{ stdenv, fetchurl, dos2unix, which, qt
+, Carbon ? null }:
 
 stdenv.mkDerivation rec {
   name = "qscreenshot-1.0";
@@ -8,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1spj5fg2l8p5bk81xsv6hqn1kcrdiy54w19jsfb7g5i94vcb1pcx";
   };
 
-  buildInputs = [ dos2unix which qt ];
+  buildInputs = [ dos2unix which qt ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon ];
 
   # Remove carriage returns that cause /bin/sh to abort
   preConfigure = ''

--- a/pkgs/applications/version-management/rcs/default.nix
+++ b/pkgs/applications/version-management/rcs/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ed ];
 
-  doCheck = true;
+  doCheck = !stdenv.isDarwin;
 
   NIX_CFLAGS_COMPILE = [ "-std=c99" ];
 

--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, cmake, boost, ffmpeg }:
+{ stdenv, fetchurl, cmake, boost, ffmpeg, zlib
+, Accelerate ? null, CoreGraphics ? null }:
 
 stdenv.mkDerivation rec {
   name = "chromaprint-${version}";
@@ -11,7 +12,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ boost ffmpeg ];
+  buildInputs = [ boost ffmpeg zlib ]
+  ++ stdenv.lib.optionals stdenv.isDarwin [ Accelerate CoreGraphics ];
 
   cmakeFlags = [ "-DBUILD_EXAMPLES=ON" ];
 

--- a/pkgs/development/libraries/cmocka/default.nix
+++ b/pkgs/development/libraries/cmocka/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  postPatch = ''
+    substituteInPlace cmake/Modules/DefineCompilerFlags.cmake \
+      --replace "(GNU|Clang)" "GNU"
+  '';
+
   meta = with stdenv.lib; {
     description = "Lightweight library to simplify and generalize unit tests for C";
 

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
     "--builtin-libraries=replace"
   ];
 
-  postInstall = ''		
-    ar qf $out/lib/libtalloc.a bin/default/talloc_[0-9]*.o		
+  postInstall = stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    ar qf $out/lib/libtalloc.a bin/default/talloc_[0-9]*.o
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/vmmlib/default.nix
+++ b/pkgs/development/libraries/vmmlib/default.nix
@@ -1,9 +1,11 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, blas }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, blas
+, Accelerate ? null, CoreGraphics ? null }:
 
 stdenv.mkDerivation rec {
   version = "1.6.2";
   name = "vmmlib-${version}";
-  buildInputs = [ stdenv pkgconfig cmake boost blas ];
+  buildInputs = [ stdenv pkgconfig cmake boost blas ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Accelerate CoreGraphics ];
 
   src = fetchFromGitHub {
     owner = "VMML";
@@ -16,9 +18,14 @@ stdenv.mkDerivation rec {
 		./disable-cpack.patch   #disable the need of cpack/rpm
 	    ];
   
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "gcc" "cc"
+  '';
+
   enableParallelBuilding = true;
 
-  doCheck = true;
+  doCheck = !stdenv.isDarwin;
 
   checkTarget = "test";
 

--- a/pkgs/development/tools/sqsh/default.nix
+++ b/pkgs/development/tools/sqsh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, freetds, readline }:
+{ stdenv, fetchurl, freetds, readline, libiconv }:
 
 stdenv.mkDerivation rec {
   version = "2.5.16.1";
@@ -9,6 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "1wi0hdmhk7l8nrz4j3kaa177mmxyklmzhj7sq1gj4q6fb8v1yr6n";
   };
 
+  NIX_CFLAGS_COMPILE = "-DHAVE_STRERROR";
+
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace configure \
+      --replace libct.so libct.dylib
+  '';
+
   preConfigure =
     ''
     export SYBASE=${freetds}
@@ -17,6 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     freetds
     readline
+    libiconv
   ];
 
   meta = {

--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, autoreconfHook, file, openssl, perl, unzip }:
+{ stdenv, fetchurl, autoreconfHook, file, openssl, perl, unzip
+, IOKit ? null, DiskArbitration ? null, ApplicationServices ? null }:
 
 stdenv.mkDerivation rec {
   name = "net-snmp-5.7.3";
@@ -16,6 +17,9 @@ stdenv.mkDerivation rec {
 
       # http://comments.gmane.org/gmane.network.net-snmp.user/32434
       substituteInPlace "man/Makefile.in" --replace 'grep -vE' '@EGREP@ -v'
+
+      ln -s "darwin13.h" "include/net-snmp/system/darwin14.h"
+      ln -s "darwin13.h" "include/net-snmp/system/darwin15.h"
     '';
 
   configureFlags =
@@ -27,7 +31,8 @@ stdenv.mkDerivation rec {
       "--with-openssl=${openssl.dev}"
     ] ++ stdenv.lib.optional stdenv.isLinux "--with-mnttab=/proc/mounts";
 
-  buildInputs = [ autoreconfHook file perl unzip openssl ];
+  buildInputs = [ autoreconfHook file perl unzip openssl ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit DiskArbitration ApplicationServices ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/x11/xorg/darwin/0002-sdksyms.sh-Use-CPPFLAGS-not-CFLAGS.patch
+++ b/pkgs/servers/x11/xorg/darwin/0002-sdksyms.sh-Use-CPPFLAGS-not-CFLAGS.patch
@@ -1,7 +1,7 @@
-From 91971455ee46b1059de75260ef0d1a45170d8b65 Mon Sep 17 00:00:00 2001
+From 8d0796bfa8ab8599994b5d029182428d62398712 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston <jeremyhu@apple.com>
 Date: Fri, 13 Jan 2012 12:00:57 -0800
-Subject: [PATCH 2/6] sdksyms.sh: Use CPPFLAGS, not CFLAGS
+Subject: [PATCH 5000/5005] sdksyms.sh: Use CPPFLAGS, not CFLAGS
 
 CFLAGS can include flags which are not useful to the preprocessor
 or can even cause it to fail.  This fixes a build issue on darwin
@@ -14,7 +14,7 @@ Reviewed-by: Keith Packard <keithp@keithp.com>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/hw/xfree86/Makefile.am b/hw/xfree86/Makefile.am
-index 27f2cc6..d898c43 100644
+index 85bd0be..6de7c10 100644
 --- a/hw/xfree86/Makefile.am
 +++ b/hw/xfree86/Makefile.am
 @@ -48,8 +48,7 @@ DIST_SUBDIRS = common ddc i2c x86emu int10 fbdevhw os-support \
@@ -22,12 +22,12 @@ index 27f2cc6..d898c43 100644
  nodist_Xorg_SOURCES = sdksyms.c
  
 -AM_CFLAGS = $(DIX_CFLAGS) @XORG_CFLAGS@
--AM_CPPFLAGS = $(XORG_INCS) -I$(srcdir)/parser -I$(top_srcdir)/miext/cw \
-+AM_CPPFLAGS = $(DIX_CFLAGS) @XORG_CFLAGS@ $(XORG_INCS) -I$(srcdir)/parser -I$(top_srcdir)/miext/cw \
+-AM_CPPFLAGS = $(XORG_INCS) -I$(srcdir)/parser \
++AM_CPPFLAGS = $(DIX_CFLAGS) @XORG_CFLAGS@ $(XORG_INCS) -I$(srcdir)/parser \
  	-I$(srcdir)/ddc -I$(srcdir)/i2c -I$(srcdir)/modes -I$(srcdir)/ramdac \
  	-I$(srcdir)/dri -I$(srcdir)/dri2 -I$(top_srcdir)/dri3
  
-@@ -135,7 +134,7 @@ CLEANFILES = sdksyms.c sdksyms.dep Xorg.sh
+@@ -137,7 +136,7 @@ CLEANFILES = sdksyms.c sdksyms.dep Xorg.sh
  EXTRA_DIST += sdksyms.sh
  
  sdksyms.dep sdksyms.c: sdksyms.sh
@@ -37,5 +37,4 @@ index 27f2cc6..d898c43 100644
  SDKSYMS_DEP = sdksyms.dep
  -include $(SDKSYMS_DEP)
 -- 
-2.3.2 (Apple Git-55)
-
+2.8.1

--- a/pkgs/servers/x11/xorg/darwin/0004-Use-old-miTrapezoids-and-miTriangles-routines.patch
+++ b/pkgs/servers/x11/xorg/darwin/0004-Use-old-miTrapezoids-and-miTriangles-routines.patch
@@ -1,7 +1,7 @@
-From b229a04bde765424542eeba17a7e2bc25785a890 Mon Sep 17 00:00:00 2001
+From 963cad095b31c534f827019cb0b83a96b37cbef2 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Sat, 2 Nov 2013 11:00:23 -0700
-Subject: [PATCH 4/6] Use old miTrapezoids and miTriangles routines
+Subject: [PATCH 5003/5005] Use old miTrapezoids and miTriangles routines
 
 Reverts commits:
     788ccb9a8bcf6a4fb4054c507111eec3338fb969
@@ -19,10 +19,10 @@ Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
  5 files changed, 201 insertions(+), 4 deletions(-)
 
 diff --git a/fb/fbpict.c b/fb/fbpict.c
-index c8378ad..cafb027 100644
+index 7ea0b66..434d890 100644
 --- a/fb/fbpict.c
 +++ b/fb/fbpict.c
-@@ -499,10 +499,8 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
+@@ -508,10 +508,8 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
      ps->UnrealizeGlyph = fbUnrealizeGlyph;
      ps->CompositeRects = miCompositeRects;
      ps->RasterizeTrapezoid = fbRasterizeTrapezoid;
@@ -34,7 +34,7 @@ index c8378ad..cafb027 100644
      return TRUE;
  }
 diff --git a/render/mipict.c b/render/mipict.c
-index a725104..e14293a 100644
+index 4b85512..a39eb2c 100644
 --- a/render/mipict.c
 +++ b/render/mipict.c
 @@ -575,8 +575,8 @@ miPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
@@ -49,10 +49,10 @@ index a725104..e14293a 100644
      ps->RasterizeTrapezoid = 0; /* requires DDX support */
      ps->AddTraps = 0;           /* requires DDX support */
 diff --git a/render/mipict.h b/render/mipict.h
-index 23ce9e8..e0f1d4c 100644
+index 3241be4..8ee7a8a 100644
 --- a/render/mipict.h
 +++ b/render/mipict.h
-@@ -122,6 +122,16 @@ miCompositeRects(CARD8 op,
+@@ -102,9 +102,36 @@ miCompositeRects(CARD8 op,
                   xRenderColor * color, int nRect, xRectangle *rects);
  
  extern _X_EXPORT void
@@ -65,22 +65,14 @@ index 23ce9e8..e0f1d4c 100644
 +	     int	    ntri,
 +	     xTriangle	    *tris);
 +
-+extern _X_EXPORT void
- 
- miTriStrip(CARD8 op,
-            PicturePtr pSrc,
-@@ -137,10 +147,27 @@ miTriFan(CARD8 op,
-          PictFormatPtr maskFormat,
-          INT16 xSrc, INT16 ySrc, int npoints, xPointFixed * points);
- 
 +extern _X_EXPORT PicturePtr
-+miCreateAlphaPicture (ScreenPtr	    pScreen, 
-+		      PicturePtr    pDst,
-+		      PictFormatPtr pPictFormat,
-+		      CARD16	    width,
-+		      CARD16	    height);
++miCreateAlphaPicture (ScreenPtr            pScreen, 
++                     PicturePtr    pDst,
++                     PictFormatPtr pPictFormat,
++                     CARD16        width,
++                     CARD16        height);
 +
- extern _X_EXPORT void
++extern _X_EXPORT void
   miTrapezoidBounds(int ntrap, xTrapezoid * traps, BoxPtr box);
  
  extern _X_EXPORT void
@@ -293,5 +285,4 @@ index 922f22a..bdca9ca 100644
 +}
 +
 -- 
-2.3.2 (Apple Git-55)
-
+2.8.1

--- a/pkgs/servers/x11/xorg/darwin/0006-fb-Revert-fb-changes-that-broke-XQuartz.patch
+++ b/pkgs/servers/x11/xorg/darwin/0006-fb-Revert-fb-changes-that-broke-XQuartz.patch
@@ -1,7 +1,7 @@
-From 4c7572abafeac9b2dcd884c444c5a5bae5b302c3 Mon Sep 17 00:00:00 2001
+From 33dd8bad4b6a018d1bbe66b6e6de972c58cfc9f1 Mon Sep 17 00:00:00 2001
 From: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
 Date: Sat, 31 May 2014 13:14:20 -0700
-Subject: [PATCH 6/6] fb: Revert fb changes that broke XQuartz
+Subject: [PATCH 5005/5005] fb: Revert fb changes that broke XQuartz
 
     http://bugs.freedesktop.org/show_bug.cgi?id=26124
 
@@ -20,10 +20,10 @@ This reverts commit 3c2c59eed3c68c0e5a93c38cf01eedad015e3157.
  4 files changed, 2 insertions(+), 162 deletions(-)
 
 diff --git a/fb/fb.h b/fb/fb.h
-index 59eaac3..046b948 100644
+index 256a1ee..8e87498 100644
 --- a/fb/fb.h
 +++ b/fb/fb.h
-@@ -1116,9 +1116,6 @@ extern _X_EXPORT void
+@@ -1111,9 +1111,6 @@ extern _X_EXPORT void
  extern _X_EXPORT Bool
   fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats);
  
@@ -34,7 +34,7 @@ index 59eaac3..046b948 100644
   * fbpixmap.c
   */
 diff --git a/fb/fbpict.c b/fb/fbpict.c
-index 6ee63e9..9c4cc42 100644
+index be8274b..66dd633 100644
 --- a/fb/fbpict.c
 +++ b/fb/fbpict.c
 @@ -65,152 +65,6 @@ fbComposite(CARD8 op,
@@ -95,7 +95,7 @@ index 6ee63e9..9c4cc42 100644
 -    pixman_glyph_cache_freeze (glyphCache);
 -
 -    if (n_glyphs > N_STACK_GLYPHS) {
--	if (!(pglyphs = malloc (n_glyphs * sizeof (pixman_glyph_t))))
+-	if (!(pglyphs = xallocarray(n_glyphs, sizeof(pixman_glyph_t))))
 -	    goto out;
 -    }
 -
@@ -190,7 +190,7 @@ index 6ee63e9..9c4cc42 100644
  static pixman_image_t *
  create_solid_fill_image(PicturePtr pict)
  {
-@@ -461,8 +315,7 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
+@@ -470,8 +324,7 @@ fbPictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
          return FALSE;
      ps = GetPictureScreen(pScreen);
      ps->Composite = fbComposite;
@@ -239,5 +239,4 @@ index 71bcc5d..55330fc 100644
          free(depths[d].vids);
      free(depths);
 -- 
-2.3.2 (Apple Git-55)
-
+2.8.1

--- a/pkgs/tools/networking/quicktun/default.nix
+++ b/pkgs/tools/networking/quicktun/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     description = "Very simple, yet secure VPN software";
     homepage = "http://wiki.ucis.nl/QuickTun";
     maintainers = [ maintainers.fpletz ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/security/sslscan/default.nix
+++ b/pkgs/tools/security/sslscan/default.nix
@@ -15,6 +15,14 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
   ];
 
+  patches = [
+    # this patch can be removed after post-1.11.7 release
+    (fetchurl {
+      url = "https://github.com/rbsec/sslscan/commit/b076e67819ebe69d1bd34c66a7000630d27791d7.patch";
+      sha256 = "08cszm9hh3ljxm7m66l7lqdpiarb55bsbwdan3by6dy5l843yhgz";
+    })
+  ];
+
   meta = with stdenv.lib; {
     description = "Tests SSL/TLS services and discover supported cipher suites";
     homepage = https://github.com/rbsec/sslscan;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7005,7 +7005,9 @@ in
 
   chmlib = callPackage ../development/libraries/chmlib { };
 
-  chromaprint = callPackage ../development/libraries/chromaprint { };
+  chromaprint = callPackage ../development/libraries/chromaprint {
+    inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics;
+  };
 
   cilaterm = callPackage ../development/libraries/cil-aterm {
     stdenv = overrideInStdenv stdenv [gnumake380];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10520,7 +10520,9 @@ in
 
   neo4j = callPackage ../servers/nosql/neo4j { };
 
-  net_snmp = callPackage ../servers/monitoring/net-snmp { };
+  net_snmp = callPackage ../servers/monitoring/net-snmp {
+    inherit (darwin.apple_sdk.frameworks) IOKit DiskArbitration ApplicationServices;
+  };
 
   newrelic-sysmond = callPackage ../servers/monitoring/newrelic-sysmond { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14473,6 +14473,7 @@ in
 
   qscreenshot = callPackage ../applications/graphics/qscreenshot {
     qt = qt4;
+    inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
   qsynth = callPackage ../applications/audio/qsynth { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7169,7 +7169,9 @@ in
 
   eigen2 = callPackage ../development/libraries/eigen/2.0.nix {};
 
-  vmmlib = callPackage ../development/libraries/vmmlib {};
+  vmmlib = callPackage ../development/libraries/vmmlib {
+    inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics;
+  };
 
   enchant = callPackage ../development/libraries/enchant { };
 


### PR DESCRIPTION
###### Motivation for this change

These are some more fixes for Darwin stuff. All of the touched files should build on Darwin and hopefully they don't break anything on Linux.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
