### PR TITLE
Add seven font families from Impallari Type

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -86,6 +86,7 @@
   cko = "Christine Koppelt <christine.koppelt@gmail.com>";
   cleverca22 = "Michael Bishop <cleverca22@gmail.com>";
   cmcdragonkai = "Roger Qiu <roger.qiu@matrix.ai>";
+  cmfwyp = "cmfwyp <cmfwyp@riseup.net>";
   coconnor = "Corey O'Connor <coreyoconnor@gmail.com>";
   codsl = "codsl <codsl@riseup.net>";
   codyopel = "Cody Opel <codyopel@gmail.com>";

--- a/pkgs/data/fonts/cabin/default.nix
+++ b/pkgs/data/fonts/cabin/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "cabin-1.005";
+
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Cabin";
+    rev = "982839c790e9dc57c343972aa34c51ed3b3677fd";
+    sha256 = "16v7spviphvdh2rrr8klv11lc9hxphg12ddf0qs7xdx801ri0ppn";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v "fonts/OTF/"*.otf $out/share/fonts/opentype/
+    cp -v README.md FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A humanist sans with 4 weights and true italics";
+    longDescription = ''
+      The Cabin font family is a humanist sans with 4 weights and true italics,
+      inspired by Edward Johnston’s and Eric Gill’s typefaces, with a touch of
+      modernism. Cabin incorporates modern proportions, optical adjustments, and
+      some elements of the geometric sans. It remains true to its roots, but has
+      its own personality.
+
+      The weight distribution is almost monotone, although top and bottom curves
+      are slightly thin. Counters of the b, g, p and q are rounded and optically
+      adjusted. The curved stem endings have a 10 degree angle. E and F have
+      shorter center arms. M is splashed.
+    '';
+    homepage = http://www.impallari.com/cabin;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ cmfwyp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/dosis/default.nix
+++ b/pkgs/data/fonts/dosis/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "dosis-1.007";
+
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Dosis";
+    rev = "12df1e13e58768f20e0d48ff15651b703f9dd9dc";
+    sha256 = "0glniyg07z5gx5gsa1ymarg2gsncjyf94wi6j9bf68v5s2w3v7md";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v "fonts/OTF v1.007 Fontlab/"*.otf $out/share/fonts/opentype/
+    cp -v README.md FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A very simple, rounded, sans serif family";
+    longDescription = ''
+      Dosis is a very simple, rounded, sans serif family.
+
+      The lighter weights are minimalist. The bolder weights have more
+      personality. The medium weight is nice and balanced. The overall result is
+      a family that's clean and modern, and can express a wide range of
+      voices & feelings.
+
+      It comes in 7 incremental weights: ExtraLight, Light, Book, Medium,
+      Semibold, Bold & ExtraBold
+    '';
+    homepage = http://www.impallari.com/dosis;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ cmfwyp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/encode-sans/default.nix
+++ b/pkgs/data/fonts/encode-sans/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "encode-sans-1.002";
+
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Encode-Sans";
+    rev = "11162b46892d20f55bd42a00b48cbf06b5871f75";
+    sha256 = "1v5k79qlsl6nggilmjw56axwwr2b3838x6vqch4lh0dck5ri9w2c";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/doc/${name}
+    cp -v *.ttf $out/share/fonts/truetype/
+    cp -v README.md FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A versatile sans serif font family";
+    longDescription = ''
+      The Encode Sans family is a versatile workhorse. Featuring a huge range of
+      weights and widths, it's ready for all kind of typographic challenges. It
+      also includes Tabular and Old Style figures, as well as full set of Small
+      Caps and other Open Type features.
+
+      Designed by Pablo Impallari and Andres Torresi.
+    '';
+    homepage = http://www.impallari.com/projects/overview/encode;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ cmfwyp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/libre-baskerville/default.nix
+++ b/pkgs/data/fonts/libre-baskerville/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "libre-baskerville-1.000";
+
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Libre-Baskerville";
+    rev = "2fba7c8e0a8f53f86efd3d81bc4c63674b0c613f";
+    sha256 = "0i9ra6ip81zzjxl71p8zwa6ymlmkf4yi5ny22vlwx9a53kbf4ifl";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/doc/${name}
+    cp -v *.ttf $out/share/fonts/truetype/
+    cp -v README.md FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A webfont family optimized for body text";
+    longDescription = ''
+      Libre Baskerville is a webfont family optimized for body text. It's Based
+      on 1941 ATF Baskerville Specimens but it has a taller x-height, wider
+      counters and less contrast that allow it to work on small sizes in any
+      screen.
+    '';
+    homepage = http://www.impallari.com/projects/overview/libre-baskerville;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ cmfwyp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/libre-bodoni/default.nix
+++ b/pkgs/data/fonts/libre-bodoni/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "libre-bodoni-2.000";
+
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Libre-Bodoni";
+    rev = "995a40e8d6b95411d660cbc5bb3f726ffd080c7d";
+    sha256 = "1ncfkvmcxh2lphfra43h8482qglpd965v96agvz092697xwrbyn9";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v "fonts/v2000 - initial glyphs migration/OTF/"*.otf $out/share/fonts/opentype/
+    cp -v README.md FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bodoni fonts adapted for today's web requirements";
+    longDescription = ''
+      The Libre Bodoni fonts are based on the 19th century Morris Fuller
+      Benton's ATF design, but specifically adapted for today's web
+      requirements.
+
+      They are a perfect choice for everything related to elegance, style,
+      luxury and fashion.
+
+      Libre Bodoni currently features four styles: Regular, Italic, Bold and
+      Bold Italic.
+    '';
+    homepage = https://github.com/impallari/Libre-Bodoni;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ cmfwyp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/libre-caslon/default.nix
+++ b/pkgs/data/fonts/libre-caslon/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "libre-caslon-${version}";
+  version = "1.002";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "impallari";
+      repo = "Libre-Caslon-Text";
+      rev = "c31e21f7e8cf91f18d90f778ce20e66c68219c74";
+      name = "libre-caslon-text-${version}-src";
+      sha256 = "0zczv9qm8cgc7w1p64mnf0p0fi7xv89zhf1zzf1qcna15kbgc705";
+    })
+
+    (fetchFromGitHub {
+      owner = "impallari";
+      repo = "Libre-Caslon-Display";
+      rev = "3491f6a9cfde2bc15e736463b0bc7d93054d5da1";
+      name = "libre-caslon-display-${version}-src";
+      sha256 = "12jrny3y8w8z61lyw470drnhliji5b24lgxap4w3brp6z3xjph95";
+    })
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v "libre-caslon-text-${version}-src/fonts/OTF/"*.otf $out/share/fonts/opentype/
+    cp -v "libre-caslon-display-${version}-src/fonts/OTF/"*.otf $out/share/fonts/opentype/
+    cp -v libre-caslon-text-${version}-src/README.md libre-caslon-text-${version}-src/FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Caslon fonts based on hand-lettered American Caslons of 1960s";
+    homepage = http://www.impallari.com/librecaslon;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ cmfwyp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/libre-franklin/default.nix
+++ b/pkgs/data/fonts/libre-franklin/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "libre-franklin-1.014";
+
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Libre-Franklin";
+    rev = "006293f34c47bd752fdcf91807510bc3f91a0bd3";
+    sha256 = "0df41cqhw5dz3g641n4nd2jlqjf5m4fkv067afk3759m4hg4l78r";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    cp -v "fonts/OTF/"*.otf $out/share/fonts/opentype/
+    cp -v README.md FONTLOG.txt $out/share/doc/${name}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A reinterpretation and expansion based on the 1912 Morris Fuller Benton’s classic.";
+    homepage = https://github.com/impallari/Libre-Franklin;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ cmfwyp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12087,6 +12087,8 @@ in
 
   libre-baskerville = callPackage ../data/fonts/libre-baskerville { };
 
