### PR TITLE
monit: 5.10 -> 5.19.0

### DIFF
--- a/pkgs/tools/system/monit/default.nix
+++ b/pkgs/tools/system/monit/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, openssl, bison, flex, pam, usePAM ? stdenv.isLinux }:
 
 stdenv.mkDerivation rec {
-  name = "monit-5.10";
-  
+  name = "monit-5.19.0";
+
   src = fetchurl {
     url = "${meta.homepage}dist/${name}.tar.gz";
-    sha256 = "0lwlils6b59kr6zg328q113c7mrpggqydpq4l6j52sqv3dd1b49p";
+    sha256 = "1f32dz7zzp575d35m8xkgjgrqs2vbls0q6vdzm7wwashcm1xbz5y";
   };
 
   nativeBuildInputs = [ bison flex ];


### PR DESCRIPTION
###### Motivation for this change

monit disables SSLv23 now by default, see
- https://mmonit.com/monit/changes/
- https://lwn.net/Vulnerabilities/691497/

also related to https://github.com/NixOS/nixpkgs/issues/18856
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
