### PR TITLE
lib.options: automatically generate example for booleans

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -93,16 +93,22 @@ rec {
           visible = opt.visible or true;
           readOnly = opt.readOnly or false;
           type = opt.type.name or null;
-        }
-        // (if opt ? example then { example = scrubOptionValue opt.example; } else {})
-        // (if opt ? default then { default = scrubOptionValue opt.default; } else {})
-        // (if opt ? defaultText then { default = opt.defaultText; } else {});
+        };
+        docOptionDefault =
+          if opt ? defaultText then { default = opt.defaultText; }
+          else if opt ? default then { default = scrubOptionValue opt.default; }
+          else { };
+        docOptionExample =
+          if opt ? example then { example = scrubOptionValue opt.example; }
+          else if opt.type == lib.types.bool then
+            { example = !docOptionDefault.default or false; }
+          else { };
 
         subOptions =
           let ss = opt.type.getSubOptions opt.loc;
           in if ss != {} then optionAttrSetToDocList' opt.loc ss else [];
       in
-        [ docOption ] ++ subOptions) (collect isOption options);
+        [ (docOption // docOptionDefault // docOptionExample) ] ++ subOptions) (collect isOption options);
 
 
   /* This function recursively removes all derivation attributes from

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -102,6 +102,8 @@ rec {
           if opt ? example then { example = scrubOptionValue opt.example; }
           else if opt.type == lib.types.bool then
             { example = !docOptionDefault.default or false; }
+          else if opt ? type && isBool (docOptionDefault.default or null) && opt.type.check (!docOptionDefault.default) then
+            { example = !docOptionDefault.default or false; }
           else { };
 
         subOptions =


### PR DESCRIPTION
###### Motivation for this change

Remove the need to provide an example for boolean options. Since there are only two possibilities, setting `example = !default` is reasonable. This should remove the amount of boilerplate in nixpkgs by a few hundred lines.

Also catches cases where `type == bool` but `default` is not defined and provides `example = true`.

The second commit catches cases where `type != bool` but `isBool default` holds (type may be undefined or something like `nullOr bool`) and `!default` is a valid value.
If this is too expensive we can also drop it, but since this is only executed for the manual generation, it should be ok. 

The first commit adds 853 example values to options-db.xml, the second one another 3.

ref #18803 could use this :wink: 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
