### PR TITLE
webkitgtk: 2.12.4 -> 2.12.5

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.12.nix
+++ b/pkgs/development/libraries/webkitgtk/2.12.nix
@@ -11,7 +11,7 @@ assert enableGeoLocation -> geoclue2 != null;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "webkitgtk-${version}";
-  version = "2.12.4";
+  version = "2.12.5";
 
   meta = {
     description = "Web content rendering engine, GTK+ port";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://webkitgtk.org/releases/${name}.tar.xz";
-    sha256 = "0xwsc2lpb4q55vdgmwljx43219l0sa6r5mqs3bmw3fwsb5vk2ka2";
+    sha256 = "0h0wig413399wws6l88mn1nnjbqb42vb55yvz8az39b4p1a7h53b";
   };
 
   patches = [ ./finding-harfbuzz-icu.patch ];


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/700654/
https://github.com/NixOS/nixpkgs/issues/18856
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
