### PR TITLE
nextcloud: init at 10.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -367,6 +367,7 @@
   samuelrivas = "Samuel Rivas <samuelrivas@gmail.com>";
   sander = "Sander van der Burg <s.vanderburg@tudelft.nl>";
   schmitthenner = "Fabian Schmitthenner <development@schmitthenner.eu>";
+  schneefux = "schneefux <schneefux+nixos_pkg@schneefux.xyz>";
   schristo = "Scott Christopher <schristopher@konputa.com>";
   scolobb = "Sergiu Ivanov <sivanov@colimite.fr>";
   sepi = "Raffael Mancini <raffael@mancini.lu>";

--- a/pkgs/servers/mail/postfix/pflogsumm.nix
+++ b/pkgs/servers/mail/postfix/pflogsumm.nix
@@ -28,6 +28,7 @@ buildPerlPackage rec {
 
   meta = {
     homepage = "http://jimsun.linxnet.com/postfix_contrib.html";
+    maintainers = with stdenv.lib.maintainers; [ schneefux ];
     description = "Postfix activity overview";
     license = stdenv.lib.licenses.gpl2Plus;
   };

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Sharing solution for files, calendars, contacts and more";
     homepage = https://nextcloud.com;
+    maintainers = with stdenv.lib.maintainers; [ schneefux ];
     license = stdenv.lib.licenses.agpl3Plus;
     platforms = with stdenv.lib.platforms; unix;
   };

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  name= "nextcloud-${version}";
+  version = "10.0.0";
+
+  src = fetchurl {
+    url = "https://download.nextcloud.com/server/releases/${name}.tar.bz2";
+    sha256 = "07vnhw3xrady7p7y2hc3sm9bcdj21gxyx9rwgawmy28019y1gahs";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "env-variable.patch";
+      url = "https://github.com/nextcloud/server/commit/4277051442c2b6025da936493cb674dcf754d34c.patch";
+      sha256 = "1r1xcka9j9n0mkvj2nnhlwvhzicv9jjnxcszxs5g5ji88i1y0md2";
+    }) # exposes $NEXTCLOUD_CONFIG_DIR for Nextcloud 10 and below
+  ];
+
+  installPhase = ''
+    mkdir -p $out/
+    cp -R ./* $out/
+  '';
+
+  meta = {
+    description = "Sharing solution for files, calendars, contacts and more";
+    homepage = https://nextcloud.com;
+    license = stdenv.lib.licenses.agpl3Plus;
+    platforms = with stdenv.lib.platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2805,6 +2805,8 @@ in
 
   newsbeuter-dev = callPackage ../applications/networking/feedreaders/newsbeuter/dev.nix { };
 
+  nextcloud = callPackage ../servers/nextcloud { };
+
   ngrep = callPackage ../tools/networking/ngrep { };
 
   ngrok = callPackage ../tools/networking/ngrok { };


### PR DESCRIPTION
###### Motivation for this change

Based on the OwnCloud package, added the latest NextCloud 9.0 and NextCloud 10.0 packages.
Added an up-to-date patch that implements the possibility to specify a configuration file via environment variables, as seen [here](https://github.com/NixOS/nixpkgs/blob/staging/pkgs/servers/owncloud/default.nix#L18).

To use with nginx:

```
…
root ${pkgs.nextcloud};
…
location ~ \.php(?:$|/) {
  …
  fastcgi_param NEXTCLOUD_CONFIG_DIR '/etc/nextcloud';
  …
}
…
location ^~ /apps {
  alias /var/www/nextcloud-apps;
}
…
```

Additional NextCloud configuration options needed:

``` php
…
'datadirectory' => '/var/www/nextcloud-data',
'apps_paths' =>
 array(
  0 =>
   array(
    'path' => '/var/www/nextcloud-apps',
    'url' => '/apps',
    'writable' => true,
  ),
),
…
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @matejc
