### PR TITLE
Add option to grant additional capabilities to containers

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -129,6 +129,9 @@ let
         --setenv HOST_ADDRESS6="$HOST_ADDRESS6" \
         --setenv LOCAL_ADDRESS6="$LOCAL_ADDRESS6" \
         --setenv PATH="$PATH" \
+        ${if cfg.additionalCapabilities != null then
+          ''--capability="${concatStringsSep " " cfg.additionalCapabilities}"'' else ""
+        } \
         ${containerInit cfg} "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/init"
     '';
 
@@ -302,6 +305,7 @@ let
   dummyConfig =
     {
       extraVeths = {};
+      additionalCapabilities = [];
       hostAddress = null;
       hostAddress6 = null;
       localAddress = null;
@@ -365,6 +369,17 @@ in
                 <option>config</option>, you can specify the path to
                 the evaluated NixOS system configuration, typically a
                 symlink to a system profile.
+              '';
+            };
+
+            additionalCapabilities = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              example = [ "CAP_NET_ADMIN" "CAP_MKNOD" ];
+              description = ''
+                Grant additional capabilities to the container.  See the
+                capabilities(7) and systemd-nspawn(1) man pages for more
+                information.
               '';
             };
 


### PR DESCRIPTION
Adds and option `additionalCapabilities` to allow to grant additional capabilities to a container.
###### Motivation for this change

This helps with running programs such as OpenVPN or tinc that setup tunnel interfaces and thus require `CAP_NET_ADMIN`, to run inside a container.

See #18708 for more detail.

/cc @Mic92 
###### Things done
- [x] Tested using `nixos-rebuild test`
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
