### PR TITLE
iproute2: 4.5.0 -> 4.7.0

### DIFF
--- a/pkgs/os-specific/linux/iproute/1000-ubuntu-poc-fan-driver.patch
+++ b/pkgs/os-specific/linux/iproute/1000-ubuntu-poc-fan-driver.patch
@@ -57,7 +57,7 @@ Index: iproute2-4.1.1/ip/link_iptnl.c
 +
 +		if (addr)
 +			fprintf(f, "underlay %s ",
-+				format_host(AF_INET, 4, &addr, s1, sizeof(s1)));
++				format_host_r(AF_INET, 4, &addr, s1, sizeof(s1)));
 +	}
 +
  	if (tb[IFLA_IPTUN_LINK] && rta_getattr_u32(tb[IFLA_IPTUN_LINK])) {

--- a/pkgs/os-specific/linux/iproute/1001-ubuntu-poc-fan-driver-v3.patch
+++ b/pkgs/os-specific/linux/iproute/1001-ubuntu-poc-fan-driver-v3.patch
@@ -111,9 +111,9 @@ Index: iproute2-4.1.1/ip/link_iptnl.c
 +		p = RTA_PAYLOAD(i);
 +		m = RTA_DATA(i);
 +		fprintf(f, "%s/%d:%s/%d ",
-+			rt_addr_n2a(AF_INET, p, &m->overlay, b1, INET_ADDRSTRLEN),
++			rt_addr_n2a_r(AF_INET, p, &m->overlay, b1, INET_ADDRSTRLEN),
 +			m->overlay_prefix,
-+			rt_addr_n2a(AF_INET, p, &m->underlay, b2, INET_ADDRSTRLEN),
++			rt_addr_n2a_r(AF_INET, p, &m->underlay, b2, INET_ADDRSTRLEN),
 +			m->underlay_prefix);
 +	}
 +}

--- a/pkgs/os-specific/linux/iproute/1002-ubuntu-poc-fan-driver-vxlan.patch
+++ b/pkgs/os-specific/linux/iproute/1002-ubuntu-poc-fan-driver-vxlan.patch
@@ -6,9 +6,9 @@ Index: iproute2-4.3.0/include/linux/if_link.h
 --- iproute2-4.3.0.orig/include/linux/if_link.h
 +++ iproute2-4.3.0/include/linux/if_link.h
 @@ -392,6 +392,7 @@ enum {
- 	IFLA_VXLAN_GBP,
- 	IFLA_VXLAN_REMCSUM_NOPARTIAL,
  	IFLA_VXLAN_COLLECT_METADATA,
+ 	IFLA_VXLAN_LABEL,
+ 	IFLA_VXLAN_GPE,
 +	IFLA_VXLAN_FAN_MAP = 33,
  	__IFLA_VXLAN_MAX
  };
@@ -88,9 +88,9 @@ Index: iproute2-4.3.0/ip/iplink_vxlan.c
  			  struct nlmsghdr *n)
  {
 @@ -201,6 +243,10 @@ static int vxlan_parse_opt(struct link_u
- 			udp6zerocsumrx = 0;
- 		} else if (!matches(*argv, "gbp")) {
  			gbp = 1;
+ 		} else if (!matches(*argv, "gpe")) {
+ 			gpe = 1;
 +		} else if (!matches(*argv, "fan-map")) {
 +			NEXT_ARG();
 +			if (fan_parse_map(&argc, &argv, n))
@@ -117,9 +117,9 @@ Index: iproute2-4.3.0/ip/iplink_vxlan.c
 +		p = RTA_PAYLOAD(i);
 +		m = RTA_DATA(i);
 +		fprintf(f, "%s/%d:%s/%d ",
-+			rt_addr_n2a(AF_INET, p, &m->overlay, b1, INET_ADDRSTRLEN),
++			rt_addr_n2a_r(AF_INET, p, &m->overlay, b1, INET_ADDRSTRLEN),
 +			m->overlay_prefix,
-+			rt_addr_n2a(AF_INET, p, &m->underlay, b2, INET_ADDRSTRLEN),
++			rt_addr_n2a_r(AF_INET, p, &m->underlay, b2, INET_ADDRSTRLEN),
 +			m->underlay_prefix);
 +	}
 +}

--- a/pkgs/os-specific/linux/iproute/default.nix
+++ b/pkgs/os-specific/linux/iproute/default.nix
@@ -3,11 +3,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "iproute2-4.5.0";
+  name = "iproute2-${version}";
+  version = "4.7.0";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/net/iproute2/${name}.tar.xz";
-    sha256 = "0jj9phsi8m2sbnz7bbh9cf9vckm67hs62ab5srdwnrg4acpjj59z";
+    sha256 = "14kvpdlxq8204f5ayfdfb6mc0423mbf3px9q0spdly9sng7xnq4g";
   };
 
   patches = lib.optionals enableFan [
@@ -28,6 +29,7 @@ stdenv.mkDerivation rec {
     "LIBDIR=$(out)/lib"
     "SBINDIR=$(out)/sbin"
     "MANDIR=$(out)/share/man"
+    "BASH_COMPDIR=$(out)/share/bash-completion/completions/iproute2"
     "DOCDIR=$(TMPDIR)/share/doc/${name}" # Don't install docs
   ];
 


### PR DESCRIPTION
###### Motivation for this change

New version available
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

iproute now packages a bash-completion file which it installs to
$BASH_COMPDIR.
