### PR TITLE
Move to explicit gtk2 and gtk3 choice

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -29,7 +29,11 @@ following incompatible changes:</para>
 
 <itemizedlist>
   <listitem>
-    <para></para>
+    <para>
+      <literal>gnome</literal> alias has been removed along with
+      <literal>gtk</literal>, <literal>gtkmm</literal> and several others.
+      Now you need to use versioned attributes, like <literal>gnome3</literal>.
+    </para>
   </listitem>
 </itemizedlist>
 

--- a/pkgs/applications/audio/ams-lv2/default.nix
+++ b/pkgs/applications/audio/ams-lv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cairo, fftw, gtk, gtkmm, lv2, lvtk, pkgconfig, python }:
+{ stdenv, fetchurl, cairo, fftw, gtkmm2, lv2, lvtk, pkgconfig, python }:
 
 stdenv.mkDerivation  rec {
   name = "ams-lv2-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation  rec {
     sha256 = "1kqbl7rc3zrs27c5ga0frw3mlpx15sbxzhf04sfbrd9l60535fd5";
   };
 
-  buildInputs = [ cairo fftw gtk gtkmm lv2 lvtk pkgconfig python ];
+  buildInputs = [ cairo fftw gtkmm2 lv2 lvtk pkgconfig python ];
 
   configurePhase = "python waf configure --prefix=$out";
 

--- a/pkgs/applications/audio/ardour/ardour3.nix
+++ b/pkgs/applications/audio/ardour/ardour3.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, alsaLib, aubio, boost, cairomm, curl, doxygen, dbus, fftw
-, fftwSinglePrec, flac, glibc, glibmm, graphviz, gtk, gtkmm, libjack2
+, fftwSinglePrec, flac, glibc, glibmm, graphviz, gtkmm2, libjack2
 , libgnomecanvas, libgnomecanvasmm, liblo, libmad, libogg, librdf
 , librdf_raptor, librdf_rasqal, libsamplerate, libsigcxx, libsndfile
 , libusb, libuuid, libxml2, libxslt, lilv-svn, lv2, makeWrapper, pango
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = 
     [ alsaLib aubio boost cairomm curl doxygen dbus fftw fftwSinglePrec flac glibc
-      glibmm graphviz gtk gtkmm libjack2 libgnomecanvas libgnomecanvasmm liblo
+      glibmm graphviz gtkmm2 libjack2 libgnomecanvas libgnomecanvasmm liblo
       libmad libogg librdf librdf_raptor librdf_rasqal libsamplerate
       libsigcxx libsndfile libusb libuuid libxml2 libxslt lilv-svn lv2
       makeWrapper pango perl pkgconfig python rubberband serd sord-svn sratom suil taglib vampSDK

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, alsaLib, aubio, boost, cairomm, curl, doxygen, dbus, fftw
-, fftwSinglePrec, flac, glibc, glibmm, graphviz, gtk, gtkmm, libjack2
+, fftwSinglePrec, flac, glibc, glibmm, graphviz, gtkmm2, libjack2
 , libgnomecanvas, libgnomecanvasmm, liblo, libmad, libogg, librdf
 , librdf_raptor, librdf_rasqal, libsamplerate, libsigcxx, libsndfile
 , libusb, libuuid, libxml2, libxslt, lilv-svn, lv2, makeWrapper, pango
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ alsaLib aubio boost cairomm curl doxygen dbus fftw fftwSinglePrec flac glibc
-      glibmm graphviz gtk gtkmm libjack2 libgnomecanvas libgnomecanvasmm liblo
+      glibmm graphviz gtkmm2 libjack2 libgnomecanvas libgnomecanvasmm liblo
       libmad libogg librdf librdf_raptor librdf_rasqal libsamplerate
       libsigcxx libsndfile libusb libuuid libxml2 libxslt lilv-svn lv2
       makeWrapper pango perl pkgconfig python rubberband serd sord-svn sratom suil taglib vampSDK

--- a/pkgs/applications/audio/audacity/default.nix
+++ b/pkgs/applications/audio/audacity/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, wxGTK30, pkgconfig, gettext, gtk, glib, zlib, perl, intltool,
+{ stdenv, fetchurl, wxGTK30, pkgconfig, gettext, gtk2, glib, zlib, perl, intltool,
   libogg, libvorbis, libmad, alsaLib, libsndfile, soxr, flac, lame, fetchpatch,
   expat, libid3tag, ffmpeg, soundtouch /*, portaudio - given up fighting their portaudio.patch */
   }:
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig gettext wxGTK30 expat alsaLib
-    libsndfile soxr libid3tag gtk
+    libsndfile soxr libid3tag gtk2
     ffmpeg libmad lame libvorbis flac soundtouch
   ]; #ToDo: detach sbsms
 

--- a/pkgs/applications/audio/beast/default.nix
+++ b/pkgs/applications/audio/beast/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, zlib, guile, libart_lgpl, pkgconfig, intltool
-, gtk, glib, libogg, libvorbis, libgnomecanvas, gettext, perl }:
+, gtk2, glib, libogg, libvorbis, libgnomecanvas, gettext, perl }:
 
 stdenv.mkDerivation rec {
   name = "beast-0.7.1";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ zlib guile libart_lgpl pkgconfig intltool gtk glib
+    [ zlib guile libart_lgpl pkgconfig intltool gtk2 glib
       libogg libvorbis libgnomecanvas gettext
     ];
 

--- a/pkgs/applications/audio/bitwig-studio/default.nix
+++ b/pkgs/applications/audio/bitwig-studio/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, alsaLib, bzip2, cairo, dpkg, freetype, gdk_pixbuf
-, glib, gtk, harfbuzz, jdk, lib, libX11, libXau, libXcursor, libXdmcp
+, glib, gtk2, harfbuzz, jdk, lib, libX11, libXau, libXcursor, libXdmcp
 , libXext, libXfixes, libXrender, libbsd, libjack2, libpng, libxcb
 , libxkbcommon, libxkbfile, makeWrapper, pixman, xcbutil, xcbutilwm
 , xdg_utils, zenity, zlib }:
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   libPath = lib.makeLibraryPath [
-    alsaLib bzip2.out cairo freetype gdk_pixbuf glib gtk harfbuzz
+    alsaLib bzip2.out cairo freetype gdk_pixbuf glib gtk2 harfbuzz
     libX11 libXau libXcursor libXdmcp libXext libXfixes libXrender
     libbsd libjack2 libpng libxcb libxkbfile pixman xcbutil xcbutilwm
     zlib

--- a/pkgs/applications/audio/calf/default.nix
+++ b/pkgs/applications/audio/calf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cairo, expat, fftwSinglePrec, fluidsynth, glib
-, gtk, libjack2, ladspaH , libglade, lv2, pkgconfig }:
+, gtk2, libjack2, ladspaH , libglade, lv2, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "calf-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ 
-    cairo expat fftwSinglePrec fluidsynth glib gtk libjack2 ladspaH
+    cairo expat fftwSinglePrec fluidsynth glib gtk2 libjack2 ladspaH
     libglade lv2 pkgconfig
   ];
 

--- a/pkgs/applications/audio/eq10q/default.nix
+++ b/pkgs/applications/audio/eq10q/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fftw, gtkmm, libxcb, lv2, pkgconfig, xorg }:
+{ stdenv, fetchurl, cmake, fftw, gtkmm2, libxcb, lv2, pkgconfig, xorg }:
 stdenv.mkDerivation rec {
   name = "eq10q-${version}";
   version = "2.0";
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "08vlfly0qqrfqiwpn5g5php680icpk97pwnwjadmj5syhgvi0i3h";
   };
 
-  buildInputs = [ cmake fftw gtkmm libxcb lv2 pkgconfig xorg.libpthreadstubs xorg.libXdmcp xorg.libxshmfence ];
+  buildInputs = [ cmake fftw gtkmm2 libxcb lv2 pkgconfig xorg.libpthreadstubs xorg.libXdmcp xorg.libxshmfence ];
 
   installFlags = ''
     DESTDIR=$(out)

--- a/pkgs/applications/audio/faust/faust2alsa.nix
+++ b/pkgs/applications/audio/faust/faust2alsa.nix
@@ -6,7 +6,7 @@
 , freetype
 , gdk_pixbuf
 , glib
-, gtk
+, gtk2
 , pango
 }:
 
@@ -22,7 +22,7 @@ faust.wrapWithBuildEnv {
     freetype
     gdk_pixbuf
     glib
-    gtk
+    gtk2
     pango
   ];
 

--- a/pkgs/applications/audio/faust/faust2jack.nix
+++ b/pkgs/applications/audio/faust/faust2jack.nix
@@ -1,5 +1,5 @@
 { faust
-, gtk
+, gtk2
 , jack2Full
 , opencv
 }:
@@ -15,7 +15,7 @@ faust.wrapWithBuildEnv {
   ];
 
   propagatedBuildInputs = [
-    gtk
+    gtk2
     jack2Full
     opencv
   ];

--- a/pkgs/applications/audio/gigedit/default.nix
+++ b/pkgs/applications/audio/gigedit/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchsvn, autoconf, automake, docbook_xml_dtd_45
-, docbook_xsl, gtkmm, intltool, libgig, libsndfile, libtool, libxslt
+, docbook_xsl, gtkmm2, intltool, libgig, libsndfile, libtool, libxslt
 , pkgconfig }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   preConfigure = "make -f Makefile.cvs";
 
   buildInputs = [ 
-    autoconf automake docbook_xml_dtd_45 docbook_xsl gtkmm intltool
+    autoconf automake docbook_xml_dtd_45 docbook_xsl gtkmm2 intltool
     libgig libsndfile libtool libxslt pkgconfig 
   ];
 

--- a/pkgs/applications/audio/gjay/default.nix
+++ b/pkgs/applications/audio/gjay/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, mpd_clientlib, dbus_glib, audacious, gtk, gsl
+{ stdenv, fetchurl, pkgconfig, mpd_clientlib, dbus_glib, audacious, gtk2, gsl
 , libaudclient }:
 
 stdenv.mkDerivation {
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ mpd_clientlib dbus_glib audacious gtk gsl libaudclient ];
+  buildInputs = [ mpd_clientlib dbus_glib audacious gtk2 gsl libaudclient ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/audio/gmpc/default.nix
+++ b/pkgs/applications/audio/gmpc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libtool, intltool, pkgconfig, glib
-, gtk, curl, mpd_clientlib, libsoup, gob2, vala_0_23, libunique
+, gtk2, curl, mpd_clientlib, libsoup, gob2, vala_0_23, libunique
 , libSM, libICE, sqlite, hicolor_icon_theme, wrapGAppsHook
 }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libtool intltool pkgconfig glib gtk curl mpd_clientlib libsoup
+    libtool intltool pkgconfig glib gtk2 curl mpd_clientlib libsoup
     libunique libmpd gob2 vala_0_23 libSM libICE sqlite hicolor_icon_theme
     wrapGAppsHook
   ];

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, gettext, intltool, pkgconfig, python
 , avahi, bluez, boost, eigen, fftw, glib, glib_networking
-, glibmm, gsettings_desktop_schemas, gtk, gtkmm, libjack2
+, glibmm, gsettings_desktop_schemas, gtkmm2, libjack2
 , ladspaH, librdf, libsndfile, lilv, lv2, serd, sord, sratom
 , webkitgtk2, wrapGAppsHook, zita-convolver, zita-resampler
 , optimizationSupport ? false # Enable support for native CPU extensions
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     avahi bluez boost eigen fftw glib glibmm glib_networking.out
-    gsettings_desktop_schemas gtk gtkmm libjack2 ladspaH librdf
+    gsettings_desktop_schemas gtkmm2 libjack2 ladspaH librdf
     libsndfile lilv lv2 serd sord sratom webkitgtk2 zita-convolver
     zita-resampler
   ];

--- a/pkgs/applications/audio/ingen/default.nix
+++ b/pkgs/applications/audio/ingen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, boost, ganv, glibmm, gtk, gtkmm, libjack2, lilv-svn
+{ stdenv, fetchsvn, boost, ganv, glibmm, gtkmm2, libjack2, lilv-svn
 , lv2, makeWrapper, pkgconfig, python, raul, rdflib, serd, sord-svn, sratom
 , suil
 }:
@@ -14,7 +14,7 @@ stdenv.mkDerivation  rec {
   };
 
   buildInputs = [
-    boost ganv glibmm gtk gtkmm libjack2 lilv-svn lv2 makeWrapper pkgconfig
+    boost ganv glibmm gtkmm2 libjack2 lilv-svn lv2 makeWrapper pkgconfig
     python raul serd sord-svn sratom suil
   ];
 

--- a/pkgs/applications/audio/jack-rack/default.nix
+++ b/pkgs/applications/audio/jack-rack/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, libjack2, ladspaH, gtk, alsaLib, libxml2, librdf }:
+{ stdenv, fetchurl, pkgconfig, libjack2, ladspaH, gtk2, alsaLib, libxml2, librdf }:
 stdenv.mkDerivation rec {
   name = "jack-rack-1.4.7";
   src = fetchurl {
     url = "mirror://sourceforge/jack-rack/${name}.tar.bz2";
     sha256 = "1lmibx9gicagcpcisacj6qhq6i08lkl5x8szysjqvbgpxl9qg045";
   };
-  buildInputs = [ pkgconfig libjack2 ladspaH gtk alsaLib libxml2 librdf ];
+  buildInputs = [ pkgconfig libjack2 ladspaH gtk2 alsaLib libxml2 librdf ];
 
   meta = {
     description = ''An effects "rack" for the JACK low latency audio API'';

--- a/pkgs/applications/audio/jalv/default.nix
+++ b/pkgs/applications/audio/jalv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, libjack2, lilv, lv2, pkgconfig, python
+{ stdenv, fetchurl, gtk2, libjack2, lilv, lv2, pkgconfig, python
 , serd, sord , sratom, suil }:
 
 stdenv.mkDerivation  rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation  rec {
   };
 
   buildInputs = [
-    gtk libjack2 lilv lv2 pkgconfig python serd sord sratom suil
+    gtk2 libjack2 lilv lv2 pkgconfig python serd sord sratom suil
   ];
 
   configurePhase = "python waf configure --prefix=$out";

--- a/pkgs/applications/audio/lash/default.nix
+++ b/pkgs/applications/audio/lash/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, alsaLib, gtk, libjack2, libuuid, libxml2
+{ stdenv, fetchurl, alsaLib, gtk2, libjack2, libuuid, libxml2
 , makeWrapper, pkgconfig, readline }:
 
 assert libuuid != null;
@@ -15,7 +15,7 @@ stdenv.mkDerivation  rec {
   # http://permalink.gmane.org/gmane.linux.redhat.fedora.extras.cvs/822346
   patches = [ ./socket.patch ./gcc-47.patch ];
 
-  buildInputs = [ alsaLib gtk libjack2 libxml2 makeWrapper
+  buildInputs = [ alsaLib gtk2 libjack2 libxml2 makeWrapper
     pkgconfig readline ];
   propagatedBuildInputs = [ libuuid ];
 

--- a/pkgs/applications/audio/lingot/default.nix
+++ b/pkgs/applications/audio/lingot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk, alsaLib, libglade }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk2, alsaLib, libglade }:
 
 stdenv.mkDerivation {
   name = "lingot-0.9.1";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ pkgconfig intltool gtk alsaLib libglade ];
+  buildInputs = [ pkgconfig intltool gtk2 alsaLib libglade ];
 
   configureFlags = "--disable-jack";
 

--- a/pkgs/applications/audio/mhwaveedit/default.nix
+++ b/pkgs/applications/audio/mhwaveedit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, SDL , alsaLib, gtk, libjack2, ladspaH
+{ stdenv, fetchurl, makeWrapper, SDL , alsaLib, gtk2, libjack2, ladspaH
 , ladspaPlugins, libsamplerate, libsndfile, pkgconfig, libpulseaudio, lame
 , vorbis-tools }:
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation  rec {
     sha256 = "010rk4mr631s440q9cfgdxx2avgzysr9aq52diwdlbq9cddifli3";
   };
 
-  buildInputs = [ SDL alsaLib gtk libjack2 ladspaH libsamplerate libsndfile
+  buildInputs = [ SDL alsaLib gtk2 libjack2 ladspaH libsamplerate libsndfile
      pkgconfig libpulseaudio makeWrapper ];
 
   configureFlags = "--with-default-ladspa-path=${ladspaPlugins}/lib/ladspa";

--- a/pkgs/applications/audio/morituri/default.nix
+++ b/pkgs/applications/audio/morituri/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   };
 
   pythonPath = with pythonPackages; [
-    pygobject gst_python musicbrainzngs
+    pygobject2 gst_python musicbrainzngs
     pycdio pyxdg setuptools
     CDDB
   ];

--- a/pkgs/applications/audio/mp3info/default.nix
+++ b/pkgs/applications/audio/mp3info/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, ncurses, pkgconfig, gtk }:
+{ fetchurl, stdenv, ncurses, pkgconfig, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "mp3info-0.8.5a";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "042f1czcs9n2sbqvg4rsvfwlqib2gk976mfa2kxlfjghx5laqf04";
   };
 
-  buildInputs = [ ncurses pkgconfig gtk ];
+  buildInputs = [ ncurses pkgconfig gtk2 ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/audio/paprefs/default.nix
+++ b/pkgs/applications/audio/paprefs/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, libpulseaudio, gtkmm, libglademm
+{ fetchurl, stdenv, pkgconfig, libpulseaudio, gtkmm2, libglademm
 , dbus_glib, GConf, gconfmm, intltool }:
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1c5b3sb881szavly220q31g7rvpn94wr7ywlk00hqb9zaikml716";
   };
 
-  buildInputs = [ libpulseaudio gtkmm libglademm dbus_glib gconfmm ];
+  buildInputs = [ libpulseaudio gtkmm2 libglademm dbus_glib gconfmm ];
 
   nativeBuildInputs = [ pkgconfig intltool ];
 

--- a/pkgs/applications/audio/patchage/default.nix
+++ b/pkgs/applications/audio/patchage/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, alsaLib, boost, dbus_glib, fetchsvn, ganv, glibmm, gtk2
-, gtkmm, libjack2, pkgconfig, python2
+{ stdenv, alsaLib, boost, dbus_glib, fetchsvn, ganv, glibmm
+, gtkmm2, libjack2, pkgconfig, python2
 }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    alsaLib boost dbus_glib ganv glibmm gtk2 gtkmm libjack2
+    alsaLib boost dbus_glib ganv glibmm gtkmm2 libjack2
     pkgconfig python2
   ];
 

--- a/pkgs/applications/audio/petrifoo/default.nix
+++ b/pkgs/applications/audio/petrifoo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, alsaLib, cmake, gtk, libjack2, libgnomecanvas
+{ stdenv, fetchurl, alsaLib, cmake, gtk2, libjack2, libgnomecanvas
 , libpthreadstubs, libsamplerate, libsndfile, libtool, libxml2
 , pkgconfig, openssl }:
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation  rec {
   };
 
   buildInputs =
