### PR TITLE
openocd: externalize jimtcl and libjaylink dependencies

### DIFF
--- a/pkgs/development/interpreters/jimtcl/default.nix
+++ b/pkgs/development/interpreters/jimtcl/default.nix
@@ -10,9 +10,8 @@ stdenv.mkDerivation {
     sha256 = "00ldal1w9ysyfmx28xdcaz81vaazr1fqixxb2abk438yfpp1i9hq";
   };
 
-  buildInputs = [
-    sqlite readline asciidoc SDL SDL_gfx
-  ];
+  buildInputs = [ asciidoc ];
+  propagatedBuildInputs = [ readline SDL SDL_gfx sqlite ];
 
   NIX_CFLAGS_COMPILE = [ "-I${SDL.dev}/include/SDL" ];
 

--- a/pkgs/development/tools/misc/libjaylink/default.nix
+++ b/pkgs/development/tools/misc/libjaylink/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, libusb }:
+stdenv.mkDerivation {
+  name = "libjaylink-0.1.0";
+
+  src = fetchgit {
+    url = "git://git.zapb.de/libjaylink.git";
+    rev = "aee8ed0d9449a2157b1f19ba1a0de0992593d803";
+    sha256 = "1qjy8zis7pz070z54fjrrjb8il76rxdc4s61qx6gr8wdanrspldg";
+  };
+
+  buildInputs = [ autoreconfHook pkgconfig libusb ];
+
+  meta = {
+    description = "Shared library written in C to access SEGGER J-Link and compatible devices";
+    homepage = http://git.zapb.de/libjaylink.git;
+    license = stdenv.lib.licenses.gpl2plus;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ elitak ];
+  };
+}

--- a/pkgs/development/tools/misc/libjaylink/default.nix
+++ b/pkgs/development/tools/misc/libjaylink/default.nix
@@ -10,11 +10,11 @@ stdenv.mkDerivation {
 
   buildInputs = [ autoreconfHook pkgconfig libusb ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Shared library written in C to access SEGGER J-Link and compatible devices";
     homepage = http://git.zapb.de/libjaylink.git;
-    license = stdenv.lib.licenses.gpl2plus;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = with stdenv.lib.maintainers; [ elitak ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ elitak ];
   };
 }

--- a/pkgs/development/tools/misc/openocd/default.nix
+++ b/pkgs/development/tools/misc/openocd/default.nix
@@ -1,17 +1,20 @@
-{ stdenv, fetchurl, libftdi, libusb1, pkgconfig, hidapi }:
-
-stdenv.mkDerivation rec {
-  name = "openocd-${version}";
+{ stdenv, fetchurl, libftdi, libusb1, pkgconfig, hidapi, jimtcl, libjaylink }:
+let
   version = "0.9.0";
+in
+stdenv.mkDerivation {
+  name = "openocd-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/openocd/openocd-${version}.tar.bz2";
     sha256 = "0hzlnm19c4b35vsxs6ik94xbigv3ykdgr8gzrdir6sqmkan44w43";
   };
 
-  buildInputs = [ libftdi libusb1 pkgconfig hidapi ];
+  buildInputs = [ libftdi libusb1 pkgconfig hidapi jimtcl libjaylink ];
 
   configureFlags = [
+    "--disable-internal-jimtcl"
+    "--disable-internal-libjaylink"
     "--enable-jtag_vpi"
     "--enable-usb_blaster_libftdi"
     "--enable-amtjtagaccel"
@@ -23,6 +26,11 @@ stdenv.mkDerivation rec {
     "--enable-sysfsgpio"
     "--enable-remote-bitbang"
   ];
+
+  # FIXME HACK since inputs from jimctl arent being propagated properly?!
+  preConfigure = ''
+    export LIBS="-lreadline -lSDL -lSDL_gfx -lsqlite3"
+  '';
 
   postInstall = ''
     mkdir -p "$out/etc/udev/rules.d"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16784,6 +16784,8 @@ in
   libjack2 = jack2Full.override { prefix = "lib"; };
   libjack2-git = callPackage ../misc/jackaudio/git.nix { };
 
+  libjaylink = callPackage ../development/tools/misc/libjaylink { };
+
   keynav = callPackage ../tools/X11/keynav { };
 
   lilypond = callPackage ../misc/lilypond { guile = guile_1_8; };


### PR DESCRIPTION
###### Motivation for this change

I was working on bumping openocd to 0.90, but was beaten to it. Absent from the recent changes are the externalization of the jimtcl and libjaylink dependencies, so here they are.

There's a FIXME in here that ought to be addressed before committing. I couldn't figure out how to get the propagatedBuildInputs included automatically in the link step, so I had to add in the `-l<lib>` flags manually. How do I avoid this?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
