### PR TITLE
gtk-gnutella: disable bindnow/fortify/pic/relro hardening

### DIFF
--- a/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
+++ b/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ bison binutils gettext pkgconfig ];
   buildInputs = [ glib gnutls gtk libxml2 zlib ];
 
+  hardeningDisable = [ "bindnow" "fortify" "pic" "relro" ];
+
   configureScript = "./build.sh --configure-only";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
- gnutella now segfaults on launch
- this updates the hardening flags based on debian's settings at https://lintian.debian.org/full/lucab@debian.org.html#gtk-gnutella_1.1.8-2
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
