### PR TITLE
Add `htmlhint` and `csslint` to `nodePackages`

### DIFF
--- a/pkgs/development/node-packages/node-packages-v4.nix
+++ b/pkgs/development/node-packages/node-packages-v4.nix
@@ -7825,6 +7825,15 @@ let
         sha1 = "5fa55e02be7ca934edfc12665632e849b72e5209";
       };
     };
+    "parserlib-1.0.0" = {
+      name = "parserlib";
+      packageName = "parserlib";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parserlib/-/parserlib-1.0.0.tgz";
+        sha1 = "88340e7e8d95bac9e09236742eef53bec1e4b30f";
+      };
+    };
     "bluebird-2.9.9" = {
       name = "bluebird";
       packageName = "bluebird";
@@ -18615,10 +18624,10 @@ in
   bower2nix = nodeEnv.buildNodePackage {
     name = "bower2nix";
     packageName = "bower2nix";
-    version = "3.1.0";
+    version = "3.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.0.tgz";
-      sha1 = "f18a46335854ff9c5b4fe78f88309d7bf0631a1b";
+      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.1.tgz";
+      sha1 = "77cc8f966a3595686f5d6fae30ad9bd2cc20bfe3";
     };
     dependencies = [
       (sources."argparse-1.0.4" // {
@@ -21605,6 +21614,26 @@ in
     meta = {
       description = "Cordova command line interface tool";
       license = "Apache-2.0";
+    };
+    production = true;
+  };
+  csslint = nodeEnv.buildNodePackage {
+    name = "csslint";
+    packageName = "csslint";
+    version = "1.0.2";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/csslint/-/csslint-1.0.2.tgz";
+      sha1 = "d01ab277845686c3c4a0d6166b3817ee114bd73d";
+    };
+    dependencies = [
+      sources."clone-1.0.2"
+      sources."parserlib-1.0.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "CSSLint";
+      homepage = http://csslint.net/;
+      license = "MIT";
     };
     production = true;
   };

--- a/pkgs/development/node-packages/node-packages-v4.nix
+++ b/pkgs/development/node-packages/node-packages-v4.nix
@@ -11124,76 +11124,49 @@ let
         sha1 = "605f34e75ea702681fcd06b2f4ee2e7b4e019006";
       };
     };
-    "escodegen-1.8.1" = {
-      name = "escodegen";
-      packageName = "escodegen";
-      version = "1.8.1";
+    "csslint-0.10.0" = {
+      name = "csslint";
+      packageName = "csslint";
+      version = "0.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz";
-        sha1 = "5a5b53af4693110bebb0867aa3430dd3b70a1018";
+        url = "https://registry.npmjs.org/csslint/-/csslint-0.10.0.tgz";
+        sha1 = "3a6a04e7565c8e9d19beb49767c7ec96e8365805";
       };
     };
-    "handlebars-4.0.5" = {
-      name = "handlebars";
-      packageName = "handlebars";
-      version = "4.0.5";
+    "jshint-2.8.0" = {
+      name = "jshint";
+      packageName = "jshint";
+      version = "2.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz";
-        sha1 = "92c6ed6bb164110c50d4d8d0fbddc70806c6f8e7";
+        url = "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz";
+        sha1 = "1d09a3bd913c4cadfa81bf18d582bd85bffe0d44";
       };
     };
-    "supports-color-3.1.2" = {
-      name = "supports-color";
-      packageName = "supports-color";
-      version = "3.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz";
-        sha1 = "72a262894d9d408b956ca05ff37b2ed8a6e2a2d5";
-      };
-    };
-    "estraverse-1.9.3" = {
-      name = "estraverse";
-      packageName = "estraverse";
-      version = "1.9.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz";
-        sha1 = "af67f2dc922582415950926091a4005d29c9bb44";
-      };
-    };
-    "source-map-0.2.0" = {
-      name = "source-map";
-      packageName = "source-map";
-      version = "0.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz";
-        sha1 = "dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d";
-      };
-    };
-    "has-flag-1.0.0" = {
-      name = "has-flag";
-      packageName = "has-flag";
+    "xml-1.0.0" = {
+      name = "xml";
+      packageName = "xml";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz";
-        sha1 = "9d9e793165ce017a00f00418c43f942a7b1d11fa";
+        url = "https://registry.npmjs.org/xml/-/xml-1.0.0.tgz";
+        sha1 = "de3ee912477be2f250b60f612f34a8c4da616efe";
       };
     };
-    "when-3.4.6" = {
-      name = "when";
-      packageName = "when";
-      version = "3.4.6";
+    "parserlib-0.2.5" = {
+      name = "parserlib";
+      packageName = "parserlib";
+      version = "0.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/when/-/when-3.4.6.tgz";
-        sha1 = "8fbcb7cc1439d2c3a68c431f1516e6dcce9ad28c";
+        url = "https://registry.npmjs.org/parserlib/-/parserlib-0.2.5.tgz";
+        sha1 = "85907dd8605aa06abb3dd295d50bb2b8fa4dd117";
       };
     };
