### PR TITLE
nano: 2.6.3 -> 2.7.0

### DIFF
--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -12,10 +12,10 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "nano-${version}";
-  version = "2.6.3";
+  version = "2.7.0";
   src = fetchurl {
-    url = "https://nano-editor.org/dist/v2.6/${name}.tar.gz";
-    sha256 = "00ym3zws1vdds726drgr5wj14mjn18d96ghn6vjci0915zhm8h2g";
+    url = "mirror://gnu/nano/${name}.tar.xz";
+    sha256 = "08cmnca3s377z74yjw1afz59l2h9s40wsa9wxw5y4x5f2jaz6spq";
   };
   nativeBuildInputs = [ texinfo ] ++ optional enableNls gettext;
   buildInputs = [ ncurses ];
@@ -25,15 +25,6 @@ stdenv.mkDerivation rec {
     ${optionalString (!enableNls) "--disable-nls"}
     ${optionalString enableTiny "--enable-tiny"}
   '';
-
-  patchFlags = [ "-p0" ];
-
-  patches = optional stdenv.isDarwin
-    (fetchurl {
-      name = "darwin.patch";
-      url = "https://trac.macports.org/browser/trunk/dports/editors/nano/files/patch-src-winio.c.diff?rev=151356&format=txt";
-      sha256 = "184q33irz9px2svwr2qx70zvfby5zlwlhv4k607yzsy90fq2jpdd";
-    });
 
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/text.c --replace "__time_t" "time_t"


### PR DESCRIPTION
###### Motivation for this change

Update nano to the last version, return the gnu mirror and remove darwin patch for compiling 2.6.3
###### Things done
- [X] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
