### PR TITLE
Update libyaml and pyyaml

### DIFF
--- a/pkgs/development/libraries/libyaml/default.nix
+++ b/pkgs/development/libraries/libyaml/default.nix
@@ -1,20 +1,14 @@
 { stdenv, fetchurl, fetchpatch }:
 let
-  version = "0.1.6";
+  version = "0.1.7";
 in
 stdenv.mkDerivation {
   name = "libyaml-${version}";
 
   src = fetchurl {
     url = "http://pyyaml.org/download/libyaml/yaml-${version}.tar.gz";
-    sha256 = "0j9731s5zjb8mjx7wzf6vh7bsqi38ay564x6s9nri2nh9cdrg9kx";
+    sha256 = "0a87931cx5m14a1x8rbjix3nz7agrcgndf4h392vm62a4rby9240";
   };
-
-  patches = [(fetchpatch {
-    name = "CVE-2014-9130.diff";
-    url = "http://bitbucket.org/xi/libyaml/commits/2b915675/raw/";
-    sha256 = "1vrkga2wk060wccg61c2mj5prcyv181qikgdfi1z4hz8ygmpvl04";
-  })];
 
   meta = with stdenv.lib; {
     homepage = http://pyyaml.org/;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20486,11 +20486,11 @@ in modules // {
 
 
   pyyaml = buildPythonPackage (rec {
-    name = "PyYAML-3.11";
+    name = "PyYAML-3.12";
 
     src = pkgs.fetchurl {
       url = "http://pyyaml.org/download/pyyaml/${name}.zip";
-      sha256 = "19bb3ac350ef878dda84a62d37c7d5c17a137386dde9c2ce7249c7a21d7f6ac9";
+      sha256 = "19s1lxi0idq4a0bpvld866pv5b16lqxypyswmsdi5ys4210jxj2s";
     };
 
     buildInputs = with self; [ pkgs.pyrex ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
