### PR TITLE
flex: 2.6.0 -> 2.6.1

### DIFF
--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, bison, m4 }:
 
 stdenv.mkDerivation rec {
-  name = "flex-2.6.0";
+  name = "flex-2.6.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/flex/${name}.tar.bz2";
-    sha256 = "1sdqx63yadindzafrq1w31ajblf9gl1c301g068s20s7bbpi3ri4";
+    url = "https://github.com/westes/flex/releases/download/v2.6.1/flex-2.6.1.tar.gz";
+    sha256 = "0fy14c35yz2m1n1m4f02by3501fn0cca37zn7jp8lpp4b3kgjhrw";
   };
 
   buildInputs = [ bison ];
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = http://flex.sourceforge.net/;
+    homepage = https://github.com/westes/flex;
     description = "A fast lexical analyser generator";
     platforms = stdenv.lib.platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/18856
https://lwn.net/Vulnerabilities/696808/
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
