### PR TITLE
LLVM 3.8.1

### DIFF
--- a/pkgs/development/compilers/llvm/3.8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/clang/default.nix
@@ -6,7 +6,7 @@ let
     name = "clang-${version}";
 
     unpackPhase = ''
-      unpackFile ${fetch "cfe" "1ybcac8hlr9vl3wg8s4v6cp0c0qgqnwprsv85lihbkq3vqv94504"}
+      unpackFile ${fetch "cfe" "1prc72xmkgx8wrzmrr337776676nhsp1qd3mw2bvb22bzdnq7lsc"}
       mv cfe-${version}.src clang
       sourceRoot=$PWD/clang
       unpackFile ${clang-tools-extra_src}

--- a/pkgs/development/compilers/llvm/3.8/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/default.nix
@@ -2,7 +2,7 @@
 let
   callPackage = newScope (self // { inherit stdenv isl version fetch; });
 
-  version = "3.8.0";
+  version = "3.8.1";
 
   fetch = fetch_v version;
   fetch_v = ver: name: sha256: fetchurl {
@@ -10,8 +10,8 @@ let
     inherit sha256;
   };
 
-  compiler-rt_src = fetch "compiler-rt" "1c2nkp9563873ffz22qmhc0wakgj428pch8rmhym8agjamz3ily8";
-  clang-tools-extra_src = fetch "clang-tools-extra" "1i0yrgj8qrzjjswraz0i55lg92ljpqhvjr619d268vka208aigdg";
+  compiler-rt_src = fetch "compiler-rt" "0p0y85c7izndbpg2l816z7z7558axq11d5pwkm4h11sdw7d13w0d";
+  clang-tools-extra_src = fetch "clang-tools-extra" "15n39r4ssphpaq4a0wzyjm7ilwxb0bch6nrapy8c5s8d49h5qjk6";
 
   self = {
     llvm = callPackage ./llvm.nix {

--- a/pkgs/development/compilers/llvm/3.8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "0yr3fh8vj38289b9cwk37zsy7x98dcd3kjy7xxy8mg20p48lb01n";
+  src = fetch "libcxx" "1k7f9qk5bgwa02ksh6yr9hccwcbhmcdzl1fpbdw6s2c89iwg7mvp";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/3.8/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/3.8/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "0175rv2ynkklbg96kpw13iwhnzyrlw3r12f4h09p9v7nmxqhivn5";
+  src = fetch "libcxxabi" "1qfs2iis1i0ppv11jndc98cvd7s25pj46pq2sfyldmzswdxmzdg1";
 
   buildInputs = [ cmake ] ++ stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
 

--- a/pkgs/development/compilers/llvm/3.8/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.8/lldb.nix
@@ -15,7 +15,7 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "0dasg12gf5crrd9pbi5rd1y8vwlgqp8nxgw9g4z47w3x2i28zxp3";
+  src = fetch "lldb" "18z8vhfgh4m57hl66i83cp4d4mv3i86z2hjhbp5rvqs7d88li49l";
 
   postUnpack = ''
     # Hack around broken standalone builf as of 3.8

--- a/pkgs/development/compilers/llvm/3.8/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.8/lldb.nix
@@ -25,12 +25,9 @@ stdenv.mkDerivation {
     cp "$(ls -d llvm-*.src)/lib/Support/regex_impl.h" "$srcDir/tools/lib/Support/"
   '';
 
-  buildInputs = [ cmake python which swig ncurses zlib libedit ];
+  buildInputs = [ cmake python which swig ncurses zlib libedit llvm ];
 
-  preConfigure = ''
-    export CXXFLAGS="-pthread"
-    export LDFLAGS="-ldl"
-  '';
+  hardeningDisable = [ "format" ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"

--- a/pkgs/development/compilers/llvm/3.8/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.8/llvm.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  src = fetch "llvm" "0ikfq0gxac8xpvxj23l4hk8f12ydx48fljgrz1gl9xp0ks704nsm";
+  src = fetch "llvm" "1ybmnid4pw2hxn12ax5qa5kl1ldfns0njg8533y3mzslvd5cx0kf";
 in stdenv.mkDerivation rec {
   name = "llvm-${version}";
 


### PR DESCRIPTION
###### Motivation for this change

Bump LLVM from 3.8.0 to 3.8.1.

First commit is needed to fix LLDB after hardening changes (even on 3.8.0), second bumps to 3.8.1.

Resulting tools seem to work, more testing probably required.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
