### PR TITLE
davfs2: 1.5.2 -> 1.5.3

### DIFF
--- a/pkgs/tools/filesystems/davfs2/default.nix
+++ b/pkgs/tools/filesystems/davfs2/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, neon, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "davfs2-1.5.2";
+  name = "davfs2-1.5.3";
 
   src = fetchurl {
     url = "mirror://savannah/davfs2/${name}.tar.gz";
-    sha256 = "0n5k2xxfxmbsavg5fhp65lmy30hq9jg3w242rdzafvksnnda2d5y";
+    sha256 = "1x9ri19995ika89cmc56za7z3ipiizhh6zdhi4mf4p7chxzdnhrw";
   };
 
   buildInputs = [ neon zlib ];


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/694102/
https://github.com/NixOS/nixpkgs/issues/18856

stack smashing bug 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
