### PR TITLE
jq: fix cve-2015-8863

### DIFF
--- a/pkgs/development/tools/jq/default.nix
+++ b/pkgs/development/tools/jq/default.nix
@@ -19,6 +19,15 @@ stdenv.mkDerivation {
     inherit (s) url sha256;
   };
 
+  patchFlags = [ "-p2" ];
+  patches = [
+    # cve-2015-8863
+    (fetchurl {
+      url = https://github.com/stedolan/jq/commit/8eb1367ca44e772963e704a700ef72ae2e12babd.patch;
+      sha256 = "0vwvgs4kfdq0h72syzkm87rz90h87j79y2whz32f8nq74shfhpdq";
+    })
+  ];
+
   # jq is linked to libjq:
   configureFlags = [
     "LDFLAGS=-Wl,-rpath,\\\${libdir}"


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/686291/
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
