### PR TITLE
Mount a separate filesystem for /run/setuid-wrapper-dirs

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -3,6 +3,8 @@ let
 
   inherit (config.security) wrapperDir wrappers;
 
+  parentWrapperDir = dirOf wrapperDir;
+
   programs =
     (lib.mapAttrsToList
       (n: v: (if v ? "program" then v else v // {program=n;}))
@@ -15,8 +17,7 @@ let
     hardeningEnable = [ "pie" ];
     installPhase = ''
       mkdir -p $out/bin
-      parentWrapperDir=$(dirname ${wrapperDir})
-      gcc -Wall -O2 -DWRAPPER_DIR=\"$parentWrapperDir\" \
+      gcc -Wall -O2 -DWRAPPER_DIR=\"${parentWrapperDir}\" \
           -lcap-ng -lcap ${./wrapper.c} -o $out/bin/security-wrapper
     '';
   };
@@ -155,6 +156,11 @@ in
 
     security.wrappers.fusermount.source = "${pkgs.fuse}/bin/fusermount";
 
+    boot.specialFileSystems.${parentWrapperDir} = {
+      fsType = "tmpfs";
+      options = [ "nodev" ];
+    };
+
     # Make sure our wrapperDir exports to the PATH env variable when
     # initializing the shell
     environment.extraInit = ''
@@ -182,19 +188,15 @@ in
           # Remove the old /run/setuid-wrappers-dir path from the
           # system as well...
           #
-          # TDOO: this is only necessary for ugprades 16.09 => 17.x;
+          # TODO: this is only necessary for ugprades 16.09 => 17.x;
           # this conditional removal block needs to be removed after
           # the release.
           if [ -d /run/setuid-wrapper-dirs ]; then
             rm -rf /run/setuid-wrapper-dirs
           fi
 
-          # Get the "/run/wrappers" path, we want to place the tmpdirs
-          # for the wrappers there
-          parentWrapperDir="$(dirname ${wrapperDir})"
-
-          mkdir -p "$parentWrapperDir"
-          wrapperDir=$(mktemp --directory --tmpdir="$parentWrapperDir" wrappers.XXXXXXXXXX)
+          # We want to place the tmpdirs for the wrappers to the parent dir.
+          wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
           chmod a+rx $wrapperDir
 
           ${lib.concatStringsSep "\n" mkWrappedPrograms}
@@ -206,13 +208,6 @@ in
             ln --symbolic --force --no-dereference $wrapperDir ${wrapperDir}-tmp
             mv --no-target-directory ${wrapperDir}-tmp ${wrapperDir}
             rm --force --recursive $old
-          elif [ -d ${wrapperDir} ]; then
-            # Compatibility with old state, just remove the folder and symlink
-            rm -f ${wrapperDir}/*
-            # if it happens to be a tmpfs
-            ${pkgs.utillinux}/bin/umount ${wrapperDir} || true
-            rm -d ${wrapperDir}
-            ln -d --symbolic $wrapperDir ${wrapperDir}
           else
             # For initial setup
             ln --symbolic $wrapperDir ${wrapperDir}

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -291,7 +291,7 @@ in
     # Sync mount options with systemd's src/core/mount-setup.c: mount_table.
     boot.specialFileSystems = {
       "/proc" = { fsType = "proc"; options = [ "nosuid" "noexec" "nodev" ]; };
-      "/run" = { fsType = "tmpfs"; options = [ "nodev" "strictatime" "mode=755" "size=${config.boot.runSize}" ]; };
+      "/run" = { fsType = "tmpfs"; options = [ "nosuid" "nodev" "strictatime" "mode=755" "size=${config.boot.runSize}" ]; };
       "/dev" = { fsType = "devtmpfs"; options = [ "nosuid" "strictatime" "mode=755" "size=${config.boot.devSize}" ]; };
       "/dev/shm" = { fsType = "tmpfs"; options = [ "nosuid" "nodev" "strictatime" "mode=1777" "size=${config.boot.devShmSize}" ]; };
       "/dev/pts" = { fsType = "devpts"; options = [ "nosuid" "noexec" "mode=620" "gid=${toString config.ids.gids.tty}" ]; };


### PR DESCRIPTION
###### Motivation for this change

This makes `/run/setuid-wrapper-dirs` a separate tmpfs with `nosuid` bit unset; this makes it possible to return `nosuid` to `/run`. To ensure smooth transition, this adds more logic to activation script to check if a special filesystem already exists, and mount it rather than remount if it's not.

Tested by checking that after switch from old configuration (with `/run/setuid-wrapper-dirs` already existing, which is a more difficult case to handle) `sudo` works, and that after a clean reboot it works too.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
