### PR TITLE
fontconfig: fix dependencies on OSX

### DIFF
--- a/pkgs/data/fonts/dejavu-fonts/default.nix
+++ b/pkgs/data/fonts/dejavu-fonts/default.nix
@@ -47,6 +47,6 @@ stdenv.mkDerivation rec {
     # See http://dejavu-fonts.org/wiki/License for details
     license = stdenv.lib.licenses.free;
 
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     python freetype zlib glib libungif libpng libjpeg libtiff libxml2
   ]
     ++ lib.optionals withGTK [ gtk2 pango ]
-    ++ lib.optionals (withGTK && stdenv.isDarwin) [ Carbon Cocoa ];
+    ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
 
   configureFlags =
     lib.optionals (!withPython) [ "--disable-python-scripting" "--disable-python-extension" ]

--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -35,7 +35,8 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     lib.optionals (!withPython) [ "--disable-python-scripting" "--disable-python-extension" ]
-    ++ lib.optional withGTK "--enable-gtk2-use";
+    ++ lib.optional withGTK "--enable-gtk2-use"
+    ++ lib.optional (!withGTK) "--without-x";
 
   preConfigure = ''
     cp -r "${gnulib}" ./gnulib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1617,7 +1617,9 @@ in
 
   flvtool2 = callPackage ../tools/video/flvtool2 { };
 
-  fontforge = lowPrio (callPackage ../tools/misc/fontforge { });
+  fontforge = lowPrio (callPackage ../tools/misc/fontforge {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+  });
   fontforge-gtk = callPackage ../tools/misc/fontforge {
     withGTK = true;
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;


### PR DESCRIPTION
###### Motivation for this change

Since 4f73633f26e80fb8b06f68793973c6e5089c790c fontconfig depends on dejavu_fonts, which don't build on OSX. This fixes it.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
