### PR TITLE
odp-dpdk: 10.10.01 -> 2016-08-16

### DIFF
--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "odp-dpdk-${version}";
-  version = "1.10.1.0";
+  version = "2016-08-16";
 
   src = fetchgit {
     url = "https://git.linaro.org/lng/odp-dpdk.git";
-    rev = "0ed1ced007d98980f90604675083bf30c354e867";
-    sha256 = "1kf090bizr0p0cxn525qpmypb5j86imvxrfpmwbl7vqqfh74j5ax";
+    rev = "7068593f600e2b5a23ee1780d5c722c54e966df1";
+    sha256 = "0pz0zkxqaac193x21wmj3x88gfza6bvhmv5yf8fzkpm9zxnl2sy4";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, autoreconfHook, openssl, libpcap, dpdk, bash }:
+{ stdenv, fetchgit, autoreconfHook, openssl, libpcap, dpdk }:
 
 stdenv.mkDerivation rec {
   name = "odp-dpdk-${version}";
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1kf090bizr0p0cxn525qpmypb5j86imvxrfpmwbl7vqqfh74j5ax";
   };
 
-  nativeBuildInputs = [ autoreconfHook bash ];
-  buildInputs = [ stdenv openssl dpdk libpcap ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ openssl dpdk libpcap ];
 
   RTE_SDK = "${dpdk}";
   RTE_TARGET = "x86_64-native-linuxapp-gcc";


### PR DESCRIPTION
Fixes build against dpdk 16.06

Tested build against linux, linux_latest, linux_3_18, linux_4_1,
linux_4_6, linux_grsec_nixos, linux_chromiumos_3_18.
