### PR TITLE
txt2man: mention runtime dependencies on gawk and coreutils

### DIFF
--- a/pkgs/tools/misc/txt2man/default.nix
+++ b/pkgs/tools/misc/txt2man/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, coreutils, gawk }:
 
 stdenv.mkDerivation rec {
   name = "txt2man-1.5.6";
@@ -12,7 +12,27 @@ stdenv.mkDerivation rec {
     makeFlags=prefix="$out"
   '';
 
-  meta = { 
+  patchPhase = ''
+    for f in bookman src2man txt2man; do
+        substituteInPlace $f --replace "gawk" "${gawk}/bin/gawk"
+
+        substituteInPlace $f --replace "(date" "(${coreutils}/bin/date"
+        substituteInPlace $f --replace "=cat" "=${coreutils}/bin/cat"
+        substituteInPlace $f --replace "cat <<" "${coreutils}/bin/cat <<"
+        substituteInPlace $f --replace "expand" "${coreutils}/bin/expand"
+        substituteInPlace $f --replace "(uname" "(${coreutils}/bin/uname"
+    done
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    # gawk and coreutils are part of stdenv but will not
+    # necessarily be in PATH at runtime.
+    sh -c 'unset PATH; printf hello | ./txt2man'
+  '';
+
+  meta = {
     description = "Convert flat ASCII text to man page format";
     homepage = http://mvertes.free.fr/;
     license = stdenv.lib.licenses.gpl2;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The commit message in 1a2b47463b45c2b05ec80ade28781afc986576af is
incorrect -- the package seemed to work because only the help message
was invoked:

```
result/bin/txt2man -h
```

To guard against such trivial successes, this commit introduces a
test.
