### PR TITLE
Kde 16.08.1

### DIFF
--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -1,6 +1,8 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash -p coreutils findutils gnused nix wget
 
+set -efuo pipefail
+
 SRCS=
 if [ -d "$1" ]; then
     SRCS="$(pwd)/$1/srcs.nix"

--- a/pkgs/desktops/kde-5/applications/fetch.sh
+++ b/pkgs/desktops/kde-5/applications/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/applications/16.08.0/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/applications/16.08.1/ -A '*.tar.xz' )

--- a/pkgs/desktops/kde-5/applications/srcs.nix
+++ b/pkgs/desktops/kde-5/applications/srcs.nix
@@ -1,2069 +1,2069 @@
-# DO NOT EDIT! This file is generated automatically by fetchsrcs.sh
+# DO NOT EDIT! This file is generated automatically by fetch-kde-qt.sh
 { fetchurl, mirror }:
 
 {
   akonadi = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/akonadi-16.08.0.tar.xz";
-      sha256 = "0xml678j47f9xd2dvyvw2v93yklwkvxamrp2v3739iqp03qfc210";
-      name = "akonadi-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/akonadi-16.08.1.tar.xz";
+      sha256 = "1km4qis98z19b5vy0g8r52mnd4i301ycf9l96a4vw4q56wmss2f1";
+      name = "akonadi-16.08.1.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/akonadi-calendar-16.08.0.tar.xz";
-      sha256 = "0g61sbj1ifkw349xmwch6hkazs1n6m92jhc1gm8az4zfnipms8yw";
-      name = "akonadi-calendar-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/akonadi-calendar-16.08.1.tar.xz";
+      sha256 = "12bz190cww8r34j0543wavf4d9ydkwszxh1ayxkg6hlf67yv2jpf";
+      name = "akonadi-calendar-16.08.1.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/akonadi-contacts-16.08.0.tar.xz";
-      sha256 = "1c50nnfk8r351a1pc0hyl03gbmnzqvicj6533gbl60104zg0cl49";
-      name = "akonadi-contacts-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/akonadi-contacts-16.08.1.tar.xz";
+      sha256 = "09dx4vi1329fgr2gya833p3zwasz4y8vh4fwlis3669zns6nvn6w";
+      name = "akonadi-contacts-16.08.1.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/akonadi-mime-16.08.0.tar.xz";
-      sha256 = "0b541y6ir78f5acdlzzr0bv9q8gd1p4rklrm0pcddvs1d28s5ng2";
-      name = "akonadi-mime-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/akonadi-mime-16.08.1.tar.xz";
+      sha256 = "16hyz28gjp1b0w6l33cgdrli4b777yanryfr8nn1mp4y8p2375fp";
+      name = "akonadi-mime-16.08.1.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/akonadi-notes-16.08.0.tar.xz";
-      sha256 = "0xwrj9y071g1svmwj1nrfff3vr371va7rm8mmx5hw6ringakgxn6";
-      name = "akonadi-notes-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/akonadi-notes-16.08.1.tar.xz";
+      sha256 = "1m95zckfr9wlcjsf3h6v2fg7rbivd28gjj2yddrrv7wx57xmky4j";
+      name = "akonadi-notes-16.08.1.tar.xz";
     };
   };
   akonadi-search = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/akonadi-search-16.08.0.tar.xz";
-      sha256 = "12lpgm5111dd2ny6fdhcxish397x54mcnma504f3ibk7f3brwnmf";
-      name = "akonadi-search-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/akonadi-search-16.08.1.tar.xz";
+      sha256 = "1qdqzb9achabb3vs7dm3pi3pk3l8rmk6ymmzlxr79l98cfmw39bk";
+      name = "akonadi-search-16.08.1.tar.xz";
     };
   };
   analitza = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/analitza-16.08.0.tar.xz";
-      sha256 = "1j8axc4618jb45vxp0ii51sr2wh6vmr1f8ycn3xqnd9ln936qqyz";
-      name = "analitza-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/analitza-16.08.1.tar.xz";
+      sha256 = "1l08g9gzi6aabzh62cg2k4731nbw8hnfb7qy1mjb4yn2gap0c4cd";
+      name = "analitza-16.08.1.tar.xz";
     };
   };
   ark = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ark-16.08.0.tar.xz";
-      sha256 = "1a8aklvpk5s319665s1c0mnbzknbyhbq2lm79hflal3r28g3acvj";
-      name = "ark-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ark-16.08.1.tar.xz";
+      sha256 = "1g9qvxw26hqngvbp4i82lmhpbr4nxidv7pj0sg1ji48jzycjbd3q";
+      name = "ark-16.08.1.tar.xz";
     };
   };
   artikulate = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/artikulate-16.08.0.tar.xz";
-      sha256 = "1j57y5zwp6zpd2hzh01a13m49rbgkzkf3ncfx122d7vih9f8kzvd";
-      name = "artikulate-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/artikulate-16.08.1.tar.xz";
+      sha256 = "1rbs6yf3pmhp9xj3lpr0h14pb4mylffhav2nb8sb42hw7c3pjycb";
+      name = "artikulate-16.08.1.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/audiocd-kio-16.08.0.tar.xz";
-      sha256 = "0ndb7b67yssmsxlnphpkyk4yx9n3xx2w20q4fz55r6zrp7yphm1a";
-      name = "audiocd-kio-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/audiocd-kio-16.08.1.tar.xz";
+      sha256 = "15x9nv014sdvc80vqldsgxrgickrrda6hrm26jcvp483qzvpjp82";
+      name = "audiocd-kio-16.08.1.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/baloo-widgets-16.08.0.tar.xz";
-      sha256 = "0daf0wkz14p82fl7731r1dhcy2w1zqlia722jskzmn4g86c9lf7d";
-      name = "baloo-widgets-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/baloo-widgets-16.08.1.tar.xz";
+      sha256 = "0lb42ci06xka82147awcwdhw35d1spvhdkfiq3qpbbyq8ajqxq18";
+      name = "baloo-widgets-16.08.1.tar.xz";
     };
   };
   blinken = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/blinken-16.08.0.tar.xz";
-      sha256 = "16x0l7fajrdgqm6pwhkn1za8bwliw556z6fc4bxm2jgcmdih7znq";
-      name = "blinken-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/blinken-16.08.1.tar.xz";
+      sha256 = "0xk39mcyad8s8haj2rmg2m7x46qzayl8zivc8v8h28vn80lvhk4v";
+      name = "blinken-16.08.1.tar.xz";
     };
   };
   bomber = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/bomber-16.08.0.tar.xz";
-      sha256 = "05j7xrcxs0lvniprd9818ck0jrjn6j8hjf773riqzsqr463v183h";
-      name = "bomber-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/bomber-16.08.1.tar.xz";
+      sha256 = "0rsgwr8vlnfli8zb77l9vdqn60k7kpdxpsaq16nhxxwl2n3780gn";
+      name = "bomber-16.08.1.tar.xz";
     };
   };
   bovo = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/bovo-16.08.0.tar.xz";
-      sha256 = "184h61fbkrasp9hik21pa45fxhgvvqmsf424n46i93m48fa7vwzl";
-      name = "bovo-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/bovo-16.08.1.tar.xz";
+      sha256 = "1vc4dv5gh2vif98fz4rcdb8zv20sashq4xbgfvk0xq3ls9j3qdyi";
+      name = "bovo-16.08.1.tar.xz";
     };
   };
   calendarsupport = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/calendarsupport-16.08.0.tar.xz";
-      sha256 = "04sbgp75vdg69jdjp9wgkcblzcwa7v5hwsdyb2ahz9ga27qsxgan";
-      name = "calendarsupport-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/calendarsupport-16.08.1.tar.xz";
+      sha256 = "08xvnmlpkwrsdz5fawcddcd5s7dn3zczfk5shk9a00734nc4akkb";
+      name = "calendarsupport-16.08.1.tar.xz";
     };
   };
   cantor = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/cantor-16.08.0.tar.xz";
-      sha256 = "0j798qxa8j8f6fjkvpag48gcqjrifgxhcm8raccx3bqlxz7145gh";
-      name = "cantor-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/cantor-16.08.1.tar.xz";
+      sha256 = "1cawdhpmyfb5qgbxil38szghi8q7hslpljzgsn7ma3gy6sqv3k9s";
+      name = "cantor-16.08.1.tar.xz";
     };
   };
   cervisia = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/cervisia-16.08.0.tar.xz";
-      sha256 = "0azjsigiz26y9fn1i8gaqdzw2bhvdn9v63ii51iazggjb49sk17v";
-      name = "cervisia-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/cervisia-16.08.1.tar.xz";
+      sha256 = "0apb29k4r2wsf6hn3rl2h1yvmy8npi4dmvjhr02j3gqfxic68vf1";
+      name = "cervisia-16.08.1.tar.xz";
     };
   };
   dolphin = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/dolphin-16.08.0.tar.xz";
-      sha256 = "0xqyb1qdxg19sp7xwkys9x92cx5wnbjz3sdmr2yc4j56fjqhih3j";
-      name = "dolphin-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/dolphin-16.08.1.tar.xz";
+      sha256 = "022mnq1x9la8yxim3svf3vj2x43gdp5qd6fwr50lvxw4i4gc8giy";
+      name = "dolphin-16.08.1.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/dolphin-plugins-16.08.0.tar.xz";
-      sha256 = "12pxw5vzznzkd9mr6dshh18mlgk0pmmkqic1mn1i53w0sj9r1zl2";
-      name = "dolphin-plugins-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/dolphin-plugins-16.08.1.tar.xz";
+      sha256 = "1vi0pwvz76w13gglpbn1dwxbzr5hmwjhdpi64nmbqjgi71i9x2sa";
+      name = "dolphin-plugins-16.08.1.tar.xz";
     };
   };
   dragon = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/dragon-16.08.0.tar.xz";
-      sha256 = "0vjhrdyshd7rd4i7yn6v1ldi0fsyabwph1pjjdylq1cz4clc7mzi";
-      name = "dragon-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/dragon-16.08.1.tar.xz";
+      sha256 = "1441jgg8bwvqghz31xnkwwlsayw134q0jiffgh1nis4rxm2rln8h";
+      name = "dragon-16.08.1.tar.xz";
     };
   };
   eventviews = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/eventviews-16.08.0.tar.xz";
-      sha256 = "1gms9q04icycjcazqkhg0i6mlf01rg45pp3zyndw6l7y3v9gcnq2";
-      name = "eventviews-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/eventviews-16.08.1.tar.xz";
+      sha256 = "0hp282if9fzw1xv4zdwrvar7wkchi9psl373r1594a7rjz9iby5j";
+      name = "eventviews-16.08.1.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ffmpegthumbs-16.08.0.tar.xz";
-      sha256 = "0nymi6g51xal5cllnp6rqxr7gcanp07njvpc7w02i2daan6cf5li";
-      name = "ffmpegthumbs-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ffmpegthumbs-16.08.1.tar.xz";
+      sha256 = "08gna4lcz6ipjkm2vx862n1w61cxzkskaapsd22zxfmgfhmqyp73";
+      name = "ffmpegthumbs-16.08.1.tar.xz";
     };
   };
   filelight = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/filelight-16.08.0.tar.xz";
-      sha256 = "1dynl9b4vp8qas23ysbbjmrf71k36z5cwnb2av3k0b53vf8h694p";
-      name = "filelight-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/filelight-16.08.1.tar.xz";
+      sha256 = "0l059q0vh4yp2y5m0alvcz74g4amiks6yfhh45bd38vkvfay8073";
+      name = "filelight-16.08.1.tar.xz";
     };
   };
   gpgmepp = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/gpgmepp-16.08.0.tar.xz";
-      sha256 = "0ydwl5qkvxnmzr3f375giykbhj8mm6kv1hywb6kyzafxcwn9ryqf";
-      name = "gpgmepp-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/gpgmepp-16.08.1.tar.xz";
+      sha256 = "1fqxjfn3mqkar8akpfh0i2lr30bvf99fm2ldsx34x7fq3kh29ys5";
+      name = "gpgmepp-16.08.1.tar.xz";
     };
   };
   granatier = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/granatier-16.08.0.tar.xz";
-      sha256 = "16j2xap43jpj6v6bclf99805rgpfzxcxnb715malcx69krqacfy2";
-      name = "granatier-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/granatier-16.08.1.tar.xz";
+      sha256 = "1k270rqcyf37gl1r4086q4r49ssvawy56d32y1n02ph289m3dgl6";
+      name = "granatier-16.08.1.tar.xz";
     };
   };
   grantleetheme = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/grantleetheme-16.08.0.tar.xz";
-      sha256 = "152b8brnd4q7zmxg4a3xizm56cqxy67aa7gc0znjcg8ga11szrpx";
-      name = "grantleetheme-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/grantleetheme-16.08.1.tar.xz";
+      sha256 = "10xajrlmkjpz6xl3jg47mdvpf478vvxx3rcwcvd2zxaza9yyakms";
+      name = "grantleetheme-16.08.1.tar.xz";
     };
   };
   gwenview = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/gwenview-16.08.0.tar.xz";
-      sha256 = "0in10ssq543snsdm4dks2z4hspqiwr0hygc2y8mpcg9kvq11j1w1";
-      name = "gwenview-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/gwenview-16.08.1.tar.xz";
+      sha256 = "1i55zd0pbgg2xinqzhxpsqx0vqp3dwn4z7bbf85m5cldbi070yv8";
+      name = "gwenview-16.08.1.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/incidenceeditor-16.08.0.tar.xz";
-      sha256 = "102chdy0siwnpv9rbxfy7aj1rz4gbwqq6sws7i92paj1k57ln361";
-      name = "incidenceeditor-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/incidenceeditor-16.08.1.tar.xz";
+      sha256 = "0wl89kwbnqrafflrdphczrn3l5gjgl5fqxvz4z995ri9m98kvgin";
+      name = "incidenceeditor-16.08.1.tar.xz";
     };
   };
   jovie = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/jovie-16.08.0.tar.xz";
-      sha256 = "0npcs6pq3w6r6wlg4j6dkl4zk9adm8fi84sh8vw89p9iksa2bgjm";
-      name = "jovie-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/jovie-16.08.1.tar.xz";
+      sha256 = "0nkrcvdsjcpba2awgvk0nv8ni3b5596p2jygxa906w50sjkcf5bk";
+      name = "jovie-16.08.1.tar.xz";
     };
   };
   juk = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/juk-16.08.0.tar.xz";
-      sha256 = "051zsjlq4bfiynkwb6gfx221j0fyvbd01dgx4adjgi15arw0l4kh";
-      name = "juk-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/juk-16.08.1.tar.xz";
+      sha256 = "1kj5iw3hfgqwz08imcfjicgm5m4v7m1fny6da8jidvwzyn46nll4";
+      name = "juk-16.08.1.tar.xz";
     };
   };
   kaccessible = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kaccessible-16.08.0.tar.xz";
