### PR TITLE
vault: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -2,15 +2,26 @@
 
 buildGoPackage rec {
   name = "vault-${version}";
-  version = "0.6.0";
-  rev = "v${version}";
+  version = "0.6.1";
 
   goPackagePath = "github.com/hashicorp/vault";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "hashicorp";
     repo = "vault";
-    sha256 = "0byb91nqrhl7w0rq0ilml1ybamh8w1qga47a790kggsmjhcj9ybx";
+    rev = "v${version}";
+    sha256 = "06xf2dpn0q398qb6wbh9j1wjl5smqq9nrrn2039g48haqm8853jx";
+  };
+
+  buildFlagsArray = ''
+    -ldflags=
+      -X github.com/hashicorp/vault/version.GitCommit=${version}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.vaultproject.io;
+    description = "A tool for managing secrets";
+    license = licenses.mpl20;
+    maintainers = [ maintainers.rushmorem ];
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
