### PR TITLE
nginx module: update statsd, develkit, rtmp

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -121,10 +121,10 @@
 
   statsd = {
     src = fetchFromGitHub {
-      owner = "zebrafishlabs";
+      owner = "apcera";
       repo = "nginx-statsd";
-      rev = "b756a12abf110b9e36399ab7ede346d4bb86d691";
-      sha256 = "1psrb5v071idlplvbnaq904nlhqw1zrbw4aawfs278zcdmq67zn8";
+      rev = "2147d61dc31dd4865604be92349e6192a905d21a";
+      sha256 = "19s3kwjgf51jkwknh7cfi82p6kifl8rl146wxc3ijds12776ilsv";
     };
   };
 

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -15,8 +15,8 @@
     src = fetchFromGitHub {
       owner = "arut";
       repo = "nginx-rtmp-module";
-      rev = "v1.1.7";
-      sha256 = "0i0fa1znkj7cipy5nlkw4k40klhp9jzk28wxy2vrvd2jvh91x3ma";
+      rev = "v1.1.9";
+      sha256 = "19vqw1ba01m2wlncpycw9vj5n8741pv36hd3dy9jjdxwlzdjzyi5";
     };
   };
 

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -72,8 +72,8 @@
     src = fetchFromGitHub {
       owner = "simpl";
       repo = "ngx_devel_kit";
-      rev = "v0.2.19";
-      sha256 = "1cqcasp4lc6yq5pihfcdw4vp4wicngvdc3nqg3bg52r63c1qrz76";
+      rev = "v0.3.0";
+      sha256 = "1br1997zqsjcb1aqm6h6xmi5yx7akxk0qvk8wxc0fnvmyhgzxgx0";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

nginx statsd module doesn't build, the zebrafishlabs github repo seems dead -- switch to a working one

update ngx_devel_kit and rtmp to fix mainline build
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [X] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
