### PR TITLE
security.hidepid: enable by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1609.xml
+++ b/nixos/doc/manual/release-notes/rl-1609.xml
@@ -90,6 +90,12 @@ following incompatible changes:</para>
     Use <literal>security.audit.enable = true;</literal> to explicitly enable it.</para>
   </listitem>
 
+  <listitem>
+    <para>Process information hiding is now enabled by default.
+    Use <literal>security.hideProcessInformation.enable = false;</literal>
+    to explicitly disable it.</para>
+  </listitem>
+
 </itemizedlist>
 
 

--- a/nixos/modules/security/hidepid.nix
+++ b/nixos/modules/security/hidepid.nix
@@ -3,7 +3,9 @@ with lib;
 
 {
   options = {
-    security.hideProcessInformation = mkEnableOption "" // {
+    security.hideProcessInformation = mkOption {
+      default = true;
+      example = false;
       description = ''
         Restrict access to process information to the owning user.  Enabling
         this option implies, among other things, that command-line arguments
@@ -16,6 +18,7 @@ with lib;
         to its supplementary groups via
         <option>systemd.services.&lt;name?&gt;.serviceConfig.SupplementaryGroups</option>.
       '';
+      type = types.bool;
     };
   };
 

--- a/nixos/modules/security/hidepid.nix
+++ b/nixos/modules/security/hidepid.nix
@@ -3,18 +3,20 @@ with lib;
 
 {
   options = {
-    security.hideProcessInformation = mkEnableOption "" // { description = ''
-      Restrict access to process information to the owning user.  Enabling
-      this option implies, among other things, that command-line arguments
-      remain private.  This option is recommended for most systems, unless
-      there's a legitimate reason for allowing unprivileged users to inspect
-      the process information of other users.
+    security.hideProcessInformation = mkEnableOption "" // {
+      description = ''
+        Restrict access to process information to the owning user.  Enabling
+        this option implies, among other things, that command-line arguments
+        remain private.  This option is recommended for most systems, unless
+        there's a legitimate reason for allowing unprivileged users to inspect
+        the process information of other users.
 
-      Members of the group "proc" are exempt from process information hiding.
-      To allow a service to run without process information hiding, add "proc"
-      to its supplementary groups via
-      <option>systemd.services.&lt;name?&gt;.serviceConfig.SupplementaryGroups</option>.
-    ''; };
+        Members of the group "proc" are exempt from process information hiding.
+        To allow a service to run without process information hiding, add "proc"
+        to its supplementary groups via
+        <option>systemd.services.&lt;name?&gt;.serviceConfig.SupplementaryGroups</option>.
+      '';
+    };
   };
 
   config = mkIf config.security.hideProcessInformation {


### PR DESCRIPTION
###### Motivation for this change

The description states that this feature is recommended if there is no valid reason to disable it, so our default should follow this recommendation.
Since improved security is one major achievement of 16.09 I propose to add this to 16.09.

If there are objections against making this the default, we should adjust the description.
If there are only objections against getting this into 16.09 I can rewrite to 17.03.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @joachifm @edolstra 
