### PR TITLE
Haskell stack nix shell: using lib.getLib/Dev now

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -19,12 +19,13 @@ stdenv.mkDerivation (args // {
   STACK_PLATFORM_VARIANT="nix";
   STACK_IN_NIX_SHELL=1;
   STACK_IN_NIX_EXTRA_ARGS =
-    concatMap (pkg: ["--extra-lib-dirs=${pkg}/lib"
-                     "--extra-include-dirs=${pkg}/include"]) buildInputs ++
+    concatMap (pkg: ["--extra-lib-dirs=${getLib pkg}/lib"
+                     "--extra-include-dirs=${getDev pkg}/include"]) buildInputs ++
     extraArgs;
 
   # XXX: workaround for https://ghc.haskell.org/trac/ghc/ticket/11042.
   LD_LIBRARY_PATH = makeLibraryPath (LD_LIBRARY_PATH ++ buildInputs);
+                    # ^^^ Internally uses `getOutput "lib"` (equiv. to getLib)
 
   preferLocalBuild = true;
 


### PR DESCRIPTION
###### Motivation for this change

The generic stack builder is now using getLib and getDev to retrieve the right paths to give to the stack that will run in nix.
The user doesn't have anymore to know in advance which packages have splitted outputs and which do not.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
