### PR TITLE
nixos-generate-config: update default to use grub for UEFI as well

### DIFF
--- a/nixos/doc/manual/installation/installing-uefi.xml
+++ b/nixos/doc/manual/installation/installing-uefi.xml
@@ -12,33 +12,50 @@ changes:
 
 <itemizedlist>
   <listitem>
-    <para>You should boot the live CD in UEFI mode (consult your
-    specific hardware's documentation for instructions). You may find
-    the <link
-    xlink:href="http://www.rodsbooks.com/refind">rEFInd
-    boot manager</link> useful.</para>
+    <para>You will need your drive's partition table to be stored using
+    the GPT, rather than MBR, format. (That is likely already the case
+    if your current operating system boots in UEFI mode). Use
+    <command>gdisk</command> rather than <command>fdisk</command> to
+    partition your disk.</para>
   </listitem>
   <listitem>
-    <para>Instead of <command>fdisk</command>, you should use
-    <command>gdisk</command> to partition your disks. You will need to
-    have a separate partition for <filename>/boot</filename> with
-    partition code EF00, and it should be formatted as a
-    <literal>vfat</literal> filesystem.</para>
+    <para>If you don't have one already, you will need to create a
+    separate partition (called the EFP) with partition code EF00 and the
+    GPT <literal>boot</literal> flag. It should be formatted as a
+    <literal>vfat</literal> filesystem and be about ~100-200MB. You set
+    configurations to have it mounted in
+    <literal>boot.loader.efi.efiSysMountPoint</literal>
+    (<literal>/boot</literal> by default).</para>
   </listitem>
   <listitem>
-    <para>You must set <option>boot.loader.systemd-boot.enable</option> to
+    <para>If you want your device to be bootable in BIOS (legacy) mode
+    as well, and if you don't have one already, you will need to create
+    a separate "BIOS boot" partition with partition code EF02. This
+    partition does not need to be formatted, or mounted, and can be as
+    small as 1MB.</para>
+  </listitem>
+  <listitem>
+    <para>During installation, after mounting your installation partition to
+    <code>/mnt</code>, you must manually mount the EFP partition to
+    <code>/mnt/boot</code> (or your selected mountpoint).</para>
+  </listitem>
+  <listitem>
+    <para>You must set <option>boot.loader.grub.efiSupport</option> to
     <literal>true</literal>. <command>nixos-generate-config</command>
-    should do this automatically for new configurations when booted in
-    UEFI mode.</para>
+    should do this automatically for new configurations when the
+    installation device is booted in UEFI mode.</para>
   </listitem>
   <listitem>
-    <para>After having mounted your installation partition to
-    <code>/mnt</code>, you must mount the <code>boot</code> partition
-    to <code>/mnt/boot</code>.</para>
+    <para>If you have not booted the installation device in UEFI mode,
+    you'll probably need to set
+    <literal>boot.loader.grub.efiInstallAsRemovable</literal> to
+    <literal>true</literal> and
+    <literal>boot.loader.efi.canTouchEfiVariables</literal> to
+    <literal>false</literal>.</para>
   </listitem>
   <listitem>
     <para>You may want to look at the options starting with
-    <option>boot.loader.efi</option> and <option>boot.loader.systemd-boot</option>
+    <option>boot.loader.efi</option> and <option>boot.loader.grub</option>
     as well.</para>
   </listitem>
 </itemizedlist>

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -515,24 +515,34 @@ if ($showHardwareConfig) {
     if ($force || ! -e $fn) {
         print STDERR "writing $fn...\n";
 
-        my $bootLoaderConfig = "";
-        if (-e "/sys/firmware/efi/efivars") {
-            $bootLoaderConfig = <<EOF;
-  # Use the systemd-boot EFI boot loader.
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-EOF
-        } elsif ($virt ne "systemd-nspawn") {
-            $bootLoaderConfig = <<EOF;
+        my $bootLoaderConfig = <<EOF;
   # Use the GRUB 2 boot loader.
   boot.loader.grub.enable = true;
-  boot.loader.grub.version = 2;
+
+  # Define which hard drive you want to install GRUB on for BIOS/legacy mode
+  # booting (use "nodev" if you don't care to support legacy mode)
+EOF
+        if (-e "/sys/firmware/efi/efivars") {
+            $bootLoaderConfig .= <<EOF;
+  boot.loader.grub.device = "nodev";
+
+  boot.loader.grub.efiSupport = true;
+  boot.loader.grub.efiInstallAsRemovable = false;
+  boot.loader.efi.canTouchEfiVariables = true;
+  # boot.loader.efi.efiSysMountPoint = "/boot/efi";
+EOF
+        } elsif ($virt ne "systemd-nspawn") {
+            $bootLoaderConfig .= <<EOF;
+  # boot.loader.grub.device = "/dev/sda";
+
+  # The following options are only useful if you want to support EFI booting
   # boot.loader.grub.efiSupport = true;
   # boot.loader.grub.efiInstallAsRemovable = true;
+  # boot.loader.efi.canTouchEfiVariables = false;
   # boot.loader.efi.efiSysMountPoint = "/boot/efi";
-  # Define on which hard drive you want to install Grub.
-  # boot.loader.grub.device = "/dev/sda"; # or "nodev" for efi only
 EOF
+        } else {
+            $bootLoaderConfig = "";
         }
 
         write_file($fn, <<EOF);


### PR DESCRIPTION
Also updates & beefs up UEFI installation instructions to close #9096

Currently we default to systemd-boot (previously gumniboot) when the
installation device (on which nixos-generate-config typically runs) is
booted in UEFI mode, and we default to GRUB when the device is booted
in BIOS mode.

This patch attempts to unify the two branches by using GRUB in both
cases. The advantages are:
- Consistency between the two cases
- GRUB can create disks that are bootable in both UEFI and BIOS mode
- GRUB can install itself on a UEFI device while booted in BIOS mode
  (using efiInstallAsRemovable to avoid touching EFI vars)

For systems booted in UEFI mode, it will generate this config:

``` nix
{
  # Use the GRUB 2 boot loader.
  boot.loader.grub.enable = true;

  # Define which hard drive you want to install GRUB on for BIOS/legacy mode
  # booting (use "nodev" if you don't care to support legacy mode)
  boot.loader.grub.device = "nodev";

  boot.loader.grub.efiSupport = true;
  boot.loader.grub.efiInstallAsRemovable = false;
  boot.loader.efi.canTouchEfiVariables = true;
  # boot.loader.efi.efiSysMountPoint = "/boot/efi";
}
```

For systems booted in BIOS mode, it will generate this:

``` nix
{  
  # Use the GRUB 2 boot loader.
  boot.loader.grub.enable = true;

  # Define which hard drive you want to install GRUB on for BIOS/legacy mode
  # booting (use "nodev" if you don't care to support legacy mode)
  # boot.loader.grub.device = "/dev/sda";

  # The following options are only useful if you want to support EFI booting
  # boot.loader.grub.efiSupport = true;
  # boot.loader.grub.efiInstallAsRemovable = true;
  # boot.loader.efi.canTouchEfiVariables = false;
  # boot.loader.efi.efiSysMountPoint = "/boot/efi";
}
```

The manual post-patch looks like this:

---

2.1. UEFI Installation

NixOS can also be installed on UEFI systems. The procedure is by and large the same as a BIOS installation, with the following changes:
- You will need your drive's partition table to be stored using the GPT, rather than MBR, format. (That is likely already the case if your current operating system boots in UEFI mode). Use gdisk rather than fdisk to partition your disk.
- If you don't have one already, you will need to create a separate partition (called the EFP) with partition code EF00 and the GPT boot flag. It should be formatted as a vfat filesystem and be about ~100-200MB. You set configurations to have it mounted in boot.loader.efi.efiSysMountPoint (/boot by default).
- If you want your device to be bootable in BIOS (legacy) mode as well, and if you don't have one already, you will need to create a separate "BIOS boot" partition with partition code EF02. This partition does not need to be formatted, or mounted, and can be as small as 1MB.
- During installation, after mounting your installation partition to /mnt, you must manually mount the EFP partition to /mnt/boot (or your selected mountpoint).
- You must set boot.loader.grub.efiSupport to true. nixos-generate-config should do this automatically for new configurations when the installation device is booted in UEFI mode.
- If you have not booted the installation device in UEFI mode, you'll probably need to set boot.loader.grub.efiInstallAsRemovable to true and boot.loader.efi.canTouchEfiVariables to false.
- You may want to look at the options starting with boot.loader.efi and boot.loader.grub as well.

---
