### PR TITLE
systemtap: init at 51b7ca

### DIFF
--- a/pkgs/development/tools/profiling/systemtap/default.nix
+++ b/pkgs/development/tools/profiling/systemtap/default.nix
@@ -1,16 +1,17 @@
-{ fetchurl, linuxPackages, makeWrapper, runCommand, fetchgit
-, elfutils, pkgconfig, gettext, stow, gnumake }:
+{ fetchgit, pkgconfig, gettext, runCommand, makeWrapper
+, elfutils, kernel, gnumake }:
 let
   ## fetchgit info
   url = git://sourceware.org/git/systemtap.git;
-  rev = "51b7cae3023adf137081059c7cc44a13f652ba4c";
-  sha256 = "18m3lf11r99f4yr1m172548lghc0i22zqbys1fwlwakbczz0a2lz";
+  rev = "a10bdceb7c9a7dc52c759288dd2e555afcc5184a";
+  sha256 = "1kllzfnh4ksis0673rma5psglahl6rvy0xs5v05qkqn6kl7irmg1";
+  version = "2016-09-16";
 
-  inherit (linuxPackages) kernel;
-  version = kernel.stdenv.lib.substring 0 6 rev;
+  inherit (kernel) stdenv;
+  inherit (stdenv) lib;
 
   ## stap binaries
