### PR TITLE
strongswan: 5.4.0 -> 5.5.0

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "strongswan-${version}";
-  version = "5.4.0";
+  version = "5.5.0";
 
   src = fetchurl {
     url = "http://download.strongswan.org/${name}.tar.bz2";
-    sha256 = "12dy7dfwblihrc2zs0fdvyimvgi2g5mvgh0ksjkxi73axam8ya7q";
+    sha256 = "0m449i5s51ikqh36s1sp4rvw60wqyv0j12kyd31yl9b7mjc3jijq";
   };
 
   dontPatchELF = true;


### PR DESCRIPTION
###### Motivation for this change

New version available
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
