### PR TITLE
openshift: 1.0.1 -> 1.3.0

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,24 +1,42 @@
-{ stdenv, fetchgit, go, git, which }:
+{ stdenv, fetchFromGitHub, go, which }:
 
+let
+  version = "1.3.0";
+  versionMajor = "1";
+  versionMinor = "3";
+in
 stdenv.mkDerivation rec {
   name = "openshift-origin-${version}";
-  version = "1.0.1";
+  inherit version;
 
-  src = fetchgit {
-    url = https://github.com/openshift/origin.git;
-    rev = "1b601951daa44964c9bc7e4a2264d65489e3a58c";
-    sha256 = "0hvipgnkpph81jx6h6bar49j5zkrxzi6h71b4y75c0l7af129wdi";
-    leaveDotGit = true;
-    deepClone = true;
+  src = fetchFromGitHub {
+    owner = "openshift";
+    repo = "origin";
+    rev = "v${version}";
+    sha256 = "07s7xv8x8pch68j7lsw29im0axi07x32ag9wh9aqa0y570q9xgxy";
   };
 
-  buildInputs = [ go git which ];
+  buildInputs = [ go which ];
 
-  buildPhase = "hack/build-go.sh";
+  patchPhase = ''
+    patchShebangs ./hack
+  '';
+
+  buildPhase = ''
+    export GOPATH=$(pwd)
+    # Openshift build require this variables to be set
+    # unless there is a .git folder which is not the case with fetchFromGitHub
+    export OS_GIT_VERSION=${version}
+    export OS_GIT_MAJOR=${versionMajor}
+    export OS_GIT_MINOR=${versionMinor}
+    make build
+  '';
 
   installPhase = ''
+    export GOOS=$(go env GOOS)
+    export GOARCH=$(go env GOARCH)
     mkdir -p "$out/bin"
-    cp _output/local/go/bin/* "$out/bin/"
+    mv _output/local/bin/$GOOS/$GOARCH/* "$out/bin/"
   '';
 
   meta = with stdenv.lib; {
@@ -27,6 +45,5 @@ stdenv.mkDerivation rec {
     homepage = http://www.openshift.org;
     maintainers = with maintainers; [offline];
     platforms = [ "x86_64-linux" ];
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The current openshift package was broken and outdated.
This package contains both the client `oc` and the server `openshift`.
The client is usable and tested.
The server part runs but I didn't setup a cluster with it so I'm not sure everything works.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
