### PR TITLE
haskellPackages.idris: fix build on ghc-8.0.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -38,6 +38,13 @@ self: super: {
   # cabal-install can use the native Cabal library.
   cabal-install = super.cabal-install.override { Cabal = null; };
 
+  idris = overrideCabal super.idris (drv: {
+    # "idris" binary cannot find Idris library otherwise while building.
+    # After installing it's completely fine though. Nix-specific issue so not
+    # reported.
+    preBuild = "export LD_LIBRARY_PATH=$PWD/dist/build:$LD_LIBRARY_PATH";
+  });
+
   # jailbreak-cabal can use the native Cabal library.
   jailbreak-cabal = super.jailbreak-cabal.override { Cabal = null; };
 


### PR DESCRIPTION
This is the same fix as in configuration-ghc-7.10.x.nix.
