### PR TITLE
pamix: init at 1.4.1

### DIFF
--- a/pkgs/applications/audio/pamix/default.nix
+++ b/pkgs/applications/audio/pamix/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub
+, autoreconfHook, autoconf-archive, pkgconfig
+, libpulseaudio, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "pamix-${version}";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner  = "patroclos";
+    repo   = "pamix";
+    rev    = "v${version}";
+    sha256 = "06pxpalzynb8z7qwhkfs7sj823k9chdmpyj40rp27f2znf2qga19";
+  };
+
+  nativeBuildInputs = [ autoreconfHook autoconf-archive pkgconfig ];
+  buildInputs = [ libpulseaudio ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "Pulseaudio terminal mixer";
+    homepage    = https://github.com/patroclos/PAmix;
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ericsagnes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14226,6 +14226,8 @@ in
 
   osmo = callPackage ../applications/office/osmo { };
 
+  pamix = callPackage ../applications/audio/pamix { };
+
   pamixer = callPackage ../applications/audio/pamixer { };
 
   pan = callPackage ../applications/networking/newsreaders/pan {


### PR DESCRIPTION
###### Motivation for this change

Adding [pamix](https://github.com/patroclos/PAmix) to nixpkgs.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
