### PR TITLE
vcsh: 1.20141026-1 -> 1.20151229-1

### DIFF
--- a/pkgs/applications/version-management/vcsh/default.nix
+++ b/pkgs/applications/version-management/vcsh/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  version = "1.20141026-1";
+  version = "1.20151229-1";
   name = "vcsh-${version}";
 
   src = fetchurl {
     url = "https://github.com/RichiH/vcsh/archive/v${version}.tar.gz";
-    sha256 = "1wgrmkygsbmk8zj88kjx9aim2fc44hh2d1a83h4mn2j714pffh33";
+    sha256 = "0wgg5zz11ql2v37vby5gbqvnbs80g1q83b9qbvm8d2pqx8bsb0kn";
   };
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];


### PR DESCRIPTION
###### Motivation for this change

Version out-of-dated for more than one year. New version haven't been updated for one year.

So I expect the new version to be better choice.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