-      sha256 = "1z9i0ylkph3ws5w8qh0h70ykhyjigmjlmmlrnjvxq36mszi2ph5v";
-      name = "kaccessible-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kaccessible-16.08.1.tar.xz";
+      sha256 = "086spk1aignmb2bry6hbw11nssm99dk38mnk4s89f444ydczs3fs";
+      name = "kaccessible-16.08.1.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kaccounts-integration-16.08.0.tar.xz";
-      sha256 = "0fs5y06j0psg0y97z54yv6mv1w88zm1dbvrmzwdckap9iyhgdk5w";
-      name = "kaccounts-integration-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kaccounts-integration-16.08.1.tar.xz";
+      sha256 = "0pjj0d8pnnz5zjmkjzb0x157msv0r0hk4h5vdji1jr0bwwhmwaw9";
+      name = "kaccounts-integration-16.08.1.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kaccounts-providers-16.08.0.tar.xz";
-      sha256 = "1sphbdfiqyjcyxvdpbrsfx8jci2k8w1vh56v6hpnv7dn042dmmim";
-      name = "kaccounts-providers-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kaccounts-providers-16.08.1.tar.xz";
+      sha256 = "1ji88wgvymdh63ykmv12n5gnr0zwmsch56n7wpwn5wvxs34wimqx";
+      name = "kaccounts-providers-16.08.1.tar.xz";
     };
   };
   kajongg = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kajongg-16.08.0.tar.xz";
-      sha256 = "0ydl7pdlp9nrfpxnkznaj6mwdq8w660flf5y3bgvv8jdxnaz7cyn";
-      name = "kajongg-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kajongg-16.08.1.tar.xz";
+      sha256 = "0z8kin497631fa7wls6bi42q32ijqgy674cigcmz9jfgn2hwkbc0";
+      name = "kajongg-16.08.1.tar.xz";
     };
   };
   kalarmcal = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kalarmcal-16.08.0.tar.xz";
-      sha256 = "0ai9h67w6dwsnw18hkxxwmpar4nf3k0zpv6fd1f1y9mvk2xdr6vw";
-      name = "kalarmcal-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kalarmcal-16.08.1.tar.xz";
+      sha256 = "10r31l6ak6dbksfj5444ndv06qx0jl4si634hv3i77q20jys1j26";
+      name = "kalarmcal-16.08.1.tar.xz";
     };
   };
   kalgebra = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kalgebra-16.08.0.tar.xz";
-      sha256 = "0ypwsp8pd72v4h99wcjpjkara3dbzidbjf8xksk7zskyp5c5rqxn";
-      name = "kalgebra-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kalgebra-16.08.1.tar.xz";
+      sha256 = "1wfiqlhhm36p137wcgpbvnhr6idqwkdann99pb1y463jblrdibv6";
+      name = "kalgebra-16.08.1.tar.xz";
     };
   };
   kalzium = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kalzium-16.08.0.tar.xz";
-      sha256 = "0vfylw7nw0f4dfi62ala5v1gkg4zf2g36pdl57afbbq1pc8v1qpf";
-      name = "kalzium-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kalzium-16.08.1.tar.xz";
+      sha256 = "09rz69cqqmicmwm9dj9yzq4l3j4w74ih8wcw0xyky948p3x6dh2r";
+      name = "kalzium-16.08.1.tar.xz";
     };
   };
   kamera = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kamera-16.08.0.tar.xz";
-      sha256 = "0l0nk3q8m6lww7r8gqdkkhl4s7mv7saxjxs7jkypll1q0686pmk7";
-      name = "kamera-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kamera-16.08.1.tar.xz";
+      sha256 = "01fvdbwi10pnhwg9q7w5lyr027mpy67mzdwpcwv4h1js6dsi68nz";
+      name = "kamera-16.08.1.tar.xz";
     };
   };
   kanagram = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kanagram-16.08.0.tar.xz";
-      sha256 = "180hpi4zhmhbmkn9166zpxk9pp3w08pryj33pkq6qcsbsflmnmic";
-      name = "kanagram-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kanagram-16.08.1.tar.xz";
+      sha256 = "0a2rk092sgp1ysaw7h47y6lmw9z269j7llnw5vzq3mblc2ay2sda";
+      name = "kanagram-16.08.1.tar.xz";
     };
   };
   kapman = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kapman-16.08.0.tar.xz";
-      sha256 = "1jhiwvi9hx46h1gwf1qmpi6cvyncybhfjsf0m51329cgx2hdfzl5";
-      name = "kapman-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kapman-16.08.1.tar.xz";
+      sha256 = "0x7b1d6hhl0nwyz8qzcz9nnjv8477ghifzgiyw3g1bx8044wqlsk";
+      name = "kapman-16.08.1.tar.xz";
     };
   };
   kapptemplate = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kapptemplate-16.08.0.tar.xz";
-      sha256 = "1zdaafrynh083vqr2b587c862qz0220hinmf9dc345gfss244zzf";
-      name = "kapptemplate-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kapptemplate-16.08.1.tar.xz";
+      sha256 = "1zkq5hpi8y4bny0q8p0aa3s4jpd5bxw18m5jxadjm4gfznnw8afv";
+      name = "kapptemplate-16.08.1.tar.xz";
     };
   };
   kate = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kate-16.08.0.tar.xz";
-      sha256 = "0z1fqd73il15y0hpjshhmd0cv6l2s3pm90m9l5k0ggg8vy0l1pqv";
-      name = "kate-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kate-16.08.1.tar.xz";
+      sha256 = "0z1q5lnkqnx40zbxj3bnwg9wrx7xk7xzfwc8i02zzvx50n7qn57n";
+      name = "kate-16.08.1.tar.xz";
     };
   };
   katomic = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/katomic-16.08.0.tar.xz";
-      sha256 = "14g0fiyxmlpwnfw25z3yxdzhixcahxss7rm4k06km37nzxmcca8l";
-      name = "katomic-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/katomic-16.08.1.tar.xz";
+      sha256 = "1ilaz15qg1fasd0yv03vcspxx54cbw2m99wl39zzrh7jc3df0ad8";
+      name = "katomic-16.08.1.tar.xz";
     };
   };
   kblackbox = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kblackbox-16.08.0.tar.xz";
-      sha256 = "0pq9rw1inxm5vjv4bcwklgh90wrz3sirf80v75dy2myiriv02y08";
-      name = "kblackbox-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kblackbox-16.08.1.tar.xz";
+      sha256 = "1w7rh9m6qwdid2li7xhmsfs0v7q95gyl24529xm17y79k1qxcbm7";
+      name = "kblackbox-16.08.1.tar.xz";
     };
   };
   kblocks = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kblocks-16.08.0.tar.xz";
-      sha256 = "04si5m0rbshm8h09ln6xqhfnsakrqqm3gi1gyk1agcpa5wr1hfyf";
-      name = "kblocks-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kblocks-16.08.1.tar.xz";
+      sha256 = "086b8k8zhs9v0rp06z9wx8gaaphc2178px5501rqx6062azxflil";
+      name = "kblocks-16.08.1.tar.xz";
     };
   };
   kblog = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kblog-16.08.0.tar.xz";
-      sha256 = "1qrdxad83dzjc5lpvj7dcghzkryp0anrp97sk7dlkmf1j7mj5w7n";
-      name = "kblog-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kblog-16.08.1.tar.xz";
+      sha256 = "1vc2a3c4iz2jm2137zw3i69n6qam2rlhvjr8ybv84xv9s7b3pz25";
+      name = "kblog-16.08.1.tar.xz";
     };
   };
   kbounce = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kbounce-16.08.0.tar.xz";
-      sha256 = "13a2xzkym62rxvk3haxjca1n8vx13r093r5dzsn9fb0gwc47p60x";
-      name = "kbounce-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kbounce-16.08.1.tar.xz";
+      sha256 = "0a4khwdrhzg33i4bbz1kb7w2jyzahnj1agcdybpzbqjnczgv4rnn";
+      name = "kbounce-16.08.1.tar.xz";
     };
   };
   kbreakout = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kbreakout-16.08.0.tar.xz";
-      sha256 = "1b1z702ify3av1275160sz740z1yyfv4x5jxrdzwf554sy8nqigg";
-      name = "kbreakout-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kbreakout-16.08.1.tar.xz";
+      sha256 = "14i4yyxxd9w72sgdfwp47y8drbdl7lsb8fxgdswg91dpcnm1jmgi";
+      name = "kbreakout-16.08.1.tar.xz";
     };
   };
   kbruch = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kbruch-16.08.0.tar.xz";
-      sha256 = "15v86pdgpdrkaxa75pj39w7c2x89b1gx3inxvpx51rfcjxdiqsz4";
-      name = "kbruch-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kbruch-16.08.1.tar.xz";
+      sha256 = "02dyc90ir79swf8vjd53flxqp2imaaa9c5dikflbxiahj4k6rpa4";
+      name = "kbruch-16.08.1.tar.xz";
     };
   };
   kcachegrind = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kcachegrind-16.08.0.tar.xz";
-      sha256 = "0bx0viz57d4qabsw0yl3max042wqzcnqkkvyd7yq1mdkjvywl522";
-      name = "kcachegrind-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kcachegrind-16.08.1.tar.xz";
+      sha256 = "1d7i162a6v7xhykzpszmia7cizrsgh040wk0ql7ijgb838iawflg";
+      name = "kcachegrind-16.08.1.tar.xz";
     };
   };
   kcalc = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kcalc-16.08.0.tar.xz";
-      sha256 = "1pk52k6cid8gppy5m9psfhq20jdcd1z9930yyj2sp9d5ynbk0hxb";
-      name = "kcalc-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kcalc-16.08.1.tar.xz";
+      sha256 = "18nhvmgd0d2m0ji23536fhqykf4xdnnky5x0hy6vkja0dw91aggg";
+      name = "kcalc-16.08.1.tar.xz";
     };
   };
   kcalcore = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kcalcore-16.08.0.tar.xz";
-      sha256 = "124hybji5j7838gxy69w4cafgrkh8wjh40v0iwqkiaq3nwjv3q0n";
-      name = "kcalcore-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kcalcore-16.08.1.tar.xz";
+      sha256 = "12q30gsaw2fr7wx6jpswa7aby8d58wldxagbcdkwcifv78d7bgk7";
+      name = "kcalcore-16.08.1.tar.xz";
     };
   };
   kcalutils = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kcalutils-16.08.0.tar.xz";
-      sha256 = "02dvdxnxl51qml8wmpvay7apq7zww7nf7nqwmli10m79ppdw1jmw";
-      name = "kcalutils-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kcalutils-16.08.1.tar.xz";
+      sha256 = "0fvhy2r5mw871ld18rab4nx9cv52fg7vwkxj31gbvx6rbzbmzsrs";
+      name = "kcalutils-16.08.1.tar.xz";
     };
   };
   kcharselect = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kcharselect-16.08.0.tar.xz";
-      sha256 = "11vyhlx33jjlwp1vri4l1vpzcgi07f86cqcfd84hnyr48v9dnya1";
-      name = "kcharselect-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kcharselect-16.08.1.tar.xz";
+      sha256 = "1mx2biawax867rfq42w0mi4b7v10j17anfq64gx5q6vi79k6jqaj";
+      name = "kcharselect-16.08.1.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kcolorchooser-16.08.0.tar.xz";
-      sha256 = "0j9s2f2x0vzkl24ajhm8ff1mx6r05j07sjx8v507pbfmxj2h64iz";
-      name = "kcolorchooser-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kcolorchooser-16.08.1.tar.xz";
+      sha256 = "1s490hkjbinhlc3pf2waks9ka8dvkpq3l5vblmd11h1yckbpcdqi";
+      name = "kcolorchooser-16.08.1.tar.xz";
     };
   };
   kcontacts = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kcontacts-16.08.0.tar.xz";
-      sha256 = "063qip4jrcv8qzz1gvq49wjzjsrp8ladaspagqd4jbq65qvnpz96";
-      name = "kcontacts-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kcontacts-16.08.1.tar.xz";
+      sha256 = "198qqs7001m2ywmryx9489jpay1g7i9g04bl9y25jr2a3lf4id87";
+      name = "kcontacts-16.08.1.tar.xz";
     };
   };
   kcron = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kcron-16.08.0.tar.xz";
-      sha256 = "17bhhvni66wx4ihqzqcn9mglidw7r1lak08jgdbnadxj1nalph8l";
-      name = "kcron-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kcron-16.08.1.tar.xz";
+      sha256 = "062ndya5r67imkx0fw2whgppfm9j3jwxscfz8vd64g3532kai9n5";
+      name = "kcron-16.08.1.tar.xz";
     };
   };
   kde-baseapps = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-baseapps-16.08.0.tar.xz";
-      sha256 = "0sajfiwij3znmgmayj1d1q4xmzr0j0a4nb6181j3a360vg5zd42f";
-      name = "kde-baseapps-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-baseapps-16.08.1.tar.xz";
+      sha256 = "0s9391mx2wh1yvi5ykp5nj3zfr5qvkqpwljjgvhfr2i1a4h24551";
+      name = "kde-baseapps-16.08.1.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdebugsettings-16.08.0.tar.xz";
-      sha256 = "08w6b514vrg7100d10m6iwqpgh6ap06dh1b79xax0rqlpcpl40yn";
-      name = "kdebugsettings-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdebugsettings-16.08.1.tar.xz";
+      sha256 = "0b3940wzm3bl0w0wdjk62ikf6cxlzipckwzq7skpnp115j90pnyp";
+      name = "kdebugsettings-16.08.1.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-dev-scripts-16.08.0.tar.xz";
-      sha256 = "197w58zhbm6cs54wa4rxf5hmw9gjyvwpabdlfvn1dzr53fx0wlh1";
-      name = "kde-dev-scripts-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-dev-scripts-16.08.1.tar.xz";
+      sha256 = "1biw748yyiy2xwb4jyx1g4h6v9m0q3qwxh6kc4l7fb9qsjam0222";
+      name = "kde-dev-scripts-16.08.1.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-dev-utils-16.08.0.tar.xz";
-      sha256 = "1a1cxr95sgfpzjcdq0b0jny8lwx734xn3nm9axakq614mq1mqhcw";
-      name = "kde-dev-utils-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-dev-utils-16.08.1.tar.xz";
+      sha256 = "00dgfclyl95nv5s77w56h472hb02v91fhdx0qkk0vikj2n1z7l9n";
+      name = "kde-dev-utils-16.08.1.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdeedu-data-16.08.0.tar.xz";
-      sha256 = "09c9v0h5bys1nx6ll18s91lwghhri1aqnhs86igp81a5k3rgvjf3";
-      name = "kdeedu-data-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdeedu-data-16.08.1.tar.xz";
+      sha256 = "0qh6ain1qi7l5455j3ir6fq7rs735j2q2czxl2ys8qji5j1yidwa";
+      name = "kdeedu-data-16.08.1.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdegraphics-mobipocket-16.08.0.tar.xz";
-      sha256 = "183dxwfx4d17wzy81jjjh2v1lhi7hi7glwgd5dh208v30h36h1fv";
-      name = "kdegraphics-mobipocket-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdegraphics-mobipocket-16.08.1.tar.xz";
+      sha256 = "1lzwlvcf6wp1g2n46811cq2m3h212w161z6kasdg7wf7rcghbmvd";
+      name = "kdegraphics-mobipocket-16.08.1.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdegraphics-thumbnailers-16.08.0.tar.xz";
-      sha256 = "1i0cfnsh74bic5z4hvrakss55ci3xlfslcmwklp20804ngfkq6h8";
-      name = "kdegraphics-thumbnailers-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdegraphics-thumbnailers-16.08.1.tar.xz";
+      sha256 = "068cvcnaf8kyls49143w8lwg24hk58byiv23qh2xxv180ps12hkm";
+      name = "kdegraphics-thumbnailers-16.08.1.tar.xz";
     };
   };
   kde-l10n-ar = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ar-16.08.0.tar.xz";
