### PR TITLE
longview: unstable-2015-09-10 -> 1.1.5

### DIFF
--- a/pkgs/servers/monitoring/longview/default.nix
+++ b/pkgs/servers/monitoring/longview/default.nix
@@ -1,14 +1,14 @@
 {stdenv, fetchFromGitHub, perl, perlPackages, makeWrapper, glibc }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.5pre";
+  version = "1.1.5";
   name = "longview-${version}";
 
   src = fetchFromGitHub {
     owner = "linode";
     repo = "longview";
-    rev = "5bcc9b60896b72de2d14f046f911477c26eb70ba";
-    sha256 = "1i6va44bx2zfgbld7znf1slph0iqidlahq2xh3kd8q4lhvbrjn02";
+    rev = "v${version}";
+    sha256 = "1i9lli8iw8sb1bd633i82fzhx5gz85ma9d1hra41pkv2p3h823pa";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Linode Longview monitoring script got a new version.
https://github.com/linode/longview/releases/tag/v1.1.5
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
