### PR TITLE
adb-sync: init at 2016-08-31

### DIFF
--- a/pkgs/development/mobile/adb-sync/default.nix
+++ b/pkgs/development/mobile/adb-sync/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, python, androidsdk, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "adb-sync-${version}";
+  version = "2016-08-31";
+
+  src = fetchgit {
+    url = "https://github.com/google/adb-sync";
+    rev = "7fc48ad1e15129ebe34e9f89b04bfbb68ced144d";
+    sha256 = "1y016bjky5sn58v91jyqfz7vw8qfqnfhb9s9jd32k8y29hy5vy4d";
+  };
+
+  preferLocalBuild = true;
+
+  buildInputs = [ python androidsdk makeWrapper ];
+
+  phases = "installPhase";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/adb-channel $src/adb-sync $out/bin/
+    patchShebangs $out/bin
+    wrapProgram $out/bin/adb-sync --suffix PATH : ${androidsdk}/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tool to synchronise files between a PC and an Android devices using ADB (Android Debug Bridge)";
+    homepage = "https://github.com/google/adb-sync";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ scolobb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -473,6 +473,8 @@ in
     pkgs_i686 = pkgsi686Linux;
   };
 
+  adb-sync = callPackage ../development/mobile/adb-sync { };
+
   apg = callPackage ../tools/security/apg { };
 
   autorevision = callPackage ../tools/misc/autorevision { };


### PR DESCRIPTION
###### Motivation for this change

Package `adb-sync`.
###### Things done
- [X ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
