### PR TITLE
timewarrior: 1.0.0.beta1 -> 1.0.0

### DIFF
--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "timewarrior-${version}";
-  version = "1.0.0.beta1";
+  version = "1.0.0";
 
   enableParallelBuilding = true;
 
   src = fetchurl {
     url = "https://taskwarrior.org/download/timew-${version}.tar.gz";
-    sha256 = "1gkh07mw8hiqslw8ps35r9lp5jbdy93s0sdrcbp34dd5h99qx587";
+    sha256 = "1d8b9sjdbdld81n535iwip9igl16kcw452wa47fmndp8w487j0mc";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
