### PR TITLE
nixos: Generalise the container tests in stage-2 boot

### DIFF
--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -29,14 +29,14 @@ setPath "@path@"
 # Normally, stage 1 mounts the root filesystem read/writable.
 # However, in some environments, stage 2 is executed directly, and the
 # root is read-only.  So make it writable here.
-if [ "$container" != systemd-nspawn ]; then
+if [ -z "$container" ]; then
     mount -n -o remount,rw none /
 fi
 
 
 # Likewise, stage 1 mounts /proc, /dev and /sys, so if we don't have a
 # stage 1, we need to do that here.
-if [ ! -e /proc/1 ]; then
+if [ ! -e /proc/1 ] || [ -n "$container" ]; then
     specialMount() {
         local device="$1"
         local mountPoint="$2"


### PR DESCRIPTION
###### Motivation for this change

This way, stage-2 behaves correctly also for libvirt-lxc containers.

Some more discussion on this:
https://github.com/NixOS/nixpkgs/commit/a7a08188bf650ababa36300a9a6f34169e2a73bf
https://github.com/NixOS/nixpkgs/commit/bfe46a653ba2f8ff9902128f485cbd87c49cbca7
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
