### PR TITLE
libmsgpack: fixed mingw32 cross-build

### DIFF
--- a/pkgs/development/libraries/libmsgpack/generic.nix
+++ b/pkgs/development/libraries/libmsgpack/generic.nix
@@ -8,7 +8,12 @@ stdenv.mkDerivation rec {
 
   inherit src patches;
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  crossAttrs = {
+  } // stdenv.lib.optionalAttrs (stdenv.cross.libc == "msvcrt") {
+    cmakeFlags = "-DMSGPACK_BUILD_EXAMPLES=OFF -DCMAKE_SYSTEM_NAME=Windows";
+  };
 
   meta = with stdenv.lib; {
     description = "MessagePack implementation for C and C++";


### PR DESCRIPTION
###### Motivation for this change

`cmake`, as usual, should be in `nativeBuildInputs` and we need to add a few cmake flags for mingw32 build to succeed. The cross-build was tested for all three versions of libmsgpack in nixpkgs (and the non-cross-build should be unaffected by these changes).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
