### PR TITLE
rtlwifi_new: init at 2016-09-12

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -419,6 +419,7 @@
   ttuegel = "Thomas Tuegel <ttuegel@gmail.com>";
   tv = "Tomislav Viljetić <tv@shackspace.de>";
   tvestelind = "Tomas Vestelind <tomas.vestelind@fripost.org>";
+  tvorog = "Marsel Zaripov <marszaripov@gmail.com>";
   twey = "James ‘Twey’ Kay <twey@twey.co.uk>";
   uralbash = "Svintsov Dmitry <root@uralbash.ru>";
   urkud = "Yury G. Kudryashov <urkud+nix@ya.ru>";

--- a/pkgs/os-specific/linux/firmware/rtlwifi_new-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtlwifi_new-firmware/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, linuxPackages }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "rtlwifi_new-firmware-${linuxPackages.rtlwifi_new.version}";
+  inherit (linuxPackages.rtlwifi_new) src;
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p "$out/lib/firmware"
+    cp -rf firmware/rtlwifi/ "$out/lib/firmware"
+  '';
+
+  meta = {
+    description = "Firmware for the newest Realtek rtlwifi codes";
+    inherit (src.meta) homepage;
+    license = licenses.unfreeRedistributableFirmware;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ tvorog ];
+  };
+}

--- a/pkgs/os-specific/linux/rtlwifi_new/default.nix
+++ b/pkgs/os-specific/linux/rtlwifi_new/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchFromGitHub, kernel }:
+
+with lib;
+
+let modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless/realtek/rtlwifi";
+
+in stdenv.mkDerivation rec {
+  name = "rtlwifi_new-${version}";
+  version = "2016-09-12";
+
+  src = fetchFromGitHub {
+    owner = "lwfinger";
+    repo = "rtlwifi_new";
+    rev = "7a1b37d2121e8ab1457f002b2729fc23e6ff3e10";
+    sha256 = "0z8grf0fak2ryxwzapp9di77c4bghzkv8lffv76idkcnxgq6sclv";
+  };
+
+  hardeningDisable = [ "pic" "format" ];
+
+  makeFlags = "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    mkdir -p ${modDestDir}
+    find . -name '*.ko' -exec cp --parents {} ${modDestDir} \;
+    find ${modDestDir} -name '*.ko' -exec xz -f {} \;
+  '';
+
+  meta = {
+    description = "The newest Realtek rtlwifi codes";
+    inherit (src.meta) homepage;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ tvorog ];
+    priority = -1;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11371,6 +11371,8 @@ in
 
     rtl8812au = callPackage ../os-specific/linux/rtl8812au { };
 
+    rtlwifi_new = callPackage ../os-specific/linux/rtlwifi_new { };
+
     openafsClient = callPackage ../servers/openafs-client { };
 
     facetimehd = callPackage ../os-specific/linux/facetimehd { };
@@ -11694,6 +11696,8 @@ in
   rt5677-firmware = callPackage ../os-specific/linux/firmware/rt5677 { };
 
   rtl8723bs-firmware = callPackage ../os-specific/linux/firmware/rtl8723bs-firmware { };
+
+  rtlwifi_new-firmware = callPackage ../os-specific/linux/firmware/rtlwifi_new-firmware { };
 
   s3ql = callPackage ../tools/backup/s3ql { };
 


### PR DESCRIPTION
###### Motivation for this change

It fixes problems with my realtek wireless network adapter
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
