### PR TITLE
pythonPackages.django_accept_header: init at 0.3.2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9480,6 +9480,25 @@ in modules // {
     };
   };
 
+  django_accept_header = buildPythonPackage rec {
+    name = "django-accept-header-${version}";
+    version = "0.3.2";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/d/django-accept-header/${name}.tar.gz";
+      sha256 = "1a8jwxx2y0vylpwhfp3j1zhdzx3d8y0pgc3566xg81md6091ngrl";
+    };
+
+    buildInputs =  with self; [ pytest ];
+    propagatedBuildInputs = with self; [ django ];
+
+    meta = {
+      descriotion = "A Django middleware that inspects the HTTP Accept headers sent by browsers";
+      homepage = https://github.com/fladi/django-accept-header;
+      license = licenses.free; # ISC License (ISCL), MIT like
+    };
+  };
+
   django_appconf = buildPythonPackage rec {
     name = "django-appconf-${version}";
     version = "1.0.1";


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
