### PR TITLE
Beets: fix keyfinder plugin (did not work) and add copyartifacts plugin

### DIFF
--- a/pkgs/tools/audio/beets/copyartifacts-plugin.nix
+++ b/pkgs/tools/audio/beets/copyartifacts-plugin.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, pythonPackages }:
+
+buildPythonApplication rec {
+  name = "beets-copyartifacts";
+
+  src = fetchFromGitHub {
+    repo = "beets-copyartifacts";
+    owner = "sbarakat";
+    rev = "dac4a1605111e24bb5b498aa84cead7c87480834";
+    sha256 = "0p5cskfgqinzh48a58hw56f96g9lar3k3g2p0ip1m9kawzf6axng";
+  };
+
+  postPatch = ''
+    sed -i -e '/install_requires/,/\]/{/beets/d}' setup.py
+    sed -i -e '/namespace_packages/d' setup.py
+    printf 'from pkgutil import extend_path\n__path__ = extend_path(__path__, __name__)\n' >beetsplug/__init__.py
+  '';
+
+  meta = {
+    description = "Beets plugin to move non-music files during the import process";
+    homepage = "https://github.com/sbarakat/beets-copyartifacts";
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -8,6 +8,7 @@
 , enableDiscogs        ? true
 , enableEmbyupdate     ? true
 , enableFetchart       ? true
+, enableKeyfinder      ? true, keyfinder-cli ? null
 , enableLastfm         ? true
 , enableMpd            ? true
 , enableReplaygain     ? true, bs1770gain ? null
@@ -26,6 +27,7 @@ assert enableBadfiles    -> flac != null && mp3val != null;
 assert enableConvert     -> ffmpeg != null;
 assert enableDiscogs     -> pythonPackages.discogs_client != null;
 assert enableFetchart    -> pythonPackages.responses      != null;
+assert enableKeyfinder   -> keyfinder-cli != null;
 assert enableLastfm      -> pythonPackages.pylast         != null;
 assert enableMpd         -> pythonPackages.mpd            != null;
 assert enableReplaygain  -> bs1770gain                    != null;
@@ -43,6 +45,7 @@ let
     discogs = enableDiscogs;
     embyupdate = enableEmbyupdate;
     fetchart = enableFetchart;
+    keyfinder = enableKeyfinder;
     lastgenre = enableLastfm;
     lastimport = enableLastfm;
     mpdstats = enableMpd;
@@ -55,7 +58,7 @@ let
   pluginsWithoutDeps = [
     "beatport" "bench" "bpd" "bpm" "bucket" "cue" "duplicates" "edit" "embedart"
     "export" "filefilter" "freedesktop" "fromfilename" "ftintitle" "fuzzy" "hook" "ihate"
-    "importadded" "importfeeds" "info" "inline" "ipfs" "keyfinder" "lyrics"
+    "importadded" "importfeeds" "info" "inline" "ipfs" "lyrics"
     "mbcollection" "mbsubmit" "mbsync" "metasync" "missing" "permissions" "play"
     "plexupdate" "random" "rewrite" "scrub" "smartplaylist" "spotify" "the"
     "types" "zero"
@@ -99,6 +102,7 @@ in buildPythonApplication rec {
                                    pythonPackages.requests2
     ++ optional enableConvert      ffmpeg
     ++ optional enableDiscogs      pythonPackages.discogs_client
+    ++ optional enableKeyfinder    keyfinder-cli
     ++ optional enableLastfm       pythonPackages.pylast
     ++ optional enableMpd          pythonPackages.mpd
     ++ optional enableThumbnails   pythonPackages.pyxdg
@@ -121,6 +125,7 @@ in buildPythonApplication rec {
 
   patches = [
     ./replaygain-default-bs1770gain.patch
+    ./keyfinder-default-bin.patch
   ];
 
   postPatch = ''

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -15,7 +15,8 @@
 , enableWeb            ? true
 
 # External plugins
-, enableAlternatives ? false
+, enableAlternatives   ? false
+, enableCopyArtifacts  ? false
 
 , bashInteractive, bashCompletion
 }:
@@ -103,6 +104,9 @@ in buildPythonApplication rec {
     ++ optional enableThumbnails   pythonPackages.pyxdg
     ++ optional enableWeb          pythonPackages.flask
     ++ optional enableAlternatives (import ./alternatives-plugin.nix {
+      inherit stdenv buildPythonApplication pythonPackages fetchFromGitHub;
+    })
+    ++ optional enableCopyArtifacts (import ./copyartifacts-plugin.nix {
       inherit stdenv buildPythonApplication pythonPackages fetchFromGitHub;
     });
 

--- a/pkgs/tools/audio/beets/keyfinder-default-bin.patch
+++ b/pkgs/tools/audio/beets/keyfinder-default-bin.patch
@@ -1,0 +1,35 @@
+diff --git a/beetsplug/keyfinder.py b/beetsplug/keyfinder.py
+index b6131a4..b493792 100644
+--- a/beetsplug/keyfinder.py
++++ b/beetsplug/keyfinder.py
+@@ -30,7 +30,7 @@ class KeyFinderPlugin(BeetsPlugin):
+     def __init__(self):
+         super(KeyFinderPlugin, self).__init__()
+         self.config.add({
+-            u'bin': u'KeyFinder',
++            u'bin': u'keyfinder-cli',
+             u'auto': True,
+             u'overwrite': False,
+         })
+@@ -59,7 +59,7 @@ class KeyFinderPlugin(BeetsPlugin):
+                 continue
+ 
+             try:
+-                output = util.command_output([bin, b'-f',
++                output = util.command_output([bin,
+                                               util.syspath(item.path)])
+             except (subprocess.CalledProcessError, OSError) as exc:
+                 self._log.error(u'execution failed: {0}', exc)
+diff --git a/test/test_keyfinder.py b/test/test_keyfinder.py
+index 00952fe..01ff8d4 100644
+--- a/test/test_keyfinder.py
++++ b/test/test_keyfinder.py
+@@ -46,7 +46,7 @@ class KeyFinderTest(unittest.TestCase, TestHelper):
+         item.load()
+         self.assertEqual(item['initial_key'], 'C#m')
+         self.command_output.assert_called_with(
+-            ['KeyFinder', '-f', util.syspath(item.path)])
++            ['keyfinder-cli', util.syspath(item.path)])
+ 
+     def test_add_key_on_import(self):
+         self.command_output.return_value = 'dbm'


### PR DESCRIPTION
###### Motivation for this change
1. `keyfinder` did not work.
2. `copyartifacts` is a useful plugin to copy some album extras (scans, logs, cues etc.) along with the audio files
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend — none do.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
