### PR TITLE
Reorganize ocaml packages 

### DIFF
--- a/pkgs/applications/misc/llpp/default.nix
+++ b/pkgs/applications/misc/llpp/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, makeWrapper, fetchgit, pkgconfig, ninja, ocaml, findlib, mupdf, lablgl
+{ stdenv, lib, makeWrapper, fetchgit, pkgconfig, ninja, ocaml, findlib, mupdf, lablgl
 , gtk3, openjpeg, jbig2dec, mujs, xsel, openssl, freetype, ncurses }:
+
+assert lib.versionAtLeast (lib.getVersion ocaml) "4.02";
 
 let ocamlVersion = (builtins.parseDrvName (ocaml.name)).version;
 in stdenv.mkDerivation rec {

--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, ocamlPackages, zlib }:
+{ stdenv, fetchurl, zlib
+, ocaml, ocamlfuse, findlib, gapi_ocaml, ocaml_sqlite3, camlidl }:
 
 stdenv.mkDerivation rec {
   name = "google-drive-ocamlfuse-${version}";
@@ -9,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1hjm6hyva9sl6lddb0372wsy7f76105iaxh976yyzfn3b4ran6ab";
   };
 
-  buildInputs = [ zlib ] ++ (with ocamlPackages; [ocaml ocamlfuse findlib gapi_ocaml ocaml_sqlite3 camlidl]);
+  buildInputs = [ zlib ocaml ocamlfuse findlib gapi_ocaml ocaml_sqlite3 camlidl];
 
   configurePhase = "ocaml setup.ml -configure --prefix \"$out\"";
   buildPhase = "ocaml setup.ml -build";

--- a/pkgs/applications/science/logic/coq/8.3.nix
+++ b/pkgs/applications/science/logic/coq/8.3.nix
@@ -3,7 +3,10 @@
 #   However, coq can build without csdp by setting it to null.
 #   In this case some Micromega tactics will search the user's path for the csdp program and will fail if it is not found.
 
-{ stdenv, make, fetchurl, ocaml, findlib, camlp5, ncurses, lablgtk ? null, csdp ? null }:
+{ stdenv, lib, make, fetchurl
+, ocaml, findlib, camlp5, ncurses, lablgtk ? null, csdp ? null }:
+
+assert lib.versionOlder ocaml.version "4";
 
 let 
   version = "8.3pl4";

--- a/pkgs/applications/science/math/glsurf/default.nix
+++ b/pkgs/applications/science/math/glsurf/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://www.lama.univ-savoie.fr/~raffalli/glsurf;
     description = "A program to draw implicit surfaces and curves";
+    broken = true;
   };
 }

--- a/pkgs/applications/science/math/scilab/default.nix
+++ b/pkgs/applications/science/math/scilab/default.nix
@@ -67,5 +67,6 @@ stdenv.mkDerivation rec {
     description = "Scientific software package for numerical computations (Matlab lookalike)";
     # see http://www.scilab.org/legal
     license = "SciLab";
+    broken = true;
   };
 }

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -2,7 +2,7 @@
 , libuuid, gettext, ncurses, dev86, iasl, pciutils, bzip2
 , lvm2, utillinux, procps, texinfo, perl, pythonPackages
 , glib, bridge-utils, xorg, pixman, iproute, udev, bison
-, flex, cmake, ocaml, ocamlPackages, figlet, libaio, yajl
+, flex, cmake, ocamlPackages, figlet, libaio, yajl
 , checkpolicy, transfig, glusterfs, acl, fetchgit, xz, spice
 , spice_protocol, usbredir, alsaLib, quilt
 , coreutils, gawk, gnused, gnugrep, diffutils, multipath-tools
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
       dev86 iasl pciutils bzip2 xz texinfo perl yajl
       pythonPackages.python pythonPackages.wrapPython
       glib bridge-utils pixman iproute udev bison xorg.libX11
-      flex ocaml ocamlPackages.findlib figlet libaio
+      flex ocamlPackages.ocaml ocamlPackages.findlib figlet libaio
       checkpolicy pythonPackages.markdown transfig
       glusterfs acl cmake spice spice_protocol usbredir
       alsaLib quilt

