### PR TITLE
xclip: 0.12-svn-20140209 -> 0.13

### DIFF
--- a/pkgs/tools/misc/xclip/default.nix
+++ b/pkgs/tools/misc/xclip/default.nix
@@ -1,20 +1,23 @@
-{ stdenv, fetchsvn, xlibsWrapper, libXmu, autoreconfHook }:
+{ stdenv, fetchFromGitHub, autoreconfHook, libXmu }:
 
 stdenv.mkDerivation rec {
-  # The last release from 2012, 0.12, lacks '-targets'
-  name = "xclip-0.12-svn-20140209";
+  name = "xclip-${version}";
+  version = "0.13";
 
-  src = fetchsvn {
-    url = "svn://svn.code.sf.net/p/xclip/code/trunk";
-    rev = "87";
-    sha256 = "1rbcdgr73916wvzfgqjs1jhgzk8qs1yw2iiqy7ifrkjafhi37w6b";
+  src = fetchFromGitHub {
+    owner = "astrand";
+    repo = "xclip";
+    rev = version;
+    sha256 = "0q0hmvcjlv8arhh1pzhja2wglyj6n7z209jnpnzd281kqqv4czcs";
   };
 
-  buildInputs = [ xlibsWrapper libXmu autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ libXmu ];
 
   meta = {
     description = "Tool to access the X clipboard from a console application";
-    homepage = http://sourceforge.net/projects/xclip/;
+    homepage = https://github.com/astrand/xclip;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.all;
   };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
