### PR TITLE
duplicity: add dependency on rsync

### DIFF
--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, librsync, ncftp, gnupg, makeWrapper
+{ stdenv, fetchurl, pythonPackages, librsync, ncftp, gnupg, rsync, makeWrapper
 }:
 
 let
@@ -16,7 +16,7 @@ in stdenv.mkDerivation {
     python setup.py install --prefix=$out
     wrapProgram $out/bin/duplicity \
       --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${pycrypto}):$(toPythonPath ${ecdsa}):$(toPythonPath ${paramiko}):$(toPythonPath ${boto}):$(toPythonPath ${lockfile})" \
-      --prefix PATH : "${stdenv.lib.makeBinPath [ gnupg ncftp ]}"
+      --prefix PATH : "${stdenv.lib.makeBinPath [ gnupg ncftp rsync ]}"
     wrapProgram $out/bin/rdiffdir \
       --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${pycrypto}):$(toPythonPath ${ecdsa}):$(toPythonPath ${paramiko}):$(toPythonPath ${boto}):$(toPythonPath ${lockfile})"
   '';


### PR DESCRIPTION
###### Motivation for this change

To enable duplicity to work with the rsync:// protocol.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @viric @peti 

---

When using the rsync:// protocol, duplicity expects to find the rsync binary in the path.
Without rsync in the path, duplicity fails with the following error

```
Attempt 1 failed. AttributeError: 'NoneType' object has no attribute 'rfind'
```

Adding rsync to the path enables the rsync:// protocol to work correctly.
