### PR TITLE
lcms: fix cve-2013-4276

### DIFF
--- a/pkgs/development/libraries/lcms/cve-2013-4276.patch
+++ b/pkgs/development/libraries/lcms/cve-2013-4276.patch
@@ -1,0 +1,62 @@
+diff -ur lcms-1.19.dfsg/samples/icctrans.c lcms-1.19.dfsg-patched/samples/icctrans.c
+--- lcms-1.19.dfsg/samples/icctrans.c	2009-10-30 15:57:45.000000000 +0000
++++ lcms-1.19.dfsg-patched/samples/icctrans.c	2013-08-06 11:53:14.385266647 +0100
+@@ -86,6 +86,8 @@
+ static LPcmsNAMEDCOLORLIST InputColorant = NULL;
+ static LPcmsNAMEDCOLORLIST OutputColorant = NULL;
+ 
++unsigned int Buffer_size = 4096;
++
+ 
+ // isatty replacement
+ 
+@@ -500,7 +502,7 @@
+ 
+     Prefix[0] = 0;
+     if (!lTerse)
+-        sprintf(Prefix, "%s=", C);
++        snprintf(Prefix, 20, "%s=", C);
+ 
+     if (InHexa)
+     {
+@@ -648,7 +650,9 @@
+ static
+ void GetLine(char* Buffer)
+ {    
+-    scanf("%s", Buffer);
++    char User_buffer[Buffer_size];
++    fgets(User_buffer, (Buffer_size - 1), stdin);
++    sscanf(User_buffer,"%s", Buffer);
+     
+     if (toupper(Buffer[0]) == 'Q') { // Quit?
+ 
+@@ -668,7 +672,7 @@
+ static
+ double GetAnswer(const char* Prompt, double Range)
+ {
+-    char Buffer[4096];
++    char Buffer[Buffer_size];
+     double val = 0.0;
+ 	       
+     if (Range == 0.0) {              // Range 0 means double value
+@@ -738,7 +742,7 @@
+ static
+ WORD GetIndex(void)
+ {
+-    char Buffer[4096], Name[40], Prefix[40], Suffix[40];
++    char Buffer[Buffer_size], Name[40], Prefix[40], Suffix[40];
+     int index, max;
+ 
+     max = cmsNamedColorCount(hTrans)-1;
+diff -ur lcms-1.19.dfsg/tifficc/tiffdiff.c lcms-1.19.dfsg-patched/tifficc/tiffdiff.c
+--- lcms-1.19.dfsg/tifficc/tiffdiff.c	2009-10-30 15:57:46.000000000 +0000
++++ lcms-1.19.dfsg-patched/tifficc/tiffdiff.c	2013-08-06 11:49:06.698951157 +0100
+@@ -633,7 +633,7 @@
+     cmsIT8SetSheetType(hIT8, "TIFFDIFF");
+     
+    
+-    sprintf(Buffer, "Differences between %s and %s", TiffName1, TiffName2);
++    snprintf(Buffer, 256, "Differences between %s and %s", TiffName1, TiffName2);
+   
+     cmsIT8SetComment(hIT8, Buffer);
+ 

--- a/pkgs/development/libraries/lcms/default.nix
+++ b/pkgs/development/libraries/lcms/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation {
     sha256 = "1abkf8iphwyfs3z305z3qczm3z1i9idc1lz4gvfg92jnkz5k5bl0";
   };
 
+  patches = [ ./cve-2013-4276.patch ];
+
   outputs = [ "bin" "dev" "out" "man" ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/561443/
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