-   [ alsaLib cmake  gtk libjack2 libgnomecanvas libpthreadstubs
+   [ alsaLib cmake gtk2 libjack2 libgnomecanvas libpthreadstubs
      libsamplerate libsndfile libtool libxml2 pkgconfig openssl
    ];
 

--- a/pkgs/applications/audio/praat/default.nix
+++ b/pkgs/applications/audio/praat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, alsaLib, gtk, pkgconfig }:
+{ stdenv, fetchurl, alsaLib, gtk2, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "praat-${version}";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     cp praat $out/bin
   '';
 
-  buildInputs = [ alsaLib gtk pkgconfig ];
+  buildInputs = [ alsaLib gtk2 pkgconfig ];
 
   meta = {
     description = "Doing phonetics by computer";

--- a/pkgs/applications/audio/qtractor/default.nix
+++ b/pkgs/applications/audio/qtractor/default.nix
@@ -1,4 +1,4 @@
-{ alsaLib, autoconf, automake, dssi, fetchurl, gtk, libjack2
+{ alsaLib, autoconf, automake, dssi, fetchurl, gtk2, libjack2
 , ladspaH, ladspaPlugins, liblo, libmad, libsamplerate, libsndfile
 , libtool, libvorbis, lilv, lv2, pkgconfig, qt4, rubberband, serd
 , sord, sratom, stdenv, suil }:
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ alsaLib autoconf automake dssi gtk libjack2 ladspaH
+    [ alsaLib autoconf automake dssi gtk2 libjack2 ladspaH
       ladspaPlugins liblo libmad libsamplerate libsndfile libtool
       libvorbis lilv lv2 pkgconfig qt4 rubberband serd sord sratom
       suil

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -9,7 +9,7 @@ assert withGstPlugins -> gst_plugins_base != null
 
 let
   version = "2.6.3";
-  inherit (pythonPackages) buildPythonApplication python mutagen pygtk pygobject dbus-python;
+  inherit (pythonPackages) buildPythonApplication python mutagen pygtk pygobject2 dbus-python;
 in buildPythonApplication {
   # call the package quodlibet and just quodlibet
   name = "quodlibet${stdenv.lib.optionalString withGstPlugins "-with-gst-plugins"}-${version}";
@@ -48,7 +48,7 @@ in buildPythonApplication {
   ];
 
   propagatedBuildInputs = [
-    mutagen pygtk pygobject dbus-python gst_python intltool
+    mutagen pygtk pygobject2 dbus-python gst_python intltool
   ];
 
   postInstall = stdenv.lib.optionalString withGstPlugins ''

--- a/pkgs/applications/audio/seq24/default.nix
+++ b/pkgs/applications/audio/seq24/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, alsaLib, gtkmm, libjack2, pkgconfig }:
+{ stdenv, fetchurl, alsaLib, gtkmm2, libjack2, pkgconfig }:
 
 stdenv.mkDerivation  rec {
   name = "seq24-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation  rec {
 
   patches = [ ./mutex_no_nameclash.patch ];
 
-  buildInputs = [ alsaLib gtkmm libjack2 ];
+  buildInputs = [ alsaLib gtkmm2 libjack2 ];
   nativeBuildInputs = [ pkgconfig ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, dpkg, xorg, alsaLib, makeWrapper, openssl, freetype
-, glib, pango, cairo, atk, gdk_pixbuf, gtk, cups, nspr, nss, libpng, GConf
-, libgcrypt, systemd, fontconfig, dbus, expat, ffmpeg_0_10, curl, zlib, gnome }:
+, glib, pango, cairo, atk, gdk_pixbuf, gtk2, cups, nspr, nss, libpng, GConf
+, libgcrypt, systemd, fontconfig, dbus, expat, ffmpeg_0_10, curl, zlib, gnome2 }:
 
 assert stdenv.system == "x86_64-linux";
 
@@ -22,7 +22,7 @@ let
     GConf
     gdk_pixbuf
     glib
-    gtk
+    gtk2
     libgcrypt
     libpng
     nss
@@ -83,7 +83,7 @@ stdenv.mkDerivation {
       librarypath="${stdenv.lib.makeLibraryPath deps}:$libdir"
       wrapProgram $out/share/spotify/spotify \
         --prefix LD_LIBRARY_PATH : "$librarypath" \
-        --prefix PATH : "${gnome.zenity}/bin"
+        --prefix PATH : "${gnome2.zenity}/bin"
 
       # Desktop file
       mkdir -p "$out/share/applications/"

--- a/pkgs/applications/audio/xsynth-dssi/default.nix
+++ b/pkgs/applications/audio/xsynth-dssi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, alsaLib, autoconf, automake, dssi, gtk, libjack2,
+{ stdenv, fetchurl, alsaLib, autoconf, automake, dssi, gtk2, libjack2,
 ladspaH, ladspaPlugins, liblo, pkgconfig }:
 
 stdenv.mkDerivation  rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation  rec {
     sha256 = "00nwv2pqjbmxqdc6xdm0cljq6z05lv4y6bibmhz1kih9lm0lklnk";
   };
 
-  buildInputs = [ alsaLib autoconf automake dssi gtk libjack2 ladspaH
+  buildInputs = [ alsaLib autoconf automake dssi gtk2 libjack2 ladspaH
     ladspaPlugins liblo pkgconfig ];
 
   installPhase = ''

--- a/pkgs/applications/editors/atom/env.nix
+++ b/pkgs/applications/editors/atom/env.nix
@@ -1,11 +1,11 @@
-{ stdenv, lib, zlib, glib, alsaLib, dbus, gtk, atk, pango, freetype, fontconfig
+{ stdenv, lib, zlib, glib, alsaLib, dbus, gtk2, atk, pango, freetype, fontconfig
 , libgnome_keyring3, gdk_pixbuf, gvfs, cairo, cups, expat, libgpgerror, nspr
 , gconf, nss, xorg, libcap, systemd, libnotify
 }:
 
 let
   packages = [
-    stdenv.cc.cc zlib glib dbus gtk atk pango freetype libgnome_keyring3
+    stdenv.cc.cc zlib glib dbus gtk2 atk pango freetype libgnome_keyring3
     fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gconf nss
     xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
     xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr

--- a/pkgs/applications/editors/brackets/default.nix
+++ b/pkgs/applications/editors/brackets/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchurl, buildEnv, gtk, glib, gdk_pixbuf, alsaLib, nss, nspr, gconf
+{ stdenv, fetchurl, buildEnv, gtk2, glib, gdk_pixbuf, alsaLib, nss, nspr, gconf
 , cups, libgcrypt_1_5, systemd, makeWrapper, dbus }:
 let
   bracketsEnv = buildEnv {
     name = "env-brackets";
     paths = [
-      gtk glib gdk_pixbuf stdenv.cc.cc alsaLib nss nspr gconf cups libgcrypt_1_5
+      gtk2 glib gdk_pixbuf stdenv.cc.cc alsaLib nss nspr gconf cups libgcrypt_1_5
       dbus systemd.lib
     ];
   };

--- a/pkgs/applications/editors/codeblocks/default.nix
+++ b/pkgs/applications/editors/codeblocks/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, file, zip, wxGTK, gtk
+{ stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, file, zip, wxGTK, gtk2
 , contribPlugins ? false, hunspell, gamin, boost
 }:
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "044njhps4cm1ijfdyr5f9wjyd0vblhrz9b4603ma52wcdq25093p";
   };
 
-  buildInputs = [ automake autoconf libtool pkgconfig file zip wxGTK gtk ]
+  buildInputs = [ automake autoconf libtool pkgconfig file zip wxGTK gtk2 ]
     ++ optionals contribPlugins [ hunspell gamin boost ];
   enableParallelBuilding = true;
   patches = [ ./writable-projects.patch ];

--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeDesktopItem, freetype, fontconfig, libX11, libXrender, zlib, jdk, glib, gtk, libXtst, webkitgtk2, makeWrapper, ... }:
+{ stdenv, makeDesktopItem, freetype, fontconfig, libX11, libXrender, zlib, jdk, glib, gtk2, libXtst, webkitgtk2, makeWrapper, ... }:
 
 { name, src ? builtins.getAttr stdenv.system sources, sources ? null, description }:
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper $out/eclipse/eclipse $out/bin/eclipse \
       --prefix PATH : ${jdk}/bin \
-      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath ([ glib gtk libXtst ] ++ stdenv.lib.optional (webkitgtk2 != null) webkitgtk2)} \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath ([ glib gtk2 libXtst ] ++ stdenv.lib.optional (webkitgtk2 != null) webkitgtk2)} \
       --add-flags "-configuration \$HOME/.eclipse/''${productId}_$productVersion/configuration"
 
     # Create desktop item.

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -1,16 +1,16 @@
 { stdenv, lib, fetchurl, makeDesktopItem, makeWrapper
 , freetype, fontconfig, libX11, libXext, libXrender, zlib
-, glib, gtk, libXtst, jdk
+, glib, libXtst, jdk
 , webkitgtk2 ? null  # for internal web browser
 , buildEnv, writeText, runCommand
 , callPackage
-} @ args:
+}:
 
 assert stdenv ? glibc;
 
 rec {
 
-  buildEclipse = import ./build-eclipse.nix args;
+  buildEclipse = callPackage ./build-eclipse.nix { };
 
   eclipse-sdk-35 = buildEclipse {
     name = "eclipse-sdk-3.5.2";

--- a/pkgs/applications/editors/geany/with-vte.nix
+++ b/pkgs/applications/editors/geany/with-vte.nix
@@ -1,8 +1,8 @@
-{ runCommand, makeWrapper, geany, gnome }:
+{ runCommand, makeWrapper, geany, gnome2 }:
 let name = builtins.replaceStrings ["geany-"] ["geany-with-vte-"] geany.name;
 in
 runCommand "${name}" { nativeBuildInputs = [ makeWrapper ]; } "
    mkdir -p $out
    ln -s ${geany}/share $out
-   makeWrapper ${geany}/bin/geany $out/bin/geany --prefix LD_LIBRARY_PATH : ${gnome.vte}/lib
+   makeWrapper ${geany}/bin/geany $out/bin/geany --prefix LD_LIBRARY_PATH : ${gnome2.vte}/lib
 "

--- a/pkgs/applications/editors/gobby/default.nix
+++ b/pkgs/applications/editors/gobby/default.nix
@@ -1,7 +1,7 @@
 { avahiSupport ? false # build support for Avahi in libinfinity
 , gnomeSupport ? false # build support for Gnome(gnome-vfs)
 , stdenv, fetchurl, pkgconfig
-, gtkmm, gsasl, gtksourceview, libxmlxx, libinfinity, intltool
+, gtkmm2, gsasl, gtksourceview, libxmlxx, libinfinity, intltool
 , gnome_vfs ? null}:
 
 let
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
     sha256 = "165x0r668ma5blziisvbr8qig3jw9hf7i6w8r7wwvz3wsac3bswc";
   };
 
-  buildInputs = [ pkgconfig gtkmm gsasl gtksourceview libxmlxx libinf intltool ]
+  buildInputs = [ pkgconfig gtkmm2 gsasl gtksourceview libxmlxx libinf intltool ]
     ++ stdenv.lib.optional gnomeSupport gnome_vfs;
   
   configureFlags = ''

--- a/pkgs/applications/editors/leafpad/default.nix
+++ b/pkgs/applications/editors/leafpad/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gtk }:
+{ stdenv, fetchurl, intltool, pkgconfig, gtk2 }:
 
 stdenv.mkDerivation rec {
   version = "0.8.18.1";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0b0az2wvqgvam7w0ns1j8xp2llslm1rx6h7zcsy06a7j0yp257cm";
   };
 
-  buildInputs = [ intltool pkgconfig gtk ];
+  buildInputs = [ intltool pkgconfig gtk2 ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/editors/lighttable/default.nix
+++ b/pkgs/applications/editors/lighttable/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, buildEnv, zlib, glib, alsaLib, makeDesktopItem
-, dbus, gtk, atk, pango, freetype, fontconfig, libgnome_keyring3, gdk_pixbuf
+, dbus, gtk2, atk, pango, freetype, fontconfig, libgnome_keyring3, gdk_pixbuf
 , cairo, cups, expat, libgpgerror, nspr, gnome3, nss, xorg, systemd, libnotify
 }:
 
 let
   libPath = stdenv.lib.makeLibraryPath [
-      stdenv.cc.cc zlib glib dbus gtk atk pango freetype libgnome_keyring3 nss
+      stdenv.cc.cc zlib glib dbus gtk2 atk pango freetype libgnome_keyring3 nss
       fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gnome3.gconf
       xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
       xorg.libXcomposite xorg.libXi xorg.libXfixes libnotify xorg.libXrandr

--- a/pkgs/applications/editors/monodevelop/default.nix
+++ b/pkgs/applications/editors/monodevelop/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchgit, fetchNuGet
 , autoconf, automake, pkgconfig, shared_mime_info, intltool
-, glib, mono, gtk-sharp, gnome, gnome-sharp, unzip
+, glib, mono, gtk-sharp-2_0, gnome2, gnome-sharp, unzip
 , dotnetPackages
 }:
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     autoconf automake pkgconfig shared_mime_info intltool
-    mono gtk-sharp gnome-sharp unzip
+    mono gtk-sharp-2_0 gnome-sharp unzip
     pkgconfig
     dotnetPackages.NUnit
     dotnetPackages.NUnitRunners
@@ -57,9 +57,9 @@ stdenv.mkDerivation rec {
     for prog in monodevelop mdtool; do
     patch -p 0 $out/bin/$prog <<EOF
     2a3,5
-    > export MONO_GAC_PREFIX=${gnome-sharp}:${gtk-sharp}:\$MONO_GAC_PREFIX
+    > export MONO_GAC_PREFIX=${gnome-sharp}:${gtk-sharp-2_0}:\$MONO_GAC_PREFIX
     > export PATH=${mono}/bin:\$PATH
-    > export LD_LIBRARY_PATH=${stdenv.lib.makeLibraryPath [ glib gnome.libgnomeui gnome.gnome_vfs gnome-sharp gtk-sharp gtk-sharp.gtk ]}:\$LD_LIBRARY_PATH
+    > export LD_LIBRARY_PATH=${stdenv.lib.makeLibraryPath [ glib gnome2.libgnomeui gnome2.gnome_vfs gnome-sharp gtk-sharp-2_0 gtk-sharp-2_0.gtk ]}:\$LD_LIBRARY_PATH
     > 
     EOF
     done

--- a/pkgs/applications/editors/scite/default.nix
+++ b/pkgs/applications/editors/scite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk }:
+{ stdenv, fetchurl, pkgconfig, gtk2 }:
 
 let
   version = "3.3.7";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     sha256 = "0x7i6yxq50frsjkrp3lc5zy0d1ssq2n91igjn0dmqajpg7kls2dd";
   };
 
-  buildInputs = [ pkgconfig gtk ];
+  buildInputs = [ pkgconfig gtk2 ];
   sourceRoot = "scintilla/gtk";
 
   buildPhase = ''

--- a/pkgs/applications/editors/sublime/default.nix
+++ b/pkgs/applications/editors/sublime/default.nix
@@ -1,6 +1,6 @@
-{ fetchurl, stdenv, glib, xorg, cairo, gtk, makeDesktopItem }:
+{ fetchurl, stdenv, glib, xorg, cairo, gtk2, makeDesktopItem }:
 let
-  libPath = stdenv.lib.makeLibraryPath [glib xorg.libX11 gtk cairo];
+  libPath = stdenv.lib.makeLibraryPath [glib xorg.libX11 gtk2 cairo];
 in
 assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
 

--- a/pkgs/applications/editors/sublime3/default.nix
+++ b/pkgs/applications/editors/sublime3/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, glib, xorg, cairo, gtk, pango, makeWrapper, openssl, bzip2,
+{ fetchurl, stdenv, glib, xorg, cairo, gtk2, pango, makeWrapper, openssl, bzip2,
   pkexecPath ? "/var/setuid-wrappers/pkexec", libredirect,
   gksuSupport ? false, gksu}:
 
@@ -7,7 +7,7 @@ assert gksuSupport -> gksu != null;
 
 let
   build = "3114";
-  libPath = stdenv.lib.makeLibraryPath [glib xorg.libX11 gtk cairo pango];
+  libPath = stdenv.lib.makeLibraryPath [glib xorg.libX11 gtk2 cairo pango];
   redirects = [ "/usr/bin/pkexec=${pkexecPath}" ]
     ++ stdenv.lib.optional gksuSupport "/usr/bin/gksudo=${gksu}/bin/gksudo";
 in let

--- a/pkgs/applications/editors/supertux-editor/default.nix
+++ b/pkgs/applications/editors/supertux-editor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, mono, gtk-sharp, pkgconfig, makeWrapper, gnome, gtk }:
+{ stdenv, fetchFromGitHub, mono, gtk-sharp-2_0, pkgconfig, makeWrapper, gnome2, gtk2 }:
 stdenv.mkDerivation rec {
   version = "git-2014-08-20";
   name = "supertux-editor-${version}";
@@ -10,19 +10,19 @@ stdenv.mkDerivation rec {
     sha256 = "08y5haclgxvcii3hpdvn1ah8qd0f3n8xgxxs8zryj02b8n7cz3vx";
   };
 
-  buildInputs = [mono gtk-sharp pkgconfig makeWrapper gnome.libglade gtk ];
+  buildInputs = [mono gtk-sharp-2_0 pkgconfig makeWrapper gnome2.libglade gtk2 ];
 
   installPhase = ''
     mkdir -p $out/bin $out/lib/supertux-editor
     cp *.{dll,dll.config,exe} $out/lib/supertux-editor
     makeWrapper "${mono}/bin/mono" $out/bin/supertux-editor \
       --add-flags "$out/lib/supertux-editor/supertux-editor.exe" \
-      --prefix MONO_GAC_PREFIX : ${gtk-sharp} \
+      --prefix MONO_GAC_PREFIX : ${gtk-sharp-2_0} \
       --suffix LD_LIBRARY_PATH : $(echo $NIX_LDFLAGS | sed 's/ -L/:/g;s/ -rpath /:/g;s/-rpath //')
 
     makeWrapper "${mono}/bin/mono" $out/bin/supertux-editor-debug \
       --add-flags "--debug $out/lib/supertux-editor/supertux-editor.exe" \
-      --prefix MONO_GAC_PREFIX : ${gtk-sharp} \
+      --prefix MONO_GAC_PREFIX : ${gtk-sharp-2_0} \
       --suffix LD_LIBRARY_PATH : $(echo $NIX_LDFLAGS | sed 's/ -L/:/g;s/ -rpath /:/g;s/-rpath //')
   '';
 

--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchhg, fetchurl, fetchzip, gtk, glib, pkgconfig, unzip, ncurses, zip }:
+{ stdenv, fetchhg, fetchurl, fetchzip, gtk2, glib, pkgconfig, unzip, ncurses, zip }:
 let
   # Textadept requires a whole bunch of external dependencies.
   # The build system expects to be able to download them with wget.
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
   name = "textadept-${version}";
 
   buildInputs = [
-    gtk glib pkgconfig unzip ncurses zip
+    gtk2 glib pkgconfig unzip ncurses zip
   ];
 
   src = fetchhg {

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -1,7 +1,7 @@
 # TODO tidy up eg The patchelf code is patching gvim even if you don't build it..
 # but I have gvim with python support now :) - Marc
 args@{pkgs, source ? "default", fetchurl, fetchFromGitHub, stdenv, ncurses, pkgconfig, gettext
-, composableDerivation, lib, config, glib, gtk, python, perl, tcl, ruby
+, composableDerivation, lib, config, glib, gtk2, python, perl, tcl, ruby
 , libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
 , libICE
 
@@ -79,7 +79,7 @@ composableDerivation {
       = [ "--enable-gui=${args.gui}" "--with-features=${args.features}" ];
 
     nativeBuildInputs
-      = [ ncurses pkgconfig gtk libX11 libXext libSM libXpm libXt libXaw libXau
+      = [ ncurses pkgconfig gtk2 libX11 libXext libSM libXpm libXt libXaw libXau
           libXmu glib libICE ];
 
     # most interpreters aren't tested yet.. (see python for example how to do it)

--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -1,5 +1,5 @@
 { stdenv, pkgs, fetchurl, fetchFromGitHub, pkgconfig, libconfig, 
-  gtkmm, glibmm, libxml2, libsecret, curl, unrar, libzip, 
+  gtkmm2, glibmm, libxml2, libsecret, curl, unrar, libzip,
   librsvg, gst_all_1, autoreconfHook, makeWrapper }:
 stdenv.mkDerivation {
   name = "ahoviewer-1.4.6";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
   enableParallelBuilding = true; 
   nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
-  buildInputs = [ glibmm libconfig gtkmm glibmm libxml2 
+  buildInputs = [ glibmm libconfig gtkmm2 glibmm libxml2
                   libsecret curl unrar libzip librsvg 
                   gst_all_1.gstreamer
                   gst_all_1.gst-plugins-good 

--- a/pkgs/applications/graphics/cinepaint/default.nix
+++ b/pkgs/applications/graphics/cinepaint/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, gtk, freetype, fontconfig, lcms,
+{ stdenv, fetchurl, cmake, pkgconfig, gtk2, freetype, fontconfig, lcms,
   flex, libtiff, libjpeg, libpng, libexif, zlib, perl, libX11,
   perlXMLParser, python, pygtk, gettext, intltool, babl, gegl,
   glib, makedepend, xf86vidmodeproto, xineramaproto, libXmu, openexr,
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0b5g4bkq62yiz1cnb2vfij0a8fw5w5z202v5dm4dh89k7cj0yq4w";
   };
 
-  buildInputs = [ libpng gtk freetype fontconfig lcms flex libtiff libjpeg
+  buildInputs = [ libpng gtk2 freetype fontconfig lcms flex libtiff libjpeg
     libexif zlib perl libX11 perlXMLParser python pygtk gettext intltool babl
     gegl glib makedepend xf86vidmodeproto xineramaproto libXmu openexr mesa
     libXext libXpm libXau libXxf86vm pixman libpthreadstubs fltk

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk, pkgconfig, perl, perlXMLParser, libxml2, gettext
+{stdenv, fetchurl, gtk2, pkgconfig, perl, perlXMLParser, libxml2, gettext
 , python, libxml2Python, docbook5, docbook_xsl, libxslt, intltool, libart_lgpl
 , withGNOME ? false, libgnomeui }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ gtk perlXMLParser libxml2 gettext python libxml2Python docbook5
+    [ gtk2 perlXMLParser libxml2 gettext python libxml2Python docbook5
       libxslt docbook_xsl libart_lgpl
     ] ++ stdenv.lib.optional withGNOME libgnomeui;
 

--- a/pkgs/applications/graphics/gcolor2/default.nix
+++ b/pkgs/applications/graphics/gcolor2/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk, perl, perlXMLParser, pkgconfig } :
+{stdenv, fetchurl, gtk2, perl, perlXMLParser, pkgconfig } :
 
 let version = "0.4"; in
 stdenv.mkDerivation {
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
         [ ./gcolor2-amd64.patch ] else
         [ ];
 
-buildInputs = [ gtk perl perlXMLParser pkgconfig ];
+buildInputs = [ gtk2 perl perlXMLParser pkgconfig ];
 
   meta = {
     description = "Simple GTK+2 color selector";

--- a/pkgs/applications/graphics/geeqie/default.nix
+++ b/pkgs/applications/graphics/geeqie/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, autoconf, automake, gtk, libpng, exiv2
+{ stdenv, fetchurl, pkgconfig, autoconf, automake, gtk2, libpng, exiv2
 , lcms, intltool, gettext, fbida
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-gps" ];
 
   buildInputs = [
-    pkgconfig autoconf automake gtk libpng exiv2 lcms intltool gettext
+    pkgconfig autoconf automake gtk2 libpng exiv2 lcms intltool gettext
   ];
 
   postInstall = ''

--- a/pkgs/applications/graphics/gimp/2.8.nix
+++ b/pkgs/applications/graphics/gimp/2.8.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, babl, gegl, gtk, glib, gdk_pixbuf
+{ stdenv, fetchurl, pkgconfig, intltool, babl, gegl, gtk2, glib, gdk_pixbuf
 , pango, cairo, freetype, fontconfig, lcms, libpng, libjpeg, poppler, libtiff
 , webkit, libmng, librsvg, libwmf, zlib, libzip, ghostscript, aalib, jasper
 , python, pygtk, libart_lgpl, libexif, gettext, xorg, wrapPython }:
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig intltool babl gegl gtk glib gdk_pixbuf pango cairo
+    [ pkgconfig intltool babl gegl gtk2 glib gdk_pixbuf pango cairo
       freetype fontconfig lcms libpng libjpeg poppler libtiff webkit
       libmng librsvg libwmf zlib libzip ghostscript aalib jasper
       python pygtk libart_lgpl libexif gettext xorg.libXpm
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
   '';
 
-  passthru = { inherit gtk; }; # probably its a good idea to use the same gtk in plugins ?
+  passthru = { gtk = gtk2; }; # probably its a good idea to use the same gtk in plugins ?
 
   #configureFlags = [ "--disable-print" ];
 

--- a/pkgs/applications/graphics/giv/default.nix
+++ b/pkgs/applications/graphics/giv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gdk_pixbuf, scons, pkgconfig, gtk, glib,
+{ stdenv, fetchFromGitHub, gdk_pixbuf, scons, pkgconfig, gtk2, glib,
   pcre, cfitsio, perl, gob2, vala_0_23, libtiff, json_glib }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   installPhase = "scons install";
 
-  buildInputs = [ gdk_pixbuf pkgconfig gtk glib scons pcre cfitsio perl gob2 vala_0_23 libtiff
+  buildInputs = [ gdk_pixbuf pkgconfig gtk2 glib scons pcre cfitsio perl gob2 vala_0_23 libtiff
     json_glib ];
 
   meta = {

--- a/pkgs/applications/graphics/gqview/default.nix
+++ b/pkgs/applications/graphics/gqview/default.nix
@@ -1,9 +1,9 @@
-{stdenv, fetchurl, pkgconfig, gtk, libpng}:
+{stdenv, fetchurl, pkgconfig, gtk2, libpng}:
 
-assert pkgconfig != null && gtk != null && libpng != null;
+assert pkgconfig != null && gtk2 != null && libpng != null;
 # Note that we cannot just copy gtk's png attribute, since gtk might
 # not be linked against png.
-# !!! assert libpng == gtk.libpng;
+# !!! assert libpng == gtk2.libpng;
 
 stdenv.mkDerivation {
   name = "gqview-2.1.5";
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
     sha256 = "0ilm5s7ps9kg4f5hzgjhg0xhn6zg0v9i7jnd67zrx9h7wsaa9zhj";
   };
 
-  buildInputs = [pkgconfig gtk libpng];
+  buildInputs = [pkgconfig gtk2 libpng];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, perl, perlXMLParser, gtk, libXft
-, libpng, zlib, popt, boehmgc, libxml2, libxslt, glib, gtkmm
+{ stdenv, fetchurl, fetchpatch, pkgconfig, perl, perlXMLParser, libXft
+, libpng, zlib, popt, boehmgc, libxml2, libxslt, glib, gtkmm2
 , glibmm, libsigcxx, lcms, boost, gettext, makeWrapper, intltool
 , gsl, python, numpy, pyxml, lxml, poppler, imagemagick, libwpg, librevenge
 , libvisio, libcdr, libexif, unzip, automake114x, autoconf
@@ -49,8 +49,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    pkgconfig perl perlXMLParser gtk libXft libpng zlib popt boehmgc
-    libxml2 libxslt glib gtkmm glibmm libsigcxx lcms boost gettext
+    pkgconfig perl perlXMLParser libXft libpng zlib popt boehmgc
+    libxml2 libxslt glib gtkmm2 glibmm libsigcxx lcms boost gettext
     makeWrapper intltool gsl poppler imagemagick libwpg librevenge
     libvisio libcdr libexif automake114x autoconf
   ] ++ stdenv.lib.optional boxMakerPlugin unzip;

--- a/pkgs/applications/graphics/k3d/default.nix
+++ b/pkgs/applications/graphics/k3d/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, unzip, ftgl, glew, asciidoc
 , cmake, mesa, zlib, python, expat, libxml2, libsigcxx, libuuid, freetype
 , libpng, boost, doxygen, cairomm, pkgconfig, imagemagick, libjpeg, libtiff
-, gettext, intltool, perl, gtkmm, glibmm, gtkglext, pangox_compat, libXmu }:
+, gettext, intltool, perl, gtkmm2, glibmm, gtkglext, pangox_compat, libXmu }:
 
 stdenv.mkDerivation rec {
   version = "0.8.0.5";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
      cmake mesa zlib python expat libxml2 libsigcxx libuuid freetype libpng
      boost boost doxygen cairomm pkgconfig imagemagick libjpeg libtiff
      gettext intltool perl unzip ftgl glew asciidoc
-     gtkmm glibmm gtkglext pangox_compat libXmu
+     gtkmm2 glibmm gtkglext pangox_compat libXmu
     ];
 
   #doCheck = false;

--- a/pkgs/applications/graphics/mypaint/default.nix
+++ b/pkgs/applications/graphics/mypaint/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gettext, glib, gtk, hicolor_icon_theme, json_c
+{ stdenv, fetchurl, gettext, glib, gtk2, hicolor_icon_theme, json_c
 , lcms2, libpng , makeWrapper, pkgconfig, pygtk, python, pythonPackages
 , scons, swig
 }:
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    gettext glib gtk json_c lcms2 libpng makeWrapper pkgconfig pygtk
+    gettext glib gtk2 json_c lcms2 libpng makeWrapper pkgconfig pygtk
     python scons swig
   ];
 

--- a/pkgs/applications/graphics/pqiv/default.nix
+++ b/pkgs/applications/graphics/pqiv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, getopt, which, pkgconfig, gtk } :
+{ stdenv, fetchurl, getopt, which, pkgconfig, gtk2 } :
 
 stdenv.mkDerivation (rec {
   name = "pqiv-0.12";
@@ -8,7 +8,7 @@ stdenv.mkDerivation (rec {
     sha256 = "646c69f2f4e7289913f6b8e8ae984befba9debf0d2b4cc8af9955504a1fccf1e";
   };
 
-  buildInputs = [ getopt which pkgconfig gtk ];
+  buildInputs = [ getopt which pkgconfig gtk2 ];
 
   preConfigure=''
     substituteInPlace configure --replace /bin/bash "$shell"

--- a/pkgs/applications/graphics/qiv/default.nix
+++ b/pkgs/applications/graphics/qiv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, imlib2, file, lcms2, libexif } :
+{ stdenv, fetchurl, pkgconfig, gtk2, imlib2, file, lcms2, libexif } :
 
 stdenv.mkDerivation (rec {
   version = "2.3.1";
@@ -9,7 +9,7 @@ stdenv.mkDerivation (rec {
     sha256 = "1rlf5h67vhj7n1y7jqkm9k115nfnzpwngj3kzqsi2lg676srclv7";
   };
 
-  buildInputs = [ pkgconfig gtk imlib2 file lcms2 libexif ];
+  buildInputs = [ pkgconfig gtk2 imlib2 file lcms2 libexif ];
 
   preBuild=''
     substituteInPlace Makefile --replace /usr/local "$out"

--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, pkgconfig, gtk, cmake, pixman, libpthreadstubs, gtkmm, libXau
-, libXdmcp, lcms2, libiptcdata, libcanberra, fftw, expat, pcre, libsigcxx 
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, pixman, libpthreadstubs, gtkmm2, libXau
+, libXdmcp, lcms2, libiptcdata, libcanberra_gtk2, fftw, expat, pcre, libsigcxx
 , mercurial  # Not really needed for anything, but it fails if it does not find 'hg'
 }:
 
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1v4px239vlmk9l8wbzlvlyni4ns12icxmgfz21m86jkd10pj5dgr";
   };
   
-  buildInputs = [ pkgconfig gtk cmake pixman libpthreadstubs gtkmm libXau libXdmcp
-    lcms2 libiptcdata mercurial libcanberra fftw expat pcre libsigcxx ];
+  buildInputs = [ pkgconfig cmake pixman libpthreadstubs gtkmm2 libXau libXdmcp
+    lcms2 libiptcdata mercurial libcanberra_gtk2 fftw expat pcre libsigcxx ];
 
   patchPhase = ''
     patch -p1 < ${./sigc++_fix.patch}

--- a/pkgs/applications/graphics/sane/frontends.nix
+++ b/pkgs/applications/graphics/sane/frontends.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, sane-backends, libX11, gtk, pkgconfig, libusb ? null}:
+{ stdenv, fetchurl, sane-backends, libX11, gtk2, pkgconfig, libusb ? null}:
 
 stdenv.mkDerivation rec {
   name = "sane-frontends-1.0.14";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sed -e '/SANE_CAP_ALWAYS_SETTABLE/d' -i src/gtkglue.c
   '';
 
-  buildInputs = [sane-backends libX11 gtk pkgconfig] ++
+  buildInputs = [sane-backends libX11 gtk2 pkgconfig] ++
 	(if libusb != null then [libusb] else []);
 
   meta = {

--- a/pkgs/applications/graphics/sane/xsane.nix
+++ b/pkgs/applications/graphics/sane/xsane.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, sane-backends, sane-frontends, libX11, gtk, pkgconfig, libpng
+{ stdenv, fetchurl, sane-backends, sane-frontends, libX11, gtk2, pkgconfig, libpng
 , libusb ? null
 , gimpSupport ? false, gimp_2_8 ? null
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     chmod a+rX -R .
   '';
 
-  buildInputs = [libpng sane-backends sane-frontends libX11 gtk pkgconfig ]
+  buildInputs = [libpng sane-backends sane-frontends libX11 gtk2 pkgconfig ]
     ++ (if libusb != null then [libusb] else [])
     ++ stdenv.lib.optional gimpSupport gimp_2_8;
 

--- a/pkgs/applications/graphics/ufraw/default.nix
+++ b/pkgs/applications/graphics/ufraw/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gtk, gettext, bzip2, zlib
+{ fetchurl, stdenv, pkgconfig, gtk2, gettext, bzip2, zlib
 , libjpeg, libtiff, cfitsio, exiv2, lcms2, gtkimageview, lensfun }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig gtk gtkimageview gettext bzip2 zlib
+    [ pkgconfig gtk2 gtkimageview gettext bzip2 zlib
       libjpeg libtiff cfitsio exiv2 lcms2 lensfun
     ];
 

--- a/pkgs/applications/graphics/xara/default.nix
+++ b/pkgs/applications/graphics/xara/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, automake, gettext, freetype, libxml2, pango, pkgconfig
-, wxGTK, gtk, perl, zip}:
+, wxGTK, gtk2, perl, zip}:
 
 stdenv.mkDerivation {
   name = "xaralx-0.7r1785";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ automake pkgconfig gettext perl zip ];
-  buildInputs = [ wxGTK gtk libxml2 freetype pango ];
+  buildInputs = [ wxGTK gtk2 libxml2 freetype pango ];
 
   configureFlags = "--disable-svnversion";
 

--- a/pkgs/applications/graphics/xournal/default.nix
+++ b/pkgs/applications/graphics/xournal/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, ghostscript, atk, gtk, glib, fontconfig, freetype
+, ghostscript, atk, gtk2, glib, fontconfig, freetype
 , libgnomecanvas, libgnomeprint, libgnomeprintui
 , pango, libX11, xproto, zlib, poppler
 , autoconf, automake, libtool, pkgconfig}:
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    ghostscript atk gtk glib fontconfig freetype
+    ghostscript atk gtk2 glib fontconfig freetype
     libgnomecanvas libgnomeprint libgnomeprintui
     pango libX11 xproto zlib poppler
   ];

--- a/pkgs/applications/graphics/xzgv/default.nix
+++ b/pkgs/applications/graphics/xzgv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, pkgconfig, texinfo }:
+{ stdenv, fetchurl, gtk2, pkgconfig, texinfo }:
 
 stdenv.mkDerivation rec {
   name = "xzgv-${version}";
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/xzgv/xzgv-${version}.tar.gz";
     sha256 = "1rh432wnvzs434knzbda0fslhfx0gngryrrnqkfm6gwd2g5mxcph";
   };
-  buildInputs = [ gtk pkgconfig texinfo ];
+  buildInputs = [ gtk2 pkgconfig texinfo ];
   patches = [ ./fix-linker-paths.patch ];
   postPatch = ''
     substituteInPlace config.mk \

--- a/pkgs/applications/misc/adobe-reader/default.nix
+++ b/pkgs/applications/misc/adobe-reader/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libX11, cups, zlib, libxml2, pango, atk, gtk, glib
+{ stdenv, fetchurl, libX11, cups, zlib, libxml2, pango, atk, gtk2, glib
 , gdk_pixbuf }:
 
 assert stdenv.system == "i686-linux";
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   # versions.
 
   libPath = stdenv.lib.makeLibraryPath
-    [ stdenv.cc.cc libX11 zlib libxml2 cups pango atk gtk glib gdk_pixbuf ];
+    [ stdenv.cc.cc libX11 zlib libxml2 cups pango atk gtk2 glib gdk_pixbuf ];
 
   passthru.mozillaPlugin = "/libexec/adobe-reader/Browser/intellinux";
 

--- a/pkgs/applications/misc/artha/default.nix
+++ b/pkgs/applications/misc/artha/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, dbus_glib, gtk, pkgconfig, wordnet }:
+{ stdenv, fetchurl, dbus_glib, gtk2, pkgconfig, wordnet }:
 
 stdenv.mkDerivation rec {
   name = "artha-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0qr4ihl7ma3cq82xi1fpzvf74mm9vsg0j035xvmcp3r6rmw2fycx";
   };
 
-  buildInputs = [ dbus_glib gtk pkgconfig wordnet ];
+  buildInputs = [ dbus_glib gtk2 pkgconfig wordnet ];
 
   meta = with stdenv.lib; {
     description = "An offline thesaurus based on WordNet";

--- a/pkgs/applications/misc/avrdudess/default.nix
+++ b/pkgs/applications/misc/avrdudess/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, mono, avrgcclibc, avrdude, gtk, xdg_utils }:
+{ stdenv, fetchurl, unzip, mono, avrgcclibc, avrdude, gtk2, xdg_utils }:
 
 stdenv.mkDerivation rec {
   name = "avrdudess-2.2.20140102";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
     cat >> "$out/bin/avrdudess" << __EOF__
     #!${stdenv.shell}
-    export LD_LIBRARY_PATH="${stdenv.lib.makeLibraryPath [gtk mono]}"
+    export LD_LIBRARY_PATH="${stdenv.lib.makeLibraryPath [gtk2 mono]}"
     # We need PATH from user env for xdg-open to find its tools, which
     # typically depend on the currently running desktop environment.
     export PATH="${stdenv.lib.makeBinPath [ avrgcclibc avrdude xdg_utils ]}:\$PATH"

--- a/pkgs/applications/misc/batti/default.nix
+++ b/pkgs/applications/misc/batti/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl
 , pkgconfig, gettext, pythonPackages
-, gtk, gdk_pixbuf, upower
+, gtk2, gdk_pixbuf, upower
 , makeWrapper }:
 
 let
-  inherit (pythonPackages) dbus-python pygtk python;
+  inherit (pythonPackages) dbus-python pygtk2 python;
 in stdenv.mkDerivation rec {
 
   name = "batti-${version}";
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = with stdenv.lib;
-  [ pkgconfig gettext python gtk pygtk dbus-python gdk_pixbuf upower makeWrapper ];
+  [ pkgconfig gettext python gtk2 pygtk2 dbus-python gdk_pixbuf upower makeWrapper ];
 
   configurePhase = "true";
 

--- a/pkgs/applications/misc/clipit/default.nix
+++ b/pkgs/applications/misc/clipit/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, intltool, pkgconfig, gtk, xdotool }:
+{ fetchurl, stdenv, intltool, pkgconfig, gtk2, xdotool }:
 
 stdenv.mkDerivation rec {
   name = "clipit-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jrwn8qfgb15rwspdp1p8hb1nc0ngmpvgr87d4k3lhlvqg2cfqva";
   };
 
-  buildInputs = [ intltool pkgconfig gtk xdotool  ];
+  buildInputs = [ intltool pkgconfig gtk2 xdotool  ];
 
   meta = with stdenv.lib; {
     description = "Lightweight GTK+ Clipboard Manager";

--- a/pkgs/applications/misc/d4x/default.nix
+++ b/pkgs/applications/misc/d4x/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, glib, pkgconfig, openssl, boost }:
+{ stdenv, fetchurl, gtk2, glib, pkgconfig, openssl, boost }:
 
 stdenv.mkDerivation {
   name = "d4x-2.5.7.1";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "1i1jj02bxynisqapv31481sz9jpfp3f023ky47spz1v1wlwbs13m";
   };
 
-  buildInputs = [ gtk glib pkgconfig openssl boost ];
+  buildInputs = [ gtk2 glib pkgconfig openssl boost ];
 
   meta = {
     description = "Graphical download manager";

--- a/pkgs/applications/misc/eaglemode/default.nix
+++ b/pkgs/applications/misc/eaglemode/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, perl, libX11, libjpeg, libpng, libtiff, pkgconfig,
-librsvg, glib, gtk, libXext, libXxf86vm, poppler, xineLib }:
+librsvg, glib, gtk2, libXext, libXxf86vm, poppler, xineLib }:
 
 stdenv.mkDerivation rec {
   name = "eaglemode-0.86.0";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ perl libX11 libjpeg libpng libtiff pkgconfig
-    librsvg glib gtk libXxf86vm libXext poppler xineLib ];
+    librsvg glib gtk2 libXxf86vm libXext poppler xineLib ];
 
   # The program tries to dlopen both Xxf86vm and Xext, so we use the
   # trick on NIX_LDFLAGS and dontPatchELF to make it find them.

--- a/pkgs/applications/misc/epdfview/default.nix
+++ b/pkgs/applications/misc/epdfview/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, gtk, poppler }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, gtk2, poppler }:
 
 stdenv.mkDerivation rec {
   name = "epdfview-0.1.8";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1w7qybh8ssl4dffi5qfajq8mndw7ipsd92vkim03nywxgjp4i1ll";
   };
 
-  buildInputs = [ pkgconfig gtk poppler ];
+  buildInputs = [ pkgconfig gtk2 poppler ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/misc/evilvte/default.nix
+++ b/pkgs/applications/misc/evilvte/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, makeWrapper, pkgconfig,
-  gnome, glib, pango, cairo, gdk_pixbuf, atk, freetype, xorg,
+  gnome2, glib, pango, cairo, gdk_pixbuf, atk, freetype, xorg,
   configH
 }:
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    gnome.vte glib pango gnome.gtk cairo gdk_pixbuf atk freetype xorg.libX11
+    gnome2.vte glib pango gnome2.gtk cairo gdk_pixbuf atk freetype xorg.libX11
     xorg.xproto xorg.kbproto xorg.libXext xorg.xextproto makeWrapper pkgconfig
   ];
 

--- a/pkgs/applications/misc/fme/default.nix
+++ b/pkgs/applications/misc/fme/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, autoconf, automake, gettext
-, fluxbox, bc, gtkmm, glibmm, libglademm, libsigcxx }:
+, fluxbox, bc, gtkmm2, glibmm, libglademm, libsigcxx }:
 
 stdenv.mkDerivation rec{
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec{
     sha256 = "d1c81a6a38c0faad02943ad65d6d0314bd205c6de841669a2efe43e4c503e63d";
   };
 
-  buildInputs = [ pkgconfig autoconf automake gettext fluxbox bc gtkmm glibmm libglademm libsigcxx ];
+  buildInputs = [ pkgconfig autoconf automake gettext fluxbox bc gtkmm2 glibmm libglademm libsigcxx ];
 
   preConfigure = ''
     ./autogen.sh

--- a/pkgs/applications/misc/gkrellm/default.nix
+++ b/pkgs/applications/misc/gkrellm/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, gettext, pkgconfig, glib, gtk, libX11, libSM, libICE
+{ fetchurl, stdenv, gettext, pkgconfig, glib, gtk2, libX11, libSM, libICE
 , IOKit ? null }:
 
 stdenv.mkDerivation rec {
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "12rc6zaa7kb60b9744lbrlfkxxfniprm6x0mispv63h4kh75navh";
   };
 
-  buildInputs = [gettext pkgconfig glib gtk libX11 libSM libICE]
+  buildInputs = [gettext pkgconfig glib gtk2 libX11 libSM libICE]
     ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/misc/gksu/default.nix
+++ b/pkgs/applications/misc/gksu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, gnome3, libgksu,
+{ stdenv, fetchurl, pkgconfig, gtk2, gnome3, libgksu,
   intltool, libstartup_notification, gtk_doc, wrapGAppsHook
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk gnome3.gconf libstartup_notification gnome3.libgnome_keyring
+    gtk2 gnome3.gconf libstartup_notification gnome3.libgnome_keyring
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/misc/gosmore/default.nix
+++ b/pkgs/applications/misc/gosmore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, libxml2, gtk, curl, pkgconfig } :
+{ stdenv, fetchsvn, libxml2, gtk2, curl, pkgconfig } :
 
 let
   version = "31801";
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     ignoreExternals = true;
   };
 
-  buildInputs = [ libxml2 gtk curl ];
+  buildInputs = [ libxml2 gtk2 curl ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/applications/misc/gpa/default.nix
+++ b/pkgs/applications/misc/gpa/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gtk, gpgme, libgpgerror, libassuan }:
+{ stdenv, fetchurl, intltool, pkgconfig, gtk2, gpgme, libgpgerror, libassuan }:
 
 stdenv.mkDerivation rec {
   name = "gpa-0.9.9";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0d235hcqai7m3qb7m9kvr2r4qg4714f87j9fdplwrlz1p4wdfa38";
   };
 
-  buildInputs = [ intltool pkgconfig gtk gpgme libgpgerror libassuan ];
+  buildInputs = [ intltool pkgconfig gtk2 gpgme libgpgerror libassuan ];
 
   meta = with stdenv.lib; {
     description = "Graphical user interface for the GnuPG";

--- a/pkgs/applications/misc/gpscorrelate/default.nix
+++ b/pkgs/applications/misc/gpscorrelate/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, exiv2, libxml2, gtk
+{ fetchurl, stdenv, pkgconfig, exiv2, libxml2, gtk2
 , libxslt, docbook_xsl, docbook_xml_dtd_42 }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgconfig exiv2 libxml2 gtk
+    pkgconfig exiv2 libxml2 gtk2
     libxslt docbook_xsl docbook_xml_dtd_42
   ];
 

--- a/pkgs/applications/misc/green-pdfviewer/default.nix
+++ b/pkgs/applications/misc/green-pdfviewer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, poppler, pkgconfig, gdk_pixbuf, SDL, gtk }:
+{ stdenv, fetchFromGitHub, poppler, pkgconfig, gdk_pixbuf, SDL, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "green-pdfviewer-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0d0lv33flhgsxhc77kfp2avdz5gvml04r8l1j95yjz2rr096lzlj";
   };
 
-  buildInputs = [ poppler pkgconfig gdk_pixbuf SDL gtk ];
+  buildInputs = [ poppler pkgconfig gdk_pixbuf SDL gtk2 ];
 
   patches = [
     ./gdk-libs.patch

--- a/pkgs/applications/misc/grip/default.nix
+++ b/pkgs/applications/misc/grip/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, glib, pkgconfig, libgnome, libgnomeui, vte
+{ stdenv, fetchurl, gtk2, glib, pkgconfig, libgnome, libgnomeui, vte
 , curl, cdparanoia, libid3tag, ncurses, libtool }:
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1zb6zpq7qmn6bflbgfwisyg3vrjr23yi1c1kqvwndl1f0shr8qyl";
   };
 
-  buildInputs = [ gtk glib pkgconfig libgnome libgnomeui vte curl cdparanoia
+  buildInputs = [ gtk2 glib pkgconfig libgnome libgnomeui vte curl cdparanoia
     libid3tag ncurses libtool ];
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/misc/hamster-time-tracker/default.nix
+++ b/pkgs/applications/misc/hamster-time-tracker/default.nix
@@ -21,7 +21,7 @@ pythonPackages.buildPythonApplication rec {
     docbook2x libxslt gnome_doc_utils intltool dbus_glib hicolor_icon_theme
   ];
 
-  propagatedBuildInputs = with pythonPackages; [ pygobject pygtk pyxdg gnome_python dbus-python sqlite3 ];
+  propagatedBuildInputs = with pythonPackages; [ pygobject2 pygtk pyxdg gnome_python dbus-python sqlite3 ];
 
   configurePhase = ''
     python waf configure --prefix="$out"

--- a/pkgs/applications/misc/hyperterm/default.nix
+++ b/pkgs/applications/misc/hyperterm/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, lib, fetchurl, dpkg, gtk, atk, glib, pango, gdk_pixbuf, cairo
+{ stdenv, lib, fetchurl, dpkg, gtk2, atk, glib, pango, gdk_pixbuf, cairo
 , freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr
 , libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver
 , GConf, nss, nspr, alsaLib, cups, expat, libudev, libpulseaudio }:
 
 let
   libPath = stdenv.lib.makeLibraryPath [
-    stdenv.cc.cc gtk atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
+    stdenv.cc.cc gtk2 atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
     libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes
     libXrender libX11 libXtst libXScrnSaver GConf nss nspr alsaLib cups expat libudev libpulseaudio
   ];

--- a/pkgs/applications/misc/jigdo/default.nix
+++ b/pkgs/applications/misc/jigdo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, db, gtk, bzip2 }:
+{ stdenv, fetchurl, db, gtk2, bzip2 }:
 
 stdenv.mkDerivation {
   name = "jigdo-0.7.3";
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     sha256 = "0cp4jz3sg9g86vprh90pmwpcfla79f0dr50w14yh01k0yaq70fs8";
   };
 
-  buildInputs = [ db gtk bzip2 ];
+  buildInputs = [ db gtk2 bzip2 ];
 
   configureFlags = "--without-libdb";
 

--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -1,7 +1,7 @@
 { stdenv, callPackage, overrideCC, fetchurl, makeWrapper, pkgconfig
 , zip, python, zlib, which, icu, libmicrohttpd, lzma, ctpp2, aria2, wget, bc
 , libuuid, glibc, libX11, libXext, libXt, libXrender, glib, dbus, dbus_glib
-, gtk, gdk_pixbuf, pango, cairo , freetype, fontconfig, alsaLib, atk
+, gtk2, gdk_pixbuf, pango, cairo , freetype, fontconfig, alsaLib, atk
 }:
 
 let
@@ -98,7 +98,7 @@ stdenv.mkDerivation rec {
 
     rm $out/bin/kiwix
     makeWrapper $out/lib/kiwix/kiwix-launcher $out/bin/kiwix \
-      --suffix LD_LIBRARY_PATH : ${makeLibraryPath [stdenv.cc.cc libX11 libXext libXt libXrender glib dbus dbus_glib gtk gdk_pixbuf pango cairo freetype fontconfig alsaLib atk]} \
+      --suffix LD_LIBRARY_PATH : ${makeLibraryPath [stdenv.cc.cc libX11 libXext libXt libXrender glib dbus dbus_glib gtk2 gdk_pixbuf pango cairo freetype fontconfig alsaLib atk]} \
       --suffix PATH : ${aria2}/bin
   '';
 

--- a/pkgs/applications/misc/lighthouse/default.nix
+++ b/pkgs/applications/misc/lighthouse/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig
-, libX11, libxcb, cairo, gtk, pango, python27, python3
+, libX11, libxcb, cairo, gtk2, pango, python27, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
    };
 
   buildInputs = [
-    pkgconfig libX11 libxcb cairo gtk pango python27 python3
+    pkgconfig libX11 libxcb cairo gtk2 pango python27 python3
   ];
 
   makeFlags = [ "PREFIX=\${out}" ];

--- a/pkgs/applications/misc/lxappearance/default.nix
+++ b/pkgs/applications/misc/lxappearance/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, libX11, gtk }:
+{ stdenv, fetchurl, intltool, pkgconfig, libX11, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "lxappearance-0.6.1";
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/project/lxde/LXAppearance/${name}.tar.xz";
     sha256 = "1phnv1b2jdj2vlibjyc9z01izcf3k5zxj8glsaf0i3vh77zqmqq9";
   };
-  buildInputs = [ intltool libX11 pkgconfig gtk ];
+  buildInputs = [ intltool libX11 pkgconfig gtk2 ];
   meta = {
     description = "A lightweight program for configuring the theme and fonts of gtk applications";
     maintainers = [ stdenv.lib.maintainers.hinton ];

--- a/pkgs/applications/misc/multisync/default.nix
+++ b/pkgs/applications/misc/multisync/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, glib, ORBit2, libbonobo, libtool, pkgconfig
+{ stdenv, fetchurl, gtk2, glib, ORBit2, libbonobo, libtool, pkgconfig
 , libgnomeui, GConf, automake, autoconf }:
 
 stdenv.mkDerivation {
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   };
   
   buildInputs =
-    [ gtk glib ORBit2 libbonobo libtool pkgconfig libgnomeui GConf
+    [ gtk2 glib ORBit2 libbonobo libtool pkgconfig libgnomeui GConf
       automake autoconf
     ];
     

--- a/pkgs/applications/misc/navit/default.nix
+++ b/pkgs/applications/misc/navit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, pkgconfig, gtk, SDL, fontconfig, freetype, imlib2, SDL_image, mesa,
+{ stdenv, fetchsvn, pkgconfig, gtk2, SDL, fontconfig, freetype, imlib2, SDL_image, mesa,
 libXmu, freeglut, python, gettext, quesoglc, gd, postgresql, cmake, qt4, SDL_ttf, fribidi}:
 stdenv.mkDerivation rec {
   name = "navit-svn-3537";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ gtk SDL fontconfig freetype imlib2 SDL_image mesa
+  buildInputs = [ gtk2 SDL fontconfig freetype imlib2 SDL_image mesa
     libXmu freeglut python gettext quesoglc gd postgresql qt4 SDL_ttf fribidi ];
 
   nativeBuildInputs = [ pkgconfig cmake ];

--- a/pkgs/applications/misc/openbox-menu/default.nix
+++ b/pkgs/applications/misc/openbox-menu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, gtk, menu-cache }:
+{ stdenv, fetchurl, pkgconfig, glib, gtk2, menu-cache }:
 
 stdenv.mkDerivation rec {
   name = "openbox-menu-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1hi4b6mq97y6ajq4hhsikbkk23aha7ikaahm92djw48mgj2f1w8l";
   };
 
-  buildInputs = [ pkgconfig glib gtk menu-cache ];
+  buildInputs = [ pkgconfig glib gtk2 menu-cache ];
 
   patches = [ ./with-svg.patch ];
 

--- a/pkgs/applications/misc/pcmanfm/default.nix
+++ b/pkgs/applications/misc/pcmanfm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, gtk, intltool, libfm, libX11, pango, pkgconfig }:
+{ stdenv, fetchurl, glib, gtk2, intltool, libfm, libX11, pango, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "pcmanfm-1.2.4";
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "04z3vd9si24yi4c8calqncdpb9b6mbj4cs4f3fs86i6j05gvpk9q";
   };
 
-  buildInputs = [ glib gtk intltool libfm libX11 pango pkgconfig ];
+  buildInputs = [ glib gtk2 intltool libfm libX11 pango pkgconfig ];
 
   meta = with stdenv.lib; {
     homepage = "http://blog.lxde.org/?cat=28/";

--- a/pkgs/applications/misc/pdfmod/default.nix
+++ b/pkgs/applications/misc/pdfmod/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, gnome_doc_utils, intltool, lib
-, mono, gtk-sharp, gnome-sharp, hyena
+, mono, gtk-sharp-2_0, gnome-sharp, hyena
 , which, makeWrapper, glib, gnome3, poppler, wrapGAppsHook
 }:
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   }) ];
 
   buildInputs = [
-    pkgconfig gnome_doc_utils intltool mono gtk-sharp gnome-sharp
+    pkgconfig gnome_doc_utils intltool mono gtk-sharp-2_0 gnome-sharp
     hyena which makeWrapper wrapGAppsHook
   ];
 
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
   postInstall = ''
     makeWrapper "${mono}/bin/mono" "$out/bin/pdfmod" \
       --add-flags "$out/lib/pdfmod/PdfMod.exe" \
-      --prefix MONO_GAC_PREFIX : ${gtk-sharp} \
+      --prefix MONO_GAC_PREFIX : ${gtk-sharp-2_0} \
       --prefix MONO_GAC_PREFIX : ${gnome-sharp} \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ glib gnome-sharp gnome3.gconf gtk-sharp gtk-sharp.gtk poppler ]}
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ glib gnome-sharp gnome3.gconf gtk-sharp-2_0 gtk-sharp-2_0.gtk poppler ]}
   '';
 
   dontStrip = true;

--- a/pkgs/applications/misc/pmenu/default.nix
+++ b/pkgs/applications/misc/pmenu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, pythonPackages, gnome }:
+{ stdenv, fetchFromGitLab, pythonPackages, gnome2 }:
 
 stdenv.mkDerivation rec {
   name = "pmenu-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pythonPackages.wrapPython ];
 
-  buildInputs = [ pythonPackages.pygtk gnome.gnome_menus ];
+  buildInputs = [ pythonPackages.pygtk gnome2.gnome_menus ];
 
   pythonPath = [ pythonPackages.pygtk ];
   

--- a/pkgs/applications/misc/tangogps/default.nix
+++ b/pkgs/applications/misc/tangogps/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gettext, gtk, gconf
+{ fetchurl, stdenv, pkgconfig, gettext, gtk2, gconf
 , curl, libexif, sqlite, libxml2 }:
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "15q2kkrv4mfsivfdzjgpxr7s2amw7d501q2ayjl3ff4vmvfn5516";
   };
 
