### PR TITLE
Tomcat: 7.0.70 -> 7.0.72 for CVE (HTTPoxy)

### DIFF
--- a/pkgs/servers/http/tomcat/default.nix
+++ b/pkgs/servers/http/tomcat/default.nix
@@ -5,12 +5,12 @@ let
   common = { versionMajor, versionMinor, sha256 } @ args: stdenv.mkDerivation (rec {
     name = "apache-tomcat-${version}";
     version = "${versionMajor}.${versionMinor}";
-    
+
     src = fetchurl {
       url = "mirror://apache/tomcat/tomcat-${versionMajor}/v${version}/bin/${name}.tar.gz";
       inherit sha256;
     };
-    
+
     outputs = [ "out" "webapps" ];
     installPhase =
       ''
@@ -19,7 +19,7 @@ let
         mkdir -p $webapps/webapps
         mv $out/webapps $webapps/
       '';
-    
+
     meta = {
       homepage = https://tomcat.apache.org/;
       description = "An implementation of the Java Servlet and JavaServer Pages technologies";
@@ -39,8 +39,8 @@ in {
 
   tomcat7 = common {
     versionMajor = "7";
-    versionMinor = "0.70";
-    sha256 = "0x4chqb7kkmadmhf2hlank856hw2vpgjl14fak74ybimlcb3dwqk";
+    versionMinor = "0.72";
+    sha256 = "1nx5pmz3bq3n20fdspqh8ljqy1nj67rwi1vsqjpkrvd996x7p73p";
   };
 
   tomcat8 = common {
@@ -54,11 +54,11 @@ in {
     versionMinor = "5.5";
     sha256 = "0idfxjrw5q45f531gyjnv6xjkbj9nhy2v1w4z7558z96230a0fqj";
   };
-  
+
   tomcatUnstable = common {
     versionMajor = "9";
     versionMinor = "0.0.M10";
     sha256 = "0p3pqwz9zjvr9w73divsyaa53mbazf0icxfs06wvgxsvkbgj5gq9";
   };
-  
+
 }


### PR DESCRIPTION
# Please backport to 16.09
###### Motivation for this change

http://tomcat.apache.org/tomcat-7.0-doc/changelog.html
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
