### PR TITLE
mysql_jdbc: 5.1.38 -> 5.1.39

### DIFF
--- a/pkgs/servers/sql/mysql/jdbc/default.nix
+++ b/pkgs/servers/sql/mysql/jdbc/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, ant, unzip}:
 
-stdenv.mkDerivation {
-  name = "mysql-connector-java-5.1.38";
+stdenv.mkDerivation rec {
+  name = "mysql-connector-java-5.1.39";
   builder = ./builder.sh;
 
   src = fetchurl {
-    url = http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.zip;
-    sha256 = "0b1j2dylnpk6b17gn3168qdrrwq8kdil57nxrd08n1lnkirdsx33";
+    url = "http://dev.mysql.com/get/Downloads/Connector-J/${name}.zip";
+    sha256 = "0d0g51hfx7a2r6nbni8yramg4vpqk0sql0aaib6q576a0nnrq78r";
   };
 
   buildInputs = [ unzip ant ];


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/646898/
https://github.com/NixOS/nixpkgs/issues/18856
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
