### PR TITLE
deluge module: support specifying number of open files

### DIFF
--- a/nixos/modules/services/torrent/deluge.nix
+++ b/nixos/modules/services/torrent/deluge.nix
@@ -5,26 +5,36 @@ with lib;
 let
   cfg = config.services.deluge;
   cfg_web = config.services.deluge.web;
+  openFilesLimit = 4096;
+
 in {
   options = {
-    services.deluge = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = ''
-          Start Deluge daemon.
-        ''; 
-      };  
-    };
+    services = {
+      deluge = {
+        enable = mkOption {
+          default = false;
+          example = true;
+          description = "Start the Deluge daemon";
+        };
 
-    services.deluge.web = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = ''
-          Start Deluge Web daemon.
-        ''; 
-      };  
+        openFilesLimit = mkOption {
+          default = openFilesLimit;
+          example = 8192;
+          description = ''
+            Number of files to allow deluged to open.
+          '';
+        };
+      };
+
+      deluge.web = {
+        enable = mkOption {
+          default = false;
+          example = true;
+          description = ''
+            Start Deluge Web daemon.
+          '';
+        };
+      };
     };
   };
 
@@ -35,11 +45,14 @@ in {
       description = "Deluge BitTorrent Daemon";
       wantedBy = [ "multi-user.target" ];
       path = [ pkgs.pythonPackages.deluge ];
-      serviceConfig.ExecStart = "${pkgs.pythonPackages.deluge}/bin/deluged -d";
-      # To prevent "Quit & shutdown daemon" from working; we want systemd to manage it!
-      serviceConfig.Restart = "on-success";
-      serviceConfig.User = "deluge";
-      serviceConfig.Group = "deluge";
+      serviceConfig = {
+        ExecStart = "${pkgs.pythonPackages.deluge}/bin/deluged -d";
+        # To prevent "Quit & shutdown daemon" from working; we want systemd to manage it!
+        Restart = "on-success";
+        User = "deluge";
+        Group = "deluge";
+        LimitNOFILE = cfg.openFilesLimit;
+      };
     };
 
     systemd.services.delugeweb = mkIf cfg_web.enable {


### PR DESCRIPTION
###### Motivation for this change

Deluge can use up all the file descriptors. This change allows changing the number.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
