### PR TITLE
redprl: init at 2016-09-22

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -12,6 +12,7 @@
   abbradar = "Nikolay Amiantov <ab@fmap.me>";
   aboseley = "Adam Boseley <adam.boseley@gmail.com>";
   abuibrahim = "Ruslan Babayev <ruslan@babayev.com>";
+  acowley = "Anthony Cowley <acowley@gmail.com>";
   adev = "Adrien Devresse <adev@adev.name>";
   Adjective-Object = "Maxwell Huang-Hobbs <mhuan13@gmail.com>";
   adnelson = "Allen Nelson <ithinkican@gmail.com>";

--- a/pkgs/applications/science/logic/redprl/default.nix
+++ b/pkgs/applications/science/logic/redprl/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchgit, mlton }:
+stdenv.mkDerivation {
+  name = "redprl-2016-09-22";
+  src = fetchgit {
+    url = "https://github.com/RedPRL/sml-redprl.git";
+    rev = "3215faf0d494f4ac14d6e10172329a161df192c4";
+    sha256 = "0pcq4q9xy34j7ziwbly4qxccpkcrl92r9y11bv6hdkbzwm1g2a77";
+    fetchSubmodules = true;
+  };
+  buildInputs = [ mlton ];
+  builder = builtins.toFile "builder.sh" ''
+    source $stdenv/setup
+    mkdir -p $out/bin
+    cp -r $src/* .
+    chmod -R +w src
+    ./script/mlton.sh
+    mv ./bin/redprl $out/bin
+  '';
+  meta = {
+    description = "A proof assistant for Nominal Computational Type Theory";
+    homepage = "http://www.redprl.org/";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.acowley ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17471,6 +17471,8 @@ in
 
   putty = callPackage ../applications/networking/remote/putty { };
 
+  redprl = callPackage ../applications/science/logic/redprl { };
+
   retroarchBare = callPackage ../misc/emulators/retroarch { };
 
   retroarch = wrapRetroArch { retroarch = retroarchBare; };


### PR DESCRIPTION
###### Motivation for this change

Include the RedPRL proof assistant in nixpkgs.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
