### PR TITLE
i3pystatus: 3.34 -> 3.35

### DIFF
--- a/pkgs/applications/window-managers/i3/pystatus.nix
+++ b/pkgs/applications/window-managers/i3/pystatus.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
-  version = "3.34";
+  version = "3.35";
   pname = "i3pystatus";
   disabled = !python3Packages.isPy3k;
 
   src = fetchurl {
     url = "mirror://pypi/i/${pname}/${name}.tar.gz";
-    sha256 = "1bpkkf9q4zqq7fh65zynbv26nq24rfznmw71jjvda7g8kjrwjdk5";
+    sha256 = "0g5m05rbqvq1qrspm6fyzky9xfhaz5pvc4hfzgdxrzijn8nfc860";
   };
 
   propagatedBuildInputs = with python3Packages; [ keyring colour netifaces praw psutil basiciw ] ++


### PR DESCRIPTION
###### Motivation for this change

Update i3pystatus to the last version

PostIntall wrapper is already not needed but I didn't remove for compatibility. Better use `i3pystatus -c bar.py` for loading the config.

Please, merge after #18267 
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
