### PR TITLE
groonga: 6.0.7 -> 6.0.8

### DIFF
--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -7,11 +7,11 @@
 stdenv.mkDerivation rec {
 
   name    = "groonga-${version}";
-  version = "6.0.7";
+  version = "6.0.8";
 
   src = fetchurl {
-    url    = "http://packages.groonga.org/source/groonga/groonga-6.0.7.tar.gz";
-    sha256 = "19vpjjq3mqaqy9idlmqg2agrz9dc48a9id8j7nx158pkwjvpj7jf";
+    url    = "http://packages.groonga.org/source/groonga/${name}.tar.gz";
+    sha256 = "05mp6zkavxj87nbx0jr48rpjjcf7fzdczxa93sxp4zq2dsnn5s5r";
   };
 
   buildInputs = with stdenv.lib; [ pkgconfig mecab kytea libedit ] ++


### PR DESCRIPTION
###### Motivation for this change

Update Groonga to the latest version.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
