### PR TITLE
plan9port: 2015-06-29 -> 2015-11-10

### DIFF
--- a/pkgs/tools/system/plan9port/builder.sh
+++ b/pkgs/tools/system/plan9port/builder.sh
@@ -5,7 +5,7 @@ export PLAN9_TARGET=$PLAN9
 
 configurePhase()
 {
-    echo CFLAGS=\"-I${fontconfig_dev}/include -I${libXt_dev}/include\" > LOCAL.config
+    echo CFLAGS=\"-I${fontconfig_dev}/include -I${libXt_dev}/include -I${freetype_dev}/include\" > LOCAL.config
     echo X11=\"${libXt_dev}/include\" >> LOCAL.config
 
     for f in `grep -l -r /usr/local/plan9`; do

--- a/pkgs/tools/system/plan9port/sam_chord_9front.patch
+++ b/pkgs/tools/system/plan9port/sam_chord_9front.patch
@@ -1,0 +1,215 @@
+diff -r -c p9p/src/cmd/sam/xec.c p9p-patched/src/cmd/sam/xec.c
+*** p9p/src/cmd/sam/xec.c	2016-04-18 21:07:22.000000000 +0300
+--- p9p-patched/src/cmd/sam/xec.c	2016-08-31 06:35:26.910876148 +0300
+***************
+*** 277,282 ****
+--- 277,283 ----
+  	else
+  		while(n++ && undo(FALSE))
+  			;
++ 	moveto(f, f->dot.r);
+  	return TRUE;
+  }
+  
+diff -r -c p9p/src/cmd/samterm/flayer.c p9p-patched/src/cmd/samterm/flayer.c
+*** p9p/src/cmd/samterm/flayer.c	2016-04-18 21:07:22.000000000 +0300
+--- p9p-patched/src/cmd/samterm/flayer.c	2016-08-31 06:46:19.441411045 +0300
+***************
+*** 254,274 ****
+  int
+  flselect(Flayer *l)
+  {
+- 	int ret;
+  	if(l->visible!=All)
+  		flupfront(l);
+! 	frselect(&l->f, mousectl);
+! 	ret = 0;
+! 	if(l->f.p0==l->f.p1){
+! 		if(mousep->msec-l->click<Clicktime && l->f.p0+l->origin==l->p0){
+! 			ret = 1;
+  			l->click = 0;
+! 		}else
+! 			l->click = mousep->msec;
+! 	}else
+! 		l->click = 0;
+  	l->p0 = l->f.p0+l->origin, l->p1 = l->f.p1+l->origin;
+! 	return ret;
+  }
+  
+  void
+--- 254,271 ----
+  int
+  flselect(Flayer *l)
+  {
+  	if(l->visible!=All)
+  		flupfront(l);
+! 	if(l->f.p0==l->f.p1)
+! 		if(mousep->msec-l->click<Clicktime && l->f.p0+l->origin==l->p0 && 
+! 			l->f.p0==frcharofpt(&l->f, mousep->xy)){
+  			l->click = 0;
+! 			return 1;
+! 		}
+! 	l->click = mousep->msec;
+! 	frselect(&l->f, mousectl);
+  	l->p0 = l->f.p0+l->origin, l->p1 = l->f.p1+l->origin;
+! 	return 0;
+  }
+  
+  void
+diff -r -c p9p/src/cmd/samterm/main.c p9p-patched/src/cmd/samterm/main.c
+*** p9p/src/cmd/samterm/main.c	2016-04-18 21:07:22.000000000 +0300
+--- p9p-patched/src/cmd/samterm/main.c	2016-08-31 06:52:05.670322598 +0300
+***************
+*** 23,33 ****
+  char	hostlock = 1;
+  char	hasunlocked = 0;
+  int	maxtab = 8;
+- int	chord;
+  int	autoindent;
+  
+- #define chording 0	/* code here for reference but it causes deadlocks */
+- 
+  void
+  notifyf(void *a, char *msg)
+  {
+--- 23,30 ----
+***************
+*** 39,45 ****
+  void
+  threadmain(int argc, char *argv[])
+  {
+! 	int i, got, scr, w;
+  	Text *t;
+  	Rectangle r;
+  	Flayer *nwhich;
+--- 36,42 ----
+  void
+  threadmain(int argc, char *argv[])
+  {
+! 	int i, got, scr, chord;
+  	Text *t;
+  	Rectangle r;
+  	Flayer *nwhich;
+***************
+*** 84,89 ****
+--- 81,87 ----
+  	startnewfile(Tstartcmdfile, &cmd);
+  
+  	got = 0;
++ 	chord = 0;
+  	if(protodebug) print("loop\n");
+  	for(;;got = waitforio()){
+  		if(hasunlocked && RESIZED())
+***************
+*** 108,163 ****
+  				continue;
+  			}
+  			nwhich = flwhich(mousep->xy);
+! 			scr = which && ptinrect(mousep->xy, which->scroll);
+  			if(mousep->buttons)
+  				flushtyping(1);
+! 			if(chording && chord==1 && !mousep->buttons)
+  				chord = 0;
+! 			if(chording && chord)
+  				chord |= mousep->buttons;
+! 			else if(mousep->buttons&1){
+! 				if(nwhich){
+! 					if(nwhich!=which)
+! 						current(nwhich);
+! 					else if(scr)
+! 						scroll(which, 1);
+! 					else{
+! 						t=(Text *)which->user1;
+! 						if(flselect(which)){
+! 							outTsl(Tdclick, t->tag, which->p0);
+! 							t->lock++;
+! 						}else if(t!=&cmd)
+! 							outcmd();
+! 						if(mousep->buttons&1)
+! 							chord = mousep->buttons;
+  					}
+  				}
+  			}else if((mousep->buttons&2) && which){
+  				if(scr)
+  					scroll(which, 2);
+  				else
+  					menu2hit();
+! 			}else if((mousep->buttons&4)){
+  				if(scr)
+! 					scroll(which, 3);
+  				else
+  					menu3hit();
+  			}
+  			mouseunblock();
+  		}
+- 		if(chording && chord){
+- 			t = (Text*)which->user1;
+- 			if(!t->lock && !hostlock){
+- 				w = which-t->l;
+- 				if(chord&2){
+- 					cut(t, w, 1, 1);
+- 					chord &= ~2;
+- 				}else if(chord&4){
+- 					paste(t, w);
+- 					chord &= ~4;
+- 				}
+- 			}
+- 		}
+  	}
+  }
+  
+--- 106,159 ----
+  				continue;
+  			}
+  			nwhich = flwhich(mousep->xy);
+! 			scr = which && (ptinrect(mousep->xy, which->scroll) ||
+! 				mousep->buttons&(8|16));
+  			if(mousep->buttons)
+  				flushtyping(1);
+! 			if((mousep->buttons&1)==0)
+  				chord = 0;
+! 			if(chord && which && which==nwhich){
+  				chord |= mousep->buttons;
+! 				t = (Text *)which->user1;
+! 				if(!t->lock){
+! 					int w = which-t->l;
+! 					if(chord&2){
+! 						cut(t, w, 1, 1);
+! 						chord &= ~2;
+! 					}
+! 					if(chord&4){
+! 						paste(t, w);
+! 						chord &= ~4;
+  					}
+  				}
++ 			}else if(mousep->buttons&(1|8)){
++ 				if(scr)
++ 					scroll(which, (mousep->buttons&8) ? 4 : 1);
++ 				else if(nwhich && nwhich!=which)
++ 					current(nwhich);
++ 				else{
++ 					t=(Text *)which->user1;
++ 					if(flselect(which)){
++ 						outTsl(Tdclick, t->tag, which->p0);
++ 						t->lock++;
++ 					}else if(t!=&cmd)
++ 						outcmd();
++ 					if(mousep->buttons&1)
++ 						chord = mousep->buttons;
++ 				}
+  			}else if((mousep->buttons&2) && which){
+  				if(scr)
+  					scroll(which, 2);
+  				else
+  					menu2hit();
+! 			}else if(mousep->buttons&(4|16)){
+  				if(scr)
+! 					scroll(which, (mousep->buttons&16) ? 5 : 3);
+  				else
+  					menu3hit();
+  			}
+  			mouseunblock();
+  		}
+  	}
+  }
+  


### PR DESCRIPTION
###### Motivation for this change

Changes: https://github.com/NixOS/nixpkgs/pull/18141/files?w=1
Updated to latest upstream.
Fixed build warning about deprecated flags.
Ported chording patches from 9front.
Fixed up fontsrv for system fonts access (DejaVu in acme \ sam \ 9term should be possible now).
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested normal acme operations and sam's patched chroding.

Tested `9 fontsrv & 9 9p ls font` to see fontstv lists system fonts correctly (See `9 man fontsrv` for fontsrv instructions).
