### PR TITLE
Linux-kernel: Workaround for keyboard not working

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -203,6 +203,12 @@ in
         # Misc. stuff.
         "pcips2" "atkbd"
 
+        # Temporary fix for https://github.com/NixOS/nixpkgs/issues/18451
+        # Remove as soon as upstream gets fixed - marking it:
+        # TODO
+        # FIXME
+        "i8042"
+
         # To wait for SCSI devices to appear.
         "scsi_wait_scan"
 


### PR DESCRIPTION
###### Motivation for this change

fix keyboard not working because of missing module
###### Things done

works for me, as suggested in the archlinux and nixos threads:
https://github.com/NixOS/nixpkgs/issues/18451
https://bugs.archlinux.org/task/50700
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

…18451

remove after upstream gets fixed
