### PR TITLE
adb-sync: Make `platforms` correspond to those of `androidsdk`

### DIFF
--- a/pkgs/development/mobile/adb-sync/default.nix
+++ b/pkgs/development/mobile/adb-sync/default.nix
@@ -10,8 +10,6 @@ stdenv.mkDerivation rec {
     sha256 = "1y016bjky5sn58v91jyqfz7vw8qfqnfhb9s9jd32k8y29hy5vy4d";
   };
 
-  preferLocalBuild = true;
-
   buildInputs = [ python androidsdk makeWrapper ];
 
   phases = "installPhase";
@@ -27,7 +25,8 @@ stdenv.mkDerivation rec {
     description = "A tool to synchronise files between a PC and an Android devices using ADB (Android Debug Bridge)";
     homepage = "https://github.com/google/adb-sync";
     license = licenses.asl20;
-    platforms = platforms.all;
+    platforms = platforms.unix;
+    hydraPlatforms = [];
     maintainers = with maintainers; [ scolobb ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This commit limits the platforms supported by `adb-sync` to those supported by `androidsdk`, which is its main dependency.

This commit also prevents `adb-sync` from being built by Hydra (just like `androidsdk`) and should fix [these](http://hydra.nixos.org/eval/1290936?filter=adb-sync&compare=1290887&full=#tabs-still-succeed) build failures.
