### PR TITLE
xfce4-sensors-plugin: init at 1.2.6

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -88,6 +88,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   xfce4-hardware-monitor-plugin = callPackage ./panel-plugins/xfce4-hardware-monitor-plugin.nix { };
   xfce4_netload_plugin          = callPackage ./panel-plugins/xfce4-netload-plugin.nix          { };
   xfce4_notes_plugin            = callPackage ./panel-plugins/xfce4-notes-plugin.nix            { };
+  xfce4-sensors-plugin          = callPackage ./panel-plugins/xfce4-sensors-plugin.nix          { };
   xfce4_systemload_plugin       = callPackage ./panel-plugins/xfce4-systemload-plugin.nix       { };
   xfce4_verve_plugin            = callPackage ./panel-plugins/xfce4-verve-plugin.nix            { };
   xfce4_xkb_plugin              = callPackage ./panel-plugins/xfce4-xkb-plugin.nix              { };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, pkgconfig, intltool, gnome2, libxfce4ui,
+  libxfce4util, xfce4panel, libnotify, lm_sensors, hddtemp, netcat
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${ver_maj}.${ver_min}";
+  pname  = "xfce4-sensors-plugin";
+  ver_maj = "1.2";
+  ver_min = "6";
+
+  src = fetchurl {
+    url = "mirror://xfce/src/panel-plugins/${pname}/${ver_maj}/${name}.tar.bz2";
+    sha256 = "1h0vpqxcziml3gwrbvd8xvy1mwh9mf2a68dvxsy03rs5pm1ghpi3";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+  ];
+
+  buildInputs = [
+    gnome2.gtk
+    libxfce4ui
+    libxfce4util
+    xfce4panel
+    libnotify
+    lm_sensors
+    hddtemp
+    netcat
+   ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--with-pathhddtemp=${hddtemp}/bin/hddtemp"
+    "--with-pathnetcat=${netcat}/bin/netcat"
+  ];
+
+  meta = {
+    homepage = "http://goodies.xfce.org/projects/panel-plugins/${pname}";
+    description = "A panel plug-in for different sensors using acpi, lm_sensors and hddtemp";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
