### PR TITLE
as31: Apply Debian patch for CVE-2012-0808

### DIFF
--- a/pkgs/development/compilers/as31/default.nix
+++ b/pkgs/development/compilers/as31/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, yacc }:
+{ stdenv, fetchpatch, fetchurl, yacc }:
 
 let
 
@@ -13,6 +13,15 @@ in stdenv.mkDerivation {
   };
 
   buildInputs = [ yacc ];
+
+  patches = [
+    # CVE-2012-0808
+    (fetchpatch {
+       name = "as31-mkstemps.patch";
+       url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=655496;filename=as31-mkstemps.patch;msg=5";
+       sha256 = "0iia4wa8m141bwz4588yxb1dp2qwhapcii382sncm6jvwyngwh21";
+     })
+  ];
 
   preConfigure = ''
     chmod +x ./configure


### PR DESCRIPTION
###### Motivation for this change

Fix CVE-2012-0808. Patch is from Debian (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=655496).
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Shoutout to #18856, due to which I just discovered monitor.nixos.org despite using Nix for quite a while now, which let me know of this vulnerability in the packages I maintain.
