### PR TITLE
libcommuni: 2016-03-23 -> 2016-08-17, communi 2016-01-03 -> 2016-08-19

### DIFF
--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -2,12 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "communi-${version}";
-  version = "2016-01-03";
+  version = "2016-08-19";
 
   src = fetchgit {
     url = "https://github.com/communi/communi-desktop.git";
-    rev = "ad1b9a30ed6c51940c0d2714b126a32b5d68c876";
-    sha256 = "0jx963pfvzk4dbk8mrmzfrhzybk5y6ib9yzaj662wliayrzj7vpg";
+    rev = "d516b01b1382a805de65f21f3475e0a8e64a97b5";
+    sha256 = "1pn7mr7ch1ck5qv9zdn3ril40c9kk6l04475564rpzf11jly76an";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ makeQtWrapper qmakeHook ];
@@ -32,6 +33,10 @@ stdenv.mkDerivation rec {
     wrapQtProgram "$out/bin/communi"
     substituteInPlace "$out/share/applications/communi.desktop" \
       --replace "/usr/bin" "$out/bin"
+  '';
+
+  postFixup = ''
+    patchelf --set-rpath "$out/lib:$(patchelf --print-rpath $out/bin/.communi-wrapped)" $out/bin/.communi-wrapped
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libcommuni/default.nix
+++ b/pkgs/development/libraries/libcommuni/default.nix
@@ -1,17 +1,18 @@
-{ fetchgit, qtbase, qmakeHook, which, stdenv
+{ stdenv, fetchFromGitHub, qtbase, qtdeclarative, qmakeHook, which
 }:
 
 stdenv.mkDerivation rec {
   name = "libcommuni-${version}";
-  version = "2016-03-23";
+  version = "2016-08-17";
 
-  src = fetchgit {
-    url = "https://github.com/communi/libcommuni.git";
-    rev = "6a5110b25e2838e7dc2c62d16b9fd06d12beee7e";
-    sha256 = "184ah5xqg5pgy8h6fyyz2k0vak1fmhrcidwz828yl4lsvz1vjqh1";
+  src = fetchFromGitHub {
+    owner = "communi";
+    repo = "libcommuni";
+    rev = "dedba6faf57c31c8c70fd563ba12d75a9caee8a3";
+    sha256 = "0wvs53z34vfs5xlln4a6sbd4981svag89xm0f4k20mb1i052b20i";
   };
 
-  buildInputs = [ qtbase ];
+  buildInputs = [ qtbase qtdeclarative ];
   nativeBuildInputs = [ qmakeHook which ];
 
   enableParallelBuild = true;


### PR DESCRIPTION
###### Motivation for this change

Build was broken (missing dependency in libcommuni) so I also updated it 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm not sure about the RPATH thing here: after the build the executable contains RPATH entries to its store path and to the path where it was built (e.g. /tmp), then the fixupPhase removes the store RPATH entry, so i add it again in postFixup. Probably we should remove the build directory entry aswell?

cc maintainer @hrdinka 
