### PR TITLE
Allow passing extra paths to non-python packages into python.buildEnv.

### DIFF
--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -1,5 +1,6 @@
 { stdenv, python, buildEnv, makeWrapper
 , extraLibs ? []
+, extraPaths ? []
 , postBuild ? ""
 , ignoreCollisions ? false }:
 
@@ -8,7 +9,7 @@ let
   recursivePthLoader = import ../../python-modules/recursive-pth-loader/default.nix { stdenv = stdenv; python = python; };
   env = (
   let
-    paths = stdenv.lib.filter (x : x ? pythonPath) (stdenv.lib.closePropagation extraLibs) ++ [ python recursivePthLoader ];
+    paths = stdenv.lib.filter (x : x ? pythonPath) (stdenv.lib.closePropagation extraLibs) ++ [ python recursivePthLoader ] ++ extraPaths;
   in buildEnv {
     name = "${python.name}-env";
 


### PR DESCRIPTION
Useful e.g. to pass GCC through when using theano.
