### PR TITLE
rtl8723bs: 6918e9b2ff29 -> 2016-04-11, fix build against 4.7

### DIFF
--- a/pkgs/os-specific/linux/firmware/rtl8723bs-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtl8723bs-firmware/default.nix
@@ -1,7 +1,7 @@
 { stdenv, linuxPackages }:
 with stdenv.lib;
 stdenv.mkDerivation {
-  name = "rtl8723bs-firmware-${linuxPackages.rtl8723bs.rev}";
+  name = "rtl8723bs-firmware-${linuxPackages.rtl8723bs.version}";
   inherit (linuxPackages.rtl8723bs) src;
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, nukeReferences, kernel }:
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "rtl8723bs-${kernel.version}-${rev}";
-  rev = "6918e9b2ff297b1cc7fde193e72452c33c10e1c8";
+  name = "rtl8723bs-${kernel.version}-${version}";
+  version = "2016-04-11";
 
   src = fetchFromGitHub {
     owner = "hadess";
     repo = "rtl8723bs";
-    inherit rev;
-    sha256 = "07srd457wnz29nvvq02wz66s387bhjbydnmbs3qr7ljprabhsgmi";
+    rev = "11ab92d8ccd71c80f0102828366b14ef6b676fb2";
+    sha256 = "05q7mf12xcb00v6ba4wwvqi53q7ph5brfkj17xf6vkx4jr7xxnmm";
   };
 
   buildInputs = [ nukeReferences ];
@@ -33,7 +33,8 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/hadess/rtl8723bs";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
-    broken = ! versionAtLeast kernel.version "3.19";
+    broken = (! versionAtLeast kernel.version "3.19")
+      || (kernel.features.grsecurity or false);
     maintainers = with maintainers; [ elitak ];
   };
 }


### PR DESCRIPTION
Upstream
https://github.com/hadess/rtl8723bs/commit/e71a5fc58c3a1092805c69e7bccb5ab2f6da38f9
adds linux 4.7 support; all subsequent commits are error fixes so we
bump to current HEAD for good measure.

Built against linux and linux_latest.

cc @elitak
