### PR TITLE
nixos manual: cleanup generation

### DIFF
--- a/nixos/doc/manual/configuration/configuration.xml
+++ b/nixos/doc/manual/configuration/configuration.xml
@@ -24,7 +24,6 @@ effect after you run <command>nixos-rebuild</command>.</para>
 <xi:include href="networking.xml" />
 <xi:include href="linux-kernel.xml" />
 
-<xi:include href="emacs.xml" />
 <xi:include href="modules.xml" xpointer="xpointer(//section[@id='modules']/*)" />
 
 <!-- Apache; libvirtd virtualisation -->

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -63,12 +63,6 @@ let
     ''
       cp -prd $sources/* . # */
       chmod -R u+w .
-      cp ${../../modules/services/databases/postgresql.xml} configuration/postgresql.xml
-      cp ${../../modules/services/misc/gitlab.xml} configuration/gitlab.xml
-      cp ${../../modules/services/misc/taskserver/doc.xml} configuration/taskserver.xml
-      cp ${../../modules/security/acme.xml} configuration/acme.xml
-      cp ${../../modules/i18n/input-method/default.xml} configuration/input-methods.xml
-      cp ${../../modules/services/editors/emacs.xml} configuration/emacs.xml
       ln -s ${modulesDoc} configuration/modules.xml
       ln -s ${optionsDocBook} options-db.xml
       echo "${version}" > version

--- a/nixos/modules/services/editors/emacs.nix
+++ b/nixos/modules/services/editors/emacs.nix
@@ -83,4 +83,6 @@ in {
       EDITOR = mkOverride 900 "${editorScript}/bin/emacseditor";
     } else {};
   };
+
+  meta.doc = ./emacs.xml;
 }


### PR DESCRIPTION
###### Motivation for this change
- removes unneeded steps of the NixOS manual generation
- use `meta.doc` for emacs module documentation
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
