### PR TITLE
plex: remove plexpass

### DIFF
--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -1,14 +1,9 @@
 { stdenv, fetchurl, rpmextract, glibc
 , dataDir ? "/var/lib/plex" # Plex's data directory must be baked into the package due to symlinks.
-, enablePlexPass ? false
 }:
 
 let
-  plexpkg = if enablePlexPass then {
-    version = "1.0.1.2396";
-    vsnHash = "c094d0d";
-    sha256 = "0bhbpaj88989zn1q590mkcqshcpir87yiac9x1dl0afzpxj09lcz";
-  } else {
+  plexpkg = {
     version = "1.0.0.2261";
     vsnHash = "a17e99e";
     sha256 = "14li33ni6aaa1qwvc02a066k52s1qwhpv55prvlmq3m5jm3iv0lr";


### PR DESCRIPTION
###### Motivation for this change

Plex has emailed @thoughtpolice and I asking that links to their Plex Pass downloads be removed.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
# NOTE: I'm not running NixOS anywhere so I can't validate this change.
