### PR TITLE
libreoffice: add nix shells for source generation

### DIFF
--- a/pkgs/applications/office/libreoffice/README.md
+++ b/pkgs/applications/office/libreoffice/README.md
@@ -1,0 +1,10 @@
+LibreOffice
+===========
+
+To generate `libreoffice-srcs.nix`:
+
+    nix-shell default-gen-shell.nix --run generate
+
+To generate `libreoffice-srcs-still.nix`:
+
+    nix-shell still-gen-shell.nix --run generate

--- a/pkgs/applications/office/libreoffice/default-gen-shell.nix
+++ b/pkgs/applications/office/libreoffice/default-gen-shell.nix
@@ -1,0 +1,27 @@
+{ pkgs ? (import <nixpkgs> {}) }:
+
+with pkgs;
+
+let
+
+  primary-src = callPackage ./default-primary-src.nix {};
+
+in
+
+stdenv.mkDerivation {
+  name = "generate-libreoffice-srcs-shell";
+
+  buildCommand = "exit 1";
+
+  downloadList = stdenv.mkDerivation {
+    name = "libreoffice-${primary-src.version}-download-list";
+    inherit (primary-src) src version;
+    builder = ./download-list-builder.sh;
+  };
+
+  shellHook = ''
+    function generate {
+      ./generate-libreoffice-srcs.sh | tee libreoffice-srcs.nix
+    }
+  '';
+}

--- a/pkgs/applications/office/libreoffice/default-primary-src.nix
+++ b/pkgs/applications/office/libreoffice/default-primary-src.nix
@@ -1,0 +1,17 @@
+{ fetchurl }:
+
+rec {
+  major = "5";
+  minor = "2";
+  patch = "1";
+  tweak = "2";
+
+  subdir = "${major}.${minor}.${patch}";
+
+  version = "${subdir}${if tweak == "" then "" else "."}${tweak}";
+
+  src = fetchurl {
+    url = "http://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
+    sha256 = "14g2xwpid4vsgmc69rs7hz1wx96dfkq0cbm32vjgljsm7a19qfc1";
+  };
+}

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -19,14 +19,14 @@
 }:
 
 let
+  primary-src = import ./default-primary-src.nix { inherit fetchurl; };
+in
+
+with { inherit (primary-src) major minor subdir version; };
+
+let
   lib = stdenv.lib;
   langsSpaces = lib.concatStringsSep " " langs;
-  major = "5";
-  minor = "2";
-  patch = "1";
-  tweak = "2";
-  subdir = "${major}.${minor}.${patch}";
-  version = "${subdir}${if tweak == "" then "" else "."}${tweak}";
 
   fetchThirdParty = {name, md5, brief, subDir ? ""}: fetchurl {
     inherit name md5;
@@ -64,10 +64,7 @@ let
 in stdenv.mkDerivation rec {
   name = "libreoffice-${version}";
 
-  src = fetchurl {
-    url = "http://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "14g2xwpid4vsgmc69rs7hz1wx96dfkq0cbm32vjgljsm7a19qfc1";
-  };
+  inherit (primary-src) src;
 
   # Openoffice will open libcups dynamically, so we link it directly
   # to make its dlopen work.

--- a/pkgs/applications/office/libreoffice/download-list-builder.sh
+++ b/pkgs/applications/office/libreoffice/download-list-builder.sh
@@ -1,0 +1,3 @@
+source $stdenv/setup
+
+tar --extract --file=$src libreoffice-$version/download.lst -O > $out

--- a/pkgs/applications/office/libreoffice/generate-libreoffice-srcs.sh
+++ b/pkgs/applications/office/libreoffice/generate-libreoffice-srcs.sh
@@ -2,10 +2,6 @@
 
 # Ideally we would move as much as possible into derivation dependencies
 
-# Take the list of files from the main package, ooo.lst.in
-
-# This script wants an argument: download list file
-
 cat <<EOF
 [
 EOF
@@ -22,7 +18,7 @@ write_entry(){
 }
 
 saved_line=
-cat "$(dirname "$0")/libreoffice-srcs-additions.sh" "$@" |
+cat "$(dirname "$0")/libreoffice-srcs-additions.sh" "$downloadList" |
 while read line; do
   case "$line" in
     EVAL\ *)

--- a/pkgs/applications/office/libreoffice/still-gen-shell.nix
+++ b/pkgs/applications/office/libreoffice/still-gen-shell.nix
@@ -1,0 +1,27 @@
+{ pkgs ? (import <nixpkgs> {}) }:
+
+with pkgs;
+
+let
+
+  primary-src = callPackage ./still-primary-src.nix {};
+
+in
+
+stdenv.mkDerivation {
+  name = "generate-libreoffice-srcs-shell";
+
+  buildCommand = "exit 1";
+
+  downloadList = stdenv.mkDerivation {
+    name = "libreoffice-${primary-src.version}-download-list";
+    inherit (primary-src) src version;
+    builder = ./download-list-builder.sh;
+  };
+
+  shellHook = ''
+    function generate {
+      ./generate-libreoffice-srcs.sh | tee libreoffice-srcs-still.nix
+    }
+  '';
+}

--- a/pkgs/applications/office/libreoffice/still-primary-src.nix
+++ b/pkgs/applications/office/libreoffice/still-primary-src.nix
@@ -1,0 +1,17 @@
+{ fetchurl }:
+
+rec {
+  major = "5";
+  minor = "1";
+  patch = "5";
+  tweak = "2";
+
+  subdir = "${major}.${minor}.${patch}";
+
+  version = "${subdir}${if tweak == "" then "" else "."}${tweak}";
+
+  src = fetchurl {
+    url = "http://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
+    sha256 = "1qg0dj0zwh5ifhmvv4k771nmyqddz4ifn75s9mr1p0nyix8zks8x";
+  };
+}

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -19,14 +19,14 @@
 }:
 
 let
+  primary-src = import ./still-primary-src.nix { inherit fetchurl; };
+in
+
+with { inherit (primary-src) major minor subdir version; };
+
+let
   lib = stdenv.lib;
   langsSpaces = lib.concatStringsSep " " langs;
-  major = "5";
-  minor = "1";
-  patch = "5";
-  tweak = "2";
-  subdir = "${major}.${minor}.${patch}";
-  version = "${subdir}${if tweak == "" then "" else "."}${tweak}";
 
   fetchThirdParty = {name, md5, brief, subDir ? ""}: fetchurl {
     inherit name md5;
@@ -64,10 +64,7 @@ let
 in stdenv.mkDerivation rec {
   name = "libreoffice-${version}";
 
-  src = fetchurl {
-    url = "http://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "1qg0dj0zwh5ifhmvv4k771nmyqddz4ifn75s9mr1p0nyix8zks8x";
-  };
+  inherit (primary-src) src;
 
   # we only have this problem on i686 ATM
   patches = if stdenv.is64bit then null else [


### PR DESCRIPTION
###### Motivation for this change
#18649 - The srcs generation for libreoffice is a bit more manual than ideal.

Here I've made shell environments for the `default` and `still` libreoffice source generators, which each has a derivation for its `download.lst` file. There is now a readme file that shows how to run the scripts.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
