### PR TITLE
brogue: fix crash by stackprotector hardening

### DIFF
--- a/pkgs/games/brogue/default.nix
+++ b/pkgs/games/brogue/default.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
     cp -r bin/fonts $out/share/brogue/
   '';
 
+  # fix crash; shouldn’t be a security risk because it’s an offline game
+  hardeningDisable = [ "stackprotector" ];
+
   meta = with stdenv.lib; {
     description = "A roguelike game";
     homepage = https://sites.google.com/site/broguegame/;


### PR DESCRIPTION
- [x] NixOS
- [ ] OS X
- [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