+  libre-bodoni = callPackage ../data/fonts/libre-bodoni { };
+
   lmmath = callPackage ../data/fonts/lmodern/lmmath.nix {};
 
   lmodern = callPackage ../data/fonts/lmodern { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12003,6 +12003,8 @@ in
 
   cabin = callPackage ../data/fonts/cabin { };
 
+  dosis = callPackage ../data/fonts/dosis { };
+
   dosemu_fonts = callPackage ../data/fonts/dosemu-fonts { };
 
   eb-garamond = callPackage ../data/fonts/eb-garamond { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12089,6 +12089,8 @@ in
 
   libre-bodoni = callPackage ../data/fonts/libre-bodoni { };
 
+  libre-caslon = callPackage ../data/fonts/libre-caslon { };
+
   lmmath = callPackage ../data/fonts/lmodern/lmmath.nix {};
 
   lmodern = callPackage ../data/fonts/lmodern { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12085,6 +12085,8 @@ in
 
   libertine = callPackage ../data/fonts/libertine { };
 
+  libre-baskerville = callPackage ../data/fonts/libre-baskerville { };
+
   lmmath = callPackage ../data/fonts/lmodern/lmmath.nix {};
 
   lmodern = callPackage ../data/fonts/lmodern { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12001,6 +12001,8 @@ in
 
   docbook5_xsl = self.docbook_xsl_ns;
 
+  cabin = callPackage ../data/fonts/cabin { };
+
   dosemu_fonts = callPackage ../data/fonts/dosemu-fonts { };
 
   eb-garamond = callPackage ../data/fonts/eb-garamond { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12018,6 +12018,8 @@ in
     inherit (pythonPackages) scfbuild;
   };
 
+  encode-sans = callPackage ../data/fonts/encode-sans { };
+
   fantasque-sans-mono = callPackage ../data/fonts/fantasque-sans-mono {};
 
   fira = callPackage ../data/fonts/fira { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12091,6 +12091,8 @@ in
 
   libre-caslon = callPackage ../data/fonts/libre-caslon { };
 
+  libre-franklin = callPackage ../data/fonts/libre-franklin { };
+
   lmmath = callPackage ../data/fonts/lmodern/lmmath.nix {};
 
   lmodern = callPackage ../data/fonts/lmodern { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
