### PR TITLE
git-crypt: allow any platform

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     version = "0.5.0";
     maintainers = [ maintainers.dochang ];
-    platforms = platforms.linux;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Since this works anywhere that its dependencies work, and I get tired of patching it everytime i want to install on darwin.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
