### PR TITLE
Miscellaneous packages: Use sha256 instead of md5 (part 2)

### DIFF
--- a/pkgs/applications/editors/emacs-modes/cua/default.nix
+++ b/pkgs/applications/editors/emacs-modes/cua/default.nix
@@ -3,6 +3,6 @@
   builder = ./builder.sh;
   src = fetchurl {
     url = http://tarballs.nixos.org/cua-mode-2.10.el;
-    md5 = "5bf5e43f5f38c8383868c7c6c5baca09";
+    sha256 = "01877xjbq0v9wrpcbnhvppdn9wxliwkkjg3dr6k795mjgslwhr1b";
   };
 }

--- a/pkgs/applications/graphics/batik/default.nix
+++ b/pkgs/applications/graphics/batik/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   builder = ./builder.sh;
   src = fetchurl {
     url = http://tarballs.nixos.org/batik-1.6.zip;
-    md5 = "edff288fc64f968ff96ca49763d50f3c";
+    sha256 = "0cf15dspmzcnfda8w5lbsdx28m4v2rpq1dv5zx0r0n99ihqd1sh6";
   };
 
   buildInputs = [unzip];

--- a/pkgs/applications/science/math/scilab/default.nix
+++ b/pkgs/applications/science/math/scilab/default.nix
@@ -16,8 +16,7 @@ stdenv.mkDerivation rec {
   name = "scilab-${version}";
   src = fetchurl {
     url = "http://www.scilab.org/download/${version}/${name}-src.tar.gz";
-    # md5 coming from http://www.scilab.org/download/index_download.php
-    md5 = "17a7a6aa52918f33d96777a0dc423658";
+    sha256 = "1adk6jqlj7i3gjklvlf1j3il1nb22axnp4rvwl314an62siih0sc";
   };
 
   buildInputs = [gfortran ncurses]

--- a/pkgs/applications/version-management/kdesvn/default.nix
+++ b/pkgs/applications/version-management/kdesvn/default.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
   name = "kdesvn-1.6.0";
 
   src = fetchurl rec {
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/kdesvn/${name}.tar.bz2/${md5}/${name}.tar.bz2";
-    md5 = "7e6adc98ff4777a06d5752d3f2b58fa3";
+    url = "http://pkgs.fedoraproject.org/repo/pkgs/kdesvn/${name}.tar.bz2/7e6adc98ff4777a06d5752d3f2b58fa3/${name}.tar.bz2";
+    sha256 = "15hg6xyx5rqldfhi1yhq5ss15y6crm2is3zqm680z0bndcj6ys05";
   };
 
   prePatch = ''

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook-ebnf/default.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook-ebnf/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   builder = ./builder.sh;
   dtd = fetchurl {
     url = http://www.docbook.org/xml/ebnf/1.2b1/dbebnf.dtd;
-    md5 = "e50f7d38caf4285965c7a247e026fa7c";
+    sha256 = "0min5dsc53my13b94g2yd65q1nkjcf4x1dak00bsc4ckf86mrx95";
   };
   catalog = ./docbook-ebnf.cat;
 

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.3.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.3.nix
@@ -5,7 +5,7 @@ import ./generic.nix {
   name = "docbook-xml-4.3";
   src = fetchurl {
     url = http://www.docbook.org/xml/4.3/docbook-xml-4.3.zip;
-    md5 = "ab200202b9e136a144db1e0864c45074";
+    sha256 = "0r1l2if1z4wm2v664sqdizm4gak6db1kx9y50jq89m3gxaa8l1i3";
   };
   meta = {
     branch = "4.3";

--- a/pkgs/development/compilers/ocaml/3.08.0.nix
+++ b/pkgs/development/compilers/ocaml/3.08.0.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   builder = ./builder.sh;
   src = fetchurl {
     url = http://tarballs.nixos.org/ocaml-3.08.0.tar.gz;
-    md5 = "c6ef478362295c150101cdd2efcd38e0";
+    sha256 = "135g5waj7djzrj0dbc8z1llasfs2iv5asq41jifhldxb4l2b97mx";
   };
   configureScript = ./configure-3.08.0;
   dontAddPrefix = "True";

--- a/pkgs/development/interpreters/lua-4/default.nix
+++ b/pkgs/development/interpreters/lua-4/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = http://www.lua.org/ftp/lua-4.0.1.tar.gz;
-    md5 = "a31d963dbdf727f9b34eee1e0d29132c";
+    sha256 = "0ajd906hasii365xdihv9mdmi3cixq758blx0289x4znkha6wx6z";
   };
 
   configurePhase = "sed -i -e 's/CFLAGS= -O2/CFLAGS = -O3 -fPIC/' config";

--- a/pkgs/development/python-modules/breathe/default.nix
+++ b/pkgs/development/python-modules/breathe/default.nix
@@ -6,7 +6,7 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "mirror://pypi/b/breathe/${name}.tar.gz";
-    md5 = "e35f6ce54485663857129370047f6057";
+    sha256 = "0m3w8yx24nm01xxx6aj08cklnifwlzzmczc5b0ni40l63lhvm3lp";
   };
 
   propagatedBuildInputs = [ docutils six sphinx ];

--- a/pkgs/development/python-modules/rhpl/default.nix
+++ b/pkgs/development/python-modules/rhpl/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   
   src = fetchurl {
     url = http://ftp-stud.hs-esslingen.de/pub/Mirrors/archive.fedoraproject.org/fedora/linux/releases/10/Everything/source/SRPMS//rhpl-0.218-1.src.rpm;
-    md5 = "a72c6b66df782ca1d4950959d2aad292";
+    sha256 = "0c3sc74cjzz5dmpr2gi5naxcc5p2qmzagz7k561xj07njn0ddg16";
   };
   
   inherit python;

--- a/pkgs/development/tools/build-managers/gnumake/3.80/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/3.80/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = http://tarballs.nixos.org/make-3.80.tar.bz2;
-    md5 = "0bbd1df101bc0294d440471e50feca71";
+    sha256 = "06rgz6npynr8whmf7rxgkyvcz0clf3ggwf4cyhj3fcscn3kkk6x9";
   };
 
   patches = [./log.patch];

--- a/pkgs/development/tools/build-managers/mk/default.nix
+++ b/pkgs/development/tools/build-managers/mk/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "mk-2006-01-31";
   src = fetchurl {
     url = http://tarballs.nixos.org/mk-20060131.tar.gz;
-    md5 = "167fd4e0eea4f49def01984ec203289b";
+    sha256 = "0za8dp1211bdp4584xb59liqpww7w1ql0cmlv34p9y928nibcxsr";
   };
   builder = ./builder.sh;
 


### PR DESCRIPTION
More of the same from #18347
###### Motivation for this change
#4491 - md5 is a bad hash
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
