### PR TITLE
rainbowstream: 1.3.3 -> 1.3.5

### DIFF
--- a/pkgs/development/python-modules/rainbowstream/setup.patch
+++ b/pkgs/development/python-modules/rainbowstream/setup.patch
@@ -1,0 +1,24 @@
+diff --git a/setup.py b/setup.py
+index 07b5913..2b7b15e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -24,15 +24,16 @@ install_requires = [
+ ]
+ 
+ # Default user (considers non virtualenv method)
+-user = os.environ.get('SUDO_USER', os.environ['USER'])
++user = os.environ.get('SUDO_USER', os.environ.get('USER', None))
+ 
+ # Copy default config if not exists
+ default = os.path.expanduser("~") + os.sep + '.rainbow_config.json'
+ if not os.path.isfile(default):
+     cmd = 'cp rainbowstream/colorset/config ' + default
+     os.system(cmd)
+-    cmd = 'chown ' + quote(user) + ' ' + default
+-    os.system(cmd)
++    if user:
++        cmd = 'chown ' + quote(user) + ' ' + default
++        os.system(cmd)
+     cmd = 'chmod 777 ' + default
+     os.system(cmd)
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13207,17 +13207,18 @@ in modules // {
 
   rainbowstream = buildPythonPackage rec {
     name = "rainbowstream-${version}";
-    version = "1.3.3";
+    version = "1.3.5";
 
     src = pkgs.fetchurl {
       url    = "mirror://pypi/r/rainbowstream/${name}.tar.gz";
-      sha256 = "08598slbn8sm2hjs0q1041fv7m56k2ky4q66rsihacjw0mg7blai";
+      sha256 = "0a8bs9g81ns47d4vaj5pfgw9zwbcp0nivlm5rps4dlb6qwvzni1w";
     };
 
     doCheck = false;
 
     patches = [
       ../development/python-modules/rainbowstream/image.patch
+      ../development/python-modules/rainbowstream/setup.patch
     ];
 
     postPatch = ''
@@ -13241,6 +13242,7 @@ in modules // {
     buildInputs = with self; [
       pkgs.libjpeg pkgs.freetype pkgs.zlib pkgs.glibcLocales
       pillow twitter pyfiglet requests2 arrow dateutil modules.readline pysocks
+      pocket
     ];
 
     meta = {
@@ -13248,6 +13250,27 @@ in modules // {
       homepage    = "http://www.rainbowstream.org/";
       license     = licenses.mit;
       maintainers = with maintainers; [ thoughtpolice ];
+    };
+  };
+
+  pocket = buildPythonPackage rec {
+    name = "pocket-${version}";
+    version = "0.3.6";
+
+    src = pkgs.fetchurl {
+      url    = "mirror://pypi/p/pocket/${name}.tar.gz";
+      sha256 = "1fc9vc5nyzf1kzmnrs18dmns7nn8wjfrg7br1w4c5sgs35mg2ywh";
+    };
+
+    buildInputs = with self; [
+      requests2
+    ];
+
+    meta = {
+      description = "Wrapper for the pocket API";
+      homepage    = "https://github.com/tapanpandita/pocket";
+      license     = licenses.bsd3;
+      maintainers = with maintainers; [ ericsagnes ];
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Update rainbowstream to latest version.

Also:
- Added a patch to fix the build. The problem has been reported upstream via https://github.com/DTVD/rainbowstream/pull/193.
- Added a new dependency: `pocket`

cc rainbowstream maintainer @thoughtpolice 
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
