### PR TITLE
fetchbower: add git to build inputs

### DIFF
--- a/pkgs/build-support/fetchbower/default.nix
+++ b/pkgs/build-support/fetchbower/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, bower2nix }:
+{ stdenv, lib, bower2nix, git }:
 let
   bowerVersion = version:
     let
@@ -20,7 +20,7 @@ let
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
     inherit outputHash;
-    buildInputs = [ bower2nix ];
+    buildInputs = [ bower2nix git ];
   };
 
 in fetchbower


### PR DESCRIPTION
###### Motivation for this change

fetch-bower depends on git.

Note: there's a bug in fetch-bower when git is NOT in PATH it will silently continue.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
