### PR TITLE
configuration-hackage2nix.yaml: language-puppet

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2420,7 +2420,7 @@ dont-distribute-packages:
   language-lua-qq:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-mixal:                               [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-objc:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
-  language-puppet:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
+  language-puppet:                              [ i686-linux, x86_64-darwin ]
   language-python-colour:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-qux:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-sh:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
###### Motivation for this change

`language-puppet` has been disabled by 68f43cf9a9c7189a938fbff7f4debf811c28c891

But it has been building without error on hydra for `x86_64-linux`:
https://hydra.nixos.org/job/nixos/release-16.09/nixpkgs.haskellPackages.language-puppet.x86_64-linux
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

enable for x86_64-linux only
