### PR TITLE
grub: Do not check for duplicated devices in mirroredBoots on UEFI

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -465,7 +465,7 @@ in
             + "'boot.loader.grub.mirroredBoots' to make the system bootable.";
         }
         {
-          assertion = all (c: c < 2) (mapAttrsToList (_: c: c) bootDeviceCounters);
+          assertion = cfg.efiSupport || all (c: c < 2) (mapAttrsToList (_: c: c) bootDeviceCounters);
           message = "You cannot have duplicated devices in mirroredBoots";
         }
         {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

When Grub is to be used with UEFI, it is not going to write to any MBR
of any disk. As such, it is safe to use multiple "nodev" device entries
when mirroring the ESP partition to multiple disks.

E.g.:

```
boot.loader.grub = {
  enable = true;
  version = 2;
  zfsSupport = true;
  efiSupport = true;
  mirroredBoots = [
    { devices = [ "nodev" ]; path = "/boot1"; efiSysMountPoint = "/boot1"; }
    { devices = [ "nodev" ]; path = "/boot2"; efiSysMountPoint = "/boot2"; }
    { devices = [ "nodev" ]; path = "/boot3"; efiSysMountPoint = "/boot3"; }
  ];
};

boot.loader.efi.canTouchEfiVariables = true;
```

Fixes #18584
