### PR TITLE
pkgs.xorriso: 1.4.4 -> 1.4.6

### DIFF
--- a/pkgs/tools/cd-dvd/xorriso/default.nix
+++ b/pkgs/tools/cd-dvd/xorriso/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, libcdio, zlib, bzip2, readline, acl, attr }:
 
 stdenv.mkDerivation rec {
-  name = "xorriso-1.4.4";
+  name = "xorriso-1.4.6";
 
   src = fetchurl {
     url = "mirror://gnu/xorriso/${name}.tar.gz";
-    sha256 = "1izv8dvwacyh432vv1rm6lyjrq0v205kyakfra6iwa146c9m9fgr";
+    sha256 = "112p0ghwzxrcjbsir1n2jxhq103ckrw93wzvd55qqvzfgs674vsj";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

See http://lists.gnu.org/archive/html/info-gnu/2016-09/msg00010.html
for release announcement
