### PR TITLE
zstd: 0.7.5 -> 1.0.0

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "zstd-${version}";
-  version = "0.7.5";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
-    sha256 = "07b4gmmkk2b28vmmhcg8h2imzccav1qklgvbdg2k6nl9p88zwzkd";
+    sha256 = "0h8r8vlk8v28cxxgdp7h7dcygbpn8g95wffsvhzybxhfvkrlw6f2";
     rev = "v${version}";
     repo = "zstd";
-    owner = "Cyan4973";
+    owner = "facebook";
   };
 
   # The Makefiles don't properly use file targets, but blindly rebuild
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       compression speed. Speed/ratio trade-off is configurable by small
       increment, to fit different situations. Note however that decompression
       speed is preserved and remain roughly the same at all settings, a
-      property shared by most LZ compression algorithms, such as zlib. 
+      property shared by most LZ compression algorithms, such as zlib.
     '';
     homepage = http://www.zstd.net/;
     # The licence of the CLI programme is GPLv2+, that of the library BSD-2.


### PR DESCRIPTION
###### Motivation for this change

Facebook moved made `zstd` an official facebook organization project and released 1.0.0. Changelog can be found here: https://github.com/facebook/zstd/compare/v0.7.5...v1.0.0
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

``` bash

$ nix-shell -p nox --run "nox-review wip"
==> We're in a git repo, trying to fetch it
Building in /run/user/1000/nox-review-tybbfig5: zstd
/nix/store/fm40hr2n5sciqvr5bv3lrsgvaymkrzmy-zstd-1.0.0
Result in /run/user/1000/nox-review-tybbfig5
total 0
lrwxrwxrwx 1 spotter users 54 Sep  3 15:31 result -> /nix/store/fm40hr2n5sciqvr5bv3lrsgvaymkrzmy-zstd-1.0.0
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)

``` bash
$ nix-shell -p nox --run "nox-review wip"
==> We're in a git repo, trying to fetch it
Building in /run/user/1000/nox-review-tybbfig5: zstd
/nix/store/fm40hr2n5sciqvr5bv3lrsgvaymkrzmy-zstd-1.0.0
Result in /run/user/1000/nox-review-tybbfig5
total 0
lrwxrwxrwx 1 spotter users 54 Sep  3 15:31 result -> /nix/store/fm40hr2n5sciqvr5bv3lrsgvaymkrzmy-zstd-1.0.0

$ cd /run/user/1000/nox-review-tybbfig5/

$ ./result/bin/zstd --version
*** zstd command line interface 64-bits v1.0.0, by Yann Collet ***

$ ./result/bin/zstd --help
*** zstd command line interface 64-bits v1.0.0, by Yann Collet ***
Usage :
      zstd [args] [FILE(s)] [-o file]

FILE    : a filename
          with no FILE, or when FILE is - , read standard input
Arguments :
 -#     : # compression level (1-19, default:3)
 -d     : decompression
 -D file: use `file` as Dictionary
 -o file: result stored into `file` (only if 1 input file)
 -f     : overwrite output without prompting
--rm    : remove source file(s) after successful de/compression
 -k     : preserve source file(s) (default)
 -h/-H  : display help/long help and exit

Advanced arguments :
 -V     : display Version number and exit
 -v     : verbose mode; specify multiple times to increase log level (default:2)
 -q     : suppress warnings; specify twice to suppress errors too
 -c     : force write to standard output, even if it is the console
 -r     : operate recursively on directories
--ultra : enable levels beyond 19, up to 22 (requires more memory)
--no-dictID : don't write dictID into header (dictionary compression)
--[no-]check : integrity check (default:enabled)
--test  : test compressed file integrity
--[no-]sparse : sparse mode (default:enabled on file, disabled on stdout)

Dictionary builder :
--train ## : create a dictionary from a training set of files
 -o file : `file` is dictionary name (default: dictionary)
--maxdict ## : limit dictionary to specified size (default : 112640)
 -s#    : dictionary selectivity level (default: 9)
--dictID ## : force dictionary ID to specified value (default: random)

Benchmark arguments :
 -b#    : benchmark file(s), using # compression level (default : 1)
 -e#    : test all compression levels from -bX to # (default: 1)
 -i#    : minimum evaluation time in seconds (default : 3s)
 -B#    : cut file into independent blocks of size # (default: no block)

$ wc -l ./result/include/zstd.h
587 ./result/include/zstd.h

$ gpg2 --encrypt --recipient       CE87D62D2F7870737B09498EBCC9DA829DB12C14 --armor --output file.asc ./re
sult/include/zstd.h
gpg: EE71B79607FA4306: There is no assurance this key belongs to the named user
sub  rsa2048/EE71B79607FA4306 2014-11-07 keybase.io/mbbx6spp <mbbx6spp@keybase.io>
 Primary key fingerprint: CE87 D62D 2F78 7073 7B09  498E BCC9 DA82 9DB1 2C14
      Subkey fingerprint: A1FC B970 A9A5 BAFD 5B7C  D0EC EE71 B796 07FA 4306

It is NOT certain that the key belongs to the person named
in the user ID.  If you *really* know what you are doing,
you may answer the next question with yes.

Use this key anyway? (y/N) y

$ zstd -9 file.asc -o file.asc.zst
file.asc             : 75.92%   ( 12153 =>   9227 bytes, file.asc.zst)

$ mv file.asc file.asc.orig

$ zstd -d file.asc.zst
file.asc.zst        : 12153 bytes

$ diff file.asc file.asc.orig
```
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also updated to use the new repository location under `facebook` organization which is new official home.
