### PR TITLE
pythonPackages.mathics: Fix install

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13164,6 +13164,11 @@ in modules // {
       substituteInPlace setup.py --replace "sympy==0.7.6" "sympy"
     '';
 
+    postFixup = ''
+      wrapPythonProgramsIn $out/bin $out
+      patchPythonScript $out/${python.sitePackages}/mathics/manage.py
+    '';
+
     propagatedBuildInputs = with self; [
       cython
       sympy


### PR DESCRIPTION
###### Motivation for this change

This fixes `nixos/tests/mathics.nix` (part of #18209). Once integrated to master it should be cherry-picked to `release-16.09`.

I have tested the patch against both `master` and `release-16.09`.

cc @domenkozar @benley 
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This fixes the broken test nixos/tests/mathics.nix
