### PR TITLE
add .overrideDerivation and .overrideAttrs to packages created with callPackages

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -106,11 +106,9 @@ rec {
     let
       f = if builtins.isFunction fn then fn else import fn;
       auto = builtins.intersectAttrs (builtins.functionArgs f) autoArgs;
-      finalArgs = auto // args;
-      pkgs = f finalArgs;
-      mkAttrOverridable = name: pkg: pkg // {
-        override = newArgs: mkAttrOverridable name (f (finalArgs // newArgs)).${name};
-      };
+      origArgs = auto // args;
+      pkgs = f origArgs;
+      mkAttrOverridable = name: pkg: makeOverridable (newArgs: (f newArgs).${name}) origArgs;
     in lib.mapAttrs mkAttrOverridable pkgs;
 
 


### PR DESCRIPTION
###### Motivation for this change

After I've change tomcat to `callPackages` in https://github.com/NixOS/nixpkgs/pull/18419 , I've noticed that `pkgs.tomcat8.overrideDerivation` attribute is lost. This PR is my (and @aneeshusa) vision on how to restore it.
###### Things done

[x] tested override and overrideDerivation for tomcat
[ ] tested everything else
