### PR TITLE
rootpy: init at 0.8.3

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  setupHook = ./setup-hook.sh;
+
   meta = {
     homepage = "https://root.cern.ch/";
     description = "A data analysis framework";

--- a/pkgs/applications/science/misc/root/setup-hook.sh
+++ b/pkgs/applications/science/misc/root/setup-hook.sh
@@ -1,0 +1,9 @@
+thisroot () {
+    # Workaround thisroot.sh dependency on man
+    if [ -z "${MANPATH}" ]; then
+        MANPATH=:
+    fi
+    source @out@/bin/thisroot.sh
+}
+
+envHooks+=(thisroot)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21325,6 +21325,25 @@ in modules // {
     };
   };
 
+  rootpy = buildPythonPackage rec {
+    version = "0.8.3";
+    name = "rootpy-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/d5/40/feddb2c9d1cadfe05d1d9aea1a71be093dc700879c9f6af40a10b1330f34/rootpy-0.8.3.tar.gz";
+      sha256 = "14q9bhs2a53598571x8yikj68x2iyl6090wbvdrpbwr238799b0z";
+    };
+
+    disabled = isPy3k;
+
+    propagatedBuildInputs = with self; [ pkgs.root readline numpy matplotlib ];
+
+    meta = {
+      homepage = "http://www.rootpy.org";
+      license = licenses.gpl3;
+      description = "Pythonic interface to the ROOT framework";
+    };
+  };
 
   rope = buildPythonPackage rec {
     version = "0.10.2";


### PR DESCRIPTION
###### Motivation for this change

To provide rootpy package.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
