### PR TITLE
flashplayer: 11.2.202.632 -> 11.2.202.635 (for CVE)

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
@@ -70,11 +70,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "11.2.202.632";
+  version = "11.2.202.635";
 
   src = fetchurl {
     url = "https://fpdownload.macromedia.com/pub/flashplayer/installers/archive/fp_${version}_archive.zip";
-    sha256 = "0nf2d7jn8g6bp9vilkwwkkh6pm05fg3h73njsn4yvx3285k73lpn";
+    sha256 = "0xlaf6152ksknigrv6fsasscyfnjkxml4nl22apiwzb34nrbzk3m";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

This will also need to be backported to the `16.03` and `16.09` branches after being accepted into master.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This release fixes several CVEs: CVE-2016-4271, CVE-2016-4272,
CVE-2016-4274, CVE-2016-4275, CVE-2016-4276, CVE-2016-4277,
CVE-2016-4278, CVE-2016-4279, CVE-2016-4280, CVE-2016-4281,
CVE-2016-4282, CVE-2016-4283, CVE-2016-4284, CVE-2016-4285,
CVE-2016-4287, CVE-2016-6921, CVE-2016-6922, CVE-2016-6923,
CVE-2016-6924, CVE-2016-6925, CVE-2016-6926, CVE-2016-6927,
CVE-2016-6929, CVE-2016-6930, CVE-2016-6931, CVE-2016-6932

See
https://helpx.adobe.com/security/products/flash-player/apsb16-29.html
for adobe's details.
