### PR TITLE
Make cross-compiling with the crossSystem argument work

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -183,4 +183,37 @@ rec {
         };
     in self;
 
+  /* Use this if you want to override the native derivation of a
+     package without affecting the cross derivation.
+
+     It converts a set like
+
+       let nativeDrv = origNativeDrv
+           crossDrv = origCrossDrv
+       in nativeDrv // {inherit crossDrv nativeDrv; }
+
+     to a set where the nativeDrv has been replaced with a new
+     derivation but the crossDrv is the same as before.
+
+     Note: if the old derivation does not have a crossDrv, the
+     set returned by this function will have a crossDrv attribute that
+     should not be evaluated because it will result in an error.
+     If that is a problem, this function can be changed to ommit
+     the crossDrv attribute in that situation. */
+  overrideNativeDrv = newNativeDrv: old:
+    let
+      nativeDrv = newNativeDrv;
+      crossDrv = old.crossDrv;
+    in nativeDrv // { inherit crossDrv nativeDrv; };
+
+  /* Given a list of attribute names (strings), a set of new packages,
+     and a set of old packages, produces a set that maps the specified
+     attributes to derivations that have the native derivation from the
+     new set but the cross derivation (crossDrv) from the old set. */
+  overrideNativeDrvs = attrs: newPkgs: oldPkgs:
+    let f = (attr: {
+      name = attr;
+      value = overrideNativeDrv newPkgs.${attr} oldPkgs.${attr};
+    });
+    in builtins.listToAttrs (map f attrs);
 }

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -206,14 +206,15 @@ rec {
       crossDrv = old.crossDrv;
     in nativeDrv // { inherit crossDrv nativeDrv; };
 
-  /* Given a list of attribute names (strings), a set of new packages,
-     and a set of old packages, produces a set that maps the specified
-     attributes to derivations that have the native derivation from the
-     new set but the cross derivation (crossDrv) from the old set. */
-  overrideNativeDrvs = attrs: newPkgs: oldPkgs:
+  /* Given a set of new packages and a set of old packages, produces a
+     set with the same attribute names as the set of new packages,
+     where each attribute value is a derivation that has the native
+     derivation from the new set but the cross derivation (crossDrv)
+     from the old set. */
+  overrideNativeDrvs = newPkgs: oldPkgs:
     let f = (attr: {
       name = attr;
       value = overrideNativeDrv newPkgs.${attr} oldPkgs.${attr};
     });
-    in builtins.listToAttrs (map f attrs);
+    in builtins.listToAttrs (map f (builtins.attrNames newPkgs));
 }

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -195,6 +195,10 @@ rec {
      to a set where the nativeDrv has been replaced with a new
      derivation but the crossDrv is the same as before.
 
+     It also provides an appropriate "override" function in the new
+     set that behaves like the override function usually does,
+     overriding both the native and cross derivation.
+
      Note: if the old derivation does not have a crossDrv, the
      set returned by this function will have a crossDrv attribute that
      should not be evaluated because it will result in an error.
@@ -204,7 +208,9 @@ rec {
     let
       nativeDrv = newNativeDrv;
       crossDrv = old.crossDrv;
-    in nativeDrv // { inherit crossDrv nativeDrv; };
+      override = newArgs: overrideNativeDrv
+        (newNativeDrv.override newArgs) (old.override newArgs);
+    in nativeDrv // { inherit crossDrv nativeDrv override; };
 
   /* Given a set of new packages and a set of old packages, produces a
      set with the same attribute names as the set of new packages,

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -128,12 +128,12 @@ let version = "5.4.0";
     crossMingw = cross != null && cross.libc == "msvcrt";
     crossDarwin = cross != null && cross.libc == "libSystem";
     crossConfigureFlags = let
-        gccArch = stdenv.cross.gcc.arch or null;
-        gccCpu = stdenv.cross.gcc.cpu or null;
-        gccAbi = stdenv.cross.gcc.abi or null;
-        gccFpu = stdenv.cross.gcc.fpu or null;
-        gccFloat = stdenv.cross.gcc.float or null;
-        gccMode = stdenv.cross.gcc.mode or null;
+        gccArch = cross.gcc.arch or null;
+        gccCpu = cross.gcc.cpu or null;
+        gccAbi = cross.gcc.abi or null;
+        gccFpu = cross.gcc.fpu or null;
+        gccFloat = cross.gcc.float or null;
+        gccMode = cross.gcc.mode or null;
         withArch = if gccArch != null then " --with-arch=${gccArch}" else "";
         withCpu = if gccCpu != null then " --with-cpu=${gccCpu}" else "";
         withAbi = if gccAbi != null then " --with-abi=${gccAbi}" else "";

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -145,7 +145,7 @@ let version = "5.4.0";
         withFloat +
         withMode +
         (if crossMingw && crossStageStatic then
-          " --with-headers=${libcCross}/include" +
+          " --with-sysroot=${libcCross}/include" +
           " --with-gcc" +
           " --with-gnu-as" +
           " --with-gnu-ld" +
@@ -167,7 +167,8 @@ let version = "5.4.0";
           " --disable-decimal-float" # libdecnumber requires libc
           else
           (if crossDarwin then " --with-sysroot=${getLib libcCross}/share/sysroot"
-           else                " --with-headers=${getDev libcCross}/include") +
+           else                " --with-sysroot=${getDev libcCross}" +
+                               " --with-native-system-header-dir=/include") +
           # Ensure that -print-prog-name is able to find the correct programs.
           (stdenv.lib.optionalString (crossMingw || crossDarwin) (
             " --with-as=${binutilsCross}/bin/${cross.config}-as" +

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -145,7 +145,8 @@ let version = "5.4.0";
         withFloat +
         withMode +
         (if crossMingw && crossStageStatic then
-          " --with-sysroot=${libcCross}/include" +
+          " --with-sysroot=${libcCross}" +
+          " --with-native-system-header-dir=/include" +
           " --with-gcc" +
           " --with-gnu-as" +
           " --with-gnu-ld" +
@@ -552,6 +553,6 @@ stdenv.mkDerivation ({
 # This is only here because it was here in previous commits and we
 # want to avoid a meaningless mass rebuild.  These variables get
 # overridden via crossAttrs in an actual cross-build.
-// { crossMingw = false; crossStageStatic = true; }
+// { crossMingw = false; inherit crossStageStatic; }
 
 )

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -149,8 +149,7 @@ let version = "5.4.0";
         withFloat +
         withMode +
         (if crossMingw && crossStageStatic then
-          " --with-sysroot=${libcCross}" +
-          " --with-native-system-header-dir=/include" +
+          " --with-headers=${libcCross}/include" +
           " --with-gcc" +
           " --with-gnu-as" +
           " --with-gnu-ld" +

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -17,8 +17,11 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv ? cross;
+  # This is just here because it was present in previous commits and
+  # we want to avoid a meaningless mass rebuild.
+  dontStrip = false;
+
+  crossAttrs.dontStrip = true; # Don't run the native `strip' when cross-compiling.
 
   postInstall =
     ''

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -21,7 +21,11 @@ stdenv.mkDerivation rec {
 
   inherit doCheck;
 
-  dontStrip = stdenv ? cross; # Don't run the native `strip' when cross-compiling.
+  # This is just here because it was present in previous commits and
+  # we want to avoid a meaningless mass rebuild.
+  dontStrip = false;
+
+  crossAttrs.dontStrip = true; # Don't run the native `strip' when cross-compiling.
 
   # Install headers and libs in the right places.
   postFixup = ''

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -28,8 +28,12 @@ stdenv.mkDerivation rec {
      in
        import ./readline-6.3-patches.nix patch);
 
-  # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv ? cross;
+  # This is just here because it was present in previous commits and
+  # we want to avoid a meaningless mass rebuild.
+  dontStrip = false;
+
+  crossAttrs.dontStrip = true; # Don't run the native `strip' when cross-compiling.
+
   bash_cv_func_sigsetjmp = if stdenv.isCygwin then "missing" else null;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -21,15 +21,13 @@ stdenv.mkDerivation rec {
   # leads to the failure of a number of tests.
   doCheck = false;
 
-  # This is just here because it was here in previous commits and we
-  # want to avoid a mass-rebuild of everything that depends on libtool.
+  # This is just here because it was present in previous commits and
+  # we want to avoid a meaningless mass rebuild.
   dontStrip = false;
 
-  crossAttrs = {
-    # Don't run the native `strip' when cross-compiling.  This breaks at least
-    # with `.a' files for MinGW.
-    dontStrip = true;
-  };
+  # Don't run the native `strip' when cross-compiling.  This breaks at least
+  # with `.a' files for MinGW.
+  crossAttrs.dontStrip = true;
 
   meta = {
     description = "GNU Libtool, a generic library support script";

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -21,9 +21,15 @@ stdenv.mkDerivation rec {
   # leads to the failure of a number of tests.
   doCheck = false;
 
-  # Don't run the native `strip' when cross-compiling.  This breaks at least
-  # with `.a' files for MinGW.
-  dontStrip = stdenv ? cross;
+  # This is just here because it was here in previous commits and we
+  # want to avoid a mass-rebuild of everything that depends on libtool.
+  dontStrip = false;
+
+  crossAttrs = {
+    # Don't run the native `strip' when cross-compiling.  This breaks at least
+    # with `.a' files for MinGW.
+    dontStrip = true;
+  };
 
   meta = {
     description = "GNU Libtool, a generic library support script";

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -57,7 +57,7 @@ rec {
   # Return a modified stdenv that adds a cross compiler to the
   # builds.
   makeStdenvCross = stdenv: cross: binutilsCross: gccCross: stdenv //
-    { mkDerivation = {name ? "", buildInputs ? [], nativeBuildInputs ? [],
+    rec { mkDerivation = {name ? "", buildInputs ? [], nativeBuildInputs ? [],
             propagatedBuildInputs ? [], propagatedNativeBuildInputs ? [],
             selfNativeBuildInput ? false, ...}@args: let
 
@@ -115,6 +115,27 @@ rec {
         in nativeDrv // {
           inherit crossDrv nativeDrv;
         };
+
+      # mkDerivationWithCrossArg allows us to make arbitary changes to
+      # derivation depending on what system we are cross-compiling for, without
+      # affecting the native derivation.  The argument to
+      # mkDerivationWithCrossArg, attrFunc, should be a function that takes a
+      # single argument named cross.  When cross is null, attrFunc should return
+      # the attributes for making a native version of the derivation (one that
+      # runs on the system on which it was built).  When cross is not null, it
+      # will be equal to the top-level crossSystem argument (and equal to
+      # stdenv.cross), and attrFunc should return the attributes for
+      # cross-compiling a derivation to be run on the specified system.
+      #
+      # It is often an error to use "stdenv ? cross" or "stdenv.cross" in an
+      # expression for a derivation (outside of crossAttrs), because then the
+      # presence of the crossSystem argument might end up affecting the native
+      # derivation.  Instead, use mkDerivationWithCrossArg and write
+      # conditionals based on the cross argument that gets passed to attrFunc.
+      mkDerivationWithCrossArg = attrFunc:
+        let nativeDrv = (mkDerivation (attrFunc null)).nativeDrv;
+            crossDrv = (mkDerivation (attrFunc cross)).crossDrv;
+        in nativeDrv // { inherit crossDrv nativeDrv; };
     } // {
       inherit cross gccCross binutilsCross;
       ccCross = gccCross;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -256,6 +256,9 @@ let
       # derivation (e.g., in assertions).
       passthru);
 
+  # This gets overridden in makeStdvenvCross to do something more useful.
+  mkDerivationWithCrossArg = attrFunc: mkDerivation (attrFunc null);
+
   # The stdenv that we are producing.
   result =
     derivation (
@@ -334,6 +337,8 @@ let
       needsPax = isLinux;
 
       inherit mkDerivation;
+
+      inherit mkDerivationWithCrossArg;
 
       # For convenience, bring in the library functions in lib/ so
       # packages don't have to do that themselves.

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -284,22 +284,13 @@ rec {
       shellPackage = stage4.pkgs.bash;
     };
 
-    /* outputs TODO
-    allowedRequisites = with stage4.pkgs;
-      [ gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
-        glibc gnumake gnused gnutar gnugrep gnupatch patchelf attr acl
-        paxctl zlib pcre linuxHeaders ed gcc gcc.cc libsigsegv
-      ];
-      */
+    overrides = lib.overrideNativeDrvs [
+      "attr" "acl" "bash" "binutils" "bzip2" "coreutils" "diffutils"
+      "findutils" "gawk" "gcc" "glibc" "gnugrep" "gnumake" "gnused"
+      "gnutar" "gnupatch" "gzip" "patchelf" "paxctl" "pcre" "xz"
+      "zlib"
+    ] stage4.pkgs;
 
-    overrides = pkgs: {
-      gcc = cc;
-
-      inherit (stage4.pkgs)
-        gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
-        glibc gnumake gnused gnutar gnugrep gnupatch patchelf
-        attr acl paxctl zlib pcre;
-    };
   };
 
 }

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -292,13 +292,12 @@ rec {
       ];
       */
 