-      sha256 = "0dkxjb7af1xb3q1c2d4hpl8vn9391fbacfbnahxyil3zqxp0z5i7";
-      name = "kde-l10n-ar-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ar-16.08.1.tar.xz";
+      sha256 = "0v1h0qciqr4kanb0mb6hjma35spjhp51vx0r7kb3girmv4ik2mii";
+      name = "kde-l10n-ar-16.08.1.tar.xz";
     };
   };
   kde-l10n-ast = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ast-16.08.0.tar.xz";
-      sha256 = "0x7pjg1x5yw76145biwfyrw8b0nx06xbzc57rqvy8k773qr5zilj";
-      name = "kde-l10n-ast-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ast-16.08.1.tar.xz";
+      sha256 = "1srk025iqvrwjcks9hcjlzxqmlmfmzn3xlgi1c60nncb046q7xa6";
+      name = "kde-l10n-ast-16.08.1.tar.xz";
     };
   };
   kde-l10n-bg = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-bg-16.08.0.tar.xz";
-      sha256 = "1617b7a1rr43jhj8jdqyircm72jvqcrqqkzl3s8hwi6daprpqik9";
-      name = "kde-l10n-bg-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-bg-16.08.1.tar.xz";
+      sha256 = "014s77imwl3awy3fd4yzdv0k61j1h0rlvnlfk7mzkyyjgxhh9wqg";
+      name = "kde-l10n-bg-16.08.1.tar.xz";
     };
   };
   kde-l10n-bs = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-bs-16.08.0.tar.xz";
-      sha256 = "1vmk5mmrs0d1123cx5y003lkim1kxc9d8x3flsxkpyb1c155nvpw";
-      name = "kde-l10n-bs-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-bs-16.08.1.tar.xz";
+      sha256 = "0ijsbkllls8966hrh19p2062fmnjan0hibl6650ihgypsci15y57";
+      name = "kde-l10n-bs-16.08.1.tar.xz";
     };
   };
   kde-l10n-ca = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ca-16.08.0.tar.xz";
-      sha256 = "18m2g0iagiaqfbg1lr1i3z9nm4qva0ipl1rh22p2slqivqcrvg51";
-      name = "kde-l10n-ca-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ca-16.08.1.tar.xz";
+      sha256 = "12kn3skciqmsqwqdpx7n4286cz1w7rdgx4mggvk05db0bhrybjzg";
+      name = "kde-l10n-ca-16.08.1.tar.xz";
     };
   };
   kde-l10n-ca_valencia = {
-    version = "ca_valencia-16.08.0";
+    version = "ca_valencia-16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ca@valencia-16.08.0.tar.xz";
-      sha256 = "1h68h6dzkkhpl5rsdw6ykg9prs9l1xbwwm7mqxxljxsd8bmpdv4g";
-      name = "kde-l10n-ca_valencia-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ca@valencia-16.08.1.tar.xz";
+      sha256 = "0dfjx9pfzwilz746lrdgpx51cig8wr9igbm7pdidpaz5wryqfsif";
+      name = "kde-l10n-ca_valencia-16.08.1.tar.xz";
     };
   };
   kde-l10n-cs = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-cs-16.08.0.tar.xz";
-      sha256 = "0wg84mxj4sbwi3ck4vdva0fbs7gsyr2xjzk6bd49a70ls9icp39x";
-      name = "kde-l10n-cs-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-cs-16.08.1.tar.xz";
+      sha256 = "1b14wgczd6qfkgy1rfj2dmw0l0vc3jkf1yf0ih5y0s3zqx081k34";
+      name = "kde-l10n-cs-16.08.1.tar.xz";
     };
   };
   kde-l10n-da = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-da-16.08.0.tar.xz";
-      sha256 = "0jkkqw69bv3r6avcywsxbqy99lbcyfbn3r9ipqcmka3hpss8cf18";
-      name = "kde-l10n-da-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-da-16.08.1.tar.xz";
+      sha256 = "1hdppgawypnya6sk60bz62cc7dnhh5m1dcq68hx67a9wrf6hw21i";
+      name = "kde-l10n-da-16.08.1.tar.xz";
     };
   };
   kde-l10n-de = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-de-16.08.0.tar.xz";
-      sha256 = "0g6cglysjzzbc67wv29zqikvgzmq928a3arwd50hjvg85dh50w4f";
-      name = "kde-l10n-de-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-de-16.08.1.tar.xz";
+      sha256 = "0r0kkrmk4gzn9nhly9c908ajciy9k9rxy8wrqampj4gynxsrc07w";
+      name = "kde-l10n-de-16.08.1.tar.xz";
     };
   };
   kde-l10n-el = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-el-16.08.0.tar.xz";
-      sha256 = "037wiqbw172rkqlq5709arwkdi8qmhrrqc00rhy612x7m075n2ln";
-      name = "kde-l10n-el-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-el-16.08.1.tar.xz";
+      sha256 = "1d6ipj1hyjzwlcparbi533iqgvbx9lhdmqnzdhjxnim1hia25wan";
+      name = "kde-l10n-el-16.08.1.tar.xz";
     };
   };
   kde-l10n-en_GB = {
-    version = "en_GB-16.08.0";
+    version = "en_GB-16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-en_GB-16.08.0.tar.xz";
-      sha256 = "0nbkijpaxsi365c6q44wq0wbv0bqgpyhrb1d2a3v7lhcb9jv6ci9";
-      name = "kde-l10n-en_GB-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-en_GB-16.08.1.tar.xz";
+      sha256 = "102qlxmcynqf30x25ygmh7x6x0d12fbr4dri1nj8rkd8bmi214di";
+      name = "kde-l10n-en_GB-16.08.1.tar.xz";
     };
   };
   kde-l10n-eo = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-eo-16.08.0.tar.xz";
-      sha256 = "1qsl7r9da29hxqs7y0i17zyzvpfxi9h2srdq345ppyxdk3avbvp7";
-      name = "kde-l10n-eo-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-eo-16.08.1.tar.xz";
+      sha256 = "131y6259yi3kwzn17a11nx5xmxc1llg105g2x0sfayc7k4i5y24z";
+      name = "kde-l10n-eo-16.08.1.tar.xz";
     };
   };
   kde-l10n-es = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-es-16.08.0.tar.xz";
-      sha256 = "1hm2rvsbrxmci1939iicms5qb1fbm0f1b27zlhgzmf6j3pmg25b3";
-      name = "kde-l10n-es-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-es-16.08.1.tar.xz";
+      sha256 = "1qzwfi21cfs5j88hxmkbbrp8isrxv6b6c3ld2s41lj6a67sdw21k";
+      name = "kde-l10n-es-16.08.1.tar.xz";
     };
   };
   kde-l10n-et = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-et-16.08.0.tar.xz";
-      sha256 = "0ng6qg7sw3dypn7yg7m8803cpqm39x0b9jn2q0f3jmx46ys9kyyi";
-      name = "kde-l10n-et-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-et-16.08.1.tar.xz";
+      sha256 = "1dci7x9w8dzmzwj5f6c4i9x6v5g68ll9dwfvwf060vy2pnnnlw7g";
+      name = "kde-l10n-et-16.08.1.tar.xz";
     };
   };
   kde-l10n-eu = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-eu-16.08.0.tar.xz";
-      sha256 = "0dmiipd0l1dza14fyd17g7qwih4n1fzg2fjkx9vhwdzl5anxmb13";
-      name = "kde-l10n-eu-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-eu-16.08.1.tar.xz";
+      sha256 = "1n21mhqlr3wj6gd9kbfvfck5f1ql1ywanbp084afxqcbx82pb7j3";
+      name = "kde-l10n-eu-16.08.1.tar.xz";
     };
   };
   kde-l10n-fa = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-fa-16.08.0.tar.xz";
-      sha256 = "129i0fhdxab5k8vjiml0ylyja5hz6dmr3x8qarf0mfspwhi7pkna";
-      name = "kde-l10n-fa-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-fa-16.08.1.tar.xz";
+      sha256 = "15ay6hqgpdv80fa3gjksfmjiczr4zwpwh4mj1zdrdm241kdhp1jp";
+      name = "kde-l10n-fa-16.08.1.tar.xz";
     };
   };
   kde-l10n-fi = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-fi-16.08.0.tar.xz";
-      sha256 = "1rjzsagskszi14lv1ak6ailfxxiqqq2ry26dz53agq8qd4md19y3";
-      name = "kde-l10n-fi-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-fi-16.08.1.tar.xz";
+      sha256 = "130hpabvd2rjd0x11k9yxjl94aslaz90bhf3mfm5bnjjlm8iqwz5";
+      name = "kde-l10n-fi-16.08.1.tar.xz";
     };
   };
   kde-l10n-fr = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-fr-16.08.0.tar.xz";
-      sha256 = "09brqj4xx8apsldxjpx797ggmwv3flm7cbxh39kc3q8c7dpzr4a5";
-      name = "kde-l10n-fr-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-fr-16.08.1.tar.xz";
+      sha256 = "0mkbbba9jldks003cmcdbfiqw7g6nr4majz8skb7srq8ma7sf9x4";
+      name = "kde-l10n-fr-16.08.1.tar.xz";
     };
   };
   kde-l10n-ga = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ga-16.08.0.tar.xz";
-      sha256 = "1ig3hvy58p7d3j4h6r1nz8yj65mfpamxajmrg3aid56i8rc81ibk";
-      name = "kde-l10n-ga-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ga-16.08.1.tar.xz";
+      sha256 = "0hmj03ajgijjg3lmrsypff2nxzf61vmvf0qwrxiy3q40vvgj5mbr";
+      name = "kde-l10n-ga-16.08.1.tar.xz";
     };
   };
   kde-l10n-gl = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-gl-16.08.0.tar.xz";
-      sha256 = "09hrpgxcp2s20d1ia6plkglkhhj8mzfh8d01y0jfc8b1h5br282w";
-      name = "kde-l10n-gl-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-gl-16.08.1.tar.xz";
+      sha256 = "0n0nim3pkhql2lx9kqplcs6v225c2cirhazsb6ldblkhxbk0hgfb";
+      name = "kde-l10n-gl-16.08.1.tar.xz";
     };
   };
   kde-l10n-he = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-he-16.08.0.tar.xz";
-      sha256 = "09zf3a0gbs5h5r3mrpc9gkd4l2j9nw1k7vdwahxjpsdhvs1bwx3h";
-      name = "kde-l10n-he-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-he-16.08.1.tar.xz";
+      sha256 = "0x4rn81ijx2b0z4s2b67d69gnnx0ldl43c311jf0dn9cyadjws07";
+      name = "kde-l10n-he-16.08.1.tar.xz";
     };
   };
   kde-l10n-hi = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-hi-16.08.0.tar.xz";
-      sha256 = "1xvvkl5pr3w0s1pizarg0mmkvckxss944a188avqfsqrav642458";
-      name = "kde-l10n-hi-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-hi-16.08.1.tar.xz";
+      sha256 = "1if5h20ywpkh85fx95i0mrv993gfj1rm3yp9jzz8x250b6ggbfd5";
+      name = "kde-l10n-hi-16.08.1.tar.xz";
     };
   };
   kde-l10n-hr = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-hr-16.08.0.tar.xz";
-      sha256 = "0cyz0ysz9xr93dlq2n758nw2kyi2f8b7h3gr4im7syj05nk0fhb6";
-      name = "kde-l10n-hr-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-hr-16.08.1.tar.xz";
+      sha256 = "0fg27qkj23b49hvbksqsiv3jj571b4i9msk82ygzvxl2ay5him52";
+      name = "kde-l10n-hr-16.08.1.tar.xz";
     };
   };
   kde-l10n-hu = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-hu-16.08.0.tar.xz";
-      sha256 = "0imcb7zd7rzf2nc8darlj4i843gha3ihbi0lvh6pnnmcxvc2dzdh";
-      name = "kde-l10n-hu-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-hu-16.08.1.tar.xz";
+      sha256 = "1nw0922gk4f89r06fkgqvs092dbi4kjbfxvj86gq98v1ms0pns69";
+      name = "kde-l10n-hu-16.08.1.tar.xz";
     };
   };
   kde-l10n-ia = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ia-16.08.0.tar.xz";
-      sha256 = "1x14165y0qvpjn3mkg03l4p0mij9a6haxkrbkkqvv1waapifyxsl";
-      name = "kde-l10n-ia-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ia-16.08.1.tar.xz";
+      sha256 = "0plsffy1khy9cacqhabr1j2g0xi3v21qgydj6phb6d5j82p1c79i";
+      name = "kde-l10n-ia-16.08.1.tar.xz";
     };
   };
   kde-l10n-id = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-id-16.08.0.tar.xz";
-      sha256 = "1mf3viq3yligqg8vqca31ybs9s59nxmylvwqmg8ndy9ni4mni2wx";
-      name = "kde-l10n-id-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-id-16.08.1.tar.xz";
+      sha256 = "0ihir3axvkczkik2nnfh4mmqkx2gpmvzri48i34p5dz21n8ca4ha";
+      name = "kde-l10n-id-16.08.1.tar.xz";
     };
   };
   kde-l10n-is = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-is-16.08.0.tar.xz";
-      sha256 = "07xdlvk3nqc9wsrnd1a0hm6igwc0hnryffs99jvd0dlbq0hzakl3";
-      name = "kde-l10n-is-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-is-16.08.1.tar.xz";
+      sha256 = "0qrayzxpx1phk2m6kcq5b6i05swds1fis4651r5xk69dc2zqlbjn";
+      name = "kde-l10n-is-16.08.1.tar.xz";
     };
   };
   kde-l10n-it = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-it-16.08.0.tar.xz";
-      sha256 = "05xir0spl5fbyynwjkf13zzqgwl1mzi97bfjfi1x8jhiq0jqhafn";
-      name = "kde-l10n-it-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-it-16.08.1.tar.xz";
+      sha256 = "1qhv4rywr9qlszlx8a7crqshr5zmxxgscq8s1c735jcm57bk8wzl";
+      name = "kde-l10n-it-16.08.1.tar.xz";
     };
   };
   kde-l10n-ja = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ja-16.08.0.tar.xz";
-      sha256 = "1gdngf075021750rxfbrcbbh8wb1nknzclgghsj8j94qb96ij87m";
-      name = "kde-l10n-ja-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ja-16.08.1.tar.xz";
+      sha256 = "1zwb8r1vanrl4q0mhqgd4qj8smyygqgka4b4zjqr6h2klklwsxsg";
+      name = "kde-l10n-ja-16.08.1.tar.xz";
     };
   };
   kde-l10n-kk = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-kk-16.08.0.tar.xz";
-      sha256 = "0y5qdnkdhc7lnd3casxil757mmklsysm8kvs9i09j4b5ldmkin0r";
-      name = "kde-l10n-kk-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-kk-16.08.1.tar.xz";
+      sha256 = "1zdhfhjxpr73f34nh24y6ddgp3zkqim4dy8mblk84w8wsg80i6gj";
+      name = "kde-l10n-kk-16.08.1.tar.xz";
     };
   };
   kde-l10n-km = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-km-16.08.0.tar.xz";
-      sha256 = "0a27rhjf40q5003jy3aancaf9qnygmfqk4g7jic1x1d64n3khz9c";
-      name = "kde-l10n-km-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-km-16.08.1.tar.xz";
+      sha256 = "1qx2cm9cv7b33pkzpfgcqppr6q4qqzf9v152wjfdk096jq6yfijv";
+      name = "kde-l10n-km-16.08.1.tar.xz";
     };
   };
   kde-l10n-ko = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ko-16.08.0.tar.xz";
