### PR TITLE
ocaml: 4.02 -> 4.03.0

### DIFF
--- a/pkgs/development/compilers/ocaml/4.03.nix
+++ b/pkgs/development/compilers/ocaml/4.03.nix
@@ -1,0 +1,80 @@
+let
+  safeX11 = stdenv: !(stdenv.isArm || stdenv.isMips);
+in
+
+{ stdenv, fetchurl, ncurses, buildEnv, libX11, xproto, useX11 ? safeX11 stdenv }:
+
+assert useX11 -> !stdenv.isArm && !stdenv.isMips;
+
+let
+   useNativeCompilers = !stdenv.isMips;
+   inherit (stdenv.lib) optionals optionalString;
+in
+
+stdenv.mkDerivation rec {
+
+  x11env = buildEnv { name = "x11env"; paths = [libX11 xproto]; };
+  x11lib = x11env + "/lib";
+  x11inc = x11env + "/include";
+
+  name = "ocaml-4.03.0";
+
+  src = fetchurl {
+    url = "http://caml.inria.fr/pub/distrib/ocaml-4.03/${name}.tar.xz";
+    sha256 = "1qwwvy8nzd87hk8rd9sm667nppakiapnx4ypdwcrlnav2dz6kil3";
+  };
+
+  patches = [ ./ocamlbuild.patch ];
+
+  prefixKey = "-prefix ";
+  configureFlags = optionals useX11 [ "-x11lib" x11lib
+                                      "-x11include" x11inc ];
+
+  buildFlags = "world" + optionalString useNativeCompilers " bootstrap world.opt";
+  buildInputs = [ncurses] ++ optionals useX11 [ libX11 xproto ];
+  installTargets = "install" + optionalString useNativeCompilers " installopt";
+  preConfigure = ''
+    CAT=$(type -tp cat)
+    sed -e "s@/bin/cat@$CAT@" -i config/auto-aux/sharpbang
+  '';
+  postBuild = ''
+    mkdir -p $out/include
+    ln -sv $out/lib/ocaml/caml $out/include/caml
+  '';
+
+  passthru = {
+    nativeCompilers = useNativeCompilers;
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://caml.inria.fr/ocaml;
+    branch = "4.02";
+    license = with licenses; [
+      qpl /* compiler */
+      lgpl2 /* library */
+    ];
+    description = "Most popular variant of the Caml language";
+
+    longDescription =
+      ''
+        OCaml is the most popular variant of the Caml language.  From a
+        language standpoint, it extends the core Caml language with a
+        fully-fledged object-oriented layer, as well as a powerful module
+        system, all connected by a sound, polymorphic type system featuring
+        type inference.
+
+        The OCaml system is an industrial-strength implementation of this
+        language, featuring a high-performance native-code compiler (ocamlopt)
+        for 9 processor architectures (IA32, PowerPC, AMD64, Alpha, Sparc,
+        Mips, IA64, HPPA, StrongArm), as well as a bytecode compiler (ocamlc)
+        and an interactive read-eval-print loop (ocaml) for quick development
+        and portability.  The OCaml distribution includes a comprehensive
+        standard library, a replay debugger (ocamldebug), lexer (ocamllex) and
+        parser (ocamlyacc) generators, a pre-processor pretty-printer (camlp4)
+        and a documentation generator (ocamldoc).
+      '';
+
+    platforms = with platforms; linux ++ darwin;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5045,6 +5045,8 @@ in
 
   ocaml_4_02 = callPackage ../development/compilers/ocaml/4.02.nix { };
 
+  ocaml_4_03 = callPackage ../development/compilers/ocaml/4.03.nix { };
+
   orc = callPackage ../development/compilers/orc { };
 
   metaocaml_3_09 = callPackage ../development/compilers/ocaml/metaocaml-3.09.nix { };
@@ -5509,7 +5511,7 @@ in
 
   };
 
-  ocamlPackages = recurseIntoAttrs ocamlPackages_4_01_0;
+  ocamlPackages = recurseIntoAttrs ocamlPackages_4_03_0;
   ocamlPackages_3_10_0 = (mkOcamlPackages ocaml_3_10_0 pkgs.ocamlPackages_3_10_0)
   // { lablgtk = ocamlPackages_3_10_0.lablgtk_2_14; };
   ocamlPackages_3_11_2 = (mkOcamlPackages ocaml_3_11_2 pkgs.ocamlPackages_3_11_2)
@@ -5519,7 +5521,8 @@ in
   ocamlPackages_4_00_1 = mkOcamlPackages ocaml_4_00_1 pkgs.ocamlPackages_4_00_1;
   ocamlPackages_4_01_0 = mkOcamlPackages ocaml_4_01_0 pkgs.ocamlPackages_4_01_0;
   ocamlPackages_4_02 = mkOcamlPackages ocaml_4_02 pkgs.ocamlPackages_4_02;
-  ocamlPackages_latest = ocamlPackages_4_02;
+  ocamlPackages_4_03_0 = mkOcamlPackages ocaml_4_03 pkgs.ocamlPackages_4_03_0;
+  ocamlPackages_latest = ocamlPackages_4_03_0;
 
   ocaml_make = callPackage ../development/ocaml-modules/ocamlmake { };
 


### PR DESCRIPTION
###### Motivation for this change

Tezos requires ocaml-4-03 to run: https://github.com/tezos/tezos/blob/master/scripts/install_build_deps.sh#L3
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
