### PR TITLE
lowPrio removed from rustBeta and rustUnstable

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5486,10 +5486,10 @@ in
 
   rust = rustStable;
   rustStable = callPackage ../development/compilers/rust {};
-  rustBeta = lowPrio (callPackage ../development/compilers/rust/beta.nix {});
-  rustUnstable = lowPrio (callPackage ../development/compilers/rust/head.nix {
+  rustBeta = callPackage ../development/compilers/rust/beta.nix {};
+  rustUnstable = callPackage ../development/compilers/rust/head.nix {
     rustPlatform = recurseIntoAttrs (makeRustPlatform rustBeta);
-  });
+  };
 
   cargo = rust.cargo;
   rustc = rust.rustc;


### PR DESCRIPTION
###### Motivation for this change

If I have to wait through another rustUnstable and rust Beta build cycle I might just commit suicide.
###### Things done

Not committed suicide
