### PR TITLE
pktgen: disable parallel building

### DIFF
--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
   RTE_TARGET = "x86_64-native-linuxapp-gcc";
   GUI = stdenv.lib.optionalString withGtk "true";
 
-  enableParallelBuilding = true;
-
   NIX_CFLAGS_COMPILE = [ "-march=core2" ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

As was accidentally discovered compilation may fail when using multiple cores.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The error is the same as in failed build here: https://hydra.nixos.org/build/40256742/nixlog/1/raw
