### PR TITLE
manuskript: cleanup of install

### DIFF
--- a/pkgs/applications/editors/manuskript/default.nix
+++ b/pkgs/applications/editors/manuskript/default.nix
@@ -17,11 +17,17 @@ python3Packages.buildPythonApplication rec {
     zlib
   ];
 
+  patchPhase = ''
+    substituteInPlace manuskript/ui/welcome.py \
+      --replace sample-projects $out/share/${name}/sample-projects
+   '';
+
   buildPhase = '''';
 
   installPhase = ''
-    mkdir -p $out
-    cp -av * $out/
+    mkdir -p $out/share/${name}
+    cp -av  bin/ i18n/ libs/ manuskript/ resources/ icons/ $out
+    cp -r sample-projects/ $out/share/${name}
   '';
 
   doCheck = false;
@@ -29,6 +35,18 @@ python3Packages.buildPythonApplication rec {
   meta = {
     description = "A open-source tool for writers";
     homepage = http://www.theologeek.ch/manuskript;
+    longDescription = ''
+    Manuskript is a tool for those writer who like to organize and
+    plan everything before writing.  The snowflake method can help you
+    grow your idea into a book, by leading you step by step and asking
+    you questions to go deeper. While writing, keep track of notes
+    about every characters, plot, event, place in your story.
+
+    Develop complex characters and keep track of all useful infos.
+    Create intricate plots, linked to your characters, and use them to
+    outline your story. Organize your ideas about the world your
+    characters live in.
+    '';
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.steveej ];
     platforms = stdenv.lib.platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

The install was overly broad, and installed e.g. README.md, TODO.t2t, CREDITS, COPYING and other files at the top of $out. Cleaned up, put examples in separate folder, etc.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
