### PR TITLE
[WIP] Money-Manager-Ex: 0.9.5.1 -> 1.2.7

### DIFF
--- a/pkgs/applications/office/mmex/default.nix
+++ b/pkgs/applications/office/mmex/default.nix
@@ -1,16 +1,16 @@
-# To use this program, copy all that is in $out/opt/mmax into a writable directory,
-# and run it from there. This is the intended usage, as far as I understand.
+{ stdenv, fetchgit, sqlite, wxGTK30, gettext }:
 
-{ fetchsvn, stdenv, wxGTK }:
 
-let version = "0.9.5.1";
+let
+  version = "1.2.7";
 in
   stdenv.mkDerivation {
     name = "money-manager-ex-${version}";
 
-    src = fetchsvn {
-      url = "https://moneymanagerex.svn.sourceforge.net/svnroot/moneymanagerex/tags/releases/${version}";
-      sha256 = "0mby1p01fyxk5pgd7h3919q91r10zbfk16rfz1kbchqxqz87x4jq";
+    src = fetchgit {
+      url = "https://github.com/moneymanagerex/moneymanagerex.git";
+      rev = "refs/tags/v${version}";
+      sha256 = "0d6jcsj3m3b9mj68vfwr7dn67dws11p0pdys3spyyiv1464vmywi";
     };
 
     preConfigure = ''
@@ -18,19 +18,13 @@ in
       export CXXFLAGS="$CFLAGS"
     '';
 
-    installPhase = ''
-      mkdir -p $out/opt/mmex
-      cp -r mmex runtime/{*.txt,*.png,*.db3,en,help,*.wav,*.ico} $out/opt/mmex
-    '';
-
-    buildInputs = [ wxGTK ];
+    buildInputs = [ sqlite wxGTK30 gettext ];
 
     meta = {
       description = "Easy-to-use personal finance software";
-      homepage = http://www.codelathe.com/mmex;
+      homepage = http://www.moneymanagerex.org/;
       license = stdenv.lib.licenses.gpl2Plus;
       maintainers = with stdenv.lib.maintainers; [viric];
       platforms = with stdenv.lib.platforms; linux;
-      broken = true;
     };
   }

--- a/pkgs/development/libraries/wxGTK-3.0/default.nix
+++ b/pkgs/development/libraries/wxGTK-3.0/default.nix
@@ -1,9 +1,12 @@
 { stdenv, fetchurl, pkgconfig, gtk, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
 , gstreamer, gst_plugins_base, GConf, setfile
-, withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true,
+, withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true
+, withWebKit ? false, webkitgtk2 ? null
 }:
 
+
 assert withMesa -> mesa != null;
+assert withWebKit -> webkitgtk2 != null;
 
 with stdenv.lib;
 
@@ -22,6 +25,7 @@ stdenv.mkDerivation {
     [ gtk libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer
       gst_plugins_base GConf ]
     ++ optional withMesa mesa
+    ++ optional withWebKit webkitgtk2
     ++ optional stdenv.isDarwin setfile;
 
   nativeBuildInputs = [ pkgconfig ];
@@ -34,7 +38,9 @@ stdenv.mkDerivation {
     ++ optional withMesa "--with-opengl"
     ++ optionals stdenv.isDarwin
       # allow building on 64-bit
-      [ "--with-cocoa" "--enable-universal-binaries" ];
+      [ "--with-cocoa" "--enable-universal-binaries" ]
+    ++ optionals withWebKit
+      ["--enable-webview" "--enable-webview-webkit"];
 
   SEARCH_LIB = optionalString withMesa "${mesa}/lib";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14011,7 +14011,9 @@ in
 
   MMA = callPackage ../applications/audio/MMA { };
 
-  mmex = callPackage ../applications/office/mmex { };
+  mmex = callPackage ../applications/office/mmex {
+    wxGTK30 = wxGTK30.override { withWebKit  = true ; };
+  };
 
   moc = callPackage ../applications/audio/moc {
     ffmpeg = ffmpeg_2;


### PR DESCRIPTION
###### Roadmap
- [X] Ensure that `GTK30.withWebKit = true` is set for mmex's build.
###### Motivation for this change

Money-Manager-Ex has been broken (https://github.com/NixOS/nixpkgs/issues/9424) for several months now. 
Money-Manager-Ex depends on wxWidgets-3 compiled with WebView so GTK30 also needed to be modified. 
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
