### PR TITLE
st: 0.6 -> 0.7

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -33,6 +33,7 @@
   anderspapitto = "Anders Papitto <anderspapitto@gmail.com>";
   andres = "Andres Loeh <ksnixos@andres-loeh.de>";
   andrewrk = "Andrew Kelley <superjoe30@gmail.com>";
+  andsild = "Anders Sildnes <andsild@gmail.com>";
   aneeshusa = "Aneesh Agrawal <aneeshusa@gmail.com>";
   antono = "Antono Vasiljev <self@antono.info>";
   ardumont = "Antoine R. Dumont <eniotna.t@gmail.com>";

--- a/pkgs/applications/misc/st/default.nix
+++ b/pkgs/applications/misc/st/default.nix
@@ -1,33 +1,32 @@
-{ stdenv, fetchurl, pkgconfig, writeText, libX11, ncurses, libXext, libXft, fontconfig
-, conf ? null, patches ? []}:
+{ stdenv, fetchurl, pkgconfig, writeText, libX11, ncurses, libXext, libXft
+, fontconfig, conf ? null, patches ? []}:
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
-  name = "st-0.6";
-  
+let patches' = if isNull patches then [] else patches;
+in stdenv.mkDerivation rec {
+  name = "st-0.7";
+
   src = fetchurl {
     url = "http://dl.suckless.org/st/${name}.tar.gz";
-    sha256 = "0avsfc1qp8zvshsfjwwrkvk411jlqy58z225bsdhjkl1qc40qcc5";
+    sha256 = "f7870d906ccc988926eef2cc98950a99cc78725b685e934c422c03c1234e6000";
   };
 
-  inherit patches;
+  patches = patches' ++ [ ./st-fix-deletekey.patch ];
 
   configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
   preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
-  
-  buildInputs = [ pkgconfig libX11 ncurses libXext libXft fontconfig ];
 
-  NIX_LDFLAGS = "-lfontconfig";
+  buildInputs = [ pkgconfig libX11 ncurses libXext libXft fontconfig ];
 
   installPhase = ''
     TERMINFO=$out/share/terminfo make install PREFIX=$out
   '';
-    
+
   meta = {
     homepage = http://st.suckless.org/;
     license = stdenv.lib.licenses.mit;
-    maintainers = with maintainers; [viric];
+    maintainers = with maintainers; [viric andsild];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/st/st-fix-deletekey.patch
+++ b/pkgs/applications/misc/st/st-fix-deletekey.patch
@@ -1,0 +1,15 @@
+diff --git a/config.def.h b/config.def.h
+index 1896246..b41747f 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -315,8 +315,8 @@ static Key key[] = {
+ 	{ XK_Delete,        ControlMask,    "\033[3;5~",    +1,    0,    0},
+ 	{ XK_Delete,        ShiftMask,      "\033[2K",      -1,    0,    0},
+ 	{ XK_Delete,        ShiftMask,      "\033[3;2~",    +1,    0,    0},
+-	{ XK_Delete,        XK_ANY_MOD,     "\033[P",       -1,    0,    0},
+-	{ XK_Delete,        XK_ANY_MOD,     "\033[3~",      +1,    0,    0},
++	{ XK_Delete,        XK_ANY_MOD,     "\033[P",       +1,    0,    0},
++	{ XK_Delete,        XK_ANY_MOD,     "\033[3~",      -1,    0,    0},
+ 	{ XK_BackSpace,     XK_NO_MOD,      "\177",          0,    0,    0},
+ 	{ XK_BackSpace,     Mod1Mask,       "\033\177",      0,    0,    0},
+ 	{ XK_Home,          ShiftMask,      "\033[2J",       0,   -1,    0},


### PR DESCRIPTION
Note: first PR, sorry for any mistakes that might have been made
###### Motivation for this change

updating old software
###### Things done

Adding patch for delete key, from old bug; http://lists.suckless.org/dev/1212/13800.html
(the order of + and - operators are wrong)
Bump version from 0.6 -> 0.7
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@viric was the old maintainer
