### PR TITLE
systemd-unit-options: startAt can be a list

### DIFF
--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -309,7 +309,7 @@ in rec {
     };
 
     startAt = mkOption {
-      type = types.str;
+      type = with types; either str (listOf str);
       default = "";
       example = "Sun 14:00:00";
       description = ''


### PR DESCRIPTION
OnCalendar entrys can be specified multiple times in a systemd timer, to
make more complex scheduling possible.

Tested by manually checking the timer generated by the following:

```
systemd = {
  services.huhu = {
    description = "meh";
    wantedBy = [ "default.target" ];
    serviceConfig.ExecStart = "/bin/sh -c 'printf HUHU!'";
    startAt = [ "*:*:0/30" "*:0/1:15" ];
  };
};
```

It prints HUHU to the log at seconds 0, 15 and 30 of each minute.