-  buildInputs = [ pkgconfig gettext gtk gconf curl libexif sqlite libxml2 ];
+  buildInputs = [ pkgconfig gettext gtk2 gconf curl libexif sqlite libxml2 ];
 
   # bogus includes fail with newer library version
   postPatch = ''

--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitLab, pkgconfig, cmake, gettext, cairo, pango, pcre
-, glib , imlib2, gtk, libXinerama , libXrender, libXcomposite, libXdamage
+, glib , imlib2, gtk2, libXinerama , libXrender, libXcomposite, libXdamage
 , libX11 , libXrandr, librsvg, libpthreadstubs , libXdmcp
 , libstartup_notification , hicolor_icon_theme, wrapGAppsHook
 }:
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake gettext wrapGAppsHook ];
 
-  buildInputs = [ cairo pango pcre glib imlib2 gtk libXinerama libXrender
+  buildInputs = [ cairo pango pcre glib imlib2 gtk2 libXinerama libXrender
     libXcomposite libXdamage libX11 libXrandr librsvg libpthreadstubs
     libXdmcp libstartup_notification hicolor_icon_theme ];
 

--- a/pkgs/applications/misc/viking/default.nix
+++ b/pkgs/applications/misc/viking/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, makeWrapper, pkgconfig, intltool, gettext, gtk, expat, curl
+{ fetchurl, stdenv, makeWrapper, pkgconfig, intltool, gettext, gtk2, expat, curl
 , gpsd, bc, file, gnome_doc_utils, libexif, libxml2, libxslt, scrollkeeper
 , docbook_xml_dtd_412, gexiv2, sqlite, gpsbabel, expect }:
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "09kq0sxs2czps0d6xzgkkp41746v44ip63m72qvfs7rsrnqj7qnz";
   };
 
-  buildInputs = [ makeWrapper pkgconfig intltool gettext gtk expat curl gpsd bc file gnome_doc_utils
+  buildInputs = [ makeWrapper pkgconfig intltool gettext gtk2 expat curl gpsd bc file gnome_doc_utils
     libexif libxml2 libxslt scrollkeeper docbook_xml_dtd_412 gexiv2 sqlite
   ];
 

--- a/pkgs/applications/misc/workrave/default.nix
+++ b/pkgs/applications/misc/workrave/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch
 , autoconf, automake, gettext, intltool, libtool, pkgconfig
 , libICE, libSM, libXScrnSaver, libXtst, cheetah
-, glib, glibmm, gtk, gtkmm, atk, pango, pangomm, cairo, cairomm
+, glib, glibmm, gtkmm2, atk, pango, pangomm, cairo, cairomm
 , dbus, dbus_glib, GConf, gconfmm, gdome2, gstreamer, libsigcxx }:
 
 stdenv.mkDerivation rec {
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     libICE libSM libXScrnSaver libXtst cheetah
-    glib glibmm gtk gtkmm atk pango pangomm cairo cairomm
+    glib glibmm gtkmm2 atk pango pangomm cairo cairomm
     dbus dbus_glib GConf gconfmm gdome2 gstreamer libsigcxx
   ];
 

--- a/pkgs/applications/misc/xautoclick/default.nix
+++ b/pkgs/applications/misc/xautoclick/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, xorg, pkgconfig
-, gtkSupport ? true, gtk
+, gtkSupport ? true, gtk2
 , qtSupport ? true, qt4
 }:
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0h522f12a7v2b89411xm51iwixmjp2mp90rnizjgiakx9ajnmqnm";
   };
   buildInputs = [ xorg.libX11 xorg.libXtst xorg.xinput xorg.libXi xorg.libXext pkgconfig ]
-    ++ stdenv.lib.optionals gtkSupport [ gtk ]
+    ++ stdenv.lib.optionals gtkSupport [ gtk2 ]
     ++ stdenv.lib.optionals qtSupport [ qt4 ];
   patchPhase = ''
     substituteInPlace configure --replace /usr/X11R6 ${xorg.libX11.dev}

--- a/pkgs/applications/misc/xneur/default.nix
+++ b/pkgs/applications/misc/xneur/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, xorg, pcre, gstreamer, glib, libxml2
-, aspell, cairo, imlib2, xosd, libnotify, gtk, pango, atk, enchant,
+, aspell, cairo, imlib2, xosd, libnotify, gtk2, pango, atk, enchant,
  gdk_pixbuf}:
 
 let s = import ./src-for-default.nix; in
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ xorg.libX11 pkgconfig pcre gstreamer glib libxml2 aspell cairo
       xorg.libXpm imlib2 xosd xorg.libXt xorg.libXext xorg.libXi libnotify
-      gtk pango enchant gdk_pixbuf
+      gtk2 pango enchant gdk_pixbuf
     ];
 
   preConfigure = ''
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
     sed -e 's@for imlib2_dir in@for imlib2_dir in ${imlib2} @' -i configure
     sed -e 's@for xosd_dir in@for xosd_dir in ${xosd} @' -i configure
 
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${gtk.dev}/include/gtk-2.0"
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${gtk.out}/lib/gtk-2.0/include"
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${gtk2.dev}/include/gtk-2.0"
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${gtk2.out}/lib/gtk-2.0/include"
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${cairo.dev}/include/cairo"
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${pango.dev}/include/pango-1.0"
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${atk.dev}/include/atk-1.0"

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -11,7 +11,7 @@
 , nspr, systemd, kerberos
 , utillinux, alsaLib
 , bison, gperf
-, glib, gtk, dbus_glib
+, glib, gtk2, dbus_glib
 , libXScrnSaver, libXcursor, libXtst, mesa
 , protobuf, speechd, libXdamage, cups
 
@@ -116,7 +116,7 @@ let
       nspr nss systemd
       utillinux alsaLib
       bison gperf kerberos
-      glib gtk dbus_glib
+      glib gtk2 dbus_glib
       libXScrnSaver libXcursor libXtst mesa
       pciutils protobuf speechd libXdamage
       pythonPackages.gyp pythonPackages.ply pythonPackages.jinja2

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -25,7 +25,7 @@
 , libXinerama
 , libXrender
 , libXt
-, libcanberra
+, libcanberra_gtk2
 , libgnome
 , libgnomeui
 , defaultIconTheme
