### PR TITLE
android-studio: enable Android emulator support

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -3,18 +3,25 @@
 , coreutils
 , fetchurl
 , findutils
+, file
 , git
+, glxinfo
 , gnugrep
 , gnutar
 , gzip
 , jdk
+, libpulseaudio
+, libX11
 , libXrandr
 , makeWrapper
+, pciutils
 , pkgsi686Linux
+, setxkbmap
 , stdenv
 , unzip
 , which
 , writeTextFile
+, xkeyboard_config
 , zlib
 }:
 
@@ -40,6 +47,12 @@ let
         jdk
         which
 
+        # For Android emulator
+        file
+        glxinfo
+        pciutils
+        setxkbmap
+
         # Used during setup wizard
         gnutar
         gzip
@@ -47,17 +60,22 @@ let
         # Runtime stuff
         git
 
-      ]}" --set LD_LIBRARY_PATH "${stdenv.lib.makeLibraryPath [
+      ]}" --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
         # Gradle wants libstdc++.so.6
         stdenv.cc.cc.lib
         # mksdcard wants 32 bit libstdc++.so.6
         pkgsi686Linux.stdenv.cc.cc.lib
+
         # aapt wants libz.so.1
         zlib
         pkgsi686Linux.zlib
         # Support multiple monitors
         libXrandr
-      ]}"
+
+        # For Android emulator
+        libpulseaudio
+        libX11
+      ]}" --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb"
     '';
     src = fetchurl {
       url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";


### PR DESCRIPTION
###### Motivation for this change

These changes are needed to be able to run the system emulator (QEMU)
from Android Studio. In addition to the added dependencies,
$LD_LIBRARY_PATH had to be changed from --set to --prefix, so that libGL
is found (on NixOS).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
