### PR TITLE
python-qscintilla: unbreak

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20713,6 +20713,7 @@ in modules // {
       preConfigure = ''
         mkdir -p $out
         lndir ${self.pyqt4} $out
+        rm -rf "$out/nix-support"
         cd Python
         ${python.executable} ./configure-old.py \
             --destdir $out/lib/${python.libPrefix}/site-packages/PyQt4 \


### PR DESCRIPTION
This unbreaks tortoisehg. Fix stolen from
https://github.com/NixOS/nixpkgs/commit/7fd851f613bda4c98d1e8e5e410302abc718114b
