### PR TITLE
security.acme: require networking for client, remove loop without fallbackHost

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -166,7 +166,8 @@ in
                           ++ concatLists (mapAttrsToList (name: root: [ "-d" (if root == null then name else "${name}:${root}")]) data.extraDomains);
                 acmeService = {
                   description = "Renew ACME Certificate for ${cert}";
-                  after = [ "network.target" ];
+                  after = [ "network.target" "network-online.target" ];
+                  wants = [ "network-online.target" ];
                   serviceConfig = {
                     Type = "oneshot";
                     SuccessExitStatus = [ "0" "1" ];

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -39,8 +39,8 @@ with lib;
     };
 
     acmeFallbackHost = mkOption {
-      type = types.str;
-      default = "0.0.0.0";
+      type = types.nullOr types.str;
+      default = null;
       description = ''
         Host which to proxy requests to if acme challenge is not found. Useful
         if you want multiple hosts to be able to verify the same domain name.


### PR DESCRIPTION
###### Motivation for this change

Two changes:
##### require networking

The acme client requires networking to request a certificate.
This could probably be improved since the acme client only needs connectivity when there is no valid certificate present:
- acme-check.service
  - need no networking
  - check if certificate is valid
    - if yes, succeed
    - if no, enter failed state
  - has `OnFailure` set to acme-renew.service
- acme-renew.service
  - needs networking
  - request certificate just like it does at the moment
##### remove loop

When `acmeFallbackHost` was not set it defaulted to 0.0.0.0 causing a request loop
This removes the fallback section from the nginx config if no `acmeFallbackHost` is set.

Was there a reason to implement it this way that I'm missing? 

CC maintainers: @globin @fpletz @abbradar 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
