### PR TITLE
mc: Enable support for SFTP and SMB.

### DIFF
--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, gpm, file, e2fsprogs
-, libX11, libICE, perl, zip, unzip, gettext, slang}:
+, libX11, libICE, perl, zip, unzip, gettext, slang, libssh2, openssl}:
 
 stdenv.mkDerivation rec {
   name = "mc-${version}";
@@ -10,7 +10,10 @@ stdenv.mkDerivation rec {
     sha256 = "0fvqzffppj0aja9hi0k1xdjg5m6s99immlla1y9yzn5fp8vwpl36";    
   };
   
-  buildInputs = [ pkgconfig perl glib gpm slang zip unzip file gettext libX11 libICE e2fsprogs ];
+  buildInputs = [ pkgconfig perl glib gpm slang zip unzip file gettext libX11 libICE e2fsprogs
+    libssh2 openssl ];
+
+  configureFlags = [ "--enable-vfs-smb" ];
 
   meta = {
     description = "File Manager and User Shell for the GNU Project";


### PR DESCRIPTION
###### Motivation for this change

This enables the support for the SFTP and SMB remote filesystems in Midnight Commander.

Closure-size: +2 MB
Tested on master and release-16.03
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
