### PR TITLE
pythonPackages.django: have gis extensions only on linux

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9177,13 +9177,14 @@ in modules // {
       sha256 = "01bh5yra6zyxcpqacahbwfbn0y4ivw07j2jsw3crvmjzivb6if26";
     };
 
-    patches = [
+    # Gdal is marked as only supported for linux platform. This makes
+    # django build without its support on support on other platforms.
+    patches = optional stdenv.isLinux
       (pkgs.substituteAll {
         src = ../development/python-modules/django/1.10-gis-libs.template.patch;
         geos = pkgs.geos;
         gdal = self.gdal;
-      })
-    ];
+      });
 
     # patch only $out/bin to avoid problems with starter templates (see #3134)
     postFixup = ''


### PR DESCRIPTION
###### Motivation for this change

cc @FRidh 

quick fix to get ansible2 working again on darwin. See  #18194
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See https://github.com/NixOS/nixpkgs/issues/18194
