### PR TITLE
pkgs.autoconf-archive: 2016.03.20 -> 2016.09.16

### DIFF
--- a/pkgs/development/tools/misc/autoconf-archive/default.nix
+++ b/pkgs/development/tools/misc/autoconf-archive/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "autoconf-archive-${version}";
-  version = "2016.03.20";
+  version = "2016.09.16";
 
   src = fetchurl {
     url = "mirror://gnu/autoconf-archive/autoconf-archive-${version}.tar.xz";
-    sha256 = "0dz4fnc723jqn3by22ds5fys7g31apzm1r9allldvva0yvzjxyw8";
+    sha256 = "10mxz9hfnfz66m1l9s28sbyfb9a04akz92wkyv9blhpq6p9fzwp8";
   };
 
   buildInputs = [ xz ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
