### PR TITLE
udiskie: 1.4.8 -> 1.5.1

### DIFF
--- a/pkgs/applications/misc/udiskie/default.nix
+++ b/pkgs/applications/misc/udiskie/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, asciidoc-full, gettext
+, gobjectIntrospection, gtk3, hicolor_icon_theme, libnotify
+, pythonPackages, udisks2, wrapGAppsHook }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "udiskie-${version}";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "coldfix";
+    repo = "udiskie";
+    rev = version;
+    sha256 = "01x5fvllb262x6r3547l23z7p6hr7ddz034bkhmj2cqmf83sxwxd";
+  };
+
+  buildInputs = [
+    asciidoc-full        # For building man page.
+    hicolor_icon_theme
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    gettext gobjectIntrospection gtk3 libnotify pythonPackages.docopt
+    pythonPackages.pygobject3 pythonPackages.pyyaml udisks2
+  ];
+
+  postBuild = "make -C doc";
+
+  postInstall = ''
+    mkdir -p $out/share/man/man8
+    cp -v doc/udiskie.8 $out/share/man/man8/
+  '';
+
+  # tests require dbusmock
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Removable disk automounter for udisks";
+    license = licenses.mit;
+    homepage = https://github.com/coldfix/udiskie;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14672,6 +14672,8 @@ in
 
   udevil = callPackage ../applications/misc/udevil {};
 
+  udiskie = callPackage ../applications/misc/udiskie { };
+
   sakura = callPackage ../applications/misc/sakura {
     vte = gnome3.vte;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27136,6 +27136,8 @@ in modules // {
 
     buildInputs = [
       pkgs.asciidoc-full        # For building man page.
+      pkgs.hicolor_icon_theme
+      pkgs.wrapGAppsHook
     ];
 
     propagatedBuildInputs = with self; [ pkgs.gobjectIntrospection pkgs.gtk3 pyyaml pygobject3 pkgs.libnotify pkgs.udisks2 pkgs.gettext self.docopt ];
@@ -27145,11 +27147,6 @@ in modules // {
     postInstall = ''
       mkdir -p $out/share/man/man8
       cp -v doc/udiskie.8 $out/share/man/man8/
-    '';
-
-    preFixup = ''
-        wrapProgram "$out/bin/"* \
-          --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
     '';
 
     # tests require dbusmock

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27121,49 +27121,8 @@ in modules // {
     };
   };
 
-  udiskie = buildPythonApplication rec {
-    version = "1.5.1";
-    name = "udiskie-${version}";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "coldfix";
-      repo = "udiskie";
-      rev = version;
-      sha256 = "01x5fvllb262x6r3547l23z7p6hr7ddz034bkhmj2cqmf83sxwxd";
-    };
-
-    preConfigure = ''
-      export XDG_RUNTIME_DIR=/tmp
-    '';
-
-    buildInputs = [
-      pkgs.asciidoc-full        # For building man page.
-      pkgs.hicolor_icon_theme
-      pkgs.wrapGAppsHook
-    ];
-
-    propagatedBuildInputs = with self; [
-      pkgs.gobjectIntrospection pkgs.gtk3 pyyaml pygobject3
-      pkgs.libnotify pkgs.udisks2 pkgs.gettext self.docopt
-    ];
-
-    postBuild = "make -C doc";
-
-    postInstall = ''
-      mkdir -p $out/share/man/man8
-      cp -v doc/udiskie.8 $out/share/man/man8/
-    '';
-
-    # tests require dbusmock
-    doCheck = false;
-
-    meta = {
-      description = "Removable disk automounter for udisks";
-      license = licenses.mit;
-      homepage = https://github.com/coldfix/udiskie;
-      maintainers = with maintainers; [ AndersonTorres ];
-    };
-  };
+  # For backwards compatibility. Please use nixpkgs.udiskie instead.
+  udiskie = pkgs.udiskie.override { pythonPackages = self; };
 
   # Should be bumped along with EFL!
   pythonefl = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27121,13 +27121,15 @@ in modules // {
     };
   };
 
-  udiskie = buildPythonPackage rec {
-    version = "1.4.8";
+  udiskie = buildPythonApplication rec {
+    version = "1.5.1";
     name = "udiskie-${version}";
 
-    src = pkgs.fetchurl {
-      url = "https://github.com/coldfix/udiskie/archive/${version}.tar.gz";
-      sha256 = "0fj1kh6pmwyyy54ybc5fa625lhrxzhzmfx1nwz2lym5cpm4b21fl";
+    src = pkgs.fetchFromGitHub {
+      owner = "coldfix";
+      repo = "udiskie";
+      rev = version;
+      sha256 = "01x5fvllb262x6r3547l23z7p6hr7ddz034bkhmj2cqmf83sxwxd";
     };
 
     preConfigure = ''
@@ -27140,7 +27142,10 @@ in modules // {
       pkgs.wrapGAppsHook
     ];
 
-    propagatedBuildInputs = with self; [ pkgs.gobjectIntrospection pkgs.gtk3 pyyaml pygobject3 pkgs.libnotify pkgs.udisks2 pkgs.gettext self.docopt ];
+    propagatedBuildInputs = with self; [
+      pkgs.gobjectIntrospection pkgs.gtk3 pyyaml pygobject3
+      pkgs.libnotify pkgs.udisks2 pkgs.gettext self.docopt
+    ];
 
     postBuild = "make -C doc";
 


### PR DESCRIPTION
###### Motivation for this change

Version bump and use of GApps wrapper and icon hooks. Unfortunately, despite the use of gapps wrapper I still get some missing icons in the tray menu.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
