### PR TITLE
kernel-common: Add ZBUD

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -512,9 +512,15 @@ with stdenv.lib;
   TRANSPARENT_HUGEPAGE_MADVISE? y
 
   # zram support (e.g for in-memory compressed swap).
-  ZSMALLOC y
   ZRAM m
   ZSWAP? y
+  ZBUD? y
+  ${optionalString (versionOlder version "3.18") ''
+    ZSMALLOC y
+  ''}
+  ${optionalString (versionAtLeast version "3.18") ''
+    ZSMALLOC m
+  ''}
 
   # Enable PCIe and USB for the brcmfmac driver
   BRCMFMAC_USB? y


### PR DESCRIPTION
###### Motivation for this change

Fix #18533
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I built a NixOS generation based on master with this change and the warnings mentioned in #18533 no longer appear.

---

Ping @abbradar 
