### PR TITLE
czmqpp: init at 1.2.0

### DIFF
--- a/pkgs/development/libraries/czmqpp/default.nix
+++ b/pkgs/development/libraries/czmqpp/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, czmq }:
+
+stdenv.mkDerivation rec {
+  name = "czmqpp-${version}";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "zeromq";
+    repo = "czmqpp";
+    rev = "v${version}";
+    sha256 = "0z8lwq53yk4h7pgibicx3q9idz15qb95r0pjpz0j5vql6qh46rja";
+  };
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "C++ wrapper for czmq. Aims to be minimal, simple and consistent";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ chris-martin ];
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  propagatedBuildInputs = [ czmq ];
+
+  # https://github.com/zeromq/czmqpp/issues/42
+  patches = [ ./socket.patch ];
+}

--- a/pkgs/development/libraries/czmqpp/socket.patch
+++ b/pkgs/development/libraries/czmqpp/socket.patch
@@ -1,0 +1,17 @@
+--- /src/socket.cpp
++++ /src/socket.cpp
+@@ -60,12 +60,12 @@
+ int socket::bind(const std::string& address)
+ {
+     // format-security: format not a string literal and no format arguments.
+-    return zsocket_bind(self_, address.c_str());
++    return zsocket_bind(self_, "%s", address.c_str());
+ }
+ int socket::connect(const std::string& address)
+ {
+     // format-security: format not a string literal and no format arguments.
+-    return zsocket_connect(self_, address.c_str());
++    return zsocket_connect(self_, "%s", address.c_str());
+ }
+
+ bool operator==(const socket& sock_a, const socket& sock_b)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9951,6 +9951,8 @@ in
 
   czmq = callPackage ../development/libraries/czmq { };
 
+  czmqpp = callPackage ../development/libraries/czmqpp { };
+
   zimlib = callPackage ../development/libraries/zimlib { };
 
   zita-convolver = callPackage ../development/libraries/audio/zita-convolver { };


### PR DESCRIPTION
###### Motivation for this change

This is a dependency of [libbitcoin-client](https://github.com/libbitcoin/libbitcoin-client) (#18644) (which I hope to be submitting another PR for soon)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
