### PR TITLE
ntl: init at 9.11.0

### DIFF
--- a/pkgs/development/libraries/ntl/default.nix
+++ b/pkgs/development/libraries/ntl/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, perl, gmp, libtool
+}:
+
+stdenv.mkDerivation rec {
+  name = "ntl-${version}";
+  version = "9.11.0";
+  src = fetchurl {
+    url = "http://www.shoup.net/ntl/ntl-${version}.tar.gz";
+    sha256 = "1wcwxpcby1c50llncz131334qq26lzh3dz21rahymgvakrq0369p";
+  };
+
+  buildInputs = [ perl gmp libtool ];
+
+  sourceRoot = "${name}/src";
+
+  enableParallelBuilding = true;
+
+  dontAddPrefix = true;
+
+  configureFlags = [ "DEF_PREFIX=$(out)" "WIZARD=off" "SHARED=on" "NATIVE=off" "CXX=c++" ];
+
+  # doCheck = true; # takes some time
+
+  meta = {
+    description = "A Library for doing Number Theory";
+    longDescription = ''
+      NTL is a high-performance, portable C++ library providing data
+      structures and algorithms for manipulating signed, arbitrary
+      length integers, and for vectors, matrices, and polynomials over
+      the integers and over finite fields.
+    '';
+    homepage = http://www.shoup.net/ntl/;
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8950,6 +8950,8 @@ in
 
   non = callPackage ../applications/audio/non { };
 
+  ntl = callPackage ../development/libraries/ntl { };
+
   nspr = callPackage ../development/libraries/nspr {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change

Provides `libntl.so` from NTL (http://www.shoup.net/ntl/).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