-      sha256 = "0g8plf0z329xyiwi4aia96i3psypqsx9wfhnb26kwwgl6vjd4nin";
-      name = "kde-l10n-ko-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ko-16.08.1.tar.xz";
+      sha256 = "18za5mpnx8xfkpmpjp2i04kl6a2chjgz8g7vhymi01m1dhf7ql5f";
+      name = "kde-l10n-ko-16.08.1.tar.xz";
     };
   };
   kde-l10n-lt = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-lt-16.08.0.tar.xz";
-      sha256 = "0c5akrzfmjkrf4z8p5yfy9f3q8p6bf3l97aajcj2jzqxmxqrkgxz";
-      name = "kde-l10n-lt-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-lt-16.08.1.tar.xz";
+      sha256 = "147z5af6qn7c6qrxxzmcc9qkagc4y6nffqal3fsrs84pjrsav72j";
+      name = "kde-l10n-lt-16.08.1.tar.xz";
     };
   };
   kde-l10n-lv = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-lv-16.08.0.tar.xz";
-      sha256 = "1l0yfc4999sjl01m07rmzw2h9cd0pw2d9j4wa7fjs2pf89z5z2y6";
-      name = "kde-l10n-lv-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-lv-16.08.1.tar.xz";
+      sha256 = "19pf8khdszfnlfybrsdwm0gbnphr43109b81fa6bsxcc57knagwg";
+      name = "kde-l10n-lv-16.08.1.tar.xz";
     };
   };
   kde-l10n-mr = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-mr-16.08.0.tar.xz";
-      sha256 = "0jnrycqxszxq7mw7kwyhprb7pmrqz5v9kkhqf2bm4k9mf5553a0w";
-      name = "kde-l10n-mr-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-mr-16.08.1.tar.xz";
+      sha256 = "0vwa1mz9igx592bq89fnq7350ln4g5cvdmm1hnay94c5qxc12s0z";
+      name = "kde-l10n-mr-16.08.1.tar.xz";
     };
   };
   kde-l10n-nb = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-nb-16.08.0.tar.xz";
-      sha256 = "1ga30ki4yaa4ajbrjp0fz75r67cvrc801skx31x6d1cw6xjyi72l";
-      name = "kde-l10n-nb-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-nb-16.08.1.tar.xz";
+      sha256 = "1dz3a5bwsmbckdmh2v2crnal7183sqav6y5z01xdq0wyjjy8kizc";
+      name = "kde-l10n-nb-16.08.1.tar.xz";
     };
   };
   kde-l10n-nds = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-nds-16.08.0.tar.xz";
-      sha256 = "1ibv7rq1ap5zmal4bf8a8z285mf6g55bcmli67gvhwfvy13vkg9s";
-      name = "kde-l10n-nds-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-nds-16.08.1.tar.xz";
+      sha256 = "1gjvwg6gmxbvk7q26f7i50ivfmh4s2djl7m9dsaj6rk53cknhd8s";
+      name = "kde-l10n-nds-16.08.1.tar.xz";
     };
   };
   kde-l10n-nl = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-nl-16.08.0.tar.xz";
-      sha256 = "0pysm6sjdls14d8cqmywnljwk2k94q9z7rdm7m3p75p4q778drda";
-      name = "kde-l10n-nl-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-nl-16.08.1.tar.xz";
+      sha256 = "1r3mwnkkr8k3zb87j6lr4lrgq02rccqpp5m273z1c5n0kqcbp50h";
+      name = "kde-l10n-nl-16.08.1.tar.xz";
     };
   };
   kde-l10n-nn = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-nn-16.08.0.tar.xz";
-      sha256 = "1v3q9jr6ginh24ph99qyb57phm86zwph3xv6zbymg61vghv398q2";
-      name = "kde-l10n-nn-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-nn-16.08.1.tar.xz";
+      sha256 = "0r38zvmh05mcfh7grayb771mrdl2637xnx75nx7lnvkvmlf6dngh";
+      name = "kde-l10n-nn-16.08.1.tar.xz";
     };
   };
   kde-l10n-pa = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-pa-16.08.0.tar.xz";
-      sha256 = "10c1c6hql80x714msa45cpbgl4nagaf9mydfb160lsvaa1whzzbd";
-      name = "kde-l10n-pa-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-pa-16.08.1.tar.xz";
+      sha256 = "04828d9wsd51g3a45nzddxhxdwwk447qlkswxjzayiy7w6pjspch";
+      name = "kde-l10n-pa-16.08.1.tar.xz";
     };
   };
   kde-l10n-pl = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-pl-16.08.0.tar.xz";
-      sha256 = "1xz33a9af2ccl249ymaqawz1ymrxa5zwhg2gayxk5jmv2fsvhikp";
-      name = "kde-l10n-pl-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-pl-16.08.1.tar.xz";
+      sha256 = "068ab65ivm4qw3hmhv97v8ck2qg7z8aglfwq0lqrlb5famg158di";
+      name = "kde-l10n-pl-16.08.1.tar.xz";
     };
   };
   kde-l10n-pt = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-pt-16.08.0.tar.xz";
-      sha256 = "1wp0i6mlk4nhd7v502kc4gh7zymgiakqlx3jjpjaqsv31igya406";
-      name = "kde-l10n-pt-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-pt-16.08.1.tar.xz";
+      sha256 = "1ix32ry9zzgdwmpqfvzsfdz357l56nwqd42rnszgjzs4sdikl3y8";
+      name = "kde-l10n-pt-16.08.1.tar.xz";
     };
   };
   kde-l10n-pt_BR = {
-    version = "pt_BR-16.08.0";
+    version = "pt_BR-16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-pt_BR-16.08.0.tar.xz";
-      sha256 = "0nv8k2fn8jdv80vcwiri5w937qcp2gj8bjmi3hcc9qirdqh8wjap";
-      name = "kde-l10n-pt_BR-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-pt_BR-16.08.1.tar.xz";
+      sha256 = "0id10qm9gzg2c9as2np8a0sfnx9acsnf06igvwxnyazar8k831hs";
+      name = "kde-l10n-pt_BR-16.08.1.tar.xz";
     };
   };
   kde-l10n-ro = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ro-16.08.0.tar.xz";
-      sha256 = "0bqw4zb5hz1wccgicyfd8d8zzhq69jf16f3qr6c6ry345hkx1ywm";
-      name = "kde-l10n-ro-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ro-16.08.1.tar.xz";
+      sha256 = "1j6vdc62xw4pbn0lz0zmwylc43m9kxn78zx0qn5gc51i2n3sb8bm";
+      name = "kde-l10n-ro-16.08.1.tar.xz";
     };
   };
   kde-l10n-ru = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ru-16.08.0.tar.xz";
-      sha256 = "1pi549z9wzjsaixn246wq9bqkgy2azhwccwhyy5d0d442d23xwqv";
-      name = "kde-l10n-ru-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ru-16.08.1.tar.xz";
+      sha256 = "1bqrjgh89yskqx5hpd08z949nplp7f53is1vm9slrvn94hcslc46";
+      name = "kde-l10n-ru-16.08.1.tar.xz";
     };
   };
   kde-l10n-sk = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-sk-16.08.0.tar.xz";
-      sha256 = "09lyhmiishxiihnpv9lli329zl4v05q3578ib5nrzrkrlky512m9";
-      name = "kde-l10n-sk-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-sk-16.08.1.tar.xz";
+      sha256 = "18w6zbix3iwrgyswlr8390yb3q4fli1krana7pimfhll29wg9s2v";
+      name = "kde-l10n-sk-16.08.1.tar.xz";
     };
   };
   kde-l10n-sl = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-sl-16.08.0.tar.xz";
-      sha256 = "1maz22c0mp8bgj1rcg0ms2cncx0gg82diwpb930shjmivr8zhmrd";
-      name = "kde-l10n-sl-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-sl-16.08.1.tar.xz";
+      sha256 = "1q9gjl8cz02nwy90w31apr8rv5bhp8xanmc6ckijfl7xz5a5r7ig";
+      name = "kde-l10n-sl-16.08.1.tar.xz";
     };
   };
   kde-l10n-sr = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-sr-16.08.0.tar.xz";
-      sha256 = "190ww2065537lny8jnm81lqcxpfllhf45snj93zl41pcva4zw4jg";
-      name = "kde-l10n-sr-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-sr-16.08.1.tar.xz";
+      sha256 = "019m72c4l486rwq6cm309jsaasz96grv2bb8wrgxy2r69y2qnzqj";
+      name = "kde-l10n-sr-16.08.1.tar.xz";
     };
   };
   kde-l10n-sv = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-sv-16.08.0.tar.xz";
-      sha256 = "0bl1qz3zqrq8vjbnacvdym9yzycpjhgy62r2577h2ybds31fj81n";
-      name = "kde-l10n-sv-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-sv-16.08.1.tar.xz";
+      sha256 = "0ml489l1jv07x1d157gacsgnyx95j4fapd0r6q4d2r5mdm77w36b";
+      name = "kde-l10n-sv-16.08.1.tar.xz";
     };
   };
   kde-l10n-tr = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-tr-16.08.0.tar.xz";
-      sha256 = "1gbm055f4cbcl1h9k2r6fnjnnjj5wss8zyyc16id57ydzvnkdbi1";
-      name = "kde-l10n-tr-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-tr-16.08.1.tar.xz";
+      sha256 = "008fjcf7p2pk1g4mzsc98vqlaaagf1bkmha323rgqrz07jzjax63";
+      name = "kde-l10n-tr-16.08.1.tar.xz";
     };
   };
   kde-l10n-ug = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-ug-16.08.0.tar.xz";
-      sha256 = "1hqdh0v83yvn4hnl51hsabkcbn5rhw0xcwn4nzqm6q2ib68rzhal";
-      name = "kde-l10n-ug-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-ug-16.08.1.tar.xz";
+      sha256 = "1d38j4cyzzxv35i39rmhrlyc097n56gghvwcl16nj55qbm41nb22";
+      name = "kde-l10n-ug-16.08.1.tar.xz";
     };
   };
   kde-l10n-uk = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-uk-16.08.0.tar.xz";
-      sha256 = "00ijcfs6688d822iwg85msk8hxl7qhq5lx3bkw1xwdnmqf0nlxqj";
-      name = "kde-l10n-uk-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-uk-16.08.1.tar.xz";
+      sha256 = "1684139ic7vsr68jfk91kmlvw5bjxm2p2p2zkim0md8gmjw279bd";
+      name = "kde-l10n-uk-16.08.1.tar.xz";
     };
   };
   kde-l10n-wa = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-wa-16.08.0.tar.xz";
-      sha256 = "0g9jjpn6fzkdvy16mw1yhahrv5y2ybjwi091c01sh9c9rwfj5qpg";
-      name = "kde-l10n-wa-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-wa-16.08.1.tar.xz";
+      sha256 = "07nalfxn0gw8ygi5cjq5xzyszk4pa4bb2lyll5nfh0h971kiwrk0";
+      name = "kde-l10n-wa-16.08.1.tar.xz";
     };
   };
   kde-l10n-zh_CN = {
-    version = "zh_CN-16.08.0";
+    version = "zh_CN-16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-zh_CN-16.08.0.tar.xz";
-      sha256 = "0997azdrq2i4rfijchr3jz9b6why4hm79cddn1c7wdk3943xz094";
-      name = "kde-l10n-zh_CN-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-zh_CN-16.08.1.tar.xz";
+      sha256 = "120f7a4qwxjh0l6n0pcckwi0y5lzy99l7p40i032yd4awjm0jdx6";
+      name = "kde-l10n-zh_CN-16.08.1.tar.xz";
     };
   };
   kde-l10n-zh_TW = {
-    version = "zh_TW-16.08.0";
+    version = "zh_TW-16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-l10n/kde-l10n-zh_TW-16.08.0.tar.xz";
-      sha256 = "04d1awymijlkp2q15vjzs7j6aznpsb4kivc6jx24ly7cp3vn66zm";
-      name = "kde-l10n-zh_TW-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-l10n/kde-l10n-zh_TW-16.08.1.tar.xz";
+      sha256 = "00z9rld3a76lw3gb621zqclfkdww46fvd86sdws3r6d71zv659h0";
+      name = "kde-l10n-zh_TW-16.08.1.tar.xz";
     };
   };
   kdelibs = {
-    version = "4.14.23";
+    version = "4.14.24";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdelibs-4.14.23.tar.xz";
-      sha256 = "1k8zn5fmdjrb1v45czz80bvnyp1cbajgsbp2qb988m3k5p7nxzis";
-      name = "kdelibs-4.14.23.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdelibs-4.14.24.tar.xz";
+      sha256 = "1vs60cwwva59fifhg392c60wwp49bvwmm7m6xlai24wzfgl67rj5";
+      name = "kdelibs-4.14.24.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdenetwork-filesharing-16.08.0.tar.xz";
-      sha256 = "075vimzf0arlkcsnvaq75zipz4w02nx9gcy6vcbwb914ljf05cc1";
-      name = "kdenetwork-filesharing-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdenetwork-filesharing-16.08.1.tar.xz";
+      sha256 = "0gkyi2s4hiq3i17cizh0c6dzvc7b19d8bcan22jxb6jx6drm8yq3";
+      name = "kdenetwork-filesharing-16.08.1.tar.xz";
     };
   };
   kdenlive = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdenlive-16.08.0.tar.xz";
-      sha256 = "1qmhqbawxzl3plh6aa9kqcviwm6c4sqa9qi4npn64mjvwap1b9qd";
-      name = "kdenlive-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdenlive-16.08.1.tar.xz";
+      sha256 = "0aza2y5xybgj8qnfsc4vbpvmvdvscdmv1bqc67nks72z7c48cpfl";
+      name = "kdenlive-16.08.1.tar.xz";
     };
   };
   kdepim = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdepim-16.08.0.tar.xz";
-      sha256 = "0jcndq5j0j5vyp9k25gbnd18yyfigg0vdrqrsl2m6ybsgwyf3l02";
-      name = "kdepim-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdepim-16.08.1.tar.xz";
+      sha256 = "0ibbc9whg6wy0ipfza5jjwf5y6lz5cbd30nxj93p3adfd4bl55by";
+      name = "kdepim-16.08.1.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdepim-addons-16.08.0.tar.xz";
-      sha256 = "0r5v8q6pila5diqgfny3ky8c94p8rrf1qg5zwa433xpdmz8ip2jg";
-      name = "kdepim-addons-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdepim-addons-16.08.1.tar.xz";
+      sha256 = "0mbr9m9h79wvklzh6lh5mmq47b69xi2dy589hham3xy69s067g0n";
+      name = "kdepim-addons-16.08.1.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdepim-apps-libs-16.08.0.tar.xz";
-      sha256 = "1l8y0a52snxzbp245w9m55b3qx9v7wcdh2b046hx0isw8i65jial";
-      name = "kdepim-apps-libs-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdepim-apps-libs-16.08.1.tar.xz";
+      sha256 = "0nwsdham4gf97d0d1wn1v440grbny8rj0gj29z10ia2v3zkx6cgd";
+      name = "kdepim-apps-libs-16.08.1.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdepim-runtime-16.08.0.tar.xz";
-      sha256 = "19hc43xiw1g268nkrbg370qmnnmmmnxzgscx88fxb2pnlvqkz0fb";
-      name = "kdepim-runtime-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdepim-runtime-16.08.1.tar.xz";
+      sha256 = "097jxiwv9vg3scc95j563v3y28iv4a6rkq0w2w1d5f499d6bc7wf";
+      name = "kdepim-runtime-16.08.1.tar.xz";
     };
   };
   kde-runtime = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kde-runtime-16.08.0.tar.xz";
