### PR TITLE
nvme-cli: init at 0.9

### DIFF
--- a/pkgs/os-specific/linux/nvme-cli/default.nix
+++ b/pkgs/os-specific/linux/nvme-cli/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "nvme-cli-${version}";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "linux-nvme";
+    repo = "nvme-cli";
+    rev = "v${version}";
+    sha256 = "16n0gg1zx4fgadcq94kx6bgysqw60jvybjwynk7mj3fzdbvzrqyh";
+  };
+
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "NVM-Express user space tooling for Linux";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ tavyc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11602,6 +11602,8 @@ in
 
   numad = callPackage ../os-specific/linux/numad { };
 
+  nvme-cli = callPackage ../os-specific/linux/nvme-cli { };
+
   open-vm-tools = callPackage ../applications/virtualization/open-vm-tools {
     inherit (gnome2) gtk gtkmm;
   };


### PR DESCRIPTION
###### Motivation for this change

This adds a package for nvme-cli, a set of tools to manage NVMe SSDs on Linux.

Tested on release-16.09 with a Samsung 950 Pro SSD.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
