### PR TITLE
postgrey: init at 1.36

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -275,6 +275,7 @@
       prometheus = 255;
       telegraf = 256;
       gitlab-runner = 257;
+      postgrey = 258;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -520,6 +521,7 @@
       prometheus = 255;
       #telegraf = 256; # unused
       gitlab-runner = 257;
+      postgrey = 258;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -216,6 +216,7 @@
   ./services/mail/opensmtpd.nix
   ./services/mail/postfix.nix
   ./services/mail/postsrsd.nix
+  ./services/mail/postgrey.nix
   ./services/mail/spamassassin.nix
   ./services/mail/rspamd.nix
   ./services/mail/rmilter.nix

--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -7,21 +7,25 @@ with lib; let
 in {
 
   options = {
-    services.postgrey = {
+    services.postgrey = with types; {
       enable = mkOption {
+        type = bool;
         default = false;
         description = "Whether to run the Postgrey daemon";
       };
       inetAddr = mkOption {
+        type = nullOr string;
         default = null;
         example = "127.0.0.1";
         description = "The inet address to bind to. If none given, bind to /var/run/postgrey.sock";
       };
       inetPort = mkOption {
+        type = int;
         default = 10030;
         description = "The tcp port to bind to";
       };
       greylistText = mkOption {
+        type = string;
         default = "Greylisted for %%s seconds";
         description = "Response status text for greylisted messages";
       };

--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -1,0 +1,75 @@
+{ config, lib, pkgs, ... }:
+
+with lib; let
+
+  cfg = config.services.postgrey;
+
+in {
+
+  options = {
+    services.postgrey = {
+      enable = mkOption {
+        default = false;
+        description = "Whether to run the Postgrey daemon";
+      };
+      inetAddr = mkOption {
+        default = null;
+        example = "127.0.0.1";
+        description = "The inet address to bind to. If none given, bind to /var/run/postgrey.sock";
+      };
+      inetPort = mkOption {
+        default = 10030;
+        description = "The tcp port to bind to";
+      };
+      greylistText = mkOption {
+        default = "Greylisted for %%s seconds";
+        description = "Response status text for greylisted messages";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.postgrey ];
+
+    users = {
+      extraUsers = {
+        postgrey = {
+          description = "Postgrey Daemon";
+          uid = config.ids.uids.postgrey;
+          group = "postgrey";
+        };
+      };
+      extraGroups = {
+        postgrey = {
+          gid = config.ids.gids.postgrey;
+        };
+      };
+    };
+
+    systemd.services.postgrey = let
+      bind-flag = if isNull cfg.inetAddr then
+        "--unix=/var/run/postgrey.sock"
+      else
+        "--inet=${cfg.inetAddr}:${cfg.inetPort}";
+    in {
+      description = "Postfix Greylisting Service";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "postfix.service" ];
+      preStart = ''
+        mkdir -p /var/postgrey
+        chown postgrey:postgrey /var/postgrey
+        chmod 0770 /var/postgrey
+      '';
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = ''${pkgs.postgrey}/bin/postgrey ${bind-flag} --pidfile=/var/run/postgrey.pid --group=postgrey --user=postgrey --dbdir=/var/postgrey --greylist-text="${cfg.greylistText}"'';
+        Restart = "always";
+        RestartSec = 5;
+        TimeoutSec = 10;
+      };
+    };
+
+  };
+
+}

--- a/pkgs/servers/mail/postgrey/default.nix
+++ b/pkgs/servers/mail/postgrey/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, perl, perlPackages, lib, runCommand, postfix }:
+
+let
+    mk-perl-flags = inputs: lib.concatStringsSep " " (map (dep: "-I ${dep}/lib/perl5/site_perl") inputs);
+    postgrey-flags = mk-perl-flags (with perlPackages; [
+      NetServer BerkeleyDB DigestSHA1 NetAddrIP IOMultiplex
+    ]);
+    policy-test-flags = mk-perl-flags (with perlPackages; [
+      ParseSyslog
+    ]);
+    version = "1.36";
+    name = "postgrey-${version}";
+in runCommand name {
+  src = fetchurl {
+    url = "http://postgrey.schweikert.ch/pub/${name}.tar.gz";
+    sha256 = "09jzb246ki988389r9gryigriv9sravk40q75fih5n0q4p2ghax2";
+  };
+  meta = with stdenv.lib; {
+    description = "A postfix policy server to provide greylisting";
+    homepage = "https://postgrey.schweikert.ch/";
+    platforms = postfix.meta.platforms;
+    licenses = licenses.gpl2;
+  };
+} ''
+    mkdir -p $out/bin
+    cd $out
+    tar -xzf $src --strip-components=1
+    mv postgrey policy-test bin
+    sed -i -e "s,#!/usr/bin/perl -T,#!${perl}/bin/perl -T ${postgrey-flags}," \
+           -e "s#/etc/postfix#$out#" \
+        bin/postgrey
+    sed -i -e "s,#!/usr/bin/perl,#!${perl}/bin/perl ${policy-test-flags}," \
+        bin/policy-test
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9963,6 +9963,8 @@ in
   pfixtools = callPackage ../servers/mail/postfix/pfixtools.nix { };
   pflogsumm = callPackage ../servers/mail/postfix/pflogsumm.nix { };
 
+  postgrey = callPackage ../servers/mail/postgrey { };
+
   pshs = callPackage ../servers/http/pshs { };
 
   libpulseaudio = callPackage ../servers/pulseaudio { libOnly = true; };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6608,6 +6608,14 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
+  IOMultiplex = buildPerlPackage {
+    name = "IO-Multiplex-1.16";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/B/BB/BBB/IO-Multiplex-1.16.tar.gz;
+      sha256 = "74d22c44b5ad2e7190e2786e8a17d74bbf4cef89b4d1157ba33598b5a2720dad";
+    };
+  };
+  
   IOPager = buildPerlPackage {
     name = "IO-Pager-0.06";
     src = fetchurl {
@@ -9997,6 +10005,14 @@ let self = _self // overrides; _self = with self; {
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JT/JTBRAUN/${name}.tar.gz";
       sha256 = "11y6fpz4j6kdimyaz2a6ig0jz0x7csqslhxaipxnjqi5h85hy071";
+    };
+  };
+
+  ParseSyslog = buildPerlPackage {
+    name = "Parse-Syslog-1.10";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/D/DS/DSCHWEI/Parse-Syslog-1.10.tar.gz;
+      sha256 = "659a2145441ef36d9835decaf83da308fcd03f49138cb3d90928e8bfc9f139d9";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Provide a postgrey package and service to use in mail servers
###### Things done
- Built on platform(s)
  - [x] NixOS
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [ ] Provide tighter integration with the postfix service (in progress for a later PR)

---

also init `Parse::Syslog` and `IO::Multiplex` perl dependencies.
