### PR TITLE
facter: 3.1.8 -> 3.4.1 and add/update related dependencies

### DIFF
--- a/pkgs/development/libraries/cpp-hocon/default.nix
+++ b/pkgs/development/libraries/cpp-hocon/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake, boost, curl, leatherman }:
+
+stdenv.mkDerivation rec {
+  name = "cpp-hocon-${version}";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    sha256 = "0v2mnak6fh13dkl25lfvw1la2dfjqrh3lq1d40r3a52m56vwflrg";
+    rev = version;
+    repo = "cpp-hocon";
+    owner = "puppetlabs";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost curl leatherman ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = " A C++ port of the Typesafe Config library";
+    license = licenses.asl20;
+    maintainers = [ maintainers.womfoo ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/development/libraries/leatherman/default.nix
+++ b/pkgs/development/libraries/leatherman/default.nix
@@ -2,20 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "leatherman-${version}";
-  version = "0.7.5";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
-    sha256 = "103qzhjhgw7jh0xcaxag735wfm6q35xprq5wmdimfhhmmrmjr51g";
+    sha256 = "18nidasykbwdd9qzwc8pnzhczy6acr3rsxwvv2v3j5gq3nbsk2mc";
     rev = version;
     repo = "leatherman";
     owner = "puppetlabs";
   };
 
   buildInputs = [ boost cmake curl ];
-
-  # curl upgrade to 7.50.0 (#17152) broke the curl mock tests, disabling for now
-  # upstream bug raised https://tickets.puppetlabs.com/browse/LTH-108
-  cmakeFlags = [ "-DLEATHERMAN_MOCK_CURL=OFF" ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/puppetlabs/leatherman/;  

--- a/pkgs/tools/system/facter/default.nix
+++ b/pkgs/tools/system/facter/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, boost, cmake, curl, leatherman, libyamlcpp, openssl, ruby, utillinux }:
+{ stdenv, fetchurl, boost, cmake, cpp-hocon, curl, leatherman, libyamlcpp, openssl, ruby, utillinux }:
 
 stdenv.mkDerivation rec {
   name = "facter-${version}";
-  version = "3.1.8";
+  version = "3.4.1";
   src = fetchurl {
     url = "https://downloads.puppetlabs.com/facter/${name}.tar.gz";
-    sha256 = "1fhfjf5bm5kyjiady14fxhpp7hdrkgx56vsvdbqj82km0xqcxpj9";
+    sha256 = "1vvvqni68l3hmnxi8jp0n2rwzxyh1vmgv6xa2954h94dfax6dmcj";
   };
 
   cmakeFlags = [ "-DFACTER_RUBY=${ruby}/lib/libruby.so" ];
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   libyamlcpp_ = libyamlcpp.override { makePIC = true; };
 
-  buildInputs = [ boost cmake curl leatherman libyamlcpp_ openssl ruby utillinux ];
+  buildInputs = [ boost cmake cpp-hocon curl leatherman libyamlcpp_ openssl ruby utillinux ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/puppetlabs/facter;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7085,6 +7085,8 @@ in
 
   cppdb = callPackage ../development/libraries/cppdb { };
 
+  cpp-hocon = callPackage ../development/libraries/cpp-hocon { };
+
   cpp-netlib = callPackage ../development/libraries/cpp-netlib { };
 
   cppcms = callPackage ../development/libraries/cppcms { };


### PR DESCRIPTION
###### Motivation for this change
- update to latest facter and leatherman upstream
- add new cpp-hocon dependency
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
