### PR TITLE
Trinity on nixos

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -70,6 +70,11 @@ rec {
     ftp://ftp.funet.fi/pub/mirrors/ftp.kernel.org/pub/
   ];
 
+  # Trinity DE mirrors
+  tde = [
+    http://tde-mirror.yosemite.net/trinity/releases/
+  ];
+
   # Mirrors of ftp://ftp.kde.org/pub/kde/.
   kde = [
     "http://download.kde.org/download.php?url="

--- a/pkgs/desktops/tde/R14/default.nix
+++ b/pkgs/desktops/tde/R14/default.nix
@@ -12,4 +12,5 @@ rec {
   dbus-tqt = callPackage ./dependencies/dbus-tqt { };
   dbus-1-tqt = callPackage ./dependencies/dbus-1-tqt { };
   libart-lgpl = callPackage ./dependencies/libart-lgpl { };
+  tqca-tls = callPackage ./dependencies/tqca-tls { };
 }

--- a/pkgs/desktops/tde/R14/default.nix
+++ b/pkgs/desktops/tde/R14/default.nix
@@ -8,5 +8,5 @@ rec {
   tqt3-nothread = callPackage ./dependencies/tqt3 { threadSupport = false; };
   tqt3 = tqt3-thread;
   tqtinterface = callPackage ./dependencies/tqtinterface { };
-
+  arts = callPackage ./dependencies/arts { };
 }

--- a/pkgs/desktops/tde/R14/default.nix
+++ b/pkgs/desktops/tde/R14/default.nix
@@ -13,4 +13,5 @@ rec {
   dbus-1-tqt = callPackage ./dependencies/dbus-1-tqt { };
   libart-lgpl = callPackage ./dependencies/libart-lgpl { };
   tqca-tls = callPackage ./dependencies/tqca-tls { };
+  avahi-tqt =  callPackage ./dependencies/avahi-tqt { };
 }

--- a/pkgs/desktops/tde/R14/default.nix
+++ b/pkgs/desktops/tde/R14/default.nix
@@ -4,9 +4,12 @@ rec {
 
   #### Dependencies
 
+  tqt3 = tqt3-thread;
   tqt3-thread = callPackage ./dependencies/tqt3 { threadSupport = true; };
   tqt3-nothread = callPackage ./dependencies/tqt3 { threadSupport = false; };
-  tqt3 = tqt3-thread;
   tqtinterface = callPackage ./dependencies/tqtinterface { };
   arts = callPackage ./dependencies/arts { };
+  dbus-tqt = callPackage ./dependencies/dbus-tqt { };
+  dbus-1-tqt = callPackage ./dependencies/dbus-1-tqt { };
+  libart-lgpl = callPackage ./dependencies/libart-lgpl { };
 }

--- a/pkgs/desktops/tde/R14/default.nix
+++ b/pkgs/desktops/tde/R14/default.nix
@@ -14,4 +14,5 @@ rec {
   libart-lgpl = callPackage ./dependencies/libart-lgpl { };
   tqca-tls = callPackage ./dependencies/tqca-tls { };
   avahi-tqt =  callPackage ./dependencies/avahi-tqt { };
+  tdelibs =  callPackage ./dependencies/tdelibs { openssl = pkgs.libressl; };
 }

--- a/pkgs/desktops/tde/R14/default.nix
+++ b/pkgs/desktops/tde/R14/default.nix
@@ -1,0 +1,11 @@
+{ callPackage, pkgs }:
+
+rec {
+
+  #### Dependencies
+
+  tqt3-thread = callPackage ./dependencies/tqt3 { threadSupport = true; };
+  tqt3-nothread = callPackage ./dependencies/tqt3 { threadSupport = false; };
+  tqt3 = tqt3-thread;
+
+}

--- a/pkgs/desktops/tde/R14/default.nix
+++ b/pkgs/desktops/tde/R14/default.nix
@@ -7,5 +7,6 @@ rec {
   tqt3-thread = callPackage ./dependencies/tqt3 { threadSupport = true; };
   tqt3-nothread = callPackage ./dependencies/tqt3 { threadSupport = false; };
   tqt3 = tqt3-thread;
+  tqtinterface = callPackage ./dependencies/tqtinterface { };
 
 }

--- a/pkgs/desktops/tde/R14/dependencies/arts/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/arts/default.nix
@@ -1,0 +1,75 @@
+{ stdenv, fetchurl, pkgconfig, cmake
+, glib, pcre, libtool, libogg, libvorbis
+, tqtinterface
+, audiofileSupport ? true, audiofile ? null
+, lameSupport ? true, lame ? null
+, libmadSupport ? true, libmad ? null
+, libmp3spltSupport ? true, libmp3splt ? null
+, mpdSupport ? true, mpd ? null
+, vorbisToolsSupport ? true, vorbisTools ? null
+, alsaSupport ? true, alsaLib ? null
+, jack2Support ? true, jack2Full ? null
+}:
+
+assert audiofileSupport   -> (audiofile != null);
+assert lameSupport        -> (lame != null);
+assert libmadSupport      -> (libmad != null);
+assert libmp3spltSupport  -> (libmp3splt != null);
+assert mpdSupport         -> (mpd != null);
+assert vorbisToolsSupport -> (vorbisTools != null);
+assert alsaSupport        -> (alsaLib != null);
+assert jack2Support     -> (jack2Full != null);
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+
+  name = "arts-${version}";
+  version = "${majorVer}.${minorVer}";
+  majorVer = "R14.0";
+  minorVer = "3";
+
+  src = fetchurl {
+    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
+    sha256 = "0hh7gkyi5q6r5siz41fr5557zqgxlqja9c8yzyxvq2hgsrdh4883";
+  };
+
+  buildInputs = [ pkgconfig cmake libtool glib pcre ];
+  propagatedBuildInputs = [ libogg libvorbis tqtinterface ]
+    ++ optional audiofileSupport audiofile
+    ++ optional lameSupport lame
+    ++ optional libmadSupport libmad
+    ++ optional libmp3spltSupport libmp3splt
+    ++ optional mpdSupport mpd
+    ++ optional vorbisToolsSupport vorbisTools
+    ++ optional alsaSupport alsaLib
+    ++ optional jack2Support jack2Full;
+
+  cmakeFlags = ''
+    -DWITH_ALSA=${if alsaSupport then "ON" else "OFF"}
+    -DWITH_AUDIOFILE=${if audiofileSupport then "ON" else "OFF"}
+    -DWITH_LIBJACK=${if jack2Support then "ON" else "OFF"}
+    -DWITH_MAD=${if libmadSupport then "ON" else "OFF"}
+    -DWITH_SNDIO=OFF
+    -DWITH_ESOUND=OFF
+    -DWITH_VORBIS=ON
+  '';
+
+  preConfigure = ''
+    cd arts
+  '';
+
+  # It doesn't find libmcop.so library without that 'hack'
+  postConfigure = ''
+    export LD_LIBRARY_PATH=$(pwd)/mcop:$LD_LIBRARY_PATH
+  '';
+
+  meta = with stdenv.lib;{
+    description = "Analog Real-Time Synthesizer";
+    homepage = http://www.trinitydesktop.org;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTores ];
+    platforms = platforms.linux;
+  };
+}
+# TODO: investigate about Audio-Convert tool
+# TODO: investigate about jack

