### PR TITLE
kmymoney: fix build on 32bit machines

### DIFF
--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -21,7 +21,10 @@ stdenv.mkDerivation rec {
 
   KDEDIRS = libalkimia;
 
-  patches = [ ./qgpgme.patch ];
+  patches = [
+    ./qgpgme.patch
+    ./seqaccessmgrtest.patch
+  ];
 
   meta = {
     homepage = http://kmymoney2.sourceforge.net/;

--- a/pkgs/applications/office/kmymoney/seqaccessmgrtest.patch
+++ b/pkgs/applications/office/kmymoney/seqaccessmgrtest.patch
@@ -1,0 +1,26 @@
+Fix tests for 32bit builds until we can bring these upstream
+diff --git a/kmymoney/mymoney/storage/mymoneyseqaccessmgrtest.cpp b/kmymoney/mymoney/storage/mymoneyseqaccessmgrtest.cpp
+index dcb4b4a..e803203 100644
+--- a/kmymoney/mymoney/storage/mymoneyseqaccessmgrtest.cpp
++++ b/kmymoney/mymoney/storage/mymoneyseqaccessmgrtest.cpp
+@@ -58,13 +58,13 @@ void MyMoneySeqAccessMgrTest::testEmptyConstructor()
+   QCOMPARE(m->m_nextPayeeID, 0ul);
+   QCOMPARE(m->m_nextScheduleID, 0ul);
+   QCOMPARE(m->m_nextReportID, 0ul);
+-  QCOMPARE(m->m_institutionList.count(), 0ul);
+-  QCOMPARE(m->m_accountList.count(), 5ul);
+-  QCOMPARE(m->m_transactionList.count(), 0ul);
+-  QCOMPARE(m->m_transactionKeys.count(), 0ul);
+-  QCOMPARE(m->m_payeeList.count(), 0ul);
+-  QCOMPARE(m->m_tagList.count(), 0ul);
+-  QCOMPARE(m->m_scheduleList.count(), 0ul);
++  QCOMPARE(m->m_institutionList.count(), (size_t)0);
++  QCOMPARE(m->m_accountList.count(), (size_t)5);
++  QCOMPARE(m->m_transactionList.count(), (size_t)0);
++  QCOMPARE(m->m_transactionKeys.count(), (size_t)0);
++  QCOMPARE(m->m_payeeList.count(), (size_t)0);
++  QCOMPARE(m->m_tagList.count(), (size_t)0);
++  QCOMPARE(m->m_scheduleList.count(), (size_t)0);
+ 
+   QCOMPARE(m->m_dirty, false);
+   QCOMPARE(m->m_creationDate, QDate::currentDate());


### PR DESCRIPTION
###### Motivation for this change

This fixes the 32bit buid issues mentioned in https://github.com/NixOS/nixpkgs/issues/18209#issuecomment-246268289
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
