### PR TITLE
libxmlxx: 2.38.1 -> 2.40.1

### DIFF
--- a/pkgs/development/libraries/libxmlxx/default.nix
+++ b/pkgs/development/libraries/libxmlxx/default.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchurl, pkgconfig, libxml2, glibmm, perl }:
 
 stdenv.mkDerivation rec {
-  name = "libxml++-2.38.1";
+  name = "libxml++-${maj_ver}.${min_ver}";
+  maj_ver = "2.40";
+  min_ver = "1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libxml++/2.38/${name}.tar.xz";
-    sha256 = "0px0ljcf9rsfa092dzmm097yn7wln6d5fgsvj9lnrnq3kcc2j9c8";
+    url = "mirror://gnome/sources/libxml++/${maj_ver}/${name}.tar.xz";
+    sha256 = "1sb3akryklvh2v6m6dihdnbpf1lkx441v972q9hlz1sq6bfspm2a";
   };
 
   nativeBuildInputs = [ pkgconfig perl ];
@@ -13,8 +15,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ glibmm ];
 
   propagatedBuildInputs = [ libxml2 ];
-
-  configureFlags = "--disable-documentation"; #doesn't build without this for some reason
 
   meta = with stdenv.lib; {
     homepage = http://libxmlplusplus.sourceforge.net/;


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
