### PR TITLE
ocamlPackages.ocplib-json-typed: init at 0.4

### DIFF
--- a/pkgs/development/ocaml-modules/ocplib-json-typed/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-json-typed/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchgit, ocaml, findlib, ocplib-endian, uri }:
+
+let version = "0.4"; in
+
+stdenv.mkDerivation {
+  name = "ocaml-ocplib-json-typed-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/OCamlPro/ocplib-json-typed.git";
+    rev = "09225b02e0cb9cb16868acc7c35ae1b4fc6daafb";
+    sha256 = "0nk68qzl953pkahvg92xshn9ax218sd5fz8rxb3nwa1qsjd0dimz";
+  };
+
+  buildInputs = [ ocaml findlib ocplib-endian uri];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "Libraries for reliable manipulation JSON objects";
+    homepage = https://github.com/OCamlPro/ocplib-json-typed;
+    license = stdenv.lib.licenses.lgpl21;
+    platforms = ocaml.meta.platforms or [];
+    maintainers = with stdenv.lib.maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5365,6 +5365,8 @@ in
 
     ocplib-endian = callPackage ../development/ocaml-modules/ocplib-endian { };
 
+    ocplib-json-typed = callPackage ../development/ocaml-modules/ocplib-json-typed { };
+
     ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };
 
     ojquery = callPackage ../development/ocaml-modules/ojquery { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