@@ -98,7 +98,7 @@ stdenv.mkDerivation {
       libXinerama
       libXrender
       libXt
-      libcanberra
+      libcanberra_gtk2
       libgnome
       libgnomeui
       mesa

--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkgconfig, gtk, gtk3, pango, perl, python, zip, libIDL
+{ lib, stdenv, fetchurl, pkgconfig, gtk2, gtk3, pango, perl, python, zip, libIDL
 , libjpeg, zlib, dbus, dbus_glib, bzip2, xorg
 , freetype, fontconfig, file, alsaLib, nspr, nss, libnotify
 , yasm, mesa, sqlite, unzip, makeWrapper, pysqlite
@@ -30,7 +30,7 @@ common = { pname, version, sha512 }: stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig gtk perl zip libIDL libjpeg zlib bzip2
+    [ pkgconfig gtk2 perl zip libIDL libjpeg zlib bzip2
       python dbus dbus_glib pango freetype fontconfig xorg.libXi
       xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
       alsaLib nspr nss libnotify xorg.pixman yasm mesa
@@ -121,7 +121,8 @@ common = { pname, version, sha512 }: stdenv.mkDerivation rec {
   };
 
   passthru = {
-    inherit gtk nspr version;
+    inherit nspr version;
+    gtk = gtk2;
     isFirefox3Like = true;
     browserName = "firefox";
     ffmpegSupport = lib.versionAtLeast version "46.0";

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -2,7 +2,7 @@
 
 ## various stuff that can be plugged in
 , gnash, flashplayer, hal-flash
-, MPlayerPlugin, gecko_mediaplayer, ffmpeg, gst_all, xorg, libpulseaudio, libcanberra
+, MPlayerPlugin, gecko_mediaplayer, ffmpeg, gst_all, xorg, libpulseaudio, libcanberra_gtk2
 , supportsJDK, jrePlugin, icedtea_web
 , trezor-bridge, bluejeans, djview4, adobe-reader
 , google_talk_plugin, fribid, gnome3/*.gnome_shell*/
@@ -54,7 +54,7 @@ let
          ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash
          ++ lib.optional (config.pulseaudio or false) libpulseaudio;
   gst-plugins = with gst_all; [ gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-ffmpeg ];
-  gtk_modules = [ libcanberra ];
+  gtk_modules = [ libcanberra_gtk2 ];
 
 in
 stdenv.mkDerivation {

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -4,7 +4,7 @@
 , glib, fontconfig, freetype, pango, cairo, libX11, libXi, atk, gconf, nss, nspr
 , libXcursor, libXext, libXfixes, libXrender, libXScrnSaver, libXcomposite
 , alsaLib, libXdamage, libXtst, libXrandr, expat, cups
-, dbus_libs, gtk, gdk_pixbuf, gcc
+, dbus_libs, gtk2, gdk_pixbuf, gcc
 
 # Will crash without.
 , systemd
@@ -44,7 +44,7 @@ let
     glib fontconfig freetype pango cairo libX11 libXi atk gconf nss nspr
     libXcursor libXext libXfixes libXrender libXScrnSaver libXcomposite
     alsaLib libXdamage libXtst libXrandr expat cups
-    dbus_libs gtk gdk_pixbuf gcc
+    dbus_libs gtk2 gdk_pixbuf gcc
     systemd
     libexif
     liberation_ttf curl utillinux xdg_utils wget

--- a/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, xorg, gtk, glib, gdk_pixbuf, dpkg, libXext, libXfixes
+{ stdenv, fetchurl, xorg, gtk2, glib, gdk_pixbuf, dpkg, libXext, libXfixes
 , libXrender, libuuid, libXrandr, libXcomposite, libpulseaudio
 }:
 
@@ -7,10 +7,10 @@ with stdenv.lib;
 let
 
   rpathInstaller = makeLibraryPath
-    [gtk glib stdenv.cc.cc];
+    [gtk2 glib stdenv.cc.cc];
 
   rpathPlugin = makeLibraryPath
-    ([ stdenv.cc.cc gtk glib xorg.libX11 gdk_pixbuf libXext libXfixes libXrender libXrandr libXcomposite libpulseaudio ] ++ optional (libuuid != null) libuuid);
+    ([ stdenv.cc.cc gtk2 glib xorg.libX11 gdk_pixbuf libXext libXfixes libXrender libXrandr libXcomposite libpulseaudio ] ++ optional (libuuid != null) libuuid);
 
 in
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
@@ -14,7 +14,7 @@
 , libXcursor
 , libXt
 , libvdpau
-, gtk
+, gtk2
 , glib
 , pango
 , cairo
@@ -118,7 +118,7 @@ stdenv.mkDerivation rec {
 
   rpath = lib.makeLibraryPath
     [ zlib alsaLib curl nspr fontconfig freetype expat libX11
-      libXext libXrender libXcursor libXt gtk glib pango atk cairo gdk_pixbuf
+      libXext libXrender libXcursor libXt gtk2 glib pango atk cairo gdk_pixbuf
       libvdpau nss
     ];
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/gmtk/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/gmtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gtk, GConf, alsaLib }:
+{ stdenv, fetchurl, intltool, pkgconfig, gtk2, GConf, alsaLib }:
 
 stdenv.mkDerivation rec {
   name = "gmtk-1.0.9b";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "07y5hd94qhvlk9a9vhrpznqaml013j3rq52r3qxmrj74gg4yf4zc";
   };
 
-  buildInputs = [ intltool pkgconfig gtk GConf alsaLib ];
+  buildInputs = [ intltool pkgconfig gtk2 GConf alsaLib ];
 
   meta = {
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/networking/browsers/mozilla-plugins/google-talk-plugin/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/google-talk-plugin/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, rpm, cpio, mesa, xorg, cairo
-, libpng, gtk, glib, gdk_pixbuf, fontconfig, freetype, curl
+, libpng, gtk2, glib, gdk_pixbuf, fontconfig, freetype, curl
 , dbus_glib, alsaLib, libpulseaudio, systemd, pango
 }:
 
@@ -16,7 +16,7 @@ let
       xorg.libXrender
       cairo
       libpng
-      gtk
+      gtk2
       glib
       fontconfig
       freetype
@@ -26,7 +26,7 @@ let
   rpathProgram = makeLibraryPath
     [ gdk_pixbuf
       glib
-      gtk
+      gtk2
       xorg.libX11
       xorg.libXcomposite
       xorg.libXfixes

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -2,7 +2,7 @@
 , freetype, fontconfig, libXft, libXrender, libxcb, expat, libXau, libXdmcp
 , libuuid, cups, xz
 , gstreamer, gst_plugins_base, libxml2
-, gtkSupport ? true, glib, gtk, pango, gdk_pixbuf, cairo, atk
+, gtkSupport ? true, glib, gtk2, pango, gdk_pixbuf, cairo, atk
 , kdeSupport ? false, qt4, kdelibs
 }:
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       libXft freetype fontconfig libXrender libuuid expat
       gstreamer libxml2 gst_plugins_base
     ]
-    ++ stdenv.lib.optionals gtkSupport [ glib gtk pango gdk_pixbuf cairo atk ]
+    ++ stdenv.lib.optionals gtkSupport [ glib gtk2 pango gdk_pixbuf cairo atk ]
     ++ stdenv.lib.optionals kdeSupport [ kdelibs qt4 ];
 
   libPath = stdenv.lib.makeLibraryPath buildInputs

--- a/pkgs/applications/networking/browsers/surf/default.nix
+++ b/pkgs/applications/networking/browsers/surf/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, makeWrapper, gtk, webkit, pkgconfig, glib, glib_networking, libsoup, gsettings_desktop_schemas, patches ? null}:
+{stdenv, fetchurl, makeWrapper, gtk2, webkit, pkgconfig, glib, glib_networking, libsoup, gsettings_desktop_schemas, patches ? null}:
 
 stdenv.mkDerivation rec {
   name = "surf-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jj93izd8fizxfa6ln9w1h9bwki81sz5dhskh5x1rl34zd38aq4m";
   };
 
-  buildInputs = [ gtk makeWrapper webkit gsettings_desktop_schemas pkgconfig glib libsoup ];
+  buildInputs = [ gtk2 makeWrapper webkit gsettings_desktop_schemas pkgconfig glib libsoup ];
 
   # Allow users set their own list of patches
   inherit patches;

--- a/pkgs/applications/networking/browsers/vimb/default.nix
+++ b/pkgs/applications/networking/browsers/vimb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libsoup, webkit, gtk, glib_networking
+{ stdenv, fetchurl, pkgconfig, libsoup, webkit, gtk2, glib_networking
 , gsettings_desktop_schemas, makeWrapper
 }:
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0d9rankzgmnx5423pyfkbxy0qxw3ck2vrdjdnlhddy15wkk87i9f";
   };
 
-  buildInputs = [ makeWrapper gtk libsoup pkgconfig webkit gsettings_desktop_schemas ];
+  buildInputs = [ makeWrapper gtk2 libsoup pkgconfig webkit gsettings_desktop_schemas ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/applications/networking/browsers/vimprobable2/default.nix
+++ b/pkgs/applications/networking/browsers/vimprobable2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, glib, glib_networking, gtk, libsoup, libX11, perl,
+{ stdenv, fetchurl, makeWrapper, glib, glib_networking, gtk2, libsoup, libX11, perl,
   pkgconfig, webkit, gsettings_desktop_schemas }:
 
 stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "13jdximksh9r3cgd2f8vms0pbsn3x0gxvyqdqiw16xp5fmdx5kzr";
   };
 
-  buildInputs = [ makeWrapper gtk libsoup libX11 perl pkgconfig webkit gsettings_desktop_schemas ];
+  buildInputs = [ makeWrapper gtk2 libsoup libX11 perl pkgconfig webkit gsettings_desktop_schemas ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -4,7 +4,7 @@
 , freetype, fontconfig, libXft, libXrender, libxcb, expat, libXau, libXdmcp
 , libuuid, xz
 , gstreamer, gst_plugins_base, libxml2
-, glib, gtk, pango, gdk_pixbuf, cairo, atk, gnome3
+, glib, gtk2, pango, gdk_pixbuf, cairo, atk, gnome3
 , nss, nspr
 , patchelf
 }:
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
   buildInputs =
     [ stdenv.cc.cc stdenv.cc.libc zlib libX11 libXt libXext libSM libICE
       libXi libXft libXcursor libXfixes libXScrnSaver libXcomposite libXdamage libXtst libXrandr
-      atk alsaLib dbus_libs cups gtk gdk_pixbuf libexif ffmpeg systemd
+      atk alsaLib dbus_libs cups gtk2 gdk_pixbuf libexif ffmpeg systemd
       freetype fontconfig libXrender libuuid expat glib nss nspr
       gstreamer libxml2 gst_plugins_base pango cairo gnome3.gconf
       patchelf

--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, jre, glib, libXtst, gtk, makeWrapper }:
+{ fetchurl, stdenv, jre, glib, libXtst, gtk2, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "davmail-4.7.2";
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
   installPhase = ''
   mkdir -p $out/bin
   cp ./* $out/bin/ -R
-  wrapProgram $out/bin/davmail.sh --prefix PATH : ${jre}/bin --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk libXtst ]}
+  wrapProgram $out/bin/davmail.sh --prefix PATH : ${jre}/bin --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
    '';
 }

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk_pixbuf
-, glib, gnome, gtk, libnotify, libX11, libXcomposite, libXcursor, libXdamage
+, glib, gnome2, gtk2, libnotify, libX11, libXcomposite, libXcursor, libXdamage
 , libXext, libXfixes, libXi, libXrandr, libXrender, libXtst, nspr, nss, pango
 , systemd, libXScrnSaver }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
     libPath = stdenv.lib.makeLibraryPath [
         stdenv.cc.cc alsaLib atk cairo cups dbus expat fontconfig freetype
-        gdk_pixbuf glib gnome.GConf gtk libnotify libX11 libXcomposite
+        gdk_pixbuf glib gnome2.GConf gtk2 libnotify libX11 libXcomposite
         libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
         libXtst nspr nss pango systemd libXScrnSaver
      ];

--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, python, intltool, pkgconfig, libX11, gtk
+{ stdenv, fetchurl, python, intltool, pkgconfig, libX11
 , ldns, pythonPackages
 
 , enableJingle ? true, farstream ? null, gst_plugins_bad ? null
 ,                      libnice ? null
 , enableE2E ? true
 , enableRST ? true
-, enableSpelling ? true, gtkspell ? null
+, enableSpelling ? true, gtkspell2 ? null
 , enableNotifications ? false
 , extraPythonPackages ? pkgs: []
 }:
@@ -14,7 +14,7 @@ assert enableJingle -> farstream != null && gst_plugins_bad != null
                     && libnice != null;
 assert enableE2E -> pythonPackages.pycrypto != null;
 assert enableRST -> pythonPackages.docutils != null;
-assert enableSpelling -> gtkspell != null;
+assert enableSpelling -> gtkspell2 != null;
 assert enableNotifications -> pythonPackages.notify != null;
 
 with stdenv.lib;
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
       src/features_window.py
     sed -i -e "s|'drill'|'${ldns}/bin/drill'|" src/common/resolver.py
   '' + optionalString enableSpelling ''
-    sed -i -e 's|=.*find_lib.*|= "${gtkspell}/lib/libgtkspell.so"|'   \
+    sed -i -e 's|=.*find_lib.*|= "${gtkspell2}/lib/libgtkspell.so"|'   \
       src/gtkspell.py
   '';
 
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
-    pythonPackages.pygobject pythonPackages.pyGtkGlade
+    pythonPackages.pygobject2 pythonPackages.pyGtkGlade
     pythonPackages.sqlite3 pythonPackages.pyasn1
     pythonPackages.pyxdg
     pythonPackages.nbxmpp

--- a/pkgs/applications/networking/instant-messengers/oneteam/default.nix
+++ b/pkgs/applications/networking/instant-messengers/oneteam/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , perl, xulrunner, cmake, perlPackages, zip, unzip, pkgconfig
-, libpulseaudio, glib, gtk, pixman, nspr, nss, libXScrnSaver
+, libpulseaudio, glib, gtk2, pixman, nspr, nss, libXScrnSaver
 , scrnsaverproto
 }:
 
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig cmake zip unzip ];
 
   buildInputs =
-    [ perl xulrunner libpulseaudio glib gtk pixman nspr
+    [ perl xulrunner libpulseaudio glib gtk2 pixman nspr
       nss libXScrnSaver scrnsaverproto
-    ] ++ [ perlPackages.SubName gtk glib ];
+    ] ++ [ perlPackages.SubName gtk2 glib ];
 
   postPatch = ''
     sed -e '1i#include <netinet/in.h>' -i src/rtp/otRTPDecoder.cpp src/rtp/otRTPEncoder.cpp

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-latex/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-latex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, pidgin, texLive, imagemagick, glib, gtk }:
+{ stdenv, fetchurl, pkgconfig, pidgin, texLive, imagemagick, glib, gtk2 }:
 
 let version = "1.5.0";
 in
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [pkgconfig];
-  buildInputs = [gtk glib pidgin];
+  buildInputs = [gtk2 glib pidgin];
   makeFlags = "PREFIX=$(out)";
 
   postPatch = ''

--- a/pkgs/applications/networking/instant-messengers/pidgin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, gtk, gtkspell, aspell
+{ stdenv, fetchurl, makeWrapper, pkgconfig, gtk2, gtkspell2, aspell
 , gstreamer, gst_plugins_base, gst_plugins_good, startupnotification, gettext
 , perl, perlXMLParser, libxml2, nss, nspr, farsight2
 , libXScrnSaver, ncurses, avahi, dbus, dbus_glib, intltool, libidn
@@ -26,7 +26,7 @@ let unwrapped = stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [
-    gtkspell aspell
+    gtkspell2 aspell
     gstreamer gst_plugins_base gst_plugins_good startupnotification
     libxml2 nss nspr farsight2
     libXScrnSaver ncurses python
@@ -38,7 +38,7 @@ let unwrapped = stdenv.mkDerivation rec {
   ++ (lib.optional (libgcrypt != null) libgcrypt);
 
   propagatedBuildInputs = [
-    pkgconfig gtk perl perlXMLParser gettext
+    pkgconfig gtk2 perl perlXMLParser gettext
   ];
 
   patches = [./pidgin-makefile.patch ./add-search-path.patch ];

--- a/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = with pythonPackages; 
     [
-      python twisted urwid beautifulsoup wxPython pygobject
+      python twisted urwid beautifulsoup wxPython pygobject2
       wokkel dbus-python pyfeed wrapPython setuptools
     ];
 

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, dpkg
-, alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype, glib, gnome
+, alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype, glib, gnome2
 , libnotify, nspr, nss, systemd, xorg }:
 
 let
@@ -16,10 +16,10 @@ let
     fontconfig
     freetype
     glib
-    gnome.GConf
-    gnome.gdk_pixbuf
-    gnome.gtk
-    gnome.pango
+    gnome2.GConf
+    gnome2.gdk_pixbuf
+    gnome2.gtk
+    gnome2.pango
     libnotify
     nspr
     nss

--- a/pkgs/applications/networking/irc/hexchat/default.nix
+++ b/pkgs/applications/networking/irc/hexchat/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, gtk, lua, perl, python
-, libtool, pciutils, dbus_glib, libcanberra, libproxy
+{ stdenv, fetchurl, pkgconfig, gtk2, lua, perl, python
+, libtool, pciutils, dbus_glib, libcanberra_gtk2, libproxy
 , libsexy, enchant, libnotify, openssl, intltool
 , desktop_file_utils, hicolor_icon_theme
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk lua perl python pciutils dbus_glib libcanberra libproxy
+    gtk2 lua perl python pciutils dbus_glib libcanberra_gtk2 libproxy
     libsexy libnotify openssl desktop_file_utils hicolor_icon_theme
   ];
 

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, wrapGAppsHook
-, curl, dbus, dbus_glib, enchant, gtk, gnutls, gnupg, gpgme, hicolor_icon_theme
-, libarchive, libcanberra, libetpan, libnotify, libsoup, libxml2, networkmanager
+, curl, dbus, dbus_glib, enchant, gtk2, gnutls, gnupg, gpgme, hicolor_icon_theme
+, libarchive, libcanberra_gtk2, libetpan, libnotify, libsoup, libxml2, networkmanager
 , openldap , perl, pkgconfig, poppler, python, shared_mime_info, webkitgtk2
 , glib_networking, gsettings_desktop_schemas
 
@@ -55,13 +55,13 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs =
-    [ curl dbus dbus_glib gtk gnutls gsettings_desktop_schemas hicolor_icon_theme
+    [ curl dbus dbus_glib gtk2 gnutls gsettings_desktop_schemas hicolor_icon_theme
       libetpan perl pkgconfig python wrapGAppsHook glib_networking
     ]
     ++ optional enableSpellcheck enchant
     ++ optionals (enablePgp || enablePluginSmime) [ gnupg gpgme ]
     ++ optional enablePluginArchive libarchive
-    ++ optional enablePluginNotificationSounds libcanberra
+    ++ optional enablePluginNotificationSounds libcanberra_gtk2
     ++ optional enablePluginNotificationDialogs libnotify
     ++ optional enablePluginFancy libsoup
     ++ optional enablePluginRssyl libxml2

--- a/pkgs/applications/networking/mailreaders/sylpheed/default.nix
+++ b/pkgs/applications/networking/mailreaders/sylpheed/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk
+{ stdenv, fetchurl, pkgconfig, gtk2
 
 , openssl ? null
 , gpgme ? null
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig gtk ]
+    [ pkgconfig gtk2 ]
     ++ optional sslSupport openssl
     ++ optional gpgSupport gpgme;
 

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -15,7 +15,7 @@
 , glibc
 , gst_plugins_base
 , gstreamer
-, gtk
+, gtk2
 , kerberos
 , libX11
 , libXScrnSaver
@@ -26,7 +26,7 @@
 , libXinerama
 , libXrender
 , libXt
-, libcanberra
+, libcanberra_gtk2
 , libgnome
 , libgnomeui
 , mesa
@@ -87,7 +87,7 @@ stdenv.mkDerivation {
       glibc
       gst_plugins_base
       gstreamer
-      gtk
+      gtk2
       kerberos
       libX11
       libXScrnSaver
@@ -98,7 +98,7 @@ stdenv.mkDerivation {
       libXinerama
       libXrender
       libXt
-      libcanberra
+      libcanberra_gtk2
       libgnome
       libgnomeui
       mesa

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, which, m4, gtk, pango, perl, python, zip, libIDL
+{ stdenv, fetchurl, pkgconfig, which, m4, gtk2, pango, perl, python, zip, libIDL
 , libjpeg, libpng, zlib, dbus, dbus_glib, bzip2, xorg
 , freetype, fontconfig, file, alsaLib, nspr, nss, libnotify
 , yasm, mesa, sqlite, unzip, makeWrapper, pysqlite
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = # from firefox30Pkgs.xulrunner, without gstreamer and libvpx
-    [ pkgconfig which libpng gtk perl zip libIDL libjpeg zlib bzip2
+    [ pkgconfig which libpng gtk2 perl zip libIDL libjpeg zlib bzip2
       python dbus dbus_glib pango freetype fontconfig xorg.libXi
       xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
       alsaLib nspr nss libnotify xorg.pixman yasm mesa

--- a/pkgs/applications/networking/newsreaders/pan/default.nix
+++ b/pkgs/applications/networking/newsreaders/pan/default.nix
@@ -1,9 +1,9 @@
 { spellChecking ? true
-, stdenv, fetchurl, pkgconfig, gtk, gtkspell ? null
+, stdenv, fetchurl, pkgconfig, gtk2, gtkspell2 ? null
 , perl, pcre, gmime, gettext, intltool, dbus_glib, libnotify
 }:
 
-assert spellChecking -> gtkspell != null;
+assert spellChecking -> gtkspell2 != null;
 
 let version = "0.139"; in
 
@@ -15,8 +15,8 @@ stdenv.mkDerivation {
     sha1 = "01ea0361a6d81489888e6abb075fd552999c3c60";
   };
 
-  buildInputs = [ pkgconfig gtk perl gmime gettext intltool dbus_glib libnotify ]
-    ++ stdenv.lib.optional spellChecking gtkspell;
+  buildInputs = [ pkgconfig gtk2 perl gmime gettext intltool dbus_glib libnotify ]
+    ++ stdenv.lib.optional spellChecking gtkspell2;
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/networking/p2p/ldcpp/default.nix
+++ b/pkgs/applications/networking/p2p/ldcpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, scons, pkgconfig, gtk, bzip2, libglade, openssl
+{ stdenv, fetchurl, scons, pkgconfig, gtk2, bzip2, libglade, openssl
 , libX11, boost, zlib, libnotify }:
 
 stdenv.mkDerivation rec {
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     url = http://launchpad.net/linuxdcpp/1.1/1.1.0/+download/linuxdcpp-1.1.0.tar.bz2;
     sha256 = "12i92hirmwryl1qy0n3jfrpziwzb82f61xca9jcjwyilx502f0b6";
   };
-  buildInputs = [ scons pkgconfig gtk bzip2 libglade openssl libX11 boost libnotify ];
+  buildInputs = [ scons pkgconfig gtk2 bzip2 libglade openssl libX11 boost libnotify ];
 
   installPhase = ''
     export NIX_LDFLAGS="$NIX_LDFLAGS -lX11";

--- a/pkgs/applications/networking/p2p/transgui/default.nix
+++ b/pkgs/applications/networking/p2p/transgui/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchsvn, pkgconfig, makeDesktopItem, unzip, fpc, lazarus,
-libX11, glib, gtk, gdk_pixbuf, pango, atk, cairo, openssl }:
+libX11, glib, gtk2, gdk_pixbuf, pango, atk, cairo, openssl }:
 
 stdenv.mkDerivation rec {
   name = "transgui-5.0.1-svn-r${revision}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig unzip fpc lazarus stdenv.cc
-    libX11 glib gtk gdk_pixbuf pango atk cairo openssl
+    libX11 glib gtk2 gdk_pixbuf pango atk cairo openssl
   ];
 
   NIX_LDFLAGS = "

--- a/pkgs/applications/networking/remote/citrix-receiver/default.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/default.nix
@@ -8,7 +8,7 @@
 , tzdata
 , cacert
 , glib
-, gtk
+, gtk2
 , atk
 , gdk_pixbuf
 , cairo
@@ -56,13 +56,13 @@ stdenv.mkDerivation rec {
     makeWrapper
     busybox
     file
-    gtk
+    gtk2
     gdk_pixbuf
   ];
 
   libPath = stdenv.lib.makeLibraryPath [
     glib
-    gtk
+    gtk2
     atk
     gdk_pixbuf
     cairo
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper "$ICAInstDir/wfica -icaroot $ICAInstDir" "$out/bin/wfica" \
       --set ICAROOT "$ICAInstDir" \
-      --set GTK_PATH "${gtk.out}/lib/gtk-2.0:${gnome3.gnome_themes_standard}/lib/gtk-2.0" \
+      --set GTK_PATH "${gtk2.out}/lib/gtk-2.0:${gnome3.gnome_themes_standard}/lib/gtk-2.0" \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
       --set LD_LIBRARY_PATH "$libPath" \

--- a/pkgs/applications/networking/remote/putty/default.nix
+++ b/pkgs/applications/networking/remote/putty/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, gtk, pkgconfig, autoconf, automake, perl, halibut, libtool }:
+{ stdenv, fetchurl, ncurses, gtk2, pkgconfig, autoconf, automake, perl, halibut, libtool }:
 
 stdenv.mkDerivation rec {
   version = "0.67";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     cd unix
   '';
 
-  buildInputs = [ gtk ncurses pkgconfig autoconf automake perl halibut libtool ];
+  buildInputs = [ gtk2 ncurses pkgconfig autoconf automake perl halibut libtool ];
 
   meta = with stdenv.lib; {
     description = "A Free Telnet/SSH Client";

--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, pkgconfig, makeWrapper
-, glib, gtk, gettext, libxkbfile, libgnome_keyring, libX11
+, glib, gtk2, gettext, libxkbfile, libgnome_keyring, libX11
 , freerdp, libssh, libgcrypt, gnutls, makeDesktopItem }:
 
 let
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ cmake pkgconfig makeWrapper
-                  glib gtk gettext libxkbfile libgnome_keyring libX11
+                  glib gtk2 gettext libxkbfile libgnome_keyring libX11
                   freerdp libssh libgcrypt gnutls ];
 
   cmakeFlags = "-DWITH_VTE=OFF -DWITH_TELEPATHY=OFF -DWITH_AVAHI=OFF";

--- a/pkgs/applications/networking/sniffers/etherape/default.nix
+++ b/pkgs/applications/networking/sniffers/etherape/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libtool, gtk, libpcap, libglade, libgnome, libgnomeui
+{ stdenv, fetchurl, pkgconfig, libtool, gtk2, libpcap, libglade, libgnome, libgnomeui
 , gnomedocutils, scrollkeeper, libxslt }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-scrollkeeper" ];
   buildInputs = [
-    pkgconfig libtool gtk libpcap libglade libgnome libgnomeui gnomedocutils
+    pkgconfig libtool gtk2 libpcap libglade libgnome libgnomeui gnomedocutils
     scrollkeeper libxslt
   ];
 

--- a/pkgs/applications/office/gnucash/2.6.nix
+++ b/pkgs/applications/office/gnucash/2.6.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, libxml2, libxslt, perl, perlPackages, gconf, guile
-, intltool, glib, gtk, libofx, aqbanking, gwenhywfar, libgnomecanvas, goffice
+, intltool, glib, gtk2, libofx, aqbanking, gwenhywfar, libgnomecanvas, goffice
 , webkit, glibcLocales, gsettings_desktop_schemas, makeWrapper, dconf, file
 , gettext, swig, slibGuile, enchant, bzip2, isocodes, libdbi, libdbiDrivers
 , pango, gdk_pixbuf
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     intltool pkgconfig libxml2 libxslt glibcLocales file gettext swig enchant
     bzip2 isocodes
     # glib, gtk...
-    glib gtk goffice webkit
+    glib gtk2 goffice webkit
     # gnome...
     dconf gconf libgnomecanvas gsettings_desktop_schemas
     # financial
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
   '';
 
   # The following settings fix failures in the test suite. It's not required otherwise.
-  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath [ guile glib gtk pango gdk_pixbuf ];
+  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath [ guile glib gtk2 pango gdk_pixbuf ];
   preCheck = "export GNC_DOT_DIR=$PWD/dot-gnucash";
   doCheck = true;
 

--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, libxml2, gconf, glib, gtk, libgnomeui, libofx
+{ fetchurl, stdenv, pkgconfig, libxml2, gconf, glib, gtk2, libgnomeui, libofx
 , libgtkhtml, gtkhtml, libgnomeprint, goffice, enchant, gettext, libbonoboui
 , intltool, perl, guile, slibGuile, swig, isocodes, bzip2, makeWrapper, libglade
 , libgsf, libart_lgpl, perlPackages, aqbanking, gwenhywfar
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgconfig libxml2 gconf glib gtk libgnomeui libgtkhtml gtkhtml
+    pkgconfig libxml2 gconf glib gtk2 libgnomeui libgtkhtml gtkhtml
     libgnomeprint goffice enchant gettext intltool perl guile slibGuile
     swig isocodes bzip2 makeWrapper libofx libglade libgsf libart_lgpl
     perlPackages.DateManip perlPackages.FinanceQuote aqbanking gwenhywfar

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pam, python3, libxslt, perl, ArchiveZip
 , CompressZlib, zlib, libjpeg, expat, pkgconfigUpstream, freetype, libwpd
 , libxml2, db, sablotron, curl, fontconfig, libsndfile, neon
-, bison, flex, zip, unzip, gtk3, gtk, libmspack, getopt, file, cairo, which
+, bison, flex, zip, unzip, gtk3, gtk2, libmspack, getopt, file, cairo, which
 , icu, boost, jdk, ant, cups, xorg, libcmis
 , openssl, gperf, cppunit, GConf, ORBit2, poppler
 , librsvg, gnome_vfs, mesa, bsh, CoinMP, libwps, libabw
@@ -242,7 +242,7 @@ in stdenv.mkDerivation rec {
   buildInputs = with xorg;
     [ ant ArchiveZip autoconf automake bison boost cairo clucene_core
       CompressZlib cppunit cups curl db dbus_glib expat file flex fontconfig
-      freetype GConf getopt gnome_vfs gperf gtk3 gtk
+      freetype GConf getopt gnome_vfs gperf gtk3 gtk2
       hunspell icu jdk lcms libcdr libexttextcat unixODBC libjpeg
       libmspack librdf_redland librsvg libsndfile libvisio libwpd libwpg libX11
       libXaw libXext libXi libXinerama libxml2 libxslt libXtst

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pam, python3, libxslt, perl, ArchiveZip
 , CompressZlib, zlib, libjpeg, expat, pkgconfigUpstream, freetype, libwpd
 , libxml2, db, sablotron, curl, fontconfig, libsndfile, neon
-, bison, flex, zip, unzip, gtk3, gtk, libmspack, getopt, file, cairo, which
+, bison, flex, zip, unzip, gtk3, gtk2, libmspack, getopt, file, cairo, which
 , icu, boost, jdk, ant, cups, xorg, libcmis
 , openssl, gperf, cppunit, GConf, ORBit2, poppler
 , librsvg, gnome_vfs, mesa, bsh, CoinMP, libwps, libabw
@@ -246,7 +246,7 @@ in stdenv.mkDerivation rec {
   buildInputs = with xorg;
     [ ant ArchiveZip autoconf automake bison boost cairo clucene_core
       CompressZlib cppunit cups curl db dbus_glib expat file flex fontconfig
-      freetype GConf getopt gnome_vfs gperf gtk3 gtk
+      freetype GConf getopt gnome_vfs gperf gtk3 gtk2
       hunspell icu jdk lcms libcdr libexttextcat unixODBC libjpeg
       libmspack librdf_redland librsvg libsndfile libvisio libwpd libwpg libX11
       libXaw libXext libXi libXinerama libxml2 libxslt libXtst

--- a/pkgs/applications/office/osmo/default.nix
+++ b/pkgs/applications/office/osmo/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, gtk, libxml2, gettext, libical, libnotify
-, libarchive, gtkspell, webkitgtk2, libgringotts }:
+{ stdenv, fetchurl, pkgconfig, gtk2, libxml2, gettext, libical, libnotify
+, libarchive, gtkspell2, webkitgtk2, libgringotts }:
 
 stdenv.mkDerivation rec {
   name = "osmo-${version}";
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0vaayrmyiqn010gr11drmhkkg8fkxdmla3gwj9v3zvp5x44kab05";
   };
 
-  buildInputs = [ pkgconfig gtk libxml2 gettext libical libnotify libarchive
-    gtkspell webkitgtk2 libgringotts ];
+  buildInputs = [ pkgconfig gtk2 libxml2 gettext libical libnotify libarchive
+    gtkspell2 webkitgtk2 libgringotts ];
 
   meta = with stdenv.lib; {
     description = "A handy personal organizer";

--- a/pkgs/applications/office/planner/default.nix
+++ b/pkgs/applications/office/planner/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl
 , pkgconfig
 , intltool
-, gnome
+, gnome2
 , libxslt
 , python
 }:
@@ -20,15 +20,17 @@ in stdenv.mkDerivation {
     sha256 = "15h6ps58giy5r1g66sg1l4xzhjssl362mfny2x09khdqsvk2j38k";
   };
 
-  buildInputs = [
+  buildInputs = with gnome2; [
     pkgconfig
     intltool
-    gnome.GConf
-    gnome.gtk
-    gnome.libgnomecanvas
-    gnome.libgnomeui
-    gnome.libglade
-    gnome.scrollkeeper
+
+    GConf
+    gtk
+    libgnomecanvas
+    libgnomeui
+    libglade
+    scrollkeeper
+
     libxslt
     python
   ];

--- a/pkgs/applications/office/zim/default.nix
+++ b/pkgs/applications/office/zim/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildPythonApplication, pythonPackages, pygtk, pygobject, python }:
+{ stdenv, lib, fetchurl, buildPythonApplication, pythonPackages, pygtk, pygobject2, python }:
 
 #
 # TODO: Declare configuration options for the following optional dependencies:
@@ -17,7 +17,7 @@ buildPythonApplication rec {
     sha256 = "15pdq4fxag85qjsrdmmssiq85qsk5vnbp8mrqnpvx8lm8crz6hjl";
   };
 
-  propagatedBuildInputs = [ pythonPackages.sqlite3 pygtk pythonPackages.pyxdg pygobject ];
+  propagatedBuildInputs = [ pythonPackages.sqlite3 pygtk pythonPackages.pyxdg pygobject2 ];
 
   preBuild = ''
     export HOME=$TMP

--- a/pkgs/applications/science/electronics/geda/default.nix
+++ b/pkgs/applications/science/electronics/geda/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, guile, gtk, flex, gawk, perl }:
+{ stdenv, fetchurl, pkgconfig, guile, gtk2, flex, gawk, perl }:
 
 stdenv.mkDerivation rec {
   name = "geda-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = "--disable-update-xdg-database";
-  buildInputs = [ pkgconfig guile gtk flex gawk perl ];
+  buildInputs = [ pkgconfig guile gtk2 flex gawk perl ];
 
   meta = with stdenv.lib; {
     description = "Full GPL'd suite of Electronic Design Automation tools";

--- a/pkgs/applications/science/electronics/gerbv/default.nix
+++ b/pkgs/applications/science/electronics/gerbv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, gettext, libtool, automake, autoconf, cairo, gtk, autoreconfHook }:
+{ stdenv, fetchgit, pkgconfig, gettext, libtool, automake, autoconf, cairo, gtk2, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "gerbv-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "00jn1xhf6kblxc5gac1wvk8zm12fy6sk81nj3jwdag0z6wk3z446";
   };
 
-  buildInputs = [ pkgconfig gettext libtool automake autoconf cairo gtk autoreconfHook ];
+  buildInputs = [ pkgconfig gettext libtool automake autoconf cairo gtk2 autoreconfHook ];
 
   configureFlags = ["--disable-update-desktop-database"];
 

--- a/pkgs/applications/science/electronics/gtkwave/default.nix
+++ b/pkgs/applications/science/electronics/gtkwave/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk, gperf, pkgconfig, bzip2, tcl, tk, judy, xz}:
+{stdenv, fetchurl, gtk2, gperf, pkgconfig, bzip2, tcl, tk, judy, xz}:
 stdenv.mkDerivation rec {
   name = "gtkwave-3.3.70";
 
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "1akzf1sq8mwarrbrbz5chrvgwlsp444h5za8rg1dfyqk733s7piz";
   };
 
-  buildInputs = [ gtk gperf pkgconfig bzip2 tcl tk judy xz ];
+  buildInputs = [ gtk2 gperf pkgconfig bzip2 tcl tk judy xz ];
 
   configureFlags = [ "--with-tcl=${tcl}/lib" "--with-tk=${tk}/lib" "--enable-judy" ];
 

--- a/pkgs/applications/science/electronics/pcb/default.nix
+++ b/pkgs/applications/science/electronics/pcb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, bison, intltool, flex, netpbm, imagemagick, dbus, xlibsWrapper, mesa, shared_mime_info, tcl, tk, gnome, pangox_compat, gd, xorg }:
+{ stdenv, fetchurl, pkgconfig, gtk2, bison, intltool, flex, netpbm, imagemagick, dbus, xlibsWrapper, mesa, shared_mime_info, tcl, tk, gnome2, pangox_compat, gd, xorg }:
 
 stdenv.mkDerivation rec {
   name = "pcb-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0l6944hq79qsyp60i5ai02xwyp8l47q7xdm3js0jfkpf72ag7i42";
   };
 
-  buildInputs = [ pkgconfig gtk bison intltool flex netpbm imagemagick dbus xlibsWrapper mesa tcl shared_mime_info tk gnome.gtkglext pangox_compat gd xorg.libXmu ];
+  buildInputs = [ pkgconfig gtk2 bison intltool flex netpbm imagemagick dbus xlibsWrapper mesa tcl shared_mime_info tk gnome2.gtkglext pangox_compat gd xorg.libXmu ];
 
   configureFlags = ["--disable-update-desktop-database"];
 

--- a/pkgs/applications/science/electronics/xoscope/default.nix
+++ b/pkgs/applications/science/electronics/xoscope/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk, pkgconfig}:
+{stdenv, fetchurl, gtk2, pkgconfig}:
 
 stdenv.mkDerivation rec {
   name = "xoscope-2.0";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "00xlvvqyw6l1ljbsx1vgx2v1jfh0xacz1a0yhq1dj6yxf5wh58x8";
   };
 
-  buildInputs = [ gtk pkgconfig ];
+  buildInputs = [ gtk2 pkgconfig ];
 
   # from: https://aur.archlinux.org/packages.php?ID=12140&detail=1
   patches = [ ./gtkdepre.diff ];

--- a/pkgs/applications/science/geometry/drgeo/default.nix
+++ b/pkgs/applications/science/geometry/drgeo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libglade, gtk, guile, libxml2, perl
+{ stdenv, fetchurl, libglade, gtk2, guile, libxml2, perl
 , intltool, libtool, pkgconfig }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
   patches = [ ./struct.patch ];
 
-  buildInputs = [libglade gtk guile libxml2
+  buildInputs = [libglade gtk2 guile libxml2
     perl intltool libtool pkgconfig];
 
   prebuild = ''

--- a/pkgs/applications/science/logic/verifast/default.nix
+++ b/pkgs/applications/science/logic/verifast/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, gtk, gdk_pixbuf, atk, pango, glib, cairo, freetype
+{ stdenv, fetchurl, gtk2, gdk_pixbuf, atk, pango, glib, cairo, freetype
 , fontconfig, libxml2, gnome2 }:
 
 assert stdenv.isLinux;
 
 let
   libPath = stdenv.lib.makeLibraryPath
-    [ stdenv.cc.libc stdenv.cc.cc gtk gdk_pixbuf atk pango glib cairo
+    [ stdenv.cc.libc stdenv.cc.cc gtk2 gdk_pixbuf atk pango glib cairo
       freetype fontconfig libxml2 gnome2.gtksourceview
     ] + ":${stdenv.cc.cc.lib}/lib64";
 

--- a/pkgs/applications/science/math/pssp/default.nix
+++ b/pkgs/applications/science/math/pssp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libxml2, readline, zlib, perl, cairo, gtk, gsl
+{ stdenv, fetchurl, libxml2, readline, zlib, perl, cairo, gtk2, gsl
 , pkgconfig, gtksourceview, pango, gettext, libglade
 }:
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0vri2pzvmm38qaihfvwlry30f40lcnps4blg59ixic4q20ldxf5d";
   };
 
-  buildInputs = [ libxml2 readline zlib perl cairo gtk gsl pkgconfig
+  buildInputs = [ libxml2 readline zlib perl cairo gtk2 gsl pkgconfig
     gtksourceview pango gettext libglade ];
 
   doCheck = false;

--- a/pkgs/applications/science/math/scilab/default.nix
+++ b/pkgs/applications/science/math/scilab/default.nix
@@ -3,7 +3,7 @@
 , Xaw3d, withXaw3d ? false
 #, withPVMlib ? false
 , tcl, tk, withTk ? false
-, gtk, withGtk ? false # working ?
+, gtk2, withGtk ? false # working ?
 #, withF2c ? false
 , ocaml, withOCaml ? false
 #, withJava ? false
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [gfortran ncurses]
-  ++ lib.optionals withGtk [gtk]
+  ++ lib.optionals withGtk [gtk2]
   ++ lib.optionals withOCaml [ocaml]
   ++ lib.optional withX xlibsWrapper
   ;

--- a/pkgs/applications/science/misc/boinc/default.nix
+++ b/pkgs/applications/science/misc/boinc/default.nix
@@ -1,6 +1,6 @@
 { fetchFromGitHub, stdenv, autoconf, automake, pkgconfig, m4, curl,
 mesa, libXmu, libXi, freeglut, libjpeg, libtool, wxGTK, xcbutil,
-sqlite, gtk, patchelf, libXScrnSaver, libnotify, libX11, libxcb }:
+sqlite, gtk2, patchelf, libXScrnSaver, libnotify, libX11, libxcb }:
 
 stdenv.mkDerivation rec {
   version = "7.4.42";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libtool automake autoconf m4 pkgconfig curl mesa libXmu libXi
-    freeglut libjpeg wxGTK sqlite gtk libXScrnSaver libnotify patchelf libX11 
+    freeglut libjpeg wxGTK sqlite gtk2 libXScrnSaver libnotify patchelf libX11
     libxcb xcbutil
   ];
 

--- a/pkgs/applications/science/misc/openmodelica/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchgit, fetchsvn, autoconf, automake, libtool, gfortran, clang, cmake, gnumake,
 hwloc, jre, liblapack, blas, hdf5, expat, ncurses, readline, qt4, webkit, which,
 lp_solve, omniorb, sqlite, libatomic_ops, pkgconfig, file, gettext, flex, bison,
-doxygen, boost, openscenegraph, gnome, pangox_compat, xorg, git, bash, gtk, makeWrapper }:
+doxygen, boost, openscenegraph, gnome2, pangox_compat, xorg, git, bash, gtk2, makeWrapper }:
 
 let
 
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
   buildInputs = [autoconf cmake automake libtool gfortran clang gnumake
     hwloc jre liblapack blas hdf5 expat ncurses readline qt4 webkit which
     lp_solve omniorb sqlite libatomic_ops pkgconfig file gettext flex bison
-    doxygen boost openscenegraph gnome.gtkglext pangox_compat xorg.libXmu
-    git gtk makeWrapper];
+    doxygen boost openscenegraph gnome2.gtkglext pangox_compat xorg.libXmu
+    git gtk2 makeWrapper];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/version-management/rabbitvcs/default.nix
+++ b/pkgs/applications/version-management/rabbitvcs/default.nix
@@ -11,7 +11,7 @@ python2Packages.buildPythonApplication rec {
     sha256 = "0964pdylrx4n9c9l8ncwv4q1p63y4hadb5v4pgvm0m2fah2jlkly";
   };
 
-  pythonPath = with python2Packages; [ configobj dbus-python pygobject pygtk simplejson pysvn dulwich tkinter gvfs xdg_utils ];
+  pythonPath = with python2Packages; [ configobj dbus-python pygobject2 pygtk simplejson pysvn dulwich tkinter gvfs xdg_utils ];
 
   prePatch = ''
       sed -ie 's|if sys\.argv\[1\] == "install":|if False:|' ./setup.py

--- a/pkgs/applications/version-management/smartgithg/default.nix
+++ b/pkgs/applications/version-management/smartgithg/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, lib, makeWrapper
 , jre
-, gtk, glib
+, gtk2, glib
 , libXtst
 , git, mercurial, subversion
 , which
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       which
     ];
     runtime_lib_paths = lib.makeLibraryPath [
-      gtk glib
+      gtk2 glib
       libXtst
     ];
   in ''

--- a/pkgs/applications/video/coriander/default.nix
+++ b/pkgs/applications/video/coriander/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, glib, gtk, libgnomeui, libXv, libraw1394, libdc1394
+{stdenv, fetchurl, pkgconfig, glib, gtk2, libgnomeui, libXv, libraw1394, libdc1394
 , SDL, automake, GConf }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     cp ${automake}/share/automake-*/mkinstalldirs .
   '';
 
-  buildInputs = [ pkgconfig glib gtk libgnomeui libXv libraw1394 libdc1394 SDL GConf ];
+  buildInputs = [ pkgconfig glib gtk2 libgnomeui libXv libraw1394 libdc1394 SDL GConf ];
   
   meta = {
     homepage = http://damien.douxchamps.net/ieee1394/coriander/;

--- a/pkgs/applications/video/gnash/default.nix
+++ b/pkgs/applications/video/gnash/default.nix
@@ -3,7 +3,7 @@
 , gst_ffmpeg, speex
 , libogg, libxml2, libjpeg, mesa, libpng, libungif, libtool
 , boost, freetype, agg, dbus, curl, pkgconfig, gettext
-, glib, gtk, gtkglext, pangox_compat, xlibsWrapper, ming, dejagnu, python, perl
+, glib, gtk2, gtkglext, pangox_compat, xlibsWrapper, ming, dejagnu, python, perl
 , freefont_ttf, haxe, swftools
 , lib, makeWrapper
 , xulrunner }:
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     gettext xlibsWrapper SDL SDL_mixer gstreamer gst_plugins_base gst_plugins_good
     gst_ffmpeg speex libtool
     libogg libxml2 libjpeg mesa libpng libungif boost freetype agg
-    dbus curl pkgconfig glib gtk gtkglext pangox_compat
+    dbus curl pkgconfig glib gtk2 gtkglext pangox_compat
     xulrunner
     makeWrapper
   ]

--- a/pkgs/applications/video/gnome-mplayer/default.nix
+++ b/pkgs/applications/video/gnome-mplayer/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, glib, gtk, dbus, dbus_glib, GConf}:
+{stdenv, fetchurl, pkgconfig, glib, gtk2, dbus, dbus_glib, GConf}:
 
 stdenv.mkDerivation rec {
   name = "gnome-mplayer-1.0.4";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1k5yplsvddcm7xza5h4nfb6vibzjcqsk8gzis890alizk07f5xp2";
   };
 
-  buildInputs = [pkgconfig glib gtk dbus dbus_glib GConf];
+  buildInputs = [pkgconfig glib gtk2 dbus dbus_glib GConf];
   
   meta = {
     homepage = http://kdekorte.googlepages.com/gnomemplayer;

--- a/pkgs/applications/video/kazam/default.nix
+++ b/pkgs/applications/video/kazam/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python3Packages, gst_all_1, makeWrapper, gobjectIntrospection
-, gtk3, libwnck3, keybinder, intltool, libcanberra }:
+, gtk3, libwnck3, keybinder, intltool, libcanberra_gtk2 }:
 
 
 python3Packages.buildPythonApplication rec {
@@ -25,7 +25,7 @@ python3Packages.buildPythonApplication rec {
   patches = [ ./datadir.patch ./bug_1190693.patch ];
   prePatch = ''
     rm setup.cfg
-    substituteInPlace kazam/backend/grabber.py --replace "/usr/bin/canberra-gtk-play" "${libcanberra}/bin/canberra-gtk-play"
+    substituteInPlace kazam/backend/grabber.py --replace "/usr/bin/canberra-gtk-play" "${libcanberra_gtk2}/bin/canberra-gtk-play"
   '';
 
   # no tests

--- a/pkgs/applications/video/key-mon/default.nix
+++ b/pkgs/applications/video/key-mon/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonApplication, gnome, librsvg, pygtk, pythonPackages }:
+{ stdenv, fetchurl, buildPythonApplication, gnome2, librsvg, pygtk, pythonPackages }:
 
 buildPythonApplication rec {
   name = "key-mon-${version}";
@@ -11,7 +11,7 @@ buildPythonApplication rec {
   };
 
   propagatedBuildInputs =
-    [ gnome.python_rsvg librsvg pygtk pythonPackages.xlib ];
+    [ gnome2.python_rsvg librsvg pygtk pythonPackages.xlib ];
 
   doCheck = false;
 

--- a/pkgs/applications/video/kino/default.nix
+++ b/pkgs/applications/video/kino/default.nix
@@ -50,7 +50,7 @@
 #AMR-WB float support      no
 #AMR-WB IF2 support        no
 
-{ stdenv, fetchurl, gtk, libglade, libxml2, libraw1394, libsamplerate, libdv
+{ stdenv, fetchurl, gtk2, libglade, libxml2, libraw1394, libsamplerate, libdv
 , pkgconfig, perl, perlXMLParser, libavc1394, libiec61883, libXv, gettext
 , libX11, glib, cairo, intltool, ffmpeg, libv4l
 }:
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
     sha256 = "020s05k0ma83rq2kfs8x474pqicaqp9spar81qc816ddfrnh8k8i";
   };
 
-  buildInputs = [ gtk libglade libxml2 libraw1394 libsamplerate libdv 
+  buildInputs = [ gtk2 libglade libxml2 libraw1394 libsamplerate libdv
       pkgconfig perl perlXMLParser libavc1394 libiec61883 intltool libXv gettext libX11 glib cairo ffmpeg libv4l ]; # TODOoptional packages 
 
   configureFlags = "--enable-local-ffmpeg=no";

--- a/pkgs/applications/video/miro/default.nix
+++ b/pkgs/applications/video/miro/default.nix
@@ -69,13 +69,13 @@ in buildPythonApplication rec {
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share"
   '';
 
-  buildInputs = with pythonPackages; [ pygtk pygobject ] ++ [
+  buildInputs = with pythonPackages; [ pygtk pygobject2 ] ++ [
     pkgconfig pyrex096 ffmpeg boost glib gtk2 webkitgtk2 libsoup
     taglib gsettings_desktop_schemas sqlite
   ];
 
   propagatedBuildInputs = with pythonPackages; [
-    pygobject pygtk pycurl sqlite3 mutagen pycairo dbus-python
+    pygobject2 pygtk pycurl sqlite3 mutagen pycairo dbus-python
     pywebkitgtk] ++ [ libtorrentRasterbar
     gst_python gst_plugins_base gst_plugins_good gst_ffmpeg
   ] ++ optional enableBonjour avahi;

--- a/pkgs/applications/video/mkcast/default.nix
+++ b/pkgs/applications/video/mkcast/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, wmctrl, pythonPackages, byzanz
-, xdpyinfo, makeWrapper, gtk, xorg, gnome3 }:
+, xdpyinfo, makeWrapper, gtk2, xorg, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "mkcast-2015-03-13";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "15wp3n3z8gw7kjdxs4ahda17n844awhxsqbql5ipsdhqfxah2d8p";
   };
 
-  buildInputs = with pythonPackages; [ makeWrapper pygtk gtk xlib ];
+  buildInputs = with pythonPackages; [ makeWrapper pygtk gtk2 xlib ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/applications/video/xvidcap/default.nix
+++ b/pkgs/applications/video/xvidcap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, perlXMLParser, pkgconfig, gtk
+{ stdenv, fetchurl, perl, perlXMLParser, pkgconfig, gtk2
 , scrollkeeper, libglade, libXmu, libX11, libXext, gettext
 , lame, libXfixes, libXdamage }:
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   patches = [ ./xlib.patch ];
   buildInputs = [
-    perl perlXMLParser pkgconfig gtk scrollkeeper
+    perl perlXMLParser pkgconfig gtk2 scrollkeeper
     libglade libXmu gettext lame libXdamage libXfixes libXext libX11
   ];
 

--- a/pkgs/applications/virtualization/bochs/default.nix
+++ b/pkgs/applications/virtualization/bochs/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, config
 , pkgconfig, libtool
-, gtk, mesa, readline, libX11, libXpm
+, gtk2, mesa, readline, libX11, libXpm
 , docbook_xml_dtd_45, docbook_xsl
 , sdlSupport ? true, SDL2 ? null
 , termSupport ? true , ncurses ? null
@@ -12,7 +12,7 @@
 
 assert sdlSupport -> (SDL2 != null);
 assert termSupport -> (ncurses != null);
-assert wxSupport -> (gtk != null && wxGTK != null);
+assert wxSupport -> (gtk2 != null && wxGTK != null);
 assert wgetSupport -> (wget != null);
 assert curlSupport -> (curl != null);
 
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
   busMouse = config.bochs.busMouse or false;
 
   buildInputs = with stdenv.lib;
-  [ pkgconfig libtool gtk mesa readline libX11 libXpm docbook_xml_dtd_45 docbook_xsl ]
+  [ pkgconfig libtool gtk2 mesa readline libX11 libXpm docbook_xml_dtd_45 docbook_xsl ]
   ++ optionals termSupport [ ncurses ]
   ++ optionals sdlSupport [ SDL2 ]
   ++ optionals wxSupport [ wxGTK ]
@@ -143,7 +143,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional busMouse "--enable-busmouse"
     ;
 
-  NIX_CFLAGS_COMPILE="-I${gtk.dev}/include/gtk-2.0/ -I${libtool}/include/";
+  NIX_CFLAGS_COMPILE="-I${gtk2.dev}/include/gtk-2.0/ -I${libtool}/include/";
   NIX_LDFLAGS="-L${libtool.lib}/lib";
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/window-managers/compiz/default.nix
+++ b/pkgs/applications/window-managers/compiz/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, pkgconfig
-, libXrender, renderproto, gtk, libwnck, pango, cairo
+, libXrender, renderproto, gtk2, libwnck, pango, cairo
 , GConf, libXdamage, damageproto, libxml2, libxslt, glibmm
 , metacity
 , libstartup_notification, libpthreadstubs, libxcb, intltool
@@ -24,7 +24,7 @@ let
     sha256="00m73im5kdpbfjg9ryzxnab5qvx5j51gxwr3wzimkrcbax6vb3ph";
   };
   buildInputs = [cmake pkgconfig
-    libXrender renderproto gtk libwnck pango cairo
+    libXrender renderproto gtk2 libwnck pango cairo
     GConf libXdamage damageproto libxml2 libxslt glibmm libstartup_notification
     metacity
     libpthreadstubs libxcb intltool

--- a/pkgs/applications/window-managers/fbpanel/default.nix
+++ b/pkgs/applications/window-managers/fbpanel/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig
-, libX11, libXmu, libXpm, gtk, libpng, libjpeg, libtiff, librsvg
+, libX11, libXmu, libXpm, gtk2, libpng, libjpeg, libtiff, librsvg
 }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "e14542cc81ea06e64dd4708546f5fd3f5e01884c3e4617885c7ef22af8cf3965";
   };
   buildInputs =
-    [ pkgconfig libX11 libXmu libXpm gtk libpng libjpeg libtiff librsvg ];
+    [ pkgconfig libX11 libXmu libXpm gtk2 libpng libjpeg libtiff librsvg ];
 
   preConfigure = "patchShebangs .";
 

--- a/pkgs/applications/window-managers/trayer/default.nix
+++ b/pkgs/applications/window-managers/trayer/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, pkgconfig, gdk_pixbuf, gtk, libXmu }:
+{ stdenv, fetchFromGitHub, pkgconfig, gdk_pixbuf, gtk2, libXmu }:
 
 stdenv.mkDerivation rec {
   name = "trayer-1.1.6";
 
-  buildInputs = [ pkgconfig gdk_pixbuf gtk libXmu ];
+  buildInputs = [ pkgconfig gdk_pixbuf gtk2 libXmu ];
 
   src = fetchFromGitHub {
     owner = "sargon";

--- a/pkgs/data/misc/ddccontrol-db/default.nix
+++ b/pkgs/data/misc/ddccontrol-db/default.nix
@@ -5,7 +5,7 @@
 , libxml2
 , pciutils
 , pkgconfig
-, gtk
+, gtk2
 }:
 
 let version = "20061014"; in
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
       libxml2
       pciutils
       pkgconfig
-      gtk
+      gtk2
     ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-2/bindings/gnome-python/default.nix
+++ b/pkgs/desktops/gnome-2/bindings/gnome-python/default.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 let
-  inherit (pythonPackages) python pygobject pygtk dbus-python;
+  inherit (pythonPackages) python pygobject2 pygtk dbus-python;
 in stdenv.mkDerivation rec {
   version = "2.28";
   name = "gnome-python-${version}.1";
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
     cp bonobo/*.{py,defs} $out/share/pygtk/2.0/defs/
   '';
 
-  buildInputs = [ python pkgconfig pygobject pygtk glib gtk GConf libgnome dbus-python gnome_vfs ];
+  buildInputs = [ python pkgconfig pygobject2 pygtk glib gtk GConf libgnome dbus-python gnome_vfs ];
 
   doCheck = false;
 

--- a/pkgs/desktops/gnome-2/bindings/python-rsvg/default.nix
+++ b/pkgs/desktops/gnome-2/bindings/python-rsvg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gnome, librsvg, pkgconfig, pygtk, python, gtk }:
+{ stdenv, fetchurl, gnome2, librsvg, pkgconfig, pygtk, python, gtk }:
 
 stdenv.mkDerivation rec {
   ver_maj = "2.32";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   installPhase = "python waf install";
 
-  buildInputs = [ gtk gnome.gnome_python librsvg pkgconfig pygtk python ];
+  buildInputs = [ gtk gnome2.gnome_python librsvg pkgconfig pygtk python ];
 
   meta = with stdenv.lib; {
     homepage = "http://www.pygtk.org";

--- a/pkgs/desktops/gnome-3/3.20/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/gnome-control-center/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, gnome3, ibus, intltool, upower, makeWrapper
-, libcanberra, libcanberra_gtk3, accountsservice, libpwquality, libpulseaudio
+, libcanberra_gtk2, libcanberra_gtk3, accountsservice, libpwquality, libpulseaudio
 , gdk_pixbuf, librsvg, libxkbfile, libnotify, libgudev
 , libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
 , cracklib, python, libkrb5, networkmanagerapplet, networkmanager
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
 
   buildInputs = with gnome3;
-    [ pkgconfig intltool ibus gtk glib upower libcanberra gsettings_desktop_schemas
+    [ pkgconfig intltool ibus gtk glib upower libcanberra_gtk2 gsettings_desktop_schemas
       libxml2 gnome_desktop gnome_settings_daemon polkit libxslt libgtop gnome-menus
       gnome_online_accounts libsoup colord libpulseaudio fontconfig colord-gtk libpwquality
       accountsservice libkrb5 networkmanagerapplet libwacom samba libnotify libxkbfile

--- a/pkgs/desktops/gnome-3/3.20/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/gnome-shell/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = with gnome3;
     [ gsettings_desktop_schemas gnome_keyring gnome-menus glib gcr json_glib accountsservice
-      libcroco intltool libsecret pkgconfig libsoup polkit libcanberra gdk_pixbuf librsvg
+      libcroco intltool libsecret pkgconfig libsoup polkit libcanberra_gtk2 gdk_pixbuf librsvg
       clutter networkmanager libstartup_notification telepathy_glib docbook_xsl docbook_xsl_ns
       libXtst p11_kit networkmanagerapplet gjs mutter libpulseaudio caribou evolution_data_server
       libical libtool nss gtk gstreamer makeWrapper gdm

--- a/pkgs/desktops/gnome-3/3.20/core/gsound/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/gsound/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libcanberra, gobjectIntrospection, libtool, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, glib, libcanberra_gtk2, gobjectIntrospection, libtool, gnome3 }:
 
 let
   majVer = "1.0";
@@ -10,7 +10,7 @@ in stdenv.mkDerivation rec {
     sha256 = "ea0dd94429c0645f2f98824274ef04543fe459dd83a5449a68910acc3ba67f29";
   };
 
-  buildInputs = [ pkgconfig glib libcanberra gobjectIntrospection libtool ];
+  buildInputs = [ pkgconfig glib libcanberra_gtk2 gobjectIntrospection libtool ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/GSound;

--- a/pkgs/desktops/gnome-3/3.20/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/mutter/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, gnome3, intltool, gobjectIntrospection, upower, cairo
-, pango, cogl, clutter, libstartup_notification, libcanberra, zenity, libcanberra_gtk3
+, pango, cogl, clutter, libstartup_notification, libcanberra_gtk2, zenity, libcanberra_gtk3
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = with gnome3;
     [ pkgconfig intltool glib gobjectIntrospection gtk gsettings_desktop_schemas upower
-      gnome_desktop cairo pango cogl clutter zenity libstartup_notification libcanberra
+      gnome_desktop cairo pango cogl clutter zenity libstartup_notification libcanberra_gtk2
       gnome3.geocode_glib
       libcanberra_gtk3 zenity libtool makeWrapper xkeyboard_config libxkbfile libxkbcommon ];
 

--- a/pkgs/desktops/gnome-3/3.20/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/totem/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./x86.patch ];
 
-  propagatedBuildInputs = [ gobjectIntrospection python3Packages.pylint python3Packages.pygobject ];
+  propagatedBuildInputs = [ gobjectIntrospection python3Packages.pylint python3Packages.pygobject2 ];
 
   configureFlags = [ "--with-nautilusdir=$(out)/lib/nautilus/extensions-3.0" ];
 

--- a/pkgs/desktops/gnome-3/3.20/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/default.nix
@@ -45,7 +45,7 @@ let
     hitori gnome-taquin
   ];
 
-  inherit (pkgs) glib gtk2 webkitgtk24x webkitgtk212x gtk3 gtkmm3 libcanberra;
+  inherit (pkgs) glib gtk2 webkitgtk24x webkitgtk212x gtk3 gtkmm3 libcanberra_gtk2;
   inherit (pkgs.gnome2) ORBit2;
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };

--- a/pkgs/desktops/gnome-3/3.20/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/misc/geary/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_32
 , makeWrapper, gdk_pixbuf, cmake, desktop_file_utils
-, libnotify, libcanberra, libsecret, gmime
+, libnotify, libcanberra_gtk3, libsecret, gmime
 , libpthreadstubs, sqlite
 , gnome3, librsvg, gnome_doc_utils, webkitgtk }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];
 
   buildInputs = [ intltool pkgconfig gtk3 makeWrapper cmake desktop_file_utils gnome_doc_utils
-                  vala_0_32 webkitgtk libnotify libcanberra gnome3.libgee libsecret gmime sqlite
+                  vala_0_32 webkitgtk libnotify libcanberra_gtk3 gnome3.libgee libsecret gmime sqlite
                   libpthreadstubs gnome3.gsettings_desktop_schemas gnome3.gcr
                   gdk_pixbuf librsvg gnome3.defaultIconTheme ];
 

--- a/pkgs/desktops/gnome-3/3.20/misc/pomodoro/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/misc/pomodoro/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, which, automake113x, intltool, pkgconfig, libtool, makeWrapper,
-  dbus_glib, libcanberra, gst_all_1, vala_0_32, gnome3, gtk3, gst_plugins_base,
+  dbus_glib, libcanberra_gtk2, gst_all_1, vala_0_32, gnome3, gtk3, gst_plugins_base,
   glib, gobjectIntrospection, telepathy_glib
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     which automake113x intltool glib gobjectIntrospection pkgconfig libtool
-    makeWrapper dbus_glib libcanberra vala_0_32 gst_all_1.gstreamer
+    makeWrapper dbus_glib libcanberra_gtk2 vala_0_32 gst_all_1.gstreamer
     gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
     gnome3.gsettings_desktop_schemas gnome3.gnome_desktop
     gnome3.gnome_common gnome3.gnome_shell gtk3 telepathy_glib

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -5,9 +5,10 @@ let
 callPackage = newScope (deps // xfce_self);
 
 deps = { # xfce-global dependency overrides should be here
-  inherit (pkgs.gnome) libglade libwnck vte gtksourceview;
+  inherit (pkgs.gnome2) libglade libwnck vte gtksourceview;
   inherit (pkgs.gnome3) dconf;
   inherit (pkgs.perlPackages) URI;
+  gtk = pkgs.gtk2;
 };
 
 xfce_self = rec { # the lines are very long but it seems better than the even-odd line approach

--- a/pkgs/development/compilers/aliceml/default.nix
+++ b/pkgs/development/compilers/aliceml/default.nix
@@ -1,4 +1,4 @@
-{stdenv, gcc, glibc, fetchurl, fetchgit, libtool, autoconf, automake, file, gnumake, which, zsh, m4, pkgconfig, perl, gnome, pango, sqlite, libxml2, zlib, gmp, smlnj }:
+{stdenv, gcc, glibc, fetchurl, fetchgit, libtool, autoconf, automake, file, gnumake, which, zsh, m4, pkgconfig, perl, gnome2, pango, sqlite, libxml2, zlib, gmp, smlnj }:
 
 stdenv.mkDerivation {
   name = "aliceml-1.4-7d44dc8e";
@@ -18,8 +18,8 @@ stdenv.mkDerivation {
   buildInputs = [
     stdenv gcc glibc
     libtool gnumake autoconf automake
-    file which zsh m4 gnome.gtk zlib gmp
-    gnome.libgnomecanvas pango sqlite
+    file which zsh m4 gnome2.gtk zlib gmp
+    gnome2.libgnomecanvas pango sqlite
     libxml2 pkgconfig perl smlnj
   ];
 

--- a/pkgs/development/compilers/boo/default.nix
+++ b/pkgs/development/compilers/boo/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, dbus, mono, makeWrapper, nant
-, shared_mime_info, gtksourceview, gtk
+, shared_mime_info, gtksourceview, gtk2
 , targetVersion ? "4.5" }:
 
 let
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig mono makeWrapper nant shared_mime_info gtksourceview
-    gtk
+    gtk2
   ];
 
   patches = [ ./config.patch ];

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -1,7 +1,7 @@
 {
 stdenv, fetchurl
 , fpc
-, gtk, glib, pango, atk, gdk_pixbuf
+, gtk2, glib, pango, atk, gdk_pixbuf
 , libXi, inputproto, libX11, xproto, libXext, xextproto
 , makeWrapper
 }:
@@ -15,7 +15,7 @@ let
     name = "lazarus-${version}";
   };
   buildInputs = [
-    fpc gtk glib libXi inputproto
+    fpc gtk2 glib libXi inputproto
     libX11 xproto libXext xextproto pango atk
     stdenv.cc makeWrapper gdk_pixbuf
   ];

--- a/pkgs/development/compilers/gnu-smalltalk/default.nix
+++ b/pkgs/development/compilers/gnu-smalltalk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libtool, zip, libffi, libsigsegv, readline, gmp,
-gnutls, gnome, cairo, SDL, sqlite, emacsSupport ? false, emacs ? null }:
+gnutls, gnome2, cairo, SDL, sqlite, emacsSupport ? false, emacs ? null }:
 
 assert emacsSupport -> (emacs != null);
 
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
   # The dependencies and their justification are explained at
   # http://smalltalk.gnu.org/download
   buildInputs = [
-    pkgconfig libtool zip libffi libsigsegv-shared readline gmp gnutls gnome.gtk
+    pkgconfig libtool zip libffi libsigsegv-shared readline gmp gnutls gnome2.gtk
     cairo SDL sqlite
   ]
   ++ stdenv.lib.optional emacsSupport emacs;

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -26,7 +26,7 @@
 , mesa_noglu
 , freetype
 , fontconfig
-, gnome
+, gnome2
 , cairo
 , alsaLib
 , atk
@@ -177,7 +177,7 @@ let result = stdenv.mkDerivation rec {
    * libXt is only needed on amd64
    */
   libraries =
-    [stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu xorg.libXxf86vm alsaLib fontconfig freetype gnome.pango gnome.gtk cairo gdk_pixbuf atk] ++
+    [stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt mesa_noglu xorg.libXxf86vm alsaLib fontconfig freetype gnome2.pango gnome2.gtk cairo gdk_pixbuf atk] ++
     (if swingSupport then [xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp xorg.libXt xorg.libXrender stdenv.cc.cc] else []);
 
   rpath = stdenv.lib.strings.makeLibraryPath libraries;

--- a/pkgs/development/guile-modules/guile-gnome/default.nix
+++ b/pkgs/development/guile-modules/guile-gnome/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, guile, guile_lib, gwrap
-, pkgconfig, gconf, glib, gnome_vfs, gtk
+, pkgconfig, gconf, glib, gnome_vfs, gtk2
 , libglade, libgnome, libgnomecanvas, libgnomeui
 , pango, guileCairo, autoconf, automake, texinfo }:
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     gconf
     glib
     gnome_vfs
-    gtk
+    gtk2
     libglade
     libgnome
     libgnomecanvas

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -229,7 +229,7 @@ self: super: {
   });
   gtk = pkgs.lib.overrideDerivation (addPkgconfigDepend (
     addBuildTool super.gtk self.gtk2hs-buildtools
-  ) pkgs.gtk) (drv: {
+  ) pkgs.gtk2) (drv: {
     hardeningDisable = [ "fortify" ];
   });
   gtksourceview2 = (addPkgconfigDepend super.gtksourceview2 pkgs.gtk2).override { inherit (pkgs.gnome2) gtksourceview; };

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -49,7 +49,7 @@ let
         overrideScope = f: callPackageWithScope (mkScope (fix' (extends f scope.__unfix__))) drv args;
       };
 
-      mkScope = scope: pkgs // pkgs.xorg // pkgs.gnome // scope;
+      mkScope = scope: pkgs // pkgs.xorg // pkgs.gnome2 // scope;
       defaultScope = mkScope self;
       callPackage = drv: args: callPackageWithScope defaultScope drv args;
 

--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, makeFontsConf, makeWrapper
 , cairo, coreutils, fontconfig, freefont_ttf
-, glib, gmp, gtk, libffi, libjpeg, libpng
+, glib, gmp, gtk2, libffi, libjpeg, libpng
 , libtool, mpfr, openssl, pango, poppler
 , readline, sqlite
 , disableDocs ? true
@@ -17,7 +17,7 @@ let
     fontconfig
     glib
     gmp
-    gtk
+    gtk2
     libjpeg
     libpng
     mpfr

--- a/pkgs/development/libraries/aqbanking/gwenhywfar.nix
+++ b/pkgs/development/libraries/aqbanking/gwenhywfar.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gnutls, gtk, libgcrypt, pkgconfig, gettext, qt4
+{ stdenv, fetchurl, gnutls, gtk2, libgcrypt, pkgconfig, gettext, qt4
 
 , pluginSearchPaths ? [
     "/run/current-system/sw/lib/gwenhywfar/plugins"
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext ];
 
-  buildInputs = [ gtk qt4 gnutls libgcrypt ];
+  buildInputs = [ gtk2 qt4 gnutls libgcrypt ];
 
   QTDIR = qt4;
 

--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, libsndfile, pkgconfig, python }:
+{ stdenv, fetchurl, gtk2, libsndfile, pkgconfig, python }:
 
 stdenv.mkDerivation rec {
   name = "lv2-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1saq0vwqy5zjdkgc5ahs8kcabxfmff2mmg68fiqrkv8hiw9m6jks";
   };
 
-  buildInputs = [ gtk libsndfile pkgconfig python ];
+  buildInputs = [ gtk2 libsndfile pkgconfig python ];
 
   configurePhase = "python waf configure --prefix=$out";
 

--- a/pkgs/development/libraries/audio/lvtk/default.nix
+++ b/pkgs/development/libraries/audio/lvtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, boost, gtkmm, lv2, pkgconfig, python }:
+{ stdenv, fetchurl, boost, gtkmm2, lv2, pkgconfig, python }:
 
 stdenv.mkDerivation rec {
   name = "lvtk-${version}";
@@ -10,7 +10,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig python ];
-  buildInputs = [ boost gtkmm lv2 ];
+  buildInputs = [ boost gtkmm2 lv2 ];
+
+  enableParallelBuilding = true;
 
   # Fix including the boost libraries during linking
   postPatch = ''

--- a/pkgs/development/libraries/audio/raul/default.nix
+++ b/pkgs/development/libraries/audio/raul/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, boost, gtk, pkgconfig, python }:
+{ stdenv, fetchsvn, boost, gtk2, pkgconfig, python }:
 
 stdenv.mkDerivation rec {
   name = "raul-svn-${rev}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0yvm3j57lch89dixx7zsip7pxsws0xxy1y6ck7a3l0534qc5kny4";
   };
 
