### PR TITLE
deadpixi-sam: init at 2016-09-15

### DIFF
--- a/pkgs/applications/editors/deadpixi-sam/default.nix
+++ b/pkgs/applications/editors/deadpixi-sam/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, freetype, libX11, libXt, libXft
+}:
+
+stdenv.mkDerivation rec {
+  name = "deadpixi-sam-unstable";
+  version = "2016-09-15";
+    src = fetchFromGitHub {
+      owner = "deadpixi";
+      repo = "sam";
+      rev = "a6a8872246e8634d884b0ce52bc3be9770ab1b0f";
+      sha256 = "1zr8dl0vp1xic3dq69h4bp2fcxsjhrzasfl6ayvkibjd6z5dn07p";
+    };
+
+  postPatch = ''
+    substituteInPlace config.mk.def \
+      --replace "/usr/include/freetype2" "${freetype.dev}/include/freetype2"
+  '';
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+  buildInputs = [ libX11 libXt libXft ];
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    mv deadpixi-sam.desktop $out/share/applications
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Updated version of the sam text editor";
+    license = with licenses; lpl-102;
+    maintainers = with maintainers; [ ramkromberg ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10675,6 +10675,10 @@ in
       HTTPDate MailDKIM LWP IOSocketSSL;
   };
 
+  deadpixi-sam-unstable = callPackage ../applications/editors/deadpixi-sam { };
+  deadpixi-sam = deadpixi-sam-unstable;
+  sam = deadpixi-sam;
+
   samba3 = callPackage ../servers/samba/3.x.nix { };
 
   samba4 = callPackage ../servers/samba/4.x.nix {


### PR DESCRIPTION
###### Motivation for this change

A standalone updated sam.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- x ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
