### PR TITLE
Use machinectl shell for nixos-container run/root-login instead of nsenter+su

### DIFF
--- a/pkgs/tools/virtualization/nixos-container/default.nix
+++ b/pkgs/tools/virtualization/nixos-container/default.nix
@@ -6,8 +6,6 @@ substituteAll {
     isExecutable = true;
     src = ./nixos-container.pl;
     perl = "${perl}/bin/perl -I${perlPackages.FileSlurp}/lib/perl5/site_perl";
-    su = "${shadow.su}/bin/su";
-    inherit utillinux;
 
     postInstall = ''
       t=$out/etc/bash_completion.d


### PR DESCRIPTION
Unfortunately, `nsenter`+`su` don't grant the "real" container environment and lead to surprising results where the same command run via a service inside a container fails, but works perfectly fine using `nixos-container run`. See https://github.com/NixOS/nixpkgs/issues/18708#issuecomment-247864660 and https://github.com/NixOS/nixpkgs/issues/18708#issuecomment-248227752 for such a case.

Note, that `machinectl shell` currently prints some boilerplate messages when entering and leaving a container:

```
# machinectl shell vpn
Connected to machine vpn. Press ^] three times within 1s to exit session.
...
Connection to machine vpn terminated.
```

I've submitted systemd/systemd#4196 to get rid of this.
###### Motivation for this change

`machinectl shell` tries hard open a session inside the container that is isolated from its host environment, so it's better suited than the current implementation using `nsenter`+`su`.

https://github.com/systemd/systemd/issues/825#issuecomment-127917622 for more background.

Ref. #18708 
###### Things done
- [x] Tested using `nixos-rebuild test`
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
