### PR TITLE
jimtcl: fix build

### DIFF
--- a/pkgs/development/interpreters/jimtcl/default.nix
+++ b/pkgs/development/interpreters/jimtcl/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
     sqlite readline asciidoc SDL SDL_gfx
   ];
 
+  NIX_CFLAGS_COMPILE = [ "-I${SDL.dev}/include/SDL" ];
+
   configureFlags = [
     "--with-ext=oo"
     "--with-ext=tree"
@@ -24,12 +26,6 @@ stdenv.mkDerivation {
     "--enable-utf8"
     "--ipv6"
   ];
-
-  preConfigurePhase = ''
-    export CFLAGS=$(sdl-config --cflags)
-    export LDFLAGS=$(sdl-config --libs)
-  '';
-
 
   meta = {
     description = "An open source small-footprint implementation of the Tcl programming language";


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
