### PR TITLE
Tomcat 5: fix src url, and move from md5 to sha256

### DIFF
--- a/pkgs/servers/http/tomcat/5.0.nix
+++ b/pkgs/servers/http/tomcat/5.0.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = https://archive.apache.org/dist/tomcat/tomcat-5/archive/v5.0.27/bin/jakarta-tomcat-5.0.27.tar.gz;
-    md5 = "b802ee042677e284bcf65738c7bdc3b6";
+    sha256 = "0y3xfzb3wch359c6w0a2npxbj3vasrmr5jlvws8m08qn8d5wjgw7";
   };
 
   inherit jdk;

--- a/pkgs/servers/http/tomcat/5.0.nix
+++ b/pkgs/servers/http/tomcat/5.0.nix
@@ -1,14 +1,16 @@
 {stdenv, fetchurl, jdk}:
 
+let version = "5.5.36"; in
+
 stdenv.mkDerivation {
 
-  name = "jakarta-tomcat-5.0.27";
+  name = "jakarta-tomcat-${version}";
 
   builder = ./builder.sh;
 
   src = fetchurl {
-    url = https://archive.apache.org/dist/tomcat/tomcat-5/archive/v5.0.27/bin/jakarta-tomcat-5.0.27.tar.gz;
-    sha256 = "0y3xfzb3wch359c6w0a2npxbj3vasrmr5jlvws8m08qn8d5wjgw7";
+    url = "https://archive.apache.org/dist/tomcat/tomcat-5/v${version}/bin/apache-tomcat-${version}.tar.gz";
+    sha256 = "01mzvh53wrs1p2ym765jwd00gl6kn8f9k3nhdrnhdqr8dhimfb2p";
   };
 
   inherit jdk;

--- a/pkgs/servers/http/tomcat/5.0.nix
+++ b/pkgs/servers/http/tomcat/5.0.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   builder = ./builder.sh;
 
   src = fetchurl {
-    url = http://apache.essentkabel.com/jakarta/tomcat-5/v5.0.27/bin/jakarta-tomcat-5.0.27.tar.gz;
+    url = https://archive.apache.org/dist/tomcat/tomcat-5/archive/v5.0.27/bin/jakarta-tomcat-5.0.27.tar.gz;
     md5 = "b802ee042677e284bcf65738c7bdc3b6";
   };
 


### PR DESCRIPTION
###### Motivation for this change
#18336 - tomcat 5.0 source url is broken
#4491 - moving away from md5
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
