### PR TITLE
txt2man: enable darwin platform

### DIFF
--- a/pkgs/tools/misc/txt2man/default.nix
+++ b/pkgs/tools/misc/txt2man/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     description = "Convert flat ASCII text to man page format";
     homepage = http://mvertes.free.fr/;
     license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     maintainers = with stdenv.lib.maintainers; [ bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested on Mac OS X 10.10, Nix 1.11.4 with:

```
nix-build -A txt2man
result/txt2man
```
