### PR TITLE
ocaml_4_03: init at 4.03.0

### DIFF
--- a/pkgs/development/compilers/ocaml/4.03.nix
+++ b/pkgs/development/compilers/ocaml/4.03.nix
@@ -1,0 +1,80 @@
+let
+  safeX11 = stdenv: !(stdenv.isArm || stdenv.isMips);
+in
+
+{ stdenv, fetchurl, ncurses, buildEnv, libX11, xproto, useX11 ? safeX11 stdenv }:
+
+assert useX11 -> !stdenv.isArm && !stdenv.isMips;
+
+let
+   useNativeCompilers = !stdenv.isMips;
+   inherit (stdenv.lib) optionals optionalString;
+in
+
+stdenv.mkDerivation rec {
+
+  x11env = buildEnv { name = "x11env"; paths = [libX11 xproto]; };
+  x11lib = x11env + "/lib";
+  x11inc = x11env + "/include";
+
+  name = "ocaml-4.03.0";
+
+  src = fetchurl {
+    url = "http://caml.inria.fr/pub/distrib/ocaml-4.03/${name}.tar.xz";
+    sha256 = "1qwwvy8nzd87hk8rd9sm667nppakiapnx4ypdwcrlnav2dz6kil3";
+  };
+
+  patches = [ ./ocamlbuild.patch ];
+
+  prefixKey = "-prefix ";
+  configureFlags = optionals useX11 [ "-x11lib" x11lib
+                                      "-x11include" x11inc ];
+
+  buildFlags = "world" + optionalString useNativeCompilers " bootstrap world.opt";
+  buildInputs = [ncurses] ++ optionals useX11 [ libX11 xproto ];
+  installTargets = "install" + optionalString useNativeCompilers " installopt";
+  preConfigure = ''
+    CAT=$(type -tp cat)
+    sed -e "s@/bin/cat@$CAT@" -i config/auto-aux/sharpbang
+  '';
+  postBuild = ''
+    mkdir -p $out/include
+    ln -sv $out/lib/ocaml/caml $out/include/caml
+  '';
+
+  passthru = {
+    nativeCompilers = useNativeCompilers;
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://caml.inria.fr/ocaml;
+    branch = "4.03";
+    license = with licenses; [
+      qpl /* compiler */
+      lgpl2 /* library */
+    ];
+    description = "Most popular variant of the Caml language";
+
+    longDescription =
+      ''
+        OCaml is the most popular variant of the Caml language.  From a
+        language standpoint, it extends the core Caml language with a
+        fully-fledged object-oriented layer, as well as a powerful module
+        system, all connected by a sound, polymorphic type system featuring
+        type inference.
+
+        The OCaml system is an industrial-strength implementation of this
+        language, featuring a high-performance native-code compiler (ocamlopt)
+        for 9 processor architectures (IA32, PowerPC, AMD64, Alpha, Sparc,
+        Mips, IA64, HPPA, StrongArm), as well as a bytecode compiler (ocamlc)
+        and an interactive read-eval-print loop (ocaml) for quick development
+        and portability.  The OCaml distribution includes a comprehensive
+        standard library, a replay debugger (ocamldebug), lexer (ocamllex) and
+        parser (ocamlyacc) generators, a pre-processor pretty-printer (camlp4)
+        and a documentation generator (ocamldoc).
+      '';
+
+    platforms = with platforms; linux ++ darwin;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5028,6 +5028,8 @@ in
 
   ocaml_4_02 = callPackage ../development/compilers/ocaml/4.02.nix { };
 
+  ocaml_4_03 = callPackage ../development/compilers/ocaml/4.03.nix { };
+
   orc = callPackage ../development/compilers/orc { };
 
   metaocaml_3_09 = callPackage ../development/compilers/ocaml/metaocaml-3.09.nix { };
@@ -7270,8 +7272,8 @@ in
     x265 = if stdenv.isDarwin then null else x265;
     xavs = if stdenv.isDarwin then null else xavs;
     inherit (darwin) CF;
-    inherit (darwin.apple_sdk.frameworks) 
-      Cocoa CoreServices CoreAudio AVFoundation MediaToolbox 
+    inherit (darwin.apple_sdk.frameworks)
+      Cocoa CoreServices CoreAudio AVFoundation MediaToolbox
       VideoDecodeAcceleration;
   };
 


### PR DESCRIPTION
###### Motivation for this change

flow needs ocaml 4.03 on Mac OS X. Copied nix expression for ocaml 4.02 and only changed the version.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
