### PR TITLE
androidenv: update packages

### DIFF
--- a/pkgs/development/mobile/androidenv/addon.xml
+++ b/pkgs/development/mobile/androidenv/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdk:sdk-addon xmlns:sdk="http://schemas.android.com/sdk/android/addon/7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2016-07-21 16:22:25.601902 with ADRT.-->
+	<!--Generated on 2016-09-13 10:48:39.682447 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -587,7 +587,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:39 2016.-->
+				<!--Built on: Mon Aug 15 05:06:49 2016.-->
 				<sdk:size>34908058</sdk:size>
 				<sdk:checksum type="sha1">1f92abf3a76be66ae8032257fc7620acbd2b2e3a</sdk:checksum>
 				<sdk:url>google_apis-3-r03.zip</sdk:url>
@@ -614,7 +614,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:43 2016.-->
+				<!--Built on: Mon Aug 15 05:06:49 2016.-->
 				<sdk:size>42435735</sdk:size>
 				<sdk:checksum type="sha1">9b6e86d8568558de4d606a7debc4f6049608dbd0</sdk:checksum>
 				<sdk:url>google_apis-4_r02.zip</sdk:url>
@@ -641,7 +641,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:47 2016.-->
+				<!--Built on: Mon Aug 15 05:06:51 2016.-->
 				<sdk:size>49123776</sdk:size>
 				<sdk:checksum type="sha1">46eaeb56b645ee7ffa24ede8fa17f3df70db0503</sdk:checksum>
 				<sdk:url>google_apis-5_r01.zip</sdk:url>
@@ -668,7 +668,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:52 2016.-->
+				<!--Built on: Mon Aug 15 05:06:51 2016.-->
 				<sdk:size>53382941</sdk:size>
 				<sdk:checksum type="sha1">5ff545d96e031e09580a6cf55713015c7d4936b2</sdk:checksum>
 				<sdk:url>google_apis-6_r01.zip</sdk:url>
@@ -695,7 +695,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:55 2016.-->
+				<!--Built on: Mon Aug 15 05:06:52 2016.-->
 				<sdk:size>53691339</sdk:size>
 				<sdk:checksum type="sha1">2e7f91e0fe34fef7f58aeced973c6ae52361b5ac</sdk:checksum>
 				<sdk:url>google_apis-7_r01.zip</sdk:url>
@@ -722,7 +722,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:59 2016.-->
+				<!--Built on: Mon Aug 15 05:06:52 2016.-->
 				<sdk:size>59505020</sdk:size>
 				<sdk:checksum type="sha1">3079958e7ec87222cac1e6b27bc471b27bf2c352</sdk:checksum>
 				<sdk:url>google_apis-8_r02.zip</sdk:url>
@@ -749,7 +749,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:04 2016.-->
+				<!--Built on: Mon Aug 15 05:06:50 2016.-->
 				<sdk:size>63401546</sdk:size>
 				<sdk:checksum type="sha1">78664645a1e9accea4430814f8694291a7f1ea5d</sdk:checksum>
 				<sdk:url>google_apis-9_r02.zip</sdk:url>
@@ -776,7 +776,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:09 2016.-->
+				<!--Built on: Mon Aug 15 05:06:52 2016.-->
 				<sdk:size>65781578</sdk:size>
 				<sdk:checksum type="sha1">cc0711857c881fa7534f90cf8cc09b8fe985484d</sdk:checksum>
 				<sdk:url>google_apis-10_r02.zip</sdk:url>
@@ -807,7 +807,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:13 2016.-->
+				<!--Built on: Mon Aug 15 05:06:54 2016.-->
 				<sdk:size>83477179</sdk:size>
 				<sdk:checksum type="sha1">5eab5e81addee9f3576d456d205208314b5146a5</sdk:checksum>
 				<sdk:url>google_apis-11_r01.zip</sdk:url>
@@ -834,7 +834,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:18 2016.-->
+				<!--Built on: Mon Aug 15 05:06:51 2016.-->
 				<sdk:size>86099835</sdk:size>
 				<sdk:checksum type="sha1">e9999f4fa978812174dfeceec0721c793a636e5d</sdk:checksum>
 				<sdk:url>google_apis-12_r01.zip</sdk:url>
@@ -865,7 +865,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:23 2016.-->
+				<!--Built on: Mon Aug 15 05:06:54 2016.-->
 				<sdk:size>88615525</sdk:size>
 				<sdk:checksum type="sha1">3b153edd211c27dc736c893c658418a4f9041417</sdk:checksum>
 				<sdk:url>google_apis-13_r01.zip</sdk:url>
@@ -896,7 +896,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:28 2016.-->
+				<!--Built on: Mon Aug 15 05:06:53 2016.-->
 				<sdk:size>106533714</sdk:size>
 				<sdk:checksum type="sha1">f8eb4d96ad0492b4c0db2d7e4f1a1a3836664d39</sdk:checksum>
 				<sdk:url>google_apis-14_r02.zip</sdk:url>
@@ -925,7 +925,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:33 2016.-->
+				<!--Built on: Mon Aug 15 05:06:54 2016.-->
 				<sdk:size>106624396</sdk:size>
 				<sdk:checksum type="sha1">d0d2bf26805eb271693570a1aaec33e7dc3f45e9</sdk:checksum>
 				<sdk:url>google_apis-15_r03.zip</sdk:url>
@@ -958,7 +958,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:40 2016.-->
+				<!--Built on: Mon Aug 15 05:06:54 2016.-->
 				<sdk:size>127341982</sdk:size>
 				<sdk:checksum type="sha1">ee6acf1b01020bfa8a8e24725dbc4478bee5e792</sdk:checksum>
 				<sdk:url>google_apis-16_r04.zip</sdk:url>
@@ -991,7 +991,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:46 2016.-->
+				<!--Built on: Mon Aug 15 05:06:55 2016.-->
 				<sdk:size>137231243</sdk:size>
 				<sdk:checksum type="sha1">a076be0677f38df8ca5536b44dfb411a0c808c4f</sdk:checksum>
 				<sdk:url>google_apis-17_r04.zip</sdk:url>
@@ -1024,7 +1024,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:40:53 2016.-->
+				<!--Built on: Mon Aug 15 05:06:54 2016.-->
 				<sdk:size>143195183</sdk:size>
 				<sdk:checksum type="sha1">6109603409debdd40854d4d4a92eaf8481462c8b</sdk:checksum>
 				<sdk:url>google_apis-18_r04.zip</sdk:url>
