### PR TITLE
vagrant: make patches a list

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -33,11 +33,13 @@ in stdenv.mkDerivation rec {
     "-p1"
     "-d ./opt/vagrant/embedded/gems/gems/vagrant-${version}"
   ];
-  patches = (fetchpatch {
-    url = "https://patch-diff.githubusercontent.com/raw/mitchellh/vagrant/pull/7611.diff";
-    name = "fix_incorrect_ssh_keys_permissions.patch";
-    sha256 = "0lqa9xpg79ggp9fc8gzb5lv675ydj2p8l55bx4hs1hf8zz2c1hjf";
-  });
+  patches = [
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/mitchellh/vagrant/pull/7611.diff";
+      name = "fix_incorrect_ssh_keys_permissions.patch";
+      sha256 = "0lqa9xpg79ggp9fc8gzb5lv675ydj2p8l55bx4hs1hf8zz2c1hjf";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "A tool for building complete development environments";


### PR DESCRIPTION
###### Motivation for this change

Fix #18283, I didn't notice this when I skimmed over that PR.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg 

This has more correct semantics, allows for multiple patches, and makes
using overrideDerivation to add/remove patches work as expected.
