### PR TITLE
Start session D-Bus daemon via systemd user units

### DIFF
--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -122,6 +122,30 @@ in
 
     systemd.services.dbus.restartTriggers = [ configDir ];
 
+    systemd.user = {
+      services.dbus = {
+        description = "D-Bus User Message Bus";
+        requires = [ "dbus.socket" ];
+        # NixOS doesn't support "Also" so we pull it in manually
+        # As the .service is supposed to come up at the same time as
+        # the .socket, we use basic.target instead of default.target
+        wantedBy = [ "basic.target" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.dbus_daemon}/bin/dbus-daemon --session --address=systemd: --nofork --nopidfile --systemd-activation";
+          ExecReload = "${pkgs.dbus_daemon}/bin/dbus-send --print-reply --session --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig";
+        };
+      };
+
+      sockets.dbus = {
+        description = "D-Bus User Message Bus Socket";
+        socketConfig = {
+          ListenStream = "%t/bus";
+          ExecStartPost = "-${config.systemd.package}/bin/systemctl --user set-environment DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus";
+        };
+        wantedBy = [ "sockets.target" ];
+      };
+    };
+
     environment.pathsToLink = [ "/etc/dbus-1" "/share/dbus-1" ];
 
   };

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -228,7 +228,7 @@ in
 
       startDbusSession = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           Whether to start a new DBus session when you log in with dbus-launch.
         '';


### PR DESCRIPTION
###### Motivation for this change

This fixes a non-fatal error in KDE 5 startup. It is also upstream's recommended way to start D-Bus. When kdbus is ready, it will be the only way to start session busses.
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Thanks to @peterhoeg for the implementation!
