### PR TITLE
libxml++: add 3.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -227,6 +227,7 @@
   linquize = "Linquize <linquize@yahoo.com.hk>";
   linus = "Linus Arver <linusarver@gmail.com>";
   lnl7 = "Daiderd Jordan <daiderd@gmail.com>";
+  loskutov = "Ignat Loskutov <ignat.loskutov@gmail.com>";
   lovek323 = "Jason O'Conal <jason@oconal.id.au>";
   lowfatcomputing = "Andreas Wagner <andreas.wagner@lowfatcomputing.org>";
   lsix = "Lancelot SIX <lsix@lancelotsix.com>";

--- a/pkgs/development/libraries/libxmlxx/v3.nix
+++ b/pkgs/development/libraries/libxmlxx/v3.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl
+, pkgconfig, libxml2, glibmm, perl }:
+stdenv.mkDerivation rec {
+  name = "libxml++-3.0.0";
+  src = fetchurl {
+    url = "mirror://gnome/sources/libxml++/3.0/${name}.tar.xz";
+    sha256 = "0lkrajbdys5f6w6qwfijih3hnbk4c6809qx2mmxkb7bj2w269wrg";
+  };
+
+  buildInputs = [ pkgconfig glibmm perl ];
+
+  propagatedBuildInputs = [ libxml2 ];
+
+  meta = {
+    homepage = http://libxmlplusplus.sourceforge.net/;
+    description = "C++ wrapper for the libxml2 XML parser library, version 3";
+    license = "LGPLv2+";
+    maintainers = with stdenv.maintainers; [ ];
+  };
+}

--- a/pkgs/development/libraries/libxmlxx/v3.nix
+++ b/pkgs/development/libraries/libxmlxx/v3.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     description = "C++ wrapper for the libxml2 XML parser library, version 3";
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ loskutov ];
   };
 }

--- a/pkgs/development/libraries/libxmlxx/v3.nix
+++ b/pkgs/development/libraries/libxmlxx/v3.nix
@@ -1,20 +1,26 @@
-{ stdenv, fetchurl
-, pkgconfig, libxml2, glibmm, perl }:
+{ stdenv, fetchurl, pkgconfig, libxml2, glibmm, perl }:
+
 stdenv.mkDerivation rec {
-  name = "libxml++-3.0.0";
+  name = "libxml++-${maj_ver}.${min_ver}";
+  maj_ver = "3.0";
+  min_ver = "0";
+
   src = fetchurl {
-    url = "mirror://gnome/sources/libxml++/3.0/${name}.tar.xz";
+    url = "mirror://gnome/sources/libxml++/${maj_ver}/${name}.tar.xz";
     sha256 = "0lkrajbdys5f6w6qwfijih3hnbk4c6809qx2mmxkb7bj2w269wrg";
   };
 
-  buildInputs = [ pkgconfig glibmm perl ];
+  nativeBuildInputs = [ pkgconfig perl ];
+
+  buildInputs = [ glibmm ];
 
   propagatedBuildInputs = [ libxml2 ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://libxmlplusplus.sourceforge.net/;
     description = "C++ wrapper for the libxml2 XML parser library, version 3";
-    license = "LGPLv2+";
-    maintainers = with stdenv.maintainers; [ ];
+    license = licenses.lgpl2Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8893,6 +8893,7 @@ in
   };
 
   libxmlxx = callPackage ../development/libraries/libxmlxx { };
+  libxmlxx3 = callPackage ../development/libraries/libxmlxx/v3.nix { };
 
   libxmp = callPackage ../development/libraries/libxmp { };
 


### PR DESCRIPTION
###### Motivation for this change

Version 3.0.0 of libxml++ has released and it's not yet available in nixpkgs. As it's a major release and it doesn't provide backwards compatibility with 2.\* releases, it's submitted as a new derivation.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
