### PR TITLE
owncloud: update minor versions, init 9.1.1

### DIFF
--- a/pkgs/servers/owncloud/default.nix
+++ b/pkgs/servers/owncloud/default.nix
@@ -38,28 +38,33 @@ in {
   };
 
   owncloud70 = common {
-    versiona = "7.0.12";
-    sha256 = "d1a0f73f5094ec1149b50e2409b5fea0a9bebb16d663789d4b8f98fed341aa91";
+    versiona = "7.0.15";
+    sha256 = "1b2a0fccxlkqyyzsymx7qw8qbhsks3i6h1ybvxv8nn8hgw33nqv7";
   };
 
   owncloud80 = common {
-    versiona = "8.0.12";
-    sha256 = "04n8r9kya5w1vlib4rbchf0qcl1mrsrrjml9010a9zhh2kajg1g0";
+    versiona = "8.0.15";
+    sha256 = "18042jkp4p3b6xh394zm80126975g94r4ka8gzwhyvgfwpgxrx84";
   };
 
   owncloud81 = common {
-    versiona = "8.1.7";
-    sha256 = "0xl67axyh7pblsjb1j86vjd8ic42ga1f7yl3ghxy8rk2xrs8cii7";
+    versiona = "8.1.10";
+    sha256 = "1vspsd3l86mrhhddmyafwdr961f4dy6ln2j4dds2h45wf6296c63";
   };
 
   owncloud82 = common {
-    versiona = "8.2.4";
-    sha256 = "03br4lsjz9zxd083lqa0ag3f29224l1ksz59r4fdnnbafj9ixv0s";
+    versiona = "8.2.8";
+    sha256 = "0k10b3gfpfk3imxhkra0vn6a004xmcma09lw6pgxnalpmpbm8jiy";
   };
 
   owncloud90 = common {
-    versiona = "9.0.2";
-    sha256 = "845c43fe981fa0fd07fc3708f41f1ea15ecb11c2a15c65a4de191fc85b237c74";
+    versiona = "9.0.5";
+    sha256 = "1igpjc4rfaxqrkf2dln85wvdii54nrmwlh17fq3g0232l3vw9hn8";
+  };
+
+  owncloud91 = common {
+    versiona = "9.1.1";
+    sha256 = "1fd73ggzj2v43j284is2c6936gwkmz1inr5fm88rmq5pxcqkbgx6";
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2996,7 +2996,8 @@ in
     owncloud80
     owncloud81
     owncloud82
-    owncloud90;
+    owncloud90
+    owncloud91;
 
   owncloud-client = callPackage ../applications/networking/owncloud-client { };
 


### PR DESCRIPTION
###### Motivation for this change

Updated minor Owncloud releases 7 to 9 and added 9.1. Fixes security issues, related to #18856.
I did not test the output files, I just updated the hashes and confirmed that the build does not fail.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
