### PR TITLE
sudo: Allow root to use sudo to switch groups

### DIFF
--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -74,7 +74,7 @@ in
         Defaults env_keep+=SSH_AUTH_SOCK
 
         # "root" is allowed to do anything.
-        root        ALL=(ALL) SETENV: ALL
+        root        ALL=(ALL:ALL) SETENV: ALL
 
         # Users in the "wheel" group can do anything.
         %wheel      ALL=(ALL:ALL) ${if cfg.wheelNeedsPassword then "" else "NOPASSWD: ALL, "}SETENV: ALL


### PR DESCRIPTION
###### Motivation for this change

The comment says that `# "root" is allowed to do anything.`.

Well if root is really allowed to do anything, then it should be allowed to switch between groups when using `sudo -g`.

Currently this is what happens:

```
> sudo -i
> sudo -g wheel id
Sorry, user root is not allowed to execute '/run/current-system/sw/bin/id' as root:wheel on matrix-central.
```
