### PR TITLE
MongoDB service: switch configuration format to YAML

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1609.xml
+++ b/nixos/doc/manual/release-notes/rl-1609.xml
@@ -106,6 +106,11 @@ following incompatible changes:</para>
     tool introduced to generate Go package definition from its Go source automatically.</para>
   </listitem>
 
+  <listitem>
+    <para><literal>services.mongodb.extraConfig</literal> configuration format
+    was changed to YAML.</para>
+  </listitem>
+
 </itemizedlist>
 
 

--- a/nixos/modules/services/databases/mongodb.nix
+++ b/nixos/modules/services/databases/mongodb.nix
@@ -12,13 +12,11 @@ let
 
   mongoCnf = pkgs.writeText "mongodb.conf"
   ''
-    bind_ip = ${cfg.bind_ip}
-    ${optionalString cfg.quiet "quiet = true"}
-    dbpath = ${cfg.dbpath}
-    syslog = true
-    fork = true
-    pidfilepath = ${cfg.pidFile}
-    ${optionalString (cfg.replSetName != "") "replSet = ${cfg.replSetName}"}
+    net.bindIp: ${cfg.bind_ip}
+    ${optionalString cfg.quiet "systemLog.quiet: true"}
+    systemLog.destination: syslog
+    storage.dbPath: ${cfg.dbpath}
+    ${optionalString (cfg.replSetName != "") "replication.replSetName: ${cfg.replSetName}"}
     ${cfg.extraConfig}
   '';
 
@@ -84,9 +82,9 @@ in
       extraConfig = mkOption {
         default = "";
         example = ''
-          nojournal = true
+          storage.journal.enabled: false
         '';
-        description = "MongoDB extra configuration";
+        description = "MongoDB extra configuration in YAML format";
       };
     };
 
@@ -112,7 +110,7 @@ in
         after = [ "network.target" ];
 
         serviceConfig = {
-          ExecStart = "${mongodb}/bin/mongod --quiet --config ${mongoCnf}";
+          ExecStart = "${mongodb}/bin/mongod --quiet --config ${mongoCnf} --fork --pidfilepath ${cfg.pidFile}";
           User = cfg.user;
           PIDFile = cfg.pidFile;
           Type = "forking";

--- a/nixos/tests/pump.io.nix
+++ b/nixos/tests/pump.io.nix
@@ -77,7 +77,7 @@ in {
            }; };
            mongodb.enable = true;
            mongodb.extraConfig = ''
-             nojournal = true
+             storage.journal.enabled: false
            '';
           };
           systemd.services.mongodb.unitConfig.Before = "pump.io.service";


### PR DESCRIPTION
###### Motivation for this change

Configuration format has changed from MongoDB 2.6 to YAML and MongoDB 2.4 is EOL since March 2016.
The YAML format is the [default format](https://docs.mongodb.com/manual/reference/configuration-options/#configuration-file) and 2.4 configuration file format is meant only for backwards compatibility.

It make sense to have YAML file as default as it is how users would expect to configure MongoDB if they read the upstream documentation.

This will likely break the mongodb service if the used package is `mongodb248`, but as 2.4 is EOL and YAML format is the default and provides more configuration options there is a trade-off to chose.

cc @elitak as he resurrected 2.4.8
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
