### PR TITLE
nixos/tests/pump.io: Fix systemd unit config

### DIFF
--- a/nixos/tests/pump.io.nix
+++ b/nixos/tests/pump.io.nix
@@ -81,7 +81,7 @@ in {
            '';
           };
           systemd.services.mongodb.unitConfig.Before = "pump.io.service";
-          systemd.services.mongodb.unitConfig.RequiredBy = "pump.io.service";
+          systemd.services."pump.io".unitConfig.Requires = "mongodb.service";
         };
     };
 


### PR DESCRIPTION
###### Motivation for this change

The pump.io test case was failing (see #18209).
###### Things done
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
