### PR TITLE
minizinc: init at 2.0.14

### DIFF
--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, cmake, flex, bison }:
+let
+  version = "2.0.14";
+in
+stdenv.mkDerivation {
+  name = "minizinc-${version}";
+
+  buildInputs = [ cmake flex bison ];
+
+  src = fetchFromGitHub {
+    rev = "${version}";
+    owner = "MiniZinc";
+    repo = "libminizinc";
+    sha256 = "02wy91nv79lrvvhhimcxp7sqz5wd457n1n68zl7qcsm5vfn1hm4q";
+  };
+
+  # meta is all the information about the package..
+  meta = with stdenv.lib; {
+    homepage = "http://www.minizinc.org/";
+    description = "MiniZinc is a medium-level constraint modelling language.";
+
+    longDescription = ''
+      MiniZinc is a medium-level constraint modelling
+      language. It is high-level enough to express most
+      constraint problems easily, but low-level enough
+      that it can be mapped onto existing solvers easily and consistently.
+      It is a subset of the higher-level language Zinc.
+    '';
+
+    license = licenses.mpl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheenobu ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6561,6 +6561,8 @@ in
 
   minify = callPackage ../development/web/minify { };
 
+  minizinc = callPackage ../development/tools/minizinc { };
+
   mk = callPackage ../development/tools/build-managers/mk { };
 
   msitools = callPackage ../development/tools/misc/msitools { };


### PR DESCRIPTION
###### Motivation for this change

New package. Requested.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
