### PR TITLE
mplayer: fix on darwin

### DIFF
--- a/pkgs/applications/audio/cdparanoia/default.nix
+++ b/pkgs/applications/audio/cdparanoia/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = stdenv.lib.optional stdenv.isDarwin [
+  propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin [
     Carbon
     IOKit
   ];


### PR DESCRIPTION
###### Motivation for this change

These changes should get mplayer building on Darwin systems.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
