### PR TITLE
openmpi: fix libtool issue  #18147 by stripping libtool *.la files

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -42,6 +42,10 @@ in stdenv.mkDerivation rec {
     patchShebangs ompi/mpi/fortran/base/gen-mpi-sizeof.pl
   '';
 
+  postInstall = ''
+		rm -f $out/lib/*.la
+   '';
+
   meta = {
     homepage = http://www.open-mpi.org/;
     description = "Open source MPI-2 implementation";


### PR DESCRIPTION
###### Motivation for this change

Solve issue #18147

> > > > openmpi nix package do not strip the *.la files coming from libtool.

This generate dependency issues for other project using libtool and nix, due to libtool trying to link against the dependencies of openmpi itself ( e.g libibverbs ) when it should not.

This issue has been encountered here #17937

It is a general good practice to strip libtool *.la file in package. 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
