### PR TITLE
Digikam 5.1

### DIFF
--- a/pkgs/applications/graphics/digikam/5.1.nix
+++ b/pkgs/applications/graphics/digikam/5.1.nix
@@ -1,0 +1,113 @@
+{ stdenv, fetchurl, cmake, ecm, makeQtWrapper
+
+# For `digitaglinktree`
+, perl, sqlite
+
+, qtbase
+, qtxmlpatterns
+, qtsvg
+, qtwebkit
+
+, kconfigwidgets
+, kcoreaddons
+, kdoctools
+, kfilemetadata
+, knotifications
+, knotifyconfig
+, ktextwidgets
+, kwidgetsaddons
+, kxmlgui
+
+, bison
+, boost
+, eigen
+, exiv2
+, flex
+, jasper
+, lcms2
+, lensfun
+, libgphoto2
+, libkipi
+, liblqr1
+, libusb1
+, marble
+, mysql
+, opencv
+, threadweaver
+
+, oxygen
+}:
+
+stdenv.mkDerivation rec {
+  name    = "digikam-${version}";
+  version = "5.1.0";
+
+  src = fetchurl {
+    url = "http://download.kde.org/stable/digikam/${name}.tar.xz";
+    sha256 = "1w97a5cmg39dgmjgmjwa936gcrmxjms3h2ww61qi1lny84p5x4a7";
+  };
+
+  nativeBuildInputs = [ cmake ecm makeQtWrapper ];
+
+  buildInputs = [
+    qtbase
+    qtxmlpatterns
+    qtsvg
+    qtwebkit
+
+    kconfigwidgets
+    kcoreaddons
+    kdoctools
+    kfilemetadata
+    knotifications
+    knotifyconfig
+    ktextwidgets
+    kwidgetsaddons
+    kxmlgui
+
+    bison
+    boost
+    eigen
+    exiv2
+    flex
+    jasper
+    lcms2
+    lensfun
+    libgphoto2
+    libkipi
+    liblqr1
+    libusb1
+    marble.unwrapped
+    mysql
+    opencv
+    threadweaver
+
+    oxygen
+  ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DLIBUSB_LIBRARIES=${libusb1.out}/lib"
+    "-DLIBUSB_INCLUDE_DIR=${libusb1.dev}/include/libusb-1.0"
+    "-DENABLE_MYSQLSUPPORT=1"
+    "-DENABLE_INTERNALMYSQL=1"
+  ];
+
+  fixupPhase = ''
+    substituteInPlace $out/bin/digitaglinktree \
+      --replace "/usr/bin/perl" "${perl}/bin/perl" \
+      --replace "/usr/bin/sqlite3" "${sqlite}/bin/sqlite3"
+
+    wrapQtProgram $out/bin/digikam
+    wrapQtProgram $out/bin/showfoto
+  '';
+
+  meta = {
+    description = "Photo Management Program";
+    license = stdenv.lib.licenses.gpl2;
+    homepage = http://www.digikam.org;
+    maintainers = with stdenv.lib.maintainers; [ the-kenny ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/desktops/kde-5/applications/default.nix
+++ b/pkgs/desktops/kde-5/applications/default.nix
@@ -57,6 +57,7 @@ let
     libkexiv2 = callPackage ./libkexiv2.nix {};
     libkipi = callPackage ./libkipi.nix {};
     libkomparediff2 = callPackage ./libkomparediff2.nix {};
+    marble = callPackage ./marble.nix {};
     okular = callPackage ./okular.nix {};
     print-manager = callPackage ./print-manager.nix {};
     spectacle = callPackage ./spectacle.nix {};

--- a/pkgs/desktops/kde-5/applications/marble.nix
+++ b/pkgs/desktops/kde-5/applications/marble.nix
@@ -1,0 +1,24 @@
+{ kdeApp, lib, kdeWrapper
+, ecm, qtscript, qtsvg, qtquickcontrols
+, gpsd
+}:
+
+let
+  unwrapped =
+    kdeApp {
+      name = "marble";
+      meta.license = with lib.licenses; [ lgpl21 gpl3 ];
+
+      nativeBuildInputs = [ ecm ];
+      propagatedBuildInputs = [
+        qtscript qtsvg qtquickcontrols
+        gpsd
+      ];
+
+      enableParallelBuilding = true;
+    };
+in
+kdeWrapper unwrapped {
+  targets = [ "bin/marble-qt" ];
+  paths = [ unwrapped ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15748,6 +15748,8 @@ in
 
   dhewm3 = callPackage ../games/dhewm3 {};
 
+  digikam5 = kde5.callPackage ../applications/graphics/digikam/5.1.nix {};
+
   drumkv1 = callPackage ../applications/audio/drumkv1 { };
 
   duckmarines = callPackage ../games/duckmarines { love = love_0_9; };


### PR DESCRIPTION
###### Motivation for this change

This PR introduces `digikam-5.1.0`, the latest release, as `pkgs.digikam5`. I decided to keep our old version `kde4.digikam`, `digikam-4.12.0` as my newer package doesn't come with all optional features enabled yet. It's not in `kde5` either, as the digikam developers are trying to decouple it from KDE completly. 

I'm opening a PR to discuss if we should remove the old `kde4` version and see if I made any mistakes while packaging a `kde5` application. 

Also note that there are various (external) binaries not-yet in the closure, so for example stitching panoramas or merging bracketed image-sets require you to manually choose the path to one of the supported tools. I'll tackle this soon.

Fixes https://github.com/NixOS/nixpkgs/issues/17552

Feedback welcome!
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
