### PR TITLE
curlcpp: init at 20160901

### DIFF
--- a/pkgs/development/libraries/curlcpp/default.nix
+++ b/pkgs/development/libraries/curlcpp/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, curl }: 
+
+stdenv.mkDerivation {
+  name = "curlcpp-20160901";
+
+  src = fetchFromGitHub {
+    owner = "JosephP91";
+    repo = "curlcpp";
+    rev = "98286da1d6c9f6158344a8e272eae5030cbf6c0e";
+    sha256 = "00nm2b8ik1yvaz5dp1b61jid841jv6zf8k5ma2nxbf1di1apqh0d";
+  };
+
+  buildInputs = [ cmake curl ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://josephp91.github.io/curlcpp/";
+    description = "Object oriented C++ wrapper for CURL";
+    platforms = platforms.unix ;
+    license = licenses.mit;
+    maintainers = [ maintainers.juliendehos ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7064,6 +7064,8 @@ in
 
   cryptopp = callPackage ../development/libraries/crypto++ { };
 
+  curlcpp = callPackage ../development/libraries/curlcpp { };
+
   cutee = callPackage ../development/libraries/cutee { };
 
   cxxtools = callPackage ../development/libraries/cxxtools { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
