### PR TITLE
cheat: init at 2.1.26

### DIFF
--- a/pkgs/applications/misc/cheat/default.nix
+++ b/pkgs/applications/misc/cheat/default.nix
@@ -1,0 +1,20 @@
+{ python3Packages, fetchurl, lib }:
+
+python3Packages.buildPythonApplication rec {
+  version = "2.1.26";
+  name = "cheat-${version}";
+
+  propagatedBuildInputs = with python3Packages; [ docopt pygments ];
+
+  src = fetchurl {
+    url = "mirror://pypi/c/cheat/${name}.tar.gz";
+    sha256 = "0yilm9ba6ll9wzh20gj3lg9mnc50q95m6sqmjp2vcghwgipdixpm";
+  };
+
+  meta = {
+    description = "cheat allows you to create and view interactive cheatsheets on the command-line";
+    maintainers = with lib.maintainers; [ mic92 ];
+    license = with lib.licenses; [gpl3 mit];
+    homepage = "https://github.com/chrisallenlane/cheat";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6281,6 +6281,8 @@ in
 
   cgdb = callPackage ../development/tools/misc/cgdb { };
 
+  cheat = callPackage ../applications/misc/cheat { };
+
   chefdk = callPackage ../development/tools/chefdk {
     ruby = ruby_2_0;
   };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
