### PR TITLE
emacs-modes: add upstream tramp

### DIFF
--- a/pkgs/applications/editors/emacs-modes/tramp/default.nix
+++ b/pkgs/applications/editors/emacs-modes/tramp/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchurl, emacs, texinfo }:
+
+stdenv.mkDerivation rec {
+  name = "tramp-2.3.0";
+  src = fetchurl {
+    url = "mirror://gnu/tramp/${name}.tar.gz";
+    sha256 = "1srwm24lwyf00w1661wbx03xg6j943dk05jhwnwdjf99m82cqbgi";
+  };
+  buildInputs = [ emacs texinfo ];
+  meta = {
+    description = "Transparently access remote files from Emacs. Newer versions than built-in.";
+    homepage = https://www.gnu.org/software/tramp;
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -1566,6 +1566,8 @@ let
     };
   };
 
+  tramp = callPackage ../applications/editors/emacs-modes/tramp { };
+
   tracking = melpaBuild rec {
     pname   = "tracking";
     version = circe.version;


### PR DESCRIPTION
###### Motivation for this change

I kept running into http://emacs.stackexchange.com/questions/21026/tramp-recreates-dev-null-as-a-regular-file

This should be fixed in more recent versions of tramp, unfortunately tramp in emacs 24.5 is still shipped with the bug.

I added it as an emacs package, to be used in `emacsWithPackages`, we might consider making it standard, though.
###### Things done
- Built on platform(s)
  - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
