### PR TITLE
idea.phpstorm: 10.0.4 -> 2016.2.1

### DIFF
--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -228,12 +228,12 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "10.0.4";
+    version = "2016.2.1";
     description = "Professional IDE for Web and PHP developers";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "0fi042zvjpg5pn2mnhj3bbrdkl1b9vmhpf2l6ca4nr0rhjjv7dsm";
+      sha256 = "0vgr0ds6z0y8qw2v55nr3pi5zb5x0n6pxm13hcp44iradns5kmbp";
     };
     wmClass = "jetbrains-phpstorm";
   };

--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -238,6 +238,19 @@ in
     wmClass = "jetbrains-phpstorm";
   };
 
+  phpstorm10 = buildPhpStorm rec {
+    name = "phpstorm-${version}";
+    version = "10.0.4";
+    description = "Professional IDE for Web and PHP developers";
+    license = stdenv.lib.licenses.unfree;
+    src = fetchurl {
+      url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
+      sha256 = "0fi042zvjpg5pn2mnhj3bbrdkl1b9vmhpf2l6ca4nr0rhjjv7dsm";
+    };
+    wmClass = "jetbrains-phpstorm";
+  };
+
+
   webstorm = buildWebStorm rec {
     name = "webstorm-${version}";
     version = "10.0.5";


### PR DESCRIPTION
###### Motivation for this change

There is a new version of PhpStorm (2016.2.1). The naming scheme has changed to 2016.x schema with release of 2016.1 in March 2016.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
