### PR TITLE
linphone: 3.8.5 -> 3.9.1, remove lime support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, pkgconfig, readline, openldap, cyrus_sasl, libupnp
-, zlib, libxml2, gtk2, libnotify, speex, ffmpeg, libX11, polarssl, libsoup, udev
+, zlib, libxml2, gtk2, libnotify, speex, ffmpeg, libX11, libsoup, udev
 , ortp, mediastreamer, sqlite, belle-sip, libosip, libexosip
 , mediastreamer-openh264, makeWrapper
 }:
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     readline openldap cyrus_sasl libupnp zlib libxml2 gtk2 libnotify speex ffmpeg libX11
-    polarssl libsoup udev ortp mediastreamer sqlite belle-sip libosip libexosip
+    libsoup udev ortp mediastreamer sqlite belle-sip libosip libexosip
   ];
 
   nativeBuildInputs = [ intltool pkgconfig makeWrapper ];
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-ldap"
     "--with-ffmpeg=${ffmpeg.dev}"
-    "--with-polarssl=${polarssl}"
-    "--enable-lime"
     "--enable-external-ortp"
     "--enable-external-mediastreamer"
   ];

--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -5,11 +5,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "linphone-3.8.5";
+  name = "linphone-${version}";
+  major = "3.9";
+  version = "${major}.1";
 
   src = fetchurl {
-    url = "mirror://savannah/linphone/3.8.x/sources/${name}.tar.gz";
-    sha256 = "10brlbwkk61nhd5v2sim1vfv11xm138l1cqqh3imhs2sigmzzlax";
+    url = "mirror://savannah/linphone/${major}.x/sources/${name}.tar.gz";
+    sha256 = "1b14gwq36d0sbn1125if9zydll9kliigk19zchbqiy9n2gjymrl4";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Build was broken (http://hydra.nixos.org/build/39883461) due to linphone requiring polarssl. Since we upgraded to mbedTLS this breaks.

```
Edit: Here's the link to a discussion on the ML about mbedTLS adoption: 
http://lists.nongnu.org/archive/html/linphone-developers/2015-12/msg00042.html 
I could not find any updates
```

I bumped the version to the latests available preconfigured tarball and disabled LIME (the component that uses polarssl for encrypted IM).

There are newer (not preconfigured) "releases" on github, but they need `bctoolkit` which is not packaged (not going to package because I doubt there is interest for linphone on nixos).

**I don't have SIP so I can't test if it works beyond running the binary.**

CC: #18209
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
