### PR TITLE
freerdp: add missing libXrender dependency

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/unstable.nix
+++ b/pkgs/applications/networking/remote/freerdp/unstable.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, openssl, zlib, libX11, libXcursor
-, libXdamage, libXext, glib, alsaLib, ffmpeg, libxkbfile, libXinerama, libXv
+, libXdamage, libXext, libXrender, glib, alsaLib, ffmpeg, libxkbfile, libXinerama, libXv
 , substituteAll
 , libpulseaudio ? null, cups ? null, pcsclite ? null
 , buildServer ? true, optimize ? true
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       });
 
   buildInputs = [
-    cmake pkgconfig openssl zlib libX11 libXcursor libXdamage libXext glib
+    cmake pkgconfig openssl zlib libX11 libXcursor libXdamage libXext libXrender glib
     alsaLib ffmpeg libxkbfile libXinerama libXv cups libpulseaudio pcsclite
   ];
 
@@ -51,4 +51,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

With this patch, freerdp will work but scaling/smartsizing is disabled due to the missing libXrender library.

This doesn't change anything in terms of weston failing to build.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc: @joachifm 
