### PR TITLE
fribidi: 0.19.6 -> 0.19.7

### DIFF
--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -2,14 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "fribidi-${version}";
-  version = "0.19.6";
+  version = "0.19.7";
 
   src = fetchurl {
     url = "http://fribidi.org/download/${name}.tar.bz2";
-    sha256 = "0zg1hpaml34ny74fif97j7ngrshlkl3wk3nja3gmlzl17i1bga6b";
+    sha256 = "13jsb5qadlhsaxkbrb49nqslmbh904vvzhsm5mm2ghmv29i2l8h8";
   };
 
   hardeningDisable = [ "format" ];
+
+  outputs = [ "out" "devdoc" ];
 
   meta = with stdenv.lib; {
     homepage = http://fribidi.org/;


### PR DESCRIPTION
###### Motivation for this change

maintenance.

tested binary.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
