### PR TITLE
swiProlog: 6.6.6 -> 7.2.3

### DIFF
--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -4,14 +4,14 @@
 }:
 
 let
-  version = "6.6.6";
+  version = "7.2.3";
 in
 stdenv.mkDerivation {
   name = "swi-prolog-${version}";
 
   src = fetchurl {
-    url = "http://www.swi-prolog.org/download/stable/src/pl-${version}.tar.gz";
-    sha256 = "0vcrfskm2hyhv30lxr6v261myb815jc3bgmcn1lgsc9g9qkvp04z";
+    url = "http://www.swi-prolog.org/download/stable/src/swipl-${version}.tar.gz";
+    sha256 = "1da6sr8pz1zffs79nfa1d25a11ibhalm1vdwsb17p265nx8psra3";
   };
 
   buildInputs = [ gmp readline openssl libjpeg unixODBC libXinerama


### PR DESCRIPTION
SWI-Prolog 6.6.6 is over two years old. The latest release (7.2.3) has features I rely on.
- [ ] Tested using sandboxing
- Built on platforms
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
