### PR TITLE
valauncher: init at 1.2

### DIFF
--- a/pkgs/applications/misc/valauncher/default.nix
+++ b/pkgs/applications/misc/valauncher/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, gtk3, vala_0_26, pkgconfig, gnome3 }:
+
+stdenv.mkDerivation rec {
+  version = "1.2";
+  name = "valauncher-${version}";
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "valauncher";
+    rev = "v${version}";
+    sha256 = "1d1gfmzmr5ra2rnjc6rbz31mf3hk7q04lh4i1hljgk7fh90dacb6";
+  };
+
+  buildInputs = [ cmake gtk3 vala_0_26 pkgconfig gnome3.libgee ];
+
+  meta = with stdenv.lib; {
+      description = "A fast dmenu-like gtk3 application launcher";
+      homepage = https://github.com/Mic92/valauncher;
+      license = licenses.mit;
+      maintainers = with maintainers; [ mic92 ];
+      platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17452,6 +17452,8 @@ in
 
   utf8proc = callPackage ../development/libraries/utf8proc { };
 
+  valauncher = callPackage ../applications/misc/valauncher { };
+
   vault = callPackage ../tools/security/vault { };
 
   vbam = callPackage ../misc/emulators/vbam {


### PR DESCRIPTION
###### Motivation for this change

to get all custom patches in <nixpkgs> upstream
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
