### PR TITLE
sane-frontends: fix source url, move from md5 to sha256

### DIFF
--- a/pkgs/applications/graphics/sane/frontends.nix
+++ b/pkgs/applications/graphics/sane/frontends.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "sane-frontends-1.0.14";
 
   src = fetchurl {
-    url = "ftp://ftp.sane-project.org/pub/sane/sane-frontends-1.0.14/${name}.tar.gz";
+    url = "https://alioth.debian.org/frs/download.php/file/1140/${name}.tar.gz";
     md5 = "c63bf7b0bb5f530cf3c08715db721cd3";
   };
 

--- a/pkgs/applications/graphics/sane/frontends.nix
+++ b/pkgs/applications/graphics/sane/frontends.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://alioth.debian.org/frs/download.php/file/1140/${name}.tar.gz";
-    md5 = "c63bf7b0bb5f530cf3c08715db721cd3";
+    sha256 = "1ad4zr7rcxpda8yzvfkq1rfjgx9nl6lan5a628wvpdbh3fn9v0z7";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
#18340 - sane-frontends src is broken
#4491 - avoiding use of md5
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
