### PR TITLE
cogl: 1.22.0 -> 1.22.2, enable wayland support

### DIFF
--- a/pkgs/development/libraries/cogl/1.22.nix
+++ b/pkgs/development/libraries/cogl/1.22.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchurl, pkgconfig, mesa_noglu, glib, gdk_pixbuf, xorg, libintlOrEmpty
-, pangoSupport ? true, pango, cairo, gobjectIntrospection
+, pangoSupport ? true, pango, cairo, gobjectIntrospection, wayland
 , gstreamerSupport ? true, gst_all_1 }:
 
 let
   ver_maj = "1.22";
-  ver_min = "0";
+  ver_min = "2";
 in
 stdenv.mkDerivation rec {
   name = "cogl-${ver_maj}.${ver_min}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/cogl/${ver_maj}/${name}.tar.xz";
-    sha256 = "689dfb5d14fc1106e9d2ded0f7930dcf7265d0bc84fa846b4f03941633eeaa91";
+    sha256 = "03f0ha3qk7ca0nnkkcr1garrm1n1vvfqhkz9lwjm592fnv6ii9rr";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -19,11 +19,13 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-introspection"
     "--enable-kms-egl-platform"
+    "--enable-wayland-egl-platform"
+    "--enable-wayland-egl-server"
   ] ++ stdenv.lib.optional gstreamerSupport "--enable-cogl-gst"
     ++ stdenv.lib.optionals (!stdenv.isDarwin) [ "--enable-gles1" "--enable-gles2" ];
 
   propagatedBuildInputs = with xorg; [
-      glib gdk_pixbuf gobjectIntrospection
+      glib gdk_pixbuf gobjectIntrospection wayland
       mesa_noglu libXrandr libXfixes libXcomposite libXdamage
     ]
     ++ libintlOrEmpty


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @lovek323 
