### PR TITLE
Miscellaneous: Don't use mkEnableOption

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -163,18 +163,36 @@ in {
       };
 
       zeroconf = {
-        discovery.enable =
-          mkEnableOption "discovery of pulseaudio sinks in the local network";
-        publish.enable =
-          mkEnableOption "publishing the pulseaudio sink in the local network";
+        discovery.enable = mkOption {
+          default = false;
+          example = true;
+          type = types.bool;
+          description = "Whether to enable discovery of pulseaudio sinks in the local network.";
+        };
+        publish.enable = mkOption {
+          default = false;
+          example = true;
+          type = types.bool;
+          description = "Whether to enable publishing the pulseaudio sink in the local network.";
+        };
       };
 
       # TODO: enable by default?
       tcp = {
-        enable = mkEnableOption "tcp streaming support";
+        enable = mkOption {
+          default = false;
+          example = true;
+          type = types.bool;
+          description = "Whether to enable tcp streaming support.";
+        };
 
         anonymousClients = {
-          allowAll = mkEnableOption "all anonymous clients to stream to the server";
+          allowAll = mkOption {
+            default = false;
+            example = true;
+            type = types.bool;
+            description = "Whether to enable all anonymous clients to stream to the server.";
+          };
           allowedIpRanges = mkOption {
             type = types.listOf types.str;
             default = [];

--- a/nixos/modules/hardware/ksm.nix
+++ b/nixos/modules/hardware/ksm.nix
@@ -1,7 +1,12 @@
 { config, lib, ... }:
 
 {
-  options.hardware.enableKSM = lib.mkEnableOption "Kernel Same-Page Merging";
+  options.hardware.enableKSM = lib.mkOption {
+    default = false;
+    example = true;
+    type = lib.types.bool;
+    description = "Whether to enable Kernel Same-Page Merging.";
+  };
 
   config = lib.mkIf config.hardware.enableKSM {
     systemd.services.enable-ksm = {

--- a/nixos/modules/hardware/video/webcam/facetimehd.nix
+++ b/nixos/modules/hardware/video/webcam/facetimehd.nix
@@ -12,7 +12,12 @@ in
 
 {
 
-  options.hardware.facetimehd.enable = mkEnableOption "facetimehd kernel module";
+  options.hardware.facetimehd.enable = mkOption {
+    default = false;
+    example = true;
+    type = types.bool;
+    description = "Whether to enable facetimehd kernel module.";
+  };
 
   config = mkIf cfg.enable {
 

--- a/nixos/modules/programs/kbdlight.nix
+++ b/nixos/modules/programs/kbdlight.nix
@@ -7,7 +7,12 @@ let
 
 in
 {
-  options.programs.kbdlight.enable = mkEnableOption "kbdlight";
+  options.programs.kbdlight.enable = mkOption {
+    default = false;
+    example = true;
+    type = types.bool;
+    description = "Whether to enable kbdlight.";
+  };
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.kbdlight ];

--- a/nixos/modules/programs/tmux.nix
+++ b/nixos/modules/programs/tmux.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 
 let
-  inherit (lib) mkOption mkEnableOption mkIf mkMerge types;
+  inherit (lib) mkOption mkIf mkMerge types;
 
   cfg = config.programs.tmux;
 
@@ -61,7 +61,14 @@ in {
   options = {
     programs.tmux = {
 
-      enable = mkEnableOption "<command>tmux</command> - a <command>screen</command> replacement.";
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = ''
+          Whether to enable <command>tmux</command> - a <command>screen</command> replacement.
+        '';
+      };
 
       aggressiveResize = mkOption {
         default = false;

--- a/nixos/modules/security/grsecurity.nix
+++ b/nixos/modules/security/grsecurity.nix
@@ -27,7 +27,12 @@ in
 
   options.security.grsecurity = {
 
-    enable = mkEnableOption "grsecurity/PaX";
+    enable = mkOption {
+      default = false;
+      example = true;
+      type = types.bool;
+      description = "Whether to enable grsecurity/PaX.";
+    };
 
     lockTunables = mkOption {
       type = types.bool;

--- a/nixos/modules/services/audio/icecast.nix
+++ b/nixos/modules/services/audio/icecast.nix
@@ -44,7 +44,12 @@ in {
 
     services.icecast = {
 
-      enable = mkEnableOption "Icecast server";
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = "Whether to enable Icecast server.";
+      };
 
       hostname = mkOption {
         type = types.str;

--- a/nixos/modules/services/audio/mopidy.nix
+++ b/nixos/modules/services/audio/mopidy.nix
@@ -21,7 +21,12 @@ in {
 
     services.mopidy = {
 
-      enable = mkEnableOption "Mopidy, a music player daemon";
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = "Whether to enable Mopidy, a music player daemon.";
+      };
 
       dataDir = mkOption {
         default = "/var/lib/mopidy";

--- a/nixos/modules/services/audio/squeezelite.nix
+++ b/nixos/modules/services/audio/squeezelite.nix
@@ -15,7 +15,14 @@ in {
 
     services.squeezelite= {
 
-      enable = mkEnableOption "Squeezelite, a software Squeezebox emulator";
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = ''
+          Whether to enable Squeezelite, a software Squeezebox emulator.
+        '';
+      };
 
       dataDir = mkOption {
         default = "/var/lib/squeezelite";

--- a/nixos/modules/services/audio/ympd.nix
+++ b/nixos/modules/services/audio/ympd.nix
@@ -12,7 +12,12 @@ in {
 
     services.ympd = {
 
-      enable = mkEnableOption "ympd, the MPD Web GUI";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable ympd, the MPD Web GUI.";
+        example = true;
+      };
 
       webPort = mkOption {
         type = types.string;

--- a/nixos/modules/services/backup/rsnapshot.nix
+++ b/nixos/modules/services/backup/rsnapshot.nix
@@ -19,7 +19,12 @@ in
 {
   options = {
     services.rsnapshot = {
-      enable = mkEnableOption "rsnapshot backups";
+      enable = mkOption {
+        description = "Whether to enable rsnapshot backups.";
+        default = false;
+        example = true;
+        type = types.bool;
+      };
       enableManualRsnapshot = mkOption {
         description = "Whether to enable manual usage of the rsnapshot command with this module.";
         default = true;

--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -8,7 +8,12 @@ in
 {
   options = {
     services.znapzend = {
-      enable = mkEnableOption "ZnapZend daemon";
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = "Whether to enable ZnapZend daemon.";
+      };
     };
   };
 

--- a/nixos/modules/services/cluster/kubernetes.nix
+++ b/nixos/modules/services/cluster/kubernetes.nix
@@ -391,7 +391,12 @@ in {
     };
 
     kube2sky = {
-      enable = mkEnableOption "Whether to enable kube2sky dns service.";
+      enable = mkOption {
+        description = "Whether to enable kube2sky dns service.";
+        default = false;
+        example = true;
+        type = types.bool;
+      };
 
       domain = mkOption  {
         description = "Kuberntes kube2sky domain under which all DNS names will be hosted.";

--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -25,12 +25,22 @@ in
     services.slurm = {
 
       server = {
-        enable = mkEnableOption "slurm control daemon";
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = "Whether to enable slurm control daemon.";
+        };
 
       };
       
       client = {
-        enable = mkEnableOption "slurm rlient daemon";
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = "Whether to enable slurm rlient daemon.";
+        };
 
       };
 

--- a/nixos/modules/services/computing/torque/mom.nix
+++ b/nixos/modules/services/computing/torque/mom.nix
@@ -17,7 +17,12 @@ in
   options = {
 
     services.torque.mom = {
-      enable = mkEnableOption "torque computing node";
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = "Whether to enable torque computing node.";
+      };
 
       serverNode = mkOption {
         type = types.str;

--- a/nixos/modules/services/computing/torque/server.nix
+++ b/nixos/modules/services/computing/torque/server.nix
@@ -11,7 +11,12 @@ in
 
     services.torque.server = {
 
-      enable = mkEnableOption "torque server";
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = "Whether to enable torque server.";
+      };
 
     };
 

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -18,7 +18,12 @@ in
 {
   options = {
     services.buildkite-agent = {
-      enable = mkEnableOption "buildkite-agent";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable buildkite-agent.";
+      };
 
       token = mkOption {
         type = types.str;

--- a/nixos/modules/services/continuous-integration/gocd-agent/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-agent/default.nix
@@ -7,7 +7,12 @@ let
 in {
   options = {
     services.gocd-agent = {
-      enable = mkEnableOption "gocd-agent";
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = "Whether to enable gocd-agent.";
+      };
 
       user = mkOption {
         default = "gocd-agent";

--- a/nixos/modules/services/continuous-integration/gocd-server/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-server/default.nix
@@ -7,7 +7,12 @@ let
 in {
   options = {
     services.gocd-server = {
-      enable = mkEnableOption "gocd-server";
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = "Whether to enable gocd-server.";
+      };
 
       user = mkOption {
         default = "gocd-server";

--- a/nixos/modules/services/databases/riak.nix
+++ b/nixos/modules/services/databases/riak.nix
@@ -16,7 +16,12 @@ in
 
     services.riak = {
 
-      enable = mkEnableOption "riak";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable riak.";
+      };
 
       package = mkOption {
         type = types.package;

--- a/nixos/modules/services/development/hoogle.nix
+++ b/nixos/modules/services/development/hoogle.nix
@@ -14,7 +14,12 @@ let
 in {
 
   options.services.hoogle = {
-    enable = mkEnableOption "Haskell documentation server";
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Whether to enable Haskell documentation server.";
+    };
 
     port = mkOption {
       type = types.int;

--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -19,7 +19,12 @@ in
 {
   options = {
     services.factorio = {
-      enable = mkEnableOption name;
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable ${name}.";
+      };
       port = mkOption {
         type = types.int;
         default = 34197;

--- a/nixos/modules/services/hardware/irqbalance.nix
+++ b/nixos/modules/services/hardware/irqbalance.nix
@@ -9,7 +9,12 @@ let
 
 in
 {
-  options.services.irqbalance.enable = mkEnableOption "irqbalance daemon";
+  options.services.irqbalance.enable = mkOption {
+    type = types.bool;
+    default = false;
+    example = true;
+    description = "Whether to enable irqbalance daemon.";
+  };
 
   config = mkIf cfg.enable {
 

--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -17,7 +17,12 @@ in {
   options = {
 
     services.pcscd = {
-      enable = mkEnableOption "PCSC-Lite daemon";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable PCSC-Lite daemon.";
+      };
 
       plugins = mkOption {
         type = types.listOf types.package;

--- a/nixos/modules/services/hardware/sane_extra_backends/brscan4.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan4.nix
@@ -67,9 +67,12 @@ in
 {
   options = {
 
-    hardware.sane.brscan4.enable = 
-      mkEnableOption "Brother's brscan4 scan backend" // {
+    hardware.sane.brscan4.enable = mkOption {
+      default = false;
+      example = true;
+      type = types.bool;
       description = ''
+        Whether to enable Brother's brscan4 scan backend.
         When enabled, will automatically register the "brscan4" sane
         backend and bring configuration files to their expected location. 
       '';

--- a/nixos/modules/services/logging/graylog.nix
+++ b/nixos/modules/services/logging/graylog.nix
@@ -29,7 +29,12 @@ in
 
     services.graylog = {
 
-      enable = mkEnableOption "Graylog";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable Graylog.";
+      };
 
       package = mkOption {
         type = types.package;

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -72,7 +72,12 @@ in
 {
 
   options.services.dovecot2 = {
-    enable = mkEnableOption "Dovecot 2.x POP3/IMAP server";
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Whether to enable Dovecot 2.x POP3/IMAP server.";
+    };
 
     enablePop3 = mkOption {
       type = types.bool;

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -43,7 +43,12 @@ in
 
     services.rspamd = {
 
-      enable = mkEnableOption "Whether to run the rspamd daemon.";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable the rspamd daemon.";
+      };
 
       debug = mkOption {
         default = false;

--- a/nixos/modules/services/misc/bepasty.nix
+++ b/nixos/modules/services/misc/bepasty.nix
@@ -13,7 +13,12 @@ let
 in
 {
   options.services.bepasty = {
-    enable = mkEnableOption "Bepasty servers";
+    enable = mkOption {
+      type = types.bool;
+      description = "Whether to enable Bepasty servers.";
+      default = false;
+      example = true;
+    };
 
     servers = mkOption {
       default = {};

--- a/nixos/modules/services/misc/calibre-server.nix
+++ b/nixos/modules/services/misc/calibre-server.nix
@@ -16,7 +16,12 @@ in
 
     services.calibre-server = {
 
-      enable = mkEnableOption "calibre-server";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable calibre-server.";
+      };
 
       libraryDir = mkOption {
         description = ''

--- a/nixos/modules/services/misc/cfdyndns.nix
+++ b/nixos/modules/services/misc/cfdyndns.nix
@@ -8,7 +8,12 @@ in
 {
   options = {
     services.cfdyndns = {
-      enable = mkEnableOption "Cloudflare Dynamic DNS Client";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable Cloudflare Dynamic DNS Client.";
+      };
 
       email = mkOption {
         type = types.str;

--- a/nixos/modules/services/misc/confd.nix
+++ b/nixos/modules/services/misc/confd.nix
@@ -17,7 +17,12 @@ let
 
 in {
   options.services.confd = {
-    enable = mkEnableOption "confd service";
+    enable = mkOption {
+      description = "Whether to enable confd service.";
+      default = false;
+      example = true;
+      type = types.bool;
+    };
 
     backend = mkOption {
       description = "Confd config storage backend to use.";

--- a/nixos/modules/services/misc/emby.nix
+++ b/nixos/modules/services/misc/emby.nix
@@ -9,7 +9,12 @@ in
 {
   options = {
     services.emby = {
-      enable = mkEnableOption "Emby Media Server";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable Emby Media Server.";
+      };
 
       user = mkOption {
         type = types.str;

--- a/nixos/modules/services/misc/gammu-smsd.nix
+++ b/nixos/modules/services/misc/gammu-smsd.nix
@@ -53,7 +53,12 @@ in {
   options = {
     services.gammu-smsd = {
 
-      enable = mkEnableOption "gammu-smsd daemon";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable gammu-smsd daemon.";
+      };
 
       user = mkOption {
         type = types.str;

--- a/nixos/modules/services/misc/mathics.nix
+++ b/nixos/modules/services/misc/mathics.nix
@@ -8,7 +8,12 @@ let
 in {
   options = {
     services.mathics = {
-      enable = mkEnableOption "Mathics notebook service";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable Mathics notebook service.";
+      };
 
       external = mkOption {
         type = types.bool;

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -93,7 +93,12 @@ ${cfg.extraConfig}
 in {
   options = {
     services.matrix-synapse = {
-      enable = mkEnableOption "matrix.org synapse";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable matrix.org synapse.";
+      };
       package = mkOption {
         type = types.package;
         default = pkgs.matrix-synapse;

--- a/nixos/modules/services/misc/nzbget.nix
+++ b/nixos/modules/services/misc/nzbget.nix
@@ -9,7 +9,12 @@ in
 {
   options = {
     services.nzbget = {
-      enable = mkEnableOption "NZBGet";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable NZBGet.";
+      };
 
       package = mkOption {
         type = types.package;

--- a/nixos/modules/services/misc/octoprint.nix
+++ b/nixos/modules/services/misc/octoprint.nix
@@ -29,7 +29,14 @@ in
 
     services.octoprint = {
 
-      enable = mkEnableOption "OctoPrint, web interface for 3D printers";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to enable OctoPrint, web interface for 3D printers.
+        '';
+      };
 
       host = mkOption {
         type = types.str;

--- a/nixos/modules/services/misc/packagekit.nix
+++ b/nixos/modules/services/misc/packagekit.nix
@@ -30,12 +30,16 @@ in
   options = {
 
     services.packagekit = {
-      enable = mkEnableOption
-        ''
-          PackageKit provides a cross-platform D-Bus abstraction layer for
-          installing software. Software utilizing PackageKit can install
-          software regardless of the package manager.
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to enable PackageKit, which provides a cross-platform D-Bus
+          abstraction layer for installing software. Software utilizing
+          PackageKit can install software regardless of the package manager.
         '';
+      };
     };
 
   };

--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -9,7 +9,12 @@ in
 {
   options = {
     services.plex = {
-      enable = mkEnableOption "Plex Media Server";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable Plex Media Server.";
+      };
 
       # FIXME: In order for this config option to work, symlinks in the Plex
       # package in the Nix store have to be changed to point to this directory.

--- a/nixos/modules/services/misc/ripple-data-api.nix
+++ b/nixos/modules/services/misc/ripple-data-api.nix
@@ -35,7 +35,12 @@ let
 in {
   options = {
     services.rippleDataApi = {
-      enable = mkEnableOption "ripple data api";
+      enable = mkOption {
+        description = "Whether to enable ripple data api.";
+        default = false;
+        example = true;
+        type = types.bool;
+      };
 
       port = mkOption {
         description = "Ripple data api port";

--- a/nixos/modules/services/misc/ripple-rest.nix
+++ b/nixos/modules/services/misc/ripple-rest.nix
@@ -23,9 +23,19 @@ let
 
 in {
   options.services.rippleRest = {
-    enable = mkEnableOption "ripple rest";
+    enable = mkOption {
+      description = "Whether to enable ripple rest.";
+      default = false;
+      example = true;
+      type = types.bool;
+    };
 
-    debug = mkEnableOption "debug for ripple-rest";
+    debug = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Whether to enable debug for ripple-rest.";
+    };
 
     host = mkOption {
       description = "Ripple rest host.";
@@ -40,7 +50,12 @@ in {
     };
 
     ssl = {
-      enable = mkEnableOption "ssl";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable ssl.";
+      };
 
       keyPath = mkOption {
         description = "Path to the ripple rest key file.";

--- a/nixos/modules/services/misc/rippled.nix
+++ b/nixos/modules/services/misc/rippled.nix
@@ -202,7 +202,12 @@ in
 
   options = {
     services.rippled = {
-      enable = mkEnableOption "rippled";
+      enable = mkOption {
+        description = "Whether to enable rippled.";
+        default = false;
+        example = true;
+        type = types.bool;
+      };
 
       package = mkOption {
 	description = "Which rippled package to use.";
@@ -374,7 +379,12 @@ in
       };
 
       statsd = {
-        enable = mkEnableOption "statsd monitoring for rippled";
+        enable = mkOption {
+          description = "Whether to enable statsd monitoring for rippled.";
+          default = false;
+          example = true;
+          type = types.bool;
+        };
 
         address = mkOption {
           description = "The UDP address and port of the listening StatsD server.";

--- a/nixos/modules/services/misc/sonarr.nix
+++ b/nixos/modules/services/misc/sonarr.nix
@@ -8,7 +8,12 @@ in
 {
   options = {
     services.sonarr = {
-      enable = mkEnableOption "Sonarr";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable Sonarr.";
+      };
     };
   };
 

--- a/nixos/modules/services/misc/spice-vdagentd.nix
+++ b/nixos/modules/services/misc/spice-vdagentd.nix
@@ -7,7 +7,12 @@ in
 {
   options = {
     services.spice-vdagentd = {
-      enable = mkEnableOption "Spice guest vdagent daemon";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable Spice guest vdagent daemon.";
+      };
     };
   };
 

--- a/nixos/modules/services/misc/subsonic.nix
+++ b/nixos/modules/services/misc/subsonic.nix
@@ -5,7 +5,12 @@ with lib;
 let cfg = config.services.subsonic; in {
   options = {
     services.subsonic = {
-      enable = mkEnableOption "Subsonic daemon";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable Subsonic daemon.";
+      };
 
       home = mkOption {
         type = types.path;

--- a/nixos/modules/services/misc/sundtek.nix
+++ b/nixos/modules/services/misc/sundtek.nix
@@ -8,7 +8,12 @@ let
 in
 {
   options.services.sundtek = {
-    enable = mkEnableOption "Sundtek driver";
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Whether to enable Sundtek driver.";
+    };
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/monitoring/das_watchdog.nix
+++ b/nixos/modules/services/monitoring/das_watchdog.nix
@@ -12,7 +12,12 @@ in {
   ###### interface
 
   options = {
-    services.das_watchdog.enable = mkEnableOption "realtime watchdog";
+    services.das_watchdog.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Whether to enable realtime watchdog.";
+    };
   };
 
   ###### implementation

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -46,7 +46,12 @@ let
 
 in {
   options.services.grafana = {
-    enable = mkEnableOption "grafana";
+    enable = mkOption {
+      description = "Whether to enable grafana.";
+      default = false;
+      example = true;
+      type = types.bool;
+    };
 
     protocol = mkOption {
       description = "Which protocol to listen.";

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -370,7 +370,12 @@ in {
     };
 
     beacon = {
-      enable = mkEnableOption "graphite beacon";
+      enable = mkOption {
+        description = "Whether to enable graphite beacon.";
+        default = false;
+        example = true;
+        type = types.bool;
+      };
 
       config = mkOption {
         description = "Graphite beacon configuration.";

--- a/nixos/modules/services/monitoring/hdaps.nix
+++ b/nixos/modules/services/monitoring/hdaps.nix
@@ -8,11 +8,15 @@ let
 in
 {
   options = {
-    services.hdapsd.enable = mkEnableOption
-      ''
-        Hard Drive Active Protection System Daemon,
-        devices are detected and managed automatically by udev and systemd
+    services.hdapsd.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to enable Hard Drive Active Protection System Daemon.
+        Devices are detected and managed automatically by udev and systemd.
       '';
+    };
   };
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/monitoring/prometheus/node-exporter.nix
+++ b/nixos/modules/services/monitoring/prometheus/node-exporter.nix
@@ -10,7 +10,12 @@ let
 in {
   options = {
     services.prometheus.nodeExporter = {
-      enable = mkEnableOption "prometheus node exporter";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable prometheus node exporter.";
+      };
 
       port = mkOption {
         type = types.int;

--- a/nixos/modules/services/monitoring/smartd.nix
+++ b/nixos/modules/services/monitoring/smartd.nix
@@ -94,7 +94,15 @@ in
 
     services.smartd = {
 
-      enable = mkEnableOption "smartd daemon from <literal>smartmontools</literal> package";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to enable smartd daemon from
+          <literal>smartmontools</literal> package.
+        '';
+      };
 
       autodetect = mkOption {
         default = true;

--- a/nixos/modules/services/monitoring/teamviewer.nix
+++ b/nixos/modules/services/monitoring/teamviewer.nix
@@ -14,7 +14,12 @@ in
 
   options = {
 
-    services.teamviewer.enable = mkEnableOption "TeamViewer daemon";
+    services.teamviewer.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = "Whether to enable TeamViewer daemon.";
+    };
       
   };
 

--- a/nixos/modules/services/monitoring/telegraf.nix
+++ b/nixos/modules/services/monitoring/telegraf.nix
@@ -16,7 +16,12 @@ in {
   ###### interface
   options = {
     services.telegraf = {
-      enable = mkEnableOption "telegraf server";
+      enable = mkOption {
+        default = false;
+        example = true;
+        description = "Whether to enable telegraf server.";
+        type = types.bool;
+      };
 
       package = mkOption {
         default = pkgs.telegraf;

--- a/nixos/modules/services/monitoring/uptime.nix
+++ b/nixos/modules/services/monitoring/uptime.nix
@@ -1,6 +1,6 @@
 { config, pkgs, lib, ... }:
 let
-  inherit (lib) mkOption mkEnableOption mkIf mkMerge types optionalAttrs optional;
+  inherit (lib) mkOption mkIf mkMerge types optionalAttrs optional;
 
   cfg = config.services.uptime;
 
@@ -49,9 +49,21 @@ in {
       type = types.bool;
     };
 
-    enableWebService = mkEnableOption "the uptime monitoring program web service";
+    enableWebService = mkOption {
+      description = ''
+        Whether to enable the uptime monitoring program web service.
+      '';
+      type = types.bool;
+      default = false;
+      example = true;
+    };
 
-    enableSeparateMonitoringService = mkEnableOption "the uptime monitoring service" // { default = cfg.enableWebService; };
+    enableSeparateMonitoringService = mkOption {
+      description = "Whether to enable the uptime monitoring service.";
+      type = types.bool;
+      default = cfg.enableWebService;
+      example = true;
+    };
 
     nodeEnv = mkOption {
       description = "The node environment to run in (development, production, etc.)";

--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -131,7 +131,12 @@ in
               The number of shares required to store a file.
             '';
           };
-          storage.enable = mkEnableOption "storage service";
+          storage.enable = mkOption {
+            type = types.bool;
+            default = false;
+            example = true;
+            description = "Whether to enable storage service.";
+          };
           storage.reservedSpace = mkOption {
             default = "1G";
             type = types.str;
@@ -139,7 +144,12 @@ in
               The amount of filesystem space to not use for storage.
             '';
           };
-          helper.enable = mkEnableOption "helper service";
+          helper.enable = mkOption {
+            type = types.bool;
+            default = false;
+            example = true;
+            description = "Whether to enable helper service.";
+          };
           package = mkOption {
             default = pkgs.tahoelafs;
             defaultText = "pkgs.tahoelafs";

--- a/nixos/modules/services/network-filesystems/xtreemfs.nix
+++ b/nixos/modules/services/network-filesystems/xtreemfs.nix
@@ -89,7 +89,12 @@ in
 
     services.xtreemfs = {
 
-      enable = mkEnableOption "XtreemFS";
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = "Whether to enable XtreemFS.";
+      };
 
       homeDir = mkOption {
         default = "/var/lib/xtreemfs";
@@ -171,7 +176,12 @@ in
           '';
         };
         replication = {
-          enable = mkEnableOption "XtreemFS DIR replication plugin";
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            example = true;
+            description = "Whether to enable XtreemFS DIR replication plugin.";
+          };
           extraConfig = mkOption {
             example = ''
               # participants of the replication including this replica
@@ -305,7 +315,12 @@ in
           '';
         };
         replication = {
-          enable = mkEnableOption "XtreemFS MRC replication plugin";
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            example = true;
+            description = "Whether to enable XtreemFS MRC replication plugin.";
+          };
           extraConfig = mkOption {
             example = ''
               # participants of the replication including this replica


### PR DESCRIPTION
This removes usages of `mkEnableOption` (#18767).

This is a work in progress. There are about a hundred more usages.
