### PR TITLE
nettle: 3.1.1 -> 3.2

### DIFF
--- a/pkgs/development/libraries/nettle/default.nix
+++ b/pkgs/development/libraries/nettle/default.nix
@@ -1,10 +1,10 @@
 { callPackage, fetchurl, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "3.1.1";
+  version = "3.2";
 
   src = fetchurl {
     url = "mirror://gnu/nettle/nettle-${version}.tar.gz";
-    sha256 = "0k1x57zviysvi91lkk66cg8v819vywm5g5yqs22wppfqcifx5m2z";
+    sha256 = "15wxhk52yc62rx0pddmry66hqm6z5brrrkx4npd3wh9nybg86hpa";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/18856
https://lwn.net/Vulnerabilities/674493/

```
- CVE-2015-8803 CVE-2015-8804 CVE-2015-8805
  (improper cryptographic calculations)

It has been discovered that multiple carry propagation bugs are
producing wrong results in calculations. They affect the NIST P-256 and
P-384 curves. The P-256 bug is in the C code and affects multiple
architectures. The P-384 bug is in the assembly code and only affects 64
bit x86. The computation compiles a certain curve point with 1, which
should not change the coordinates, however it does.

Impact
======

The impact is currently unclear, but miscalculations in cryptographic
functions are classified as security issues.
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
