### PR TITLE
davix: 0.4.0 -> 0.6.4

### DIFF
--- a/pkgs/tools/networking/davix/default.nix
+++ b/pkgs/tools/networking/davix/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, openssl, libxml2, boost }:
 
 stdenv.mkDerivation rec {
-  name = "davix-0.4.0";
+  name = "davix-0.6.4";
   buildInputs = [ stdenv pkgconfig cmake openssl libxml2 boost ];
 
   src = fetchFromGitHub {
     owner = "cern-it-sdc-id";
     repo = "davix";
-    rev = "R_0_4_0-1";
-    sha256 = "0i6ica7rmpc3hbybjql5mr500cd43w4qzc69cj1djkc6bqqb752v";
+    rev = "R_0_6_4";
+    sha256 = "10hg7rs6aams96d4ghldgkrrnikskdpmn8vy6hj5j0s17a2yms6q";
   };
 
 


### PR DESCRIPTION
###### Motivation for this change

Update davix to last upstream release 0.6.4
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