-    "cli-1.0.0" = {
+    "cli-0.6.6" = {
       name = "cli";
       packageName = "cli";
-      version = "1.0.0";
+      version = "0.6.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz";
-        sha1 = "ee07dfc1390e3f2e6a9957cf88e1d4bfa777719d";
+        url = "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz";
+        sha1 = "02ad44a380abf27adac5e6f0cdd7b043d74c53e3";
       };
     };
     "exit-0.1.2" = {
@@ -11284,6 +11257,78 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz";
         sha1 = "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0";
+      };
+    };
+    "escodegen-1.8.1" = {
+      name = "escodegen";
+      packageName = "escodegen";
+      version = "1.8.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz";
+        sha1 = "5a5b53af4693110bebb0867aa3430dd3b70a1018";
+      };
+    };
+    "handlebars-4.0.5" = {
+      name = "handlebars";
+      packageName = "handlebars";
+      version = "4.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz";
+        sha1 = "92c6ed6bb164110c50d4d8d0fbddc70806c6f8e7";
+      };
+    };
+    "supports-color-3.1.2" = {
+      name = "supports-color";
+      packageName = "supports-color";
+      version = "3.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz";
+        sha1 = "72a262894d9d408b956ca05ff37b2ed8a6e2a2d5";
+      };
+    };
+    "estraverse-1.9.3" = {
+      name = "estraverse";
+      packageName = "estraverse";
+      version = "1.9.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz";
+        sha1 = "af67f2dc922582415950926091a4005d29c9bb44";
+      };
+    };
+    "source-map-0.2.0" = {
+      name = "source-map";
+      packageName = "source-map";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz";
+        sha1 = "dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d";
+      };
+    };
+    "has-flag-1.0.0" = {
+      name = "has-flag";
+      packageName = "has-flag";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz";
+        sha1 = "9d9e793165ce017a00f00418c43f942a7b1d11fa";
+      };
+    };
+    "when-3.4.6" = {
+      name = "when";
+      packageName = "when";
+      version = "3.4.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/when/-/when-3.4.6.tgz";
+        sha1 = "8fbcb7cc1439d2c3a68c431f1516e6dcce9ad28c";
+      };
+    };
+    "cli-1.0.0" = {
+      name = "cli";
+      packageName = "cli";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz";
+        sha1 = "ee07dfc1390e3f2e6a9957cf88e1d4bfa777719d";
       };
     };
     "body-parser-1.15.2" = {
@@ -24071,6 +24116,134 @@ in
     meta = {
       description = "Complete high-scaled reverse-proxy solution";
       homepage = https://github.com/dotcloud/hipache;
+      license = "MIT";
+    };
+    production = true;
+  };
+  htmlhint = nodeEnv.buildNodePackage {
+    name = "htmlhint";
+    packageName = "htmlhint";
+    version = "0.9.13";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/htmlhint/-/htmlhint-0.9.13.tgz";
+      sha1 = "08163cb1e6aa505048ebb0b41063a7ca07dc6c88";
+    };
+    dependencies = [
+      sources."async-1.4.2"
+      sources."colors-1.0.3"
+      sources."commander-2.6.0"
+      (sources."csslint-0.10.0" // {
+        dependencies = [
+          sources."parserlib-0.2.5"
+        ];
+      })
+      (sources."glob-5.0.15" // {
+        dependencies = [
+          (sources."inflight-1.0.5" // {
+            dependencies = [
+              sources."wrappy-1.0.2"
+            ];
+          })
+          sources."inherits-2.0.3"
+          (sources."minimatch-3.0.3" // {
+            dependencies = [
+              (sources."brace-expansion-1.1.6" // {
+                dependencies = [
+                  sources."balanced-match-0.4.2"
+                  sources."concat-map-0.0.1"
+                ];
+              })
+            ];
+          })
+          (sources."once-1.4.0" // {
+            dependencies = [
+              sources."wrappy-1.0.2"
+            ];
+          })
+          sources."path-is-absolute-1.0.0"
+        ];
+      })
+      (sources."jshint-2.8.0" // {
+        dependencies = [
+          (sources."cli-0.6.6" // {
+            dependencies = [
+              (sources."glob-3.2.11" // {
+                dependencies = [
+                  sources."inherits-2.0.3"
+                  (sources."minimatch-0.3.0" // {
+                    dependencies = [
+                      sources."lru-cache-2.7.3"
+                      sources."sigmund-1.0.1"
+                    ];
+                  })
+                ];
+              })
+            ];
+          })
+          (sources."console-browserify-1.1.0" // {
+            dependencies = [
+              sources."date-now-0.1.4"
+            ];
+          })
+          sources."exit-0.1.2"
+          (sources."htmlparser2-3.8.3" // {
+            dependencies = [
+              sources."domhandler-2.3.0"
+              (sources."domutils-1.5.1" // {
+                dependencies = [
+                  (sources."dom-serializer-0.1.0" // {
+                    dependencies = [
+                      sources."domelementtype-1.1.3"
+                      sources."entities-1.1.1"
+                    ];
+                  })
+                ];
+              })
+              sources."domelementtype-1.3.0"
+              (sources."readable-stream-1.1.14" // {
+                dependencies = [
+                  sources."core-util-is-1.0.2"
+                  sources."isarray-0.0.1"
+                  sources."string_decoder-0.10.31"
+                  sources."inherits-2.0.3"
+                ];
+              })
+              sources."entities-1.0.0"
+            ];
+          })
+          (sources."minimatch-2.0.10" // {
+            dependencies = [
+              (sources."brace-expansion-1.1.6" // {
+                dependencies = [
+                  sources."balanced-match-0.4.2"
+                  sources."concat-map-0.0.1"
+                ];
+              })
+            ];
+          })
+          sources."shelljs-0.3.0"
+          sources."lodash-3.7.0"
+        ];
+      })
+      (sources."parse-glob-3.0.4" // {
+        dependencies = [
+          (sources."glob-base-0.3.0" // {
+            dependencies = [
+              sources."glob-parent-2.0.0"
+            ];
+          })
+          sources."is-dotfile-1.0.2"
+          sources."is-extglob-1.0.0"
+          sources."is-glob-2.0.1"
+        ];
+      })
+      sources."strip-json-comments-1.0.4"
+      sources."xml-1.0.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "A Static Code Analysis Tool for HTML";
+      homepage = "https://github.com/yaniswang/HTMLHint#readme";
       license = "MIT";
     };
     production = true;

