### PR TITLE
libtcod: fix build

### DIFF
--- a/pkgs/development/libraries/libtcod/default.nix
+++ b/pkgs/development/libraries/libtcod/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromBitbucket, cmake, SDL, mesa, upx }:
+{ stdenv, fetchFromBitbucket, cmake, SDL, mesa, upx, zlib }:
 
 stdenv.mkDerivation rec {
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags="-DLIBTCOD_SAMPLES=OFF";
 
-  buildInputs = [ cmake SDL mesa upx ];
+  buildInputs = [ cmake SDL mesa upx zlib ];
 
   meta = {
     description = "API for roguelike games";


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
