### PR TITLE
bcc: install documentation not as executable

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -17,17 +17,18 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags="-DBCC_KERNEL_MODULES_DIR=${kernel.dev}/lib/modules -DBCC_KERNEL_HAS_SOURCE_DIR=1";
-    
+
   postInstall = ''
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/share/doc
+    mv $out/share/bcc/tools/doc/*.txt $out/share/doc
     for f in $out/share/bcc/tools\/*; do
-      ln -s $f $out/bin/$(basename $f) 
+      ln -s $f $out/bin/$(basename $f)
       wrapProgram $f \
         --prefix LD_LIBRARY_PATH : $out/lib \
         --prefix PYTHONPATH : $out/lib/python2.7/site-packages \
         --prefix PYTHONPATH : :${pythonPackages.netaddr}/lib/${python.libPrefix}/site-packages
     done
-  '';  
+  '';
 
   meta = with stdenv.lib; {
     description = "Dynamic Tracing Tools for Linux";


### PR DESCRIPTION
###### Motivation for this change

in bcc/tools documentation was wrapped as executable
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
