### PR TITLE
haskellPackages.hasktags: remove bin/test

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -991,4 +991,8 @@ self: super: {
   # https://bitbucket.org/ssaasen/spy/pull-requests/3/fsnotify-dropped-system-filepath
   spy = appendPatch super.spy ./patches/spy.patch;
 
+  hasktags = overrideCabal super.hasktags (drv: {
+    postFixup = "rm $out/bin/test";
+  });
+
 }


### PR DESCRIPTION
I had `haskellPackages.hasktags` installed in my nix profile, which [caused some confusion](https://github.com/fish-shell/fish-shell/issues/3359) when I switched to the NixOS 16.09 channel where the Hasktags package apparently produces a `test` executable that can shadow the `test` program from coreutils.

This PR removes that executable from `hasktags`'s `bin` output.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