--- a/pkgs/development/node-packages/node-packages-v4.nix
+++ b/pkgs/development/node-packages/node-packages-v4.nix
@@ -3766,13 +3766,13 @@ let
         sha1 = "b5835739270cfe26acf632099fded2a07f209e5e";
       };
     };
-    "pbkdf2-3.0.5" = {
+    "pbkdf2-3.0.6" = {
       name = "pbkdf2";
       packageName = "pbkdf2";
-      version = "3.0.5";
+      version = "3.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.5.tgz";
-        sha1 = "10d907817f11d1191c11499bd067f04330a0aec3";
+        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.6.tgz";
+        sha1 = "943d289ccd92b3dec55cc77dd696d44d6087e8bd";
       };
     };
     "public-encrypt-4.0.0" = {
@@ -9818,13 +9818,13 @@ let
         sha1 = "62b110e289a471418e3ec36a617d472e301dfc89";
       };
     };
-    "for-in-0.1.5" = {
+    "for-in-0.1.6" = {
       name = "for-in";
       packageName = "for-in";
-      version = "0.1.5";
+      version = "0.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz";
-        sha1 = "007374e2b6d5c67420a1479bdb75a04872b738c4";
+        url = "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz";
+        sha1 = "c9f96e89bfad18a545af5ec3ed352a1d9e5b4dc8";
       };
     };
     "glob-base-0.3.0" = {
@@ -11349,13 +11349,13 @@ let
         sha1 = "488b1d1d2451cb3d3a6b192cfc030f44c5855fea";
       };
     };
-    "http-proxy-1.14.0" = {
+    "http-proxy-1.15.1" = {
       name = "http-proxy";
       packageName = "http-proxy";
-      version = "1.14.0";
+      version = "1.15.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/http-proxy/-/http-proxy-1.14.0.tgz";
-        sha1 = "be32ab34dd5229e87840f4c27cb335ee195b2a83";
+        url = "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.1.tgz";
+        sha1 = "91a6088172e79bc0e821d5eb04ce702f32446393";
       };
     };
     "isbinaryfile-3.0.1" = {
@@ -12951,13 +12951,13 @@ let
         sha1 = "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6";
       };
     };
-    "es6-promise-3.3.0" = {
+    "es6-promise-3.3.1" = {
       name = "es6-promise";
       packageName = "es6-promise";
-      version = "3.3.0";
+      version = "3.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.0.tgz";
-        sha1 = "c0859acb27b6804895a6067c981d410e68d2b116";
+        url = "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz";
+        sha1 = "a08cdde84ccdbf34d027a1451bc91d4bcd28a613";
       };
     };
     "ignore-by-default-1.0.1" = {
@@ -16264,13 +16264,13 @@ let
         sha1 = "fe85b2ec75a59037f2adfec100fd6c601761152e";
       };
     };
