### PR TITLE
corebird: init at 1.3.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -197,6 +197,7 @@
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
   joelteon = "Joel Taylor <me@joelt.io>";
   joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
+  jonafato = "Jon Banafato <jon@jonafato.com>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
   jraygauthier = "Raymond Gauthier <jraygauthier@gmail.com>";
   juliendehos = "Julien Dehos <dehos@lisic.univ-littoral.fr>";

--- a/pkgs/applications/networking/corebird/default.nix
+++ b/pkgs/applications/networking/corebird/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, gtk3, json_glib, sqlite, libsoup, gettext, vala_0_32
+, automake, autoconf, libtool, pkgconfig, gnome3, gst_all_1, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  version = "1.3.1";
+  name = "corebird-${version}";
+
+  src = fetchFromGitHub {
+    owner = "baedert";
+    repo = "corebird";
+    rev = version;
+    sha256 = "1a7b6hinl5p7yanf75a0khki2fvd04km1xlkwnspgx75cmnbnn5z";
+  };
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  nativeBuildInputs = [ automake autoconf libtool pkgconfig wrapGAppsHook ];
+
+  buildInputs = [
+    gtk3 json_glib sqlite libsoup gettext vala_0_32 gnome3.rest
+  ] ++ (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav ]);
+
+  meta = {
+    description = "Native Gtk+ Twitter client for the Linux desktop";
+    longDescription = "Corebird is a modern, easy and fun Twitter client.";
+    homepage = http://corebird.baedert.org;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.jonafato ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -734,6 +734,8 @@ in
 
   consul-template = callPackage ../tools/system/consul-template { };
 
+  corebird = callPackage ../applications/networking/corebird { };
+
   corosync = callPackage ../servers/corosync { };
 
   cherrytree = callPackage ../applications/misc/cherrytree { };


### PR DESCRIPTION
###### Motivation for this change

Corebird is a Twitter client for Linux.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first contribution to nixpkgs. Feedback welcome and appreciated.
