### PR TITLE
lato: init at 2.0

### DIFF
--- a/pkgs/data/fonts/lato/default.nix
+++ b/pkgs/data/fonts/lato/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "lato-2.0";
+
+  src = fetchurl {
+    url = http://www.latofonts.com/download/Lato2OFL.zip;
+    sha256 = "1f5540g0ja1nx3ddd3ywn77xc81ssrxpq8n3gyb9sabyq2b4xda2";
+  };
+
+  sourceRoot = "Lato2OFL";
+
+  buildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/lato
+    cp *.ttf $out/share/fonts/lato
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.latofonts.com/;
+
+    description = ''
+      Sans-serif typeface family designed in Summer 2010 by Łukasz Dziedzic
+    '';
+
+    longDescription = ''
+      Lato is a sans-serif typeface family designed in the Summer 2010 by
+      Warsaw-based designer Łukasz Dziedzic ("Lato" means "Summer" in Polish).
+      In December 2010 the Lato family was published under the open-source Open
+      Font License by his foundry tyPoland, with support from Google.
+
+      In 2013-2014, the family was greatly extended to cover 3000+ glyphs per
+      style. The Lato 2.010 family now supports 100+ Latin-based languages, 50+
+      Cyrillic-based languages as well as Greek and IPA phonetics. In the
+      process, the metrics and kerning of the family have been revised and four
+      additional weights were created.
+    '';
+
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ chris-martin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12112,6 +12112,8 @@ in
 
   kochi-substitute-naga10 = callPackage ../data/fonts/kochi-substitute-naga10 {};
 
+  lato = callPackage ../data/fonts/lato {};
+
   league-of-moveable-type = callPackage ../data/fonts/league-of-moveable-type {};
 
   liberation_ttf_from_source = callPackage ../data/fonts/redhat-liberation-fonts { };


### PR DESCRIPTION
###### Motivation for this change

Adds the Lato font.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
