### PR TITLE
Spice: Upgrade all the spice packages

### DIFF
--- a/pkgs/applications/virtualization/spice-vdagent/default.nix
+++ b/pkgs/applications/virtualization/spice-vdagent/default.nix
@@ -1,16 +1,17 @@
 {stdenv, fetchurl, pkgconfig, alsaLib, spice_protocol, glib,
- libpciaccess, libxcb, libXrandr, libXinerama, libXfixes}:
+ libpciaccess, libxcb, libXrandr, libXinerama, libXfixes, dbus}:
 stdenv.mkDerivation rec {
-  name = "spice-vdagent-0.16.0";
+  name = "spice-vdagent-0.17.0";
   src = fetchurl {
     url = "http://www.spice-space.org/download/releases/${name}.tar.bz2";
-    sha256 = "0z8gwc5va2i64mjippavmxajdb9az83ffqyhlbynm6dxw131d5av";
+    sha256 = "0gdkyylyg1hksg0i0anvznqfli2q39335fnrmcd6847frpc8njpi";
   };
   postPatch = ''
     substituteInPlace data/spice-vdagent.desktop --replace /usr $out
   '';
   buildInputs = [ pkgconfig alsaLib spice_protocol glib
-                  libpciaccess libxcb libXrandr libXinerama libXfixes ] ;
+                  libpciaccess libxcb libXrandr libXinerama libXfixes
+                  dbus ] ;
   meta = {
     description = "Enhanced SPICE integration for linux QEMU guest";
     longDescription = ''

--- a/pkgs/desktops/gnome-3/3.20/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/default.nix
@@ -271,7 +271,7 @@ let
 
   gnome-boxes = callPackage ./apps/gnome-boxes {
     gtkvnc = pkgs.gtkvnc.override { enableGTK3 = true; };
-    spice_gtk = pkgs.spice_gtk.override { enableGTK3 = true; };
+    spice_gtk = pkgs.spice_gtk;
   };
 
   gnome-calendar = callPackage ./apps/gnome-calendar { };
@@ -390,7 +390,7 @@ let
   gpaste = callPackage ./misc/gpaste { };
 
   pidgin-im-gnome-shell-extension = callPackage ./misc/pidgin { };
-  
+
   gtkhtml = callPackage ./misc/gtkhtml { };
 
   pomodoro = callPackage ./misc/pomodoro { };

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, gtk2, spice_protocol, intltool, celt_0_5_1
+{ stdenv, fetchurl, pkgconfig, spice_protocol, intltool, celt_0_5_1
 , openssl, libpulseaudio, pixman, gobjectIntrospection, libjpeg_turbo, zlib
 , cyrus_sasl, pythonPackages, autoreconfHook, usbredir, libsoup
-, gtk3, enableGTK3 ? false }:
+, gtk3, epoxy }:
 
 with stdenv.lib;
 
 let
   inherit (pythonPackages) python pygtk;
 in stdenv.mkDerivation rec {
-  name = "spice-gtk-0.29";
+  name = "spice-gtk-0.32";
 
   src = fetchurl {
     url = "http://www.spice-space.org/download/gtk/${name}.tar.bz2";
-    sha256 = "0wz9sm44gnmwjpmyacwd5jyzvhfl1wlf1dn3qda20si42cky5is4";
+    sha256 = "00pf94xh2xf0h1g13lnavxrysd0d0x22l5jl108cvq1mjc4z8j2c";
   };
 
   buildInputs = [
     spice_protocol celt_0_5_1 openssl libpulseaudio pixman gobjectIntrospection
-    libjpeg_turbo zlib cyrus_sasl python pygtk usbredir
-  ] ++ (if enableGTK3 then [ gtk3 ] else [ gtk2 ]);
+    libjpeg_turbo zlib cyrus_sasl python pygtk usbredir gtk3 epoxy
+  ];
 
   nativeBuildInputs = [ pkgconfig intltool libsoup autoreconfHook ];
 
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-maintainer-mode"
-    (if enableGTK3 then "--with-gtk3" else "--with-gtk=2.0")
+    "--with-gtk3"
   ];
 
   dontDisableStatic = true; # Needed by the coroutine test
@@ -43,9 +43,9 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    description = "A GTK+2 and GTK+3 SPICE widget";
+    description = "A GTK+3 SPICE widget";
     longDescription = ''
-      spice-gtk is a GTK+2 and GTK+3 SPICE widget. It features glib-based
+      spice-gtk is a GTK+3 SPICE widget. It features glib-based
       objects for SPICE protocol parsing and a gtk widget for embedding
       the SPICE display into other applications such as virt-manager.
       Python bindings are available too.

--- a/pkgs/development/libraries/spice-protocol/default.nix
+++ b/pkgs/development/libraries/spice-protocol/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "spice-protocol-0.12.10";
+  name = "spice-protocol-0.12.12";
 
   src = fetchurl {
     url = "http://www.spice-space.org/download/releases/${name}.tar.bz2";
-    sha256 = "1yrfacqgnabmx2q768mim892ga2wnlp5cavkf51v3idyjmqhv3vq";
+    sha256 = "00wx81f2ml62g3maw63jq9w217zym921rdi38h7lpm5m8ckxraqp";
   };
 
   postInstall = ''

--- a/pkgs/development/libraries/spice/default.nix
+++ b/pkgs/development/libraries/spice/default.nix
@@ -5,11 +5,11 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "spice-0.12.6";
+  name = "spice-0.12.8";
 
   src = fetchurl {
     url = "http://www.spice-space.org/download/releases/${name}.tar.bz2";
-    sha256 = "1dk9hp78ldqb0a52kdlqq0scnk3drnhj7rsw8r7hmy2v2cqflj7i";
+    sha256 = "0za03i77j8i3g5l2np2j7vy8cqsdbkm9wbv4hjnaqq9xhz2sa0gr";
   };
 
   buildInputs = [ pixman celt alsaLib openssl libjpeg zlib

--- a/pkgs/development/libraries/usbredir/default.nix
+++ b/pkgs/development/libraries/usbredir/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "usbredir-${version}";
-  version = "0.7";
+  version = "0.7.1";
 
   src = fetchurl {
     url = "http://spice-space.org/download/usbredir/${name}.tar.bz2";
-    sha256 = "1ah64271r83lvh8hrpkxzv0iwpga1wkrfkx4rkljpijx5dqs0qqa";
+    sha256 = "1wsnmk4wjpdhbn1zaxg6bmyxspcki2zgy0am9lk037rnl4krwzj0";
   };
 
   buildInputs = [ pkgconfig libusb ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15328,7 +15328,7 @@ in
 
   virt-viewer = callPackage ../applications/virtualization/virt-viewer {
     gtkvnc = gtkvnc.override { enableGTK3 = true; };
-    spice_gtk = spice_gtk.override { enableGTK3 = true; };
+    spice_gtk = spice_gtk;
   };
 
   virtmanager = callPackage ../applications/virtualization/virt-manager {
@@ -15336,7 +15336,7 @@ in
     vte = gnome3.vte;
     dconf = gnome3.dconf;
     gtkvnc = gtkvnc.override { enableGTK3 = true; };
-    spice_gtk = spice_gtk.override { enableGTK3 = true; };
+    spice_gtk = spice_gtk;
     system-libvirt = libvirt;
   };
 


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/690141/ spice has a vulnerability in everything below 0.12.7. I'm not sure if you can backport that change without the rest. Maybe a maintainer will know :)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Somewhat related to https://github.com/NixOS/nixpkgs/issues/18856
