### PR TITLE
busybox: 1.23.2 -> 1.24.2

### DIFF
--- a/pkgs/os-specific/linux/busybox/busybox-in-store.patch
+++ b/pkgs/os-specific/linux/busybox/busybox-in-store.patch
@@ -2,14 +2,13 @@ Allow BusyBox to be invoked as "<something>-busybox". This is
 necessary when it's run from the Nix store as <hash>-busybox during
 stdenv bootstrap.
 
-diff -ru -x '*~' busybox-1.22.1-orig/libbb/appletlib.c busybox-1.22.1/libbb/appletlib.c
---- busybox-1.22.1-orig/libbb/appletlib.c	2014-01-09 19:15:44.000000000 +0100
-+++ busybox-1.22.1/libbb/appletlib.c	2014-10-29 09:53:01.232052068 +0100
-@@ -764,7 +764,7 @@
+--- busybox-1.24.2-orig/libbb/appletlib.c	2016-03-17 21:35:49.000000000 +0100
++++ busybox-1.24.2/libbb/appletlib.c	2016-09-25 08:48:18.293104041 +0200
+@@ -779,7 +779,7 @@
  	int applet = find_applet_by_name(name);
  	if (applet >= 0)
  		run_applet_no_and_exit(applet, argv);
--	if (strncmp(name, "busybox", 7) == 0)
+-	if (is_prefixed_with(name, "busybox"))
 +	if (strstr(name, "busybox") != 0)
  		exit(busybox_main(argv));
  }

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -26,11 +26,11 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "busybox-1.23.2";
+  name = "busybox-1.24.2";
 
   src = fetchurl {
     url = "http://busybox.net/downloads/${name}.tar.bz2";
-    sha256 = "16ii9sqracvh2r1gfzhmlypl269nnbkpvrwa7270k35d3bigk9h5";
+    sha256 = "0mf8f6ly8yi1fbr15jkyv6hxwh2x800x661rcd11rwsnqqzga7p7";
   };
 
   hardeningDisable = [ "format" ] ++ lib.optional enableStatic [ "fortify" ];


### PR DESCRIPTION
###### Motivation for this change

fixes https://lwn.net/Vulnerabilities/696815/
related to https://github.com/NixOS/nixpkgs/issues/18856
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
