### PR TITLE
fetchipfs: draft

### DIFF
--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchipfs }:
 
 stdenv.mkDerivation rec {
   name = "hello-2.10";
 
-  src = fetchurl {
-    url = "mirror://gnu/hello/${name}.tar.gz";
-    sha256 = "0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i";
+  src = fetchipfs {
+    url    = "https://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz";
+    ipfs   = "QmeWBgpeMSNV9Mvp85N7jyFxbhUpgySANJsef5XQYyykjd";
+    sha256 = "0lbgr8d2vhblhczc16llcrvid6v7s678733zac6jbm6gy2di1mjb";
+    execs  = [ "configure" ];
   };
 
   doCheck = false;

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -5,9 +5,8 @@ stdenv.mkDerivation rec {
 
   src = fetchipfs {
     url    = "https://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz";
-    ipfs   = "QmeWBgpeMSNV9Mvp85N7jyFxbhUpgySANJsef5XQYyykjd";
-    sha256 = "0lbgr8d2vhblhczc16llcrvid6v7s678733zac6jbm6gy2di1mjb";
-    execs  = [ "configure" ];
+    ipfs   = "QmWyj65ak3wd8kG2EvPCXKd6Tij15m4SwJz6g2yG2rQ7w8";
+    sha256 = "1im1gglfm4k10bh4mdaqzmx3lm3kivnsmxrvl6vyvmfqqzljq75l";
   };
 
   doCheck = false;

--- a/pkgs/build-support/fetchipfs/builder.sh
+++ b/pkgs/build-support/fetchipfs/builder.sh
@@ -1,0 +1,93 @@
+source $stdenv/setup
+
+# Curl flags to handle redirects, not use EPSV, handle cookies for
+# servers to need them during redirects, and work on SSL without a
+# certificate (this isn't a security problem because we check the
+# cryptographic hash of the output anyway).
+
+set -o noglob
+
+curl="curl            \
+ --location           \
+ --max-redirs 20      \
+ --retry 2            \
+ --disable-epsv       \
+ --cookie-jar cookies \
+ --insecure           \
+ --speed-time 5       \
+ -#                   \
+ --fail               \
+ $curlOpts            \
+ $NIX_CURL_FLAGS"
+
+finish() {
+    find "$out" -type f -exec chmod 644 {} \;
+    for exes in $execs; do
+        chmod +x "$out/$exes"
+    done
+    runHook postFetch
+    set +o noglob
+    exit 0
+}
+
+echo
+echo -n "[0m[01;36m=IPFS=[0m get"
+
+if test -d "/ipfs/$ipfs"; then
+    echo " /ipfs/$ipfs"
+    (timeout 5 cp -r "/ipfs/$ipfs" "$out" && finish)
+    echo "Timed out"
+fi
+
+if $curl --retry 0 --head --silent "localhost:$port/ipfs/$ipfs" > /dev/null; then
+    curlexit=18;
+    echo " localhost:$port/ipfs/$ipfs"
+    # if we get error code 18, resume partial download
+    while [ $curlexit -eq 18 ]; do
+        # keep this inside an if statement, since on failure it doesn't abort the script
+        if $curl -C - --fail "http://localhost:$port/api/v0/get?arg=$ipfs&archive=true" --output "$ipfs.tar"; then
+            unpackFile "$ipfs.tar"
+            mv "$ipfs" "$out"
+            finish
+        else
+            curlexit=$?;
+        fi
+    done
+fi
+
+if test -n "$url"; then
+    curlexit=18;
+    echo " $url"
+    mkdir download
+    cd download
+    while [ $curlexit -eq 18 ]; do
+        # keep this inside an if statement, since on failure it doesn't abort the script
+        if $curl "$url" -O; then
+            tmpfile=$(echo *)
+            unpackFile $tmpfile
+            rm $tmpfile
+            mv $(echo *) "$out"
+            finish
+        else
+            curlexit=$?;
+        fi
+    done
+fi
+
+curlexit=18;
+echo " https://ipfs.io/ipfs/$ipfs"
+while [ $curlexit -eq 18 ]; do
+    # keep this inside an if statement, since on failure it doesn't abort the script
+    if $curl "https://ipfs.io/api/v0/get?arg=$ipfs&archive=true&compress=true" --output "$ipfs.tar.gz"; then
+        unpackFile "$ipfs.tar.gz"
+        mv "$ipfs" "$out"
+        finish
+    else
+        curlexit=$?;
+    fi
+done
+
+echo "[01;31merror:[0m cannot download $ipfs from ipfs or the given url"
+echo
+set +o noglob
+exit 1

--- a/pkgs/build-support/fetchipfs/default.nix
+++ b/pkgs/build-support/fetchipfs/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, curl
+}:
+
+{ ipfs
+, url            ? ""
+, curlOpts       ? ""
+, outputHash     ? ""
+, outputHashAlgo ? ""
+, md5            ? ""
+, sha1           ? ""
+, sha256         ? ""
+, sha512         ? ""
+, meta           ? {}
+, port           ? "8080"
+, postFetch      ? ""
+, execs          ? []
+}:
+
+assert sha512 != "" -> builtins.compareVersions "1.11" builtins.nixVersion <= 0;
+
+let
+
+  hasHash = (outputHash != "" && outputHashAlgo != "")
+    || md5 != "" || sha1 != "" || sha256 != "" || sha512 != "";
+
+in
+
+if (!hasHash) then throw "Specify sha for fetchipfs fixed-output derivation" else stdenv.mkDerivation {
+  name = "ipfs_"+ipfs;
+  builder = ./builder.sh;
+  buildInputs = [ curl ];
+
+  # New-style output content requirements.
+  outputHashAlgo = if outputHashAlgo != "" then outputHashAlgo else
+      if sha512 != "" then "sha512" else if sha256 != "" then "sha256" else if sha1 != "" then "sha1" else "md5";
+  outputHash = if outputHash != "" then outputHash else
+      if sha512 != "" then sha512 else if sha256 != "" then sha256 else if sha1 != "" then sha1 else md5;
+
+  outputHashMode = "recursive";
+
+  inherit curlOpts
+          postFetch
+          ipfs
+          execs
+          url
+          port;
+
+  # Doing the download on a remote machine just duplicates network
+  # traffic, so don't do that.
+  preferLocalBuild = true;
+
+  inherit meta;
+}

--- a/pkgs/build-support/fetchipfs/default.nix
+++ b/pkgs/build-support/fetchipfs/default.nix
@@ -14,7 +14,6 @@
 , meta           ? {}
 , port           ? "8080"
 , postFetch      ? ""
-, execs          ? []
 }:
 
 assert sha512 != "" -> builtins.compareVersions "1.11" builtins.nixVersion <= 0;
@@ -27,7 +26,7 @@ let
 in
 
 if (!hasHash) then throw "Specify sha for fetchipfs fixed-output derivation" else stdenv.mkDerivation {
-  name = "ipfs_"+ipfs;
+  name = ipfs;
   builder = ./builder.sh;
   buildInputs = [ curl ];
 
@@ -42,7 +41,6 @@ if (!hasHash) then throw "Specify sha for fetchipfs fixed-output derivation" els
   inherit curlOpts
           postFetch
           ipfs
-          execs
           url
           port;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -197,6 +197,10 @@ in
     inherit curl stdenv;
   };
 
+  fetchipfs = import ../build-support/fetchipfs {
+    inherit curl stdenv;
+  };
+
   # fetchurlBoot is used for curl and its dependencies in order to
   # prevent a cyclic dependency (curl depends on curl.tar.bz2,
   # curl.tar.bz2 depends on fetchurl, fetchurl depends on curl).  It


### PR DESCRIPTION
###### Motivation for this change

A first draft to start discussion for a `fetchipfs` fixed output derivation.
###### Things done
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a wip:
fetchipfs will take an ipfs path and an optional url. It tries first to download from ipfs via the localhost api and if that fails it'll try to download from the url and add the path to ipfs.

I've changed the `hello` program to showcase usage. After reaching consensus in discussion and filling holes, I'll force push to clean up the branch and remove the changes to `hello`.

The reasoning to not depend on `ipfs` is that it isn't that small and needs to be run as daemon, which would be only for nixos possible in an efficient manner.

Limitations: 
- It expects to find the ipfs api under localhost:5001, this should be probably customizable with environment variables.
- The ipfs path can and will be only verified when the ipfs daemon is running and reachable (if it's not in ipfs, but the daemon is reachable, it will download from the url, verify the sha and verify the resulting ipfs path by adding it to ipfs).
