### PR TITLE
qemu: 2.6.1 -> 2.7.0 for CVEs

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -15,7 +15,7 @@
 
 with stdenv.lib;
 let
-  version = "2.6.1";
+  version = "2.7.0";
   audio = optionalString (hasSuffix "linux" stdenv.system) "alsa,"
     + optionalString pulseSupport "pa,"
     + optionalString sdlSupport "sdl,";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://wiki.qemu.org/download/qemu-${version}.tar.bz2";
-    sha256 = "1l88iqk0swqccrnjwczgl9arqsvy77bis862zxajy7z3dqdzshj9";
+    sha256 = "0lqyz01z90nvxpc3nx4djbci7hx62cwvs5zwd6phssds0sap6vij";
   };
 
   buildInputs =
@@ -47,22 +47,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./no-etc-install.patch
-    (fetchpatch {
-      url = "http://git.qemu.org/?p=qemu.git;a=patch;h=fff39a7ad09da07ef490de05c92c91f22f8002f2";
-      name = "9pfs-forbid-illegal-path-names.patch";
-      sha256 = "081j85p6m7s1cfh3aq1i2av2fsiarlri9gs939s0wvc6pdyb4b70";
-    })
-    (fetchpatch {
-      url = "http://git.qemu.org/?p=qemu.git;a=patch;h=805b5d98c649d26fc44d2d7755a97f18e62b438a";
-      name = "9pfs-forbid-.-and-..-in-file-names.patch";
-      sha256 = "0km6knll492dx745gx37bi6dhmz08cmjiyf479ajkykp0aljii24";
-    })
-    (fetchpatch {
-      url = "http://git.qemu.org/?p=qemu.git;a=patch;h=56f101ecce0eafd09e2daf1c4eeb1377d6959261";
-      name = "9pfs-directory-traversal-CVE-2016-7116.patch";
-      sha256 = "06pr070qj19w5mjxr36bcqxmgpiczncigqsbwfc8ncjhm1h7dmry";
-    })
   ];
+  hardeningDisable = [ "stackprotector" ];
 
   configureFlags =
     [ "--smbd=smbd" # use `smbd' from $PATH


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/18856
### qemu-kvm (4 issues)
- [x] [`#686857`](https://lwn.net/Vulnerabilities/686857/) ([search](http://search.nix.gsc.io/?q=qemu-kvm&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu-kvm+in%3Apath&type=Code))  qemu-kvm: code execution
- [x] [`#687235`](https://lwn.net/Vulnerabilities/687235/) ([search](http://search.nix.gsc.io/?q=qemu-kvm&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu-kvm+in%3Apath&type=Code))  qemu: information leak
- [x] [`#666755`](https://lwn.net/Vulnerabilities/666755/) ([search](http://search.nix.gsc.io/?q=qemu-kvm&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu-kvm+in%3Apath&type=Code))  qemu: three vulnerabilities
- [x] [`#674496`](https://lwn.net/Vulnerabilities/674496/) ([search](http://search.nix.gsc.io/?q=qemu-kvm&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu-kvm+in%3Apath&type=Code))  qemu: multiple vulnerabilities
### qemu (12 issues)
- [x] [`#700388`](https://lwn.net/Vulnerabilities/700388/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: directory/path traversal
- [x] [`#692861`](https://lwn.net/Vulnerabilities/692861/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: multiple vulnerabilities
- [x] [`#695959`](https://lwn.net/Vulnerabilities/695959/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: two vulnerabilities
- [x] [`#691104`](https://lwn.net/Vulnerabilities/691104/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: denial of service
- [x] [`#690402`](https://lwn.net/Vulnerabilities/690402/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: denial of service
- [x] [`#689261`](https://lwn.net/Vulnerabilities/689261/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: two vulnerabilities
- [x] [`#687235`](https://lwn.net/Vulnerabilities/687235/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: information leak
- [x] [`#686861`](https://lwn.net/Vulnerabilities/686861/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: denial of service
- [x] [`#680800`](https://lwn.net/Vulnerabilities/680800/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  xen: multiple denial of service vulnerabilities
- [x] [`#666755`](https://lwn.net/Vulnerabilities/666755/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: three vulnerabilities
- [x] [`#674609`](https://lwn.net/Vulnerabilities/674609/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: privilege escalation
- [x] [`#674496`](https://lwn.net/Vulnerabilities/674496/) ([search](http://search.nix.gsc.io/?q=qemu&i=fosho&repos=nixos-nixpkgs), [files](https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=qemu+in%3Apath&type=Code))  qemu: multiple vulnerabilities
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Thanks to @NeQuissimus and @joachifm on this.
