### PR TITLE
mailman: 2.1.18 -> 2.1.23

### DIFF
--- a/pkgs/servers/mail/mailman/default.nix
+++ b/pkgs/servers/mail/mailman/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, python, pythonPackages }:
 
 stdenv.mkDerivation rec {
-  name = "mailman-2.1.18";
+  name = "mailman-2.1.23";
 
   src = fetchurl {
     url = "mirror://gnu/mailman/${name}.tgz";
-    sha256 = "0jc360crakvpz71msl0h11zv3849fqzlj9jfh1g7x3j4459n07fw";
+    sha256 = "0s9ywix4m3n7qa0baws744ildg48hsa87jahpsfiqqilhmpwl8mh";
   };
 
   buildInputs = [ python pythonPackages.dns ];


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Alerts/700805/
https://github.com/NixOS/nixpkgs/issues/18856

Note that mailman3  is out too, but this is still up to date.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
