### PR TITLE
Add ex

### DIFF
--- a/pkgs/applications/editors/ex/1_1.nix
+++ b/pkgs/applications/editors/ex/1_1.nix
@@ -1,0 +1,12 @@
+{ pkgs, fetchurl, stdenv }:
+
+import ./mk_ex.nix {
+  pkgs = pkgs;
+  fetchurl = fetchurl;
+  stdenv   = stdenv;
+  version  = "1.1";
+  release  = "160706";
+  hash     = "1lccx9zxl33bmra44yphgl0pa1f3ly8yvnmf2r2bdy99j252s636";
+  desc     = "The very first version of the original vi (version 1.1 released on January 1, 1978 on 1BSD)";
+}
+

--- a/pkgs/applications/editors/ex/2_2.nix
+++ b/pkgs/applications/editors/ex/2_2.nix
@@ -1,0 +1,13 @@
+{ pkgs, fetchurl, stdenv }:
+
+import ./mk_ex.nix {
+  pkgs = pkgs;
+  fetchurl = fetchurl;
+  stdenv   = stdenv;
+  version  = "2.2";
+  release  = "160715";
+  hash     = "1afrj2ga03a7i3m1zkxkj3jsa2n6bs8smlpbzj67vdjzfi63wq91";
+  desc     = "vi version 2.2 (from 2BSD, May 1979)";
+}
+
+

--- a/pkgs/applications/editors/ex/3_2.nix
+++ b/pkgs/applications/editors/ex/3_2.nix
@@ -1,0 +1,12 @@
+{ pkgs, fetchurl, stdenv }:
+
+import ./mk_ex.nix {
+  pkgs = pkgs;
+  fetchurl = fetchurl;
+  stdenv   = stdenv;
+  version  = "3.2";
+  release  = "160719";
+  hash     = "0c7an0001pmzw7xhhpwzy58wk1c26nq5vwxg8xjz932piwgn3dlc";
+  desc     = "vi version 3.2 (from 3BSD, January 1980)";
+}
+

--- a/pkgs/applications/editors/ex/3_6.nix
+++ b/pkgs/applications/editors/ex/3_6.nix
@@ -1,0 +1,12 @@
+{ pkgs, fetchurl, stdenv }:
+
+import ./mk_ex.nix {
+  pkgs = pkgs;
+  fetchurl = fetchurl;
+  stdenv   = stdenv;
+  version  = "3.6";
+  release  = "160723";
+  hash     = "1r3w299cgh176hqgd9g69lrwn4ci8dbqjiygf0k4g8hlx151lrp3";
+  desc     = "vi version 3.6 (from 4.0BSD, November 1980)";
+}
+

--- a/pkgs/applications/editors/ex/3_7.nix
+++ b/pkgs/applications/editors/ex/3_7.nix
@@ -1,0 +1,12 @@
+{ pkgs, fetchurl, stdenv }:
+
+import ./mk_ex.nix {
+  pkgs = pkgs;
+  fetchurl = fetchurl;
+  stdenv   = stdenv;
+  version  = "3.7";
+  release  = "160713";
+  hash     = "19d4vw5kwi651gk4l5nwd0h7a4hh66csn9m5qiblf11lbx9yfg3a";
+  desc     = "The original vi (version 3.7 released in October 1981 on 4.1cBSD)";
+}
+

--- a/pkgs/applications/editors/ex/3_7_4_4.nix
+++ b/pkgs/applications/editors/ex/3_7_4_4.nix
@@ -1,0 +1,12 @@
+{ pkgs, fetchurl, stdenv }:
+
+import ./mk_ex.nix {
+  pkgs = pkgs;
+  fetchurl = fetchurl;
+  stdenv   = stdenv;
+  version  = "3.7_4.4BSD";
+  release  = "160705";
+  hash     = "1aj8c4ym8d49p9n851zbda3bw3ym1mgyjilz37bpk3jn2lmikj51";
+  desc     = "The final release of the original vi";
+}
+

--- a/pkgs/applications/editors/ex/mk_ex.nix
+++ b/pkgs/applications/editors/ex/mk_ex.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
 
   configurePhase = ''
     sed -i 's/^PREFIX.*//' Makefile.in
+
+    # for ex-3.7
+    sed -i 's,PRESERVEDIR=/var/preserve,PRESERVEDIR=/tmp/ex-3.7-preserve,' Makefile.in
+
     sh ./configure
   '';
 

--- a/pkgs/applications/editors/ex/mk_ex.nix
+++ b/pkgs/applications/editors/ex/mk_ex.nix
@@ -1,0 +1,33 @@
+{ pkgs, fetchurl, stdenv, version, release, hash, desc }:
+
+stdenv.mkDerivation rec {
+  name = "ex-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/n-t-roff/${name}/archive/${release}.tar.gz";
+    sha256 = hash;
+  };
+
+  buildInputs = with pkgs; [ ncurses ];
+
+  configurePhase = ''
+    sed -i 's/^PREFIX.*//' Makefile.in
+    sh ./configure
+  '';
+
+  buildPhase = ''
+    PREFIX=$out make
+  '';
+
+  installPhase = ''
+    PREFIX=$out make install
+  '';
+
+  meta = {
+    description = desc;
+    license = stdenv.lib.licenses.gpl3Plus;
+    homepage = "https://github.com/n-t-roff/${name}";
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1510,6 +1510,8 @@ in
 
   ex_3_7 = callPackage ../applications/editors/ex/3_7.nix { };
 
+  ex_3_7_4_4 = callPackage ../applications/editors/ex/3_7_4_4.nix { };
+
   exa = callPackage ../tools/misc/exa { };
 
   exempi = callPackage ../development/libraries/exempi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1500,6 +1500,8 @@ in
 
   evtest = callPackage ../applications/misc/evtest { };
 
+  ex_1_1 = callPackage ../applications/editors/ex/1_1.nix { };
+
   exa = callPackage ../tools/misc/exa { };
 
   exempi = callPackage ../development/libraries/exempi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1506,6 +1506,8 @@ in
 
   ex_3_2 = callPackage ../applications/editors/ex/3_2.nix { };
 
+  ex_3_6 = callPackage ../applications/editors/ex/3_6.nix { };
+
   exa = callPackage ../tools/misc/exa { };
 
   exempi = callPackage ../development/libraries/exempi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1504,6 +1504,8 @@ in
 
   ex_2_2 = callPackage ../applications/editors/ex/2_2.nix { };
 
+  ex_3_2 = callPackage ../applications/editors/ex/3_2.nix { };
+
   exa = callPackage ../tools/misc/exa { };
 
   exempi = callPackage ../development/libraries/exempi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1502,6 +1502,8 @@ in
 
   ex_1_1 = callPackage ../applications/editors/ex/1_1.nix { };
 
+  ex_2_2 = callPackage ../applications/editors/ex/2_2.nix { };
+
   exa = callPackage ../tools/misc/exa { };
 
   exempi = callPackage ../development/libraries/exempi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1508,6 +1508,8 @@ in
 
   ex_3_6 = callPackage ../applications/editors/ex/3_6.nix { };
 
+  ex_3_7 = callPackage ../applications/editors/ex/3_7.nix { };
+
   exa = callPackage ../tools/misc/exa { };
 
   exempi = callPackage ../development/libraries/exempi { };


### PR DESCRIPTION
###### Motivation for this change

This adds some (all?) versions of the `ex` editor, the predecessor for `vi`.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Please suggest enhancements to the codebase.
