### PR TITLE
syncthing: use service files from upstream when possible

### DIFF
--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, go }:
+{ stdenv, lib, fetchFromGitHub, go, pkgs }:
 
 stdenv.mkDerivation rec {
   version = "0.14.6";
@@ -25,15 +25,28 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/etc/systemd/{system,user}
+
     cp bin/* $out/bin
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    substitute etc/linux-systemd/system/syncthing-resume.service \
+               $out/etc/systemd/system/syncthing-resume.service \
+               --replace /usr/bin/pkill ${pkgs.procps}/bin/pkill
+
+    substitute etc/linux-systemd/system/syncthing@.service \
+               $out/etc/systemd/system/syncthing@.service \
+               --replace /usr/bin/syncthing $out/bin/syncthing
+
+    substitute etc/linux-systemd/user/syncthing.service \
+               $out/etc/systemd/user/syncthing.service \
+               --replace /usr/bin/syncthing $out/bin/syncthing
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://www.syncthing.net/;
     description = "Open Source Continuous File Synchronization";
-    license = stdenv.lib.licenses.mpl20;
-    maintainers = with stdenv.lib.maintainers; [ pshendry joko peterhoeg ];
-    platforms = with stdenv.lib.platforms; linux ++ freebsd ++ openbsd ++ netbsd;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ pshendry joko peterhoeg ];
+    platforms = with platforms; linux ++ freebsd ++ openbsd ++ netbsd;
   };
 }

--- a/pkgs/applications/networking/syncthing/inotify.nix
+++ b/pkgs/applications/networking/syncthing/inotify.nix
@@ -15,12 +15,24 @@ buildGoPackage rec {
 
   goDeps = ./inotify-deps.nix;
 
-  meta = {
+  postInstall = ''
+    mkdir -p $bin/etc/systemd/{system,user}
+
+    substitute $src/etc/linux-systemd/system/syncthing-inotify@.service \
+               $bin/etc/systemd/system/syncthing-inotify@.service \
+               --replace /usr/bin/syncthing-inotify $bin/bin/syncthing-inotify
+
+    substitute $src/etc/linux-systemd/user/syncthing-inotify.service \
+               $bin/etc/systemd/user/syncthing-inotify.service \
+               --replace /usr/bin/syncthing-inotify $bin/bin/syncthing-inotify
+  '';
+
+  meta = with stdenv.lib; {
     homepage = https://github.com/syncthing/syncthing-inotify;
     description = "File watcher intended for use with Syncthing";
-    license = stdenv.lib.licenses.mpl20;
-    maintainers = with stdenv.lib.maintainers; [ joko ];
-    platforms = with stdenv.lib.platforms; linux ++ freebsd ++ openbsd ++ netbsd;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ joko peterhoeg ];
+    platforms = with platforms; linux ++ freebsd ++ openbsd ++ netbsd;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

There are the following parts to this PR:

 1) Copy in the upstream unit files
 2) Make the nixos module use the definition from upstream
 3) Enable restarting of all instances (system and user) on resume
 4) Enable the ports required for discovery and transfer in the firewall

Why? No point repeating ourselves when upstream is shipping perfectly good unit files.

We are only doing this for the user services as NixOS handles the named system instances slightly differently.

Apologies for the whitespace noise and the back and forth on this. Should be good now (turns out I had a local service definition that override this).

Further to: #17320.

Cc: @rnhmjoj @jokogr
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
