### PR TITLE
buildImage: fix add / to end of source cp to resolve any softlinks

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -165,7 +165,7 @@ EOF
       if [ -n "$contents" ]; then
         echo Adding contents
         for c in $contents; do
-          cp -drf $c/* layer/
+          cp -drf $c/*/ layer/
           chmod -R ug+w layer/
         done
       fi
@@ -193,7 +193,7 @@ EOF
       preMount = lib.optionalString (contents != null) ''
         echo Adding contents
         for c in ${builtins.toString contents}; do
-          cp -drf $c/* layer/
+          cp -drf $c/*/ layer/
           chmod -R ug+w layer/
         done
       '';


### PR DESCRIPTION
###### Motivation for this change

docker buildImage fails if multiple packages attempt to copy a symlink added a / to end of source of cp 

e.g

```
with import  <nixpkgs> {};
with dockerTools;
with pkgs;

let
  rustDtImage = buildImage {
    name = "ppickfor/nix-rustdt";
    contents = [
      rustc
      rustfmt
      rustracer
      cargo
      rainicorn
      eclipses.eclipse-rustdt
      xorg.fontadobe100dpi.out
      fontconfig.out
      fontconfig.bin
      findutils
      coreutils
      bash
      less
      moreutils
      gnugrep
    ];
     /*
     runAsRoot = ''
        #!${stdenv.shell}
        mkdir /tmp
        chmod a=rwx,o+t /tmp
      '';
      */
  };
in {
  rustDtDocker = rustDtImage;
}
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
