### PR TITLE
tcpkali: init at 0.9

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -130,6 +130,7 @@
   ericsagnes = "Eric Sagnes <eric.sagnes@gmail.com>";
   erikryb = "Erik Rybakken <erik.rybakken@math.ntnu.no>";
   ertes = "Ertugrul Söylemez <esz@posteo.de>";
+  ethercrow = "Dmitry Ivanov <ethercrow@gmail.com>";
   exi = "Reno Reckling <nixos@reckling.org>";
   exlevan = "Alexey Levan <exlevan@gmail.com>";
   expipiplus1 = "Joe Hermaszewski <nix@monoid.al>";

--- a/pkgs/applications/networking/tcpkali/default.nix
+++ b/pkgs/applications/networking/tcpkali/default.nix
@@ -1,0 +1,21 @@
+{stdenv, autoreconfHook, fetchFromGitHub, bison}:
+
+let version = "0.9"; in
+
+stdenv.mkDerivation rec {
+  name = "tcpkali-${version}";
+  src = fetchFromGitHub {
+    owner = "machinezone";
+    repo = "tcpkali";
+    rev = "v${version}";
+    sha256 = "03cbmnc60wkd7f4bapn5cbm3c4zas2l0znsbpci2mn8ms8agif82";
+  };
+  buildInputs = [autoreconfHook bison];
+  meta = {
+    description = "High performance TCP and WebSocket load generator and sink";
+    license = stdenv.lib.licenses.bsd2;
+    inherit (src.meta) homepage;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ ethercrow ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3697,6 +3697,8 @@ in
 
   tcpflow = callPackage ../tools/networking/tcpflow { };
 
+  tcpkali = callPackage ../applications/networking/tcpkali { };
+
   teamviewer = callPackage ../applications/networking/remote/teamviewer {
     stdenv = stdenv_32bit;
   };


### PR DESCRIPTION
###### Motivation for this change

tcpkali is a nice tool for testing and generating load
https://github.com/machinezone/tcpkali
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