-      sha256 = "0k8snjk12abp9bpyc3q6rs46s972czb7jdsphjld8k448hz102kk";
-      name = "kde-runtime-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kde-runtime-16.08.1.tar.xz";
+      sha256 = "0szmm32m3gifdpvib4ik5cwcm0ixz5npfzs0gkasq6k9mnf68z65";
+      name = "kde-runtime-16.08.1.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdesdk-kioslaves-16.08.0.tar.xz";
-      sha256 = "04ci03wyhh7wxvjl0a4rdav2rc1xgz16ylcbswr0aphbacprqckj";
-      name = "kdesdk-kioslaves-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdesdk-kioslaves-16.08.1.tar.xz";
+      sha256 = "09g4ax7ah52ihdmp9xrymarq945kymkh65qqqd1rgf0zjaj2af7p";
+      name = "kdesdk-kioslaves-16.08.1.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdesdk-thumbnailers-16.08.0.tar.xz";
-      sha256 = "1a6iiwamzycc25nn8phip17yajyzpn57smsg9rghl8wq057mcllg";
-      name = "kdesdk-thumbnailers-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdesdk-thumbnailers-16.08.1.tar.xz";
+      sha256 = "0ygkndgfihb8jissn5jq35vd2j73z5i2rdj2jbgik7hrm2rzjzfs";
+      name = "kdesdk-thumbnailers-16.08.1.tar.xz";
     };
   };
   kdewebdev = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdewebdev-16.08.0.tar.xz";
-      sha256 = "0x7fp4d2s1zi3kawzjzqlhla0bv0ai66k5bldpg58bpbs56h9f1n";
-      name = "kdewebdev-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdewebdev-16.08.1.tar.xz";
+      sha256 = "1xi72wfj57z06s2d7ijjc2vpi14nqdavcp2gmczp08lf4n7lkfjr";
+      name = "kdewebdev-16.08.1.tar.xz";
     };
   };
   kdf = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdf-16.08.0.tar.xz";
-      sha256 = "1cj4wkndbl0ywfy6sj6bsar0v5bc0cxh9d8qd7x0m15qnsx43j44";
-      name = "kdf-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdf-16.08.1.tar.xz";
+      sha256 = "02azfa3j9m95m6ch1h4b5r2cwbyq987rxzyxsldsbna3x80kqpsv";
+      name = "kdf-16.08.1.tar.xz";
     };
   };
   kdgantt2 = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdgantt2-16.08.0.tar.xz";
-      sha256 = "1kbzx5gxyph5cr1m6g6kw3f988p3aq121k6a3hb2ddjgg8yqaxmi";
-      name = "kdgantt2-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdgantt2-16.08.1.tar.xz";
+      sha256 = "1qz44461wk2h2bi5xpyrh5s201azqigph3vclp92phy55s12q83s";
+      name = "kdgantt2-16.08.1.tar.xz";
     };
   };
   kdiamond = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kdiamond-16.08.0.tar.xz";
-      sha256 = "0fpjgkfdzw8kgag3b9rrxyahl6kcmfvlrzw2jci8sz40vd69qw53";
-      name = "kdiamond-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kdiamond-16.08.1.tar.xz";
+      sha256 = "0w2kxndpjq2s35qz05vsbr1qnd30lnxhmkyxmy5r7qcqkfdjfwbb";
+      name = "kdiamond-16.08.1.tar.xz";
     };
   };
   kfloppy = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kfloppy-16.08.0.tar.xz";
-      sha256 = "06nmaimw6lch5cdkmvb4x7dpb3d7zcsr7wzvhhh9bbygc3rmhi17";
-      name = "kfloppy-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kfloppy-16.08.1.tar.xz";
+      sha256 = "133ib3kicmaxryc4623fmayk12gp4nnymi3g3d97kyk0nmrx1vg7";
+      name = "kfloppy-16.08.1.tar.xz";
     };
   };
   kfourinline = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kfourinline-16.08.0.tar.xz";
-      sha256 = "0zjq3x6ghfa5ckjba4bfwiacwy3yvby3a951bfw5rh813mgn7zsj";
-      name = "kfourinline-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kfourinline-16.08.1.tar.xz";
+      sha256 = "0114ldvw1826v75az3wdppd4qdnhswiixm03801rsp680fg9fm9s";
+      name = "kfourinline-16.08.1.tar.xz";
     };
   };
   kgeography = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kgeography-16.08.0.tar.xz";
-      sha256 = "1cgghdxgqxxjhfmsqwnyrw7lzzshnbmi9frnc9gk4hc3w767nyqs";
-      name = "kgeography-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kgeography-16.08.1.tar.xz";
+      sha256 = "0psxpq1ap8cm3adf5j6hr0z858wx41aag95n8mx7vgyfjgaj81s4";
+      name = "kgeography-16.08.1.tar.xz";
     };
   };
   kget = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kget-16.08.0.tar.xz";
-      sha256 = "1ygm6l8xxdyi7dzii4hfp0mpwjhyizmrzmhkcmv708z7api19ms8";
-      name = "kget-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kget-16.08.1.tar.xz";
+      sha256 = "0brihzmn7fz43mi1mf8flkbbk80pv2sg3ny1il4cdkk6nwryk3dn";
+      name = "kget-16.08.1.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kgoldrunner-16.08.0.tar.xz";
-      sha256 = "1xmm2wq8f3pc67ip4hz9x3qqpav1rxm2nqdcbn2z7bivcdmv99jr";
-      name = "kgoldrunner-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kgoldrunner-16.08.1.tar.xz";
+      sha256 = "10bllkkiisb4ci97wzfln5b8bxs5l72k29mbd4qqxhq69r8xqi5c";
+      name = "kgoldrunner-16.08.1.tar.xz";
     };
   };
   kgpg = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kgpg-16.08.0.tar.xz";
-      sha256 = "1d0zfhq5ks5an9716n0b9a8xbwsnm8p7vl701gn8jpzb4w9cvrns";
-      name = "kgpg-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kgpg-16.08.1.tar.xz";
+      sha256 = "0zpq8smwh648jsxkf82pc2xvz980f07ilp2rzd8yr3w2n18gz120";
+      name = "kgpg-16.08.1.tar.xz";
     };
   };
   khangman = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/khangman-16.08.0.tar.xz";
-      sha256 = "070556i32fcrbirgwpf04ijqwv8izxmhrbf0rwwldrn3lky2mpfa";
-      name = "khangman-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/khangman-16.08.1.tar.xz";
+      sha256 = "1jz8wardcsip8c3r7s7lz1zn5gifb9jdksi0hdzn1kv1ha70dfyr";
+      name = "khangman-16.08.1.tar.xz";
     };
   };
   khelpcenter = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/khelpcenter-16.08.0.tar.xz";
-      sha256 = "1js8jxain4w1iz3xs9098js17rf1mnhcfl46qqsc5ks2909450h1";
-      name = "khelpcenter-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/khelpcenter-16.08.1.tar.xz";
+      sha256 = "0nv7i3dm6d7wr9y34l009fybdlmp4j5891wl9wwzp6ccnw2qls4g";
+      name = "khelpcenter-16.08.1.tar.xz";
     };
   };
   kholidays = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kholidays-16.08.0.tar.xz";
-      sha256 = "0q87d55wf1qpqn0mjymhx316rqdcwg4w7hn8l0c221g9zyzd53qk";
-      name = "kholidays-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kholidays-16.08.1.tar.xz";
+      sha256 = "0dcnlbkmpzj58l9qvggsxk54cf1gspax388dniz5ihs07mkksg24";
+      name = "kholidays-16.08.1.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kidentitymanagement-16.08.0.tar.xz";
-      sha256 = "05k7m4vg5s5ks4wsk4xx5ncnbl4gy0w59xdhwyy01vg8hawnldlj";
-      name = "kidentitymanagement-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kidentitymanagement-16.08.1.tar.xz";
+      sha256 = "1cdm4p62idsmzb3q6ywlqll7ivkrbbraia6bdc3ad9p2m6mjkwkk";
+      name = "kidentitymanagement-16.08.1.tar.xz";
     };
   };
   kig = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kig-16.08.0.tar.xz";
-      sha256 = "0nm3d1wxhfkxhbab5y3h8scriyy9l35r34rd77pmk00khsl0d965";
-      name = "kig-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kig-16.08.1.tar.xz";
+      sha256 = "0slpafdkhyfpixm6iypd62y85j85f62fi2yd3hrmq8859qsp7n74";
+      name = "kig-16.08.1.tar.xz";
     };
   };
   kigo = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kigo-16.08.0.tar.xz";
-      sha256 = "0k9hjbaysiqjn9bgj7pvix0ag1ksyqdcwfdz5rxvvv6l6j3c96hs";
-      name = "kigo-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kigo-16.08.1.tar.xz";
+      sha256 = "10mrb94vlhg598r4bpydxj2llzh9239c0ziz3yllnw2jh7xw94rs";
+      name = "kigo-16.08.1.tar.xz";
     };
   };
   killbots = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/killbots-16.08.0.tar.xz";
-      sha256 = "05irljnrkmw2mp7v4hmindhnw7ww26abnibb8fqmj72ryck39asg";
-      name = "killbots-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/killbots-16.08.1.tar.xz";
+      sha256 = "1fr7vj9y5bh9dcznvslzsp3f20qrmqfaq8jl4rbas08882lx7am4";
+      name = "killbots-16.08.1.tar.xz";
     };
   };
   kimap = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kimap-16.08.0.tar.xz";
-      sha256 = "1k08m16kpf94w827n4j69sr2v7a855ap8ghg56vhfn24kbxrw9m8";
-      name = "kimap-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kimap-16.08.1.tar.xz";
+      sha256 = "01nlqmprbzirw0kwqw1m1klwq401nz3sfc51gi1r01ghhskwfjj0";
+      name = "kimap-16.08.1.tar.xz";
     };
   };
   kio-extras = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kio-extras-16.08.0.tar.xz";
-      sha256 = "03axqhn9f7bdjzflmncxxbvbn0lwyia65qshis4ysqkd0sh0rinn";
-      name = "kio-extras-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kio-extras-16.08.1.tar.xz";
+      sha256 = "08cis03pzl7ncmpxc6wss7zm4jwgyxqw873ab70mvibcax9wfky0";
+      name = "kio-extras-16.08.1.tar.xz";
     };
   };
   kiriki = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kiriki-16.08.0.tar.xz";
-      sha256 = "0jz6nm6371z60yrszs0c61sq2b5ny304v5j5bvcd0nx4prdri302";
-      name = "kiriki-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kiriki-16.08.1.tar.xz";
+      sha256 = "15p205hcvvf9w1bwcciwaq8igf6nspzjili48x13pzcmmgjf46m8";
+      name = "kiriki-16.08.1.tar.xz";
     };
   };
   kiten = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kiten-16.08.0.tar.xz";
-      sha256 = "1jxxm14ghmmcy6vyzl1r4vz0a63nvykcaqh2pydab0a3b8l2s93b";
-      name = "kiten-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kiten-16.08.1.tar.xz";
+      sha256 = "1n94jzy50imvhgan3d5av9iifd0g2bn65gi5bxf9yzq48a6npnkv";
+      name = "kiten-16.08.1.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kjumpingcube-16.08.0.tar.xz";
-      sha256 = "1kwgqzlwnb8699pdja4w3d7iv25a7ma121p36pvmh457s8zlgwhl";
-      name = "kjumpingcube-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kjumpingcube-16.08.1.tar.xz";
+      sha256 = "1i8agl9l996yf1x88s1xg2a3gahjjy2swscw5lb35li565rm7vyr";
+      name = "kjumpingcube-16.08.1.tar.xz";
     };
   };
   kldap = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kldap-16.08.0.tar.xz";
-      sha256 = "03wsvgw5rv4l01iprz2pp0sqvmkyqgk6pgbqk5dfiy8zxiij3j95";
-      name = "kldap-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kldap-16.08.1.tar.xz";
+      sha256 = "0m28i0rprj36b3ds51ljmhlpkld4ghl0259z9cc5fh4k7pnfi6jr";
+      name = "kldap-16.08.1.tar.xz";
     };
   };
   kleopatra = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kleopatra-16.08.0.tar.xz";
-      sha256 = "143w1jclw4r7790mygc6a6rrh0x6r98ai699mn351ai9r9z4cfx5";
-      name = "kleopatra-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kleopatra-16.08.1.tar.xz";
+      sha256 = "0f7ydyfp9iyg3jzrn02x8bm1x41yysixzwlcpl8l3qimibs65840";
+      name = "kleopatra-16.08.1.tar.xz";
     };
   };
   klettres = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/klettres-16.08.0.tar.xz";
-      sha256 = "1wfnlci02w5llrckbjfjbi6xk2h43bq98m4zgpib5nk8ib4jaffn";
-      name = "klettres-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/klettres-16.08.1.tar.xz";
+      sha256 = "11xhprq24hq3f7vvifp1ilmcihadxwyk0jmpb643w898kh6qv9hd";
+      name = "klettres-16.08.1.tar.xz";
     };
   };
   klickety = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/klickety-16.08.0.tar.xz";
-      sha256 = "1jz02spcr46id1qbxmc9wwgws48p3cbqdy032a563c8hacqgac32";
-      name = "klickety-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/klickety-16.08.1.tar.xz";
+      sha256 = "1hrplywk2b5qkw9ijpkyxgln2zwqj1ja2prp3acqs1683rsdndam";
+      name = "klickety-16.08.1.tar.xz";
     };
   };
   klines = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/klines-16.08.0.tar.xz";
-      sha256 = "1xwg8pa4k3a68s0bsxbphpm40kkzgchkxw4ha6xpmhva94nx82d1";
-      name = "klines-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/klines-16.08.1.tar.xz";
+      sha256 = "07754lvllpjb016da1r7y4n72mp07h8bn16mq38qsxa1d0rdjjd6";
+      name = "klines-16.08.1.tar.xz";
     };
   };
   kmag = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmag-16.08.0.tar.xz";
-      sha256 = "076lni6qv3b5chj0sgcxvj5an4jvhchagk930kihbpfiqg769c61";
-      name = "kmag-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmag-16.08.1.tar.xz";
+      sha256 = "0d75z94p28zwh7pz7ss75fscwfcphvnxdd4bj0yr1hz4rzk5bmd2";
+      name = "kmag-16.08.1.tar.xz";
     };
   };
   kmahjongg = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmahjongg-16.08.0.tar.xz";
-      sha256 = "0j8c5iz11z5n08fywspvkcizw053kb2s1pxvgp5fr9h93mxn6cmk";
-      name = "kmahjongg-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmahjongg-16.08.1.tar.xz";
+      sha256 = "0xap6jw1gx86k8yhs7mmyp69jg4401551kmrhwbfz8cdpbzdrgz3";
+      name = "kmahjongg-16.08.1.tar.xz";
     };
   };
   kmailtransport = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmailtransport-16.08.0.tar.xz";
-      sha256 = "1nm5kwr7mq813invmaq72j69lcxyg2i5bmf7d5j4flvxhl3psaz1";
-      name = "kmailtransport-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmailtransport-16.08.1.tar.xz";
+      sha256 = "052pnk3pqv9g58l5zlpz1mj17x72zrzjds77gd9vavmgmngzz2nd";
+      name = "kmailtransport-16.08.1.tar.xz";
     };
   };
   kmbox = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmbox-16.08.0.tar.xz";
