### PR TITLE
nlohmann_json: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -2,19 +2,26 @@
 
 stdenv.mkDerivation rec {
   name = "nlohmann_json-${version}";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
     owner = "nlohmann";
     repo = "json";
     rev = "v${version}";
-    sha256 = "10sk8d23vh0c7b3qafjz2n8r5jv8vc275bl069ikhqnx1zxv6hwp";
+    sha256 = "192mg2y93g9q0jdn3fdffydpxk19nsrcv92kfip6srkdkwja18ri";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   doCheck = true;
   checkTarget = "test";
+
+  crossAttrs = {
+    cmakeFlags = "-DBuildTests=OFF";
+    doCheck = false;
+  } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
+    cmakeFlags = "-DBuildTests=OFF -DCMAKE_SYSTEM_NAME=Windows";
+  };
 
   meta = with stdenv.lib; {
     description = "Header only C++ library for the JSON file format";


### PR DESCRIPTION
###### Motivation for this change

`cmake` should be in `nativeBuildInputs` as it is only required at build time. For obvious reasons we can't have the tests running during a cross-compile. I figured I'd update the package version while I was at it, though these changes have also been tested independently of the version update.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
