### PR TITLE
vivaldi: 1.3 -> 1.4

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -10,17 +10,18 @@
 }:
 
 let
-  version = "1.3";
-  build = "551.30-1";
+  version = "1.4";
+  build = "589.29-1";
   fullVersion = "stable_${version}.${build}";
 
   info = if stdenv.is64bit then {
       arch = "amd64";
-      sha256 = "89d0630c9df56cfb12a87f23430179f6d14a8c57fb029d1c8d28ab06c98b7640";
+      sha256 = "14sb58qrqnqcpkzacwnwfln558p018zargppxq21p5ic8s92v1g6";
     } else {
       arch = "i386";
-      sha256 = "0a7e07833f5359e38516222767da63edeca92177cbb6d4ef4946a6ef7c7b2946";
+      sha256 = "0c4l9ji5xlxwzcjsrvxjkx53j76y777fj6hh7plfkkanlrfkryac";
     };
+
 in stdenv.mkDerivation rec {
   product    = "vivaldi";
   name       = "${product}-${version}";
@@ -65,6 +66,17 @@ in stdenv.mkDerivation rec {
     cp -r opt "$out"
     mkdir "$out/bin"
     ln -s "$out/opt/vivaldi/vivaldi" "$out/bin/vivaldi"
+    mkdir -p "$out/share"
+    cp -r usr/share/{applications,xfce4} "$out"/share
+    substituteInPlace "$out"/share/applications/*.desktop \
+      --replace /usr/bin/vivaldi-stable "$out"/bin/vivaldi
+    local d
+    for d in 16 22 24 32 48 64 128 256; do
+      mkdir -p "$out"/share/icons/hicolor/''${d}x''${d}/apps
+      ln -s \
+        "$out"/opt/vivaldi/product_logo_''${d}.png \
+        "$out"/share/icons/hicolor/''${d}x''${d}/apps/vivaldi.png
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
