### PR TITLE
manual: add node.js to languages & frameworks

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -61,6 +61,10 @@ pkgs.stdenv.mkDerivation {
       outputFile = "languages-frameworks/idris.xml";
     }
   + toDocbook {
+      inputFile = ../pkgs/development/node-packages/README.md;
+      outputFile = "languages-frameworks/node.xml";
+    }
+  + toDocbook {
       inputFile = ../pkgs/development/r-modules/README.md;
       outputFile = "languages-frameworks/r.xml";
     }

--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -21,6 +21,7 @@ such as Perl or Haskell.  These are described in this chapter.</para>
 <xi:include href="idris.xml" /> <!-- generated from ../../pkgs/development/idris-modules/README.md  -->
 <xi:include href="java.xml" />
 <xi:include href="lua.xml" />
+<xi:include href="node.xml" /> <!-- generated from ../../pkgs/development/node-packages/README.md  -->
 <xi:include href="perl.xml" />
 <xi:include href="python.xml" />
 <xi:include href="qt.xml" />

--- a/pkgs/development/node-packages/README.md
+++ b/pkgs/development/node-packages/README.md
@@ -1,5 +1,7 @@
-NPM packages
-===========
+Node.js packages
+===============
+To add a package from [NPM](https://www.npmjs.com/) to nixpkgs:
+
  1. Install node2nix: `nix-env -f '<nixpkgs>' -iA node2nix`.
  2. Modify `pkgs/development/node-packages/node-packages.json`, to add, update,
     or remove package entries.


### PR DESCRIPTION
###### Motivation for this change

fixes #18609 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
