### PR TITLE
pg_repack: init at 1.3.4

### DIFF
--- a/pkgs/servers/sql/postgresql/pg_repack/default.nix
+++ b/pkgs/servers/sql/postgresql/pg_repack/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, postgresql, openssl, zlib, readline }:
+
+stdenv.mkDerivation rec {
+    name = "pg_repack-${version}";
+    version = "1.3.4";
+
+    buildInputs = [ postgresql openssl zlib readline ];
+
+    src = fetchFromGitHub {
+      owner = "reorg";
+      repo = "pg_repack";
+      rev = "ver_${version}";
+      sha256 = "1hig4x8iycchlp42q8565jzi6hkj8gpbhl9kpn73jvk7afl7z0c8";
+    };
+
+    installPhase = ''
+      install -D bin/pg_repack -t $out/bin/
+      install -D lib/pg_repack.so -t $out/lib/
+      install -D lib/{pg_repack--${version}.sql,pg_repack.control} -t $out/share/extension
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Reorganize tables in PostgreSQL databases with minimal locks";
+      longDescription = ''
+        pg_repack is a PostgreSQL extension which lets you remove bloat from tables and indexes, and optionally restore
+        the physical order of clustered indexes. Unlike CLUSTER and VACUUM FULL it works online, without holding an
+        exclusive lock on the processed tables during processing. pg_repack is efficient to boot,
+        with performance comparable to using CLUSTER directly.
+      '';
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ danbst ];
+      inherit (postgresql.meta) platforms;
+      inherit (src.meta) homepage;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9127,6 +9127,8 @@ in
 
   pdf2xml = callPackage ../development/libraries/pdf2xml {} ;
 
+  pg_repack = callPackage ../servers/sql/postgresql/pg_repack {};
+
   phonon = callPackage ../development/libraries/phonon {};
 
   phonon-backend-gstreamer = callPackage ../development/libraries/phonon/backends/gstreamer.nix {};


### PR DESCRIPTION
###### Motivation for this change

pg_repack is a great extension for removing bloat from databases online. It supports postgresqls up to 9.5. In my case, it reduced database size from 70G to 40G without downtime.

It should be used as postgresql plugin. e.g.:

```
    services.postgresql.extraPlugins = [ pkgs.pg_repack ];
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
