### PR TITLE
squishyball: init at 19580

### DIFF
--- a/pkgs/applications/audio/opusfile/default.nix
+++ b/pkgs/applications/audio/opusfile/default.nix
@@ -8,7 +8,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl libogg libopus ];
+  buildInputs = [ openssl libogg ];
+  propagatedBuildInputs = [ libopus ];
+  patches = [ ./include-multistream.patch ];
 
   meta = {
     description = "High-level API for decoding and seeking in .opus files";

--- a/pkgs/applications/audio/opusfile/include-multistream.patch
+++ b/pkgs/applications/audio/opusfile/include-multistream.patch
@@ -1,0 +1,12 @@
+diff -Naur a/include/opusfile.h b/include/opusfile.h
+--- a/include/opusfile.h	2014-04-29 19:07:09.000000000 +0200
++++ b/include/opusfile.h	2016-09-05 17:50:15.147553798 +0200
+@@ -107,7 +107,7 @@
+ # include <stdarg.h>
+ # include <stdio.h>
+ # include <ogg/ogg.h>
+-# include <opus_multistream.h>
++# include <opus/opus_multistream.h>
+ 
+ /**@cond PRIVATE*/
+ 

--- a/pkgs/applications/audio/squishyball/default.nix
+++ b/pkgs/applications/audio/squishyball/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, autoreconfHook, fetchsvn, flac, libao, libvorbis, ncurses
+, opusfile, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  name = "squishyball-${rev}";
+  rev = "19580";
+
+  src = fetchsvn {
+    url = "https://svn.xiph.org/trunk/squishyball";
+    rev = rev;
+    sha256 = "013vq52q9z6kpg9iyc2jnb3m2gihcjblvwpg4yj4wy1q2c05pzqp";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ flac libao libvorbis ncurses opusfile ];
+
+  patches = [ ./gnu-screen.patch ];
+
+  postInstall = ''
+    # Why doesn’t this happen automagically?
+    mkdir -p $out/share/man/man1
+    cp squishyball.1 $out/share/man/man1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tool to perform sample comparison testing on the command line";
+    longDescription = ''
+       squishyball is a simple command-line utility for performing
+       double-blind A/B, A/B/X or X/X/Y testing on the command line.
+       The user specifies two input files to be compared and uses the
+       keyboard during playback to flip between the randomized samples
+       to perform on-the-fly compar‐ isons.  After a predetermined
+       number of trials, squishyball prints the trial results to
+       stdout and exits.  Results (stdout) may be redirected to a file
+       without affecting interactive use of the terminal.
+
+       squishyball can also be used to perform casual, non-randomized
+       comparisons of groups of up to ten samples; this is the default
+       mode of operation.
+    '';
+    homepage = https://svn.xiph.org/trunk/squishyball;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ michalrus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/squishyball/gnu-screen.patch
+++ b/pkgs/applications/audio/squishyball/gnu-screen.patch
@@ -1,0 +1,20 @@
+diff -Naur a/main.c b/main.c
+--- a/main.c	2016-09-06 13:37:32.259895631 +0200
++++ b/main.c	2016-09-07 01:41:51.014309863 +0200
+@@ -693,6 +693,11 @@
+     }
+ 
+     /* set up terminal */
++    if (!strncmp(getenv("TERM"), "screen", 6)) {
++      char term[256];
++      snprintf(term, sizeof(term), "xterm%s", getenv("TERM") + 6);
++      setenv("TERM", term, 1);
++    }
+     atexit(min_panel_remove);
+     panel_init(pcm, test_files, test_mode, start, end>0 ? end : len, len,
+                beep_mode, restart_mode, tests, running_score);
+@@ -1170,4 +1175,3 @@
+     fprintf(stderr,"Done.\n");
+   return 0;
+ }
+-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14642,6 +14642,8 @@ in
 
   spideroak = callPackage ../applications/networking/spideroak { };
 
+  squishyball = callPackage ../applications/audio/squishyball { };
+
   ssvnc = callPackage ../applications/networking/remote/ssvnc { };
 
   viber = callPackage ../applications/networking/instant-messengers/viber { };


### PR DESCRIPTION
###### Motivation for this change

A nice tool to do A/B/X audio testing from Xiph.Org Foundation.

Also, I made `opusfile.h` include not `<opus_multistream.h>` but `<opus/opus_multistream.h>`, because this is our location in `libopus`.

Also, `libopus` build input should be propagated.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ x Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
