### PR TITLE
hhvm: 3.12.1 -> 3.15.0

### DIFF
--- a/pkgs/development/compilers/hhvm/default.nix
+++ b/pkgs/development/compilers/hhvm/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   name    = "hhvm-${version}";
-  version = "3.14.5";
+  version = "3.15.0";
 
   # use git version since we need submodules
   src = fetchgit {
     url    = "https://github.com/facebook/hhvm.git";
-    rev    = "f516f1bb9046218f89885a220354c19dda6d8f4d";
-    sha256 = "0sv856ran15rvnrj4dk0a5jirip5w4336a0aycv9wh77wm4s8xdb";
+    rev    = "92a682ebaa3c85b84857852d8621f528607fe27d";
+    sha256 = "0mn3bfvhdf6b4lflyjfjyr7nppkq505xkaaagk111fqy91rdzd3b";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Package claimed to be updated to 3.14.5, but git rev was still pointing to 3.12.1
Instead of updating to the correct 3.12.1 rev, I updated package to latest 3.15.0
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
