### PR TITLE
rustracer: 1.2.10 -> 1.2.10-master-160831

### DIFF
--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -4,15 +4,15 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "racer-${version}";
-  version = "1.2.10";
+  version = "1.2.10-master-160831";
   src = fetchFromGitHub {
     owner = "phildawes";
     repo = "racer";
-    rev = "e5ffe9efc1d10d4a7d66944b4c0939b7c575530e";
-    sha256 = "1cvgd6gcwb82p387h4wl8wz07z64is8jrihmf2z84vxmlrasmprm";
+    rev = "a1ebc93b96e80ab62d830c32d5446b9f43eb6d30";
+    sha256 = "1vv4kziha4jbhnfmk8pcalb5dwiga7p1a2qfyf5yinx998g6rdpd";
   };
 
-  depsSha256 = "1d44q7hfxijn40q7y6xawgd3c91i90fmd1dyx7i2v9as29js5694";
+  depsSha256 = "0f8wj76yrxzizk8z3zffwqrz52waf2vl9qschma6ndidqbbpxwf7";
 
   buildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change

update rust racer so that rustdt works
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
