### PR TITLE
ledger-web: init at 1.5.2

### DIFF
--- a/pkgs/applications/office/ledger-web/Gemfile
+++ b/pkgs/applications/office/ledger-web/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'ledger_web'

--- a/pkgs/applications/office/ledger-web/Gemfile.lock
+++ b/pkgs/applications/office/ledger-web/Gemfile.lock
@@ -1,0 +1,61 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    backports (3.6.8)
+    database_cleaner (1.5.3)
+    diff-lcs (1.2.5)
+    directory_watcher (1.5.1)
+    ledger_web (1.5.2)
+      database_cleaner
+      directory_watcher (~> 1.5.1)
+      pg
+      rack (>= 1.3.6)
+      rspec
+      sequel
+      sinatra
+      sinatra-contrib
+      sinatra-session
+    multi_json (1.12.1)
+    pg (0.18.4)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    sequel (4.37.0)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-contrib (1.4.7)
+      backports (>= 2.0)
+      multi_json
+      rack-protection
+      rack-test
+      sinatra (~> 1.4.0)
+      tilt (>= 1.3, < 3)
+    sinatra-session (1.0.0)
+      sinatra (>= 1.0)
+    tilt (2.0.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ledger_web (= 1.5.2)
+
+BUNDLED WITH
+   1.12.5

--- a/pkgs/applications/office/ledger-web/default.nix
+++ b/pkgs/applications/office/ledger-web/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, bundlerEnv, ruby
+, withPostgresql ? true, postgresql
+, withSqlite ? false, sqlite
+}:
+
+let
+  _name = "ledger-web";
+  cmd = "ledger_web";
+
+  env = bundlerEnv {
+    name = _name;
+    inherit ruby;
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+    meta = with lib; {
+      homepage = https://github.com/peterkeen/ledger-web;
+      platforms = platforms.linux;
+      maintainers = [ peterhoeg ];
+      license = licenses.mit;
+    };
+  };
+
+in stdenv.mkDerivation rec {
+  name = "${_name}-${version}";
+  version = "1.5.2";
+
+  buildInputs = [ env ruby makeWrapper ]
+    ++ lib.optional withPostgresql postgresql
+    ++ lib.optional withSqlite sqlite;
+
+  src = fetchFromGitHub {
+    owner = "peterkeen";
+    repo = _name;
+    rev = "v${version}";
+    sha256 = "0an4d46h3pp7a8s96jl0dnw1imwdgnb2j474b9wrbidwc6cmfrm7";
+  };
+
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+
+    cp --no-preserve=mode -r bin lib $out
+
+    chmod 0755 $out/bin/${cmd}
+
+    wrapProgram $out/bin/${cmd} \
+      --set BUNDLE_BIN ${env.bundler}/bin/bundle \
+      --set GEM_PATH   ${env}/${env.ruby.gemPath}
+  '';
+}

--- a/pkgs/applications/office/ledger-web/gemset.nix
+++ b/pkgs/applications/office/ledger-web/gemset.nix
@@ -1,0 +1,164 @@
+{
+  backports = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zcgqw7m7jb8n7b2jwla5cq0nw9wsgddxfmn0a9v89ihzd4i1a5k";
+      type = "gem";
+    };
+    version = "3.6.8";
+  };
+  database_cleaner = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fx6zmqznklmkbjl6f713jyl11d4g9q220rcl86m2jp82r8kfwjj";
+      type = "gem";
+    };
+    version = "1.5.3";
+  };
+  diff-lcs = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vf9civd41bnqi6brr5d9jifdw73j9khc6fkhfl1f8r9cpkdvlx1";
+      type = "gem";
+    };
+    version = "1.2.5";
+  };
+  directory_watcher = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fwc2shba7vks262ind74y3g76qp7znjq5q8b2dvza0yidgywhcq";
+      type = "gem";
+    };
+    version = "1.5.1";
+  };
+  ledger_web = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0i4vagaiyayymlr41rsy4lg2cl1r011ib0ql9dgjadfy6imb4kqh";
+      type = "gem";
+    };
+    version = "1.5.2";
+  };
+  multi_json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wpc23ls6v2xbk3l1qncsbz16npvmw8p0b38l8czdzri18mp51xk";
+      type = "gem";
+    };
+    version = "1.12.1";
+  };
+  pg = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07dv4ma9xd75xpsnnwwg1yrpwpji7ydy0q1d9dl0yfqbzpidrw32";
+      type = "gem";
+    };
+    version = "0.18.4";
+  };
+  rack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09bs295yq6csjnkzj7ncj50i6chfxrhmzg1pk6p0vd2lb9ac8pj5";
+      type = "gem";
+    };
+    version = "1.6.4";
+  };
+  rack-protection = {
+    dependencies = ["rack"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cvb21zz7p9wy23wdav63z5qzfn4nialik22yqp6gihkgfqqrh5r";
+      type = "gem";
+    };
+    version = "1.5.3";
+  };
+  rack-test = {
+    dependencies = ["rack"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h6x5jq24makgv2fq5qqgjlrk74dxfy62jif9blk43llw8ib2q7z";
+      type = "gem";
+    };
+    version = "0.6.3";
+  };
+  rspec = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16g3mmih999f0b6vcz2c3qsc7ks5zy4lj1rzjh8hf6wk531nvc6s";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  rspec-core = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12yndf7y6g3s1306bv1aycsmd0gjy5m172spdhx54svca2fcpzy1";
+      type = "gem";
+    };
+    version = "3.5.2";
+  };
+  rspec-expectations = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bbqfrb1x8gmwf8x2xhhwvvlhwbbafq4isbvlibxi6jk602f09gs";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  rspec-mocks = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nl3ksivh9wwrjjd47z5dggrwx40v6gpb3a0gzbp1gs06a5dmk24";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  rspec-support = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10vf3k3d472y573mag2kzfsfrf6rv355s13kadnpryk8d36yq5r0";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  sequel = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11vdpr3r4dwhcan16gs4gjm2k21y9qz7ri5w2zz54pmnxp499cjw";
+      type = "gem";
+    };
+    version = "4.37.0";
+  };
+  sinatra = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1b81kbr65mmcl9cdq2r6yc16wklyp798rxkgmm5pr9fvsj7jwmxp";
+      type = "gem";
+    };
+    version = "1.4.7";
+  };
+  sinatra-contrib = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vi3i0icbi2figiayxpvxbqpbn1syma7w4p4zw5mav1ln4c7jnfr";
+      type = "gem";
+    };
+    version = "1.4.7";
+  };
+  sinatra-session = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "183xl8i4d2hc03afd1i52gwn2xi3vzrv02g22llhfy5wkmm44gmq";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  tilt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lgk8bfx24959yq1cn55php3321wddw947mgj07bxfnwyipy9hqf";
+      type = "gem";
+    };
+    version = "2.0.5";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13774,6 +13774,7 @@ in
     boost = boost155;
   };
   ledger = self.ledger3;
+  ledger-web = callPackage ../applications/office/ledger-web { };
 
   lighthouse = callPackage ../applications/misc/lighthouse { };
 


### PR DESCRIPTION
###### Motivation for this change

Most other Ledger CLI software has been packaged.

cc: @peterkeen
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
