### PR TITLE
jq: Fix CVE-2015-8863 and CVE-2016-4074

### DIFF
--- a/pkgs/development/tools/jq/default.nix
+++ b/pkgs/development/tools/jq/default.nix
@@ -1,33 +1,39 @@
-{stdenv, fetchurl, oniguruma}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="jq";
-    version="1.5";
-    name="${baseName}-${version}";
+{ stdenv, lib, fetchurl, fetchpatch, oniguruma }:
+
+stdenv.mkDerivation rec {
+  name = "jq-${version}";
+  version="1.5";
+
+  src = fetchurl {
     url="https://github.com/stedolan/jq/releases/download/jq-1.5/jq-1.5.tar.gz";
     sha256="0g29kyz4ykasdcrb0zmbrp2jqs9kv1wz9swx849i2d1ncknbzln4";
   };
-  buildInputs = [
-    oniguruma
+
+  buildInputs = [ oniguruma ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2015-8863.patch";
+      url = https://github.com/stedolan/jq/commit/8eb1367ca44e772963e704a700ef72ae2e12babd.diff;
+      sha256 = "18bjanzvklfzlzzd690y88725l7iwl4f6wnr429na5pfmircbpvh";
+    })
+    (fetchpatch {
+      name = "CVE-2016-4074.patch";
+      url = https://patch-diff.githubusercontent.com/raw/stedolan/jq/pull/1214.diff;
+      sha256 = "1w8bapnyp56di6p9casbfczfn8258rw0z16grydavdjddfm280l9";
+    })
   ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
+  patchFlags = [ "-p2" ]; # `src` subdir was introduced after v1.5 was released
 
   # jq is linked to libjq:
   configureFlags = [
     "LDFLAGS=-Wl,-rpath,\\\${libdir}"
   ];
+
   meta = {
-    inherit (s) version;
     description = ''A lightweight and flexible command-line JSON processor'';
-    license = stdenv.lib.licenses.mit ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ raskin ];
+    platforms = with lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Part of #18856.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

jq has not had a release since August 2015, so use the latest version
from git. CVE-2015-8863 has a fix committed to the current master, while
CVE-2016-4074 has not had a fix committed to master, so add a separate
patch for that.

I manually confirmed that the CVEs are fixed in the resulting binary.
