### PR TITLE
zpaq: only set -mtune on i686,x86_64

### DIFF
--- a/pkgs/tools/archivers/zpaq/default.nix
+++ b/pkgs/tools/archivers/zpaq/default.nix
@@ -20,9 +20,9 @@ stdenv.mkDerivation rec {
       + (lib.optionalString (!isi686 && !isx86_64) "-DNOJIT ")
       + "-Dunix";
     CXXFLAGS = with stdenv; ""
-      + (lib.optionalString (isi686) "-march=i686 ")
-      + (lib.optionalString (isx86_64) "-march=nocona ")
-      + "-O3 -mtune=generic -DNDEBUG";
+      + (lib.optionalString isi686   "-march=i686   -mtune=generic ")
+      + (lib.optionalString isx86_64 "-march=nocona -mtune=generic ")
+      + "-O3 -DNDEBUG";
   in ''
     buildFlagsArray=( "CPPFLAGS=${CPPFLAGS}" "CXXFLAGS=${CXXFLAGS}" )
   '';


### PR DESCRIPTION
###### Motivation for this change

Needed for building on armv5tel-linux.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
