### PR TITLE
vifm: groff -> mandoc

### DIFF
--- a/pkgs/applications/misc/vifm/default.nix
+++ b/pkgs/applications/misc/vifm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl
 , pkgconfig
 , ncurses, libX11
-, utillinux, file, which, groff
+, utillinux, file, which, mandoc
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ncurses libX11 utillinux file which groff ];
+  buildInputs = [ ncurses libX11 utillinux file which mandoc ];
 
   meta = with stdenv.lib; {
     description = "A vi-like file manager";


### PR DESCRIPTION
one of multiple groff -> mandoc test subjects. the nicest of the lot since it supported mandoc right out of the box.
