### PR TITLE
New hoogle for ghcWithHoogle

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -287,6 +287,7 @@ self: super: {
   hadoop-rpc = dontCheck super.hadoop-rpc;              # http://hydra.cryp.to/build/527461/nixlog/2/raw
   hasql = dontCheck super.hasql;                        # http://hydra.cryp.to/build/502489/nixlog/4/raw
   hjsonschema = overrideCabal super.hjsonschema (drv: { testTarget = "local"; });
+  hoogle_5_0_4 = super.hoogle_5_0_4.override { haskell-src-exts = self.haskell-src-exts_1_18_2; };
   marmalade-upload = dontCheck super.marmalade-upload;  # http://hydra.cryp.to/build/501904/nixlog/1/raw
   network-transport-tcp = dontCheck super.network-transport-tcp;
   network-transport-zeromq = dontCheck super.network-transport-zeromq; # https://github.com/tweag/network-transport-zeromq/issues/30

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -87,7 +87,7 @@ let
             packages = selectFrom self;
             hoogle = callPackage ./hoogle.nix {
               inherit packages;
-              hoogle = self.hoogle_4_2_43;
+              hoogle = self.hoogle_5_0_4;
             };
           in withPackages (packages ++ [ hoogle ]);
 

--- a/pkgs/development/haskell-modules/hoogle-local-wrapper.sh
+++ b/pkgs/development/haskell-modules/hoogle-local-wrapper.sh
@@ -2,4 +2,4 @@
 
 COMMAND=$1
 shift
-exec @hoogle@/bin/hoogle "$COMMAND" -d @out@/share/doc/hoogle "$@"
+exec @hoogle@/bin/hoogle "$COMMAND" --database @out@/share/doc/hoogle/default.hoo "$@"


### PR DESCRIPTION
###### Motivation for this change

Convert the `ghcWithHoogle` expression to work with hoogle >= 5.0.4.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