-  stapBuild = kernel.stdenv.mkDerivation {
+  stapBuild = stdenv.mkDerivation {
     name = "systemtap-${version}";
     src = fetchgit { inherit url rev sha256; };
     buildInputs = [ elfutils pkgconfig gettext ];
@@ -18,39 +19,34 @@ let
   };
 
   ## a kernel build dir as expected by systemtap
-  kernelBuildDir = runCommand "kbuild-${kernel.version}-merged" {
-    buildInputs = [ stow ];
-  } ''
+  kernelBuildDir = runCommand "kbuild-${kernel.version}-merged" { } ''
     mkdir -p $out
-    stowFrom () {
-      D="$(dirname $1)"
-      P="$(basename $1)"
-      shift
-      stow -d $D -t $out -v "$@" -S $P
-    }
-    stowFrom ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build --ignore=source
-    ln -s ${kernel.dev}/vmlinux $out/vmlinux
-    ln -s ${kernel}/System.map $out/System.map
-    ln -s ${kernel.dev}/lib/modules/${kernel.modDirVersion}/source $out/source
+    for f in \
+        ${kernel}/System.map \
+        ${kernel.dev}/vmlinux \
+        ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build/{*,.*}
+    do
+      ln -s $(readlink -f $f) $out
+    done
   '';
 
 in runCommand "systemtap-${kernel.version}-${version}" {
   inherit stapBuild kernelBuildDir;
   buildInputs = [ makeWrapper ];
-  meta = with kernel.stdenv.lib; {
+  meta = {
     homepage = https://sourceware.org/systemtap/;
-    repositories.git = git://sourceware.org/git/systemtap.git;
-    description = "SystemTap provides a simple command line interface and scripting language for writing instrumentation for a live running kernel plus user-space applications.";
-    license = licenses.gpl2;
-    platforms = platforms.linux;
+    repositories.git = url;
+    description = "Provides a scripting language for instrumentation on a live kernel plus user-space";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
   };
 } ''
   mkdir -p $out/bin
   for bin in $stapBuild/bin/*; do # hello emacs */
-    ln -s $bin $out/bin/$(basename $bin)
+    ln -s $bin $out/bin
   done
   rm $out/bin/stap
   makeWrapper $stapBuild/bin/stap $out/bin/stap \
     --add-flags "-r $kernelBuildDir" \
-    --prefix PATH : ${kernel.stdenv.cc.cc}/bin:${elfutils}/bin:${gnumake}/bin
+    --prefix PATH : ${lib.makeBinPath [ stdenv.cc.cc elfutils gnumake ]}
 ''

--- a/pkgs/development/tools/profiling/systemtap/default.nix
+++ b/pkgs/development/tools/profiling/systemtap/default.nix
@@ -1,0 +1,56 @@
+{ fetchurl, linuxPackages, makeWrapper, runCommand, fetchgit
+, elfutils, pkgconfig, gettext, stow, gnumake }:
+let
+  ## fetchgit info
+  url = git://sourceware.org/git/systemtap.git;
+  rev = "51b7cae3023adf137081059c7cc44a13f652ba4c";
+  sha256 = "18m3lf11r99f4yr1m172548lghc0i22zqbys1fwlwakbczz0a2lz";
+
+  inherit (linuxPackages) kernel;
+  version = kernel.stdenv.lib.substring 0 6 rev;
+
+  ## stap binaries
+  stapBuild = kernel.stdenv.mkDerivation {
+    name = "systemtap-${version}";
+    src = fetchgit { inherit url rev sha256; };
+    buildInputs = [ elfutils pkgconfig gettext ];
+    enableParallelBuilding = true;
+  };
+
+  ## a kernel build dir as expected by systemtap
+  kernelBuildDir = runCommand "kbuild-${kernel.version}-merged" {
+    buildInputs = [ stow ];
+  } ''
+    mkdir -p $out
+    stowFrom () {
+      D="$(dirname $1)"
+      P="$(basename $1)"
+      shift
+      stow -d $D -t $out -v "$@" -S $P
+    }
+    stowFrom ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build --ignore=source
+    ln -s ${kernel.dev}/vmlinux $out/vmlinux
+    ln -s ${kernel}/System.map $out/System.map
+    ln -s ${kernel.dev}/lib/modules/${kernel.modDirVersion}/source $out/source
+  '';
+
+in runCommand "systemtap-${kernel.version}-${version}" {
+  inherit stapBuild kernelBuildDir;
+  buildInputs = [ makeWrapper ];
+  meta = with kernel.stdenv.lib; {
+    homepage = https://sourceware.org/systemtap/;
+    repositories.git = git://sourceware.org/git/systemtap.git;
+    description = "SystemTap provides a simple command line interface and scripting language for writing instrumentation for a live running kernel plus user-space applications.";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+} ''
+  mkdir -p $out/bin
+  for bin in $stapBuild/bin/*; do # hello emacs */
+    ln -s $bin $out/bin/$(basename $bin)
+  done
+  rm $out/bin/stap
+  makeWrapper $stapBuild/bin/stap $out/bin/stap \
+    --add-flags "-r $kernelBuildDir" \
+    --prefix PATH : ${kernel.stdenv.cc.cc}/bin:${elfutils}/bin:${gnumake}/bin
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11397,6 +11397,8 @@ in
 
     sysdig = callPackage ../os-specific/linux/sysdig {};
 
+    systemtap = callPackage ../development/tools/profiling/systemtap { };
+
     tp_smapi = callPackage ../os-specific/linux/tp_smapi { };
 
     v86d = callPackage ../os-specific/linux/v86d { };
@@ -14962,8 +14964,6 @@ in
 
   # linux only by now
   synergy = callPackage ../applications/misc/synergy { };
-
-  systemtap = callPackage ../development/tools/profiling/systemtap { };
 
   tabbed = callPackage ../applications/window-managers/tabbed {
     # if you prefer a custom config, write the config.h in tabbed.config.h

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14963,6 +14963,8 @@ in
   # linux only by now
   synergy = callPackage ../applications/misc/synergy { };
 
+  systemtap = callPackage ../development/tools/profiling/systemtap { };
+
   tabbed = callPackage ../applications/window-managers/tabbed {
     # if you prefer a custom config, write the config.h in tabbed.config.h
     # and enable


### PR DESCRIPTION
###### Motivation for this change

Systemtap is very useful in monitoring kernel and userspace execution. Apparently it got removed in january: https://www.mail-archive.com/nix-commits-bounces@lists.science.uu.nl/msg00047.html

I got this version working on kernel 4.7.3, though.
###### Things done
- Built on platform(s)
  - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [ ] Provide debug info for kernel and userland, in a way accessible to systemtap

---

master needs to be tracked in order to support recent kernels
