### PR TITLE
emacs-25-macport: init at 25.1-mac-6.0

### DIFF
--- a/pkgs/applications/editors/emacs/macport-25.1.nix
+++ b/pkgs/applications/editors/emacs/macport-25.1.nix
@@ -36,7 +36,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patch -p1 < patch-mac
-    sed -i 's|/usr/share/locale|${gettext}/share/locale|g' lisp/international/mule-cmds.el
+    substituteInPlace lisp/international/mule-cmds.el \
+      --replace /usr/share/locale ${gettext}/share/locale
   '';
 
   configureFlags = [

--- a/pkgs/applications/editors/emacs/macport-25.1.nix
+++ b/pkgs/applications/editors/emacs/macport-25.1.nix
@@ -1,0 +1,90 @@
+{ stdenv, fetchurl, ncurses, pkgconfig, texinfo, libxml2, gnutls, gettext, autoconf, automake
+, AppKit, Carbon, Cocoa, IOKit, OSAKit, Quartz, QuartzCore, WebKit
+, ImageCaptureCore, GSS, ImageIO # These may be optional
+}:
+
+stdenv.mkDerivation rec {
+  emacsName = "emacs-25.1";
+  name = "${emacsName}-mac-6.0";
+
+  builder = ./builder.sh;
+
+  src = fetchurl {
+    url = "ftp://ftp.gnu.org/gnu/emacs/${emacsName}.tar.xz";
+    sha256 = "19f2798ee3bc26c95dca3303e7ab141e7ad65d6ea2b6945eeba4dbea7df48f33";
+  };
+
+  macportSrc = fetchurl {
+    url = "ftp://ftp.math.s.chiba-u.ac.jp/emacs/${name}.tar.gz";
+    sha256 = "2f7a3fd826e6dea541ada04f4a1ff2903a87a1f736b89c5b90bf7bb820568e34";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ ncurses libxml2 gnutls pkgconfig texinfo gettext autoconf automake];
+
+  propagatedBuildInputs = [
+    AppKit Carbon Cocoa IOKit OSAKit Quartz QuartzCore WebKit
+    ImageCaptureCore GSS ImageIO   # may be optional
+  ];
+
+  postUnpack = ''
+    mv $sourceRoot $name
+    tar xzf $macportSrc
+    mv $name $sourceRoot
+  '';
+
+  postPatch = ''
+    patch -p1 < patch-mac
+    sed -i 's|/usr/share/locale|${gettext}/share/locale|g' lisp/international/mule-cmds.el
+  '';
+
+  configureFlags = [
+    "LDFLAGS=-L${ncurses.out}/lib"
+    "--with-xml2=yes"
+    "--with-gnutls=yes"
+    "--with-mac"
+    "--enable-mac-app=$$out/Applications"
+  ];
+
+  CFLAGS = "-O3 -DMAC_OS_X_VERSION_MAX_ALLOWED=1090";
+  LDFLAGS = "-O3 -L${ncurses.out}/lib";
+
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp/
+    cp ${./site-start.el} $out/share/emacs/site-lisp/site-start.el
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "GNU Emacs 25, the extensible, customizable text editor";
+    homepage    = http://www.gnu.org/software/emacs/;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jwiegley ];
+    platforms   = platforms.darwin;
+
+    longDescription = ''
+      GNU Emacs is an extensible, customizable text editor—and more.  At its
+      core is an interpreter for Emacs Lisp, a dialect of the Lisp
+      programming language with extensions to support text editing.
+
+      The features of GNU Emacs include: content-sensitive editing modes,
+      including syntax coloring, for a wide variety of file types including
+      plain text, source code, and HTML; complete built-in documentation,
+      including a tutorial for new users; full Unicode support for nearly all
+      human languages and their scripts; highly customizable, using Emacs
+      Lisp code or a graphical interface; a large number of extensions that
+      add other functionality, including a project planner, mail and news
+      reader, debugger interface, calendar, and more.  Many of these
+      extensions are distributed with GNU Emacs; others are available
+      separately.
+
+      This is "Mac port" addition to GNU Emacs 24. This provides a native
+      GUI support for Mac OS X 10.4 - 10.11. Note that Emacs 23 and later
+      already contain the official GUI support via the NS (Cocoa) port for
+      Mac OS X 10.4 and later. So if it is good enough for you, then you
+      don't need to try this.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7294,8 +7294,8 @@ in
     x265 = if stdenv.isDarwin then null else x265;
     xavs = if stdenv.isDarwin then null else xavs;
     inherit (darwin) CF;
-    inherit (darwin.apple_sdk.frameworks) 
-      Cocoa CoreServices CoreAudio AVFoundation MediaToolbox 
+    inherit (darwin.apple_sdk.frameworks)
+      Cocoa CoreServices CoreAudio AVFoundation MediaToolbox
       VideoDecodeAcceleration;
   };
 
@@ -7955,7 +7955,7 @@ in
   libcaca = callPackage ../development/libraries/libcaca { };
 
   libcanberra_gtk3 = callPackage ../development/libraries/libcanberra {
-    gtk = pkgs.gtk3; 
+    gtk = pkgs.gtk3;
   };
   libcanberra_gtk2 = pkgs.libcanberra_gtk3.override { gtk = pkgs.gtk2; };
 
@@ -12893,6 +12893,13 @@ in
       ImageCaptureCore GSS ImageIO;
   });
   emacs24Macport = self.emacs24Macport_24_5;
+
+  emacs25Macport_25_1 = lowPrio (callPackage ../applications/editors/emacs/macport-25.1.nix {
+    inherit (darwin.apple_sdk.frameworks)
+      AppKit Carbon Cocoa IOKit OSAKit Quartz QuartzCore WebKit
+      ImageCaptureCore GSS ImageIO;
+  });
+  emacs25Macport = self.emacs25Macport_25_1;
 
   emacsPackagesGen = emacs: self: let callPackage = newScope self; in rec {
     inherit emacs;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
