### PR TITLE
cmocka: fix build for Darwin

### DIFF
--- a/pkgs/development/libraries/cmocka/default.nix
+++ b/pkgs/development/libraries/cmocka/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, cmake }:
+{ fetchurl, stdenv, cmake, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "cmocka-${version}";
@@ -8,6 +8,18 @@ stdenv.mkDerivation rec {
     url = "https://cmocka.org/files/1.0/cmocka-${version}.tar.xz";
     sha256 = "0fvm6rdalqcxckbddch8ycdw6n2ckldblv117n09chi2l7bm0q5k";
   };
+
+  patches = [
+    # This fixes the build for clang-3.7.0 and thus Darwin.
+    # See https://open.cryptomilk.org/issues/43 for more info.
+    #
+    # The patch is already merged to upstream, so it should be removed
+    # here on next release.
+    (fetchpatch {
+      url = "https://git.cryptomilk.org/projects/cmocka.git/patch/?id=1b595a80934fa95234fb290913cfe533f740d965";
+      sha256 = "1fg8xwb1mrrmw4dqa65ghnvgfdkpi0lv4j2gq0lm9ayvsi3v00vp";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -43,6 +55,6 @@ stdenv.mkDerivation rec {
 
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ kragniz ];
+    maintainers = with maintainers; [ kragniz rasendubi ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

See https://open.cryptomilk.org/issues/43 for upstream issue.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
