### PR TITLE
Qt 5.7 fixes

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -76,5 +76,9 @@ stdenv.mkDerivation rec {
     homepage = http://www.videolan.org/vlc/;
     platforms = platforms.linux;
     license = licenses.lgpl21Plus;
+    broken =
+      if withQt5
+      then builtins.compareVersions qtbase.version "5.7.0" >= 0
+      else false;
   };
 }

--- a/pkgs/development/libraries/mlt/qt-5.nix
+++ b/pkgs/development/libraries/mlt/qt-5.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     "--enable-opengl"
   ];
 
+  CXXFLAGS = "-std=c++11";
+
   enableParallelBuilding = true;
 
   postInstall = ''

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-DQT_NO_DEBUG" ];
 
+  CXXFLAGS = lib.optional qt5Support "-std=c++11";
+
   configureFlags = with lib;
     [
       "--enable-xpdf-headers"


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
