### PR TITLE
Janestreet

### DIFF
--- a/pkgs/development/ocaml-modules/async/default.nix
+++ b/pkgs/development/ocaml-modules/async/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async_kernel_p4,
- async_unix_p4, async_extra, pa_ounit}:
+ async_unix_p4, async_extra_p4, pa_ounit}:
 
 buildOcaml rec {
   name = "async";
@@ -12,7 +12,7 @@ buildOcaml rec {
     sha256 = "ecc4ca939ab098e689332921b110dbaacd06d9f8d8bf697023dfff3ca37dc1e9";
   };
 
-  propagatedBuildInputs = [ async_kernel_p4 async_unix_p4 async_extra pa_ounit ];
+  propagatedBuildInputs = [ async_kernel_p4 async_unix_p4 async_extra_p4 pa_ounit ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async;

--- a/pkgs/development/ocaml-modules/async/default.nix
+++ b/pkgs/development/ocaml-modules/async/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async_kernel_p4,
- async_unix, async_extra, pa_ounit}:
+ async_unix_p4, async_extra, pa_ounit}:
 
 buildOcaml rec {
   name = "async";
@@ -12,7 +12,7 @@ buildOcaml rec {
     sha256 = "ecc4ca939ab098e689332921b110dbaacd06d9f8d8bf697023dfff3ca37dc1e9";
   };
 
-  propagatedBuildInputs = [ async_kernel_p4 async_unix async_extra pa_ounit ];
+  propagatedBuildInputs = [ async_kernel_p4 async_unix_p4 async_extra pa_ounit ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async;

--- a/pkgs/development/ocaml-modules/async/default.nix
+++ b/pkgs/development/ocaml-modules/async/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async_kernel,
+{stdenv, buildOcaml, fetchurl, async_kernel_p4,
  async_unix, async_extra, pa_ounit}:
 
 buildOcaml rec {
@@ -12,7 +12,7 @@ buildOcaml rec {
     sha256 = "ecc4ca939ab098e689332921b110dbaacd06d9f8d8bf697023dfff3ca37dc1e9";
   };
 
-  propagatedBuildInputs = [ async_kernel async_unix async_extra pa_ounit ];
+  propagatedBuildInputs = [ async_kernel_p4 async_unix async_extra pa_ounit ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async;

--- a/pkgs/development/ocaml-modules/async_extra/default.nix
+++ b/pkgs/development/ocaml-modules/async_extra/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async_kernel, async_unix,
- bin_prot_p4, core, custom_printf, fieldslib_p4, herelib, pa_ounit,
+ bin_prot_p4, core_p4, custom_printf, fieldslib_p4, herelib, pa_ounit,
  pipebang, pa_test, sexplib_p4}:
 
 buildOcaml rec {
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test pa_ounit ];
-  propagatedBuildInputs = [ async_kernel async_unix core bin_prot_p4 custom_printf
+  propagatedBuildInputs = [ async_kernel async_unix core_p4 bin_prot_p4 custom_printf
                             fieldslib_p4 herelib pipebang sexplib_p4 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/async_extra/default.nix
+++ b/pkgs/development/ocaml-modules/async_extra/default.nix
@@ -1,6 +1,6 @@
 {stdenv, buildOcaml, fetchurl, async_kernel, async_unix,
  bin_prot, core, custom_printf, fieldslib_p4, herelib, pa_ounit,
- pipebang, pa_test, sexplib}:
+ pipebang, pa_test, sexplib_p4}:
 
 buildOcaml rec {
   name = "async_extra";
@@ -15,7 +15,7 @@ buildOcaml rec {
 
   buildInputs = [ pa_test pa_ounit ];
   propagatedBuildInputs = [ async_kernel async_unix core bin_prot custom_printf
-                            fieldslib_p4 herelib pipebang sexplib ];
+                            fieldslib_p4 herelib pipebang sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_extra;

--- a/pkgs/development/ocaml-modules/async_extra/default.nix
+++ b/pkgs/development/ocaml-modules/async_extra/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async_kernel_p4, async_unix,
+{stdenv, buildOcaml, fetchurl, async_kernel_p4, async_unix_p4,
  bin_prot_p4, core_p4, custom_printf, fieldslib_p4, herelib, pa_ounit,
  pipebang, pa_test, sexplib_p4}:
 
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test pa_ounit ];
-  propagatedBuildInputs = [ async_kernel_p4 async_unix core_p4 bin_prot_p4 custom_printf
+  propagatedBuildInputs = [ async_kernel_p4 async_unix_p4 core_p4 bin_prot_p4 custom_printf
                             fieldslib_p4 herelib pipebang sexplib_p4 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/async_extra/default.nix
+++ b/pkgs/development/ocaml-modules/async_extra/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async_kernel, async_unix,
+{stdenv, buildOcaml, fetchurl, async_kernel_p4, async_unix,
  bin_prot_p4, core_p4, custom_printf, fieldslib_p4, herelib, pa_ounit,
  pipebang, pa_test, sexplib_p4}:
 
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test pa_ounit ];
-  propagatedBuildInputs = [ async_kernel async_unix core_p4 bin_prot_p4 custom_printf
+  propagatedBuildInputs = [ async_kernel_p4 async_unix core_p4 bin_prot_p4 custom_printf
                             fieldslib_p4 herelib pipebang sexplib_p4 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/async_extra/default.nix
+++ b/pkgs/development/ocaml-modules/async_extra/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async_kernel, async_unix,
- bin_prot, core, custom_printf, fieldslib, herelib, pa_ounit,
+ bin_prot, core, custom_printf, fieldslib_p4, herelib, pa_ounit,
  pipebang, pa_test, sexplib}:
 
 buildOcaml rec {
@@ -15,7 +15,7 @@ buildOcaml rec {
 
   buildInputs = [ pa_test pa_ounit ];
   propagatedBuildInputs = [ async_kernel async_unix core bin_prot custom_printf
-                            fieldslib herelib pipebang sexplib ];
+                            fieldslib_p4 herelib pipebang sexplib ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_extra;

--- a/pkgs/development/ocaml-modules/async_extra/default.nix
+++ b/pkgs/development/ocaml-modules/async_extra/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async_kernel, async_unix,
- bin_prot, core, custom_printf, fieldslib_p4, herelib, pa_ounit,
+ bin_prot_p4, core, custom_printf, fieldslib_p4, herelib, pa_ounit,
  pipebang, pa_test, sexplib_p4}:
 
 buildOcaml rec {
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test pa_ounit ];
-  propagatedBuildInputs = [ async_kernel async_unix core bin_prot custom_printf
+  propagatedBuildInputs = [ async_kernel async_unix core bin_prot_p4 custom_printf
                             fieldslib_p4 herelib pipebang sexplib_p4 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/async_find/default.nix
+++ b/pkgs/development/ocaml-modules/async_find/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async, core_p4, sexplib_p4}:
+{stdenv, buildOcaml, fetchurl, async_p4, core_p4, sexplib_p4}:
 
 buildOcaml rec {
   name = "async_find";
@@ -11,7 +11,7 @@ buildOcaml rec {
     sha256 = "4e3fda72f50174f05d96a5a09323f236c041b1a685890c155822956f3deb8803";
   };
 
-  propagatedBuildInputs = [ async core_p4 sexplib_p4 ];
+  propagatedBuildInputs = [ async_p4 core_p4 sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_find;

--- a/pkgs/development/ocaml-modules/async_find/default.nix
+++ b/pkgs/development/ocaml-modules/async_find/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async, core, sexplib_p4}:
+{stdenv, buildOcaml, fetchurl, async, core_p4, sexplib_p4}:
 
 buildOcaml rec {
   name = "async_find";
@@ -11,7 +11,7 @@ buildOcaml rec {
     sha256 = "4e3fda72f50174f05d96a5a09323f236c041b1a685890c155822956f3deb8803";
   };
 
-  propagatedBuildInputs = [ async core sexplib_p4 ];
+  propagatedBuildInputs = [ async core_p4 sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_find;

--- a/pkgs/development/ocaml-modules/async_find/default.nix
+++ b/pkgs/development/ocaml-modules/async_find/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async, core, sexplib}:
+{stdenv, buildOcaml, fetchurl, async, core, sexplib_p4}:
 
 buildOcaml rec {
   name = "async_find";
@@ -11,7 +11,7 @@ buildOcaml rec {
     sha256 = "4e3fda72f50174f05d96a5a09323f236c041b1a685890c155822956f3deb8803";
   };
 
-  propagatedBuildInputs = [ async core sexplib ];
+  propagatedBuildInputs = [ async core sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_find;

--- a/pkgs/development/ocaml-modules/async_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/async_kernel/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, core_kernel,
- bin_prot, fieldslib, pa_ounit, pa_test,
+ bin_prot, fieldslib_p4, pa_ounit, pa_test,
  sexplib, herelib}:
 
 buildOcaml rec {
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test pa_ounit ];
-  propagatedBuildInputs = [ core_kernel bin_prot fieldslib herelib sexplib ];
+  propagatedBuildInputs = [ core_kernel bin_prot fieldslib_p4 herelib sexplib ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_kernel;

--- a/pkgs/development/ocaml-modules/async_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/async_kernel/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, core_kernel,
- bin_prot, fieldslib_p4, pa_ounit, pa_test,
+ bin_prot_p4, fieldslib_p4, pa_ounit, pa_test,
  sexplib_p4, herelib}:
 
 buildOcaml rec {
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test pa_ounit ];
-  propagatedBuildInputs = [ core_kernel bin_prot fieldslib_p4 herelib sexplib_p4 ];
+  propagatedBuildInputs = [ core_kernel bin_prot_p4 fieldslib_p4 herelib sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_kernel;

--- a/pkgs/development/ocaml-modules/async_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/async_kernel/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, core_kernel,
+{stdenv, buildOcaml, fetchurl, core_kernel_p4,
  bin_prot_p4, fieldslib_p4, pa_ounit, pa_test,
  sexplib_p4, herelib}:
 
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test pa_ounit ];
-  propagatedBuildInputs = [ core_kernel bin_prot_p4 fieldslib_p4 herelib sexplib_p4 ];
+  propagatedBuildInputs = [ core_kernel_p4 bin_prot_p4 fieldslib_p4 herelib sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_kernel;

--- a/pkgs/development/ocaml-modules/async_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/async_kernel/default.nix
@@ -1,6 +1,6 @@
 {stdenv, buildOcaml, fetchurl, core_kernel,
  bin_prot, fieldslib_p4, pa_ounit, pa_test,
- sexplib, herelib}:
+ sexplib_p4, herelib}:
 
 buildOcaml rec {
   name = "async_kernel";
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test pa_ounit ];
-  propagatedBuildInputs = [ core_kernel bin_prot fieldslib_p4 herelib sexplib ];
+  propagatedBuildInputs = [ core_kernel bin_prot fieldslib_p4 herelib sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_kernel;

--- a/pkgs/development/ocaml-modules/async_shell/default.nix
+++ b/pkgs/development/ocaml-modules/async_shell/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async, core_p4, core_extended}:
+{stdenv, buildOcaml, fetchurl, async, core_p4, core_extended_p4}:
 
 buildOcaml rec {
   name = "async_shell";
@@ -11,7 +11,7 @@ buildOcaml rec {
     sha256 = "0b4497bea9124c5a665ee58fb0a73c5cbf2f757479df902e6870627196e6c105";
   };
 
-  propagatedBuildInputs = [ async core_p4 core_extended ];
+  propagatedBuildInputs = [ async core_p4 core_extended_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_shell;

--- a/pkgs/development/ocaml-modules/async_shell/default.nix
+++ b/pkgs/development/ocaml-modules/async_shell/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async, core, core_extended}:
+{stdenv, buildOcaml, fetchurl, async, core_p4, core_extended}:
 
 buildOcaml rec {
   name = "async_shell";
@@ -11,7 +11,7 @@ buildOcaml rec {
     sha256 = "0b4497bea9124c5a665ee58fb0a73c5cbf2f757479df902e6870627196e6c105";
   };
 
-  propagatedBuildInputs = [ async core core_extended ];
+  propagatedBuildInputs = [ async core_p4 core_extended ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_shell;

--- a/pkgs/development/ocaml-modules/async_shell/default.nix
+++ b/pkgs/development/ocaml-modules/async_shell/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async, core_p4, core_extended_p4}:
+{stdenv, buildOcaml, fetchurl, async_p4, core_p4, core_extended_p4}:
 
 buildOcaml rec {
   name = "async_shell";
@@ -11,7 +11,7 @@ buildOcaml rec {
     sha256 = "0b4497bea9124c5a665ee58fb0a73c5cbf2f757479df902e6870627196e6c105";
   };
 
-  propagatedBuildInputs = [ async core_p4 core_extended_p4 ];
+  propagatedBuildInputs = [ async_p4 core_p4 core_extended_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_shell;

--- a/pkgs/development/ocaml-modules/async_ssl/default.nix
+++ b/pkgs/development/ocaml-modules/async_ssl/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async, comparelib, core_p4, ctypes, openssl,
+{stdenv, buildOcaml, fetchurl, async_p4, comparelib, core_p4, ctypes, openssl,
  fieldslib_p4, herelib, pa_bench, pa_ounit, pipebang, pa_test, sexplib_p4}:
 
 buildOcaml rec {
@@ -13,7 +13,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_bench pa_test ];
-  propagatedBuildInputs = [ ctypes async comparelib core_p4 fieldslib_p4 pa_ounit
+  propagatedBuildInputs = [ ctypes async_p4 comparelib core_p4 fieldslib_p4 pa_ounit
                             herelib pipebang sexplib_p4 openssl ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/async_ssl/default.nix
+++ b/pkgs/development/ocaml-modules/async_ssl/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async, comparelib, core, ctypes, openssl,
- fieldslib, herelib, pa_bench, pa_ounit, pipebang, pa_test, sexplib}:
+ fieldslib_p4, herelib, pa_bench, pa_ounit, pipebang, pa_test, sexplib}:
 
 buildOcaml rec {
   name = "async_ssl";
@@ -13,7 +13,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_bench pa_test ];
-  propagatedBuildInputs = [ ctypes async comparelib core fieldslib pa_ounit
+  propagatedBuildInputs = [ ctypes async comparelib core fieldslib_p4 pa_ounit
                             herelib pipebang sexplib openssl ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/async_ssl/default.nix
+++ b/pkgs/development/ocaml-modules/async_ssl/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async, comparelib, core, ctypes, openssl,
+{stdenv, buildOcaml, fetchurl, async, comparelib, core_p4, ctypes, openssl,
  fieldslib_p4, herelib, pa_bench, pa_ounit, pipebang, pa_test, sexplib_p4}:
 
 buildOcaml rec {
@@ -13,7 +13,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_bench pa_test ];
-  propagatedBuildInputs = [ ctypes async comparelib core fieldslib_p4 pa_ounit
+  propagatedBuildInputs = [ ctypes async comparelib core_p4 fieldslib_p4 pa_ounit
                             herelib pipebang sexplib_p4 openssl ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/async_ssl/default.nix
+++ b/pkgs/development/ocaml-modules/async_ssl/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async, comparelib, core, ctypes, openssl,
- fieldslib_p4, herelib, pa_bench, pa_ounit, pipebang, pa_test, sexplib}:
+ fieldslib_p4, herelib, pa_bench, pa_ounit, pipebang, pa_test, sexplib_p4}:
 
 buildOcaml rec {
   name = "async_ssl";
@@ -14,7 +14,7 @@ buildOcaml rec {
 
   buildInputs = [ pa_bench pa_test ];
   propagatedBuildInputs = [ ctypes async comparelib core fieldslib_p4 pa_ounit
-                            herelib pipebang sexplib openssl ];
+                            herelib pipebang sexplib_p4 openssl ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_ssl;

--- a/pkgs/development/ocaml-modules/async_unix/default.nix
+++ b/pkgs/development/ocaml-modules/async_unix/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, async_kernel,
+{stdenv, buildOcaml, fetchurl, async_kernel_p4,
  bin_prot_p4, comparelib, core_p4, fieldslib_p4, herelib, pa_ounit,
  pipebang, pa_test, sexplib_p4}:
 
@@ -15,7 +15,7 @@ buildOcaml rec {
 
   hasSharedObjects = true;
   buildInputs = [ pa_ounit ];
-  propagatedBuildInputs = [ async_kernel core_p4 bin_prot_p4 comparelib
+  propagatedBuildInputs = [ async_kernel_p4 core_p4 bin_prot_p4 comparelib
                             fieldslib_p4 herelib pipebang pa_test sexplib_p4 ];
 
    meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/async_unix/default.nix
+++ b/pkgs/development/ocaml-modules/async_unix/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async_kernel,
- bin_prot, comparelib, core, fieldslib, herelib, pa_ounit,
+ bin_prot, comparelib, core, fieldslib_p4, herelib, pa_ounit,
  pipebang, pa_test, sexplib}:
 
 buildOcaml rec {
@@ -16,7 +16,7 @@ buildOcaml rec {
   hasSharedObjects = true;
   buildInputs = [ pa_ounit ];
   propagatedBuildInputs = [ async_kernel core bin_prot comparelib
-                            fieldslib herelib pipebang pa_test sexplib ];
+                            fieldslib_p4 herelib pipebang pa_test sexplib ];
 
    meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_unix;

--- a/pkgs/development/ocaml-modules/async_unix/default.nix
+++ b/pkgs/development/ocaml-modules/async_unix/default.nix
@@ -1,6 +1,6 @@
 {stdenv, buildOcaml, fetchurl, async_kernel,
  bin_prot, comparelib, core, fieldslib_p4, herelib, pa_ounit,
- pipebang, pa_test, sexplib}:
+ pipebang, pa_test, sexplib_p4}:
 
 buildOcaml rec {
   name = "async_unix";
@@ -16,7 +16,7 @@ buildOcaml rec {
   hasSharedObjects = true;
   buildInputs = [ pa_ounit ];
   propagatedBuildInputs = [ async_kernel core bin_prot comparelib
-                            fieldslib_p4 herelib pipebang pa_test sexplib ];
+                            fieldslib_p4 herelib pipebang pa_test sexplib_p4 ];
 
    meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/async_unix;

--- a/pkgs/development/ocaml-modules/async_unix/default.nix
+++ b/pkgs/development/ocaml-modules/async_unix/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async_kernel,
- bin_prot_p4, comparelib, core, fieldslib_p4, herelib, pa_ounit,
+ bin_prot_p4, comparelib, core_p4, fieldslib_p4, herelib, pa_ounit,
  pipebang, pa_test, sexplib_p4}:
 
 buildOcaml rec {
@@ -15,7 +15,7 @@ buildOcaml rec {
 
   hasSharedObjects = true;
   buildInputs = [ pa_ounit ];
-  propagatedBuildInputs = [ async_kernel core bin_prot_p4 comparelib
+  propagatedBuildInputs = [ async_kernel core_p4 bin_prot_p4 comparelib
                             fieldslib_p4 herelib pipebang pa_test sexplib_p4 ];
 
    meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/async_unix/default.nix
+++ b/pkgs/development/ocaml-modules/async_unix/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, async_kernel,
- bin_prot, comparelib, core, fieldslib_p4, herelib, pa_ounit,
+ bin_prot_p4, comparelib, core, fieldslib_p4, herelib, pa_ounit,
  pipebang, pa_test, sexplib_p4}:
 
 buildOcaml rec {
@@ -15,7 +15,7 @@ buildOcaml rec {
 
   hasSharedObjects = true;
   buildInputs = [ pa_ounit ];
-  propagatedBuildInputs = [ async_kernel core bin_prot comparelib
+  propagatedBuildInputs = [ async_kernel core bin_prot_p4 comparelib
                             fieldslib_p4 herelib pipebang pa_test sexplib_p4 ];
 
    meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, cmdliner, re, uri, fieldslib_p4, sexplib, conduit,
+{stdenv, buildOcaml, fetchurl, cmdliner, re, uri, fieldslib_p4, sexplib_p4, conduit,
  stringext, base64, magic-mime, ounit, alcotest, lwt ? null,
  async ? null, async_ssl ? null}:
 
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ alcotest ];
-  propagatedBuildInputs = [ cmdliner re uri fieldslib_p4 sexplib sexplib
+  propagatedBuildInputs = [ cmdliner re uri fieldslib_p4 sexplib_p4 sexplib_p4
                             conduit stringext base64 magic-mime ounit async
                             async_ssl lwt ];
 

--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, cmdliner, re, uri, fieldslib, sexplib, conduit,
+{stdenv, buildOcaml, fetchurl, cmdliner, re, uri, fieldslib_p4, sexplib, conduit,
  stringext, base64, magic-mime, ounit, alcotest, lwt ? null,
  async ? null, async_ssl ? null}:
 
@@ -14,7 +14,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ alcotest ];
-  propagatedBuildInputs = [ cmdliner re uri fieldslib sexplib sexplib
+  propagatedBuildInputs = [ cmdliner re uri fieldslib_p4 sexplib sexplib
                             conduit stringext base64 magic-mime ounit async
                             async_ssl lwt ];
 

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, sexplib, stringext, uri, cstruct, ipaddr,
+{stdenv, buildOcaml, fetchurl, sexplib_p4, stringext, uri, cstruct, ipaddr,
  async ? null, async_ssl ? null, lwt ? null}:
 
 buildOcaml rec {
@@ -10,7 +10,7 @@ buildOcaml rec {
     sha256 = "5cf1a46aa0254345e5143feebe6b54bdef96314e9987f44e69f24618d620faa1";
   };
 
-  propagatedBuildInputs = ([ sexplib stringext uri cstruct ipaddr ]
+  propagatedBuildInputs = ([ sexplib_p4 stringext uri cstruct ipaddr ]
                             ++ stdenv.lib.optional (lwt != null) lwt
                             ++ stdenv.lib.optional (async != null) async
                             ++ stdenv.lib.optional (async_ssl != null) async_ssl);

--- a/pkgs/development/ocaml-modules/core/default.nix
+++ b/pkgs/development/ocaml-modules/core/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
- core_kernel, bin_prot, comparelib, custom_printf, enumerate,
+ core_kernel, bin_prot_p4, comparelib, custom_printf, enumerate,
  fieldslib_p4, herelib, pa_bench, pa_test, pa_ounit,
  pipebang, sexplib_p4, typerep_p4, variantslib_p4}:
 
@@ -17,7 +17,7 @@ buildOcaml rec {
   hasSharedObjects = true;
 
   buildInputs = [ pa_bench pa_test pa_ounit ];
-  propagatedBuildInputs = [ type_conv core_kernel bin_prot comparelib
+  propagatedBuildInputs = [ type_conv core_kernel bin_prot_p4 comparelib
                             custom_printf enumerate fieldslib_p4 herelib
                             pipebang sexplib_p4 typerep_p4 variantslib_p4 ];
 

--- a/pkgs/development/ocaml-modules/core/default.nix
+++ b/pkgs/development/ocaml-modules/core/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
- core_kernel, bin_prot_p4, comparelib, custom_printf, enumerate,
+ core_kernel_p4, bin_prot_p4, comparelib, custom_printf, enumerate,
  fieldslib_p4, herelib, pa_bench, pa_test, pa_ounit,
  pipebang, sexplib_p4, typerep_p4, variantslib_p4}:
 
@@ -17,7 +17,7 @@ buildOcaml rec {
   hasSharedObjects = true;
 
   buildInputs = [ pa_bench pa_test pa_ounit ];
-  propagatedBuildInputs = [ type_conv core_kernel bin_prot_p4 comparelib
+  propagatedBuildInputs = [ type_conv core_kernel_p4 bin_prot_p4 comparelib
                             custom_printf enumerate fieldslib_p4 herelib
                             pipebang sexplib_p4 typerep_p4 variantslib_p4 ];
 

--- a/pkgs/development/ocaml-modules/core/default.nix
+++ b/pkgs/development/ocaml-modules/core/default.nix
@@ -1,7 +1,7 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
  core_kernel, bin_prot, comparelib, custom_printf, enumerate,
  fieldslib_p4, herelib, pa_bench, pa_test, pa_ounit,
- pipebang, sexplib_p4, typerep_p4, variantslib}:
+ pipebang, sexplib_p4, typerep_p4, variantslib_p4}:
 
 buildOcaml rec {
   name = "core";
@@ -19,7 +19,7 @@ buildOcaml rec {
   buildInputs = [ pa_bench pa_test pa_ounit ];
   propagatedBuildInputs = [ type_conv core_kernel bin_prot comparelib
                             custom_printf enumerate fieldslib_p4 herelib
-                            pipebang sexplib_p4 typerep_p4 variantslib ];
+                            pipebang sexplib_p4 typerep_p4 variantslib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/core;

--- a/pkgs/development/ocaml-modules/core/default.nix
+++ b/pkgs/development/ocaml-modules/core/default.nix
@@ -1,6 +1,6 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
  core_kernel, bin_prot, comparelib, custom_printf, enumerate,
- fieldslib, herelib, pa_bench, pa_test, pa_ounit,
+ fieldslib_p4, herelib, pa_bench, pa_test, pa_ounit,
  pipebang, sexplib, typerep_p4, variantslib}:
 
 buildOcaml rec {
@@ -18,7 +18,7 @@ buildOcaml rec {
 
   buildInputs = [ pa_bench pa_test pa_ounit ];
   propagatedBuildInputs = [ type_conv core_kernel bin_prot comparelib
-                            custom_printf enumerate fieldslib herelib
+                            custom_printf enumerate fieldslib_p4 herelib
                             pipebang sexplib typerep_p4 variantslib ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/core/default.nix
+++ b/pkgs/development/ocaml-modules/core/default.nix
@@ -1,7 +1,7 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
  core_kernel, bin_prot, comparelib, custom_printf, enumerate,
  fieldslib_p4, herelib, pa_bench, pa_test, pa_ounit,
- pipebang, sexplib, typerep_p4, variantslib}:
+ pipebang, sexplib_p4, typerep_p4, variantslib}:
 
 buildOcaml rec {
   name = "core";
@@ -19,7 +19,7 @@ buildOcaml rec {
   buildInputs = [ pa_bench pa_test pa_ounit ];
   propagatedBuildInputs = [ type_conv core_kernel bin_prot comparelib
                             custom_printf enumerate fieldslib_p4 herelib
-                            pipebang sexplib typerep_p4 variantslib ];
+                            pipebang sexplib_p4 typerep_p4 variantslib ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/core;

--- a/pkgs/development/ocaml-modules/core/default.nix
+++ b/pkgs/development/ocaml-modules/core/default.nix
@@ -1,7 +1,7 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
  core_kernel, bin_prot, comparelib, custom_printf, enumerate,
  fieldslib, herelib, pa_bench, pa_test, pa_ounit,
- pipebang, sexplib, typerep, variantslib}:
+ pipebang, sexplib, typerep_p4, variantslib}:
 
 buildOcaml rec {
   name = "core";
@@ -19,7 +19,7 @@ buildOcaml rec {
   buildInputs = [ pa_bench pa_test pa_ounit ];
   propagatedBuildInputs = [ type_conv core_kernel bin_prot comparelib
                             custom_printf enumerate fieldslib herelib
-                            pipebang sexplib typerep variantslib ];
+                            pipebang sexplib typerep_p4 variantslib ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/core;

--- a/pkgs/development/ocaml-modules/core_extended/default.nix
+++ b/pkgs/development/ocaml-modules/core_extended/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, bin_prot, comparelib, core, custom_printf,
- fieldslib, pa_bench, pa_ounit, pipebang, pa_test, textutils, re2, sexplib}:
+ fieldslib_p4, pa_bench, pa_ounit, pipebang, pa_test, textutils, re2, sexplib}:
 
 buildOcaml rec {
   name = "core_extended";
@@ -14,7 +14,7 @@ buildOcaml rec {
 
   hasSharedObjects = true;
   buildInputs = [ pa_bench pa_test pa_ounit ];
-  propagatedBuildInputs = [bin_prot comparelib core custom_printf fieldslib
+  propagatedBuildInputs = [bin_prot comparelib core custom_printf fieldslib_p4
                            pipebang textutils re2 sexplib ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/core_extended/default.nix
+++ b/pkgs/development/ocaml-modules/core_extended/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, bin_prot, comparelib, core, custom_printf,
+{stdenv, buildOcaml, fetchurl, bin_prot_p4, comparelib, core, custom_printf,
  fieldslib_p4, pa_bench, pa_ounit, pipebang, pa_test, textutils, re2, sexplib_p4}:
 
 buildOcaml rec {
@@ -14,7 +14,7 @@ buildOcaml rec {
 
   hasSharedObjects = true;
   buildInputs = [ pa_bench pa_test pa_ounit ];
-  propagatedBuildInputs = [bin_prot comparelib core custom_printf fieldslib_p4
+  propagatedBuildInputs = [bin_prot_p4 comparelib core custom_printf fieldslib_p4
                            pipebang textutils re2 sexplib_p4 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/core_extended/default.nix
+++ b/pkgs/development/ocaml-modules/core_extended/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, bin_prot, comparelib, core, custom_printf,
- fieldslib_p4, pa_bench, pa_ounit, pipebang, pa_test, textutils, re2, sexplib}:
+ fieldslib_p4, pa_bench, pa_ounit, pipebang, pa_test, textutils, re2, sexplib_p4}:
 
 buildOcaml rec {
   name = "core_extended";
@@ -15,7 +15,7 @@ buildOcaml rec {
   hasSharedObjects = true;
   buildInputs = [ pa_bench pa_test pa_ounit ];
   propagatedBuildInputs = [bin_prot comparelib core custom_printf fieldslib_p4
-                           pipebang textutils re2 sexplib ];
+                           pipebang textutils re2 sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/core_extended;

--- a/pkgs/development/ocaml-modules/core_extended/default.nix
+++ b/pkgs/development/ocaml-modules/core_extended/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, bin_prot_p4, comparelib, core_p4, custom_printf,
- fieldslib_p4, pa_bench, pa_ounit, pipebang, pa_test, textutils, re2, sexplib_p4}:
+ fieldslib_p4, pa_bench, pa_ounit, pipebang, pa_test, textutils, re2_p4, sexplib_p4}:
 
 buildOcaml rec {
   name = "core_extended";
@@ -15,7 +15,7 @@ buildOcaml rec {
   hasSharedObjects = true;
   buildInputs = [ pa_bench pa_test pa_ounit ];
   propagatedBuildInputs = [bin_prot_p4 comparelib core_p4 custom_printf fieldslib_p4
-                           pipebang textutils re2 sexplib_p4 ];
+                           pipebang textutils re2_p4 sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/core_extended;

--- a/pkgs/development/ocaml-modules/core_extended/default.nix
+++ b/pkgs/development/ocaml-modules/core_extended/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, bin_prot_p4, comparelib, core, custom_printf,
+{stdenv, buildOcaml, fetchurl, bin_prot_p4, comparelib, core_p4, custom_printf,
  fieldslib_p4, pa_bench, pa_ounit, pipebang, pa_test, textutils, re2, sexplib_p4}:
 
 buildOcaml rec {
@@ -14,7 +14,7 @@ buildOcaml rec {
 
   hasSharedObjects = true;
   buildInputs = [ pa_bench pa_test pa_ounit ];
-  propagatedBuildInputs = [bin_prot_p4 comparelib core custom_printf fieldslib_p4
+  propagatedBuildInputs = [bin_prot_p4 comparelib core_p4 custom_printf fieldslib_p4
                            pipebang textutils re2 sexplib_p4 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/core_extended/default.nix
+++ b/pkgs/development/ocaml-modules/core_extended/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, bin_prot_p4, comparelib, core_p4, custom_printf,
- fieldslib_p4, pa_bench, pa_ounit, pipebang, pa_test, textutils, re2_p4, sexplib_p4}:
+ fieldslib_p4, pa_bench, pa_ounit, pipebang, pa_test, textutils_p4, re2_p4, sexplib_p4}:
 
 buildOcaml rec {
   name = "core_extended";
@@ -15,7 +15,7 @@ buildOcaml rec {
   hasSharedObjects = true;
   buildInputs = [ pa_bench pa_test pa_ounit ];
   propagatedBuildInputs = [bin_prot_p4 comparelib core_p4 custom_printf fieldslib_p4
-                           pipebang textutils re2_p4 sexplib_p4 ];
+                           pipebang textutils_p4 re2_p4 sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/core_extended;

--- a/pkgs/development/ocaml-modules/core_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/core_kernel/default.nix
@@ -1,7 +1,7 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
  bin_prot, comparelib, custom_printf, enumerate,
  fieldslib, herelib, pa_bench, pa_test, pa_ounit,
- pipebang, sexplib, typerep, variantslib}:
+ pipebang, sexplib, typerep_p4, variantslib}:
 
 buildOcaml rec {
   name = "core_kernel";
@@ -19,7 +19,7 @@ buildOcaml rec {
   buildInputs = [ pa_test pa_ounit ];
   propagatedBuildInputs = [ type_conv pa_bench bin_prot comparelib custom_printf
                             enumerate fieldslib herelib pipebang sexplib
-                            typerep variantslib ];
+                            typerep_p4 variantslib ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/core_kernel;

--- a/pkgs/development/ocaml-modules/core_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/core_kernel/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
- bin_prot, comparelib, custom_printf, enumerate,
+ bin_prot_p4, comparelib, custom_printf, enumerate,
  fieldslib_p4, herelib, pa_bench, pa_test, pa_ounit,
  pipebang, sexplib_p4, typerep_p4, variantslib_p4}:
 
@@ -17,7 +17,7 @@ buildOcaml rec {
   hasSharedObjects = true;
 
   buildInputs = [ pa_test pa_ounit ];
-  propagatedBuildInputs = [ type_conv pa_bench bin_prot comparelib custom_printf
+  propagatedBuildInputs = [ type_conv pa_bench bin_prot_p4 comparelib custom_printf
                             enumerate fieldslib_p4 herelib pipebang sexplib_p4
                             typerep_p4 variantslib_p4 ];
 

--- a/pkgs/development/ocaml-modules/core_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/core_kernel/default.nix
@@ -1,7 +1,7 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
  bin_prot, comparelib, custom_printf, enumerate,
  fieldslib_p4, herelib, pa_bench, pa_test, pa_ounit,
- pipebang, sexplib, typerep_p4, variantslib}:
+ pipebang, sexplib_p4, typerep_p4, variantslib}:
 
 buildOcaml rec {
   name = "core_kernel";
@@ -18,7 +18,7 @@ buildOcaml rec {
 
   buildInputs = [ pa_test pa_ounit ];
   propagatedBuildInputs = [ type_conv pa_bench bin_prot comparelib custom_printf
-                            enumerate fieldslib_p4 herelib pipebang sexplib
+                            enumerate fieldslib_p4 herelib pipebang sexplib_p4
                             typerep_p4 variantslib ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/core_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/core_kernel/default.nix
@@ -1,7 +1,7 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
  bin_prot, comparelib, custom_printf, enumerate,
  fieldslib_p4, herelib, pa_bench, pa_test, pa_ounit,
- pipebang, sexplib_p4, typerep_p4, variantslib}:
+ pipebang, sexplib_p4, typerep_p4, variantslib_p4}:
 
 buildOcaml rec {
   name = "core_kernel";
@@ -19,7 +19,7 @@ buildOcaml rec {
   buildInputs = [ pa_test pa_ounit ];
   propagatedBuildInputs = [ type_conv pa_bench bin_prot comparelib custom_printf
                             enumerate fieldslib_p4 herelib pipebang sexplib_p4
-                            typerep_p4 variantslib ];
+                            typerep_p4 variantslib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/core_kernel;

--- a/pkgs/development/ocaml-modules/core_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/core_kernel/default.nix
@@ -1,6 +1,6 @@
 {stdenv, buildOcaml, fetchurl, type_conv,
  bin_prot, comparelib, custom_printf, enumerate,
- fieldslib, herelib, pa_bench, pa_test, pa_ounit,
+ fieldslib_p4, herelib, pa_bench, pa_test, pa_ounit,
  pipebang, sexplib, typerep_p4, variantslib}:
 
 buildOcaml rec {
@@ -18,7 +18,7 @@ buildOcaml rec {
 
   buildInputs = [ pa_test pa_ounit ];
   propagatedBuildInputs = [ type_conv pa_bench bin_prot comparelib custom_printf
-                            enumerate fieldslib herelib pipebang sexplib
+                            enumerate fieldslib_p4 herelib pipebang sexplib
                             typerep_p4 variantslib ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,4 +1,4 @@
-{stdenv, writeText, fetchurl, ocaml, ocplib-endian, sexplib, findlib,
+{stdenv, writeText, fetchurl, ocaml, ocplib-endian, sexplib_p4, findlib,
  async ? null, lwt ? null, camlp4}:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   configureFlags = stdenv.lib.strings.concatStringsSep " " ((if lwt != null then ["--enable-lwt"] else []) ++
                                           (if async != null then ["--enable-async"] else []));
   buildInputs = [ocaml findlib camlp4];
-  propagatedBuildInputs = [ocplib-endian sexplib lwt async];
+  propagatedBuildInputs = [ocplib-endian sexplib_p4 lwt async];
 
   createFindlibDestdir = true;
   dontStrip = true;

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,5 +1,5 @@
 {stdenv, writeText, fetchurl, ocaml, ocplib-endian, sexplib_p4, findlib,
- async ? null, lwt ? null, camlp4}:
+ async_p4 ? null, lwt ? null, camlp4}:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
 
@@ -12,9 +12,9 @@ stdenv.mkDerivation {
   };
 
   configureFlags = stdenv.lib.strings.concatStringsSep " " ((if lwt != null then ["--enable-lwt"] else []) ++
-                                          (if async != null then ["--enable-async"] else []));
+                                          (if async_p4 != null then ["--enable-async"] else []));
   buildInputs = [ocaml findlib camlp4];
-  propagatedBuildInputs = [ocplib-endian sexplib_p4 lwt async];
+  propagatedBuildInputs = [ocplib-endian sexplib_p4 lwt async_p4];
 
   createFindlibDestdir = true;
   dontStrip = true;

--- a/pkgs/development/ocaml-modules/custom_printf/default.nix
+++ b/pkgs/development/ocaml-modules/custom_printf/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, type_conv, sexplib, pa_ounit}:
+{stdenv, buildOcaml, fetchurl, type_conv, sexplib_p4, pa_ounit}:
 
 buildOcaml rec {
   name = "custom_printf";
@@ -12,7 +12,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_ounit ];
-  propagatedBuildInputs = [ type_conv sexplib ];
+  propagatedBuildInputs = [ type_conv sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/custom_printf;

--- a/pkgs/development/ocaml-modules/ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/ezjsonm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, jsonm, hex, sexplib, lwt }:
+{ stdenv, fetchzip, ocaml, findlib, jsonm, hex, sexplib_p4, lwt }:
 
 let version = "0.4.1"; in
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ ocaml findlib ];
-  propagatedBuildInputs = [ jsonm hex sexplib lwt ];
+  propagatedBuildInputs = [ jsonm hex sexplib_p4 lwt ];
   createFindlibDestdir = true;
 
   configureFlags = "--enable-lwt";

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, sexplib}:
+{stdenv, buildOcaml, fetchurl, sexplib_p4}:
 
 buildOcaml rec {
   name = "ipaddr";
@@ -9,7 +9,7 @@ buildOcaml rec {
     sha256 = "7051013d8f58abff433187d70cd7ddd7a6b49a6fbe6cad1893f571f65b8ed3d0";
   };
 
-  propagatedBuildInputs = [ sexplib ];
+  propagatedBuildInputs = [ sexplib_p4 ];
 
   configurePhase = ''
    ocaml setup.ml -configure --prefix $out

--- a/pkgs/development/ocaml-modules/janestreet/async-extra.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async-extra.nix
@@ -1,0 +1,17 @@
+{stdenv, buildOcamlJane, fetchurl, async_kernel, async_unix,
+ bin_prot, core, ppx_custom_printf, fieldslib, herelib,
+ pipebang, sexplib, async_rpc_kernel}:
+
+buildOcamlJane rec {
+  name = "async_extra";
+  hash = "1xdwab19fycr4cdm3dh9vmx42f8lvf9s4f9pjgdydxfrm7yzyrfh";
+  propagatedBuildInputs = [ async_kernel async_unix core bin_prot ppx_custom_printf
+                            fieldslib herelib pipebang sexplib async_rpc_kernel ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/async_extra;
+    description = "Jane Street Capital's asynchronous execution library (extra)";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/async-kernel.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async-kernel.nix
@@ -1,0 +1,16 @@
+{stdenv, buildOcamlJane, fetchurl, core_kernel,
+ bin_prot, fieldslib,
+ sexplib, herelib, opam, js_build_tools, ocaml_oasis}:
+
+buildOcamlJane rec {
+  name = "async_kernel";
+  hash = "1n6ifbrq6q6hq8bxh6b9vhg11mv9r6jgp1b7vfw7mh5s2nrd4b60";
+  propagatedBuildInputs = [ core_kernel bin_prot fieldslib herelib sexplib ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/async_kernel;
+    description = "Jane Street Capital's asynchronous execution library (core) ";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
@@ -1,0 +1,18 @@
+{stdenv, buildOcamlJane, async_kernel, bin_prot, core_kernel,
+ fieldslib, ppx_assert, ppx_bench, ppx_driver, ppx_expect, ppx_inline_test,
+ ppx_jane, sexplib, typerep, variantslib}:
+
+buildOcamlJane rec {
+  name = "async_rpc_kernel";
+  hash = "0pvys7giqix1nfidw1f4i3r94cf03ba1mvhadpm2zpdir3av91sw";
+  propagatedBuildInputs = [ async_kernel bin_prot core_kernel fieldslib
+    ppx_assert ppx_bench ppx_driver ppx_expect ppx_inline_test ppx_jane
+    sexplib typerep variantslib ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/async_rpc_kernel;
+    description = "Platform-independent core of Async RPC library";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/async-unix.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async-unix.nix
@@ -1,0 +1,17 @@
+{stdenv, buildOcamlJane, fetchurl, async_kernel,
+ bin_prot, comparelib, core, fieldslib, herelib,
+ pipebang, sexplib}:
+
+buildOcamlJane rec {
+  name = "async_unix";
+  hash = "03ng7f0s22wwzspakiqj442vs1a7yf834109jcj9r3g1awwfhcy7";
+  propagatedBuildInputs = [ async_kernel core bin_prot comparelib
+                            fieldslib herelib pipebang sexplib ];
+
+  meta = with stdenv.lib; {
+   homepage = https://github.com/janestreet/async_unix;
+   description = "Jane Street Capital's asynchronous execution library (unix)";
+   license = licenses.asl20;
+   maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/async.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async.nix
@@ -1,0 +1,16 @@
+{stdenv, buildOcamlJane, fetchurl, async_kernel,
+ async_unix, async_extra}:
+
+buildOcamlJane rec {
+  name = "async";
+  version = "113.33.03";
+  hash = "0wyspkp8k833fh03r3h016nbfn6kjfhvb2bg42cly6agcak59fmr";
+  propagatedBuildInputs = [ async_kernel async_unix async_extra ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/async;
+    description = "Jane Street Capital's asynchronous execution library";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
@@ -1,0 +1,17 @@
+{stdenv, buildOcamlJane, type_conv}:
+
+buildOcamlJane rec {
+  name = "bin_prot";
+  version = "113.33.03";
+  minimumSupportedOcamlVersion = "4.02";
+  hash = "0jlarpfby755j0kikz6vnl1l6q0ga09b9zrlw6i84r22zchnqdsh";
+
+  propagatedBuildInputs = [ type_conv ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/bin_prot;
+    description = "Binary protocol generator ";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
@@ -1,0 +1,30 @@
+{ buildOcaml, opam, js_build_tools, ocaml_oasis, fetchurl } :
+
+{ name, version ? "113.33.03", buildInputs ? [],
+  hash ? "",
+  minimumSupportedOcamlVersion ? "4.02", ...
+}@args:
+
+buildOcaml (args // {
+  inherit name version minimumSupportedOcamlVersion;
+  src = fetchurl {
+    url = "https://github.com/janestreet/${name}/archive/${version}.tar.gz";
+    sha256 = hash;
+  };
+
+  hasSharedObjects = true;
+
+  buildInputs = [ ocaml_oasis js_build_tools opam ] ++ buildInputs;
+
+  dontAddPrefix = true;
+
+  configurePhase = "./configure --prefix $out";
+
+  buildPhase = "OCAML_TOPLEVEL_PATH=`ocamlfind query findlib`/.. make";
+
+  installPhase = ''
+    opam-installer -i --prefix $prefix --libdir `ocamlfind printconf destdir` --stubsdir `ocamlfind printconf destdir`/${name} ${name}.install
+    if [ -d $out/lib/${name} ]; then if [ "$(ls -A $out/lib/${name})" ]; then mv $out/lib/${name}/* `ocamlfind printconf destdir`/${name}; fi; rmdir $out/lib/${name}; fi
+  '';
+
+})

--- a/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
@@ -24,7 +24,12 @@ buildOcaml (args // {
 
   installPhase = ''
     opam-installer -i --prefix $prefix --libdir `ocamlfind printconf destdir` --stubsdir `ocamlfind printconf destdir`/${name} ${name}.install
-    if [ -d $out/lib/${name} ]; then if [ "$(ls -A $out/lib/${name})" ]; then mv $out/lib/${name}/* `ocamlfind printconf destdir`/${name}; fi; rmdir $out/lib/${name}; fi
+    if [ -d $out/lib/${name} ]
+      then if [ "$(ls -A $out/lib/${name})" ]
+        then mv $out/lib/${name}/* `ocamlfind printconf destdir`/${name}
+      fi
+      rmdir $out/lib/${name}
+    fi
   '';
 
 })

--- a/pkgs/development/ocaml-modules/janestreet/core-extended.nix
+++ b/pkgs/development/ocaml-modules/janestreet/core-extended.nix
@@ -1,0 +1,22 @@
+{stdenv, buildOcamlJane, fetchurl,
+ core,
+ bin_prot, fieldslib, sexplib, typerep, variantslib,
+ ppx_assert, ppx_bench, ppx_driver, ppx_expect, ppx_inline_test, ppx_jane,
+ re2, textutils,
+ ocaml_oasis, opam, js_build_tools}:
+
+buildOcamlJane rec {
+  name = "core_extended";
+  hash = "1j4ipcn741j8w3h4gpv5sygjzg6b5g6gc2jcrr4n0jyn5dq8b0p5";
+  propagatedBuildInputs =
+    [ core bin_prot fieldslib sexplib typerep variantslib
+      ppx_assert ppx_bench ppx_driver ppx_expect ppx_inline_test ppx_jane
+      re2 textutils ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/core_extended;
+    description = "Jane Street Capital's standard library overlay";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/core.nix
+++ b/pkgs/development/ocaml-modules/janestreet/core.nix
@@ -1,0 +1,20 @@
+{stdenv, buildOcamlJane, fetchurl,
+ core_kernel,
+ bin_prot, fieldslib, sexplib, typerep, variantslib,
+ ppx_assert, ppx_bench, ppx_driver, ppx_expect, ppx_inline_test, ppx_jane,
+ ocaml_oasis, opam, js_build_tools}:
+
+buildOcamlJane rec {
+  name = "core";
+  hash = "0nz6d5glgymbpchvcpw77yis9jgi2bll32knzy9vx99wn83zdrmd";
+  propagatedBuildInputs =
+    [ core_kernel bin_prot fieldslib sexplib typerep variantslib
+      ppx_assert ppx_bench ppx_driver ppx_expect ppx_inline_test ppx_jane ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/core;
+    description = "Jane Street Capital's standard library overlay";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/core_kernel.nix
+++ b/pkgs/development/ocaml-modules/janestreet/core_kernel.nix
@@ -1,0 +1,19 @@
+{stdenv, buildOcamlJane, fetchurl,
+ bin_prot, fieldslib, sexplib, typerep, variantslib,
+ ppx_assert, ppx_bench, ppx_driver, ppx_expect, ppx_inline_test, ppx_jane,
+ ocaml_oasis, opam, js_build_tools}:
+
+buildOcamlJane rec {
+  name = "core_kernel";
+  hash = "13gamj056nlib04l7yh80lqpdx0pnswzlb52fkqa01awwp5nf3z6";
+  propagatedBuildInputs =
+    [ bin_prot fieldslib sexplib typerep variantslib
+      ppx_assert ppx_bench ppx_driver ppx_expect ppx_inline_test ppx_jane ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/core_kernel;
+    description = "Jane Street Capital's standard library overlay (kernel)";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
@@ -1,0 +1,19 @@
+{ stdenv, type_conv, buildOcamlJane }:
+
+buildOcamlJane rec {
+  name = "fieldslib";
+  version = "113.33.03";
+
+  minimumSupportedOcamlVersion = "4.02";
+
+  hash = "0mkbix32f8sq32q81hb10z2q31bw5f431jxv0jafbdrif0vr6xqd";
+
+  propagatedBuildInputs = [ type_conv ];
+
+  meta = with stdenv.lib; {
+    homepage = https://ocaml.janestreet.com/;
+    description = "OCaml syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/js-build-tools-darwin.patch
+++ b/pkgs/development/ocaml-modules/janestreet/js-build-tools-darwin.patch
@@ -1,0 +1,11 @@
+--- a/ocamlbuild_goodies/jane_street_ocamlbuild_goodies.ml
++++ b/ocamlbuild_goodies/jane_street_ocamlbuild_goodies.ml
+@@ -65,7 +65,7 @@ let track_external_deps = function
+
+     let stat, md5sum =
+       match run_and_read "uname" |> String.trim with
+-      | "Darwin" ->
++      | "FreeBSD" | "NetBSD" ->
+         (S [A "stat"; A "-f"; A "%d:%i:%m"],
+          A "md5")
+       | _ ->

--- a/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
+++ b/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
@@ -19,6 +19,8 @@ buildOcaml rec {
   configurePhase = "./configure --prefix $prefix";
   installPhase = "opam-installer -i --prefix $prefix --libdir `ocamlfind printconf destdir` ${name}.install";
 
+  patches = [ ./js-build-tools-darwin.patch ];
+
   meta = with stdenv.lib; {
     description = "Jane Street Build Tools";
     maintainers = [ maintainers.maurer ];

--- a/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
+++ b/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
@@ -1,0 +1,27 @@
+{stdenv, buildOcaml, fetchurl, ocaml_oasis, opam}:
+
+buildOcaml rec {
+  name = "js-build-tools";
+  version = "113.33.06";
+
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchurl {
+    url = "https://github.com/janestreet/${name}/archive/${version}.tar.gz";
+    sha256 = "1nvgyp4gsnlnpix3li6kr90b12iin5ihichv298p03i6h2809dia";
+  };
+
+  hasSharedObjects = true;
+
+  buildInputs = [ ocaml_oasis opam ];
+
+  dontAddPrefix = true;
+  configurePhase = "./configure --prefix $prefix";
+  installPhase = "opam-installer -i --prefix $prefix --libdir `ocamlfind printconf destdir` ${name}.install";
+
+  meta = with stdenv.lib; {
+    description = "Jane Street Build Tools";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
@@ -9,7 +9,7 @@ buildOcamlJane rec {
       ppx_type_conv sexplib ];
 
   meta = with stdenv.lib; {
-    description = "Assert-like extension nodes that raise useful errors on failure.";
+    description = "Assert-like extension nodes that raise useful errors on failure";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
@@ -1,0 +1,16 @@
+{stdenv, buildOcamlJane,
+ ppx_compare, ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools, ppx_type_conv, sexplib}:
+
+buildOcamlJane rec {
+  name = "ppx_assert";
+  hash = "0n7fa1j79ykbkhp8xz0ksg5096asri5d0msshsaqhw5fz18chvz4";
+  propagatedBuildInputs =
+    [ ppx_compare ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools
+      ppx_type_conv sexplib ];
+
+  meta = with stdenv.lib; {
+    description = "Assert-like extension nodes that raise useful errors on failure.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
@@ -1,0 +1,18 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver, ppx_inline_test, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_bench";
+  minimumSupportedOcamlVersion = "4.02";
+  hash = "1l5jlwy1d1fqz70wa2fkf7izngp6nx3g4s9bmnd6ca4dx1x5bksk";
+
+  hasSharedObjects = true;
+
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_inline_test ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "Syntax extension for writing in-line benchmarks in ocaml code.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
@@ -11,7 +11,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_inline_test ppx_tools ];
 
   meta = with stdenv.lib; {
-    description = "Syntax extension for writing in-line benchmarks in ocaml code.";
+    description = "Syntax extension for writing in-line benchmarks in ocaml code";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_tools, ppx_type_conv, bin_prot}:
+
+buildOcamlJane rec {
+  name = "ppx_bin_prot";
+  hash = "0kwmrrrybdkmphqczsr3lg3imsxcjb8iy41syvn44s3kcjfyyzbz";
+  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv bin_prot ];
+
+  meta = with stdenv.lib; {
+    description = "Generation of bin_prot readers and writers from types";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
@@ -8,7 +8,7 @@ buildOcamlJane rec {
     [ppx_core ppx_driver ppx_tools ppx_type_conv ];
 
   meta = with stdenv.lib; {
-    description = "Generation of fast comparison functions from type expressions and definitions.";
+    description = "Generation of fast comparison functions from type expressions and definitions";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
@@ -1,0 +1,15 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver, ppx_tools, ppx_type_conv}:
+
+buildOcamlJane rec {
+  name = "ppx_compare";
+  hash = "05cnwxfxm8201lpfmcqkcqfy6plh5c2151jbj4qsnxhlvvjli459";
+  propagatedBuildInputs =
+    [ppx_core ppx_driver ppx_tools ppx_type_conv ];
+
+  meta = with stdenv.lib; {
+    description = "Generation of fast comparison functions from type expressions and definitions.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-core.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-core.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_core";
+  hash = "0df7vyai488lfkyh8szw2hvn22jsyrkfvq1b91j1s0g0y27nnfax";
+  propagatedBuildInputs =
+    [ ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "PPX standard library";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
@@ -8,7 +8,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_sexp_conv ppx_tools ];
 
   meta = with stdenv.lib; {
-    description = "Extensions to printf-style format-strings for user-defined string conversion.";
+    description = "Extensions to printf-style format-strings for user-defined string conversion";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
@@ -1,0 +1,15 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver, ppx_sexp_conv, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_custom_printf";
+  hash = "06y85m6ky376byja4w7gdwd339di5ag0xrf0czkylzjsnylhdr85";
+
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_sexp_conv ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "Extensions to printf-style format-strings for user-defined string conversion.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-driver.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-driver.nix
@@ -1,0 +1,15 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_optcomp}:
+
+buildOcamlJane rec {
+  name = "ppx_driver";
+  hash = "19cpfdn1n36vl5l9d6h7c61ffn0wmiipprn5by0354i5aywj8gpn";
+  propagatedBuildInputs =
+    [ ppx_core ppx_optcomp ];
+
+  meta = with stdenv.lib; {
+    description = "A driver is an executable created from a set of OCaml AST transformers linked together with a command line frontend.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-driver.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-driver.nix
@@ -8,7 +8,7 @@ buildOcamlJane rec {
     [ ppx_core ppx_optcomp ];
 
   meta = with stdenv.lib; {
-    description = "A driver is an executable created from a set of OCaml AST transformers linked together with a command line frontend.";
+    description = "A driver is an executable created from a set of OCaml AST transformers linked together with a command line frontend";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
@@ -7,7 +7,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv ];
 
   meta = with stdenv.lib; {
-    description = "Generate a list containing all values of a finite type.";
+    description = "Generate a list containing all values of a finite type";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_tools, ppx_type_conv}:
+
+buildOcamlJane rec {
+  name = "ppx_enumerate";
+  hash = "0m11921q2pjzkwckf21fynd2qfy83n9jjsgks23yagdai8a7ym16";
+  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv ];
+
+  meta = with stdenv.lib; {
+    description = "Generate a list containing all values of a finite type.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
@@ -1,0 +1,19 @@
+{stdenv, buildOcamlJane,
+ ppx_assert, ppx_compare, ppx_core, ppx_custom_printf, ppx_driver,
+ ppx_fields_conv, ppx_here, ppx_inline_test, ppx_sexp_conv, ppx_tools,
+ ppx_variants_conv, re, sexplib, variantslib, fieldslib}:
+
+buildOcamlJane rec {
+  name = "ppx_expect";
+  hash = "0cwagb4cj3x1vsr19kyfa9pxlvaz9a5v863cahi5glinsh4mzgdx";
+  propagatedBuildInputs =
+    [ ppx_assert ppx_compare ppx_core ppx_custom_printf ppx_driver
+      ppx_fields_conv ppx_here ppx_inline_test ppx_sexp_conv ppx_tools
+      ppx_variants_conv re sexplib variantslib fieldslib ];
+
+  meta = with stdenv.lib; {
+    description = "Cram-like framework for OCaml";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-fail.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-fail.nix
@@ -7,7 +7,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_here ppx_tools ];
 
   meta = with stdenv.lib; {
-    description = "Syntax extension that makes failwith include a position.";
+    description = "Syntax extension that makes failwith include a position";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-fail.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-fail.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver, ppx_here, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_fail";
+  hash = "1ms5axpc0zg469zj4799nz3wwxi6rmmyvqj52dy03crmpj71s18l";
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_here ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "Syntax extension that makes failwith include a position.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
@@ -7,7 +7,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv ];
 
   meta = with stdenv.lib; {
-    description = "Generation of accessor and iteration functions for ocaml records.";
+    description = "Generation of accessor and iteration functions for ocaml records";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_tools, ppx_type_conv}:
+
+buildOcamlJane rec {
+  name = "ppx_fields_conv";
+  hash = "11w9wfjgkv7yxv3rwlwi6m193zan6rhmi45q7n3ddi2s8ls3gra7";
+  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv ];
+
+  meta = with stdenv.lib; {
+    description = "Generation of accessor and iteration functions for ocaml records.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
@@ -7,7 +7,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_driver ];
 
   meta = with stdenv.lib; {
-    description = "A ppx rewriter that defines an extension node whose value is its source position.";
+    description = "A ppx rewriter that defines an extension node whose value is its source position";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver}:
+
+buildOcamlJane rec {
+  name = "ppx_here";
+  hash = "1mzdgn8k171zkwmbizf1a48l525ny0w3363c7gknpnifcinxniiw";
+  propagatedBuildInputs = [ ppx_core ppx_driver ];
+
+  meta = with stdenv.lib; {
+    description = "A ppx rewriter that defines an extension node whose value is its source position.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_inline_test";
+  hash = "0ygapa54i0wwcj3jcqwiimrc6z0b7aafgjhbk37h6vvclnm5n7f6";
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "Syntax extension for writing in-line tests in ocaml code.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
@@ -7,7 +7,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_tools ];
 
   meta = with stdenv.lib; {
-    description = "Syntax extension for writing in-line tests in ocaml code.";
+    description = "Syntax extension for writing in-line tests in ocaml code";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
@@ -15,7 +15,7 @@ buildOcamlJane rec {
       ppx_sexp_message ppx_sexp_value ppx_typerep_conv ppx_variants_conv ];
 
   meta = with stdenv.lib; {
-    description = "ppx_jane is a ppx_driver including all standard ppx rewriters.";
+    description = "A ppx_driver including all standard ppx rewriters";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
@@ -1,0 +1,22 @@
+{stdenv, buildOcamlJane,
+ ppx_assert,
+ ppx_bench, ppx_bin_prot, ppx_compare, ppx_custom_printf, ppx_driver,
+ ppx_enumerate, ppx_expect, ppx_fail, ppx_fields_conv, ppx_here,
+ ppx_inline_test, ppx_let, ppx_pipebang, ppx_sexp_conv, ppx_sexp_message,
+ ppx_sexp_value, ppx_typerep_conv, ppx_variants_conv}:
+
+buildOcamlJane rec {
+  name = "ppx_jane";
+  hash  = "1la0rp8fhzfglwb15gqh1pl1ld8ls4cnidaw9mjc5q1hb0yj1qd9";
+  propagatedBuildInputs =
+    [ ppx_assert ppx_bench ppx_bin_prot ppx_compare ppx_custom_printf
+      ppx_driver ppx_enumerate ppx_expect ppx_fail ppx_fields_conv
+      ppx_here ppx_inline_test ppx_let ppx_pipebang ppx_sexp_conv
+      ppx_sexp_message ppx_sexp_value ppx_typerep_conv ppx_variants_conv ];
+
+  meta = with stdenv.lib; {
+    description = "ppx_jane is a ppx_driver including all standard ppx rewriters.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver}:
+
+buildOcamlJane rec {
+  name = "ppx_let";
+  hash = "0whnfq4rgkq4apfqnvc100wlk25pmqdyvy6s21dsn3fcm9hff467";
+  propagatedBuildInputs = [ ppx_core ppx_driver ];
+
+  meta = with stdenv.lib; {
+    description = "A ppx rewriter for monadic and applicative let bindings and match statements";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
@@ -1,0 +1,15 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_optcomp";
+  hash = "09m2x2a5ics4bz1j29n5slhh1rlyhcwdfmf44v1jfxcby3f0riwd";
+  propagatedBuildInputs =
+    [ ppx_core ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "ppx_optcomp stands for Optional Compilation. It is a tool used to handle optional compilations of pieces of code depending of the word size, the version of the compiler, etc.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_pipebang";
+  hash = "0k25bhj9ziiw89xvs4svz7cgazbbmprba9wbic2llffg55fp7acc";
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "A ppx rewriter that inlines reverse application operators |> and |!";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
@@ -7,7 +7,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib];
 
   meta = with stdenv.lib; {
-    description = "A ppx rewriter that defines an extension node whose value is its source position";
+    description = "PPX syntax extension that generates code for converting OCaml types to and from s-expressions, as defined in the sexplib library";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_tools, ppx_type_conv, sexplib}:
+
+buildOcamlJane rec {
+  name = "ppx_sexp_conv";
+  hash = "1kgbmlc11w5jhbhmy5n0f734l44zwyry48342dm5qydi9sfzcgq2";
+  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib];
+
+  meta = with stdenv.lib; {
+    description = "A ppx rewriter that defines an extension node whose value is its source position.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
@@ -7,7 +7,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib];
 
   meta = with stdenv.lib; {
-    description = "A ppx rewriter that defines an extension node whose value is its source position.";
+    description = "A ppx rewriter that defines an extension node whose value is its source position";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_sexp_message";
+  hash = "0inbff25qii868p141jb1y8n3vjfyz66jpnsl9nma6nkkyjkp05j";
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "Easy construction of S-Expressions";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
@@ -7,7 +7,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools ];
 
   meta = with stdenv.lib; {
-    description = "A ppx rewriter that simplifies building S-Expression from OCaml Values.";
+    description = "A ppx rewriter that simplifies building S-Expression from OCaml Values";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_sexp_value";
+  hash = "04602ppqfwx33ghjywam00hlqqzsz4d99r60k9q0v1mynk9pjhj0";
+  propagatedBuildInputs = [ ppx_core ppx_driver ppx_here ppx_sexp_conv ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "A ppx rewriter that simplifies building S-Expression from OCaml Values.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-type-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-type-conv.nix
@@ -8,7 +8,7 @@ buildOcamlJane rec {
     [ ppx_core ppx_deriving ppx_driver ppx_tools ];
 
   meta = with stdenv.lib; {
-    description = "The type_conv library factors out functionality needed by different preprocessors that generate code from type specifications.";
+    description = "The type_conv library factors out functionality needed by different preprocessors that generate code from type specifications";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/ppx-type-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-type-conv.nix
@@ -1,0 +1,15 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_deriving, ppx_driver, ppx_tools}:
+
+buildOcamlJane rec {
+  name = "ppx_type_conv";
+  hash = "0gv0mqwn97dwrfm6rj442565y8dz7kiq8s8vadnhywrl7j4znqyq";
+  propagatedBuildInputs =
+    [ ppx_core ppx_deriving ppx_driver ppx_tools ];
+
+  meta = with stdenv.lib; {
+    description = "The type_conv library factors out functionality needed by different preprocessors that generate code from type specifications.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_tools, ppx_type_conv, typerep}:
+
+buildOcamlJane rec {
+  name = "ppx_typerep_conv";
+  hash = "0dldlx73r07j6w0i7h4hxly0v678naa79na5rafsk2974gs5ih9g";
+  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv typerep ];
+
+  meta = with stdenv.lib; {
+    description = "Automatic generation of runtime types from type definitions";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
@@ -1,0 +1,14 @@
+{stdenv, buildOcamlJane,
+ ppx_core, ppx_tools, ppx_type_conv, sexplib}:
+
+buildOcamlJane rec {
+  name = "ppx_variants_conv";
+  hash = "0kgal8b9yh7wrd75hllb9fyl6zbksfnr9k7pykpzdm3js98dirhn";
+  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib];
+
+  meta = with stdenv.lib; {
+    description = "Generation of accessor and iteration functions for ocaml variant types.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
@@ -7,7 +7,7 @@ buildOcamlJane rec {
   propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib];
 
   meta = with stdenv.lib; {
-    description = "Generation of accessor and iteration functions for ocaml variant types.";
+    description = "Generation of accessor and iteration functions for ocaml variant types";
     maintainers = [ maintainers.maurer ];
     license = licenses.asl20;
   };

--- a/pkgs/development/ocaml-modules/janestreet/re2.nix
+++ b/pkgs/development/ocaml-modules/janestreet/re2.nix
@@ -1,0 +1,20 @@
+{stdenv, buildOcamlJane,
+ bin_prot, core_kernel, fieldslib, sexplib, typerep, variantslib,
+ ppx_assert, ppx_bench, ppx_driver, ppx_expect, ppx_inline_test, ppx_jane,
+ rsync}:
+
+buildOcamlJane rec {
+  name = "re2";
+  hash = "0fw5jscb1i17aw8v4l965zw20kyimhfnmf4w83wqaaxkqy3l6fqw";
+  buildInputs = [ rsync ];
+  propagatedBuildInputs =
+    [ bin_prot core_kernel fieldslib sexplib typerep variantslib
+      ppx_assert ppx_bench ppx_driver ppx_expect ppx_inline_test ppx_jane ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/re2;
+    description = "OCaml bindings for RE2";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/sexplib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/sexplib.nix
@@ -1,0 +1,18 @@
+{stdenv, buildOcamlJane, type_conv}:
+
+buildOcamlJane rec {
+  minimumSupportedOcamlVersion = "4.02";
+  name = "sexplib";
+  version = "113.33.03";
+
+  hash = "1klar4qw4s7bj47ig7kxz2m4j1q3c60pfppis4vxrxv15r0kfh22";
+
+  propagatedBuildInputs = [ type_conv ];
+
+  meta = with stdenv.lib; {
+    homepage = https://ocaml.janestreet.com/;
+    description = "Library for serializing OCaml values to and from S-expressions";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/textutils.nix
+++ b/pkgs/development/ocaml-modules/janestreet/textutils.nix
@@ -1,0 +1,18 @@
+{stdenv, buildOcamlJane,
+ bin_prot, core, fieldslib, sexplib, typerep, variantslib,
+ ppx_assert, ppx_bench, ppx_driver, ppx_expect, ppx_inline_test, ppx_jane}:
+
+buildOcamlJane rec {
+  name = "textutils";
+  hash = "0mkjm9b3k7db7zzrq4403v8qbkgqgkjlz120vcbqh6z7d7ql65vb";
+  propagatedBuildInputs =
+    [ bin_prot core fieldslib sexplib typerep variantslib
+      ppx_assert ppx_bench ppx_driver ppx_expect ppx_inline_test ppx_jane ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/textutils;
+    description = "Text output utilities";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/typerep.nix
+++ b/pkgs/development/ocaml-modules/janestreet/typerep.nix
@@ -1,0 +1,20 @@
+{stdenv, buildOcamlJane, type_conv}:
+
+buildOcamlJane rec {
+  name = "typerep";
+  version = "113.33.03";
+
+  minimumSupportedOcamlVersion = "4.00";
+
+  hash = "1ss34nq20vfgx8hwi5sswpmn3my9lvrpdy5dkng746xchwi33ar7";
+
+  propagatedBuildInputs = [ type_conv ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/typerep;
+    description = "Runtime types for OCaml (beta version)";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/janestreet/variantslib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/variantslib.nix
@@ -1,0 +1,19 @@
+{stdenv, buildOcamlJane, type_conv}:
+
+buildOcamlJane rec {
+  name = "variantslib";
+  version = "113.33.03";
+
+  minimumSupportedOcamlVersion = "4.00";
+
+  hash = "1hv0f75msrryxsl6wfnbmhc0n8kf7qxs5f82ry3b8ldb44s3wigp";
+
+  propagatedBuildInputs = [ type_conv ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/janestreet/variantslib;
+    description = "OCaml variants as first class values";
+    license = licenses.asl20;
+    maintainers = [ maintainers.maurer maintainers.ericbmerritt ];
+  };
+}

--- a/pkgs/development/ocaml-modules/pa_test/default.nix
+++ b/pkgs/development/ocaml-modules/pa_test/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, type_conv, pa_ounit, sexplib, herelib}:
+{stdenv, buildOcaml, fetchurl, type_conv, pa_ounit, sexplib_p4, herelib}:
 
 buildOcaml rec {
   name = "pa_test";
@@ -12,7 +12,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_ounit ];
-  propagatedBuildInputs = [ type_conv sexplib herelib ];
+  propagatedBuildInputs = [ type_conv sexplib_p4 herelib ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/pa_test;

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -1,0 +1,28 @@
+{stdenv, buildOcaml, fetchurl,
+ cppo, ppx_tools, result, ounit}:
+
+buildOcaml rec {
+  name = "ppx_deriving";
+  version = "v3.3";
+
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchurl {
+    url = "https://github.com/whitequark/${name}/archive/${version}.tar.gz";
+    sha256 = "1j20c6r2v7h05a4v9m8z5m1yqgwif41yrp63mik14pf3dkrj8x3f";
+  };
+
+  hasSharedObjects = true;
+
+  buildInputs = [ cppo ounit ];
+  propagatedBuildInputs =
+    [ ppx_tools result ];
+
+  installPhase = "OCAMLPATH=$OCAMLPATH:`ocamlfind printconf destdir` make install";
+
+  meta = with stdenv.lib; {
+    description = "deriving is a library simplifying type-driven code generation on OCaml >=4.02.";
+    maintainers = [ maintainers.maurer ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/ocaml-modules/re2/default.nix
+++ b/pkgs/development/ocaml-modules/re2/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, ocaml, core, pa_ounit, pa_test,
+{stdenv, buildOcaml, fetchurl, ocaml, core_p4, pa_ounit, pa_test,
  bin_prot_p4, comparelib, sexplib_p4, rsync}:
 
 buildOcaml rec {
@@ -16,7 +16,7 @@ buildOcaml rec {
             else null;
 
   buildInputs = [ pa_ounit pa_test rsync ];
-  propagatedBuildInputs = [ core bin_prot_p4 comparelib sexplib_p4 ];
+  propagatedBuildInputs = [ core_p4 bin_prot_p4 comparelib sexplib_p4 ];
 
   hasSharedObjects = true;
 

--- a/pkgs/development/ocaml-modules/re2/default.nix
+++ b/pkgs/development/ocaml-modules/re2/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, ocaml, core, pa_ounit, pa_test,
- bin_prot, comparelib, sexplib, rsync}:
+ bin_prot, comparelib, sexplib_p4, rsync}:
 
 buildOcaml rec {
   name = "re2";
@@ -16,7 +16,7 @@ buildOcaml rec {
             else null;
 
   buildInputs = [ pa_ounit pa_test rsync ];
-  propagatedBuildInputs = [ core bin_prot comparelib sexplib ];
+  propagatedBuildInputs = [ core bin_prot comparelib sexplib_p4 ];
 
   hasSharedObjects = true;
 

--- a/pkgs/development/ocaml-modules/re2/default.nix
+++ b/pkgs/development/ocaml-modules/re2/default.nix
@@ -1,5 +1,5 @@
 {stdenv, buildOcaml, fetchurl, ocaml, core, pa_ounit, pa_test,
- bin_prot, comparelib, sexplib_p4, rsync}:
+ bin_prot_p4, comparelib, sexplib_p4, rsync}:
 
 buildOcaml rec {
   name = "re2";
@@ -16,7 +16,7 @@ buildOcaml rec {
             else null;
 
   buildInputs = [ pa_ounit pa_test rsync ];
-  propagatedBuildInputs = [ core bin_prot comparelib sexplib_p4 ];
+  propagatedBuildInputs = [ core bin_prot_p4 comparelib sexplib_p4 ];
 
   hasSharedObjects = true;
 

--- a/pkgs/development/ocaml-modules/textutils/default.nix
+++ b/pkgs/development/ocaml-modules/textutils/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, core, pa_ounit, pa_test, sexplib_p4}:
+{stdenv, buildOcaml, fetchurl, core_p4, pa_ounit, pa_test, sexplib_p4}:
 
 buildOcaml rec {
   name = "textutils";
@@ -12,7 +12,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test ];
-  propagatedBuildInputs = [ core pa_ounit sexplib_p4 ];
+  propagatedBuildInputs = [ core_p4 pa_ounit sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/textutils;

--- a/pkgs/development/ocaml-modules/textutils/default.nix
+++ b/pkgs/development/ocaml-modules/textutils/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, core, pa_ounit, pa_test, sexplib}:
+{stdenv, buildOcaml, fetchurl, core, pa_ounit, pa_test, sexplib_p4}:
 
 buildOcaml rec {
   name = "textutils";
@@ -12,7 +12,7 @@ buildOcaml rec {
   };
 
   buildInputs = [ pa_test ];
-  propagatedBuildInputs = [ core pa_ounit sexplib ];
+  propagatedBuildInputs = [ core pa_ounit sexplib_p4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/textutils;

--- a/pkgs/development/ocaml-modules/uri/default.nix
+++ b/pkgs/development/ocaml-modules/uri/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, re, sexplib, stringext, ounit }:
+{ stdenv, fetchzip, ocaml, findlib, re, sexplib_p4, stringext, ounit }:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4";
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ ocaml findlib ounit ];
-  propagatedBuildInputs = [ re sexplib stringext ];
+  propagatedBuildInputs = [ re sexplib_p4 stringext ];
 
   configurePhase = "ocaml setup.ml -configure --prefix $out --enable-tests";
   buildPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5539,6 +5539,8 @@ in
     ppx_enumerate = callPackage ../development/ocaml-modules/janestreet/ppx-enumerate.nix {};
 
     ppx_fail = callPackage ../development/ocaml-modules/janestreet/ppx-fail.nix {};
+
+    ppx_fields_conv = callPackage ../development/ocaml-modules/janestreet/ppx-fields-conv.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5527,6 +5527,8 @@ in
     ppx_sexp_conv = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-conv.nix {};
 
     ppx_assert = callPackage ../development/ocaml-modules/janestreet/ppx-assert.nix {};
+
+    ppx_inline_test = callPackage ../development/ocaml-modules/janestreet/ppx-inline-test.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5553,6 +5553,8 @@ in
     ppx_typerep_conv = callPackage ../development/ocaml-modules/janestreet/ppx-typerep-conv.nix {};
 
     ppx_variants_conv = callPackage ../development/ocaml-modules/janestreet/ppx-variants-conv.nix {};
+
+    ppx_expect = callPackage ../development/ocaml-modules/janestreet/ppx-expect.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5387,7 +5387,7 @@ in
       camlp5 = camlp5_transitional;
     };
 
-    textutils = callPackage ../development/ocaml-modules/textutils { };
+    textutils_p4 = callPackage ../development/ocaml-modules/textutils { };
 
     type_conv_108_08_00 = callPackage ../development/ocaml-modules/type_conv/108.08.00.nix { };
     type_conv_109_60_01 = callPackage ../development/ocaml-modules/type_conv/109.60.01.nix { };
@@ -5575,6 +5575,8 @@ in
     core = callPackage ../development/ocaml-modules/janestreet/core.nix {};
 
     re2 = callPackage ../development/ocaml-modules/janestreet/re2.nix {};
+
+    textutils = callPackage ../development/ocaml-modules/janestreet/textutils.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5535,6 +5535,8 @@ in
     ppx_bin_prot = callPackage ../development/ocaml-modules/janestreet/ppx-bin-prot.nix {};
 
     ppx_custom_printf = callPackage ../development/ocaml-modules/janestreet/ppx-custom-printf.nix {};
+
+    ppx_enumerate = callPackage ../development/ocaml-modules/janestreet/ppx-enumerate.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5523,6 +5523,8 @@ in
     ppx_compare = callPackage ../development/ocaml-modules/janestreet/ppx-compare.nix {};
 
     ppx_here = callPackage ../development/ocaml-modules/janestreet/ppx-here.nix {};
+
+    ppx_sexp_conv = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-conv.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5072,7 +5072,7 @@ in
 
     async_unix_p4 = callPackage ../development/ocaml-modules/async_unix { };
 
-    async =
+    async_p4 =
       if lib.versionOlder "4.02" ocaml_version
       then callPackage ../development/ocaml-modules/async { }
       else null;
@@ -5626,6 +5626,11 @@ in
       if lib.versionOlder "4.02" ocaml_version
       then callPackage ../development/ocaml-modules/janestreet/async-extra.nix {}
       else async_extra_p4;
+
+    async =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/async.nix {}
+      else async_p4;
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;
@@ -5753,9 +5758,11 @@ in
   tinycc = callPackage ../development/compilers/tinycc { };
 
   trv = callPackage ../development/tools/misc/trv {
-   inherit (ocamlPackages_4_02) findlib camlp4 async
-     async_extra async_shell async_find cohttp uri;
+   inherit (ocamlPackages_4_02) findlib camlp4
+     async_shell async_find cohttp uri;
     ocaml = ocaml_4_02;
+    async = ocamlPackages_4_02.async_p4;
+    async_extra = ocamlPackages_4_02.async_extra_p4;
     async_unix = ocamlPackages_4_02.async_unix_p4;
     core_extended = ocamlPackages_4_02.core_extended_p4;
     sexplib = ocamlPackages_4_02.sexplib_p4;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5519,6 +5519,8 @@ in
     ppx_driver = callPackage ../development/ocaml-modules/janestreet/ppx-driver.nix {};
 
     ppx_type_conv = callPackage ../development/ocaml-modules/janestreet/ppx-type-conv.nix {};
+
+    ppx_compare = callPackage ../development/ocaml-modules/janestreet/ppx-compare.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5064,7 +5064,7 @@ in
 
     async_find = callPackage ../development/ocaml-modules/async_find { };
 
-    async_kernel = callPackage ../development/ocaml-modules/async_kernel { };
+    async_kernel_p4 = callPackage ../development/ocaml-modules/async_kernel { };
 
     async_shell = callPackage ../development/ocaml-modules/async_shell { };
 
@@ -5609,6 +5609,11 @@ in
       if lib.versionOlder "4.02" ocaml_version
       then callPackage ../development/ocaml-modules/janestreet/core-extended.nix {}
       else core_extended_p4;
+
+     async_kernel =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/async-kernel.nix {}
+      else async_kernel_p4;
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5504,6 +5504,11 @@ in
 
     # Jane Street
     js_build_tools = callPackage ../development/ocaml-modules/janestreet/js-build-tools.nix {};
+
+    buildOcamlJane = callPackage ../development/ocaml-modules/janestreet/buildOcamlJane.nix {};
+
+    ppx_core = callPackage ../development/ocaml-modules/janestreet/ppx-core.nix {};
+
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5549,6 +5549,8 @@ in
     ppx_sexp_message = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-message.nix {};
 
     ppx_sexp_value = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-value.nix {};
+
+    ppx_typerep_conv = callPackage ../development/ocaml-modules/janestreet/ppx-typerep-conv.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5521,6 +5521,8 @@ in
     ppx_type_conv = callPackage ../development/ocaml-modules/janestreet/ppx-type-conv.nix {};
 
     ppx_compare = callPackage ../development/ocaml-modules/janestreet/ppx-compare.nix {};
+
+    ppx_here = callPackage ../development/ocaml-modules/janestreet/ppx-here.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5545,6 +5545,8 @@ in
     ppx_let = callPackage ../development/ocaml-modules/janestreet/ppx-let.nix {};
 
     ppx_pipebang = callPackage ../development/ocaml-modules/janestreet/ppx-pipebang.nix {};
+
+    ppx_sexp_message = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-message.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5533,6 +5533,8 @@ in
     ppx_bench = callPackage ../development/ocaml-modules/janestreet/ppx-bench.nix {};
 
     ppx_bin_prot = callPackage ../development/ocaml-modules/janestreet/ppx-bin-prot.nix {};
+
+    ppx_custom_printf = callPackage ../development/ocaml-modules/janestreet/ppx-custom-printf.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5436,6 +5436,11 @@ in
       then callPackage ../development/ocaml-modules/ppx_blob {}
       else null;
 
+    ppx_deriving =
+      if lib.versionAtLeast ocaml_version "4.02"
+      then callPackage ../development/ocaml-modules/ppx_deriving {}
+      else null;
+
     ppx_tools =
       if lib.versionAtLeast ocaml_version "4.02"
       then callPackage ../development/ocaml-modules/ppx_tools {}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5470,7 +5470,7 @@ in
 
     twt = callPackage ../development/ocaml-modules/twt { };
 
-    typerep = callPackage ../development/ocaml-modules/typerep { };
+    typerep_p4 = callPackage ../development/ocaml-modules/typerep { };
 
     utop = callPackage ../development/tools/ocaml/utop { };
 
@@ -5555,6 +5555,8 @@ in
     ppx_variants_conv = callPackage ../development/ocaml-modules/janestreet/ppx-variants-conv.nix {};
 
     ppx_expect = callPackage ../development/ocaml-modules/janestreet/ppx-expect.nix {};
+
+    typerep = callPackage ../development/ocaml-modules/janestreet/typerep.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5517,6 +5517,8 @@ in
     ppx_optcomp = callPackage ../development/ocaml-modules/janestreet/ppx-optcomp.nix {};
 
     ppx_driver = callPackage ../development/ocaml-modules/janestreet/ppx-driver.nix {};
+
+    ppx_type_conv = callPackage ../development/ocaml-modules/janestreet/ppx-type-conv.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5303,7 +5303,7 @@ in
 
     core_extended = callPackage ../development/ocaml-modules/core_extended { };
 
-    core_kernel = callPackage ../development/ocaml-modules/core_kernel { };
+    core_kernel_p4 = callPackage ../development/ocaml-modules/core_kernel { };
 
     core = callPackage ../development/ocaml-modules/core { };
 
@@ -5569,6 +5569,8 @@ in
     variantslib = callPackage ../development/ocaml-modules/janestreet/variantslib.nix {};
 
     bin_prot = callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {};
+
+    core_kernel = callPackage ../development/ocaml-modules/janestreet/core_kernel.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5146,7 +5146,7 @@ in
 
     biniou = callPackage ../development/ocaml-modules/biniou { };
 
-    bin_prot = callPackage ../development/ocaml-modules/bin_prot { };
+    bin_prot_p4 = callPackage ../development/ocaml-modules/bin_prot { };
 
     ocaml_cairo = callPackage ../development/ocaml-modules/ocaml-cairo { };
 
@@ -5567,6 +5567,8 @@ in
     sexplib = callPackage ../development/ocaml-modules/janestreet/sexplib.nix {};
 
     variantslib = callPackage ../development/ocaml-modules/janestreet/variantslib.nix {};
+
+    bin_prot = callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5305,7 +5305,7 @@ in
 
     core_kernel_p4 = callPackage ../development/ocaml-modules/core_kernel { };
 
-    core = callPackage ../development/ocaml-modules/core { };
+    core_p4 = callPackage ../development/ocaml-modules/core { };
 
     ocaml_cryptgps = callPackage ../development/ocaml-modules/cryptgps { };
 
@@ -5571,6 +5571,8 @@ in
     bin_prot = callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {};
 
     core_kernel = callPackage ../development/ocaml-modules/janestreet/core_kernel.nix {};
+
+    core = callPackage ../development/ocaml-modules/janestreet/core.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5511,6 +5511,7 @@ in
 
     ppx_optcomp = callPackage ../development/ocaml-modules/janestreet/ppx-optcomp.nix {};
 
+    ppx_driver = callPackage ../development/ocaml-modules/janestreet/ppx-driver.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5537,6 +5537,8 @@ in
     ppx_custom_printf = callPackage ../development/ocaml-modules/janestreet/ppx-custom-printf.nix {};
 
     ppx_enumerate = callPackage ../development/ocaml-modules/janestreet/ppx-enumerate.nix {};
+
+    ppx_fail = callPackage ../development/ocaml-modules/janestreet/ppx-fail.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5369,7 +5369,7 @@ in
     piqi = callPackage ../development/ocaml-modules/piqi { };
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 
-    re2 = callPackage ../development/ocaml-modules/re2 { };
+    re2_p4 = callPackage ../development/ocaml-modules/re2 { };
 
     result = callPackage ../development/ocaml-modules/ocaml-result { };
 
@@ -5573,6 +5573,8 @@ in
     core_kernel = callPackage ../development/ocaml-modules/janestreet/core_kernel.nix {};
 
     core = callPackage ../development/ocaml-modules/janestreet/core.nix {};
+
+    re2 = callPackage ../development/ocaml-modules/janestreet/re2.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5070,7 +5070,7 @@ in
 
     async_ssl = callPackage ../development/ocaml-modules/async_ssl { };
 
-    async_unix = callPackage ../development/ocaml-modules/async_unix { };
+    async_unix_p4 = callPackage ../development/ocaml-modules/async_unix { };
 
     async =
       if lib.versionOlder "4.02" ocaml_version
@@ -5614,6 +5614,12 @@ in
       if lib.versionOlder "4.02" ocaml_version
       then callPackage ../development/ocaml-modules/janestreet/async-kernel.nix {}
       else async_kernel_p4;
+
+     async_unix =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/async-unix.nix {}
+      else async_unix_p4;
+
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;
@@ -5741,9 +5747,10 @@ in
   tinycc = callPackage ../development/compilers/tinycc { };
 
   trv = callPackage ../development/tools/misc/trv {
-   inherit (ocamlPackages_4_02) findlib camlp4 async async_unix
+   inherit (ocamlPackages_4_02) findlib camlp4 async
      async_extra async_shell async_find cohttp uri;
     ocaml = ocaml_4_02;
+    async_unix = ocamlPackages_4_02.async_unix_p4;
     core_extended = ocamlPackages_4_02.core_extended_p4;
     sexplib = ocamlPackages_4_02.sexplib_p4;
     core = ocamlPackages_4_02.core_p4;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5301,7 +5301,7 @@ in
 
     comparelib = callPackage ../development/ocaml-modules/comparelib { };
 
-    core_extended = callPackage ../development/ocaml-modules/core_extended { };
+    core_extended_p4 = callPackage ../development/ocaml-modules/core_extended { };
 
     core_kernel_p4 = callPackage ../development/ocaml-modules/core_kernel { };
 
@@ -5577,6 +5577,8 @@ in
     re2 = callPackage ../development/ocaml-modules/janestreet/re2.nix {};
 
     textutils = callPackage ../development/ocaml-modules/janestreet/textutils.nix {};
+
+    core_extended = callPackage ../development/ocaml-modules/janestreet/core-extended.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;
@@ -5704,9 +5706,12 @@ in
   tinycc = callPackage ../development/compilers/tinycc { };
 
   trv = callPackage ../development/tools/misc/trv {
-   inherit (ocamlPackages_4_02) findlib camlp4 core async async_unix
-     async_extra sexplib async_shell core_extended async_find cohttp uri;
+   inherit (ocamlPackages_4_02) findlib camlp4 async async_unix
+     async_extra async_shell async_find cohttp uri;
     ocaml = ocaml_4_02;
+    core_extended = ocamlPackages_4_02.core_extended_p4;
+    sexplib = ocamlPackages_4_02.sexplib_p4;
+    core = ocamlPackages_4_02.core_p4;
   };
 
   bupc = callPackage ../development/compilers/bupc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5531,6 +5531,8 @@ in
     ppx_inline_test = callPackage ../development/ocaml-modules/janestreet/ppx-inline-test.nix {};
 
     ppx_bench = callPackage ../development/ocaml-modules/janestreet/ppx-bench.nix {};
+
+    ppx_bin_prot = callPackage ../development/ocaml-modules/janestreet/ppx-bin-prot.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5541,6 +5541,8 @@ in
     ppx_fail = callPackage ../development/ocaml-modules/janestreet/ppx-fail.nix {};
 
     ppx_fields_conv = callPackage ../development/ocaml-modules/janestreet/ppx-fields-conv.nix {};
+
+    ppx_let = callPackage ../development/ocaml-modules/janestreet/ppx-let.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5202,7 +5202,7 @@ in
 
     faillib = callPackage ../development/ocaml-modules/faillib { };
 
-    fieldslib = callPackage ../development/ocaml-modules/fieldslib { };
+    fieldslib_p4 = callPackage ../development/ocaml-modules/fieldslib { };
 
     fileutils = callPackage ../development/ocaml-modules/fileutils { };
 
@@ -5558,7 +5558,11 @@ in
 
     ppx_jane = callPackage ../development/ocaml-modules/janestreet/ppx-jane.nix {};
 
+
+    # Core sublibs
     typerep = callPackage ../development/ocaml-modules/janestreet/typerep.nix {};
+
+    fieldslib = callPackage ../development/ocaml-modules/janestreet/fieldslib.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5551,6 +5551,8 @@ in
     ppx_sexp_value = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-value.nix {};
 
     ppx_typerep_conv = callPackage ../development/ocaml-modules/janestreet/ppx-typerep-conv.nix {};
+
+    ppx_variants_conv = callPackage ../development/ocaml-modules/janestreet/ppx-variants-conv.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5487,7 +5487,7 @@ in
     uuseg = callPackage ../development/ocaml-modules/uuseg { };
     uutf = callPackage ../development/ocaml-modules/uutf { };
 
-    variantslib = callPackage ../development/ocaml-modules/variantslib { };
+    variantslib_p4 = callPackage ../development/ocaml-modules/variantslib { };
 
     vg = callPackage ../development/ocaml-modules/vg { };
 
@@ -5565,6 +5565,8 @@ in
     fieldslib = callPackage ../development/ocaml-modules/janestreet/fieldslib.nix {};
 
     sexplib = callPackage ../development/ocaml-modules/janestreet/sexplib.nix {};
+
+    variantslib = callPackage ../development/ocaml-modules/janestreet/variantslib.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5405,7 +5405,7 @@ in
     sexplib_111_25_00 = callPackage ../development/ocaml-modules/sexplib/111.25.00.nix { };
     sexplib_112_24_01 = callPackage ../development/ocaml-modules/sexplib/112.24.01.nix { };
 
-    sexplib =
+    sexplib_p4 =
       if lib.versionOlder "4.02" ocaml_version
       then sexplib_112_24_01
       else if lib.versionOlder "4.00" ocaml_version
@@ -5563,6 +5563,8 @@ in
     typerep = callPackage ../development/ocaml-modules/janestreet/typerep.nix {};
 
     fieldslib = callPackage ../development/ocaml-modules/janestreet/fieldslib.nix {};
+
+    sexplib = callPackage ../development/ocaml-modules/janestreet/sexplib.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5509,6 +5509,8 @@ in
 
     ppx_core = callPackage ../development/ocaml-modules/janestreet/ppx-core.nix {};
 
+    ppx_optcomp = callPackage ../development/ocaml-modules/janestreet/ppx-optcomp.nix {};
+
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5560,25 +5560,55 @@ in
 
 
     # Core sublibs
-    typerep = callPackage ../development/ocaml-modules/janestreet/typerep.nix {};
+    typerep =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/typerep.nix {}
+      else typerep_p4;
 
-    fieldslib = callPackage ../development/ocaml-modules/janestreet/fieldslib.nix {};
+    fieldslib =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/fieldslib.nix {}
+      else fieldslib_p4;
 
-    sexplib = callPackage ../development/ocaml-modules/janestreet/sexplib.nix {};
+    sexplib =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/sexplib.nix {}
+      else sexplib_p4;
 
-    variantslib = callPackage ../development/ocaml-modules/janestreet/variantslib.nix {};
+    variantslib =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/variantslib.nix {}
+      else variantslib_p4;
 
-    bin_prot = callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {};
+    bin_prot =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {}
+      else bin_prot_p4;
 
-    core_kernel = callPackage ../development/ocaml-modules/janestreet/core_kernel.nix {};
+    core_kernel =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/core_kernel.nix {}
+      else core_kernel_p4;
 
-    core = callPackage ../development/ocaml-modules/janestreet/core.nix {};
+    core =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/core.nix {}
+      else core_p4;
 
-    re2 = callPackage ../development/ocaml-modules/janestreet/re2.nix {};
+    re2 =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/re2.nix {}
+      else re2_p4;
 
-    textutils = callPackage ../development/ocaml-modules/janestreet/textutils.nix {};
+    textutils =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/textutils.nix {}
+      else textutils_p4;
 
-    core_extended = callPackage ../development/ocaml-modules/janestreet/core-extended.nix {};
+    core_extended =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/core-extended.nix {}
+      else core_extended_p4;
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5060,7 +5060,7 @@ in
 
     asn1-combinators = callPackage ../development/ocaml-modules/asn1-combinators { };
 
-    async_extra = callPackage ../development/ocaml-modules/async_extra { };
+    async_extra_p4 = callPackage ../development/ocaml-modules/async_extra { };
 
     async_find = callPackage ../development/ocaml-modules/async_find { };
 
@@ -5610,18 +5610,22 @@ in
       then callPackage ../development/ocaml-modules/janestreet/core-extended.nix {}
       else core_extended_p4;
 
-     async_kernel =
+    async_kernel =
       if lib.versionOlder "4.02" ocaml_version
       then callPackage ../development/ocaml-modules/janestreet/async-kernel.nix {}
       else async_kernel_p4;
 
     async_rpc_kernel = callPackage ../development/ocaml-modules/janestreet/async-rpc-kernel.nix {};
 
-     async_unix =
+    async_unix =
       if lib.versionOlder "4.02" ocaml_version
       then callPackage ../development/ocaml-modules/janestreet/async-unix.nix {}
       else async_unix_p4;
 
+    async_extra =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/async-extra.nix {}
+      else async_extra_p4;
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5556,6 +5556,8 @@ in
 
     ppx_expect = callPackage ../development/ocaml-modules/janestreet/ppx-expect.nix {};
 
+    ppx_jane = callPackage ../development/ocaml-modules/janestreet/ppx-jane.nix {};
+
     typerep = callPackage ../development/ocaml-modules/janestreet/typerep.nix {};
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5547,6 +5547,8 @@ in
     ppx_pipebang = callPackage ../development/ocaml-modules/janestreet/ppx-pipebang.nix {};
 
     ppx_sexp_message = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-message.nix {};
+
+    ppx_sexp_value = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-value.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5529,6 +5529,8 @@ in
     ppx_assert = callPackage ../development/ocaml-modules/janestreet/ppx-assert.nix {};
 
     ppx_inline_test = callPackage ../development/ocaml-modules/janestreet/ppx-inline-test.nix {};
+
+    ppx_bench = callPackage ../development/ocaml-modules/janestreet/ppx-bench.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5502,6 +5502,8 @@ in
       oasis = ocaml_oasis;
     };
 
+    # Jane Street
+    js_build_tools = callPackage ../development/ocaml-modules/janestreet/js-build-tools.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5543,6 +5543,8 @@ in
     ppx_fields_conv = callPackage ../development/ocaml-modules/janestreet/ppx-fields-conv.nix {};
 
     ppx_let = callPackage ../development/ocaml-modules/janestreet/ppx-let.nix {};
+
+    ppx_pipebang = callPackage ../development/ocaml-modules/janestreet/ppx-pipebang.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5525,6 +5525,8 @@ in
     ppx_here = callPackage ../development/ocaml-modules/janestreet/ppx-here.nix {};
 
     ppx_sexp_conv = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-conv.nix {};
+
+    ppx_assert = callPackage ../development/ocaml-modules/janestreet/ppx-assert.nix {};
   };
 
   ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5615,6 +5615,8 @@ in
       then callPackage ../development/ocaml-modules/janestreet/async-kernel.nix {}
       else async_kernel_p4;
 
+    async_rpc_kernel = callPackage ../development/ocaml-modules/janestreet/async-rpc-kernel.nix {};
+
      async_unix =
       if lib.versionOlder "4.02" ocaml_version
       then callPackage ../development/ocaml-modules/janestreet/async-unix.nix {}


### PR DESCRIPTION
###### Motivation for this change

OCaml has switched its primary macro system in OCaml 4.02 to PPX (from camlp4).
Jane Street, who produces one of the OCaml basis libraries, took this opportunity to change their build system, rip out all of their camlp4 stuff, and replace it with PPX.
New libraries and programs which depend on the new PPX style macros are being released, so we need a way to support them.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

To deal with older compilers and packages, I did a few things in addition to packaging the new code:
- Each package which has transitioned to PPX has been renamed to packagename_p4, allowing its last camlp4 release to be referenced explicitly
- Each package which transitioned to PPX had an if statement added which will diversion to packagename_p4 if the compiler is too old, so OCaml 4.0.0, 3.1, etc will still be able to access e.g. "sexplib" rather than "sexplib_p4"
- Existing packages which referenced a transitioning package were pointed at the _p4 version.
