### PR TITLE
mandb: fix apropos

### DIFF
--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -15,6 +15,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ libpipeline db groff ];
   troff="${groff}/bin/groff";
 
+  postPatch = ''
+    substituteInPlace src/man_db.conf.in \
+      --replace "/usr/local/share" "/run/current-system/sw/share" \
+      --replace "/usr/share" "/run/current-system/sw/share"
+  '';
+
   configureFlags = [
     "--disable-setuid"
     "--localstatedir=/var"


### PR DESCRIPTION
###### Motivation for this change

apropos was broken.
###### Instructions

For building the system's database, _su -l root -c mandb_.
For a per-user db, write a _~/.manpath_ with something like this:

```
MANPATH_MAP /home/luser0/.nix-profile/bin   /home/luser0/.nix-profile/share/man
MANPATH_MAP /home/luser0/.nix-profile/sbin  /home/luser0/.nix-profile/share/man
MANDB_MAP   /home/luser0/.nix-profile/share/man /home/luser0/var/cache/man

```

And execute _mkdir -p /home/luser0/var/cache/man & mandb -u_.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
