### PR TITLE
rethinkdb: 2.3.4 -> 2.3.5

### DIFF
--- a/pkgs/servers/nosql/rethinkdb/default.nix
+++ b/pkgs/servers/nosql/rethinkdb/default.nix
@@ -1,14 +1,15 @@
 { stdenv, fetchurl, which, m4, python
 , protobuf, boost, zlib, curl, openssl, icu, jemalloc, libtool
+, pythonPackages, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
   name = "rethinkdb-${version}";
-  version = "2.3.4";
+  version = "2.3.5";
 
   src = fetchurl {
     url = "https://download.rethinkdb.com/dist/${name}.tgz";
-    sha256 = "19z1m4r1mqnbia207q0nvs39rn7jk8zsr2rvps2d11fp3ryr59wk";
+    sha256 = "047fz3r0rn95mqr5p1xfdprf0hq4avq2a1q8zsdifxxid7hyx2nx";
   };
 
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
@@ -28,13 +29,18 @@ stdenv.mkDerivation rec {
     "--lib-path=${jemalloc}/lib"
   ];
 
-  buildInputs = [ protobuf boost zlib curl openssl icu ]
+  buildInputs = [ protobuf boost zlib curl openssl icu makeWrapper ]
     ++ stdenv.lib.optional (!stdenv.isDarwin) jemalloc
     ++ stdenv.lib.optional stdenv.isDarwin libtool;
 
   nativeBuildInputs = [ which m4 python ];
 
   enableParallelBuilding = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/rethinkdb \
+      --prefix PATH ":" "${pythonPackages.rethinkdb}/bin"
+  '';
 
   meta = {
     description = "An open-source distributed database built with love";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8365,6 +8365,24 @@ in modules // {
     };
   };
 
+  rethinkdb = buildPythonPackage rec {
+    name = "rethinkdb-${version}";
+    version = "2.3.0.post6";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/r/rethinkdb/${name}.tar.gz";
+      sha256 = "05qwkmq6kn437ywyjs02jxbry720gw39q4z4jdb0cnbbi76lwddm";
+    };
+
+    doCheck = false;
+
+    meta = {
+      description = "Python driver library for the RethinkDB database server";
+      homepage = "https://pypi.python.org/pypi/rethinkdb";
+      license = licenses.agpl3;
+    };
+  };
+
   roman = buildPythonPackage rec {
     version = "2.0.0";
     name = "roman-${version}";


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
