### PR TITLE
asunder: init at 2.8

### DIFF
--- a/pkgs/applications/audio/asunder/default.nix
+++ b/pkgs/applications/audio/asunder/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchurl, makeWrapper, gtk, libcddb, intltool, pkgconfig, cdparanoia
+, mp3Support ? false, lame
+, oggSupport ? true, vorbis-tools
+, flacSupport ? true, flac
+, opusSupport ? false, opusTools
+, wavpackSupport ? false, wavpack
+#, musepackSupport ? false, TODO: mpcenc
+, monkeysAudioSupport ? false, monkeysAudio
+#, aacSupport ? false, TODO: neroAacEnc
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  version = "2.8";
+  name = "asunder-${version}";
+  src = fetchurl {
+    url = "http://littlesvr.ca/asunder/releases/${name}.tar.bz2";
+    sha256 = "1nq9kd4rd4k2kibf57gdbm0zw2gxa234vvvdhxkm8g5bhx5h3iyq";
+  };
+
+  buildInputs = [ gtk libcddb intltool pkgconfig makeWrapper ];
+
+  runtimeDeps =
+    optional mp3Support lame ++
+    optional oggSupport vorbis-tools ++
+    optional flacSupport flac ++
+    optional opusSupport opusTools ++
+    optional wavpackSupport wavpack ++
+    optional monkeysAudioSupport monkeysAudio ++
+    [ cdparanoia ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/asunder" \
+      --prefix PATH : "${makeBinPath runtimeDeps}"
+  '';
+
+  meta = {
+    description = "A graphical Audio CD ripper and encoder for Linux";
+    homepage = http://littlesvr.ca/asunder/index.php;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ mudri ];
+    platforms = platforms.linux;
+
+    longDescription = ''
+      Asunder is a graphical Audio CD ripper and encoder for Linux. You can use
+      it to save tracks from an Audio CD as any of WAV, MP3, OGG, FLAC, Opus,
+      WavPack, Musepack, AAC, and Monkey's Audio files.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -925,6 +925,8 @@ in
 
   asciidoctor = callPackage ../tools/typesetting/asciidoctor { };
 
+  asunder = callPackage ../applications/audio/asunder { };
+
   autossh = callPackage ../tools/networking/autossh { };
 
   asynk = callPackage ../tools/networking/asynk { };


### PR DESCRIPTION
###### Motivation for this change

Add the asunder package for CD ripping.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I can't find the packages required for Musepack and AAC support, so they don't work. Other formats can be ripped to, though I have only actually tested FLAC. The defaults are chosen to be what I imagine to be unobjectionable, but I'm happy to have the defaults changed.
