### PR TITLE
bsdbuild: init at 3.1

### DIFF
--- a/pkgs/development/tools/misc/bsdbuild/default.nix
+++ b/pkgs/development/tools/misc/bsdbuild/default.nix
@@ -1,0 +1,68 @@
+{ stdenv, fetchurl, perl, libtool, pkgconfig, gettext, groff, ed }:
+
+stdenv.mkDerivation rec {
+  name = "bsdbuild-${version}";
+  version = "3.1";
+
+  src = fetchurl {
+    url = "http://stable.hypertriton.com/bsdbuild/${name}.tar.gz";
+    sha256 = "1zrdjh7a6z4khhfw9zrp490afq306cpl5v8wqz2z55ys7k1n5ifl";
+  };
+
+  buildInputs = [ perl groff ed ];
+  nativeBuildInputs = [ pkgconfig libtool gettext ];
+
+  prePatch = ''
+    #ignore unfamiliar flags
+    substituteInPlace configure \
+      --replace '--sbindir=*' '--sbindir=* | --includedir=* | --oldincludedir=*'
+    #same for packages using bsdbuild
+    substituteInPlace mkconfigure.pl \
+      --replace '--sbindir=*' '--sbindir=* | --includedir=* | --oldincludedir=*'
+    #insert header for missing NULL macro
+    for f in db4.pm sdl_ttf.pm mysql.pm uim.pm strlcpy.pm getpwuid.pm \
+      getaddrinfo.pm strtoll.pm free_null.pm getpwnam_r.pm \
+      gettimeofday.pm gethostbyname.pm xinerama.pm strsep.pm \
+      fontconfig.pm gettext.pm pthreads.pm strlcat.pm kqueue.pm wgl.pm \
+      alsa.pm crypt.pm cracklib.pm freesg-rg.pm edacious.pm mmap.pm \
+      agar.pm x11.pm x11.pm execvp.pm agar-core.pm dyld.pm getopt.pm \
+      strtold.pm sdl_image.pm shl_load.pm glx.pm percgi.pm timerfd.pm \
+      glob.pm dlopen.pm freesg.pm csidl.pm perl.pm select.pm \
+      portaudio.pm etubestore.pm;
+    do
+ed -s -v BSDBuild/$f << EOF
+/#include
+i
+#include <stddef.h>
+.
+w
+EOF
+    done
+  '';
+
+  configureFlags = [
+    "--with-libtool=${libtool}/bin/libtool"
+    "--enable-nls=yes"
+    "--with-gettext=${gettext}"
+    "--with-manpages=yes"
+  ];
+
+  meta = {
+    homepage = http://bsdbuild.hypertriton.com;
+    description = "A cross-platform build system.";
+
+    longDescription = ''
+      BSDBuild is a cross-platform build system. Derived from the
+      traditional 4.4BSD make libraries, BSDBuild allows BSD-style
+      Makefiles (without BSD make extensions), and works natively
+      under most operating systems and make flavors. Since BSDBuild
+      is implemented as a library (as opposed to a macro package),
+      Makefiles are edited directly, as opposed to being compiled
+      (however, if the build directory is separate from the source
+      directory, BSDBuild will produce the required Makefiles in place).
+    '';
+
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -964,6 +964,8 @@ in
 
   bogofilter = callPackage ../tools/misc/bogofilter { };
 
+  bsdbuild = callPackage ../development/tools/misc/bsdbuild { };
+
   bsdiff = callPackage ../tools/compression/bsdiff { };
 
   btar = callPackage ../tools/backup/btar {


### PR DESCRIPTION
###### Motivation for this change

autotools like. used in some bsd stuff.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [*] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- I've ported libagar to test it works. See (https://github.com/NixOS/nixpkgs/pull/18070).