-      sha256 = "0mwi1sxdxkzfmjvf8rjxnhgs07g6p528km5cfqcsxvz3fcwqmwpd";
-      name = "kmbox-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmbox-16.08.1.tar.xz";
+      sha256 = "10v9x4i1waqrdq28lk4fvxg8bjpldjajdfsv2qv1wyl28kkr8xkb";
+      name = "kmbox-16.08.1.tar.xz";
     };
   };
   kmime = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmime-16.08.0.tar.xz";
-      sha256 = "1bd063fzzixcgcg17hpq6jxd2hp4y97gfhih2vc63bwf4vfs6vhj";
-      name = "kmime-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmime-16.08.1.tar.xz";
+      sha256 = "188lwyp345vigjgqbljlvw84jsjisfs6drvknx4qvk74a6idj078";
+      name = "kmime-16.08.1.tar.xz";
     };
   };
   kmines = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmines-16.08.0.tar.xz";
-      sha256 = "0pnqqmb18xzfcknidjrydc714ni4w04xwhshmwlx7i0wpakwkkcw";
-      name = "kmines-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmines-16.08.1.tar.xz";
+      sha256 = "1m7p0bwpq4ry1dw78nic73jcyf78zyrxc4cw9phdavrwvfvajzng";
+      name = "kmines-16.08.1.tar.xz";
     };
   };
   kmix = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmix-16.08.0.tar.xz";
-      sha256 = "0sk18bykx1hb3sl476vdbrhnhs1n3ygp79kgil2wx2g6m20q5d3c";
-      name = "kmix-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmix-16.08.1.tar.xz";
+      sha256 = "0ikiillqsi1s2rl65j8f9883xg5y78a53nfha7wrzav5insyvrd0";
+      name = "kmix-16.08.1.tar.xz";
     };
   };
   kmousetool = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmousetool-16.08.0.tar.xz";
-      sha256 = "1y9lfri6iw7wkaxrixm613h4wdpszaiggvbailljyl8vx82r4q5z";
-      name = "kmousetool-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmousetool-16.08.1.tar.xz";
+      sha256 = "0dfmjs9d1pr4sxa5v6fk2bbx4anawm0841spg8vijxikwi67vayk";
+      name = "kmousetool-16.08.1.tar.xz";
     };
   };
   kmouth = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmouth-16.08.0.tar.xz";
-      sha256 = "1rx46fxfzj32a27yb597xsh1jjxn5h7kb39ywk8f2kkqvcn1dgyl";
-      name = "kmouth-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmouth-16.08.1.tar.xz";
+      sha256 = "01hin9yzv8zvj1pihr409clci905i3fhrwqz9izk1nhq3djxg7ld";
+      name = "kmouth-16.08.1.tar.xz";
     };
   };
   kmplot = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kmplot-16.08.0.tar.xz";
-      sha256 = "1syz6dk5ha2znwg5kj34hg2hrbl83wxzxiqznlwpmh2qr4kssrml";
-      name = "kmplot-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kmplot-16.08.1.tar.xz";
+      sha256 = "069qsi1bk385sil9m75y0zs7nzv8qscrfpdm8iip53fwf10bx5qa";
+      name = "kmplot-16.08.1.tar.xz";
     };
   };
   knavalbattle = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/knavalbattle-16.08.0.tar.xz";
-      sha256 = "030j6mq6lx3bi96g3nkj5mif996r6dg3df2331c0r0s42icw1mv1";
-      name = "knavalbattle-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/knavalbattle-16.08.1.tar.xz";
+      sha256 = "0xxx053p42j8r6zlz6vv6avx6iqqm5aq6q3ggjib70w4ixl1wqmp";
+      name = "knavalbattle-16.08.1.tar.xz";
     };
   };
   knetwalk = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/knetwalk-16.08.0.tar.xz";
-      sha256 = "0lnsvpijx5ln5mscg2s46j0xzivhni6wj47yr7lvpkjrgy715c7d";
-      name = "knetwalk-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/knetwalk-16.08.1.tar.xz";
+      sha256 = "15nrfcd6l08lkshh6gyqfawr2b9izsirwdg9mqnnymdji8lg91nl";
+      name = "knetwalk-16.08.1.tar.xz";
     };
   };
   kolf = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kolf-16.08.0.tar.xz";
-      sha256 = "06v1hyvj7dym9sn8gd7698f1806pr3h6nplxj5p4mm1ckhn6h59z";
-      name = "kolf-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kolf-16.08.1.tar.xz";
+      sha256 = "040fsd1kdww4yv258w1na3b5x3sxb14dj035rmw1y48lw883g439";
+      name = "kolf-16.08.1.tar.xz";
     };
   };
   kollision = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kollision-16.08.0.tar.xz";
-      sha256 = "0v3lixqy932v8dnzw892jafsjzxzldmzrcmaah0qnxq9qf9q3x1x";
-      name = "kollision-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kollision-16.08.1.tar.xz";
+      sha256 = "0w9wsgdqcpgklv31iqhbd79n6qiqk49jkhrc2c6zhmxqp588wy14";
+      name = "kollision-16.08.1.tar.xz";
     };
   };
   kolourpaint = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kolourpaint-16.08.0.tar.xz";
-      sha256 = "1bfshyfgcgvpjyxzx7yb7ws0kfyb6765nsd7pad2jc7cs5x8x5m7";
-      name = "kolourpaint-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kolourpaint-16.08.1.tar.xz";
+      sha256 = "1siari77ivnrbllncviy504sz8q1f1mhdpjp45z69hsjn6bw8rcz";
+      name = "kolourpaint-16.08.1.tar.xz";
     };
   };
   kompare = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kompare-16.08.0.tar.xz";
-      sha256 = "0xx5l2gi031p7z488d5dn805k3likhp444520b2453vlfasmwh9z";
-      name = "kompare-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kompare-16.08.1.tar.xz";
+      sha256 = "0xmr3g2azrzhrjz1n9sp8wif7rxh574a1mg3prhl636pqcijq1bw";
+      name = "kompare-16.08.1.tar.xz";
     };
   };
   konquest = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/konquest-16.08.0.tar.xz";
-      sha256 = "18pp4h67wkzimayq3xpz3cqw06dky7k4vhfh4l2lbgm9nvlg3bwl";
-      name = "konquest-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/konquest-16.08.1.tar.xz";
+      sha256 = "1hsh9n17gqwnash5f8z8zpnwxl0n09zn9hv1qn39zad23vg6fjjd";
+      name = "konquest-16.08.1.tar.xz";
     };
   };
   konsole = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/konsole-16.08.0.tar.xz";
-      sha256 = "1kn80clbzq5sc6fby1gapw28lpxkbvjbk6c04avbfkg1d25n5mfg";
-      name = "konsole-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/konsole-16.08.1.tar.xz";
+      sha256 = "0dgphhg2icqagaw16i8z3x3mw8rmmpl3wmafbaca1gn9xw67md1g";
+      name = "konsole-16.08.1.tar.xz";
     };
   };
   kontactinterface = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kontactinterface-16.08.0.tar.xz";
-      sha256 = "1snafjnmpz6xpldgksxi92dkx0kq1w2xcbkv4a8jqm7mllrxvjvy";
-      name = "kontactinterface-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kontactinterface-16.08.1.tar.xz";
+      sha256 = "0a8swis8i3dbv9nbbw8ksbghj5pvfsba6kkh2l4lgmkbdi0m9a3s";
+      name = "kontactinterface-16.08.1.tar.xz";
     };
   };
   kopete = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kopete-16.08.0.tar.xz";
-      sha256 = "1yd69aspsnmrg2f1l33clhpj8l5qqyns1djn63j9v76r4lxkrbnp";
-      name = "kopete-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kopete-16.08.1.tar.xz";
+      sha256 = "0l2wkf8b2jp6gnr2930xxxz9jqmh6mlms5h8934k89z9x00ha1p5";
+      name = "kopete-16.08.1.tar.xz";
     };
   };
   kpat = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kpat-16.08.0.tar.xz";
-      sha256 = "038fzs09bijmryka925hx7j4ln7z3f0qdzv7wwm9mkkp5wi4fpi6";
-      name = "kpat-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kpat-16.08.1.tar.xz";
+      sha256 = "1gpvha8636lwlb1qcdkirs5whil2fh6fp5xd3yh31dppxwryadaf";
+      name = "kpat-16.08.1.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kpimtextedit-16.08.0.tar.xz";
-      sha256 = "0bz729yr01p9sjf6bh76pfn3miisas3smxwzy31hh18r9n4f7xsa";
-      name = "kpimtextedit-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kpimtextedit-16.08.1.tar.xz";
+      sha256 = "1a73s0w49jrblxmzfsp25pknvpggx1p765w2hflij4yr0cb0ganz";
+      name = "kpimtextedit-16.08.1.tar.xz";
     };
   };
   kppp = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kppp-16.08.0.tar.xz";
-      sha256 = "1gx9ldjfasxfjr8i9pxlbwjdcypg2ffjiwddbp5pw1x6sfmyci7i";
-      name = "kppp-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kppp-16.08.1.tar.xz";
+      sha256 = "00fv4r6fiq7kkfi3awvk8b7ccj21hm5f7jdgkhacs6np5kv4spnd";
+      name = "kppp-16.08.1.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kqtquickcharts-16.08.0.tar.xz";
-      sha256 = "1bzhql082hgsmcngaclkjlfs7k1hyz17y3prcgw9qgm4nv4i18hq";
-      name = "kqtquickcharts-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kqtquickcharts-16.08.1.tar.xz";
+      sha256 = "0xy84v0z0mx30ynsym7qian2khck8mfgkm62sfd5v3xkgffhhdyh";
+      name = "kqtquickcharts-16.08.1.tar.xz";
     };
   };
   krdc = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/krdc-16.08.0.tar.xz";
-      sha256 = "1qq1r49knndy9hz4l04ix6ax2y66q4jq0qmh0b49ldamvm0b27w0";
-      name = "krdc-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/krdc-16.08.1.tar.xz";
+      sha256 = "1mq867gv8l6i1xlykm0fnfsgz52h60hb3s06aq1rp97yddclr4q1";
+      name = "krdc-16.08.1.tar.xz";
     };
   };
   kremotecontrol = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kremotecontrol-16.08.0.tar.xz";
-      sha256 = "1z6nhyq6x3kfsfsri3jmvdmkfdrxykc065w7kplfzrqqgnsw12gh";
-      name = "kremotecontrol-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kremotecontrol-16.08.1.tar.xz";
+      sha256 = "09iyp1sfva7rzxrp7ma90l3ls8yda5hyypvvn3kliv6rap0vrwv5";
+      name = "kremotecontrol-16.08.1.tar.xz";
     };
   };
   kreversi = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kreversi-16.08.0.tar.xz";
-      sha256 = "03z3f09z70f3c2lbvdmr3injjdd8nmwbs2drxcxmkx17p4vg9w1h";
-      name = "kreversi-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kreversi-16.08.1.tar.xz";
+      sha256 = "15g87r85wh4b9vx21bsxp2vavfgzy8kdgwyvv39gg87rl62j7qxf";
+      name = "kreversi-16.08.1.tar.xz";
     };
   };
   krfb = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/krfb-16.08.0.tar.xz";
-      sha256 = "1rvqk8sm75idnkb99v2mpfl1r32qyjcqcmbhw78lgb8nwpfr8cbs";
-      name = "krfb-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/krfb-16.08.1.tar.xz";
+      sha256 = "0952cxnfbwab6d1ji6wwx3snv4a9k031h8pph3n47xxr12nkjj19";
+      name = "krfb-16.08.1.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kross-interpreters-16.08.0.tar.xz";
-      sha256 = "1njd0j893zw6bdavqiqbzp02g0y1zhb8gmbq0rb46if1q5igj10d";
-      name = "kross-interpreters-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kross-interpreters-16.08.1.tar.xz";
+      sha256 = "1026amgj0r1r180535mpnm5f780pm7v25ilk7ynf834lad3is95k";
+      name = "kross-interpreters-16.08.1.tar.xz";
     };
   };
   kruler = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kruler-16.08.0.tar.xz";
-      sha256 = "1rcy5djmwlr4jvi7ig0075z40wfjby3hs7k40nzi3hl3khq2clfg";
-      name = "kruler-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kruler-16.08.1.tar.xz";
+      sha256 = "0j3hi77wlf5nwdmqiq5g34zb8pdzxn313hmc0k99p1gvkb1xn4zp";
+      name = "kruler-16.08.1.tar.xz";
     };
   };
   ksaneplugin = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ksaneplugin-16.08.0.tar.xz";
-      sha256 = "0439bsn8d0w72f73ixxh205aqvbdbks9n0xxb0dq16d9msykvflm";
-      name = "ksaneplugin-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ksaneplugin-16.08.1.tar.xz";
+      sha256 = "0bx7vaw5vkr7fvmn6ywil8997d1qy6qv7sycxz3ydc5ljg1ansmr";
+      name = "ksaneplugin-16.08.1.tar.xz";
     };
   };
   kscd = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kscd-16.08.0.tar.xz";
-      sha256 = "1jn7sp0ahgnqn8ws7qsaz9ax9ighx1w9jsgn3l1jqqwal2mz0gbv";
-      name = "kscd-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kscd-16.08.1.tar.xz";
+      sha256 = "1a6sq2dgkgvhycjxz95xa2b2xdibhl0ky54chj7hmdf43w69bdzc";
+      name = "kscd-16.08.1.tar.xz";
     };
   };
   kshisen = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kshisen-16.08.0.tar.xz";
-      sha256 = "0asvxgkn3pqws91a93r5wvpafz7zfchk5xmk08b74shscidi4nl6";
-      name = "kshisen-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kshisen-16.08.1.tar.xz";
+      sha256 = "1j33byc485rxbcf3wk8kra7vxq4r1sg8cpfrlxwiyb9ibk762jlh";
+      name = "kshisen-16.08.1.tar.xz";
     };
   };
   ksirk = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ksirk-16.08.0.tar.xz";
-      sha256 = "0gh6j8ml5062m99ps7wm9nkn5b1w5lcqsjh22rd81cvl8wy48sx4";
-      name = "ksirk-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ksirk-16.08.1.tar.xz";
+      sha256 = "121j8jz9gabdqv5fh4c2qcsg4ndj72xnmavvdrlib8a7qidjzaga";
+      name = "ksirk-16.08.1.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ksnakeduel-16.08.0.tar.xz";
-      sha256 = "1sd5vjjcg3yr8jcp76ilcql953b0wzk950w1h1lbgrll2hr81bm3";
-      name = "ksnakeduel-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ksnakeduel-16.08.1.tar.xz";
+      sha256 = "1qzqr5ai5d7azh7xmm2vihbz3jzxxvb6qvhpfrix0yf4yr8m8fxz";
+      name = "ksnakeduel-16.08.1.tar.xz";
     };
   };
   kspaceduel = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kspaceduel-16.08.0.tar.xz";
-      sha256 = "1whvibw0d1gbb28lc04q93wpalsihgqzd9hi1yabwfa5piac9ldb";
-      name = "kspaceduel-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kspaceduel-16.08.1.tar.xz";
+      sha256 = "0zy6m325gaivwfrr20mfwn8pdgl1i4ym1ymwb5dyw7a5yfi27m7n";
+      name = "kspaceduel-16.08.1.tar.xz";
     };
   };
   ksquares = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ksquares-16.08.0.tar.xz";
