### PR TITLE
Greybird: 2016-08-16 -> 2016-09-13

### DIFF
--- a/pkgs/misc/themes/greybird/default.nix
+++ b/pkgs/misc/themes/greybird/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchFromGitHub, autoreconfHook, sass, glib, libxml2, gdk_pixbuf, librsvg, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
-  pname = "Greybird";
-  version = "2016-08-16";
   name = "${pname}-${version}";
+  pname = "Greybird";
+  version = "2016-09-13";
 
   src = fetchFromGitHub {
     repo = "${pname}";
     owner = "shimmerproject";
-    rev = "fcaa400df68b1a29bb9dc8eb9c772a241f17c9ea";
-    sha256 = "02f2zlkhi2als39ajq3v91iik708g5a9iyl3cvd65n80gr4jifmr";
+    rev = "1942afc8732f904a1139fd41d7afd74263b87887";
+    sha256 = "0qawc7rx5s3mnk5awvlbp6k5m9aj5krb1lasmgl2cb9fk09khf2v";
   };
 
   nativeBuildInputs = [ autoreconfHook sass glib libxml2 gdk_pixbuf librsvg ];
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
   
   meta = {
     description = "Grey and blue theme (Gtk, Xfce, Emerald, Metacity, Mutter, Unity)";
-    homepage = http://shimmerproject.org/our-projects/greybird/;
+    homepage = https://github.com/shimmerproject/Greybird;
     license = with stdenv.lib.licenses; [ gpl2Plus cc-by-nc-sa-30 ];
-    maintainers = [ stdenv.lib.maintainers.romildo ];
     platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
