### PR TITLE
Updated gmic to the latest version

### DIFF
--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gmic-${version}";
-  version = "1.7.4";
+  version = "1.7.7";
 
   src = fetchurl {
     url = "http://gmic.eu/files/source/gmic_${version}.tar.gz";
-    sha256 = "1k4swqi1adq479b6zdpvy5kdpkvjkfihkj9iwgw9mgi0xdqikjry";
+    sha256 = "0shcxgq8nc391c0y0zh3l87g3p7fvsmgshi1x1jvvwwq1b9nf6vp";
   };
 
   buildInputs = [ fftw zlib libjpeg libtiff libpng ];
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   preBuild = ''
     buildFlagsArray=( \
       CURL_CFLAGS= CURL_LIBS= \
-      EXR_CFLAGS= EXR_LIBS= \
+      OPENEXR_CFLAGS= OPENEXR_LIBS= \
       OPENCV_CFLAGS= OPENCV_LIBS= \
       X11_CFLAGS="-Dcimg_display=0" X11_LIBS= \
       cli \


### PR DESCRIPTION
###### Motivation for this change

Updating to the latest GMIC version.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