-  buildInputs = [ boost gtk pkgconfig python ];
+  buildInputs = [ boost gtk2 pkgconfig python ];
 
   configurePhase = "python waf configure --prefix=$out";
 

--- a/pkgs/development/libraries/audio/suil/default.nix
+++ b/pkgs/development/libraries/audio/suil/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, lv2, pkgconfig, python, serd, sord, sratom, qt4 }:
+{ stdenv, fetchurl, gtk2, lv2, pkgconfig, python, serd, sord, sratom, qt4 }:
 
 stdenv.mkDerivation rec {
   name = "suil-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1s3adyiw7sa5gfvm5wasa61qa23629kprxyv6w8hbxdiwp0hhxkq";
   };
 
-  buildInputs = [ gtk lv2 pkgconfig python qt4 serd sord sratom ];
+  buildInputs = [ gtk2 lv2 pkgconfig python qt4 serd sord sratom ];
 
   configurePhase = "python waf configure --prefix=$out";
 

--- a/pkgs/development/libraries/clutter-gtk/0.10.8.nix
+++ b/pkgs/development/libraries/clutter-gtk/0.10.8.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, clutter, gtk }:
+{ fetchurl, stdenv, pkgconfig, clutter, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "clutter-gtk-0.10.8";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0508x1jfnlq0zhgscysvfa7i7ljkzm23d2myikvdjwc8ar8zjrvq";
   };
 
-  propagatedBuildInputs = [ clutter gtk ];
+  propagatedBuildInputs = [ clutter gtk2 ];
   nativeBuildInputs = [ pkgconfig ];
 
   configureFlags = [ "--disable-introspection" ]; # not needed anywhere AFAIK

--- a/pkgs/development/libraries/cwiid/default.nix
+++ b/pkgs/development/libraries/cwiid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, autoreconfHook, fetchgit, bison, flex, bluez, pkgconfig, gtk }:
+{ stdenv, autoreconfHook, fetchgit, bison, flex, bluez, pkgconfig, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "cwiid-2010-02-21-git";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sed -i -e '/$(LDCONFIG)/d' common/include/lib.mak.in
   '';
 
-  buildInputs = [ autoreconfHook bison flex bluez pkgconfig gtk ];
+  buildInputs = [ autoreconfHook bison flex bluez pkgconfig gtk2 ];
 
   postInstall = ''
     # Some programs (for example, cabal-install) have problems with the double 0

--- a/pkgs/development/libraries/farsight2/default.nix
+++ b/pkgs/development/libraries/farsight2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libnice, pkgconfig, python, gstreamer, gst_plugins_base
-, pygobject, gst_python, gupnp_igd }:
+, pygobject2, gst_python, gupnp_igd }:
 
 stdenv.mkDerivation rec {
   name = "farsight2-0.0.31";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "16qz4x14rdycm4nrn5wx6k2y22fzrazsbmihrxdwafx9cyf23kjm";
   };
 
-  buildInputs = [ libnice python pygobject gst_python gupnp_igd ];
+  buildInputs = [ libnice python pygobject2 gst_python gupnp_igd ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/farstream/default.nix
+++ b/pkgs/development/libraries/farstream/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libnice, pkgconfig, python, gstreamer, gst-plugins-base
-, pygobject, gst-python, gupnp_igd
+, pygobject2, gst-python, gupnp_igd
 , gst-plugins-good, gst-plugins-bad, gst-libav
 }:
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0c5vlyiwb799wpby4g9vffiy0nf09gy2cr84ksfy3jwzsxf5n38j";
   };
 
-  buildInputs = [ libnice python pygobject gupnp_igd libnice ];
+  buildInputs = [ libnice python pygobject2 gupnp_igd libnice ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/libraries/ganv/default.nix
+++ b/pkgs/development/libraries/ganv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, graphviz, gtk, gtkmm, pkgconfig, python }:
+{ stdenv, fetchsvn, graphviz, gtkmm2, pkgconfig, python }:
 
 stdenv.mkDerivation rec {
   name = "ganv-svn-${rev}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0klzng3jvc09lj4hxnzlb8z5s5qp8rj16b1x1j6hcbqdja54fccj";
   };
 
-  buildInputs = [ graphviz gtk gtkmm pkgconfig python ];
+  buildInputs = [ graphviz gtkmm2 pkgconfig python ];
 
   configurePhase = "python waf configure --prefix=$out";
 

--- a/pkgs/development/libraries/gegl/default.nix
+++ b/pkgs/development/libraries/gegl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, babl, libpng, cairo, libjpeg
-, librsvg, pango, gtk, bzip2, intltool
+, librsvg, pango, gtk2, bzip2, intltool
 , OpenGL ? null }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = if stdenv.isDarwin then "-lintl" else null;
 
-  buildInputs = [ babl libpng cairo libjpeg librsvg pango gtk bzip2 intltool ]
+  buildInputs = [ babl libpng cairo libjpeg librsvg pango gtk2 bzip2 intltool ]
     ++ stdenv.lib.optional stdenv.isDarwin OpenGL;
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, dbus, dbus_glib, glib, pkgconfig, libxml2, gnome, libxslt }:
+{ stdenv, fetchurl, dbus, dbus_glib, glib, pkgconfig, libxml2, gnome2, libxslt }:
 
 stdenv.mkDerivation rec {
   name = "geoclue-0.12.0";
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "15j619kvmdgj2hpma92mkxbzjvgn8147a7500zl3bap9g8bkylqg";
   };
 
-  buildInputs = [ pkgconfig libxml2 gnome.GConf libxslt ];
+  buildInputs = [ pkgconfig libxml2 gnome2.GConf libxslt ];
 
   propagatedBuildInputs = [dbus glib dbus_glib];
 

--- a/pkgs/development/libraries/gio-sharp/default.nix
+++ b/pkgs/development/libraries/gio-sharp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, which, pkgconfig, mono, gtk-sharp }:
+{ stdenv, fetchFromGitHub, autoconf, automake, which, pkgconfig, mono, gtk-sharp-2_0 }:
 
 stdenv.mkDerivation rec {
   name = "gio-sharp-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig autoconf automake which ];
-  buildInputs = [ mono gtk-sharp ];
+  buildInputs = [ mono gtk-sharp-2_0 ];
 
   dontStrip = true;
 

--- a/pkgs/development/libraries/gnome-sharp/default.nix
+++ b/pkgs/development/libraries/gnome-sharp/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, gtk, mono, gtk-sharp, gnome}:
+{stdenv, fetchurl, pkgconfig, gtk2, mono, gtk-sharp-2_0, gnome2}:
 
 stdenv.mkDerivation {
   name = "gnome-sharp-2.24.1";
@@ -7,8 +7,8 @@ stdenv.mkDerivation {
     sha256 = "0cfvs7hw67fp0wimskqd0gdfx323gv6hi0c5pf59krnmhdrl6z8p";
   };
 
-  buildInputs = [ pkgconfig gtk mono gtk-sharp ]
-  ++ (with gnome; [ libart_lgpl gnome_vfs libgnome libgnomecanvas libgnomeui]);
+  buildInputs = [ pkgconfig gtk2 mono gtk-sharp-2_0 ]
+  ++ (with gnome2; [ libart_lgpl gnome_vfs libgnome libgnomecanvas libgnomeui]);
 
   patches = [ ./Makefile.in.patch ];
 

--- a/pkgs/development/libraries/goffice/0.8.nix
+++ b/pkgs/development/libraries/goffice/0.8.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, glib, gtk, libglade, bzip2
+{ fetchurl, stdenv, pkgconfig, glib, gtk2, libglade, bzip2
 , pango, libgsf, libxml2, libart, intltool, gettext
 , cairo, gconf, libgnomeui, pcre, goffice/*just meta*/ }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [
     # All these are in the "Requires:" field of `libgoffice-0.6.pc'.
-    glib libgsf libxml2 gtk libglade libart cairo pango
+    glib libgsf libxml2 gtk2 libglade libart cairo pango
   ];
 
   postInstall =

--- a/pkgs/development/libraries/goocanvas/default.nix
+++ b/pkgs/development/libraries/goocanvas/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, cairo, glib, pkgconfig }:
+{ stdenv, fetchurl, gtk2, cairo, glib, pkgconfig }:
 
 stdenv.mkDerivation rec {
   majVersion = "1.0";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "07kicpcacbqm3inp7zq32ldp95mxx4kfxpaazd0x5jk7hpw2w1qw";
   };
 
-  buildInputs = [ gtk cairo glib pkgconfig ];
+  buildInputs = [ gtk2 cairo glib pkgconfig ];
 
   meta = { 
     description = "Canvas widget for GTK+ based on the the Cairo 2D library";

--- a/pkgs/development/libraries/gstreamer/legacy/gst-python/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-python/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, python, gstreamer
-, gst_plugins_base, pygobject
+, gst_plugins_base, pygobject2
 }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   patches = [ ./disable-testFake.patch ];
 
   buildInputs =
-    [ pkgconfig gst_plugins_base pygobject ]
+    [ pkgconfig gst_plugins_base pygobject2 ]
     ;
 
   propagatedBuildInputs = [ gstreamer python ];

--- a/pkgs/development/libraries/gtdialog/default.nix
+++ b/pkgs/development/libraries/gtdialog/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, cdk, unzip, gtk, glib, ncurses, pkgconfig}:
+{stdenv, fetchurl, cdk, unzip, gtk2, glib, ncurses, pkgconfig}:
 let
   s = # Generated upstream information
   rec {
@@ -10,7 +10,7 @@ let
     sha256="0nvcldyhj8abr8jny9pbyfjwg8qfp9f2h508vjmrvr5c5fqdbbm0";
   };
   buildInputs = [
-    cdk unzip gtk glib ncurses pkgconfig
+    cdk unzip gtk2 glib ncurses pkgconfig
   ];
 in
 stdenv.mkDerivation {

--- a/pkgs/development/libraries/gtk-sharp-beans/default.nix
+++ b/pkgs/development/libraries/gtk-sharp-beans/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, which, pkgconfig, mono, gtk-sharp, gio-sharp }:
+{ stdenv, fetchFromGitHub, autoreconfHook, which, pkgconfig, mono, gtk-sharp-2_0, gio-sharp }:
 
 stdenv.mkDerivation rec {
   name = "gtk-sharp-beans-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook which ];
-  buildInputs = [ mono gtk-sharp gio-sharp ];
+  buildInputs = [ mono gtk-sharp-2_0 gio-sharp ];
 
   dontStrip = true;
 

--- a/pkgs/development/libraries/gtk-sharp/2.0.nix
+++ b/pkgs/development/libraries/gtk-sharp/2.0.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, mono
 , glib
 , pango
-, gtk
+, gtk2
 , GConf ? null
 , libglade ? null
 , libgtkhtml ? null
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
   '';
 
   buildInputs = [
-    pkgconfig mono glib pango gtk GConf libglade libgnomecanvas
+    pkgconfig mono glib pango gtk2 GConf libglade libgnomecanvas
     libgtkhtml libgnomeui libgnomeprint libgnomeprintui gtkhtml libxml2
   ];
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
   inherit monoDLLFixer;
 
   passthru = {
-    inherit gtk;
+    gtk = gtk2;
   };
 
   meta = {

--- a/pkgs/development/libraries/gtkdatabox/default.nix
+++ b/pkgs/development/libraries/gtkdatabox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk }:
+{ stdenv, fetchurl, pkgconfig, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "gtkdatabox-0.9.2.0";
@@ -8,9 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "0h20685bzw5j5h6mw8c6apbrbrd9w518c6xdhr55147px11nhnkl";
   };
 
-  buildInputs = [ pkgconfig gtk ];
+  buildInputs = [ pkgconfig ];
 
-  propagatedBuildInputs = [ gtk ];
+  propagatedBuildInputs = [ gtk2 ];
 
   meta = {
     description = "Gtk+ widget for displaying large amounts of numerical data";

--- a/pkgs/development/libraries/gtkimageview/default.nix
+++ b/pkgs/development/libraries/gtkimageview/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gtk }:
+{ fetchurl, stdenv, pkgconfig, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "gtkimageview-1.6.4";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1if3yh5z6nkv5wnkk0qyy9pkk03vn5rqbfk23q87kj39pqscgr37";
   };
 
-  buildInputs = [ pkgconfig gtk ];
+  buildInputs = [ pkgconfig gtk2 ];
 
   preConfigure = ''
     sed '/DEPRECATED_FLAGS/d' -i configure

--- a/pkgs/development/libraries/gtkmathview/default.nix
+++ b/pkgs/development/libraries/gtkmathview/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, gtk, t1lib, glib, libxml2, popt, gmetadom ? null }:
+{stdenv, fetchurl, pkgconfig, gtk2, t1lib, glib, libxml2, popt, gmetadom ? null }:
 
 let
   pname = "gtkmathview";
@@ -13,8 +13,8 @@ stdenv.mkDerivation {
     sha256 = "0hwcamf5fi35frg7q6kgisc9v0prqbhsplb2gl55cg3av9sh3hqx";
   };
 
-  buildInputs = [pkgconfig gtk t1lib glib gmetadom libxml2 popt];
-  propagatedBuildInputs = [gtk t1lib];
+  buildInputs = [pkgconfig t1lib glib gmetadom libxml2 popt];
+  propagatedBuildInputs = [gtk2 t1lib];
 
   patches = [ ./gcc-4.3-build-fixes.patch ./gcc-4.4-build-fixes.patch ];
 

--- a/pkgs/development/libraries/gtkmm/2.x.nix
+++ b/pkgs/development/libraries/gtkmm/2.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, glibmm, cairomm, pangomm, atkmm }:
+{ stdenv, fetchurl, pkgconfig, gtk2, glibmm, cairomm, pangomm, atkmm }:
 
 stdenv.mkDerivation rec {
   name = "gtkmm-${minVer}.4";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [pkgconfig];
 
-  propagatedBuildInputs = [ glibmm gtk atkmm cairomm pangomm ];
+  propagatedBuildInputs = [ glibmm gtk2 atkmm cairomm pangomm ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/gtkmozembed-sharp/default.nix
+++ b/pkgs/development/libraries/gtkmozembed-sharp/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, mono, gtksharp, gtk, monoDLLFixer}:
+{stdenv, fetchurl, pkgconfig, mono, gtksharp, gtk2, monoDLLFixer}:
 
 stdenv.mkDerivation {
   name = "gtkmozembed-sharp-0.7-pre41601";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    pkgconfig mono gtksharp gtk
+    pkgconfig mono gtksharp gtk2
   ];
 
   inherit monoDLLFixer;

--- a/pkgs/development/libraries/gtkspell/default.nix
+++ b/pkgs/development/libraries/gtkspell/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk, aspell, pkgconfig, enchant, intltool}:
+{stdenv, fetchurl, gtk2, aspell, pkgconfig, enchant, intltool}:
 
 stdenv.mkDerivation {
   name = "gtkspell-2.0.16";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "00hdv28bp72kg1mq2jdz1sdw2b8mb9iclsp7jdqwpck705bdriwg";
   };
   
-  buildInputs = [aspell pkgconfig gtk enchant intltool];
+  buildInputs = [aspell pkgconfig gtk2 enchant intltool];
 
   meta = {
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -2,7 +2,7 @@
 , glib, dbus, udev, libgudev, udisks2, libgcrypt
 , libgphoto2, avahi, libarchive, fuse, libcdio
 , libxml2, libxslt, docbook_xsl, samba, libmtp
-, gnomeSupport ? false, gnome,libgnome_keyring, gconf, makeWrapper }:
+, gnomeSupport ? false, gnome, libgnome_keyring, makeWrapper }:
 
 let
   ver_maj = "1.22";

--- a/pkgs/development/libraries/hyena/default.nix
+++ b/pkgs/development/libraries/hyena/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, mono, gtk-sharp, monoDLLFixer }:
+{ stdenv, fetchurl, pkgconfig, mono, gtk-sharp-2_0, monoDLLFixer }:
 
 stdenv.mkDerivation rec {
   name = "hyena-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgconfig mono gtk-sharp
+    pkgconfig mono gtk-sharp-2_0
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/java/classpath/default.nix
+++ b/pkgs/development/libraries/java/classpath/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, javac, jvm, antlr, pkgconfig, gtk, gconf, ecj }:
+{ fetchurl, stdenv, javac, jvm, antlr, pkgconfig, gtk2, gconf, ecj }:
 
 stdenv.mkDerivation rec {
   name = "classpath-0.99";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./missing-casts.patch ];
 
-  buildInputs = [ javac jvm antlr pkgconfig gtk gconf ecj ];
+  buildInputs = [ javac jvm antlr pkgconfig gtk2 gconf ecj ];
 
   configurePhase = ''
     # GCJ tries to compile all of Classpath during the `configure' run when

--- a/pkgs/development/libraries/java/swt/default.nix
+++ b/pkgs/development/libraries/java/swt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, unzip, jdk, pkgconfig, gtk
+{ stdenv, lib, fetchurl, unzip, jdk, pkgconfig, gtk2
 , libXt, libXtst, libXi, mesa, webkit, libsoup, xorg
 , pango, gdk_pixbuf, glib
 }:
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
   sourceRoot = ".";
 
   nativeBuildInputs = [ unzip pkgconfig ];
-  buildInputs = [ jdk gtk libXt libXtst libXi mesa webkit libsoup ];
+  buildInputs = [ jdk gtk2 libXt libXtst libXi mesa webkit libsoup ];
 
   NIX_LFLAGS = (map (x: "-L${lib.getLib x}/lib") [ xorg.libX11 pango gdk_pixbuf glib ]) ++
     [ "-lX11" "-lpango-1.0" "-lgdk_pixbuf-2.0" "-lglib-2.0" ];

--- a/pkgs/development/libraries/keybinder/default.nix
+++ b/pkgs/development/libraries/keybinder/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, gnome3, pygobject3, pygtk
-, gtk_doc, gtk2, python, pygobject, lua, libX11, libXext, libXrender, gobjectIntrospection
+, gtk_doc, gtk2, python, lua, libX11, libXext, libXrender, gobjectIntrospection
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/keybinder3/default.nix
+++ b/pkgs/development/libraries/keybinder3/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pkgconfig, gnome3, pygobject3, pygtk
-, gtk_doc, gtk3, python, pygobject, lua, libX11, libXext, libXrender, gobjectIntrospection
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pkgconfig, gnome3, pygtk
+, gtk_doc, gtk3, python, lua, libX11, libXext, libXrender, gobjectIntrospection
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/libappindicator/default.nix
+++ b/pkgs/development/libraries/libappindicator/default.nix
@@ -5,7 +5,7 @@
 , glib, dbus_glib, gtkVersion
 , gtk2 ? null, libindicator-gtk2 ? null, libdbusmenu-gtk2 ? null
 , gtk3 ? null, libindicator-gtk3 ? null, libdbusmenu-gtk3 ? null
-, python, pygobject, pygtk, gobjectIntrospection, vala_0_23
+, python, pygobject2, pygtk, gobjectIntrospection, vala_0_23
 , monoSupport ? false, mono ? null, gtk-sharp ? null
  }:
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib dbus_glib
-    python pygobject pygtk gobjectIntrospection vala_0_23
+    python pygobject2 pygtk gobjectIntrospection vala_0_23
   ] ++ (if gtkVersion == "2"
     then [ gtk2 libindicator-gtk2 libdbusmenu-gtk2 ] ++ optionals monoSupport [ mono gtk-sharp ]
     else [ gtk3 libindicator-gtk3 libdbusmenu-gtk3 ]);

--- a/pkgs/development/libraries/libfm/default.nix
+++ b/pkgs/development/libraries/libfm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, gtk, intltool, menu-cache, pango, pkgconfig, vala_0_23
+{ stdenv, fetchurl, glib, gtk2, intltool, menu-cache, pango, pkgconfig, vala_0_23
 , extraOnly ? false }:
 let
     inherit (stdenv.lib) optional;
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "0bsh4p7h2glhxf1cc1lvbxyb4qy0y1zsnl9izf7vrldkikrgc13q";
   };
 
-  buildInputs = [ glib gtk intltool pango pkgconfig vala_0_23 ]
+  buildInputs = [ glib gtk2 intltool pango pkgconfig vala_0_23 ]
                 ++ optional (!extraOnly) menu-cache;
 
   configureFlags = optional extraOnly "--with-extra-only";

--- a/pkgs/development/libraries/libgksu/default.nix
+++ b/pkgs/development/libraries/libgksu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, wrapGAppsHook, gtk, gnome, gnome3,
+{ stdenv, fetchurl, pkgconfig, wrapGAppsHook, gtk2, gnome2, gnome3,
   libstartup_notification, libgtop, perl, perlXMLParser,
   autoreconfHook, intltool, gtk_doc, docbook_xsl, xauth, sudo
 }:
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk gnome.GConf libstartup_notification
-    gnome3.libgnome_keyring libgtop gnome.libglade perl perlXMLParser
+    gtk2 gnome2.GConf libstartup_notification
+    gnome3.libgnome_keyring libgtop gnome2.libglade perl perlXMLParser
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -1,7 +1,7 @@
 {stdenv, lib, fetchurl, gettext, perl, perlXMLParser, intltool, pkgconfig, glib,
   libxml2, sqlite, libusb1, zlib, sg3_utils, gdk_pixbuf, taglib,
-  libimobiledevice, python, pygobject, mutagen,
-  monoSupport ? true, mono, gtk-sharp
+  libimobiledevice, python, pygobject2, mutagen,
+  monoSupport ? true, mono, gtk-sharp-2_0
 }:
 
 stdenv.mkDerivation rec {
@@ -21,10 +21,10 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   propagatedBuildInputs = [ glib libxml2 sqlite zlib sg3_utils
-    gdk_pixbuf taglib libimobiledevice python pygobject mutagen ];
+    gdk_pixbuf taglib libimobiledevice python pygobject2 mutagen ];
 
   nativeBuildInputs = [ gettext perlXMLParser intltool pkgconfig perl
-    libimobiledevice.swig ] ++ lib.optionals monoSupport [ mono gtk-sharp ];
+    libimobiledevice.swig ] ++ lib.optionals monoSupport [ mono gtk-sharp-2_0 ];
 
   meta = {
     homepage = http://gtkpod.sourceforge.net/;

--- a/pkgs/development/libraries/libindicate/default.nix
+++ b/pkgs/development/libraries/libindicate/default.nix
@@ -4,8 +4,8 @@
 , pkgconfig, autoconf
 , glib, dbus_glib, libdbusmenu-glib
 , gtkVersion, gtk2 ? null, gtk3 ? null
-, python, pygobject, pygtk, gobjectIntrospection, vala_0_23, gnome_doc_utils
-, monoSupport ? false, mono ? null, gtk-sharp ? null
+, python, pygobject2, pygtk, gobjectIntrospection, vala_0_23, gnome_doc_utils
+, monoSupport ? false, mono ? null, gtk-sharp-2_0 ? null
  }:
 
 with lib;
@@ -26,9 +26,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib dbus_glib libdbusmenu-glib
-    python pygobject pygtk gobjectIntrospection vala_0_23 gnome_doc_utils
+    python pygobject2 pygtk gobjectIntrospection vala_0_23 gnome_doc_utils
   ] ++ (if gtkVersion == "2"
-    then [ gtk2 ] ++ optionals monoSupport [ mono gtk-sharp ]
+    then [ gtk2 ] ++ optionals monoSupport [ mono gtk-sharp-2_0 ]
     else [ gtk3 ]);
 
   postPatch = ''

--- a/pkgs/development/libraries/libiodbc/default.nix
+++ b/pkgs/development/libraries/libiodbc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, useGTK ? false }:
+{ stdenv, fetchurl, pkgconfig, gtk2, useGTK ? false }:
 
 stdenv.mkDerivation rec {
   name = "libiodbc-3.52.8";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "16hjb6fcval85gnkgkxfhw4c5h3pgf86awyh8p2bhnnvzc0ma5hq";
   };
 
-  buildInputs = stdenv.lib.optionals useGTK [ gtk pkgconfig ];
+  buildInputs = stdenv.lib.optionals useGTK [ gtk2 pkgconfig ];
 
   preBuild =
     ''

--- a/pkgs/development/libraries/libsexy/default.nix
+++ b/pkgs/development/libraries/libsexy/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig
-, glib, gtk, libxml2, pango
+, glib, gtk2, libxml2, pango
 }:
  
 stdenv.mkDerivation {
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ glib gtk libxml2 pango ];
+  buildInputs = [ glib gtk2 libxml2 pango ];
 
   meta = with stdenv.lib; {
     description = "A collection of GTK+ widgets";

--- a/pkgs/development/libraries/libunique/default.nix
+++ b/pkgs/development/libraries/libunique/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, gtk, dbus_glib }:
+{ stdenv, fetchurl, pkgconfig, glib, gtk2, dbus_glib }:
 
 stdenv.mkDerivation rec {
   name = "libunique-1.1.6";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     ./1.1.6-include-terminator.patch
   ];
 
-  buildInputs = [ pkgconfig glib gtk dbus_glib ];
+  buildInputs = [ pkgconfig glib gtk2 dbus_glib ];
 
   # don't make deprecated usages hard errors
   preBuild = ''substituteInPlace unique/dbus/Makefile --replace -Werror ""'';

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libvirt, glib, libxml2, intltool, libtool, yajl
-, nettle, libgcrypt, python, pygobject, gobjectIntrospection, libcap_ng, numactl
+, nettle, libgcrypt, python, pygobject2, gobjectIntrospection, libcap_ng, numactl
 , xen
 }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig libvirt glib libxml2 intltool libtool yajl nettle libgcrypt
-    python pygobject gobjectIntrospection libcap_ng numactl xen
+    python pygobject2 gobjectIntrospection libcap_ng numactl xen
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libwnck/default.nix
+++ b/pkgs/development/libraries/libwnck/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, intltool, xorg }:
+{ stdenv, fetchurl, pkgconfig, gtk2, intltool, xorg }:
 
 let
   ver_maj = "2.31";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
-  buildInputs = [ pkgconfig gtk intltool xorg.libX11 xorg.libXres ];
+  buildInputs = [ pkgconfig gtk2 intltool xorg.libX11 xorg.libXres ];
   # ?another optional: startup-notification
 
   configureFlags = [ "--disable-introspection" ]; # not needed anywhere AFAIK

--- a/pkgs/development/libraries/ntrack/default.nix
+++ b/pkgs/development/libraries/ntrack/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, qt4, pkgconfig, libnl, pygobject, python }:
+{ stdenv, fetchurl, glib, qt4, pkgconfig, libnl, python }:
 
 let
   version = "016";

--- a/pkgs/development/libraries/openscenegraph/default.nix
+++ b/pkgs/development/libraries/openscenegraph/default.nix
@@ -2,7 +2,7 @@
 , libpng, coin3d, jasper, gdal_1_11, xproto, libX11, libXmu
 , freeglut, mesa, doxygen, ffmpeg, xineLib, unzip, zlib, openal
 , libxml2, curl, a52dec, faad2, gdk_pixbuf, pkgconfig, kbproto, SDL
-, qt4, poppler, librsvg, gtk
+, qt4, poppler, librsvg, gtk2
 , withApps ? true }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     cmake giflib libjpeg libtiff lib3ds freetype libpng coin3d jasper
     gdal_1_11 xproto libX11 libXmu freeglut mesa doxygen ffmpeg
     xineLib unzip zlib openal libxml2 curl a52dec faad2 gdk_pixbuf
-    pkgconfig kbproto SDL qt4 poppler librsvg gtk
+    pkgconfig kbproto SDL qt4 poppler librsvg gtk2
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -6,7 +6,7 @@
 , buildMultimedia ? stdenv.isLinux, alsaLib, gstreamer, gst_plugins_base
 , buildWebkit ? stdenv.isLinux
 , flashplayerFix ? false, gdk_pixbuf
-, gtkStyle ? false, libgnomeui, gtk, GConf, gnome_vfs
+, gtkStyle ? false, libgnomeui, gtk2, GConf, gnome_vfs
 , developerBuild ? false
 , docs ? false
 , examples ? false
