### PR TITLE
calc: remove redundant groff dependency

### DIFF
--- a/pkgs/applications/science/math/calc/default.nix
+++ b/pkgs/applications/science/math/calc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, glibc, readline, ncurses, groff, utillinux }:
+{ stdenv, fetchurl, makeWrapper, glibc, readline, ncurses, utillinux }:
 
 with stdenv.lib;
 let
@@ -7,7 +7,6 @@ let
     BINDIR=$out/bin LIBDIR=$out/lib CALC_INCDIR=$out/include/calc CALC_SHAREDIR=$out/share/calc MANDIR=$out/share/man/man1 \
     USE_READLINE=-DUSE_READLINE READLINE_LIB=-lreadline READLINE_EXTRAS='-lhistory -lncurses' \
     TERMCONTROL=-DUSE_TERMIOS \
-    NROFF=groff
   '';
 in
 stdenv.mkDerivation rec {
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "14mnz6smhi3a0rgmwvddk9w3vdisi8khq67i8nqsl47vgs8n1kqg";
   };
 
-  buildInputs = [ makeWrapper readline ncurses groff utillinux ];
+  buildInputs = [ makeWrapper readline ncurses utillinux ];
 
   configurePhase = ''
     sed -i 's/all: check_include/all:/' Makefile


### PR DESCRIPTION
1. wasn't even using groff. just referenced it in the makefiles without calling it properly or really needing it.
2. one of multiple groff -> mandoc test subjects
