### PR TITLE
gitlab-runner: add package and service

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -48,6 +48,7 @@
   auntie = "Jonathan Glines <auntieNeo@gmail.com>";
   avnik = "Alexander V. Nikolaev <avn@avnik.info>";
   aycanirican = "Aycan iRiCAN <iricanaycan@gmail.com>";
+  bachp = "Pascal Bach <pascal.bach@nextrem.ch>";
   badi = "Badi' Abdul-Wahid <abdulwahidc@gmail.com>";
   balajisivaraman = "Balaji Sivaraman<sivaraman.balaji@gmail.com>";
   Baughn = "Svein Ove Aas <sveina@gmail.com>";

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -275,6 +275,7 @@
       mattermost = 254;
       prometheus = 255;
       telegraf = 256;
+      gitlab-runner = 257;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -520,6 +521,7 @@
       mattermost = 254;
       prometheus = 255;
       #telegraf = 256; # unused
+      gitlab-runner = 257;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -133,6 +133,7 @@
   ./services/computing/slurm/slurm.nix
   ./services/continuous-integration/buildkite-agent.nix
   ./services/continuous-integration/hydra/default.nix
+  ./services/continuous-integration/gitlab-runner.nix
   ./services/continuous-integration/gocd-agent/default.nix
   ./services/continuous-integration/gocd-server/default.nix
   ./services/continuous-integration/jenkins/default.nix

--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.gitlab-runner;
+  configFile = pkgs.writeText "config.toml" cfg.configText;
+in
+{
+  options.services.gitlab-runner = {
+    enable = mkEnableOption "Gitlab Runner";
+
+    configText = mkOption {
+      description = "Verbatim config.toml to use";
+    };
+
+    workDir = mkOption {
+      default = "/var/lib/gitlab-runner";
+      type = types.path;
+      description = "The working directory used";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.gitlab-runner = {
+      description = "Gitlab Runner";
+      after = [ "network.target" "docker.service" ];
+      requires = [ "docker.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = ''${pkgs.gitlab-runner.bin}/bin/gitlab-runner run \
+          --working-directory ${cfg.workDir} \
+          --config ${configFile} \
+          --service gitlab-runner \
+          --user gitlab-runner \
+        '';
+      };
+    };
+
+    users.extraUsers.gitlab-runner = {
+      group = "gitlab-runner";
+      extraGroups = [ "docker" ];
+      uid = config.ids.uids.gitlab-runner;
+      home = cfg.workDir;
+      createHome = true;
+    };
+
+    users.extraGroups.gitlab-runner.gid = config.ids.gids.gitlab-runner;
+  };
+}

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,0 +1,66 @@
+{ lib, buildGoPackage, fetchFromGitLab, fetchurl, go-bindata }:
+
+let
+  version = "1.6.0";
+  # Gitlab runner embeds some docker images these are prebuilt for arm and x86_64
+  docker_x86_64 = fetchurl {
+    url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-x86_64.tar.xz";
+    sha256 = "1ygc2ipprd5pr8b7y511id1af91zw15f8j28v3rx4vjapmbzpk8d";
+  };
+
+  docker_arm = fetchurl {
+    url = "https://gitlab-ci-multi-runner-downloads.s3.amazonaws.com/v${version}/docker/prebuilt-arm.tar.xz";
+    sha256 = "0aw6cfh92f7fywzry0yswa635hpmzh6fqcav0ljc5vqs26wdmjc1";
+  };
+in
+buildGoPackage rec {
+  inherit version;
+  name = "gitlab-runner-${version}";
+  goPackagePath = "gitlab.com/gitlab-org/gitlab-ci-multi-runner";
+  commonPackagePath = "${goPackagePath}/common";
+  buildFlagsArray = ''
+    -ldflags=
+      -X ${commonPackagePath}.NAME=gitlab-runner
+      -X ${commonPackagePath}.VERSION=${version}
+      -X ${commonPackagePath}.REVISION=v${version}
+  '';
+
+  src = fetchFromGitLab {
+    owner = "gitlab-org";
+    repo = "gitlab-ci-multi-runner";
+    rev = "v${version}";
+    sha256 = "10w222k4klxqyzk08c0j7nmhdbdnn70p6n1hfqy6h5mczlffqv61";
+  };
+
+  buildInputs = [ go-bindata ];
+
+  preBuild = ''
+    (
+    # go-bindata names the assets after the filename thus we create a symlink with the name we want
+    cd go/src/${goPackagePath}
+    ln -sf ${docker_x86_64} prebuilt-x86_64.tar.xz
+    ln -sf ${docker_arm} prebuilt-arm.tar.xz
+    go-bindata \
+        -pkg docker \
+        -nocompress \
+        -nomemcopy \
+        -o executors/docker/bindata.go \
+        prebuilt-x86_64.tar.xz \
+        prebuilt-arm.tar.xz
+    )
+  '';
+
+  postInstall = ''
+    install -d $out/bin
+    # The recommended name is gitlab-runner so we create a symlink with that name
+    ln -sf gitlab-ci-multi-runner $bin/bin/gitlab-runner
+  '';
+
+  meta = with lib; {
+    description = "GitLab Runner the continous integration executor of GitLab";
+    license = licenses.mit;
+    homepage = "https://about.gitlab.com/gitlab-ci/";
+    platforms = platforms.unix;
+    maintainers = [ lib.maintainers.bachp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1783,6 +1783,8 @@ in
     ruby = ruby_2_2;
   };
 
+  gitlab-runner = callPackage ../development/tools/continuous-integration/gitlab-runner { };
+
   gitlab-shell = callPackage ../applications/version-management/gitlab-shell {
     ruby = ruby_2_2;
   };


### PR DESCRIPTION
###### Motivation for this change

Gitlab runner allows execution of [Gitlab CI](https://about.gitlab.com/gitlab-ci/) on a NixOS Machine.
Maintaining runner using a declarative approach is very advantageous. So running a gitlab-runner with docker on a NixOS machine allows to maintain a large number of runners
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
