### PR TITLE
qweechat: init at 2016-07-29

### DIFF
--- a/pkgs/applications/networking/irc/qweechat/default.nix
+++ b/pkgs/applications/networking/irc/qweechat/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, python27Packages }:
+
+python27Packages.buildPythonApplication rec {
+  version = "2016-07-29";
+  name = "qweechat-unstable-${version}";
+  namePrefix = "";
+
+ src = fetchFromGitHub {
+    owner = "weechat";
+    repo = "qweechat";
+    rev = "f5e54d01691adb3abef47e051a6412186c33313c";
+    sha256 = "0dhlriwvkrsn7jj01p2wqhf2p63n9qd173jsgccgxlacm2zzvhaz";
+  };
+
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace 'qweechat = qweechat.qweechat' 'qweechat = qweechat.qweechat:main'
+  '';
+
+  propagatedBuildInputs = with python27Packages; [
+     pyside
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/weechat/qweechat;
+    description = "Qt remote GUI for WeeChat";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ramkromberg ];
+    platform = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15851,6 +15851,8 @@ in
 
   privateer = callPackage ../games/privateer { };
 
+  qweechat = callPackage ../applications/networking/irc/qweechat { };
+
   qqwing = callPackage ../games/qqwing { };
 
   quake3wrapper = callPackage ../games/quake3/wrapper { };


### PR DESCRIPTION
###### Motivation for this change

A qt front end for weechat. Headless so you can run weechat on the one box, and this on the other.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

re-pushed with platforms.linux since darwin breaks over qt.
