### PR TITLE
docker: 1.10.3 -> 1.12.1

### DIFF
--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -11,9 +11,6 @@ import ./make-test.nix ({ pkgs, ...} : {
       { config, pkgs, ... }:
         {
           virtualisation.docker.enable = true;
-          # FIXME: The default "devicemapper" storageDriver fails in NixOS VM
-          # tests.
-          virtualisation.docker.storageDriver = "overlay";
         };
     };
 

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchFromGitHub
+, go, libapparmor, apparmor-parser, libseccomp }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "containerd-${version}";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "docker";
+    repo = "containerd";
+    rev = "v${version}";
+    sha256 = "0hlvbd5n4v337ywkc8mnbhp9m8lg8612krv45262n87c2ijyx09s";
+  };
+
+  buildInputs = [ go ];
+
+  preBuild = ''
+    ln -s $(pwd) vendor/src/github.com/docker/containerd
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/* $out/bin
+  '';
+
+  preFixup = ''
+    # remove references to go compiler
+    while read file; do
+      sed -ri "s,${go},$(echo "${go}" | sed "s,$NIX_STORE/[^-]*,$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee,"),g" $file
+    done < <(find $out/bin -type f 2>/dev/null)
+  '';
+
+  meta = {
+    homepage = https://containerd.tools/;
+    description = "A daemon to control runC";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ offline ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/virtualization/runc/default.nix
+++ b/pkgs/applications/virtualization/runc/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, lib, fetchFromGitHub, go-md2man
+, go, pkgconfig, libapparmor, apparmor-parser, libseccomp }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "runc-${version}";
+  version = "2016-06-15";
+
+  src = fetchFromGitHub {
+    owner = "opencontainers";
+    repo = "runc";
+    rev = "cc29e3dded8e27ba8f65738f40d251c885030a28";
+    sha256 = "18fwb3kq10zhhx184yn3j396gpbppy3y4ypb8m2b2pdms39s6pyx";
+  };
+
+  outputs = [ "out" "man" ];
+
+  hardeningDisable = ["fortify"];
+
+  buildInputs = [ go-md2man go pkgconfig libseccomp libapparmor apparmor-parser ];
+
+  makeFlags = ''BUILDTAGS+=seccomp BUILDTAGS+=apparmor'';
+
+  preBuild = ''
+    patchShebangs .
+    substituteInPlace libcontainer/apparmor/apparmor.go \
+      --replace /sbin/apparmor_parser ${apparmor-parser}/bin/apparmor_parser
+  '';
+
+  installPhase = ''
+    install -Dm755 runc $out/bin/runc
+
+    # Include contributed man pages
+    man/md2man-all.sh -q
+    manRoot="$man/share/man"
+    mkdir -p "$manRoot"
+    for manDir in man/man?; do
+      manBase="$(basename "$manDir")" # "man1"
+      for manFile in "$manDir"/*; do
+        manName="$(basename "$manFile")" # "docker-build.1"
+        mkdir -p "$manRoot/$manBase"
+        gzip -c "$manFile" > "$manRoot/$manBase/$manName.gz"
+      done
+    done
+  '';
+
+  preFixup = ''
+    # remove references to go compiler
+    while read file; do
+      sed -ri "s,${go},$(echo "${go}" | sed "s,$NIX_STORE/[^-]*,$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee,"),g" $file
+    done < <(find $out/bin -type f 2>/dev/null)
+  '';
+
+  meta = {
+    homepage = https://runc.io/;
+    description = "A CLI tool for spawning and running containers according to the OCI specification";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ offline ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/md2man/default.nix
+++ b/pkgs/development/tools/misc/md2man/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, buildGoPackage, go, fetchFromGitHub }:
+
+with lib;
+
+buildGoPackage rec {
+  name = "go-md2man-${version}";
+  version = "1.0.6";
+
+  goPackagePath = "github.com/cpuguy83/go-md2man";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "cpuguy83";
+    repo = "go-md2man";
+    sha256 = "1rm3zjrmfpzy0l3qp02xmd5pqzl77pdql9pbxhl0k1qw2vfzrjv6";
+  };
+
+  meta = {
+    description = "Go tool to convert markdown to man pages";
+    license = licenses.mit;
+    homepage = https://github.com/cpuguy83/go-md2man;
+    maintainers = with maintainers; [offline];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12770,9 +12770,7 @@ in
 
   dmtx-utils = callPackage ../tools/graphics/dmtx-utils { };
 
-  docker = callPackage ../applications/virtualization/docker {
-    btrfs-progs = btrfs-progs_4_4_1;
-  };
+  docker = callPackage ../applications/virtualization/docker { };
 
   docker-gc = callPackage ../applications/virtualization/docker/gc.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12666,6 +12666,8 @@ in
   conkeror-unwrapped = callPackage ../applications/networking/browsers/conkeror { };
   conkeror = self.wrapFirefox conkeror-unwrapped { };
 
+  containerd = callPackage ../applications/virtualization/containerd { };
+
   cpp_ethereum = callPackage ../applications/misc/webthree-umbrella {
     withOpenCL = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14655,6 +14655,8 @@ in
 
   rubyripper = callPackage ../applications/audio/rubyripper {};
 
+  runc = callPackage ../applications/virtualization/runc {};
+
   rxvt = callPackage ../applications/misc/rxvt { };
 
   # urxvt

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6577,6 +6577,8 @@ in
   maven = maven3;
   maven3 = callPackage ../development/tools/build-managers/apache-maven { };
 
+  go-md2man = callPackage ../development/tools/misc/md2man {};
+
   minify = callPackage ../development/web/minify { };
 
   minizinc = callPackage ../development/tools/minizinc { };


### PR DESCRIPTION
###### Motivation for this change

Docker we have is very old. This build is also much better as previous, it provides man files, has dependency clean-up and removes uneeded references to go compiler. I've tested this with and without nixos and works without any issues. It would be nice to have this merged in 16.09 @domenkozar 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
