### PR TITLE
wordpress: 4.3.1 -> 4.6.1 + add a test

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
@@ -5,7 +5,8 @@ with lib;
 
 let
 
-  version = "4.3.1";
+  # Upgrading? We have a test! nix-build ./nixos/tests/wordpress.nix
+  version = "4.6.1";
   fullversion = "${version}";
 
   # Our bare-bones wp-config.php file using the above settings
@@ -74,7 +75,7 @@ let
       owner = "WordPress";
       repo = "WordPress";
       rev = "${fullversion}";
-      sha256 = "1rk10vcv4z9p04hfzc0wkbilrgx7m9ssyr6c3w6vw3vl1bcgqxza";
+      sha256 = "0n82xgjg1ry2p73hhgpslnkdzrma5n6hxxq76s7qskkzj0qjfvpn";
     };
     installPhase = ''
       mkdir -p $out
@@ -98,7 +99,7 @@ let
       # symlink additional plugin(s)
       ${concatMapStrings (plugin: "ln -s ${plugin} $out/wp-content/plugins/${plugin.name}\n") (config.plugins) }
 
-      # symlink additional translation(s) 
+      # symlink additional translation(s)
       mkdir -p $out/wp-content/languages
       ${concatMapStrings (language: "ln -s ${language}/*.mo ${language}/*.po $out/wp-content/languages/\n") (selectedLanguages) }
     '';
@@ -123,7 +124,7 @@ in
   options = {
     dbHost = mkOption {
       default = "localhost";
-      description = "The location of the database server.";  
+      description = "The location of the database server.";
       example = "localhost";
     };
     dbName = mkOption {
@@ -253,7 +254,7 @@ in
       done
       ${pkgs.mysql}/bin/mysql -e 'CREATE DATABASE ${config.dbName};'
       ${pkgs.mysql}/bin/mysql -e 'GRANT ALL ON ${config.dbName}.* TO ${config.dbUser}@localhost IDENTIFIED BY "${config.dbPassword}";'
-    else 
+    else
       echo "Good, no need to do anything database related."
     fi
   '';

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -1,0 +1,60 @@
+import ./make-test.nix ({ pkgs, ... }:
+
+{
+  name = "wordpress";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ grahamc ]; # under duress!
+  };
+
+  nodes =
+    { web =
+        { config, pkgs, ... }:
+        {
+          services.mysql.enable = true;
+          services.mysql.package = pkgs.mysql;
+          services.mysql.initialScript = pkgs.writeText "start.sql" ''
+            CREATE DATABASE wordpress;
+	    CREATE USER 'wordpress'@'localhost' IDENTIFIED BY 'wordpress';
+            GRANT ALL on wordpress.* TO 'wordpress'@'localhost';
+          '';
+
+          services.httpd = {
+            enable = true;
+            logPerVirtualHost = true;
+            adminAddr="js@lastlog.de";
+            extraModules = [
+              { name = "php7"; path = "${pkgs.php}/modules/libphp7.so"; }
+            ];
+
+            virtualHosts = [
+              {
+                hostName = "wordpress";
+                extraSubservices =
+                  [
+                    {
+                      serviceType = "wordpress";
+                      dbPassword = "wordpress";
+                      wordpressUploads = "/data/uploads";
+                      languages = [ "de_DE" "en_GB" ];
+                    }
+                  ];
+              }
+            ];
+          };
+        };
+    };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      startAll;
+
+      $web->waitForUnit("mysql");
+      $web->waitForUnit("httpd");
+
+      $web->succeed("curl -L 127.0.0.1:80 | grep 'Welcome to the famous'");
+
+
+    '';
+
+})


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/18856
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
