### PR TITLE
patch ati-drivers for kernel 4.6

### DIFF
--- a/pkgs/os-specific/linux/ati-drivers/default.nix
+++ b/pkgs/os-specific/linux/ati-drivers/default.nix
@@ -71,8 +71,11 @@ stdenv.mkDerivation rec {
     ./patches/15.9-kcl_str.patch
     ./patches/15.9-mtrr.patch
     ./patches/15.9-preempt.patch
-    ./patches/15.9-sep_printf.patch
-  ];
+    ./patches/15.9-sep_printf.patch ]
+  ++ optionals ( kernel != null &&
+                 (builtins.compareVersions kernel.version "4.6") >= 0 )
+               [ ./patches/kernel-4.6-get_user_pages.patch
+                 ./patches/kernel-4.6-page_cache_release-put_page.patch ];
 
   buildInputs =
     [ xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM

--- a/pkgs/os-specific/linux/ati-drivers/patches/kernel-4.6-get_user_pages.patch
+++ b/pkgs/os-specific/linux/ati-drivers/patches/kernel-4.6-get_user_pages.patch
@@ -1,0 +1,25 @@
+diff --git a/common/lib/modules/fglrx/build_mod/firegl_public.c b/common/lib/modules/fglrx/build_mod/firegl_public.c
+index 9c70211..b2242af 100755
+--- a/common/lib/modules/fglrx/build_mod/firegl_public.c
++++ b/common/lib/modules/fglrx/build_mod/firegl_public.c
+@@ -3220,7 +3220,7 @@ int ATI_API_CALL KCL_LockUserPages(unsigned long vaddr, unsigned long* page_list
+     int ret;
+ 
+     down_read(&current->mm->mmap_sem);
+-    ret = get_user_pages(current, current->mm, vaddr, page_cnt, 1, 0, (struct page **)page_list, NULL);
++    ret = get_user_pages(vaddr, page_cnt, 1, 0, (struct page **)page_list, NULL);
+     up_read(&current->mm->mmap_sem);
+ 
+     return ret;
+@@ -3238,7 +3238,7 @@ int ATI_API_CALL KCL_LockReadOnlyUserPages(unsigned long vaddr, unsigned long* p
+     int ret;
+ 
+     down_read(&current->mm->mmap_sem);
+-    ret = get_user_pages(current, current->mm, vaddr, page_cnt, 0, 0, (struct page **)page_list, NULL);
++    ret = get_user_pages(vaddr, page_cnt, 0, 0, (struct page **)page_list, NULL);
+     up_read(&current->mm->mmap_sem);
+ 
+     return ret;
+-- 
+2.9.2
+

--- a/pkgs/os-specific/linux/ati-drivers/patches/kernel-4.6-page_cache_release-put_page.patch
+++ b/pkgs/os-specific/linux/ati-drivers/patches/kernel-4.6-page_cache_release-put_page.patch
@@ -1,0 +1,16 @@
+diff --git a/common/lib/modules/fglrx/build_mod/firegl_public.c b/common/lib/modules/fglrx/build_mod/firegl_public.c
+index b2242af..586129c 100755
+--- a/common/lib/modules/fglrx/build_mod/firegl_public.c
++++ b/common/lib/modules/fglrx/build_mod/firegl_public.c
+@@ -3249,7 +3249,7 @@ void ATI_API_CALL KCL_UnlockUserPages(unsigned long* page_list, unsigned int pag
+     unsigned int i;
+     for (i=0; i<page_cnt; i++)
+     {
+-        page_cache_release((struct page*)page_list[i]);
++        put_page((struct page*)page_list[i]);
+     }
+ }
+ 
+-- 
+2.9.2
+


### PR DESCRIPTION
###### Motivation for this change

fixes #18202
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

this uses the patch from
https://github.com/manjaro/packages-extra/commit/ddae91f2 to account
for https://github.com/torvalds/linux/commit/d4edcf0d and the patch
from https://www.virtualbox.org/ticket/15298 to account for
https://github.com/torvalds/linux/commit/09cbfeaf