-      sha256 = "19rlzka8z7imhv4cbrwajkv4g38qg2mwm8pniyl0w818nj4jbjlp";
-      name = "ksquares-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ksquares-16.08.1.tar.xz";
+      sha256 = "1rccb2qifqfb68apag01i3y97jbrskarf3480p61ixk7lrmbbrx4";
+      name = "ksquares-16.08.1.tar.xz";
     };
   };
   kstars = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kstars-16.08.0.tar.xz";
-      sha256 = "0zridrc65av69q7yi3k0jq744ifr94wpv725vx3wy8v5wlsc3rcx";
-      name = "kstars-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kstars-16.08.1.tar.xz";
+      sha256 = "1fwl9hry23lmhyx5ldqspa7hp6bvmjp8kzwi6p9y1kbwzbzmki0k";
+      name = "kstars-16.08.1.tar.xz";
     };
   };
   ksudoku = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ksudoku-16.08.0.tar.xz";
-      sha256 = "15j9kjww92dmy6bvrs4pp2j6xxmz5xpci08wnab5mxsq6f6fghhs";
-      name = "ksudoku-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ksudoku-16.08.1.tar.xz";
+      sha256 = "1msxx4hay0njp7bxjgplq7ylblbr56mf01l70sywj5madvvrmh8y";
+      name = "ksudoku-16.08.1.tar.xz";
     };
   };
   ksystemlog = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ksystemlog-16.08.0.tar.xz";
-      sha256 = "1ksp8innmziyxjkxdw53sqaz66jf82xp8p2cfypw6r2zb506wq96";
-      name = "ksystemlog-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ksystemlog-16.08.1.tar.xz";
+      sha256 = "0garxwsgzdc5j6426gv3wqqgxra6qfdlk7xrk6mhlyg3wnwy8lz9";
+      name = "ksystemlog-16.08.1.tar.xz";
     };
   };
   kteatime = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kteatime-16.08.0.tar.xz";
-      sha256 = "1hqvyypbphsplq5aqdh24wzh7msqh757y1zgpclxl6xbjxx1ys5z";
-      name = "kteatime-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kteatime-16.08.1.tar.xz";
+      sha256 = "0m6rri4mgr9qzcpxr5ifm1xs5mpmx7nz074gscff662nv4cj1h5n";
+      name = "kteatime-16.08.1.tar.xz";
     };
   };
   ktimer = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktimer-16.08.0.tar.xz";
-      sha256 = "01gj0i5h08phhw9ds42ql1kmrl5brfasshgbxa9nvgd6i35zjp74";
-      name = "ktimer-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktimer-16.08.1.tar.xz";
+      sha256 = "0n94r34d24dnpi8rr6lb2vqrx1bz29xb92a63dm3s6pvbrw7zmhr";
+      name = "ktimer-16.08.1.tar.xz";
     };
   };
   ktnef = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktnef-16.08.0.tar.xz";
-      sha256 = "03fhx1kyzhm1fs0p7i2488r41dbyl2knkapg0cfd8zd0pcnv518f";
-      name = "ktnef-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktnef-16.08.1.tar.xz";
+      sha256 = "0gjq14gcc34mqx21f74kzqb1575fhckaq13fpf00ascar0s1w0sx";
+      name = "ktnef-16.08.1.tar.xz";
     };
   };
   ktouch = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktouch-16.08.0.tar.xz";
-      sha256 = "0i60f712bgldvf8dcjpd8hyf3fwlrmly96ddrkd8p5860vdyxxm1";
-      name = "ktouch-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktouch-16.08.1.tar.xz";
+      sha256 = "0jjn59hjbj5mc0svd8nrnqdwa4xz4wj76512gx1w1lga37ysk5gx";
+      name = "ktouch-16.08.1.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-accounts-kcm-16.08.0.tar.xz";
-      sha256 = "0hfs46fza537cdwmx18430qnwphvqihxa9z0ys7mlhwa8gffa9gq";
-      name = "ktp-accounts-kcm-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-accounts-kcm-16.08.1.tar.xz";
+      sha256 = "12icgnf165v549nlwzpn3dn7237k7xi3vfg0a1i7r2mzbhdw6xf5";
+      name = "ktp-accounts-kcm-16.08.1.tar.xz";
     };
   };
   ktp-approver = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-approver-16.08.0.tar.xz";
-      sha256 = "0wvi076x2xxbrd4swf8gbi30fnwa58hxnahl3ri5gpz34c7y5c3v";
-      name = "ktp-approver-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-approver-16.08.1.tar.xz";
+      sha256 = "08qkcn2avc5aiakn6ksjikd50x5xd1ilwy5cf2fk1jqn6zbxglm0";
+      name = "ktp-approver-16.08.1.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-auth-handler-16.08.0.tar.xz";
-      sha256 = "0jyff6znszz82h3l92wjzkh9c1csnsyncd34hxvkyarxm6wb1s8f";
-      name = "ktp-auth-handler-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-auth-handler-16.08.1.tar.xz";
+      sha256 = "0wjz5r287f13p2s34hdjg0sy23xanwnp0274pk2hxbybf9v4ryvi";
+      name = "ktp-auth-handler-16.08.1.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-call-ui-16.08.0.tar.xz";
-      sha256 = "16jw9jap985p411qjkzay83yy1xrnykbnq7f315d7wqxrry3pvf1";
-      name = "ktp-call-ui-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-call-ui-16.08.1.tar.xz";
+      sha256 = "1gbw3a1yfm6kc85gpqhx6q7kp2fwmjgmxp819w9wrgg1qwmjyxrw";
+      name = "ktp-call-ui-16.08.1.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-common-internals-16.08.0.tar.xz";
-      sha256 = "1l88fnagbq9b63nfvyncq5bylpv6m9h9z1znmz1z67fp5x6lcmh9";
-      name = "ktp-common-internals-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-common-internals-16.08.1.tar.xz";
+      sha256 = "0ylpwjn3jknp77f8g69mkcj1zcjn9khfhxla6mci4h7cbxka9wdf";
+      name = "ktp-common-internals-16.08.1.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-contact-list-16.08.0.tar.xz";
-      sha256 = "06cd9yzj7lw6v6n9fqjc4lafpi1z0yl2wyipibk47xmwckx5bw9f";
-      name = "ktp-contact-list-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-contact-list-16.08.1.tar.xz";
+      sha256 = "0ach7dvlch162jyyw01hdlbwwh72gdp6rmmkkx65cf3g0sqhvwp4";
+      name = "ktp-contact-list-16.08.1.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-contact-runner-16.08.0.tar.xz";
-      sha256 = "10yd1z90q0a8d3qcl07lnvj1j150awl2fjf74njdlxya2s0wgdmq";
-      name = "ktp-contact-runner-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-contact-runner-16.08.1.tar.xz";
+      sha256 = "0721mys632jn4i040v541997fb5pca2fr2nj9p49bp0r7kmgj6qr";
+      name = "ktp-contact-runner-16.08.1.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-desktop-applets-16.08.0.tar.xz";
-      sha256 = "0gbvdq7qpschhc3iq22sm505m3ph4j7r38kfzq6f51gf4284hv9x";
-      name = "ktp-desktop-applets-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-desktop-applets-16.08.1.tar.xz";
+      sha256 = "1fln9kndpwl8arsr1i8vsicz0cv10r00w4niv163al11yqk3ng5g";
+      name = "ktp-desktop-applets-16.08.1.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-filetransfer-handler-16.08.0.tar.xz";
-      sha256 = "119q2isisqpbrcffparv73n69869cc6wqih0jr34m85q2c7ifr7p";
-      name = "ktp-filetransfer-handler-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-filetransfer-handler-16.08.1.tar.xz";
+      sha256 = "01581r1xylj6f78vqqxi0gf5nyj2k3vyyvkz5vjkq7di140mmw97";
+      name = "ktp-filetransfer-handler-16.08.1.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-kded-module-16.08.0.tar.xz";
-      sha256 = "1izc4gvh433gpnbbhdhb2bfx3sx5rj8bdiqcpba43xrvimq5mhbd";
-      name = "ktp-kded-module-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-kded-module-16.08.1.tar.xz";
+      sha256 = "1dpaay5qkqnxy0q80gqp2mydjngx815xrdmxcvh9pm3c4w0as8lh";
+      name = "ktp-kded-module-16.08.1.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-send-file-16.08.0.tar.xz";
-      sha256 = "1lsvs101w2xldi176am896vyihbm7w2js2h033v5p7bswnkg2mgm";
-      name = "ktp-send-file-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-send-file-16.08.1.tar.xz";
+      sha256 = "1nchxvc2n8a2d02cz8vlazr4fl8gpngl44lq3jymdggz58w8rji9";
+      name = "ktp-send-file-16.08.1.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktp-text-ui-16.08.0.tar.xz";
-      sha256 = "11ybqnkkp2r0wdczc0p3prmq9r3vhk6v81fhl4pnmcypghcgaf3f";
-      name = "ktp-text-ui-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktp-text-ui-16.08.1.tar.xz";
+      sha256 = "0mj5zih4pbqdc2m62s85ck7r3m12ywh0frg6n4hi8xw909w7x25m";
+      name = "ktp-text-ui-16.08.1.tar.xz";
     };
   };
   ktuberling = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/ktuberling-16.08.0.tar.xz";
-      sha256 = "1dd66s2ys266jr8pp5x2vvkzlysx93baw1kpiy550rb4gsb3l537";
-      name = "ktuberling-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/ktuberling-16.08.1.tar.xz";
+      sha256 = "1brm1xdma1d5fcgbyn8nw3pwncnyvxknrwlbr7capgwqn7s9pckl";
+      name = "ktuberling-16.08.1.tar.xz";
     };
   };
   kturtle = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kturtle-16.08.0.tar.xz";
-      sha256 = "01rphmyn89n32k579mg04gmfkjlphbn55cdqv0km4ngipiv32mj3";
-      name = "kturtle-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kturtle-16.08.1.tar.xz";
+      sha256 = "1d6kw35dzyq3c62j7pqsl57l8cpw98awr6bdr1v2w8xdiw9xi73c";
+      name = "kturtle-16.08.1.tar.xz";
     };
   };
   kubrick = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kubrick-16.08.0.tar.xz";
-      sha256 = "081bh8msbfcx9vkdbrlgclwngrxswpmd3hfzjfndhaw8ibp42hsi";
-      name = "kubrick-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kubrick-16.08.1.tar.xz";
+      sha256 = "1x34gyqa77b03hqs50vajqcmw9yrqxq1f4niyfj43wkw2b4jks9f";
+      name = "kubrick-16.08.1.tar.xz";
     };
   };
   kuser = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kuser-16.08.0.tar.xz";
-      sha256 = "0yq1jil5nfm2zw5sisvcvrjbxxlzjq3z8vxn41ch0ppfdpcsknjs";
-      name = "kuser-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kuser-16.08.1.tar.xz";
+      sha256 = "0dkv9x052iavp3hnrvnarm8hv3416kamdizwp3c22w2cfz3q4rdc";
+      name = "kuser-16.08.1.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kwalletmanager-16.08.0.tar.xz";
-      sha256 = "174rd9d4yqrdk93hnr5nrzq3b7ilk0hjzhlsy9dqm9pr9yix79g0";
-      name = "kwalletmanager-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kwalletmanager-16.08.1.tar.xz";
+      sha256 = "1w99076da86qw2271hkknrjc0mfp7f0xi5544kbk76aanaj73wvm";
+      name = "kwalletmanager-16.08.1.tar.xz";
     };
   };
   kwordquiz = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/kwordquiz-16.08.0.tar.xz";
-      sha256 = "1nngkkwd22nzcj4syayizmhvw8svkrhwa12ab5cfa0fmx30ivz86";
-      name = "kwordquiz-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/kwordquiz-16.08.1.tar.xz";
+      sha256 = "08n6ajpx5x2vpf63d4fnfw2a4hcfmca2q4nd5y04kl1sccx67zig";
+      name = "kwordquiz-16.08.1.tar.xz";
     };
   };
   libgravatar = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libgravatar-16.08.0.tar.xz";
-      sha256 = "169sy6lzsvgrhm9arjg84qcy34hm5xwycl09cg2cw6l141c5yyv0";
-      name = "libgravatar-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libgravatar-16.08.1.tar.xz";
+      sha256 = "1izh80plcd3ss3brl0mi0alics4y53d355smpgjkfqyc80zxs7wz";
+      name = "libgravatar-16.08.1.tar.xz";
     };
   };
   libkcddb = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkcddb-16.08.0.tar.xz";
-      sha256 = "1qlq62nl11dhsqn61zrvv80mybwzxhcgzdblrxqq8l352y1l916x";
-      name = "libkcddb-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkcddb-16.08.1.tar.xz";
+      sha256 = "1i9xb96xari03q8fw20laqh5d3fyvigzqkdw6lw61fwxzpjrphk8";
+      name = "libkcddb-16.08.1.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkcompactdisc-16.08.0.tar.xz";
-      sha256 = "1i2pd9xr2i61xb6128dzsf5il2sk3bqp9d8ps45lm4vld73ryxmk";
-      name = "libkcompactdisc-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkcompactdisc-16.08.1.tar.xz";
+      sha256 = "1qjij6kvvs8k650sg7skbgh0n4wgdkyjdsg8rydg93r0fqh5yagq";
+      name = "libkcompactdisc-16.08.1.tar.xz";
     };
   };
   libkdcraw = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkdcraw-16.08.0.tar.xz";
-      sha256 = "1cmhj1jpfpaxkkgx4imh79kcd5v3zdg27i971j9z828ysdl8b9rf";
-      name = "libkdcraw-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkdcraw-16.08.1.tar.xz";
+      sha256 = "05206lbf2j0pry640ja5ajdlmalz4szfg2xzddfp00m87bgxbr2b";
+      name = "libkdcraw-16.08.1.tar.xz";
     };
   };
   libkdegames = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkdegames-16.08.0.tar.xz";
-      sha256 = "0zh8nw3ndrvinl7qg6zhnzwn3i4qixk3wyxcf1nrfz0m294ys9yf";
-      name = "libkdegames-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkdegames-16.08.1.tar.xz";
+      sha256 = "11r5bf23fyymqqsj3ckbmya3f0zsdgrd4fw7jkfbxw7bfjjpr890";
+      name = "libkdegames-16.08.1.tar.xz";
     };
   };
   libkdepim = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkdepim-16.08.0.tar.xz";
-      sha256 = "1n3ijr5v73sd94hj6n0xwplx7019lljv151z0rjn6fakf199p32l";
-      name = "libkdepim-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkdepim-16.08.1.tar.xz";
+      sha256 = "0p72dk6w0bvn7qikpqlxd7yhlrnn9wqnrq6b6p0ngnzhrsybjffm";
+      name = "libkdepim-16.08.1.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkeduvocdocument-16.08.0.tar.xz";
-      sha256 = "0sv5p57lk8f0skw2z42whhizk7s3nh5hh0pf9yaxml64clmypwbk";
-      name = "libkeduvocdocument-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkeduvocdocument-16.08.1.tar.xz";
+      sha256 = "113z6hi6v7mj4z6qk3gj04ah60ys8fn14jwlrxj8xf5qb0fvhzbn";
+      name = "libkeduvocdocument-16.08.1.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkexiv2-16.08.0.tar.xz";
-      sha256 = "183h9ifbzwngi5mwdq85n2jx0k67z7dzxnd43k6fv5l6h2b5l7y7";
-      name = "libkexiv2-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkexiv2-16.08.1.tar.xz";
+      sha256 = "1h7bd3p03xap6m6qpb0ww8ganyb9z7sdk2hpp25ar12snjpfgh0y";
+      name = "libkexiv2-16.08.1.tar.xz";
     };
   };
   libkface = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkface-16.08.0.tar.xz";
