### PR TITLE
mongodb service: Add test case and fix default storage engine on i686

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -260,6 +260,7 @@ in rec {
   #tests.logstash = callTest tests/logstash.nix {};
   tests.mathics = callTest tests/mathics.nix {};
   tests.misc = callTest tests/misc.nix {};
+  tests.mongodb = callTest tests/mongodb.nix {};
   tests.mumble = callTest tests/mumble.nix {};
   tests.munin = callTest tests/munin.nix {};
   tests.mysql = callTest tests/mysql.nix {};

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -1,0 +1,34 @@
+# This test start mongodb, runs a query using mongo shell
+
+import ./make-test.nix ({ pkgs, ...} : let
+  testQuery = pkgs.writeScript "nixtest.js" ''
+    db.greetings.insert({ "greeting": "hello" });
+    print(db.greetings.findOne().greeting);
+  '';
+in {
+  name = "mongodb";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ bluescreen303 offline wkennington cstrahan rvl ];
+  };
+
+  nodes = {
+    one =
+      { config, pkgs, ... }:
+        {
+          services = {
+           mongodb.enable = true;
+           mongodb.extraConfig = ''
+             # Allow starting engine with only a small virtual disk
+             storage.journal.enabled: false
+             storage.mmapv1.smallFiles: true
+           '';
+          };
+        };
+    };
+
+  testScript = ''
+    startAll;
+    $one->waitForUnit("mongodb.service");
+    $one->succeed("mongo nixtest ${testQuery}") =~ /hello/ or die;
+  '';
+})

--- a/pkgs/servers/nosql/mongodb/default.nix
+++ b/pkgs/servers/nosql/mongodb/default.nix
@@ -80,6 +80,11 @@ in stdenv.mkDerivation rec {
     substituteInPlace src/third_party/s2/s2cap.cc --replace drem remainder
     substituteInPlace src/third_party/s2/s2latlng.cc --replace drem remainder
     substituteInPlace src/third_party/s2/s2latlngrect.cc --replace drem remainder
+  '' + stdenv.lib.optionalString stdenv.isi686 ''
+
+    # don't fail by default on i686
+    substituteInPlace src/mongo/db/storage/storage_options.h \
+      --replace 'engine("wiredTiger")' 'engine("mmapv1")'
   '';
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

As reported in #18209, the pump.io release test uses MongoDB and [fails on i686-linux](http://hydra.nixos.org/build/40183334).

This is because MongoDB set their default storage engine to something that doesn't work on i686.

Now I imagine that most serious mongoers would be using 64-bit systems, but it would be kinder to users who are testing things, etc, if it just worked by default on all linux systems. So the first commit does that.

The second commit is a simple test case for the NixOS mongodb service.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- Note: I actually tested off the nixos-unstable branch (binary caches), then rebased to master. Both x86_64-linux and i686-linux systems were tested.
