### PR TITLE
xmlmirror: move README.md to better place

### DIFF
--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -61,7 +61,7 @@ with pkgs; rec {
     
     installPhase = ''
       mkdir -p $out/share
-      mkdir -p $doc
+      mkdir -p $doc/share/${name}
       
       cp Demo* $out/share
       cp -R codemirror-5.12 $out/share
@@ -72,7 +72,7 @@ with pkgs; rec {
       cp *.html $out/share
       cp *.json $out/share
       cp *.rng $out/share
-      cp README.md $doc/
+      cp README.md $doc/share/${name}
     '';
     
     postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

README.md should be installed into a subfolder
