### PR TITLE
libagar: init at 1.5

### DIFF
--- a/pkgs/development/libraries/libagar/default.nix
+++ b/pkgs/development/libraries/libagar/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, pkgconfig, libtool, perl, bsdbuild, gettext, mandoc
+, libpng, libjpeg, xlibsWrapper, libXinerama, freetype, SDL, mesa
+, libsndfile, portaudio, mysql, fontconfig
+}:
+
+let srcs = import ./srcs.nix { inherit fetchurl; }; in
+stdenv.mkDerivation rec {
+  name = "libagar-${version}";
+  inherit (srcs) version src;
+
+  preConfigure = ''
+    substituteInPlace configure.in \
+      --replace '_BSD_SOURCE' '_DEFAULT_SOURCE'
+    cat configure.in | ${bsdbuild}/bin/mkconfigure > configure
+  '';
+
+  configureFlags = [
+    "--with-libtool=${libtool}/bin/libtool"
+    "--enable-nls=yes"
+    "--with-gettext=${gettext}"
+    "--with-jpeg=${libjpeg.dev}"
+    "--with-gl=${mesa}"
+    "--with-mysql=yes"
+    "--with-manpages=yes"
+  ];
+
+  outputs = [ "out" "devdoc" ];
+
+  nativeBuildInputs = [ pkgconfig libtool gettext ];
+  buildInputs = [
+    bsdbuild perl xlibsWrapper libXinerama SDL mesa  mysql.client mandoc
+    freetype.dev libpng libjpeg.dev fontconfig portaudio libsndfile
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform GUI toolkit";
+    homepage = http://libagar.org/index.html;
+    license = with licenses; bsd3;
+    maintainers = with maintainers; [ ramkromberg ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/libraries/libagar/libagar_test.nix
+++ b/pkgs/development/libraries/libagar/libagar_test.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, bsdbuild, libagar, perl, libjpeg, libpng, openssl }:
+
+let srcs = import ./srcs.nix { inherit fetchurl; }; in
+stdenv.mkDerivation rec {
+  name = "libagar-test-${version}";
+  inherit (srcs) version src;
+
+  sourceRoot = "agar-1.5.0/tests";
+
+  preConfigure = ''
+    substituteInPlace configure.in \
+      --replace '_BSD_SOURCE' '_DEFAULT_SOURCE'
+    cat configure.in | ${bsdbuild}/bin/mkconfigure > configure
+  '';
+
+  configureFlags = "--with-agar=${libagar}";
+
+  buildInputs = [ perl bsdbuild libagar libjpeg libpng openssl ];
+
+  meta = with stdenv.lib; {
+    description = "Tests for libagar";
+    homepage = http://libagar.org/index.html;
+    license = with licenses; bsd3;
+    maintainers = with maintainers; [ ramkromberg ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/libraries/libagar/srcs.nix
+++ b/pkgs/development/libraries/libagar/srcs.nix
@@ -1,0 +1,10 @@
+{ fetchurl }:
+rec {
+  version = "1.5.0";
+
+  src = fetchurl {
+    url = "http://stable.hypertriton.com/agar/agar-${version}.tar.gz";
+    sha256 = "001wcqk5z67qg0raw9zlwmv62drxiwqykvsbk10q2mrc6knjsd42";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7904,6 +7904,9 @@ in
 
   libaccounts-glib = callPackage ../development/libraries/libaccounts-glib { };
 
+  libagar = callPackage ../development/libraries/libagar { };
+  libagar_test = callPackage ../development/libraries/libagar/libagar_test.nix { };
+
   libao = callPackage ../development/libraries/libao {
     usePulseAudio = config.pulseaudio or true;
     inherit (darwin.apple_sdk.frameworks) CoreAudio CoreServices AudioUnit;


### PR DESCRIPTION
###### Motivation for this change

A C GUI toolkit. Not used by anything in the repositories so set to lowPrio to not burden hydra needlessly.

Note: Depended on the now merged bsdbuild (https://github.com/NixOS/nixpkgs/pull/18069).
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: Seems there's a bug in i3wm with bad widget positioning. xfce shows agartest works fine.
