### PR TITLE
aria2: 1.24.0 -> 1.26.1

### DIFF
--- a/pkgs/tools/networking/aria2/default.nix
+++ b/pkgs/tools/networking/aria2/default.nix
@@ -1,30 +1,23 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, autoreconfHook
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook
 , openssl, c-ares, libxml2, sqlite, zlib, libssh2
 , Security
 }:
 
 stdenv.mkDerivation rec {
   name = "aria2-${version}";
-  version = "1.24.0";
+  version = "1.26.1";
 
   src = fetchFromGitHub {
     owner = "aria2";
     repo = "aria2";
     rev = "release-${version}";
-    sha256 = "0sb8s2rf2l0x7m8fx8kys7vad0lfw3k9071iai03kxplkdvg96n9";
+    sha256 = "1nf7z55cc6ljpz7zzb8ppg8ybg531gfbhyggya7lnr5ka74h87b5";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
 
   buildInputs = [ openssl c-ares libxml2 sqlite zlib libssh2 ] ++
     stdenv.lib.optional stdenv.isDarwin Security;
-
-  patches = stdenv.lib.optionals stdenv.isDarwin [
-    (fetchpatch {
-      url = https://github.com/aria2/aria2/commit/1e59e357af626edc870b7f53c1ae8083658d0d1a.patch;
-      sha256 = "1xjj4ll1v6adl6vdkl84v0mh7ma6p469ph1wpvksxrq6qp8345qj";
-    })
-  ];
 
   configureFlags = [ "--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt" ];
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
