### PR TITLE
Speech synthesizer improvements

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -40,6 +40,7 @@
   arobyn = "Alexei Robyn <shados@shados.net>";
   artuuge = "Artur E. Ruuge <artuuge@gmail.com>";
   ashalkhakov = "Artyom Shalkhakov <artyom.shalkhakov@gmail.com>";
+  aske = "Kirill Boltaev <aske@fmap.me>";
   asppsa = "Alastair Pharo <asppsa@gmail.com>";
   astsmtl = "Alexander Tsamutali <astsmtl@yandex.ru>";
   aszlig = "aszlig <aszlig@redmoonstudios.org>";

--- a/pkgs/applications/audio/espeak-ng/default.nix
+++ b/pkgs/applications/audio/espeak-ng/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, autoconf, automake, which, libtool, pkgconfig
+, ronn
+, pcaudiolibSupport ? true, pcaudiolib
+, sonicSupport ? true, sonic }:
+
+stdenv.mkDerivation rec {
+  name = "espeak-ng-${version}";
+  version = "2016-08-28";
+
+  src = fetchFromGitHub {
+    owner = "espeak-ng";
+    repo = "espeak-ng";
+    rev = "b784e77c5708b61feed780d8f1113c4c8eb92200";
+    sha256 = "1whix4mv0qvsvifgpwwbdzhv621as3rxpn9ijqc2683h6k8pvcfk";
+  };
+
+  nativeBuildInputs = [ autoconf automake which libtool pkgconfig ronn ];
+
+  buildInputs = lib.optional pcaudiolibSupport pcaudiolib
+             ++ lib.optional sonicSupport sonic;
+
+  preConfigure = "./autogen.sh";
+
+  postInstall = ''
+    patchelf --set-rpath "$(patchelf --print-rpath $out/bin/espeak-ng)" $out/bin/speak-ng
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open source speech synthesizer that supports over 70 languages, based on eSpeak";
+    homepage = "https://github.com/espeak-ng/espeak-ng";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ aske ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/pcaudiolib/default.nix
+++ b/pkgs/development/libraries/pcaudiolib/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, autoconf, automake, which, libtool, pkgconfig,
+  alsaLib, portaudio, 
+  pulseaudioSupport ? true, libpulseaudio }:
+
+stdenv.mkDerivation rec {
+  name = "pcaudiolib-${version}";
+  version = "2016-07-19";
+
+  src = fetchFromGitHub {
+    owner = "rhdunn";
+    repo = "pcaudiolib";
+    rev = "4f836ea909bdaa8a6e0e89c587efc745b546b459";
+    sha256 = "0z99nh4ibb9md2cd21762n1dmv6jk988785s1cxd8lsy4hp4pwfa";
+  };
+
+  nativeBuildInputs = [ autoconf automake which libtool pkgconfig ];
+
+  buildInputs = [ portaudio alsaLib ] ++ lib.optional pulseaudioSupport libpulseaudio;
+
+  preConfigure = "./autogen.sh";
+
+  meta = with stdenv.lib; {
+    description = "Provides a C API to different audio devices";
+    homepage = "https://github.com/rhdunn/pcaudiolib";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ aske ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/sonic/default.nix
+++ b/pkgs/development/libraries/sonic/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "sonic-${version}";
+  version = "2016-03-01";
+
+  src = fetchFromGitHub {
+    owner = "waywardgeek";
+    repo = "sonic";
+    rev = "71bdf26c55716a45af50c667c0335a9519e952dd";
+    sha256 = "1kcl8fdf92kafmfhvyjal5gvkn99brkjyzbi9gw3rd5b30m3xz2b";
+  };
+
+  postPatch = ''
+    sed -i "s,^PREFIX=.*,PREFIX=$out," Makefile
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple library to speed up or slow down speech";
+    homepage = "https://github.com/waywardgeek/sonic";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ aske ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/speechd/default.nix
+++ b/pkgs/development/libraries/speechd/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "speech-dispatcher-${version}";
-  version = "0.8.3";
+  version = "0.8.5";
 
   src = fetchurl {
     url = "http://www.freebsoft.org/pub/projects/speechd/${name}.tar.gz";
-    sha256 = "0kqy7z4l59n2anc7xn588w4rkacig1hajx8c53qrh90ypar978ln";
+    sha256 = "18jlxnhlahyi6njc6l6576hfvmzivjjgfjyd2n7vvrvx9inphjrb";
   };
 
   buildInputs = [ intltool libtool glib dotconf libsndfile libao python3Packages.python ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12963,6 +12963,8 @@ in
 
   espeak = callPackage ../applications/audio/espeak { };
 
+  espeak-ng = callPackage ../applications/audio/espeak-ng { };
+
   espeakedit = callPackage ../applications/audio/espeak/edit.nix { };
 
   esniper = callPackage ../applications/networking/esniper { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12961,9 +12961,10 @@ in
     pythonPackages = python3Packages;
   };
 
-  espeak = callPackage ../applications/audio/espeak { };
+  espeak-classic = callPackage ../applications/audio/espeak { };
 
   espeak-ng = callPackage ../applications/audio/espeak-ng { };
+  espeak = self.espeak-ng;
 
   espeakedit = callPackage ../applications/audio/espeak/edit.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9015,6 +9015,10 @@ in
 
   pangoxsl = callPackage ../development/libraries/pangoxsl { };
 
+  pcaudiolib = callPackage ../development/libraries/pcaudiolib {
+    pulseaudioSupport = config.pulseaudio or true;
+  };
+
   pcg_c = callPackage ../development/libraries/pcg-c { };
 
   pcl = callPackage ../development/libraries/pcl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9418,6 +9418,8 @@ in
 
   sofia_sip = callPackage ../development/libraries/sofia-sip { };
 
+  sonic = callPackage ../development/libraries/sonic { };
+
   soprano = callPackage ../development/libraries/soprano { };
 
   soqt = callPackage ../development/libraries/soqt { };


### PR DESCRIPTION
###### Motivation for this change

Switch to espeak-ng: recently updated drop-in replacement of espeak.
Also update speechd. 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
