### PR TITLE
Cscope cleanup

### DIFF
--- a/pkgs/development/tools/misc/cscope/default.nix
+++ b/pkgs/development/tools/misc/cscope/default.nix
@@ -8,13 +8,6 @@ stdenv.mkDerivation rec {
     sha256 = "07jdhxvp3dv7acvp0pwsdab1g2ncxjlcf838lj7vxgjs1p26lwzb";
   };
 
-  preConfigure = ''
-    sed -i "contrib/xcscope/cscope-indexer" \
-        -"es|^PATH=.*$|PATH=\"$out/bin:\$PATH\"|g"
-    sed -i "contrib/xcscope/xcscope.el" \
-        -"es|\"cscope-indexer\"|\"$out/libexec/cscope/cscope-indexer\"|g";
-  '';
-
   configureFlags = "--with-ncurses=${ncurses.dev}";
 
   buildInputs = [ ncurses ];
@@ -23,6 +16,11 @@ stdenv.mkDerivation rec {
   postInstall = ''
     # Install Emacs mode.
     cd "contrib/xcscope"
+
+    sed -i "cscope-indexer" \
+        -"es|^PATH=.*$|PATH=\"$out/bin:\$PATH\"|g"
+    sed -i "xcscope.el" \
+        -"es|\"cscope-indexer\"|\"$out/libexec/cscope/cscope-indexer\"|g";
 
     mkdir -p "$out/libexec/cscope"
     cp "cscope-indexer" "$out/libexec/cscope"

--- a/pkgs/development/tools/misc/cscope/default.nix
+++ b/pkgs/development/tools/misc/cscope/default.nix
@@ -1,4 +1,6 @@
-{ fetchurl, stdenv, ncurses, pkgconfig, emacs}:
+{ fetchurl, stdenv, ncurses, pkgconfig
+, emacsSupport ? true, emacs
+}:
 
 stdenv.mkDerivation rec {
   name = "cscope-15.8a";
@@ -11,10 +13,9 @@ stdenv.mkDerivation rec {
   configureFlags = "--with-ncurses=${ncurses.dev}";
 
   buildInputs = [ ncurses ];
-  nativeBuildInputs = [ pkgconfig emacs ];
+  nativeBuildInputs = [ pkgconfig ] + stdenv.lib.optional emacsSupport emacs;
 
-  postInstall = ''
-    # Install Emacs mode.
+  postInstall = stdenv.lib.optionalString emacsSupport ''
     cd "contrib/xcscope"
 
     sed -i "cscope-indexer" \

--- a/pkgs/development/tools/misc/cscope/default.nix
+++ b/pkgs/development/tools/misc/cscope/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, ncurses, pkgconfig
+{ fetchurl, stdenv, ncurses
 , emacsSupport ? true, emacs
 }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   configureFlags = "--with-ncurses=${ncurses.dev}";
 
   buildInputs = [ ncurses ];
-  nativeBuildInputs = [ pkgconfig ] + stdenv.lib.optional emacsSupport emacs;
+  nativeBuildInputs = stdenv.lib.optional emacsSupport emacs;
 
   postInstall = stdenv.lib.optionalString emacsSupport ''
     cd "contrib/xcscope"

--- a/pkgs/development/tools/misc/cscope/default.nix
+++ b/pkgs/development/tools/misc/cscope/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "cscope-15.8a";
+  name = "cscope-15.8b";
 
   src = fetchurl {
     url = "mirror://sourceforge/cscope/${name}.tar.gz";
-    sha256 = "07jdhxvp3dv7acvp0pwsdab1g2ncxjlcf838lj7vxgjs1p26lwzb";
+    sha256 = "1byk29rcpyygrnr03h5j3y8j0aqxldd9dr5ihi9q982sy28x12a8";
   };
 
   configureFlags = "--with-ncurses=${ncurses.dev}";


### PR DESCRIPTION
Follow up from PR #18684
###### Motivation for this change

Make the emacs support optional, update to the latest version, and various cleanups.
###### Change details
- do all emacs mode creation in postInstall
- make emacs support optional
- remove unused dependency on pkgconfig
- 15.8a -> 15.8b
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
