### PR TITLE
Freetts: fix build

### DIFF
--- a/pkgs/development/libraries/freetts/default.nix
+++ b/pkgs/development/libraries/freetts/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, apacheAnt, unzip, sharutils, lib}:
+{stdenv, fetchurl, apacheAnt, unzip, sharutils, lib, jdk}:
 
 stdenv.mkDerivation {
   name = "freetts-1.2.2";
@@ -6,11 +6,11 @@ stdenv.mkDerivation {
     url = mirror://sourceforge/freetts/freetts-1.2.2-src.zip;
     sha256 = "0mnikqhpf4f4jdr0irmibr8yy0dnffx1i257y22iamxi7a6by2r7";
   };
-  buildInputs = [ apacheAnt unzip sharutils ];
+  buildInputs = [ apacheAnt unzip sharutils jdk ];
   unpackPhase = ''
     unzip $src -x META-INF/*
   '';
-  
+
   buildPhase = ''
     cd */lib
     sed -i -e "s/more/cat/" jsapi.sh
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
     install -v -m755 -d $out/{lib,docs/{audio,images}}
     install -v -m644 lib/*.jar $out/lib
   '';
-  
+
   meta = {
     description = "Text to speech system based on Festival written in Java";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change
#18282 - freetts build is broken
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

All I've verified is that it does build now.
