### PR TITLE
oasis: 0.4.6 -> 0.4.7

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
@@ -1,4 +1,4 @@
-{ buildOcaml, opam, js_build_tools, ocaml_oasis, fetchurl } :
+{ buildOcaml, opam, js_build_tools, ocaml_oasis_46, fetchurl } :
 
 { name, version ? "113.33.03", buildInputs ? [],
   hash ? "",
@@ -14,7 +14,7 @@ buildOcaml (args // {
 
   hasSharedObjects = true;
 
-  buildInputs = [ ocaml_oasis js_build_tools opam ] ++ buildInputs;
+  buildInputs = [ ocaml_oasis_46 js_build_tools opam ] ++ buildInputs;
 
   dontAddPrefix = true;
 

--- a/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
+++ b/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, ocaml_oasis, opam}:
+{stdenv, buildOcaml, fetchurl, ocaml_oasis_46, opam}:
 
 buildOcaml rec {
   name = "js-build-tools";
@@ -13,7 +13,7 @@ buildOcaml rec {
 
   hasSharedObjects = true;
 
-  buildInputs = [ ocaml_oasis opam ];
+  buildInputs = [ ocaml_oasis_46 opam ];
 
   dontAddPrefix = true;
   configurePhase = "./configure --prefix $prefix";

--- a/pkgs/development/tools/ocaml/oasis/0.4.6.nix
+++ b/pkgs/development/tools/ocaml/oasis/0.4.6.nix
@@ -2,11 +2,11 @@
  ocamlmod, ocamlify, ounit, expect}:
 
 stdenv.mkDerivation {
-  name = "ocaml-oasis-0.4.7";
+  name = "ocaml-oasis-0.4.6";
 
   src = fetchurl {
-    url = http://forge.ocamlcore.org/frs/download.php/1635/oasis-0.4.6.tar.gz;
-    sha256 = "13crvqiy0hhlnm4qfyxq2jjvs11ldxf15c4g9q91k1x3wj04pg2l";
+    url = http://forge.ocamlcore.org/frs/download.php/1604/oasis-0.4.6.tar.gz;
+    sha256 = "1yxv3ckkf87nz0cyll0yy1kd295j5pv3jqwkfrr1y65wkz5vw90k";
   };
 
   createFindlibDestdir = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5357,6 +5357,7 @@ in
     ocamlnet = callPackage ../development/ocaml-modules/ocamlnet { };
 
     ocaml_oasis = callPackage ../development/tools/ocaml/oasis { };
+    ocaml_oasis_46 = callPackage ../development/tools/ocaml/oasis/0.4.6.nix { };
 
     ocaml_optcomp = callPackage ../development/ocaml-modules/optcomp { };
 


### PR DESCRIPTION
###### Motivation for this change

Update oasis to allow new-style `setup.ml`
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Kept a copy of oasis_46 around for the moment to service qtest. The opam repository shows this too https://github.com/ocaml/opam-repository/issues/7305 and is keeping 4.6 around for it and similar packages for the moment.
