### PR TITLE
collectd: patch deprecated usage of readdir_r()

### DIFF
--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -49,6 +49,11 @@ stdenv.mkDerivation rec {
     varnish yajl jdk libtool python udev net_snmp hiredis libmnl
   ];
 
+  patches = [
+    # Replace deprecated readdir_r() with readdir() to avoid a fatal warning.
+    ./readdir-fix.patch
+  ];
+
   # for some reason libsigrok isn't auto-detected
   configureFlags =
     stdenv.lib.optional (libsigrok != null) "--with-libsigrok" ++

--- a/pkgs/tools/system/collectd/readdir-fix.patch
+++ b/pkgs/tools/system/collectd/readdir-fix.patch
@@ -1,0 +1,55 @@
+diff -Naur collectd-5.6.0/src/vserver.c collectd-5.6.0/src/vserver.c
+--- collectd-5.6.0/src/vserver.c	2016-09-11 01:10:25.279038699 -0700
++++ collectd-5.6.0/src/vserver.c	2016-09-25 07:44:40.771177458 -0700
+@@ -132,15 +132,8 @@
+ 
+ static int vserver_read (void)
+ {
+-#if NAME_MAX < 1024
+-# define DIRENT_BUFFER_SIZE (sizeof (struct dirent) + 1024 + 1)
+-#else
+-# define DIRENT_BUFFER_SIZE (sizeof (struct dirent) + NAME_MAX + 1)
+-#endif
+-
+ 	DIR 			*proc;
+ 	struct dirent 	*dent; /* 42 */
+-	char dirent_buffer[DIRENT_BUFFER_SIZE];
+ 
+ 	errno = 0;
+ 	proc = opendir (PROCDIR);
+@@ -165,19 +158,23 @@
+ 
+ 		int status;
+ 
+-		status = readdir_r (proc, (struct dirent *) dirent_buffer, &dent);
+-		if (status != 0)
+-		{
+-			char errbuf[4096];
+-			ERROR ("vserver plugin: readdir_r failed: %s",
+-					sstrerror (errno, errbuf, sizeof (errbuf)));
+-			closedir (proc);
+-			return (-1);
+-		}
+-		else if (dent == NULL)
++		errno = 0;
++		dent = readdir (proc);
++		if (dent == NULL)
+ 		{
+-			/* end of directory */
+-			break;
++			if (errno != 0)
++			{
++				char errbuf[4096];
++				ERROR ("vserver plugin: readdir failed: %s",
++						sstrerror (errno, errbuf, sizeof (errbuf)));
++				closedir (proc);
++				return (-1);
++			}
++			else
++			{
++				/* end of directory */
++				break;
++			}
+ 		}
+ 
+ 		if (dent->d_name[0] == '.')


### PR DESCRIPTION
###### Motivation for this change

On a nixpkgs pulled yesterday, usage of `readdir_r()` in collectd was considered a compiler error, due to a combination of -Werror and the recent deprecation of `readdir_r()`.

This patch refactors the call site to use `readdir()`.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I have _not_ sent this patch upstream yet.
