### PR TITLE
transcrypt: 0.9.7 -> 0.9.9

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/transcrypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/transcrypt/default.nix
@@ -1,20 +1,26 @@
-{ stdenv, fetchurl, git, openssl }:
+{ stdenv, fetchFromGitHub, git, makeWrapper, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "transcrypt-0.9.7";
+  name = "transcrypt-${version}";
+  version = "0.9.9";
 
-  src = fetchurl {
-    url = https://github.com/elasticdog/transcrypt/archive/v0.9.7.tar.gz;
-    sha256 = "0pgrf74wdc7whvwz7lkkq6qfk38n37dc5668baq7czgckibvjqdh";
+  src = fetchFromGitHub {
+    owner = "elasticdog";
+    repo = "transcrypt";
+    rev = "v${version}";
+    sha256 = "0brsgj3qmvkgxzqqamk8krwyarwff1dlb3jjd09snnbfl0kdq1a5";
   };
 
-  buildInputs = [ git openssl ];
+  buildInputs = [ git makeWrapper openssl ];
 
   installPhase = ''
     install -m 755 -D transcrypt $out/bin/transcrypt
     install -m 644 -D man/transcrypt.1 $out/share/man/man1/transcrypt.1
     install -m 644 -D contrib/bash/transcrypt $out/share/bash-completion/completions/transcrypt
     install -m 644 -D contrib/zsh/_transcrypt $out/share/zsh/site-functions/_transcrypt
+
+    wrapProgram $out/bin/transcrypt \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ git openssl ]}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Bump to the latest upstream release version.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I also realized that the git/openssl runtime dependencies were not actually being picked up, so I've added in the standard `wrapProgram` setup to make the `$PATH` explicit.
