### PR TITLE
radicale service: use "simple" service type

### DIFF
--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -52,8 +52,7 @@ in
       description = "A Simple Calendar and Contact Server";
       after = [ "network-interfaces.target" ];
       wantedBy = [ "multi-user.target" ];
-      script = "${pkgs.pythonPackages.radicale}/bin/radicale -C ${confFile} -d";
-      serviceConfig.Type = "forking";
+      script = "${pkgs.pythonPackages.radicale}/bin/radicale -C ${confFile} -f";
       serviceConfig.User = "radicale";
       serviceConfig.Group = "radicale";
     };


### PR DESCRIPTION
This makes Radicale logging visible through the systemd journal by default. Running Radicale using `-f` (= foreground) makes it emit logging on stdout where systemd will capture it.
