### PR TITLE
containers: fix dynamic hash lookup

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -159,7 +159,7 @@ let
             fi
           ''
         else
-          ''${ipcmd} add ${cfg.attribute} dev $ifaceHost'';
+          ''${ipcmd} add ${cfg.${attribute}} dev $ifaceHost'';
       renderExtraVeth = name: cfg:
         if cfg.hostBridge != null then
           ''


### PR DESCRIPTION
###### Motivation for this change

we want the content of attribute as a key:
b9df84cd4f6b70bdfa395a91dbf3d712adc7e18d broke this
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
