### PR TITLE
libchamplain: 0.12.13 -> 0.12.14

### DIFF
--- a/pkgs/development/libraries/libchamplain/default.nix
+++ b/pkgs/development/libraries/libchamplain/default.nix
@@ -1,13 +1,14 @@
 { fetchurl, stdenv, pkgconfig, glib, gtk3, cairo, clutter, sqlite
 , clutter_gtk, libsoup /*, libmemphis */ }:
 
-let version = "0.12.13"; in
 stdenv.mkDerivation rec {
+  major = "0.12";
+  version = "${major}.14";
   name = "libchamplain-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libchamplain/0.12/libchamplain-${version}.tar.xz";
-    sha256 = "1arzd1hsgq14rbiwa1ih2g250x6ljna2s2kiqfrw155c612s9cxk";
+    url = "mirror://gnome/sources/libchamplain/${major}/${name}.tar.xz";
+    sha256 = "13snnka1jqc5qrgij8bm22xy02pncf3dn5ij3jh4rrpzq7g1sqpi";
   };
 
   buildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

new version

**no maintainers here but this is used in gnome**
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
