### PR TITLE
cryptol: Make Z3 available for REPL users

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4443,7 +4443,15 @@ in
     coq = coq_8_5;
   });
 
-  cryptol = haskellPackages.cryptol;
+  # Users installing via `nix-env` will likely be using the REPL,
+  # which has a hard dependency on Z3, so make sure it is available.
+  cryptol = haskellPackages.cryptol.overrideDerivation (oldAttrs: {
+    buildInputs = (oldAttrs.buildInputs or []) ++ [ makeWrapper ];
+    installPhase = (oldAttrs.installPhase or "") + ''
+      wrapProgram $out/bin/cryptol \
+        --prefix 'PATH' ':' "${lib.getBin z3}/bin"
+    '';
+  });
 
   devpi-client = callPackage ../development/tools/devpi-client {};
 


### PR DESCRIPTION
###### Motivation for this change

The Cryptol REPL has a hard dependency on Z3, but the rest of the
library uses SBV to support multiple solvers. Ensure that Z3 is
available for `pkgs.cryptol`, which is likely to be installed via
nix-env for REPL usage, but do not change pkgs.haskellPackages.cryptol,
which is likely to be used as a dependency (in Nix expressions).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #18490. cc @peti 

I think multiple outputs might be a better way to do this, but I'm not very familiar with how they work, or the Haskell infrastructure.
