### PR TITLE
googleearth: 6.0.3.2197 -> 7.1.4.1529

### DIFF
--- a/pkgs/applications/misc/googleearth/default.nix
+++ b/pkgs/applications/misc/googleearth/default.nix
@@ -1,77 +1,79 @@
 { stdenv, fetchurl, glibc, mesa, freetype, glib, libSM, libICE, libXi, libXv
 , libXrender, libXrandr, libXfixes, libXcursor, libXinerama, libXext, libX11, qt4
-, zlib, fontconfig }:
+, zlib, fontconfig, dpkg }:
 
-/* I haven't found any x86_64 package from them */
-assert stdenv.system == "i686-linux";
-
-stdenv.mkDerivation {
-  name = "googleearth-6.0.3.2197";
-
-  src = fetchurl {
-    url = http://dl.google.com/earth/client/current/GoogleEarthLinux.bin;
-    sha256 = "0bcpmnlk03382x577qbnbw3i6y08hr3qmg85pqj35scnl6van74c";
-  };
-
-  nativeBuildInputs = [
+let
+  arch =
+    if stdenv.system == "x86_64-linux" then "amd64"
+    else if stdenv.system == "i686-linux" then "i386"
+    else abort "Unsupported architecture";
+  sha256 =
+    if arch == "amd64"
+    then "00ydkbpndjac0w04p6ldj07jbzgy48rcjpirhc5r8glbl8zdh52s"
+    else "1mgj98kq6dz6kl3vmjghlxzdpp2mffqn2whiraja459brqz9mf10";
+  fullPath = stdenv.lib.makeLibraryPath [
     glibc
     glib
     stdenv.cc.cc
-    libSM 
-    libICE 
-    libXi 
+    libSM
+    libICE
+    libXi
     libXv
     mesa
-    libXrender 
-    libXrandr 
-    libXfixes 
-    libXcursor 
-    libXinerama 
-    freetype 
-    libXext 
-    libX11 
+    libXrender
+    libXrandr
+    libXfixes
+    libXcursor
+    libXinerama
+    freetype
+    libXext
+    libX11
     qt4
     zlib
     fontconfig
   ];
+in
+stdenv.mkDerivation rec {
+  version = "7.1.4.1529";
+  name = "googleearth-${version}";
+
+  src = fetchurl {
+    url = "https://dl.google.com/earth/client/current/google-earth-stable_current_${arch}.deb";
+    inherit sha256;
+  };
 
   phases = "unpackPhase installPhase";
-  
+
+  buildInputs = [ dpkg ];
+
   unpackPhase = ''
-    bash $src --noexec --target unpacked
-    cd unpacked
+    dpkg-deb -x ${src} ./
   '';
-  
+
   installPhase =''
-    mkdir -p $out/{opt/googleearth/,bin};
-    tar xf googleearth-data.tar -C $out/opt/googleearth
-    tar xf googleearth-linux-x86.tar -C $out/opt/googleearth
-    cp bin/googleearth $out/opt/googleearth
-    cat > $out/bin/googleearth << EOF
-    #!/bin/sh
-    export GOOGLEEARTH_DATA_PATH=$out/opt/googleearth
-    exec $out/opt/googleearth/googleearth
-    EOF
-    chmod +x $out/bin/googleearth
+    mkdir $out
+    mv usr/* $out/
+    rmdir usr
+    mv * $out/
+    rm $out/bin/google-earth $out/opt/google/earth/free/google-earth
+    ln -s $out/opt/google/earth/free/googleearth $out/bin/google-earth
 
-    fullPath=
-    for i in $nativeBuildInputs; do
-      fullPath=$fullPath:$i/lib
-    done
-          
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath $fullPath \
-      $out/opt/googleearth/googleearth-bin
+      --set-rpath "${fullPath}:\$ORIGIN" \
+      $out/opt/google/earth/free/googleearth-bin
 
-    for a in $out/opt/googleearth/*.so* ; do
-      patchelf --set-rpath $fullPath $a
+    for a in $out/opt/google/earth/free/*.so* ; do
+      patchelf --set-rpath "${fullPath}:\$ORIGIN" $a
     done
   '';
+
+  dontPatchELF = true;
 
   meta = {
     description = "A world sphere viewer";
     homepage = http://earth.google.com;
     license = stdenv.lib.licenses.unfree;
     maintainers = [ stdenv.lib.maintainers.viric ];
+    platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Tried to use Google Earth, it was broken (see #17956) and the version was last changed back in 2010.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
