### PR TITLE
freerdp: allow weston to build against unstable with --enable-rdp-compositor

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/unstable.nix
+++ b/pkgs/applications/networking/remote/freerdp/unstable.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "1lydkh6by0sjy6dl57bzg7c11ccyp24s80pwxw9h5kmxkbw6mx5q";
   };
 
+  prePatch = ''
+    substituteInPlace "libfreerdp/freerdp.pc.in" --replace "Requires:" "Requires: @WINPR_PKG_CONFIG_FILENAME@"
+  '';
+
   patches = [
   ] ++ stdenv.lib.optional (pcsclite != null)
       (substituteAll {
@@ -38,7 +42,6 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional buildServer "-DWITH_SERVER=ON"
     ++ stdenv.lib.optional optimize "-DWITH_SSE2=ON";
 
-
   meta = with stdenv.lib; {
     description = "A Remote Desktop Protocol Client";
     longDescription = ''
@@ -51,4 +54,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

Weston fails to build due to recent changes in freerdp.

I checked with Arch Linux where weston is **not** built with the rdp compositor.

I honestly have no clue if this is needed, but at this moment we have to pick one of these 3:

a) revert the latest freerdp patches and remain on an old and vulnerable version
b) remove the rdp compositor support from weston
c) keep weston broken

Offhand option B sounds like the lessor evil to me.

cc: @joachifm
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
