### PR TITLE
xsel: 1.2.0 -> git-2016-09-02

### DIFF
--- a/pkgs/tools/misc/xsel/default.nix
+++ b/pkgs/tools/misc/xsel/default.nix
@@ -1,15 +1,29 @@
-{stdenv, fetchurl, xlibsWrapper}:
+{stdenv, lib, fetchFromGitHub, libX11, autoreconfHook }:
 
-stdenv.mkDerivation {
-  name = "xsel-1.2.0";
-  src = fetchurl {
-    url = http://www.vergenet.net/~conrad/software/xsel/download/xsel-1.2.0.tar.gz;
-    sha256 = "070lbcpw77j143jrbkh0y1v10ppn1jwmjf92800w7x42vh4cw9xr";
+stdenv.mkDerivation rec {
+  name = "xsel-unstable-${version}";
+
+  version = "2016-09-02";
+
+  src = fetchFromGitHub {
+    owner = "kfish";
+    repo = "xsel";
+    rev = "aa7f57eed805adb09e9c59c8ea841870e8206b81";
+    sha256 = "04mrc8j0rr7iy1k6brfxnx26pmxm800gh4nqrxn6j2lz6vd5y9m5";
   };
 
-  buildInputs = [xlibsWrapper];
+  buildInputs = [ libX11 autoreconfHook ];
 
-  meta = {
-    platforms = stdenv.lib.platforms.unix;
+  # We need a README file, otherwise autoconf complains.
+  postUnpack = ''
+    mv $sourceRoot/README{.md,}
+  '';
+
+  meta = with lib; {
+    description = "Command-line program for getting and setting the contents of the X selection";
+    homepage = "http://www.kfish.org/software/xsel";
+    license = licenses.mit;
+    maintainers = [ maintainers.cstrahan ];
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The last xsel release was in 2008. Since then, a number of bugs have
been fixed. For example, pasting a moderately sized chunk of text (>4000 chars)
into chrome would cause the current tab to hang indefinitely.

A couple examples in the wild:
- https://github.com/kfish/xsel/issues/14
- https://github.com/kfish/xsel/issues/13
- https://github.com/kfish/xsel/pull/16
- https://bugs.chromium.org/p/chromium/issues/detail?id=515401
- https://github.com/electron/electron/issues/3116
- https://github.com/neovim/neovim/issues/4719
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