@@ -65,13 +65,13 @@ stdenv.mkDerivation rec {
         src = ./dlopen-gtkstyle.diff;
         # substituteAll ignores env vars starting with capital letter
         gconf = GConf.out;
-        gtk = gtk.out;
+        gtk = gtk2.out;
         libgnomeui = libgnomeui.out;
         gnome_vfs = gnome_vfs.out;
       })
     ++ stdenv.lib.optional flashplayerFix (substituteAll {
         src = ./dlopen-webkit-nsplugin.diff;
-        gtk = gtk.out;
+        gtk = gtk2.out;
         gdk_pixbuf = gdk_pixbuf.out;
       })
     ++ [(fetchpatch {
@@ -131,7 +131,7 @@ stdenv.mkDerivation rec {
     [ cups # Qt dlopen's libcups instead of linking to it
       postgresql sqlite libjpeg libmng libtiff icu ]
     ++ optionals (mysql != null) [ mysql.lib ]
-    ++ optionals gtkStyle [ gtk gdk_pixbuf ]
+    ++ optionals gtkStyle [ gtk2 gdk_pixbuf ]
     ++ optionals stdenv.isDarwin [ cf-private ApplicationServices OpenGL Cocoa AGL libcxx libobjc ];
 
   nativeBuildInputs = [ perl pkgconfig which ];

--- a/pkgs/development/libraries/qt-5/5.5/default.nix
+++ b/pkgs/development/libraries/qt-5/5.5/default.nix
@@ -66,7 +66,7 @@ let
         harfbuzz = pkgs.harfbuzz-icu;
         cups = if stdenv.isLinux then pkgs.cups else null;
         # GNOME dependencies are not used unless gtkStyle == true
-        inherit (pkgs.gnome) libgnomeui GConf gnome_vfs;
+        inherit (pkgs.gnome2) libgnomeui GConf gnome_vfs;
         bison = pkgs.bison2; # error: too few arguments to function 'int yylex(...
         inherit developerBuild decryptSslTraffic;
       };

--- a/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
@@ -19,7 +19,7 @@
 , buildExamples ? false
 , buildTests ? false
 , developerBuild ? false
-, libgnomeui, GConf, gnome_vfs, gtk
+, libgnomeui, GConf, gnome_vfs, gtk2
 , decryptSslTraffic ? false
 }:
 
@@ -28,7 +28,7 @@ let
   system-x86_64 = lib.elem stdenv.system lib.platforms.x86_64;
 
   # Search path for Gtk plugin
-  gtkLibPath = lib.makeLibraryPath [ gtk gnome_vfs libgnomeui GConf ];
+  gtkLibPath = lib.makeLibraryPath [ gtk2 gnome_vfs libgnomeui GConf ];
 
   dontInvalidateBacking = fetchurl {
     url = "https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=patch;h=0f68f8920573cdce1729a285a92ac8582df32841;hp=24c50f8dcf7fa61ac3c3d4d6295c259a104a2b8c";
@@ -211,7 +211,7 @@ stdenv.mkDerivation {
     ++ lib.optional (mysql != null) mysql.lib
     ++ lib.optional (postgresql != null) postgresql
     # FIXME: move to the main list on rebuild.
-    ++ [gnome_vfs.out libgnomeui.out gtk GConf];
+    ++ [gnome_vfs.out libgnomeui.out gtk2 GConf];
 
   nativeBuildInputs = [ lndir patchelf perl pkgconfig python ];
 

--- a/pkgs/development/libraries/qt-5/5.5/qtwebkit/default.nix
+++ b/pkgs/development/libraries/qt-5/5.5/qtwebkit/default.nix
@@ -1,5 +1,5 @@
 { qtSubmodule, stdenv, qtdeclarative, qtlocation, qtsensors
-, fontconfig, gdk_pixbuf, gtk, libwebp, libxml2, libxslt
+, fontconfig, gdk_pixbuf, gtk2, libwebp, libxml2, libxslt
 , sqlite, systemd, glib, gst_all_1
 , bison2, flex, gdb, gperf, perl, pkgconfig, python, ruby
 , substituteAll
@@ -18,12 +18,12 @@ qtSubmodule {
   patches =
     let dlopen-webkit-nsplugin = substituteAll {
           src = ./0001-dlopen-webkit-nsplugin.patch;
-          gtk = gtk.out;
+          gtk = gtk2.out;
           gdk_pixbuf = gdk_pixbuf.out;
         };
         dlopen-webkit-gtk = substituteAll {
           src = ./0002-dlopen-webkit-gtk.patch;
-          gtk = gtk.out;
+          gtk = gtk2.out;
         };
         dlopen-webkit-udev = substituteAll {
           src = ./0003-dlopen-webkit-udev.patch;

--- a/pkgs/development/libraries/qt-5/5.6/qtwebkit/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebkit/default.nix
@@ -1,5 +1,5 @@
 { qtSubmodule, stdenv, qtdeclarative, qtlocation, qtsensors
-, fontconfig, gdk_pixbuf, gtk, libwebp, libxml2, libxslt
+, fontconfig, gdk_pixbuf, gtk2, libwebp, libxml2, libxslt
 , sqlite, systemd, glib, gst_all_1
 , bison2, flex, gdb, gperf, perl, pkgconfig, python, ruby
 , substituteAll
@@ -18,12 +18,12 @@ qtSubmodule {
   patches =
     let dlopen-webkit-nsplugin = substituteAll {
           src = ./0001-dlopen-webkit-nsplugin.patch;
-          gtk = gtk.out;
+          gtk = gtk2.out;
           gdk_pixbuf = gdk_pixbuf.out;
         };
         dlopen-webkit-gtk = substituteAll {
           src = ./0002-dlopen-webkit-gtk.patch;
-          gtk = gtk.out;
+          gtk = gtk2.out;
         };
         dlopen-webkit-udev = substituteAll {
           src = ./0003-dlopen-webkit-udev.patch;

--- a/pkgs/development/libraries/qt-5/5.7/qtwebkit/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtwebkit/default.nix
@@ -1,5 +1,5 @@
 { qtSubmodule, stdenv, qtdeclarative, qtlocation, qtsensors
-, fontconfig, gdk_pixbuf, gtk, libwebp, libxml2, libxslt
+, fontconfig, gdk_pixbuf, gtk2, libwebp, libxml2, libxslt
 , sqlite, systemd, glib, gst_all_1
 , bison2, flex, gdb, gperf, perl, pkgconfig, python, ruby
 , substituteAll
@@ -18,12 +18,12 @@ qtSubmodule {
   patches =
     let dlopen-webkit-nsplugin = substituteAll {
           src = ./0001-dlopen-webkit-nsplugin.patch;
-          gtk = gtk.out;
+          gtk = gtk2.out;
           gdk_pixbuf = gdk_pixbuf.out;
         };
         dlopen-webkit-gtk = substituteAll {
           src = ./0002-dlopen-webkit-gtk.patch;
-          gtk = gtk.out;
+          gtk = gtk2.out;
         };
         dlopen-webkit-udev = substituteAll {
           src = ./0003-dlopen-webkit-udev.patch;

--- a/pkgs/development/libraries/smpeg/default.nix
+++ b/pkgs/development/libraries/smpeg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchsvn, SDL, autoconf, automake, libtool, gtk, m4, pkgconfig, mesa, makeWrapper }:
+{ stdenv, fetchsvn, SDL, autoconf, automake, libtool, gtk2, m4, pkgconfig, mesa, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "smpeg-svn${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ SDL gtk mesa ];
+  buildInputs = [ SDL gtk2 mesa ];
 
   nativeBuildInputs = [ autoconf automake libtool m4 pkgconfig makeWrapper ];
 

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, spice_protocol, intltool, celt_0_5_1
+{ stdenv, fetchurl, pkgconfig, gtk2, spice_protocol, intltool, celt_0_5_1
 , openssl, libpulseaudio, pixman, gobjectIntrospection, libjpeg_turbo, zlib
 , cyrus_sasl, python, pygtk, autoreconfHook, usbredir, libsoup
 , gtk3, enableGTK3 ? false }:
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     spice_protocol celt_0_5_1 openssl libpulseaudio pixman gobjectIntrospection
     libjpeg_turbo zlib cyrus_sasl python pygtk usbredir
-  ] ++ (if enableGTK3 then [ gtk3 ] else [ gtk ]);
+  ] ++ (if enableGTK3 then [ gtk3 ] else [ gtk2 ]);
 
   nativeBuildInputs = [ pkgconfig intltool libsoup autoreconfHook ];
 

--- a/pkgs/development/libraries/wxGTK-2.8/default.nix
+++ b/pkgs/development/libraries/wxGTK-2.8/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
+{ stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
 , gstreamer, gst_plugins_base, GConf, libX11, cairo
 , withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true,
 }:
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1l1w4i113csv3bd5r8ybyj0qpxdq83lj6jrc5p7cc10mkwyiagqz";
   };
 
-  buildInputs = [ gtk libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer gst_plugins_base GConf libX11 cairo ]
+  buildInputs = [ gtk2 libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer gst_plugins_base GConf libX11 cairo ]
     ++ optional withMesa mesa;
 
   nativeBuildInputs = [ pkgconfig ];
@@ -56,7 +56,10 @@ stdenv.mkDerivation rec {
     (cd $out/include && ln -s wx-*/* .)
   ";
 
-  passthru = {inherit gtk compat24 compat26 unicode;};
+  passthru = {
+    inherit compat24 compat26 unicode;
+    gtk = gtk2;
+  };
 
   enableParallelBuilding = true;
   

--- a/pkgs/development/libraries/wxGTK-2.9/default.nix
+++ b/pkgs/development/libraries/wxGTK-2.9/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
+{ stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
 , gstreamer, gst_plugins_base, GConf, setfile
 , withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true,
 }:
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs =
-    [ gtk libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer
+    [ gtk2 libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer
       gst_plugins_base GConf ]
     ++ optional withMesa mesa
     ++ optional stdenv.isDarwin setfile;
@@ -52,7 +52,10 @@ stdenv.mkDerivation {
     (cd $out/include && ln -s wx-*/* .)
   ";
 
-  passthru = {inherit gtk compat24 compat26 unicode;};
+  passthru = {
+    inherit compat24 compat26 unicode;
+    gtk = gtk2;
+  };
 
   enableParallelBuilding = true;
   

--- a/pkgs/development/libraries/wxGTK-3.0/default.nix
+++ b/pkgs/development/libraries/wxGTK-3.0/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
+{ stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
 , gstreamer, gst_plugins_base, GConf, setfile
 , withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true,
 }:
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs =
-    [ gtk libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer
+    [ gtk2 libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer
       gst_plugins_base GConf ]
     ++ optional withMesa mesa
     ++ optional stdenv.isDarwin setfile;
@@ -52,7 +52,10 @@ stdenv.mkDerivation {
     (cd $out/include && ln -s wx-*/* .)
   ";
 
-  passthru = {inherit gtk compat24 compat26 unicode;};
+  passthru = {
+    inherit compat24 compat26 unicode;
+    gtk = gtk2;
+  };
 
   enableParallelBuilding = true;
   

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -1,7 +1,7 @@
 { stdenv, stdenv_32bit, fetchurl, unzip, makeWrapper
 , platformTools, buildTools, support, supportRepository, platforms, sysimages, addons
 , libX11, libXext, libXrender, libxcb, libXau, libXdmcp, libXtst, mesa, alsaLib
-, freetype, fontconfig, glib, gtk, atk, file, jdk, coreutils, libpulseaudio, dbus
+, freetype, fontconfig, glib, gtk2, atk, file, jdk, coreutils, libpulseaudio, dbus
 , zlib, glxinfo, xkeyboardconfig
 }:
 { platformVersions, abiVersions, useGoogleAPIs, useExtraSupportLibs ? false, useGooglePlayServices ? false }:
@@ -67,15 +67,15 @@ stdenv.mkDerivation rec {
       
       wrapProgram `pwd`/android \
         --prefix PATH : ${jdk}/bin \
-        --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ glib gtk libXtst ]}
+        --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ glib gtk2 libXtst ]}
     
       wrapProgram `pwd`/uiautomatorviewer \
         --prefix PATH : ${jdk}/bin \
-        --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk libXtst ]}
+        --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
     
       wrapProgram `pwd`/hierarchyviewer \
         --prefix PATH : ${jdk}/bin \
-        --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk libXtst ]}
+        --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
       
       # The emulators need additional libraries, which are dynamically loaded => let's wrap them
 
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
         patchelf --set-rpath ${makeLibraryPath [ libX11 libXext libXrender freetype fontconfig ]} libcairo-swt.so
         
         wrapProgram `pwd`/monitor \
-          --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ gtk atk stdenv.cc.cc libXtst ]}
+          --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ gtk2 atk stdenv.cc.cc libXtst ]}
 
         cd ../..
       ''
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
         patchelf --set-rpath ${makeLibraryPath [ libX11 libXext libXrender freetype fontconfig ]} libcairo-swt.so
         
         wrapProgram `pwd`/monitor \
-          --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ gtk atk stdenv.cc.cc libXtst ]}
+          --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ gtk2 atk stdenv.cc.cc libXtst ]}
 
         cd ../..
       ''

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -40,7 +40,7 @@ rec {
 
   androidsdk = import ./androidsdk.nix {
     inherit (pkgs) stdenv fetchurl unzip makeWrapper;
-    inherit (pkgs) zlib glxinfo freetype fontconfig glib gtk atk mesa file alsaLib jdk coreutils libpulseaudio dbus;
+    inherit (pkgs) zlib glxinfo freetype fontconfig glib gtk2 atk mesa file alsaLib jdk coreutils libpulseaudio dbus;
     inherit (pkgs.xorg) libX11 libXext libXrender libxcb libXau libXdmcp libXtst xkeyboardconfig;
     
     inherit platformTools buildTools support supportRepository platforms sysimages addons;

--- a/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk, libgnomecanvas, libglade, gtksourceview, camlp4 }:
+{ stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk2, libgnomecanvas, libglade, gtksourceview, camlp4 }:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -14,7 +14,7 @@ stdenv.mkDerivation (rec {
     sha256 = "1fnh0amm7lwgyjdhmlqgsp62gwlar1140425yc1j6inwmgnsp0a9";
   };
 
-  buildInputs = [ ocaml findlib pkgconfig gtk libgnomecanvas libglade gtksourceview camlp4 ];
+  buildInputs = [ ocaml findlib pkgconfig gtk2 libgnomecanvas libglade gtksourceview camlp4 ];
 
   configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml_version}/site-lib";
   buildFlags = "world";

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk, libgnomecanvas, libglade, gtksourceview, camlp4}:
+{stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk2, libgnomecanvas, libglade, gtksourceview, camlp4}:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     sha256 = "1bybn3jafxf4cx25zvn8h2xj9agn1xjbn7j3ywxxqx6az7rfnnwp";
   };
 
-  buildInputs = [ocaml findlib pkgconfig gtk libgnomecanvas libglade gtksourceview camlp4];
+  buildInputs = [ocaml findlib pkgconfig gtk2 libgnomecanvas libglade gtksourceview camlp4];
 
   configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml_version}/site-lib";
   buildFlags = "world";

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, automake, ocaml, autoconf, gnum4, pkgconfig, freetype, lablgtk, unzip, cairo, findlib, gdk_pixbuf, glib, gtk, pango }:
+{stdenv, fetchurl, automake, ocaml, autoconf, gnum4, pkgconfig, freetype, lablgtk, unzip, cairo, findlib, gdk_pixbuf, glib, gtk2, pango }:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   patches = [ ./META.patch ];
 
   buildInputs = [ ocaml automake gnum4 autoconf unzip pkgconfig
-                  findlib freetype lablgtk cairo gdk_pixbuf gtk pango ];
+                  findlib freetype lablgtk cairo gdk_pixbuf gtk2 pango ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/ocaml-cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo2/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, ocaml, findlib, pkgconfig, cairo, lablgtk, gtk,
+{ stdenv, fetchurl, ocaml, findlib, pkgconfig, cairo, lablgtk, gtk2,
   enableGtkSupport ? true # Whether to compile with support for Gtk
                           # integration (library file cairo2_gtk). Depends
-                          # on lablgtk and gtk.
+                          # on lablgtk and gtk2.
 }:
 
 let
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ ocaml findlib pkgconfig cairo ]
-                ++ optionals enableGtkSupport [ gtk ];
+                ++ optionals enableGtkSupport [ gtk2 ];
 
   # lablgtk2 is marked as a propagated build input since loading the
   # cairo.lablgtk2 package from the toplevel tries to load lablgtk2 as

--- a/pkgs/development/python-modules/libsexy/default.nix
+++ b/pkgs/development/python-modules/libsexy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonPackage, libsexy, pkgconfig, libxml2, pygtk, pango, gtk, glib, }:
+{ stdenv, fetchurl, buildPythonPackage, libsexy, pkgconfig, libxml2, pygtk, pango, gtk2, glib, }:
 
 stdenv.mkDerivation rec {
   name = "python-libsexy-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
-    libsexy gtk glib pango libxml2
+    libsexy gtk2 glib pango libxml2
   ];
 
   postInstall = ''

--- a/pkgs/development/python-modules/pygtk/default.nix
+++ b/pkgs/development/python-modules/pygtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, pkgconfig, gtk, pygobject, pycairo
+{ stdenv, fetchurl, python, pkgconfig, gtk2, pygobject2, pycairo
 , buildPythonPackage, libglade ? null, isPy3k }:
 
 buildPythonPackage rec {
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   buildInputs = [ pkgconfig ]
     ++ stdenv.lib.optional (libglade != null) libglade;
 
-  propagatedBuildInputs = [ gtk pygobject pycairo ];
+  propagatedBuildInputs = [ gtk2 pygobject2 pycairo ];
 
   configurePhase = "configurePhase";
 
@@ -43,8 +43,8 @@ buildPythonPackage rec {
 
   postInstall = ''
     rm $out/bin/pygtk-codegen-2.0
-    ln -s ${pygobject}/bin/pygobject-codegen-2.0  $out/bin/pygtk-codegen-2.0
-    ln -s ${pygobject}/lib/${python.libPrefix}/site-packages/pygobject-${pygobject.version}.pth \
+    ln -s ${pygobject2}/bin/pygobject-codegen-2.0  $out/bin/pygtk-codegen-2.0
+    ln -s ${pygobject2}/lib/${python.libPrefix}/site-packages/pygobject-${pygobject2.version}.pth \
                   $out/lib/${python.libPrefix}/site-packages/${name}.pth
   '';
 }

--- a/pkgs/development/python-modules/pygtksourceview/default.nix
+++ b/pkgs/development/python-modules/pygtksourceview/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, python, mkPythonDerivation, pkgconfig, pygobject, glib, pygtk, gnome2 }:
+{ lib, fetchurl, python, mkPythonDerivation, pkgconfig, pygobject2, glib, pygtk, gnome2 }:
 
 let version = "2.10.1"; in
 
@@ -12,7 +12,7 @@ mkPythonDerivation {
 
   patches = [ ./codegendir.patch ];
 
-  buildInputs = [ python pkgconfig pygobject glib pygtk gnome2.gtksourceview ];
+  buildInputs = [ python pkgconfig pygobject2 glib pygtk gnome2.gtksourceview ];
 
   meta = {
     platforms = lib.platforms.unix;

--- a/pkgs/development/tools/java/visualvm/default.nix
+++ b/pkgs/development/tools/java/visualvm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, lib, makeWrapper, jdk, gtk }:
+{ stdenv, fetchzip, lib, makeWrapper, jdk, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "visualvm-1.3.8";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
     # To get the native LAF, JVM needs to see GTK’s .so-s.
     wrapProgram $out/bin/visualvm \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk ]}"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk2 ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/distcc/default.nix
+++ b/pkgs/development/tools/misc/distcc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, popt, avahi, pkgconfig, python, gtk, runCommand
+{ stdenv, fetchFromGitHub, popt, avahi, pkgconfig, python, gtk2, runCommand
 , gcc, autoconf, automake, which, procps, libiberty_static
 , sysconfDir ? ""   # set this parameter to override the default value $out/etc
 , static ? false
@@ -16,7 +16,7 @@ let
       sha256 = "1vj31wcdas8wy52hy6749mlrca9v6ynycdiigx5ay8pnya9z73c6";
     };
 
-    buildInputs = [popt avahi pkgconfig python gtk autoconf automake pkgconfig which procps libiberty_static];
+    buildInputs = [popt avahi pkgconfig python gtk2 autoconf automake pkgconfig which procps libiberty_static];
     preConfigure =
     ''
       export CPATH=$(ls -d ${gcc.cc}/lib/gcc/*/${gcc.cc.version}/plugin/include)
@@ -28,7 +28,7 @@ let
                             ${if static then "LDFLAGS=-static" else ""}
                             --with${if static == true || popt == null then "" else "out"}-included-popt
                             --with${if avahi != null then "" else "out"}-avahi
-                            --with${if gtk != null then "" else "out"}-gtk
+                            --with${if gtk2 != null then "" else "out"}-gtk
                             --without-gnome
                             --enable-rfc2553
                             --disable-Werror   # a must on gcc 4.6

--- a/pkgs/development/tools/misc/gtkdialog/default.nix
+++ b/pkgs/development/tools/misc/gtkdialog/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk, pkgconfig, hicolor_icon_theme }:
+{stdenv, fetchurl, gtk2, pkgconfig, hicolor_icon_theme }:
 
 stdenv.mkDerivation {
   name = "gtkdialog-0.8.3";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "ff89d2d7f1e6488e5df5f895716ac1d4198c2467a2a5dc1f51ab408a2faec38e";
   };
 
-  buildInputs = [ gtk pkgconfig hicolor_icon_theme ];
+  buildInputs = [ gtk2 pkgconfig hicolor_icon_theme ];
 
   meta = {
     homepage = http://gtkdialog.googlecode.com/;

--- a/pkgs/development/tools/misc/saleae-logic/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic/default.nix
@@ -6,7 +6,7 @@
 #
 # In NixOS, simply add this package to services.udev.packages.
 
-{ stdenv, fetchurl, unzip, glib, libSM, libICE, gtk, libXext, libXft
+{ stdenv, fetchurl, unzip, glib, libSM, libICE, gtk2, libXext, libXft
 , fontconfig, libXrender, libXfixes, libX11, libXi, libXrandr, libXcursor
 , freetype, libXinerama, libxcb, zlib, pciutils
 , makeDesktopItem, xkeyboardconfig
@@ -15,7 +15,7 @@
 let
 
   libPath = stdenv.lib.makeLibraryPath [
-    glib libSM libICE gtk libXext libXft fontconfig libXrender libXfixes libX11
+    glib libSM libICE gtk2 libXext libXft fontconfig libXrender libXfixes libX11
     libXi libXrandr libXcursor freetype libXinerama libxcb zlib stdenv.cc.cc.lib
   ];
 

--- a/pkgs/development/tools/node-webkit/nw11.nix
+++ b/pkgs/development/tools/node-webkit/nw11.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, buildEnv, makeWrapper
-, xorg, alsaLib, dbus, glib, gtk, atk, pango, freetype, fontconfig
+, xorg, alsaLib, dbus, glib, gtk2, atk, pango, freetype, fontconfig
 , gdk_pixbuf, cairo, zlib, nss, nssTools, nspr, gconf, expat, systemd, libcap
 , libnotify}:
 let
@@ -9,7 +9,7 @@ let
   nwEnv = buildEnv {
     name = "node-webkit-env";
     paths = [
-      xorg.libX11 xorg.libXrender glib gtk atk pango cairo gdk_pixbuf
+      xorg.libX11 xorg.libXrender glib gtk2 atk pango cairo gdk_pixbuf
       freetype fontconfig xorg.libXcomposite alsaLib xorg.libXdamage
       xorg.libXext xorg.libXfixes nss nspr gconf expat dbus stdenv.cc
       xorg.libXtst xorg.libXi xorg.libXcursor xorg.libXrandr libcap

--- a/pkgs/development/tools/node-webkit/nw12.nix
+++ b/pkgs/development/tools/node-webkit/nw12.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, buildEnv, makeWrapper
-, xorg, alsaLib, dbus, glib, gtk, atk, pango, freetype, fontconfig
+, xorg, alsaLib, dbus, glib, gtk2, atk, pango, freetype, fontconfig
 , gdk_pixbuf, cairo, zlib, nss, nssTools, nspr, gconf, expat, systemd, libcap
 , libnotify}:
 let
@@ -9,7 +9,7 @@ let
   nwEnv = buildEnv {
     name = "nwjs-env";
     paths = [
-      xorg.libX11 xorg.libXrender glib gtk atk pango cairo gdk_pixbuf
+      xorg.libX11 xorg.libXrender glib gtk2 atk pango cairo gdk_pixbuf
       freetype fontconfig xorg.libXcomposite alsaLib xorg.libXdamage
       xorg.libXext xorg.libXfixes nss nspr gconf expat dbus
       xorg.libXtst xorg.libXi xorg.libXcursor xorg.libXrandr libcap

--- a/pkgs/development/tools/node-webkit/nw9.nix
+++ b/pkgs/development/tools/node-webkit/nw9.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, buildEnv, makeWrapper
-, xorg, alsaLib, dbus, glib, gtk, atk, pango, freetype, fontconfig
+, xorg, alsaLib, dbus, glib, gtk2, atk, pango, freetype, fontconfig
 , gdk_pixbuf, cairo, zlib, nss, nssTools, nspr, gconf, expat, systemd }:
 let
   bits = if stdenv.system == "x86_64-linux" then "x64"
@@ -8,7 +8,7 @@ let
   nwEnv = buildEnv {
     name = "node-webkit-env";
     paths = [
-      xorg.libX11 xorg.libXrender glib gtk atk pango cairo gdk_pixbuf
+      xorg.libX11 xorg.libXrender glib gtk2 atk pango cairo gdk_pixbuf
       freetype fontconfig xorg.libXcomposite alsaLib xorg.libXdamage
       xorg.libXext xorg.libXfixes nss nspr gconf expat dbus stdenv.cc.cc
       xorg.libXtst xorg.libXi

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, binutils
-, pkgconfig, gtk, glib, pango, libglade }:
+, pkgconfig, gtk2, glib, pango, libglade }:
 
 stdenv.mkDerivation rec {
   name = "sysprof-1.2.0";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wb4d844rsy8qjg3z5m6rnfm72da4xwzrrkkb1q5r10sq1pkrw5s";
   };
 
-  buildInputs = [ binutils pkgconfig gtk glib pango libglade ];
+  buildInputs = [ binutils pkgconfig gtk2 glib pango libglade ];
 
   meta = {
     homepage = http://sysprof.com/;

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cairo, fontconfig, freetype, gdk_pixbuf, glib
-, glibc, gtk, libX11, makeWrapper, nspr, nss, pango, unzip, gconf
+, glibc, gtk2, libX11, makeWrapper, nspr, nss, pango, unzip, gconf
 , libXi, libXrender, libXext
 }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     mv chromedriver $out/bin
     patchelf --set-interpreter ${glibc.out}/lib/ld-linux-x86-64.so.2 $out/bin/chromedriver
     wrapProgram "$out/bin/chromedriver" \
-      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib cairo fontconfig freetype gdk_pixbuf glib gtk libX11 nspr nss pango libXrender gconf libXext libXi ]}:\$LD_LIBRARY_PATH"
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib cairo fontconfig freetype gdk_pixbuf glib gtk2 libX11 nspr nss pango libXrender gconf libXext libXi ]}:\$LD_LIBRARY_PATH"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/thrust/default.nix
+++ b/pkgs/development/tools/thrust/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildEnv, makeWrapper, glib, alsaLib , dbus, gtk, atk
+{ stdenv, fetchurl, buildEnv, makeWrapper, glib, alsaLib , dbus, gtk2, atk
 , pango, freetype, fontconfig, gdk_pixbuf , cairo, cups, expat, nspr, gconf, nss
 , xorg, libcap, unzip
 }:
@@ -7,7 +7,7 @@ let
   thrustEnv = buildEnv {
     name = "env-thrust";
     paths = [
-      stdenv.cc.cc glib dbus gtk atk pango freetype fontconfig gdk_pixbuf
+      stdenv.cc.cc glib dbus gtk2 atk pango freetype fontconfig gdk_pixbuf
       cairo cups expat alsaLib nspr gconf nss xorg.libXrender xorg.libX11
       xorg.libXext xorg.libXdamage xorg.libXtst xorg.libXcomposite
       xorg.libXi xorg.libXfixes xorg.libXrandr xorg.libXcursor libcap

--- a/pkgs/development/tools/unity3d/default.nix
+++ b/pkgs/development/tools/unity3d/default.nix
@@ -4,7 +4,7 @@
 , cairo, dbus, expat, zlib, libpng12, nodejs, gnutar, gcc, gcc_32bit
 , libX11, libXcursor, libXdamage, libXfixes, libXrender, libXi
 , libXcomposite, libXext, libXrandr, libXtst, libSM, libICE, libxcb
-, mono, libgnomeui, gnome_vfs, gnome-sharp, gtk-sharp, chromium
+, mono, libgnomeui, gnome_vfs, gnome-sharp, gtk-sharp-2_0, chromium
 }:
 
 let
@@ -19,10 +19,10 @@ let
   binPath = lib.makeBinPath [ nodejs gnutar ];
   developBinPath = lib.makeBinPath [ mono ];
   developLibPath = lib.makeLibraryPath [
-    glib libgnomeui gnome_vfs gnome-sharp gtk-sharp gtk-sharp.gtk
+    glib libgnomeui gnome_vfs gnome-sharp gtk-sharp-2_0 gtk-sharp-2_0.gtk
   ];
   developDotnetPath = lib.concatStringsSep ":" [
-    gnome-sharp gtk-sharp
+    gnome-sharp gtk-sharp-2_0
   ];
 
   ver = "5.3.5";

--- a/pkgs/games/ckan/default.nix
+++ b/pkgs/games/ckan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, perl, mono, gtk, curl }:
+{ stdenv, fetchFromGitHub, makeWrapper, perl, mono, gtk2, curl }:
 
 stdenv.mkDerivation rec {
   name = "ckan-${version}";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
   checkTarget = "test";
 
-  libraries = stdenv.lib.makeLibraryPath [ gtk curl ];
+  libraries = stdenv.lib.makeLibraryPath [ gtk2 curl ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/games/crack-attack/default.nix
+++ b/pkgs/games/crack-attack/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, freeglut, SDL, mesa, libXi, libXmu}:
+{ stdenv, fetchurl, pkgconfig, gtk2, freeglut, SDL, mesa, libXi, libXmu}:
 
 stdenv.mkDerivation {
   name = "crack-attack-1.1.14";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1sakj9a2q05brpd7lkqxi8q30bccycdzd96ns00s6jbxrzjlijkm";
   };
 
-  buildInputs = [ pkgconfig gtk freeglut SDL mesa libXi libXmu ];
+  buildInputs = [ pkgconfig gtk2 freeglut SDL mesa libXi libXmu ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/games/eboard/default.nix
+++ b/pkgs/games/eboard/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, pkgconfig, gtk }:
+{ stdenv, fetchurl, perl, pkgconfig, gtk2 }:
 
 stdenv.mkDerivation {
   name = "eboard-1.1.1";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   patches = [ ./eboard.patch ];
 
-  buildInputs = [ gtk ];
+  buildInputs = [ gtk2 ];
   nativeBuildInputs = [ perl pkgconfig ];
 
   hardeningDisable = [ "format" ];

--- a/pkgs/games/eduke32/default.nix
+++ b/pkgs/games/eduke32/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, flac, gtk, libvorbis, libvpx, makeDesktopItem, mesa, nasm
+{ stdenv, fetchurl, flac, gtk2, libvorbis, libvpx, makeDesktopItem, mesa, nasm
 , pkgconfig, SDL2, SDL2_mixer }:
 
 let
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1nlq5jbglg00c1z1vsyl627fh0mqfxvk5qyxav5vzla2b4svik2v";
   };
 
-  buildInputs = [ flac gtk libvorbis libvpx mesa SDL2 SDL2_mixer ]
+  buildInputs = [ flac gtk2 libvorbis libvpx mesa SDL2 SDL2_mixer ]
     ++ stdenv.lib.optional (stdenv.system == "i686-linux") nasm;
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, zlib, bzip2, pkgconfig, curl, lzma, gettext
 , sdlClient ? true, SDL, SDL_mixer, SDL_image, SDL_ttf, SDL_gfx, freetype, fluidsynth
-, gtkClient ? false, gtk
+, gtkClient ? false, gtk2
 , server ? true, readline }:
 
 let
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ zlib bzip2 curl lzma gettext ]
     ++ optionals sdlClient [ SDL SDL_mixer SDL_image SDL_ttf SDL_gfx freetype fluidsynth ]
-    ++ optionals gtkClient [ gtk ]
+    ++ optionals gtkClient [ gtk2 ]
     ++ optional server readline;
 
   configureFlags = []

--- a/pkgs/games/fsg/default.nix
+++ b/pkgs/games/fsg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, glib, pkgconfig, mesa, wxGTK, libX11, xproto }:
+{ stdenv, fetchurl, gtk2, glib, pkgconfig, mesa, wxGTK, libX11, xproto }:
 
 stdenv.mkDerivation {
   name = "fsg-4.4";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ gtk glib pkgconfig mesa wxGTK libX11 xproto ];
+  buildInputs = [ gtk2 glib pkgconfig mesa wxGTK libX11 xproto ];
 
   preBuild = ''
     sed -e '

--- a/pkgs/games/pioneers/default.nix
+++ b/pkgs/games/pioneers/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk, pkgconfig, intltool } :
+{stdenv, fetchurl, gtk2, pkgconfig, intltool } :
 
 stdenv.mkDerivation rec {
   name = "pioneers-0.12.3";
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "1yqypk5wmia8fqyrg9mn9xw6yfd0fpkxj1355csw1hgx8mh44y1d";
   };
 
-  buildInputs = [ gtk pkgconfig intltool ];
+  buildInputs = [ gtk2 pkgconfig intltool ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/games/planetaryannihilation/default.nix
+++ b/pkgs/games/planetaryannihilation/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, config, fetchurl, patchelf, makeWrapper, gtk, glib, udev, alsaLib, atk
+{ stdenv, config, fetchurl, patchelf, makeWrapper, gtk2, glib, udev, alsaLib, atk
 , nspr, fontconfig, cairo, pango, nss, freetype, gnome3, gdk_pixbuf, curl, systemd, xorg }:
 
 # TODO: use dynamic attributes once Nix 1.7 is out
@@ -34,9 +34,9 @@ stdenv.mkDerivation {
     ln -s ${systemd}/lib/libudev.so.1 $out/lib/libudev.so.0
 
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/PA"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib xorg.libXdamage xorg.libXfixes gtk glib stdenv.glibc.out "$out" xorg.libXext pango udev xorg.libX11 xorg.libXcomposite alsaLib atk nspr fontconfig cairo pango nss freetype gnome3.gconf gdk_pixbuf xorg.libXrender ]}:{stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64" "$out/host/CoherentUI_Host" 
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib xorg.libXdamage xorg.libXfixes gtk2 glib stdenv.glibc.out "$out" xorg.libXext pango udev xorg.libX11 xorg.libXcomposite alsaLib atk nspr fontconfig cairo pango nss freetype gnome3.gconf gdk_pixbuf xorg.libXrender ]}:{stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64" "$out/host/CoherentUI_Host"
 
-    wrapProgram $out/PA --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib stdenv.glibc.out xorg.libX11 xorg.libXcursor gtk glib curl "$out" ]}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64"
+    wrapProgram $out/PA --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib stdenv.glibc.out xorg.libX11 xorg.libXcursor gtk2 glib curl "$out" ]}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64"
 
     for f in $out/lib/*; do
       patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib curl xorg.libX11 stdenv.glibc.out xorg.libXcursor "$out" ]}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64" $f

--- a/pkgs/games/privateer/default.nix
+++ b/pkgs/games/privateer/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchsvn, boost, cmake, ffmpeg, freeglut, glib,
-  gtk, libjpeg, libpng, libpthreadstubs, libvorbis, libXau, libXdmcp,
+  gtk2, libjpeg, libpng, libpthreadstubs, libvorbis, libXau, libXdmcp,
   libXmu, mesa, openal, pixman, pkgconfig, python27Full, SDL }:
 
 stdenv.mkDerivation {
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs =
-    [ boost cmake ffmpeg freeglut glib gtk libjpeg libpng
+    [ boost cmake ffmpeg freeglut glib gtk2 libjpeg libpng
       libpthreadstubs libvorbis libXau libXdmcp libXmu mesa openal
       pixman pkgconfig python27Full SDL ];
 

--- a/pkgs/games/rigsofrods/default.nix
+++ b/pkgs/games/rigsofrods/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, fetchFromGitHub, stdenv, wxGTK30, freeimage, cmake, zziplib, mesa, boost,
-  pkgconfig, libuuid, openal, ogre, ois, curl, gtk, pixman, mygui, unzip,
+  pkgconfig, libuuid, openal, ogre, ois, curl, gtk2, pixman, mygui, unzip,
   angelscript, ogrepaged, mysocketw, libxcb
   }:
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ wxGTK30 freeimage cmake zziplib mesa boost pkgconfig
-    libuuid openal ogre ois curl gtk mygui unzip angelscript
+    libuuid openal ogre ois curl gtk2 mygui unzip angelscript
     ogrepaged mysocketw libxcb ];
 
   meta = {

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, wxGTK30, openal, pkgconfig, curl, libtorrentRasterbar
-, libpng, libX11, gettext, bash, gawk, boost, libnotify, gtk, doxygen, spring
+, libpng, libX11, gettext, bash, gawk, boost, libnotify, gtk2, doxygen, spring
 , makeWrapper, glib, minizip, alure, pcre, jsoncpp }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cmake wxGTK30 openal pkgconfig curl gettext libtorrentRasterbar pcre jsoncpp
-    boost libpng libX11 libnotify gtk doxygen makeWrapper glib minizip alure
+    boost libpng libX11 libnotify gtk2 doxygen makeWrapper glib minizip alure
   ];
 
   patches = [ ./revert_58b423e.patch ]; # Allows springLobby to continue using system installed spring until #707 is fixed

--- a/pkgs/games/zandronum/bin.nix
+++ b/pkgs/games/zandronum/bin.nix
@@ -8,7 +8,7 @@
 , freetype
 , gdk_pixbuf
 , glib
-, gtk
+, gtk2
 , libjpeg_turbo
 , mesa_glu
 , mesa_noglu
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     freetype
     gdk_pixbuf
     glib
-    gtk
+    gtk2
     libjpeg_turbo
     mesa_glu
     mesa_noglu

--- a/pkgs/misc/drivers/hplip/3.15.9.nix
+++ b/pkgs/misc/drivers/hplip/3.15.9.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation {
   pythonPath = with pythonPackages; [
     dbus
     pillow
-    pygobject
+    pygobject2
     recursivePthLoader
     reportlab
     usbutils

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation {
   pythonPath = with pythonPackages; [
     dbus
     pillow
-    pygobject
+    pygobject2
     recursivePthLoader
     reportlab
     usbutils

--- a/pkgs/misc/emulators/fs-uae/default.nix
+++ b/pkgs/misc/emulators/fs-uae/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig
-, gettext, gtk, SDL, zlib, glib, openal, mesa, lua, freetype }:
+, gettext, gtk2, SDL, zlib, glib, openal, mesa, lua, freetype }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec{
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec{
     sha256 = "05wngvpqj8kj4wzi5jzzhvs19iljb3m6ba1l2hk4rz68b400ndv6";
   };
 
-  buildInputs = [ pkgconfig gettext gtk SDL zlib glib openal mesa lua freetype ];
+  buildInputs = [ pkgconfig gettext gtk2 SDL zlib glib openal mesa lua freetype ];
 
   phases = "unpackPhase buildPhase installPhase";
 

--- a/pkgs/misc/emulators/gens-gs/default.nix
+++ b/pkgs/misc/emulators/gens-gs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, SDL, nasm, zlib, libpng, mesa }:
+{ stdenv, fetchurl, pkgconfig, gtk2, SDL, nasm, zlib, libpng, mesa }:
 
 stdenv.mkDerivation { 
   name = "gens-gs-7";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1ha5s6d3y7s9aq9f4zmn9p88109c3mrj36z2w68jhiw5xrxws833";
   };
 
-  buildInputs = [ pkgconfig gtk SDL nasm zlib libpng mesa ];
+  buildInputs = [ pkgconfig gtk2 SDL nasm zlib libpng mesa ];
 
   # Work around build failures on recent GTK+.
   # See http://ubuntuforums.org/showthread.php?p=10535837

--- a/pkgs/misc/emulators/higan/default.nix
+++ b/pkgs/misc/emulators/higan/default.nix
@@ -4,7 +4,7 @@
 , udev
 , mesa, SDL
 , libao, openal, libpulseaudio
-, gtk, gtksourceview
+, gtk2, gtksourceview
 }:
 
 with stdenv.lib;
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   postPatch = "sed '1i#include <cmath>' -i higan/fc/ppu/ppu.cpp";
 
   buildInputs =
-  [ p7zip pkgconfig libX11 libXv udev mesa SDL libao openal libpulseaudio gtk gtksourceview ];
+  [ p7zip pkgconfig libX11 libXv udev mesa SDL libao openal libpulseaudio gtk2 gtksourceview ];
 
   unpackPhase = ''
     7z x $src

--- a/pkgs/misc/emulators/mess/default.nix
+++ b/pkgs/misc/emulators/mess/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, pkgconfig, SDL, gtk, GConf, mesa
+{ stdenv, fetchurl, unzip, pkgconfig, SDL, gtk2, GConf, mesa
 , expat, zlib }:
 
 let
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   makeFlags = "TARGET=mess BUILD_EXPAT= BUILD_ZLIB= NOWERROR=1";
 
   buildInputs =
-    [ unzip pkgconfig SDL gtk GConf mesa expat zlib ];
+    [ unzip pkgconfig SDL gtk2 GConf mesa expat zlib ];
 
   installPhase =
     ''

--- a/pkgs/misc/emulators/mupen64plus/default.nix
+++ b/pkgs/misc/emulators/mupen64plus/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, which, pkgconfig, SDL, gtk, mesa, SDL_ttf}:
+{stdenv, fetchurl, which, pkgconfig, SDL, gtk2, mesa, SDL_ttf}:
 
 stdenv.mkDerivation {
   name = "mupen64plus-1.5";
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
     sha256 = "0gygfgyr2sg4yx77ijk133d1ra0v1yxi4xjxrg6kp3zdjmhdmcjq";
   };
 
-  buildInputs = [ which pkgconfig SDL gtk mesa SDL_ttf ];
+  buildInputs = [ which pkgconfig SDL gtk2 mesa SDL_ttf ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/misc/emulators/snes9x-gtk/default.nix
+++ b/pkgs/misc/emulators/snes9x-gtk/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, nasm, SDL, zlib, libpng, ncurses, mesa, intltool, gtk, pkgconfig, libxml2, xlibsWrapper, libpulseaudio}:
+{stdenv, fetchurl, nasm, SDL, zlib, libpng, ncurses, mesa, intltool, gtk2, pkgconfig, libxml2, xlibsWrapper, libpulseaudio}:
 
 stdenv.mkDerivation rec {
   name = "snes9x-gtk-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "9f7c5d2d0fa3fe753611cf94e8879b73b8bb3c0eab97cdbcb6ab7376efa78dc3";
   };
 
-  buildInputs = [ nasm SDL zlib libpng ncurses mesa intltool gtk pkgconfig libxml2 xlibsWrapper libpulseaudio];
+  buildInputs = [ nasm SDL zlib libpng ncurses mesa intltool gtk2 pkgconfig libxml2 xlibsWrapper libpulseaudio];
 
   sourceRoot = "snes9x-${version}-src/gtk";
 

--- a/pkgs/misc/emulators/uae/default.nix
+++ b/pkgs/misc/emulators/uae/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, gtk, alsaLib, SDL}:
+{stdenv, fetchurl, pkgconfig, gtk2, alsaLib, SDL}:
 
 stdenv.mkDerivation rec {
   name = "uae-0.8.29";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-sdl" "--with-sdl-sound" "--with-sdl-gfx" "--with-alsa" ];
 
-  buildInputs = [ pkgconfig gtk alsaLib SDL ];
+  buildInputs = [ pkgconfig gtk2 alsaLib SDL ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/misc/emulators/vice/default.nix
+++ b/pkgs/misc/emulators/vice/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, perl, libpng, giflib, libjpeg, alsaLib, readline, mesa, libX11
-, pkgconfig, gtk, SDL, autoreconfHook, makeDesktopItem
+, pkgconfig, gtk2, SDL, autoreconfHook, makeDesktopItem
 }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ perl libpng giflib libjpeg alsaLib readline mesa
-                  pkgconfig gtk SDL autoreconfHook ];
+                  pkgconfig gtk2 SDL autoreconfHook ];
   configureFlags = "--with-sdl --enable-fullscreen --enable-gnomeui";
 
   desktopItem = makeDesktopItem {

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   ++ lib.optional pulseaudioSupport      pkgs.libpulseaudio
   ++ lib.optional xineramaSupport        pkgs.xorg.libXinerama
   ++ lib.optionals gstreamerSupport      (with pkgs.gst_all; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-ffmpeg ])
-  ++ lib.optionals gtkSupport    [ pkgs.gtk3 pkgs.gnome.glib ]
+  ++ lib.optionals gtkSupport    [ pkgs.gtk3 pkgs.glib ]
   ++ lib.optionals openclSupport [ pkgs.opencl-headers pkgs.opencl-icd ]
   ++ lib.optionals xmlSupport    [ pkgs.libxml2 pkgs.libxslt ]
   ++ lib.optionals tlsSupport    [ pkgs.openssl pkgs.gnutls ]

--- a/pkgs/misc/screensavers/xscreensaver/default.nix
+++ b/pkgs/misc/screensavers/xscreensaver/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, bc, perl, pam, libXext, libXScrnSaver, libX11
-, libXrandr, libXmu, libXxf86vm, libXrender, libXxf86misc, libjpeg, mesa, gtk
+, libXrandr, libXmu, libXxf86vm, libXrender, libXxf86misc, libjpeg, mesa, gtk2
 , libxml2, libglade, intltool, xorg, makeWrapper, gle
 , forceInstallAllHacks ? false
 }:
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig bc perl libjpeg mesa gtk libxml2 libglade pam
+    [ pkgconfig bc perl libjpeg mesa gtk2 libxml2 libglade pam
       libXext libXScrnSaver libX11 libXrandr libXmu libXxf86vm libXrender
       libXxf86misc intltool xorg.appres makeWrapper gle
     ];

--- a/pkgs/misc/themes/arc/default.nix
+++ b/pkgs/misc/themes/arc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gnome3, gtk, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gnome3, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   version = "2016-06-06";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   preferLocalBuild = true;
 
-  configureFlags = "--with-gnome=${gnome3.version}";
+  configureFlags = "--with-gnome=${gnome3.version} ";
 
   meta = with stdenv.lib; {
     description = "A flat theme with transparent elements for GTK 3, GTK 2 and Gnome-Shell";

--- a/pkgs/misc/themes/gtk2/oxygen-gtk/default.nix
+++ b/pkgs/misc/themes/gtk2/oxygen-gtk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl,
-  cmake, dbus_glib, glib, gtk, gdk_pixbuf, pkgconfig, xorg }:
+  cmake, dbus_glib, glib, gtk2, gdk_pixbuf, pkgconfig, xorg }:
 
 stdenv.mkDerivation rec {
   version = "1.4.6";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "09mz4szsz3yswbj0nbw6qzlc5bc4id0f9r6ifm60b5nc8x1l72d2";
   };
 
-  buildInputs = [ cmake dbus_glib glib gtk gdk_pixbuf
+  buildInputs = [ cmake dbus_glib glib gtk2 gdk_pixbuf
    pkgconfig xorg.libXau xorg.libXdmcp xorg.libpthreadstubs
    xorg.libxcb xorg.pixman ];
 

--- a/pkgs/misc/themes/gtk3/clearlooks-phenix/default.nix
+++ b/pkgs/misc/themes/gtk3/clearlooks-phenix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   version = "5.0.7";

--- a/pkgs/os-specific/linux/alsa-tools/default.nix
+++ b/pkgs/os-specific/linux/alsa-tools/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, alsaLib, pkgconfig, gtk, gtk3, fltk13 }:
+{ stdenv, fetchurl, alsaLib, pkgconfig, gtk2, gtk3, fltk13 }:
+# Comes from upstream as as bundle of several tools,
+# some use gtk2, some gtk3 (and some even fltk13).
 
 stdenv.mkDerivation rec {
   name = "alsa-tools-${version}";
@@ -12,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ldbaz3qr7z0639xg37ba7cmrb512rrjavap6r5jjl0ab665ad3x";
   };
 
-  buildInputs = [ alsaLib pkgconfig gtk gtk3 fltk13 ];
+  buildInputs = [ alsaLib pkgconfig gtk2 gtk3 fltk13 ];
 
   patchPhase = ''
     export tools="as10k1 hda-verb hdspmixer echomixer hdajackretask hdspconf hwmixvolume mixartloader rmedigicontrol sscape_ctl vxloader envy24control hdajacksensetest hdsploader ld10k1 pcxhrloader sb16_csp us428control"

--- a/pkgs/os-specific/linux/bluez/bluez5.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   pythonPath = with pythonPackages;
-    [ dbus pygobject pygobject3 recursivePthLoader ];
+    [ dbus pygobject2 pygobject3 recursivePthLoader ];
 
   buildInputs =
     [ pkgconfig dbus glib alsaLib pythonPackages.python pythonPackages.wrapPython

--- a/pkgs/os-specific/linux/bluez/bluez5_28.nix
+++ b/pkgs/os-specific/linux/bluez/bluez5_28.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
   };
 
   pythonPath = with pythonPackages;
-    [ dbus pygobject pygobject3 recursivePthLoader ];
+    [ dbus pygobject2 pygobject3 recursivePthLoader ];
 
   buildInputs =
     [ pkgconfig dbus glib alsaLib python pythonPackages.wrapPython

--- a/pkgs/os-specific/linux/latencytop/default.nix
+++ b/pkgs/os-specific/linux/latencytop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, glib, pkgconfig, gtk }:
+{ stdenv, fetchurl, ncurses, glib, pkgconfig, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "latencytop-0.5";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1vq3j9zdab6njly2wp900b3d5244mnxfm88j2bkiinbvxbxp4zwy";
   };
 
-  buildInputs = [ ncurses glib pkgconfig gtk ];
+  buildInputs = [ ncurses glib pkgconfig gtk2 ];
 
   meta = {
     homepage = http://latencytop.org;

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, kernel ? null, xorg, zlib, perl
-, gtk, atk, pango, glib, gdk_pixbuf, cairo, nukeReferences
+, gtk2, atk, pango, glib, gdk_pixbuf, cairo, nukeReferences
 , # Whether to build the libraries only (i.e. not the kernel module or
   # nvidia-settings).  Used to support 32-bit binaries on 64-bit
   # Linux.
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
   allLibPath  = makeLibraryPath [xorg.libXext xorg.libX11 xorg.libXrandr zlib stdenv.cc.cc];
 
   gtkPath = optionalString (!libsOnly) (makeLibraryPath
-    [ gtk atk pango glib gdk_pixbuf cairo ] );
+    [ gtk2 atk pango glib gdk_pixbuf cairo ] );
   programPath = makeLibraryPath [ xorg.libXv ];
 
   patches = if (!libsOnly) && (versionAtLeast kernel.dev.version "4.7") then [ ./365.35-kernel-4.7.patch ] else [];

--- a/pkgs/os-specific/linux/nvidia-x11/legacy173.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy173.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, kernel, xorg, zlib, gtk, atk, pango, glib, gdk_pixbuf}:
+{stdenv, fetchurl, kernel, xorg, zlib, gtk2, atk, pango, glib, gdk_pixbuf}:
 
 let
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   cudaPath = stdenv.lib.makeLibraryPath [zlib stdenv.cc.cc];
 
-  programPath = stdenv.lib.makeLibraryPath [ gtk atk pango glib gdk_pixbuf xorg.libXv ];
+  programPath = stdenv.lib.makeLibraryPath [ gtk2 atk pango glib gdk_pixbuf xorg.libXv ];
 
   meta = {
     homepage = http://www.nvidia.com/object/unix.html;

--- a/pkgs/os-specific/linux/nvidia-x11/legacy304.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy304.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, kernel ? null, xorg, zlib, perl
-, gtk, atk, pango, glib, gdk_pixbuf
+, gtk2, atk, pango, glib, gdk_pixbuf
 , # Whether to build the libraries only (i.e. not the kernel module or
   # nvidia-settings).  Used to support 32-bit binaries on 64-bit
   # Linux.
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
   cudaPath = stdenv.lib.makeLibraryPath [zlib stdenv.cc.cc];
 
   programPath = optionalString (!libsOnly) (stdenv.lib.makeLibraryPath
-    [ gtk atk pango glib gdk_pixbuf xorg.libXv ] );
+    [ gtk2 atk pango glib gdk_pixbuf xorg.libXv ] );
 
   buildInputs = [ perl ];
 

--- a/pkgs/os-specific/linux/nvidia-x11/legacy340.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/legacy340.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, kernel ? null, xorg, zlib, perl
-, gtk, atk, pango, glib, gdk_pixbuf
+, gtk2, atk, pango, glib, gdk_pixbuf
 , # Whether to build the libraries only (i.e. not the kernel module or
   # nvidia-settings).  Used to support 32-bit binaries on 64-bit
   # Linux.
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
   allLibPath  = makeLibraryPath [xorg.libXext xorg.libX11 xorg.libXrandr zlib stdenv.cc.cc];
 
   programPath = optionalString (!libsOnly) (makeLibraryPath
-    [ gtk atk pango glib gdk_pixbuf xorg.libXv ] );
+    [ gtk2 atk pango glib gdk_pixbuf xorg.libXv ] );
 
   buildInputs = [ perl ];
 

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, dpdk, libpcap, utillinux
 , pkgconfig
-, gtk, withGtk ? false
+, gtk2, withGtk ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ dpdk libpcap ]
-    ++ stdenv.lib.optionals withGtk [gtk];
+    ++ stdenv.lib.optionals withGtk [gtk2];
 
   RTE_SDK = "${dpdk}";
   RTE_TARGET = "x86_64-native-linuxapp-gcc";

--- a/pkgs/os-specific/linux/pommed/default.nix
+++ b/pkgs/os-specific/linux/pommed/default.nix
@@ -7,7 +7,7 @@
 , alsaLib
 , audiofile
 , pkgconfig
-, gtk
+, gtk2
 , gettext
 , libXpm
 }:
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     audiofile
     dbus_glib
     pkgconfig
-    gtk
+    gtk2
     gettext
     libXpm
   ];

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, curl, python, munge, perl, pam, openssl
-, ncurses, mysql, gtk, lua, hwloc, numactl
+, ncurses, mysql, gtk2, lua, hwloc, numactl
 }:
 
 stdenv.mkDerivation rec {
@@ -15,14 +15,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    curl python munge perl pam openssl mysql.lib ncurses gtk lua hwloc numactl
+    curl python munge perl pam openssl mysql.lib ncurses gtk2 lua hwloc numactl
   ];
 
   configureFlags =
     [ "--with-munge=${munge}"
       "--with-ssl=${openssl.dev}"
       "--sysconfdir=/etc/slurm"
-    ] ++ stdenv.lib.optional (gtk == null)  "--disable-gtktest";
+    ] ++ stdenv.lib.optional (gtk2 == null)  "--disable-gtktest";
 
   preConfigure = ''
     substituteInPlace ./doc/html/shtml2html.py --replace "/usr/bin/env python" "${python.interpreter}"

--- a/pkgs/servers/gpsd/default.nix
+++ b/pkgs/servers/gpsd/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ];
 
   pythonPath = [
-    pythonPackages.pygobject
+    pythonPackages.pygobject2
     pythonPackages.pygtk
   ];
 

--- a/pkgs/servers/neard/default.nix
+++ b/pkgs/servers/neard/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ autoreconfHook pkgconfig systemd glib dbus libnl pythonPackages.python pythonPackages.wrapPython ];
-  pythonPath = [ pythonPackages.pygobject pythonPackages.dbus-python pythonPackages.pygtk ];
+  pythonPath = [ pythonPackages.pygobject2 pythonPackages.dbus-python pythonPackages.pygtk ];
 
   configureFlags = [ "--disable-debug" "--enable-tools" "--enable-ese" "--with-systemdsystemunitdir=$out/lib/systemd/system" ];
 

--- a/pkgs/tools/X11/nitrogen/default.nix
+++ b/pkgs/tools/X11/nitrogen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, gtk2, gtkmm }:
+{ stdenv, fetchurl, pkgconfig, glib, gtkmm2 }:
 
 let version = "1.5.2";
 in
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "60a2437ce6a6c0ba44505fc8066c1973140d4bb48e1e5649f525c7b0b8bf9fd2";
   };
 
-  buildInputs = [ glib gtk2 gtkmm pkgconfig ];
+  buildInputs = [ glib gtkmm2 pkgconfig ];
 
   NIX_LDFLAGS = "-lX11";
 

--- a/pkgs/tools/X11/obconf/default.nix
+++ b/pkgs/tools/X11/obconf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, libglade, openbox,
+{ stdenv, fetchurl, pkgconfig, gtk2, libglade, openbox,
   imlib2, libstartup_notification, makeWrapper }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgconfig gtk libglade openbox imlib2 libstartup_notification makeWrapper
+    pkgconfig gtk2 libglade openbox imlib2 libstartup_notification makeWrapper
   ];
 
   postInstall = ''

--- a/pkgs/tools/X11/xnee/default.nix
+++ b/pkgs/tools/X11/xnee/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, libX11, xproto, libXext, xextproto, libXtst
-, gtk, libXi, inputproto, pkgconfig, recordproto, texinfo }:
+, gtk2, libXi, inputproto, pkgconfig, recordproto, texinfo }:
 
 stdenv.mkDerivation rec {
   version = "3.19";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     '';
 
   buildInputs =
-    [ libX11 xproto libXext xextproto libXtst gtk
+    [ libX11 xproto libXext xextproto libXtst gtk2
       libXi inputproto pkgconfig recordproto
       texinfo
     ];

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pythonPackages, pkgconfig
-, xorg, gtk, glib, pango, cairo, gdk_pixbuf, atk
+, xorg, gtk2, glib, pango, cairo, gdk_pixbuf, atk
 , makeWrapper, xkbcomp, xorgserver, getopt, xauth, utillinux, which, fontsConf, xkeyboard_config
 , ffmpeg, x264, libvpx, libwebp
 , libfakeXinerama }:
@@ -22,7 +22,7 @@ in buildPythonApplication rec {
     xorg.xproto xorg.fixesproto xorg.libXtst xorg.libXfixes xorg.libXcomposite xorg.libXdamage
     xorg.libXrandr xorg.libxkbfile
 
-    pango cairo gdk_pixbuf atk gtk glib
+    pango cairo gdk_pixbuf atk gtk2 glib
 
     ffmpeg libvpx x264 libwebp
 
@@ -30,7 +30,7 @@ in buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with pythonPackages; [
-    pillow pygtk pygobject rencode pycrypto cryptography pycups lz4 dbus-python
+    pillow pygtk pygobject2 rencode pycrypto cryptography pycups lz4 dbus-python
   ];
 
   preBuild = ''

--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, gobjectIntrospection
-, python, gtk, pygtk, gnutls, cairo, libtool, glib, pkgconfig, libtasn1
+, python, gtk2, pygtk, gnutls, cairo, libtool, glib, pkgconfig, libtasn1
 , libffi, cyrus_sasl, intltool, perl, perlPackages, libpulseaudio
-, kbproto, libX11, libXext, xextproto, pygobject, libgcrypt, gtk3, vala_0_23
+, kbproto, libX11, libXext, xextproto, pygobject2, libgcrypt, gtk3, vala_0_23
 , pygobject3, libogg, enableGTK3 ? false, libgpgerror }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     python gnutls cairo libtool pkgconfig glib libffi libgcrypt
     intltool cyrus_sasl libpulseaudio perl perlPackages.TextCSV
     gobjectIntrospection libogg libgpgerror
-  ] ++ (if enableGTK3 then [ gtk3 vala_0_23 pygobject3 ] else [ gtk pygtk pygobject ]);
+  ] ++ (if enableGTK3 then [ gtk3 vala_0_23 pygobject3 ] else [ gtk2 pygtk pygobject2 ]);
 
   NIX_CFLAGS_COMPILE = "-fstack-protector-all";
   configureFlags = [
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags = stdenv.lib.optionalString (!enableGTK3)
-    "CODEGENDIR=${pygobject}/share/pygobject/2.0/codegen/ DEFSDIR=${pygtk}/share/pygtk/2.0/defs/";
+    "CODEGENDIR=${pygobject2}/share/pygobject/2.0/codegen/ DEFSDIR=${pygtk}/share/pygtk/2.0/defs/";
 
   # Fix broken .la files
   preFixup = ''

--- a/pkgs/tools/archivers/xarchiver/default.nix
+++ b/pkgs/tools/archivers/xarchiver/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk, pkgconfig, intltool }:
+{ stdenv, fetchFromGitHub, gtk2, pkgconfig, intltool }:
 
 stdenv.mkDerivation rec {
   version = "0.5.4.7";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0w9lx8d8r50j48qfhn2r0dlcnwy3pjyy6xjvgpr0qagy5l1q1qj4";
   };
 
-  buildInputs = [ gtk pkgconfig intltool ];
+  buildInputs = [ gtk2 pkgconfig intltool ];
 
   meta = {
     description = "GTK+ frontend to 7z,zip,rar,tar,bzip2, gzip,arj, lha, rpm and deb (open and extract only)";

--- a/pkgs/tools/audio/playerctl/default.nix
+++ b/pkgs/tools/audio/playerctl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, which, gnome, glib,
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, which, gnome2, glib,
   pkgconfig, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    which autoconf automake libtool gnome.gtkdoc glib pkgconfig
+    which autoconf automake libtool gnome2.gtkdoc glib pkgconfig
     gobjectIntrospection
   ];
 

--- a/pkgs/tools/graphics/nip2/default.nix
+++ b/pkgs/tools/graphics/nip2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libxml2, flex, bison, vips, gnome,
+{ stdenv, fetchurl, pkgconfig, glib, libxml2, flex, bison, vips, gnome2,
 fftw, gsl, goffice, libgsf }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
   [ pkgconfig glib libxml2 flex bison vips
-    gnome.gtk fftw gsl goffice libgsf
+    gnome2.gtk fftw gsl goffice libgsf
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/graphics/pdf2svg/default.nix
+++ b/pkgs/tools/graphics/pdf2svg/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, cairo, gtk, poppler }:
+, cairo, gtk2, poppler }:
 
 stdenv.mkDerivation rec {
   name = "pdf2svg-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "14ffdm4y26imq99wjhkrhy9lp33165xci1l5ndwfia8hz53bl02k";
   };
 
-  buildInputs = [ autoreconfHook cairo pkgconfig poppler gtk ];
+  buildInputs = [ autoreconfHook cairo pkgconfig poppler gtk2 ];
 
   meta = with stdenv.lib; {
     description = "PDF converter to SVG format";

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libxml2, flex, bison, vips, gnome,
+{ stdenv, fetchurl, pkgconfig, glib, libxml2, flex, bison, vips,
   fftw, orc, lcms, imagemagick, openexr, libtiff, libjpeg, libgsf, libexif,
   python27, libpng, matio ? null, cfitsio ? null, libwebp ? null
 }:

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
@@ -1,5 +1,5 @@
 { clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, fetchsvn, gyp, which, ninja, 
-  python, pkgconfig, protobuf, gtk, zinnia, qt4, libxcb, tegaki-zinnia-japanese,
+  python, pkgconfig, protobuf, gtk2, zinnia, qt4, libxcb, tegaki-zinnia-japanese,
   fcitx, gettext }:
 let
   japanese_usage_dictionary = fetchsvn {
@@ -23,7 +23,7 @@ in clangStdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gyp which ninja python pkgconfig ];
-  buildInputs = [ protobuf gtk zinnia qt4 libxcb fcitx gettext ];
+  buildInputs = [ protobuf gtk2 zinnia qt4 libxcb fcitx gettext ];
 
   postUnpack = ''
     rmdir $sourceRoot/src/third_party/japanese_usage_dictionary/

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
@@ -1,4 +1,4 @@
-{ clangStdenv, fetchFromGitHub, fetchsvn, gyp, which, ninja, python, pkgconfig, protobuf, ibus, gtk, zinnia, qt4, libxcb, tegaki-zinnia-japanese }:
+{ clangStdenv, fetchFromGitHub, fetchsvn, gyp, which, ninja, python, pkgconfig, protobuf, ibus, gtk2, zinnia, qt4, libxcb, tegaki-zinnia-japanese }:
 
 let
   japanese_usage_dictionary = fetchsvn {
@@ -20,7 +20,7 @@ in clangStdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gyp which ninja python pkgconfig ];
-  buildInputs = [ protobuf ibus gtk zinnia qt4 libxcb ];
+  buildInputs = [ protobuf ibus gtk2 zinnia qt4 libxcb ];
 
   src = fetchFromGitHub {
     owner  = "google";

--- a/pkgs/tools/inputmethods/nabi/default.nix
+++ b/pkgs/tools/inputmethods/nabi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk, libhangul }:
+{ stdenv, fetchurl, pkgconfig, gtk2, libhangul }:
 
 stdenv.mkDerivation {
   name = "nabi-1.0.0";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "0craa24pw7b70sh253arv9bg9sy4q3mhsjwfss3bnv5nf0xwnncw";
   };
 
-  buildInputs = [ gtk libhangul pkgconfig ];
+  buildInputs = [ gtk2 libhangul pkgconfig ];
 
   meta = with stdenv.lib; {
     description = "The Easy Hangul XIM";

--- a/pkgs/tools/misc/alarm-clock-applet/default.nix
+++ b/pkgs/tools/misc/alarm-clock-applet/default.nix
@@ -2,7 +2,7 @@
 , glib
 , gtk2
 , gst_all_1
-, gnome
+, gnome2
 , libnotify
 , libxml2
 , libunique
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
     gtk2
     gst_all_1.gstreamer
     gst_plugins
-    gnome.GConf
-    gnome.gnome_icon_theme
+    gnome2.GConf
+    gnome2.gnome_icon_theme
     libnotify
     libxml2
     libunique
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     wrapGAppsHook
   ];
 
-  propagatedUserEnvPkgs = [ gnome.GConf.out ];
+  propagatedUserEnvPkgs = [ gnome2.GConf.out ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/misc/ddccontrol/default.nix
+++ b/pkgs/tools/misc/ddccontrol/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoreconfHook, intltool, perl, perlPackages, libxml2
-, pciutils, pkgconfig, gtk, ddccontrol-db
+, pciutils, pkgconfig, gtk2, ddccontrol-db
 }:
 
 let version = "0.4.2"; in
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook intltool pkgconfig ];
 
   buildInputs = [
-    perl perlPackages.libxml_perl libxml2 pciutils gtk ddccontrol-db
+    perl perlPackages.libxml_perl libxml2 pciutils gtk2 ddccontrol-db
   ];
 
   patches = [ ./automake.patch ];

--- a/pkgs/tools/misc/gnokii/default.nix
+++ b/pkgs/tools/misc/gnokii/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, perl, gettext, libusb, pkgconfig, bluez
-, readline, pcsclite, libical, gtk, glib, libXpm }:
+, readline, pcsclite, libical, gtk2, glib, libXpm }:
 
 stdenv.mkDerivation rec {
   name = "gnokii-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     perl intltool gettext libusb
-    glib gtk pkgconfig bluez readline
+    glib gtk2 pkgconfig bluez readline
     libXpm pcsclite libical
   ];
 

--- a/pkgs/tools/misc/gparted/default.nix
+++ b/pkgs/tools/misc/gparted/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, gettext, makeWrapper
-, parted, gtk, glib, libuuid, pkgconfig, gtkmm, libxml2, hicolor_icon_theme
+, parted, glib, libuuid, pkgconfig, gtkmm2, libxml2, hicolor_icon_theme
 , gpart, hdparm, procps, utillinux
 }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-doc" ];
 
-  buildInputs = [ parted gtk glib libuuid gtkmm libxml2 hicolor_icon_theme ];
+  buildInputs = [ parted glib libuuid gtkmm2 libxml2 hicolor_icon_theme ];
   nativeBuildInputs = [ intltool gettext makeWrapper pkgconfig ];
 
   postInstall = ''

--- a/pkgs/tools/misc/gsmartcontrol/default.nix
+++ b/pkgs/tools/misc/gsmartcontrol/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, smartmontools, gtk, gtkmm, libglademm, pkgconfig, pcre }:
+{ fetchurl, stdenv, smartmontools, gtkmm2, libglademm, pkgconfig, pcre }:
 
 stdenv.mkDerivation rec {
   version="0.8.7";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ipykzqpfvlr84j38hr7q2cag4imrn1gql10slp8bfrs4h1si3vh";
   };
 
-  buildInputs = [ smartmontools gtk gtkmm libglademm pkgconfig pcre ];
+  buildInputs = [ smartmontools gtkmm2 libglademm pkgconfig pcre ];
 
   #installTargets = "install datainstall";
 

--- a/pkgs/tools/networking/connman-notify/default.nix
+++ b/pkgs/tools/networking/connman-notify/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     pythonPackages.python
     pythonPackages.dbus-python
-    pythonPackages.pygobject
+    pythonPackages.pygobject2
     pythonPackages.pygtk
     pythonPackages.notify
   ];

--- a/pkgs/tools/networking/gftp/default.nix
+++ b/pkgs/tools/networking/gftp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, readline, ncurses, gettext, openssl, pkgconfig }:
+{ stdenv, fetchurl, gtk2, readline, ncurses, gettext, openssl, pkgconfig }:
 
 stdenv.mkDerivation {
   name = "gftp-2.0.19";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1z8b26n23k0sjbxgrix646b06cnpndpq7cbcj0ilsvvdx5ms81jk";
   };
 
-  buildInputs = [ gtk readline ncurses gettext openssl pkgconfig ];
+  buildInputs = [ gtk2 readline ncurses gettext openssl pkgconfig ];
 
   meta = { 
     description = "GTK+-based FTP client";

--- a/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
+++ b/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, bison, pkgconfig
-, glib, gtk, libxml2, gettext, zlib, binutils, gnutls }:
+, glib, gtk2, libxml2, gettext, zlib, binutils, gnutls }:
 
 let
   name = "gtk-gnutella";
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ bison binutils gettext pkgconfig ];
-  buildInputs = [ glib gnutls gtk libxml2 zlib ];
+  buildInputs = [ glib gnutls gtk2 libxml2 zlib ];
 
   hardeningDisable = [ "bindnow" "fortify" "pic" "relro" ];
 

--- a/pkgs/tools/networking/wicd/default.nix
+++ b/pkgs/tools/networking/wicd/default.nix
@@ -4,7 +4,7 @@
 , locale ? "C" }:
 
 let
-  inherit (pythonPackages) python pygobject dbus-python pyGtkGlade pycairo;
+  inherit (pythonPackages) python pygobject2 dbus-python pyGtkGlade pycairo;
 in stdenv.mkDerivation rec {
   name = "wicd-${version}";
   version = "1.7.2.4";
@@ -38,15 +38,15 @@ in stdenv.mkDerivation rec {
     substituteInPlace in/scripts=wicd.in --subst-var-by TEMPLATE-DEFAULT $out/share/other/dhclient.conf.template.default
 
     sed -i "2iexport PATH=${stdenv.lib.makeBinPath [ python wpa_supplicant dhcpcd dhcp wirelesstools nettools nettools iputils openresolv iproute ]}\$\{PATH:+:\}\$PATH" in/scripts=wicd.in
-    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pygobject}):$(toPythonPath ${dbus-python})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd.in
+    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pygobject2}):$(toPythonPath ${dbus-python})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd.in
     sed -i "2iexport PATH=${python}/bin\$\{PATH:+:\}\$PATH" in/scripts=wicd-client.in
-    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pyGtkGlade})/gtk-2.0:$(toPythonPath ${pygobject}):$(toPythonPath ${pygobject})/gtk-2.0:$(toPythonPath ${pycairo}):$(toPythonPath ${dbus-python})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd-client.in
+    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pyGtkGlade})/gtk-2.0:$(toPythonPath ${pygobject2}):$(toPythonPath ${pygobject2})/gtk-2.0:$(toPythonPath ${pycairo}):$(toPythonPath ${dbus-python})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd-client.in
     sed -i "2iexport PATH=${python}/bin\$\{PATH:+:\}\$PATH" in/scripts=wicd-gtk.in
-    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pyGtkGlade})/gtk-2.0:$(toPythonPath ${pygobject}):$(toPythonPath ${pygobject})/gtk-2.0:$(toPythonPath ${pycairo}):$(toPythonPath ${dbus-python}):$(toPythonPath ${pythonPackages.notify})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd-gtk.in
+    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pyGtkGlade})/gtk-2.0:$(toPythonPath ${pygobject2}):$(toPythonPath ${pygobject2})/gtk-2.0:$(toPythonPath ${pycairo}):$(toPythonPath ${dbus-python}):$(toPythonPath ${pythonPackages.notify})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd-gtk.in
     sed -i "2iexport PATH=${python}/bin\$\{PATH:+:\}\$PATH" in/scripts=wicd-cli.in
-    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pyGtkGlade})/gtk-2.0:$(toPythonPath ${pygobject}):$(toPythonPath ${pycairo}):$(toPythonPath ${dbus-python})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd-cli.in
+    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pyGtkGlade})/gtk-2.0:$(toPythonPath ${pygobject2}):$(toPythonPath ${pycairo}):$(toPythonPath ${dbus-python})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd-cli.in
     sed -i "2iexport PATH=${python}/bin\$\{PATH:+:\}\$PATH" in/scripts=wicd-curses.in
-    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pyGtkGlade})/gtk-2.0:$(toPythonPath ${pygobject}):$(toPythonPath ${pycairo}):$(toPythonPath ${dbus-python}):$(toPythonPath ${pythonPackages.urwid}):$(toPythonPath ${pythonPackages.curses})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd-curses.in
+    sed -i "3iexport PYTHONPATH=$(toPythonPath $out):$(toPythonPath ${pyGtkGlade})/gtk-2.0:$(toPythonPath ${pygobject2}):$(toPythonPath ${pycairo}):$(toPythonPath ${dbus-python}):$(toPythonPath ${pythonPackages.urwid}):$(toPythonPath ${pythonPackages.curses})\$\{PYTHONPATH:+:\}\$PYTHONPATH" in/scripts=wicd-curses.in
     rm po/ast.po
   '';
 

--- a/pkgs/tools/security/jd-gui/default.nix
+++ b/pkgs/tools/security/jd-gui/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, gtk, atk, gdk_pixbuf, pango, makeWrapper }:
+{ stdenv, fetchurl, gtk2, atk, gdk_pixbuf, pango, makeWrapper }:
 
 let
   dynlibPath = stdenv.lib.makeLibraryPath
-    [ gtk atk gdk_pixbuf pango ];
+    [ gtk2 atk gdk_pixbuf pango ];
 in
 stdenv.mkDerivation rec {
   name    = "jd-gui-${version}";

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -9,7 +9,7 @@
 with stdenv.lib;
 
 let
-  inherit (pythonPackages) python pygtk pygobject pycairo pysqlite;
+  inherit (pythonPackages) python pygtk pygobject2 pycairo pysqlite;
 in stdenv.mkDerivation rec {
   name = "nmap${optionalString graphicalSupport "-graphical"}-${version}";
   version = "7.12";
@@ -26,12 +26,12 @@ in stdenv.mkDerivation rec {
   postInstall = ''
       wrapProgram $out/bin/ndiff --prefix PYTHONPATH : "$(toPythonPath $out)" --prefix PYTHONPATH : "$PYTHONPATH"
   '' + optionalString graphicalSupport ''
-      wrapProgram $out/bin/zenmap --prefix PYTHONPATH : "$(toPythonPath $out)" --prefix PYTHONPATH : "$PYTHONPATH" --prefix PYTHONPATH : $(toPythonPath ${pygtk})/gtk-2.0 --prefix PYTHONPATH : $(toPythonPath ${pygobject})/gtk-2.0 --prefix PYTHONPATH : $(toPythonPath ${pycairo})/gtk-2.0
+      wrapProgram $out/bin/zenmap --prefix PYTHONPATH : "$(toPythonPath $out)" --prefix PYTHONPATH : "$PYTHONPATH" --prefix PYTHONPATH : $(toPythonPath ${pygtk})/gtk-2.0 --prefix PYTHONPATH : $(toPythonPath ${pygobject2})/gtk-2.0 --prefix PYTHONPATH : $(toPythonPath ${pycairo})/gtk-2.0
   '';
 
   buildInputs = [ libpcap pkgconfig openssl makeWrapper python ]
     ++ optionals graphicalSupport [
-      libX11 gtk pygtk pysqlite pygobject pycairo
+      libX11 gtk pygtk pysqlite pygobject2 pycairo
     ];
 
   meta = {

--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, makeDesktopItem
-, libXrender, libX11, libXext, libXt, alsaLib, dbus, dbus_glib, glib, gtk
+, libXrender, libX11, libXext, libXt, alsaLib, dbus, dbus_glib, glib, gtk2
 , atk, pango, freetype, fontconfig, gdk_pixbuf, cairo, zlib
 }:
 
 let
   libPath = stdenv.lib.makeLibraryPath [
-    stdenv.cc.cc zlib glib alsaLib dbus dbus_glib gtk atk pango freetype
+    stdenv.cc.cc zlib glib alsaLib dbus dbus_glib gtk2 atk pango freetype
     fontconfig gdk_pixbuf cairo libXrender libX11 libXext libXt
   ];
 in

--- a/pkgs/tools/system/bootchart/default.nix
+++ b/pkgs/tools/system/bootchart/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, lib, pkgconfig, glib, gtk, python27, pythonPackages }:
+{stdenv, fetchurl, lib, pkgconfig, glib, gtk2, python27, pythonPackages }:
 
 stdenv.mkDerivation rec {
   version = "0.14.7";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1abn4amsyys6vwn7csxsxny94n24ycca3xhqxqcmdc4j0dzn3kmb";
   };
 
-  buildInputs = [ pkgconfig glib gtk python27 pythonPackages.wrapPython pythonPackages.pygtk ];
+  buildInputs = [ pkgconfig glib gtk2 python27 pythonPackages.wrapPython pythonPackages.pygtk ];
   pythonPath = with pythonPackages; [ pygtk pycairo ];
 
   installPhase = ''

--- a/pkgs/tools/system/gdmap/default.nix
+++ b/pkgs/tools/system/gdmap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk, pkgconfig, libxml2, intltool, gettext }:
+{ stdenv, fetchurl, gtk2, pkgconfig, libxml2, intltool, gettext }:
 
 stdenv.mkDerivation rec {
   name = "gdmap-0.8.1";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0nr8l88cg19zj585hczj8v73yh21k7j13xivhlzl8jdk0j0cj052";
   };
 
-  buildInputs = [ gtk pkgconfig libxml2 intltool gettext ];
+  buildInputs = [ gtk2 pkgconfig libxml2 intltool gettext ];
 
   patches = [ ./get_sensitive.patch ./set_flags.patch ];
 

--- a/pkgs/tools/typesetting/xmlroff/default.nix
+++ b/pkgs/tools/typesetting/xmlroff/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libxml2, libxslt, popt, perl
-, glib, pango, pangoxsl, gtk, libtool, autoconf, automake }:
+, glib, pango, pangoxsl, gtk2, libtool, autoconf, automake }:
 
 stdenv.mkDerivation rec {
   name = "xmlroff-${version}";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     glib
     pango
     pangoxsl
-    gtk
+    gtk2
     popt
   ];
 

--- a/pkgs/tools/video/mjpegtools/default.nix
+++ b/pkgs/tools/video/mjpegtools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, gtk, libdv, libjpeg, libpng, libX11, pkgconfig, SDL, SDL_gfx
+{ stdenv, lib, fetchurl, gtk2, libdv, libjpeg, libpng, libX11, pkgconfig, SDL, SDL_gfx
 , withMinimal ? false
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   buildInputs = [ libdv libjpeg libpng pkgconfig ]
-              ++ lib.optional (!withMinimal) [ gtk libX11 SDL SDL_gfx ];
+              ++ lib.optional (!withMinimal) [ gtk2 libX11 SDL SDL_gfx ];
 
   NIX_CFLAGS_COMPILE = lib.optional (!withMinimal) "-I${SDL.dev}/include/SDL";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1939,11 +1939,11 @@ in
   sbsigntool = callPackage ../tools/security/sbsigntool { };
 
   gsmartcontrol = callPackage ../tools/misc/gsmartcontrol {
-    inherit (gnome) libglademm;
+    inherit (gnome2) libglademm;
   };
 
   gssdp = callPackage ../development/libraries/gssdp {
-    inherit (gnome) libsoup;
+    inherit (gnome2) libsoup;
   };
 
   gt5 = callPackage ../tools/system/gt5 { };
@@ -1966,7 +1966,7 @@ in
   gup = callPackage ../development/tools/build-managers/gup {};
 
   gupnp = callPackage ../development/libraries/gupnp {
-    inherit (gnome) libsoup;
+    inherit (gnome2) libsoup;
   };
 
   gupnp_av = callPackage ../development/libraries/gupnp-av {};
@@ -2601,7 +2601,7 @@ in
   mdbtools = callPackage ../tools/misc/mdbtools { };
 
   mdbtools_git = callPackage ../tools/misc/mdbtools/git.nix {
-    inherit (gnome) scrollkeeper;
+    inherit (gnome2) scrollkeeper;
   };
 
   mdk = callPackage ../development/tools/mdk { };
@@ -2788,7 +2788,7 @@ in
 
   networkmanager_openconnect = callPackage ../tools/networking/network-manager/openconnect.nix { };
 
-  networkmanagerapplet = newScope gnome ../tools/networking/network-manager-applet { };
+  networkmanagerapplet = newScope gnome2 ../tools/networking/network-manager-applet { };
 
   newsbeuter = callPackage ../applications/networking/feedreaders/newsbeuter { };
 
@@ -3361,7 +3361,7 @@ in
   reiserfsprogs = callPackage ../tools/filesystems/reiserfsprogs { };
 
   relfs = callPackage ../tools/filesystems/relfs {
-    inherit (gnome) gnome_vfs GConf;
+    inherit (gnome2) gnome_vfs GConf;
   };
 
   remarkjs = callPackage ../development/web/remarkjs { };
@@ -3694,7 +3694,7 @@ in
 
   stricat = callPackage ../tools/security/stricat { };
 
-  staruml = callPackage ../tools/misc/staruml { inherit (gnome) GConf; libgcrypt = libgcrypt_1_5; };
+  staruml = callPackage ../tools/misc/staruml { inherit (gnome2) GConf; libgcrypt = libgcrypt_1_5; };
 
   privoxy = callPackage ../tools/networking/privoxy {
     w3m = w3m-batch;
@@ -3912,7 +3912,7 @@ in
   vifm = callPackage ../applications/misc/vifm { };
 
   viking = callPackage ../applications/misc/viking {
-    inherit (gnome) scrollkeeper;
+    inherit (gnome2) scrollkeeper;
     inherit (gnome3) gexiv2;
   };
 
@@ -4217,9 +4217,9 @@ in
   xflux-gui = callPackage ../tools/misc/xflux/gui.nix {
     pexpect = pythonPackages.pexpect;
     pyGtkGlade = pythonPackages.pyGtkGlade;
-    pygobject = pythonPackages.pygobject;
+    pygobject = pythonPackages.pygobject2;
     pyxdg = pythonPackages.pyxdg;
-    gnome_python = gnome.gnome_python;
+    gnome_python = gnome2.gnome_python;
   };
 
   xfsprogs = callPackage ../tools/filesystems/xfsprogs { };
@@ -4385,7 +4385,7 @@ in
   };
 
   boo = callPackage ../development/compilers/boo {
-    inherit (gnome) gtksourceview;
+    inherit (gnome2) gtksourceview;
   };
 
   colm = callPackage ../development/compilers/colm { };
@@ -4666,8 +4666,8 @@ in
     langC = false;
     profiledCompiler = false;
     inherit zip unzip zlib boehmgc gettext pkgconfig perl;
-    inherit gtk;
-    inherit (gnome) libart_lgpl;
+    gtk = gtk2;
+    inherit (gnome2) libart_lgpl;
   });
 
   gnat = gnat45; # failed to make 4.6 or 4.8 build
@@ -5253,10 +5253,10 @@ in
     lablgl = callPackage ../development/ocaml-modules/lablgl { };
 
     lablgtk_2_14 = callPackage ../development/ocaml-modules/lablgtk/2.14.0.nix {
-      inherit (gnome) libgnomecanvas libglade gtksourceview;
+      inherit (gnome2) libgnomecanvas libglade gtksourceview;
     };
     lablgtk = callPackage ../development/ocaml-modules/lablgtk {
-      inherit (gnome) libgnomecanvas libglade gtksourceview;
+      inherit (gnome2) libgnomecanvas libglade gtksourceview;
     };
 
     lablgtk-extras =
@@ -5622,7 +5622,7 @@ in
   };
 
   thrust = callPackage ../development/tools/thrust {
-    gconf = pkgs.gnome.GConf;
+    gconf = pkgs.gnome2.GConf;
   };
 
   tinycc = callPackage ../development/compilers/tinycc { };
@@ -6102,8 +6102,8 @@ in
   guileCairo = callPackage ../development/guile-modules/guile-cairo { };
 
   guileGnome = callPackage ../development/guile-modules/guile-gnome {
-    gconf = gnome.GConf;
-    inherit (gnome) gnome_vfs libglade libgnome libgnomecanvas libgnomeui;
+    gconf = gnome2.GConf;
+    inherit (gnome2) gnome_vfs libglade libgnome libgnomecanvas libgnomeui;
   };
 
   guile_lib = callPackage ../development/guile-modules/guile-lib { };
@@ -6291,7 +6291,7 @@ in
 
   checkstyle = callPackage ../development/tools/analysis/checkstyle { };
 
-  chromedriver = callPackage ../development/tools/selenium/chromedriver { gconf = gnome.GConf; };
+  chromedriver = callPackage ../development/tools/selenium/chromedriver { gconf = gnome2.GConf; };
 
   chrpath = callPackage ../development/tools/misc/chrpath { };
 
@@ -6618,15 +6618,15 @@ in
   node_webkit = node_webkit_0_9;
 
   nwjs_0_12 = callPackage ../development/tools/node-webkit/nw12.nix {
-    gconf = pkgs.gnome.GConf;
+    gconf = pkgs.gnome2.GConf;
   };
 
   node_webkit_0_11 = callPackage ../development/tools/node-webkit/nw11.nix {
-    gconf = pkgs.gnome.GConf;
+    gconf = pkgs.gnome2.GConf;
   };
 
   node_webkit_0_9 = callPackage ../development/tools/node-webkit/nw9.nix {
-    gconf = pkgs.gnome.GConf;
+    gconf = pkgs.gnome2.GConf;
   };
 
   noweb = callPackage ../development/tools/literate-programming/noweb { };
@@ -6683,7 +6683,7 @@ in
   };
 
   radare = callPackage ../development/tools/analysis/radare {
-    inherit (gnome) vte;
+    inherit (gnome2) vte;
     lua = lua5;
     useX11 = config.radare.useX11 or false;
     pythonBindings = config.radare.pythonBindings or false;
@@ -6691,7 +6691,7 @@ in
     luaBindings = config.radare.luaBindings or false;
   };
   radare2 = callPackage ../development/tools/analysis/radare2 {
-    inherit (gnome) vte;
+    inherit (gnome2) vte;
     lua = lua5;
     useX11 = config.radare.useX11 or false;
     pythonBindings = config.radare.pythonBindings or false;
@@ -7048,7 +7048,7 @@ in
   classpath = callPackage ../development/libraries/java/classpath {
     javac = gcj;
     jvm = gcj;
-    gconf = gnome.GConf;
+    gconf = gnome2.GConf;
   };
 
   clearsilver = callPackage ../development/libraries/clearsilver { };
@@ -7230,7 +7230,7 @@ in
   faad2 = callPackage ../development/libraries/faad2 { };
 
   factor-lang = callPackage ../development/compilers/factor-lang {
-    inherit (pkgs.gnome) gtkglext;
+    inherit (pkgs.gnome2) gtkglext;
   };
 
   farbfeld = callPackage ../development/libraries/farbfeld { };
@@ -7359,7 +7359,7 @@ in
   gcab = callPackage ../development/libraries/gcab { };
 
   gdome2 = callPackage ../development/libraries/gdome2 {
-    inherit (gnome) gtkdoc;
+    inherit (gnome2) gtkdoc;
   };
 
   gdbm = callPackage ../development/libraries/gdbm { };
@@ -7374,7 +7374,9 @@ in
     inherit (darwin.apple_sdk.frameworks) OpenGL;
   };
 
-  gegl_0_3 = callPackage ../development/libraries/gegl/3.0.nix { };
+  gegl_0_3 = callPackage ../development/libraries/gegl/3.0.nix {
+    gtk = self.gtk2;
+  };
 
   geoclue = callPackage ../development/libraries/geoclue {};
 
@@ -7558,7 +7560,7 @@ in
   gnonlin = callPackage ../development/libraries/gstreamer/legacy/gnonlin {};
 
   gusb = callPackage ../development/libraries/gusb {
-    inherit (gnome) gtkdoc;
+    inherit (gnome2) gtkdoc;
   };
 
   qt-mobility = callPackage ../development/libraries/qt-mobility {};
@@ -7657,32 +7659,28 @@ in
 
   gtk3 = callPackage ../development/libraries/gtk+/3.x.nix { };
 
-  gtk = pkgs.gtk2;
-
-  gtkmm = callPackage ../development/libraries/gtkmm/2.x.nix { };
+  gtkmm2 = callPackage ../development/libraries/gtkmm/2.x.nix { };
   gtkmm3 = callPackage ../development/libraries/gtkmm/3.x.nix { };
 
   gtkmozembedsharp = callPackage ../development/libraries/gtkmozembed-sharp {
-    gtksharp = gtk-sharp;
+    gtksharp = gtk-sharp-2_0;
   };
 
   gtk-sharp-2_0 = callPackage ../development/libraries/gtk-sharp/2.0.nix {
-    inherit (gnome) libglade libgtkhtml gtkhtml
+    inherit (gnome2) libglade libgtkhtml gtkhtml
               libgnomecanvas libgnomeui libgnomeprint
               libgnomeprintui GConf;
   };
 
   gtk-sharp-3_0 = callPackage ../development/libraries/gtk-sharp/3.0.nix {
-    inherit (gnome) libglade libgtkhtml gtkhtml
+    inherit (gnome2) libglade libgtkhtml gtkhtml
               libgnomecanvas libgnomeui libgnomeprint
               libgnomeprintui GConf;
   };
 
-  gtk-sharp = gtk-sharp-2_0;
-
   gtk-sharp-beans = callPackage ../development/libraries/gtk-sharp-beans { };
 
-  gtkspell = callPackage ../development/libraries/gtkspell { };
+  gtkspell2 = callPackage ../development/libraries/gtkspell { };
 
   gtkspell3 = callPackage ../development/libraries/gtkspell/3.nix { };
 
@@ -7690,7 +7688,9 @@ in
 
   gts = callPackage ../development/libraries/gts { };
 
-  gvfs = callPackage ../development/libraries/gvfs { gconf = gnome.GConf; };
+  gvfs = callPackage ../development/libraries/gvfs {
+    gnome = self.gnome2;
+  };
 
   gwenhywfar = callPackage ../development/libraries/aqbanking/gwenhywfar.nix { };
 
@@ -7939,11 +7939,14 @@ in
 
   libcaca = callPackage ../development/libraries/libcaca { };
 
-  libcanberra = callPackage ../development/libraries/libcanberra { };
-  libcanberra_gtk3 = libcanberra.override { gtk = gtk3; };
+  libcanberra_gtk3 = callPackage ../development/libraries/libcanberra {
+    gtk = pkgs.gtk3; 
+  };
+  libcanberra_gtk2 = pkgs.libcanberra_gtk3.override { gtk = pkgs.gtk2; };
+
   libcanberra_kde = if (config.kde_runtime.libcanberraWithoutGTK or true)
-    then libcanberra.override { gtk = null; }
-    else libcanberra;
+    then pkgs.libcanberra_gtk2.override { gtk = null; }
+    else pkgs.libcanberra_gtk2;
 
   libcec = callPackage ../development/libraries/libcec { };
   libcec_platform = callPackage ../development/libraries/libcec/platform.nix { };
@@ -7960,7 +7963,7 @@ in
   libcdr = callPackage ../development/libraries/libcdr { lcms = lcms2; };
 
   libchamplain = callPackage ../development/libraries/libchamplain {
-    inherit (gnome) libsoup;
+    inherit (gnome2) libsoup;
   };
 
   libchardet = callPackage ../development/libraries/libchardet { };
@@ -8342,7 +8345,7 @@ in
   libiec61883 = callPackage ../development/libraries/libiec61883 { };
 
   libinfinity = callPackage ../development/libraries/libinfinity {
-    inherit (gnome) gtkdoc;
+    inherit (gnome2) gtkdoc;
   };
 
   libinput = callPackage ../development/libraries/libinput {
@@ -8636,7 +8639,7 @@ in
   libunibreak = callPackage ../development/libraries/libunibreak { };
 
   libunique = callPackage ../development/libraries/libunique/default.nix { };
-  libunique3 = callPackage ../development/libraries/libunique/3.x.nix { inherit (gnome) gtkdoc; };
+  libunique3 = callPackage ../development/libraries/libunique/3.x.nix { inherit (gnome2) gtkdoc; };
 
   liburcu = callPackage ../development/libraries/liburcu { };
 
@@ -9822,18 +9825,18 @@ in
   wxGTK = wxGTK28;
 
   wxGTK28 = callPackage ../development/libraries/wxGTK-2.8 {
-    inherit (gnome) GConf;
+    inherit (gnome2) GConf;
     withMesa = lib.elem system lib.platforms.mesaPlatforms;
   };
 
   wxGTK29 = callPackage ../development/libraries/wxGTK-2.9/default.nix {
-    inherit (gnome) GConf;
+    inherit (gnome2) GConf;
     inherit (darwin.stubs) setfile;
     withMesa = lib.elem system lib.platforms.mesaPlatforms;
   };
 
   wxGTK30 = callPackage ../development/libraries/wxGTK-3.0/default.nix {
-    inherit (gnome) GConf;
+    inherit (gnome2) GConf;
     inherit (darwin.stubs) setfile;
     withMesa = lib.elem system lib.platforms.mesaPlatforms;
   };
@@ -10048,7 +10051,7 @@ in
   smack = callPackage ../development/libraries/java/smack { };
 
   swt = callPackage ../development/libraries/java/swt {
-    inherit (gnome) libsoup;
+    inherit (gnome2) libsoup;
   };
 
 
@@ -10170,11 +10173,9 @@ in
 
   pyexiv2 = pythonPackages.pyexiv2;
 
-  pygobject = pythonPackages.pygobject;
-
-  pygobject3 = pythonPackages.pygobject3;
-
-  pygtk = pythonPackages.pygtk;
+  inherit (self.pythonPackages)
+    pygtk
+    pygobject2 pygobject3;
 
   pygtksourceview = pythonPackages.pygtksourceview;
 
@@ -10750,7 +10751,7 @@ in
 
   storm = callPackage ../servers/computing/storm { };
 
-  slurm-llnl = callPackage ../servers/computing/slurm { gtk = null; };
+  slurm-llnl = callPackage ../servers/computing/slurm { gtk2 = null; };
 
   slurm-llnl-full = appendToName "full" (callPackage ../servers/computing/slurm { });
 
@@ -11401,7 +11402,7 @@ in
 
     virtualbox = callPackage ../applications/virtualization/virtualbox {
       stdenv = stdenv_32bit;
-      inherit (gnome) libIDL;
+      inherit (gnome2) libIDL;
       enableExtensionPack = config.virtualbox.enableExtensionPack or false;
       pulseSupport = config.pulseaudio or false;
     };
@@ -11588,7 +11589,7 @@ in
   numad = callPackage ../os-specific/linux/numad { };
 
   open-vm-tools = callPackage ../applications/virtualization/open-vm-tools {
-    inherit (gnome) gtk gtkmm;
+    inherit (gnome2) gtk gtkmm;
   };
 
   go-bindata = callPackage ../development/tools/go-bindata { };
@@ -11734,7 +11735,7 @@ in
   sysfsutils = callPackage ../os-specific/linux/sysfsutils { };
 
   sysprof = callPackage ../development/tools/profiling/sysprof {
-    inherit (gnome) libglade;
+    inherit (gnome2) libglade;
   };
 
   # Provided with sysfsutils.
@@ -12242,7 +12243,9 @@ in
 
   inherit (callPackages ../data/fonts/tai-languages { }) tai-ahom;
 
-  tango-icon-theme = callPackage ../data/icons/tango-icon-theme { };
+  tango-icon-theme = callPackage ../data/icons/tango-icon-theme {
+    gtk = self.gtk2;
+  };
 
   themes = name: callPackage (../data/misc/themes + ("/" + name + ".nix")) {};
 
@@ -12324,7 +12327,7 @@ in
   };
 
   abiword = callPackage ../applications/office/abiword {
-    inherit (gnome) libglade libgnomecanvas;
+    inherit (gnome2) libglade libgnomecanvas;
     iconTheme = gnome3.defaultIconTheme;
   };
 
@@ -12384,12 +12387,12 @@ in
   ardour = ardour4;
 
   ardour3 =  callPackage ../applications/audio/ardour/ardour3.nix {
-    inherit (gnome) libgnomecanvas libgnomecanvasmm;
+    inherit (gnome2) libgnomecanvas libgnomecanvasmm;
     inherit (vamp) vampSDK;
   };
 
   ardour4 =  callPackage ../applications/audio/ardour {
-    inherit (gnome) libgnomecanvas libgnomecanvasmm;
+    inherit (gnome2) libgnomecanvas libgnomecanvasmm;
     inherit (vamp) vampSDK;
   };
 
@@ -12400,7 +12403,7 @@ in
   artha = callPackage ../applications/misc/artha { };
 
   atomEnv = callPackage ../applications/editors/atom/env.nix {
-    gconf = gnome.GConf;
+    gconf = gnome2.GConf;
   };
 
   atom = callPackage ../applications/editors/atom { };
@@ -12496,7 +12499,7 @@ in
   bazaarTools = callPackage ../applications/version-management/bazaar/tools.nix { };
 
   beast = callPackage ../applications/audio/beast {
-    inherit (gnome) libgnomecanvas libart_lgpl;
+    inherit (gnome2) libgnomecanvas libart_lgpl;
     guile = guile_1_8;
   };
 
@@ -12551,7 +12554,7 @@ in
   bviplus = callPackage ../applications/editors/bviplus { };
 
   calf = callPackage ../applications/audio/calf {
-      inherit (gnome) libglade;
+      inherit (gnome2) libglade;
   };
 
   calcurse = callPackage ../applications/misc/calcurse { };
@@ -12655,7 +12658,7 @@ in
   CompBus = callPackage ../applications/audio/CompBus { };
 
   compiz = callPackage ../applications/window-managers/compiz {
-    inherit (gnome) GConf ORBit2 metacity;
+    inherit (gnome2) GConf ORBit2 metacity;
   };
 
   constant-detune-chorus = callPackage ../applications/audio/constant-detune-chorus { };
@@ -12663,7 +12666,7 @@ in
   copyq = callPackage ../applications/misc/copyq { };
 
   coriander = callPackage ../applications/video/coriander {
-    inherit (gnome) libgnomeui GConf;
+    inherit (gnome2) libgnomeui GConf;
   };
 
   cortex = callPackage ../applications/misc/cortex { };
@@ -12733,7 +12736,7 @@ in
   });
 
   darktable = callPackage ../applications/graphics/darktable {
-    inherit (gnome) GConf libglade;
+    inherit (gnome2) GConf libglade;
     pugixml = pugixml.override { shared = true; };
   };
 
@@ -12758,7 +12761,7 @@ in
   dfilemanager = qt5.callPackage ../applications/misc/dfilemanager { };
 
   dia = callPackage ../applications/graphics/dia {
-    inherit (pkgs.gnome) libart_lgpl libgnomeui;
+    inherit (pkgs.gnome2) libart_lgpl libgnomeui;
   };
 
   diffuse = callPackage ../applications/version-management/diffuse { };
@@ -13091,7 +13094,7 @@ in
   eterm = callPackage ../applications/misc/eterm { };
 
   etherape = callPackage ../applications/networking/sniffers/etherape {
-    inherit (gnome) gnomedocutils libgnome libglade libgnomeui scrollkeeper;
+    inherit (gnome2) gnomedocutils libgnome libglade libgnomeui scrollkeeper;
   };
 
   evilvte = callPackage ../applications/misc/evilvte {
@@ -13188,7 +13191,7 @@ in
   grepm = callPackage ../applications/search/grepm { };
 
   grip = callPackage ../applications/misc/grip {
-    inherit (gnome) libgnome libgnomeui vte;
+    inherit (gnome2) libgnome libgnomeui vte;
   };
 
   gsimplecal = callPackage ../applications/misc/gsimplecal { };
@@ -13234,7 +13237,7 @@ in
   filezilla = callPackage ../applications/networking/ftp/filezilla { };
 
   inherit (callPackages ../applications/networking/browsers/firefox {
-    inherit (gnome) libIDL;
+    inherit (gnome2) libIDL;
     inherit (pythonPackages) pysqlite;
     libpng = libpng_apng;
     enableGTK3 = false;
@@ -13244,8 +13247,8 @@ in
   firefox-esr = wrapFirefox firefox-esr-unwrapped { };
 
   firefox-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
-    gconf = pkgs.gnome.GConf;
-    inherit (pkgs.gnome) libgnome libgnomeui;
+    gconf = pkgs.gnome2.GConf;
+    inherit (pkgs.gnome2) libgnome libgnomeui;
     inherit (pkgs.gnome3) defaultIconTheme;
   };
 
@@ -13258,8 +13261,8 @@ in
 
   firefox-beta-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
     generated = import ../applications/networking/browsers/firefox-bin/beta_sources.nix;
-    gconf = pkgs.gnome.GConf;
-    inherit (pkgs.gnome) libgnome libgnomeui;
+    gconf = pkgs.gnome2.GConf;
+    inherit (pkgs.gnome2) libgnome libgnomeui;
     inherit (pkgs.gnome3) defaultIconTheme;
   };
 
@@ -13287,7 +13290,7 @@ in
   fluxbox = callPackage ../applications/window-managers/fluxbox { };
 
   fme = callPackage ../applications/misc/fme {
-    inherit (gnome) libglademm;
+    inherit (gnome2) libglademm;
   };
 
   fomp = callPackage ../applications/audio/fomp { };
@@ -13327,7 +13330,7 @@ in
   get_iplayer = callPackage ../applications/misc/get_iplayer {};
 
   gimp_2_8 = callPackage ../applications/graphics/gimp/2.8.nix {
-    inherit (gnome) libart_lgpl;
+    inherit (gnome2) libart_lgpl;
     webkit = null;
     lcms = lcms2;
     wrapPython = pythonPackages.wrapPython;
@@ -13432,12 +13435,12 @@ in
   gmu = callPackage ../applications/audio/gmu { };
 
   gnash = callPackage ../applications/video/gnash {
-    inherit (gnome) gtkglext;
+    inherit (gnome2) gtkglext;
     xulrunner = firefox-unwrapped;
   };
 
   gnome_mplayer = callPackage ../applications/video/gnome-mplayer {
-    inherit (gnome) GConf;
+    inherit (gnome2) GConf;
   };
 
   gnumeric = callPackage ../applications/office/gnumeric { };
@@ -13449,7 +13452,7 @@ in
   gocr = callPackage ../applications/graphics/gocr { };
 
   gobby5 = callPackage ../applications/editors/gobby {
-    inherit (gnome) gtksourceview;
+    inherit (gnome2) gtksourceview;
   };
 
   gphoto2 = callPackage ../applications/misc/gphoto2 { };
@@ -13463,7 +13466,7 @@ in
 
   gtkpod = callPackage ../applications/audio/gtkpod {
     gnome = gnome3;
-    inherit (gnome) libglade;
+    inherit (gnome2) libglade;
   };
 
   jbidwatcher = callPackage ../applications/misc/jbidwatcher {
@@ -13473,7 +13476,7 @@ in
   qrencode = callPackage ../tools/graphics/qrencode { };
 
   gecko_mediaplayer = callPackage ../applications/networking/browsers/mozilla-plugins/gecko-mediaplayer {
-    inherit (gnome) GConf;
+    inherit (gnome2) GConf;
     browser = firefox-unwrapped;
   };
 
@@ -13486,14 +13489,14 @@ in
   gmpc = callPackage ../applications/audio/gmpc {};
 
   gmtk = callPackage ../applications/networking/browsers/mozilla-plugins/gmtk {
-    inherit (gnome) GConf;
+    inherit (gnome2) GConf;
   };
 
   gnome-mpv = callPackage ../applications/video/gnome-mpv { };
 
   gollum = callPackage ../applications/misc/gollum { };
 
-  google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome.GConf; };
+  google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
 
   google-chrome-beta = google-chrome.override { channel = "beta"; };
 
@@ -13522,8 +13525,8 @@ in
   };
 
   guake = callPackage ../applications/misc/guake {
-    gconf = gnome.GConf;
-    vte = gnome.vte.override { pythonSupport = true; };
+    gconf = gnome2.GConf;
+    vte = gnome2.vte.override { pythonSupport = true; };
   };
 
   guitone = callPackage ../applications/version-management/guitone {
@@ -13544,7 +13547,7 @@ in
   hakuneko = callPackage ../tools/misc/hakuneko { };
 
   hamster-time-tracker = callPackage ../applications/misc/hamster-time-tracker {
-    inherit (gnome) gnome_python;
+    inherit (gnome2) gnome_python;
   };
 
   hello = callPackage ../applications/misc/hello { };
@@ -13579,7 +13582,7 @@ in
 
   hydrogen = callPackage ../applications/audio/hydrogen { };
 
-  hyperterm = callPackage ../applications/misc/hyperterm { inherit (gnome) GConf; };
+  hyperterm = callPackage ../applications/misc/hyperterm { inherit (gnome2) GConf; };
 
   slack = callPackage ../applications/networking/instant-messengers/slack { };
 
@@ -13782,7 +13785,7 @@ in
   kile = kde5.callPackage ../applications/editors/kile/frameworks.nix { };
 
   kino = callPackage ../applications/video/kino {
-    inherit (gnome) libglade;
+    inherit (gnome2) libglade;
     ffmpeg = ffmpeg_2;
   };
 
@@ -13838,7 +13841,7 @@ in
   lci = callPackage ../applications/science/logic/lci {};
 
   ldcpp = callPackage ../applications/networking/p2p/ldcpp {
-    inherit (gnome) libglade;
+    inherit (gnome2) libglade;
   };
 
   lemonbar = callPackage ../applications/window-managers/lemonbar { };
@@ -13856,7 +13859,7 @@ in
 
   libreoffice-fresh = lowPrio (callPackage ../applications/office/libreoffice {
     inherit (perlPackages) ArchiveZip CompressZlib;
-    inherit (gnome) GConf ORBit2 gnome_vfs;
+    inherit (gnome2) GConf ORBit2 gnome_vfs;
     inherit (gnome3) gsettings_desktop_schemas defaultIconTheme;
     zip = zip.override { enableNLS = false; };
     bluez5 = bluez5_28;
@@ -13874,7 +13877,7 @@ in
 
   libreoffice-still = lowPrio (callPackage ../applications/office/libreoffice/still.nix {
     inherit (perlPackages) ArchiveZip CompressZlib;
-    inherit (gnome) GConf ORBit2 gnome_vfs;
+    inherit (gnome2) GConf ORBit2 gnome_vfs;
     inherit (gnome3) gsettings_desktop_schemas defaultIconTheme;
     zip = zip.override { enableNLS = false; };
     #glm = glm_0954;
@@ -13898,7 +13901,7 @@ in
   };
 
   lingot = callPackage ../applications/audio/lingot {
-    inherit (gnome) libglade;
+    inherit (gnome2) libglade;
   };
 
   linuxband = callPackage ../applications/audio/linuxband { };
@@ -13949,7 +13952,7 @@ in
   };
 
   lilyterm = callPackage ../applications/misc/lilyterm {
-    inherit (gnome) vte;
+    inherit (gnome2) vte;
     gtk = gtk2;
   };
 
@@ -14055,7 +14058,7 @@ in
 
   monotoneViz = callPackage ../applications/version-management/monotone-viz {
     inherit (ocamlPackages_4_01_0) lablgtk ocaml camlp4;
-    inherit (gnome) libgnomecanvas glib;
+    inherit (gnome2) libgnomecanvas glib;
   };
 
   moonlight-embedded = callPackage ../applications/misc/moonlight-embedded { };
@@ -14149,7 +14152,7 @@ in
   multimon-ng = callPackage ../applications/misc/multimon-ng { };
 
   multisync = callPackage ../applications/misc/multisync {
-    inherit (gnome) ORBit2 libbonobo libgnomeui GConf;
+    inherit (gnome2) ORBit2 libbonobo libgnomeui GConf;
   };
 
   inherit (callPackages ../applications/networking/mumble {
@@ -14305,7 +14308,7 @@ in
   nvpy = callPackage ../applications/editors/nvpy { };
 
   obconf = callPackage ../tools/X11/obconf {
-    inherit (gnome) libglade;
+    inherit (gnome2) libglade;
   };
 
   obs-studio = qt5.callPackage ../applications/video/obs-studio {
@@ -14368,7 +14371,7 @@ in
   panotools = callPackage ../applications/graphics/panotools { };
 
   paprefs = callPackage ../applications/audio/paprefs {
-    inherit (gnome) libglademm gconfmm GConf;
+    inherit (gnome2) libglademm gconfmm GConf;
   };
 
   pavucontrol = callPackage ../applications/audio/pavucontrol { };
@@ -14391,7 +14394,7 @@ in
   perseus = callPackage ../applications/science/math/perseus {};
 
   petrifoo = callPackage ../applications/audio/petrifoo {
-    inherit (gnome) libgnomecanvas;
+    inherit (gnome2) libgnomecanvas;
   };
 
   pdftk = callPackage ../tools/typesetting/pdftk { };
@@ -14470,7 +14473,7 @@ in
   };
 
   pinta = callPackage ../applications/graphics/pinta {
-    gtksharp = gtk-sharp;
+    gtksharp = gtk-sharp-2_0;
   };
 
   plugin-torture = callPackage ../applications/audio/plugin-torture { };
@@ -14719,7 +14722,7 @@ in
   scite = callPackage ../applications/editors/scite { };
 
   scribus = callPackage ../applications/office/scribus {
-    inherit (gnome) libart_lgpl;
+    inherit (gnome2) libart_lgpl;
   };
 
   seafile-client = callPackage ../applications/networking/seafile-client { };
@@ -14884,7 +14887,7 @@ in
   };
 
   spotify = callPackage ../applications/audio/spotify {
-    inherit (gnome) GConf;
+    inherit (gnome2) GConf;
     libgcrypt = libgcrypt_1_5;
     libpng = libpng12;
   };
@@ -14979,7 +14982,7 @@ in
   tailor = callPackage ../applications/version-management/tailor {};
 
   tangogps = callPackage ../applications/misc/tangogps {
-    gconf = gnome.GConf;
+    gconf = gnome2.GConf;
   };
 
   teamspeak_client = qt55.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
@@ -15020,7 +15023,7 @@ in
   terminal-notifier = callPackage ../applications/misc/terminal-notifier {};
 
   terminator = callPackage ../applications/misc/terminator {
-    vte = gnome.vte.override { pythonSupport = true; };
+    vte = gnome2.vte.override { pythonSupport = true; };
     inherit (pythonPackages) notify;
   };
 
@@ -15035,14 +15038,14 @@ in
   thinkingRock = callPackage ../applications/misc/thinking-rock { };
 
   thunderbird = callPackage ../applications/networking/mailreaders/thunderbird {
-    inherit (gnome) libIDL;
+    inherit (gnome2) libIDL;
     inherit (pythonPackages) pysqlite;
     libpng = libpng_apng;
   };
 
   thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin {
-    gconf = pkgs.gnome.GConf;
-    inherit (pkgs.gnome) libgnome libgnomeui;
+    gconf = pkgs.gnome2.GConf;
+    inherit (pkgs.gnome2) libgnome libgnomeui;
   };
 
   tig = gitAndTools.tig;
@@ -15214,7 +15217,7 @@ in
   };
 
   virtmanager = callPackage ../applications/virtualization/virt-manager {
-    inherit (gnome) gnome_python;
+    inherit (gnome2) gnome_python;
     vte = gnome3.vte;
     dconf = gnome3.dconf;
     gtkvnc = gtkvnc.override { enableGTK3 = true; };
@@ -15350,7 +15353,7 @@ in
   wordnet = callPackage ../applications/misc/wordnet { };
 
   workrave = callPackage ../applications/misc/workrave {
-    inherit (gnome) GConf gconfmm;
+    inherit (gnome2) GConf gconfmm;
     inherit (python27Packages) cheetah;
   };
 
@@ -15413,7 +15416,7 @@ in
   wxhexeditor = callPackage ../applications/editors/wxhexeditor { };
 
   wxcam = callPackage ../applications/video/wxcam {
-    inherit (gnome) libglade;
+    inherit (gnome2) libglade;
     wxGTK = wxGTK28;
     gtk = gtk2;
   };
@@ -15513,7 +15516,7 @@ in
   xneur = xneur_0_13;
 
   gxneur = callPackage ../applications/misc/gxneur  {
-    inherit (gnome) libglade GConf;
+    inherit (gnome2) libglade GConf;
   };
 
   xiphos = callPackage ../applications/misc/xiphos {
@@ -15524,7 +15527,7 @@ in
   };
 
   xournal = callPackage ../applications/graphics/xournal {
-    inherit (gnome) libgnomeprint libgnomeprintui libgnomecanvas;
+    inherit (gnome2) libgnomeprint libgnomeprintui libgnomecanvas;
   };
 
   apvlv = callPackage ../applications/misc/apvlv { };
@@ -15577,7 +15580,7 @@ in
   xsd = callPackage ../development/libraries/xsd { };
 
   xscreensaver = callPackage ../misc/screensavers/xscreensaver {
-    inherit (gnome) libglade;
+    inherit (gnome2) libglade;
   };
 
   xss-lock = callPackage ../misc/screensavers/xss-lock { };
@@ -15609,7 +15612,7 @@ in
   xnee = callPackage ../tools/X11/xnee { };
 
   xvidcap = callPackage ../applications/video/xvidcap {
-    inherit (gnome) scrollkeeper libglade;
+    inherit (gnome2) scrollkeeper libglade;
   };
 
   xzgv = callPackage ../applications/graphics/xzgv { };
@@ -16274,23 +16277,25 @@ in
     callPackage = newScope pkgs.enlightenment;
   });
 
-  gnome2 = callPackage ../desktops/gnome-2 {
+  gnome2 = recurseIntoAttrs (callPackage ../desktops/gnome-2 {
     callPackage = pkgs.newScope pkgs.gnome2;
     self = pkgs.gnome2;
   } // {
     inherit (pkgs)
       # GTK Libs
-      glib glibmm atk atkmm cairo pango pangomm gdk_pixbuf gtk gtkmm
+      glib glibmm atk atkmm cairo pango pangomm gdk_pixbuf gtkmm2
 
       # Included for backwards compatibility
       libsoup libwnck gtk_doc gnome_doc_utils;
-  };
+
+    gtk = self.gtk2;
+    gtkmm = self.gtkmm2;
+    libcanberra = self.libcanberra_gtk2;
+  });
 
   gnome3_20 = recurseIntoAttrs (callPackage ../desktops/gnome-3/3.20 { });
 
   gnome3 = gnome3_20;
-
-  gnome = recurseIntoAttrs gnome2;
 
   hsetroot = callPackage ../tools/X11/hsetroot { };
 
@@ -16562,7 +16567,7 @@ in
   ### SCIENCE/GEOMETRY
 
   drgeo = callPackage ../applications/science/geometry/drgeo {
-    inherit (gnome) libglade;
+    inherit (gnome2) libglade;
     guile = guile_1_8;
   };
 
@@ -17000,7 +17005,7 @@ in
   pcalc = callPackage ../applications/science/math/pcalc { };
 
   pspp = callPackage ../applications/science/math/pssp {
-    inherit (gnome) libglade gtksourceview;
+    inherit (gnome2) libglade gtksourceview;
   };
 
   singular = callPackage ../applications/science/math/singular {};
@@ -17037,7 +17042,7 @@ in
 
   celestia = callPackage ../applications/science/astronomy/celestia {
     lua = lua5_1;
-    inherit (pkgs.gnome) gtkglext;
+    inherit (pkgs.gnome2) gtkglext;
   };
 
   cytoscape = callPackage ../applications/science/misc/cytoscape { };
@@ -17142,7 +17147,7 @@ in
 
   darling-dmg = callPackage ../tools/filesystems/darling-dmg { };
 
-  desmume = callPackage ../misc/emulators/desmume { inherit (pkgs.gnome) gtkglext libglade; };
+  desmume = callPackage ../misc/emulators/desmume { inherit (pkgs.gnome2) gtkglext libglade; };
 
   dbacl = callPackage ../tools/misc/dbacl { };
 
@@ -17162,7 +17167,7 @@ in
 
   dpkg = callPackage ../tools/package-management/dpkg { };
 
-  ekiga = newScope pkgs.gnome ../applications/networking/instant-messengers/ekiga { };
+  ekiga = newScope pkgs.gnome2 ../applications/networking/instant-messengers/ekiga { };
 
   emulationstation = callPackage ../misc/emulators/emulationstation { };
 
@@ -17273,7 +17278,7 @@ in
   martyr = callPackage ../development/libraries/martyr { };
 
   mess = callPackage ../misc/emulators/mess {
-    inherit (pkgs.gnome) GConf;
+    inherit (pkgs.gnome2) GConf;
   };
 
   moltengamepad = callPackage ../misc/drivers/moltengamepad { };
@@ -17347,7 +17352,7 @@ in
 
   mnemonicode = callPackage ../misc/mnemonicode { };
 
-  mysqlWorkbench = newScope gnome ../applications/misc/mysql-workbench {
+  mysqlWorkbench = newScope gnome2 ../applications/misc/mysql-workbench {
     lua = lua5_1;
     libctemplate = libctemplate_2_2;
   };
@@ -17686,7 +17691,7 @@ in
   snes9x-gtk = callPackage ../misc/emulators/snes9x-gtk { };
 
   higan = callPackage ../misc/emulators/higan {
-    inherit (gnome) gtksourceview;
+    inherit (gnome2) gtksourceview;
   };
 
   misc = callPackage ../misc/misc.nix { };

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -580,7 +580,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
       sha256 = "1hnn0a2qsjcjprsxas424bzvhsdwy0yc2jj5xbp698c0m9kfk24y";
     };
 
-    buildInputs = [ pkgs.gtk-sharp ];
+    buildInputs = [ pkgs.gtk-sharp-2_0 ];
 
     meta = {
       description = "A generic framework for creating extensible applications";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -7,7 +7,7 @@
 
 { fetchurl, fetchzip, stdenv, lua, callPackage, unzip, zziplib, pkgconfig, libtool
 , pcre, oniguruma, gnulib, tre, glibc, sqlite, openssl, expat, cairo
-, perl, gtk, python, glib, gobjectIntrospection, libevent, zlib, autoreconfHook
+, perl, gtk2, python, glib, gobjectIntrospection, libevent, zlib, autoreconfHook
 , fetchFromGitHub, libmpack
 }:
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -232,8 +232,7 @@ in modules // {
 
   pygame-git = callPackage ../development/python-modules/pygame/git.nix { };
 
-  pygobject = callPackage ../development/python-modules/pygobject { };
-
+  pygobject2 = callPackage ../development/python-modules/pygobject { };
   pygobject3 = callPackage ../development/python-modules/pygobject/3.nix { };
 
   pygtk = callPackage ../development/python-modules/pygtk { libglade = null; };
@@ -241,7 +240,7 @@ in modules // {
   pygtksourceview = callPackage ../development/python-modules/pygtksourceview { };
 
   pyGtkGlade = self.pygtk.override {
-    libglade = pkgs.gnome.libglade;
+    libglade = pkgs.gnome2.libglade;
   };
 
   pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix {
@@ -14821,7 +14820,7 @@ in modules // {
         configure
     '';
 
-    buildInputs = with self; [ python pkgs.pkgconfig pkgs.libnotify pygobject pygtk pkgs.glib pkgs.gtk pkgs.dbus_glib ];
+    buildInputs = with self; [ python pkgs.pkgconfig pkgs.libnotify pygobject2 pygtk pkgs.glib pkgs.gtk2 pkgs.dbus_glib ];
 
     postInstall = "cd $out/lib/python*/site-packages && ln -s gtk-*/pynotify .";
 
@@ -22802,7 +22801,7 @@ in modules // {
     # error: invalid command 'test'
     doCheck = false;
 
-    propagatedBuildInputs = with self; [ pkgs.xorg.libX11 dbus-python pygobject ];
+    propagatedBuildInputs = with self; [ pkgs.xorg.libX11 dbus-python pygobject2 ];
 
     meta = {
       description = "High-level, platform independent Skype API wrapper for Python";


### PR DESCRIPTION
###### Motivation for this change

GTK3 is the recommended version of GTK library right now and GTK2 is in maintenance-mode. Usually an alias points to the latest version of a package, though there are some notable exceptions in the tree, such as GTK, Python and several others. This proposal is in the spirit of current work of moving to Python 3 by default (#18185).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is work in progress; many packages are still in the need of change. It would be good to have some feedback on whether we want this before moving further, also any help with fixing all references is much appreciated.
