### PR TITLE
nvidia-x11 fixes from master to release-16.03

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/365.35-kernel-4.7.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/365.35-kernel-4.7.patch
@@ -1,0 +1,40 @@
+diff -Naur NVIDIA-Linux-x86_64-367.35-no-compat32-upstream/kernel/nvidia-drm/nvidia-drm-fb.c NVIDIA-Linux-x86_64-367.35-no-compat32/kernel/nvidia-drm/nvidia-drm-fb.c
+--- NVIDIA-Linux-x86_64-367.35-no-compat32-upstream/kernel/nvidia-drm/nvidia-drm-fb.c	2016-07-31 19:07:06.595038290 -0400
++++ NVIDIA-Linux-x86_64-367.35-no-compat32/kernel/nvidia-drm/nvidia-drm-fb.c	2016-07-31 19:09:18.532197060 -0400
+@@ -114,7 +114,7 @@
+      * We don't support any planar format, pick up first buffer only.
+      */
+ 
+-    gem = drm_gem_object_lookup(dev, file, cmd->handles[0]);
++    gem = drm_gem_object_lookup(file, cmd->handles[0]);
+ 
+     if (gem == NULL)
+     {
+diff -Naur NVIDIA-Linux-x86_64-367.35-no-compat32-upstream/kernel/nvidia-drm/nvidia-drm-gem.c NVIDIA-Linux-x86_64-367.35-no-compat32/kernel/nvidia-drm/nvidia-drm-gem.c
+--- NVIDIA-Linux-x86_64-367.35-no-compat32-upstream/kernel/nvidia-drm/nvidia-drm-gem.c	2016-07-31 19:07:06.595038290 -0400
++++ NVIDIA-Linux-x86_64-367.35-no-compat32/kernel/nvidia-drm/nvidia-drm-gem.c	2016-07-31 19:08:56.187492736 -0400
+@@ -408,7 +408,7 @@
+ 
+     mutex_lock(&dev->struct_mutex);
+ 
+-    gem = drm_gem_object_lookup(dev, file, handle);
++    gem = drm_gem_object_lookup(file, handle);
+ 
+     if (gem == NULL)
+     {
+diff -Naur NVIDIA-Linux-x86_64-367.35-no-compat32-upstream/kernel/nvidia-uvm/uvm_linux.h NVIDIA-Linux-x86_64-367.35-no-compat32/kernel/nvidia-uvm/uvm_linux.h
+--- NVIDIA-Linux-x86_64-367.35-no-compat32-upstream/kernel/nvidia-uvm/uvm_linux.h	2016-07-31 19:07:06.600038448 -0400
++++ NVIDIA-Linux-x86_64-367.35-no-compat32/kernel/nvidia-uvm/uvm_linux.h	2016-07-31 19:08:06.506926763 -0400
+@@ -554,12 +554,6 @@
+     INIT_RADIX_TREE(tree, GFP_NOWAIT);
+ }
+ 
+-static bool radix_tree_empty(struct radix_tree_root *tree)
+-{
+-    void *dummy;
+-    return radix_tree_gang_lookup(tree, &dummy, 0, 1) == 0;
+-}
+-
+ 
+ #if !defined(NV_USLEEP_RANGE_PRESENT)
+ static void __sched usleep_range(unsigned long min, unsigned long max)

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
     [ gtk atk pango glib gdk_pixbuf cairo ] );
   programPath = makeLibraryPath [ xorg.libXv ];
 
-  patches = if versionAtLeast kernel.version "4.7" then [ ./365.35-kernel-4.7.patch ] else [];
+  patches = if (!libsOnly) && (versionAtLeast kernel.dev.version "4.7") then [ ./365.35-kernel-4.7.patch ] else [];
 
   buildInputs = [ perl nukeReferences ];
 

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -12,7 +12,7 @@ assert (!libsOnly) -> kernel != null;
 
 let
 
-  versionNumber = "361.45.11";
+  versionNumber = "367.35";
 
   # Policy: use the highest stable version as the default (on our master).
   inherit (stdenv.lib) makeLibraryPath;
@@ -28,12 +28,12 @@ stdenv.mkDerivation {
     if stdenv.system == "i686-linux" then
       fetchurl {
         url = "http://download.nvidia.com/XFree86/Linux-x86/${versionNumber}/NVIDIA-Linux-x86-${versionNumber}.run";
-        sha256 = "036v7bzh9zy7zvaz2wf7zsamrynbg1yr1dll7sf1l928w059i6pb";
+        sha256 = "05g36bxcfk21ab8b0ay3zy21k5nd71468p9y1nbflx7ghpx25jrq";
       }
     else if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "http://download.nvidia.com/XFree86/Linux-x86_64/${versionNumber}/NVIDIA-Linux-x86_64-${versionNumber}-no-compat32.run";
-        sha256 = "1f8bxmf8cr3cgzxgap5ccb1yrqyrrdig19dp282y6z9xjq27l074";
+        sha256 = "0m4k8f0212l63h22wk6hgi8fbfsgxqih5mizsw4ixqqmjd75av4a";
       }
     else throw "nvidia-x11 does not support platform ${stdenv.system}";
 
@@ -52,6 +52,8 @@ stdenv.mkDerivation {
   gtkPath = optionalString (!libsOnly) (makeLibraryPath
     [ gtk atk pango glib gdk_pixbuf cairo ] );
   programPath = makeLibraryPath [ xorg.libXv ];
+
+  patches = if versionAtLeast kernel.version "4.7" then [ ./365.35-kernel-4.7.patch ] else [];
 
   buildInputs = [ perl nukeReferences ];
 


### PR DESCRIPTION
###### Motivation for this change

nvidia-x11 no longer builds on 16.03 with the 4.7 kernel.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
