### PR TITLE
irssi: 1.8.19 -> 1.8.20 (security)

### DIFF
--- a/pkgs/applications/networking/irc/irssi/default.nix
+++ b/pkgs/applications/networking/irc/irssi/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
 
-  version = "0.8.19";
+  version = "0.8.20";
   name = "irssi-${version}";
 
   src = fetchurl {
     urls = [ "https://github.com/irssi/irssi/releases/download/${version}/${name}.tar.gz" ];
-    sha256 = "0ny8dry1b8siyc5glaxcwzng0d2mxnwxk74v64f8xplqhrvlnkzy";
+    sha256 = "0riz2wsdcs5hx5rwynm99fi01973lfrss21y8qy30dw2m9v0zqpm";
   };
 
   buildInputs = [ pkgconfig ncurses glib openssl perl libintlOrEmpty ];


### PR DESCRIPTION
###### Motivation for this change

new minor version update (security)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

https://irssi.org/security/irssi_sa_2016.txt
  CVE-2016-7044
  CVE-2016-7045
