### PR TITLE
giflib: 5.1.0 -> 5.1.4

### DIFF
--- a/pkgs/development/libraries/giflib/5.1.nix
+++ b/pkgs/development/libraries/giflib/5.1.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl, xmlto, docbook_xml_dtd_412, docbook_xsl, libxml2 }:
 
 stdenv.mkDerivation {
-  name = "giflib-5.1.0";
+  name = "giflib-5.1.4";
   src = fetchurl {
-    url = mirror://sourceforge/giflib/giflib-5.1.0.tar.bz2;
-    sha256 = "06wd32akyawppar9mqdvyhcw47ssdfcj39lryim2w4v83i7nkv2s";
+    url = mirror://sourceforge/giflib/giflib-5.1.4.tar.bz2;
+    sha256 = "1md83dip8rf29y40cm5r7nn19705f54iraz6545zhwa6y8zyq9yz";
   };
 
   buildInputs = [ xmlto docbook_xml_dtd_412 docbook_xsl libxml2 ];


### PR DESCRIPTION
had some strange deadlocks with an off-nixpkgs math lib. this fixed them.

only tested against sxiv.

```
Version 5.1.4
=============

Code Fixes
----------

* Fix SF bug #94: giflib 5 loves to fail to load images... a LOT.

* Fix SF Bug #92: Fix buffer overread in gifbuild.

* Fix SF Bug #93: Add bounds check in gifbuild netscape2.0 path

* Fix SF Bug #89: Fix buffer overread in gifbuild.

Version 5.1.3
=============

As of this version the library and code has been seriously abused by fuzzers,
smoking out crash bugs (now fixed) induced by various kinds of severely
malformed GIF.

Code Fixes
----------

* Prevent malloc randomess from causing the header output routine to emit
  a GIF89 version string even when no GIF89 features are present. Only
  breaks tests, not production code, but it's odd this wasn't caught sooner.

* Prevent malloc randomess from producing sporadic failures by causing
  sanity checks added in 5.1.2 to misfire.

* Bulletproof gif2rgb against 0-height images. Addressed SF bug #78:
  Heap overflow in gif2rgb with images of size 0, also SF bug #82.

* Remove unnecessary duplicate EGifClose() in gifcolor.c. Fixes SF bug #83
  introduced in 5.1.2.

* Fix SF Bug #84: incorrect return of DGifSlurp().

Version 5.1.2
=============

Code Fixes
----------

* Code hardening using reallocarray() from OpenBSD.

* Sanity check in giffilter catches files with malformed extension records
  Fixes SourceForge bug #63: malformed gif causes segfault in giffilter.

* Inexpensive sanity check in DGifSlurp() catches malformed files with
  no image descriptor. Fixes SourceForge bug #64: malformed gif causes
  crash in giftool.

* Fix SourceForge bug #66: GifDrawBoxedText8x8() modifying constant input
  parameter.

* Bail out of GIF read on invalid pixel width. Addresses Savannah bug
  #67: invalid shift in dgif_lib.c

* Fix SourceForge bug #69: #69 Malformed: Gif file with no extension
  block after a GRAPHICS_EXT_FUNC_CODE extension causes segfault (in
  giftext).

* Fix SourceForge bug #71: Buffer overwrite when giffixing a malformed gif.

* Fix SourceForge bug #73: Null pointer deference in gifclrmap (only
  reachable with malformed GIF).

* Fix SourceForge bug #74: Double free in gifsponge under 5.1.1,
  for any valid gif image.

* Fix SourceForge bug #75: GAGetArgs overflows due to uncounted use of va_arg.

* Sanity check in giffix catches some malformed files. Addresses
  SourceForge bug #77: dgif_lib.c: extension processing error


Version 5.1.1
=============

Code Fixes
----------

* Numerous minor fixes in getarg.c. Affects only the utilities, not the
  core library.

* Fix SourceForge bug #59: DGifOpen can segfault if DGifGetScreenDesc fails.

* SourceForge patch #20: In gifalloc, fix usage of realloc() in case of failure.

* Fix SourceForge bug #61 Leak in gifsponge.

Build Fixes
----------

* glibtoolize port fix for OS X.
```
