### PR TITLE
fcgi: Patch to protect against stack smashing

### DIFF
--- a/pkgs/development/libraries/fcgi/default.nix
+++ b/pkgs/development/libraries/fcgi/default.nix
@@ -1,14 +1,24 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  name = "fcgi-2.4.0";
+  name = "fcgi-${version}";
+  version = "2.4.0";
 
   src = fetchurl {
-    url = "http://www.fastcgi.com/dist/${name}.tar.gz";
+    url = "https://launchpad.net/debian/+archive/primary/+files/libfcgi_${version}.orig.tar.gz";
+    #    url = "http://www.fastcgi.com/dist/${name}.tar.gz";
     sha256 = "1f857wnl1d6jfrgfgfpz3zdaj8fch3vr13mnpcpvy8bang34bz36";
   };
 
-  patches = [ ./gcc-4.4.diff ];
+  patches = [
+    ./gcc-4.4.diff
+    (fetchpatch {
+      # Fix a stack-smashing bug:
+      # xhttps://bugs.debian.org/cgi-bin/bugreport.cgi?bug=681591
+      url = "https://bugs.launchpad.net/ubuntu/+source/libfcgi/+bug/933417/+attachment/2745025/+files/poll.patch";
+      sha256 = "0v3gw0smjvrxh1bv3zx9xp633gbv5dd5bcn3ipj6ckqjyv4i6i7m";
+    })
+  ];
 
   postInstall = "ln -s . $out/include/fastcgi";
 


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/642646/
https://github.com/NixOS/nixpkgs/issues/18856
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
