### PR TITLE
fstar: remove workaround

### DIFF
--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -64,10 +64,6 @@ stdenv.mkDerivation rec {
   installFlags = "-C src/ocaml-output";
 
   postInstall = ''
-    # Workaround for FStarLang/FStar#456
-    mv $out/lib/fstar/* $out/lib/
-    rmdir $out/lib/fstar
-
     wrapProgram $out/bin/fstar.exe --prefix PATH ":" "${z3}/bin"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The workaround is no longer needed since it was patched upstream. See https://github.com/FStarLang/FStar/issues/456
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This fixes the build for me. Not sure if the error hydra is getting http://hydra.nixos.org/build/36843062 will be resolved or is caused by something other

(CC #18209)
