### PR TITLE
gsl: 2.1 -> 2.2

### DIFF
--- a/pkgs/development/interpreters/lush/default.nix
+++ b/pkgs/development/interpreters/lush/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, libX11, xproto, indent, readline, gsl, freeglut, mesa, SDL
-, blas, binutils, intltool, gettext, zlib}:
+, blas, binutils, intltool, gettext, zlib, libSM}:
 
 stdenv.mkDerivation rec {
   baseName = "lush";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libX11 xproto indent readline gsl freeglut mesa SDL blas binutils
+    libX11 libSM xproto indent readline gsl freeglut mesa SDL blas binutils
     intltool gettext zlib
   ];
 

--- a/pkgs/development/libraries/gsl/default.nix
+++ b/pkgs/development/libraries/gsl/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, fetchpatch, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "gsl-2.1";
+  name = "gsl-2.2";
 
   src = fetchurl {
     url = "mirror://gnu/gsl/${name}.tar.gz";
-    sha256 = "0rhcia9jhr3p1f1wybwyllwqfs9bggz99i3mi5lpyqcpff1hdbar";
+    sha256 = "1pyq2c0j91z955746myn29c89jwkd435s2cbj8ks2hpag6d0mr2d";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Also fix broken `lush2` (was making `nox-review wip` fail).
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
