### PR TITLE
lttng-modules: 2.6.3 -> 2.8.0

### DIFF
--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   pname = "lttng-modules-${version}";
   name = "${pname}-${kernel.version}";
-  version = "2.6.3";
+  version = "2.8.0";
 
   src = fetchurl {
     url = "http://lttng.org/files/lttng-modules/lttng-modules-${version}.tar.bz2";
-    sha256 = "0sk7cyjf5ylmxqrrrz5zmmw4c0dmxh1f98aj870gmcnxfa76y4mx";
+    sha256 = "0a9xwq0kgpx1y800l232h524f19g3py6cnxff10j9p01q6lzhrxh";
   };
 
   preConfigure = ''


### PR DESCRIPTION
Built against linux and linux_latest

cc @bjornfor
