### PR TITLE
avfs: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/tools/filesystems/avfs/default.nix
+++ b/pkgs/tools/filesystems/avfs/default.nix
@@ -2,13 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "avfs-${version}";
-  version = "1.0.3";
+  version = "1.0.4";
   src = fetchurl {
     url = "mirror://sourceforge/avf/${version}/${name}.tar.bz2";
-    sha256 = "1j7ysjkv0kbkwjagcdgwcnbii1smd58pwwlpz0l7amki5dxygpn6";
+    sha256 = "005iw01ppjslfzbbx52dhmp1f7a8d071s5pxvjlk11zdv4h22rbb";
   };
 
-  buildInputs = [ pkgconfig fuse xz ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ fuse xz ];
 
   configureFlags = [
     "--enable-library"


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
