### PR TITLE
youtube-dl: 2016.07.16 -> 2016.09.19

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -14,11 +14,11 @@ with stdenv.lib;
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.09.18";
+  version = "2016.09.19";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "c6482194cc64c8031df175762f3653cc44e40a83d23a2020314e55cdd9a75c02";
+    sha256 = "276637e83525778a83d0457f6b9fbc29d6109bc8366d43125432ce835d28545e";
   };
 
   buildInputs = [ makeWrapper zip ] ++ optional generateManPage pandoc;

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -14,11 +14,11 @@ with stdenv.lib;
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.07.16";
+  version = "2016.09.18";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "017x2hqc2bacypjmn9ac9f91y9y6afydl0z7dich5l627494hvfg";
+    sha256 = "c6482194cc64c8031df175762f3653cc44e40a83d23a2020314e55cdd9a75c02";
   };
 
   buildInputs = [ makeWrapper zip ] ++ optional generateManPage pandoc;


### PR DESCRIPTION
###### Motivation for this change

youtube-dl couldn't play twitch streams (server response 400 Bad Request). Newest version fixes this.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
