### PR TITLE
telegraf: init at 0.13.2

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -275,6 +275,7 @@
       gocd-server = 252;
       terraria = 253;
       mattermost = 254;
+      telegraf = 255;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -520,6 +521,7 @@
       gocd-server = 252;
       terraria = 253;
       mattermost = 254;
+      telegraf = 255;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -293,6 +293,7 @@
   ./services/monitoring/smartd.nix
   ./services/monitoring/statsd.nix
   ./services/monitoring/systemhealth.nix
+  ./services/monitoring/telegraf.nix
   ./services/monitoring/teamviewer.nix
   ./services/monitoring/ups.nix
   ./services/monitoring/uptime.nix

--- a/nixos/modules/services/monitoring/telegraf.nix
+++ b/nixos/modules/services/monitoring/telegraf.nix
@@ -1,0 +1,71 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.telegraf;
+
+  configFile = pkgs.runCommand "config.toml" {
+    buildInputs = [ pkgs.remarshal ];
+  } ''
+    remarshal -if json -of toml \
+      < ${pkgs.writeText "config.json" (builtins.toJSON cfg.extraConfig)} \
+      > $out
+  '';
+in
+{
+
+  ###### interface
+
+  options = {
+
+    services.telegraf = {
+
+      enable = mkEnableOption "telegraf server";
+
+      package = mkOption {
+        default = pkgs.telegraf;
+        defaultText = "pkgs.telegraf";
+        description = "Which telegraf derivation to use";
+        type = types.package;
+      };
+
+      extraConfig = mkOption {
+        default = {};
+        description = "Extra configuration options for telegraf";
+        type = types.attrs;
+      };
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.telegraf.enable {
+
+    systemd.services.telegraf = {
+      description = "Telegraf Agent";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-interfaces.target" ];
+      serviceConfig = {
+        ExecStart = ''${cfg.package}/bin/telegraf -config "${configFile}"'';
+        User = "telegraf";
+        Group = "telegraf";
+      };
+    };
+
+    users.extraUsers = [{
+      name = "telegraf";
+      uid = config.ids.uids.telegraf;
+      description = "telegraf daemon user";
+    }];
+
+    users.extraGroups = [{
+      name = "telegraf";
+      gid = config.ids.gids.telegraf;
+    }];
+  };
+
+}
+

--- a/pkgs/tools/system/telegraf/default.nix
+++ b/pkgs/tools/system/telegraf/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "telegraf-${version}";
+  version = "0.13.2";
+
+  src = fetchFromGitHub {
+    owner = "influxdata";
+    repo = "telegraf";
+    rev = "${version}";
+    sha256 = "1zdb85wkx5q7c799sn695ckzym6avqz05xlvw0d1p919c2ilba9f";
+  };
+
+  goPackagePath = "github.com/influxdata/telegraf";
+
+  # Generated with the `gdm2nix.rb` script and the `Godeps` file from the
+  # influxdb repo root.
+  goDeps = ./deps.json;
+
+  meta = with lib; {
+    description = " The plugin-driven server agent for collecting & reporting metrics. ";
+    license = licenses.mit;
+    homepage = https://github.com/influxdata/telegraf;
+    maintainers = with maintainers; [ roblabla ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/system/telegraf/deps.json
+++ b/pkgs/tools/system/telegraf/deps.json
@@ -1,0 +1,587 @@
+[
+  {
+    "goPackagePath": "github.com/Shopify/sarama",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/Shopify/sarama.git",
+      "rev": "8aadb476e66ca998f2f6bb3c993e9a2daa3666b9",
+      "sha256": "1ndaddqcll9r22jg9x36acanxv5ds3xwahrm4b6nmmg06670gksv"
+    }
+  },
+  {
+    "goPackagePath": "github.com/Sirupsen/logrus",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/Sirupsen/logrus.git",
+      "rev": "219c8cb75c258c552e999735be6df753ffc7afdc",
+      "sha256": "04v55846v1535dplldyjhr0yqxl6n1mr4kiy2vz3ragv92xpshr6"
+    }
+  },
+  {
+    "goPackagePath": "github.com/aerospike/aerospike-client-go",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/aerospike/aerospike-client-go.git",
+      "rev": "45863b7fd8640dc12f7fdd397104d97e1986f25a",
+      "sha256": "0cnsq8waah9m8m6y6cjz2sppac38aq8gsykw6d8zps0w4rjgf1aw"
+    }
+  },
+  {
+    "goPackagePath": "github.com/amir/raidman",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/amir/raidman.git",
+      "rev": "53c1b967405155bfc8758557863bf2e14f814687",
+      "sha256": "08a6zz4akkm7lk02w53vfhkxdf0ikv32x41rc4jyi2qaf0wyw6b4"
+    }
+  },
+  {
+    "goPackagePath": "github.com/aws/aws-sdk-go",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/aws/aws-sdk-go.git",
+      "rev": "13a12060f716145019378a10e2806c174356b857",
+      "sha256": "09yl85kk2y4ayk44af5rbnkq4vy82vbh2z5ac4vpl2vgv7zyh46h"
+    }
+  },
+  {
+    "goPackagePath": "github.com/beorn7/perks",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/beorn7/perks.git",
+      "rev": "3ac7bf7a47d159a033b107610db8a1b6575507a4",
+      "sha256": "1qc3l4r818xpvrhshh1sisc5lvl9479qspcfcdbivdyh0apah83r"
+    }
+  },
+  {
+    "goPackagePath": "github.com/cenkalti/backoff",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/cenkalti/backoff.git",
+      "rev": "4dc77674aceaabba2c7e3da25d4c823edfb73f99",
+      "sha256": "0icf4vrgzksr0g8h6y00rd92h1mym6waf3mbqpf890bkw60gnm0w"
+    }
+  },
+  {
+    "goPackagePath": "github.com/couchbase/go-couchbase",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/couchbase/go-couchbase.git",
+      "rev": "cb664315a324d87d19c879d9cc67fda6be8c2ac1",
+      "sha256": "1dfw1apwrlfwl7bahb6dy5g9z2vs431l4lpaj3k9bnm13p0awivr"
+    }
+  },
+  {
+    "goPackagePath": "github.com/couchbase/gomemcached",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/couchbase/gomemcached.git",
+      "rev": "a5ea6356f648fec6ab89add00edd09151455b4b2",
+      "sha256": "00x57qqdv9ciyxiw2y6p4s65sfgi4cs6zi39qlqlw90nh133xnwi"
+    }
+  },
+  {
+    "goPackagePath": "github.com/couchbase/goutils",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/couchbase/goutils.git",
+      "rev": "5823a0cbaaa9008406021dc5daf80125ea30bba6",
+      "sha256": "15v5ps2i2y2hczwxs2ci4c2w4p3pn3bl7vc5wlaqnc7i14f9285c"
+    }
+  },
+  {
+    "goPackagePath": "github.com/dancannon/gorethink",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/dancannon/gorethink.git",
+      "rev": "e7cac92ea2bc52638791a021f212145acfedb1fc",
+      "sha256": "0f9gwsqf93qzvfpdwgam7vcfzrrkcj2s9ms4p056kcyxv9snwq3g"
+    }
+  },
+  {
+    "goPackagePath": "github.com/davecgh/go-spew",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/davecgh/go-spew.git",
+      "rev": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d",
+      "sha256": "15h9kl73rdbzlfmsdxp13jja5gs7sknvqkpq2qizq3qv3nr1x8dk"
+    }
+  },
+  {
+    "goPackagePath": "github.com/docker/engine-api",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/docker/engine-api.git",
+      "rev": "8924d6900370b4c7e7984be5adc61f50a80d7537",
+      "sha256": "1klimc3d1a2vfgl14a7js20ricpghq5jzvh8l46kf87ycjwc0q4n"
+    }
+  },
+  {
+    "goPackagePath": "github.com/docker/go-connections",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/docker/go-connections.git",
+      "rev": "f549a9393d05688dff0992ef3efd8bbe6c628aeb",
+      "sha256": "0k1yf4bimmwxc0qiz997nagfmddbm8nwb0c1q16387m8lgw1gbwg"
+    }
+  },
+  {
+    "goPackagePath": "github.com/docker/go-units",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/docker/go-units.git",
+      "rev": "5d2041e26a699eaca682e2ea41c8f891e1060444",
+      "sha256": "0hn8xdbaykp046inc4d2mwig5ir89ighma8hk18dfkm8rh1vvr8i"
+    }
+  },
+  {
+    "goPackagePath": "github.com/eapache/go-resiliency",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/eapache/go-resiliency.git",
+      "rev": "b86b1ec0dd4209a588dc1285cdd471e73525c0b3",
+      "sha256": "1kzv95bh3nidm2cr7iv9lk3s2qiw1i17n8gyl2x6xk6qv8b0bc21"
+    }
+  },
+  {
+    "goPackagePath": "github.com/eapache/queue",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/eapache/queue.git",
+      "rev": "ded5959c0d4e360646dc9e9908cff48666781367",
+      "sha256": "0inclypw0kln8hsn34c5ww34h0qa9fcqwak93lac5dp59rz5430n"
+    }
+  },
+  {
+    "goPackagePath": "github.com/eclipse/paho.mqtt.golang",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/eclipse/paho.mqtt.golang.git",
+      "rev": "0f7a459f04f13a41b7ed752d47944528d4bf9a86",
+      "sha256": "13l6mrx9z859r4r7kpa9rsbf4ni7dn6xgz8iyv2xnz53pqffanjh"
+    }
+  },
+  {
+    "goPackagePath": "github.com/go-sql-driver/mysql",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/go-sql-driver/mysql.git",
+      "rev": "1fca743146605a172a266e1654e01e5cd5669bee",
+      "sha256": "02vbq8j4r3skg3fmiv1wvjqh1542dr515w8f3d42b5lpwc1fsn38"
+    }
+  },
+  {
+    "goPackagePath": "github.com/gobwas/glob",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/gobwas/glob.git",
+      "rev": "49571a1557cd20e6a2410adc6421f85b66c730b5",
+      "sha256": "16j7pdxajqrl20a737p7kgsngr2f7gkkpgqxxmfkrmgckgkc8cvk"
+    }
+  },
+  {
+    "goPackagePath": "github.com/golang/protobuf",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/golang/protobuf.git",
+      "rev": "552c7b9542c194800fd493123b3798ef0a832032",
+      "sha256": "1zaw1xxnvgsvfcrv5xkn1f7p87vyh9i6mc44csl11fgc2hvqp6xm"
+    }
+  },
+  {
+    "goPackagePath": "github.com/golang/snappy",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/golang/snappy.git",
+      "rev": "427fb6fc07997f43afa32f35e850833760e489a7",
+      "sha256": "1hgk9zhkfdvxrz13k0glqwlz414803zkrzd01mv6fjhpsjmcx53b"
+    }
+  },
+  {
+    "goPackagePath": "github.com/gonuts/go-shellquote",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/gonuts/go-shellquote.git",
+      "rev": "e842a11b24c6abfb3dd27af69a17f482e4b483c2",
+      "sha256": "19lbz7wl241bsyzsv2ai40b2vnj8c9nl107b6jf9gid3i6h0xydg"
+    }
+  },
+  {
+    "goPackagePath": "github.com/gorilla/context",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/gorilla/context.git",
+      "rev": "1ea25387ff6f684839d82767c1733ff4d4d15d0a",
+      "sha256": "1nh1nzxcsgd215x4xn59wc4cbqfa8zvhvnnx5p8fkrn4bj1cgak4"
+    }
+  },
+  {
+    "goPackagePath": "github.com/gorilla/mux",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/gorilla/mux.git",
+      "rev": "c9e326e2bdec29039a3761c07bece13133863e1e",
+      "sha256": "1bplp6v14isjdfpf8328k8bvkn35n451axkxlm822d9h5ccg47g6"
+    }
+  },
+  {
+    "goPackagePath": "github.com/hailocab/go-hostpool",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/hailocab/go-hostpool.git",
+      "rev": "e80d13ce29ede4452c43dea11e79b9bc8a15b478",
+      "sha256": "05ld4wp3illkbgl043yf8jq9y1ld0zzvrcg8jdij129j50xgfxny"
+    }
+  },
+  {
+    "goPackagePath": "github.com/hashicorp/consul",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/hashicorp/consul.git",
+      "rev": "5aa90455ce78d4d41578bafc86305e6e6b28d7d2",
+      "sha256": "1xas814kkhwnjg5ghhlkgygcgi5p7h6dczmpbrzzh3yygbfdzxgw"
+    }
+  },
+  {
+    "goPackagePath": "github.com/hpcloud/tail",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/hpcloud/tail.git",
+      "rev": "b2940955ab8b26e19d43a43c4da0475dd81bdb56",
+      "sha256": "1x266pdfvcymsbdrdsns06qq5qfjb62z6h4512ylhakbm64qkn4s"
+    }
+  },
+  {
+    "goPackagePath": "github.com/influxdata/config",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/influxdata/config.git",
+      "rev": "b79f6829346b8d6e78ba73544b1e1038f1f1c9da",
+      "sha256": "0k4iywy83n3kq2f58a41rjinj03wp1di67aacpf04p25qmf46c4z"
+    }
+  },
+  {
+    "goPackagePath": "github.com/influxdata/influxdb",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/influxdata/influxdb.git",
+      "rev": "e094138084855d444195b252314dfee9eae34cab",
+      "sha256": "0vv243lqwl4rwgg1zaxlw42zfjjad4vcafaiisvvkyamnndzlkla"
+    }
+  },
+  {
+    "goPackagePath": "github.com/influxdata/toml",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/influxdata/toml.git",
+      "rev": "af4df43894b16e3fd2b788d01bd27ad0776ef2d0",
+      "sha256": "1faf51s89sk1z41qfsazmddgwll7jq9xna67k3h3vry86c4vs2j4"
+    }
+  },
+  {
+    "goPackagePath": "github.com/kardianos/osext",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/kardianos/osext.git",
+      "rev": "29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc",
+      "sha256": "1mawalaz84i16njkz6f9fd5jxhcbxkbsjnav3cmqq2dncv2hyv8a"
+    }
+  },
+  {
+    "goPackagePath": "github.com/kardianos/service",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/kardianos/service.git",
+      "rev": "5e335590050d6d00f3aa270217d288dda1c94d0a",
+      "sha256": "1g10qisgywfqj135yyiq63pnbjgr201gz929ydlgyzqq6yk3bn3h"
+    }
+  },
+  {
+    "goPackagePath": "github.com/klauspost/crc32",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/klauspost/crc32.git",
+      "rev": "19b0b332c9e4516a6370a0456e6182c3b5036720",
+      "sha256": "0fcnsf1m0bzplgp28dz8skza6l7rc65s180x85rzbdl9l3zzi43r"
+    }
+  },
+  {
+    "goPackagePath": "github.com/lib/pq",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/lib/pq.git",
+      "rev": "e182dc4027e2ded4b19396d638610f2653295f36",
+      "sha256": "1636v3snixapjf7rbjq0xn1sbym7hwckqfla0dm5cr4a5q4fw5cj"
+    }
+  },
+  {
+    "goPackagePath": "github.com/matttproud/golang_protobuf_extensions",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/matttproud/golang_protobuf_extensions.git",
+      "rev": "d0c3fe89de86839aecf2e0579c40ba3bb336a453",
+      "sha256": "0jkjgpi1s8l9bdbf14fh8050757jqy36kn1l1hxxlb2fjn1pcg0r"
+    }
+  },
+  {
+    "goPackagePath": "github.com/miekg/dns",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/miekg/dns.git",
+      "rev": "cce6c130cdb92c752850880fd285bea1d64439dd",
+      "sha256": "098gadhfjiijlgq497gbccvf26xrmjvln1fws56m0ljcgszq3jdx"
+    }
+  },
+  {
+    "goPackagePath": "github.com/mreiferson/go-snappystream",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/mreiferson/go-snappystream.git",
+      "rev": "028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504",
+      "sha256": "0jdd5whp74nvg35d9hzydsi3shnb1vrnd7shi9qz4wxap7gcrid6"
+    }
+  },
+  {
+    "goPackagePath": "github.com/naoina/go-stringutil",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/naoina/go-stringutil.git",
+      "rev": "6b638e95a32d0c1131db0e7fe83775cbea4a0d0b",
+      "sha256": "00831p1wn3rimybk1z8l30787kn1akv5jax5wx743nn76qcmkmc6"
+    }
+  },
+  {
+    "goPackagePath": "github.com/nats-io/nats",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/nats-io/nats.git",
+      "rev": "b13fc9d12b0b123ebc374e6b808c6228ae4234a3",
+      "sha256": "08cj053v0v7i9k7pn7c54hn3pm1c8g53gjhiv969hf4mk2h75q1i"
+    }
+  },
+  {
+    "goPackagePath": "github.com/nats-io/nuid",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/nats-io/nuid.git",
+      "rev": "4f84f5f3b2786224e336af2e13dba0a0a80b76fa",
+      "sha256": "18ckzxmlg6ihjqd3r6ds8blgga58zibk52xp3lz5c7kv0hf6xa8y"
+    }
+  },
+  {
+    "goPackagePath": "github.com/nsqio/go-nsq",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/nsqio/go-nsq.git",
+      "rev": "0b80d6f05e15ca1930e0c5e1d540ed627e299980",
+      "sha256": "1zi9jazjfzilp2g0xy30dlx9nd9g47cjqrnqxallly97mz9n01xr"
+    }
+  },
+  {
+    "goPackagePath": "github.com/opencontainers/runc",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/opencontainers/runc.git",
+      "rev": "89ab7f2ccc1e45ddf6485eaa802c35dcf321dfc8",
+      "sha256": "1rnaqcsww7plr430r4ksv9si4l91l25li0bwa1b03g3sn2shirk1"
+    }
+  },
+  {
+    "goPackagePath": "github.com/prometheus/client_golang",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/prometheus/client_golang.git",
+      "rev": "18acf9993a863f4c4b40612e19cdd243e7c86831",
+      "sha256": "1gyjvwnvgyl0fs4hd2vp5hj1dsafhwb2h55w8zgzdpshvhwrpmhv"
+    }
+  },
+  {
+    "goPackagePath": "github.com/prometheus/client_model",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/prometheus/client_model.git",
+      "rev": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6",
+      "sha256": "11a7v1fjzhhwsl128znjcf5v7v6129xjgkdpym2lial4lac1dhm9"
+    }
+  },
+  {
+    "goPackagePath": "github.com/prometheus/common",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/prometheus/common.git",
+      "rev": "e8eabff8812b05acf522b45fdcd725a785188e37",
+      "sha256": "08magd2aw7dqaa8bbv85404zvy120ify61msfpy75az5rdl5anxq"
+    }
+  },
+  {
+    "goPackagePath": "github.com/prometheus/procfs",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/prometheus/procfs.git",
+      "rev": "406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8",
+      "sha256": "0yla9hz15pg63394ygs9iiwzsqyv29labl8p424hijwsc9z9nka8"
+    }
+  },
+  {
+    "goPackagePath": "github.com/samuel/go-zookeeper",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/samuel/go-zookeeper.git",
+      "rev": "218e9c81c0dd8b3b18172b2bbfad92cc7d6db55f",
+      "sha256": "1v0m6wn83v4pbqz6hs7z1h5hbjk7k6npkpl7icvcxdcjd7rmyjp2"
+    }
+  },
+  {
+    "goPackagePath": "github.com/shirou/gopsutil",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/shirou/gopsutil.git",
+      "rev": "4d0c402af66c78735c5ccf820dc2ca7de5e4ff08",
+      "sha256": "1wkp7chzpz6brq2y0k2mvsf0iaknns279wfsjn5gm6gvih49lqni"
+    }
+  },
+  {
+    "goPackagePath": "github.com/soniah/gosnmp",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/soniah/gosnmp.git",
+      "rev": "b1b4f885b12c5dcbd021c5cee1c904110de6db7d",
+      "sha256": "00g12rh60w0b1aflphgd2v6i8xjashpxsf9mdrwyaq75921x9qkq"
+    }
+  },
+  {
+    "goPackagePath": "github.com/sparrc/aerospike-client-go",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/sparrc/aerospike-client-go.git",
+      "rev": "d4bb42d2c2d39dae68e054116f4538af189e05d5",
+      "sha256": "0z2d3k1k6qh60aq81dr9g8y2mb19wwlx5isy0nqg0gzx3jb7v7xz"
+    }
+  },
+  {
+    "goPackagePath": "github.com/streadway/amqp",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/streadway/amqp.git",
+      "rev": "b4f3ceab0337f013208d31348b578d83c0064744",
+      "sha256": "1whcg2l6w2q7xrkk8q5y95i90ckq72bpgksii9ibrpyixbx7p5xp"
+    }
+  },
+  {
+    "goPackagePath": "github.com/stretchr/testify",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/stretchr/testify.git",
+      "rev": "1f4a1643a57e798696635ea4c126e9127adb7d3c",
+      "sha256": "0nam9d68rn8ha8ldif22kkgv6k6ph3y88fp26159wdrs63ca3bzl"
+    }
+  },
+  {
+    "goPackagePath": "github.com/vjeantet/grok",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/vjeantet/grok.git",
+      "rev": "83bfdfdfd1a8146795b28e547a8e3c8b28a466c2",
+      "sha256": "03zdcg9gy482gbasa7sw4cpw1k1n3dr2q06q80qnkqn268p7hp80"
+    }
+  },
+  {
+    "goPackagePath": "github.com/wvanbergen/kafka",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/wvanbergen/kafka.git",
+      "rev": "46f9a1cf3f670edec492029fadded9c2d9e18866",
+      "sha256": "1czmbilprffdbwnrq4wcllaqknbq91l6p0ni6b55fkaggnwck694"
+    }
+  },
+  {
+    "goPackagePath": "github.com/wvanbergen/kazoo-go",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/wvanbergen/kazoo-go.git",
+      "rev": "0f768712ae6f76454f987c3356177e138df258f8",
+      "sha256": "1paaayg03nknbnl3kdl0ybqv4llz7iwry7f29i0bh9srb6c87x16"
+    }
+  },
+  {
+    "goPackagePath": "github.com/yuin/gopher-lua",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/yuin/gopher-lua.git",
+      "rev": "bf3808abd44b1e55143a2d7f08571aaa80db1808",
+      "sha256": "02m7ly5yzc3snvxlfl9j4ggwd7v0kpvy3pqgqbfr7scdjxdap4nm"
+    }
+  },
+  {
+    "goPackagePath": "github.com/zensqlmonitor/go-mssqldb",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/zensqlmonitor/go-mssqldb.git",
+      "rev": "ffe5510c6fa5e15e6d983210ab501c815b56b363",
+      "sha256": "079x8ms8lv5p6253ppaxva37k6w04xnd38y8763rr2giswxqzlkl"
+    }
+  },
+  {
+    "goPackagePath": "golang.org/x/crypto",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/golang/crypto.git",
+      "rev": "5dc8cb4b8a8eb076cbb5a06bc3b8682c15bdbbd3",
+      "sha256": "18c1vpqlj10z1id66hglgnv51d9gwphgsdvxgghc6mcm01f1g5xj"
+    }
+  },
+  {
+    "goPackagePath": "golang.org/x/net",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/golang/net.git",
+      "rev": "6acef71eb69611914f7a30939ea9f6e194c78172",
+      "sha256": "1fcsv50sbq0lpzrhx3m9jw51wa255fsbqjwsx9iszq4d0gysnnvc"
+    }
+  },
+  {
+    "goPackagePath": "golang.org/x/text",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/golang/text.git",
+      "rev": "a71fd10341b064c10f4a81ceac72bcf70f26ea34",
+      "sha256": "1igxqrgnnb6983fl0yck0xal2hwnkcgbslr7cxyrg7a65vawd0q1"
+    }
+  },
+  {
+    "goPackagePath": "gopkg.in/dancannon/gorethink.v1",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/dancannon/gorethink.git",
+      "rev": "7d1af5be49cb5ecc7b177bf387d232050299d6ef",
+      "sha256": "0036hcadshka19bcqmq4mm9ssl9qhsx1n96lj1y24mh9g1api8fi"
+    }
+  },
+  {
+    "goPackagePath": "gopkg.in/fatih/pool.v2",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/fatih/pool.git",
+      "rev": "cba550ebf9bce999a02e963296d4bc7a486cb715",
+      "sha256": "1jlrakgnpvhi2ny87yrsj1gyrcncfzdhypa9i2mlvvzqlj4r0dn0"
+    }
+  },
+  {
+    "goPackagePath": "gopkg.in/mgo.v2",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/go-mgo/mgo.git",
+      "rev": "d90005c5262a3463800497ea5a89aed5fe22c886",
+      "sha256": "1z81k6mnfk07hkrkw31l16qycyiwa6wzyhysmywgkh58sm5dc9m7"
+    }
+  },
+  {
+    "goPackagePath": "gopkg.in/yaml.v2",
+    "fetch": {
+      "type": "git",
+      "url": "https://github.com/go-yaml/yaml.git",
+      "rev": "a83829b6f1293c91addabc89d0571c246397bbf4",
+      "sha256": "1m4dsmk90sbi17571h6pld44zxz7jc4lrnl4f27dpd1l8g5xvjhh"
+    }
+  }
+]

