### PR TITLE
Revert "nixos/pam: clean up generated files (no functional change) (#…

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -229,107 +229,104 @@ let
       # module provides the right hooks.
       text = mkDefault
         (''
-           # Account management.
-           account sufficient pam_unix.so
-         '' + optionalString use_ldap ''
-           account sufficient ${pam_ldap}/lib/security/pam_ldap.so
-         '' + optionalString config.krb5.enable ''
-           account sufficient ${pam_krb5}/lib/security/pam_krb5.so
-         '' + ''
+          # Account management.
+          account sufficient pam_unix.so
+          ${optionalString use_ldap
+              "account sufficient ${pam_ldap}/lib/security/pam_ldap.so"}
+          ${optionalString config.krb5.enable
+              "account sufficient ${pam_krb5}/lib/security/pam_krb5.so"}
 
-           # Authentication management.
-         '' + optionalString cfg.rootOK ''
-           auth sufficient pam_rootok.so
-         '' + optionalString cfg.requireWheel ''
-           auth required pam_wheel.so use_uid
-         '' + optionalString cfg.logFailures ''
-           auth required pam_tally.so
-         '' + optionalString (config.security.pam.enableSSHAgentAuth && cfg.sshAgentAuth) ''
-           auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=~/.ssh/authorized_keys:~/.ssh/authorized_keys2:/etc/ssh/authorized_keys.d/%u
-         '' + optionalString cfg.fprintAuth ''
-           auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so
-         '' + optionalString cfg.u2fAuth ''
-           auth sufficient ${pkgs.pam_u2f}/lib/security/pam_u2f.so
-         '' + optionalString cfg.usbAuth ''
-           auth sufficient ${pkgs.pam_usb}/lib/security/pam_usb.so
-         ''
+          # Authentication management.
+          ${optionalString cfg.rootOK
+              "auth sufficient pam_rootok.so"}
+          ${optionalString cfg.requireWheel
+              "auth required pam_wheel.so use_uid"}
+          ${optionalString cfg.logFailures
+              "auth required pam_tally.so"}
+          ${optionalString (config.security.pam.enableSSHAgentAuth && cfg.sshAgentAuth)
+              "auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=~/.ssh/authorized_keys:~/.ssh/authorized_keys2:/etc/ssh/authorized_keys.d/%u"}
+          ${optionalString cfg.fprintAuth
+              "auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so"}
+          ${optionalString cfg.u2fAuth
+              "auth sufficient ${pkgs.pam_u2f}/lib/security/pam_u2f.so"}
+          ${optionalString cfg.usbAuth
+              "auth sufficient ${pkgs.pam_usb}/lib/security/pam_usb.so"}
+        '' +
+          # Modules in this block require having the password set in PAM_AUTHTOK.
+          # pam_unix is marked as 'sufficient' on NixOS which means nothing will run
+          # after it succeeds. Certain modules need to run after pam_unix
+          # prompts the user for password so we run it once with 'required' at an
+          # earlier point and it will run again with 'sufficient' further down.
+          # We use try_first_pass the second time to avoid prompting password twice
+          (optionalString (cfg.unixAuth && (config.security.pam.enableEcryptfs || cfg.pamMount)) ''
+              auth required pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} likeauth
+              ${optionalString config.security.pam.enableEcryptfs
+                "auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap"}
+              ${optionalString cfg.pamMount
+                "auth optional ${pkgs.pam_mount}/lib/security/pam_mount.so"}
+            '') + ''
+          ${optionalString cfg.unixAuth
+              "auth sufficient pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} likeauth try_first_pass"}
+          ${optionalString cfg.otpwAuth
+              "auth sufficient ${pkgs.otpw}/lib/security/pam_otpw.so"}
+          ${let oath = config.security.pam.oath; in optionalString cfg.oathAuth
+              "auth sufficient ${pkgs.oathToolkit}/lib/security/pam_oath.so window=${toString oath.window} usersfile=${toString oath.usersFile} digits=${toString oath.digits}"}
+          ${optionalString use_ldap
+              "auth sufficient ${pam_ldap}/lib/security/pam_ldap.so use_first_pass"}
+          ${optionalString config.krb5.enable ''
+            auth [default=ignore success=1 service_err=reset] ${pam_krb5}/lib/security/pam_krb5.so use_first_pass
+            auth [default=die success=done] ${pam_ccreds}/lib/security/pam_ccreds.so action=validate use_first_pass
+            auth sufficient ${pam_ccreds}/lib/security/pam_ccreds.so action=store use_first_pass
+          ''}
+          auth required pam_deny.so
 