--- a/pkgs/desktops/tde/R14/dependencies/arts/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/arts/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, cmake
 , glib, pcre, libtool, libogg, libvorbis
-, tqtinterface
+, tde
 , audiofileSupport ? true, audiofile ? null
 , lameSupport ? true, lame ? null
 , libmadSupport ? true, libmad ? null
@@ -18,23 +18,27 @@ assert libmp3spltSupport  -> (libmp3splt != null);
 assert mpdSupport         -> (mpd != null);
 assert vorbisToolsSupport -> (vorbisTools != null);
 assert alsaSupport        -> (alsaLib != null);
-assert jack2Support     -> (jack2Full != null);
+assert jack2Support       -> (jack2Full != null);
 
+let baseName = "arts"; in
 with stdenv.lib;
 stdenv.mkDerivation rec {
 
-  name = "arts-${version}";
-  version = "${majorVer}.${minorVer}";
-  majorVer = "R14.0";
-  minorVer = "3";
+  name = "${baseName}-${version}";
+  srcName = "${baseName}-R${version}";
+  version = "${majorVer}.${minorVer}.${patchVer}";
+  majorVer = "14";
+  minorVer = "0";
+  patchVer = "4";
 
   src = fetchurl {
-    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
-    sha256 = "0hh7gkyi5q6r5siz41fr5557zqgxlqja9c8yzyxvq2hgsrdh4883";
+    url = "mirror://tde/R${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "13x5bk093yxr96br1x8wd0a5s00ikjvsmwz6agwmc667sw0a290v";
   };
 
-  buildInputs = [ pkgconfig cmake libtool glib pcre ];
-  propagatedBuildInputs = [ libogg libvorbis tqtinterface ]
+  nativeBuildInputs = [ pkgconfig cmake libtool ];
+  buildInputs = [ glib pcre ];
+  propagatedBuildInputs = [ libogg libvorbis tde.tqtinterface ]
     ++ optional audiofileSupport audiofile
     ++ optional lameSupport lame
     ++ optional libmadSupport libmad
@@ -55,7 +59,7 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    cd arts
+    cd ${baseName}
   '';
 
   # It doesn't find libmcop.so library without that 'hack'

--- a/pkgs/desktops/tde/R14/dependencies/arts/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/arts/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     description = "Analog Real-Time Synthesizer";
     homepage = http://www.trinitydesktop.org;
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTores ];
+    maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/tde/R14/dependencies/avahi-tqt/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/avahi-tqt/default.nix
@@ -1,16 +1,20 @@
 { stdenv, fetchurl, pkgconfig, cmake
 , nssmdns, avahi, tde }:
 
