### PR TITLE
influxdb test: fix

### DIFF
--- a/nixos/tests/influxdb.nix
+++ b/nixos/tests/influxdb.nix
@@ -22,18 +22,15 @@ import ./make-test.nix ({ pkgs, ...} : {
 
     # create database
     $one->succeed(q~
-      curl -X POST 'http://localhost:8086/db?u=root&p=root' \
-        -d '{"name": "test"}'
+      curl -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE test"
     ~);
 
     # write some points and run simple query
     $one->succeed(q~
-      curl -X POST 'http://localhost:8086/db/test/series?u=root&p=root' \
-        -d '[{"name":"foo","columns":["val"],"points":[[6666]]}]'
+      curl -XPOST 'http://localhost:8086/write?db=test' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
     ~);
     $one->succeed(q~
-      curl -G 'http://localhost:8086/db/test/series?u=root&p=root' \
-        --data-urlencode 'q=select * from foo limit 1' | grep 6666
+      curl -GET 'http://localhost:8086/query' --data-urlencode "db=test" --data-urlencode "q=SELECT \"value\" FROM \"cpu_load_short\" WHERE \"region\"='us-west'"  | grep "0\.64"
     ~);
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Update influxdb test commands.
Data from the [documentation example](https://docs.influxdata.com/influxdb/v1.0/guides/writing_data/) was used.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @offlinehacker 
