### PR TITLE
libspatialite: enable *nix platform builds for libspatialite

### DIFF
--- a/pkgs/development/libraries/libspatialite/default.nix
+++ b/pkgs/development/libraries/libspatialite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, sqlite, zlib, proj, geos }:
+{ stdenv, fetchurl, pkgconfig, libxml2, sqlite, zlib, proj, geos, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "libspatialite-4.2.0";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0b9ipmp09y2ij7yajyjsh0zcwps8n5g88lzfzlkph33lail8l4wz";
   };
 
-  buildInputs = [ pkgconfig libxml2 sqlite zlib proj geos ];
+  buildInputs = [ pkgconfig libxml2 sqlite zlib proj geos libiconv ];
 
   configureFlags = "--disable-freexl";
 
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.gaia-gis.it/fossil/libspatialite;
     # They allow any of these
     license = with licenses; [ gpl2Plus lgpl21Plus mpl11 ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fix #18537 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