-           # Modules in this block require having the password set in PAM_AUTHTOK.
-           # pam_unix is marked as 'sufficient' on NixOS which means nothing will run
-           # after it succeeds. Certain modules need to run after pam_unix
-           # prompts the user for password so we run it once with 'required' at an
-           # earlier point and it will run again with 'sufficient' further down.
-           # We use try_first_pass the second time to avoid prompting password twice
-         + optionalString (cfg.unixAuth && (config.security.pam.enableEcryptfs || cfg.pamMount)) (''
-           auth required pam_unix.so ${optionalString cfg.allowNullPassword "nullok "}likeauth
-           '' + optionalString config.security.pam.enableEcryptfs ''
-             auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap
-           '' + optionalString cfg.pamMount ''
-             auth optional ${pkgs.pam_mount}/lib/security/pam_mount.so
-           '')
-         + optionalString cfg.unixAuth ''
-           auth sufficient pam_unix.so ${optionalString cfg.allowNullPassword "nullok "}likeauth try_first_pass
-         '' + optionalString cfg.otpwAuth ''
-           auth sufficient ${pkgs.otpw}/lib/security/pam_otpw.so
-         '' + (let oath = config.security.pam.oath; in optionalString cfg.oathAuth ''
-           auth sufficient ${pkgs.oathToolkit}/lib/security/pam_oath.so window=${toString oath.window} usersfile=${toString oath.usersFile} digits=${toString oath.digits}
-         '') + optionalString use_ldap ''
-           auth sufficient ${pam_ldap}/lib/security/pam_ldap.so use_first_pass
-         '' + optionalString config.krb5.enable ''
-           auth [default=ignore success=1 service_err=reset] ${pam_krb5}/lib/security/pam_krb5.so use_first_pass
-           auth [default=die success=done] ${pam_ccreds}/lib/security/pam_ccreds.so action=validate use_first_pass
-           auth sufficient ${pam_ccreds}/lib/security/pam_ccreds.so action=store use_first_pass
-         '' + ''
-           auth required pam_deny.so
+          # Password management.
+          password requisite pam_unix.so nullok sha512
+          ${optionalString config.security.pam.enableEcryptfs
+              "password optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so"}
+          ${optionalString cfg.pamMount
+              "password optional ${pkgs.pam_mount}/lib/security/pam_mount.so"}
+          ${optionalString use_ldap
+              "password sufficient ${pam_ldap}/lib/security/pam_ldap.so"}
+          ${optionalString config.krb5.enable
+              "password sufficient ${pam_krb5}/lib/security/pam_krb5.so use_first_pass"}
+          ${optionalString config.services.samba.syncPasswordsByPam
+              "password optional ${pkgs.samba}/lib/security/pam_smbpass.so nullok use_authtok try_first_pass"}
 
