### PR TITLE
 ghdl: add support for llvm backend

### DIFF
--- a/pkgs/development/compilers/ghdl/default.nix
+++ b/pkgs/development/compilers/ghdl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gnat, zlib, llvm_35, ncurses, clang, flavour ? "mcode" }:
+{ stdenv, fetchFromGitHub, gnat, zlib, llvm_35, ncurses, clang, flavour ? "mcode" }:
 
 # mcode only works on x86, while the llvm flavour works on both x86 and x86_64.
 
@@ -13,9 +13,11 @@ in
 stdenv.mkDerivation rec {
   name = "ghdl-${flavour}-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/tgingold/ghdl/archive/v${version}.tar.gz";
-    sha256 = "09yvgqyglbakd74v2dgr470clzm744i232nixyffcds55vkij5da";
+  src = fetchFromGitHub {
+    owner = "tgingold";
+    repo = "ghdl";
+    rev = "v${version}";
+    sha256 = "0g72rk2yzr0lrpncq2c1qcv71w3mi2hjq84r1yzgjr6d0qm87r2a";
   };
 
   buildInputs = [ gnat zlib ] ++ optionals (flavour == "llvm") [ clang ncurses ];

--- a/pkgs/development/compilers/ghdl/default.nix
+++ b/pkgs/development/compilers/ghdl/default.nix
@@ -1,16 +1,26 @@
-{ stdenv, fetchurl, gnat, zlib }:
+{ stdenv, fetchurl, gnat, zlib, llvm_35, ncurses, clang, flavour ? "mcode" }:
+
+# mcode only works on x86, while the llvm flavour works on both x86 and x86_64.
+
+
+assert flavour == "llvm" || flavour == "mcode";
+
 let
+  inherit (stdenv.lib) optional;
+  inherit (stdenv.lib) optionals;
   version = "0.33";
 in
 stdenv.mkDerivation rec {
-  name = "ghdl-mcode-${version}";
+  name = "ghdl-${flavour}-${version}";
 
   src = fetchurl {
     url = "https://github.com/tgingold/ghdl/archive/v${version}.tar.gz";
     sha256 = "09yvgqyglbakd74v2dgr470clzm744i232nixyffcds55vkij5da";
   };
 
-  buildInputs = [ gnat zlib ];
+  buildInputs = [ gnat zlib ] ++ optionals (flavour == "llvm") [ clang ncurses ];
+
+  configureFlags = optional (flavour == "llvm") "--with-llvm=${llvm_35}";
 
   patchPhase = ''
     # Disable warnings-as-errors, because there are warnings (unused things)
@@ -23,11 +33,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://sourceforge.net/p/ghdl-updates/wiki/Home/";
-    description = "Free VHDL simulator, mcode flavour";
+    description = "Free VHDL simulator";
     maintainers = with stdenv.lib.maintainers; [viric];
-    # I think that mcode can only generate x86 code,
-    # so it fails to link pieces on x86_64.
-    platforms = with stdenv.lib.platforms; [ "i686-linux" ];
+    platforms = with stdenv.lib.platforms; (if flavour == "llvm" then [ "i686-linux" "x86_64-linux" ]
+      else [ "i686-linux" ]);
     license = stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4710,7 +4710,13 @@ in
     profiledCompiler = false;
   });
 
-  ghdl_mcode = callPackage_i686 ../development/compilers/ghdl { };
+  ghdl_mcode = callPackage_i686 ../development/compilers/ghdl {
+    flavour = "mcode";
+  };
+
+  ghdl_llvm = callPackage ../development/compilers/ghdl {
+    flavour = "llvm";
+  };
 
   gcl = callPackage ../development/compilers/gcl {
     gmp = gmp4;


### PR DESCRIPTION
###### Motivation for this change

This adds support for building ghdl with the llvm backend, which enables, among other things, to
have a working version for 64 bit systems.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Make the existing ghdl recipe more flexible, and introduce "ghdl_llvm"
as a package in addition to "ghdl_mcode". This seems to specifically
require llvm 3.5, though.

cc @viric
