### PR TITLE
radicale: break into own package

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -35,6 +35,14 @@ following incompatible changes:</para>
       Now you need to use versioned attributes, like <literal>gnome3</literal>.
     </para>
   </listitem>
+
+  <listitem>
+    <para>
+      The attribute name of the Radicale daemon has been changed from
+      <literal>pythonPackages.radicale</literal> to
+      <literal>radicale</literal>.
+    </para>
+  </listitem>
 </itemizedlist>
 
 

--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -33,7 +33,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.pythonPackages.radicale ];
+    environment.systemPackages = [ pkgs.radicale ];
 
     users.extraUsers = singleton
       { name = "radicale";
@@ -52,7 +52,7 @@ in
       description = "A Simple Calendar and Contact Server";
       after = [ "network-interfaces.target" ];
       wantedBy = [ "multi-user.target" ];
-      script = "${pkgs.pythonPackages.radicale}/bin/radicale -C ${confFile} -f";
+      script = "${pkgs.radicale}/bin/radicale -C ${confFile} -f";
       serviceConfig.User = "radicale";
       serviceConfig.Group = "radicale";
     };

--- a/pkgs/servers/radicale/default.nix
+++ b/pkgs/servers/radicale/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "radicale-${version}";
+  version = "1.1.1";
+
+  src = fetchurl {
+    url = "mirror://pypi/R/Radicale/Radicale-${version}.tar.gz";
+    sha256 = "1c5lv8qca21mndkx350wxv34qypqh6gb4rhzms4anr642clq3jg2";
+  };
+
+  propagatedBuildInputs = [
+    pythonPackages.flup
+    pythonPackages.ldap
+    pythonPackages.sqlalchemy
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.radicale.org/;
+    description = "CalDAV CardDAV server";
+    longDescription = ''
+      The Radicale Project is a complete CalDAV (calendar) and CardDAV
+      (contact) server solution. Calendars and address books are available for
+      both local and remote access, possibly limited through authentication
+      policies. They can be viewed and edited by calendar and contact clients
+      on mobile phones or computers.
+    '';
+    license = licenses.gpl3Plus;
+    platform = platforms.all;
+    maintainers = with maintainers; [ edwtjo pSub ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10843,6 +10843,8 @@ in
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon Cocoa;
   };
 
+  radicale = callPackage ../servers/radicale { };
+
   rake = callPackage ../development/tools/build-managers/rake { };
 
   redis = callPackage ../servers/nosql/redis { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8504,39 +8504,6 @@ in modules // {
 
   };
 
-  radicale = buildPythonPackage rec {
-    name = "radicale-${version}";
-    namePrefix = "";
-    version = "1.1.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/R/Radicale/Radicale-${version}.tar.gz";
-      sha256 = "1c5lv8qca21mndkx350wxv34qypqh6gb4rhzms4anr642clq3jg2";
-    };
-
-    propagatedBuildInputs = with self; [
-      flup
-      ldap
-      sqlalchemy
-    ];
-
-    doCheck = true;
-
-    meta = {
-      homepage = http://www.radicale.org/;
-      description = "CalDAV CardDAV server";
-      longDescription = ''
-        The Radicale Project is a complete CalDAV (calendar) and CardDAV
-        (contact) server solution. Calendars and address books are available for
-        both local and remote access, possibly limited through authentication
-        policies. They can be viewed and edited by calendar and contact clients
-        on mobile phones or computers.
-      '';
-      license = licenses.gpl3Plus;
-      maintainers = with maintainers; [ edwtjo pSub ];
-    };
-  };
-
   raven = buildPythonPackage rec {
     name = "raven-3.4.1";
 


### PR DESCRIPTION
###### Motivation for this change

Since Radicale is a piece of server software it makes sense for it to reside in the servers hierarchy of Nixpkgs. This PR pulls out the Radicale expression from `perlPackages` to its own package definition.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