@@ -1057,7 +1057,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>20</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu May 19 11:35:33 2016.-->
+				<!--Built on: Mon Aug 15 04:16:31 2016.-->
 				<sdk:size>147081</sdk:size>
 				<sdk:checksum type="sha1">5b933abe830b2f25b4c0f171d45e9e0651e56311</sdk:checksum>
 				<sdk:url>google_apis-19_r20.zip</sdk:url>
@@ -1086,11 +1086,44 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:libs>
 	</sdk:add-on>
 	<sdk:add-on>
+		<!--Generated from bid:3249234, branch:git_nyc-emu-release-->
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Thu Sep  8 15:11:39 2016.-->
+				<sdk:size>154865</sdk:size>
+				<sdk:checksum type="sha1">31361c2868f27343ee917fbd259c1463821b6145</sdk:checksum>
+				<sdk:url>google_apis-24_r1.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:vendor-id>google</sdk:vendor-id>
+		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
+		<sdk:name-id>google_apis</sdk:name-id>
+		<sdk:name-display>Google APIs</sdk:name-display>
+		<sdk:api-level>24</sdk:api-level>
+		<sdk:description>Android + Google APIs</sdk:description>
+		<sdk:libs>
+			<sdk:lib>
+				<sdk:name>com.google.android.maps</sdk:name>
+				<sdk:description>API for Google Maps</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.android.future.usb.accessory</sdk:name>
+				<sdk:description>API for USB Accessories</sdk:description>
+			</sdk:lib>
+			<sdk:lib>
+				<sdk:name>com.google.android.media.effects</sdk:name>
+				<sdk:description>Collection of video effects</sdk:description>
+			</sdk:lib>
+		</sdk:libs>
+	</sdk:add-on>
+	<sdk:add-on>
 		<!--Generated from bid:77907680, branch:perforce-->
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:41:02 2016.-->
+				<!--Built on: Mon Aug 15 05:06:45 2016.-->
 				<sdk:size>179499</sdk:size>
 				<sdk:checksum type="sha1">66a754efb24e9bb07cc51648426443c7586c9d4a</sdk:checksum>
 				<sdk:url>google_apis-21_r01.zip</sdk:url>
@@ -1123,7 +1156,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:41:05 2016.-->
+				<!--Built on: Mon Aug 15 05:06:45 2016.-->
 				<sdk:size>179259</sdk:size>
 				<sdk:checksum type="sha1">5def0f42160cba8acff51b9c0c7e8be313de84f5</sdk:checksum>
 				<sdk:url>google_apis-22_r01.zip</sdk:url>
@@ -1156,7 +1189,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:41:08 2016.-->
+				<!--Built on: Mon Aug 15 05:06:45 2016.-->
 				<sdk:size>179900</sdk:size>
 				<sdk:checksum type="sha1">04c5cc1a7c88967250ebba9561d81e24104167db</sdk:checksum>
 				<sdk:url>google_apis-23_r01.zip</sdk:url>
@@ -1190,7 +1223,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:41:13 2016.-->
+				<!--Built on: Mon Aug 15 05:06:54 2016.-->
 				<sdk:size>78266751</sdk:size>
 				<sdk:checksum type="sha1">92128a12e7e8b0fb5bac59153d7779b717e7b840</sdk:checksum>
 				<sdk:url>google_tv-12_r02.zip</sdk:url>
@@ -1212,7 +1245,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:41:18 2016.-->
+				<!--Built on: Mon Aug 15 05:06:54 2016.-->
 				<sdk:size>87721879</sdk:size>
 				<sdk:checksum type="sha1">b73f7c66011ac8180b44aa4e83b8d78c66ea9a09</sdk:checksum>
 				<sdk:url>google_tv-13_r01.zip</sdk:url>
@@ -1229,18 +1262,18 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:libs/>
 	</sdk:add-on>
 	<sdk:extra>
-		<!--Generated from bid:3078275, branch:git_nyc-dev-->
+		<!--Generated from bid:3256427, branch:git_nyc-support-release-->
 		<sdk:revision>
-			<sdk:major>35</sdk:major>
+			<sdk:major>37</sdk:major>
 			<sdk:minor>0</sdk:minor>
 			<sdk:micro>0</sdk:micro>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 21 12:00:22 2016.-->
-				<sdk:size>251973915</sdk:size>
-				<sdk:checksum type="sha1">7a201334775d78bf185ffcce686b1b168d152217</sdk:checksum>
-				<sdk:url>android_m2repository_r35.zip</sdk:url>
+				<!--Built on: Mon Sep 12 10:14:44 2016.-->
+				<sdk:size>281268000</sdk:size>
+				<sdk:checksum type="sha1">2f862a5d66d5526cd5b7655c3e9678f493e485f7</sdk:checksum>
+				<sdk:url>android_m2repository_r37.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -1275,88 +1308,16 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:old-paths>compatibility</sdk:old-paths>
 	</sdk:extra>
 	<sdk:extra>
-		<!--Generated from bid:108530044, branch:perforce-->
+		<!--Generated from bid:128809501, branch:perforce-->
 		<sdk:revision>
