### PR TITLE
smplayer: wrap mplayer

### DIFF
--- a/pkgs/applications/video/smplayer/default.nix
+++ b/pkgs/applications/video/smplayer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, qmakeHook, qtscript }:
+{ stdenv, fetchurl, qmakeHook, qtscript, mplayer, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "smplayer-16.1.0";
@@ -10,12 +10,16 @@ stdenv.mkDerivation rec {
 
   patches = [ ./basegui.cpp.patch ];
 
-  buildInputs = [ qmakeHook qtscript ];
+  buildInputs = [ qmakeHook qtscript makeWrapper ];
 
   dontUseQmakeConfigure = true;
 
   preConfigure = ''
     makeFlags="PREFIX=$out"
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/smplayer --suffix PATH : ${mplayer}/bin
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

SMplayer calls mplayer internally, so it fails to play anything when mplayer is not available.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Smplayer calls mplayer internally, so it fails then mplayer is not
present at runtime.
