### PR TITLE
eclipse-rustdt: init at 0.6.2-master-160728

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -438,6 +438,12 @@ rec {
         ln -s ${eclipse}/share $out/
       '';
 
+  eclipse-rustdt = with plugins; eclipseWithPlugins {
+    eclipse = eclipse-cpp-46;
+    jvmArgs = [ "-Xmx2048m" ];
+    plugins = [ rustdt ];
+  };
+
   plugins = callPackage ./plugins.nix { };
 
 }


### PR DESCRIPTION
###### Motivation for this change

package for eclipse with rust-dt
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
