### PR TITLE
nixos manual: disable ipv6 per interface

### DIFF
--- a/nixos/doc/manual/configuration/ipv6-config.xml
+++ b/nixos/doc/manual/configuration/ipv6-config.xml
@@ -12,8 +12,15 @@ can disable IPv6 support globally by setting:
 
 <programlisting>
 networking.enableIPv6 = false;
-</programlisting>
+</programlisting></para>
 
+<para>You can disable IPv6 on a single interface using a normal sysctl (in this
+example, we use interface <varname>eth0</varname>):
+
+<programlisting>
+boot.kernel.sysctl."net.ipv6.conf.eth0.disable_ipv6" = true;
+</programlisting>
 </para>
+
 
 </section>


### PR DESCRIPTION
###### Motivation for this change

Someone asked a question on #13293 and an answer was provided. Just wanted to add it to the documentation :smile: 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
