### PR TITLE
glibc: enable stackprotection hardening

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation ({
       "--enable-add-ons"
       "--enable-obsolete-rpc"
       "--sysconfdir=/etc"
-      "libc_cv_ssp=no"
+      "--enable-stackguard-randomization"
       (if linuxHeaders != null
        then "--with-headers=${linuxHeaders}/include"
        else "--without-headers")

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -33,6 +33,9 @@ in
       makeFlagsArray+=("bindir=$bin/bin" "sbindir=$bin/sbin" "rootsbindir=$bin/sbin")
     '';
 
+    # The stackprotector and fortify hardening flags are autodetected by glibc
+    # and enabled by default if supported. Setting it for every gcc invocation
+    # does not work.
     hardeningDisable = [ "stackprotector" "fortify" ];
 
     # When building glibc from bootstrap-tools, we need libgcc_s at RPATH for


### PR DESCRIPTION
Enables previously manually disabled stackprotector (https://github.com/NixOS/nixpkgs/pull/1) and stackguard randomization.

From https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=511811:

> If glibc is built with the --enable-stackguard-randomization option, each application gets a random canary value (at runtime) from /dev/urandom. If --enable-stackguard-randomization is absent, applications get a static canary value of "0xff0a0000". This is very unfortunate, because the attacker may be able to bypass the stack protection mechanism, by placing those 4 bytes in the canary word, before the actual canary check is performed (for example in memcpy-based buffer overflows).

@domenkozar Provided it doesn't break any builds, can we maybe get it into 16.09? We missed this in #12895 and we feel it's important. Unfortunately a full rebuild is required. :disappointed:

cc @vcunat  
