### PR TITLE
Miscellaneous packages: Use sha256 instead of md5

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -19,12 +19,12 @@ rec {
       if stdenv.system == "x86_64-linux" then
         fetchurl {
           url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.5.2-201002111343/eclipse-SDK-3.5.2-linux-gtk-x86_64.tar.gz;
-          md5 = "54e2ce0660b2b1b0eb4267acf70ea66d";
+          sha256 = "1ndvanxw62b5ywi6ww0dyimabfmjdsw9q3xpy95zd8d5ygj2qsgq";
         }
       else
         fetchurl {
           url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.5.2-201002111343/eclipse-SDK-3.5.2-linux-gtk.tar.gz;
-          md5 = "bde55a2354dc224cf5f26e5320e72dac";
+          sha256 = "0y5n0cyr9lgjmmzkfmav7j5w66rc1jq3300hcw3vrfjiv1k6ng3w";
         };
   };
   eclipse_sdk_35 = eclipse-sdk-35; # backward compatibility, added 2016-01-30

--- a/pkgs/applications/graphics/gqview/default.nix
+++ b/pkgs/applications/graphics/gqview/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = mirror://sourceforge/gqview/gqview-2.1.5.tar.gz;
-    md5 = "4644187d9b14b1dc11ac3bb146f262ea";
+    sha256 = "0ilm5s7ps9kg4f5hzgjhg0xhn6zg0v9i7jnd67zrx9h7wsaa9zhj";
   };
 
   buildInputs = [pkgconfig gtk libpng];

--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -61,7 +61,7 @@ let
     inherit version;
     src = fetchurl {
       url = "http://www.hackenberger.at/ktikz/ktikz_${version}.tar.gz";
-      md5 = "e8f0826cba2447250bcdcd389a71a2ac";
+      sha256 = "19jl49r7dw3vb3hg52man8p2lszh71pvnx7d0xawyyi0x6r8ml9i";
     };
 
     enableParallelBuilding = true;

--- a/pkgs/development/libraries/icu/54.1.nix
+++ b/pkgs/development/libraries/icu/54.1.nix
@@ -6,7 +6,7 @@ in
   stdenv.lib.overrideDerivation icu (attrs: {
     src = fetchurl {
       url = "http://download.icu-project.org/files/icu4c/54.1/icu4c-54_1-src.tgz";
-      md5 = "e844caed8f2ca24c088505b0d6271bc0";
+      sha256 = "1cwapgjmvrcv1n2wjspj3vahidg596gjfp4jn1gcb4baralcjayl";
     };
   })
 

--- a/pkgs/development/libraries/java/javasvn/default.nix
+++ b/pkgs/development/libraries/java/javasvn/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = http://tmate.org/svn/org.tmatesoft.svn_1.0.6.standalone.zip;
-    md5 = "459cae849eceef04cd65fd6fb54affcc";
+    sha256 = "0l2s3jqi5clzj5jz962i7gmy8ims51ma60mm5iflsl00dwbmgrqf";
   };
   
   inherit unzip;

--- a/pkgs/development/libraries/libb64/default.nix
+++ b/pkgs/development/libraries/libb64/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.draios.com/dependencies/libb64-1.2.src.zip";
-    md5 = "a609809408327117e2c643bed91b76c5";
+    sha256 = "1lxzi6v10qsl2r6633dx0zwqyvy0j19nmwclfd0d7qybqmhqsg9l";
   };
 
   buildInputs = [ unzip ];

--- a/pkgs/development/libraries/libcdaudio/default.nix
+++ b/pkgs/development/libraries/libcdaudio/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "libcdaudio-0.99.12";
   src = fetchurl {
     url = mirror://sourceforge/libcdaudio/libcdaudio-0.99.12.tar.gz ;
-    md5 = "63b49cf14d53eed31e7a87cca17a3963" ;
+    sha256 = "1g3ba1n12g8h7pps0vlxx8di6cmf108mbcvbl6hj8x71ndkglygb" ;
   };
 
   meta = {

--- a/pkgs/development/libraries/libjpeg/62.nix
+++ b/pkgs/development/libraries/libjpeg/62.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   
   src = fetchurl {
     url = http://www.ijg.org/files/jpegsrc.v6b.tar.gz;
-    md5 = "dbd5f3b47ed13132f04c685d608a7547";
+    sha256 = "0pg34z6rbkk5kvdz6wirf7g4mdqn5z8x97iaw17m15lr3qjfrhvm";
   };
   
   inherit libtool;

--- a/pkgs/misc/drivers/dell-530cdn/default.nix
+++ b/pkgs/misc/drivers/dell-530cdn/default.nix
@@ -3,7 +3,7 @@
 
   src = fetchurl {
     url = "http://downloads.dell.com/printer/Dell-5130cdn-Color-Laser-${version}.noarch.rpm";
-    md5 = "7fb7122e67e40b99deb9665d88df62d1";
+    sha256 = "0pj32sj6jcdnpa5v75af0hnvx4z0ky0m1k2522cfdx4cb1r2lna9";
   };
 in runCommand "Dell-5130cdn-Color-Laser-1.3-1" {} ''
   mkdir -p usr/share/cups/model

--- a/pkgs/tools/system/honcho/default.nix
+++ b/pkgs/tools/system/honcho/default.nix
@@ -7,7 +7,7 @@ let honcho = buildPythonApplication rec {
 
   src = fetchzip {
     url = "https://github.com/nickstenning/honcho/archive/v${version}.tar.gz";
-    md5 = "f5e6a7f6c1d0c167d410d7f601b4407e";
+    sha256 = "1ishyzvq19hdln2nn3bjlk0kwfqsbddpypp28n88jp3px6832w02";
   };
 
   buildInputs = with pythonPackages; [ nose mock jinja2 ];


### PR DESCRIPTION
###### Motivation for this change
#4491 - md5 is a bad hash
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
