### PR TITLE
systemd.nspawn: add definition

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -545,6 +545,7 @@
   ./system/boot/stage-1.nix
   ./system/boot/stage-2.nix
   ./system/boot/systemd.nix
+  ./system/boot/systemd-nspawn.nix
   ./system/boot/timesyncd.nix
   ./system/boot/tmp.nix
   ./system/etc/etc.nix

--- a/nixos/modules/system/boot/systemd-nspawn.nix
+++ b/nixos/modules/system/boot/systemd-nspawn.nix
@@ -1,0 +1,134 @@
+{ config, lib , pkgs, ...}:
+
+with lib;
+with import ./systemd-unit-options.nix { inherit config lib; };
+with import ./systemd-lib.nix { inherit config lib pkgs; };
+
+let
+  cfg = config.systemd.nspawn;
+  assertions = [
+    # boot = true -> processtwo != true
+  ];
+
+  checkExec = checkUnitConfig "Exec" [
+    (assertOnlyFields [
+      "Boot" "ProcessTwo" "Parameters" "Environment" "User" "WorkingDirectory"
+      "Capability" "DropCapability" "KillSignal" "Personality" "MachineId"
+      "PrivateUsers"
+    ])
+    (assertValueOneOf "Boot" boolValues)
+    (assertValueOneOf "ProcessTwo" boolValues)
+    (assertValueOneOf "PrivateUsers" (boolValues ++ [ "pick" ]))
+  ];
+
+  checkFiles = checkUnitConfig "Files" [
+    (assertOnlyFields [
+      "ReadOnly" "Volatile" "Bind" "BindReadOnly" "TemporaryFileSystems"
+      "PrivateUsersChown"
+    ])
+    (assertValueOneOf "ReadOnly" boolValues)
+    (assertValueOneOf "Volatile" (boolValues ++ [ "state" ]))
+    (assertValueOneOf "PrivateUsersChown" boolValues)
+  ];
+
+  checkNetwork = checkUnitConfig "Network" [
+    (assertOnlyFields [
+      "Private" "VirtualEthernet" "VirtualEthernetExtra" "Interface" "MACVLAN"
+      "IPVLAN" "Bridge" "Zone" "Port"
+    ])
+    (assertValueOneOf "Private" boolValues)
+    (assertValueOneOf "VirtualEthernet" boolValues)
+  ];
+
+  instanceOptions = {
+
+    execConfig = mkOption {
+      default = {};
+      example = { Parameters = "/bin/sh"; };
+      type = types.addCheck (types.attrsOf unitOption) checkExec;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[Exec]</literal> section of this unit. See
+        <citerefentry><refentrytitle>systemd.nspawn</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
+    filesConfig = mkOption {
+      default = {};
+      example = { Bind = [ "/home/alice" ]; };
+      type = types.addCheck (types.attrsOf unitOption) checkFiles;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[Files]</literal> section of this unit. See
+        <citerefentry><refentrytitle>systemd.nspawn</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
+    networkConfig = mkOption {
+      default = {};
+      example = { Private = false; };
+      type = types.addCheck (types.attrsOf unitOption) checkNetwork;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[Network]</literal> section of this unit. See
+        <citerefentry><refentrytitle>systemd.nspawn</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
+  };
+
+  instanceToUnit = name: def: 
+    { text = ''
+      [Exec]
+      ${attrsToSection def.execConfig}
+
+      [Files]
+      ${attrsToSection def.filesConfig}
+
+      [Network]
+      ${attrsToSection def.networkConfig}
+    '';
+    };
+
+in {
+
+  options = {
+
+    systemd.nspawn.enable = mkEnableOption "systemd-nspawn instance configuration";
+
+    systemd.nspawn.instances = mkOption {
+      default = {};
+      type = types.attrsOf types.optionSet;
+      options = [ instanceOptions ];
+      description = "Definition of systemd-nspawn configurations.";
+    };
+
+    systemd.nspawn.units = mkOption {
+      description = "Definition of systemd-nspawn units.";
+      default = {};
+      type = types.attrsOf types.optionSet;
+      options = { name, config, ... }:
+        { options = concreteUnitOptions;
+          config = {
+            unit = mkDefault (makeUnit name config);
+          };
+        };
+    };
+
+  };
+
+  config = mkIf config.systemd.nspawn.enable {
+    systemd.nspawn.units = mapAttrs' (n: v: nameValuePair "${n}.nspawn" (instanceToUnit n v)) cfg.instances;
+
+    environment.etc."systemd/nspawn".source =
+      generateUnits "nspawn" cfg.units [] [];
+
+    systemd.services."systemd-nspawn@" = {
+      wantedBy = [ "machine.target" ];
+    };
+  };
+
+}

--- a/nixos/modules/system/boot/systemd-nspawn.nix
+++ b/nixos/modules/system/boot/systemd-nspawn.nix
@@ -97,9 +97,7 @@ in {
 
   options = {
 
-    systemd.nspawn.enable = mkEnableOption "systemd-nspawn instance configuration";
-
-    systemd.nspawn.instances = mkOption {
+    systemd.nspawn = mkOption {
       default = {};
       type = types.attrsOf types.optionSet;
       options = [ instanceOptions ];
@@ -111,7 +109,7 @@ in {
   config =
     let
       units = mapAttrs' (n: v: nameValuePair "${n}.nspawn" (instanceToUnit n v)) cfg.instances;
-    in mkIf config.systemd.nspawn.enale {
+    in mkIf (cfg != {}) {
 
       environment.etc."systemd/nspawn".source = generateUnits "nspawn" units [] [];
 

--- a/nixos/modules/system/boot/systemd-nspawn.nix
+++ b/nixos/modules/system/boot/systemd-nspawn.nix
@@ -106,29 +106,18 @@ in {
       description = "Definition of systemd-nspawn configurations.";
     };
 
-    systemd.nspawn.units = mkOption {
-      description = "Definition of systemd-nspawn units.";
-      default = {};
-      type = types.attrsOf types.optionSet;
-      options = { name, config, ... }:
-        { options = concreteUnitOptions;
-          config = {
-            unit = mkDefault (makeUnit name config);
-          };
-        };
-    };
-
   };
 
-  config = mkIf config.systemd.nspawn.enable {
-    systemd.nspawn.units = mapAttrs' (n: v: nameValuePair "${n}.nspawn" (instanceToUnit n v)) cfg.instances;
+  config =
+    let
+      units = mapAttrs' (n: v: nameValuePair "${n}.nspawn" (instanceToUnit n v)) cfg.instances;
+    in mkIf config.systemd.nspawn.enale {
 
-    environment.etc."systemd/nspawn".source =
-      generateUnits "nspawn" cfg.units [] [];
+      environment.etc."systemd/nspawn".source = generateUnits "nspawn" units [] [];
 
-    systemd.services."systemd-nspawn@" = {
-      wantedBy = [ "machine.target" ];
-    };
+      systemd.services."systemd-nspawn@" = {
+        wantedBy = [ "machine.target" ];
+      };
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

`systemd-nspawn` can be configured via `.nspawn` files. This PR adds a nixos module to manage these files. 

In the end I want to simplify nixos-containers and make more use of upstream defaults, this is the first step but may be useful on its own.

CC @fpletz 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

this adds the option to manage systemd.nspawn files via
config.systemd.nspawn. The files are placed in "/etc/systemd/nspawn".
