### PR TITLE
tomcat: remove tomcat vm test timing issues

### DIFF
--- a/nixos/tests/tomcat.nix
+++ b/nixos/tests/tomcat.nix
@@ -23,9 +23,8 @@ import ./make-test.nix ({ pkgs, ...} : {
     startAll;
 
     $server->waitForUnit("tomcat");
-    $server->sleep(30); # Dirty, but it takes a while before Tomcat handles to requests properly
     $client->waitForUnit("network.target");
-    $client->succeed("curl --fail http://server/examples/servlets/servlet/HelloWorldExample");
-    $client->succeed("curl --fail http://server/examples/jsp/jsp2/simpletag/hello.jsp");
+    $client->waitUntilSucceeds("curl --fail http://server/examples/servlets/servlet/HelloWorldExample");
+    $client->waitUntilSucceeds("curl --fail http://server/examples/jsp/jsp2/simpletag/hello.jsp");
   '';
 })


### PR DESCRIPTION
This should fix the timing issues in the tomcat test.

@domenkozar @edolstra 
