### PR TITLE
antimicro: 2.18.2 -> 2.22, use new official repository

### DIFF
--- a/pkgs/tools/misc/antimicro/default.nix
+++ b/pkgs/tools/misc/antimicro/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "antimicro-${version}";
-  version = "2.18.2";
+  version = "2.22";
 
   src = fetchFromGitHub {
-    owner = "7185";
+    owner = "AntiMicro";
     repo = "antimicro";
     rev = "${version}";
-    sha256 = "1mqw5idn57yj6c1w8y0byzh0xafcpbhaa6czgljh206abwfixjmk";
+    sha256 = "102fh9ysd2dmfc6b73bj88m064jhlglqrz2gd7k9jccadxpbp3mq";
   };
 
   buildInputs = [
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GUI for mapping keyboard and mouse controls to a gamepad";
-    homepage = "https://github.com/Ryochan7/antimicro";
+    inherit (src.meta) homepage;
     maintainers = with maintainers; [ jb55 ];
     license = licenses.gpl3;
     platforms = with platforms; linux;


### PR DESCRIPTION
###### Motivation for this change
- new version
- antimicro community has settled for a common repository
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
