### PR TITLE
nodejs-4_x: 4.4.6 -> 4.5.0

### DIFF
--- a/pkgs/development/web/nodejs/v4.nix
+++ b/pkgs/development/web/nodejs/v4.nix
@@ -4,9 +4,9 @@
 }@args:
 
 import ./nodejs.nix (args // rec {
-  version = "4.4.6";
+  version = "4.5.0";
   src = fetchurl {
-    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
-    sha256 = "0f6bbfbea525469c91932b1aac35e0810e6bcda96f1c720e42a433942ee66106";
+    url = "https://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
+    sha256 = "126l7drvxzyifjnsw1kzi4r67i365s75c2c44122902nihvrvfcp";
   };
 })


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
