### PR TITLE
ferm: fix race condition in integration test

### DIFF
--- a/nixos/tests/ferm.nix
+++ b/nixos/tests/ferm.nix
@@ -54,6 +54,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       $client->waitForUnit("network.target");
       $server->waitForUnit("ferm.service");
       $server->waitForUnit("nginx.service");
+      $server->waitUntilSucceeds("ss -ntl | grep -q 80");
 
       subtest "port 80 is allowed", sub {
           $client->succeed("curl --fail -g http://192.168.1.1:80/status");


### PR DESCRIPTION
curl sent the request faster then nginx bound the port in some cases
- [x] Tested using sandboxing
  ([nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS,
    or option `build-use-chroot` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
