### PR TITLE
bash: set PS1 for xterm-256color as well

### DIFF
--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -95,7 +95,7 @@ in
             PROMPT_COLOR="1;31m"
             let $UID && PROMPT_COLOR="1;32m"
             PS1="\n\[\033[$PROMPT_COLOR\][\u@\h:\w]\\$\[\033[0m\] "
-            if test "$TERM" = "xterm"; then
+            if test "$TERM" = "xterm" -o "$TERM" = "xterm-256color" -o "$TERM" = "xterm-color"; then
               PS1="\[\033]2;\h:\u:\w\007\]$PS1"
             fi
           fi


### PR DESCRIPTION
###### Motivation for this change

When running a terminal with TERM=xterm-256color, the PS1 wasn't set by default. Users could, and still can, override this. But this is a better default for everyone.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
