### PR TITLE
mustache: init mustache at 1.0.2

### DIFF
--- a/pkgs/data/documentation/mustache-spec/default.nix
+++ b/pkgs/data/documentation/mustache-spec/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "mustache-spec-${version}";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "mustache";
+    repo = "mustache";
+    rev = "v${version}";
+    sha256 = "03xrfyjzm5ss6zkdlpl9ypwzcglspcdcnr3f94vj1rjfqm2rxcjw";
+  };
+
+  configurePhase = "";
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/{man/man5,doc/html}
+    cp man/mustache.5 $out/man/man5
+    cp man/mustache.5.html $out/doc/html
+  '';
+
+  meta = rec {
+    description = "Logic-less templates, specification package";
+    longDescription = ''
+      Inspired by ctemplate and et, Mustache is a framework-agnostic way to
+      render logic-free views.
+
+      Provides the specification as man page and html docs.
+
+      As ctemplates says, "It emphasizes separating logic from presentation: it
+      is impossible to embed application logic in this template language."
+
+      For a list of implementations and tips, see ${homepage}.
+    '';
+
+    homepage = "http://mustache.github.io/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ profpatsch ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12100,6 +12100,8 @@ in
 
   mro-unicode = callPackage ../data/fonts/mro-unicode { };
 
+  mustache-spec = callPackage ../data/documentation/mustache-spec { };
+
   nafees = callPackage ../data/fonts/nafees { };
 
   inherit (callPackages ../data/fonts/noto-fonts {})


### PR DESCRIPTION
###### Motivation for this change
- Built on platform(s)
  - [x] NixOS

Add a description of the mustache template system, as manpages and
html docs.

The ruby part is intentionally not packaged, since that is better done in other places and I only want to provide the description of the format.
