### PR TITLE
sysklogd: fix compile error

### DIFF
--- a/pkgs/os-specific/linux/sysklogd/default.nix
+++ b/pkgs/os-specific/linux/sysklogd/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "00f2wy6f0qng7qzga4iicyzl9j8b7mp6mrpfky5jxj93ms2w2rji";
   };
 
-  patches = [ ./systemd.patch ];
+  patches = [ ./systemd.patch ./union-wait.patch ];
 
   installFlags = "BINDIR=$(out)/sbin MANDIR=$(out)/share/man INSTALL=install";
 

--- a/pkgs/os-specific/linux/sysklogd/union-wait.patch
+++ b/pkgs/os-specific/linux/sysklogd/union-wait.patch
@@ -1,0 +1,11 @@
+--- sysklogd-1.5-old/syslogd.c	2016-08-30 22:50:59.812926945 +0100
++++ sysklogd-1.5/syslogd.c	2016-08-30 22:51:12.008842890 +0100
+@@ -2094,7 +2094,7 @@
+ 	(void) signal(SIGCHLD, reapchild);	/* reset signal handler -ASP */
+ 	wait ((int *)0);
+ #else
+-	union wait status;
++	int status;
+ 
+ 	while (wait3(&status, WNOHANG, (struct rusage *) NULL) > 0)
+ 		;


### PR DESCRIPTION
###### Motivation for this change

The sysklogd package wasn't compiling. Now it is.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

sysklogd was failing to build because it didn't know the size of the
`union wait` type.

Running `git bisect` showed 9744c7768d0e6920623a16a4e9d604de2fd52f34,
which bumped glibc from 2.23 to 2.24, as the likely suspect.  This is
corroborated by evidence such as this email:
https://lists.debian.org/debian-glibc/2016/08/msg00069.html

Linux from scratch recommends changing `union wait` to `int`:
http://www.linuxfromscratch.org/lfs/view/development/chapter06/sysklogd.html

Therefore, that's what this commit does.
