### PR TITLE
logstalgia: fix build

### DIFF
--- a/pkgs/tools/graphics/logstalgia/default.nix
+++ b/pkgs/tools/graphics/logstalgia/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, SDL, ftgl, pkgconfig, libpng, libjpeg, pcre, SDL_image, glew
-, mesa, boost, glm }:
+{ stdenv, fetchurl, SDL2, ftgl, pkgconfig, libpng, libjpeg, pcre, SDL2_image, glew
+, mesa, boost, glm, freetype }:
 
 stdenv.mkDerivation rec {
   name = "logstalgia-${version}";
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1qghz1j3jmfj093br2hfyibayg3fmhg8fvp5ix9n9rbvzc1zslsm";
   };
 
-  buildInputs = [ glew SDL ftgl pkgconfig libpng libjpeg pcre SDL_image mesa boost
-                  glm ];
+  buildInputs = [ glew SDL2 ftgl pkgconfig libpng libjpeg pcre SDL2_image mesa boost
+                  glm freetype ];
 
   meta = with stdenv.lib; {
     homepage = http://code.google.com/p/logstalgia;


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
