### PR TITLE
torbrowser: 6.0.4 -> 6.0.5

### DIFF
--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -12,13 +12,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "tor-browser-${version}";
-  version = "6.0.4";
+  version = "6.0.5";
 
   src = fetchurl {
     url = "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux${if stdenv.is64bit then "64" else "32"}-${version}_en-US.tar.xz";
     sha256 = if stdenv.is64bit then
-      "14ds39frkg4hbim0icb372crink902f7i6mqj6dmbaiz2fi88y8q" else
-      "1d2mg46dg5y16h5lwzq0ilv3zk8aqy3vg3j4a5c3wzsxj0hpl4v5";
+      "fc917bd702b1275cae3f7fa8036c3c44af9b4f003f3d4a8fbb9f6c0974277ad4" else
+      "e0c3ce406b6de082692ce3db52b6e04053e205194b26fbf0eee9014be543d98d";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
Note: This is a security update, so it should be backported to stable?!