-			<sdk:major>1</sdk:major>
-			<sdk:minor>0</sdk:minor>
-			<sdk:micro>3</sdk:micro>
+			<sdk:major>32</sdk:major>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:38:48 2016.-->
-				<sdk:size>12968916</sdk:size>
-				<sdk:checksum type="sha1">7c9ef7544cf0aea030bcc29bd8e12c04fd53e653</sdk:checksum>
-				<sdk:url>gapid_r01_linux.zip</sdk:url>
-				<sdk:host-os>linux</sdk:host-os>
-			</sdk:archive>
-			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:38:46 2016.-->
-				<sdk:size>15824058</sdk:size>
-				<sdk:checksum type="sha1">597eb271349d890566274861eba2770a84ee4c69</sdk:checksum>
-				<sdk:url>gapid_r01_osx.zip</sdk:url>
-			</sdk:archive>
-			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:38:47 2016.-->
-				<sdk:size>13220091</sdk:size>
-				<sdk:checksum type="sha1">82c9b3eb1b281f27f58fe55025227148b3deb12e</sdk:checksum>
-				<sdk:url>gapid_r01_windows.zip</sdk:url>
-				<sdk:host-os>windows</sdk:host-os>
-			</sdk:archive>
-		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-license"/>
-		<sdk:vendor-id>android</sdk:vendor-id>
-		<sdk:vendor-display>Android</sdk:vendor-display>
-		<sdk:description>Tools that support GPU debugging and profiling within an IDE.</sdk:description>
-		<sdk:name-display>GPU Debugging tools</sdk:name-display>
-		<sdk:path>gapid</sdk:path>
-	</sdk:extra>
-	<sdk:extra>
-		<!--Generated from bid:2994895, branch:git_studio-master-dev-->
-		<sdk:revision>
-			<sdk:major>3</sdk:major>
-			<sdk:minor>1</sdk:minor>
-			<sdk:micro>0</sdk:micro>
-		</sdk:revision>
-		<sdk:archives>
-			<sdk:archive>
-				<!--Built on: Tue Jun 21 13:35:11 2016.-->
-				<sdk:size>31528127</sdk:size>
-				<sdk:checksum type="sha1">a33fe37c87b095171d647385445abe164ae03514</sdk:checksum>
-				<sdk:url>gapid_2994895_linux.zip</sdk:url>
-				<sdk:host-os>linux</sdk:host-os>
-			</sdk:archive>
-			<sdk:archive>
-				<!--Built on: Tue Jun 21 13:35:14 2016.-->
-				<sdk:size>31908588</sdk:size>
-				<sdk:checksum type="sha1">81dec931c8b0a5fe7c68accd8b3f8c731a9474f3</sdk:checksum>
-				<sdk:url>gapid_2994895_osx.zip</sdk:url>
-			</sdk:archive>
-			<sdk:archive>
-				<!--Built on: Tue Jun 21 13:35:13 2016.-->
-				<sdk:size>31656334</sdk:size>
-				<sdk:checksum type="sha1">ce00f4a7364d7fdd5d25d2429f04c4d50f56be1e</sdk:checksum>
-				<sdk:url>gapid_2994895_windows.zip</sdk:url>
-				<sdk:host-os>windows</sdk:host-os>
-			</sdk:archive>
-		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-license"/>
-		<sdk:vendor-id>android</sdk:vendor-id>
-		<sdk:vendor-display>Android</sdk:vendor-display>
-		<sdk:description>Tools that support GPU debugging and profiling within an IDE.</sdk:description>
-		<sdk:name-display>GPU Debugging tools</sdk:name-display>
-		<sdk:path>gapid_3</sdk:path>
-	</sdk:extra>
-	<sdk:extra>
-		<!--Generated from bid:127098392, branch:perforce-->
-		<sdk:revision>
-			<sdk:major>31</sdk:major>
-		</sdk:revision>
-		<sdk:archives>
-			<sdk:archive>
-				<!--Built on: Mon Jul 11 10:11:05 2016.-->
-				<sdk:size>106690833</sdk:size>
-				<sdk:checksum type="sha1">20054f56e8e24c5f1aadd8cdf232d5dd54565aee</sdk:checksum>
-				<sdk:url>google_m2repository_r31.zip</sdk:url>
+				<!--Built on: Fri Jul 29 09:01:13 2016.-->
+				<sdk:size>113922721</sdk:size>
+				<sdk:checksum type="sha1">ae24bde9c8f732f4d13b72e70802be8c97dcfddf</sdk:checksum>
+				<sdk:url>google_m2repository_r32.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -1431,16 +1392,16 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:path>google_play_services_froyo</sdk:path>
 	</sdk:extra>
 	<sdk:extra>
-		<!--Generated from bid:125682601, branch:perforce-->
+		<!--Generated from bid:128810771, branch:perforce-->
 		<sdk:revision>
-			<sdk:major>31</sdk:major>
+			<sdk:major>32</sdk:major>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jun 23 11:29:48 2016.-->
-				<sdk:size>11746505</sdk:size>
-				<sdk:checksum type="sha1">3f1b502d0f6361c036cb332b8c15249a1168e08b</sdk:checksum>
-				<sdk:url>google_play_services_9256000_r31.zip</sdk:url>
+				<!--Built on: Fri Jul 29 09:01:17 2016.-->
+				<sdk:size>11820632</sdk:size>
+				<sdk:checksum type="sha1">bf0e7c1848371c7e6dd7a01e237dbd916e5cb04f</sdk:checksum>
+				<sdk:url>google_play_services_945200_r32.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>

--- a/pkgs/development/mobile/androidenv/addons.nix
+++ b/pkgs/development/mobile/androidenv/addons.nix
@@ -256,6 +256,18 @@ in
       };
     };
 
