### PR TITLE
mercurial: 3.8.2 -> 3.9.1

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -4,7 +4,7 @@
 
 let
   # if you bump version, update pkgs.tortoisehg too or ping maintainer
-  version = "3.8.2";
+  version = "3.9.1";
   name = "mercurial-${version}";
   inherit (pythonPackages) curses docutils hg-git dulwich python;
 in
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://mercurial-scm.org/release/${name}.tar.gz";
-    sha256 = "1zdz42znd6i7c3nf31j0k6frcs68qyniyvcad8k2a1hlarlv2y6b";
+    sha256 = "0x6zjl8za6nnlbmyxng4pfrr2h77zi3wbg985262ghjyx33lypk2";
   };
 
   inherit python; # pass it so that the same version can be used in hg2git

--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonApplication rec {
     name = "tortoisehg-${version}";
-    version = "3.8.1";
+    version = "3.9.1";
 
     src = fetchurl {
       url = "https://bitbucket.org/tortoisehg/targz/downloads/${name}.tar.gz";
-      sha256 = "1v5h5yz9b360ris9p8zsdjxqvaflp9z2b6b7dfb4abn2irv3jip6";
+      sha256 = "12bqvkkwkb6m5hls7gipkxbnspfrk1k6l9l0fff0wp1zajnp4pnn";
     };
 
     pythonPath = with pythonPackages; [ pyqt4 mercurial qscintilla iniparse ];


### PR DESCRIPTION
###### Motivation for this change

Update to latest version
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This change updates mercurial and tortoisehg at the same time as per comment in code.
