### PR TITLE
eog: 3.20.3 -> 3.20.4

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/core/eog/src.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/eog/src.nix
@@ -4,7 +4,7 @@ fetchurl: {
   name = "eog-3.20.4";
 
   src = fetchurl {
-    url = mirror://gnome/sources/eog/3.20/eog-3.20.3.tar.xz;
-    sha256 = "09ic1ndvl31jnlsmigd5dgdv262ybq61ik0xh35kmvgcklw8qc0n";
+    url = mirror://gnome/sources/eog/3.20/eog-3.20.4.tar.xz;
+    sha256 = "1qsv3brhi8l8fr22nd3d0fwq5xhwspqw0bammhkkq3ga0z6791wn";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

previously version number did not match with source
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
