### PR TITLE
pkcs11-helper: git rev -> 1.11, openvpn w/ pkcs11-helper support 

### DIFF
--- a/pkgs/development/libraries/pkcs11helper/default.nix
+++ b/pkgs/development/libraries/pkcs11helper/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchurl, pkgconfig, openssl, autoreconfHook }:
+{ stdenv, fetchFromGitHub, pkgconfig, openssl, autoreconfHook }:
 
-let
-  rev = "5d412bad60";
-in
 stdenv.mkDerivation rec {
-  name = "pkcs11-helper-20121123-${rev}";
+  name = "pkcs11-helper-${version}";
+  version = "1.11";
 
-  src = fetchurl {
-    url = "https://github.com/alonbl/pkcs11-helper/tarball/${rev}";
-    name = "${name}.tar.gz";
-    sha256 = "1mih6mha39yr5s5m18lg4854qc105asgnwmjw7f95kgmzni62kxp";
+  src = fetchFromGitHub {
+    owner = "OpenSC";
+    repo = "pkcs11-helper";
+    rev = "${name}";
+    sha256 = "1bfsmy9w2qf7avvs3rsc1ycqczzzw0j2wsqkd2fj4dc1fqzigq2q";
   };
 
   buildInputs = [ pkgconfig openssl autoreconfHook ];
 
   meta = with stdenv.lib; {
     homepage = https://www.opensc-project.org/opensc/wiki/pkcs11-helper;
-    license = with licenses; [ "BSD" gpl2 ];
+    license = with licenses; [ bsd3 gpl2 ];
     description = "Library that simplifies the interaction with PKCS#11 providers";
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

New version, and yubi keys with openvpn.
###### Things done

Tested building with and without the feature.
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
