### PR TITLE
tome4: fix build

### DIFF
--- a/pkgs/games/tome4/default.nix
+++ b/pkgs/games/tome4/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, openal, libvorbis, mesa_glu, premake4, SDL2, SDL2_image, SDL2_ttf}:
+{stdenv, fetchurl, openal, libpng, libvorbis, mesa_glu, premake4, SDL2, SDL2_image, SDL2_ttf }:
 
 stdenv.mkDerivation rec {
   version = "1.4.6";
@@ -7,7 +7,8 @@ stdenv.mkDerivation rec {
     url = "http://te4.org/dl/t-engine/t-engine4-src-${version}.tar.bz2";
     sha256 = "12pi2lw1k6l3p209nnkh4nfv3ppp8kpd6mkh1324c81z6mh6w4wg";
   };
-  buildInputs = [ mesa_glu openal libvorbis SDL2 SDL2_ttf SDL2_image premake4 ];
+  buildInputs = [ mesa_glu openal libpng libvorbis SDL2 SDL2_ttf SDL2_image premake4 ];
+  NIX_CFLAGS_COMPILE = [ "-I${SDL2_image}/include/SDL2" "-I${SDL2_ttf}/include/SDL2" ];
   preConfigure = ''
     sed -e "s@/opt/SDL-2.0/include/SDL2@${SDL2}/include/SDL2@g" -e "s@/usr/include/GL@/run/opengl-driver/include@g" -i premake4.lua
     premake4 gmake


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
