### PR TITLE
shared-mime-info: 1.5 -> 1.7

### DIFF
--- a/pkgs/data/misc/shared-mime-info/default.nix
+++ b/pkgs/data/misc/shared-mime-info/default.nix
@@ -1,13 +1,13 @@
 {stdenv, fetchurl, pkgconfig, gettext, perl, perlXMLParser, intltool
 , libxml2, glib}:
 
-let version = "1.5"; in
+let version = "1.7"; in
 stdenv.mkDerivation rec {
   name = "shared-mime-info-${version}";
 
   src = fetchurl {
     url = "http://freedesktop.org/~hadess/${name}.tar.xz";
-    sha256 = "1021x95xbkfc5ipx3gi2rdc0y6x2pv36yyzxc5pg6nr6xd02hhfn";
+    sha256 = "0bjd2j1rqrj150mr04j7ib71lfdlgbf235fg8d70g8mszqf7ik7a";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update shared-mime-info to the last version
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
