### PR TITLE
Frontc: init at 3.4

### DIFF
--- a/pkgs/development/ocaml-modules/frontc/default.nix
+++ b/pkgs/development/ocaml-modules/frontc/default.nix
@@ -1,0 +1,37 @@
+{stdenv, buildOcaml, fetchurl}:
+
+buildOcaml rec {
+  name = "Frontc";
+  version = "3.4";
+
+  src = fetchurl {
+    url = "http://www.irit.fr/recherches/ARCHI/MARCH/frontc/${name}-${version}.tgz";
+    sha256 = "16dz153s92dgbw1rrfwbhscy73did87kfmjwyh3qpvs748h1sc4g";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://www.irit.fr/recherches/ARCHI/MARCH/rubrique.php3?id_rubrique=61;
+    description = "C Parsing Library";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.maurer ];
+  };
+
+  meta_file = fetchurl {
+    url = https://raw.githubusercontent.com/ocaml/opam-repository/0f0e610f6499bdf0151e4170411b4f05e4d076d4/packages/FrontC/FrontC.3.4/files/META;
+    sha256 = "1flhvwr01crn7d094kby0418s1m4198np85ymjp3b4maz0n7m2mx";
+  };
+
+  opam_patch = fetchurl {
+    url = https://raw.githubusercontent.com/ocaml/opam-repository/0f0e610f6499bdf0151e4170411b4f05e4d076d4/packages/FrontC/FrontC.3.4/files/opam.patch;
+    sha256 = "0xf83ixx0mf3mznwpwp2mjflii0njdzikhhfxpnms7vhnnmlfzy5";
+  };
+
+  makeFlags = "PREFIX=$(out) OCAML_SITE=$(OCAMLFIND_DESTDIR)";
+
+  postInstall  = ''
+     cp ${meta_file} META
+     ocamlfind install FrontC $OCAMLFIND_DESTDIR/frontc/* META
+     rm -rf $OCAMLFIND_DESTDIR/frontc
+  '';
+
+}

--- a/pkgs/development/ocaml-modules/frontc/default.nix
+++ b/pkgs/development/ocaml-modules/frontc/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl}:
+{lib, buildOcaml, fetchurl}:
 
 buildOcaml rec {
   name = "FrontC";
@@ -9,7 +9,7 @@ buildOcaml rec {
     sha256 = "16dz153s92dgbw1rrfwbhscy73did87kfmjwyh3qpvs748h1sc4g";
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://www.irit.fr/recherches/ARCHI/MARCH/rubrique.php3?id_rubrique=61;
     description = "C Parsing Library";
     license = licenses.lgpl21;

--- a/pkgs/development/ocaml-modules/frontc/default.nix
+++ b/pkgs/development/ocaml-modules/frontc/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl}:
+{lib, buildOcaml, fetchurl}:
 
 buildOcaml rec {
   name = "Frontc";
@@ -9,7 +9,7 @@ buildOcaml rec {
     sha256 = "16dz153s92dgbw1rrfwbhscy73did87kfmjwyh3qpvs748h1sc4g";
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://www.irit.fr/recherches/ARCHI/MARCH/rubrique.php3?id_rubrique=61;
     description = "C Parsing Library";
     license = licenses.lgpl21;
@@ -19,11 +19,6 @@ buildOcaml rec {
   meta_file = fetchurl {
     url = https://raw.githubusercontent.com/ocaml/opam-repository/0f0e610f6499bdf0151e4170411b4f05e4d076d4/packages/FrontC/FrontC.3.4/files/META;
     sha256 = "1flhvwr01crn7d094kby0418s1m4198np85ymjp3b4maz0n7m2mx";
-  };
-
-  opam_patch = fetchurl {
-    url = https://raw.githubusercontent.com/ocaml/opam-repository/0f0e610f6499bdf0151e4170411b4f05e4d076d4/packages/FrontC/FrontC.3.4/files/opam.patch;
-    sha256 = "0xf83ixx0mf3mznwpwp2mjflii0njdzikhhfxpnms7vhnnmlfzy5";
   };
 
   makeFlags = "PREFIX=$(out) OCAML_SITE=$(OCAMLFIND_DESTDIR)";

--- a/pkgs/development/ocaml-modules/frontc/default.nix
+++ b/pkgs/development/ocaml-modules/frontc/default.nix
@@ -1,15 +1,15 @@
-{lib, buildOcaml, fetchurl}:
+{stdenv, buildOcaml, fetchurl}:
 
 buildOcaml rec {
-  name = "Frontc";
+  name = "FrontC";
   version = "3.4";
 
   src = fetchurl {
-    url = "http://www.irit.fr/recherches/ARCHI/MARCH/frontc/${name}-${version}.tgz";
+    url = "http://www.irit.fr/recherches/ARCHI/MARCH/frontc/Frontc-${version}.tgz";
     sha256 = "16dz153s92dgbw1rrfwbhscy73did87kfmjwyh3qpvs748h1sc4g";
   };
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     homepage = https://www.irit.fr/recherches/ARCHI/MARCH/rubrique.php3?id_rubrique=61;
     description = "C Parsing Library";
     license = licenses.lgpl21;
@@ -21,12 +21,15 @@ buildOcaml rec {
     sha256 = "1flhvwr01crn7d094kby0418s1m4198np85ymjp3b4maz0n7m2mx";
   };
 
+  opam_patch = fetchurl {
+    url = https://raw.githubusercontent.com/ocaml/opam-repository/0f0e610f6499bdf0151e4170411b4f05e4d076d4/packages/FrontC/FrontC.3.4/files/opam.patch;
+    sha256 = "0xf83ixx0mf3mznwpwp2mjflii0njdzikhhfxpnms7vhnnmlfzy5";
+  };
+
+  patches = [ opam_patch ];
+  patchFlags = "-p4";
+
   makeFlags = "PREFIX=$(out) OCAML_SITE=$(OCAMLFIND_DESTDIR)";
 
-  postInstall  = ''
-     cp ${meta_file} META
-     ocamlfind install FrontC $OCAMLFIND_DESTDIR/frontc/* META
-     rm -rf $OCAMLFIND_DESTDIR/frontc
-  '';
-
+  postInstall = "cp ${meta_file} $OCAMLFIND_DESTDIR/FrontC/META";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5313,6 +5313,8 @@ in
 
     ocaml_expat = callPackage ../development/ocaml-modules/expat { };
 
+    frontc = callPackage ../development/ocaml-modules/frontc { };
+
     ocamlfuse = callPackage ../development/ocaml-modules/ocamlfuse { };
 
     ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };


### PR DESCRIPTION
###### Motivation for this change

Add Frontc OCaml library
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` N/A (new package)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
