### PR TITLE
Update salt to 2016.3.3

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -8,13 +8,13 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "salt-${version}";
-  version = "2015.8.8";
+  version = "2016.3.3";
 
   disabled = pythonPackages.isPy3k;
 
   src = fetchurl {
     url = "mirror://pypi/s/salt/${name}.tar.gz";
-    sha256 = "1xcfcs50pyammb60myph4f8bi2r6iwkxwsnnhrjwvkv2ymxwxv5j";
+    sha256 = "1djjglnh6203y8dirziz5w6zh2lgszxp8ivi86nb7fgijj2h61jr";
   };
 
   propagatedBuildInputs = with pythonPackages; [
@@ -26,7 +26,6 @@ pythonPackages.buildPythonApplication rec {
     pyyaml
     pyzmq
     requests
-    salttesting
     tornado
   ] ++ extraInputs;
 

--- a/pkgs/tools/admin/salt/testing.nix
+++ b/pkgs/tools/admin/salt/testing.nix
@@ -2,17 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "SaltTesting-${version}";
-  version = "2015.7.10";
+  version = "2016.9.7";
 
   disabled = pythonPackages.isPy3k;
 
-  propagatedBuildInputs = with pythonPackages; [
-    six
-  ];
-
   src = fetchurl {
     url = "mirror://pypi/S/SaltTesting/${name}.tar.gz";
-    sha256 = "0p0y8kb77pis18rcig1kf9dnns4bnfa3mr91q40lq4mw63l1b34h";
+    sha256 = "0vcw1b1176qm9nkic3sbxh6vnv9kpd9kgyqz5fpsp5jnb2hsf1qx";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

2016.3.3 is the latest version.
Salt no longer depends on SaltTesting, but I updated that as well for good measure.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
