### PR TITLE
lib/default.nix: reorder imports for clarity

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,27 +1,45 @@
-let 
+let
 
+  # trivial, often used functions
   trivial = import ./trivial.nix;
+
+  # datatypes
+  attrsets = import ./attrsets.nix;
   lists = import ./lists.nix;
   strings = import ./strings.nix;
   stringsWithDeps = import ./strings-with-deps.nix;
-  attrsets = import ./attrsets.nix;
+
+  # packaging
+  customisation = import ./customisation.nix;
+  maintainers = import ./maintainers.nix;
+  meta = import ./meta.nix;
   sources = import ./sources.nix;
+
+  # module system
   modules = import ./modules.nix;
   options = import ./options.nix;
   types = import ./types.nix;
-  meta = import ./meta.nix;
-  debug = import ./debug.nix;
-  misc = import ./deprecated.nix;
-  maintainers = import ./maintainers.nix;
+
+  # constants
+  licenses = import ./licenses.nix;
   platforms = import ./platforms.nix;
   systems = import ./systems.nix;
-  customisation = import ./customisation.nix;
-  licenses = import ./licenses.nix;
+
+  # misc
+  debug = import ./debug.nix;
+  misc = import ./deprecated.nix;
+
+  # domain-specific
   sandbox = import ./sandbox.nix;
 
 in
-  { inherit trivial lists strings stringsWithDeps attrsets sources options
-      modules types meta debug maintainers licenses platforms systems sandbox;
+  { inherit trivial
+            attrsets lists strings stringsWithDeps
+            customisation maintainers meta sources
+            modules options types
+            licenses platforms systems
+            debug misc
+            sandbox;
   }
   # !!! don't include everything at top-level; perhaps only the most
   # commonly used functions.


### PR DESCRIPTION
This is a step in the direction of making the stdlib more self-documenting.

Group imports according to the kind of functions they contain, in a more
descriptive manner.

I tested whether I made a mistake with the imports by executing `nox-review wip`, and it reported `Nothing changed`.
Sadly, `nix-instantiate --eval --strict --arg system '"x86_64-linux"' --arg config '{ allowBroken = true; allowUnfree = true; }'` does not work, because `mkDerivation` is still way to strict and some asserts block evaluation.
