### PR TITLE
gpxsee: 2.16 -> 2.17

### DIFF
--- a/pkgs/applications/misc/gpxsee/default.nix
+++ b/pkgs/applications/misc/gpxsee/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gpxsee-${version}";
-  version = "2.16";
+  version = "2.17";
 
   src = fetchFromGitHub {
     owner = "tumic0";
     repo = "GPXSee";
     rev = version;
-    sha256 = "0xqmjh071my9klxlk5afx8r673zlknq84n7ain6mz9i8n9m1gviv";
+    sha256 = "1422kgj972ydasqqm0k02qf3v2py7if2ibri7yjg8awqilacy6by";
   };
 
   nativeBuildInputs = [ qmakeHook ];


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
