### PR TITLE
xfce4-hardware-monitor-plugin: init at 1.5.0

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -75,24 +75,25 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
 
   #### PANEL PLUGINS        from "mirror://xfce/src/panel-plugins/${p_name}/${ver_maj}/${name}.tar.{bz2,gz}"
 
-  xfce4_battery_plugin     = callPackage ./panel-plugins/xfce4-battery-plugin.nix     { };
-  xfce4_clipman_plugin     = callPackage ./panel-plugins/xfce4-clipman-plugin.nix     { };
-  xfce4_cpufreq_plugin     = callPackage ./panel-plugins/xfce4-cpufreq-plugin.nix     { };
-  xfce4_cpugraph_plugin    = callPackage ./panel-plugins/xfce4-cpugraph-plugin.nix    { };
-  xfce4_datetime_plugin    = callPackage ./panel-plugins/xfce4-datetime-plugin.nix    { };
-  xfce4_dict_plugin        = callPackage ./panel-plugins/xfce4-dict-plugin.nix        { };
-  xfce4_embed_plugin       = callPackage ./panel-plugins/xfce4-embed-plugin.nix       { };
-  xfce4_eyes_plugin        = callPackage ./panel-plugins/xfce4-eyes-plugin.nix        { };
-  xfce4_fsguard_plugin     = callPackage ./panel-plugins/xfce4-fsguard-plugin.nix     { };
-  xfce4_genmon_plugin      = callPackage ./panel-plugins/xfce4-genmon-plugin.nix      { };
-  xfce4_netload_plugin     = callPackage ./panel-plugins/xfce4-netload-plugin.nix     { };
-  xfce4_notes_plugin       = callPackage ./panel-plugins/xfce4-notes-plugin.nix       { };
-  xfce4_systemload_plugin  = callPackage ./panel-plugins/xfce4-systemload-plugin.nix  { };
-  xfce4_verve_plugin       = callPackage ./panel-plugins/xfce4-verve-plugin.nix       { };
-  xfce4_xkb_plugin         = callPackage ./panel-plugins/xfce4-xkb-plugin.nix         { };
-  xfce4_weather_plugin     = callPackage ./panel-plugins/xfce4-weather-plugin.nix     { };
-  xfce4_whiskermenu_plugin = callPackage ./panel-plugins/xfce4-whiskermenu-plugin.nix { };
-  xfce4_pulseaudio_plugin  = callPackage ./panel-plugins/xfce4-pulseaudio-plugin.nix  { };
+  xfce4_battery_plugin          = callPackage ./panel-plugins/xfce4-battery-plugin.nix          { };
+  xfce4_clipman_plugin          = callPackage ./panel-plugins/xfce4-clipman-plugin.nix          { };
+  xfce4_cpufreq_plugin          = callPackage ./panel-plugins/xfce4-cpufreq-plugin.nix          { };
+  xfce4_cpugraph_plugin         = callPackage ./panel-plugins/xfce4-cpugraph-plugin.nix         { };
+  xfce4_datetime_plugin         = callPackage ./panel-plugins/xfce4-datetime-plugin.nix         { };
+  xfce4_dict_plugin             = callPackage ./panel-plugins/xfce4-dict-plugin.nix             { };
+  xfce4_embed_plugin            = callPackage ./panel-plugins/xfce4-embed-plugin.nix            { };
+  xfce4_eyes_plugin             = callPackage ./panel-plugins/xfce4-eyes-plugin.nix             { };
+  xfce4_fsguard_plugin          = callPackage ./panel-plugins/xfce4-fsguard-plugin.nix          { };
+  xfce4_genmon_plugin           = callPackage ./panel-plugins/xfce4-genmon-plugin.nix           { };
+  xfce4-hardware-monitor-plugin = callPackage ./panel-plugins/xfce4-hardware-monitor-plugin.nix { };
+  xfce4_netload_plugin          = callPackage ./panel-plugins/xfce4-netload-plugin.nix          { };
+  xfce4_notes_plugin            = callPackage ./panel-plugins/xfce4-notes-plugin.nix            { };
+  xfce4_systemload_plugin       = callPackage ./panel-plugins/xfce4-systemload-plugin.nix       { };
+  xfce4_verve_plugin            = callPackage ./panel-plugins/xfce4-verve-plugin.nix            { };
+  xfce4_xkb_plugin              = callPackage ./panel-plugins/xfce4-xkb-plugin.nix              { };
+  xfce4_weather_plugin          = callPackage ./panel-plugins/xfce4-weather-plugin.nix          { };
+  xfce4_whiskermenu_plugin      = callPackage ./panel-plugins/xfce4-whiskermenu-plugin.nix      { };
+  xfce4_pulseaudio_plugin       = callPackage ./panel-plugins/xfce4-pulseaudio-plugin.nix       { };
 
 }; # xfce_self
 

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, pkgconfig, intltool, autoreconfHook, gnome2,
+  libgtop, libxfce4ui, libxfce4util, xfce4panel, lm_sensors
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname  = "xfce4-hardware-monitor-plugin";
+  version = "1.5.0";
+
+  src = fetchurl {
+    url = "https://git.xfce.org/panel-plugins/${pname}/snapshot/${name}.tar.bz2";
+    sha256 = "0sqvisr8gagpywq9sfyzqw37hxmj54ii89j5s2g8hx8bng5a98z1";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    intltool
+  ];
+
+  buildInputs = [
+    gnome2.gtkmm2
+    gnome2.libgnomecanvas
+    gnome2.libgnomecanvasmm
+    libgtop
+    libxfce4ui
+    libxfce4util
+    xfce4panel
+    lm_sensors
+   ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "http://goodies.xfce.org/projects/panel-plugins/${pname}";
+    description = "Hardware monitor plugin for the XFCE4 panel";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