-    overrides = lib.overrideNativeDrvs [
-      "attr" "acl" "bash" "binutils" "bzip2" "coreutils" "diffutils"
-      "findutils" "gawk" "gcc" "glibc" "gnugrep" "gnumake" "gnused"
-      "gnutar" "gnupatch" "gzip" "patchelf" "paxctl" "pcre" "xz"
-      "zlib"
-    ] stage4.pkgs;
-
+    overrides = lib.overrideNativeDrvs {
+      inherit (stage4.pkgs)
+        gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
+        gcc glibc gnumake gnused gnutar gnugrep gnupatch patchelf
+        attr acl paxctl zlib pcre;
+    };
   };
 
 }

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -284,6 +284,14 @@ rec {
       shellPackage = stage4.pkgs.bash;
     };
 
+    /* outputs TODO
+    allowedRequisites = with stage4.pkgs;
+      [ gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
+        glibc gnumake gnused gnutar gnugrep gnupatch patchelf attr acl
+        paxctl zlib pcre linuxHeaders ed gcc gcc.cc libsigsegv
+      ];
+      */
+
     overrides = lib.overrideNativeDrvs [
       "attr" "acl" "bash" "binutils" "bzip2" "coreutils" "diffutils"
       "findutils" "gawk" "gcc" "glibc" "gnugrep" "gnumake" "gnused"

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -71,7 +71,7 @@ let
   gnumake = pkgs.gnumake.crossDrv;
   patch = pkgs.patch.crossDrv;
   patchelf = pkgs.patchelf.crossDrv;
-  gcc = pkgs.gcc.cc.crossDrv;
+  gcc = pkgs.gcc.crossDrv.cc;
   gmpxx = pkgs.gmpxx.crossDrv;
   mpfr = pkgs.mpfr.crossDrv;
   zlib = pkgs.zlib.crossDrv;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4480,18 +4480,19 @@ in
 
   gccApple = throw "gccApple is no longer supported";
 
-  gccCrossStageStatic = let
-    libcCross1 =
-      if stdenv.cross.libc == "msvcrt" then windows.mingw_w64_headers
-      else if stdenv.cross.libc == "libSystem" then darwin.xcode
-      else null;
-    in wrapGCCCross {
-      gcc = forceNativeDrv (gcc.cc.override {
+  gccCrossStageStatic =
+    wrapGCCCross {
+      gcc = forceNativeDrv (callPackage ../development/compilers/gcc/5 {
         cross = crossSystem;
         crossStageStatic = true;
-        langCC = false;
+        noSysDirs = true;
+        profiledCompiler = gcc.cc.profiledCompiler;
+        isl = isl_0_14;
         libcCross = libcCross1;
         enableShared = false;
+        langCC = false;
+        langObjC = false;
+        langObjCpp = false;
       });
       libc = libcCross1;
       binutils = binutilsCross;
@@ -4507,13 +4508,20 @@ in
   };
 
   gccCrossStageFinal = wrapGCCCross {
-    gcc = forceNativeDrv (gcc.cc.override {
+    gcc = forceNativeDrv (callPackage ../development/compilers/gcc/5 {
       cross = crossSystem;
       crossStageStatic = false;
+      noSysDirs = true;
+      profiledCompiler = gcc.cc.profiledCompiler;
+      isl = isl_0_14;
+      libcCross = libcCross;
 
       # XXX: We have troubles cross-compiling libstdc++ on MinGW (see
       # <http://hydra.nixos.org/build/4268232>), so don't even try.
       langCC = crossSystem.config != "i686-pc-mingw32";
+
+      langObjC = false;
+      langObjCpp = false;
     });
     libc = libcCross;
     binutils = binutilsCross;
@@ -7432,13 +7440,20 @@ in
     withGd = true;
   };
 
-  glibcCross = forceNativeDrv (glibc.override {
+  glibcCross = forceNativeDrv (callPackage ../development/libraries/glibc {
+    installLocales = false;
     gccCross = gccCrossStageStatic;
     linuxHeaders = linuxHeadersCross;
   });
 
+  libcCross1 =
+    if crossSystem.libc == "msvcrt" then windows.mingw_w64_headers
+    else if crossSystem.libc == "libSystem" then darwin.xcode
+    else null;
+
   # We can choose:
-  libcCrossChooser = name: if name == "glibc" then glibcCross
+  libcCrossChooser = name:
+    if name == "glibc" then glibcCross
     else if name == "uclibc" then uclibcCross
     else if name == "msvcrt" then windows.mingw_w64
     else if name == "libSystem" then darwin.xcode
@@ -8306,13 +8321,16 @@ in
   # glibc provides libiconv so systems with glibc don't need to build libiconv
   # separately, but we also provide libiconvReal, which will always be a
   # standalone libiconv, just in case you want it
-  libiconv = if crossSystem != null then
-    (if crossSystem.libc == "glibc" then libcCross
-      else if crossSystem.libc == "libSystem" then darwin.libiconv
-      else libiconvReal)
-    else if stdenv.isGlibc then stdenv.cc.libc
-    else if stdenv.isDarwin then darwin.libiconv
-    else libiconvReal;
+  libiconv =
+    let
+      nativeDrv = if stdenv.isGlibc then stdenv.cc.libc
+        else if stdenv.isDarwin then darwin.libiconv
+        else libiconvReal;
+      crossDrv =
+        if crossSystem.libc == "glibc" then libcCross
+        else if crossSystem.libc == "libSystem" then darwin.libiconv
+        else libiconvReal.crossDrv;
+    in nativeDrv // { inherit crossDrv nativeDrv; };
 
   libiconvReal = callPackage ../development/libraries/libiconv {
     fetchurl = fetchurlBoot;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -57,8 +57,8 @@ let
   platform = if platform_ != null then platform_
     else config.platform or platformAuto;
 
-  topLevelArguments = {
-    inherit system bootStdenv noSysDirs config crossSystem platform lib;
+  topLevelArgs = {
+    inherit system bootStdenv noSysDirs config crossSystem platform;
   };
 
   # Allow packages to be overridden globally via the `packageOverrides'
@@ -85,9 +85,13 @@ let
           inherit lib; inherit (self) stdenv; inherit (self.xorg) lndir;
         });
 
-      stdenvDefault = self: super: (import ./stdenv.nix topLevelArguments) {} pkgs;
+      stdenvArgs = topLevelArgs // {
+        inherit lib;
+        allPackages = args: import ./. (topLevelArgs // args);
+      };
+      stdenvDefault = self: super: import ./stdenv.nix stdenvArgs;
 
-      allPackagesArgs = topLevelArguments // { inherit pkgsWithOverrides; };
+      allPackagesArgs = topLevelArgs // { inherit lib pkgsWithOverrides; };
       allPackages = self: super:
         let res = import ./all-packages.nix allPackagesArgs res self;
         in res;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -98,15 +98,11 @@ let
 
       aliases = self: super: import ./aliases.nix super;
 
-      # stdenvOverrides is used to avoid circular dependencies for building
-      # the standard build environment. This mechanism uses the override
-      # mechanism to implement some staged compilation of the stdenv.
-      #
-      # We don't want stdenv overrides in the case of cross-building, or
-      # otherwise the basic overridden packages will not be built with the
-      # crossStdenv adapter.
+      # stdenvOverrides is used to avoid having multiple of versions
+      # of certain dependencies that were used in bootstrapping the
+      # standard environment.
       stdenvOverrides = self: super:
-        lib.optionalAttrs (crossSystem == null && super.stdenv ? overrides)
+        lib.optionalAttrs (super.stdenv ? overrides)
           (super.stdenv.overrides super);
 
       customOverrides = self: super:

--- a/pkgs/top-level/stdenv.nix
+++ b/pkgs/top-level/stdenv.nix
@@ -1,31 +1,23 @@
-{ system, bootStdenv, crossSystem, config, platform, lib, ... }:
-self: super:
-
-with super;
+{ system, bootStdenv, noSysDirs, config, crossSystem, platform, lib, allPackages }:
 
 rec {
   allStdenvs = import ../stdenv {
-    inherit system platform config lib;
-    allPackages = args: import ../.. ({ inherit config system; } // args);
+    inherit system allPackages platform config lib;
   };
 
   defaultStdenv = allStdenvs.stdenv // { inherit platform; };
 
   stdenv =
-    if bootStdenv != null then (bootStdenv // {inherit platform;}) else
-      if crossSystem != null then
-        stdenvCross
-      else
-        let
-            changer = config.replaceStdenv or null;
-        in if changer != null then
-          changer {
-            # We import again all-packages to avoid recursivities.
-            pkgs = import ../.. {
-              # We remove packageOverrides to avoid recursivities
-              config = removeAttrs config [ "replaceStdenv" ];
-            };
-          }
-      else
-        defaultStdenv;
+    if bootStdenv != null then
+      bootStdenv // { inherit platform; }
+    else if crossSystem != null then
+      (allPackages { bootStdenv = defaultStdenv; }).stdenvCross
+    else if (config.replaceStdenv or null) != null then
+      config.replaceStdenv {
+        pkgs = allPackages {
+          config = removeAttrs config [ "replaceStdenv" ];
+        };
+      }
+    else
+      defaultStdenv;
 }

--- a/test/cross_system.nix
+++ b/test/cross_system.nix
@@ -22,6 +22,7 @@ rec {
   };
 
   sameLibiconv = pkgs.libiconv == pkgsWithCross.libiconv;
+  sameLibtool = pkgs.libtool == pkgsWithCross.libtool;
   sameGcc6 = pkgs.gcc6 == pkgsWithCross.gcc6;
   sameGcc5 = pkgs.gcc5 == pkgsWithCross.gcc5;
   sameGcc49 = pkgs.gcc49 == pkgsWithCross.gcc49;
@@ -31,5 +32,5 @@ rec {
   # TODO: Test that *all* GCCs are the same:
   # sameGcc = sameGcc6 && sameGcc5 && sameGcc49 && sameGcc48 && sameGcc45;
 
-  testsPass = sameLibiconv && sameGcc5;
+  testsPass = sameLibiconv && sameGcc5 && sameLibtool;
 }

--- a/test/cross_system.nix
+++ b/test/cross_system.nix
@@ -21,6 +21,8 @@ rec {
     };
   };
 
+  sameBoehmgc = pkgs.boehmgc == pkgsWithCross.boehmgc;
+  sameLibffi = pkgs.libffi == pkgsWithCross.libffi;
   sameLibiconv = pkgs.libiconv == pkgsWithCross.libiconv;
   sameLibtool = pkgs.libtool == pkgsWithCross.libtool;
   sameLibxml2 = pkgs.libxml2 == pkgsWithCross.libxml2;
@@ -29,9 +31,11 @@ rec {
   sameGcc49 = pkgs.gcc49 == pkgsWithCross.gcc49;
   sameGcc48 = pkgs.gcc48 == pkgsWithCross.gcc48;
   sameGcc45 = pkgs.gcc45 == pkgsWithCross.gcc45;
+  sameGuile = pkgs.guile == pkgsWithCross.guile;
 
   # TODO: Test that *all* GCCs are the same:
   # sameGcc = sameGcc6 && sameGcc5 && sameGcc49 && sameGcc48 && sameGcc45;
 
-  testsPass = sameLibiconv && sameLibtool && sameLibxml2 && sameGcc5;
+  testsPass = sameBoehmgc && sameLibffi && sameLibiconv && sameLibtool
+    && sameLibxml2 && sameGcc5 && sameGuile;
 }

--- a/test/cross_system.nix
+++ b/test/cross_system.nix
@@ -23,6 +23,7 @@ rec {
 
   sameLibiconv = pkgs.libiconv == pkgsWithCross.libiconv;
   sameLibtool = pkgs.libtool == pkgsWithCross.libtool;
+  sameLibxml2 = pkgs.libxml2 == pkgsWithCross.libxml2;
   sameGcc6 = pkgs.gcc6 == pkgsWithCross.gcc6;
   sameGcc5 = pkgs.gcc5 == pkgsWithCross.gcc5;
   sameGcc49 = pkgs.gcc49 == pkgsWithCross.gcc49;
@@ -32,5 +33,5 @@ rec {
   # TODO: Test that *all* GCCs are the same:
   # sameGcc = sameGcc6 && sameGcc5 && sameGcc49 && sameGcc48 && sameGcc45;
 
-  testsPass = sameLibiconv && sameGcc5 && sameLibtool;
+  testsPass = sameLibiconv && sameLibtool && sameLibxml2 && sameGcc5;
 }

--- a/test/cross_system.nix
+++ b/test/cross_system.nix
@@ -1,0 +1,35 @@
+# This file helps us test some assertions about the treatment of the
+# crossSystem top-level argument.
+#
+# Ideally, the presence of a crossSystem argument should not affect
+# *any* native derivations.  For now, we just test a few derivations
+# that are likely to have problems.
+
+rec {
+  topLevel = import ../pkgs/top-level;
+
+  pkgs = topLevel {
+    system = builtins.currentSystem;
+    crossSystem = null;
+  };
+
+  pkgsWithCross = topLevel {
+    system = builtins.currentSystem;
+    crossSystem = {
+      config = "foosys";
+      libc = "foolibc";
+    };
+  };
+
+  sameLibiconv = pkgs.libiconv == pkgsWithCross.libiconv;
+  sameGcc6 = pkgs.gcc6 == pkgsWithCross.gcc6;
+  sameGcc5 = pkgs.gcc5 == pkgsWithCross.gcc5;
+  sameGcc49 = pkgs.gcc49 == pkgsWithCross.gcc49;
+  sameGcc48 = pkgs.gcc48 == pkgsWithCross.gcc48;
+  sameGcc45 = pkgs.gcc45 == pkgsWithCross.gcc45;
+
+  # TODO: Test that *all* GCCs are the same:
+  # sameGcc = sameGcc6 && sameGcc5 && sameGcc49 && sameGcc48 && sameGcc45;
+
+  testsPass = sameLibiconv && sameGcc5;
+}


### PR DESCRIPTION
###### Motivation for this change

I would like to be able to compile software for systems that do not have Nix.  It looks like nixpkgs has a `crossSystem` argument that should allow this, but when I tried to use it, I encountered a bunch of problems.

The main problem was that the `crossSystem` argument affected a bunch of native derivations, such as gcc5, so when I tried to cross-compile, Nix would needlessly try to rebuild the stdenv, and encounter some error.

Another issue was that the cross compilers were built using the bootstrap tools instead of the normal stdenv, and they were built using gcc.cc.override which seems invalid to me.  Fixing this issue was the final thing that allowed me to successfully cross-compile for the Raspberry Pi.

See my detailed commit messages for more info.  (I actually redid the commit history before submitting this pull request to make it easy for reviewers to follow.)  Thanks!
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tried to run `nix-shell -p nox --run "nox-review wip --against d4eac027"` but its [error message](https://gist.github.com/DavidEGrayson/efc54d4637c7e521227abb53eb1b3030) did not make much sense to me.  It looks like it tried to evaluate `libcCross1` without specifying a `crossSystem` argument, which is invalid (just like it would also be invalid to evaluate libcCross).
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The main way I tested this PR was by applying `nix-build` to [this Nix expression](https://gist.github.com/DavidEGrayson/8d61032e523b3bc8bbca0c4b281afb52).  That Nix expression does several things: it ensures that the gcc5 in my pull request does not get affected by the crossSystem argument.  It also ensures that my pull request does not affect any native GCC derivations, so we will not need a mass rebuild.  It also compiles the "hello" package for the Raspberry Pi.

---
###### Future work
- I am only touching the GCC 5 recipe in this pull request, but we should apply my fixes to GCC 6 after they are accepted.
- The test I added in the new directory `test` should be automatically run by Hydra.  I do not know how to set that up.
- Note that this pull request only makes cross-compiling work if the build system is Linux.  A bit more work would be needed to make cross-compiling work on Darwin.