-      sha256 = "175912gzb4w6ndmr164j67z3xwqhy0xpxahnqb3zqlbj0gx10wp2";
-      name = "libkface-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkface-16.08.1.tar.xz";
+      sha256 = "19fqg7xja2pk6wp4bvamanwpfcs5qiyzsgldpr0q4y650ipbrf4w";
+      name = "libkface-16.08.1.tar.xz";
     };
   };
   libkgeomap = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkgeomap-16.08.0.tar.xz";
-      sha256 = "0jxk18dfvhrxs6war4p83sfdmn4zld5yl0x81dgmzfh7kc9dhws6";
-      name = "libkgeomap-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkgeomap-16.08.1.tar.xz";
+      sha256 = "0zlcd4k8yfz9l5skky7vyc2p5hgx2wnan1g0jawi2f2xzsy655nz";
+      name = "libkgeomap-16.08.1.tar.xz";
     };
   };
   libkipi = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkipi-16.08.0.tar.xz";
-      sha256 = "12829kp4sr5hzji26syw3b8awgxhhdpvgdjdid276im3a4xfhmsv";
-      name = "libkipi-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkipi-16.08.1.tar.xz";
+      sha256 = "1mksgr0x446ilbqmb0wb5lh5afj8q7a88r31wzf6x3698n0s9fdb";
+      name = "libkipi-16.08.1.tar.xz";
     };
   };
   libkleo = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkleo-16.08.0.tar.xz";
-      sha256 = "1n5qv9azkv29w67iwkpbxka213s81dlb8svs0xx2lxfb1z2dvrvh";
-      name = "libkleo-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkleo-16.08.1.tar.xz";
+      sha256 = "0a216q291vgf4v758l79aywp1f8wn40239jn9gx6ngw3p8zzf357";
+      name = "libkleo-16.08.1.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkmahjongg-16.08.0.tar.xz";
-      sha256 = "145gi58yfcbd2magqk873hjwzk02z23zn4h3a95w236gx3r573m5";
-      name = "libkmahjongg-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkmahjongg-16.08.1.tar.xz";
+      sha256 = "1bvm86xcmx3cdslm98n5kg61rmyc9p86aj8scrp3gb8di1y987zx";
+      name = "libkmahjongg-16.08.1.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libkomparediff2-16.08.0.tar.xz";
-      sha256 = "1fqghzfnzjcfrcdn6av5r27br9qiz48ng1vgj2g2bi1y75bnla6i";
-      name = "libkomparediff2-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libkomparediff2-16.08.1.tar.xz";
+      sha256 = "1cqd1amnxpylwzw5vdgy29wh1llhrvbqf5kmjxxb3a3kh2rafb53";
+      name = "libkomparediff2-16.08.1.tar.xz";
     };
   };
   libksane = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libksane-16.08.0.tar.xz";
-      sha256 = "079fy5izsly0qkbrxhkasdk9h2359izsxhaam0mzc24cf9ls2zbr";
-      name = "libksane-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libksane-16.08.1.tar.xz";
+      sha256 = "0g8vhdknph32736inzf9xbrdi51asb9md254m12cabglb1mfhia3";
+      name = "libksane-16.08.1.tar.xz";
     };
   };
   libksieve = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/libksieve-16.08.0.tar.xz";
-      sha256 = "014ijwkzz8n53yy2gjm39i85rjakv447lz048kfighpl1m08yjjz";
-      name = "libksieve-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/libksieve-16.08.1.tar.xz";
+      sha256 = "1paq508fsb1q7nfry3za7ykz41ly3qb6splf65d9n9l8aqbfx9fx";
+      name = "libksieve-16.08.1.tar.xz";
     };
   };
   lokalize = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/lokalize-16.08.0.tar.xz";
-      sha256 = "0m7sipj53ih3g2pj1a5ny667dj0jaqyrsn46bymkpz9z7rn8z5xs";
-      name = "lokalize-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/lokalize-16.08.1.tar.xz";
+      sha256 = "1dg6sw4zm7cq4di9zgjc4b1nk73sngc3ilshsr1wgdylpxaq9vrf";
+      name = "lokalize-16.08.1.tar.xz";
     };
   };
   lskat = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/lskat-16.08.0.tar.xz";
-      sha256 = "0lnpc5sfj4bfb1fz887fgkqs5prnjlsci90fis67rim9b3b45mhd";
-      name = "lskat-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/lskat-16.08.1.tar.xz";
+      sha256 = "08ds76m66ni7pfmz0cnqx6b1p6l7m8fy5mz54kh9aahchw8lwpmk";
+      name = "lskat-16.08.1.tar.xz";
     };
   };
   mailcommon = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/mailcommon-16.08.0.tar.xz";
-      sha256 = "1b43rfhnghm8apkl2qwg7i6mx8ci5lpjy1fgp6jrdcxip8yw0172";
-      name = "mailcommon-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/mailcommon-16.08.1.tar.xz";
+      sha256 = "0f25z2s8bm51p2qxl2srdjf6df9h006ji6y9vn06m1vwsyfzmg3g";
+      name = "mailcommon-16.08.1.tar.xz";
     };
   };
   mailimporter = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/mailimporter-16.08.0.tar.xz";
-      sha256 = "1bak75qb8x8g1x8kw3f1a20i07hcf8fas5arxjyb9qrs97zx6vbz";
-      name = "mailimporter-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/mailimporter-16.08.1.tar.xz";
+      sha256 = "18hy1brpl07zcwzwv83mikn17h7xrgyc5q8xqvl5awgn8cj1zk9d";
+      name = "mailimporter-16.08.1.tar.xz";
     };
   };
   marble = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/marble-16.08.0.tar.xz";
-      sha256 = "1a65w4gir65cy90sxs2x1ig95mgmrk6ai3pv2ah8kwv0gy19qc6f";
-      name = "marble-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/marble-16.08.1.tar.xz";
+      sha256 = "0fmgqx1nc77agrrcb6qxq0zkndxkxhqybvxpf0dxyd7mpwg00zd2";
+      name = "marble-16.08.1.tar.xz";
     };
   };
   messagelib = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/messagelib-16.08.0.tar.xz";
-      sha256 = "1442qvhqjm976i20h36xck9lrad29mbhcs2p146q1rggphv9yzb6";
-      name = "messagelib-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/messagelib-16.08.1.tar.xz";
+      sha256 = "0kjladmrj2plj5kjmjkhh35mlijc2k3q8pdmi91xq0paawlrziyc";
+      name = "messagelib-16.08.1.tar.xz";
     };
   };
   minuet = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/minuet-16.08.0.tar.xz";
-      sha256 = "07h65zkikpl5wwmw996wihylij1rxbf580fkrcwq6xjh4xk6c950";
-      name = "minuet-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/minuet-16.08.1.tar.xz";
+      sha256 = "1qa2a3216p8x0vr9i3jw42i134qij4v0jj0625m606ihfs2mfhbq";
+      name = "minuet-16.08.1.tar.xz";
     };
   };
   okteta = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/okteta-16.08.0.tar.xz";
-      sha256 = "1mnh1p7497206z7szf0aslb9s660iv3bzssbgkkcf96r3n50g96s";
-      name = "okteta-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/okteta-16.08.1.tar.xz";
+      sha256 = "1q9pni82frj48lncj9ipkvdb120bg49f53p09vcpfxyax6hhnb5k";
+      name = "okteta-16.08.1.tar.xz";
     };
   };
   okular = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/okular-16.08.0.tar.xz";
-      sha256 = "15qzjmpzwlq2pp0cxfcklsm0dfmla9vp649rzv76bq0qlnb0vnc2";
-      name = "okular-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/okular-16.08.1.tar.xz";
+      sha256 = "0x3njxxwacy9cj4rzsgphl3za01d59wpbax9wxhxcdwqfi332a0d";
+      name = "okular-16.08.1.tar.xz";
     };
   };
   palapeli = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/palapeli-16.08.0.tar.xz";
-      sha256 = "0l13i9gc5nqdl0zrmnnzfklv8f4v8anhhmndxs3v0r1rgjs856m4";
-      name = "palapeli-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/palapeli-16.08.1.tar.xz";
+      sha256 = "15dfh9802kdmlwzjfqciszf4lwy2pr9ypnk1s2i4aj69jwqygn62";
+      name = "palapeli-16.08.1.tar.xz";
     };
   };
   parley = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/parley-16.08.0.tar.xz";
-      sha256 = "0ljk290z9sx30985848pixpnyyf5bjf7gqb2jfv3qy8gbbkxvrfd";
-      name = "parley-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/parley-16.08.1.tar.xz";
+      sha256 = "0pwwng4rx82l7j8n9llhwn6779jjhakl84nal1s6fc4i8vack49v";
+      name = "parley-16.08.1.tar.xz";
     };
   };
   picmi = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/picmi-16.08.0.tar.xz";
-      sha256 = "1ayxzfd6xgb02bliwcrbcnsjqid81afz4mmlvkdg079mzqgnsm5l";
-      name = "picmi-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/picmi-16.08.1.tar.xz";
+      sha256 = "0lfmswabkkj6snwmx27iv9w5c2qpw6z85rvi997ccrw5yg1627hc";
+      name = "picmi-16.08.1.tar.xz";
     };
   };
   pimcommon = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/pimcommon-16.08.0.tar.xz";
-      sha256 = "0hdwdwr81viidkcxxg861pay7k3ix96wwcqj4anf1nv0cyg9i76n";
-      name = "pimcommon-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/pimcommon-16.08.1.tar.xz";
+      sha256 = "1n15i70mgfx0jnl4952gkn05ynpnkqz4fkmwycj0ib0ry9wvi2vh";
+      name = "pimcommon-16.08.1.tar.xz";
     };
   };
   poxml = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/poxml-16.08.0.tar.xz";
-      sha256 = "1r4b763rs77w03l0wwskqfjbkk83mdbk5w22s7xwr356w6h9mir1";
-      name = "poxml-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/poxml-16.08.1.tar.xz";
+      sha256 = "0cwnpcagsg1dbvfhra473g7wqmk5x2frw8y3831zwr47y6kgdr0c";
+      name = "poxml-16.08.1.tar.xz";
     };
   };
   print-manager = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/print-manager-16.08.0.tar.xz";
-      sha256 = "033bdrzr6726a35pf7wi4dw1slfpywi2si26pkxh90863620qa87";
-      name = "print-manager-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/print-manager-16.08.1.tar.xz";
+      sha256 = "1nhfkw56ri8y2pik3x76v5w3dl39k2a2ajd4gdql627sc3116c5q";
+      name = "print-manager-16.08.1.tar.xz";
     };
   };
   rocs = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/rocs-16.08.0.tar.xz";
-      sha256 = "0fc8dgaj6n4kqkxs3m7p4g83znmvqx014shx0q5lv0azjr0bp09s";
-      name = "rocs-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/rocs-16.08.1.tar.xz";
+      sha256 = "1qif7qj67rzljpkmbqjfm0gaji8wk7mc8fbddi7fpczgnz5jcmd5";
+      name = "rocs-16.08.1.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/signon-kwallet-extension-16.08.0.tar.xz";
-      sha256 = "1gbd9gf9riyrzi1gd0hxk06n6a86j103zhcwhscg9xh5fz306v3l";
-      name = "signon-kwallet-extension-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/signon-kwallet-extension-16.08.1.tar.xz";
+      sha256 = "0l68iz23d5k24ciyzdb7iywamfias34yhdcm69dpqpw1jchfcrkv";
+      name = "signon-kwallet-extension-16.08.1.tar.xz";
     };
   };
   spectacle = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/spectacle-16.08.0.tar.xz";
-      sha256 = "02fcgx8k74dqjn7bpkcydcdcw2jv2sk3w5a9kjwnwr14jcfb28zq";
-      name = "spectacle-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/spectacle-16.08.1.tar.xz";
+      sha256 = "0a9gka5xllwcdvvdbr8fj91v8zg2hlzhrh6myb0ycj7ang45gc88";
+      name = "spectacle-16.08.1.tar.xz";
     };
   };
   step = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/step-16.08.0.tar.xz";
-      sha256 = "035qflw50q22ml9nmwdl7ih3ym543dcyizc792cj3axmmhjvbpki";
-      name = "step-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/step-16.08.1.tar.xz";
+      sha256 = "0135568xaccswfj8zfimh5fbpb8ib3lz2aq9qsw05bbmrjfv4398";
+      name = "step-16.08.1.tar.xz";
     };
   };
   svgpart = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/svgpart-16.08.0.tar.xz";
-      sha256 = "1z79056lsr4w3abqic4hk7xqnpma0sqq6ir9acrgkw89qiwjinga";
-      name = "svgpart-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/svgpart-16.08.1.tar.xz";
+      sha256 = "0ws41853wcfj1nbd31mr5qr23rzlijprvbpr1y7wq6g9agdfdwxs";
+      name = "svgpart-16.08.1.tar.xz";
     };
   };
   sweeper = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/sweeper-16.08.0.tar.xz";
-      sha256 = "0ra8gldnbd6rkqrfrdljdjdh8naw1anga7g367mzik9n8vp0j5y4";
-      name = "sweeper-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/sweeper-16.08.1.tar.xz";
+      sha256 = "0ywrpdhy61hm61drclk17mlmp8i0717871mc48b5rlpgkxa31aaz";
+      name = "sweeper-16.08.1.tar.xz";
     };
   };
   syndication = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/syndication-16.08.0.tar.xz";
-      sha256 = "0kg4194lrpda95pr9qk87frfvx4r0lmqvvlivyz4nqd18w9dj4r3";
-      name = "syndication-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/syndication-16.08.1.tar.xz";
+      sha256 = "06hpw3lr3idrrbv92qd5smnnbv4yvpn5kn99bbx5rjwxbcnrklml";
+      name = "syndication-16.08.1.tar.xz";
     };
   };
   umbrello = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/umbrello-16.08.0.tar.xz";
-      sha256 = "0jhcdd8awdkky6jzki034ims04n27ix38hnxhldxj94n52crjdgl";
-      name = "umbrello-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/umbrello-16.08.1.tar.xz";
+      sha256 = "14kalb7fpknsflkxychian1j724kfw4klcb4l361cn53imqq0ngk";
+      name = "umbrello-16.08.1.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "16.08.0";
+    version = "16.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/16.08.0/src/zeroconf-ioslave-16.08.0.tar.xz";
-      sha256 = "0fb0c24rhkrrna9ymmlrxwf711bx7pnb2v0sx4jsla79r9wr2z0g";
-      name = "zeroconf-ioslave-16.08.0.tar.xz";
+      url = "${mirror}/stable/applications/16.08.1/src/zeroconf-ioslave-16.08.1.tar.xz";
+      sha256 = "00p6hwrc5zhll9vfs5vzff469lgp7xbmvpa2s11ix45wh8d2wm91";
+      name = "zeroconf-ioslave-16.08.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update KDE to 16.08.1

Somewhat personal use case: `konsole` has a [bug](https://bugs.kde.org/show_bug.cgi?id=366368) that has been fixed in the new version. Perhaps also backport to 16.09 if this is good?
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS) -- just `konsole`
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) -- again just `konsole`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
