### PR TITLE
ledger-web: we have bundlerEnv, let us use it

### DIFF
--- a/pkgs/applications/office/ledger-web/default.nix
+++ b/pkgs/applications/office/ledger-web/default.nix
@@ -1,48 +1,25 @@
-{ stdenv, lib, fetchFromGitHub, bundlerEnv, ruby
+{ lib, bundlerEnv, ruby
 , withPostgresql ? true, postgresql
 , withSqlite ? false, sqlite
 }:
 
-let
-  _name = "ledger-web";
-  cmd = "ledger_web";
+bundlerEnv rec {
+  name = "ledger-web-${version}";
 
-  env = bundlerEnv {
-    name = "${_name}-env";
-    inherit ruby;
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
-    meta = with lib; {
-      homepage = https://github.com/peterkeen/ledger-web;
-      platforms = platforms.linux;
-      maintainers = [ peterhoeg ];
-      license = licenses.mit;
-    };
+  version = (import gemset).ledger_web.version;
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  buildInputs =    lib.optional withPostgresql postgresql
+                ++ lib.optional withSqlite sqlite;
+
+  meta = with lib; {
+    description = "A web frontend to the Ledger CLI tool";
+    homepage = https://github.com/peterkeen/ledger-web;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.linux;
   };
-
-in stdenv.mkDerivation rec {
-  name = "${_name}-${version}";
-  version = "1.5.2";
-
-  buildInputs = [ env ruby ]
-    ++ lib.optional withPostgresql postgresql
-    ++ lib.optional withSqlite sqlite;
-
-  src = fetchFromGitHub {
-    owner = "peterkeen";
-    repo = _name;
-    rev = "v${version}";
-    sha256 = "0an4d46h3pp7a8s96jl0dnw1imwdgnb2j474b9wrbidwc6cmfrm7";
-  };
-
-  dontStrip = true;
-
-  installPhase = ''
-    mkdir -p $out/bin
-
-    cp --no-preserve=mode -r lib $out
-
-    ln -s ${env}/bin/${cmd} $out/bin/${cmd}
-  '';
 }


### PR DESCRIPTION
###### Motivation for this change

@cstrahan keeps making me throw perfectly good and brand new code away!

We have `bundlerEnv` - let's use it instead of manually fiddling with the install.

Further to #18349.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
