### PR TITLE
ferm: add integration test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -234,6 +234,7 @@ in rec {
   tests.etcd = hydraJob (import tests/etcd.nix { system = "x86_64-linux"; });
   tests.ec2-nixops = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-nixops;
   tests.ec2-config = hydraJob (import tests/ec2.nix { system = "x86_64-linux"; }).boot-ec2-config;
+  tests.ferm = callTest tests/ferm.nix {};
   tests.firefox = callTest tests/firefox.nix {};
   tests.firewall = callTest tests/firewall.nix {};
   tests.fleet = hydraJob (import tests/fleet.nix { system = "x86_64-linux"; });

--- a/nixos/tests/ferm.nix
+++ b/nixos/tests/ferm.nix
@@ -1,0 +1,71 @@
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "ferm";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ mic92 ];
+  };
+
+  nodes =
+    { client =
+        { config, pkgs, ... }:
+        with pkgs.lib;
+        {
+          networking = {
+            interfaces.eth1.ip6 = mkOverride 0 [ { address = "fd00::2"; prefixLength = 64; } ];
+            interfaces.eth1.ip4 = mkOverride 0 [ { address = "192.168.1.2"; prefixLength = 24; } ];
+          };
+      };
+      server =
+        { config, pkgs, ... }:
+        with pkgs.lib;
+        {
+          networking = {
+            interfaces.eth1.ip6 = mkOverride 0 [ { address = "fd00::1"; prefixLength = 64; } ];
+            interfaces.eth1.ip4 = mkOverride 0 [ { address = "192.168.1.1"; prefixLength = 24; } ];
+          };
+
+          services = {
+            ferm.enable = true;
+            ferm.config = ''
+              domain (ip ip6) table filter chain INPUT {
+                interface lo ACCEPT;
+                proto tcp dport 8080 REJECT reject-with tcp-reset;
+              }
+            '';
+            nginx.enable = true;
+            nginx.httpConfig = ''
+              server {
+                listen 80;
+                listen [::]:80;
+                listen 8080;
+                listen [::]:8080;
+
+                location /status { stub_status on; }
+              }
+            '';
+          };
+        };
+    };
+
+  testScript =
+    ''
+      startAll;
+
+      $client->waitForUnit("network.target");
+      $server->waitForUnit("ferm.service");
+      $server->waitForUnit("nginx.service");
+
+      subtest "port 80 is allowed", sub {
+          $client->succeed("curl --fail -g http://192.168.1.1:80/status");
+          $client->succeed("curl --fail -g http://[fd00::1]:80/status");
+      };
+
+      subtest "port 8080 is not allowed", sub {
+          $server->succeed("curl --fail -g http://192.168.1.1:8080/status");
+          $server->succeed("curl --fail -g http://[fd00::1]:8080/status");
+
+          $client->fail("curl --fail -g http://192.168.1.1:8080/status");
+          $client->fail("curl --fail -g http://[fd00::1]:8080/status");
+      };
+    '';
+})


### PR DESCRIPTION
###### Motivation for this change
- try out nixos testing & very bad experience with broken firewall automation
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
