### PR TITLE
kibana: 4.5.2 -> 4.6.0

### DIFF
--- a/pkgs/development/tools/misc/kibana/default.nix
+++ b/pkgs/development/tools/misc/kibana/default.nix
@@ -1,14 +1,23 @@
 { stdenv, makeWrapper, fetchurl, nodejs, coreutils, which }:
 
 with stdenv.lib;
-
-stdenv.mkDerivation rec {
+let
+  inherit (builtins) elemAt;
+  info = splitString "-" stdenv.system;
+  arch = elemAt info 0;
+  plat = elemAt info 1;
+  shas = {
+    "x86_64-linux"  = "1md3y3a8rxvf37lnfc56kbirv2rjl68pa5672yxhfmjngrr20rcw";
+    "i686-linux"    = "0d77a2v14pg5vr711hzbva8jjy0sxw9w889f2r1vhwngrhcfz4pf";
+    "x86_64-darwin" = "1cajljx13h8bncmayzvlzsynwambz61cspjnsn2h19zghn2vj2c9";
+  };
+in stdenv.mkDerivation rec {
   name = "kibana-${version}";
-  version = "4.5.2";
+  version = "4.6.0";
 
   src = fetchurl {
-    url = "http://download.elastic.co/kibana/kibana-snapshot/${name}-snapshot-linux-x86.tar.gz";
-    sha256 = "1na8xh525znxaqjhxfvpx0q3rj85cjb6l9zlzd44dl31a9l117y4";
+    url = "https://download.elastic.co/kibana/kibana/${name}-${plat}-${arch}.tar.gz";
+    sha256 = shas."${stdenv.system}";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Update kibana package from 4.5.2 to 4.6.0.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Includes supporting binary src for x86_64-linux and x86_64-darwin in addition to x86-linux

nox-review and corresponding `kibana` binary test:

``` bash
nix-shell -p nox --run "nox-review wip"
==> We're in a git repo, trying to fetch it
Building in /run/user/1000/nox-review-n5i1d5go: kibana
/nix/store/svqdl1dg5zrnqxjz3hm8ljpayc904w6v-kibana-4.6.0
Result in /run/user/1000/nox-review-n5i1d5go
total 0
lrwxrwxrwx 1 spotter users 56 Sep  3 20:11 result -> /nix/store/svqdl1dg5zrnqxjz3hm8ljpayc904w6v-kibana-4.6.0

$ cd /run/user/1000/nox-review-n5i1d5go/

$ env BABEL_CACHE_PATH=./.babelcache.json ./result/bin/kibana --version
4.6.0
```

In one terminal:

``` bash
$ env BABEL_CACHE_PATH=./.babelcache.json ./result/bin/kibana -e localhost:9200 -p 5601 --verbose -l . ser
ve
  log   [21:44:10.108] [info][listening] Server running at http://0.0.0.0:5601
^C
```

In another:

``` bash
$ curl -I localhost:5601/
HTTP/1.1 200 OK
kbn-name: kibana
kbn-version: 4.6.0
cache-control: no-cache
Date: Sun, 04 Sep 2016 02:44:33 GMT
Connection: keep-alive

```
