### PR TITLE
gazeboSimulator: fix builds

### DIFF
--- a/pkgs/development/libraries/ignition-transport/generic.nix
+++ b/pkgs/development/libraries/ignition-transport/generic.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ cppzmq ];
 
+  postPatch = ''
+    substituteInPlace cmake/ignition-config.cmake.in --replace "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_" "@CMAKE_INSTALL_"
+  '';
+
   meta = with stdenv.lib; {
     homepage = http://ignitionrobotics.org/libraries/math;
     description = "Math library by Ingition Robotics, created for the Gazebo project";

--- a/pkgs/development/libraries/sdformat/default.nix
+++ b/pkgs/development/libraries/sdformat/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
 
   inherit name;
 
+  prePatch = ''
+    substituteInPlace cmake/sdf_config.cmake.in --replace "@CMAKE_INSTALL_PREFIX@/@LIB_INSTALL_DIR@" "@LIB_INSTALL_DIR@"
+  '';
+
   enableParallelBuilding = true;
   buildInputs = [
     cmake boost ruby ignition.math2 tinyxml


### PR DESCRIPTION
###### Motivation for this change

gazeboSimulator.gazebo{6,7}{,-headless} are currently broken.

These changes fix the produced cmake files of two dependencies. I **guess** this is fallout from `multiple-outputs` since we now pass absolute paths for `--prefix` and `--libprefix` and the cmakefiles combines them into `<prefix>/<libprefix>` which results in a path like `/nix/store/<drv>//nix/store/<drv>/lib`.

This is a different approach than was taken in #15259 where `CMAKE_INSTALL_LIBDIR` was simply set to `lib`. 
Not sure which approach is better but this should at least fix the builds.
CC @therealpxc #17578 #14921 #18209 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
