### PR TITLE
teeworlds: use wrapProgram

### DIFF
--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -1,4 +1,6 @@
-{ fetchurl, stdenv, python, alsaLib, libX11, mesa_glu, SDL, lua5, zlib, bam, freetype }:
+{ fetchurl, stdenv, makeWrapper, python, alsaLib
+, libX11, mesa_glu, SDL, lua5, zlib, bam, freetype
+}:
 
 stdenv.mkDerivation rec {
   name = "teeworlds-0.6.3";
@@ -11,7 +13,9 @@ stdenv.mkDerivation rec {
   # we always want to use system libs instead of these
   postPatch = "rm -r other/{freetype,sdl}/{include,lib32,lib64}";
 
-  buildInputs = [ python alsaLib libX11 mesa_glu SDL lua5 zlib bam freetype ];
+  buildInputs = [
+    python makeWrapper alsaLib libX11 mesa_glu SDL lua5 zlib bam freetype
+  ];
 
   buildPhase = ''
     bam -a -v release
@@ -38,12 +42,8 @@ stdenv.mkDerivation rec {
     # that they can access the graphics and sounds.
     for program in $executables
     do
-      mv -v "$out/bin/$program" "$out/bin/.wrapped-$program"
-      cat > "$out/bin/$program" <<EOF
-    #!/bin/sh
-    cd "$out/share/${name}" && exec "$out/bin/.wrapped-$program" "\$@"
-    EOF
-      chmod -v +x "$out/bin/$program"
+      wrapProgram $out/bin/$program \
+        --run "cd $out/share/${name}"
     done
 
     # Copy the documentation.


### PR DESCRIPTION
###### Motivation for this change

To avoid reinventing the wrapper script. Only tested `teeworlds` program.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
