### PR TITLE
nixos/…/swap.nix: remove backslashes from deviceName

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -54,6 +54,10 @@ let
           WARNING: Don't try to hibernate when you have at least one swap partition with
           this option enabled! We have no way to set the partition into which hibernation image
           is saved, so if your image ends up on an encrypted one you would lose it!
+
+          WARNING #2: Do not use /dev/disk/by-uuid/… or /dev/disk/by-label/… as your swap device
+          when using randomEncryption as the UUIDs and labels will get erased on every boot when
+          the partition is encrypted. Best to use /dev/disk/by-partuuid/…
         '';
       };
 
@@ -72,7 +76,7 @@ let
     config = rec {
       device = mkIf options.label.isDefined
         "/dev/disk/by-label/${config.label}";
-      deviceName = escapeSystemdPath config.device;
+      deviceName = lib.replaceChars ["\\"] [""] (escapeSystemdPath config.device);
       realDevice = if config.randomEncryption then "/dev/mapper/${deviceName}" else config.device;
     };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #8277

Prior to this, backslashes would end up in fstab and the swap partition was not activated.  Swap files seemed to work fine.

cc @abbradar
