### PR TITLE
mark spl as broken spl on kernel 4.7 or higher

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -60,6 +60,9 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ jcumming wizeman wkennington ];
-    broken = (kernel.features.grsecurity or false);
+    broken = kernel.features.grsecurity or
+            # spl marked as broken until following patch is released
+            # https://github.com/zfsonlinux/spl/commit/fdbc1ba99d1f4d3958189079eee9b6c957e0264b
+            (versionAtLeast  kernel.version "4.7");
   };
 }


### PR DESCRIPTION
#18209

@shlevy [this commit](https://github.com/zfsonlinux/spl/commit/fdbc1ba99d1f4d3958189079eee9b6c957e0264b) didn't apply cleanly. would marking it broken this way be ok?
