### PR TITLE
libreoffice: md5 -> sha256

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -28,25 +28,17 @@ let
   lib = stdenv.lib;
   langsSpaces = lib.concatStringsSep " " langs;
 
-  fetchThirdParty = {name, md5, brief, subDir ? ""}: fetchurl {
-    inherit name md5;
-    url = if brief then
-            "http://dev-www.libreoffice.org/src/${subDir}${name}"
-          else
-            "http://dev-www.libreoffice.org/src/${subDir}${md5}-${name}";
-  };
-
   fetchSrc = {name, sha256}: fetchurl {
     url = "http://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${name}-${version}.tar.xz";
     inherit sha256;
   };
 
   srcs = {
-    third_party = [ (fetchurl rec {
+    third_party = [ (let md5 = "185d60944ea767075d27247c3162b3bc"; in fetchurl rec {
         url = "http://dev-www.libreoffice.org/extern/${md5}-${name}";
-        md5 = "185d60944ea767075d27247c3162b3bc";
+        sha256 = "1infwvv1p6i21scywrldsxs22f62x85mns4iq8h6vr6vlx3fdzga";
         name = "unowinreg.dll";
-      }) ] ++ (map fetchThirdParty (import ./libreoffice-srcs.nix));
+      }) ] ++ (map fetchurl (import ./libreoffice-srcs.nix));
 
     translations = fetchSrc {
       name = "translations";

--- a/pkgs/applications/office/libreoffice/generate-libreoffice-srcs.py
+++ b/pkgs/applications/office/libreoffice/generate-libreoffice-srcs.py
@@ -8,26 +8,62 @@ of the input file, and writes the result to stdout.
 
 todo - Ideally we would move as much as possible into derivation dependencies.
 """
-import collections, itertools, json, re, sys, os
+import collections, itertools, json, re, subprocess, sys, os
 
 def main():
 
+    packages = list(get_packages())
+
+    for x in packages:
+        print(x, file=sys.stderr)
+
     print('[')
 
-    for x in get_packages():
+    for x in packages:
 
-        print('{')
+        md5 = x['md5']
+        tarball = x['tarball']
 
-        print('  name = "{}";'.format(x['tarball']))
-        print('  md5 = "{}";'.format(x['md5']))
-        print('  brief = {};'.format('true' if x['brief'] else 'false'))
+        url = construct_url(x)
+        print('url: {}'.format(url), file=sys.stderr)
 
-        if 'subdir' in x:
-            print('  subDir = "{}";'.format(x['subdir']))
+        path = download(url, tarball, md5)
+        print('path: {}'.format(path), file=sys.stderr)
 
-        print('}')
+        sha256 = get_sha256(path)
+        print('sha256: {}'.format(sha256), file=sys.stderr)
+
+        print('  {')
+        print('    name = "{}";'.format(tarball))
+        print('    url = "{}";'.format(url))
+        print('    sha256 = "{}";'.format(sha256))
+        print('  }')
 
     print(']')
+
+
+def construct_url(x):
+    if x['brief']:
+        return 'http://dev-www.libreoffice.org/src/{}{}'.format(
+            x.get('subdir', ''), x['tarball'])
+    else:
+        return 'http://dev-www.libreoffice.org/src/{}{}-{}'.format(
+            x.get('subdir', ''), x['md5'], x['tarball'])
+
+
+def download(url, name, md5):
+    cmd = ['nix-prefetch-url', url, md5, '--print-path',
+           '--type', 'md5', '--name', name]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, check=True,
+                          universal_newlines=True)
+    return proc.stdout.split('\n')[1].strip()
+
+
+def get_sha256(path):
+    cmd = ['sha256sum', path]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, check=True,
+                          universal_newlines=True)
+    return proc.stdout.split(' ')[0].strip()
 
 
 def get_packages():

--- a/pkgs/applications/office/libreoffice/libreoffice-srcs-still.nix
+++ b/pkgs/applications/office/libreoffice/libreoffice-srcs-still.nix
@@ -1,528 +1,527 @@
 [
-{
-  name = "libabw-0.1.1.tar.bz2";
-  md5 = "7a3815b506d064313ba309617b6f5a0b";
-  brief = true;
-}
-{
-  name = "commons-logging-1.2-src.tar.gz";
-  md5 = "ce977548f1cbf46918e93cd38ac35163";
-  brief = true;
-}
-{
-  name = "apr-1.4.8.tar.gz";
-  md5 = "eff9d741b0999a9bbab96862dd2a2a3d";
-  brief = true;
-}
-{
-  name = "apr-util-1.5.3.tar.gz";
-  md5 = "71a11d037240b292f824ba1eb537b4e3";
-  brief = true;
-}
-{
-  name = "boost_1_59_0.tar.bz2";
-  md5 = "6aa9a5c6a4ca1016edd0ed1178e3cb87";
-  brief = true;
-}
-{
-  name = "bsh-2.0b5-src.zip";
-  md5 = "ec1941a74d3ef513c4ce57a9092b74e1";
-  brief = false;
-}
-{
-  name = "bzip2-1.0.6.tar.gz";
-  md5 = "00b516f4704d4a7cb50a1d97e6e8e15b";
-  brief = false;
-}
-{
-  name = "cairo-1.10.2.tar.gz";
-  md5 = "f101a9e88b783337b20b2e26dfd26d5f";
-  brief = false;
-}
-{
-  name = "libcdr-0.1.2.tar.bz2";
-  md5 = "6e3062b55b149d7b3c6aedb3bb5b86e2";
-  brief = true;
-}
-{
-  name = "clucene-core-2.3.3.4.tar.gz";
-  md5 = "48d647fbd8ef8889e5a7f422c1bfda94";
-  brief = false;
-}
-{
-  name = "libcmis-0.5.0.tar.gz";
-  md5 = "5821b806a98e6c38370970e682ce76e8";
-  brief = false;
-}
-{
-  name = "CoinMP-1.7.6.tgz";
-  md5 = "1cce53bf4b40ae29790d2c5c9f8b1129";
-  brief = true;
-}
-{
-  name = "collada2gltf-master-cb1d97788a.tar.bz2";
-  md5 = "4b87018f7fff1d054939d19920b751a0";
-  brief = false;
-}
-{
-  name = "cppunit-1.13.2.tar.gz";
-  md5 = "d1c6bdd5a76c66d2c38331e2d287bc01";
-  brief = true;
-}
-{
-  name = "converttexttonumber-1-5-0.oxt";
-  md5 = "1f467e5bb703f12cbbb09d5cf67ecf4a";
-  brief = false;
-}
-{
-  name = "curl-7.43.0.tar.bz2";
-  md5 = "11bddbb452a8b766b932f859aaeeed39";
-  brief = true;
-}
-{
-  name = "libe-book-0.1.2.tar.bz2";
-  md5 = "6b48eda57914e6343efebc9381027b78";
-  brief = true;
-}
-{
-  name = "epm-3.7.tar.gz";
-  md5 = "3ade8cfe7e59ca8e65052644fed9fca4";
-  brief = false;
-}
-{
-  name = "libetonyek-0.1.6.tar.bz2";
-  md5 = "77ff46936dcc83670557274e7dd2aa33";
-  brief = true;
-}
-{
-  name = "expat-2.1.1.tar.bz2";
-  md5 = "7380a64a8e3a9d66a9887b01d0d7ea81";
-  brief = true;
-}
-{
-  name = "Firebird-2.5.4.26856-0.tar.bz2";
-  md5 = "7a17ec9889424b98baa29e001a054434";
-  brief = true;
-}
-{
-  name = "fontconfig-2.8.0.tar.gz";
-  md5 = "77e15a92006ddc2adbb06f840d591c0e";
-  brief = false;
-}
-{
-  name = "crosextrafonts-20130214.tar.gz";
-  md5 = "368f114c078f94214a308a74c7e991bc";
-  brief = false;
-}
-{
-  name = "crosextrafonts-carlito-20130920.tar.gz";
-  md5 = "c74b7223abe75949b4af367942d96c7a";
-  brief = false;
-}
-{
-  name = "dejavu-fonts-ttf-2.35.zip";
-  md5 = "d8b5214d35bcd2bfcb2cffa7795b351d";
-  brief = false;
-}
-{
-  name = "gentiumbasic-fonts-1.10.zip";
-  md5 = "35efabc239af896dfb79be7ebdd6e6b9";
-  brief = false;
-}
-{
-  name = "liberation-fonts-ttf-1.07.4.tar.gz";
-  md5 = "134d8262145fc793c6af494dcace3e71";
-  brief = false;
-}
-{
-  name = "liberation-fonts-ttf-2.00.1.tar.gz";
-  md5 = "5c781723a0d9ed6188960defba8e91cf";
-  brief = false;
-}
-{
-  name = "LinLibertineG-20120116.zip";
-  md5 = "e7a384790b13c29113e22e596ade9687";
-  brief = false;
-}
-{
-  name = "open-sans-font-ttf-1.10.tar.gz";
-  md5 = "7a15edea7d415ac5150ea403e27401fd";
-  brief = false;
-}
-{
-  name = "pt-serif-font-1.0000W.tar.gz";
-  md5 = "c3c1a8ba7452950636e871d25020ce0d";
-  brief = false;
-}
-{
-  name = "source-code-font-1.009.tar.gz";
-  md5 = "0279a21fab6f245e85a6f85fea54f511";
-  brief = false;
-}
-{
-  name = "source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
-  md5 = "edc4d741888bc0d38e32dbaa17149596";
-  brief = false;
-}
-{
-  name = "libfreehand-0.1.1.tar.bz2";
-  md5 = "8cf70c5dc4d24d2dc4a107f509d2d6d7";
-  brief = true;
-}
-{
-  name = "freetype-2.4.8.tar.bz2";
-  md5 = "dbf2caca1d3afd410a29217a9809d397";
-  brief = false;
-}
-{
-  name = "glew-1.12.0.zip";
-  md5 = "3941e9cab2f4f9d8faee3e8d57ae7664";
-  brief = false;
-}
-{
-  name = "glm-0.9.4.6-libreoffice.zip";
-  md5 = "bae83fa5dc7f081768daace6e199adc3";
-  brief = false;
-}
-{
-  name = "glyphy-0.2.0.tar.bz2";
-  md5 = "5d303fb955beb9bf112267316ca9d021";
-  brief = false;
-}
-{
-  name = "graphite-minimal-1.3.6.tgz";
-  md5 = "17df8301bcc459e83f8a8f3aca6183b2";
-  brief = false;
-}
-{
-  name = "harfbuzz-0.9.40.tar.bz2";
-  md5 = "0e27e531f4c4acff601ebff0957755c2";
-  brief = true;
-}
-{
-  name = "hsqldb_1_8_0.zip";
-  md5 = "17410483b5b5f267aa18b7e00b65e6e0";
-  brief = false;
-}
-{
-  name = "hunspell-1.3.3.tar.gz";
-  md5 = "4967da60b23413604c9e563beacc63b4";
-  brief = false;
-}
-{
-  name = "hyphen-2.8.8.tar.gz";
-  md5 = "5ade6ae2a99bc1e9e57031ca88d36dad";
-  brief = false;
-}
-{
-  name = "icu4c-56_1-src.tgz";
-  md5 = "c4a2d71ff56aec5ebfab2a3f059be99d";
-  brief = false;
-}
-{
-  name = "flow-engine-0.9.4.zip";
-  md5 = "ba2930200c9f019c2d93a8c88c651a0f";
-  brief = false;
-}
-{
-  name = "flute-1.1.6.zip";
-  md5 = "d8bd5eed178db6e2b18eeed243f85aa8";
-  brief = false;
-}
-{
-  name = "libbase-1.1.6.zip";
-  md5 = "eeb2c7ddf0d302fba4bfc6e97eac9624";
-  brief = false;
-}
-{
-  name = "libfonts-1.1.6.zip";
-  md5 = "3bdf40c0d199af31923e900d082ca2dd";
-  brief = false;
-}
-{
-  name = "libformula-1.1.7.zip";
-  md5 = "3404ab6b1792ae5f16bbd603bd1e1d03";
-  brief = false;
-}
-{
-  name = "liblayout-0.2.10.zip";
-  md5 = "db60e4fde8dd6d6807523deb71ee34dc";
-  brief = false;
-}
-{
-  name = "libloader-1.1.6.zip";
-  md5 = "97b2d4dba862397f446b217e2b623e71";
-  brief = false;
-}
-{
-  name = "librepository-1.1.6.zip";
-  md5 = "8ce2fcd72becf06c41f7201d15373ed9";
-  brief = false;
-}
-{
-  name = "libserializer-1.1.6.zip";
-  md5 = "f94d9870737518e3b597f9265f4e9803";
-  brief = false;
-}
-{
-  name = "libxml-1.1.7.zip";
-  md5 = "ace6ab49184e329db254e454a010f56d";
-  brief = false;
-}
-{
-  name = "sacjava-1.3.zip";
-  md5 = "39bb3fcea1514f1369fcfc87542390fd";
-  brief = false;
-}
-{
-  name = "jpegsrc.v9a.tar.gz";
-  md5 = "3353992aecaee1805ef4109aadd433e7";
-  brief = true;
-}
-{
-  name = "libjpeg-turbo-1.4.2.tar.gz";
-  md5 = "86b0d5f7507c2e6c21c00219162c3c44";
-  brief = true;
-}
-{
-  name = "language-subtag-registry-2016-02-10.tar.bz2";
-  md5 = "d1e7c55a0383f7d720d3ead0b6117284";
-  brief = true;
-}
-{
-  name = "JLanguageTool-1.7.0.tar.bz2";
-  md5 = "b63e6340a02ff1cacfeadb2c42286161";
-  brief = false;
-}
-{
-  name = "lcms2-2.6.tar.gz";
-  md5 = "f4c08d38ceade4a664ebff7228910a33";
-  brief = true;
-}
-{
-  name = "libatomic_ops-7_2d.zip";
-  md5 = "c0b86562d5aa40761a87134f83e6adcf";
-  brief = true;
-}
-{
-  name = "libeot-0.01.tar.bz2";
-  md5 = "aa24f5dd2a2992f4a116aa72af817548";
-  brief = true;
-}
-{
-  name = "libexttextcat-3.4.4.tar.bz2";
-  md5 = "10d61fbaa6a06348823651b1bd7940fe";
-  brief = false;
-}
-{
-  name = "libgltf-0.0.2.tar.bz2";
-  md5 = "d63a9f47ab048f5009d90693d6aa6424";
-  brief = true;
-  subDir = "libgltf/";
-}
-{
-  name = "liblangtag-0.5.8.tar.bz2";
-  md5 = "aa899eff126216dafe721149fbdb511b";
-  brief = false;
-}
-{
-  name = "xmlsec1-1.2.14.tar.gz";
-  md5 = "1f24ab1d39f4a51faf22244c94a6203f";
-  brief = false;
-}
-{
-  name = "libxml2-2.9.4.tar.gz";
-  md5 = "ae249165c173b1ff386ee8ad676815f5";
-  brief = false;
-}
-{
-  name = "libxslt-1.1.28.tar.gz";
-  md5 = "9667bf6f9310b957254fdcf6596600b7";
-  brief = false;
-}
-{
-  name = "lp_solve_5.5.tar.gz";
-  md5 = "26b3e95ddf3d9c077c480ea45874b3b8";
-  brief = false;
-}
-{
-  name = "mariadb_client-2.0.0-src.tar.gz";
-  md5 = "a233181e03d3c307668b4c722d881661";
-  brief = false;
-}
-{
-  name = "mdds_0.12.1.tar.bz2";
-  md5 = "ef2560ed5416652a7fe195305b14cebe";
-  brief = true;
-}
-{
-  name = "libmspub-0.1.2.tar.bz2";
-  md5 = "ff9d0f9dd8fbc523408ea1953d5bde41";
-  brief = true;
-}
-{
-  name = "libmwaw-0.3.7.tar.bz2";
-  md5 = "4a8a53a9d997cf0e2bd208178797dbfb";
-  brief = true;
-}
-{
-  name = "mysql-connector-c++-1.1.4.tar.gz";
-  md5 = "7239a4430efd4d0189c4f24df67f08e5";
-  brief = false;
-}
-{
-  name = "mythes-1.2.4.tar.gz";
-  md5 = "a8c2c5b8f09e7ede322d5c602ff6a4b6";
-  brief = false;
-}
-{
-  name = "neon-0.30.1.tar.gz";
-  md5 = "231adebe5c2f78fded3e3df6e958878e";
-  brief = false;
-}
-{
-  name = "nss-3.22.2-with-nspr-4.12.tar.gz";
-  md5 = "6b254cf2f8cb4b27a3f0b8b7b9966ea7";
-  brief = false;
-}
-{
-  name = "libodfgen-0.1.6.tar.bz2";
-  md5 = "32572ea48d9021bbd6fa317ddb697abc";
-  brief = true;
-}
-{
-  name = "OpenCOLLADA-master-6509aa13af.tar.bz2";
-  md5 = "4ca8a6ef0afeefc864e9ef21b9f14bd6";
-  brief = true;
-}
-{
-  name = "openldap-2.4.31.tgz";
-  md5 = "804c6cb5698db30b75ad0ff1c25baefd";
-  brief = false;
-}
-{
-  name = "openssl-1.0.2h.tar.gz";
-  md5 = "9392e65072ce4b614c1392eefc1f23d0";
-  brief = true;
-}
-{
-  name = "liborcus-0.9.2.tar.gz";
-  md5 = "e6efcbe50a5fd4d50d513c9a7a4139b0";
-  brief = true;
-}
-{
-  name = "owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
-  md5 = "593f0aa47bf2efc0efda2d28fae063b2";
-  brief = true;
-}
-{
-  name = "libpagemaker-0.0.2.tar.bz2";
-  md5 = "795cc7a59ace4db2b12586971d668671";
-  brief = true;
-}
-{
-  name = "pixman-0.24.4.tar.bz2";
-  md5 = "c63f411b3ad147db2bcce1bf262a0e02";
-  brief = false;
-}
-{
-  name = "libpng-1.6.19.tar.gz";
-  md5 = "3121bdc77c365a87e054b9f859f421fe";
-  brief = true;
-}
-{
-  name = "poppler-0.26.4.tar.gz";
-  md5 = "35c0660065d023365e9854c13e289d12";
-  brief = true;
-}
-{
-  name = "postgresql-9.2.1.tar.bz2";
-  md5 = "c0b4799ea9850eae3ead14f0a60e9418";
-  brief = false;
-}
-{
-  name = "Python-3.3.5.tgz";
-  md5 = "803a75927f8f241ca78633890c798021";
-  brief = true;
-}
-{
-  name = "Python-3.5.0.tgz";
-  md5 = "a56c0c0b45d75a0ec9c6dee933c41c36";
-  brief = true;
-}
-{
-  name = "raptor2-2.0.9.tar.gz";
-  md5 = "4ceb9316488b0ea01acf011023cf7fff";
-  brief = false;
-}
-{
-  name = "rasqal-0.9.30.tar.gz";
-  md5 = "b12c5f9cfdb6b04efce5a4a186b8416b";
-  brief = false;
-}
-{
-  name = "redland-1.0.16.tar.gz";
-  md5 = "32f8e1417a64d3c6f2c727f9053f55ea";
-  brief = false;
-}
-{
-  name = "librevenge-0.0.4.tar.bz2";
-  md5 = "5b9ac52ec77d4d19157cf5962ebc0aea";
-  brief = true;
-}
-{
-  name = "rhino1_5R5.zip";
-  md5 = "798b2ffdc8bcfe7bca2cf92b62caf685";
-  brief = false;
-}
-{
-  name = "serf-1.2.1.tar.bz2";
-  md5 = "4f8e76c9c6567aee1d66aba49f76a58b";
-  brief = true;
-}
-{
-  name = "swingExSrc.zip";
-  md5 = "35c94d2df8893241173de1d16b6034c0";
-  brief = false;
-}
-{
-  name = "ucpp-1.3.2.tar.gz";
-  md5 = "0168229624cfac409e766913506961a8";
-  brief = false;
-}
-{
-  name = "vigra1.6.0.tar.gz";
-  md5 = "d62650a6f908e85643e557a236ea989c";
-  brief = false;
-}
-{
-  name = "libvisio-0.1.5.tar.bz2";
-  md5 = "cbee198a78b842b2087f32d33c522818";
-  brief = true;
-}
-{
-  name = "libwpd-0.10.1.tar.bz2";
-  md5 = "79b56bcc349264d686a67994506ad199";
-  brief = true;
-}
-{
-  name = "libwpg-0.3.1.tar.bz2";
-  md5 = "dfd066658ec9d2fb2262417039a8a1c3";
-  brief = true;
-}
-{
-  name = "libwps-0.4.2.tar.bz2";
-  md5 = "8a6c55542ce80203dd6d3b1cba99d4e5";
-  brief = true;
-}
-{
-  name = "xsltml_2.1.2.zip";
-  md5 = "a7983f859eafb2677d7ff386a023bc40";
-  brief = false;
-}
-{
-  name = "zlib-1.2.8.tar.gz";
-  md5 = "44d667c142d7cda120332623eab69f40";
-  brief = true;
-}
+  {
+    name = "libabw-0.1.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libabw-0.1.1.tar.bz2";
+    sha256 = "7a3d3415cf82ab9894f601d1b3057c4615060304d5279efdec6275e01b96a199";
+  }
+  {
+    name = "commons-logging-1.2-src.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/commons-logging-1.2-src.tar.gz";
+    sha256 = "49665da5a60d033e6dff40fe0a7f9173e886ae859ce6096c1afe34c48b677c81";
+  }
+  {
+    name = "apr-1.4.8.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/apr-1.4.8.tar.gz";
+    sha256 = "1689e415bdfab6aaa41f07836b5dd9ed4901d22ddeb99feffdb2cee3124adf49";
+  }
+  {
+    name = "apr-util-1.5.3.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/apr-util-1.5.3.tar.gz";
+    sha256 = "76db34cb508e346e3bf69347c29ed1500bf0b71bcc48d54271ad9d1c25703743";
+  }
+  {
+    name = "boost_1_59_0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/boost_1_59_0.tar.bz2";
+    sha256 = "727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca";
+  }
+  {
+    name = "bsh-2.0b5-src.zip";
+    url = "http://dev-www.libreoffice.org/src/ec1941a74d3ef513c4ce57a9092b74e1-bsh-2.0b5-src.zip";
+    sha256 = "90993aa17a786996653fc5fcf148e879fb3689b8678f9ba99b376a5a13dff513";
+  }
+  {
+    name = "bzip2-1.0.6.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/00b516f4704d4a7cb50a1d97e6e8e15b-bzip2-1.0.6.tar.gz";
+    sha256 = "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd";
+  }
+  {
+    name = "cairo-1.10.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/f101a9e88b783337b20b2e26dfd26d5f-cairo-1.10.2.tar.gz";
+    sha256 = "32018c7998358eebc2ad578ff8d8559d34fc80252095f110a572ed23d989fc41";
+  }
+  {
+    name = "libcdr-0.1.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libcdr-0.1.2.tar.bz2";
+    sha256 = "d05a986dab9f960e64466072653a900d03f8257b084440d9d16599e16060581e";
+  }
+  {
+    name = "clucene-core-2.3.3.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz";
+    sha256 = "ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab";
+  }
+  {
+    name = "libcmis-0.5.0.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/5821b806a98e6c38370970e682ce76e8-libcmis-0.5.0.tar.gz";
+    sha256 = "a87e02913dee3ee659db5abf6d7dafcfcd85dd4b24bf4389d8d4afe8c8dcf9b6";
+  }
+  {
+    name = "CoinMP-1.7.6.tgz";
+    url = "http://dev-www.libreoffice.org/src/CoinMP-1.7.6.tgz";
+    sha256 = "86c798780b9e1f5921fe4efe651a93cb420623b45aa1fdff57af8c37f116113f";
+  }
+  {
+    name = "collada2gltf-master-cb1d97788a.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/4b87018f7fff1d054939d19920b751a0-collada2gltf-master-cb1d97788a.tar.bz2";
+    sha256 = "b0adb8e71aef80751b999c9c055e419a625c4a05184e407aef2aee28752ad8cb";
+  }
+  {
+    name = "cppunit-1.13.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz";
+    sha256 = "3f47d246e3346f2ba4d7c9e882db3ad9ebd3fcbd2e8b732f946e0e3eeb9f429f";
+  }
+  {
+    name = "converttexttonumber-1-5-0.oxt";
+    url = "http://dev-www.libreoffice.org/src/1f467e5bb703f12cbbb09d5cf67ecf4a-converttexttonumber-1-5-0.oxt";
+    sha256 = "71b238efd2734be9800af07566daea8d6685aeed28db5eb5fa0e6453f4d85de3";
+  }
+  {
+    name = "curl-7.43.0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/curl-7.43.0.tar.bz2";
+    sha256 = "baa654a1122530483ccc1c58cc112fec3724a82c11c6a389f1e6a37dc8858df9";
+  }
+  {
+    name = "libe-book-0.1.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libe-book-0.1.2.tar.bz2";
+    sha256 = "b710a57c633205b933015474d0ac0862253d1c52114d535dd09b20939a0d1850";
+  }
+  {
+    name = "epm-3.7.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/3ade8cfe7e59ca8e65052644fed9fca4-epm-3.7.tar.gz";
+    sha256 = "b3fc4c5445de6c9a801504a3ea3efb2d4ea9d5a622c9427e716736e7713ddb91";
+  }
+  {
+    name = "libetonyek-0.1.6.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libetonyek-0.1.6.tar.bz2";
+    sha256 = "032f53e8d7691e48a73ddbe74fa84c906ff6ff32a33e6ee2a935b6fdb6aecb78";
+  }
+  {
+    name = "expat-2.1.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/expat-2.1.1.tar.bz2";
+    sha256 = "aff584e5a2f759dcfc6d48671e9529f6afe1e30b0cd6a4cec200cbe3f793de67";
+  }
+  {
+    name = "Firebird-2.5.4.26856-0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/Firebird-2.5.4.26856-0.tar.bz2";
+    sha256 = "4e775dcf218640d3af507a816aef0060f52a295b9ee5f66ec66f0b0564da18d3";
+  }
+  {
+    name = "fontconfig-2.8.0.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/77e15a92006ddc2adbb06f840d591c0e-fontconfig-2.8.0.tar.gz";
+    sha256 = "fa2a1c6eea654d9fce7a4b1220f10c99cdec848dccaf1625c01f076b31382335";
+  }
+  {
+    name = "crosextrafonts-20130214.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/368f114c078f94214a308a74c7e991bc-crosextrafonts-20130214.tar.gz";
+    sha256 = "c48d1c2fd613c9c06c959c34da7b8388059e2408d2bb19845dc3ed35f76e4d09";
+  }
+  {
+    name = "crosextrafonts-carlito-20130920.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/c74b7223abe75949b4af367942d96c7a-crosextrafonts-carlito-20130920.tar.gz";
+    sha256 = "4bd12b6cbc321c1cf16da76e2c585c925ce956a08067ae6f6c64eff6ccfdaf5a";
+  }
+  {
+    name = "dejavu-fonts-ttf-2.35.zip";
+    url = "http://dev-www.libreoffice.org/src/d8b5214d35bcd2bfcb2cffa7795b351d-dejavu-fonts-ttf-2.35.zip";
+    sha256 = "7e0d00f20080784c3a38a845d5858c161af14f0073d9474cdbfdedae883cc747";
+  }
+  {
+    name = "gentiumbasic-fonts-1.10.zip";
+    url = "http://dev-www.libreoffice.org/src/35efabc239af896dfb79be7ebdd6e6b9-gentiumbasic-fonts-1.10.zip";
+    sha256 = "f1691e48d02effdee0701622297394451759f13e0e0b36e788847f4b3e2ba11b";
+  }
+  {
+    name = "liberation-fonts-ttf-1.07.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/134d8262145fc793c6af494dcace3e71-liberation-fonts-ttf-1.07.4.tar.gz";
+    sha256 = "61a7e2b6742a43c73e8762cdfeaf6dfcf9abdd2cfa0b099a9854d69bc4cfee5c";
+  }
+  {
+    name = "liberation-fonts-ttf-2.00.1.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/5c781723a0d9ed6188960defba8e91cf-liberation-fonts-ttf-2.00.1.tar.gz";
+    sha256 = "7890278a6cd17873c57d9cd785c2d230d9abdea837e96516019c5885dd271504";
+  }
+  {
+    name = "LinLibertineG-20120116.zip";
+    url = "http://dev-www.libreoffice.org/src/e7a384790b13c29113e22e596ade9687-LinLibertineG-20120116.zip";
+    sha256 = "54adcb2bc8cac0927a647fbd9362f45eff48130ce6e2379dc3867643019e08c5";
+  }
+  {
+    name = "open-sans-font-ttf-1.10.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/7a15edea7d415ac5150ea403e27401fd-open-sans-font-ttf-1.10.tar.gz";
+    sha256 = "cc80fd415e57ecec067339beadd0eef9eaa45e65d3c51a922ba5f9172779bfb8";
+  }
+  {
+    name = "pt-serif-font-1.0000W.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/c3c1a8ba7452950636e871d25020ce0d-pt-serif-font-1.0000W.tar.gz";
+    sha256 = "6757feb23f889a82df59679d02b8ee1f907df0a0ac1c49cdb48ed737b60e5dfa";
+  }
+  {
+    name = "source-code-font-1.009.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/0279a21fab6f245e85a6f85fea54f511-source-code-font-1.009.tar.gz";
+    sha256 = "9b295127164c81bcf28c7ebb687f1555b71796108b443a04d40202b7364e4cce";
+  }
+  {
+    name = "source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
+    sha256 = "e7bc9a1fec787a529e49f5a26b93dcdcf41506449dfc70f92cdef6d17eb6fb61";
+  }
+  {
+    name = "libfreehand-0.1.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libfreehand-0.1.1.tar.bz2";
+    sha256 = "45dab0e5d632eb51eeb00847972ca03835d6791149e9e714f093a9df2b445877";
+  }
+  {
+    name = "freetype-2.4.8.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/dbf2caca1d3afd410a29217a9809d397-freetype-2.4.8.tar.bz2";
+    sha256 = "a9eb7da3875fcb2f022a9c280c01b94ae45ac83d8102838c05dce1277948fb71";
+  }
+  {
+    name = "glew-1.12.0.zip";
+    url = "http://dev-www.libreoffice.org/src/3941e9cab2f4f9d8faee3e8d57ae7664-glew-1.12.0.zip";
+    sha256 = "6f1083eb034efbc3b2017ef052d58f3e9bd70963ec2acd26b3d59231ee1633d4";
+  }
+  {
+    name = "glm-0.9.4.6-libreoffice.zip";
+    url = "http://dev-www.libreoffice.org/src/bae83fa5dc7f081768daace6e199adc3-glm-0.9.4.6-libreoffice.zip";
+    sha256 = "d0312c360efe04dd048b3311fe375ff36f1993b4c2e3cb58c81062990532904a";
+  }
+  {
+    name = "glyphy-0.2.0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/5d303fb955beb9bf112267316ca9d021-glyphy-0.2.0.tar.bz2";
+    sha256 = "9a8f629f7ea40ba118199a37adee8f2dfb084cffa5f7f4db3a47b8b0075777be";
+  }
+  {
+    name = "graphite-minimal-1.3.6.tgz";
+    url = "http://dev-www.libreoffice.org/src/17df8301bcc459e83f8a8f3aca6183b2-graphite-minimal-1.3.6.tgz";
+    sha256 = "db27e1a6092b8ea00b5f8eec2a3ea500756fbb769c1023a1afc3386c5918d1b8";
+  }
+  {
+    name = "harfbuzz-0.9.40.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/harfbuzz-0.9.40.tar.bz2";
+    sha256 = "1771d53583be6d91ca961854b2a24fb239ef0545eed221ae3349abae0ab8321f";
+  }
+  {
+    name = "hsqldb_1_8_0.zip";
+    url = "http://dev-www.libreoffice.org/src/17410483b5b5f267aa18b7e00b65e6e0-hsqldb_1_8_0.zip";
+    sha256 = "d30b13f4ba2e3b6a2d4f020c0dee0a9fb9fc6fbcc2d561f36b78da4bf3802370";
+  }
+  {
+    name = "hunspell-1.3.3.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/4967da60b23413604c9e563beacc63b4-hunspell-1.3.3.tar.gz";
+    sha256 = "a7b2c0de0e2ce17426821dc1ac8eb115029959b3ada9d80a81739fa19373246c";
+  }
+  {
+    name = "hyphen-2.8.8.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
+    sha256 = "304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705";
+  }
+  {
+    name = "icu4c-56_1-src.tgz";
+    url = "http://dev-www.libreoffice.org/src/c4a2d71ff56aec5ebfab2a3f059be99d-icu4c-56_1-src.tgz";
+    sha256 = "3a64e9105c734dcf631c0b3ed60404531bce6c0f5a64bfe1a6402a4cc2314816";
+  }
+  {
+    name = "flow-engine-0.9.4.zip";
+    url = "http://dev-www.libreoffice.org/src/ba2930200c9f019c2d93a8c88c651a0f-flow-engine-0.9.4.zip";
+    sha256 = "233f66e8d25c5dd971716d4200203a612a407649686ef3b52075d04b4c9df0dd";
+  }
+  {
+    name = "flute-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/d8bd5eed178db6e2b18eeed243f85aa8-flute-1.1.6.zip";
+    sha256 = "1b5b24f7bc543c0362b667692f78db8bab4ed6dafc6172f104d0bd3757d8a133";
+  }
+  {
+    name = "libbase-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/eeb2c7ddf0d302fba4bfc6e97eac9624-libbase-1.1.6.zip";
+    sha256 = "75c80359c9ce343c20aab8a36a45cb3b9ee7c61cf92c13ae45399d854423a9ba";
+  }
+  {
+    name = "libfonts-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/3bdf40c0d199af31923e900d082ca2dd-libfonts-1.1.6.zip";
+    sha256 = "e0531091787c0f16c83965fdcbc49162c059d7f0c64669e7f119699321549743";
+  }
+  {
+    name = "libformula-1.1.7.zip";
+    url = "http://dev-www.libreoffice.org/src/3404ab6b1792ae5f16bbd603bd1e1d03-libformula-1.1.7.zip";
+    sha256 = "5826d1551bf599b85742545f6e01a0079b93c1b2c8434bf409eddb3a29e4726b";
+  }
+  {
+    name = "liblayout-0.2.10.zip";
+    url = "http://dev-www.libreoffice.org/src/db60e4fde8dd6d6807523deb71ee34dc-liblayout-0.2.10.zip";
+    sha256 = "e1fb87f3f7b980d33414473279615c4644027e013012d156efa538bc2b031772";
+  }
+  {
+    name = "libloader-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/97b2d4dba862397f446b217e2b623e71-libloader-1.1.6.zip";
+    sha256 = "3d853b19b1d94a6efa69e7af90f7f2b09ecf302913bee3da796c15ecfebcfac8";
+  }
+  {
+    name = "librepository-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/8ce2fcd72becf06c41f7201d15373ed9-librepository-1.1.6.zip";
+    sha256 = "abe2c57ac12ba45d83563b02e240fa95d973376de2f720aab8fe11f2e621c095";
+  }
+  {
+    name = "libserializer-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/f94d9870737518e3b597f9265f4e9803-libserializer-1.1.6.zip";
+    sha256 = "05640a1f6805b2b2d7e2cb9c50db9a5cb084e3c52ab1a71ce015239b4a1d4343";
+  }
+  {
+    name = "libxml-1.1.7.zip";
+    url = "http://dev-www.libreoffice.org/src/ace6ab49184e329db254e454a010f56d-libxml-1.1.7.zip";
+    sha256 = "7d2797fe9f79a77009721e3f14fa4a1dec17a6d706bdc93f85f1f01d124fab66";
+  }
+  {
+    name = "sacjava-1.3.zip";
+    url = "http://dev-www.libreoffice.org/src/39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip";
+    sha256 = "085f2112c51fa8c1783fac12fbd452650596415121348393bb51f0f7e85a9045";
+  }
+  {
+    name = "jpegsrc.v9a.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/jpegsrc.v9a.tar.gz";
+    sha256 = "3a753ea48d917945dd54a2d97de388aa06ca2eb1066cbfdc6652036349fe05a7";
+  }
+  {
+    name = "libjpeg-turbo-1.4.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/libjpeg-turbo-1.4.2.tar.gz";
+    sha256 = "521bb5d3043e7ac063ce3026d9a59cc2ab2e9636c655a2515af5f4706122233e";
+  }
+  {
+    name = "language-subtag-registry-2016-02-10.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/language-subtag-registry-2016-02-10.tar.bz2";
+    sha256 = "1e3a74b39e999bc9ff9fb0dd6fa6a64a0ed6bf7f0775ff3756e7c9e8db45a353";
+  }
+  {
+    name = "JLanguageTool-1.7.0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/b63e6340a02ff1cacfeadb2c42286161-JLanguageTool-1.7.0.tar.bz2";
+    sha256 = "48c87e41636783bba438b65fd895821e369ed139e1465fac654323ad93c5a82d";
+  }
+  {
+    name = "lcms2-2.6.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/lcms2-2.6.tar.gz";
+    sha256 = "5172528839647c54c3da211837225e221be93e4733f5b5e9f57668f7107e14b1";
+  }
+  {
+    name = "libatomic_ops-7_2d.zip";
+    url = "http://dev-www.libreoffice.org/src/libatomic_ops-7_2d.zip";
+    sha256 = "cf5c52f08a2067ae4fe7c8919e3c1ccf3ee917f1749e0bcc7efffff59c68d9ad";
+  }
+  {
+    name = "libeot-0.01.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libeot-0.01.tar.bz2";
+    sha256 = "cf5091fa8e7dcdbe667335eb90a2cfdd0a3fe8f8c7c8d1ece44d9d055736a06a";
+  }
+  {
+    name = "libexttextcat-3.4.4.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/10d61fbaa6a06348823651b1bd7940fe-libexttextcat-3.4.4.tar.bz2";
+    sha256 = "9595601c41051356d03d0a7d5dcad334fe1b420d221f6885d143c14bb8d62163";
+  }
+  {
+    name = "libgltf-0.0.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libgltf/libgltf-0.0.2.tar.bz2";
+    sha256 = "d1cc7297ed1921aa969e26413b4c4e18afc882ce4d2f5a2aa2a2905706f7206b";
+  }
+  {
+    name = "liblangtag-0.5.8.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/aa899eff126216dafe721149fbdb511b-liblangtag-0.5.8.tar.bz2";
+    sha256 = "08e2f64bfe3f750be7391eb0af53967e164b628c59f02be4d83789eb4f036eaa";
+  }
+  {
+    name = "xmlsec1-1.2.14.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/1f24ab1d39f4a51faf22244c94a6203f-xmlsec1-1.2.14.tar.gz";
+    sha256 = "390a5085651828b8fe12aa978b200f59b9155eedbb91a4be89bf7cf39eefdd4a";
+  }
+  {
+    name = "libxml2-2.9.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/ae249165c173b1ff386ee8ad676815f5-libxml2-2.9.4.tar.gz";
+    sha256 = "ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c";
+  }
+  {
+    name = "libxslt-1.1.28.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/9667bf6f9310b957254fdcf6596600b7-libxslt-1.1.28.tar.gz";
+    sha256 = "5fc7151a57b89c03d7b825df5a0fae0a8d5f05674c0e7cf2937ecec4d54a028c";
+  }
+  {
+    name = "lp_solve_5.5.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/26b3e95ddf3d9c077c480ea45874b3b8-lp_solve_5.5.tar.gz";
+    sha256 = "171816288f14215c69e730f7a4f1c325739873e21f946ff83884b350574e6695";
+  }
+  {
+    name = "mariadb_client-2.0.0-src.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/a233181e03d3c307668b4c722d881661-mariadb_client-2.0.0-src.tar.gz";
+    sha256 = "fd2f751dea049c1907735eb236aeace1d811d6a8218118b00bbaa9b84dc5cd60";
+  }
+  {
+    name = "mdds_0.12.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/mdds_0.12.1.tar.bz2";
+    sha256 = "23565e9d7810a6ac30478833813db847f80e927b414a7be07b7cc03ed3aae83d";
+  }
+  {
+    name = "libmspub-0.1.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libmspub-0.1.2.tar.bz2";
+    sha256 = "26d488527ffbb0b41686d4bab756e3e6aaeb99f88adeb169d0c16d2cde96859a";
+  }
+  {
+    name = "libmwaw-0.3.7.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libmwaw-0.3.7.tar.bz2";
+    sha256 = "a66b3e45a5ba5dd89849a766e128585cac8aaf9e9c6f037040200e5bf31f1427";
+  }
+  {
+    name = "mysql-connector-c++-1.1.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/7239a4430efd4d0189c4f24df67f08e5-mysql-connector-c++-1.1.4.tar.gz";
+    sha256 = "a25f14dad39e93a2f9cdf09166ee53981f7212dce829e4208e07a522963a8585";
+  }
+  {
+    name = "mythes-1.2.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
+    sha256 = "1e81f395d8c851c3e4e75b568e20fa2fa549354e75ab397f9de4b0e0790a305f";
+  }
+  {
+    name = "neon-0.30.1.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/231adebe5c2f78fded3e3df6e958878e-neon-0.30.1.tar.gz";
+    sha256 = "00c626c0dc18d094ab374dbd9a354915bfe4776433289386ed489c2ec0845cdd";
+  }
+  {
+    name = "nss-3.22.2-with-nspr-4.12.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/6b254cf2f8cb4b27a3f0b8b7b9966ea7-nss-3.22.2-with-nspr-4.12.tar.gz";
+    sha256 = "7bc7e5483fc90071be5facd3043f94c69b153055a369c8f0b751ad374c5ae09e";
+  }
+  {
+    name = "libodfgen-0.1.6.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libodfgen-0.1.6.tar.bz2";
+    sha256 = "2c7b21892f84a4c67546f84611eccdad6259875c971e98ddb027da66ea0ac9c2";
+  }
+  {
+    name = "OpenCOLLADA-master-6509aa13af.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/OpenCOLLADA-master-6509aa13af.tar.bz2";
+    sha256 = "8f25d429237cde289a448c82a0a830791354ccce5ee40d77535642e46367d6c4";
+  }
+  {
+    name = "openldap-2.4.31.tgz";
+    url = "http://dev-www.libreoffice.org/src/804c6cb5698db30b75ad0ff1c25baefd-openldap-2.4.31.tgz";
+    sha256 = "bde845840df4794b869a6efd6a6b1086f80989038e4844b2e4d7d6b57b39c5b6";
+  }
+  {
+    name = "openssl-1.0.2h.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/openssl-1.0.2h.tar.gz";
+    sha256 = "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919";
+  }
+  {
+    name = "liborcus-0.9.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/liborcus-0.9.2.tar.gz";
+    sha256 = "adcf90f6cb1e6546ef1ea11277db39cb875786ea4b283e37f5e37c8c09b4952b";
+  }
+  {
+    name = "owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
+    sha256 = "b18b3e3ef7fae6a79b62f2bb43cc47a5346b6330f6a383dc4be34439aca5e9fb";
+  }
+  {
+    name = "libpagemaker-0.0.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libpagemaker-0.0.2.tar.bz2";
+    sha256 = "43be46721affcb5a967406c09acfc36c79d2d968917fe36a21cc004230a01e0f";
+  }
+  {
+    name = "pixman-0.24.4.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/c63f411b3ad147db2bcce1bf262a0e02-pixman-0.24.4.tar.bz2";
+    sha256 = "3d1bf79329be76103c7d9632a79962178364371807104a10e5f63ae0551731dc";
+  }
+  {
+    name = "libpng-1.6.19.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/libpng-1.6.19.tar.gz";
+    sha256 = "9f977ac8e4e3d4d5b001b32243f111eeec21bb6b59e583f2fb41fd2e48840352";
+  }
+  {
+    name = "poppler-0.26.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/poppler-0.26.4.tar.gz";
+    sha256 = "e05a4d8d8252a564ec7a96a99af772042b2d85275ffda8043f427dde31e97fe8";
+  }
+  {
+    name = "postgresql-9.2.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/c0b4799ea9850eae3ead14f0a60e9418-postgresql-9.2.1.tar.bz2";
+    sha256 = "db61d498105a7d5fe46185e67ac830c878cdd7dc1f82a87f06b842217924c461";
+  }
+  {
+    name = "Python-3.3.5.tgz";
+    url = "http://dev-www.libreoffice.org/src/Python-3.3.5.tgz";
+    sha256 = "916bc57dd8524dc27429bebae7b39d6942742cf9699b875b2b496a3d960c7168";
+  }
+  {
+    name = "Python-3.5.0.tgz";
+    url = "http://dev-www.libreoffice.org/src/Python-3.5.0.tgz";
+    sha256 = "584e3d5a02692ca52fce505e68ecd77248a6f2c99adf9db144a39087336b0fe0";
+  }
+  {
+    name = "raptor2-2.0.9.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/4ceb9316488b0ea01acf011023cf7fff-raptor2-2.0.9.tar.gz";
+    sha256 = "e26fb9c18e6ebf71100f434070d50196a21d592b715e361850c3b4e789b5f6ef";
+  }
+  {
+    name = "rasqal-0.9.30.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/b12c5f9cfdb6b04efce5a4a186b8416b-rasqal-0.9.30.tar.gz";
+    sha256 = "abf0e93d80cc79bdf383fd3e904255bf98bc729356d6cf2f673bce74b08b1cfd";
+  }
+  {
+    name = "redland-1.0.16.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/32f8e1417a64d3c6f2c727f9053f55ea-redland-1.0.16.tar.gz";
+    sha256 = "d9a274fc086e61119d5c9beafb8d05527e040ec86f4c0961276ca8de0a049dbd";
+  }
+  {
+    name = "librevenge-0.0.4.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/librevenge-0.0.4.tar.bz2";
+    sha256 = "c51601cd08320b75702812c64aae0653409164da7825fd0f451ac2c5dbe77cbf";
+  }
+  {
+    name = "rhino1_5R5.zip";
+    url = "http://dev-www.libreoffice.org/src/798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip";
+    sha256 = "1fb458d6aab06932693cc8a9b6e4e70944ee1ff052fa63606e3131df34e21753";
+  }
+  {
+    name = "serf-1.2.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/serf-1.2.1.tar.bz2";
+    sha256 = "6988d394b62c3494635b6f0760bc3079f9a0cd380baf0f6b075af1eb9fa5e700";
+  }
+  {
+    name = "swingExSrc.zip";
+    url = "http://dev-www.libreoffice.org/src/35c94d2df8893241173de1d16b6034c0-swingExSrc.zip";
+    sha256 = "64585ac36a81291a58269ec5347e7e3e2e8596dbacb9221015c208191333c6e1";
+  }
+  {
+    name = "ucpp-1.3.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz";
+    sha256 = "983941d31ee8d366085cadf28db75eb1f5cb03ba1e5853b98f12f7f51c63b776";
+  }
+  {
+    name = "vigra1.6.0.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/d62650a6f908e85643e557a236ea989c-vigra1.6.0.tar.gz";
+    sha256 = "1f188ac03a8aa4663223eca8c82f91a55293d066d67127082e29a7dba1a98c9f";
+  }
+  {
+    name = "libvisio-0.1.5.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libvisio-0.1.5.tar.bz2";
+    sha256 = "b83b7991a40b4e7f07d0cac7bb46ddfac84dece705fd18e21bfd119a09be458e";
+  }
+  {
+    name = "libwpd-0.10.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libwpd-0.10.1.tar.bz2";
+    sha256 = "efc20361d6e43f9ff74de5f4d86c2ce9c677693f5da08b0a88d603b7475a508d";
+  }
+  {
+    name = "libwpg-0.3.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libwpg-0.3.1.tar.bz2";
+    sha256 = "29049b95895914e680390717a243b291448e76e0f82fb4d2479adee5330fbb59";
+  }
+  {
+    name = "libwps-0.4.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libwps-0.4.2.tar.bz2";
+    sha256 = "254b8aeb36a3b58eabf682b04a5a6cf9b01267e762c7dc57d4533b95f30dc587";
+  }
+  {
+    name = "xsltml_2.1.2.zip";
+    url = "http://dev-www.libreoffice.org/src/a7983f859eafb2677d7ff386a023bc40-xsltml_2.1.2.zip";
+    sha256 = "75823776fb51a9c526af904f1503a7afaaab900fba83eda64f8a41073724c870";
+  }
+  {
+    name = "zlib-1.2.8.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/zlib-1.2.8.tar.gz";
+    sha256 = "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d";
+  }
 ]

--- a/pkgs/applications/office/libreoffice/libreoffice-srcs.nix
+++ b/pkgs/applications/office/libreoffice/libreoffice-srcs.nix
@@ -1,533 +1,532 @@
 [
-{
-  name = "libabw-0.1.1.tar.bz2";
-  md5 = "7a3815b506d064313ba309617b6f5a0b";
-  brief = true;
-}
-{
-  name = "commons-logging-1.2-src.tar.gz";
-  md5 = "ce977548f1cbf46918e93cd38ac35163";
-  brief = true;
-}
-{
-  name = "apr-1.4.8.tar.gz";
-  md5 = "eff9d741b0999a9bbab96862dd2a2a3d";
-  brief = true;
-}
-{
-  name = "apr-util-1.5.3.tar.gz";
-  md5 = "71a11d037240b292f824ba1eb537b4e3";
-  brief = true;
-}
-{
-  name = "boost_1_60_0.tar.bz2";
-  md5 = "65a840e1a0b13a558ff19eeb2c4f0cbe";
-  brief = true;
-}
-{
-  name = "breakpad.zip";
-  md5 = "415ce291aa6f2ee1d5db7b62bf62ade8";
-  brief = true;
-}
-{
-  name = "bsh-2.0b6-src.zip";
-  md5 = "beeca87be45ec87d241ddd0e1bad80c1";
-  brief = false;
-}
-{
-  name = "bzip2-1.0.6.tar.gz";
-  md5 = "00b516f4704d4a7cb50a1d97e6e8e15b";
-  brief = false;
-}
-{
-  name = "cairo-1.10.2.tar.gz";
-  md5 = "f101a9e88b783337b20b2e26dfd26d5f";
-  brief = false;
-}
-{
-  name = "libcdr-0.1.2.tar.bz2";
-  md5 = "6e3062b55b149d7b3c6aedb3bb5b86e2";
-  brief = true;
-}
-{
-  name = "clucene-core-2.3.3.4.tar.gz";
-  md5 = "48d647fbd8ef8889e5a7f422c1bfda94";
-  brief = false;
-}
-{
-  name = "libcmis-0.5.1.tar.gz";
-  md5 = "3270154f0f40d86fce849b161f914101";
-  brief = true;
-}
-{
-  name = "CoinMP-1.7.6.tgz";
-  md5 = "1cce53bf4b40ae29790d2c5c9f8b1129";
-  brief = true;
-}
-{
-  name = "collada2gltf-master-cb1d97788a.tar.bz2";
-  md5 = "4b87018f7fff1d054939d19920b751a0";
-  brief = false;
-}
-{
-  name = "cppunit-1.13.2.tar.gz";
-  md5 = "d1c6bdd5a76c66d2c38331e2d287bc01";
-  brief = true;
-}
-{
-  name = "converttexttonumber-1-5-0.oxt";
-  md5 = "1f467e5bb703f12cbbb09d5cf67ecf4a";
-  brief = false;
-}
-{
-  name = "curl-7.43.0.tar.bz2";
-  md5 = "11bddbb452a8b766b932f859aaeeed39";
-  brief = true;
-}
-{
-  name = "libe-book-0.1.2.tar.bz2";
-  md5 = "6b48eda57914e6343efebc9381027b78";
-  brief = true;
-}
-{
-  name = "epm-3.7.tar.gz";
-  md5 = "3ade8cfe7e59ca8e65052644fed9fca4";
-  brief = false;
-}
-{
-  name = "libetonyek-0.1.6.tar.bz2";
-  md5 = "77ff46936dcc83670557274e7dd2aa33";
-  brief = true;
-}
-{
-  name = "expat-2.2.0.tar.bz2";
-  md5 = "2f47841c829facb346eb6e3fab5212e2";
-  brief = true;
-}
-{
-  name = "Firebird-2.5.5.26952-0.tar.bz2";
-  md5 = "b0b5293991fcf07347b38431c80be1d4";
-  brief = true;
-}
-{
-  name = "fontconfig-2.8.0.tar.gz";
-  md5 = "77e15a92006ddc2adbb06f840d591c0e";
-  brief = false;
-}
-{
-  name = "crosextrafonts-20130214.tar.gz";
-  md5 = "368f114c078f94214a308a74c7e991bc";
-  brief = false;
-}
-{
-  name = "crosextrafonts-carlito-20130920.tar.gz";
-  md5 = "c74b7223abe75949b4af367942d96c7a";
-  brief = false;
-}
-{
-  name = "dejavu-fonts-ttf-2.35.zip";
-  md5 = "d8b5214d35bcd2bfcb2cffa7795b351d";
-  brief = false;
-}
-{
-  name = "gentiumbasic-fonts-1.10.zip";
-  md5 = "35efabc239af896dfb79be7ebdd6e6b9";
-  brief = false;
-}
-{
-  name = "liberation-fonts-ttf-1.07.4.tar.gz";
-  md5 = "134d8262145fc793c6af494dcace3e71";
-  brief = false;
-}
-{
-  name = "liberation-fonts-ttf-2.00.1.tar.gz";
-  md5 = "5c781723a0d9ed6188960defba8e91cf";
-  brief = false;
-}
-{
-  name = "LinLibertineG-20120116.zip";
-  md5 = "e7a384790b13c29113e22e596ade9687";
-  brief = false;
-}
-{
-  name = "open-sans-font-ttf-1.10.tar.gz";
-  md5 = "7a15edea7d415ac5150ea403e27401fd";
-  brief = false;
-}
-{
-  name = "pt-serif-font-1.0000W.tar.gz";
-  md5 = "c3c1a8ba7452950636e871d25020ce0d";
-  brief = false;
-}
-{
-  name = "source-code-font-1.009.tar.gz";
-  md5 = "0279a21fab6f245e85a6f85fea54f511";
-  brief = false;
-}
-{
-  name = "source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
-  md5 = "edc4d741888bc0d38e32dbaa17149596";
-  brief = false;
-}
-{
-  name = "libfreehand-0.1.1.tar.bz2";
-  md5 = "8cf70c5dc4d24d2dc4a107f509d2d6d7";
-  brief = true;
-}
-{
-  name = "freetype-2.4.8.tar.bz2";
-  md5 = "dbf2caca1d3afd410a29217a9809d397";
-  brief = false;
-}
-{
-  name = "glew-1.12.0.zip";
-  md5 = "3941e9cab2f4f9d8faee3e8d57ae7664";
-  brief = false;
-}
-{
-  name = "glm-0.9.4.6-libreoffice.zip";
-  md5 = "bae83fa5dc7f081768daace6e199adc3";
-  brief = false;
-}
-{
-  name = "glyphy-0.2.0.tar.bz2";
-  md5 = "5d303fb955beb9bf112267316ca9d021";
-  brief = false;
-}
-{
-  name = "graphite2-minimal-1.3.8.tgz";
-  md5 = "4311dd9ace498b57c85f611e0670df64";
-  brief = false;
-}
-{
-  name = "harfbuzz-1.2.6.tar.bz2";
-  md5 = "9f4b6831c86135faef011e991f59f77f";
-  brief = true;
-}
-{
-  name = "hsqldb_1_8_0.zip";
-  md5 = "17410483b5b5f267aa18b7e00b65e6e0";
-  brief = false;
-}
-{
-  name = "hunspell-1.4.1.tar.gz";
-  md5 = "33d370f7fe5a030985e445a5672b2067";
-  brief = false;
-}
-{
-  name = "hyphen-2.8.8.tar.gz";
-  md5 = "5ade6ae2a99bc1e9e57031ca88d36dad";
-  brief = false;
-}
-{
-  name = "icu4c-57_1-src.tgz";
-  md5 = "976734806026a4ef8bdd17937c8898b9";
-  brief = false;
-}
-{
-  name = "flow-engine-0.9.4.zip";
-  md5 = "ba2930200c9f019c2d93a8c88c651a0f";
-  brief = false;
-}
-{
-  name = "flute-1.1.6.zip";
-  md5 = "d8bd5eed178db6e2b18eeed243f85aa8";
-  brief = false;
-}
-{
-  name = "libbase-1.1.6.zip";
-  md5 = "eeb2c7ddf0d302fba4bfc6e97eac9624";
-  brief = false;
-}
-{
-  name = "libfonts-1.1.6.zip";
-  md5 = "3bdf40c0d199af31923e900d082ca2dd";
-  brief = false;
-}
-{
-  name = "libformula-1.1.7.zip";
-  md5 = "3404ab6b1792ae5f16bbd603bd1e1d03";
-  brief = false;
-}
-{
-  name = "liblayout-0.2.10.zip";
-  md5 = "db60e4fde8dd6d6807523deb71ee34dc";
-  brief = false;
-}
-{
-  name = "libloader-1.1.6.zip";
-  md5 = "97b2d4dba862397f446b217e2b623e71";
-  brief = false;
-}
-{
-  name = "librepository-1.1.6.zip";
-  md5 = "8ce2fcd72becf06c41f7201d15373ed9";
-  brief = false;
-}
-{
-  name = "libserializer-1.1.6.zip";
-  md5 = "f94d9870737518e3b597f9265f4e9803";
-  brief = false;
-}
-{
-  name = "libxml-1.1.7.zip";
-  md5 = "ace6ab49184e329db254e454a010f56d";
-  brief = false;
-}
-{
-  name = "sacjava-1.3.zip";
-  md5 = "39bb3fcea1514f1369fcfc87542390fd";
-  brief = false;
-}
-{
-  name = "jpegsrc.v9a.tar.gz";
-  md5 = "3353992aecaee1805ef4109aadd433e7";
-  brief = true;
-}
-{
-  name = "libjpeg-turbo-1.4.2.tar.gz";
-  md5 = "86b0d5f7507c2e6c21c00219162c3c44";
-  brief = true;
-}
-{
-  name = "language-subtag-registry-2016-07-19.tar.bz2";
-  md5 = "8a037dc60b16bf8c5fe871b33390a4a2";
-  brief = true;
-}
-{
-  name = "JLanguageTool-1.7.0.tar.bz2";
-  md5 = "b63e6340a02ff1cacfeadb2c42286161";
-  brief = false;
-}
-{
-  name = "lcms2-2.6.tar.gz";
-  md5 = "f4c08d38ceade4a664ebff7228910a33";
-  brief = true;
-}
-{
-  name = "libatomic_ops-7_2d.zip";
-  md5 = "c0b86562d5aa40761a87134f83e6adcf";
-  brief = true;
-}
-{
-  name = "libeot-0.01.tar.bz2";
-  md5 = "aa24f5dd2a2992f4a116aa72af817548";
-  brief = true;
-}
-{
-  name = "libexttextcat-3.4.4.tar.bz2";
-  md5 = "10d61fbaa6a06348823651b1bd7940fe";
-  brief = false;
-}
-{
-  name = "libgltf-0.0.2.tar.bz2";
-  md5 = "d63a9f47ab048f5009d90693d6aa6424";
-  brief = true;
-  subDir = "libgltf/";
-}
-{
-  name = "liblangtag-0.5.8.tar.bz2";
-  md5 = "aa899eff126216dafe721149fbdb511b";
-  brief = false;
-}
-{
-  name = "xmlsec1-1.2.20.tar.gz";
-  md5 = "ce12af00283eb90d9281956524250d6e";
-  brief = false;
-}
-{
-  name = "libxml2-2.9.4.tar.gz";
-  md5 = "ae249165c173b1ff386ee8ad676815f5";
-  brief = false;
-}
-{
-  name = "libxslt-1.1.29.tar.gz";
-  md5 = "a129d3c44c022de3b9dcf6d6f288d72e";
-  brief = false;
-}
-{
-  name = "lp_solve_5.5.tar.gz";
-  md5 = "26b3e95ddf3d9c077c480ea45874b3b8";
-  brief = false;
-}
-{
-  name = "mariadb_client-2.0.0-src.tar.gz";
-  md5 = "a233181e03d3c307668b4c722d881661";
-  brief = false;
-}
-{
-  name = "mdds-1.2.0.tar.bz2";
-  md5 = "9f3383fb7bae825eab69f3a6ec1d74b2";
-  brief = true;
-}
-{
-  name = "mDNSResponder-576.30.4.tar.gz";
-  md5 = "940057ac8b513b00e8e9ca12ef796762";
-  brief = true;
-}
-{
-  name = "libmspub-0.1.2.tar.bz2";
-  md5 = "ff9d0f9dd8fbc523408ea1953d5bde41";
-  brief = true;
-}
-{
-  name = "libmwaw-0.3.7.tar.bz2";
-  md5 = "4a8a53a9d997cf0e2bd208178797dbfb";
-  brief = true;
-}
-{
-  name = "mysql-connector-c++-1.1.4.tar.gz";
-  md5 = "7239a4430efd4d0189c4f24df67f08e5";
-  brief = false;
-}
-{
-  name = "mythes-1.2.4.tar.gz";
-  md5 = "a8c2c5b8f09e7ede322d5c602ff6a4b6";
-  brief = false;
-}
-{
-  name = "neon-0.30.1.tar.gz";
-  md5 = "231adebe5c2f78fded3e3df6e958878e";
-  brief = false;
-}
-{
-  name = "nss-3.22.2-with-nspr-4.12.tar.gz";
-  md5 = "6b254cf2f8cb4b27a3f0b8b7b9966ea7";
-  brief = false;
-}
-{
-  name = "libodfgen-0.1.6.tar.bz2";
-  md5 = "32572ea48d9021bbd6fa317ddb697abc";
-  brief = true;
-}
-{
-  name = "OpenCOLLADA-master-6509aa13af.tar.bz2";
-  md5 = "4ca8a6ef0afeefc864e9ef21b9f14bd6";
-  brief = true;
-}
-{
-  name = "openldap-2.4.31.tgz";
-  md5 = "804c6cb5698db30b75ad0ff1c25baefd";
-  brief = false;
-}
-{
-  name = "openssl-1.0.2h.tar.gz";
-  md5 = "9392e65072ce4b614c1392eefc1f23d0";
-  brief = true;
-}
-{
-  name = "liborcus-0.11.2.tar.gz";
-  md5 = "205badaee72adf99422add8c4c49d669";
-  brief = true;
-}
-{
-  name = "owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
-  md5 = "593f0aa47bf2efc0efda2d28fae063b2";
-  brief = true;
-}
-{
-  name = "libpagemaker-0.0.3.tar.bz2";
-  md5 = "5c4985a68be0b79d3f809da5e12b143c";
-  brief = true;
-}
-{
-  name = "pixman-0.24.4.tar.bz2";
-  md5 = "c63f411b3ad147db2bcce1bf262a0e02";
-  brief = false;
-}
-{
-  name = "libpng-1.6.24.tar.gz";
-  md5 = "65213080dd30a9b16193d9b83adc1ee9";
-  brief = true;
-}
-{
-  name = "poppler-0.46.0.tar.bz2";
-  md5 = "38c758d84437378ec4f5aae9f875301d";
-  brief = true;
-}
-{
-  name = "postgresql-9.2.1.tar.bz2";
-  md5 = "c0b4799ea9850eae3ead14f0a60e9418";
-  brief = false;
-}
-{
-  name = "Python-3.3.5.tgz";
-  md5 = "803a75927f8f241ca78633890c798021";
-  brief = true;
-}
-{
-  name = "Python-3.5.0.tgz";
-  md5 = "a56c0c0b45d75a0ec9c6dee933c41c36";
-  brief = true;
-}
-{
-  name = "raptor2-2.0.9.tar.gz";
-  md5 = "4ceb9316488b0ea01acf011023cf7fff";
-  brief = false;
-}
-{
-  name = "rasqal-0.9.30.tar.gz";
-  md5 = "b12c5f9cfdb6b04efce5a4a186b8416b";
-  brief = false;
-}
-{
-  name = "redland-1.0.16.tar.gz";
-  md5 = "32f8e1417a64d3c6f2c727f9053f55ea";
-  brief = false;
-}
-{
-  name = "librevenge-0.0.4.tar.bz2";
-  md5 = "5b9ac52ec77d4d19157cf5962ebc0aea";
-  brief = true;
-}
-{
-  name = "rhino1_5R5.zip";
-  md5 = "798b2ffdc8bcfe7bca2cf92b62caf685";
-  brief = false;
-}
-{
-  name = "serf-1.2.1.tar.bz2";
-  md5 = "4f8e76c9c6567aee1d66aba49f76a58b";
-  brief = true;
-}
-{
-  name = "swingExSrc.zip";
-  md5 = "35c94d2df8893241173de1d16b6034c0";
-  brief = false;
-}
-{
-  name = "ucpp-1.3.2.tar.gz";
-  md5 = "0168229624cfac409e766913506961a8";
-  brief = false;
-}
-{
-  name = "libvisio-0.1.5.tar.bz2";
-  md5 = "cbee198a78b842b2087f32d33c522818";
-  brief = true;
-}
-{
-  name = "libwpd-0.10.1.tar.bz2";
-  md5 = "79b56bcc349264d686a67994506ad199";
-  brief = true;
-}
-{
-  name = "libwpg-0.3.1.tar.bz2";
-  md5 = "dfd066658ec9d2fb2262417039a8a1c3";
-  brief = true;
-}
-{
-  name = "libwps-0.4.3.tar.bz2";
-  md5 = "027fb17fb9e43553aa6624dc18f830ac";
-  brief = true;
-}
-{
-  name = "xsltml_2.1.2.zip";
-  md5 = "a7983f859eafb2677d7ff386a023bc40";
-  brief = false;
-}
-{
-  name = "zlib-1.2.8.tar.gz";
-  md5 = "44d667c142d7cda120332623eab69f40";
-  brief = true;
-}
+  {
+    name = "libabw-0.1.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libabw-0.1.1.tar.bz2";
+    sha256 = "7a3d3415cf82ab9894f601d1b3057c4615060304d5279efdec6275e01b96a199";
+  }
+  {
+    name = "commons-logging-1.2-src.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/commons-logging-1.2-src.tar.gz";
+    sha256 = "49665da5a60d033e6dff40fe0a7f9173e886ae859ce6096c1afe34c48b677c81";
+  }
+  {
+    name = "apr-1.4.8.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/apr-1.4.8.tar.gz";
+    sha256 = "1689e415bdfab6aaa41f07836b5dd9ed4901d22ddeb99feffdb2cee3124adf49";
+  }
+  {
+    name = "apr-util-1.5.3.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/apr-util-1.5.3.tar.gz";
+    sha256 = "76db34cb508e346e3bf69347c29ed1500bf0b71bcc48d54271ad9d1c25703743";
+  }
+  {
+    name = "boost_1_60_0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/boost_1_60_0.tar.bz2";
+    sha256 = "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b";
+  }
+  {
+    name = "breakpad.zip";
+    url = "http://dev-www.libreoffice.org/src/breakpad.zip";
+    sha256 = "7060149be16a8789b0ccf596bdeaf63115f03f520acb508f72a14686fb311cb9";
+  }
+  {
+    name = "bsh-2.0b6-src.zip";
+    url = "http://dev-www.libreoffice.org/src/beeca87be45ec87d241ddd0e1bad80c1-bsh-2.0b6-src.zip";
+    sha256 = "9e93c73e23aff644b17dfff656444474c14150e7f3b38b19635e622235e01c96";
+  }
+  {
+    name = "bzip2-1.0.6.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/00b516f4704d4a7cb50a1d97e6e8e15b-bzip2-1.0.6.tar.gz";
+    sha256 = "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd";
+  }
+  {
+    name = "cairo-1.10.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/f101a9e88b783337b20b2e26dfd26d5f-cairo-1.10.2.tar.gz";
+    sha256 = "32018c7998358eebc2ad578ff8d8559d34fc80252095f110a572ed23d989fc41";
+  }
+  {
+    name = "libcdr-0.1.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libcdr-0.1.2.tar.bz2";
+    sha256 = "d05a986dab9f960e64466072653a900d03f8257b084440d9d16599e16060581e";
+  }
+  {
+    name = "clucene-core-2.3.3.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz";
+    sha256 = "ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab";
+  }
+  {
+    name = "libcmis-0.5.1.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/libcmis-0.5.1.tar.gz";
+    sha256 = "6acbdf22ecdbaba37728729b75bfc085ee5a4b49a6024757cfb86ccd3da27b0e";
+  }
+  {
+    name = "CoinMP-1.7.6.tgz";
+    url = "http://dev-www.libreoffice.org/src/CoinMP-1.7.6.tgz";
+    sha256 = "86c798780b9e1f5921fe4efe651a93cb420623b45aa1fdff57af8c37f116113f";
+  }
+  {
+    name = "collada2gltf-master-cb1d97788a.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/4b87018f7fff1d054939d19920b751a0-collada2gltf-master-cb1d97788a.tar.bz2";
+    sha256 = "b0adb8e71aef80751b999c9c055e419a625c4a05184e407aef2aee28752ad8cb";
+  }
+  {
+    name = "cppunit-1.13.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/cppunit-1.13.2.tar.gz";
+    sha256 = "3f47d246e3346f2ba4d7c9e882db3ad9ebd3fcbd2e8b732f946e0e3eeb9f429f";
+  }
+  {
+    name = "converttexttonumber-1-5-0.oxt";
+    url = "http://dev-www.libreoffice.org/src/1f467e5bb703f12cbbb09d5cf67ecf4a-converttexttonumber-1-5-0.oxt";
+    sha256 = "71b238efd2734be9800af07566daea8d6685aeed28db5eb5fa0e6453f4d85de3";
+  }
+  {
+    name = "curl-7.43.0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/curl-7.43.0.tar.bz2";
+    sha256 = "baa654a1122530483ccc1c58cc112fec3724a82c11c6a389f1e6a37dc8858df9";
+  }
+  {
+    name = "libe-book-0.1.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libe-book-0.1.2.tar.bz2";
+    sha256 = "b710a57c633205b933015474d0ac0862253d1c52114d535dd09b20939a0d1850";
+  }
+  {
+    name = "epm-3.7.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/3ade8cfe7e59ca8e65052644fed9fca4-epm-3.7.tar.gz";
+    sha256 = "b3fc4c5445de6c9a801504a3ea3efb2d4ea9d5a622c9427e716736e7713ddb91";
+  }
+  {
+    name = "libetonyek-0.1.6.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libetonyek-0.1.6.tar.bz2";
+    sha256 = "032f53e8d7691e48a73ddbe74fa84c906ff6ff32a33e6ee2a935b6fdb6aecb78";
+  }
+  {
+    name = "expat-2.2.0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/expat-2.2.0.tar.bz2";
+    sha256 = "d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff";
+  }
+  {
+    name = "Firebird-2.5.5.26952-0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/Firebird-2.5.5.26952-0.tar.bz2";
+    sha256 = "b33e63ede88184d9ef2ae6760537ab75bfe641513821410b83e837946162b7d1";
+  }
+  {
+    name = "fontconfig-2.8.0.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/77e15a92006ddc2adbb06f840d591c0e-fontconfig-2.8.0.tar.gz";
+    sha256 = "fa2a1c6eea654d9fce7a4b1220f10c99cdec848dccaf1625c01f076b31382335";
+  }
+  {
+    name = "crosextrafonts-20130214.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/368f114c078f94214a308a74c7e991bc-crosextrafonts-20130214.tar.gz";
+    sha256 = "c48d1c2fd613c9c06c959c34da7b8388059e2408d2bb19845dc3ed35f76e4d09";
+  }
+  {
+    name = "crosextrafonts-carlito-20130920.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/c74b7223abe75949b4af367942d96c7a-crosextrafonts-carlito-20130920.tar.gz";
+    sha256 = "4bd12b6cbc321c1cf16da76e2c585c925ce956a08067ae6f6c64eff6ccfdaf5a";
+  }
+  {
+    name = "dejavu-fonts-ttf-2.35.zip";
+    url = "http://dev-www.libreoffice.org/src/d8b5214d35bcd2bfcb2cffa7795b351d-dejavu-fonts-ttf-2.35.zip";
+    sha256 = "7e0d00f20080784c3a38a845d5858c161af14f0073d9474cdbfdedae883cc747";
+  }
+  {
+    name = "gentiumbasic-fonts-1.10.zip";
+    url = "http://dev-www.libreoffice.org/src/35efabc239af896dfb79be7ebdd6e6b9-gentiumbasic-fonts-1.10.zip";
+    sha256 = "f1691e48d02effdee0701622297394451759f13e0e0b36e788847f4b3e2ba11b";
+  }
+  {
+    name = "liberation-fonts-ttf-1.07.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/134d8262145fc793c6af494dcace3e71-liberation-fonts-ttf-1.07.4.tar.gz";
+    sha256 = "61a7e2b6742a43c73e8762cdfeaf6dfcf9abdd2cfa0b099a9854d69bc4cfee5c";
+  }
+  {
+    name = "liberation-fonts-ttf-2.00.1.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/5c781723a0d9ed6188960defba8e91cf-liberation-fonts-ttf-2.00.1.tar.gz";
+    sha256 = "7890278a6cd17873c57d9cd785c2d230d9abdea837e96516019c5885dd271504";
+  }
+  {
+    name = "LinLibertineG-20120116.zip";
+    url = "http://dev-www.libreoffice.org/src/e7a384790b13c29113e22e596ade9687-LinLibertineG-20120116.zip";
+    sha256 = "54adcb2bc8cac0927a647fbd9362f45eff48130ce6e2379dc3867643019e08c5";
+  }
+  {
+    name = "open-sans-font-ttf-1.10.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/7a15edea7d415ac5150ea403e27401fd-open-sans-font-ttf-1.10.tar.gz";
+    sha256 = "cc80fd415e57ecec067339beadd0eef9eaa45e65d3c51a922ba5f9172779bfb8";
+  }
+  {
+    name = "pt-serif-font-1.0000W.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/c3c1a8ba7452950636e871d25020ce0d-pt-serif-font-1.0000W.tar.gz";
+    sha256 = "6757feb23f889a82df59679d02b8ee1f907df0a0ac1c49cdb48ed737b60e5dfa";
+  }
+  {
+    name = "source-code-font-1.009.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/0279a21fab6f245e85a6f85fea54f511-source-code-font-1.009.tar.gz";
+    sha256 = "9b295127164c81bcf28c7ebb687f1555b71796108b443a04d40202b7364e4cce";
+  }
+  {
+    name = "source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
+    sha256 = "e7bc9a1fec787a529e49f5a26b93dcdcf41506449dfc70f92cdef6d17eb6fb61";
+  }
+  {
+    name = "libfreehand-0.1.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libfreehand-0.1.1.tar.bz2";
+    sha256 = "45dab0e5d632eb51eeb00847972ca03835d6791149e9e714f093a9df2b445877";
+  }
+  {
+    name = "freetype-2.4.8.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/dbf2caca1d3afd410a29217a9809d397-freetype-2.4.8.tar.bz2";
+    sha256 = "a9eb7da3875fcb2f022a9c280c01b94ae45ac83d8102838c05dce1277948fb71";
+  }
+  {
+    name = "glew-1.12.0.zip";
+    url = "http://dev-www.libreoffice.org/src/3941e9cab2f4f9d8faee3e8d57ae7664-glew-1.12.0.zip";
+    sha256 = "6f1083eb034efbc3b2017ef052d58f3e9bd70963ec2acd26b3d59231ee1633d4";
+  }
+  {
+    name = "glm-0.9.4.6-libreoffice.zip";
+    url = "http://dev-www.libreoffice.org/src/bae83fa5dc7f081768daace6e199adc3-glm-0.9.4.6-libreoffice.zip";
+    sha256 = "d0312c360efe04dd048b3311fe375ff36f1993b4c2e3cb58c81062990532904a";
+  }
+  {
+    name = "glyphy-0.2.0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/5d303fb955beb9bf112267316ca9d021-glyphy-0.2.0.tar.bz2";
+    sha256 = "9a8f629f7ea40ba118199a37adee8f2dfb084cffa5f7f4db3a47b8b0075777be";
+  }
+  {
+    name = "graphite2-minimal-1.3.8.tgz";
+    url = "http://dev-www.libreoffice.org/src/4311dd9ace498b57c85f611e0670df64-graphite2-minimal-1.3.8.tgz";
+    sha256 = "d16940175822760753e9762d0af9679c9726e64f25955677fe7ab68448601c3b";
+  }
+  {
+    name = "harfbuzz-1.2.6.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/harfbuzz-1.2.6.tar.bz2";
+    sha256 = "7537bacccb3524df0cd2a4d5bc7e168bcc10e8171e0324f3cd522583868192c1";
+  }
+  {
+    name = "hsqldb_1_8_0.zip";
+    url = "http://dev-www.libreoffice.org/src/17410483b5b5f267aa18b7e00b65e6e0-hsqldb_1_8_0.zip";
+    sha256 = "d30b13f4ba2e3b6a2d4f020c0dee0a9fb9fc6fbcc2d561f36b78da4bf3802370";
+  }
+  {
+    name = "hunspell-1.4.1.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/33d370f7fe5a030985e445a5672b2067-hunspell-1.4.1.tar.gz";
+    sha256 = "c4476aff0ced52eec334eae1e8d3fdaaebdd90f5ecd0b57cf2a92a6fd220d1bb";
+  }
+  {
+    name = "hyphen-2.8.8.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-2.8.8.tar.gz";
+    sha256 = "304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705";
+  }
+  {
+    name = "icu4c-57_1-src.tgz";
+    url = "http://dev-www.libreoffice.org/src/976734806026a4ef8bdd17937c8898b9-icu4c-57_1-src.tgz";
+    sha256 = "ff8c67cb65949b1e7808f2359f2b80f722697048e90e7cfc382ec1fe229e9581";
+  }
+  {
+    name = "flow-engine-0.9.4.zip";
+    url = "http://dev-www.libreoffice.org/src/ba2930200c9f019c2d93a8c88c651a0f-flow-engine-0.9.4.zip";
+    sha256 = "233f66e8d25c5dd971716d4200203a612a407649686ef3b52075d04b4c9df0dd";
+  }
+  {
+    name = "flute-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/d8bd5eed178db6e2b18eeed243f85aa8-flute-1.1.6.zip";
+    sha256 = "1b5b24f7bc543c0362b667692f78db8bab4ed6dafc6172f104d0bd3757d8a133";
+  }
+  {
+    name = "libbase-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/eeb2c7ddf0d302fba4bfc6e97eac9624-libbase-1.1.6.zip";
+    sha256 = "75c80359c9ce343c20aab8a36a45cb3b9ee7c61cf92c13ae45399d854423a9ba";
+  }
+  {
+    name = "libfonts-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/3bdf40c0d199af31923e900d082ca2dd-libfonts-1.1.6.zip";
+    sha256 = "e0531091787c0f16c83965fdcbc49162c059d7f0c64669e7f119699321549743";
+  }
+  {
+    name = "libformula-1.1.7.zip";
+    url = "http://dev-www.libreoffice.org/src/3404ab6b1792ae5f16bbd603bd1e1d03-libformula-1.1.7.zip";
+    sha256 = "5826d1551bf599b85742545f6e01a0079b93c1b2c8434bf409eddb3a29e4726b";
+  }
+  {
+    name = "liblayout-0.2.10.zip";
+    url = "http://dev-www.libreoffice.org/src/db60e4fde8dd6d6807523deb71ee34dc-liblayout-0.2.10.zip";
+    sha256 = "e1fb87f3f7b980d33414473279615c4644027e013012d156efa538bc2b031772";
+  }
+  {
+    name = "libloader-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/97b2d4dba862397f446b217e2b623e71-libloader-1.1.6.zip";
+    sha256 = "3d853b19b1d94a6efa69e7af90f7f2b09ecf302913bee3da796c15ecfebcfac8";
+  }
+  {
+    name = "librepository-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/8ce2fcd72becf06c41f7201d15373ed9-librepository-1.1.6.zip";
+    sha256 = "abe2c57ac12ba45d83563b02e240fa95d973376de2f720aab8fe11f2e621c095";
+  }
+  {
+    name = "libserializer-1.1.6.zip";
+    url = "http://dev-www.libreoffice.org/src/f94d9870737518e3b597f9265f4e9803-libserializer-1.1.6.zip";
+    sha256 = "05640a1f6805b2b2d7e2cb9c50db9a5cb084e3c52ab1a71ce015239b4a1d4343";
+  }
+  {
+    name = "libxml-1.1.7.zip";
+    url = "http://dev-www.libreoffice.org/src/ace6ab49184e329db254e454a010f56d-libxml-1.1.7.zip";
+    sha256 = "7d2797fe9f79a77009721e3f14fa4a1dec17a6d706bdc93f85f1f01d124fab66";
+  }
+  {
+    name = "sacjava-1.3.zip";
+    url = "http://dev-www.libreoffice.org/src/39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip";
+    sha256 = "085f2112c51fa8c1783fac12fbd452650596415121348393bb51f0f7e85a9045";
+  }
+  {
+    name = "jpegsrc.v9a.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/jpegsrc.v9a.tar.gz";
+    sha256 = "3a753ea48d917945dd54a2d97de388aa06ca2eb1066cbfdc6652036349fe05a7";
+  }
+  {
+    name = "libjpeg-turbo-1.4.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/libjpeg-turbo-1.4.2.tar.gz";
+    sha256 = "521bb5d3043e7ac063ce3026d9a59cc2ab2e9636c655a2515af5f4706122233e";
+  }
+  {
+    name = "language-subtag-registry-2016-07-19.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/language-subtag-registry-2016-07-19.tar.bz2";
+    sha256 = "e3dc30bdbfdad442c542dc0e165df9d8d2ba06a357cd55957155d8259d1661dc";
+  }
+  {
+    name = "JLanguageTool-1.7.0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/b63e6340a02ff1cacfeadb2c42286161-JLanguageTool-1.7.0.tar.bz2";
+    sha256 = "48c87e41636783bba438b65fd895821e369ed139e1465fac654323ad93c5a82d";
+  }
+  {
+    name = "lcms2-2.6.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/lcms2-2.6.tar.gz";
+    sha256 = "5172528839647c54c3da211837225e221be93e4733f5b5e9f57668f7107e14b1";
+  }
+  {
+    name = "libatomic_ops-7_2d.zip";
+    url = "http://dev-www.libreoffice.org/src/libatomic_ops-7_2d.zip";
+    sha256 = "cf5c52f08a2067ae4fe7c8919e3c1ccf3ee917f1749e0bcc7efffff59c68d9ad";
+  }
+  {
+    name = "libeot-0.01.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libeot-0.01.tar.bz2";
+    sha256 = "cf5091fa8e7dcdbe667335eb90a2cfdd0a3fe8f8c7c8d1ece44d9d055736a06a";
+  }
+  {
+    name = "libexttextcat-3.4.4.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/10d61fbaa6a06348823651b1bd7940fe-libexttextcat-3.4.4.tar.bz2";
+    sha256 = "9595601c41051356d03d0a7d5dcad334fe1b420d221f6885d143c14bb8d62163";
+  }
+  {
+    name = "libgltf-0.0.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libgltf/libgltf-0.0.2.tar.bz2";
+    sha256 = "d1cc7297ed1921aa969e26413b4c4e18afc882ce4d2f5a2aa2a2905706f7206b";
+  }
+  {
+    name = "liblangtag-0.5.8.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/aa899eff126216dafe721149fbdb511b-liblangtag-0.5.8.tar.bz2";
+    sha256 = "08e2f64bfe3f750be7391eb0af53967e164b628c59f02be4d83789eb4f036eaa";
+  }
+  {
+    name = "xmlsec1-1.2.20.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/ce12af00283eb90d9281956524250d6e-xmlsec1-1.2.20.tar.gz";
+    sha256 = "3221593ca50f362b546a0888a1431ad24be1470f96b2469c0e0df5e1c55e7305";
+  }
+  {
+    name = "libxml2-2.9.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/ae249165c173b1ff386ee8ad676815f5-libxml2-2.9.4.tar.gz";
+    sha256 = "ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c";
+  }
+  {
+    name = "libxslt-1.1.29.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/a129d3c44c022de3b9dcf6d6f288d72e-libxslt-1.1.29.tar.gz";
+    sha256 = "b5976e3857837e7617b29f2249ebb5eeac34e249208d31f1fbf7a6ba7a4090ce";
+  }
+  {
+    name = "lp_solve_5.5.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/26b3e95ddf3d9c077c480ea45874b3b8-lp_solve_5.5.tar.gz";
+    sha256 = "171816288f14215c69e730f7a4f1c325739873e21f946ff83884b350574e6695";
+  }
+  {
+    name = "mariadb_client-2.0.0-src.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/a233181e03d3c307668b4c722d881661-mariadb_client-2.0.0-src.tar.gz";
+    sha256 = "fd2f751dea049c1907735eb236aeace1d811d6a8218118b00bbaa9b84dc5cd60";
+  }
+  {
+    name = "mdds-1.2.0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/mdds-1.2.0.tar.bz2";
+    sha256 = "f44fd0635de94c7d490f9a65f74b5e55860d7bdd507951428294f9690fda45b6";
+  }
+  {
+    name = "mDNSResponder-576.30.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/mDNSResponder-576.30.4.tar.gz";
+    sha256 = "4737cb51378377e11d0edb7bcdd1bec79cbdaa7b27ea09c13e3006e58f8d92c0";
+  }
+  {
+    name = "libmspub-0.1.2.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libmspub-0.1.2.tar.bz2";
+    sha256 = "26d488527ffbb0b41686d4bab756e3e6aaeb99f88adeb169d0c16d2cde96859a";
+  }
+  {
+    name = "libmwaw-0.3.7.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libmwaw-0.3.7.tar.bz2";
+    sha256 = "a66b3e45a5ba5dd89849a766e128585cac8aaf9e9c6f037040200e5bf31f1427";
+  }
+  {
+    name = "mysql-connector-c++-1.1.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/7239a4430efd4d0189c4f24df67f08e5-mysql-connector-c++-1.1.4.tar.gz";
+    sha256 = "a25f14dad39e93a2f9cdf09166ee53981f7212dce829e4208e07a522963a8585";
+  }
+  {
+    name = "mythes-1.2.4.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz";
+    sha256 = "1e81f395d8c851c3e4e75b568e20fa2fa549354e75ab397f9de4b0e0790a305f";
+  }
+  {
+    name = "neon-0.30.1.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/231adebe5c2f78fded3e3df6e958878e-neon-0.30.1.tar.gz";
+    sha256 = "00c626c0dc18d094ab374dbd9a354915bfe4776433289386ed489c2ec0845cdd";
+  }
+  {
+    name = "nss-3.22.2-with-nspr-4.12.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/6b254cf2f8cb4b27a3f0b8b7b9966ea7-nss-3.22.2-with-nspr-4.12.tar.gz";
+    sha256 = "7bc7e5483fc90071be5facd3043f94c69b153055a369c8f0b751ad374c5ae09e";
+  }
+  {
+    name = "libodfgen-0.1.6.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libodfgen-0.1.6.tar.bz2";
+    sha256 = "2c7b21892f84a4c67546f84611eccdad6259875c971e98ddb027da66ea0ac9c2";
+  }
+  {
+    name = "OpenCOLLADA-master-6509aa13af.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/OpenCOLLADA-master-6509aa13af.tar.bz2";
+    sha256 = "8f25d429237cde289a448c82a0a830791354ccce5ee40d77535642e46367d6c4";
+  }
+  {
+    name = "openldap-2.4.31.tgz";
+    url = "http://dev-www.libreoffice.org/src/804c6cb5698db30b75ad0ff1c25baefd-openldap-2.4.31.tgz";
+    sha256 = "bde845840df4794b869a6efd6a6b1086f80989038e4844b2e4d7d6b57b39c5b6";
+  }
+  {
+    name = "openssl-1.0.2h.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/openssl-1.0.2h.tar.gz";
+    sha256 = "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919";
+  }
+  {
+    name = "liborcus-0.11.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/liborcus-0.11.2.tar.gz";
+    sha256 = "10afc617fd7600fa02bd4467d2e3c7bd058f84e4d672d558e1db90e82dafd256";
+  }
+  {
+    name = "owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/owncloud-android-library-0.9.4-no-binary-deps.tar.gz";
+    sha256 = "b18b3e3ef7fae6a79b62f2bb43cc47a5346b6330f6a383dc4be34439aca5e9fb";
+  }
+  {
+    name = "libpagemaker-0.0.3.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libpagemaker-0.0.3.tar.bz2";
+    sha256 = "3b5de037692f8e156777a75e162f6b110fa24c01749e4a66d7eb83f364e52a33";
+  }
+  {
+    name = "pixman-0.24.4.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/c63f411b3ad147db2bcce1bf262a0e02-pixman-0.24.4.tar.bz2";
+    sha256 = "3d1bf79329be76103c7d9632a79962178364371807104a10e5f63ae0551731dc";
+  }
+  {
+    name = "libpng-1.6.24.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/libpng-1.6.24.tar.gz";
+    sha256 = "be46e0d14ccac3800f816ae860d191a1187a40164b7552c44afeee97a9caa0a3";
+  }
+  {
+    name = "poppler-0.46.0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/poppler-0.46.0.tar.bz2";
+    sha256 = "e3b53c4d1baffb047d4752d68886210fcb279e75cc32c0c61c7165e4d4cf846a";
+  }
+  {
+    name = "postgresql-9.2.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/c0b4799ea9850eae3ead14f0a60e9418-postgresql-9.2.1.tar.bz2";
+    sha256 = "db61d498105a7d5fe46185e67ac830c878cdd7dc1f82a87f06b842217924c461";
+  }
+  {
+    name = "Python-3.3.5.tgz";
+    url = "http://dev-www.libreoffice.org/src/Python-3.3.5.tgz";
+    sha256 = "916bc57dd8524dc27429bebae7b39d6942742cf9699b875b2b496a3d960c7168";
+  }
+  {
+    name = "Python-3.5.0.tgz";
+    url = "http://dev-www.libreoffice.org/src/Python-3.5.0.tgz";
+    sha256 = "584e3d5a02692ca52fce505e68ecd77248a6f2c99adf9db144a39087336b0fe0";
+  }
+  {
+    name = "raptor2-2.0.9.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/4ceb9316488b0ea01acf011023cf7fff-raptor2-2.0.9.tar.gz";
+    sha256 = "e26fb9c18e6ebf71100f434070d50196a21d592b715e361850c3b4e789b5f6ef";
+  }
+  {
+    name = "rasqal-0.9.30.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/b12c5f9cfdb6b04efce5a4a186b8416b-rasqal-0.9.30.tar.gz";
+    sha256 = "abf0e93d80cc79bdf383fd3e904255bf98bc729356d6cf2f673bce74b08b1cfd";
+  }
+  {
+    name = "redland-1.0.16.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/32f8e1417a64d3c6f2c727f9053f55ea-redland-1.0.16.tar.gz";
+    sha256 = "d9a274fc086e61119d5c9beafb8d05527e040ec86f4c0961276ca8de0a049dbd";
+  }
+  {
+    name = "librevenge-0.0.4.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/librevenge-0.0.4.tar.bz2";
+    sha256 = "c51601cd08320b75702812c64aae0653409164da7825fd0f451ac2c5dbe77cbf";
+  }
+  {
+    name = "rhino1_5R5.zip";
+    url = "http://dev-www.libreoffice.org/src/798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip";
+    sha256 = "1fb458d6aab06932693cc8a9b6e4e70944ee1ff052fa63606e3131df34e21753";
+  }
+  {
+    name = "serf-1.2.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/serf-1.2.1.tar.bz2";
+    sha256 = "6988d394b62c3494635b6f0760bc3079f9a0cd380baf0f6b075af1eb9fa5e700";
+  }
+  {
+    name = "swingExSrc.zip";
+    url = "http://dev-www.libreoffice.org/src/35c94d2df8893241173de1d16b6034c0-swingExSrc.zip";
+    sha256 = "64585ac36a81291a58269ec5347e7e3e2e8596dbacb9221015c208191333c6e1";
+  }
+  {
+    name = "ucpp-1.3.2.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz";
+    sha256 = "983941d31ee8d366085cadf28db75eb1f5cb03ba1e5853b98f12f7f51c63b776";
+  }
+  {
+    name = "libvisio-0.1.5.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libvisio-0.1.5.tar.bz2";
+    sha256 = "b83b7991a40b4e7f07d0cac7bb46ddfac84dece705fd18e21bfd119a09be458e";
+  }
+  {
+    name = "libwpd-0.10.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libwpd-0.10.1.tar.bz2";
+    sha256 = "efc20361d6e43f9ff74de5f4d86c2ce9c677693f5da08b0a88d603b7475a508d";
+  }
+  {
+    name = "libwpg-0.3.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libwpg-0.3.1.tar.bz2";
+    sha256 = "29049b95895914e680390717a243b291448e76e0f82fb4d2479adee5330fbb59";
+  }
+  {
+    name = "libwps-0.4.3.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/libwps-0.4.3.tar.bz2";
+    sha256 = "0c30407865a873ff76b6d5b2d2aa599f6af68936638c81ca8292449324042a6c";
+  }
+  {
+    name = "xsltml_2.1.2.zip";
+    url = "http://dev-www.libreoffice.org/src/a7983f859eafb2677d7ff386a023bc40-xsltml_2.1.2.zip";
+    sha256 = "75823776fb51a9c526af904f1503a7afaaab900fba83eda64f8a41073724c870";
+  }
+  {
+    name = "zlib-1.2.8.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/zlib-1.2.8.tar.gz";
+    sha256 = "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d";
+  }
 ]

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -28,25 +28,17 @@ let
   lib = stdenv.lib;
   langsSpaces = lib.concatStringsSep " " langs;
 
-  fetchThirdParty = {name, md5, brief, subDir ? ""}: fetchurl {
-    inherit name md5;
-    url = if brief then
-            "http://dev-www.libreoffice.org/src/${subDir}${name}"
-          else
-            "http://dev-www.libreoffice.org/src/${subDir}${md5}-${name}";
-  };
-
   fetchSrc = {name, sha256}: fetchurl {
     url = "http://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${name}-${version}.tar.xz";
     inherit sha256;
   };
 
   srcs = {
-    third_party = [ (fetchurl rec {
+    third_party = [ (let md5 = "185d60944ea767075d27247c3162b3bc"; in fetchurl rec {
         url = "http://dev-www.libreoffice.org/extern/${md5}-${name}";
-        md5 = "185d60944ea767075d27247c3162b3bc";
+        sha256 = "1infwvv1p6i21scywrldsxs22f62x85mns4iq8h6vr6vlx3fdzga";
         name = "unowinreg.dll";
-      }) ] ++ (map fetchThirdParty (import ./libreoffice-srcs-still.nix));
+      }) ] ++ (map fetchurl (import ./libreoffice-srcs-still.nix));
 
     translations = fetchSrc {
       name = "translations";


### PR DESCRIPTION
This changes all the libreoffice sources to specify a sha256 hash rather than md5. This includes all generated sources, and one other source.
###### Motivation for this change
#4491 - md5 is an insecure hash
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
