### PR TITLE
buildRubyGem: fixes gemspec UTF-8 loading issue

### DIFF
--- a/pkgs/development/ruby-modules/gem/nix-bundle-install.rb
+++ b/pkgs/development/ruby-modules/gem/nix-bundle-install.rb
@@ -6,6 +6,11 @@ require 'fileutils'
 require 'pathname'
 require 'tmpdir'
 
+if defined?(Encoding.default_internal)
+  Encoding.default_internal = Encoding::UTF_8
+  Encoding.default_external = Encoding::UTF_8
+end
+
 # Options:
 #
 #   name        - the gem name


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/manveru/bundix/issues/5

This should probably be back-ported to 16.09 too
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

If a gemspec has UTF-8 characters in it, ruby will fail loading it with

```
invalid multibyte char (US-ASCII)
```

This change forces the encoding to be correct, we assume everyone now
uses UTF-8.
