### PR TITLE
lizardfs: fix building manpages

### DIFF
--- a/pkgs/tools/filesystems/lizardfs/default.nix
+++ b/pkgs/tools/filesystems/lizardfs/default.nix
@@ -7,6 +7,8 @@
 , asciidoc
 , libxml2
 , libxslt
+, docbook_xml_dtd_412
+, docbook_xsl
 , boost
 , pkgconfig
 , judy
@@ -25,7 +27,10 @@ stdenv.mkDerivation rec {
     sha256 = "18p2pj9crjqgxxxzdfcs3j3fqhinmwi7qxcf71jsw17syqwyygh8";
   };
 
-  buildInputs = [ cmake fuse asciidoc libxml2.bin libxslt.bin zlib boost pkgconfig judy pam makeWrapper ];
+  buildInputs = 
+    [ cmake fuse asciidoc libxml2 libxslt docbook_xml_dtd_412 docbook_xsl
+      zlib boost pkgconfig judy pam makeWrapper
+    ];
 
   patches = [ ./412.patch ];
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See https://github.com/NixOS/nixpkgs/issues/18209
