### PR TITLE
airwave: init at 1.3.2

### DIFF
--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -1,0 +1,88 @@
+{ stdenv, cmake, fetchFromGitHub, file, gcc_multi, libX11, makeWrapper
+, overrideCC, qt5, requireFile, unzip, wineStable
+}:
+
+let
+
+  version = "1.3.2";
+
+  airwave-src = fetchFromGitHub {
+    owner = "phantom-code";
+    repo = "airwave";
+    rev = version;
+    sha256 = "053kkx5yq1vas0qisidkgq0h6hzfwy3677jprjkcrwc4hp2i2v12";
+  };
+
+  stdenv_multi = overrideCC stdenv gcc_multi;
+
+  vst-sdk = stdenv.mkDerivation rec {
+    name = "vstsdk366_27_06_2016_build_61";
+    src = requireFile {
+      name = "${name}.zip";
+      url = "http://www.steinberg.net/en/company/developers.html";
+      sha256 = "05gsr13bpi2hhp34rvhllsvmn44rqvmjdpg9fsgfzgylfkz0kiki";
+    };
+    nativeBuildInputs = [ unzip ];
+    installPhase = "cp -r . $out";
+  };
+
+  wine-wow64 = wineStable.override {
+    wineBuild = "wineWow";
+  };
+
+  wine-xembed = wine-wow64.overrideDerivation (oldAttrs: {
+    patchFlags = [ "-p2" ];
+    patches = [ "${airwave-src}/fix-xembed-wine-windows.patch" ];
+  });
+
+in
+
+stdenv_multi.mkDerivation {
+  name = "airwave-${version}";
+
+  src = airwave-src;
+
+  nativeBuildInputs = [ cmake makeWrapper ];
+
+  buildInputs = [ file libX11 qt5.qtbase wine-xembed ];
+
+  postPatch = ''
+    # Binaries not used directly should land in libexec/.
+    substituteInPlace src/common/storage.cpp --replace '"/bin"' '"/libexec"'
+
+    # For airwave-host-32.exe.so, point wineg++ to 32-bit versions of
+    # these libraries, as $NIX_LDFLAGS contains only 64-bit ones.
+    substituteInPlace src/host/CMakeLists.txt --replace '-m32' \
+      '-m32 -L${wine-xembed}/lib -L${wine-xembed}/lib/wine -L${stdenv_multi.cc.libc.out}/lib/32'
+  '';
+
+  # libstdc++.so link gets lost in 64-bit executables during
+  # shrinking.
+  dontPatchELF = true;
+
+  cmakeFlags = "-DVSTSDK_PATH=${vst-sdk}";
+
+  postInstall = ''
+    mv $out/bin $out/libexec
+    mkdir $out/bin
+    mv $out/libexec/airwave-manager $out/bin
+    wrapProgram $out/libexec/airwave-host-32.exe --set WINELOADER ${wine-xembed}/bin/wine
+    wrapProgram $out/libexec/airwave-host-64.exe --set WINELOADER ${wine-xembed}/bin/wine64
+  '';
+
+  meta = with stdenv.lib; {
+    description = "WINE-based VST bridge for Linux VST hosts";
+    longDescription = ''
+      Airwave is a wine based VST bridge, that allows for the use of
+      Windows 32- and 64-bit VST 2.4 audio plugins with Linux VST
+      hosts. Due to the use of shared memory, only one extra copying
+      is made for each data transfer. Airwave also uses the XEMBED
+      protocol to correctly embed the plugin editor into the host
+      window.
+    '';
+    homepage = https://github.com/phantom-code/airwave;
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ michalrus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12261,6 +12261,8 @@ in
 
   ahoviewer = callPackage ../applications/graphics/ahoviewer { };
 
+  airwave = callPackage ../applications/audio/airwave/default.nix { };
+
   alchemy = callPackage ../applications/graphics/alchemy { };
 
   alock = callPackage ../misc/screensavers/alock { };


### PR DESCRIPTION
###### Motivation for this change

This project is invaluable for a Linux musician to have access to—still—almost inaccessible sounds on their Linux box.
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change — _none do_.
- [x] Tested execution of all binary files.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
