### PR TITLE
roboto: init at 2.134

### DIFF
--- a/pkgs/data/fonts/roboto/default.nix
+++ b/pkgs/data/fonts/roboto/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "roboto-${version}";
+  version = "2.134";
+
+  src = fetchurl {
+    url = "https://github.com/google/roboto/releases/download/v${version}/roboto-unhinted.zip";
+    sha256 = "1l033xc2n4754gwakxshh5235cnrnzy7q6zsp5zghn8ib0gdp5rb";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -a * $out/share/fonts/truetype/
+  '';
+
+  meta = {
+    homepage = https://github.com/google/roboto;
+    description = "The Roboto family of fonts";
+    longDescription = ''
+      Google’s signature family of fonts, the default font on Android and
+      Chrome OS, and the recommended font for Google’s visual language,
+      Material Design.
+    '';
+    license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12102,6 +12102,8 @@ in
 
   r5rs = callPackage ../data/documentation/rnrs/r5rs.nix { };
 
+  roboto = callPackage ../data/fonts/roboto { };
+
   hasklig = callPackage ../data/fonts/hasklig {};
 
   sound-theme-freedesktop = callPackage ../data/misc/sound-theme-freedesktop { };


### PR DESCRIPTION
###### Motivation for this change

Add the **Roboto** family of fonts package. It is Google’s signature family of fonts, the default font on Android and Chrome OS, and the recommended font for Google’s visual language, Material Design.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
