### PR TITLE
Nokogiri fixup

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems-src.nix
+++ b/pkgs/development/interpreters/ruby/rubygems-src.nix
@@ -1,6 +1,6 @@
 { fetchurl
-, version ? "2.6.2"
-, sha256 ? "1j02ajici555f35vd6ky6m4bxs8lh8nqb1c59qqib4jp4ibcv6zy"
+, version ? "2.6.6"
+, sha256 ? "0x0ldlwr627d0brw96jdbscib6d2nk19izvnh8lzsasszi1k5rkq"
 }:
 fetchurl {
   url = "http://production.cf.rubygems.org/rubygems/rubygems-${version}.tgz";

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -181,6 +181,7 @@ stdenv.mkDerivation (attrs // {
       --force \
       --http-proxy 'http://nodtd.invalid' \
       --ignore-dependencies \
+      --install-dir "$GEM_HOME" \
       --build-root '/' \
       --backtrace \
       ${documentFlag} \


### PR DESCRIPTION
###### Motivation for this change

Since nokogiri 1.6.8, the gem has build-time dependencies on other gems and that fails.

The rubygems upgrade is not strictly necessary but it's there now.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
