### PR TITLE
eclipse-cpp: 4.5.1 -> 4.6.0

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -199,6 +199,24 @@ rec {
   };
   eclipse_cpp_45 = eclipse-cpp-45; # backward compatibility, added 2016-01-30
 
+  eclipse-cpp-46 = buildEclipse {
+    name = "eclipse-cpp-4.6.0";
+    description = "Eclipse IDE for C/C++ Developers, Neon release";
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk-x86_64.tar.gz;
+          sha256 = "09fqsgvbjfdqvn7z03crkii34z4bsb34y272q68ib8741bxk0i6m";
+        }
+      else if stdenv.system == "i686-linux" then
+        fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk.tar.gz;
+          sha256 = "0ed94a7a2bccc530f32c491b7282f261cbb1e431b7369c9a8e976248f71cbd11339598b6cf3c8a047f17d1b11ee94a28cf2e1a51e354562926b4d3f0ee08b24e";
+        }
+      else throw "Unsupported system: ${stdenv.system}";
+  };
+  eclipse_cpp_46 = eclipse-cpp-46; # backward compatibility
+
   eclipse-sdk-421 = buildEclipse {
     name = "eclipse-sdk-4.2.1";
     description = "Eclipse Classic";


### PR DESCRIPTION
###### Motivation for this change

update eclipse-cpp for rustdt (needs cdt 9.0)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
