### PR TITLE
roboto-mono and roboto-slab: init at 2016-01-11

### DIFF
--- a/pkgs/data/fonts/roboto-mono/default.nix
+++ b/pkgs/data/fonts/roboto-mono/default.nix
@@ -1,0 +1,84 @@
+{ stdenv, fetchurl }:
+
+let
+  # last commit on the directory containing the fonts in the upstream repository
+  commit = "883939708704a19a295e0652036369d22469e8dc";
+in
+stdenv.mkDerivation rec {
+  name = "roboto-mono-${version}";
+  version = "2016-01-11";
+
+  srcs = [
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Regular.ttf";
+      sha256 = "0r6g1xydy824xbbjilq6pvrv8611ga3q1702v5jj1ly5np6gpddz";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Bold.ttf";
+      sha256 = "0x9qnrbd7hin873wjzrl6798bvakixd86qdw0z5b4sm56f7fjl32";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Italic.ttf";
+      sha256 = "17aia6hgpjvvrl79y0f67ncr5y1nhyxj0dzqwdg3dycsa4kij59q";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-BoldItalic.ttf";
+      sha256 = "05gqfnps6qzxgyxrrmkmw0by3j88lf88v67n8jgi2chhhm0sw40q";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Medium.ttf";
+      sha256 = "0ww96qd0cyj3waxf7a98hyd4cp8snajjvjmbhr66zilql8ylfzk0";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-MediumItalic.ttf";
+      sha256 = "1n2cvvcpwm68lazfh3s3xhj4mrc01x84mi2ackwf8ahd95fk9p5y";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Light.ttf";
+      sha256 = "0na2sxz3n1km1ryz002spfa65d91fm48x0qcda2ac0rly7dgaqjf";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-LightItalic.ttf";
+      sha256 = "171fr8wsbmvfllsbmb9pcdax2qfzhbqzyxfn5bcrz9kx5k9x6198";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-Thin.ttf";
+      sha256 = "0pv54afyprajb16ksm5vklc1q76iv72v427wgamqzrzyvxgn6ymj";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotomono/RobotoMono-ThinItalic.ttf";
+      sha256 = "1ziyysl09z24l735y940g92rqhn9v4npwqzajj9m1kn0xz21r1aw";
+    })
+  ];
+
+  sourceRoot = "./";
+
+  unpackCmd = ''
+    ttfName=$(basename $(stripHash $curSrc; echo $strippedName))
+    cp $curSrc ./$ttfName
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -a *.ttf $out/share/fonts/truetype/
+  '';
+
+  meta = {
+    homepage = https://www.google.com/fonts/specimen/Roboto+Mono;
+    description = "Google Roboto Mono fonts";
+    longDescription = ''
+      Roboto Mono is a monospaced addition to the Roboto type family. Like
+      the other members of the Roboto family, the fonts are optimized for
+      readability on screens across a wide variety of devices and reading
+      environments. While the monospaced version is related to its variable
+      width cousin, it doesn't hesitate to change forms to better fit the
+      constraints of a monospaced environment. For example, narrow glyphs
+      like 'I', 'l' and 'i' have added serifs for more even texture while
+      wider glyphs are adjusted for weight. Curved caps like 'C' and 'O'
+      take on the straighter sides from Roboto Condensed.
+    '';
+    license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/data/fonts/roboto-slab/default.nix
+++ b/pkgs/data/fonts/roboto-slab/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchurl }:
+
+let
+  # last commit on the directory containing the fonts in the upstream repository
+  commit = "883939708704a19a295e0652036369d22469e8dc";
+in
+stdenv.mkDerivation rec {
+  name = "roboto-slab-${version}";
+  version = "2016-01-11";
+
+  srcs = [
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotoslab/RobotoSlab-Regular.ttf";
+      sha256 = "04180b5zk2nzll1rrgx8f1i1za66pk6pbrp0iww2xypjqra5zahk";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotoslab/RobotoSlab-Bold.ttf";
+      sha256 = "0ayl2hf5j33vixxfa7051hzjjxnx8zhag3rr0mmmnxpsn7md44ms";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotoslab/RobotoSlab-Light.ttf";
+      sha256 = "09riqgj9ixqjdb3mkzbs799cgmnp3ja3d6izlqkhpkfm52sgafqm";
+    })
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/google/fonts/${commit}/apache/robotoslab/RobotoSlab-Thin.ttf";
+      sha256 = "1hd0m7lxhr261a4s2nb572ari6v53w2yd8yjr9i534iqfl4jcbsf";
+    })
+  ];
+
+  sourceRoot = "./";
+
+  unpackCmd = ''
+    ttfName=$(basename $(stripHash $curSrc; echo $strippedName))
+    cp $curSrc ./$ttfName
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp -a *.ttf $out/share/fonts/truetype/
+  '';
+
+  meta = {
+    homepage = https://www.google.com/fonts/specimen/Roboto+Slab;
+    description = "Google Roboto Slab fonts";
+    longDescription = ''
+      Roboto has a dual nature. It has a mechanical skeleton and the forms
+      are largely geometric. At the same time, the font features friendly
+      and open curves. While some grotesks distort their letterforms to
+      force a rigid rhythm, Roboto doesn't compromise, allowing letters to
+      be settled into their natural width. This makes for a more natural
+      reading rhythm more commonly found in humanist and serif types.
+
+      This is the Roboto Slab family, which can be used alongside the normal
+      Roboto family and the Roboto Condensed family.
+    '';
+    license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12100,6 +12100,8 @@ in
 
   roboto = callPackage ../data/fonts/roboto { };
 
+  roboto-mono = callPackage ../data/fonts/roboto-mono { };
+
   hasklig = callPackage ../data/fonts/hasklig {};
 
   sound-theme-freedesktop = callPackage ../data/misc/sound-theme-freedesktop { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12102,6 +12102,8 @@ in
 
   roboto-mono = callPackage ../data/fonts/roboto-mono { };
 
+  roboto-slab = callPackage ../data/fonts/roboto-slab { };
+
   hasklig = callPackage ../data/fonts/hasklig {};
 
   sound-theme-freedesktop = callPackage ../data/misc/sound-theme-freedesktop { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
