### PR TITLE
wireshark: 2.0.5 -> 2.2.0

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -11,7 +11,7 @@ assert withQt -> !withGtk && qt4 != null;
 with stdenv.lib;
 
 let
-  version = "2.0.5";
+  version = "2.2.0";
   variant = if withGtk then "gtk" else if withQt then "qt" else "cli";
 in
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.bz2";
-    sha256 = "02xi3fz8blcz9cf75rs11g7bijk06wm45vpgnksp72c2609j9q0c";
+    sha256 = "010i7wpsv2231pwb1xdqs0xfwywi3514siidv6wnrfpw3rs7x156";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

There are issues related in the 2.0.5 release (see commit message for bultins).
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Release note:
https://www.wireshark.org/docs/relnotes/wireshark-2.2.0.html

Security related annonces related to 2.0.5 (subject to denial of
service attack):

https://www.wireshark.org/security/wnpa-sec-2016-50.html
https://www.wireshark.org/security/wnpa-sec-2016-51.html
https://www.wireshark.org/security/wnpa-sec-2016-52.html
https://www.wireshark.org/security/wnpa-sec-2016-53.html
https://www.wireshark.org/security/wnpa-sec-2016-54.html
https://www.wireshark.org/security/wnpa-sec-2016-55.html
