### PR TITLE
ffmpeg-full: 3.0.2 -> 3.1.3

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -141,7 +141,8 @@
 /*
  *  Darwin frameworks
  */
-, Cocoa, CoreServices, AVFoundation, MediaToolbox, VideoDecodeAcceleration, CF
+, Cocoa, CoreAudio, CoreServices, AVFoundation, MediaToolbox
+, VideoDecodeAcceleration, CF
 }:
 
 /* Maintainer notes:
@@ -236,14 +237,17 @@ assert nvenc -> nvidia-video-sdk != null && nonfreeLicensing;
 
 stdenv.mkDerivation rec {
   name = "ffmpeg-full-${version}";
-  version = "3.0.2";
+  version = "3.1.3";
 
   src = fetchurl {
     url = "https://www.ffmpeg.org/releases/ffmpeg-${version}.tar.xz";
-    sha256 = "08sjp4dxgcinmv9ly7nm24swmn2cnbbhvph44ihlplf4n33kr542";
+    sha256 = "08l8290gipm632dhrqndnphdpkc5ncqc1j3hxdx46r1a3q3mqmzq";
   };
 
-  patchPhase = ''patchShebangs .'';
+  patchPhase = ''patchShebangs .
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i 's/#ifndef __MAC_10_11/#if 1/' ./libavcodec/audiotoolboxdec.c
+  '';
 
   configureFlags = [
     /*
@@ -412,8 +416,8 @@ stdenv.mkDerivation rec {
     ++ optional ((isLinux || isFreeBSD) && libva != null) libva
     ++ optionals isLinux [ alsaLib libraw1394 libv4l ]
     ++ optionals nvenc [ nvidia-video-sdk ]
-    ++ optionals stdenv.isDarwin [ Cocoa CoreServices AVFoundation MediaToolbox
-                                   VideoDecodeAcceleration ];
+    ++ optionals stdenv.isDarwin [ Cocoa CoreServices CoreAudio AVFoundation 
+                                   MediaToolbox VideoDecodeAcceleration ];
 
   # Build qt-faststart executable
   buildPhase = optional qtFaststartProgram ''make tools/qt-faststart'';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7204,8 +7204,9 @@ in
     x265 = if stdenv.isDarwin then null else x265;
     xavs = if stdenv.isDarwin then null else xavs;
     inherit (darwin) CF;
-    inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices AVFoundation
-                                          MediaToolbox VideoDecodeAcceleration;
+    inherit (darwin.apple_sdk.frameworks) 
+      Cocoa CoreServices CoreAudio AVFoundation MediaToolbox 
+      VideoDecodeAcceleration;
   };
 
   ffmpegthumbnailer = callPackage ../development/libraries/ffmpegthumbnailer {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This required a minor patch to work with the darwin stdenv on OS X 10.11
and newer.
