### PR TITLE
Add ripgrep package

### DIFF
--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "ripgrep-${version}";
+  version = "0.1.17";
+
+  src = fetchFromGitHub {
+    owner = "BurntSushi";
+    repo = "ripgrep";
+    rev = "${version}";
+    sha256 = "18bpb1jl9fnipgp9icf1wwzm7934lk0ycbpvzlhvs2873zqhv6a6";
+  };
+
+  depsSha256 = "0fzjk5qynxivxmmz7r1za7mzdbdwzwwvxlc5a6cmxmzwnix2lby3";
+
+  meta = with stdenv.lib; {
+    description = "An untility that combines the usability of The Silver Searcher with the raw speed of grep";
+    homepage = https://github.com/BurntSushi/ripgrep;
+    license = with licenses; [ unlicense ];
+    maintainers = [ maintainers.tailhook ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1899,6 +1899,7 @@ in
   graphviz_2_32 = callPackage ../tools/graphics/graphviz/2.32.nix { };
 
   grin = callPackage ../tools/text/grin { };
+  ripgrep = callPackage ../tools/text/ripgrep { };
 
   grive = callPackage ../tools/filesystems/grive {
     json_c = json-c-0-11; # won't configure with 0.12; others are vulnerable

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2016-09-20";
-  rev = "cf9c8ccb2c7d753491fc26c64b717bb895d0b4ef";
-  sha256 = "02fq0f2zc9qhxs7h110g9ndrvmys26kp9hi93gq9vqhcizq2ici3";
+  version = "2016-09-23";
+  rev = "e2ac19b6236468033ba0c66ac23293b7ed9e3486";
+  sha256 = "16kwzjjx67pigs9b8pxdfl685l812a8ja47s61h6gshxrg3j1cs7";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change

This is a great and fast text search utility written in rust.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
