### PR TITLE
Init mandoc at 1.13.4 & replace groff with it in libedit and bsdbuild

### DIFF
--- a/pkgs/development/tools/misc/bsdbuild/default.nix
+++ b/pkgs/development/tools/misc/bsdbuild/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, libtool, pkgconfig, gettext, groff, ed }:
+{ stdenv, fetchurl, perl, libtool, pkgconfig, gettext, mandoc, ed }:
 
 stdenv.mkDerivation rec {
   name = "bsdbuild-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1zrdjh7a6z4khhfw9zrp490afq306cpl5v8wqz2z55ys7k1n5ifl";
   };
 
-  buildInputs = [ perl groff ed ];
+  buildInputs = [ perl mandoc ed ];
   nativeBuildInputs = [ pkgconfig libtool gettext ];
 
   prePatch = ''

--- a/pkgs/tools/misc/mandoc/default.nix
+++ b/pkgs/tools/misc/mandoc/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "mandoc-${version}";
+  version = "1.13.4";
+
+  src = fetchurl {
+    url = "http://mdocml.bsd.lv/snapshots/mdocml-${version}.tar.gz";
+    sha256 = "1vz0g5nvjbz1ckrg9cn6ivlnb13bcl1r6nc4yzb7300qvfnw2m8a";
+  };
+
+  buildInputs = [ zlib ];
+
+  configureLocal = ''
+    HAVE_WCHAR=1
+    MANPATH_DEFAULT="/run/current-system/sw/share/man"
+    OSNAME="NixOS"
+    PREFIX="$out"
+    HAVE_MANPATH=1
+    LD_OHASH="-lutil"
+    BUILD_DB=0
+  '';
+
+  preConfigure = ''
+    echo $configureLocal > configure.local
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://mdocml.bsd.lv/";
+    description = "suite of tools compiling mdoc and man";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ramkromberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2565,6 +2565,8 @@ in
 
   man-db = callPackage ../tools/misc/man-db { };
 
+  mandoc = callPackage ../tools/misc/mandoc { };
+
   mawk = callPackage ../tools/text/mawk { };
 
   mbox = callPackage ../tools/security/mbox { };


### PR DESCRIPTION
###### Motivation for this change

mandoc closure size:

```
23M /nix/store/6fix3zqpnahyml8zp2sxi2rwan55rgb8-glibc-2.24
104K    /nix/store/b5mwbrx8cldkchiqgwgkaagw91xfjr89-zlib-1.2.8
1.2M    /nix/store/r6ihzh49yjhl10ignd3qgr6ags0p5w61-mandoc-1.13.4
24M total
```

vs. groff closure size:

```
23M /nix/store/6fix3zqpnahyml8zp2sxi2rwan55rgb8-glibc-2.24
172K    /nix/store/scblgh0h3sh65s0rp0nv79rr82mjd6cm-attr-2.4.47
200K    /nix/store/6h29qi09p6p4kh04n3pyg7wa0sn7gryv-acl-2.2.52
4.7M    /nix/store/ly5dbisg2h0k3xnfdbk955m3pc4knvjk-gcc-5.4.0-lib
848K    /nix/store/n62975gpkckivvxvlhg9hjfknspxnkkm-gnused-4.2.2
832K    /nix/store/nyj6xd7s1n1w8c0xdwk5ddhi7bjcyi9x-bash-4.3-p46
11M /nix/store/zhhb02yrp03xzfrpk06ixb0gmwrjmjff-coreutils-8.25
49M /nix/store/xcp6lrq3ynj75cqcyy7b32jgizf9jr4b-perl-5.22.2
8.6M    /nix/store/wrbnvl7f54g3dg6846c5fkx96br7z75a-groff-1.22.3
96M total
```

and man-db closure size:

```
23M /nix/store/6fix3zqpnahyml8zp2sxi2rwan55rgb8-glibc-2.24
172K    /nix/store/scblgh0h3sh65s0rp0nv79rr82mjd6cm-attr-2.4.47
200K    /nix/store/6h29qi09p6p4kh04n3pyg7wa0sn7gryv-acl-2.2.52
4.7M    /nix/store/ly5dbisg2h0k3xnfdbk955m3pc4knvjk-gcc-5.4.0-lib
848K    /nix/store/n62975gpkckivvxvlhg9hjfknspxnkkm-gnused-4.2.2
832K    /nix/store/nyj6xd7s1n1w8c0xdwk5ddhi7bjcyi9x-bash-4.3-p46
11M /nix/store/zhhb02yrp03xzfrpk06ixb0gmwrjmjff-coreutils-8.25
49M /nix/store/xcp6lrq3ynj75cqcyy7b32jgizf9jr4b-perl-5.22.2
8.6M    /nix/store/72fi79z1bzx3dsi20b9yk9ji547rn4kz-groff-1.22.3
108K    /nix/store/glbqi0b5j96gs4mfkq2qsdmgamvifx5q-libpipeline-1.4.1
4.4M    /nix/store/xgaq1c135r0ibhl64s3bjjm4vcg0nmka-db-5.3.28
2.0M    /nix/store/gj8qyzznvz1clh6nz7054c5k37w0b16y-man-db-2.7.5
103M    total
```

mandoc is a man page compiler that can often be used as drop-in replacement to groff. e.g. see the libedit and bsdbuild commits.

Potentially, groff could be removed from the base system build. (>8.6M)

Additionally, a man pager is also supplied.

Long term, once upstream releases a version that doesn't depend on maria-db, the package could also replace man-db (base system run). (>6.4M)

Originates from OpenBSD. Alpine and Void already use it. (http://mdocml.bsd.lv/ports.html)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
