### PR TITLE
go_1_7: 1.7 -> 1.7.1 on release 16.09

### DIFF
--- a/pkgs/development/compilers/go/1.7.nix
+++ b/pkgs/development/compilers/go/1.7.nix
@@ -15,13 +15,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.7";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "03wc4r5pgxrlh3lp8l0hb1bhsrwv4hfq1fcj8n82bfk3hvj43am2";
+    sha256 = "121cvpjpbyl3lyd6j5lnnq6pr8vl7ar5zvap1132c522lxgxw356";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/remove-tools-1.7.patch
+++ b/pkgs/development/compilers/go/remove-tools-1.7.patch
@@ -1,8 +1,8 @@
 diff --git a/src/go/build/build.go b/src/go/build/build.go
-index 496fe11..8c81dbd 100644
+index 9706b8b..f250751 100644
 --- a/src/go/build/build.go
 +++ b/src/go/build/build.go
-@@ -1388,7 +1388,7 @@ func init() {
+@@ -1513,7 +1513,7 @@ func init() {
  }
  
  // ToolDir is the directory containing build tools.
@@ -12,11 +12,11 @@ index 496fe11..8c81dbd 100644
  // IsLocalImport reports whether the import path is
  // a local import path, like ".", "..", "./foo", or "../foo".
 diff --git a/src/runtime/extern.go b/src/runtime/extern.go
-index d346362..fb22b6e 100644
+index 441dcd9..a50277e 100644
 --- a/src/runtime/extern.go
 +++ b/src/runtime/extern.go
-@@ -194,6 +194,17 @@ func GOROOT() string {
- 	return defaultGoroot
+@@ -230,6 +230,17 @@ func GOROOT() string {
+ 	return sys.DefaultGoroot
  }
  
 +// GOTOOLDIR returns the root of the Go tree.


### PR DESCRIPTION
###### Motivation for this change

Cherry-pick this update into 16.09 as it's a security fix. go 1.7 is already in 16.09 👼.

/cc @domenkozar @offlinehacker 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
