### PR TITLE
opensmtpd: 5.9.2p1 -> 6.0.0p1

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -11,14 +11,14 @@
 
 stdenv.mkDerivation rec {
   name = "opensmtpd-${version}";
-  version = "5.9.2p1";
+  version = "6.0.0p1";
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ libasr libevent zlib openssl db pam ];
 
   src = fetchurl {
-    url = "http://www.opensmtpd.org/archives/${name}.tar.gz";
-    sha256 = "07d7f1m5sxyz6mkk228rcm7fsf7350994ayvmhgph333q5rz48im";
+    url = "https://www.opensmtpd.org/archives/${name}.tar.gz";
+    sha256 = "07gq21bx62w367512d0bbp9hm3pfgqh3kksg2by7n574kxc7jzm9";
   };
 
   patches = [ ./proc_path.diff ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Changelog at https://www.opensmtpd.org/announces/release-6.0.0.txt

In particular, note that
- logging format has been reworked so scripts that consume opensmtpd
  logs may need updating
- dhparams option has been removed
