### PR TITLE
megatools: 1.9.94 -> 1.9.97

### DIFF
--- a/pkgs/tools/networking/megatools/default.nix
+++ b/pkgs/tools/networking/megatools/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "megatools-${version}";
-  version = "1.9.94";
+  version = "1.9.97";
 
   src = fetchurl {
     url = "http://megatools.megous.com/builds/${name}.tar.gz";
-    sha256 = "1kms0k652sszcbzmx5nmz07gc8zbqqiskh8hvmvf6xaga7y3lgrx";
+    sha256 = "1wssf8f2ndh43sdzcfc644azqa7bjppl3b9s26mz1pjswmpca5ik";
   };
 
   buildInputs = [ pkgconfig glib fuse curl makeWrapper


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
