### PR TITLE
Add (some) PHP-extensions embedding JavaScript engines

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -207,6 +207,16 @@ let
     };
   };
 
+  v8js = assert isPhp7; buildPecl rec {
+    version = "1.3.2";
+    name = "v8js-${version}";
+
+    sha256 = "1x7gxi70zgj3vaxs89nfbnwlqcxrps1inlyfzz66pbzdbfwvc8z8";
+
+    buildInputs = [ pkgs.v8 ];
+    configureFlags = [ "--with-v8js=${pkgs.v8}" ];
+  };
+
   composer = pkgs.stdenv.mkDerivation rec {
     name = "composer-${version}";
     version = "1.2.0";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -81,6 +81,19 @@ let
     buildInputs = with pkgs; [ pkgconfig cyrus_sasl ];
   };
 
+  # No support for PHP 7 yet (and probably never will be)
+  spidermonkey = assert !isPhp7; buildPecl rec {
+    name = "spidermonkey-1.0.0";
+
+    sha256 = "1ywrsp90w6rlgq3v2vmvp2zvvykkgqqasab7h9bf3vgvgv3qasbg";
+
+    configureFlags = [
+      "--with-spidermonkey=${pkgs.spidermonkey_185}"
+    ];
+
+    buildInputs = [ pkgs.spidermonkey_185 ];
+  };
+
   xdebug = if isPhp7 then xdebug24 else xdebug23;
 
   xdebug23 = assert !isPhp7; buildPecl {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -220,6 +220,37 @@ let
     };
   };
 
+  v8 = assert isPhp7; buildPecl rec {
+    version = "0.1.0";
+    name = "v8-${version}";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/pinepain/php-v8/archive/v${version}.tar.gz";
+      sha256 = "18smnxd34b486f5n8j0wk9z7r5x1w84v89mgf76z0bn7gxdxl0xj";
+    };
+
+    buildInputs = [ pkgs.v8 ];
+    configureFlags = [ "--with-v8=${pkgs.v8}" ];
+
+    patches = [
+      (builtins.toFile "link-libv8_libbase.patch" ''
+        Index: php-v8/config.m4
+        ===================================================================
+        --- php-v8.orig/config.m4
+        +++ php-v8/config.m4
+        @@ -69,7 +69,7 @@ if test "$PHP_V8" != "no"; then
+               #static_link_extra="libv8_base.a libv8_libbase.a libv8_libplatform.a libv8_snapshot.a"
+               ;;
+             * )
+        -      static_link_extra="libv8_libplatform.a"
+        +      static_link_extra="libv8_libplatform.a libv8_libbase.a"
+               #static_link_extra="libv8_base.a libv8_libbase.a libv8_libplatform.a libv8_snapshot.a"
+               ;;
+           esac
+	''
+      )];
+  };
+
   v8js = assert isPhp7; buildPecl rec {
     version = "1.3.2";
     name = "v8js-${version}";


### PR DESCRIPTION
###### Motivation for this change

I've been playing around with all of these and they aren't currently packaged :)

This pull request adds three PHP extensions:
- _spidermonkey_ embeds PHP 5 with Spidermonkey JavaScript engine
- _V8_ is a pretty new extension embedding V8 engine with PHP 7 on a pretty low level
- _v8js_ is another extension embedding V8 with PHP 7, yet more opinionated and on a higher level
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)  [n/a]
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
