### PR TITLE
gem-config: add snappy

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -21,8 +21,8 @@
 , libiconv, postgresql, v8_3_16_14, clang, sqlite, zlib, imagemagick
 , pkgconfig , ncurses, xapian, gpgme, utillinux, fetchpatch, tzdata, icu, libffi
 , cmake, libssh2, openssl, mysql, darwin, git, perl, gecode_3, curl
-, libmsgpack, qt48, libsodium
-}:
+, libmsgpack, qt48, libsodium, snappy
+}@args:
 
 let
   v8 = v8_3_16_14;
@@ -143,6 +143,10 @@ in
 
   rugged = attrs: {
     buildInputs = [ cmake pkgconfig openssl libssh2 zlib ];
+  };
+
+  snappy = attrs: {
+    buildInputs = [ args.snappy ];
   };
 
   sqlite3 = attrs: {


### PR DESCRIPTION
###### Motivation for this change

Allow the snappy gem to be installed via Nix.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
