### PR TITLE
vboot_reference: fix build

### DIFF
--- a/pkgs/tools/system/vboot_reference/default.nix
+++ b/pkgs/tools/system/vboot_reference/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "14d3a93ha5k4al4ib43nyn1ppx7kgb12xw6mkflhx8nxmx8827nc";
   };
 
-  buildInputs = [ pkgconfig openssl ] ++
+  buildInputs = [ pkgconfig openssl stdenv.cc.libc.static ] ++
                 (if libuuid == null
                  then []
                  else [ (stdenv.lib.overrideDerivation libuuid


### PR DESCRIPTION
###### Motivation for this change

not really sure how to test this properly but this fixes the static build
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
