### PR TITLE
zoom_us: init at 2.0.63547.0830

### DIFF
--- a/pkgs/applications/networking/zoom_us/default.nix
+++ b/pkgs/applications/networking/zoom_us/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }:
+let
+  version = "2.0.63547.0830";
+in stdenv.mkDerivation {
+  name = "zoom_us-${version}";
+  src = fetchurl {
+    url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
+    sha256 = "1c843z99sv1blnhrhi78n8djk590zp89a19rjhkmyhpqrgj0x02x";
+  };
+
+  installPhase = ''
+    mkdir -p "$out"/{opt,bin}
+    cp -ra * "$out/opt"
+    ln -s "$out/opt/ZoomLauncher" "$out/bin/ZoomLauncher"
+    ln -s ZoomLauncher "$out/bin/zoom"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Video Conferencing and Web Conferencing Service";
+    license = licenses.unfree;
+    homepage = "http://zoom.us";
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15674,6 +15674,8 @@ in
     pygtk = pyGtkGlade;
   };
 
+  zoom_us = callPackage ../applications/networking/zoom_us {};
+
   zotero = callPackage ../applications/office/zotero {
     firefox = firefox-esr-unwrapped;
   };


### PR DESCRIPTION
###### Motivation for this change

Needed for work
###### Things done
- [x] Testing using nix-shell --pure
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  (could not execute, python RuntimeError)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
