### PR TITLE
firefox-bin: add curl dependency for crash reporter

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -2,6 +2,7 @@
 , alsaLib
 , atk
 , cairo
+, curl
 , cups
 , dbus_glib
 , dbus_libs
@@ -75,6 +76,7 @@ stdenv.mkDerivation {
       alsaLib
       atk
       cairo
+      curl
       cups
       dbus_glib
       dbus_libs


### PR DESCRIPTION
###### Motivation for this change

Firefox's crash reporter relies on libcurl. Without this change, crashes are not reported.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
