### PR TITLE
Fix borgbackup dependency on lz4

### DIFF
--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -23,7 +23,7 @@ python3Packages.buildPythonApplication rec {
 
   preConfigure = ''
     export BORG_OPENSSL_PREFIX="${openssl.dev}"
-    export BORG_LZ4_PREFIX="${lz4}"
+    export BORG_LZ4_PREFIX="${lz4.dev}"
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Fails to build, [per hydra log](http://hydra.nixos.org/build/40146404/log/raw), pretty clearly as a consequence of NixOS/nixpkgs@b87d5abafd8e77669f69470ee17f47e8464d3370
###### Things done
- [X] Tested using sandboxing
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @nckx 
