### PR TITLE
nodejs-6_x: 6.4.0 -> 6.6.0

### DIFF
--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -8,8 +8,8 @@ let
   inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
 
 in import ./nodejs.nix (args // rec {
-  version = "6.4.0";
-  sha256 = "1b3xpp38fd2y8zdkpvkyyvsddh5y4vly81hxkf9hi6wap0nqidj9";
+  version = "6.6.0";
+  sha256 = "0cqswab9idbz5kzj50fnalg1zrircmbn9qga0cr33lvjnv98a134";
   extraBuildInputs = stdenv.lib.optionals stdenv.isDarwin
     [ CoreServices ApplicationServices ];
   preBuild = stdenv.lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Motivation for this change

update nodejs-6_x from 6.4.0 to 6.6.0
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [X] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

\cc @LnL7 
