### PR TITLE
wavrsocvt: init at 1.0.2.0

### DIFF
--- a/pkgs/applications/misc/audio/wavrsocvt/default.nix
+++ b/pkgs/applications/misc/audio/wavrsocvt/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "wavrsocvt-1.0.2.0";
+
+  src = fetchurl {
+    url = "http://bricxcc.sourceforge.net/wavrsocvt.tgz";
+    sha256 = "15qlvdfwbiclljj7075ycm78yzqahzrgl4ky8pymix5179acm05h";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  unpackPhase = ''
+    tar -zxf $src 
+    '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp wavrsocvt $out/bin
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Convert .wav files into sound files for Lego NXT brick";
+    longDescription = ''
+    wavrsocvt is a command-line utility which can be used from a
+    terminal window or script to convert .wav files into sound
+    files for the NXT brick (.rso files). It can also convert the
+    other direction (i.e., .rso -> .wav). It can produce RSO files
+    with a sample rate between 2000 and 16000 (the min/max range of
+    supported sample rates in the standard NXT firmware).
+    You can then upload these with e.g. nxt-python.
+    '';
+    homepage = http://bricxcc.sourceforge.net/;
+    license = licenses.mpl11;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13137,6 +13137,8 @@ in
 
   wavesurfer = callPackage ../applications/misc/audio/wavesurfer { };
 
+  wavrsocvt = callPackage ../applications/misc/audio/wavrsocvt { };
+
   wireshark-cli = callPackage ../applications/networking/sniffers/wireshark {
     withQt = false;
     withGtk = false;


### PR DESCRIPTION
###### Motivation for this change

A conversion tool required to create audio files for the Lego NXT platform. 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
