### PR TITLE
twmn: fix by running pre- and post-install hooks

### DIFF
--- a/pkgs/applications/misc/twmn/default.nix
+++ b/pkgs/applications/misc/twmn/default.nix
@@ -16,8 +16,12 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out/bin"
     cp bin/* "$out/bin"
+
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

This package had the same issue as described in #15744. The custom `installPhase` doesn't call pre- and post-install hooks like it should.

The solution is also similar (see commit a1facf3).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
