### PR TITLE
gocd-agent: 16.7.0-3819 -> 16.9.0-4001

### DIFF
--- a/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
+++ b/pkgs/development/tools/continuous-integration/gocd-agent/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "gocd-agent-${version}-${rev}";
-  version = "16.7.0";
-  rev = "3819";
+  version = "16.9.0";
+  rev = "4001";
 
   src = fetchurl {
     url = "https://download.go.cd/binaries/${version}-${rev}/generic/go-agent-${version}-${rev}.zip";
-    sha256 = "24cc47099d2e9cc1d3983e1ab65957316770f791632e572189b1e6c0183403b7";
+    sha256 = "1xcwwjf2khhng6v1y7dvi579y2j643al9n0x80m0c46qb9mzd04x";
   };
   meta = with stdenv.lib; {
     description = "A continuous delivery server specializing in advanced workflow modeling and visualization";


### PR DESCRIPTION
###### Motivation for this change

Update to latest release of gocd-agent.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
