### PR TITLE
cadvisor test: fix

### DIFF
--- a/nixos/modules/services/databases/influxdb.nix
+++ b/nixos/modules/services/databases/influxdb.nix
@@ -66,16 +66,16 @@ let
       enabled = false;
     }];
 
-    collectd = {
+    collectd = [{
       enabled = false;
       typesdb = "${pkgs.collectd}/share/collectd/types.db";
       database = "collectd_db";
       port = 25826;
-    };
+    }];
 
-    opentsdb = {
+    opentsdb = [{
       enabled = false;
-    };
+    }];
 
     continuous_queries = {
       enabled = true;
@@ -170,6 +170,11 @@ in
       preStart = ''
         mkdir -m 0770 -p ${cfg.dataDir}
         if [ "$(id -u)" = 0 ]; then chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}; fi
+      '';
+      postStart = mkBefore ''
+        until ${pkgs.curl.bin}/bin/curl -s -o /dev/null 'http://127.0.0.1${toString configOptions.http.bind-address}'/ping; do
+          sleep 1;
+        done
       '';
     };
 

--- a/nixos/modules/services/monitoring/cadvisor.nix
+++ b/nixos/modules/services/monitoring/cadvisor.nix
@@ -90,6 +90,7 @@ in {
             ${optionalString cfg.storageDriverSecure "-storage_driver_secure"}
           ''}
         '';
+        TimeoutStartSec=300;
       };
     };
 

--- a/nixos/tests/cadvisor.nix
+++ b/nixos/tests/cadvisor.nix
@@ -24,9 +24,6 @@ import ./make-test.nix ({ pkgs, ... } : {
 
       $influxdb->waitForUnit("influxdb.service");
 
-      # Wait until influxdb admin interface is available
-      $influxdb->waitUntilSucceeds("curl -f 127.0.0.1:8083");
-
       # create influxdb database
       $influxdb->succeed(q~
         curl -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE root"

--- a/nixos/tests/influxdb.nix
+++ b/nixos/tests/influxdb.nix
@@ -17,9 +17,6 @@ import ./make-test.nix ({ pkgs, ...} : {
   
     $one->waitForUnit("influxdb.service");
 
-    # Check if admin interface is avalible
-    $one->waitUntilSucceeds("curl -f 127.0.0.1:8083");
-
     # create database
     $one->succeed(q~
       curl -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE test"


### PR DESCRIPTION
###### Motivation for this change

Fixing cadvisor test on Hydra.

Cadvisor module startup timeout on Hydra (probably due to the high load).
Increasing `TimeoutStartSec` should hopefully fix the problem.

This PR also include a few change to the influxdb module:
- add a postStart to make sure influxdb is ready when the service is started (that allow to slightly simplify cadvisor and influxdb tests).
- update configuration to remove a few warnings.

cc @domenkozar @offlinehacker 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
