### PR TITLE
Allow configuration of events{} block in nginx module

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -18,9 +18,13 @@ let
 
     ${cfg.config}
 
-    ${optionalString (cfg.httpConfig == "" && cfg.config == "") ''
-    events {}
+    ${optionalString (cfg.eventsConfig != "" || cfg.config == "") ''
+    events {
+      ${cfg.eventsConfig}
+    }
+    ''}
 
+    ${optionalString (cfg.httpConfig == "" && cfg.config == "") ''
     http {
       include ${cfg.package}/conf/mime.types;
       include ${cfg.package}/conf/fastcgi.conf;
@@ -98,7 +102,6 @@ let
     }''}
 
     ${optionalString (cfg.httpConfig != "") ''
-    events {}
     http {
       include ${cfg.package}/conf/mime.types;
       include ${cfg.package}/conf/fastcgi.conf;
@@ -272,12 +275,20 @@ in
         ";
       };
 
+      eventsConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Configuration lines to be set inside the events block.
+        '';
+      };
+
       appendHttpConfig = mkOption {
         type = types.lines;
         default = "";
         description = "
           Configuration lines to be appended to the generated http block.
-          This is mutually exclusive with using config and httpConfig for 
+          This is mutually exclusive with using config and httpConfig for
           specifying the whole http block verbatim.
         ";
       };


### PR DESCRIPTION
Remove empty `events{}` block generation from nginx module.
###### Motivation for this change

Always having an empty `events{}` block in the generated nginx configuration prevents the admin from setting a custom `events{}` configuration from `services.nginx.config`, since nginx only allows one block of this type and fails with:

```
nginx: [emerg] "events" directive is duplicate in /nix/store/p7njvyi9i1crp7dl6wrnvi33yvm6fism-nginx.conf:13
nginx.service: Main process exited, code=exited, status=1/FAILURE
```

See https://github.com/NixOS/nixpkgs/commit/3cf5d5ebed8c7c20f0da1ec3bc66388f1886b8ec#commitcomment-19065789 for more info.

I'm unaware of the reason of why this change was made in the first place. The original commit message does not contain any additional information and I have not found any problem in my testing after reverting the commit in question.
###### Things done
- [x] Tested using `nixos-rebuild test`
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