-    "uc.micro-1.0.2" = {
+    "uc.micro-1.0.3" = {
       name = "uc.micro";
       packageName = "uc.micro";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.2.tgz";
-        sha1 = "466f26316a0bb707def6682f91f50139b8b8d538";
+        url = "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz";
+        sha1 = "7ed50d5e0f9a9fb0a573379259f2a77458d50192";
       };
     };
     "htmlparser2-3.9.1" = {
@@ -17506,13 +17506,13 @@ let
         sha1 = "fecd7a18e7ce5ca6abfb953e1f86213a49f1625b";
       };
     };
-    "loader-utils-0.2.15" = {
+    "loader-utils-0.2.16" = {
       name = "loader-utils";
       packageName = "loader-utils";
-      version = "0.2.15";
+      version = "0.2.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.15.tgz";
-        sha1 = "c7df3342a9d4e2103dddc97d4060daccc246d6ac";
+        url = "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz";
+        sha1 = "f08632066ed8282835dff88dfb52704765adee6d";
       };
     };
     "memory-fs-0.3.0" = {
@@ -19026,7 +19026,7 @@ in
               })
             ];
           })
-          sources."pbkdf2-3.0.5"
+          sources."pbkdf2-3.0.6"
           (sources."public-encrypt-4.0.0" // {
             dependencies = [
               sources."bn.js-4.11.6"
@@ -20154,7 +20154,7 @@ in
                           })
                         ];
                       })
-                      sources."pbkdf2-3.0.5"
+                      sources."pbkdf2-3.0.6"
                       (sources."public-encrypt-4.0.0" // {
                         dependencies = [
                           sources."bn.js-4.11.6"
@@ -22761,7 +22761,7 @@ in
                         dependencies = [
                           (sources."for-own-0.1.4" // {
                             dependencies = [
-                              sources."for-in-0.1.5"
+                              sources."for-in-0.1.6"
                             ];
                           })
                           sources."is-extendable-0.1.1"
@@ -23806,7 +23806,7 @@ in
                     dependencies = [
                       (sources."for-own-0.1.4" // {
                         dependencies = [
-                          sources."for-in-0.1.5"
+                          sources."for-in-0.1.6"
                         ];
                       })
                       sources."is-extendable-0.1.1"
@@ -24494,7 +24494,7 @@ in
                     dependencies = [
                       (sources."for-own-0.1.4" // {
                         dependencies = [
-                          sources."for-in-0.1.5"
+                          sources."for-in-0.1.6"
                         ];
                       })
                       sources."is-extendable-0.1.1"
@@ -24861,7 +24861,7 @@ in
         ];
       })
       sources."graceful-fs-4.1.6"
-      (sources."http-proxy-1.14.0" // {
+      (sources."http-proxy-1.15.1" // {
         dependencies = [
           sources."eventemitter3-1.2.0"
           sources."requires-port-1.0.0"
@@ -25495,7 +25495,7 @@ in
                     dependencies = [
                       (sources."for-own-0.1.4" // {
                         dependencies = [
-                          sources."for-in-0.1.5"
+                          sources."for-in-0.1.6"
                         ];
                       })
                       sources."is-extendable-0.1.1"
@@ -27681,7 +27681,7 @@ in
                     dependencies = [
                       (sources."for-own-0.1.4" // {
                         dependencies = [
-                          sources."for-in-0.1.5"
+                          sources."for-in-0.1.6"
                         ];
                       })
                       sources."is-extendable-0.1.1"
@@ -28003,7 +28003,7 @@ in
           sources."ms-0.7.1"
         ];
       })
-      sources."es6-promise-3.3.0"
+      sources."es6-promise-3.3.1"
       sources."ignore-by-default-1.0.1"
       (sources."lodash.defaults-3.1.2" // {
         dependencies = [
@@ -33252,7 +33252,7 @@ in
               sources."entities-1.1.1"
               sources."linkify-it-1.2.4"
               sources."mdurl-1.0.1"
-              sources."uc.micro-1.0.2"
+              sources."uc.micro-1.0.3"
             ];
           })
           (sources."sanitize-html-1.13.0" // {
@@ -35847,7 +35847,7 @@ in
       })
       sources."acorn-3.3.0"
       sources."interpret-0.6.6"
