### PR TITLE
raspberrypifw: Don't strip ELF files

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "06g691px0abndp5zvz2ba1g675rcqb64n055h5ahgnlck5cdpawg";
   };
 
+  dontStrip = true;    # Stripping breaks some of the binaries
+
   installPhase = ''
     mkdir -p $out/share/raspberrypi/boot
     cp -R boot/* $out/share/raspberrypi/boot


### PR DESCRIPTION
###### Motivation for this change

Stripping ELF files breaks some executables:
`.../bin/raspivid: relocation error: .../bin/raspivid: symbol , version GLIBC_2.4 not defined in file libc.so.6 with link time reference`

After setting dontStrip:
`raspivid Camera App v1.3.12`

Tested on a Raspberry Pi 3 on release-16.09
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @dezgeg 
