### PR TITLE
container: Increase startup timeout

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -509,6 +509,8 @@ in
 
         Restart = "on-failure";
 
+        TimeoutStartSec = 360;
+
         # Hack: we don't want to kill systemd-nspawn, since we call
         # "machinectl poweroff" in preStop to shut down the
         # container cleanly. But systemd requires sending a signal


### PR DESCRIPTION
###### Motivation for this change

on master and release-16.09 the container tests fail for strange reasons. maybe waiting a bit longer for the container to start is not the solution but brings us forward in diagnosis of the problem

---

Waiting for the whole container should be longer than waiting for a
single service.

But now I just want to have a chance to see why the containers systemd
even thinks it should wait for dev-vda.device…
