### PR TITLE
ghc801: disable MADV_FREE

### DIFF
--- a/pkgs/development/compilers/ghc/8.0.1.nix
+++ b/pkgs/development/compilers/ghc/8.0.1.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     # Fix https://ghc.haskell.org/trac/ghc/ticket/12130
     (fetchFilteredPatch { url = https://git.haskell.org/ghc.git/patch/4d71cc89b4e9648f3fbb29c8fcd25d725616e265; sha256 = "0syaxb4y4s2dc440qmrggb4vagvqqhb55m6mx12rip4i9qhxl8k0"; })
     (fetchFilteredPatch { url = https://git.haskell.org/ghc.git/patch/2f8cd14fe909a377b3e084a4f2ded83a0e6d44dd; sha256 = "06zvlgcf50ab58bw6yw3krn45dsmhg4cmlz4nqff8k4z1f1bj01v"; })
-  ];
+  ] ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch;
 
   buildInputs = [ ghc perl hscolour ];
 

--- a/pkgs/development/compilers/ghc/ghc-no-madv-free.patch
+++ b/pkgs/development/compilers/ghc/ghc-no-madv-free.patch
@@ -1,0 +1,18 @@
+diff --git a/rts/posix/OSMem.c b/rts/posix/OSMem.c
+index 99620ee..e052a84 100644
+--- a/rts/posix/OSMem.c
++++ b/rts/posix/OSMem.c
+@@ -523,13 +523,7 @@ void osDecommitMemory(void *at, W_ size)
+         sysErrorBelch("unable to make released memory unaccessible");
+ #endif
+ 
+-#ifdef MADV_FREE
+-    // Try MADV_FREE first, FreeBSD has both and MADV_DONTNEED
+-    // just swaps memory out
+-    r = madvise(at, size, MADV_FREE);
+-#else
+     r = madvise(at, size, MADV_DONTNEED);
+-#endif
+     if(r < 0)
+         sysErrorBelch("unable to decommit memory");
+ }


### PR DESCRIPTION
###### Motivation for this change

This fixes GHC 8.0 on Linux < 4.5.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #18118.

/cc @peti 