-      (sources."loader-utils-0.2.15" // {
+      (sources."loader-utils-0.2.16" // {
         dependencies = [
           sources."big.js-3.1.3"
           sources."emojis-list-2.0.1"
@@ -36073,7 +36073,7 @@ in
                         dependencies = [
                           (sources."for-own-0.1.4" // {
                             dependencies = [
-                              sources."for-in-0.1.5"
+                              sources."for-in-0.1.6"
                             ];
                           })
                           sources."is-extendable-0.1.1"

--- a/pkgs/development/node-packages/node-packages-v5.nix
+++ b/pkgs/development/node-packages/node-packages-v5.nix
@@ -3757,13 +3757,13 @@ let
         sha1 = "b5835739270cfe26acf632099fded2a07f209e5e";
       };
     };
-    "pbkdf2-3.0.5" = {
+    "pbkdf2-3.0.6" = {
       name = "pbkdf2";
       packageName = "pbkdf2";
-      version = "3.0.5";
+      version = "3.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.5.tgz";
-        sha1 = "10d907817f11d1191c11499bd067f04330a0aec3";
+        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.6.tgz";
+        sha1 = "943d289ccd92b3dec55cc77dd696d44d6087e8bd";
       };
     };
     "public-encrypt-4.0.0" = {
@@ -9800,13 +9800,13 @@ let
         sha1 = "62b110e289a471418e3ec36a617d472e301dfc89";
       };
     };
-    "for-in-0.1.5" = {
+    "for-in-0.1.6" = {
       name = "for-in";
       packageName = "for-in";
-      version = "0.1.5";
+      version = "0.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz";
-        sha1 = "007374e2b6d5c67420a1479bdb75a04872b738c4";
+        url = "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz";
+        sha1 = "c9f96e89bfad18a545af5ec3ed352a1d9e5b4dc8";
       };
     };
     "glob-base-0.3.0" = {
@@ -11331,13 +11331,13 @@ let
         sha1 = "488b1d1d2451cb3d3a6b192cfc030f44c5855fea";
       };
     };
-    "http-proxy-1.14.0" = {
+    "http-proxy-1.15.1" = {
       name = "http-proxy";
       packageName = "http-proxy";
-      version = "1.14.0";
+      version = "1.15.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/http-proxy/-/http-proxy-1.14.0.tgz";
-        sha1 = "be32ab34dd5229e87840f4c27cb335ee195b2a83";
+        url = "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.1.tgz";
+        sha1 = "91a6088172e79bc0e821d5eb04ce702f32446393";
       };
     };
     "isbinaryfile-3.0.1" = {
@@ -12933,13 +12933,13 @@ let
         sha1 = "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6";
       };
     };
-    "es6-promise-3.3.0" = {
+    "es6-promise-3.3.1" = {
       name = "es6-promise";
       packageName = "es6-promise";
-      version = "3.3.0";
+      version = "3.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.0.tgz";
-        sha1 = "c0859acb27b6804895a6067c981d410e68d2b116";
+        url = "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz";
+        sha1 = "a08cdde84ccdbf34d027a1451bc91d4bcd28a613";
       };
     };
     "ignore-by-default-1.0.1" = {
@@ -16255,13 +16255,13 @@ let
         sha1 = "fe85b2ec75a59037f2adfec100fd6c601761152e";
       };
     };
-    "uc.micro-1.0.2" = {
+    "uc.micro-1.0.3" = {
       name = "uc.micro";
       packageName = "uc.micro";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.2.tgz";
-        sha1 = "466f26316a0bb707def6682f91f50139b8b8d538";
+        url = "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz";
+        sha1 = "7ed50d5e0f9a9fb0a573379259f2a77458d50192";
       };
     };
     "htmlparser2-3.9.1" = {
@@ -17497,13 +17497,13 @@ let
         sha1 = "fecd7a18e7ce5ca6abfb953e1f86213a49f1625b";
       };
     };
-    "loader-utils-0.2.15" = {
+    "loader-utils-0.2.16" = {
       name = "loader-utils";
       packageName = "loader-utils";
-      version = "0.2.15";
+      version = "0.2.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.15.tgz";
-        sha1 = "c7df3342a9d4e2103dddc97d4060daccc246d6ac";
+        url = "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz";
+        sha1 = "f08632066ed8282835dff88dfb52704765adee6d";
       };
     };
     "memory-fs-0.3.0" = {
@@ -18346,7 +18346,7 @@ in
       sources."create-hash-1.1.2"
       sources."create-hmac-1.1.4"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.5"
+      sources."pbkdf2-3.0.6"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -19014,7 +19014,7 @@ in
       sources."create-hash-1.1.2"
       sources."create-hmac-1.1.4"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.5"
+      sources."pbkdf2-3.0.6"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -20077,7 +20077,7 @@ in
       sources."is-buffer-1.1.4"
       sources."for-own-0.1.4"
       sources."is-extendable-0.1.1"
-      sources."for-in-0.1.5"
+      sources."for-in-0.1.6"
       sources."glob-base-0.3.0"
       sources."is-dotfile-1.0.2"
       sources."is-equal-shallow-0.1.3"
@@ -20589,7 +20589,7 @@ in
       sources."is-buffer-1.1.4"
       sources."for-own-0.1.4"
       sources."is-extendable-0.1.1"
-      sources."for-in-0.1.5"
+      sources."for-in-0.1.6"
       sources."glob-base-0.3.0"
       sources."is-dotfile-1.0.2"
       sources."glob-parent-2.0.0"
@@ -20940,7 +20940,7 @@ in
       })
       sources."glob-7.0.6"
       sources."graceful-fs-4.1.6"
