### PR TITLE
groff: add missing depedencies for optional postscript and html outputs

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1907,6 +1907,8 @@ in
 
   groff = callPackage ../tools/text/groff {
     ghostscript = null;
+    psutils = null;
+    netpbm = null;
   };
 
   groonga = callPackage ../servers/search/groonga { };


### PR DESCRIPTION
###### Motivation for this change

groff html tables output & pdf\postscript output was broken.

The added dependencies are defaulted null so nothing changed for the base system.

Test with the following:
testOutputs.groff:

```
.TS
allbox;
c s s
c c c
n n n.
AT&T Common Stock
Year    Price   Dividend
1971    41-54   $2.60
2   41-54   2.70
3   46-55   2.87
4   40-53   3.24
5   45-52   3.40
6   51-59   .95*
.TE

```

For postscript:
`tbl ./testOutputs.groff | groff > table.pdf`
For html:
`tbl ./testOutputs.groff | groff -Thtml > table.html`

Note 1: Technically, man-db needs to override it's groff buildInput to allow correct outputting of postscript and html man pages. This isn't done by default to reduce closure size.

Note2 : Originally another namespace called groffFull was introduced in this PR that didn't null out the dependencies. But, it required prolonged recompilation of systemd & co.  So, I gave up on that.
Someday, when mandoc is ready, groff will be removed from the base system and these new dependencies could be made the groff default so the few packages that can't use mandoc for whatever reason will have all that they need.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
