### PR TITLE
k3d: 0.8.0.3 -> 0.8.0.5, fixes build

### DIFF
--- a/pkgs/applications/graphics/k3d/default.nix
+++ b/pkgs/applications/graphics/k3d/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl, unzip, ftgl, glew, asciidoc
+{ stdenv, fetchFromGitHub, unzip, ftgl, glew, asciidoc
 , cmake, mesa, zlib, python, expat, libxml2, libsigcxx, libuuid, freetype
 , libpng, boost, doxygen, cairomm, pkgconfig, imagemagick, libjpeg, libtiff
 , gettext, intltool, perl, gtkmm, glibmm, gtkglext, pangox_compat, libXmu }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.0.3";
+  version = "0.8.0.5";
   name = "k3d-${version}";
-  src = fetchurl {
-    url = "https://github.com/K-3D/k3d/archive/${name}.zip";
-    sha256 = "09ywwvlk8hh1357pnal96kc40ma4jq7776hqk0609rgz13s6babp";
+  src = fetchFromGitHub {
+    owner = "K-3D";
+    repo = "k3d";
+    rev = name;
+    sha256 = "0q05d51vhnmrq887n15frpwkhx8w7n20h2sc1lpr338jzpryihb3";
   };
   
   cmakeFlags = "-DK3D_BUILD_DOCS=false -DK3D_BUILD_GUIDE=false";


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
