### PR TITLE
bower2nix 3.0.1 -> 3.1.1

### DIFF
--- a/pkgs/development/node-packages/default-v4.nix
+++ b/pkgs/development/node-packages/default-v4.nix
@@ -38,4 +38,13 @@ nodePackages // {
   npm2nix = nodePackages."npm2nix-git://github.com/NixOS/npm2nix.git#5.12.0".override {
     postInstall = "npm run-script prepublish";
   };
+
+  bower2nix = nodePackages.bower2nix.override (oldAttrs: {
+    buildInputs = oldAttrs.buildInputs ++ [ pkgs.makeWrapper ];
+    postInstall = ''
+      for prog in bower2nix fetch-bower; do
+        wrapProgram "$out/bin/$prog" --prefix PATH : "${pkgs.git}/bin"
+      done
+    '';
+  });
 }

--- a/pkgs/development/node-packages/default-v5.nix
+++ b/pkgs/development/node-packages/default-v5.nix
@@ -32,4 +32,13 @@ nodePackages // {
     
     dontNpmInstall = true; # We face an error with underscore not found, but the package will work fine if we ignore this.
   });
+
+  bower2nix = nodePackages.bower2nix.override (oldAttrs: {
+    buildInputs = oldAttrs.buildInputs ++ [ pkgs.makeWrapper ];
+    postInstall = ''
+      for prog in bower2nix fetch-bower; do
+        wrapProgram "$out/bin/$prog" --prefix PATH : "${pkgs.git}/bin"
+      done
+    '';
+  });
 }

--- a/pkgs/development/node-packages/default-v6.nix
+++ b/pkgs/development/node-packages/default-v6.nix
@@ -32,4 +32,13 @@ nodePackages // {
     
     dontNpmInstall = true; # We face an error with underscore not found, but the package will work fine if we ignore this.
   });
+
+  bower2nix = nodePackages.bower2nix.override (oldAttrs: {
+    buildInputs = oldAttrs.buildInputs ++ [ pkgs.makeWrapper ];
+    postInstall = ''
+      for prog in bower2nix fetch-bower; do
+        wrapProgram "$out/bin/$prog" --prefix PATH : "${pkgs.git}/bin"
+      done
+    '';
+  });
 }

--- a/pkgs/development/node-packages/node-packages-v4.nix
+++ b/pkgs/development/node-packages/node-packages-v4.nix
@@ -18570,10 +18570,10 @@ in
   bower2nix = nodeEnv.buildNodePackage {
     name = "bower2nix";
     packageName = "bower2nix";
-    version = "3.1.0";
+    version = "3.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.0.tgz";
-      sha1 = "f18a46335854ff9c5b4fe78f88309d7bf0631a1b";
+      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.1.tgz";
+      sha1 = "wfzj1k6jkfnk1bkgbmpni59mdab8zk3p";
     };
     dependencies = [
       (sources."argparse-1.0.4" // {

--- a/pkgs/development/node-packages/node-packages-v5.nix
+++ b/pkgs/development/node-packages/node-packages-v5.nix
@@ -18101,10 +18101,10 @@ in
   bower2nix = nodeEnv.buildNodePackage {
     name = "bower2nix";
     packageName = "bower2nix";
-    version = "3.1.0";
+    version = "3.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.0.tgz";
-      sha1 = "f18a46335854ff9c5b4fe78f88309d7bf0631a1b";
+      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.1.tgz";
+      sha1 = "wfzj1k6jkfnk1bkgbmpni59mdab8zk3p";
     };
     dependencies = [
       sources."argparse-1.0.4"

--- a/pkgs/top-level/node-packages-generated.nix
+++ b/pkgs/top-level/node-packages-generated.nix
@@ -5381,15 +5381,15 @@
     cpu = [ ];
   };
   by-spec."bower2nix"."*" =
-    self.by-version."bower2nix"."3.0.1";
-  by-version."bower2nix"."3.0.1" = self.buildNodePackage {
-    name = "bower2nix-3.0.1";
-    version = "3.0.1";
+    self.by-version."bower2nix"."3.1.1";
+  by-version."bower2nix"."3.1.1" = self.buildNodePackage {
+    name = "bower2nix-3.1.1";
+    version = "3.1.1";
     bin = true;
     src = fetchurl {
-      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.0.1.tgz";
-      name = "bower2nix-3.0.1.tgz";
-      sha1 = "06a52c033a66a890fb0c7c45a43074f3bc2e4a44";
+      url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.1.tgz";
+      name = "bower2nix-3.1.1.tgz";
+      sha1 = "wfzj1k6jkfnk1bkgbmpni59mdab8zk3p";
     };
     deps = {
       "argparse-1.0.4" = self.by-version."argparse"."1.0.4";


### PR DESCRIPTION
###### Motivation for this change
1. A new version of bower2nix with some bug fixes.
2. An update for bower2nix in the new nodePackages (node2nix) setup. (Fixes #18454)

/cc @svanderburg @shlevy 

I would also like to get this into the 16.09 release if possible. The commits do cherry-pick cleanly onto `release-16.09`.

Cheers
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip --against master"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
