### PR TITLE
pcre2: 10.21 -> 10.22

### DIFF
--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     arpack fftw fftwSinglePrec gmp libgit2 libunwind llvmShared mpfr
-    pcre2 openblas openlibm openspecfun readline suitesparse utf8proc
+    pcre2.dev openblas openlibm openspecfun readline suitesparse utf8proc
     zlib
   ] ++
     stdenv.lib.optionals stdenv.isDarwin [CoreServices ApplicationServices] ;
@@ -121,6 +121,8 @@ stdenv.mkDerivation rec {
       "USE_SYSTEM_OPENSPECFUN=1"
       "USE_SYSTEM_PATCHELF=1"
       "USE_SYSTEM_PCRE=1"
+      "PCRE_CONFIG=${pcre2.dev}/bin/pcre2-config"
+      "PCRE_INCL_PATH=${pcre2.dev}/include/pcre2.h"
       "USE_SYSTEM_READLINE=1"
       "USE_SYSTEM_UTF8PROC=1"
       "USE_SYSTEM_ZLIB=1"

--- a/pkgs/development/compilers/julia/git.nix
+++ b/pkgs/development/compilers/julia/git.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     arpack fftw fftwSinglePrec gmp libgit2 libunwind mpfr
-    pcre2 openblas openlibm openspecfun readline suitesparse utf8proc
+    pcre2.dev openblas openlibm openspecfun readline suitesparse utf8proc
     zlib
   ];
 
@@ -131,6 +131,8 @@ stdenv.mkDerivation rec {
       "USE_SYSTEM_OPENSPECFUN=1"
       "USE_SYSTEM_PATCHELF=1"
       "USE_SYSTEM_PCRE=1"
+      "PCRE_CONFIG=${pcre2.dev}/bin/pcre2-config"
+      "PCRE_INCL_PATH=${pcre2.dev}/include/pcre2.h"
       "USE_SYSTEM_READLINE=1"
       "USE_SYSTEM_UTF8PROC=1"
       "USE_SYSTEM_ZLIB=1"

--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "pcre2-10.21";
+  name = "pcre2-${version}";
+  version = "10.22";
   src = fetchurl {
     url = "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/${name}.tar.bz2";
-    sha256 = "1q6lrj9b08l1q39vxipb0fi88x6ybvkr6439h8bjb9r8jd81fsn6";
+    sha256 = "05pl338962d7syd1rbkg96916mq7d3amz1n2fjnm0v5cyhcldd5j";
   };
 
   configureFlags = [
@@ -13,11 +14,17 @@ stdenv.mkDerivation rec {
     "--enable-jit"
   ];
 
-  meta = {
-	description = "Perl Compatible Regular Expressions";
+  outputs = [ "bin" "dev" "out" "doc" "man" "devdoc" ];
+
+  postFixup = ''
+    moveToOutput bin/pcre2-config "$dev"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Perl Compatible Regular Expressions";
     homepage = "http://www.pcre.org/";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = [ stdenv.lib.maintainers.ttuegel ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ttuegel ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
##### Motivation for this change

maintenance.

passed internal tests.
added outputs following pcre's example.
Tested fish to execute and verified in it's build logs it finds pcre2-config but nothing else apart from that.
Tested ponyc to build.
Fixed up julia but couldn't finish the build since the tests required too much RAM... Made it past the regex tests so it should be fine :D @FRidh @7c6f434c

Note: emacs users will need to adjust\fix the julia and pcre2el modes if they're pulling them off melpa.
