### PR TITLE
Run riak with its `dataDir` as `HOME` so Erlang cookie can be written

### DIFF
--- a/nixos/modules/services/databases/riak.nix
+++ b/nixos/modules/services/databases/riak.nix
@@ -108,6 +108,7 @@ in
         pkgs.bash
       ];
 
+      environment.HOME = "${cfg.dataDir}";
       environment.RIAK_DATA_DIR = "${cfg.dataDir}";
       environment.RIAK_LOG_DIR = "${cfg.logDir}";
       environment.RIAK_ETC_DIR = "/etc/riak";


### PR DESCRIPTION
Merging this would fix #18852 
###### Motivation for this change

As we're unable to change the Erlang cookie path (`~/.erlang.cookie`), it might be better to make Riak's `dataDir` its `HOME` dir, which is writable. The current solution adds `environment.HOME = "${cfg.dataDir}"` to the service.

Alternatively we could perhaps make it the `riak` user's an actual homedir. I suppose this would also allow scripts to run as this user, but that might not be required or even desired, accumulating state in more/different places.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