-      sources."http-proxy-1.14.0"
+      sources."http-proxy-1.15.1"
       sources."isbinaryfile-3.0.1"
       sources."lodash-3.10.1"
       (sources."log4js-0.6.38" // {
@@ -21015,7 +21015,7 @@ in
       sources."is-buffer-1.1.4"
       sources."for-own-0.1.4"
       sources."is-extendable-0.1.1"
-      sources."for-in-0.1.5"
+      sources."for-in-0.1.6"
       sources."glob-base-0.3.0"
       sources."is-dotfile-1.0.2"
       sources."is-equal-shallow-0.1.3"
@@ -21491,7 +21491,7 @@ in
       sources."is-buffer-1.1.4"
       sources."for-own-0.1.4"
       sources."is-extendable-0.1.1"
-      sources."for-in-0.1.5"
+      sources."for-in-0.1.6"
       (sources."glob-base-0.3.0" // {
         dependencies = [
           sources."glob-parent-2.0.0"
@@ -22384,7 +22384,7 @@ in
     dependencies = [
       sources."chokidar-1.6.0"
       sources."debug-2.2.0"
-      sources."es6-promise-3.3.0"
+      sources."es6-promise-3.3.1"
       sources."ignore-by-default-1.0.1"
       sources."lodash.defaults-3.1.2"
       sources."minimatch-3.0.3"
@@ -22433,7 +22433,7 @@ in
       sources."is-buffer-1.1.4"
       sources."for-own-0.1.4"
       sources."is-extendable-0.1.1"
-      sources."for-in-0.1.5"
+      sources."for-in-0.1.6"
       sources."glob-base-0.3.0"
       sources."is-dotfile-1.0.2"
       sources."is-equal-shallow-0.1.3"
@@ -25112,7 +25112,7 @@ in
       sources."entities-1.1.1"
       sources."linkify-it-1.2.4"
       sources."mdurl-1.0.1"
-      sources."uc.micro-1.0.2"
+      sources."uc.micro-1.0.3"
       (sources."htmlparser2-3.9.1" // {
         dependencies = [
           sources."readable-stream-2.1.5"
@@ -26364,7 +26364,7 @@ in
       })
       sources."acorn-3.3.0"
       sources."interpret-0.6.6"
-      sources."loader-utils-0.2.15"
+      sources."loader-utils-0.2.16"
       sources."memory-fs-0.3.0"
       sources."mkdirp-0.5.1"
       (sources."node-libs-browser-0.6.0" // {
@@ -26505,7 +26505,7 @@ in
       sources."is-posix-bracket-0.1.1"
       sources."for-own-0.1.4"
       sources."is-extendable-0.1.1"
-      sources."for-in-0.1.5"
+      sources."for-in-0.1.6"
       sources."glob-base-0.3.0"
       sources."is-dotfile-1.0.2"
       sources."is-equal-shallow-0.1.3"

--- a/pkgs/development/node-packages/node-packages-v5.nix
+++ b/pkgs/development/node-packages/node-packages-v5.nix
@@ -7807,6 +7807,15 @@ let
         sha1 = "5fa55e02be7ca934edfc12665632e849b72e5209";
       };
     };
+    "parserlib-1.0.0" = {
+      name = "parserlib";
+      packageName = "parserlib";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parserlib/-/parserlib-1.0.0.tgz";
+        sha1 = "88340e7e8d95bac9e09236742eef53bec1e4b30f";
+      };
+    };
     "bluebird-2.9.9" = {
       name = "bluebird";
       packageName = "bluebird";
@@ -18146,10 +18155,10 @@ in
   bower2nix = nodeEnv.buildNodePackage {
     name = "bower2nix";
     packageName = "bower2nix";
-    version = "3.1.0";
+    version = "3.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.0.tgz";
-      sha1 = "f18a46335854ff9c5b4fe78f88309d7bf0631a1b";
+      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.1.tgz";
+      sha1 = "77cc8f966a3595686f5d6fae30ad9bd2cc20bfe3";
     };
     dependencies = [
       sources."argparse-1.0.4"
@@ -19454,6 +19463,26 @@ in
     meta = {
       description = "Cordova command line interface tool";
       license = "Apache-2.0";
+    };
+    production = true;
+  };
+  csslint = nodeEnv.buildNodePackage {
+    name = "csslint";
+    packageName = "csslint";
+    version = "1.0.2";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/csslint/-/csslint-1.0.2.tgz";
+      sha1 = "d01ab277845686c3c4a0d6166b3817ee114bd73d";
+    };
+    dependencies = [
+      sources."clone-1.0.2"
+      sources."parserlib-1.0.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "CSSLint";
+      homepage = http://csslint.net/;
+      license = "MIT";
     };
     production = true;
   };

--- a/pkgs/development/node-packages/node-packages-v5.nix
+++ b/pkgs/development/node-packages/node-packages-v5.nix
@@ -11106,76 +11106,49 @@ let
         sha1 = "605f34e75ea702681fcd06b2f4ee2e7b4e019006";
       };
     };
