### PR TITLE
glide: 0.10.2 -> 0.12.2

### DIFF
--- a/pkgs/development/tools/glide/default.nix
+++ b/pkgs/development/tools/glide/default.nix
@@ -1,16 +1,22 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "glide-${version}";
-  version = "0.10.2";
-  rev = "${version}";
+  version = "0.12.2";
   
   goPackagePath = "github.com/Masterminds/glide";
 
   src = fetchFromGitHub {
-    inherit rev;
+    rev = "v${version}";
     owner = "Masterminds";
     repo = "glide";
-    sha256 = "1qb2n5i04gabb2snnwfr8wv4ypcp1pdzvgga62m9xkhk4p2w6pwl";
+    sha256 = "15cdrcslkiggd6sg5j40amflydpqz1s63f13mvlg309adfhsk4qz";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://glide.sh;
+    description = "Package management for Go";
+    license = licenses.mit;
+    maintainers = [ maintainers.rushmorem ];
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
