### PR TITLE
redis-desktop-manager: fix build

### DIFF
--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     qtquick1 qtquickcontrols qtsvg qttools
   ];
 
-  configurePhase = "true";
+  dontUseQmakeConfigure = true;
 
   buildPhase = ''
     srcdir=$PWD


### PR DESCRIPTION
###### Motivation for this change

Fix broken RDM build.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

We need to run the pre/post configure hooks. Thanks for the tip, @ttuegel.
