### PR TITLE
init: docbook2mdoc, texi2mdoc &  pod2mdoc

### DIFF
--- a/pkgs/tools/misc/docbook2mdoc/default.nix
+++ b/pkgs/tools/misc/docbook2mdoc/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, expat }:
+
+stdenv.mkDerivation rec {
+  name = "docbook2mdoc-${version}";
+  version = "0.0.9";
+
+  src = fetchurl {
+    url = "http://mdocml.bsd.lv/docbook2mdoc/snapshots/${name}.tgz";
+    sha256 = "07il80sg89xf6ym4bry6hxdacfzqgbwkxzyf7bjaihmw5jj0lclk";
+  };
+
+  buildInputs = [ expat.dev ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://mdocml.bsd.lv/";
+    description = "converter from DocBook V4.x and v5.x XML into mdoc";
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ramkromberg ];
+  };
+}

--- a/pkgs/tools/misc/pod2mdoc/default.nix
+++ b/pkgs/tools/misc/pod2mdoc/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "pod2mdoc-${version}";
+  version = "0.0.10";
+
+  src = fetchurl {
+    url = "http://mdocml.bsd.lv/pod2mdoc/snapshots/${name}.tgz";
+    sha256 = "0nwa9zv9gmfi5ysz1wfm60kahc7nv0133n3dfc2vh2y3gj8mxr4f";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+    install -m 0755 pod2mdoc $out/bin
+    install -m 0444 pod2mdoc.1 $out/share/man/man1
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://mdocml.bsd.lv/";
+    description = "converter from POD into mdoc";
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ramkromberg ];
+  };
+}

--- a/pkgs/tools/misc/texi2mdoc/default.nix
+++ b/pkgs/tools/misc/texi2mdoc/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "texi2mdoc-${version}";
+  version = "0.1.2";
+
+  src = fetchurl {
+    url = "http://mdocml.bsd.lv/texi2mdoc/snapshots/${name}.tgz";
+    sha256 = "1zjb61ymwfkw6z5g0aqmsn6qpw895zdxv7fv3059gj3wqa3zsibs";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://mdocml.bsd.lv/";
+    description = "converter from Texinfo into mdoc";
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ramkromberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1393,6 +1393,8 @@ in
     inherit (perlPackages) XMLSAX XMLParser XMLNamespaceSupport;
   };
 
+  docbook2mdoc = callPackage ../tools/misc/docbook2mdoc { };
+
   dog = callPackage ../tools/system/dog { };
 
   dosfstools = callPackage ../tools/filesystems/dosfstools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6823,6 +6823,8 @@ in
 
   texi2html = callPackage ../development/tools/misc/texi2html { };
 
+  texi2mdoc = callPackage ../tools/misc/texi2mdoc { };
+
   travis = callPackage ../development/tools/misc/travis { };
 
   tweak = callPackage ../applications/editors/tweak { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3198,6 +3198,8 @@ in
 
   podiff = callPackage ../tools/text/podiff { };
 
+  pod2mdoc = callPackage ../tools/misc/pod2mdoc { };
+
   poedit = callPackage ../tools/text/poedit { };
 
   polipo = callPackage ../servers/polipo { };


### PR DESCRIPTION
###### Motivation for this change

convert docbook, texinfo and perlpod to mdoc.
Very small & light standalone binaries.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
