### PR TITLE
mdf2iso: init at 0.3.1

### DIFF
--- a/pkgs/tools/cd-dvd/mdf2iso/default.nix
+++ b/pkgs/tools/cd-dvd/mdf2iso/default.nix
@@ -1,0 +1,20 @@
+{stdenv, fetchgit}:
+
+stdenv.mkDerivation rec {
+  name = "mdf2iso-${version}";
+  version = "0.3.1";
+
+  src = fetchgit {
+    url    = https://anonscm.debian.org/cgit/collab-maint/mdf2iso.git;
+    rev    = "5a8acaf3645bff863f9f16ea1d3632c312f01523";
+    sha256 = "0f2jx8dg1sxc8y0sisqhqsqg7pj1j84fp08nahp0lfcq522pqbhl";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Small utility that converts MDF images to ISO format";
+    homepage = src.url;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.oxij ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1020,6 +1020,8 @@ in
 
   cdrkit = callPackage ../tools/cd-dvd/cdrkit { };
 
+  mdf2iso = callPackage ../tools/cd-dvd/mdf2iso { };
+
   libceph = self.ceph.lib;
   ceph = callPackage ../tools/filesystems/ceph { boost = boost159; };
   ceph-dev = self.ceph;


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
