### PR TITLE
pygtk: fix broken symlink

### DIFF
--- a/pkgs/development/python-modules/pygobject/default.nix
+++ b/pkgs/development/python-modules/pygobject/default.nix
@@ -1,8 +1,9 @@
 { stdenv, fetchurl, python, mkPythonDerivation, pkgconfig, glib }:
 
 mkPythonDerivation rec {
-  name = "pygobject-2.28.6";
-  
+  name = "pygobject-${version}";
+  version = "2.28.6";
+
   src = fetchurl {
     url = "mirror://gnome/sources/pygobject/2.28/${name}.tar.xz";
     sha256 = "1f5dfxjnil2glfwxnqr14d2cjfbkghsbsn8n04js2c2icr7iv2pv";

--- a/pkgs/development/python-modules/pygtk/default.nix
+++ b/pkgs/development/python-modules/pygtk/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   postInstall = ''
     rm $out/bin/pygtk-codegen-2.0
     ln -s ${pygobject}/bin/pygobject-codegen-2.0  $out/bin/pygtk-codegen-2.0
-    ln -s ${pygobject}/lib/${python.libPrefix}/site-packages/${pygobject.name}.pth \
+    ln -s ${pygobject}/lib/${python.libPrefix}/site-packages/pygobject-${pygobject.version}.pth \
                   $out/lib/${python.libPrefix}/site-packages/${name}.pth
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

${pygobject.name} now contains a python2- prefix resulting
in a broken symlink. this breaks pygtk and every depending application
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` <- skipped that because of libreoffice, other packages such as gpodder, gajim works fine
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
