### PR TITLE
ffmpeg: 3.1.2 -> 3.1.3

### DIFF
--- a/pkgs/development/libraries/ffmpeg/3.1.nix
+++ b/pkgs/development/libraries/ffmpeg/3.1.nix
@@ -5,8 +5,8 @@
 }@args:
 
 callPackage ./generic.nix (args // rec {
-  version = "${branch}.2";
+  version = "${branch}.3";
   branch = "3.1";
-  sha256 = "1xvh1c8nlws0wx6b7yl1pvkybgzaj5585h1r6z1gzhck1f0qvsv2";
+  sha256 = "0f4ajs0c4088nkal4gqagx05wfyhd1izfxmzxxsdh56ibp38kg2q";
   darwinFrameworks = [ Cocoa CoreMedia ];
 })


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
