### PR TITLE
mlterm: fix cairo and multiple other features

### DIFF
--- a/pkgs/applications/misc/mlterm/default.nix
+++ b/pkgs/applications/misc/mlterm/default.nix
@@ -1,5 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, autoconf
-, libX11, gdk_pixbuf, cairo, libXft, gtk3, vte, fribidi, libssh2
+{ stdenv, fetchurl, pkgconfig, autoconf, makeDesktopItem
+, libX11, gdk_pixbuf, cairo, libXft, gtk3, vte
+, harfbuzz #substituting glyphs with opentype fonts
+, fribidi, m17n_lib #bidi and encoding
+, openssl, libssh2 #build-in ssh
 }:
 
 stdenv.mkDerivation rec {
@@ -13,11 +16,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoconf ];
   buildInputs = [
-    libX11 gdk_pixbuf.dev cairo libXft gtk3 vte fribidi libssh2
+    libX11 gdk_pixbuf.dev cairo libXft gtk3 vte
+    harfbuzz fribidi m17n_lib openssl libssh2
   ];
 
+  #bad configure.ac and Makefile.in everywhere
   preConfigure = ''
-    sed -ie 's#-L/usr/local/lib -R/usr/local/lib##g' \
+    sed -ie 's;-L/usr/local/lib -R/usr/local/lib;;g' \
       xwindow/libtype/Makefile.in \
       main/Makefile.in \
       tool/mlfc/Makefile.in \
@@ -26,24 +31,69 @@ stdenv.mkDerivation rec {
       xwindow/libotl/Makefile.in
     sed -ie 's;cd ..srcdir. && rm -f ...lang..gmo.*;;g' \
       tool/mlconfig/po/Makefile.in.in
+    #utmp and mlterm-fb
+    substituteInPlace configure.in \
+      --replace "-m 2755 -g utmp" " " \
+      --replace "-m 4755 -o root" " "
+    substituteInPlace configure \
+      --replace "-m 2755 -g utmp" " " \
+      --replace "-m 4755 -o root" " "
   '';
+  NIX_LDFLAGS = "
+    -L${stdenv.cc.cc.lib}/lib
+    -lX11 -lgdk_pixbuf-2.0 -lcairo -lfontconfig -lfreetype -lXft
+    -lvte-2.91 -lgtk-3 -lharfbuzz -lfribidi -lm17n
+  " + stdenv.lib.optionalString (openssl != null) "
+    -lcrypto
+  " + stdenv.lib.optionalString (libssh2 != null) "
+    -lssh2
+  ";
 
   configureFlags = [
     "--with-x=yes"
-    "--with-gtk=3.0"
-    "--with-imagelib=gdk-pixbuf"
-    "--with-gui=xlib"
+    "--with-gui=xlib,fb"
+    "--with-imagelib=gdk-pixbuf" #or mlimgloader depending on your bugs of choice
     "--with-type-engines=cairo,xft,xcore"
-    "--enable-ind"
-    "--enable-fribidi"
+    "--with-gtk=3.0"
+    "--enable-ind" #indic scripts
+    "--enable-fribidi" #bidi scripts
+    "--enable-m17nlib" #character encodings
     "--with-tools=mlclient,mlconfig,mlcc,mlterm-menu,mlimgloader,registobmp,mlfc"
-    "--disable-utmp"
+     #mlterm-menu and mlconfig depend on enabling gnome3.at-spi2-core
+     #and configuring ~/.mlterm/key correctly.
+ ] ++ stdenv.lib.optional (libssh2 == null) [
+    "--disable-ssh2"
  ];
+
+  postInstall = ''
+    mkdir -p "$out/share/icons/hicolor/scalable/apps"
+    cp contrib/icon/mlterm-icon.svg "$out/share/icons/hicolor/scalable/apps/mlterm.svg"
+
+    mkdir -p "$out/share/icons/hicolor/48x48/apps"
+    cp contrib/icon/mlterm-icon-gnome2.png "$out/share/icons/hicolor/48x48/apps/mlterm.png"
+
+    mkdir -p "$out/share/applications"
+    cp $desktopItem/share/applications/* $out/share/applications
+  '';
+
+  desktopItem = makeDesktopItem rec {
+    name = "mlterm";
+    exec = "mlterm %U";
+    icon = "mlterm";
+    type = "Application";
+    comment = "Terminal emulator";
+    desktopName = "mlterm";
+    genericName = "Terminal emulator";
+    categories = stdenv.lib.concatStringsSep ";" [
+      "Application" "System" "TerminalEmulator"
+    ];
+    startupNotify = "false";
+  };
 
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/projects/mlterm/;
     license = licenses.bsd2;
-    maintainers = with maintainers; [ vrthra ];
+    maintainers = with maintainers; [ vrthra ramkromberg ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15604,7 +15604,9 @@ in
   xterm = callPackage ../applications/misc/xterm { };
 
   mlterm = callPackage ../applications/misc/mlterm {
-    vte = gnome3.vte_290;
+    vte = gnome3.vte;
+    libssh2 = null;
+    openssl = null;
   };
 
   finalterm = callPackage ../applications/misc/finalterm { };


### PR DESCRIPTION
###### Motivation for this change

I've missed a lot of bugs and extra features aside from the broken bidi:
1. The cario & xft rendering engines weren't linked properly.
2. n17m encoding was missing.
3. mlterm-fb (the framebuffer version) was missing.
4. nulled out the ssh\crypto stuff.
5. the -oft option for substitution glyphs wasn't working without harfbuzz (for instance, the st ligature can be shown as ﬆ with a proper opentype font using _mlterm -oft_.)
6. indic scripts built-in needed specifying.
7. fixed up utmp.
8. Got the background image working. There's two ways about this, each with it's own bugs. See _man mlterm_.
9. A desktop shortcut and icon.
10. A couple of other fixes and improvements...

Note 1: mlterm-menu  and mlconfig need:
1. _services.gnome3.at-spi2-core.enable = true;_ in _configuration.nix_.
2. a correctly configured _~/.mlterm/key_ and _~/.mlterm/menu_. e.g.
key:

```
Control+F5="menu:mlterm-menu"
Control+F6="menu:mlconfig"
```

menu:

```
"Font Size" {
        "Larger"        "fontsize=larger"
        "Smaller"       "fontsize=smaller"
}
"Encoding" {
        "Auto"          "encoding=auto"
        "UTF-8"         "encoding=UTF-8"
}
"Full Reset"    "full_reset"
-
pty_list
"New PTY"       "open_pty"
```

Note 2: I haven't tested _mlterm-fb_ since I don't have the hardware for it.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
