### PR TITLE
amdapp-sdk: fix build for gcc 5

### DIFF
--- a/pkgs/development/misc/amdapp-sdk/default.nix
+++ b/pkgs/development/misc/amdapp-sdk/default.nix
@@ -22,6 +22,7 @@ let
       url = "http://download2-developer.amd.com/amd/APPSDK/AMD-APP-SDK-v2.7-lnx${bits}.tgz";
       x86 = "1v26n7g1xvlg5ralbfk3qiy34gj8fascpnjzm3120b6sgykfp16b";
       x86_64 = "08bi43bgnsxb47vbirh09qy02w7zxymqlqr8iikk9aavfxjlmch1";
+      patches = [ ./gcc-5.patch];
     };
 
     "2.8" = {
@@ -30,7 +31,7 @@ let
       x86_64 = "d9c120367225bb1cd21abbcf77cb0a69cfb4bb6932d0572990104c566aab9681";
 
       # TODO: Add support for aparapi, java parallel api
-      patches = [ ./01-remove-aparapi-samples.patch ];
+      patches = [ ./01-remove-aparapi-samples.patch ./gcc-5.patch];
     };
   };
 

--- a/pkgs/development/misc/amdapp-sdk/gcc-5.patch
+++ b/pkgs/development/misc/amdapp-sdk/gcc-5.patch
@@ -1,0 +1,11 @@
+--- include/CL/cl.hpp
++++ include/CL/cl.hpp
+@@ -201,7 +201,7 @@
+ #include <functional>
+ #define __CL_FUNCTION_TYPE typename std::function
+ #define CL_USE_CPP_FUNCTORS
+-#elif (__GNUC__ == 4 && __GNUC_MINOR__ >= 1 && !defined(STLPORT)) || defined(__APPLE__) || defined(__MACOSX)
++#elif (((__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ >= 5)) && !defined(STLPORT)) || defined(__APPLE__) || defined(__MACOSX)
+ #include <tr1/functional>
+ #define __CL_FUNCTION_TYPE typename std::tr1::function
+ #define CL_USE_CPP_FUNCTORS


### PR DESCRIPTION
This allows the amdapp-sdk samples to be build with gcc 5.
This fixes the failing builds 

http://hydra.nixos.org/build/40828779
and
http://hydra.nixos.org/build/40829516

Related to https://github.com/NixOS/nixpkgs/issues/18209

@domenkozar 
