### PR TITLE
ffmpeg3: fix darwin build

### DIFF
--- a/pkgs/development/libraries/ffmpeg/3.1.nix
+++ b/pkgs/development/libraries/ffmpeg/3.1.nix
@@ -1,4 +1,4 @@
-{ callPackage
+{ stdenv, callPackage
 # Darwin frameworks
 , Cocoa, CoreMedia
 , ...
@@ -9,4 +9,5 @@ callPackage ./generic.nix (args // rec {
   branch = "3.1";
   sha256 = "0f4ajs0c4088nkal4gqagx05wfyhd1izfxmzxxsdh56ibp38kg2q";
   darwinFrameworks = [ Cocoa CoreMedia ];
+  patches = stdenv.lib.optional stdenv.isDarwin ./sdk_detection.patch;
 })

--- a/pkgs/development/libraries/ffmpeg/sdk_detection.patch
+++ b/pkgs/development/libraries/ffmpeg/sdk_detection.patch
@@ -1,0 +1,12 @@
+diff --git a/libavcodec/audiotoolboxdec.c b/libavcodec/audiotoolboxdec.c
+--- a/libavcodec/audiotoolboxdec.c
++++ b/libavcodec/audiotoolboxdec.c
+@@ -32,7 +32,7 @@
+ #include "libavutil/opt.h"
+ #include "libavutil/log.h"
+ 
+-#ifndef __MAC_10_11
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+ #define kAudioFormatEnhancedAC3 'ec-3'
+ #endif
+ 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
