### PR TITLE
Update libtiff URLs

### DIFF
--- a/pkgs/development/libraries/libgeotiff/default.nix
+++ b/pkgs/development/libraries/libgeotiff/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "libgeotiff-1.2.5";
 
   src = fetchurl {
-    url = ftp://ftp.remotesensing.org/pub/geotiff/libgeotiff/libgeotiff-1.2.5.tar.gz;
+    url = http://download.osgeo.org/geotiff/libgeotiff/libgeotiff-1.2.5.tar.gz;
     sha256 = "0z2yx77pm0zs81hc0b4lwzdd5s0rxcbylnscgq80b649src1fyzj";
   };
 

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -7,10 +7,7 @@ stdenv.mkDerivation rec {
   name = "libtiff-${version}";
 
   src = fetchurl {
-    urls =
-      [ "ftp://ftp.remotesensing.org/pub/libtiff/tiff-${version}.tar.gz"
-        "http://download.osgeo.org/libtiff/tiff-${version}.tar.gz"
-      ];
+    url = "http://download.osgeo.org/libtiff/tiff-${version}.tar.gz";
     sha256 = "136nf1rj9dp5jgv1p7z4dk0xy3wki1w0vfjbk82f645m0w4samsd";
   };
 


### PR DESCRIPTION
###### Motivation for this change
#18607 - remotesensing.org stopped hosting libtiff
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