+  google_apis_24 = buildGoogleApis {
+    name = "google_apis-24";
+      src = fetchurl {
+        url = https://dl.google.com/android/repository/google_apis-24_r1.zip;
+        sha1 = "31361c2868f27343ee917fbd259c1463821b6145";
+      };
+      meta = {
+        description = "Android + Google APIs";
+
+      };
+    };
+
   android_support_extra = buildGoogleApis {
     name = "android_support_extra";
     src = fetchurl {
@@ -271,8 +283,8 @@ in
   google_play_services = buildGoogleApis {
     name = "google_play_services";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/google_play_services_9256000_r31.zip;
-      sha1 = "3f1b502d0f6361c036cb332b8c15249a1168e08b";
+      url = https://dl.google.com/android/repository/google_play_services_945200_r32.zip;
+      sha1 = "bf0e7c1848371c7e6dd7a01e237dbd916e5cb04f";
     };
     meta = {
       description = "Google Play services client library and sample code";

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -10,16 +10,16 @@ with { inherit (stdenv.lib) makeLibraryPath; };
 
 stdenv.mkDerivation rec {
   name = "android-sdk-${version}";
-  version = "25.1.7";
+  version = "25.2.2";
 
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "http://dl.google.com/android/repository/tools_r${version}-linux.zip";
-      sha1 = "p03br08zfq0j7aar5638z8fdh5n9x1in";
+      sha256 = "0q53yq8fjc10kr4fz3rap5vsil3297w5nn4kw1z0ms7yz1d1im8h";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "http://dl.google.com/android/repository/tools_r${version}-macosx.zip";
-      sha1 = "7fzlfms37cfk25kk4f9zriy63djmbi8g";
+      sha256 = "1wq7xm0rhy0h6qylv7fq9mhf8hqihrr1nzf7d322rc3g0jfrdrcl";
     }
     else throw "platform not ${stdenv.system} supported!";
 

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -6,10 +6,11 @@ rec {
   };
   
   buildTools = import ./build-tools.nix {
-    inherit (pkgs) stdenv fetchurl unzip;
+    inherit (pkgs) stdenv fetchurl unzip zlib file;
     stdenv_32bit = pkgs_i686.stdenv;
     zlib_32bit = pkgs_i686.zlib;
-    ncurses_32bit = pkgs_i686.ncurses;
+    ncurses_32bit = pkgs_i686.ncurses5;
+    ncurses = pkgs.ncurses5;
   };
   
   support = import ./support.nix {

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -1,16 +1,16 @@
 {stdenv, zlib, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "24";
+  version = "24.0.2";
   name = "android-platform-tools-r${version}";
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-linux.zip";
-      sha1 = "qabpsfhm7shvyjy6amdl7b3d41n64zsr";
+      sha256 = "0y36mlwh4kb77d3vcpqxqwkxsadllap6g6jjylf3rb7blh5l4zw6";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-macosx.zip";
-      sha1 = "5s808wby36xxkfmrj4va9dnc0rwsz2gh";
+      sha256 = "1whfhdwjir2sv2pfypagva813yn0fx8idi6c2mxhddv2mlws6zk4";
     }
     else throw "System ${stdenv.system} not supported!";
 

--- a/pkgs/development/mobile/androidenv/platforms-linux.nix
+++ b/pkgs/development/mobile/androidenv/platforms-linux.nix
@@ -283,8 +283,8 @@ in
   platform_24 = buildPlatform {
     name = "android-platform-7.0";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/platform-24_r01.zip;
-      sha1 = "27516dab4848f55896e16f7089038c62bbbffea7";
+      url = https://dl.google.com/android/repository/platform-24_r02.zip;
+      sha1 = "8912da3d4bfe7a9f28f0e5ce92d3a8dc96342aee";
     };
     meta = {
       description = "Android SDK Platform 24";

--- a/pkgs/development/mobile/androidenv/platforms-macosx.nix
+++ b/pkgs/development/mobile/androidenv/platforms-macosx.nix
@@ -283,8 +283,8 @@ in
   platform_24 = buildPlatform {
     name = "android-platform-7.0";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/platform-24_r01.zip;
-      sha1 = "27516dab4848f55896e16f7089038c62bbbffea7";
+      url = https://dl.google.com/android/repository/platform-24_r02.zip;
+      sha1 = "8912da3d4bfe7a9f28f0e5ce92d3a8dc96342aee";
     };
     meta = {
       description = "Android SDK Platform 24";

--- a/pkgs/development/mobile/androidenv/repository-11.xml
+++ b/pkgs/development/mobile/androidenv/repository-11.xml
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 <sdk:sdk-repository xmlns:sdk="http://schemas.android.com/sdk/android/repository/11" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2016-07-22 11:17:21.550545 with ADRT.-->
+	<!--Generated on 2016-09-13 11:44:58.246002 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -335,18 +335,58 @@ June 2014.</sdk:license>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:ndk>
+	<sdk:ndk>
+		<!--Generated from bid:3214847, branch:aosp-ndk-r13-release-->
+		<sdk:description>NDK</sdk:description>
+		<sdk:revision>13</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Aug 23 15:40:55 2016.-->
+				<sdk:size>665405792</sdk:size>
+				<sdk:checksum type="sha1">0cbdb271b103a7e4237b34b73f0e56381e4632aa</sdk:checksum>
+				<sdk:url>android-ndk-r13-beta2-darwin-x86_64.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+				<sdk:host-bits>64</sdk:host-bits>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Aug 23 15:41:13 2016.-->
+				<sdk:size>686843165</sdk:size>
+				<sdk:checksum type="sha1">ea1a76d9ebdc82fe742d32798aaee7c980afd2f6</sdk:checksum>
+				<sdk:url>android-ndk-r13-beta2-linux-x86_64.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+				<sdk:host-bits>64</sdk:host-bits>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Aug 23 15:40:19 2016.-->
+				<sdk:size>619981813</sdk:size>
+				<sdk:checksum type="sha1">a5f6edceb3afa4ecd47071822ea32ba6bd6ac002</sdk:checksum>
+				<sdk:url>android-ndk-r13-beta2-windows-x86.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+				<sdk:host-bits>32</sdk:host-bits>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Aug 23 15:40:37 2016.-->
+				<sdk:size>680836961</sdk:size>
+				<sdk:checksum type="sha1">a0b6a0ed271b0a99cdca28ce8fd405f89defc539</sdk:checksum>
+				<sdk:url>android-ndk-r13-beta2-windows-x86_64.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+				<sdk:host-bits>64</sdk:host-bits>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-preview-license"/>
+	</sdk:ndk>
 	<sdk:platform>
-		<!--Generated from bid:3051502, branch:git_nyc-preview-release-->
+		<!--Generated from bid:3209611, branch:git_nyc-sdk-dev-->
 		<sdk:version>7.0</sdk:version>
 		<sdk:api-level>24</sdk:api-level>
 		<sdk:description>Android SDK Platform 24</sdk:description>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 13:51:08 2016.-->
-				<sdk:size>82645675</sdk:size>
-				<sdk:checksum type="sha1">27516dab4848f55896e16f7089038c62bbbffea7</sdk:checksum>
-				<sdk:url>platform-24_r01.zip</sdk:url>
+				<!--Built on: Mon Aug 22 11:05:39 2016.-->
+				<sdk:size>82648154</sdk:size>
+				<sdk:checksum type="sha1">8912da3d4bfe7a9f28f0e5ce92d3a8dc96342aee</sdk:checksum>
+				<sdk:url>platform-24_r02.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -953,6 +993,20 @@ June 2014.</sdk:license>
 		</sdk:layoutlib>
 	</sdk:platform>
 	<sdk:source>
+		<!--Generated from bid:3209611, branch:git_nyc-sdk-dev-->
+		<sdk:api-level>24</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Aug 22 11:05:30 2016.-->
+				<sdk:size>30270410</sdk:size>
+				<sdk:checksum type="sha1">6b96115830a83d654479f32ce4b724ca9011148b</sdk:checksum>
+				<sdk:url>sources-24_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
 		<!--Generated from bid:2166767, branch:git_mnc-release-->
 		<sdk:api-level>23</sdk:api-level>
 		<sdk:revision>1</sdk:revision>
@@ -1094,7 +1148,39 @@ June 2014.</sdk:license>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:source>
 	<sdk:build-tool>
-		<!--Generated from bid:3051502, branch:git_nyc-preview-release-->
+		<!--Generated from bid:3209611, branch:git_nyc-sdk-dev-->
+		<sdk:revision>
+			<sdk:major>24</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>2</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Aug 22 11:05:10 2016.-->
+				<sdk:size>48936295</sdk:size>
+				<sdk:checksum type="sha1">f199a7a788c3fefbed102eea34d6007737b803cf</sdk:checksum>
+				<sdk:url>build-tools_r24.0.2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Aug 22 11:05:08 2016.-->
+				<sdk:size>48726190</sdk:size>
+				<sdk:checksum type="sha1">8bb8fc575477491d5957de743089df412de55cda</sdk:checksum>
+				<sdk:url>build-tools_r24.0.2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Aug 22 11:05:05 2016.-->
+				<sdk:size>49512513</sdk:size>
+				<sdk:checksum type="sha1">09586a1f1c39bcfa7db5205c9a07837247deb67e</sdk:checksum>
+				<sdk:url>build-tools_r24.0.2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:3208200, branch:git_nyc-dev-->
 		<sdk:revision>
 			<sdk:major>24</sdk:major>
 			<sdk:minor>0</sdk:minor>
@@ -1102,23 +1188,23 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 13:50:49 2016.-->
-				<sdk:size>48936213</sdk:size>
-				<sdk:checksum type="sha1">d3647db5c349247787d4e124dfb717e72b4304c7</sdk:checksum>
+				<!--Built on: Tue Aug 23 11:42:33 2016.-->
+				<sdk:size>48936286</sdk:size>
+				<sdk:checksum type="sha1">84f18c392919a074fcbb9b1d967984e6b2fef8b4</sdk:checksum>
 				<sdk:url>build-tools_r24.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 13:50:47 2016.-->
-				<sdk:size>48725466</sdk:size>
-				<sdk:checksum type="sha1">4fb942e52d05ded78719410fc8644e70a62f18d6</sdk:checksum>
+				<!--Built on: Tue Aug 23 11:42:31 2016.-->
+				<sdk:size>48726085</sdk:size>
+				<sdk:checksum type="sha1">5c6457fcdfa07724fb086d8ff4e8316fc0742848</sdk:checksum>
 				<sdk:url>build-tools_r24.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 13:50:45 2016.-->
-				<sdk:size>49511433</sdk:size>
-				<sdk:checksum type="sha1">f73cc9028bff45689351ac8e093876bbeb80d1f1</sdk:checksum>
+				<!--Built on: Tue Aug 23 11:42:30 2016.-->
+				<sdk:size>49511883</sdk:size>
+				<sdk:checksum type="sha1">ac4a7cea42c3ef74d7fbf1b992fad311c550034e</sdk:checksum>
 				<sdk:url>build-tools_r24.0.1-windows.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 			</sdk:archive>
@@ -1134,21 +1220,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jun 10 15:06:14 2016.-->
+				<!--Built on: Mon Aug 15 04:18:09 2016.-->
 				<sdk:size>48960919</sdk:size>
 				<sdk:checksum type="sha1">c6271c4d78a5612ea6c7150688bcd5b7313de8d1</sdk:checksum>
 				<sdk:url>build-tools_r24-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jun 10 15:06:11 2016.-->
+				<!--Built on: Mon Aug 15 04:18:36 2016.-->
 				<sdk:size>48747930</sdk:size>
 				<sdk:checksum type="sha1">97fc4ed442f23989cc488d02c1d1de9bdde241de</sdk:checksum>
 				<sdk:url>build-tools_r24-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jun 10 15:06:10 2016.-->
+				<!--Built on: Mon Aug 15 04:19:02 2016.-->
 				<sdk:size>49535326</sdk:size>
 				<sdk:checksum type="sha1">dc61b9e5b451a0c3ec42ae2b1ce27c4d3c8da9f7</sdk:checksum>
 				<sdk:url>build-tools_r24-windows.zip</sdk:url>
@@ -1166,21 +1252,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:56 2016.-->
+				<!--Built on: Mon Aug 15 04:18:06 2016.-->
 				<sdk:size>39071201</sdk:size>
 				<sdk:checksum type="sha1">8a9f2b37f6fcf7a9fa784dc21aeaeb41bbb9f2c3</sdk:checksum>
 				<sdk:url>build-tools_r23.0.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:56 2016.-->
+				<!--Built on: Mon Aug 15 04:19:01 2016.-->
 				<sdk:size>38060914</sdk:size>
 				<sdk:checksum type="sha1">482c4cbceef8ff58aefd92d8155a38610158fdaf</sdk:checksum>
 				<sdk:url>build-tools_r23.0.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:56 2016.-->
+				<!--Built on: Mon Aug 15 04:19:55 2016.-->
 				<sdk:size>38217626</sdk:size>
 				<sdk:checksum type="sha1">fc3a92c744d3ba0a16ccb5d2b41eea5974ce0a96</sdk:checksum>
 				<sdk:url>build-tools_r23.0.2-windows.zip</sdk:url>
@@ -1198,21 +1284,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 15 17:38:51 2016.-->
+				<!--Built on: Mon Aug 15 04:18:13 2016.-->
 				<sdk:size>40733174</sdk:size>
 				<sdk:checksum type="sha1">368f2600feac7e9b511b82f53d1f2240ae4a91a3</sdk:checksum>
 				<sdk:url>build-tools_r23.0.3-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Mar 15 17:38:50 2016.-->
+				<!--Built on: Mon Aug 15 04:18:36 2016.-->
 				<sdk:size>39679533</sdk:size>
 				<sdk:checksum type="sha1">fbc98cd303fd15a31d472de6c03bd707829f00b0</sdk:checksum>
 				<sdk:url>build-tools_r23.0.3-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Mar 15 17:38:48 2016.-->
+				<!--Built on: Mon Aug 15 04:18:59 2016.-->
 				<sdk:size>39869945</sdk:size>
 				<sdk:checksum type="sha1">c6d8266c6a3243c8f1e41b786c0e3cee4c781263</sdk:checksum>
 				<sdk:url>build-tools_r23.0.3-windows.zip</sdk:url>
@@ -1263,21 +1349,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<!--Built on: Mon Aug 15 04:18:06 2016.-->
 				<sdk:size>39080519</sdk:size>
 				<sdk:checksum type="sha1">c1d6209212b01469f80fa804e0c1d39a06bc9060</sdk:checksum>
 				<sdk:url>build-tools_r23-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<!--Built on: Mon Aug 15 04:19:19 2016.-->
 				<sdk:size>38070540</sdk:size>
 				<sdk:checksum type="sha1">90ba6e716f7703a236cd44b2e71c5ff430855a03</sdk:checksum>
 				<sdk:url>build-tools_r23-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<!--Built on: Mon Aug 15 04:20:17 2016.-->
 				<sdk:size>38570715</sdk:size>
 				<sdk:checksum type="sha1">3874948f35f2f8946597679cc6e9151449f23b5d</sdk:checksum>
 				<sdk:url>build-tools_r23-windows.zip</sdk:url>
@@ -1295,21 +1381,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:53 2016.-->
+				<!--Built on: Mon Aug 15 04:18:01 2016.-->
 				<sdk:size>33104577</sdk:size>
 				<sdk:checksum type="sha1">da8b9c5c3ede39298e6cf0283c000c2ee9029646</sdk:checksum>
 				<sdk:url>build-tools_r22.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<!--Built on: Mon Aug 15 04:18:48 2016.-->
 				<sdk:size>33646102</sdk:size>
 				<sdk:checksum type="sha1">53dad7f608e01d53b17176ba11165acbfccc5bbf</sdk:checksum>
 				<sdk:url>build-tools_r22.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:54 2016.-->
+				<!--Built on: Mon Aug 15 04:19:49 2016.-->
 				<sdk:size>33254137</sdk:size>
 				<sdk:checksum type="sha1">61d8cbe069d9e0a57872a83e5e5abe164b7d52cf</sdk:checksum>
 				<sdk:url>build-tools_r22.0.1-windows.zip</sdk:url>
@@ -1328,21 +1414,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:53 2016.-->
+				<!--Built on: Mon Aug 15 04:17:57 2016.-->
 				<sdk:size>33104280</sdk:size>
 				<sdk:checksum type="sha1">a8a1619dd090e44fac957bce6842e62abf87965b</sdk:checksum>
 				<sdk:url>build-tools_r22-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:53 2016.-->
+				<!--Built on: Mon Aug 15 04:18:14 2016.-->
 				<sdk:size>33646090</sdk:size>
 				<sdk:checksum type="sha1">af95429b24088d704bc5db9bd606e34ac1b82c0d</sdk:checksum>
 				<sdk:url>build-tools_r22-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:53 2016.-->
+				<!--Built on: Mon Aug 15 04:19:09 2016.-->
 				<sdk:size>33254114</sdk:size>
 				<sdk:checksum type="sha1">08fcca41e81b172bd9f570963b90d3a84929e043</sdk:checksum>
 				<sdk:url>build-tools_r22-windows.zip</sdk:url>
@@ -1360,21 +1446,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<!--Built on: Mon Aug 15 04:17:59 2016.-->
 				<sdk:size>32637678</sdk:size>
 				<sdk:checksum type="sha1">5e35259843bf2926113a38368b08458735479658</sdk:checksum>
 				<sdk:url>build-tools_r21.1.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<!--Built on: Mon Aug 15 04:18:34 2016.-->
 				<sdk:size>33152878</sdk:size>
 				<sdk:checksum type="sha1">e7c906b4ba0eea93b32ba36c610dbd6b204bff48</sdk:checksum>
 				<sdk:url>build-tools_r21.1.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<!--Built on: Mon Aug 15 04:19:25 2016.-->
 				<sdk:size>32792587</sdk:size>
 				<sdk:checksum type="sha1">1d944759c47f60e634d2b8a1f3a4259be2f8d652</sdk:checksum>
 				<sdk:url>build-tools_r21.1.2-windows.zip</sdk:url>
@@ -1393,21 +1479,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:51 2016.-->
+				<!--Built on: Mon Aug 15 04:17:59 2016.-->
 				<sdk:size>32642454</sdk:size>
 				<sdk:checksum type="sha1">1c712ee3a1ba5a8b0548f9c32f17d4a0ddfd727d</sdk:checksum>
 				<sdk:url>build-tools_r21.1.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<!--Built on: Mon Aug 15 04:18:16 2016.-->
 				<sdk:size>33157676</sdk:size>
 				<sdk:checksum type="sha1">836a146eab0504aa9387a5132e986fe7c7381571</sdk:checksum>
 				<sdk:url>build-tools_r21.1.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:52 2016.-->
+				<!--Built on: Mon Aug 15 04:18:32 2016.-->
 				<sdk:size>32797356</sdk:size>
 				<sdk:checksum type="sha1">53fc4201237f899d5cd92f0b76ad41fb89da188b</sdk:checksum>
 				<sdk:url>build-tools_r21.1.1-windows.zip</sdk:url>
@@ -1426,21 +1512,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:51 2016.-->
+				<!--Built on: Mon Aug 15 04:17:58 2016.-->
 				<sdk:size>32642820</sdk:size>
 				<sdk:checksum type="sha1">b7455e543784d52a8925f960bc880493ed1478cb</sdk:checksum>
 				<sdk:url>build-tools_r21.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:51 2016.-->
+				<!--Built on: Mon Aug 15 04:18:34 2016.-->
 				<sdk:size>33158159</sdk:size>
 				<sdk:checksum type="sha1">df619356c2359aa5eacdd48699d15b335d9bd246</sdk:checksum>
 				<sdk:url>build-tools_r21.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:51 2016.-->
+				<!--Built on: Mon Aug 15 04:19:31 2016.-->
 				<sdk:size>32797810</sdk:size>
 				<sdk:checksum type="sha1">c79d63ac6b713a1e326ad4dae43f2ee76708a2f4</sdk:checksum>
 				<sdk:url>build-tools_r21.1-windows.zip</sdk:url>
@@ -1459,21 +1545,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<!--Built on: Mon Aug 15 04:17:56 2016.-->
 				<sdk:size>22153122</sdk:size>
 				<sdk:checksum type="sha1">e1236ab8897b62b57414adcf04c132567b2612a5</sdk:checksum>
 				<sdk:url>build-tools_r21.0.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<!--Built on: Mon Aug 15 04:18:09 2016.-->
 				<sdk:size>22668597</sdk:size>
 				<sdk:checksum type="sha1">f17471c154058f3734729ef3cc363399b1cd3de1</sdk:checksum>
 				<sdk:url>build-tools_r21.0.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<!--Built on: Mon Aug 15 04:19:02 2016.-->
 				<sdk:size>22306371</sdk:size>
 				<sdk:checksum type="sha1">37496141b23cbe633167927b7abe6e22d9f1a1c1</sdk:checksum>
 				<sdk:url>build-tools_r21.0.2-windows.zip</sdk:url>
@@ -1492,21 +1578,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:49 2016.-->
+				<!--Built on: Mon Aug 15 04:17:55 2016.-->
 				<sdk:size>22153013</sdk:size>
 				<sdk:checksum type="sha1">e573069eea3e5255e7a65bedeb767f4fd0a5f49a</sdk:checksum>
 				<sdk:url>build-tools_r21.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<!--Built on: Mon Aug 15 04:18:08 2016.-->
 				<sdk:size>22668616</sdk:size>
 				<sdk:checksum type="sha1">b60c8f9b810c980abafa04896706f3911be1ade7</sdk:checksum>
 				<sdk:url>build-tools_r21.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:50 2016.-->
+				<!--Built on: Mon Aug 15 04:18:21 2016.-->
 				<sdk:size>22306243</sdk:size>
 				<sdk:checksum type="sha1">d68e7e6fd7a48c8759aa41d713c9d4f0e4c1c1df</sdk:checksum>
 				<sdk:url>build-tools_r21.0.1-windows.zip</sdk:url>
@@ -1877,100 +1963,64 @@ June 2014.</sdk:license>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:build-tool>
 	<sdk:platform-tool>
-		<!--Generated from bid:3051502, branch:nyc_preview_release-->
+		<!--Generated from bid:3264814, branch:git_nyc-sdk-dev-->
 		<sdk:revision>
 			<sdk:major>24</sdk:major>
 			<sdk:minor>0</sdk:minor>
-			<sdk:micro>1</sdk:micro>
+			<sdk:micro>2</sdk:micro>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 13:50:59 2016.-->
-				<sdk:size>3328487</sdk:size>
-				<sdk:checksum type="sha1">597f626c206dac435b55c64bbfa13e153a7d97c2</sdk:checksum>
-				<sdk:url>platform-tools_r24-linux.zip</sdk:url>
+				<!--Built on: Mon Sep 12 16:08:48 2016.-->
+				<sdk:size>3341647</sdk:size>
+				<sdk:checksum type="sha1">a268850d31973d32de5c1515853f81924a4068cf</sdk:checksum>
+				<sdk:url>platform-tools_r24.0.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 13:50:58 2016.-->
-				<sdk:size>3143839</sdk:size>
-				<sdk:checksum type="sha1">f089af7906ccb6a43691b9bad9bb197e7104902e</sdk:checksum>
-				<sdk:url>platform-tools_r24-macosx.zip</sdk:url>
+				<!--Built on: Mon Sep 12 16:08:48 2016.-->
+				<sdk:size>3157182</sdk:size>
+				<sdk:checksum type="sha1">16053da716cbc6ef31c32a0d2f1437b22089c88c</sdk:checksum>
+				<sdk:url>platform-tools_r24.0.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 13:50:58 2016.-->
-				<sdk:size>2984063</sdk:size>
-				<sdk:checksum type="sha1">f1e2d122544d7beaa6f979e485fe742ba735802e</sdk:checksum>
-				<sdk:url>platform-tools_r24-windows.zip</sdk:url>
+				<!--Built on: Mon Sep 12 16:08:47 2016.-->
+				<sdk:size>2997417</sdk:size>
+				<sdk:checksum type="sha1">ce09a7351d5c50865691554ed56325f6e5cd733c</sdk:checksum>
+				<sdk:url>platform-tools_r24.0.2-windows.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:platform-tool>
 	<sdk:tool>
-		<!--Generated from bid:2879327, branch:aosp-emu-2.0-release-->
-		<sdk:revision>
-			<sdk:major>25</sdk:major>
-			<sdk:minor>1</sdk:minor>
-			<sdk:micro>7</sdk:micro>
-		</sdk:revision>
-		<sdk:archives>
-			<sdk:archive>
-				<!--Built on: Wed May 18 11:42:01 2016.-->
-				<sdk:size>234442830</sdk:size>
-				<sdk:checksum type="sha1">36869e6c81cda18f862959a92301761f81bc06b8</sdk:checksum>
-				<sdk:url>tools_r25.1.7-linux.zip</sdk:url>
-				<sdk:host-os>linux</sdk:host-os>
-			</sdk:archive>
-			<sdk:archive>
-				<!--Built on: Wed May 18 11:41:53 2016.-->
-				<sdk:size>161408907</sdk:size>
-				<sdk:checksum type="sha1">0fc555651bc6c7fc93237316311d3b435747bf3b</sdk:checksum>
-				<sdk:url>tools_r25.1.7-macosx.zip</sdk:url>
-				<sdk:host-os>macosx</sdk:host-os>
-			</sdk:archive>
-			<sdk:archive>
-				<!--Built on: Wed May 18 11:41:48 2016.-->
-				<sdk:size>230413711</sdk:size>
-				<sdk:checksum type="sha1">2556ac9a5fa741d44d9b989966c0bbdf15cb6424</sdk:checksum>
-				<sdk:url>tools_r25.1.7-windows.zip</sdk:url>
-				<sdk:host-os>windows</sdk:host-os>
-			</sdk:archive>
-		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-license"/>
-		<sdk:min-platform-tools-rev>
-			<sdk:major>20</sdk:major>
-		</sdk:min-platform-tools-rev>
-	</sdk:tool>
-	<sdk:tool>
-		<!--Generated from bid:3037468, branch:aosp-emu-2.2-release-->
+		<!--Generated from bid:3098464, branch:aosp-emu-2.2-release-->
 		<sdk:revision>
 			<sdk:major>25</sdk:major>
 			<sdk:minor>2</sdk:minor>
-			<sdk:micro>0</sdk:micro>
-			<sdk:preview>1</sdk:preview>
+			<sdk:micro>2</sdk:micro>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul  7 09:13:33 2016.-->
-				<sdk:size>277445993</sdk:size>
-				<sdk:checksum type="sha1">084ff93feb2f432f532cb00375e582f46b583ff2</sdk:checksum>
-				<sdk:url>tools_r25.2-linux.zip</sdk:url>
+				<!--Built on: Fri Jul 29 11:26:26 2016.-->
+				<sdk:size>273491448</sdk:size>
+				<sdk:checksum type="sha1">99257925a3d8b46fee948a7520d7b7e3e3e1890e</sdk:checksum>
+				<sdk:url>tools_r25.2.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Thu Jul  7 09:13:24 2016.-->
-				<sdk:size>195767390</sdk:size>
-				<sdk:checksum type="sha1">e49cc97f6f408fde9181f11ab942dbbea31abce3</sdk:checksum>
-				<sdk:url>tools_r25.2-macosx.zip</sdk:url>
+				<!--Built on: Fri Jul 29 11:26:16 2016.-->
+				<sdk:size>195856788</sdk:size>
+				<sdk:checksum type="sha1">bbaa3929696ce523ea62b58cc8032d7964a154c5</sdk:checksum>
+				<sdk:url>tools_r25.2.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Thu Jul  7 09:13:18 2016.-->
-				<sdk:size>301550581</sdk:size>
-				<sdk:checksum type="sha1">cc8bcbd7fb5627ab866cc583b041d0bfc18e4441</sdk:checksum>
-				<sdk:url>tools_r25.2-windows.zip</sdk:url>
+				<!--Built on: Fri Jul 29 11:26:07 2016.-->
+				<sdk:size>301642481</sdk:size>
+				<sdk:checksum type="sha1">ef898dff805c4b9e39f6e77fd9ec397fb1b1f809</sdk:checksum>
+				<sdk:url>tools_r25.2.2-windows.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 			</sdk:archive>
 		</sdk:archives>
@@ -1980,15 +2030,15 @@ June 2014.</sdk:license>
 		</sdk:min-platform-tools-rev>
 	</sdk:tool>
 	<sdk:doc>
-		<!--Generated from bid:2166767, branch:git_mnc-release-->
-		<sdk:api-level>23</sdk:api-level>
+		<!--Generated from bid:3249234, branch:git_nyc-emu-release-->
+		<sdk:api-level>24</sdk:api-level>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:04 2016.-->
-				<sdk:size>332171437</sdk:size>
-				<sdk:checksum type="sha1">060ebab2f74861e1ddd9136df26b837312bc087f</sdk:checksum>
-				<sdk:url>docs-23_r01.zip</sdk:url>
+				<!--Built on: Thu Sep  8 15:25:04 2016.-->
+				<sdk:size>419477967</sdk:size>
+				<sdk:checksum type="sha1">eef58238949ee9544876cb3e002f2d58e4ee7b5d</sdk:checksum>
+				<sdk:url>docs-24_r01.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>

--- a/pkgs/development/mobile/androidenv/sys-img.xml
+++ b/pkgs/development/mobile/androidenv/sys-img.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdk:sdk-sys-img xmlns:sdk="http://schemas.android.com/sdk/android/sys-img/3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2016-07-15 21:31:22.867420 with ADRT.-->
+	<!--Generated on 2016-09-12 21:35:04.795787 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -558,20 +558,37 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:3065232, branch:git_nyc-emu-release-->
+		<!--Generated from bid:3245079, branch:git_nyc-emu-release-->
 		<sdk:api-level>24</sdk:api-level>
 		<sdk:description>ARM EABI v7a System Image</sdk:description>
-		<sdk:revision>5</sdk:revision>
+		<sdk:revision>7</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 10:08:55 2016.-->
-				<sdk:size>497498007</sdk:size>
-				<sdk:checksum type="sha1">2eb8fb86f7312614a2a0b033d669d67206a618ff</sdk:checksum>
-				<sdk:url>sysimg_armeabi-v7a-24_r05.zip</sdk:url>
+				<!--Built on: Tue Sep  6 08:28:18 2016.-->
+				<sdk:size>283677512</sdk:size>
+				<sdk:checksum type="sha1">3454546b4eed2d6c3dd06d47757d6da9f4176033</sdk:checksum>
+				<sdk:url>armeabi-v7a-24_r07.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:uses-license ref="android-sdk-license"/>
 		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3245079, branch:git_nyc-emu-release-->
+		<sdk:api-level>24</sdk:api-level>
+		<sdk:description>ARM 64 v8a System Image</sdk:description>
+		<sdk:revision>7</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Sep  6 08:28:58 2016.-->
+				<sdk:size>384556503</sdk:size>
+				<sdk:checksum type="sha1">e8ab2e49e4efe4b064232b33b5eeaded61437d7f</sdk:checksum>
+				<sdk:url>arm64-v8a-24_r07.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>arm64-v8a</sdk:abi>
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
@@ -779,19 +796,19 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:3065232, branch:git_nyc-emu-release-->
+		<!--Generated from bid:3245079, branch:git_nyc-emu-release-->
 		<sdk:api-level>24</sdk:api-level>
 		<sdk:description>Intel x86 Atom System Image</sdk:description>
-		<sdk:revision>5</sdk:revision>
+		<sdk:revision>7</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 10:09:24 2016.-->
-				<sdk:size>535224957</sdk:size>
-				<sdk:checksum type="sha1">ce6441c4cadaecd28b364c59b36c31ef0904dae0</sdk:checksum>
-				<sdk:url>sysimg_x86-24_r05.zip</sdk:url>
+				<!--Built on: Tue Sep  6 08:29:27 2016.-->
+				<sdk:size>302213276</sdk:size>
+				<sdk:checksum type="sha1">566fdee283a907854bfa3c174265bc31f396eabd</sdk:checksum>
+				<sdk:url>x86-24_r07.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:uses-license ref="android-sdk-license"/>
 		<sdk:abi>x86</sdk:abi>
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
@@ -847,19 +864,19 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:3065232, branch:git_nyc-emu-release-->
+		<!--Generated from bid:3245079, branch:git_nyc-emu-release-->
 		<sdk:api-level>24</sdk:api-level>
 		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
-		<sdk:revision>5</sdk:revision>
+		<sdk:revision>7</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 15 10:10:10 2016.-->
-				<sdk:size>727226879</sdk:size>
-				<sdk:checksum type="sha1">e1869b32b1dcb2f4d4d18c912166b3e2bee8a841</sdk:checksum>
-				<sdk:url>sysimg_x86_64-24_r05.zip</sdk:url>
+				<!--Built on: Tue Sep  6 08:29:51 2016.-->
+				<sdk:size>407148033</sdk:size>
+				<sdk:checksum type="sha1">a379932395ced0a8f572b39c396d86e08827a9ba</sdk:checksum>
+				<sdk:url>x86_64-24_r07.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:uses-license ref="android-sdk-license"/>
 		<sdk:abi>x86_64</sdk:abi>
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>

--- a/pkgs/development/mobile/androidenv/sysimages.nix
+++ b/pkgs/development/mobile/androidenv/sysimages.nix
@@ -207,27 +207,35 @@ in
     };
   };
 
+  sysimg_arm64-v8a_24 = buildSystemImage {
+    name = "sysimg-arm64-v8a-24";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/arm64-v8a-24_r07.zip;
+      sha1 = "e8ab2e49e4efe4b064232b33b5eeaded61437d7f";
+    };
+  };
+
   sysimg_armeabi-v7a_24 = buildSystemImage {
     name = "sysimg-armeabi-v7a-24";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armeabi-v7a-24_r05.zip;
-      sha1 = "2eb8fb86f7312614a2a0b033d669d67206a618ff";
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-24_r07.zip;
+      sha1 = "3454546b4eed2d6c3dd06d47757d6da9f4176033";
     };
   };
 
   sysimg_x86_24 = buildSystemImage {
     name = "sysimg-x86-24";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-24_r05.zip;
-      sha1 = "ce6441c4cadaecd28b364c59b36c31ef0904dae0";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-24_r07.zip;
+      sha1 = "566fdee283a907854bfa3c174265bc31f396eabd";
     };
   };
 
   sysimg_x86_64_24 = buildSystemImage {
     name = "sysimg-x86_64-24";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-24_r05.zip;
-      sha1 = "e1869b32b1dcb2f4d4d18c912166b3e2bee8a841";
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-24_r07.zip;
+      sha1 = "a379932395ced0a8f572b39c396d86e08827a9ba";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

updates
###### Things done
- Built on platform(s)
  - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

build-tools      25.1.7 -> 25.2.2
sdk-tools        23.0.1 -> 24.0.2
platform-tools   24 -> 24.0.2

---

Things not working: various shell scripts have `/bin/ls`, emulator avd's don't work.
Unsure if this was so previously.

---

Most build-tools binaries are now ELF64. Reworked the patching routine to be more simplified: Find all executables and shared objects, patching them with interpreter and rpath the same way.