--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -1,6 +1,9 @@
-{ stdenv, fetchurl, coq, ocamlPackages
+{ stdenv, lib, fetchurl
+, coq, ocaml, findlib, menhir
 , tools ? stdenv.cc
 }:
+
+assert lib.versionAtLeast ocaml.version "4.02";
 
 stdenv.mkDerivation rec {
   name    = "compcert-${version}";
@@ -11,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "1vhbs1fmr9x2imqyd6yfvkbz763jhjfm9wk4nizf9rn1cvxrjqa4";
   };
 
-  buildInputs = [ coq ] ++ (with ocamlPackages; [ ocaml findlib menhir ]);
+  buildInputs = [ coq ocaml findlib menhir ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/ocaml/3.08.0.nix
+++ b/pkgs/development/compilers/ocaml/3.08.0.nix
@@ -1,10 +1,12 @@
 { stdenv, fetchurl, xlibsWrapper }:
 
-stdenv.mkDerivation {
-  name = "ocaml-3.08.0";
+stdenv.mkDerivation rec {
+  name = "ocaml-${version}";
+  version = "3.08.0";
+
   builder = ./builder.sh;
   src = fetchurl {
-    url = http://tarballs.nixos.org/ocaml-3.08.0.tar.gz;
+    url = "http://tarballs.nixos.org/${name}.tar.gz";
     sha256 = "135g5waj7djzrj0dbc8z1llasfs2iv5asq41jifhldxb4l2b97mx";
   };
   configureScript = ./configure-3.08.0;

--- a/pkgs/development/compilers/ocaml/3.10.0.nix
+++ b/pkgs/development/compilers/ocaml/3.10.0.nix
@@ -2,7 +2,8 @@
 
 stdenv.mkDerivation (rec {
 
-  name = "ocaml-3.10.0";
+  name = "ocaml-${version}";
+  version = "3.10.0";
 
   src = fetchurl {
     url = "http://caml.inria.fr/pub/distrib/ocaml-3.10/${name}.tar.bz2";

--- a/pkgs/development/compilers/ocaml/3.11.2.nix
+++ b/pkgs/development/compilers/ocaml/3.11.2.nix
@@ -8,7 +8,8 @@ in
 
 stdenv.mkDerivation rec {
   
-  name = "ocaml-3.11.2";
+  name = "ocaml-${version}";
+  version = "3.11.2";
   
   src = fetchurl {
     url = "http://caml.inria.fr/pub/distrib/ocaml-3.11/${name}.tar.bz2";

--- a/pkgs/development/compilers/ocaml/3.12.1.nix
+++ b/pkgs/development/compilers/ocaml/3.12.1.nix
@@ -8,7 +8,8 @@ in
 
 stdenv.mkDerivation rec {
   
-  name = "ocaml-3.12.1";
+  name = "ocaml-${version}";
+  version = "3.12.1";
   
   src = fetchurl {
     url = "http://caml.inria.fr/pub/distrib/ocaml-3.12/${name}.tar.bz2";

--- a/pkgs/development/compilers/ocaml/4.00.1.nix
+++ b/pkgs/development/compilers/ocaml/4.00.1.nix
@@ -7,8 +7,8 @@ let
 in
 
 stdenv.mkDerivation rec {
-  
-  name = "ocaml-4.00.1";
+  name = "ocaml-${version}";
+  version = "4.00.1";
   
   src = fetchurl {
     url = "http://caml.inria.fr/pub/distrib/ocaml-4.00/${name}.tar.bz2";

--- a/pkgs/development/compilers/ocaml/ber-metaocaml-003.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml-003.nix
@@ -67,5 +67,6 @@ stdenv.mkDerivation rec {
       A conservative extension of OCaml with the primitive type of code values,
       and three basic multi-stage expression forms: Brackets, Escape, and Run
     '';
+    broken = true;
   };
 }

--- a/pkgs/development/compilers/ocaml/ber-metaocaml-003.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml-003.nix
@@ -8,7 +8,8 @@ in
 
 stdenv.mkDerivation rec {
   
-  name = "ber-metaocaml-003";
+  name = "ber-metaocaml-${version}";
+  version = "003";
   
   src = fetchurl {
     url = "http://caml.inria.fr/pub/distrib/ocaml-3.11/ocaml-3.11.2.tar.bz2";

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation (args // rec {
   x11inc = x11env + "/include";
 
   inherit name;
+  inherit version;
 
   src = fetchurl {
     url = real_url;

--- a/pkgs/development/compilers/ocaml/metaocaml-3.09.nix
+++ b/pkgs/development/compilers/ocaml/metaocaml-3.09.nix
@@ -27,7 +27,8 @@ stdenv.mkDerivation (rec {
   meta = {
     homepage = http://www.metaocaml.org/;
     license = with stdenv.lib.licenses; [ qpl lgpl2 ];
-    desctiption = "A compiled, type-safe, multi-stage programming language";
+    description = "A compiled, type-safe, multi-stage programming language";
+    broken = true;
   };
 
 })

--- a/pkgs/development/compilers/ocaml/metaocaml-3.09.nix
+++ b/pkgs/development/compilers/ocaml/metaocaml-3.09.nix
@@ -2,7 +2,8 @@
 
 stdenv.mkDerivation (rec {
 
-  name = "metaocaml-3.09-alpha-30";
+  name = "metaocaml-${version}";
+  version = "3.09-alpha-30";
 
   src = fetchurl {
     url = "http://www.metaocaml.org/dist/old/MetaOCaml_309_alpha_030.tar.gz";

--- a/pkgs/development/libraries/cil-aterm/default.nix
+++ b/pkgs/development/libraries/cil-aterm/default.nix
@@ -9,4 +9,5 @@ stdenv.mkDerivation {
   patches = [./cil-aterm-1.3.6.patch];
   buildInputs = [ ocaml perl ];
   inherit ocaml perl;
+  meta.broken = true;
 }  

--- a/pkgs/development/ocaml-modules/ocamlnat/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnat/default.nix
@@ -1,10 +1,14 @@
-{stdenv, fetchurl, ocaml, findlib, ounit}:
+{stdenv, lib, fetchurl, ocaml, findlib, ounit}:
 
-stdenv.mkDerivation {
-  name = "ocamlnat-0.1.1";
+# https://github.com/bmeurer/ocamlnat/issues/3
+assert lib.versionOlder ocaml.version "4";
+
+stdenv.mkDerivation rec {
+  name = "ocamlnat-${version}";
+  version = "0.1.1";
 
   src = fetchurl {
-    url = http://benediktmeurer.de/files/source/ocamlnat-0.1.1.tar.bz2;
+    url = "http://benediktmeurer.de/files/source/${name}.tar.bz2";
     sha256 = "0dyvy0j6f47laxhnadvm71z1py9hz9zd49hamf6bij99cggb2ij1";
   };
 

--- a/pkgs/development/tools/analysis/verasco/default.nix
+++ b/pkgs/development/tools/analysis/verasco/default.nix
@@ -1,6 +1,9 @@
-{ stdenv, fetchurl, coq, ocamlPackages
+{ stdenv, lib, fetchurl
+, coq, ocaml, findlib, menhir, zarith
 , tools ? stdenv.cc
 }:
+
+assert lib.versionAtLeast ocaml.version "4.02";
 
 stdenv.mkDerivation rec {
   name = "verasco-1.3";
@@ -9,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0zvljrpwnv443k939zlw1f7ijwx18nhnpr8jl3f01jc5v66hr2k8";
   };
 
-  buildInputs = [ coq ] ++ (with ocamlPackages; [ ocaml findlib menhir zarith ]);
+  buildInputs = [ coq ocaml findlib menhir zarith ];
 
   preConfigure = ''
     substituteInPlace ./configure --replace '{toolprefix}gcc' '{toolprefix}cc'

--- a/pkgs/development/tools/misc/trv/default.nix
+++ b/pkgs/development/tools/misc/trv/default.nix
@@ -1,5 +1,6 @@
-{stdenv, fetchFromGitHub, ocaml, findlib, camlp4, core, async, async_unix, re2,
-  async_extra, sexplib, async_shell, core_extended, async_find, cohttp, uri, tzdata}:
+{stdenv, fetchFromGitHub, ocaml, findlib, camlp4, core_p4, async_p4, async_unix_p4
+, re2_p4, async_extra_p4, sexplib_p4, async_shell, core_extended_p4, async_find
+, cohttp, uri, tzdata}:
 
 let
   ocaml_version = (builtins.parseDrvName ocaml.name).version;
@@ -20,9 +21,9 @@ stdenv.mkDerivation {
 
 
   buildInputs = [ ocaml findlib camlp4 ];
-  propagatedBuildInputs = [ core async async_unix
-                            async_extra sexplib async_shell core_extended
-                            async_find cohttp uri re2 ];
+  propagatedBuildInputs = [ core_p4 async_p4 async_unix_p4
+                            async_extra_p4 sexplib_p4 async_shell core_extended_p4
+                            async_find cohttp uri re2_p4 ];
 
   createFindlibDestdir = true;
   dontStrip = true;

--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchzip, ncurses, ocamlPackages, opam }:
+{ stdenv, fetchzip, ncurses
+, ocaml, ocpBuild, findlib, lablgtk, ocp-index
+, opam }:
 
 stdenv.mkDerivation {
   name = "ocaml-top-1.1.2";
@@ -7,8 +9,7 @@ stdenv.mkDerivation {
     sha256 = "10wfz8d6c1lbh31kayvlb5fj7qmgh5c6xhs3q595dnf9skrf091j";
   };
 
-  buildInputs = [ ncurses opam ]
-    ++ (with ocamlPackages; [ ocaml ocpBuild findlib lablgtk ocp-index ]);
+  buildInputs = [ ncurses opam ocaml ocpBuild findlib lablgtk ocp-index ];
 
   configurePhase = ''
     export TERM=xterm
@@ -25,7 +26,7 @@ stdenv.mkDerivation {
     homepage = http://www.typerex.org/ocaml-top.html;
     license = stdenv.lib.licenses.gpl3;
     description = "A simple cross-platform OCaml code editor built for top-level evaluation";
-    platforms = ocamlPackages.ocaml.meta.platforms or [];
+    platforms = ocaml.meta.platforms or [];
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/tools/ocaml/ocamlmod/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlmod/default.nix
@@ -1,11 +1,12 @@
 {stdenv, fetchurl, ocaml, findlib}:
 
-stdenv.mkDerivation {
-  name = "ocamlmod-0.0.7";
+stdenv.mkDerivation rec {
+  name = "ocamlmod-${version}";
+  version = "0.0.8";
 
   src = fetchurl {
-    url = http://forge.ocamlcore.org/frs/download.php/1350/ocamlmod-0.0.7.tar.gz;
-    sha256 = "11kg7wh0gy492ma5c6bcjh6frv1a9lh9f26hiys2i0d1ky8s0ad3";
+    url = "http://forge.ocamlcore.org/frs/download.php/1544/${name}.tar.gz";
+    sha256 = "1w0w8lfyymvk300dv13gvhrddpcyknvyp4g2yvq2vaw7khkhjs9g";
   };
 
   buildInputs = [ocaml findlib];

--- a/pkgs/development/tools/ocaml/omake/default.nix
+++ b/pkgs/development/tools/ocaml/omake/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation {
     description = "A build system designed for scalability and portability";
     homepage = "${webpage}";
     license = "GPL";
+    broken = true;
   };
 }

--- a/pkgs/development/tools/ocaml/opam/1.0.0.nix
+++ b/pkgs/development/tools/ocaml/opam/1.0.0.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchgit, fetchurl, ocaml, unzip, ncurses, curl }:
+{ stdenv, lib, fetchgit, fetchurl, ocaml, unzip, ncurses, curl }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12.1";
+assert lib.versionAtLeast ocaml.version "3.12.1";
 
 let
   srcs = {

--- a/pkgs/development/tools/ocaml/opam/1.1.nix
+++ b/pkgs/development/tools/ocaml/opam/1.1.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchgit, fetchurl, ocaml, unzip, ncurses, curl }:
+{ stdenv, lib, fetchgit, fetchurl, ocaml, unzip, ncurses, curl }:
 
 # Opam 1.1 only works with ocaml >= 3.12.1 according to ./configure
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12.1";
+assert lib.versionAtLeast ocaml.version "3.12.1";
 
 let
   srcs = {

--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchgit, fetchurl, makeWrapper,
+{ stdenv, lib, fetchgit, fetchurl, makeWrapper,
   ocaml, unzip, ncurses, curl,
   aspcudSupport ? !stdenv.isDarwin, aspcud
 }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12.1";
+assert lib.versionAtLeast ocaml.version "3.12.1";
 
 let
   srcs = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -114,4 +114,20 @@ doNotDisplayTwice rec {
   xlibs = xorg; # added 2015-09
   youtubeDL = youtube-dl;  # added 2014-10-26
   m3d-linux = m33-linux; # added 2016-08-13
-}
+
+  inherit (ocaml-ng) # added 2016-09-14
+    ocamlPackages_3_10_0 ocamlPackages_3_11_2 ocamlPackages_3_12_1
+    ocamlPackages_4_00_1 ocamlPackages_4_01_0 ocamlPackages_4_02
+    ocamlPackages_4_03
+    ocamlPackages_latest;
+} // (with ocaml-ng; { # added 2016-09-14
+  ocaml_3_08_0 = ocamlPackages_3_08_0.ocaml;
+  ocaml_3_10_0 = ocamlPackages_3_10_0.ocaml;
+  ocaml_3_11_2 = ocamlPackages_3_11_2.ocaml;
+  ocaml_3_12_1 = ocamlPackages_3_12_1.ocaml;
+  ocaml_4_00_1 = ocamlPackages_4_00_1.ocaml;
+  ocaml_4_01_0 = ocamlPackages_4_01_0.ocaml;
+  ocaml_4_02   = ocamlPackages_4_02.ocaml;
+  ocaml_4_03   = ocamlPackages_4_03.ocaml;
+  ocaml        = ocamlPackages.ocaml;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5050,7 +5050,7 @@ in
     nodejs = nodejs-0_10;
   };
 
-  inherit (ocamlPackages) opam_1_0_0;
+  inherit (ocaml-ng.ocamlPackages_4_01_0) opam_1_0_0;
   inherit (ocaml-ng.ocamlPackages_4_01_0) opam_1_1;
   inherit (ocamlPackages) opam;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4177,9 +4177,7 @@ in
 
   wv2 = callPackage ../tools/misc/wv2 { };
 
-  wyrd = callPackage ../tools/misc/wyrd {
-    inherit (ocamlPackages) camlp4;
-  };
+  inherit (ocamlPackages) wyrd;
 
   x86info = callPackage ../os-specific/linux/x86info { };
 
@@ -4458,14 +4456,7 @@ in
 
   cmucl_binary = callPackage_i686 ../development/compilers/cmucl/binary.nix { };
 
-  compcert = callPackage ../development/compilers/compcert ((
-    if system == "x86_64-linux"
-    then { tools = pkgsi686Linux.stdenv.cc; }
-    else {}
-  ) // {
-    ocamlPackages = ocamlPackages_4_02;
-    coq = coq_8_5;
-  });
+  inherit (ocaml-ng.ocamlPackages_4_02) compcert;
 
   # Users installing via `nix-env` will likely be using the REPL,
   # which has a hard dependency on Z3, so make sure it is available.
@@ -4775,9 +4766,7 @@ in
     postFixup = "rm -rf $out/lib $out/nix-support $out/share/doc";
   });
 
-  haxe = callPackage ../development/compilers/haxe {
-    inherit (ocamlPackages) camlp4;
-  };
+  inherit (ocamlPackages) haxe;
 
   hxcpp = callPackage ../development/compilers/haxe/hxcpp.nix { };
 
@@ -4787,10 +4776,10 @@ in
 
   falcon = callPackage ../development/interpreters/falcon { };
 
-  fsharp = callPackage ../development/compilers/fsharp {};
+  fsharp = callPackage ../development/compilers/fsharp { };
 
   fstar = callPackage ../development/compilers/fstar {
-    ocamlPackages = ocamlPackages_4_02;
+    ocamlPackages = ocaml-ng.ocamlPackages_4_02;
   };
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
@@ -5043,23 +5032,9 @@ in
 
   nvidia_cg_toolkit = callPackage ../development/compilers/nvidia-cg-toolkit { };
 
-  ocaml = ocamlPackages.ocaml;
+  ocaml-ng = callPackage ./ocaml-packages.nix { };
 
-  ocaml_3_08_0 = callPackage ../development/compilers/ocaml/3.08.0.nix { };
-
-  ocaml_3_10_0 = callPackage ../development/compilers/ocaml/3.10.0.nix { };
-
-  ocaml_3_11_2 = callPackage ../development/compilers/ocaml/3.11.2.nix { };
-
-  ocaml_3_12_1 = callPackage ../development/compilers/ocaml/3.12.1.nix { };
-
-  ocaml_4_00_1 = callPackage ../development/compilers/ocaml/4.00.1.nix { };
-
-  ocaml_4_01_0 = callPackage ../development/compilers/ocaml/4.01.0.nix { };
-
-  ocaml_4_02 = callPackage ../development/compilers/ocaml/4.02.nix { };
-
-  ocaml_4_03 = callPackage ../development/compilers/ocaml/4.03.nix { };
+  ocamlPackages = recurseIntoAttrs ocaml-ng.ocamlPackages;
 
   orc = callPackage ../development/compilers/orc { };
 
@@ -5067,632 +5042,17 @@ in
 
   ber_metaocaml_003 = callPackage ../development/compilers/ocaml/ber-metaocaml-003.nix { };
 
-  mkOcamlPackages = ocaml: self:
-    let
-      callPackage = newScope self;
-      ocaml_version = (builtins.parseDrvName ocaml.name).version;
-    in rec {
-    inherit ocaml;
-    buildOcaml = callPackage ../build-support/ocaml { };
-
-    acgtk = callPackage ../applications/science/logic/acgtk { };
-
-    alcotest = callPackage ../development/ocaml-modules/alcotest {};
-
-    ansiterminal = callPackage ../development/ocaml-modules/ansiterminal { };
-
-    asn1-combinators = callPackage ../development/ocaml-modules/asn1-combinators { };
-
-    async_extra_p4 = callPackage ../development/ocaml-modules/async_extra { };
-
-    async_find = callPackage ../development/ocaml-modules/async_find { };
-
-    async_kernel_p4 = callPackage ../development/ocaml-modules/async_kernel { };
-
-    async_shell = callPackage ../development/ocaml-modules/async_shell { };
-
-    async_ssl = callPackage ../development/ocaml-modules/async_ssl { };
-
-    async_unix_p4 = callPackage ../development/ocaml-modules/async_unix { };
-
-    async_p4 =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/async { }
-      else null;
-
-    atd = callPackage ../development/ocaml-modules/atd { };
-
-    atdgen = callPackage ../development/ocaml-modules/atdgen { };
-
-    base64 = callPackage ../development/ocaml-modules/base64 { };
-
-    bolt = callPackage ../development/ocaml-modules/bolt { };
-
-    bitstring_2_0_4 = callPackage ../development/ocaml-modules/bitstring/2.0.4.nix { };
-    bitstring_git   = callPackage ../development/ocaml-modules/bitstring { };
-
-    bitstring =
-      if lib.versionOlder "4.02" ocaml_version
-      then bitstring_git
-      else bitstring_2_0_4;
-
-    camlidl = callPackage ../development/tools/ocaml/camlidl { };
-
-    camlp4 =
-      if lib.versionOlder "4.03" ocaml_version
-      then callPackage ../development/tools/ocaml/camlp4/4_03.nix { }
-      else if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/tools/ocaml/camlp4 { }
-      else null;
-
-    camlp5_old_strict =
-      if lib.versionOlder "4.00" ocaml_version
-      then camlp5_6_strict
-      else callPackage ../development/tools/ocaml/camlp5/5.15.nix { };
-
-    camlp5_old_transitional =
-      if lib.versionOlder "4.00" ocaml_version
-      then camlp5_6_transitional
-      else callPackage ../development/tools/ocaml/camlp5/5.15.nix {
-        transitional = true;
-      };
-
-    camlp5_6_strict = callPackage ../development/tools/ocaml/camlp5 { };
-
-    camlp5_6_transitional = callPackage ../development/tools/ocaml/camlp5 {
-      transitional = true;
-    };
-
-    camlp5_strict = camlp5_6_strict;
-
-    camlp5_transitional = camlp5_6_transitional;
-
-    camlpdf = callPackage ../development/ocaml-modules/camlpdf { };
-
-    calendar = callPackage ../development/ocaml-modules/calendar { };
-
-    camlzip = callPackage ../development/ocaml-modules/camlzip { };
-
-    camomile_0_8_2 = callPackage ../development/ocaml-modules/camomile/0.8.2.nix { };
-    camomile = callPackage ../development/ocaml-modules/camomile { };
-
-    camlimages_4_0 = callPackage ../development/ocaml-modules/camlimages/4.0.nix {
-      libpng = libpng12;
-      giflib = giflib_4_1;
-    };
-    camlimages_4_1 = callPackage ../development/ocaml-modules/camlimages/4.1.nix {
-      giflib = giflib_4_1;
-    };
-    camlimages = camlimages_4_1;
-
-    conduit = callPackage ../development/ocaml-modules/conduit {
-       lwt = ocaml_lwt;
-    };
-
-    biniou = callPackage ../development/ocaml-modules/biniou { };
-
-    bin_prot_p4 = callPackage ../development/ocaml-modules/bin_prot { };
-
-    ocaml_cairo = callPackage ../development/ocaml-modules/ocaml-cairo { };
-
-    ocaml_cairo2 = callPackage ../development/ocaml-modules/ocaml-cairo2 { };
-
-    cil = callPackage ../development/ocaml-modules/cil { };
-
-    cmdliner = callPackage ../development/ocaml-modules/cmdliner { };
-
-    cohttp = callPackage ../development/ocaml-modules/cohttp {
-      lwt = ocaml_lwt;
-    };
-
-    config-file = callPackage ../development/ocaml-modules/config-file { };
-
-    containers = callPackage ../development/ocaml-modules/containers { };
-
-    cpdf = callPackage ../development/ocaml-modules/cpdf { };
-
-    cppo = callPackage ../development/tools/ocaml/cppo { };
-
-    cryptokit = callPackage ../development/ocaml-modules/cryptokit { };
-
-    cstruct = callPackage ../development/ocaml-modules/cstruct {
-      lwt = ocaml_lwt;
-    };
-
-    csv = callPackage ../development/ocaml-modules/csv { };
-
-    custom_printf = callPackage ../development/ocaml-modules/custom_printf { };
-
-    ctypes = callPackage ../development/ocaml-modules/ctypes { };
-
-    dolog = callPackage ../development/ocaml-modules/dolog { };
-
-    easy-format = callPackage ../development/ocaml-modules/easy-format { };
-
-    eff = callPackage ../development/interpreters/eff { };
-
-    eliom = callPackage ../development/ocaml-modules/eliom { };
-
-    enumerate = callPackage ../development/ocaml-modules/enumerate { };
-
-    erm_xml = callPackage ../development/ocaml-modules/erm_xml { };
-
-    erm_xmpp = callPackage ../development/ocaml-modules/erm_xmpp { };
-
-    estring = callPackage ../development/ocaml-modules/estring { };
-
-    ezjsonm = callPackage ../development/ocaml-modules/ezjsonm {
-      lwt = ocaml_lwt;
-    };
-
-    faillib = callPackage ../development/ocaml-modules/faillib { };
-
-    fieldslib_p4 = callPackage ../development/ocaml-modules/fieldslib { };
-
-    fileutils = callPackage ../development/ocaml-modules/fileutils { };
-
-    findlib = callPackage ../development/tools/ocaml/findlib { };
-
-    fix = callPackage ../development/ocaml-modules/fix { };
-
-    fontconfig = callPackage ../development/ocaml-modules/fontconfig {
-      inherit (pkgs) fontconfig;
-    };
-
-    functory = callPackage ../development/ocaml-modules/functory { };
-
-    gen = callPackage ../development/ocaml-modules/gen { };
-
-    herelib = callPackage ../development/ocaml-modules/herelib { };
-
-    io-page = callPackage ../development/ocaml-modules/io-page { };
-
-    ipaddr = callPackage ../development/ocaml-modules/ipaddr { };
-
-    iso8601 = callPackage ../development/ocaml-modules/iso8601 { };
-
-    javalib = callPackage ../development/ocaml-modules/javalib {
-      extlib = ocaml_extlib_maximal;
-    };
-
-    dypgen = callPackage ../development/ocaml-modules/dypgen { };
-
-    gapi_ocaml = callPackage ../development/ocaml-modules/gapi-ocaml { };
-
-    gg = callPackage ../development/ocaml-modules/gg { };
-
-    gmetadom = callPackage ../development/ocaml-modules/gmetadom { };
-
-    gtktop = callPackage ../development/ocaml-modules/gtktop { };
-
-    hex = callPackage ../development/ocaml-modules/hex { };
-
-    jingoo = callPackage ../development/ocaml-modules/jingoo {
-      batteries = ocaml_batteries;
-      pcre = ocaml_pcre;
-    };
-
-    js_of_ocaml = callPackage ../development/tools/ocaml/js_of_ocaml { };
-
-    jsonm = callPackage ../development/ocaml-modules/jsonm { };
-
-    lablgl = callPackage ../development/ocaml-modules/lablgl { };
-
-    lablgtk_2_14 = callPackage ../development/ocaml-modules/lablgtk/2.14.0.nix {
-      inherit (gnome2) libgnomecanvas libglade gtksourceview;
-    };
-    lablgtk = callPackage ../development/ocaml-modules/lablgtk {
-      inherit (gnome2) libgnomecanvas libglade gtksourceview;
-    };
-
-    lablgtk-extras =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/lablgtk-extras { }
-      else callPackage ../development/ocaml-modules/lablgtk-extras/1.4.nix { };
-
-    lablgtkmathview = callPackage ../development/ocaml-modules/lablgtkmathview {
-      gtkmathview = callPackage ../development/libraries/gtkmathview { };
-    };
-
-    lambdaTerm-1_6 = callPackage ../development/ocaml-modules/lambda-term/1.6.nix { };
-    lambdaTerm =
-      if lib.versionOlder "4.01" ocaml_version
-      then callPackage ../development/ocaml-modules/lambda-term { }
-      else lambdaTerm-1_6;
-
-    llvm = callPackage ../development/ocaml-modules/llvm {
-      llvm = pkgs.llvm_37;
-    };
-
-    macaque = callPackage ../development/ocaml-modules/macaque { };
-
-    magic-mime = callPackage ../development/ocaml-modules/magic-mime { };
-
-    magick = callPackage ../development/ocaml-modules/magick { };
-
-    markup = callPackage ../development/ocaml-modules/markup { lwt = ocaml_lwt; };
-
-    menhir = callPackage ../development/ocaml-modules/menhir { };
-
-    merlin = callPackage ../development/tools/ocaml/merlin { };
-
-    mezzo = callPackage ../development/compilers/mezzo { };
-
-    mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
-
-    nocrypto =  callPackage ../development/ocaml-modules/nocrypto { };
-
-    ocaml_batteries = callPackage ../development/ocaml-modules/batteries { };
-
-    comparelib = callPackage ../development/ocaml-modules/comparelib { };
-
-    core_extended_p4 = callPackage ../development/ocaml-modules/core_extended { };
-
-    core_kernel_p4 = callPackage ../development/ocaml-modules/core_kernel { };
-
-    core_p4 = callPackage ../development/ocaml-modules/core { };
-
-    ocamlbuild =
-    if lib.versionOlder "4.03" ocaml_version then
-    callPackage ../development/tools/ocaml/ocamlbuild { }
-    else
-    null;
-
-    ocaml_cryptgps = callPackage ../development/ocaml-modules/cryptgps { };
-
-    ocaml_data_notation = callPackage ../development/ocaml-modules/odn { };
-
-    ocaml_expat = callPackage ../development/ocaml-modules/expat { };
-
-    frontc = callPackage ../development/ocaml-modules/frontc { };
-
-    ocamlfuse = callPackage ../development/ocaml-modules/ocamlfuse { };
-
-    ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };
-
-    ocaml_http = callPackage ../development/ocaml-modules/http { };
-
-    ocamlify = callPackage ../development/tools/ocaml/ocamlify { };
-
-    ocaml_lwt = callPackage ../development/ocaml-modules/lwt { };
-
-    ocamlmod = callPackage ../development/tools/ocaml/ocamlmod { };
-
-    ocaml_mysql = callPackage ../development/ocaml-modules/mysql { };
-
-    ocamlnet = callPackage ../development/ocaml-modules/ocamlnet { };
-
-    ocaml_oasis = callPackage ../development/tools/ocaml/oasis { };
-    ocaml_oasis_46 = callPackage ../development/tools/ocaml/oasis/0.4.6.nix { };
-
-    ocaml_optcomp = callPackage ../development/ocaml-modules/optcomp { };
-
-    ocaml_pcre = callPackage ../development/ocaml-modules/pcre {};
-
-    pgocaml = callPackage ../development/ocaml-modules/pgocaml {};
-
-    ocaml_react = callPackage ../development/ocaml-modules/react { };
-    reactivedata = callPackage ../development/ocaml-modules/reactivedata {};
-
-    ocamlscript = callPackage ../development/tools/ocaml/ocamlscript { };
-
-    ocamlsdl= callPackage ../development/ocaml-modules/ocamlsdl { };
-
-    ocaml_sqlite3 = callPackage ../development/ocaml-modules/sqlite3 { };
-
-    ocaml_ssl = callPackage ../development/ocaml-modules/ssl { };
-
-    ocaml_text = callPackage ../development/ocaml-modules/ocaml-text { };
-
-    ocpBuild = callPackage ../development/tools/ocaml/ocp-build { };
-
-    ocpIndent = callPackage ../development/tools/ocaml/ocp-indent { };
-
-    ocp-index = callPackage ../development/tools/ocaml/ocp-index { };
-
-    ocplib-endian = callPackage ../development/ocaml-modules/ocplib-endian { };
-
-    ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };
-
-    ojquery = callPackage ../development/ocaml-modules/ojquery { };
-
-    otfm = callPackage ../development/ocaml-modules/otfm { };
-
-    ounit = callPackage ../development/ocaml-modules/ounit { };
-
-    piqi = callPackage ../development/ocaml-modules/piqi { };
-    piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
-
-    re2_p4 = callPackage ../development/ocaml-modules/re2 { };
-
-    result = callPackage ../development/ocaml-modules/ocaml-result { };
-
-    sequence = callPackage ../development/ocaml-modules/sequence { };
-
-    sqlexpr = callPackage ../development/ocaml-modules/sqlexpr { };
-
-    tuntap = callPackage ../development/ocaml-modules/tuntap { };
-
-    tyxml = callPackage ../development/ocaml-modules/tyxml { };
-
-    ulex = callPackage ../development/ocaml-modules/ulex { };
-
-    ulex08 = callPackage ../development/ocaml-modules/ulex/0.8 {
-      camlp5 = camlp5_transitional;
-    };
-
-    textutils_p4 = callPackage ../development/ocaml-modules/textutils { };
-
-    type_conv_108_08_00 = callPackage ../development/ocaml-modules/type_conv/108.08.00.nix { };
-    type_conv_109_60_01 = callPackage ../development/ocaml-modules/type_conv/109.60.01.nix { };
-    type_conv_112_01_01 = callPackage ../development/ocaml-modules/type_conv/112.01.01.nix { };
-    type_conv =
-      if lib.versionOlder "4.02" ocaml_version
-      then type_conv_112_01_01
-      else if lib.versionOlder "4.00" ocaml_version
-      then type_conv_109_60_01
-      else if lib.versionOlder "3.12" ocaml_version
-      then type_conv_108_08_00
-      else null;
-
-    sexplib_108_08_00 = callPackage ../development/ocaml-modules/sexplib/108.08.00.nix { };
-    sexplib_111_25_00 = callPackage ../development/ocaml-modules/sexplib/111.25.00.nix { };
-    sexplib_112_24_01 = callPackage ../development/ocaml-modules/sexplib/112.24.01.nix { };
-
-    sexplib_p4 =
-      if lib.versionOlder "4.02" ocaml_version
-      then sexplib_112_24_01
-      else if lib.versionOlder "4.00" ocaml_version
-      then sexplib_111_25_00
-      else if lib.versionOlder "3.12" ocaml_version
-      then sexplib_108_08_00
-      else null;
-
-    ocaml_extlib = callPackage ../development/ocaml-modules/extlib { };
-    ocaml_extlib_maximal = callPackage ../development/ocaml-modules/extlib {
-      minimal = false;
-    };
-
-    ocurl = callPackage ../development/ocaml-modules/ocurl { };
-
-    pa_ounit = callPackage ../development/ocaml-modules/pa_ounit { };
-
-    pa_bench = callPackage ../development/ocaml-modules/pa_bench { };
-
-    pa_test = callPackage ../development/ocaml-modules/pa_test { };
-
-    pipebang = callPackage ../development/ocaml-modules/pipebang { };
-
-    pprint = callPackage ../development/ocaml-modules/pprint { };
-
-    ppx_blob =
-      if lib.versionAtLeast ocaml_version "4.02"
-      then callPackage ../development/ocaml-modules/ppx_blob {}
-      else null;
-
-    ppx_deriving =
-      if lib.versionAtLeast ocaml_version "4.02"
-      then callPackage ../development/ocaml-modules/ppx_deriving {}
-      else null;
-
-    ppx_tools =
-      if lib.versionAtLeast ocaml_version "4.02"
-      then callPackage ../development/ocaml-modules/ppx_tools {}
-      else null;
-
-    pycaml = callPackage ../development/ocaml-modules/pycaml { };
-
-    qcheck = callPackage ../development/ocaml-modules/qcheck {
-      oasis = ocaml_oasis;
-    };
-
-    qtest = callPackage ../development/ocaml-modules/qtest { };
-
-    re = callPackage ../development/ocaml-modules/re { };
-
-    safepass = callPackage ../development/ocaml-modules/safepass { };
-
-    sqlite3EZ = callPackage ../development/ocaml-modules/sqlite3EZ { };
-
-    stringext = callPackage ../development/ocaml-modules/stringext { };
-
-    topkg = callPackage ../development/ocaml-modules/topkg { };
-
-    tsdl = callPackage ../development/ocaml-modules/tsdl { };
-
-    twt = callPackage ../development/ocaml-modules/twt { };
-
-    typerep_p4 = callPackage ../development/ocaml-modules/typerep { };
-
-    utop = callPackage ../development/tools/ocaml/utop { };
-
-    uuidm = callPackage ../development/ocaml-modules/uuidm { };
-
-    sawja = callPackage ../development/ocaml-modules/sawja { };
-
-    uucd = callPackage ../development/ocaml-modules/uucd { };
-    uucp = callPackage ../development/ocaml-modules/uucp { };
-    uunf = callPackage ../development/ocaml-modules/uunf { };
-
-    uri = callPackage ../development/ocaml-modules/uri { };
-
-    uuseg = callPackage ../development/ocaml-modules/uuseg { };
-    uutf = callPackage ../development/ocaml-modules/uutf { };
-
-    variantslib_p4 = callPackage ../development/ocaml-modules/variantslib { };
-
-    vg = callPackage ../development/ocaml-modules/vg { };
-
-    x509 = callPackage ../development/ocaml-modules/x509 { };
-
-    xmlm = callPackage ../development/ocaml-modules/xmlm { };
-
-    xml-light = callPackage ../development/ocaml-modules/xml-light { };
-
-    yojson = callPackage ../development/ocaml-modules/yojson { };
-
-    zarith = callPackage ../development/ocaml-modules/zarith { };
-
-    zed = callPackage ../development/ocaml-modules/zed { };
-
-    ocsigen_deriving = callPackage ../development/ocaml-modules/ocsigen-deriving {
-      oasis = ocaml_oasis;
-    };
-
-    # Jane Street
-    js_build_tools = callPackage ../development/ocaml-modules/janestreet/js-build-tools.nix {};
-
-    buildOcamlJane = callPackage ../development/ocaml-modules/janestreet/buildOcamlJane.nix {};
-
-    ppx_core = callPackage ../development/ocaml-modules/janestreet/ppx-core.nix {};
-
-    ppx_optcomp = callPackage ../development/ocaml-modules/janestreet/ppx-optcomp.nix {};
-
-    ppx_driver = callPackage ../development/ocaml-modules/janestreet/ppx-driver.nix {};
-
-    ppx_type_conv = callPackage ../development/ocaml-modules/janestreet/ppx-type-conv.nix {};
-
-    ppx_compare = callPackage ../development/ocaml-modules/janestreet/ppx-compare.nix {};
-
-    ppx_here = callPackage ../development/ocaml-modules/janestreet/ppx-here.nix {};
-
-    ppx_sexp_conv = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-conv.nix {};
-
-    ppx_assert = callPackage ../development/ocaml-modules/janestreet/ppx-assert.nix {};
-
-    ppx_inline_test = callPackage ../development/ocaml-modules/janestreet/ppx-inline-test.nix {};
-
-    ppx_bench = callPackage ../development/ocaml-modules/janestreet/ppx-bench.nix {};
-
-    ppx_bin_prot = callPackage ../development/ocaml-modules/janestreet/ppx-bin-prot.nix {};
-
-    ppx_custom_printf = callPackage ../development/ocaml-modules/janestreet/ppx-custom-printf.nix {};
-
-    ppx_enumerate = callPackage ../development/ocaml-modules/janestreet/ppx-enumerate.nix {};
-
-    ppx_fail = callPackage ../development/ocaml-modules/janestreet/ppx-fail.nix {};
-
-    ppx_fields_conv = callPackage ../development/ocaml-modules/janestreet/ppx-fields-conv.nix {};
-
-    ppx_let = callPackage ../development/ocaml-modules/janestreet/ppx-let.nix {};
-
-    ppx_pipebang = callPackage ../development/ocaml-modules/janestreet/ppx-pipebang.nix {};
-
-    ppx_sexp_message = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-message.nix {};
-
-    ppx_sexp_value = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-value.nix {};
-
-    ppx_typerep_conv = callPackage ../development/ocaml-modules/janestreet/ppx-typerep-conv.nix {};
-
-    ppx_variants_conv = callPackage ../development/ocaml-modules/janestreet/ppx-variants-conv.nix {};
-
-    ppx_expect = callPackage ../development/ocaml-modules/janestreet/ppx-expect.nix {};
-
-    ppx_jane = callPackage ../development/ocaml-modules/janestreet/ppx-jane.nix {};
-
-
-    # Core sublibs
-    typerep =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/typerep.nix {}
-      else typerep_p4;
-
-    fieldslib =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/fieldslib.nix {}
-      else fieldslib_p4;
-
-    sexplib =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/sexplib.nix {}
-      else sexplib_p4;
-
-    variantslib =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/variantslib.nix {}
-      else variantslib_p4;
-
-    bin_prot =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {}
-      else bin_prot_p4;
-
-    core_kernel =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/core_kernel.nix {}
-      else core_kernel_p4;
-
-    core =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/core.nix {}
-      else core_p4;
-
-    re2 =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/re2.nix {}
-      else re2_p4;
-
-    textutils =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/textutils.nix {}
-      else textutils_p4;
-
-    core_extended =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/core-extended.nix {}
-      else core_extended_p4;
-
-    async_kernel =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/async-kernel.nix {}
-      else async_kernel_p4;
-
-    async_rpc_kernel = callPackage ../development/ocaml-modules/janestreet/async-rpc-kernel.nix {};
-
-    async_unix =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/async-unix.nix {}
-      else async_unix_p4;
-
-    async_extra =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/async-extra.nix {}
-      else async_extra_p4;
-
-    async =
-      if lib.versionOlder "4.02" ocaml_version
-      then callPackage ../development/ocaml-modules/janestreet/async.nix {}
-      else async_p4;
-  };
-
-  ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;
-  ocamlPackages_3_10_0 = (mkOcamlPackages ocaml_3_10_0 pkgs.ocamlPackages_3_10_0)
-  // { lablgtk = ocamlPackages_3_10_0.lablgtk_2_14; };
-  ocamlPackages_3_11_2 = (mkOcamlPackages ocaml_3_11_2 pkgs.ocamlPackages_3_11_2)
-  // { lablgtk = ocamlPackages_3_11_2.lablgtk_2_14; };
-  ocamlPackages_3_12_1 = (mkOcamlPackages ocaml_3_12_1 pkgs.ocamlPackages_3_12_1)
-  // { camlimages = ocamlPackages_3_12_1.camlimages_4_0; };
-  ocamlPackages_4_00_1 = mkOcamlPackages ocaml_4_00_1 pkgs.ocamlPackages_4_00_1;
-  ocamlPackages_4_01_0 = mkOcamlPackages ocaml_4_01_0 pkgs.ocamlPackages_4_01_0;
-  ocamlPackages_4_02 = mkOcamlPackages ocaml_4_02 pkgs.ocamlPackages_4_02;
-  ocamlPackages_4_03 = mkOcamlPackages ocaml_4_03 pkgs.ocamlPackages_4_03;
-  ocamlPackages_latest = ocamlPackages_4_03;
-
   ocaml_make = callPackage ../development/ocaml-modules/ocamlmake { };
 
-  ocaml-top = callPackage ../development/tools/ocaml/ocaml-top { };
+  inherit (ocamlPackages) ocaml-top;
 
   opa = callPackage ../development/compilers/opa {
     nodejs = nodejs-0_10;
   };
 
-  opam_1_0_0 = callPackage ../development/tools/ocaml/opam/1.0.0.nix { };
-  opam_1_1 = callPackage ../development/tools/ocaml/opam/1.1.nix {
-    inherit (ocamlPackages_4_01_0) ocaml;
-  };
-  opam = callPackage ../development/tools/ocaml/opam { };
-
-  ocamlnat = newScope pkgs.ocamlPackages_3_12_1 ../development/ocaml-modules/ocamlnat { };
+  inherit (ocamlPackages) opam_1_0_0;
+  inherit (ocaml-ng.ocamlPackages_4_01_0) opam_1_1;
+  inherit (ocamlPackages) opam;
 
   picat = callPackage ../development/compilers/picat {
     stdenv = overrideCC stdenv gcc49;
@@ -5791,17 +5151,7 @@ in
 
   tinycc = callPackage ../development/compilers/tinycc { };
 
-  trv = callPackage ../development/tools/misc/trv {
-   inherit (ocamlPackages_4_02) findlib camlp4
-     async_shell async_find cohttp uri;
-    ocaml = ocaml_4_02;
-    async = ocamlPackages_4_02.async_p4;
-    async_extra = ocamlPackages_4_02.async_extra_p4;
-    async_unix = ocamlPackages_4_02.async_unix_p4;
-    core_extended = ocamlPackages_4_02.core_extended_p4;
-    sexplib = ocamlPackages_4_02.sexplib_p4;
-    core = ocamlPackages_4_02.core_p4;
-  };
+  inherit (ocaml-ng.ocamlPackages_4_01_0) trv;
 
   bupc = callPackage ../development/compilers/bupc { };
 
@@ -6802,8 +6152,7 @@ in
   noweb = callPackage ../development/tools/literate-programming/noweb { };
   nuweb = callPackage ../development/tools/literate-programming/nuweb { tex = texlive.combined.scheme-small; };
 
-  omake = callPackage ../development/tools/ocaml/omake { };
-  omake_rc1 = callPackage ../development/tools/ocaml/omake/0.9.8.6-rc1.nix { };
+  inherit (ocamlPackages) omake omake_rc1;
 
   omniorb = callPackage ../development/tools/omniorb { };
 
@@ -7016,13 +6365,7 @@ in
 
   valkyrie = callPackage ../development/tools/analysis/valkyrie { };
 
-  verasco = callPackage ../development/tools/analysis/verasco ((
-    if system == "x86_64-linux"
-    then { tools = pkgsi686Linux.stdenv.cc; }
-    else {}
-  ) // {
-    ocamlPackages = ocamlPackages_4_02;
-  });
+  inherit (ocaml-ng.ocamlPackages_4_02) verasco;
 
   visualvm = callPackage ../development/tools/java/visualvm { };
 
@@ -7638,12 +6981,7 @@ in
 
   glpk = callPackage ../development/libraries/glpk { };
 
-  glsurf = callPackage ../applications/science/math/glsurf {
-    inherit (ocamlPackages) lablgl findlib ocaml_mysql mlgmp;
-    libpng = libpng12;
-    giflib = giflib_4_1;
-    camlimages = ocamlPackages.camlimages_4_0;
-  };
+  inherit (ocamlPackages) glsurf;
 
   glui = callPackage ../development/libraries/glui {};
 
@@ -13339,7 +12677,7 @@ in
 
   goldendict = qt55.callPackage ../applications/misc/goldendict { };
 
-  google-drive-ocamlfuse = callPackage ../applications/networking/google-drive-ocamlfuse { };
+  inherit (ocamlPackages) google-drive-ocamlfuse;
 
   google-musicmanager = callPackage ../applications/audio/google-musicmanager { };
 
@@ -14083,10 +13421,7 @@ in
     bison = bison2;
   };
 
-  llpp = callPackage ../applications/misc/llpp {
-    inherit (ocamlPackages_4_02) lablgl findlib;
-    ocaml = ocaml_4_02;
-  };
+  inherit (ocaml-ng.ocamlPackages_4_02) llpp;
 
   lmms = callPackage ../applications/audio/lmms { };
 
@@ -14214,10 +13549,7 @@ in
     lua = lua5;
   };
 
-  monotoneViz = callPackage ../applications/version-management/monotone-viz {
-    inherit (ocamlPackages_4_01_0) lablgtk ocaml camlp4;
-    inherit (gnome2) libgnomecanvas glib;
-  };
+  inherit (ocaml-ng.ocamlPackages_4_01_0) monotoneViz;
 
   moonlight-embedded = callPackage ../applications/misc/moonlight-embedded { };
 
@@ -15300,10 +14632,7 @@ in
 
   umurmur = callPackage ../applications/networking/umurmur { };
 
-  unison = callPackage ../applications/networking/sync/unison {
-    inherit (ocamlPackages) lablgtk;
-    enableX11 = config.unison.enableX11 or true;
-  };
+  inherit (ocamlPackages) unison;
 
   unpaper = callPackage ../tools/graphics/unpaper { };
 
@@ -16928,27 +16257,13 @@ in
 
   aspino = callPackage ../applications/science/logic/aspino {};
 
-  coq = callPackage ../applications/science/logic/coq {
-    inherit (ocamlPackages_4_01_0) ocaml findlib lablgtk;
-    camlp5 = ocamlPackages_4_01_0.camlp5_transitional;
-  };
+  inherit (ocaml-ng.ocamlPackages_4_01_0) coq;
 
-  coq_HEAD = callPackage ../applications/science/logic/coq/HEAD.nix {
-    inherit (ocamlPackages) findlib lablgtk;
-    camlp5 = ocamlPackages.camlp5_transitional;
-  };
+  inherit (ocamlPackages) coq_HEAD;
 
-  coq_8_5 = callPackage ../applications/science/logic/coq/8.5.nix {
-    inherit (ocamlPackages) findlib lablgtk;
-    camlp5 = ocamlPackages.camlp5_transitional;
-  };
+  inherit (ocamlPackages) coq_8_5;
 
-  coq_8_3 = callPackage ../applications/science/logic/coq/8.3.nix {
-    make = gnumake3;
-    inherit (ocamlPackages_3_12_1) ocaml findlib;
-    camlp5 = ocamlPackages_3_12_1.camlp5_transitional;
-    lablgtk = ocamlPackages_3_12_1.lablgtk_2_14;
-  };
+  inherit (ocaml-ng.ocamlPackages_3_12_1) coq_8_3;
 
   mkCoqPackages_8_4 = self: let callPackage = newScope self; in {
 
@@ -17041,9 +16356,7 @@ in
 
   hol = callPackage ../applications/science/logic/hol { };
 
-  hol_light = callPackage ../applications/science/logic/hol_light {
-    camlp5 = ocamlPackages.camlp5_strict;
-  };
+  inherit (ocamlPackages) hol_light;
 
   hologram = callPackage ../tools/security/hologram { };
 
@@ -17069,17 +16382,9 @@ in
 
   ltl2ba = callPackage ../applications/science/logic/ltl2ba {};
 
-  matita = callPackage ../applications/science/logic/matita {
-    ocaml = ocaml_3_11_2;
-    inherit (ocamlPackages_3_11_2) findlib lablgtk ocaml_expat gmetadom ocaml_http
-            lablgtkmathview ocaml_mysql ocaml_sqlite3 ocamlnet camlzip ocaml_pcre;
-    ulex08 = ocamlPackages_3_11_2.ulex08.override { camlp5 = ocamlPackages_3_11_2.camlp5_old_transitional; };
-  };
+  inherit (ocaml-ng.ocamlPackages_3_11_2) matita;
 
-  matita_130312 = lowPrio (callPackage ../applications/science/logic/matita/130312.nix {
-    inherit (ocamlPackages) findlib lablgtk ocaml_expat gmetadom ocaml_http
-            ocaml_mysql ocamlnet ulex08 camlzip ocaml_pcre;
-  });
+  matita_130312 = lowPrio ocamlPackages.matita_130312;
 
   metis-prover = callPackage ../applications/science/logic/metis-prover { };
 
@@ -17089,18 +16394,13 @@ in
 
   opensmt = callPackage ../applications/science/logic/opensmt { };
 
-  ott = callPackage ../applications/science/logic/ott {
-    camlp5 = ocamlPackages.camlp5_transitional;
-  };
+  inherit (ocamlPackages) ott;
 
   otter = callPackage ../applications/science/logic/otter {};
 
   picosat = callPackage ../applications/science/logic/picosat {};
 
-  prooftree = callPackage ../applications/science/logic/prooftree {
-    inherit (ocamlPackages_4_01_0) ocaml findlib lablgtk;
-    camlp5 = ocamlPackages_4_01_0.camlp5_transitional;
-  };
+  inherit (ocaml-ng.ocamlPackages_4_01_0) prooftree;
 
   prover9 = callPackage ../applications/science/logic/prover9 { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1,0 +1,717 @@
+{ lib, callPackage, newScope, pkgs, config, system }:
+
+let
+  mkOcamlPackages = ocaml: overrides:
+    let
+      packageSet = self:
+        with self; let inherit (self) callPackage; in
+  {
+    ocaml_version = self.ocaml.version; #TODO: remove all mentions of ocaml_version
+
+    callPackage = newScope self;
+
+    inherit ocaml;
+
+    # Libs
+
+    buildOcaml = callPackage ../build-support/ocaml { };
+
+    acgtk = callPackage ../applications/science/logic/acgtk { };
+
+    alcotest = callPackage ../development/ocaml-modules/alcotest {};
+
+    ansiterminal = callPackage ../development/ocaml-modules/ansiterminal { };
+
+    asn1-combinators = callPackage ../development/ocaml-modules/asn1-combinators { };
+
+    async_extra_p4 = callPackage ../development/ocaml-modules/async_extra { };
+
+    async_find = callPackage ../development/ocaml-modules/async_find { };
+
+    async_kernel_p4 = callPackage ../development/ocaml-modules/async_kernel { };
+
+    async_shell = callPackage ../development/ocaml-modules/async_shell { };
+
+    async_ssl = callPackage ../development/ocaml-modules/async_ssl { };
+
+    async_unix_p4 = callPackage ../development/ocaml-modules/async_unix { };
+
+    async_p4 =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/async { }
+      else null;
+
+    atd = callPackage ../development/ocaml-modules/atd { };
+
+    atdgen = callPackage ../development/ocaml-modules/atdgen { };
+
+    base64 = callPackage ../development/ocaml-modules/base64 { };
+
+    bolt = callPackage ../development/ocaml-modules/bolt { };
+
+    bitstring_2_0_4 = callPackage ../development/ocaml-modules/bitstring/2.0.4.nix { };
+    bitstring_git   = callPackage ../development/ocaml-modules/bitstring { };
+
+    bitstring =
+      if lib.versionOlder "4.02" ocaml_version
+      then bitstring_git
+      else bitstring_2_0_4;
+
+    camlidl = callPackage ../development/tools/ocaml/camlidl { };
+
+    camlp4 =
+      if lib.versionOlder "4.03" ocaml_version
+      then callPackage ../development/tools/ocaml/camlp4/4_03.nix { }
+      else if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/tools/ocaml/camlp4 { }
+      else null;
+
+    camlp5_old_strict =
+      if lib.versionOlder "4.00" ocaml_version
+      then camlp5_6_strict
+      else callPackage ../development/tools/ocaml/camlp5/5.15.nix { };
+
+    camlp5_old_transitional =
+      if lib.versionOlder "4.00" ocaml_version
+      then camlp5_6_transitional
+      else callPackage ../development/tools/ocaml/camlp5/5.15.nix {
+        transitional = true;
+      };
+
+    camlp5_6_strict = callPackage ../development/tools/ocaml/camlp5 { };
+
+    camlp5_6_transitional = callPackage ../development/tools/ocaml/camlp5 {
+      transitional = true;
+    };
+
+    camlp5_strict = camlp5_6_strict;
+
+    camlp5_transitional = camlp5_6_transitional;
+
+    camlpdf = callPackage ../development/ocaml-modules/camlpdf { };
+
+    calendar = callPackage ../development/ocaml-modules/calendar { };
+
+    camlzip = callPackage ../development/ocaml-modules/camlzip { };
+
+    camomile_0_8_2 = callPackage ../development/ocaml-modules/camomile/0.8.2.nix { };
+    camomile = callPackage ../development/ocaml-modules/camomile { };
+
+    camlimages_4_0 = callPackage ../development/ocaml-modules/camlimages/4.0.nix {
+      libpng = pkgs.libpng12;
+      giflib = pkgs.giflib_4_1;
+    };
+    camlimages_4_1 = callPackage ../development/ocaml-modules/camlimages/4.1.nix {
+      giflib = pkgs.giflib_4_1;
+    };
+    camlimages = camlimages_4_1;
+
+    conduit = callPackage ../development/ocaml-modules/conduit {
+       lwt = ocaml_lwt;
+    };
+
+    biniou = callPackage ../development/ocaml-modules/biniou { };
+
+    bin_prot_p4 = callPackage ../development/ocaml-modules/bin_prot { };
+
+    ocaml_cairo = callPackage ../development/ocaml-modules/ocaml-cairo { };
+
+    ocaml_cairo2 = callPackage ../development/ocaml-modules/ocaml-cairo2 { };
+
+    cil = callPackage ../development/ocaml-modules/cil { };
+
+    cmdliner = callPackage ../development/ocaml-modules/cmdliner { };
+
+    cohttp = callPackage ../development/ocaml-modules/cohttp {
+      lwt = ocaml_lwt;
+    };
+
+    config-file = callPackage ../development/ocaml-modules/config-file { };
+
+    containers = callPackage ../development/ocaml-modules/containers { };
+
+    cpdf = callPackage ../development/ocaml-modules/cpdf { };
+
+    cppo = callPackage ../development/tools/ocaml/cppo { };
+
+    cryptokit = callPackage ../development/ocaml-modules/cryptokit { };
+
+    cstruct = callPackage ../development/ocaml-modules/cstruct {
+      lwt = ocaml_lwt;
+    };
+
+    csv = callPackage ../development/ocaml-modules/csv { };
+
+    custom_printf = callPackage ../development/ocaml-modules/custom_printf { };
+
+    ctypes = callPackage ../development/ocaml-modules/ctypes { };
+
+    dolog = callPackage ../development/ocaml-modules/dolog { };
+
+    easy-format = callPackage ../development/ocaml-modules/easy-format { };
+
+    eff = callPackage ../development/interpreters/eff { };
+
+    eliom = callPackage ../development/ocaml-modules/eliom { };
+
+    enumerate = callPackage ../development/ocaml-modules/enumerate { };
+
+    erm_xml = callPackage ../development/ocaml-modules/erm_xml { };
+
+    erm_xmpp = callPackage ../development/ocaml-modules/erm_xmpp { };
+
+    estring = callPackage ../development/ocaml-modules/estring { };
+
+    ezjsonm = callPackage ../development/ocaml-modules/ezjsonm {
+      lwt = ocaml_lwt;
+    };
+
+    faillib = callPackage ../development/ocaml-modules/faillib { };
+
+    fieldslib_p4 = callPackage ../development/ocaml-modules/fieldslib { };
+
+    fileutils = callPackage ../development/ocaml-modules/fileutils { };
+
+    findlib = callPackage ../development/tools/ocaml/findlib { };
+
+    fix = callPackage ../development/ocaml-modules/fix { };
+
+    fontconfig = callPackage ../development/ocaml-modules/fontconfig {
+      inherit (pkgs) fontconfig;
+    };
+
+    functory = callPackage ../development/ocaml-modules/functory { };
+
+    gen = callPackage ../development/ocaml-modules/gen { };
+
+    herelib = callPackage ../development/ocaml-modules/herelib { };
+
+    io-page = callPackage ../development/ocaml-modules/io-page { };
+
+    ipaddr = callPackage ../development/ocaml-modules/ipaddr { };
+
+    iso8601 = callPackage ../development/ocaml-modules/iso8601 { };
+
+    javalib = callPackage ../development/ocaml-modules/javalib {
+      extlib = ocaml_extlib_maximal;
+    };
+
+    dypgen = callPackage ../development/ocaml-modules/dypgen { };
+
+    gapi_ocaml = callPackage ../development/ocaml-modules/gapi-ocaml { };
+
+    gg = callPackage ../development/ocaml-modules/gg { };
+
+    gmetadom = callPackage ../development/ocaml-modules/gmetadom { };
+
+    gtktop = callPackage ../development/ocaml-modules/gtktop { };
+
+    hex = callPackage ../development/ocaml-modules/hex { };
+
+    jingoo = callPackage ../development/ocaml-modules/jingoo {
+      batteries = ocaml_batteries;
+      pcre = ocaml_pcre;
+    };
+
+    js_of_ocaml = callPackage ../development/tools/ocaml/js_of_ocaml { };
+
+    jsonm = callPackage ../development/ocaml-modules/jsonm { };
+
+    lablgl = callPackage ../development/ocaml-modules/lablgl { };
+
+    lablgtk_2_14 = callPackage ../development/ocaml-modules/lablgtk/2.14.0.nix {
+      inherit (pkgs.gnome2) libgnomecanvas libglade gtksourceview;
+    };
+    lablgtk = callPackage ../development/ocaml-modules/lablgtk {
+      inherit (pkgs.gnome2) libgnomecanvas libglade gtksourceview;
+    };
+
+    lablgtk-extras =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/lablgtk-extras { }
+      else callPackage ../development/ocaml-modules/lablgtk-extras/1.4.nix { };
+
+    lablgtkmathview = callPackage ../development/ocaml-modules/lablgtkmathview {
+      gtkmathview = callPackage ../development/libraries/gtkmathview { };
+    };
+
+    lambdaTerm-1_6 = callPackage ../development/ocaml-modules/lambda-term/1.6.nix { };
+    lambdaTerm =
+      if lib.versionOlder "4.01" ocaml_version
+      then callPackage ../development/ocaml-modules/lambda-term { }
+      else lambdaTerm-1_6;
+
+    llvm = callPackage ../development/ocaml-modules/llvm {
+      llvm = pkgs.llvm_37;
+    };
+
+    macaque = callPackage ../development/ocaml-modules/macaque { };
+
+    magic-mime = callPackage ../development/ocaml-modules/magic-mime { };
+
+    magick = callPackage ../development/ocaml-modules/magick { };
+
+    markup = callPackage ../development/ocaml-modules/markup { lwt = ocaml_lwt; };
+
+    menhir = callPackage ../development/ocaml-modules/menhir { };
+
+    merlin = callPackage ../development/tools/ocaml/merlin { };
+
+    mezzo = callPackage ../development/compilers/mezzo { };
+
+    mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
+
+    nocrypto =  callPackage ../development/ocaml-modules/nocrypto { };
+
+    ocaml_batteries = callPackage ../development/ocaml-modules/batteries { };
+
+    comparelib = callPackage ../development/ocaml-modules/comparelib { };
+
+    core_extended_p4 = callPackage ../development/ocaml-modules/core_extended { };
+
+    core_kernel_p4 = callPackage ../development/ocaml-modules/core_kernel { };
+
+    core_p4 = callPackage ../development/ocaml-modules/core { };
+
+    ocamlbuild =
+    if lib.versionOlder "4.03" ocaml_version then
+    callPackage ../development/tools/ocaml/ocamlbuild { }
+    else
+    null;
+
+    ocaml_cryptgps = callPackage ../development/ocaml-modules/cryptgps { };
+
+    ocaml_data_notation = callPackage ../development/ocaml-modules/odn { };
+
+    ocaml_expat = callPackage ../development/ocaml-modules/expat { };
+
+    frontc = callPackage ../development/ocaml-modules/frontc { };
+
+    ocamlfuse = callPackage ../development/ocaml-modules/ocamlfuse { };
+
+    ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };
+
+    ocaml_http = callPackage ../development/ocaml-modules/http { };
+
+    ocamlify = callPackage ../development/tools/ocaml/ocamlify { };
+
+    ocaml_lwt = callPackage ../development/ocaml-modules/lwt { };
+
+    ocamlmod = callPackage ../development/tools/ocaml/ocamlmod { };
+
+    ocaml_mysql = callPackage ../development/ocaml-modules/mysql { };
+
+    ocamlnet = callPackage ../development/ocaml-modules/ocamlnet { };
+
+    ocaml_oasis = callPackage ../development/tools/ocaml/oasis { };
+    ocaml_oasis_46 = callPackage ../development/tools/ocaml/oasis/0.4.6.nix { };
+
+    ocaml_optcomp = callPackage ../development/ocaml-modules/optcomp { };
+
+    ocaml_pcre = callPackage ../development/ocaml-modules/pcre {};
+
+    pgocaml = callPackage ../development/ocaml-modules/pgocaml {};
+
+    ocaml_react = callPackage ../development/ocaml-modules/react { };
+    reactivedata = callPackage ../development/ocaml-modules/reactivedata {};
+
+    ocamlscript = callPackage ../development/tools/ocaml/ocamlscript { };
+
+    ocamlsdl= callPackage ../development/ocaml-modules/ocamlsdl { };
+
+    ocaml_sqlite3 = callPackage ../development/ocaml-modules/sqlite3 { };
+
+    ocaml_ssl = callPackage ../development/ocaml-modules/ssl { };
+
+    ocaml_text = callPackage ../development/ocaml-modules/ocaml-text { };
+
+    ocpBuild = callPackage ../development/tools/ocaml/ocp-build { };
+
+    ocpIndent = callPackage ../development/tools/ocaml/ocp-indent { };
+
+    ocp-index = callPackage ../development/tools/ocaml/ocp-index { };
+
+    ocplib-endian = callPackage ../development/ocaml-modules/ocplib-endian { };
+
+    ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };
+
+    ojquery = callPackage ../development/ocaml-modules/ojquery { };
+
+    otfm = callPackage ../development/ocaml-modules/otfm { };
+
+    ounit = callPackage ../development/ocaml-modules/ounit { };
+
+    piqi = callPackage ../development/ocaml-modules/piqi { };
+    piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
+
+    re2_p4 = callPackage ../development/ocaml-modules/re2 { };
+
+    result = callPackage ../development/ocaml-modules/ocaml-result { };
+
+    sequence = callPackage ../development/ocaml-modules/sequence { };
+
+    sqlexpr = callPackage ../development/ocaml-modules/sqlexpr { };
+
+    tuntap = callPackage ../development/ocaml-modules/tuntap { };
+
+    tyxml = callPackage ../development/ocaml-modules/tyxml { };
+
+    ulex = callPackage ../development/ocaml-modules/ulex { };
+
+    ulex08 = callPackage ../development/ocaml-modules/ulex/0.8 {
+      camlp5 = camlp5_transitional;
+    };
+
+    textutils_p4 = callPackage ../development/ocaml-modules/textutils { };
+
+    type_conv_108_08_00 = callPackage ../development/ocaml-modules/type_conv/108.08.00.nix { };
+    type_conv_109_60_01 = callPackage ../development/ocaml-modules/type_conv/109.60.01.nix { };
+    type_conv_112_01_01 = callPackage ../development/ocaml-modules/type_conv/112.01.01.nix { };
+    type_conv =
+      if lib.versionOlder "4.02" ocaml_version
+      then type_conv_112_01_01
+      else if lib.versionOlder "4.00" ocaml_version
+      then type_conv_109_60_01
+      else if lib.versionOlder "3.12" ocaml_version
+      then type_conv_108_08_00
+      else null;
+
+    sexplib_108_08_00 = callPackage ../development/ocaml-modules/sexplib/108.08.00.nix { };
+    sexplib_111_25_00 = callPackage ../development/ocaml-modules/sexplib/111.25.00.nix { };
+    sexplib_112_24_01 = callPackage ../development/ocaml-modules/sexplib/112.24.01.nix { };
+
+    sexplib_p4 =
+      if lib.versionOlder "4.02" ocaml_version
+      then sexplib_112_24_01
+      else if lib.versionOlder "4.00" ocaml_version
+      then sexplib_111_25_00
+      else if lib.versionOlder "3.12" ocaml_version
+      then sexplib_108_08_00
+      else null;
+
+    ocaml_extlib = callPackage ../development/ocaml-modules/extlib { };
+    ocaml_extlib_maximal = callPackage ../development/ocaml-modules/extlib {
+      minimal = false;
+    };
+
+    ocurl = callPackage ../development/ocaml-modules/ocurl { };
+
+    pa_ounit = callPackage ../development/ocaml-modules/pa_ounit { };
+
+    pa_bench = callPackage ../development/ocaml-modules/pa_bench { };
+
+    pa_test = callPackage ../development/ocaml-modules/pa_test { };
+
+    pipebang = callPackage ../development/ocaml-modules/pipebang { };
+
+    pprint = callPackage ../development/ocaml-modules/pprint { };
+
+    ppx_blob =
+      if lib.versionAtLeast ocaml_version "4.02"
+      then callPackage ../development/ocaml-modules/ppx_blob {}
+      else null;
+
+    ppx_deriving =
+      if lib.versionAtLeast ocaml_version "4.02"
+      then callPackage ../development/ocaml-modules/ppx_deriving {}
+      else null;
+
+    ppx_tools =
+      if lib.versionAtLeast ocaml_version "4.02"
+      then callPackage ../development/ocaml-modules/ppx_tools {}
+      else null;
+
+    pycaml = callPackage ../development/ocaml-modules/pycaml { };
+
+    qcheck = callPackage ../development/ocaml-modules/qcheck {
+      oasis = ocaml_oasis;
+    };
+
+    qtest = callPackage ../development/ocaml-modules/qtest { };
+
+    re = callPackage ../development/ocaml-modules/re { };
+
+    safepass = callPackage ../development/ocaml-modules/safepass { };
+
+    sqlite3EZ = callPackage ../development/ocaml-modules/sqlite3EZ { };
+
+    stringext = callPackage ../development/ocaml-modules/stringext { };
+
+    topkg = callPackage ../development/ocaml-modules/topkg { };
+
+    tsdl = callPackage ../development/ocaml-modules/tsdl { };
+
+    twt = callPackage ../development/ocaml-modules/twt { };
+
+    typerep_p4 = callPackage ../development/ocaml-modules/typerep { };
+
+    utop = callPackage ../development/tools/ocaml/utop { };
+
+    uuidm = callPackage ../development/ocaml-modules/uuidm { };
+
+    sawja = callPackage ../development/ocaml-modules/sawja { };
+
+    uucd = callPackage ../development/ocaml-modules/uucd { };
+    uucp = callPackage ../development/ocaml-modules/uucp { };
+    uunf = callPackage ../development/ocaml-modules/uunf { };
+
+    uri = callPackage ../development/ocaml-modules/uri { };
+
+    uuseg = callPackage ../development/ocaml-modules/uuseg { };
+    uutf = callPackage ../development/ocaml-modules/uutf { };
+
+    variantslib_p4 = callPackage ../development/ocaml-modules/variantslib { };
+
+    vg = callPackage ../development/ocaml-modules/vg { };
+
+    x509 = callPackage ../development/ocaml-modules/x509 { };
+
+    xmlm = callPackage ../development/ocaml-modules/xmlm { };
+
+    xml-light = callPackage ../development/ocaml-modules/xml-light { };
+
+    yojson = callPackage ../development/ocaml-modules/yojson { };
+
+    zarith = callPackage ../development/ocaml-modules/zarith { };
+
+    zed = callPackage ../development/ocaml-modules/zed { };
+
+    ocsigen_deriving = callPackage ../development/ocaml-modules/ocsigen-deriving {
+      oasis = ocaml_oasis;
+    };
+
+    # Jane Street
+    js_build_tools = callPackage ../development/ocaml-modules/janestreet/js-build-tools.nix {};
+
+    buildOcamlJane = callPackage ../development/ocaml-modules/janestreet/buildOcamlJane.nix {};
+
+    ppx_core = callPackage ../development/ocaml-modules/janestreet/ppx-core.nix {};
+
+    ppx_optcomp = callPackage ../development/ocaml-modules/janestreet/ppx-optcomp.nix {};
+
+    ppx_driver = callPackage ../development/ocaml-modules/janestreet/ppx-driver.nix {};
+
+    ppx_type_conv = callPackage ../development/ocaml-modules/janestreet/ppx-type-conv.nix {};
+
+    ppx_compare = callPackage ../development/ocaml-modules/janestreet/ppx-compare.nix {};
+
+    ppx_here = callPackage ../development/ocaml-modules/janestreet/ppx-here.nix {};
+
+    ppx_sexp_conv = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-conv.nix {};
+
+    ppx_assert = callPackage ../development/ocaml-modules/janestreet/ppx-assert.nix {};
+
+    ppx_inline_test = callPackage ../development/ocaml-modules/janestreet/ppx-inline-test.nix {};
+
+    ppx_bench = callPackage ../development/ocaml-modules/janestreet/ppx-bench.nix {};
+
+    ppx_bin_prot = callPackage ../development/ocaml-modules/janestreet/ppx-bin-prot.nix {};
+
+    ppx_custom_printf = callPackage ../development/ocaml-modules/janestreet/ppx-custom-printf.nix {};
+
+    ppx_enumerate = callPackage ../development/ocaml-modules/janestreet/ppx-enumerate.nix {};
+
+    ppx_fail = callPackage ../development/ocaml-modules/janestreet/ppx-fail.nix {};
+
+    ppx_fields_conv = callPackage ../development/ocaml-modules/janestreet/ppx-fields-conv.nix {};
+
+    ppx_let = callPackage ../development/ocaml-modules/janestreet/ppx-let.nix {};
+
+    ppx_pipebang = callPackage ../development/ocaml-modules/janestreet/ppx-pipebang.nix {};
+
+    ppx_sexp_message = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-message.nix {};
+
+    ppx_sexp_value = callPackage ../development/ocaml-modules/janestreet/ppx-sexp-value.nix {};
+
+    ppx_typerep_conv = callPackage ../development/ocaml-modules/janestreet/ppx-typerep-conv.nix {};
+
+    ppx_variants_conv = callPackage ../development/ocaml-modules/janestreet/ppx-variants-conv.nix {};
+
+    ppx_expect = callPackage ../development/ocaml-modules/janestreet/ppx-expect.nix {};
+
+    ppx_jane = callPackage ../development/ocaml-modules/janestreet/ppx-jane.nix {};
+
+
+    # Core sublibs
+    typerep =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/typerep.nix {}
+      else typerep_p4;
+
+    fieldslib =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/fieldslib.nix {}
+      else fieldslib_p4;
+
+    sexplib =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/sexplib.nix {}
+      else sexplib_p4;
+
+    variantslib =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/variantslib.nix {}
+      else variantslib_p4;
+
+    bin_prot =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {}
+      else bin_prot_p4;
+
+    core_kernel =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/core_kernel.nix {}
+      else core_kernel_p4;
+
+    core =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/core.nix {}
+      else core_p4;
+
+    re2 =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/re2.nix {}
+      else re2_p4;
+
+    textutils =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/textutils.nix {}
+      else textutils_p4;
+
+    core_extended =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/core-extended.nix {}
+      else core_extended_p4;
+
+    async_kernel =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/async-kernel.nix {}
+      else async_kernel_p4;
+
+    async_rpc_kernel = callPackage ../development/ocaml-modules/janestreet/async-rpc-kernel.nix {};
+
+    async_unix =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/async-unix.nix {}
+      else async_unix_p4;
+
+    async_extra =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/async-extra.nix {}
+      else async_extra_p4;
+
+    async =
+      if lib.versionOlder "4.02" ocaml_version
+      then callPackage ../development/ocaml-modules/janestreet/async.nix {}
+      else async_p4;
+
+    # Apps / from all-packages
+
+    wyrd = callPackage ../tools/misc/wyrd { };
+
+    compcert = callPackage ../development/compilers/compcert ((
+      if system == "x86_64-linux"
+      then { tools = pkgs.pkgsi686Linux.stdenv.cc; }
+      else {}
+    ) // {
+      coq = coq_8_5;
+    });
+
+    haxe = callPackage ../development/compilers/haxe { };
+
+    ocaml-top = callPackage ../development/tools/ocaml/ocaml-top { };
+
+    opam_1_0_0 = callPackage ../development/tools/ocaml/opam/1.0.0.nix { };
+    opam_1_1 = callPackage ../development/tools/ocaml/opam/1.1.nix { };
+    opam = callPackage ../development/tools/ocaml/opam { };
+
+    ocamlnat = callPackage  ../development/ocaml-modules/ocamlnat { };
+
+    trv = callPackage ../development/tools/misc/trv { };
+
+    omake = callPackage ../development/tools/ocaml/omake { };
+    omake_rc1 = callPackage ../development/tools/ocaml/omake/0.9.8.6-rc1.nix { };
+
+    verasco = callPackage ../development/tools/analysis/verasco (
+      if system == "x86_64-linux"
+      then { tools = pkgs.pkgsi686Linux.stdenv.cc; }
+      else {}
+    );
+    
+    glsurf = callPackage ../applications/science/math/glsurf {
+      libpng = pkgs.libpng12;
+      giflib = pkgs.giflib_4_1;
+      camlimages = camlimages_4_0;
+    };
+
+    google-drive-ocamlfuse = callPackage ../applications/networking/google-drive-ocamlfuse { };
+
+    llpp = callPackage ../applications/misc/llpp { };
+
+    monotoneViz = callPackage ../applications/version-management/monotone-viz {
+      inherit (pkgs.gnome2) libgnomecanvas glib;
+    };
+
+    unison = callPackage ../applications/networking/sync/unison {
+      enableX11 = config.unison.enableX11 or true;
+    };
+
+    coq = callPackage ../applications/science/logic/coq {
+      camlp5 = camlp5_transitional;
+    };
+
+    coq_HEAD = callPackage ../applications/science/logic/coq/HEAD.nix {
+      camlp5 = camlp5_transitional;
+    };
+
+    coq_8_5 = callPackage ../applications/science/logic/coq/8.5.nix {
+      camlp5 = camlp5_transitional;
+    };
+
+    coq_8_3 = callPackage ../applications/science/logic/coq/8.3.nix {
+      make = pkgs.gnumake3;
+      camlp5 = camlp5_transitional;
+      lablgtk = lablgtk_2_14;
+    };
+
+    hol_light = callPackage ../applications/science/logic/hol_light {
+      camlp5 = camlp5_strict;
+    };
+
+    matita = callPackage ../applications/science/logic/matita {
+      ulex08 = ulex08.override { camlp5 = camlp5_old_transitional; };
+    };
+
+    matita_130312 = callPackage ../applications/science/logic/matita/130312.nix { };
+
+    ott = callPackage ../applications/science/logic/ott {
+      camlp5 = camlp5_transitional;
+    };
+
+    prooftree = callPackage ../applications/science/logic/prooftree {
+      camlp5 = camlp5_transitional;
+    };
+  };
+    in lib.fix' (lib.extends overrides packageSet);
+in rec
+{
+  ocamlPackages_3_08_0 = mkOcamlPackages (callPackage ../development/compilers/ocaml/3.08.0.nix { }) (self: super: { lablgtk = self.lablgtk_2_14; });
+
+  ocamlPackages_3_10_0 = mkOcamlPackages (callPackage ../development/compilers/ocaml/3.10.0.nix { }) (self: super: { lablgtk = self.lablgtk_2_14; });
+
+  ocamlPackages_3_11_2 = mkOcamlPackages (callPackage ../development/compilers/ocaml/3.11.2.nix { }) (self: super: { lablgtk = self.lablgtk_2_14; });
+
+  ocamlPackages_3_12_1 = mkOcamlPackages (callPackage ../development/compilers/ocaml/3.12.1.nix { }) (self: super: { camlimages = self.camlimages_4_0; });
+
+  ocamlPackages_4_00_1 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.00.1.nix { }) (self: super: { });
+
+  ocamlPackages_4_01_0 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.01.0.nix { }) (self: super: { });
+
+  ocamlPackages_4_02 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.02.nix { }) (self: super: { });
+
+  ocamlPackages_4_03 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.02.nix { }) (self: super: { });
+
+  ocamlPackages_latest = ocamlPackages_4_03;
+
+  ocamlPackages = ocamlPackages_4_01_0;
+}


### PR DESCRIPTION
###### Motivation for this change

Tidy current ocaml package system up a bit.

All package definitions and `ocaml` compiler itself were moved from the big function `mkOcamlPackages` inside the `all-packages.nix` file to `ocaml-packages.nix`.

Now you have to use `ocaml-ng.ocamlPackages_${version}` (or default `ocamlPackages`) to specify which version you need in top-level, like:
- `somepackage = ocaml-ng.ocamlPackages_4_02.somepackage;` for internal `somepackage` in `ocaml-packages.nix`
- or overrides `ocamlPackages = ocaml-ng.ocamlPackages_4_02` for packages that use other `langPackages` aside of ocaml one (like `xen`, `fstar`).

So now for "internal" packages write their bare dependencies and (like it was before) choose the version you need in `all-packages`.
For other packages pass in the `ocamlPackages_version` you need.

Now there's a sort of division in `ocamlPackages` for "libs" and "apps', the former contains definitions from the old `mkOcamlPackages` function, and the latter contains derivations which use only ocaml packages and were moved there from `all-packages.nix`.

Old top-level definitions like `ocaml_3_12_1` or `ocamlPackages_3_12_1` are in `aliases.nix` as a (temporary) compatibility measure.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There's currently some ocaml work going on in #18572, so some changes will be required either there or in this PR, depending on what is merged first.
сс @vbgl