-           # Password management.
-           password requisite pam_unix.so nullok sha512
-         '' + optionalString config.security.pam.enableEcryptfs ''
-           password optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so
-         '' + optionalString cfg.pamMount ''
-           password optional ${pkgs.pam_mount}/lib/security/pam_mount.so
-         '' + optionalString use_ldap ''
-           password sufficient ${pam_ldap}/lib/security/pam_ldap.so
-         '' + optionalString config.krb5.enable ''
-           password sufficient ${pam_krb5}/lib/security/pam_krb5.so use_first_pass
-         '' + optionalString config.services.samba.syncPasswordsByPam ''
-           password optional ${pkgs.samba}/lib/security/pam_smbpass.so nullok use_authtok try_first_pass
-         '' + ''
-
-           # Session management.
-         '' + optionalString cfg.setEnvironment ''
-           session required pam_env.so envfile=${config.system.build.pamEnvironment}
-         '' + ''
-           session required pam_unix.so
-         '' + optionalString cfg.setLoginUid ''
-            session ${
-              if config.boot.isContainer then "optional" else "required"
-            } pam_loginuid.so
-         '' + optionalString cfg.makeHomeDir ''
-           session required ${pkgs.pam}/lib/security/pam_mkhomedir.so silent skel=/etc/skel umask=0022
-         '' + optionalString cfg.updateWtmp ''
-           session required ${pkgs.pam}/lib/security/pam_lastlog.so silent
-         '' + optionalString config.security.pam.enableEcryptfs ''
-           session optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so
-         '' + optionalString use_ldap ''
-           session optional ${pam_ldap}/lib/security/pam_ldap.so
-         '' + optionalString config.krb5.enable ''
-           session optional ${pam_krb5}/lib/security/pam_krb5.so
-         '' + optionalString cfg.otpwAuth ''
-           session optional ${pkgs.otpw}/lib/security/pam_otpw.so
-         '' + optionalString cfg.startSession ''
-           session optional ${pkgs.systemd}/lib/security/pam_systemd.so
-         '' + optionalString cfg.forwardXAuth ''
-           session optional pam_xauth.so xauthpath=${pkgs.xorg.xauth}/bin/xauth systemuser=99
-         '' + optionalString (cfg.limits != []) ''
-           session required ${pkgs.pam}/lib/security/pam_limits.so conf=${makeLimitsConf cfg.limits}
-         '' + optionalString (cfg.showMotd && config.users.motd != null) ''
-           session optional ${pkgs.pam}/lib/security/pam_motd.so motd=${motd}
-         '' + optionalString cfg.pamMount ''
-           session optional ${pkgs.pam_mount}/lib/security/pam_mount.so
-         '' + optionalString (cfg.enableAppArmor && config.security.apparmor.enable) ''
-           session optional ${pkgs.apparmor-pam}/lib/security/pam_apparmor.so order=user,group,default debug
-         '');
+          # Session management.
+          ${optionalString cfg.setEnvironment ''
+            session required pam_env.so envfile=${config.system.build.pamEnvironment}
+          ''}
+          session required pam_unix.so
+          ${optionalString cfg.setLoginUid
+              "session ${
+                if config.boot.isContainer then "optional" else "required"
+              } pam_loginuid.so"}
+          ${optionalString cfg.makeHomeDir
+              "session required ${pkgs.pam}/lib/security/pam_mkhomedir.so silent skel=/etc/skel umask=0022"}
+          ${optionalString cfg.updateWtmp
+              "session required ${pkgs.pam}/lib/security/pam_lastlog.so silent"}
+          ${optionalString config.security.pam.enableEcryptfs
+              "session optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so"}
+          ${optionalString use_ldap
+              "session optional ${pam_ldap}/lib/security/pam_ldap.so"}
+          ${optionalString config.krb5.enable
+              "session optional ${pam_krb5}/lib/security/pam_krb5.so"}
+          ${optionalString cfg.otpwAuth
+              "session optional ${pkgs.otpw}/lib/security/pam_otpw.so"}
+          ${optionalString cfg.startSession
+              "session optional ${pkgs.systemd}/lib/security/pam_systemd.so"}
+          ${optionalString cfg.forwardXAuth
+              "session optional pam_xauth.so xauthpath=${pkgs.xorg.xauth}/bin/xauth systemuser=99"}
+          ${optionalString (cfg.limits != [])
+              "session required ${pkgs.pam}/lib/security/pam_limits.so conf=${makeLimitsConf cfg.limits}"}
+          ${optionalString (cfg.showMotd && config.users.motd != null)
+              "session optional ${pkgs.pam}/lib/security/pam_motd.so motd=${motd}"}
+          ${optionalString cfg.pamMount
+              "session optional ${pkgs.pam_mount}/lib/security/pam_mount.so"}
+          ${optionalString (cfg.enableAppArmor && config.security.apparmor.enable)
+              "session optional ${pkgs.apparmor-pam}/lib/security/pam_apparmor.so order=user,group,default debug"}
+        '');
     };
 
   };


### PR DESCRIPTION
@bjornfor There are multiple test regressions caused by 1010271c63f503113c0e8337977610ea783880ec, so I am reverting it. You may resubmit it if you fix all the failing tests. @aszlig fixed one in e85e51d41f0f3be40490b0de9a76f20f3685659c; that may give you a template to fix the others.
