### PR TITLE
ffmpeg: 2.8.7 -> 2.8.8

### DIFF
--- a/pkgs/development/libraries/ffmpeg/2.8.nix
+++ b/pkgs/development/libraries/ffmpeg/2.8.nix
@@ -1,7 +1,7 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "${branch}.7";
+  version = "${branch}.8";
   branch = "2.8";
-  sha256 = "1rggcy8kflmlvdyf5yqv0zshycysyqz45fl06v8zsh2n6d5cwxw7";
+  sha256 = "19h6xmlcb933hgpfd40mjwkral8v389v25sx660a3p7aiyalh25p";
 })


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/18856
https://lwn.net/Vulnerabilities/675050/
~~https://lwn.net/Vulnerabilities/676796/~~
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
