### PR TITLE
mumble: make mumble vm test more robust

### DIFF
--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -566,14 +566,25 @@ sub getWindowNames {
 }
 
 
+sub hasWindow {
+    my ($self, $regexp) = @_;
+    my @names = $self->getWindowNames;
+    foreach my $n (@names) {
+        if ($n =~ /$regexp/) {
+            $self->log("match '$n' on '$regexp'");
+            return 1;
+        } else {
+            $self->log("no match '$n' on '$regexp'");
+        }
+    }
+}
+
+
 sub waitForWindow {
     my ($self, $regexp) = @_;
     $self->nest("waiting for a window to appear", sub {
         retry sub {
-            my @names = $self->getWindowNames;
-            foreach my $n (@names) {
-                return 1 if $n =~ /$regexp/;
-            }
+            return $self->hasWindow($regexp)
         }
     });
 }


### PR DESCRIPTION
This test should have a more robust retry loop and handles wrong focus on all windows.

@domenkozar @lethalman @abbradar I would like to try to run this on hydra because I cannot reproduce the failing tests locally.

Related to https://github.com/NixOS/nixpkgs/issues/18209
