### PR TITLE
heroku: 3.43.2 -> 3.43.12 and wrap the downloaded binary

### DIFF
--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -1,28 +1,74 @@
-{ stdenv, fetchurl, postgresql, ruby, makeWrapper, nodejs-6_x }:
+{ stdenv, fetchurl, bash, buildFHSUserEnv, makeWrapper, writeTextFile
+, nodejs-6_x, postgresql, ruby }:
 
 with stdenv.lib;
-stdenv.mkDerivation rec {
-  version = "3.43.2";
+
+let
+  version = "3.43.12";
+  bin_ver = "5.4.7-8dc2c80";
+
+  arch = {
+    "x86_64-linux" = "linux-amd64";
+  }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+
+  sha256 = {
+    "x86_64-linux" = "0iqjxkdw53dvy54ahmr9yijlxrp5nbikh9z7iss93z753cgxdl06";
+  }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+
+  fhsEnv = buildFHSUserEnv {
+    name = "heroku-fhs-env";
+  };
+
+  heroku = stdenv.mkDerivation rec {
+    inherit version;
+    name = "heroku";
+
+    meta = {
+      homepage = "https://toolbelt.heroku.com";
+      description = "Everything you need to get started using Heroku";
+      maintainers = with maintainers; [ aflatter mirdhyn ];
+      license = licenses.mit;
+      platforms = with platforms; unix;
+    };
+
+    src = fetchurl {
+      url = "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-${version}.tgz";
+      sha256 = "1z7z8sl2hkrc8rdvx3h00fbcrxs827xlfp6fji0ap97a6jc0v9x4";
+    };
+
+    bin = fetchurl {
+      url = "https://cli-assets.heroku.com/branches/stable/${bin_ver}/heroku-v${bin_ver}-${arch}.tar.gz";
+      inherit sha256;
+    };
+
+    installPhase = ''
+      cli=$out/share/heroku/cli
+      mkdir -p $cli
+
+      tar xzf $src -C $out --strip-components=1
+      tar xzf $bin -C $cli --strip-components=1
+
+      wrapProgram $out/bin/heroku \
+        --set HEROKU_NODE_PATH ${nodejs-6_x}/bin/node \
+        --set XDG_DATA_HOME    $out/share \
+        --set XDG_DATA_DIRS    $out/share
+
+      # When https://github.com/NixOS/patchelf/issues/66 is fixed, reinstate this and dump the fhsuserenv
+      #patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      #  $cli/bin/heroku
+    '';
+
+    buildInputs = [ fhsEnv ruby postgresql makeWrapper ];
+
+    doUnpack = false;
+  };
+
+in writeTextFile {
   name = "heroku-${version}";
-
-  meta = {
-    homepage = "https://toolbelt.heroku.com";
-    description = "Everything you need to get started using Heroku";
-    maintainers = with maintainers; [ aflatter mirdhyn ];
-    license = licenses.mit;
-    platforms = with platforms; unix;
-  };
-
-  src = fetchurl {
-    url = "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-${version}.tgz";
-    sha256 = "1sapbxg7pzi89c95k0vsp8k5bysggkjf58jwck2xs0y4ly36wbnc";
-  };
-
-  installPhase = ''
-    mkdir -p $out
-    cp -R * $out/
-    wrapProgram $out/bin/heroku --set HEROKU_NODE_PATH ${nodejs-6_x}/bin/node
+  destination = "/bin/heroku";
+  executable = true;
+  text = ''
+    #!${bash}/bin/bash -e
+    ${fhsEnv}/bin/heroku-fhs-env ${heroku}/bin/heroku
   '';
-
-  buildInputs = [ ruby postgresql makeWrapper ];
 }


### PR DESCRIPTION
###### Motivation for this change

The heroku tool has changed and now downloads a binary to do bulk of the work.

This PR also downloads the binary to wrap it properly, but due to https://github.com/NixOS/patchelf/issues/66 we cannot `patchelf` the binary and we therefore wrap the binary using ```buildFHSUserEnv```.

This needs to change when the patchelf issue has been fixed.

###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