-    "escodegen-1.8.1" = {
-      name = "escodegen";
-      packageName = "escodegen";
-      version = "1.8.1";
+    "csslint-0.10.0" = {
+      name = "csslint";
+      packageName = "csslint";
+      version = "0.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz";
-        sha1 = "5a5b53af4693110bebb0867aa3430dd3b70a1018";
+        url = "https://registry.npmjs.org/csslint/-/csslint-0.10.0.tgz";
+        sha1 = "3a6a04e7565c8e9d19beb49767c7ec96e8365805";
       };
     };
-    "handlebars-4.0.5" = {
-      name = "handlebars";
-      packageName = "handlebars";
-      version = "4.0.5";
+    "jshint-2.8.0" = {
+      name = "jshint";
+      packageName = "jshint";
+      version = "2.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz";
-        sha1 = "92c6ed6bb164110c50d4d8d0fbddc70806c6f8e7";
+        url = "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz";
+        sha1 = "1d09a3bd913c4cadfa81bf18d582bd85bffe0d44";
       };
     };
-    "supports-color-3.1.2" = {
-      name = "supports-color";
-      packageName = "supports-color";
-      version = "3.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz";
-        sha1 = "72a262894d9d408b956ca05ff37b2ed8a6e2a2d5";
-      };
-    };
-    "estraverse-1.9.3" = {
-      name = "estraverse";
-      packageName = "estraverse";
-      version = "1.9.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz";
-        sha1 = "af67f2dc922582415950926091a4005d29c9bb44";
-      };
-    };
-    "source-map-0.2.0" = {
-      name = "source-map";
-      packageName = "source-map";
-      version = "0.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz";
-        sha1 = "dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d";
-      };
-    };
-    "has-flag-1.0.0" = {
-      name = "has-flag";
-      packageName = "has-flag";
+    "xml-1.0.0" = {
+      name = "xml";
+      packageName = "xml";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz";
-        sha1 = "9d9e793165ce017a00f00418c43f942a7b1d11fa";
+        url = "https://registry.npmjs.org/xml/-/xml-1.0.0.tgz";
+        sha1 = "de3ee912477be2f250b60f612f34a8c4da616efe";
       };
     };
-    "when-3.4.6" = {
-      name = "when";
-      packageName = "when";
-      version = "3.4.6";
+    "parserlib-0.2.5" = {
+      name = "parserlib";
+      packageName = "parserlib";
+      version = "0.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/when/-/when-3.4.6.tgz";
-        sha1 = "8fbcb7cc1439d2c3a68c431f1516e6dcce9ad28c";
+        url = "https://registry.npmjs.org/parserlib/-/parserlib-0.2.5.tgz";
+        sha1 = "85907dd8605aa06abb3dd295d50bb2b8fa4dd117";
       };
     };
