### PR TITLE
Fetchdir

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -18,10 +18,12 @@ let
   customisation = import ./customisation.nix;
   licenses = import ./licenses.nix;
   sandbox = import ./sandbox.nix;
+  fetchers = import ./fetchers.nix;
 
 in
   { inherit trivial lists strings stringsWithDeps attrsets sources options
-      modules types meta debug maintainers licenses platforms systems sandbox;
+      modules types meta debug maintainers licenses platforms systems sandbox
+      fetchers;
   }
   # !!! don't include everything at top-level; perhaps only the most
   # commonly used functions.

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -1,0 +1,12 @@
+# snippets that can be shared by mutliple fetchers (pkgs/build-support)
+{
+
+  proxyImpureEnvVars = [
+    # We borrow these environment variables from the caller to allow
+    # easy proxy configuration.  This is impure, but a fixed-output
+    # derivation like fetchurl is allowed to do so since its result is
+    # by definition pure.
+    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
+  ];
+
+}

--- a/pkgs/applications/networking/browsers/chromium/update.nix
+++ b/pkgs/applications/networking/browsers/chromium/update.nix
@@ -157,9 +157,7 @@ in rec {
           fi
         '';
 
-        impureEnvVars = [
-          "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-        ];
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars;
       };
 
     in {

--- a/pkgs/applications/networking/cluster/chronos/chronos-deps.nix
+++ b/pkgs/applications/networking/cluster/chronos/chronos-deps.nix
@@ -10,9 +10,5 @@ stdenv.mkDerivation {
 
   buildInputs = [ curl ];
 
-  # We borrow these environment variables from the caller to allow
-  # easy proxy configuration.  This is impure, but a fixed-output
-  # derivation like fetchurl is allowed to do so since its result is
-  # by definition pure.
-  impureEnvVars = ["http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"];
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
 }

--- a/pkgs/applications/networking/cluster/mesos/mesos-deps.nix
+++ b/pkgs/applications/networking/cluster/mesos/mesos-deps.nix
@@ -10,9 +10,5 @@ stdenv.mkDerivation {
 
   buildInputs = [ curl ];
 
-  # We borrow these environment variables from the caller to allow
-  # easy proxy configuration.  This is impure, but a fixed-output
-  # derivation like fetchurl is allowed to do so since its result is
-  # by definition pure.
-  impureEnvVars = ["http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"];
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
 }

--- a/pkgs/build-support/docker/pull.nix
+++ b/pkgs/build-support/docker/pull.nix
@@ -26,17 +26,11 @@ let layer = stdenv.mkDerivation {
   outputHash = sha256;
   outputHashMode = "recursive";
 
-  impureEnvVars = [
-    # We borrow these environment variables from the caller to allow
-    # easy proxy configuration.  This is impure, but a fixed-output
-    # derivation like fetchurl is allowed to do so since its result is
-    # by definition pure.
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
     # This variable allows the user to pass additional options to curl
     "NIX_CURL_FLAGS"
   ];
-  
+
   # Doing the download on a remote machine just duplicates network
   # traffic, so don't do that.
   preferLocalBuild = true;

--- a/pkgs/build-support/fetchadc/default.nix
+++ b/pkgs/build-support/fetchadc/default.nix
@@ -1,15 +1,5 @@
 { stdenv, curl, adc_user, adc_pass }:
 
-let
-  impureEnvVars = [
-    # We borrow these environment variables from the caller to allow
-    # easy proxy configuration.  This is impure, but a fixed-output
-    # derivation like fetchurl is allowed to do so since its result is
-    # by definition pure.
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-  ];
-in
-
 { # Path to fetch.
   path
 

--- a/pkgs/build-support/fetchdir/builder.sh
+++ b/pkgs/build-support/fetchdir/builder.sh
@@ -1,0 +1,17 @@
+source $stdenv/setup
+
+mkdir $out
+
+# as in fetchurl ignoring the ssl certificate is not a problem
+# because we compare with the cryptographic hash anyway.
+wget --recursive \
+     --no-parent \
+     --no-host-directories \
+     --cut-dirs=$cut_dirs \
+     --convert-links \
+     --directory-prefix=$out \
+     --no-check-certificate \
+     --no-verbose \
+     "${url}"
+
+stopNest

--- a/pkgs/build-support/fetchdir/default.nix
+++ b/pkgs/build-support/fetchdir/default.nix
@@ -1,0 +1,33 @@
+# Fetches a directory recursively
+# IMPORTANT: The hash will change when upstream touches a file
+# in the folder. So make sure that doesn’t happen or older
+# nixpkgs version will have broken derivations!
+
+# Note that this is a last solution when all other fetchers
+# are not up to the job. In particular, if there’s only a small
+# number of files use fetchurl and enter their hashes manually.
+# Even if it’s a lot of files, it might be better to create a mirror
+# repository and make a release.
+
+{ stdenv, wget }:
+{ url, sha256 ? ""
+# the number of directory components that should be ignored
+# see wget(1) option --cut-dirs
+, cut-dirs ? 0 }:
+
+assert builtins.isInt cut-dirs;
+
+stdenv.mkDerivation {
+  name = "${baseNameOf (toString url)}-srcdir";
+
+  buildInputs = [ wget ];
+  builder = ./builder.sh;
+  cut_dirs = cut-dirs;
+  inherit url;
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = sha256;
+
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
+}

--- a/pkgs/build-support/fetchegg/default.nix
+++ b/pkgs/build-support/fetchegg/default.nix
@@ -17,12 +17,6 @@ stdenv.mkDerivation {
 
   eggName = name;
 
-  impureEnvVars = [
-    # We borrow these environment variables from the caller to allow
-    # easy proxy configuration.  This is impure, but a fixed-output
-    # derivation like fetchurl is allowed to do so since its result is
-    # by definition pure.
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-  ];
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
 }
 

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -56,13 +56,9 @@ stdenv.mkDerivation {
 
   GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
-  impureEnvVars = [
-    # We borrow these environment variables from the caller to allow
-    # easy proxy configuration.  This is impure, but a fixed-output
-    # derivation like fetchurl is allowed to do so since its result is
-    # by definition pure.
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy" "GIT_PROXY_COMMAND" "SOCKS_SERVER"
-    ];
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars ++ [
+    "GIT_PROXY_COMMAND" "SOCKS_SERVER"
+  ];
 
   preferLocalBuild = true;
 }

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -6,9 +6,7 @@ stdenv.mkDerivation {
   builder = ./builder.sh;
   buildInputs = [mercurial];
 
-  impureEnvVars = [
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-  ];
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
 
   # Nix <= 0.7 compatibility.
   id = md5;

--- a/pkgs/build-support/fetchmtn/default.nix
+++ b/pkgs/build-support/fetchmtn/default.nix
@@ -19,12 +19,7 @@ stdenv.mkDerivation {
   dbs = defaultDBMirrors ++ dbs;
   inherit branch cacheDB name selector;
 
-  impureEnvVars = [
-    # We borrow these environment variables from the caller to allow
-    # easy proxy configuration.  This is impure, but a fixed-output
-    # derivation like fetchurl is allowed to do so since its result is
-    # by definition pure.
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-    ];
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
+
 }
 

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -33,13 +33,6 @@ stdenv.mkDerivation {
   
   inherit url rev sshSupport openssh ignoreExternals;
 
-  impureEnvVars = [
-    # We borrow these environment variables from the caller to allow
-    # easy proxy configuration.  This is impure, but a fixed-output
-    # derivation like fetchurl is allowed to do so since its result is
-    # by definition pure.
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-    ];
-
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
   preferLocalBuild = true;
 }

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -20,13 +20,7 @@ let
   # "gnu", etc.).
   sites = builtins.attrNames mirrors;
 
-  impureEnvVars = [
-    # We borrow these environment variables from the caller to allow
-    # easy proxy configuration.  This is impure, but a fixed-output
-    # derivation like fetchurl is allowed to do so since its result is
-    # by definition pure.
-    "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars ++ [
     # This variable allows the user to pass additional options to curl
     "NIX_CURL_FLAGS"
 

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation {
   outputHashMode = "recursive";
   outputHash = sha256;
 
-  impureEnvVars = [ "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy" ];
+  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
   preferLocalBuild = true;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -154,6 +154,8 @@ in
 
   fetchdarcs = callPackage ../build-support/fetchdarcs { };
 
+  fetchdir = callPackage ../build-support/fetchdir { };
+
   fetchfossil = callPackage ../build-support/fetchfossil { };
 
   fetchgit = callPackage ../build-support/fetchgit {


### PR DESCRIPTION
This PR has two changes that closely build on each other.

First one is a refactor for an often copied list of `impureEnvVars`, which is also needed by the second change.

Second one is a new fetcher called `fetchdir`, that can grab upstream packages that come as http/ftp/… folders, based on wget.
Its functionality can be tested with this example:

``` nix
fetchdir {
    url = "https://userpages.uni-koblenz.de/~krienke/ftp/noarch/geteltorito/";
    sha256 = "0b98hfvbfhgi9sp1f3a2b3k90arzk1pzk4c6g63l1ra7jn6xm9x0";
    cut-dirs = 4;
}
```

cc @aszlig
