### PR TITLE
appstream-glib: 0.5.12 -> 0.6.3

### DIFF
--- a/pkgs/development/libraries/appstream-glib/default.nix
+++ b/pkgs/development/libraries/appstream-glib/default.nix
@@ -1,20 +1,20 @@
 { stdenv, fetchFromGitHub, pkgconfig, gettext, gtk3, intltool, glib
 , gtk_doc, autoconf, automake, libtool, libarchive, libyaml
 , gobjectIntrospection, sqlite, libsoup, gcab, attr, acl, docbook_xsl
-, libuuid, json_glib
+, libuuid, json_glib, autoconf-archive
 }:
 
 stdenv.mkDerivation rec {
-  name = "appstream-glib-0.5.12";
+  name = "appstream-glib-0.6.3";
 
   src = fetchFromGitHub {
     owner = "hughsie";
     repo = "appstream-glib";
     rev = stdenv.lib.replaceStrings ["." "-"] ["_" "_"] name;
-    sha256 = "00b0441f409vzgy0znn42k093w7hwv3495qvsakxnhvk1h1ws23s";
+    sha256 = "12l0vzhi9vpyrnf7vrpq21rb26mb6yskp5zgngdjyjanwhzmc617";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool pkgconfig intltool ];
+  nativeBuildInputs = [ autoconf automake libtool pkgconfig intltool autoconf-archive ];
   buildInputs = [ glib gtk_doc gettext sqlite libsoup
                   gcab attr acl docbook_xsl libuuid json_glib
                   libarchive libyaml gtk3 gobjectIntrospection ];


### PR DESCRIPTION
###### Motivation for this change

new version
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @lethalman  @matthewbauer 
