### PR TITLE
cockroachdb: limit platforms to those supported upstream

### DIFF
--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -27,6 +27,7 @@ buildGoPackage rec {
     homepage = https://www.cockroachlabs.com;
     description = "A scalable, survivable, strongly-consistent SQL database";
     license = licenses.asl20;
+    platforms = [ "x86_64-linux" "x86_64-darwin" "x86_64-cygwin" ];
     maintainers = [ maintainers.rushmorem ];
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
