### PR TITLE
zotero: remove esr suffix from version string.

### DIFF
--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bash, firefox, perl, unzipNLS, xorg }:
+{ stdenv, fetchurl, lib, bash, firefox, perl, unzipNLS, xorg }:
 
 let
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     unzip "${xpi}" -d "$out/libexec/zotero"
 
     BUILDID=`date +%Y%m%d`
-    GECKO_VERSION="${firefox.passthru.version}"
+    GECKO_VERSION="${lib.removeSuffix "esr" firefox.passthru.version}"
     UPDATE_CHANNEL="default"
 
     # Copy branding
@@ -52,8 +52,8 @@ stdenv.mkDerivation {
 
     # Copy application.ini and modify
     cp assets/application.ini "$out/libexec/zotero/application.ini"
-    perl -pi -e "s/{{VERSION}}/$version/" "$out/libexec/zotero/application.ini"
-    perl -pi -e "s/{{BUILDID}}/$BUILDID/" "$out/libexec/zotero/application.ini"
+    perl -pi -e "s/\{\{VERSION}}/$version/" "$out/libexec/zotero/application.ini"
+    perl -pi -e "s/\{\{BUILDID}}/$BUILDID/" "$out/libexec/zotero/application.ini"
     perl -pi -e "s/^MaxVersion.*\$/MaxVersion=$GECKO_VERSION/" "$out/libexec/zotero/application.ini"
 
     # Copy prefs.js and modify


### PR DESCRIPTION
###### Motivation for this change

Fixes #18055
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also escaped the perl regexes since that will become an error in the future.

@vcunat @ttuegel 
