### PR TITLE
mysql55: 5.5.50 -> 5.5.52

### DIFF
--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "mysql-${version}";
-  version = "5.5.50";
+  version = "5.5.52";
 
   src = fetchurl {
     url = "mirror://mysql/MySQL-5.5/${name}.tar.gz";
-    sha256 = "0lgr6badwnwbrzm6sbll4a25m02xfy85v4q6q0rq5cdjn745bb2y";
+    sha256 = "1zb2h6nmmm42qcc808bwa3sdlhyyyglv44jy4pfxmx5kwqyy283q";
   };
 
   patches = if stdenv.isCygwin then [


### PR DESCRIPTION
###### Motivation for this change

Update version / fix vulnerability / #18856 

https://lwn.net/Vulnerabilities/700651/
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
# PORT ME TO 16.09
