### PR TITLE
hping: broken on darwin

### DIFF
--- a/pkgs/tools/networking/hping/default.nix
+++ b/pkgs/tools/networking/hping/default.nix
@@ -40,10 +40,11 @@ stdenv.mkDerivation rec {
     ln -vs hping3.8.gz "$out/share/man/man8/hping2.8.gz"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A command-line oriented TCP/IP packet assembler/analyzer";
     homepage = "http://www.hping.org/";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
