### PR TITLE
fzf: fix cycle in bin output

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -23,10 +23,17 @@ buildGoPackage rec {
     sed -i -e "s|expand('<sfile>:h:h').'/bin/fzf-tmux'|'$bin/bin/fzf-tmux'|" plugin/fzf.vim
   '';
 
-  postInstall= ''
+  postInstall = ''
     cp $src/bin/fzf-tmux $bin/bin
     mkdir -p $out/share/vim-plugins
     ln -s $out/share/go/src/github.com/junegunn/fzf $out/share/vim-plugins/${name}
+  '';
+
+  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    # fixes cycle between $out and $bin
+    # otool -l shows that the binary includes an LC_RPATH to $out/lib
+    # it seems safe to remove that since but the directory does not exist.
+    install_name_tool -delete_rpath $out/lib $bin/bin/fzf
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

I have no idea why this happend, is this a more general issue with go on darwin?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] OS X
  - [x] No changes on other platforms
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
