### PR TITLE
audio services: use mkEnableOption

### DIFF
--- a/nixos/modules/services/audio/mopidy.nix
+++ b/nixos/modules/services/audio/mopidy.nix
@@ -21,13 +21,7 @@ in {
 
     services.mopidy = {
 
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Whether to enable Mopidy, a music player daemon.
-        '';
-      };
+      enable = mkEnableOption "Mopidy, a music player daemon";
 
       dataDir = mkOption {
         default = "/var/lib/mopidy";

--- a/nixos/modules/services/audio/ympd.nix
+++ b/nixos/modules/services/audio/ympd.nix
@@ -12,11 +12,7 @@ in {
 
     services.ympd = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable ympd, the MPD Web GUI.";
-      };
+      enable = mkEnableOption "ympd, the MPD Web GUI";
 
       webPort = mkOption {
         type = types.string;


### PR DESCRIPTION
###### Motivation for this change

Many, many services use the following snippet:

``` nix
      enable = mkOption {
        default = false;
        type = types.bool;
        description = ''
          Whether to enable Mopidy, a music player daemon.
        '';
      };
```

That's why `mkEnableOption` was created! 

``` nix
  mkEnableOption = name: mkOption {
    default = false;
    example = true;
    description = "Whether to enable ${name}.";
    type = lib.types.bool;
  };
```

KISS, DRY, etc. I wrote the following (unreadable) script:

``` bash
#!/usr/bin/env nix-shell
#! nix-shell -i bash -p ag

cd "$1"

for file in $(IFS=\n ag -l "enable = mkOption"); do
  perl -0777 -p -i -e 's/(.+?)enable\s+=\s+mkOption\s+\{.+?to enable (.+?)\..+?};/\1enable = mkEnableOption "\2";/igs' "$file"
done
```

which I propose we use on everything in `nixos/modules`. I wanted to create this small PR first to discuss the possible implications of that massive change before actually implementing it. 

We'd definitely need to be cautious about only using this function on services that are disabled by default. 

What do y'all think? 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
