### PR TITLE
squashfsTools: optional lz4 support

### DIFF
--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchFromGitHub, zlib, xz }:
+{ stdenv, fetchFromGitHub, zlib, xz
+, lz4 ? null
+, lz4Support ? false
+}:
+
+assert lz4Support -> (lz4 != null);
 
 stdenv.mkDerivation rec {
   name = "squashfs-4.4dev";
@@ -10,13 +15,15 @@ stdenv.mkDerivation rec {
     rev = "9c1db6d13a51a2e009f0027ef336ce03624eac0d";
   };
 
-  buildInputs = [ zlib xz ];
+  buildInputs = [ zlib xz ]
+    ++ stdenv.lib.optional lz4Support lz4;
 
   preBuild = "cd squashfs-tools";
 
   installFlags = "INSTALL_DIR=\${out}/bin";
 
-  makeFlags = "XZ_SUPPORT=1";
+  makeFlags = [ "XZ_SUPPORT=1" ]
+    ++ stdenv.lib.optional lz4Support "LZ4_SUPPORT=1";
 
   meta = {
     homepage = http://squashfs.sourceforge.net/;

--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchgit, zlib, xz }:
+{ stdenv, fetchFromGitHub, zlib, xz }:
 
 stdenv.mkDerivation rec {
   name = "squashfs-4.4dev";
 
-  src = fetchgit {
-    url = https://github.com/plougher/squashfs-tools.git;
+  src = fetchFromGitHub {
+    owner = "plougher";
+    repo = "squashfs-tools";
     sha256 = "059pa2shdysr3zfmwrhq28s12zbi5nyzbpzyaf5lmspgfh1493ks";
     rev = "9c1db6d13a51a2e009f0027ef336ce03624eac0d";
   };


### PR DESCRIPTION
###### Motivation for this change

I want it
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
