### PR TITLE
openmw: 0.39.0 -> 0.40.0

### DIFF
--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -15,14 +15,14 @@ let
     };
   });
 in stdenv.mkDerivation rec {
-  version = "0.39.0";
+  version = "0.40.0";
   name = "openmw-${version}";
 
   src = fetchFromGitHub {
     owner = "OpenMW";
     repo = "openmw";
     rev = name;
-    sha256 = "0haz8p0hwzgpj634q34if6x57rkc3zsndry5pz4a25m23sn1i72y";
+    sha256 = "0mqd4gpwvczwqfkw5zvnw7cl1nzv9lkiqq2yc2a0qasaby8qv94w";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
