### PR TITLE
Add libnabo and libpointmatcher

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -97,6 +97,7 @@
   coroa = "Jonas Hörsch <jonas@chaoflow.net>";
   couchemar = "Andrey Pavlov <couchemar@yandex.ru>";
   cransom = "Casey Ransom <cransom@hubns.net>";
+  cryptix = "Henry Bubert <cryptix@riseup.net>";
   CrystalGamma = "Jona Stubbe <nixos@crystalgamma.de>";
   cstrahan = "Charles Strahan <charles@cstrahan.com>";
   cwoac = "Oliver Matthews <oliver@codersoffortune.net>";

--- a/pkgs/development/libraries/libnabo/default.nix
+++ b/pkgs/development/libraries/libnabo/default.nix
@@ -1,0 +1,32 @@
+{stdenv, fetchFromGitHub, cmake, eigen, boost}:
+
+stdenv.mkDerivation rec {
+  version = "1.0.6";
+  name = "libnabo-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ethz-asl";
+    repo = "libnabo";
+    rev = version;
+    sha256 = "1pg4vjfq5n7zhjdf7rgvycd7bkk1iwr50fl2dljq43airxz6525w";
+  };
+
+  buildInputs = [cmake eigen boost];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = "
+    -DEIGEN_INCLUDE_DIR=${eigen}/include/eigen3
+  ";
+
+  doCheck = true;
+  checkTarget = "test";
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "A fast K Nearest Neighbor library for low-dimensional spaces";
+    license = licenses.bsd3;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ cryptix ];
+  };
+}

--- a/pkgs/development/libraries/libpointmatcher/default.nix
+++ b/pkgs/development/libraries/libpointmatcher/default.nix
@@ -1,0 +1,35 @@
+{stdenv, fetchFromGitHub, cmake, eigen, boost, libnabo}:
+
+stdenv.mkDerivation rec {
+  version = "2016-09-11";
+  name = "libpointmatcher-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ethz-asl";
+    repo = "libpointmatcher";
+    rev = "75044815d40ff934fe0bb7e05ed8bbf18c06493b";
+    sha256 = "1s7ilvg3lhr1fq8sxw05ydmbd3kl46496jnyxprhnpgvpmvqsbzl";
+  };
+
+  buildInputs = [cmake eigen boost libnabo];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = "
+    -DEIGEN_INCLUDE_DIR=${eigen}/include/eigen3
+  ";
+
+  checkPhase = ''
+  export LD_LIBRARY_PATH=$PWD
+  ./utest/utest --path ../examples/data/
+  '';
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "An \"Iterative Closest Point\" library for 2-D/3-D mapping in robotic";
+    license = licenses.bsd3;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ cryptix ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2480,6 +2480,8 @@ in
 
   libnabo = callPackage ../development/libraries/libnabo { };
 
+  libpointmatcher = callPackage ../development/libraries/libpointmatcher { };
+
   libtorrent = callPackage ../tools/networking/p2p/libtorrent { };
 
   libmpack = callPackage ../development/libraries/libmpack { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2478,6 +2478,8 @@ in
 
   libmongo-client = callPackage ../development/libraries/libmongo-client { };
 
+  libnabo = callPackage ../development/libraries/libnabo { };
+
   libtorrent = callPackage ../tools/networking/p2p/libtorrent { };
 
   libmpack = callPackage ../development/libraries/libmpack { };


### PR DESCRIPTION
###### Motivation for this change

I need these for another project and wanted to supply them to others.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
