### PR TITLE
nixos config: Add environment.xdg.mimeTypes

### DIFF
--- a/nixos/modules/config/update-mime-pkg.pl
+++ b/nixos/modules/config/update-mime-pkg.pl
@@ -1,0 +1,66 @@
+use strict;
+use File::Path qw(make_path);
+use File::Slurp;
+use JSON;
+
+# NOTE: originally started as something invoked as part
+# of activation, similar to the user-groups script.
+#
+# now that it is is a package, I guess I can port this away from
+# perl?
+
+my $out = $ARGV[1];
+
+# Read in the declared mime types
+my $spec = decode_json(read_file($ARGV[0]));
+
+my $outfile = "$out/share/mime/packages/nix-decl-types.xml";
+
+my %declOut;
+foreach my $t (@{$spec->{types}}) {
+	my $name = $t->{name};
+
+	my $alias = $t->{alias} eq "" ? "" : "<alias type=\"$t->{alias}\"/>";
+
+	my $commentPairs = $t->{comment};
+	my $comments = "";
+
+	$comments = join("\n", map {
+		my $l = $_ eq "" ? "" : " xml:lang=\"$_\"";
+		"<comment$l>$commentPairs->{$_}</comment>";
+	} keys %$commentPairs);
+
+	my @globList = @{$t->{globs}};
+	my $globs = join("\n", map { "<glob pattern=\"$_\"/>" } @globList);
+
+	my $sc = $t->{"sub-class-of"};
+	my $subClassOf = $sc eq "" ? "" : "<sub-class-of type=\"$sc\"/>";
+
+	my $magic = ""; ##TODO: magic hasn't been done yet
+
+	##TODO: icons
+	##TODO: xml prettify
+
+$declOut{$name} = <<END;
+<mime-type type="$name">
+$comments
+$globs
+$subClassOf
+$magic
+$alias
+</mime-type>
+END
+
+}
+
+my $body = join("\n", sort(values %declOut));
+
+my $fullBody = <<END;
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+	$body
+</mime-info>
+END
+
+write_file($outfile, { binmode => ':utf8' }, $fullBody)
+

--- a/nixos/modules/config/xdg.nix
+++ b/nixos/modules/config/xdg.nix
@@ -1,0 +1,116 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.environment.xdg;
+
+  mimeTypeOpts = { name, config, ... }: {
+    options = {
+
+      name = mkOption {
+        type = types.str;
+        description = ''
+           The name of the mime-type. If undefined, the name of the
+           attribute set will be used.
+        '';
+      };
+
+      comment = mkOption {
+        type = types.loaOf types.str;
+        description = ''
+           The localized descriptions of the types.
+        '';
+      };
+
+      sub-class-of = mkOption {
+        type = types.str;
+        description = ''
+          The mime type name that this is a sub-class of.
+        '';
+      };
+
+      globs = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          The list of patterns that this file can match.
+        '';
+      };
+
+      alias = mkOption {
+        type = types.str;
+        description = "Alias of this type";
+        default = "";
+      };
+
+      magic = mkOption {
+        type = types.listOf types.optionSet;
+        default = [];
+        description = ''
+          The identifying bits that identifies a files contents.
+        '';
+      };
+    };
+    config = mkMerge [ { name = mkDefault name; } ];
+  };
+
+  spec = pkgs.writeText "xdg-mime-types.json" (builtins.toJSON {
+    types = mapAttrsToList (n: t:
+      { inherit (t)
+          name comment sub-class-of globs alias magic;
+      }) cfg.mimeTypes;
+  });
+
+  match = {}: {};
+
+in
+{
+
+  ##### interface
+
+  options.environment.xdg = {
+    mimeTypes = mkOption {
+      default = {};
+      type = types.loaOf types.optionSet;
+      example = {
+        "audio/ogg" = {
+          comment = {
+            "en" = "Ogg Audio";
+            "de" = "Ogg-Audio";
+          };
+          sub-class-of = "application/ogg";
+          globs = [ "*.oga" "i*.ogg" ".*opus" ];
+          alias = "audio/x-ogg";
+          magic = [
+            match { value="OggS"; type="string"; offset="0"; }
+          ];
+        };
+      };
+      description = ''
+        Custom mime-types to be created.
+      '';
+      options = [ mimeTypeOpts ];
+    };
+  };
+
+  ##### implementation
+
+  config = {
+
+    environment.systemPackages = [
+      (pkgs.stdenv.mkDerivation {
+        src = spec;
+        name = "nix-mimetypes";
+        builder = pkgs.writeText "builder.sh" ''
+           ${pkgs.coreutils}/bin/mkdir -p $out/share/mime/packages
+           ${pkgs.perl}/bin/perl -w \
+             -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl \
+             -I${pkgs.perlPackages.JSON}/lib/perl5/site_perl \
+             ${./update-mime-pkg.pl} ${spec} "$out"
+        '';
+      })
+    ];
+  };
+}
+

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -24,6 +24,7 @@
   ./config/unix-odbc-drivers.nix
   ./config/users-groups.nix
   ./config/vpnc.nix
+  ./config/xdg.nix
   ./config/zram.nix
   ./hardware/all-firmware.nix
   ./hardware/cpu/amd-microcode.nix


### PR DESCRIPTION
###### Motivation for this change

Initial work for #18422, "XDG Configuration / Declarative Mime Types"

Notes: 
- The perl script is terrible, and the XML that is created is poorly formatted (but valid XML).
- This doesn't (yet) help package maintainers who want to declare their own custom mimeTypes within `mkDerivation`. I imagine that would be under `pkgs/build-support/`
- "match" is a no-op, and the "magic" section is not yet implemented.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