--- a/pkgs/tools/system/telegraf/gdm2nix.rb
+++ b/pkgs/tools/system/telegraf/gdm2nix.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+#
+#
+require "json"
+
+redirects = {
+  "collectd.org" => "github.com/collectd/go-collectd",
+  "golang.org/x/crypto" => "github.com/golang/crypto",
+  "golang.org/x/tools" => "github.com/golang/tools",
+  "gopkg.in/fatih/pool.v2" => "github.com/fatih/pool",
+}
+
+deps = File.read("Godeps").lines.map do |line|
+  (name, rev) = line.split(" ")
+
+  host = redirects.fetch(name, name)
+
+  url = "https://#{host}.git"
+
+  xxx = JSON.load(`nix-prefetch-git #{url} #{rev}`)
+  
+  {
+    goPackagePath: name,
+    fetch: {
+      type: "git",
+      url: url,
+      rev: rev,
+      sha256: xxx['sha256'],
+    }
+  }
+end
+
+File.write("deps.json", JSON.pretty_generate(deps))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10466,6 +10466,8 @@ in
 
   influxdb10 = (callPackage ../servers/nosql/influxdb/v1.nix { }).bin // { outputs = [ "bin" ]; };
 
+  telegraf = (callPackage ../tools/system/telegraf/default.nix { }).bin // { outputs = [ "bin" ]; };
+
   hyperdex = callPackage ../servers/nosql/hyperdex { };
 
   mysql55 = callPackage ../servers/sql/mysql/5.5.x.nix {


### PR DESCRIPTION
###### Motivation for this change

Adds telegraf, a plugin-driven server agent for collecting & reporting metrics commonly used with influxdb as a more flexible replacement for collectd.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
