### PR TITLE
oasis: fix typo

### DIFF
--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -1,11 +1,14 @@
 {stdenv, fetchurl, ocaml, findlib, ocaml_data_notation, type_conv, camlp4,
  ocamlmod, ocamlify, ounit, expect}:
 
-stdenv.mkDerivation {
-  name = "ocaml-oasis-0.4.7";
+stdenv.mkDerivation rec {
+  version = "0.4.7";
+  name = "ocaml-oasis-${version}";
 
+  # You must manually update the url, not just the version. OCamlforge keys off
+  # the number after download.php, not the filename.
   src = fetchurl {
-    url = http://forge.ocamlcore.org/frs/download.php/1635/oasis-0.4.6.tar.gz;
+    url = "http://forge.ocamlcore.org/frs/download.php/1635/oasis-${version}.tar.gz";
     sha256 = "13crvqiy0hhlnm4qfyxq2jjvs11ldxf15c4g9q91k1x3wj04pg2l";
   };
 


### PR DESCRIPTION
The URL uses the filename of 0.4.6 in the 0.4.7 package.
The package still works currently and provides 0.4.7, because ocamlforge
dispatches entirely based on the number before that, the filename is just
sugar.
