### PR TITLE
emacs24Macport: fix SDK version issue

### DIFF
--- a/pkgs/applications/editors/emacs-24/macport-24.5.nix
+++ b/pkgs/applications/editors/emacs-24/macport-24.5.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     "--enable-mac-app=$$out/Applications"
   ];
 
-  CFLAGS = "-O3";
+  CFLAGS = "-O3 -DMAC_OS_X_VERSION_MAX_ALLOWED=1090";
   LDFLAGS = "-O3 -L${ncurses.out}/lib";
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

`emacs24Macport` stopped building, and with it dependencies like `mu`.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

While this fix got me unstuck and is fairly important, imo, because emacs, it seems like something is wrong in the darwin stdenv since `AvailabilityMacros.h` should be setting this for us. Somehow a mix of versions is confounding detection mechanisms in the build system for this and probably other packages. (cc @copumpkin)
