### PR TITLE
neuron: fix issue with incorrectly prefixed python path

### DIFF
--- a/pkgs/applications/science/biology/neuron/default.nix
+++ b/pkgs/applications/science/biology/neuron/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     ## standardise python neuron install dir if any
     if [[ -d $out/lib/python ]]; then
         mkdir -p ''${out}/${python.sitePackages}
-        mv ''${out}/lib/python  ''${out}/${python.sitePackages}
+        mv ''${out}/lib/python/*  ''${out}/${python.sitePackages}/
     fi
   ''];
   


### PR DESCRIPTION
###### Motivation for this change

Additional patch for #17914 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
