### PR TITLE
ggz_base_libs: fix build

### DIFF
--- a/pkgs/development/libraries/ggz_base_libs/default.nix
+++ b/pkgs/development/libraries/ggz_base_libs/default.nix
@@ -12,8 +12,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ intltool openssl expat libgcrypt ];
 
+  patchPhase = ''
+    substituteInPlace configure \
+      --replace "/usr/local/ssl/include" "${openssl.dev}/include" \
+      --replace "/usr/local/ssl/lib" "${openssl.out}/lib"
+  '';
+
   configureFlags = [
-    "--with-ssl-dir=${openssl.dev}/"
     "--with-tls"
   ];
 


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
