### PR TITLE
calibre: 2.66.0 -> 2.68.0

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.66.0";
+  version = "2.68.0";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "1dbv6p9cq9zj51zvhfy2b7aic2zqa44lmfmq7k7fkqcgb6wmanic";
+    sha256 = "0mn6wdws1xxc4yvhp5vdzb5i5c9dsmamyms1njdzs5fv754rszpm";
   };
 
   inherit python;
@@ -129,14 +129,14 @@ stdenv.mkDerivation rec {
     ];
     categories = "Office";
     extraEntries = ''
-      Actions=ebook-edit ebook-viewer
+      Actions=Edit;Viewer;
 
-      [Desktop Action ebook-edit]
+      [Desktop Action Edit]
       Name=Edit E-book
       Icon=@out@/share/calibre/images/tweak.png
       Exec=@out@/bin/ebook-edit --detach %F
 
-      [Desktop Action ebook-viewer]
+      [Desktop Action Viewer]
       Name=E-book Viewer
       Icon=@out@/share/calibre/images/viewer.png
       Exec=@out@/bin/ebook-viewer --detach %F


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of `calibre`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
