### PR TITLE
haskell: fix ghcWithHoogle to version 4

### DIFF
--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -85,7 +85,10 @@ let
         ghcWithHoogle = selectFrom:
           let
             packages = selectFrom self;
-            hoogle = callPackage ./hoogle.nix { inherit packages; };
+            hoogle = callPackage ./hoogle.nix {
+              inherit packages;
+              hoogle = self.hoogle_4_2_43;
+            };
           in withPackages (packages ++ [ hoogle ]);
 
         ghc = ghc // {


### PR DESCRIPTION
This is a temporary fix for #17540.
