### PR TITLE
debug-info: use pkgs.stdenv.lib.overrideDerivation

### DIFF
--- a/nixos/modules/config/debug-info.nix
+++ b/nixos/modules/config/debug-info.nix
@@ -20,7 +20,7 @@ with lib;
         <!-- FIXME: ugly, see #10721 -->
         <programlisting>
         nixpkgs.config.packageOverrides = pkgs: {
-          hello = overrideDerivation pkgs.hello (attrs: {
+          hello = pkgs.stdenv.lib.overrideDerivation pkgs.hello (attrs: {
             outputs = attrs.outputs or ["out"] ++ ["debug"];
             buildInputs = attrs.buildInputs ++ [&lt;nixpkgs/pkgs/build-support/setup-hooks/separate-debug-info.sh>];
           });


### PR DESCRIPTION
###### Motivation for this change

Fix example in documentation
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Without this change, I get the error “undefined variable 'overrideDerivation'”
