### PR TITLE
plan9port 2015-11-10 -> 2016-04-18

### DIFF
--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -8,13 +8,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "plan9port-2015-11-10";
+  name = "plan9port-2016-04-18";
 
   src = fetchgit {
     # Latest, same as on github, google code is old
     url = "https://plan9port.googlesource.com/plan9";
-    rev = "0d2dfbc";
-    sha256 = "1h16wvps4rfkjim2ihkmniw8wzl7yill5910larci1c70x6zcicf";
+    rev = "35d43924484b88b9816e40d2f6bff4547f3eec47";
+    sha256 = "1dvg580rkav09fra2gnrzh271b4fw6bgqfv4ib7ds5k3j55ahcdc";
   };
 
   patches = [
@@ -29,23 +29,29 @@ stdenv.mkDerivation rec {
     find . -type f \
       -exec sed -i -e 's/_SVID_SOURCE/_DEFAULT_SOURCE/g' {} \; \
       -exec sed -i -e 's/_BSD_SOURCE/_DEFAULT_SOURCE/g' {} \;
+  '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    #add missing ctrl+c\z\x\v keybind for non-Darwin
+    substituteInPlace src/cmd/acme/text.c \
+      --replace "case Kcmd+'c':" "case 0x03: case Kcmd+'c':" \
+      --replace "case Kcmd+'z':" "case 0x1a: case Kcmd+'z':" \
+      --replace "case Kcmd+'x':" "case 0x18: case Kcmd+'x':" \
+      --replace "case Kcmd+'v':" "case 0x16: case Kcmd+'v':"
   '';
 
   builder = ./builder.sh;
 
   NIX_LDFLAGS="-lgcc_s";
-  buildInputs = stdenv.lib.optionals
-                  (!stdenv.isDarwin)
-                  [ which
-                    perl
-                    libX11
-                    fontconfig
-                    xproto
-                    libXt
-                    xextproto
-                    libXext
-                    freetype #fontsrv wants ft2build.h. provides system fonts for acme and sam.
-                  ];
+  buildInputs = stdenv.lib.optionals (!stdenv.isDarwin) [
+    which
+    perl
+    libX11
+    fontconfig
+    xproto
+    libXt
+    xextproto
+    libXext
+    freetype #fontsrv wants ft2build.h. provides system fonts for acme and sam.
+  ];
 
   enableParallelBuilding = true;
 
@@ -53,7 +59,7 @@ stdenv.mkDerivation rec {
     homepage = "http://swtch.com/plan9port/";
     description = "Plan 9 from User Space";
     license = licenses.lpl-102;
-    maintainers = with stdenv.lib.maintainers; [ ftrvxmtrx kovirobi ];
+    maintainers = with maintainers; [ ftrvxmtrx kovirobi ];
     platforms = platforms.unix;
   };
 


### PR DESCRIPTION
###### Motivation for this change
1. Review here: https://github.com/NixOS/nixpkgs/pull/18228/files?w=1
2. I've missed a few commits with the last one[1]. Sorry.
3. Restored the missing acme keybinding for linux. Macs already had command+c\z\x\v but the control+c\z\x\v ones were missing. Just ascii codes[2].
4. Full revision hash[3].
5. Some miscellaneous style changes.

I've tested rc, fontsrv, plumber sam & acme.

p.s. I have a plumber user service unit around but I'm not sure it's worth submitting. See comments.

References:
1. https://github.com/NixOS/nixpkgs/pull/18141
2. http://www.phanderson.com/C/ascii.html
3. https://plan9port.googlesource.com/plan9/+/35d43924484b88b9816e40d2f6bff4547f3eec47
###### Things done
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
