### PR TITLE
rsyslog: 8.17.0 -> 8.21.0

### DIFF
--- a/pkgs/development/libraries/fastjson/default.nix
+++ b/pkgs/development/libraries/fastjson/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, libtool, autoconf, automake }:
 
 stdenv.mkDerivation rec {
-  version = "v0.99.2";
+  version = "v0.99.4";
   name = "fastjson-${version}";
   src = fetchFromGitHub {
     repo = "libfastjson";
     owner = "rsyslog";
-    rev = "eabae907c9d991143e17da278a239819f2e8ae1c";
-    sha256 = "17fhaqdn0spc4p0848ahcy68swm6l5yd3bx6bdzxmmwj1jdrmvzk";
+    rev = "6e057a094cb225c9d80d8d6e6b1f36ca88a942dd";
+    sha256 = "1pn207p9zns0aqm6z5l5fdgb94wyyhaw83lyvyfdxmai74nbqs65";
   };
 
   buildInputs = [ autoconf automake libtool ];

--- a/pkgs/development/libraries/librelp/default.nix
+++ b/pkgs/development/libraries/librelp/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, gnutls, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "librelp-1.2.8";
+  name = "librelp-1.2.12";
 
   src = fetchurl {
     url = "http://download.rsyslog.com/librelp/${name}.tar.gz";
-    sha256 = "1qxj7isa2d10aw6c4a9pd3fx08vv06rrhac312avgcjmdqaa88r6";
+    sha256 = "1mvvxqfsfg96rb6xv3fw7mcsqmyfnsb74sc53gnhpcpp4h2p6m83";
   };
 
   buildInputs = [ pkgconfig gnutls zlib ];

--- a/pkgs/tools/system/rsyslog/default.nix
+++ b/pkgs/tools/system/rsyslog/default.nix
@@ -11,11 +11,11 @@ let
   mkFlag = cond: name: if cond then "--enable-${name}" else "--disable-${name}";
 in
 stdenv.mkDerivation rec {
-  name = "rsyslog-8.17.0";
+  name = "rsyslog-8.21.0";
 
   src = fetchurl {
     url = "http://www.rsyslog.com/files/download/rsyslog/${name}.tar.gz";
-    sha256 = "1fazpbllr3wk8aw41zk7b6iirds4h8j3im080nf8my2cjssij7pc";
+    sha256 = "1arrhc9fw79sp7dxkf7gyfwibyr2i1000pfds5c7n43mgglgvcdx";
   };
 
   #patches = [ ./fix-gnutls-detection.patch ];


### PR DESCRIPTION
###### Motivation for this change

Update`rsyslog` package (and related libraries used [only?] by it) to include the following new fixes and features:
- improved TLS syslog error messages
- more robust queue subsystem
- platform-specific build fixes
- update to librelp needed for: support the new timeout parameter in omrelp
- update to fastjson needed for: bug fix for unicode processing that can result in non US-ASCII characters to be improperly encoded and may (very unlikely) also cause a segfault.
- variety of core rsyslog bugfixes
- bugfixes or improvements for the following modules:
  - omelasticsearch
  - omkafka
  - omfwd
  - omjournal
  - omfile
  - pmrfc3164
  - imrelp
  - imfile
  - imdiag
  - imtcp
  - redis
- various performance improvements

Full changes are listed in the [ChangeLog](https://github.com/rsyslog/rsyslog/blob/v8-stable/ChangeLog#L2-L268)
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)

``` bash
$ sudo nixos-option nix.useSandbox
Value:
true

Default:
false

Description:

 If set, Nix will perform builds in a sandboxed environment that it
 will set up automatically for each build. This prevents
 impurities in builds by disallowing access to dependencies
 outside of the Nix store.

Declared by:
  "/nix/store/ka4a5g2a1nv7in0vk4ybdqpm8w0g6m3w-nixos-16.09pre89269.8512747/nixos/nixpkgs/nixos/modules/services/misc/nix-daemon.nix"

Defined by:
  "/etc/nixos/configuration.nix"
```
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux

``` bash
$ nixos-version
16.09pre89269.8512747 (Flounder)
```
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

``` bash
$ nix-shell -p nox --run "nox-review wip"
Building in /run/user/1000/nox-review-9qd80axy: fastJson rsyslog-light librelp rsyslog
/nix/store/1ajh2qbkh65gy6455i1gfw851cq78m9x-fastjson-v0.99.4
/nix/store/7jjgd180jw9jrlxkw1v1z2bp27h032l2-rsyslog-8.21.0
/nix/store/lr71n6ipcfg756zmrv0g1lhm9792dc5c-librelp-1.2.12
/nix/store/5zjkay1mkw264d6l10d70h0q5lcbsy12-rsyslog-8.21.0
Result in /run/user/1000/nox-review-9qd80axy
total 0
lrwxrwxrwx 1 spotter users 60 Sep  2 22:50 result -> /nix/store/1ajh2qbkh65gy6455i1gfw851cq78m9x-fastjson-v0.99.4
lrwxrwxrwx 1 spotter users 58 Sep  2 22:50 result-2 -> /nix/store/7jjgd180jw9jrlxkw1v1z2bp27h032l2-rsyslog-8.21.0
lrwxrwxrwx 1 spotter users 58 Sep  2 22:50 result-3 -> /nix/store/lr71n6ipcfg756zmrv0g1lhm9792dc5c-librelp-1.2.12
lrwxrwxrwx 1 spotter users 58 Sep  2 22:50 result-4 -> /nix/store/5zjkay1mkw264d6l10d70h0q5lcbsy12-rsyslog-8.21.0
```
- [X] Tested execution of all binary files (usually in `./result/bin/`)

``` bash
$ cd /run/user/1000/nox-review-9qd80axy/

$ ldd result/lib/libfastjson.so
        linux-vdso.so.1 (0x00007fffe844d000)
        libc.so.6 => /nix/store/6fix3zqpnahyml8zp2sxi2rwan55rgb8-glibc-2.24/lib/libc.so.6 (0x00007f6f19b54000)
        /nix/store/i0jphfihyndhv9lh1bgi1vlzygc1w8n1-glibc-2.24/lib64/ld-linux-x86-64.so.2 (0x000055b2ab325000)

$ readelf -Ws result/lib/libfastjson.so | head -10

Symbol table '.dynsym' contains 104 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
     1: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __snprintf_chk@GLIBC_2.3.4 (2)
     2: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND free@GLIBC_2.2.5 (3)
     3: 00000000000037d0     9 FUNC    GLOBAL DEFAULT   10 fjson_object_array_length
     4: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __vfprintf_chk@GLIBC_2.3.4 (2)
     5: 0000000000003ca0    10 FUNC    GLOBAL DEFAULT   10 fjson_tokener_new
     6: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __errno_location@GLIBC_2.2.5 (3)
[truncated]

$ ./result-2/bin/rsyslogd -v
rsyslogd 8.21.0, compiled with:
        PLATFORM:                               x86_64-unknown-linux-gnu
        PLATFORM (lsb_release -d):
        FEATURE_REGEXP:                         Yes
        GSSAPI Kerberos 5 support:              No
        FEATURE_DEBUG (debug build, slow code): No
        32bit Atomic operations supported:      Yes
        64bit Atomic operations supported:      Yes
        memory allocator:                       system default
        Runtime Instrumentation (slow code):    No
        uuid support:                           No
        Number of Bits in RainerScript integers: 64

See http://www.rsyslog.com for more information.

# inspect via ldd random builtin input module:
$ ldd ./result-2/lib/rsyslog/impstats.so
        linux-vdso.so.1 (0x00007ffe0d94a000)
        libc.so.6 => /nix/store/6fix3zqpnahyml8zp2sxi2rwan55rgb8-glibc-2.24/lib/libc.so.6 (0x00007f5a03023000)
        /nix/store/i0jphfihyndhv9lh1bgi1vlzygc1w8n1-glibc-2.24/lib64/ld-linux-x86-64.so.2 (0x000055a3159cd000)

$ ldd ./result-3/lib/librelp.so
        linux-vdso.so.1 (0x00007fffe2147000)
        libgnutls.so.30 => /nix/store/zknp8iqnl56fm3b35h8g8m377dj3klqn-gnutls-3.4.14/lib/libgnutls.so.30 (0x00007f6e35f89000)
        libc.so.6 => /nix/store/6fix3zqpnahyml8zp2sxi2rwan55rgb8-glibc-2.24/lib/libc.so.6 (0x00007f6e35beb000)
        libz.so.1 => /nix/store/b5mwbrx8cldkchiqgwgkaagw91xfjr89-zlib-1.2.8/lib/libz.so.1 (0x00007f6e359d5000)
        libp11-kit.so.0 => /nix/store/h9mfnk9qzfrivqxks12p0nfg7nixxyv0-p11-kit-0.23.2/lib/libp11-kit.so.0 (0x00007f6e3576e000)
        libidn.so.11 => /nix/store/gm42angcsdnlgl7gmaw6vg5j1gbzq5p1-libidn-1.33/lib/libidn.so.11 (0x00007f6e3553a000)
        libtasn1.so.6 => /nix/store/zfp01diq6d6lh4x7jlh2x9mg0blcs1mm-libtasn1-4.8/lib/libtasn1.so.6 (0x00007f6e35327000)
        libnettle.so.6 => /nix/store/cvli04kwqqdhqclf3qhhqs9fjp0j5chl-nettle-3.1.1/lib/libnettle.so.6 (0x00007f6e350f0000)
        libhogweed.so.4 => /nix/store/cvli04kwqqdhqclf3qhhqs9fjp0j5chl-nettle-3.1.1/lib/libhogweed.so.4 (0x00007f6e34ebc000)
        libgmp.so.10 => /nix/store/r6xfg8m89ir4kl55r8kny0fm9nbqv3n8-gmp-6.1.1/lib/libgmp.so.10 (0x00007f6e34c29000)
        /nix/store/i0jphfihyndhv9lh1bgi1vlzygc1w8n1-glibc-2.24/lib64/ld-linux-x86-64.so.2 (0x000055cb6bfeb000)
        libffi.so.6 => /nix/store/nairf8pmkk3ax5hzckmczc8cykby53l1-libffi-3.2.1/lib/../lib64/libffi.so.6 (0x00007f6e34a1e000)
        libdl.so.2 => /nix/store/6fix3zqpnahyml8zp2sxi2rwan55rgb8-glibc-2.24/lib/libdl.so.2 (0x00007f6e3481a000)
        libpthread.so.0 => /nix/store/6fix3zqpnahyml8zp2sxi2rwan55rgb8-glibc-2.24/lib/libpthread.so.0 (0x00007f6e345fd000)

$ ./result-4/bin/rsgtutil -V
rsgtutil 8.21.0
```

To test the `rsyslogd` daemon, I ran in one shell:

``` bash
$ ./result-4/bin/rsyslogd -f rsyslog.conf -n -i ./rsyslog.pid -C
```

Using config file:

```
$ cat rsyslog.conf
module(load="imudp")
module(load="imtcp")
module(load="impstats")

input(type="imudp"
      port="5012")
input(type="imtcp"
      port="5014")

action(type="omfile" file="/run/user/1000/nox-review-9qd80axy/test.log")
```

In another the following tests:

``` bash
$ nc -vzu localhost 5012

$ nc -vz localhost 5014
localhost [127.0.0.1] 5014 open

$ nc -vz localhost 5012 # expect failure since sending TCP message to UDP port
localhost [127.0.0.1] 5012 (nsp): Connection refused
?=1

$ nc -vz localhost 5015 # expect failure since sending TCP message to unbound port
localhost [127.0.0.1] 5015: Connection refused
?=1

$ echo "testing rsyslog 1 2 3\n" | nc -c localhost 5014
$ echo "testing rsyslog 1 2 3\n" | nc -c localhost 5014
$ echo "testing rsyslog 1 2 3\n" | nc -u -c localhost 5012
$ echo "testing rsyslog 1 2 3\n" | nc -u -c localhost 5012
$ echo "testing rsyslog 1 2 3\n" | nc -u -c localhost 5012
$ echo "testing rsyslog 1 2 3\n" | nc -u -c localhost 5012
$ echo "testing UDP rsyslog 1 2 3\n" | nc -u -c localhost 5012
$ echo "testing UDP rsyslog 1 2 3\n" | nc -u -c localhost 5012
$ echo "testing UDP rsyslog 1 2 3\n" | nc -u -c localhost 5012
$ echo "testing UDP rsyslog 1 2 3\n" | nc -u -c localhost 5012
$ echo "testing TCP rsyslog 1 2 3\n" | nc -c localhost 5014
$ echo "testing TCP rsyslog 1 2 3\n" | nc -c localhost 5014
$ echo "testing TCP rsyslog 1 2 3\n" | nc -c localhost 5014
```

```
$ cat /run/user/1000/nox-review-9qd80axy/test.log
2016-09-02T23:32:54.702317-05:00 testing rsyslog 1 2 3\n
2016-09-02T23:32:55.958670-05:00 testing rsyslog 1 2 3\n
2016-09-02T23:33:03.481009-05:00 testing rsyslog 1 2 3\n
2016-09-02T23:33:05.751863-05:00 testing rsyslog 1 2 3\n
2016-09-02T23:33:07.487960-05:00 testing rsyslog 1 2 3\n
2016-09-02T23:33:09.750657-05:00 testing rsyslog 1 2 3\n
2016-09-02T23:33:14.642156-05:00 testing UDP rsyslog 1 2 3\n
2016-09-02T23:33:15.468938-05:00 testing UDP rsyslog 1 2 3\n
2016-09-02T23:33:16.087750-05:00 testing UDP rsyslog 1 2 3\n
2016-09-02T23:33:16.688069-05:00 testing UDP rsyslog 1 2 3\n
2016-09-02T23:33:25.844826-05:00 testing TCP rsyslog 1 2 3\n
2016-09-02T23:33:26.509798-05:00 testing TCP rsyslog 1 2 3\n
2016-09-02T23:33:27.145829-05:00 testing TCP rsyslog 1 2 3\n
```
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

rsyslog: 8.17.0 -> 8.21.0

Also updates libraries used and distributed by rsyslog:
- librelp: 1.2.8 -> 1.2.12
- fastjson: 0.99.2 -> 0.99.4

The above did not appear to be directly depended upon by other packages, only rsyslog.
