### PR TITLE
Add mypy type checker for Python

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14202,6 +14202,24 @@ in modules // {
     '';
   };
 
+  mypy = pkgs.python35Packages.buildPythonPackage rec {
+    name = "mypy-lang-0.4.4";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/m/mypy-lang/${name}.tar.gz";
+      sha256 = "a17347f3688764db0f5ac090760260beac8ffb6a4be2db949fd3743c15467a08";
+    };
+
+    # tests are not shipped in the tarball
+    doCheck = false;
+
+    meta = {
+      homepage = http://www.mypy-lang.org/;
+      description = "Optional static typing for Python";
+      license = licenses.mit;
+    };
+  };
+
   MySQL_python = buildPythonPackage rec {
     name = "MySQL-python-1.2.5";
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
