### PR TITLE
Cadvisor: update and fix test

### DIFF
--- a/nixos/tests/cadvisor.nix
+++ b/nixos/tests/cadvisor.nix
@@ -13,10 +13,6 @@ import ./make-test.nix ({ pkgs, ... } : {
       services.cadvisor.enable = true;
       services.cadvisor.storageDriver = "influxdb";
       services.influxdb.enable = true;
-      systemd.services.influxdb.postStart = mkAfter ''
-        ${pkgs.curl.bin}/bin/curl -X POST 'http://localhost:8086/db?u=root&p=root' \
-          -d '{"name": "root"}'
-      '';
     };
   };
 
@@ -27,6 +23,15 @@ import ./make-test.nix ({ pkgs, ... } : {
       $machine->succeed("curl http://localhost:8080/containers/");
 
       $influxdb->waitForUnit("influxdb.service");
+
+      # Wait until influxdb admin interface is available
+      $influxdb->waitUntilSucceeds("curl -f 127.0.0.1:8083");
+
+      # create influxdb database
+      $influxdb->succeed(q~
+        curl -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE root"
+      ~);
+
       $influxdb->waitForUnit("cadvisor.service");
       $influxdb->succeed("curl http://localhost:8080/containers/");
     '';

--- a/pkgs/servers/monitoring/cadvisor/default.nix
+++ b/pkgs/servers/monitoring/cadvisor/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "cadvisor-${version}";
-  version = "0.10.1";
+  version = "0.23.8";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "cadvisor";
-    rev = "${version}";
-    sha256 = "0k0qfhw755k3ripsfkhml0ixaglhy64hdzxrjvlmbgc50s3j37vh";
+    rev = "v${version}";
+    sha256 = "0wan6a4rpyh5fflq88saznyf2kiic9nmj8sil1s49nh3c3y4yxcj";
   };
 
   buildInputs = [ go ];


### PR DESCRIPTION
###### Motivation for this change

Fixing the cadvisor test.

The cadvisor version was updated to match influxdb version.

@offlinehacker: Please review and test the PR. I know pretty much nothing about cadvisor, so I might have missed some important things. Also, I guess the cadvisor module should be updated to match the new version and features.

cc @domenkozar @offlinehacker 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
