### PR TITLE
freerdpUnstable: 1.2.0 -> 2.0

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/unstable.nix
+++ b/pkgs/applications/networking/remote/freerdp/unstable.nix
@@ -6,13 +6,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "freerdp-1.2.0-beta1";
+  name = "freerdp-2.0-dev";
 
   src = fetchFromGitHub {
     owner = "FreeRDP";
     repo = "FreeRDP";
-    rev = "1.2.0-beta1+android7";
-    sha256 = "08nn18jydblrif1qs92pakzd3ww7inr0i378ssn1bjp09lm1bkk0";
+    rev = "1855e36179fb197e713d41c4ef93e19cf1f0be2f";
+    sha256 = "1lydkh6by0sjy6dl57bzg7c11ccyp24s80pwxw9h5kmxkbw6mx5q";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

1.2.0 fails with recent TS servers.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
