### PR TITLE
rainicorn: init at 1.0.0

### DIFF
--- a/pkgs/development/tools/rust/rainicorn/default.nix
+++ b/pkgs/development/tools/rust/rainicorn/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "rainicorn-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "RustDT";
+    repo = "Rainicorn";
+    rev = "0f8594079a7f302f4940cc4320f5e4f39f95cdc4";
+    sha256 = "07vh4g120sx569wkzclq91blkkd7q7z582pl8vz0li1l9ij8md01";
+  };
+
+  depsSha256 = "1ckrf77s1glrqi0gvrv9wqmip4i97dk0arn0iz87jg4q2wfss85k";
+
+  meta = with stdenv.lib; {
+    description = "Rust IDEs.  parse-analysis";
+    homepage = https://github.com/RustDT/Rainicorn;
+    license = with licenses; [ mit asl20 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5554,6 +5554,7 @@ in
       };
     });
 
+  rainicorn = callPackage ../development/tools/rust/rainicorn { };
   rustfmt = callPackage ../development/tools/rust/rustfmt { };
   rustracer = callPackage ../development/tools/rust/racer { };
   rustracerd = callPackage ../development/tools/rust/racerd { };


### PR DESCRIPTION
###### Motivation for this change

add ranicor for rustdt
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