-stdenv.mkDerivation rec{
+let baseName = "avahi-tqt"; in
+with stdenv.lib;
+stdenv.mkDerivation rec {
 
-  name = "avahi-tqt-${version}";
-  version = "${majorVer}.${minorVer}";
-  majorVer = "R14";
-  minorVer = "0.3";
+  name = "${baseName}-${version}";
+  srcName = "${baseName}-R${version}";
+  version = "${majorVer}.${minorVer}.${patchVer}";
+  majorVer = "14";
+  minorVer = "0";
+  patchVer = "4";
 
   src = fetchurl {
-    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
-    sha256 = "1g56mcjg6pqhlljxj6m1b0iv7jg7s22fqjl36r0i7bkgdxz8lbwm";
+    url = "mirror://tde/R${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "179cd6c85v7h7m7dz0rm4n4jmqrqsi2n1ylgaaqps3gr8fm0w2z6";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];
@@ -18,7 +22,7 @@ stdenv.mkDerivation rec{
   buildInputs = [ nssmdns avahi tde.tqtinterface ];
 
   preConfigure = ''
-    cd avahi-tqt
+    cd ${baseName}
   '';
 
   meta = with stdenv.lib;{

--- a/pkgs/desktops/tde/R14/dependencies/avahi-tqt/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/avahi-tqt/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, pkgconfig, cmake
+, nssmdns, avahi, tde }:
+
+stdenv.mkDerivation rec{
+
+  name = "avahi-tqt-${version}";
+  version = "${majorVer}.${minorVer}";
+  majorVer = "R14";
+  minorVer = "0.3";
+
+  src = fetchurl {
+    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
+    sha256 = "1g56mcjg6pqhlljxj6m1b0iv7jg7s22fqjl36r0i7bkgdxz8lbwm";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  buildInputs = [ nssmdns avahi tde.tqtinterface ];
+
+  preConfigure = ''
+    cd avahi-tqt
+  '';
+
+  meta = with stdenv.lib;{
+    description = "Avahi TQt bindings";
+    homepage = http://www.trinitydesktop.org;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/tde/R14/dependencies/dbus-1-tqt/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/dbus-1-tqt/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec{
     description = "A backport of Harald Fernengel's Qt4 D-bus bindings";
     homepage = http://www.trinitydesktop.org;
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTores ];
+    maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/tde/R14/dependencies/dbus-1-tqt/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/dbus-1-tqt/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, cmake, pkgconfig, dbus
+, tqtinterface }:
+
+stdenv.mkDerivation rec{
+
+  name = "dbus-1-tqt-${version}";
+  version = "${majorVer}.${minorVer}";
+  majorVer = "R14";
+  minorVer = "0.3";
+
+  src = fetchurl {
+    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
+    sha256 = "1badq4x7lflgdwp8155ljv6f2wr5byy899lpg6ca6s2p3rmd4jjm";
+  };
+  
+  buildInputs = [ cmake pkgconfig ];
+  propagatedBuildInputs = [ dbus tqtinterface ];
+
+  preConfigure = "cd dbus-1-tqt";
+
+  meta = with stdenv.lib;{
+    description = "A backport of Harald Fernengel's Qt4 D-bus bindings";
+    homepage = http://www.trinitydesktop.org;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTores ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/tde/R14/dependencies/dbus-1-tqt/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/dbus-1-tqt/default.nix
@@ -1,22 +1,28 @@
-{ stdenv, fetchurl, cmake, pkgconfig, dbus
-, tqtinterface }:
+{ stdenv, fetchurl, cmake, pkgconfig
+, dbus, tde }:
 
-stdenv.mkDerivation rec{
+let baseName = "dbus-1-tqt"; in
+with stdenv.lib;
+stdenv.mkDerivation rec {
 
-  name = "dbus-1-tqt-${version}";
-  version = "${majorVer}.${minorVer}";
-  majorVer = "R14";
-  minorVer = "0.3";
+  name = "${baseName}-${version}";
+  srcName = "${baseName}-R${version}";
+  version = "${majorVer}.${minorVer}.${patchVer}";
+  majorVer = "14";
+  minorVer = "0";
+  patchVer = "4";
 
   src = fetchurl {
-    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
-    sha256 = "1badq4x7lflgdwp8155ljv6f2wr5byy899lpg6ca6s2p3rmd4jjm";
+    url = "mirror://tde/R${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "1l96pw9nj47qgv2gkc5khi5zgpj3jhf3nv1ir55harcq9nspq6ri";
   };
   
-  buildInputs = [ cmake pkgconfig ];
-  propagatedBuildInputs = [ dbus tqtinterface ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+  propagatedBuildInputs = [ dbus tde.tqtinterface ];
 
-  preConfigure = "cd dbus-1-tqt";
+  preConfigure = ''
+    cd ${baseName}
+  '';
 
   meta = with stdenv.lib;{
     description = "A backport of Harald Fernengel's Qt4 D-bus bindings";

--- a/pkgs/desktops/tde/R14/dependencies/dbus-tqt/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/dbus-tqt/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec{
     description = "D-Bus API bindings for TDE";
     homepage = http://www.trinitydesktop.org;
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTores ];
+    maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/tde/R14/dependencies/dbus-tqt/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/dbus-tqt/default.nix
@@ -1,21 +1,27 @@
-{ stdenv, fetchurl, pkgconfig, cmake, dbus-1-tqt }:
+{ stdenv, fetchurl, pkgconfig, cmake, tde }:
 
-stdenv.mkDerivation rec{
+let baseName = "dbus-tqt"; in
+with stdenv.lib;
+stdenv.mkDerivation rec {
 
-  name = "dbus-tqt-${version}";
-  version = "${majorVer}.${minorVer}";
-  majorVer = "R14";
-  minorVer = "0.3";
+  name = "${baseName}-${version}";
+  srcName = "${baseName}-R${version}";
+  version = "${majorVer}.${minorVer}.${patchVer}";
+  majorVer = "14";
+  minorVer = "0";
+  patchVer = "4";
 
   src = fetchurl {
-    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
-    sha256 = "13l2ah204y5bbp7zpqgpsis3abvpkayqq38r30dnm5nn6vg7d9zb";
+    url = "mirror://tde/R${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "05q0i918si3q7z3ghjrzmc6npm2f0arzqh295qm19bl0p6ihncgz";
   };
 
-  buildInputs = [ pkgconfig cmake ];
-  propagatedBuildInputs = [ dbus-1-tqt ];
+  nativeBuildInputs = [ pkgconfig cmake ];
+  propagatedBuildInputs = [ tde.dbus-1-tqt ];
 
-  preConfigure = "cd dbus-tqt";
+  preConfigure = ''
+    cd ${baseName}
+  '';
 
   meta = with stdenv.lib;{
     description = "D-Bus API bindings for TDE";

--- a/pkgs/desktops/tde/R14/dependencies/dbus-tqt/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/dbus-tqt/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pkgconfig, cmake, dbus-1-tqt }:
+
+stdenv.mkDerivation rec{
+
+  name = "dbus-tqt-${version}";
+  version = "${majorVer}.${minorVer}";
+  majorVer = "R14";
+  minorVer = "0.3";
+
+  src = fetchurl {
+    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
+    sha256 = "13l2ah204y5bbp7zpqgpsis3abvpkayqq38r30dnm5nn6vg7d9zb";
+  };
+
+  buildInputs = [ pkgconfig cmake ];
+  propagatedBuildInputs = [ dbus-1-tqt ];
+
+  preConfigure = "cd dbus-tqt";
+
+  meta = with stdenv.lib;{
+    description = "D-Bus API bindings for TDE";
+    homepage = http://www.trinitydesktop.org;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTores ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/tde/R14/dependencies/libart-lgpl/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/libart-lgpl/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, pkgconfig }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+
+  name = "libart-lgpl-${version}";
+  version = "${majorVer}.${minorVer}";
+  majorVer = "R14.0";
+  minorVer = "3";
+
+  src = fetchurl {
+    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
+    sha256 = "0gnzdml05ggc95cv069in72glagmn98bs10lyhmvh8k1snxqdj6h";
+  };
+
+  buildInputs = [ pkgconfig ];
+
+  configureFlags = ''
+    --enable-ansi
+  '';
+
+  preConfigure = ''
+    cd libart-lgpl
+  '';
+
+  meta = with stdenv.lib;{
+    description = "A 2D drawing library";
+    homepage = http://www.trinitydesktop.org;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTores ];
+    platforms = platforms.linux;
+  };
+}
+# Warning: autotool build, will be deprecated by cmake in the future

--- a/pkgs/desktops/tde/R14/dependencies/libart-lgpl/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/libart-lgpl/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "A 2D drawing library";
     homepage = http://www.trinitydesktop.org;
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTores ];
+    maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/tde/R14/dependencies/libart-lgpl/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/libart-lgpl/default.nix
@@ -1,26 +1,29 @@
 { stdenv, fetchurl, pkgconfig }:
 
+let baseName = "libart-lgpl"; in
 with stdenv.lib;
 stdenv.mkDerivation rec {
 
-  name = "libart-lgpl-${version}";
-  version = "${majorVer}.${minorVer}";
-  majorVer = "R14.0";
-  minorVer = "3";
+  name = "${baseName}-${version}";
+  srcName = "${baseName}-R${version}";
+  version = "${majorVer}.${minorVer}.${patchVer}";
+  majorVer = "14";
+  minorVer = "0";
+  patchVer = "4";
 
   src = fetchurl {
-    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
-    sha256 = "0gnzdml05ggc95cv069in72glagmn98bs10lyhmvh8k1snxqdj6h";
+    url = "mirror://tde/R${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "0hz7zr8g5sc06f5ayz91rk4144sdn4m36vrpzv6gl05nq37q27d0";
   };
 
-  buildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ];
 
   configureFlags = ''
     --enable-ansi
   '';
 
   preConfigure = ''
-    cd libart-lgpl
+    cd ${baseName}
   '';
 
   meta = with stdenv.lib;{

--- a/pkgs/desktops/tde/R14/dependencies/tdelibs/0001-fix-kdoctools-configurechecks.patch
+++ b/pkgs/desktops/tde/R14/dependencies/tdelibs/0001-fix-kdoctools-configurechecks.patch
@@ -1,0 +1,12 @@
+diff -Naur tdelibs/kdoctools/ConfigureChecks.cmake tdelibs-new/kdoctools/ConfigureChecks.cmake
+--- tdelibs/kdoctools/ConfigureChecks.cmake	2015-09-22 23:31:21.000000000 -0300
++++ tdelibs-new/kdoctools/ConfigureChecks.cmake	2017-02-04 19:08:12.846341516 -0200
+@@ -29,7 +29,7 @@
+   COMMAND ${UPDATE_SCRIPT}
+   RESULT_VARIABLE _result
+   OUTPUT_STRIP_TRAILING_WHITESPACE )
+-if( _result )
++if( NOT _result )
+   tde_message_fatal( "Unable to update ${ENTITIES_FILE}!\n " )
+ else( )
+   message( STATUS "Updated as follows:" )

--- a/pkgs/desktops/tde/R14/dependencies/tdelibs/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tdelibs/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, pkgconfig, cmake
+, aspell, hspell, jasper, cups, libidn
+, openexr, pcre , libutempter, libxslt
+, libxml2, glib, openssl
+, libudev # not detected in the configure phase
+, file # libmagic
+, xorg, tde }:
+
+stdenv.mkDerivation rec{
+
+  name = "tdelibs-${version}";
+  version = "${majorVer}.${minorVer}";
+  majorVer = "R14";
+  minorVer = "0.3";
+
+  src = fetchurl {
+    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
+    sha256 = "18yxw4q87zm2wxxpmchals89iqj2ppkc1wjb0vd0pmwlblb7nygz";
+  };
+
+  patches = [ ./0001-fix-kdoctools-configurechecks.patch ];
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  buildInputs =
+  [ aspell hspell jasper cups libxml2 libxslt libidn openexr
+    pcre libutempter file glib openssl libudev
+    xorg.iceauth xorg.libXtst xorg.libXrandr xorg.libXcomposite
+    tde.tqtinterface tde.arts tde.libart-lgpl tde.dbus-tqt ];
+
+  meta = with stdenv.lib;{
+    description = "TDE Libraries";
+    homepage = http://www.trinitydesktop.org;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/tde/R14/dependencies/tdelibs/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tdelibs/default.nix
@@ -6,16 +6,20 @@
 , file # libmagic
 , xorg, tde }:
 
-stdenv.mkDerivation rec{
+let baseName = "tdelibs"; in
+with stdenv.lib;
+stdenv.mkDerivation rec {
 
-  name = "tdelibs-${version}";
-  version = "${majorVer}.${minorVer}";
-  majorVer = "R14";
-  minorVer = "0.3";
+  name = "${baseName}-${version}";
+  srcName = "${baseName}-R${version}";
+  version = "${majorVer}.${minorVer}.${patchVer}";
+  majorVer = "14";
+  minorVer = "0";
+  patchVer = "4";
 
   src = fetchurl {
-    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
-    sha256 = "18yxw4q87zm2wxxpmchals89iqj2ppkc1wjb0vd0pmwlblb7nygz";
+    url = "mirror://tde/R${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "1n8ifbfgly0cr254ksnvqfzrkrnhsl8qy0grjxsajaxiizfm3gzs";
   };
 
   patches = [ ./0001-fix-kdoctools-configurechecks.patch ];
@@ -23,8 +27,8 @@ stdenv.mkDerivation rec{
   nativeBuildInputs = [ pkgconfig cmake ];
 
   buildInputs =
-  [ aspell hspell jasper cups libxml2 libxslt libidn openexr
-    pcre libutempter file glib openssl libudev
+  [ aspell hspell jasper cups libxml2 libxslt libidn
+    openexr pcre libutempter file glib openssl libudev
     xorg.iceauth xorg.libXtst xorg.libXrandr xorg.libXcomposite
     tde.tqtinterface tde.arts tde.libart-lgpl tde.dbus-tqt ];
 

--- a/pkgs/desktops/tde/R14/dependencies/tqca-tls/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqca-tls/default.nix
@@ -1,27 +1,33 @@
 { stdenv, fetchurl, pkgconfig
 , openssl, tqtinterface, tqt3 }:
 
-stdenv.mkDerivation rec{
+let baseName = "tqca-tls"; in
+with stdenv.lib;
+stdenv.mkDerivation rec {
 
-  name = "tqca-tls-${version}";
-  version = "${majorVer}.${minorVer}";
-  majorVer = "R14";
-  minorVer = "0.3";
+  name = "${baseName}-${version}";
+  srcName = "${baseName}-R${version}";
+  version = "${majorVer}.${minorVer}.${patchVer}";
+  majorVer = "14";
+  minorVer = "0";
+  patchVer = "4";
 
   src = fetchurl {
-    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
-    sha256 = "0ihbrn997w0sh2lxjikkc054igshp3x411kz899dpabrs9cq3n42";
+    url = "mirror://tde/R${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "09ra6qk27x1d2s8d0l71a59rwrp6xwhw4wwdsvm8z7f2dqz12ipz";
   };
   
-  buildInputs = [ pkgconfig ];
-  propagatedBuildInputs = [ openssl tqtinterface ];
+  nativeBuildInputs = [ pkgconfig ];
+  propagatedBuildInputs = [ openssl tde.tqtinterface ];
 
   patchPhase = ''
-    sed -i -e "s|/usr/include/tqt|${tqtinterface}/include/tqt|" tqca-tls/configure
-    sed -i -e '/for p in/ s|/usr|/FAIL|g' tqca-tls/configure
+    sed -i -e "s|/usr/include/tqt|${tde.tqtinterface}/include/tqt|" ${baseName}/configure
+    sed -i -e '/for p in/ s|/usr|/FAILURE|g' ${baseName}/configure
   '';
 
-  preConfigure = "cd tqca-tls";
+  preConfigure = ''
+    cd ${baseName}
+  '';
 
   dontAddPrefix = true;
   configureFlags = "--debug --qtdir=${tqt3} --with-openssl-inc=${openssl.dev}/include --with-openssl-lib=${openssl.out}/lib";

--- a/pkgs/desktops/tde/R14/dependencies/tqca-tls/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqca-tls/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, pkgconfig
+, openssl, tqtinterface, tqt3 }:
+
+stdenv.mkDerivation rec{
+
+  name = "tqca-tls-${version}";
+  version = "${majorVer}.${minorVer}";
+  majorVer = "R14";
+  minorVer = "0.3";
+
+  src = fetchurl {
+    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
+    sha256 = "0ihbrn997w0sh2lxjikkc054igshp3x411kz899dpabrs9cq3n42";
+  };
+  
+  buildInputs = [ pkgconfig ];
+  propagatedBuildInputs = [ openssl tqtinterface ];
+
+  patchPhase = ''
+    sed -i -e "s|/usr/include/tqt|${tqtinterface}/include/tqt|" tqca-tls/configure
+    sed -i -e '/for p in/ s|/usr|/FAIL|g' tqca-tls/configure
+  '';
+
+  preConfigure = "cd tqca-tls";
+
+  dontAddPrefix = true;
+  configureFlags = "--debug --qtdir=${tqt3} --with-openssl-inc=${openssl.dev}/include --with-openssl-lib=${openssl.out}/lib";
+
+  installPhase = ''
+    mkdir -p $out/plugins/crypto
+    cp libtqca-tls.so $out/plugins/crypto
+  '';
+
+  meta = with stdenv.lib;{
+    description = "A plugin to provide TLS capability to programs using TQCA";
+    homepage = http://www.trinitydesktop.org;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}
+# Warning: autotool build, will be deprecated by cmake in the future
+# Warning: essentially broken, it uses some strange assumptions and I don't
+# understand clearly the purpose of some variables

--- a/pkgs/desktops/tde/R14/dependencies/tqt3/0001-tqt-configure-pwd.diff
+++ b/pkgs/desktops/tde/R14/dependencies/tqt3/0001-tqt-configure-pwd.diff
@@ -1,0 +1,15 @@
+diff -Naur dependencies-old/tqt3/configure dependencies/tqt3/configure
+--- dependencies-old/tqt3/configure	2015-01-08 10:50:12.000000000 -0200
++++ dependencies/tqt3/configure	2015-01-08 10:55:15.000000000 -0200
+@@ -15,9 +15,9 @@
+ relconf=`basename $0`
+ # the directory of this script is the "source tree"
+ relpath=`dirname $0`
+-relpath=`(cd $relpath; /bin/pwd)`
++relpath=`(cd $relpath; pwd)`
+ # the current directory is the "build tree" or "object tree"
+-outpath=`/bin/pwd`
++outpath=`pwd`
+ 
+ # later cache the command line in config.status
+ OPT_CMDLINE=`echo $@ | sed "s,-v ,,g; s,-v$,,g"`

--- a/pkgs/desktops/tde/R14/dependencies/tqt3/0002-tqt-xrandr-test.diff
+++ b/pkgs/desktops/tde/R14/dependencies/tqt3/0002-tqt-xrandr-test.diff
@@ -1,0 +1,36 @@
+diff -Naur dependencies-old/tqt3/config.tests/x11/xrandr.test dependencies/tqt3/config.tests/x11/xrandr.test
+--- dependencies-old/tqt3/config.tests/x11/xrandr.test	2014-12-06 23:01:44.000000000 -0200
++++ dependencies/tqt3/config.tests/x11/xrandr.test	2015-01-08 17:17:50.000000000 -0200
+@@ -52,10 +52,9 @@
+     INCDIRS="$IN_INCDIRS $XDIRS /usr/include /include"
+     F=
+     for INCDIR in $INCDIRS; do
+-	if [ -f $INCDIR/$INC -a -f $INCDIR/$INC2 ]; then
++	if [ -f $INCDIR/$INC ]; then
+ 	    F=yes
+ 	    XRANDR_H=$INCDIR/$INC
+-	    RANDR_H=$INCDIR/$INC2
+ 	    [ "$VERBOSE" = "yes" ] && echo "  Found $INC in $INCDIR"
+ 	    break
+ 	fi
+@@ -65,6 +64,20 @@
+ 	XRANDR=no
+ 	[ "$VERBOSE" = "yes" ] && echo "  Could not find $INC anywhere in $INCDIRS"
+     fi
++    F=
++    for INCDIR in $INCDIRS; do
++	if [ -f $INCDIR/$INC2 ]; then
++	    F=yes
++	    RANDR_H=$INCDIR/$INC2
++	    [ "$VERBOSE" = "yes" ] && echo "  Found $INC2 in $INCDIR"
++	    break
++	fi
++    done
++    if [ -z "$F" ]
++    then
++	XRANDR=no
++	[ "$VERBOSE" = "yes" ] && echo "  Could not find $INC2 anywhere in $INCDIRS"
++    fi
+ fi
+ 
+ # verify that we are using XRandR 1.x >= 1.1

--- a/pkgs/desktops/tde/R14/dependencies/tqt3/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqt3/default.nix
@@ -1,0 +1,153 @@
+{ stdenv, fetchurl, pkgconfig, coreutils
+, libjpeg, libpng, libmng, zlib, libuuid, which
+, x11, xextproto, libX11, xlibsWrapper
+, threadSupport ? true
+, cupsSupport ? true, cups ? null
+, sqliteSupport ? true, sqlite ? null
+, mysqlSupport ? true, mysql ? null
+, postgresqlSupport ? true, postgresql ? null
+, odbcSupport ? true, unixODBC ? null
+, openglSupport ? true , mesa ? null, libXmu ? null
+, xftSupport ? true, libXft ? null
+, xrenderSupport ? true , libXrender ? null
+, xrandrSupport ? true, libXrandr ? null, randrproto ? null
+, xcursorSupport ? true, libXcursor ? null
+, xineramaSupport ? true, libXinerama ? null
+, xextSupport ? true, libXext ? null
+, smSupport ? true, libSM ? null
+}:
+
+assert cupsSupport -> cups != null;
+assert sqliteSupport -> sqlite != null;
+assert mysqlSupport -> mysql != null;
+assert postgresqlSupport -> postgresql != null;
+assert odbcSupport -> unixODBC != null;
+assert openglSupport -> mesa != null && libXmu != null;
+
+assert xftSupport -> libXft != null;
+assert xrenderSupport -> xftSupport && libXrender != null;
+assert xrandrSupport -> libXrandr != null && randrproto != null;
+assert xcursorSupport -> libXcursor != null;
+assert xineramaSupport -> libXinerama != null;
+assert xextSupport -> libXext != null;
+assert smSupport -> libSM != null;
+
+stdenv.mkDerivation rec {
+
+  name = "tqt3-"+ (toString(if threadSupport then "thread" else "nothread"))+ "-${version}";
+  version = "${majorVer}.${minorVer}";
+  majorVer = "R14";
+  minorVer = "0.3";
+  srcName = "tqt3-${version}";
+
+  src = fetchurl {
+    url = "mirror://tde/${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "04sm6752cmhc0jq9lcl9rv3d282mc8nqkda063160gn6jklby51x";
+  };
+
+  buildInputs = [ pkgconfig which libuuid coreutils ];
+  propagatedBuildInputs = [ libpng libmng libjpeg zlib x11
+    xlibsWrapper libX11 xextproto libXft libXrender ];
+
+  patches = [
+    # Resetting /bin/pwd to pwd
+    ./0001-tqt-configure-pwd.diff
+    # randr.h and xrandr.h aren't in the same place,
+    # so they need to be searched independently
+    ./0002-tqt-xrandr-test.diff ];
+
+  # tqt3 configure script doesn't use double-dash convention  
+  dontAddPrefix = true;
+  setupHook = ./setup-hook.sh;
+  configureFlags = ''
+    -v
+    -qt-gif
+    -system-zlib -system-libpng -system-libjpeg -system-libmng
+    -I${xextproto.out}/include
+    -L${libX11.out}/lib -I${libX11.dev}/include -lX11
+    ${if threadSupport then "-thread" else "-no-thread"}
+    ${if openglSupport
+      then "-dlopen-opengl
+       -L${mesa}/lib -I${mesa}/include
+       -L${libXmu.out}/lib -I${libXmu.dev}/include"
+      else ""}
+    ${if xrenderSupport
+      then "-xrender -L${libXrender.out}/lib -I${libXrender.dev}/include"
+      else "-no-xrender"}
+    ${if xrandrSupport
+      then "-xrandr -L${libXrandr.out}/lib -I${libXrandr.dev}/include
+      -I${randrproto}/include"
+      else "-no-xrandr"}
+    ${if xineramaSupport
+      then "-xinerama -L${libXinerama.out}/lib -I${libXinerama.dev}/include"
+      else "-no-xinerama"}
+    ${if xcursorSupport
+      then "-L${libXcursor.out}/lib -I${libXcursor.dev}/include"
+      else ""}
+    ${if xftSupport
+      then "-xft -L${libXft.out}/lib -I${libXft.dev}/include
+      -L${libXft.freetype.out}/lib -I${libXft.freetype.dev}/include
+      -L${libXft.fontconfig.lib}/lib -I${libXft.fontconfig.dev}/include"
+      else "-no-xft"}
+    ${if xextSupport
+      then "-L${libXext.out}/lib -I${libXext.dev}/include"
+      else ""}
+    ${if smSupport
+      then "-L${libSM.out}/lib -I${libSM.dev}/include"
+      else ""}
+    ${if cupsSupport
+      then "-L${cups.out}/lib -I${cups.dev}/include"
+      else ""}
+    ${if mysqlSupport
+      then "-qt-sql-mysql -L${mysql.lib}/lib
+      -I${mysql.lib}/include/mysql"
+      else ""}
+    ${if postgresqlSupport
+    then "-qt-sql-psql -L${postgresql.lib}/lib
+    -I${postgresql.out}/include -I${postgresql.out}/include/server"
+    else ""}
+    ${if sqliteSupport then "-qt-sql-sqlite
+      -L${sqlite.out}/lib/sqlite -I${sqlite.dev}/include" else ""}
+    ${if odbcSupport
+      then "-qt-sql-odbc -L${unixODBC}/lib -I${unixODBC}/include"
+      else ""}
+  '';
+
+  preConfigure = ''
+    for i in tqt3/config.tests/unix/checkavail \
+             tqt3/config.tests/*/*.test \
+             tqt3/mkspecs/*/qmake.conf; do
+      echo "Preprocessing $i..."
+      substituteInPlace "$i" \
+        --replace " /lib" " /FAILURE" \
+        --replace "/usr" "/FAILURE"
+    done
+  '';
+
+  configurePhase = ''
+    cd tqt3
+    sh configure -prefix $out $configureFlags
+    export LD_LIBRARY_PATH=$(pwd)/lib
+  '';
+
+  # Some scripts for other libraries doesn't recognize
+  # tqt-mt.pc; symlinking to tqt.pc is fine, however
+  postInstall = ''
+    cd $out/lib/pkgconfig
+    if test -f tqt-mt.pc; then
+      ln -s tqt-mt.pc tqt.pc
+    fi
+    '';
+
+  meta = with stdenv.lib;{
+    homepage = http://www.trinitydesktop.org;
+    description = "A fork of Qt3 library, tailored for TDE";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.linux;
+  };
+
+  passthru = { inherit mysqlSupport; };
+}
+# Heavily based on QT-3 expression
+# TODO: multiple inputs

--- a/pkgs/desktops/tde/R14/dependencies/tqt3/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqt3/default.nix
@@ -99,15 +99,17 @@ stdenv.mkDerivation rec {
       then "-L${cups.out}/lib -I${cups.dev}/include"
       else ""}
     ${if mysqlSupport
-      then "-qt-sql-mysql -L${mysql.lib}/lib
-      -I${mysql.lib}/include/mysql"
+      then "-qt-sql-mysql -L${mysql.out}/lib
+      -I${mysql.out}/include/mysql"
       else ""}
     ${if postgresqlSupport
-    then "-qt-sql-psql -L${postgresql.lib}/lib
-    -I${postgresql.out}/include -I${postgresql.out}/include/server"
-    else ""}
-    ${if sqliteSupport then "-qt-sql-sqlite
-      -L${sqlite.out}/lib/sqlite -I${sqlite.dev}/include" else ""}
+     then "-qt-sql-psql -L${postgresql.lib}/lib
+     -I${postgresql.out}/include -I${postgresql.out}/include/server"
+     else ""}
+    ${if sqliteSupport
+      then "-qt-sql-sqlite -L${sqlite.out}/lib/sqlite
+      -I${sqlite.dev}/include"
+      else ""}
     ${if odbcSupport
       then "-qt-sql-odbc -L${unixODBC}/lib -I${unixODBC}/include"
       else ""}
@@ -123,6 +125,9 @@ stdenv.mkDerivation rec {
         --replace "/usr" "/FAILURE"
     done
   '';
+
+  # Workaround for a compilation 'error'
+  hardeningDisable = [ "format" ];
 
   configurePhase = ''
     cd tqt3

--- a/pkgs/desktops/tde/R14/dependencies/tqt3/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqt3/default.nix
@@ -151,3 +151,4 @@ stdenv.mkDerivation rec {
 }
 # Heavily based on QT-3 expression
 # TODO: multiple inputs
+# Warning: autotool build, will be deprecated by cmake in the future

--- a/pkgs/desktops/tde/R14/dependencies/tqt3/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqt3/default.nix
@@ -32,20 +32,25 @@ assert xineramaSupport -> libXinerama != null;
 assert xextSupport -> libXext != null;
 assert smSupport -> libSM != null;
 
+let
+  baseName = "tqt3";
+in with stdenv.lib;
 stdenv.mkDerivation rec {
 
-  name = "tqt3-"+ (toString(if threadSupport then "thread" else "nothread"))+ "-${version}";
-  version = "${majorVer}.${minorVer}";
-  majorVer = "R14";
-  minorVer = "0.3";
-  srcName = "tqt3-${version}";
+  name = "${baseName}"+(toString(if threadSupport then "-thread" else "-nothread"))+"-${version}";
+  srcName = "${baseName}-R${version}";
+  version = "${majorVer}.${minorVer}.${patchVer}";
+  majorVer = "14";
+  minorVer = "0";
+  patchVer = "4";
 
   src = fetchurl {
-    url = "mirror://tde/${version}/dependencies/${srcName}.tar.bz2";
-    sha256 = "04sm6752cmhc0jq9lcl9rv3d282mc8nqkda063160gn6jklby51x";
+    url = "mirror://tde/R${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "0x3cz6rjfnpwl2f0palawjyw64yymk460yg8wmma683db082vxj7";
   };
 
-  buildInputs = [ pkgconfig which libuuid coreutils ];
+  nativeBuildInputs = [ pkgconfig which ];
+  buildInputs = [ libuuid coreutils ];
   propagatedBuildInputs = [ libpng libmng libjpeg zlib x11
     xlibsWrapper libX11 xextproto libXft libXrender ];
 
@@ -116,9 +121,9 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    for i in tqt3/config.tests/unix/checkavail \
-             tqt3/config.tests/*/*.test \
-             tqt3/mkspecs/*/qmake.conf; do
+    for i in ${baseName}/config.tests/unix/checkavail \
+             ${baseName}/config.tests/*/*.test \
+             ${baseName}/mkspecs/*/qmake.conf; do
       echo "Preprocessing $i..."
       substituteInPlace "$i" \
         --replace " /lib" " /FAILURE" \
@@ -130,7 +135,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   configurePhase = ''
-    cd tqt3
+    cd ${baseName}
     sh configure -prefix $out $configureFlags
     export LD_LIBRARY_PATH=$(pwd)/lib
   '';

--- a/pkgs/desktops/tde/R14/dependencies/tqt3/setup-hook.sh
+++ b/pkgs/desktops/tde/R14/dependencies/tqt3/setup-hook.sh
@@ -1,0 +1,3 @@
+
+export QTDIR=@out@
+export TQTDIR=@out@

--- a/pkgs/desktops/tde/R14/dependencies/tqtinterface/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqtinterface/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "A library interface for TQt";
     homepage = http://www.trinitydesktop.org;
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTores ];
+    maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/tde/R14/dependencies/tqtinterface/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqtinterface/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "14kxq7nlkalgmlxpijs78fr0zr2ha9xykzqfbr7lh3zn0r79k5a3";
   };
 
-  buildInputs = [ cmake coreutils which libuuid ];
-  propagatedBuildInputs = [ tqt3 mesa ];
+  buildInputs = [ cmake coreutils which ];
+  propagatedBuildInputs = [ tqt3 mesa libuuid ];
   setupHook = ./setup-hook.sh;
 
   cmakeFlags = [

--- a/pkgs/desktops/tde/R14/dependencies/tqtinterface/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqtinterface/default.nix
@@ -1,26 +1,30 @@
-{ stdenv, fetchurl, cmake, coreutils, which, libuuid, tqt3, mesa }:
+{ stdenv, fetchurl, cmake, coreutils, which, libuuid, mesa, tde }:
 
+let baseName = "tqtinterface"; in
+with stdenv.lib;
 stdenv.mkDerivation rec {
 
-  name = "tqtinterface-${version}";
-  version = "${majorVer}.${minorVer}";
-  majorVer = "R14.0";
-  minorVer = "3";
+  name = "${baseName}-${version}";
+  srcName = "${baseName}-R${version}";
+  version = "${majorVer}.${minorVer}.${patchVer}";
+  majorVer = "14";
+  minorVer = "0";
+  patchVer = "4";
 
   src = fetchurl {
-    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
-    sha256 = "14kxq7nlkalgmlxpijs78fr0zr2ha9xykzqfbr7lh3zn0r79k5a3";
+    url = "mirror://tde/R${version}/dependencies/${srcName}.tar.bz2";
+    sha256 = "0ygxqdbqbp6kya4r425702n6z4cqfb4rra0aai8vqpcm6cz2jri9";
   };
 
-  buildInputs = [ cmake coreutils which ];
-  propagatedBuildInputs = [ tqt3 mesa libuuid ];
+  nativeBuildInputs = [ cmake coreutils which ];
+  propagatedBuildInputs = [ mesa libuuid tde.tqt3 ];
   setupHook = ./setup-hook.sh;
 
   cmakeFlags = [
     "-DQT_VERSION=3"
-    "-DQT_PREFIX_DIR=${tqt3}"
-    "-DQT_INCLUDE_DIR=${tqt3}/include"
-    "-DMOC_EXECUTABLE=${tqt3}/bin/tqmoc" ];
+    "-DQT_PREFIX_DIR=${tde.tqt3}"
+    "-DQT_INCLUDE_DIR=${tde.tqt3}/include"
+    "-DMOC_EXECUTABLE=${tde.tqt3}/bin/tqmoc" ];
 
   preConfigure = ''
     cd tqtinterface

--- a/pkgs/desktops/tde/R14/dependencies/tqtinterface/default.nix
+++ b/pkgs/desktops/tde/R14/dependencies/tqtinterface/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, cmake, coreutils, which, libuuid, tqt3, mesa }:
+
+stdenv.mkDerivation rec {
+
+  name = "tqtinterface-${version}";
+  version = "${majorVer}.${minorVer}";
+  majorVer = "R14.0";
+  minorVer = "3";
+
+  src = fetchurl {
+    url = "mirror://tde/${version}/dependencies/${name}.tar.bz2";
+    sha256 = "14kxq7nlkalgmlxpijs78fr0zr2ha9xykzqfbr7lh3zn0r79k5a3";
+  };
+
+  buildInputs = [ cmake coreutils which libuuid ];
+  propagatedBuildInputs = [ tqt3 mesa ];
+  setupHook = ./setup-hook.sh;
+
+  cmakeFlags = [
+    "-DQT_VERSION=3"
+    "-DQT_PREFIX_DIR=${tqt3}"
+    "-DQT_INCLUDE_DIR=${tqt3}/include"
+    "-DMOC_EXECUTABLE=${tqt3}/bin/tqmoc" ];
+
+  preConfigure = ''
+    cd tqtinterface
+  '';
+
+  meta = with stdenv.lib;{
+    description = "A library interface for TQt";
+    homepage = http://www.trinitydesktop.org;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.AndersonTores ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/tde/R14/dependencies/tqtinterface/setup-hook.sh
+++ b/pkgs/desktops/tde/R14/dependencies/tqtinterface/setup-hook.sh
@@ -1,0 +1,5 @@
+
+export TDEDIR=@out@
+export TDEDIRS=@out@
+export XDG_DATA_DIRS=$XDG_DATA_DIRS:$TDEDIR/share
+export XDG_CONFIG_DIRS=$XDG_CONFIG_DIRS:$TDEDIR/etc/xdg

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17051,6 +17051,10 @@ with pkgs;
     pantheon-terminal = callPackage ../desktops/pantheon/apps/pantheon-terminal { };
   };
 
+  tde = recurseIntoAttrs (callPackage ../desktops/tde/R14 {
+    callPackage = pkgs.newScope pkgs.tde;
+  });
+
   redshift = callPackage ../applications/misc/redshift {
     inherit (python3Packages) python pygobject3 pyxdg;
   };


### PR DESCRIPTION
###### Motivation for this change

Introduce the first steps to run Trinity Desktop Environment (TDE) on NixOS.
TDE is a fork of KDE 3.5 series, intended to be its logical continuation.

Initially, some "macros" and the TQt libs are described here.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
