### PR TITLE
dell 2155cn/cdn driver: init at 1.0-1

### DIFF
--- a/pkgs/misc/drivers/dell-2155cdn/default.nix
+++ b/pkgs/misc/drivers/dell-2155cdn/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchurl, rpmextract, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "dell-2155cdn-${version}";
+  version = "1.0-1";
+
+  src = fetchurl {
+    url = "http://downloads.dell.com/printer/06_2155_Driver_Linux.zip";
+    sha256 = "1m1f1m34xiz39i33gdsgxyb7idgp0jj6mp48761v9hy8z3irza3a";
+  };
+
+  buildCommand = ''
+    dir=$out/share/ppd/Dell
+    mkdir -p $dir
+    d=$(mktemp -d)
+
+    cd $d
+    ${unzip}/bin/unzip $src
+    ${rpmextract}/bin/rpmextract Linux/Dell-2155-Color-MFP-${version}.i686.rpm
+    mv ./usr/share/cups/model/Dell/Dell_*.ppd.gz $dir
+  '';
+
+  meta = with lib; {
+    description = "PPDs for the Dell 2155cn and 2155cdn printers.";
+    homepage = https://www.dell.com;
+    # I don't know yet what the license is.
+    license = licenses.unfree;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ peterhoeg ];
+    downloadPage = http://www.dell.com/support/home/ed/en/eddhs1/product-support/product/dell-2155cn-cdn/drivers;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17164,6 +17164,8 @@ in
 
   dell-530cdn = callPackage ../misc/drivers/dell-530cdn {};
 
+  dell-2155cdn = callPackage ../misc/drivers/dell-2155cdn {};
+
   dosbox = callPackage ../misc/emulators/dosbox { };
 
   dpkg = callPackage ../tools/package-management/dpkg { };


### PR DESCRIPTION
###### Motivation for this change

I can see that the PPD files are being placed in the correct place but as I don't have the actual hardware yet, I can't confirm if the hardware really works.

I will however make sure that it actually does work as soon as the physical printer arrives.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
