### PR TITLE
keepasshttp: init at 1.8.4.1

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keepasshttp/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keepasshttp/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildEnv, fetchFromGitHub, mono }:
+
+let
+  version = "1.8.4.1";
+  drv = stdenv.mkDerivation {
+    name = "keepasshttp-${version}";
+    src = fetchFromGitHub {
+      owner = "pfn";
+      repo = "keepasshttp";
+      rev = "${version}";
+      sha256 = "1074yv0pmzdwfwkx9fh7n2igdqwsyxypv55khkyng6synbv2p2fd";
+    };
+
+    meta = {
+      description = "KeePass plugin to expose password entries securely (256bit AES/CBC) over HTTP";
+      homepage    = https://github.com/pfn/keepasshttp;
+      platforms   = with stdenv.lib.platforms; linux;
+      license     = stdenv.lib.licenses.gpl3;
+    };
+
+    pluginFilename = "KeePassHttp.plgx";
+
+    installPhase = ''
+      mkdir -p $out/lib/dotnet/keepass/
+      cp $pluginFilename $out/lib/dotnet/keepass/$pluginFilename
+    '';
+  };
+in
+  # Mono is required to compile plugin at runtime, after loading.
+  buildEnv { name = drv.name; paths = [ mono drv ]; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13089,6 +13089,8 @@ in
 
   keepass-keefox = callPackage ../applications/misc/keepass-plugins/keefox { };
 
+  keepass-keepasshttp = callPackage ../applications/misc/keepass-plugins/keepasshttp { };
+
   exrdisplay = callPackage ../applications/graphics/exrdisplay { };
 
   exrtools = callPackage ../applications/graphics/exrtools { };


### PR DESCRIPTION
###### Motivation for this change

keepasshttp is a plugin for KeePass
This package is based on the [keefox package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/keepass-plugins/keefox/default.nix)
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
