### PR TITLE
osmctools: init at 0.8.5

### DIFF
--- a/pkgs/applications/misc/osmctools/default.nix
+++ b/pkgs/applications/misc/osmctools/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, zlib } :
+
+stdenv.mkDerivation rec {
+  name = "osmctools-${version}";
+  version = "0.8.5";
+
+  src = fetchurl {
+    url = http://m.m.i24.cc/osmconvert.c;
+    sha256 = "9da0940912d1bc62223b962483fd796f92c959c48749806aee5806164e5875d7";
+  };
+
+  buildInputs = [ zlib ];
+
+  phases = [ "buildPhase" "installPhase" ];
+
+  buildPhase = ''
+    cc $src -lz -O3 -o osmconvert
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv osmconvert $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Converter between various Open Street Map file formats";
+    homepage = http://wiki.openstreetmap.org/wiki/Osmconvert;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14259,6 +14259,8 @@ in
     inherit (pkgs.kde4) kdelibs;
   };
 
+  osmctools = callPackage ../applications/misc/osmctools { };
+
   vivaldi = callPackage ../applications/networking/browsers/vivaldi {};
 
   opusfile = callPackage ../applications/audio/opusfile { };


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
