### PR TITLE
awesome: fix LUA_PATH for luaModules

### DIFF
--- a/nixos/modules/services/x11/window-managers/awesome.nix
+++ b/nixos/modules/services/x11/window-managers/awesome.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.services.xserver.windowManager.awesome;
   awesome = cfg.package;
-
+  inherit (pkgs.luaPackages) getLuaPath getLuaCPath;
 in
 
 {
@@ -46,10 +46,8 @@ in
       { name = "awesome";
         start =
           ''
-            ${concatMapStrings (pkg: ''
-              export LUA_CPATH=$LUA_CPATH''${LUA_CPATH:+;}${pkg}/lib/lua/${awesome.lua.luaversion}/?.so
-              export LUA_PATH=$LUA_PATH''${LUA_PATH:+;}${pkg}/lib/lua/${awesome.lua.luaversion}/?.lua
-            '') cfg.luaModules}
+            export LUA_CPATH="${lib.concatStringsSep ";" (map getLuaCPath cfg.luaModules)}"
+            export LUA_PATH="${lib.concatStringsSep ";" (map getLuaPath cfg.luaModules)}"
 
             ${awesome}/bin/awesome &
             waitPID=$!
@@ -59,5 +57,4 @@ in
     environment.systemPackages = [ awesome ];
 
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

lua modules can be also within share/ within a package.
Previously only lib/ was included
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
