### PR TITLE
mono: init at 4.6

### DIFF
--- a/pkgs/development/compilers/mono/4.6.nix
+++ b/pkgs/development/compilers/mono/4.6.nix
@@ -1,0 +1,7 @@
+{ stdenv, callPackage, Foundation, libobjc }:
+
+callPackage ./generic.nix (rec {
+  inherit Foundation libobjc;
+  version = "4.6.0.182";
+  sha256 = "1sajwl7fqhkcmh697qqjj4z6amzkay7xf7npsvpm10gm071s5qi6";
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4991,6 +4991,11 @@ in
     inherit (darwin.apple_sdk.frameworks) Foundation;
   });
 
+  mono46 = lowPrio (callPackage ../development/compilers/mono/4.6.nix {
+    inherit (darwin) libobjc;
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  });
+
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
   mozart-binary = callPackage ../development/compilers/mozart/binary.nix { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
