### PR TITLE
openjpeg: 2.1.0 -> 2.1.1 for critical bugfixes and no ABI break

### DIFF
--- a/pkgs/development/libraries/openjpeg/1.x.nix
+++ b/pkgs/development/libraries/openjpeg/1.x.nix
@@ -1,7 +1,8 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "${branch}.2";
+  version = "1.5.2";
   branch = "1.5";
-  sha256 = "11waq9w215zvzxrpv40afyd18qf79mxc28fda80bm3ax98cpppqm";
+  revision = "version.1.5.2";
+  sha256 = "1dvvpvb597i5z8srz2v4c5dsbxb966h125jx3m2z0r2gd2wvpfkp";
 })

--- a/pkgs/development/libraries/openjpeg/2.0.nix
+++ b/pkgs/development/libraries/openjpeg/2.0.nix
@@ -1,7 +1,8 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "${branch}.0.1";
+  version = "2.0.1";
   branch = "2";
-  sha256 = "1c2xc3nl2mg511b63rk7hrckmy14681p1m44mzw3n1fyqnjm0b0z";
+  revision = "version.2.0.1";
+  sha256 = "1r81hq0hx2papjs3hfmpsl0024f6lblk0bq53dfm2wcpi916q7pw";
 })

--- a/pkgs/development/libraries/openjpeg/2.1.nix
+++ b/pkgs/development/libraries/openjpeg/2.1.nix
@@ -1,7 +1,8 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "${branch}.0";
+  version = "2.1.1";
   branch = "2.1";
-  sha256 = "00zzm303zvv4ijzancrsb1cqbph3pgz0nky92k9qx3fq9y0vnchj";
+  revision = "v2.1.1";
+  sha256 = "1hrn10byrlw7hb7hwv2zvff89rxy3bsbn0im5ki4kdk63jw5p601";
 })

--- a/pkgs/development/libraries/openjpeg/generic.nix
+++ b/pkgs/development/libraries/openjpeg/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
 , libpng, libtiff, lcms2
 , mj2Support ? true # MJ2 executables
 , jpwlLibSupport ? true # JPWL library & executables
@@ -11,7 +11,7 @@
 , testsSupport ? false
 , jdk ? null
 # Inherit generics
-, branch, sha256, version, ...
+, branch, version, revision, sha256, ...
 }:
 
 assert jpipServerSupport -> jpipLibSupport && curl != null && fcgi != null;
@@ -26,8 +26,10 @@ in
 stdenv.mkDerivation rec {
   name = "openjpeg-${version}";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/openjpeg.mirror/${version}/openjpeg-${version}.tar.gz";
+  src = fetchFromGitHub {
+    owner = "uclouvain";
+    repo = "openjpeg";
+    rev = revision;
     inherit sha256;
   };
 


### PR DESCRIPTION
###### Motivation for this change

See:

https://github.com/uclouvain/openjpeg/blob/master/CHANGELOG.md
https://lwn.net/Vulnerabilities/700384/
https://lwn.net/Vulnerabilities/694625/
https://lwn.net/Vulnerabilities/659043/
https://github.com/NixOS/nixpkgs/issues/18856

Also openjpeg moved to github. Since the build is so heavily parameterized, I updated all the builds to use github.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
