### PR TITLE
Emacs cleanup

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -4,9 +4,9 @@
 , alsaLib, cairo, acl, gpm, AppKit, CoreWLAN, Kerberos, GSS, ImageIO
 , autoconf, automake
 , withX ? !stdenv.isDarwin
+, withGTK2 ? true, gtk2 ? null
 , withGTK3 ? false, gtk3 ? null
 , withXwidgets ? false, webkitgtk24x ? null, wrapGAppsHook ? null, glib_networking ? null
-, withGTK2 ? true, gtk2
 }:
 
 assert (libXft != null) -> libpng != null;      # probably a bug
@@ -19,8 +19,8 @@ assert withXwidgets -> withGTK3 && webkitgtk24x != null;
 
 let
   toolkit =
-    if withGTK3 then "gtk3"
-    else if withGTK2 then "gtk2"
+    if withGTK2 then "gtk2"
+    else if withGTK3 then "gtk3"
     else "lucid";
 in
 stdenv.mkDerivation rec {
@@ -31,9 +31,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cwgyiyymnx4xdg99dm2drfxcyhy2jmyf0rkr9fwj9mwwf77kwhr";
   };
 
-  patches = lib.optionals stdenv.isDarwin [
-    ./at-fdcwd.patch
-  ];
+  patches = lib.optional stdenv.isDarwin ./at-fdcwd.patch;
 
   postPatch = ''
     substituteInPlace lisp/international/mule-cmds.el \

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -63,9 +63,6 @@ stdenv.mkDerivation rec {
              "--with-gif=no" "--with-tiff=no" ])
     ++ lib.optional withXwidgets "--with-xwidgets";
 
-  NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && withX)
-    "-I${cairo.dev}/include/cairo";
-
   preConfigure = ''
     ./autogen.sh
 

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -66,8 +66,8 @@ stdenv.mkDerivation rec {
     substituteInPlace lisp/international/mule-cmds.el \
       --replace /usr/share/locale ${gettext}/share/locale
 
-    for i in Makefile.in {src,lib-src,leim}/Makefile.in; do
-        substituteInPlace $i --replace /bin/pwd pwd
+    for makefile_in in $(find . -name Makefile.in -print); do
+        substituteInPlace $makefile_in --replace /bin/pwd pwd
     done
   '';
 

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -7,7 +7,6 @@
 , withGTK3 ? false, gtk3 ? null
 , withXwidgets ? false, webkitgtk24x ? null, wrapGAppsHook ? null, glib_networking ? null
 , srcRepo ? false, autoconf ? null, automake ? null, texinfo ? null
-, srcLocal ? false
 }:
 
 assert (libXft != null) -> libpng != null;      # probably a bug
@@ -63,8 +62,6 @@ stdenv.mkDerivation rec {
 
   preConfigure = lib.optionalString srcRepo ''
     ./autogen.sh
-  '' + lib.optionalString srcLocal ''
-    find . -name '*.elc' -delete
   '' + ''
     substituteInPlace lisp/international/mule-cmds.el \
       --replace /usr/share/locale ${gettext}/share/locale

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -26,8 +26,6 @@ in
 stdenv.mkDerivation rec {
   name = "emacs-25.1";
 
-  builder = ./builder.sh;
-
   src = fetchurl {
     url = "mirror://gnu//emacs/${name}.tar.xz";
     sha256 = "0cwgyiyymnx4xdg99dm2drfxcyhy2jmyf0rkr9fwj9mwwf77kwhr";
@@ -69,6 +67,14 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && withX)
     "-I${cairo.dev}/include/cairo";
+
+  preConfigure = ''
+    ./autogen.sh
+
+    for i in Makefile.in src/Makefile.in lib-src/Makefile.in leim/Makefile.in; do
+        substituteInPlace $i --replace /bin/pwd pwd
+    done
+  '';
 
   preBuild = ''
     find . -name '*.elc' -delete

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -1,12 +1,13 @@
 { stdenv, lib, fetchurl, ncurses, xlibsWrapper, libXaw, libXpm, Xaw3d
 , pkgconfig, gettext, libXft, dbus, libpng, libjpeg, libungif
-, libtiff, librsvg, texinfo, gconf, libxml2, imagemagick, gnutls
+, libtiff, librsvg, gconf, libxml2, imagemagick, gnutls
 , alsaLib, cairo, acl, gpm, AppKit, CoreWLAN, Kerberos, GSS, ImageIO
-, autoconf, automake
 , withX ? !stdenv.isDarwin
 , withGTK2 ? true, gtk2 ? null
 , withGTK3 ? false, gtk3 ? null
 , withXwidgets ? false, webkitgtk24x ? null, wrapGAppsHook ? null, glib_networking ? null
+, srcRepo ? false, autoconf ? null, automake ? null, texinfo ? null
+, srcLocal ? false
 }:
 
 assert (libXft != null) -> libpng != null;      # probably a bug
@@ -33,14 +34,11 @@ stdenv.mkDerivation rec {
 
   patches = lib.optional stdenv.isDarwin ./at-fdcwd.patch;
 
-  postPatch = ''
-    substituteInPlace lisp/international/mule-cmds.el \
-      --replace "/usr/share/locale" "${gettext}/share/locale"
-  '';
+  nativeBuildInputs = [ pkgconfig ]
+    ++ lib.optionals srcRepo [ autoconf automake texinfo ];
 
   buildInputs =
-    [ ncurses gconf libxml2 gnutls alsaLib pkgconfig texinfo acl gpm gettext
-      autoconf automake ]
+    [ ncurses gconf libxml2 gnutls alsaLib acl gpm gettext ]
     ++ lib.optional stdenv.isLinux dbus
     ++ lib.optionals withX
       [ xlibsWrapper libXaw Xaw3d libXpm libpng libjpeg libungif libtiff librsvg libXft
@@ -63,16 +61,17 @@ stdenv.mkDerivation rec {
              "--with-gif=no" "--with-tiff=no" ])
     ++ lib.optional withXwidgets "--with-xwidgets";
 
-  preConfigure = ''
+  preConfigure = lib.optionalString srcRepo ''
     ./autogen.sh
+  '' + lib.optionalString srcLocal ''
+    find . -name '*.elc' -delete
+  '' + ''
+    substituteInPlace lisp/international/mule-cmds.el \
+      --replace /usr/share/locale ${gettext}/share/locale
 
-    for i in Makefile.in src/Makefile.in lib-src/Makefile.in leim/Makefile.in; do
+    for i in Makefile.in {src,lib-src,leim}/Makefile.in; do
         substituteInPlace $i --replace /bin/pwd pwd
     done
-  '';
-
-  preBuild = ''
-    find . -name '*.elc' -delete
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Remove old code in the derivation. Make more explicit the fact that some inputs and steps are optional.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
