### PR TITLE
secp256k1: configure with more feature flags

### DIFF
--- a/pkgs/tools/security/secp256k1/default.nix
+++ b/pkgs/tools/security/secp256k1/default.nix
@@ -1,32 +1,49 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, ... }:
+{ stdenv, fetchFromGitHub, autoreconfHook, jdk
+
+# Enable ECDSA pubkey recovery module
+, enableRecovery ? true
+
+# Enable ECDH shared secret computation (disabled by default because it is
+# experimental)
+, enableECDH ? false
+
+# Enable libsecp256k1_jni (disabled by default because it requires a jdk,
+# which is a large dependency)
+, enableJNI ? false
+
+}:
+
+let inherit (stdenv.lib) optionals; in
 
 stdenv.mkDerivation rec {
   name = "secp256k1-${version}";
 
-  # I can't find any version numbers, so we're just using the date
-  # of the last commit.
-  version = "2016-05-30";
+  # I can't find any version numbers, so we're just using the date of the
+  # last commit.
+  version = "2016-11-27";
 
   src = fetchFromGitHub {
     owner = "bitcoin-core";
     repo = "secp256k1";
-    rev = "b3be8521e694eaf45dd29baea035055183c42fe2";
-    sha256 = "1pgsy72w87yxbiqn96hnm8alsfx3rj7d9jlzdsypyf6i1rf6w4bq";
+    rev = "2928420c1b8e1feee8c20dff4e3cc41a0de2fc22";
+    sha256 = "1djsr2vrhh88353czlwb8bwlyabf008w1f7xg0fs3q33rf42w5gm";
   };
 
-  buildInputs = [ autoconf automake libtool ];
+  buildInputs = optionals enableJNI [ jdk ];
 
-  configureFlags = [ "--enable-module-recovery" ];
+  nativeBuildInputs = [ autoreconfHook ];
 
-  preConfigure = "./autogen.sh";
+  configureFlags =
+    optionals enableECDH [ "--enable-module-ecdh" "--enable-experimental" ] ++
+    optionals enableRecovery [ "--enable-module-recovery" ] ++
+    optionals enableJNI [ "--enable-jni" ];
 
   meta = with stdenv.lib; {
     description = "Optimized C library for EC operations on curve secp256k1";
     longDescription = ''
-      Optimized C library for EC operations on curve secp256k1.
-      Part of Bitcoin Core. This library is a work in progress
-      and is being used to research best practices. Use at your
-      own risk.
+      Optimized C library for EC operations on curve secp256k1. Part of
+      Bitcoin Core. This library is a work in progress and is being used
+      to research best practices. Use at your own risk.
     '';
     homepage = https://github.com/bitcoin-core/secp256k1;
     license = with licenses; [ mit ];


### PR DESCRIPTION
###### Motivation for this change

Closes #18637
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
