### PR TITLE
 luasocket: fix non-5.1 builds

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -189,14 +189,18 @@ let
       sha256 = "0j8jx8bjicvp9khs26xjya8c495wrpb7parxfnabdqa5nnsxjrwb";
     };
 
-    patchPhase = ''
-      sed -e "s,^LUAPREFIX_linux.*,LUAPREFIX_linux=$out," \
-          -i src/makefile
-    '' + stdenv.lib.optionalString stdenv.isDarwin ''
-      export PLAT=macosx
-      export LUAPREFIX_macosx=$out
-      substituteInPlace src/Makefile --replace gcc cc \
+    patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+      substituteInPlace src/makefile --replace gcc cc \
         --replace 10.3 10.5
+    '';
+
+    preBuild = ''
+      makeFlagsArray=(
+        LUAV=${lua.luaversion}
+        PLAT=${if stdenv.isDarwin then "macosx" else "linux"}
+        LUAPREFIX_linux=$out
+        LUAPREFIX_macosx=$out
+      );
     '';
 
     meta = {

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -197,15 +197,18 @@ let
     preBuild = ''
       makeFlagsArray=(
         LUAV=${lua.luaversion}
-        PLAT=${if stdenv.isDarwin then "macosx" else "linux"}
-        LUAPREFIX_linux=$out
-        LUAPREFIX_macosx=$out
+        PLAT=${if stdenv.isDarwin then "macosx"
+               else if stdenv.isFreeBSD then "freebsd"
+               else if stdenv.isLinux then "linux"
+               else if stdenv.isSunOS then "solaris"
+               else throw "unsupported platform"}
+        prefix=$out
       );
     '';
 
     meta = {
       homepage = "http://w3.impa.br/~diego/software/luasocket/";
-      hydraPlatforms = stdenv.lib.platforms.linux;
+      hydraPlatforms = with platforms; [darwin linux freebsd illumos];
       maintainers = with maintainers; [ mornfall ];
     };
   };


### PR DESCRIPTION
###### Motivation for this change

 LUAV has to be set accordingly for make,
 otherwise it will install files default to the 5.1 path.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
