### PR TITLE
git: 2.9.3 -> 2.10.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  version = "2.9.3";
+  version = "2.10.0";
   svn = subversionClient.override { perlBindings = true; };
 in
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "0qzs681a64k3shh5p0rg41l1z16fbk5sj0xga45k34hp1hsp654z";
+    sha256 = "1rr9zyafb6q3wixyjar6cc7z7vdh1dqa4b5irz3gz1df02n68cy7";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
@@ -1,11 +1,9 @@
-diff --git a/git-sh-i18n.sh b/git-sh-i18n.sh
-index e6c3116..4e34a2c 100644
 --- a/git-sh-i18n.sh
 +++ b/git-sh-i18n.sh
-@@ -15,69 +15,11 @@ else
+@@ -15,87 +15,11 @@
  fi
  export TEXTDOMAINDIR
- 
+
 -# First decide what scheme to use...
 -GIT_INTERNAL_GETTEXT_SH_SCHEME=fallthrough
 -if test -n "@@USE_GETTEXT_SCHEME@@"
@@ -44,6 +42,13 @@ index e6c3116..4e34a2c 100644
 -			git sh-i18n--envsubst "$1"
 -		)
 -	}
+-
+-	eval_ngettext () {
+-		ngettext "$1" "$2" "$3" | (
+-			export PATH $(git sh-i18n--envsubst --variables "$2");
+-			git sh-i18n--envsubst "$2"
+-		)
+-	}
 -	;;
 -poison)
 -	# Emit garbage so that tests that incorrectly rely on translatable
@@ -55,24 +60,35 @@ index e6c3116..4e34a2c 100644
 -	eval_gettext () {
 -		printf "%s" "# GETTEXT POISON #"
 -	}
+-
+-	eval_ngettext () {
+-		printf "%s" "# GETTEXT POISON #"
+-	}
 -	;;
 -*)
 -	gettext () {
 -		printf "%s" "$1"
 -	}
-+# GNU gettext
-+export GIT_INTERNAL_GETTEXT_SH_SCHEME=gnu
-+export PATH=@gettext@/bin:$PATH
- 
+-
 -	eval_gettext () {
 -		printf "%s" "$1" | (
 -			export PATH $(git sh-i18n--envsubst --variables "$1");
 -			git sh-i18n--envsubst "$1"
 -		)
 -	}
++# GNU gettext
++export GIT_INTERNAL_GETTEXT_SH_SCHEME=gnu
++export PATH=@gettext@/bin:$PATH
+
+-	eval_ngettext () {
+-		(test "$3" = 1 && printf "%s" "$1" || printf "%s" "$2") | (
+-			export PATH $(git sh-i18n--envsubst --variables "$2");
+-			git sh-i18n--envsubst "$2"
+-		)
+-	}
 -	;;
 -esac
 +. @gettext@/bin/gettext.sh
- 
+
  # Git-specific wrapper functions
  gettextln () {


### PR DESCRIPTION
###### Motivation for this change

New version of git released. Expression needs update.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
      (I tried most of my frequently used commands and everything was good. Not an extensive and thorough testing.)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Apologies, my `hub` was outdated and did not pick up the github template automatically. Just added the template manually.
