### PR TITLE
vis: 2016-07-15 -> 2016-08-24

### DIFF
--- a/pkgs/applications/editors/vis/default.nix
+++ b/pkgs/applications/editors/vis/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchFromGitHub, unzip, pkgconfig, makeWrapper
+{ stdenv, fetchFromGitHub, pkgconfig, makeWrapper, makeDesktopItem
 , ncurses, libtermkey, lpeg, lua
 , acl ? null, libselinux ? null
-, version ? "2016-07-15"
-, rev ? "5c2cee9461ef1199f2e80ddcda699595b11fdf08"
-, sha256 ? "1jmsv72hq0c2f2rnpllvd70cmxbjwfhynzwaxx24f882zlggwsnd"
+, version ? "2016-08-24"
+, rev ? "010dcd60ffda37027908f2a0b20c751b83ca975e"
+, sha256 ? "0bpbyi5yq50zw0hkh326pmdcnm91paf1yz4853dcq63y0ddv89jp"
 }:
 
 stdenv.mkDerivation rec {
-  name = "vis-nightly-${version}";
+  name = "vis-unstable-${version}";
   inherit version;
 
   src = fetchFromGitHub {
@@ -17,10 +17,9 @@ stdenv.mkDerivation rec {
     owner = "martanne";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
 
   buildInputs = [
-    unzip pkgconfig
     ncurses
     libtermkey
     lua
@@ -34,18 +33,38 @@ stdenv.mkDerivation rec {
   LUA_PATH="${lpeg}/share/lua/${lua.luaversion}/?.lua";
 
   postInstall = ''
+    mkdir -p "$out/share/applications"
+    cp $desktopItem/share/applications/* $out/share/applications
     echo wrapping $out/bin/vis with runtime environment
     wrapProgram $out/bin/vis \
       --prefix LUA_CPATH : "${lpeg}/lib/lua/${lua.luaversion}/?.so" \
       --prefix LUA_PATH : "${lpeg}/share/lua/${lua.luaversion}/?.lua" \
-      --prefix VIS_PATH : "$out/share/vis"
+      --prefix VIS_PATH : "\$HOME/.config:$out/share/vis"
   '';
+
+  desktopItem = makeDesktopItem rec {
+    name = "vis";
+    exec = "vis %U";
+    type = "Application";
+    icon = "accessories-text-editor";
+    comment = meta.description;
+    desktopName = "vis";
+    genericName = "Text editor";
+    categories = stdenv.lib.concatStringsSep ";" [
+      "Application" "Development" "IDE"
+    ];
+    mimeType = stdenv.lib.concatStringsSep ";" [
+      "text/plain" "application/octet-stream"
+    ];
+    startupNotify = "false";
+    terminal = "true";
+  };
 
   meta = with stdenv.lib; {
     description = "A vim like editor";
     homepage = http://github.com/martanne/vis;
     license = licenses.isc;
-    maintainers = [ maintainers.vrthra ];
+    maintainers = with maintainers; [ vrthra ramkromberg ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
1. update.
2. removed superfluous dependency on unzip.
3. moved pkgconfig to nativeBuildInputs.
4. renamed vis-nightly -> vis-unstable following new naming guidelines.
5. fixed VIS_PATH with _$HOME/.config_ to allow personal configurations and highlighters following upstream's usage of the variable.
6. added a desktop shortcut.
7. added myself to maintainers.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
