### PR TITLE
ibus-engines.uniemoji: init at 2016-09-20

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-uniemoji/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-uniemoji/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub
+, python3Packages
+}:
+
+stdenv.mkDerivation rec {
+  name = "ibus-uniemoji-${version}";
+  version = "2016-09-20";
+
+  src = fetchFromGitHub {
+    owner = "salty-horse";
+    repo = "ibus-uniemoji";
+    rev = "c8931a4807a721168e45463ecba00805adb3fe8d";
+    sha256 = "0fydxkdjsbfbrbb8238rfnshmhp11c38hsa7y2gp1ii6mkjngb1j";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ pyxdg python-Levenshtein ];
+
+  makeFlags = [ "PREFIX=$(out)" "SYSCONFDIR=$(out)/etc"
+                "PYTHON=${python3Packages.python.interpreter}" ];
+
+  postPatch = ''
+    sed -i "s,/etc/xdg/,$out/etc/xdg/," uniemoji.py
+    sed -i "s,/usr/share/,$out/share/,g" uniemoji.xml.in
+  '';
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    description  = "Input method (ibus) for entering unicode symbols and emoji by name";
+    homepage     = "https://github.com/salty-horse/ibus-uniemoji";
+    license      = with licenses; [ gpl3 mit ];
+    platforms    = platforms.linux;
+    maintainers  = with maintainers; [ aske ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1182,6 +1182,7 @@ in
       ibus-table = ibus-engines.table;
     };
 
+    uniemoji = callPackage ../tools/inputmethods/ibus-engines/ibus-uniemoji { };
   };
 
   ibus-with-plugins = callPackage ../tools/inputmethods/ibus/wrapper.nix {


### PR DESCRIPTION
###### Motivation for this change

Add input method for ibus which allows to enter unicode emoji and other symbols by name
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
