### PR TITLE
Use mkEnableOption throughout Nixos where appropriate

### DIFF
--- a/nixos/modules/config/krb5.nix
+++ b/nixos/modules/config/krb5.nix
@@ -15,10 +15,7 @@ in
 
     krb5 = {
 
-      enable = mkOption {
-        default = false;
-        description = "Whether to enable Kerberos V.";
-      };
+      enable = mkEnableOption "Kerberos V";
 
       defaultRealm = mkOption {
         default = "ATENA.MIT.EDU";

--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -83,13 +83,7 @@ in {
   options = {
 
     hardware.pulseaudio = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the PulseAudio sound server.
-        '';
-      };
+      enable = mkEnableOption "the PulseAudio sound server";
 
       systemWide = mkOption {
         type = types.bool;

--- a/nixos/modules/programs/blcr.nix
+++ b/nixos/modules/programs/blcr.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 
 let
-  inherit (lib) mkOption mkIf;
+  inherit (lib) mkEnableOption mkIf;
   cfg = config.environment.blcr;
   blcrPkg = config.boot.kernelPackages.blcr;
 in
@@ -10,11 +10,7 @@ in
   ###### interface
 
   options = {
-    environment.blcr.enable = mkOption {
-      default = false;
-      description =
-        "Whether to enable support for the BLCR checkpointing tool.";
-    };
+    environment.blcr.enable = mkEnableOption "support for the BLCR checkpointing tool";
   };
 
   ###### implementation

--- a/nixos/modules/security/apparmor.nix
+++ b/nixos/modules/security/apparmor.nix
@@ -1,18 +1,14 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkIf mkOption types concatMapStrings;
+  inherit (lib) mkEnableOption mkIf mkOption types concatMapStrings;
   cfg = config.security.apparmor;
 in
 
 {
    options = {
      security.apparmor = {
-       enable = mkOption {
-         type = types.bool;
-         default = false;
-         description = "Enable the AppArmor Mandatory Access Control system.";
-       };
+       enable = mkEnableOption "the AppArmor Mandatory Access Control system";
        profiles = mkOption {
          type = types.listOf types.path;
          default = [];

--- a/nixos/modules/security/oath.nix
+++ b/nixos/modules/security/oath.nix
@@ -8,13 +8,7 @@ with lib;
   options = {
 
     security.pam.oath = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable the OATH (one-time password) PAM module.
-        '';
-      };
+      enable = mkEnableOption "the OATH (one-time password) PAM module";
 
       digits = mkOption {
         type = types.enum [ 6 7 8 ];

--- a/nixos/modules/security/pam_mount.nix
+++ b/nixos/modules/security/pam_mount.nix
@@ -12,13 +12,7 @@ in
   options = {
 
     security.pam.mount = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable PAM mount system to mount fileystems on user login.
-        '';
-      };
+      enable = mkEnableOption "PAM mount system to mount fileystems on user login";
 
       extraVolumes = mkOption {
         type = types.listOf types.str;

--- a/nixos/modules/services/amqp/activemq/default.nix
+++ b/nixos/modules/services/amqp/activemq/default.nix
@@ -24,13 +24,7 @@ in {
 
   options = {
     services.activemq = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable the Apache ActiveMQ message broker service.
-        '';
-      };
+      enable = mkEnableOption "the Apache ActiveMQ message broker service";
       configurationDir = mkOption {
         default = "${activemq}/conf";
         description = ''

--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -32,13 +32,7 @@ in {
 
     services.mpd = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable MPD, the music player daemon.
-        '';
-      };
+      enable = mkEnableOption "MPD, the music player daemon";
 
       musicDirectory = mkOption {
         type = types.path;

--- a/nixos/modules/services/backup/bacula.nix
+++ b/nixos/modules/services/backup/bacula.nix
@@ -165,13 +165,7 @@ let
 in {
   options = {
     services.bacula-fd = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the Bacula File Daemon.
-        '';
-      };
+      enable = mkEnableOption "the Bacula File Daemon";
  
       name = mkOption {
         default = "${config.networking.hostName}-fd";
@@ -225,13 +219,7 @@ in {
     };
 
     services.bacula-sd = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable Bacula Storage Daemon.
-        '';
-      };
+      enable = mkEnableOption "Bacula Storage Daemon";
  
       name = mkOption {
         default = "${config.networking.hostName}-sd";
@@ -290,13 +278,7 @@ in {
     };
 
     services.bacula-dir = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable Bacula Director Daemon.
-        '';
-      };
+      enable = mkEnableOption "Bacula Director Daemon";
 
       name = mkOption {
         default = "${config.networking.hostName}-dir";

--- a/nixos/modules/services/backup/mysql-backup.nix
+++ b/nixos/modules/services/backup/mysql-backup.nix
@@ -19,12 +19,7 @@ in
 
     services.mysqlBackup = {
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable MySQL backups.
-        '';
-      };
+      enable = mkEnableOption "MySQL backups";
 
       period = mkOption {
         default = "15 01 * * *";

--- a/nixos/modules/services/backup/postgresql-backup.nix
+++ b/nixos/modules/services/backup/postgresql-backup.nix
@@ -20,12 +20,7 @@ in
 
     services.postgresqlBackup = {
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable PostgreSQL dumps.
-        '';
-      };
+      enable = mkEnableOption "PostgreSQL dumps";
 
       period = mkOption {
         default = "15 01 * * *";

--- a/nixos/modules/services/cluster/fleet.nix
+++ b/nixos/modules/services/cluster/fleet.nix
@@ -9,13 +9,7 @@ in {
 
   ##### Interface
   options.services.fleet = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable fleet service.
-      '';
-    };
+    enable = mkEnableOption "fleet service";
 
     listen = mkOption {
       type = types.listOf types.str;

--- a/nixos/modules/services/cluster/panamax.nix
+++ b/nixos/modules/services/cluster/panamax.nix
@@ -12,13 +12,7 @@ in {
 
   ##### Interface
   options.services.panamax = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable Panamax service.
-      '';
-    };
+    enable = mkEnableOption "Panamax service";
 
     UIPort = mkOption {
       type = types.int;

--- a/nixos/modules/services/continuous-integration/jenkins/default.nix
+++ b/nixos/modules/services/continuous-integration/jenkins/default.nix
@@ -5,13 +5,7 @@ let
 in {
   options = {
     services.jenkins = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the jenkins continuous integration server.
-        '';
-      };
+      enable = mkEnableOption "the jenkins continuous integration server";
 
       user = mkOption {
         default = "jenkins";

--- a/nixos/modules/services/databases/4store-endpoint.nix
+++ b/nixos/modules/services/databases/4store-endpoint.nix
@@ -13,10 +13,7 @@ with lib;
 
     services.fourStoreEndpoint = {
 
-      enable = mkOption {
-        default = false;
-        description = "Whether to enable 4Store SPARQL endpoint.";
-      };
+      enable = mkEnableOption "4Store SPARQL endpoint";
 
       database = mkOption {
         default = config.services.fourStore.database;

--- a/nixos/modules/services/databases/4store.nix
+++ b/nixos/modules/services/databases/4store.nix
@@ -14,10 +14,7 @@ with lib;
 
     services.fourStore = {
 
-      enable = mkOption {
-        default = false;
-        description = "Whether to enable 4Store RDF database server.";
-      };
+      enable = mkEnableOption "4Store RDF database server";
 
       database = mkOption {
         default = "";

--- a/nixos/modules/services/databases/firebird.nix
+++ b/nixos/modules/services/databases/firebird.nix
@@ -40,12 +40,7 @@ in
 
     services.firebird = {
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable the Firebird super server.
-        '';
-      };
+      enable = mkEnableOption "the Firebird super server";
 
       package = mkOption {
         default = pkgs.firebirdSuper;

--- a/nixos/modules/services/databases/memcached.nix
+++ b/nixos/modules/services/databases/memcached.nix
@@ -18,12 +18,7 @@ in
 
     services.memcached = {
 
-      enable = mkOption {
-        default = false;
-        description = "
-          Whether to enable Memcached.
-        ";
-      };
+      enable = mkEnableOption "Memcached";
 
       user = mkOption {
         default = "memcached";

--- a/nixos/modules/services/databases/monetdb.nix
+++ b/nixos/modules/services/databases/monetdb.nix
@@ -12,11 +12,7 @@ with lib;
 
     services.monetdb = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable MonetDB database server.";
-      };
+      enable = mkEnableOption "MonetDB database server";
 
       package = mkOption {
         type = types.path;

--- a/nixos/modules/services/databases/mongodb.nix
+++ b/nixos/modules/services/databases/mongodb.nix
@@ -32,12 +32,7 @@ in
 
     services.mongodb = {
 
-      enable = mkOption {
-        default = false;
-        description = "
-          Whether to enable the MongoDB server.
-        ";
-      };
+      enable = mkEnableOption "the MongoDB server";
 
       package = mkOption {
         default = pkgs.mongodb;

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -42,12 +42,7 @@ in
 
     services.mysql = {
 
-      enable = mkOption {
-        default = false;
-        description = "
-          Whether to enable the MySQL server.
-        ";
-      };
+      enable = mkEnableOption "the MySQL server";
 
       package = mkOption {
         type = types.package;

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -40,11 +40,7 @@ in {
   ###### interface
 
   options.services.neo4j = {
-    enable = mkOption {
-      description = "Whether to enable neo4j.";
-      default = false;
-      type = types.bool;
-    };
+    enable = mkEnableOption "neo4j";
 
     package = mkOption {
       description = "Neo4j package to use.";

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -19,14 +19,7 @@ in
 
     services.openldap = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "
-          Whether to enable the ldap server.
-        ";
-        example = true;
-      };
+      enable = mkEnableOption "the ldap server";
 
       user = mkOption {
         type = types.string;

--- a/nixos/modules/services/databases/virtuoso.nix
+++ b/nixos/modules/services/databases/virtuoso.nix
@@ -13,10 +13,7 @@ with lib;
 
     services.virtuoso = {
 
-      enable = mkOption {
-        default = false;
-        description = "Whether to enable Virtuoso Opensource database server.";
-      };
+      enable = mkEnableOption "Virtuoso Opensource database server";
 
       config = mkOption {
         default = "";

--- a/nixos/modules/services/desktops/gnome3/seahorse.nix
+++ b/nixos/modules/services/desktops/gnome3/seahorse.nix
@@ -15,13 +15,7 @@ in
 
     services.gnome3.seahorse = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable Seahorse search provider for the GNOME Shell activity search.
-        '';
-      };
+      enable = mkEnableOption "Seahorse search provider for the GNOME Shell activity search";
 
     };
 

--- a/nixos/modules/services/desktops/gnome3/sushi.nix
+++ b/nixos/modules/services/desktops/gnome3/sushi.nix
@@ -15,13 +15,7 @@ in
 
     services.gnome3.sushi = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable Sushi, a quick previewer for nautilus.
-        '';
-      };
+      enable = mkEnableOption "Sushi, a quick previewer for nautilus";
 
     };
 

--- a/nixos/modules/services/desktops/profile-sync-daemon.nix
+++ b/nixos/modules/services/desktops/profile-sync-daemon.nix
@@ -21,13 +21,7 @@ let
 in {
 
   options.services.psd = with types; {
-    enable = mkOption {
-      type = bool;
-      default = false;
-      description = ''
-        Whether to enable the Profile Sync daemon.
-      '';
-    };
+    enable = mkEnableOption "the Profile Sync daemon";
 
     users = mkOption {
       type = listOf str;

--- a/nixos/modules/services/games/ghost-one.nix
+++ b/nixos/modules/services/games/ghost-one.nix
@@ -14,10 +14,7 @@ in
   options = {
     services.ghostOne = {
 
-      enable = mkOption {
-        default = false;
-        description = "Enable Ghost-One Warcraft3 game hosting server.";
-      };
+      enable = mkEnableOption "Ghost-One Warcraft3 game hosting server";
 
       language = mkOption {
         default = "English";

--- a/nixos/modules/services/hardware/acpid.nix
+++ b/nixos/modules/services/hardware/acpid.nix
@@ -47,11 +47,7 @@ in
 
     services.acpid = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the ACPI daemon.";
-      };
+      enable = mkEnableOption "the ACPI daemon";
 
       handlers = mkOption {
         type = types.attrsOf (types.submodule {

--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -45,11 +45,7 @@ in
 
   options = {
 
-    hardware.bluetooth.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to enable support for Bluetooth.";
-    };
+    hardware.bluetooth.enable = mkEnableOption "support for Bluetooth";
 
   };
 

--- a/nixos/modules/services/hardware/brltty.nix
+++ b/nixos/modules/services/hardware/brltty.nix
@@ -9,11 +9,7 @@ in {
 
   options = {
 
-    services.brltty.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to enable the BRLTTY daemon.";
-    };
+    services.brltty.enable = mkEnableOption "the BRLTTY daemon";
 
   };
 

--- a/nixos/modules/services/hardware/thermald.nix
+++ b/nixos/modules/services/hardware/thermald.nix
@@ -8,12 +8,7 @@ in {
   ###### interface
   options = { 
     services.thermald = { 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable thermald, the temperature management daemon.
-        ''; 
-      };  
+      enable = mkEnableOption "thermald, the temperature management daemon";  
     };  
   };  
 

--- a/nixos/modules/services/hardware/thinkfan.nix
+++ b/nixos/modules/services/hardware/thinkfan.nix
@@ -52,12 +52,7 @@ in {
 
     services.thinkfan = {
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable thinkfan, fan controller for ibm/lenovo thinkpads.
-        '';
-      };
+      enable = mkEnableOption "thinkfan, fan controller for ibm/lenovo thinkpads";
 
       sensor = mkOption {
         default = "/proc/acpi/ibm/thermal";

--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -33,11 +33,7 @@ in
 
     services.tlp = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the TLP daemon.";
-      };
+      enable = mkEnableOption "the TLP daemon";
 
       extraConfig = mkOption {
         type = types.str;

--- a/nixos/modules/services/logging/fluentd.nix
+++ b/nixos/modules/services/logging/fluentd.nix
@@ -10,11 +10,7 @@ in {
   options = {
 
     services.fluentd = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable fluentd.";
-      };
+      enable = mkEnableOption "fluentd";
 
       config = mkOption {
         type = types.lines;

--- a/nixos/modules/services/logging/logcheck.nix
+++ b/nixos/modules/services/logging/logcheck.nix
@@ -105,13 +105,7 @@ in
 {
   options = {
     services.logcheck = {
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Enable the logcheck cron job.
-        '';
-      };
+      enable = mkEnableOption "the logcheck cron job";
 
       user = mkOption {
         default = "logcheck";

--- a/nixos/modules/services/logging/logstash.nix
+++ b/nixos/modules/services/logging/logstash.nix
@@ -24,11 +24,7 @@ in
 
     services.logstash = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable logstash.";
-      };
+      enable = mkEnableOption "logstash";
 
       package = mkOption {
         type = types.package;

--- a/nixos/modules/services/logging/syslog-ng.nix
+++ b/nixos/modules/services/logging/syslog-ng.nix
@@ -29,13 +29,7 @@ in {
   options = {
 
     services.syslog-ng = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the syslog-ng daemon.
-        '';
-      };
+      enable = mkEnableOption "the syslog-ng daemon";
       package = mkOption {
         type = types.package;
         default = pkgs.syslogng;

--- a/nixos/modules/services/mail/dspam.nix
+++ b/nixos/modules/services/mail/dspam.nix
@@ -35,11 +35,7 @@ in {
 
     services.dspam = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the dspam spam filter.";
-      };
+      enable = mkEnableOption "the dspam spam filter";
 
       user = mkOption {
         type = types.str;

--- a/nixos/modules/services/mail/exim.nix
+++ b/nixos/modules/services/mail/exim.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkIf mkOption singleton types;
+  inherit (lib) mkEnableOption mkIf mkOption singleton types;
   inherit (pkgs) coreutils exim;
   cfg = config.services.exim;
 in
@@ -14,11 +14,7 @@ in
 
     services.exim = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the Exim mail transfer agent.";
-      };
+      enable = mkEnableOption "the Exim mail transfer agent";
 
       config = mkOption {
         type = types.string;

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -23,11 +23,7 @@ in {
 
     services.opendkim = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the OpenDKIM sender authentication system.";
-      };
+      enable = mkEnableOption "the OpenDKIM sender authentication system";
 
       socket = mkOption {
         type = types.str;

--- a/nixos/modules/services/mail/postsrsd.nix
+++ b/nixos/modules/services/mail/postsrsd.nix
@@ -14,11 +14,7 @@ in {
 
     services.postsrsd = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the postsrsd SRS server for Postfix.";
-      };
+      enable = mkEnableOption "the postsrsd SRS server for Postfix";
 
       domain = mkOption {
         type = types.str;

--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -30,11 +30,7 @@ let
 in {
 
   options.services.apache-kafka = {
-    enable = mkOption {
-      description = "Whether to enable Apache Kafka.";
-      default = false;
-      type = types.bool;
-    };
+    enable = mkEnableOption "Apache Kafka";
 
     brokerId = mkOption {
       description = "Broker ID.";

--- a/nixos/modules/services/misc/canto-daemon.nix
+++ b/nixos/modules/services/misc/canto-daemon.nix
@@ -13,11 +13,7 @@ in {
   options = {
 
     services.canto-daemon = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the canto RSS daemon.";
-      };
+      enable = mkEnableOption "the canto RSS daemon";
     };
 
   };

--- a/nixos/modules/services/misc/cpuminer-cryptonight.nix
+++ b/nixos/modules/services/misc/cpuminer-cryptonight.nix
@@ -20,13 +20,7 @@ in
   options = {
 
     services.cpuminer-cryptonight = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the cpuminer cryptonight miner.
-        '';
-      };
+      enable = mkEnableOption "the cpuminer cryptonight miner";
       url = mkOption {
         type = types.string;
         description = "URL of mining server";

--- a/nixos/modules/services/misc/devmon.nix
+++ b/nixos/modules/services/misc/devmon.nix
@@ -8,12 +8,7 @@ let
 in {
   options = {
     services.devmon = {
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable devmon, an automatic device mounting daemon.
-        '';
-      };
+      enable = mkEnableOption "devmon, an automatic device mounting daemon";
     };
   };
 

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -8,11 +8,7 @@ let
 in {
 
   options.services.etcd = {
-    enable = mkOption {
-      description = "Whether to enable etcd.";
-      default = false;
-      type = types.bool;
-    };
+    enable = mkEnableOption "etcd";
 
     name = mkOption {
       description = "Etcd unique node name.";

--- a/nixos/modules/services/misc/folding-at-home.nix
+++ b/nixos/modules/services/misc/folding-at-home.nix
@@ -12,12 +12,7 @@ in {
 
     services.foldingAtHome = {
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable the Folding@Home to use idle CPU time.
-        '';
-      };
+      enable = mkEnableOption "the Folding@Home to use idle CPU time";
 
       nickname = mkOption {
         default = "Anonymous";

--- a/nixos/modules/services/misc/mbpfan.nix
+++ b/nixos/modules/services/misc/mbpfan.nix
@@ -8,13 +8,7 @@ let
 
 in {
   options.services.mbpfan = {
-    enable = mkOption {
-      default = false;
-      type = types.bool;
-      description = ''
-        Whether to enable the mbpfan daemon.
-      '';
-    };
+    enable = mkEnableOption "the mbpfan daemon";
 
     package = mkOption {
       type = types.package;

--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -155,13 +155,7 @@ in {
 
     services.mediatomb = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the mediatomb DLNA server.
-        '';
-      };
+      enable = mkEnableOption "the mediatomb DLNA server";
 
       serverName = mkOption {
         type = types.string;

--- a/nixos/modules/services/misc/mesos-master.nix
+++ b/nixos/modules/services/misc/mesos-master.nix
@@ -10,11 +10,7 @@ in {
   options.services.mesos = {
 
     master = {
-      enable = mkOption {
-        description = "Whether to enable the Mesos Master.";
-        default = false;
-        type = types.bool;
-      };
+      enable = mkEnableOption "the Mesos Master";
 
       port = mkOption {
         description = "Mesos Master port";

--- a/nixos/modules/services/misc/mesos-slave.nix
+++ b/nixos/modules/services/misc/mesos-slave.nix
@@ -18,11 +18,7 @@ in {
 
   options.services.mesos = {
     slave = {
-      enable = mkOption {
-        description = "Whether to enable the Mesos Slave.";
-        default = false;
-        type = types.bool;
-      };
+      enable = mkEnableOption "the Mesos Slave";
 
       ip = mkOption {
         description = "IP address to listen on.";

--- a/nixos/modules/services/misc/nix-ssh-serve.nix
+++ b/nixos/modules/services/misc/nix-ssh-serve.nix
@@ -7,11 +7,7 @@ with lib;
 
     nix.sshServe = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable serving the Nix store as a binary cache via SSH.";
-      };
+      enable = mkEnableOption "serving the Nix store as a binary cache via SSH";
 
       keys = mkOption {
         type = types.listOf types.str;

--- a/nixos/modules/services/misc/phd.nix
+++ b/nixos/modules/services/misc/phd.nix
@@ -16,12 +16,7 @@ in
 
     services.phd = {
 
-      enable = mkOption {
-        default = false;
-        description = "
-          Enable daemons for phabricator.
-        ";
-      };
+      enable = mkEnableOption "daemons for phabricator";
 
     };
 

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -56,13 +56,7 @@ in {
 
   options = {
     services.redmine = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable the redmine service.
-        '';
-      };
+      enable = mkEnableOption "the redmine service";
 
       stateDir = mkOption {
         type = types.str;

--- a/nixos/modules/services/misc/svnserve.nix
+++ b/nixos/modules/services/misc/svnserve.nix
@@ -17,10 +17,7 @@ in
 
     services.svnserve = {
 
-      enable = mkOption {
-        default = false;
-        description = "Whether to enable svnserve to serve Subversion repositories through the SVN protocol.";
-      };
+      enable = mkEnableOption "svnserve to serve Subversion repositories through the SVN protocol";
 
       svnBaseDir = mkOption {
         default = "/repos";

--- a/nixos/modules/services/monitoring/cadvisor.nix
+++ b/nixos/modules/services/monitoring/cadvisor.nix
@@ -8,11 +8,7 @@ let
 in {
   options = {
     services.cadvisor = {
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Whether to enable cadvisor service.";
-      };
+      enable = mkEnableOption "cadvisor service";
 
       listenAddress = mkOption {
         default = "127.0.0.1";

--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -26,13 +26,7 @@ let
 
 in {
   options.services.collectd = with types; {
-    enable = mkOption {
-      default = false;
-      description = ''
-        Whether to enable collectd agent.
-      '';
-      type = bool;
-    };
+    enable = mkEnableOption "collectd agent";
 
     package = mkOption {
       default = pkgs.collectd;

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -322,13 +322,7 @@ in {
   options = {
     services.prometheus = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable the Prometheus monitoring daemon.
-        '';
-      };
+      enable = mkEnableOption "the Prometheus monitoring daemon";
 
       listenAddress = mkOption {
         type = types.str;

--- a/nixos/modules/services/monitoring/riemann-dash.nix
+++ b/nixos/modules/services/monitoring/riemann-dash.nix
@@ -23,13 +23,7 @@ in {
   options = {
 
     services.riemann-dash = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable the riemann-dash dashboard daemon.
-        '';
-      };
+      enable = mkEnableOption "the riemann-dash dashboard daemon";
       config = mkOption {
         type = types.lines;
         description = ''

--- a/nixos/modules/services/monitoring/riemann.nix
+++ b/nixos/modules/services/monitoring/riemann.nix
@@ -27,13 +27,7 @@ in {
   options = {
 
     services.riemann = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable the Riemann network monitoring daemon.
-        '';
-      };
+      enable = mkEnableOption "the Riemann network monitoring daemon";
       config = mkOption {
         type = types.lines;
         description = ''

--- a/nixos/modules/services/monitoring/sysstat.nix
+++ b/nixos/modules/services/monitoring/sysstat.nix
@@ -5,13 +5,7 @@ let
 in {
   options = {
     services.sysstat = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable sar system activity collection.
-        '';
-      };
+      enable = mkEnableOption "sar system activity collection";
 
       collect-frequency = mkOption {
         default = "*:00/10";

--- a/nixos/modules/services/monitoring/systemhealth.nix
+++ b/nixos/modules/services/monitoring/systemhealth.nix
@@ -42,12 +42,7 @@ in
 {
   options = {
     services.systemhealth = {
-      enable = mkOption {
-        default = false;
-        description = ''
-          Enable the system health monitor and its generation of graphs.
-        '';
-      };
+      enable = mkEnableOption "the system health monitor and its generation of graphs";
 
       urlPrefix = mkOption {
         default = "/health";

--- a/nixos/modules/services/network-filesystems/netatalk.nix
+++ b/nixos/modules/services/network-filesystems/netatalk.nix
@@ -43,10 +43,7 @@ in
   options = {
     services.netatalk = {
 
-      enable = mkOption {
-          default = false;
-          description = "Whether to enable the Netatalk AFP fileserver.";
-        };
+      enable = mkEnableOption "the Netatalk AFP fileserver";
 
       port = mkOption {
         default = 548;
@@ -64,10 +61,7 @@ in
       };
 
       homes = {
-        enable = mkOption {
-          default = false;
-          description = "Enable sharing of the UNIX server user home directories.";
-        };
+        enable = mkEnableOption "sharing of the UNIX server user home directories";
 
         path = mkOption {
           default = "";

--- a/nixos/modules/services/network-filesystems/nfsd.nix
+++ b/nixos/modules/services/network-filesystems/nfsd.nix
@@ -19,12 +19,7 @@ in
     services.nfs = {
 
       server = {
-        enable = mkOption {
-          default = false;
-          description = ''
-            Whether to enable the kernel's NFS server.
-          '';
-        };
+        enable = mkEnableOption "the kernel's NFS server";
 
         exports = mkOption {
           default = "";

--- a/nixos/modules/services/network-filesystems/openafs-client/default.nix
+++ b/nixos/modules/services/network-filesystems/openafs-client/default.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 
 let
-  inherit (lib) mkOption mkIf;
+  inherit (lib) mkEnableOption mkOption mkIf;
 
   cfg = config.services.openafsClient;
 
@@ -26,10 +26,7 @@ in
 
     services.openafsClient = {
 
-      enable = mkOption {
-        default = false;
-        description = "Whether to enable the OpenAFS client.";
-      };
+      enable = mkEnableOption "the OpenAFS client";
 
       cellName = mkOption {
         default = "grand.central.org";

--- a/nixos/modules/services/network-filesystems/rsyncd.nix
+++ b/nixos/modules/services/network-filesystems/rsyncd.nix
@@ -30,10 +30,7 @@ in
   options = {
     services.rsyncd = {
 
-      enable = mkOption {
-        default = false;
-        description = "Whether to enable the rsync daemon.";
-      };
+      enable = mkEnableOption "the rsync daemon";
 
       motd = mkOption {
         type = types.string;

--- a/nixos/modules/services/networking/asterisk.nix
+++ b/nixos/modules/services/networking/asterisk.nix
@@ -81,13 +81,7 @@ in
 {
   options = {
     services.asterisk = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the Asterisk PBX server.
-        '';
-      };
+      enable = mkEnableOption "the Asterisk PBX server";
 
       extraConfig = mkOption {
         default = "";

--- a/nixos/modules/services/networking/atftpd.nix
+++ b/nixos/modules/services/networking/atftpd.nix
@@ -16,13 +16,7 @@ in
 
     services.atftpd = {
 
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Whenever to enable the atftpd TFTP server.
-        '';
-      };
+      enable = mkEnableOption "the atftpd TFTP server";
 
       root = mkOption {
         default = "/var/empty";

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -61,12 +61,7 @@ in
 
     services.bind = {
 
-      enable = mkOption {
-        default = false;
-        description = "
-          Whether to enable BIND domain name server.
-        ";
-      };
+      enable = mkEnableOption "BIND domain name server";
 
       cacheNetworks = mkOption {
         default = ["127.0.0.0/24"];

--- a/nixos/modules/services/networking/cntlm.nix
+++ b/nixos/modules/services/networking/cntlm.nix
@@ -15,12 +15,7 @@ in
 
     services.cntlm = {
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable the cntlm, which start a local proxy.
-        '';
-      };
+      enable = mkEnableOption "the cntlm, which start a local proxy";
 
       username = mkOption {
         description = ''

--- a/nixos/modules/services/networking/dhcpd.nix
+++ b/nixos/modules/services/networking/dhcpd.nix
@@ -39,12 +39,7 @@ in
 
     services.dhcpd = {
 
-      enable = mkOption {
-        default = false;
-        description = "
-          Whether to enable the DHCP server.
-        ";
-      };
+      enable = mkEnableOption "the DHCP server";
 
       extraConfig = mkOption {
         default = "";

--- a/nixos/modules/services/networking/ircd-hybrid/default.nix
+++ b/nixos/modules/services/networking/ircd-hybrid/default.nix
@@ -36,12 +36,7 @@ in
 
     services.ircdHybrid = {
 
-      enable = mkOption {
-        default = false;
-        description = "
-          Enable IRCD.
-        ";
-      };
+      enable = mkEnableOption "IRCD";
 
       serverName = mkOption {
         default = "hades.arpa";

--- a/nixos/modules/services/networking/kippo.nix
+++ b/nixos/modules/services/networking/kippo.nix
@@ -14,11 +14,7 @@ in
 rec {
   options = {
     services.kippo = {
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''Enable the kippo honeypot ssh server.'';
-      };
+      enable = mkEnableOption "the kippo honeypot ssh server";
       port = mkOption {
         default = 2222;
         type = types.int;

--- a/nixos/modules/services/networking/mailpile.nix
+++ b/nixos/modules/services/networking/mailpile.nix
@@ -18,12 +18,7 @@ in
   options = {
 
     services.mailpile = {
-      enable = mkOption {
-        default = false;
-        description = "
-          Whether to enable Mailpile the mail client.
-        ";
-      };
+      enable = mkEnableOption "Mailpile the mail client";
       hostname = mkOption {
         default = "localhost";
         description = "Listen to this hostname or ip.";

--- a/nixos/modules/services/networking/mstpd.nix
+++ b/nixos/modules/services/networking/mstpd.nix
@@ -6,13 +6,7 @@ with lib;
 {
   options.services.mstpd = {
     
-    enable = mkOption {
-      default = false;
-      type = types.bool;
-      description = ''
-        Whether to enable the multiple spanning tree protocol daemon.
-      '';
-    };
+    enable = mkEnableOption "the multiple spanning tree protocol daemon";
 
   };
 

--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -66,14 +66,7 @@ in
 
   options = {
 
-    networking.nat.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description =
-        ''
-          Whether to enable Network Address Translation (NAT).
-        '';
-    };
+    networking.nat.enable = mkEnableOption "Network Address Translation (NAT)";
 
     networking.nat.internalInterfaces = mkOption {
       type = types.listOf types.str;

--- a/nixos/modules/services/networking/privoxy.nix
+++ b/nixos/modules/services/networking/privoxy.nix
@@ -30,13 +30,7 @@ in
 
     services.privoxy = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the Privoxy non-caching filtering proxy.
-        '';
-      };
+      enable = mkEnableOption "the Privoxy non-caching filtering proxy";
 
       listenAddress = mkOption {
         type = types.str;

--- a/nixos/modules/services/networking/sabnzbd.nix
+++ b/nixos/modules/services/networking/sabnzbd.nix
@@ -15,10 +15,7 @@ in
 
   options = {
     services.sabnzbd = {
-      enable = mkOption {
-        default = false;
-        description = "Whether to enable the sabnzbd server.";
-      };
+      enable = mkEnableOption "the sabnzbd server";
       configFile = mkOption {
         default = "/var/lib/sabnzbd/sabnzbd.ini";
         description = "Path to config file.";

--- a/nixos/modules/services/networking/seeks.nix
+++ b/nixos/modules/services/networking/seeks.nix
@@ -20,13 +20,7 @@ in
 
     services.seeks = {
 
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = "
-          Whether to enable the Seeks server.
-        ";
-      };
+      enable = mkEnableOption "the Seeks server";
 
       confDir = mkOption {
         default = "";

--- a/nixos/modules/services/networking/spiped.nix
+++ b/nixos/modules/services/networking/spiped.nix
@@ -8,11 +8,7 @@ in
 {
   options = {
     services.spiped = {
-      enable = mkOption {
-        type        = types.bool;
-        default     = false;
-        description = "Enable the spiped service module.";
-      };
+      enable = mkEnableOption "the spiped service module";
 
       config = mkOption {
         type = types.attrsOf (types.submodule (

--- a/nixos/modules/services/networking/tftpd.nix
+++ b/nixos/modules/services/networking/tftpd.nix
@@ -8,13 +8,7 @@ with lib;
 
   options = {
 
-    services.tftpd.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable tftpd, a Trivial File Transfer Protocol server.
-      '';
-    };
+    services.tftpd.enable = mkEnableOption "tftpd, a Trivial File Transfer Protocol server";
 
     services.tftpd.path = mkOption {
       type = types.path;

--- a/nixos/modules/services/networking/tlsdated.nix
+++ b/nixos/modules/services/networking/tlsdated.nix
@@ -16,13 +16,7 @@ in
 
     services.tlsdated = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Enable tlsdated daemon.
-        '';
-      };
+      enable = mkEnableOption "tlsdated daemon";
 
       extraOptions = mkOption {
         type = types.string;

--- a/nixos/modules/services/networking/tox-bootstrapd.nix
+++ b/nixos/modules/services/networking/tox-bootstrapd.nix
@@ -19,14 +19,7 @@ in
 {
   options =
     { services.toxBootstrapd =
-        { enable = mkOption {
-            type = types.bool;
-            default = false;
-            description =
-              ''
-                Whether to enable the Tox DHT bootstrap daemon.
-              '';
-          };
+        { enable = mkEnableOption "the Tox DHT bootstrap daemon";
 
           port = mkOption {
             type = types.int;

--- a/nixos/modules/services/networking/vsftpd.nix
+++ b/nixos/modules/services/networking/vsftpd.nix
@@ -112,10 +112,7 @@ in
 
     services.vsftpd = {
 
-      enable = mkOption {
-        default = false;
-        description = "Whether to enable the vsftpd FTP server.";
-      };
+      enable = mkEnableOption "the vsftpd FTP server";
 
       userlist = mkOption {
         default = [];

--- a/nixos/modules/services/networking/websockify.nix
+++ b/nixos/modules/services/networking/websockify.nix
@@ -5,13 +5,7 @@ with lib;
 let cfg = config.services.networking.websockify; in {
   options = {
     services.networking.websockify = {
-      enable = mkOption {  
-        description = "Whether to enable websockify to forward websocket connections to TCP connections.";
-
-        default = false;   
-
-        type = types.bool; 
-      };
+      enable = mkEnableOption "websockify to forward websocket connections to TCP connections";
 
       sslCert = mkOption {
         description = "Path to the SSL certificate.";

--- a/nixos/modules/services/networking/xinetd.nix
+++ b/nixos/modules/services/networking/xinetd.nix
@@ -44,12 +44,7 @@ in
 
   options = {
 
-    services.xinetd.enable = mkOption {
-      default = false;
-      description = ''
-        Whether to enable the xinetd super-server daemon.
-      '';
-    };
+    services.xinetd.enable = mkEnableOption "the xinetd super-server daemon";
 
     services.xinetd.extraDefaults = mkOption {
       default = "";

--- a/nixos/modules/services/scheduling/atd.nix
+++ b/nixos/modules/services/scheduling/atd.nix
@@ -16,13 +16,7 @@ in
 
   options = {
 
-    services.atd.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable the <command>at</command> daemon, a command scheduler.
-      '';
-    };
+    services.atd.enable = mkEnableOption "the <command>at</command> daemon, a command scheduler";
 
     services.atd.allowEveryone = mkOption {
       type = types.bool;

--- a/nixos/modules/services/scheduling/chronos.nix
+++ b/nixos/modules/services/scheduling/chronos.nix
@@ -10,11 +10,7 @@ in {
   ###### interface
 
   options.services.chronos = {
-    enable = mkOption {
-      description = "Whether to enable graphite web frontend.";
-      default = false;
-      type = types.bool;
-    };
+    enable = mkEnableOption "graphite web frontend";
 
     httpPort = mkOption {
       description = "Chronos listening port";

--- a/nixos/modules/services/scheduling/cron.nix
+++ b/nixos/modules/services/scheduling/cron.nix
@@ -37,11 +37,7 @@ in
 
     services.cron = {
 
-      enable = mkOption {
-        type = types.bool;
-        example = true;
-        description = "Whether to enable the Vixie cron daemon.";
-      };
+      enable = mkEnableOption "the Vixie cron daemon";
 
       mailto = mkOption {
         type = types.nullOr types.str;

--- a/nixos/modules/services/scheduling/fcron.nix
+++ b/nixos/modules/services/scheduling/fcron.nix
@@ -36,11 +36,7 @@ in
 
     services.fcron = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the <command>fcron</command> daemon.";
-      };
+      enable = mkEnableOption "the <command>fcron</command> daemon";
 
       allow = mkOption {
         type = types.listOf types.str;

--- a/nixos/modules/services/scheduling/marathon.nix
+++ b/nixos/modules/services/scheduling/marathon.nix
@@ -11,13 +11,7 @@ in {
   ###### interface
 
   options.services.marathon = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-	Whether to enable the marathon mesos framework.
-      '';
-    };
+    enable = mkEnableOption "the marathon mesos framework";
 
     master = mkOption {
       type = types.str;

--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -33,11 +33,7 @@ in {
   ###### interface
 
   options.services.elasticsearch = {
-    enable = mkOption {
-      description = "Whether to enable elasticsearch.";
-      default = false;
-      type = types.bool;
-    };
+    enable = mkEnableOption "elasticsearch";
 
     package = mkOption {
       description = "Elasticsearch package to use.";

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -25,11 +25,7 @@ in
   options = {
 
     services.fail2ban = {
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Whether to enable the fail2ban service.";
-      };
+      enable = mkEnableOption "the fail2ban service";
 
       daemonConfig = mkOption {
         default =

--- a/nixos/modules/services/security/fprintd.nix
+++ b/nixos/modules/services/security/fprintd.nix
@@ -17,13 +17,7 @@ in
 
     services.fprintd = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable fprintd daemon and PAM module for fingerprint readers handling.
-        '';
-      };
+      enable = mkEnableOption "fprintd daemon and PAM module for fingerprint readers handling";
 
     };
     

--- a/nixos/modules/services/security/fprot.nix
+++ b/nixos/modules/services/security/fprot.nix
@@ -10,12 +10,7 @@ in {
 
     services.fprot = {
       updater = {
-        enable = mkOption {
-          default = false;
-          description = ''
-            Whether to enable automatic F-Prot virus definitions database updates.
-          '';
-        };
+        enable = mkEnableOption "automatic F-Prot virus definitions database updates";
 
         productData = mkOption {
           description = ''

--- a/nixos/modules/services/system/kerberos.nix
+++ b/nixos/modules/services/system/kerberos.nix
@@ -2,7 +2,7 @@
 
 let
 
-  inherit (lib) mkOption mkIf singleton;
+  inherit (lib) mkEnableOption mkOption mkIf singleton;
 
   inherit (pkgs) heimdalFull;
 
@@ -17,12 +17,7 @@ in
 
     services.kerberos_server = {
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Enable the kerberos authentification server.
-        '';
-      };
+      enable = mkEnableOption "the kerberos authentification server";
 
     };
 

--- a/nixos/modules/services/torrent/peerflix.nix
+++ b/nixos/modules/services/torrent/peerflix.nix
@@ -17,11 +17,7 @@ in {
   ###### interface
 
   options.services.peerflix = {
-    enable = mkOption {
-      description = "Whether to enable peerflix service.";
-      default = false;
-      type = types.bool;
-    };
+    enable = mkEnableOption "peerflix service";
 
     stateDir = mkOption {
       description = "Peerflix state directory.";

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -424,11 +424,7 @@ in
 
     services.httpd = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the Apache HTTP Server.";
-      };
+      enable = mkEnableOption "the Apache HTTP Server";
 
       package = mkOption {
         type = types.package;

--- a/nixos/modules/services/web-servers/fcgiwrap.nix
+++ b/nixos/modules/services/web-servers/fcgiwrap.nix
@@ -8,11 +8,7 @@ in {
 
   options = {
     services.fcgiwrap = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable fcgiwrap, a server for running CGI applications over FastCGI.";
-      };
+      enable = mkEnableOption "fcgiwrap, a server for running CGI applications over FastCGI";
 
       preforkProcesses = mkOption {
         type = types.int;

--- a/nixos/modules/services/web-servers/lighttpd/default.nix
+++ b/nixos/modules/services/web-servers/lighttpd/default.nix
@@ -119,13 +119,7 @@ in
 
     services.lighttpd = {
 
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Enable the lighttpd web server.
-        '';
-      };
+      enable = mkEnableOption "the lighttpd web server";
 
       port = mkOption {
         default = 80;

--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -7,12 +7,7 @@ with lib;
 {
   options = {
     services.varnish = {
-      enable = mkOption {
-        default = false;
-        description = "
-          Enable the Varnish Server.
-        ";
-      };
+      enable = mkEnableOption "the Varnish Server";
 
       http_address = mkOption {
         default = "*:6081";

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -18,11 +18,7 @@ in
 {
   options = {
 
-    services.xserver.desktopManager.enlightenment.enable = mkOption {
-      default = false;
-      example = true;
-      description = "Enable the Enlightenment desktop environment.";
-    };
+    services.xserver.desktopManager.enlightenment.enable = mkEnableOption "the Enlightenment desktop environment";
 
   };
 

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -53,11 +53,7 @@ in {
   options = {
 
     services.xserver.desktopManager.gnome3 = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = "Enable Gnome 3 desktop manager.";
-      };
+      enable = mkEnableOption "Gnome 3 desktop manager";
 
       sessionPath = mkOption {
         default = [];

--- a/nixos/modules/services/x11/desktop-managers/kde4.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde4.nix
@@ -50,11 +50,7 @@ in
   options = {
 
     services.xserver.desktopManager.kde4 = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable the KDE 4 desktop environment.";
-      };
+      enable = mkEnableOption "the KDE 4 desktop environment";
 
       phononBackends = mkOption {
         type = types.listOf types.str;

--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -16,11 +16,7 @@ in
   options = {
 
     services.xserver.desktopManager.kde5 = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable the Plasma 5 (KDE 5) desktop environment.";
-      };
+      enable = mkEnableOption "the Plasma 5 (KDE 5) desktop environment";
 
     };
 

--- a/nixos/modules/services/x11/desktop-managers/kodi.nix
+++ b/nixos/modules/services/x11/desktop-managers/kodi.nix
@@ -9,11 +9,7 @@ in
 {
   options = {
     services.xserver.desktopManager.kodi = {
-      enable = mkOption {
-        default = false;
-        example = true;
-        description = "Enable the kodi multimedia center.";
-      };
+      enable = mkEnableOption "the kodi multimedia center";
     };
   };
 

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -13,11 +13,7 @@ in
   options = {
 
     services.xserver.desktopManager.xfce = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable the Xfce desktop environment.";
-      };
+      enable = mkEnableOption "the Xfce desktop environment";
 
       thunarPlugins = mkOption {
         default = [];

--- a/nixos/modules/services/x11/display-managers/kdm.nix
+++ b/nixos/modules/services/x11/display-managers/kdm.nix
@@ -78,13 +78,7 @@ in
 
     services.xserver.displayManager.kdm = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the KDE display manager.
-        '';
-      };
+      enable = mkEnableOption "the KDE display manager";
 
       enableXDMCP = mkOption {
         type = types.bool;

--- a/nixos/modules/services/x11/display-managers/slim.nix
+++ b/nixos/modules/services/x11/display-managers/slim.nix
@@ -47,13 +47,7 @@ in
 
     services.xserver.displayManager.slim = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = config.services.xserver.enable;
-        description = ''
-          Whether to enable SLiM as the display manager.
-        '';
-      };
+      enable = mkEnableOption "SLiM as the display manager";
 
       theme = mkOption {
         type = types.nullOr types.path;

--- a/nixos/modules/services/x11/xfs.nix
+++ b/nixos/modules/services/x11/xfs.nix
@@ -16,11 +16,7 @@ in
 
     services.xfs = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the X Font Server.";
-      };
+      enable = mkEnableOption "the X Font Server";
 
     };
 

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -8,13 +8,7 @@ in
 
   options = {
 
-    services.resolved.enable = mkOption {
-      default = false;
-      type = types.bool;
-      description = ''
-        Whether to enable the systemd DNS resolver daemon.
-      '';
-    };
+    services.resolved.enable = mkEnableOption "the systemd DNS resolver daemon";
 
     services.resolved.fallbackDns = mkOption {
       default = [ ];

--- a/nixos/modules/tasks/trackpoint.nix
+++ b/nixos/modules/tasks/trackpoint.nix
@@ -9,13 +9,7 @@ with lib;
 
     hardware.trackpoint = {
 
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Enable sensitivity and speed configuration for trackpoints.
-        '';
-      };
+      enable = mkEnableOption "sensitivity and speed configuration for trackpoints";
 
       sensitivity = mkOption {
         default = 128;

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -58,10 +58,7 @@ in
   ###### interface
 
   options.virtualisation.azure.agent = {
-    enable = mkOption {
-      default = false;
-      description = "Whether to enable the Windows Azure Linux Agent.";
-    };
+    enable = mkEnableOption "the Windows Azure Linux Agent";
     verboseLogging = mkOption {
       default = false;
       description = "Whether to enable verbose logging.";

--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -15,10 +15,7 @@ in
 
   ###### interface
 
-  options.virtualisation.virtualbox.guest.enable = mkOption {
-    default = false;
-    description = "Whether to enable the VirtualBox service and other guest additions.";
-  };
+  options.virtualisation.virtualbox.guest.enable = mkEnableOption "the VirtualBox service and other guest additions";
 
   ###### implementation
 


### PR DESCRIPTION
###### Motivation for this change

From #18524:

> Many, many services use the following snippet:
> 
> ``` nix
>       enable = mkOption {
>         default = false;
>         type = types.bool;
>         description = ''
>           Whether to enable Mopidy, a music player daemon.
>         '';
>       };
> ```
> 
> That's why `mkEnableOption` was created! 
> 
> ``` nix
>   mkEnableOption = name: mkOption {
>     default = false;
>     example = true;
>     description = "Whether to enable ${name}.";
>     type = lib.types.bool;
>   };
> ```

I wrote this script:

``` bash
#!/usr/bin/env nix-shell
#! nix-shell -i bash -p ag

git checkout master nixos/modules/
cd "nixos/modules"

# Loop through files with "enable = mkOption"
for file in $(IFS=\n ag -l "enable = mkOption"); do
  # This line will exit 0 if the default for "enable" is false.
  if perl -0777 -e 'exit 1 if (<STDIN> =~ m/.+?enable\s+=\s+mkOption\s+{(.|\n)+?default\s+=\s+true;(.|\n)+?};/)' < "$file"; then
    # This line will replace
    # enable = mkEnableOption "Foobar, the baz";
    # with
    # enable = mkEnableOption "Foobar, the baz";
    perl -0777 -p -i -e 's/(.+?)enable\s+?=\s+?mkOption\s+?\{.+?enable ([^\n]+?)\..+?};/\1enable = mkEnableOption "\2";/igs' "$file"
  fi
done

cd ../../
# Loop through the modified files and confirm the diffs
for file in $(git status --porcelain | awk 'match($1, "M"){print $2}'); do
  echo "----------------------------------------------------"
  echo "Does the diff look ok for $file?"
  echo "----------------------------------------------------"
  git --no-pager diff master "$file"
  read -r -p "[y/N]: " response
  case $response in
    [yY][eE][sS]|[yY])
      git add "$file"
      tmp=${file%.nix}
      name=${tmp##*/}
      git commit -m "$name module: use mkEnableOption"
      ;;
    *)
      git checkout master "$file"
      ;;
  esac
done
```

I was conservative, and only accepted diffs where the description was close to exactly the same. I've also broken it up into a commit per file, which will allow for easier reverting (without redoing all this work), should a problem arise. 

Next steps would be to review the diffs where the script broke/did not correctly fill in the description, and manually change those to use `mkEnableOption`.  
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
