### PR TITLE
hyperterm: init at 0.7.6

### DIFF
--- a/pkgs/applications/misc/hyperterm/default.nix
+++ b/pkgs/applications/misc/hyperterm/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchurl, dpkg, gtk, atk, glib, pango, gdk_pixbuf, cairo
+, freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr
+, libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver
+, GConf, nss, nspr, alsaLib, cups, expat, libudev, libpulseaudio }:
+
+let
+  libPath = stdenv.lib.makeLibraryPath [
+    stdenv.cc.cc gtk atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
+    libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes
+    libXrender libX11 libXtst libXScrnSaver GConf nss nspr alsaLib cups expat libudev libpulseaudio
+  ];
+in
+stdenv.mkDerivation rec {
+  version = "0.7.6";
+  name = "hyperterm-${version}";
+  src = fetchurl {
+    url = https://github.com/zeit/hyperterm/releases/download/v0.7.1/hyperterm-0.7.1.deb;
+    sha256 = "1xdwhmzlkg1ly1xgsbv99xk4x1g1x270vx1b12dvf10ck5x9v63a";
+  };
+  buildInputs = [ dpkg ];
+  unpackPhase = ''
+    mkdir pkg
+    dpkg-deb -x $src pkg
+    sourceRoot=pkg
+  '';
+  installPhase = ''
+    mkdir -p "$out/bin"
+    ln -s "$out/opt/HyperTerm/HyperTerm" "$out/bin/HyperTerm"
+    mv opt "$out/"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:\$ORIGIN" "$out/opt/HyperTerm/HyperTerm"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}" "$out/opt/HyperTerm/resources/app/node_modules/child_pty/build/Release/exechelper"
+    mv usr/* "$out/"
+  '';
+  dontPatchELF = true;
+  meta = with lib; {
+    description = "A terminal built on web technologies";
+    homepage    = https://hyperterm.org/;
+    maintainers = with maintainers; [ puffnfresh ];
+    license     = licenses.mit;
+    platforms   = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13449,6 +13449,8 @@ in
 
   hydrogen = callPackage ../applications/audio/hydrogen { };
 
+  hyperterm = callPackage ../applications/misc/hyperterm { inherit (gnome) GConf; };
+
   slack = callPackage ../applications/networking/instant-messengers/slack { };
 
   spectrwm = callPackage ../applications/window-managers/spectrwm { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