-    "cli-1.0.0" = {
+    "cli-0.6.6" = {
       name = "cli";
       packageName = "cli";
-      version = "1.0.0";
+      version = "0.6.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz";
-        sha1 = "ee07dfc1390e3f2e6a9957cf88e1d4bfa777719d";
+        url = "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz";
+        sha1 = "02ad44a380abf27adac5e6f0cdd7b043d74c53e3";
       };
     };
     "exit-0.1.2" = {
@@ -11266,6 +11239,78 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz";
         sha1 = "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0";
+      };
+    };
+    "escodegen-1.8.1" = {
+      name = "escodegen";
+      packageName = "escodegen";
+      version = "1.8.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz";
+        sha1 = "5a5b53af4693110bebb0867aa3430dd3b70a1018";
+      };
+    };
+    "handlebars-4.0.5" = {
+      name = "handlebars";
+      packageName = "handlebars";
+      version = "4.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz";
+        sha1 = "92c6ed6bb164110c50d4d8d0fbddc70806c6f8e7";
+      };
+    };
+    "supports-color-3.1.2" = {
+      name = "supports-color";
+      packageName = "supports-color";
+      version = "3.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz";
+        sha1 = "72a262894d9d408b956ca05ff37b2ed8a6e2a2d5";
+      };
+    };
+    "estraverse-1.9.3" = {
+      name = "estraverse";
+      packageName = "estraverse";
+      version = "1.9.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz";
+        sha1 = "af67f2dc922582415950926091a4005d29c9bb44";
+      };
+    };
+    "source-map-0.2.0" = {
+      name = "source-map";
+      packageName = "source-map";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz";
+        sha1 = "dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d";
+      };
+    };
+    "has-flag-1.0.0" = {
+      name = "has-flag";
+      packageName = "has-flag";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz";
+        sha1 = "9d9e793165ce017a00f00418c43f942a7b1d11fa";
+      };
+    };
+    "when-3.4.6" = {
+      name = "when";
+      packageName = "when";
+      version = "3.4.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/when/-/when-3.4.6.tgz";
+        sha1 = "8fbcb7cc1439d2c3a68c431f1516e6dcce9ad28c";
+      };
+    };
+    "cli-1.0.0" = {
+      name = "cli";
+      packageName = "cli";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz";
+        sha1 = "ee07dfc1390e3f2e6a9957cf88e1d4bfa777719d";
       };
     };
     "body-parser-1.15.2" = {
@@ -20691,6 +20736,80 @@ in
     meta = {
       description = "Complete high-scaled reverse-proxy solution";
       homepage = https://github.com/dotcloud/hipache;
+      license = "MIT";
+    };
+    production = true;
+  };
+  htmlhint = nodeEnv.buildNodePackage {
+    name = "htmlhint";
+    packageName = "htmlhint";
+    version = "0.9.13";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/htmlhint/-/htmlhint-0.9.13.tgz";
+      sha1 = "08163cb1e6aa505048ebb0b41063a7ca07dc6c88";
+    };
+    dependencies = [
+      sources."async-1.4.2"
+      sources."colors-1.0.3"
+      sources."commander-2.6.0"
+      sources."csslint-0.10.0"
+      sources."glob-5.0.15"
+      (sources."jshint-2.8.0" // {
+        dependencies = [
+          sources."minimatch-2.0.10"
+        ];
+      })
+      sources."parse-glob-3.0.4"
+      sources."strip-json-comments-1.0.4"
+      sources."xml-1.0.0"
+      sources."parserlib-0.2.5"
+      sources."inflight-1.0.5"
+      sources."inherits-2.0.3"
+      sources."minimatch-3.0.3"
+      sources."once-1.4.0"
+      sources."path-is-absolute-1.0.0"
+      sources."wrappy-1.0.2"
+      sources."brace-expansion-1.1.6"
+      sources."balanced-match-0.4.2"
+      sources."concat-map-0.0.1"
+      (sources."cli-0.6.6" // {
+        dependencies = [
+          sources."glob-3.2.11"
+          sources."minimatch-0.3.0"
+        ];
+      })
+      sources."console-browserify-1.1.0"
+      sources."exit-0.1.2"
+      sources."htmlparser2-3.8.3"
+      sources."shelljs-0.3.0"
+      sources."lodash-3.7.0"
+      sources."lru-cache-2.7.3"
+      sources."sigmund-1.0.1"
+      sources."date-now-0.1.4"
+      sources."domhandler-2.3.0"
+      sources."domutils-1.5.1"
+      sources."domelementtype-1.3.0"
+      sources."readable-stream-1.1.14"
+      sources."entities-1.0.0"
+      (sources."dom-serializer-0.1.0" // {
+        dependencies = [
+          sources."domelementtype-1.1.3"
+          sources."entities-1.1.1"
+        ];
+      })
+      sources."core-util-is-1.0.2"
+      sources."isarray-0.0.1"
+      sources."string_decoder-0.10.31"
+      sources."glob-base-0.3.0"
+      sources."is-dotfile-1.0.2"
+      sources."is-extglob-1.0.0"
+      sources."is-glob-2.0.1"
+      sources."glob-parent-2.0.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "A Static Code Analysis Tool for HTML";
+      homepage = "https://github.com/yaniswang/HTMLHint#readme";
       license = "MIT";
     };
     production = true;

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -7,6 +7,7 @@
 , "castnow"
 , "coffee-script"
 , "cordova"
+, "csslint"
 , "dnschain"
 , "docker-registry-server"
 , "elasticdump"

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -18,6 +18,7 @@
 , { "guifi-earth": "https://github.com/jmendeth/guifi-earth/tarball/f3ee96835fd4fb0e3e12fadbd2cb782770d64854 " }
 , "gulp"
 , "hipache"
+, "htmlhint"
 , "istanbul"
 , "jayschema"
 , "jshint"


### PR DESCRIPTION
These patches add the NPM packages `htmlhint` and `csslint`, linters
for HTML and CSS respectively, to `nodePackages`.
