### PR TITLE
mlterm: 3.3.8 -> 3.7.2

### DIFF
--- a/pkgs/applications/misc/mlterm/default.nix
+++ b/pkgs/applications/misc/mlterm/default.nix
@@ -1,38 +1,49 @@
-{ stdenv, fetchurl, pkgconfig, libX11, gdk_pixbuf, cairo, libXft, gtk2, fribidi }:
+{ stdenv, fetchurl, pkgconfig, autoconf
+, libX11, gdk_pixbuf, cairo, libXft, gtk3, vte, fribidi, libssh2
+}:
 
 stdenv.mkDerivation rec {
   name = "mlterm-${version}";
-  version = "3.3.8";
+  version = "3.7.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/mlterm/01release/${name}/${name}.tar.gz";
-    sha256 = "088pgxynzxxii7wdmjp2fdkxydirx4k05588zkhlzalkb5l8ji1i";
+    sha256 = "1b24w8hfck1ylfkdz9z55vlmsb36q9iyfr0i9q9y98dfk0f0rrw8";
   };
 
-  buildInputs = [ pkgconfig libX11 gdk_pixbuf cairo libXft gtk2 fribidi ];
+  nativeBuildInputs = [ pkgconfig autoconf ];
+  buildInputs = [
+    libX11 gdk_pixbuf.dev cairo libXft gtk3 vte fribidi libssh2
+  ];
 
   preConfigure = ''
     sed -ie 's#-L/usr/local/lib -R/usr/local/lib##g' \
       xwindow/libtype/Makefile.in \
       main/Makefile.in \
-      java/Makefile.in \
+      tool/mlfc/Makefile.in \
       tool/mlimgloader/Makefile.in \
-      tool/registobmp/Makefile.in \
-      tool/mlconfig/Makefile.in
-    sed -ie 's;cd ..srcdir. && rm -f ...lang..gmo.*;;g' tool/mlconfig/po/Makefile.in.in
+      tool/mlconfig/Makefile.in \
+      xwindow/libotl/Makefile.in
+    sed -ie 's;cd ..srcdir. && rm -f ...lang..gmo.*;;g' \
+      tool/mlconfig/po/Makefile.in.in
   '';
 
   configureFlags = [
+    "--with-x=yes"
+    "--with-gtk=3.0"
     "--with-imagelib=gdk-pixbuf"
+    "--with-gui=xlib"
     "--with-type-engines=cairo,xft,xcore"
-    "--with-x"
     "--enable-ind"
+    "--enable-fribidi"
+    "--with-tools=mlclient,mlconfig,mlcc,mlterm-menu,mlimgloader,registobmp,mlfc"
+    "--disable-utmp"
  ];
 
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/projects/mlterm/;
     license = licenses.bsd2;
-    maintainers = [ maintainers.vrthra ];
+    maintainers = with maintainers; [ vrthra ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15601,7 +15601,9 @@ in
 
   xterm = callPackage ../applications/misc/xterm { };
 
-  mlterm = callPackage ../applications/misc/mlterm { };
+  mlterm = callPackage ../applications/misc/mlterm {
+    vte = gnome3.vte_290;
+  };
 
   finalterm = callPackage ../applications/misc/finalterm { };
 


### PR DESCRIPTION
###### Motivation for this change

The one reason to use mlterm, bidirectional text, wasn't working.

Notes:
1. Tested working with and without the fribidi update ( https://github.com/NixOS/nixpkgs/pull/18623 ).
2. 2014-08-16 (3.3.8) -> 2016-08-14 (3.7.2).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
