### PR TITLE
openjdk: Keep {include,man} in $out/lib/opendjk.

### DIFF
--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -122,15 +122,16 @@ let
 
       cp -av build/*/images/j2sdk-image/* $out/lib/openjdk
 
-      # Move some stuff to top-level.
-      mv $out/lib/openjdk/include $out/include
-      mv $out/lib/openjdk/man $out/share/man
+      # Remove some broken manpages.
+      rm -rf $out/lib/openjdk/man/ja*
+
+      # Mirror some stuff in top-level.
+      mkdir $out/include $out/share/man
+      ln -s $out/lib/openjdk/include/* $out/include
+      ln -s $out/lib/openjdk/man/* $out/share/man
 
       # jni.h expects jni_md.h to be in the header search path.
       ln -s $out/include/linux/*_md.h $out/include/
-
-      # Remove some broken manpages.
-      rm -rf $out/share/man/ja*
 
       # Remove crap from the installation.
       rm -rf $out/lib/openjdk/demo $out/lib/openjdk/sample

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -127,8 +127,8 @@ let
 
       # Mirror some stuff in top-level.
       mkdir $out/include $out/share/man
-      ln -s $out/lib/openjdk/include/* $out/include
-      ln -s $out/lib/openjdk/man/* $out/share/man
+      ln -s $out/lib/openjdk/include/* $out/include/
+      ln -s $out/lib/openjdk/man/* $out/share/man/
 
       # jni.h expects jni_md.h to be in the header search path.
       ln -s $out/include/linux/*_md.h $out/include/


### PR DESCRIPTION
###### Motivation for this change

Some JDK consumers expect the `include` directory, in particular, to be in `JAVA_HOME`. [bazel](https://github.com/bazelbuild/bazel) is one such example. It seems to do no harm to stick with the standard here, and just symlink the `{include,man}` directories into their current top-level locations as well.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a standard layout that some JDK consumers expect.
