### PR TITLE
chibi-scheme: 0.7 -> 0.7.3

### DIFF
--- a/pkgs/development/interpreters/chibi/default.nix
+++ b/pkgs/development/interpreters/chibi/default.nix
@@ -1,22 +1,24 @@
-{ stdenv, fetchurl, makeWrapper }:
+{ stdenv, fetchFromGitHub, makeWrapper }:
 let
-  version = "0.7";
+  version = "0.7.3";
   name = "chibi-scheme-${version}";
 in
 stdenv.mkDerivation {
   inherit name;
 
   meta = {
-    homepage = "https://code.google.com/p/chibi-scheme/";
+    homepage = "https://github.com/ashinn/chibi-scheme";
     description = "Small Footprint Scheme for use as a C Extension Language";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.DerGuteMoritz ];
   };
 
-  src = fetchurl {
-    url = "http://abrek.synthcode.com/${name}.tgz";
-    sha256 = "1hhkq0khgi8i24xv66y7r6pgk1issn1i2bf7rv91rbk0wm0kv7qm";
+  src = fetchFromGitHub {
+    owner = "ashinn";
+    repo = "chibi-scheme";
+    rev = version;
+    sha256 = "05b17flppkll1a2c2aq6lxh4iif4pjmpxmyrmiqzk0ls85gvai2x";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Update the `chibi-scheme` (attribute `chibi`) package from version 0.7
to version 0.7.3.

The homepage listed for this package before this change,
https://code.google.com/p/chibi-scheme/, now redirects to
https://github.com/ashinn/chibi-scheme; this patch changes this
package to use this GitHub version of the software.

I have tested this change per nixpkgs manual section 10.1 ("Making
patches").
