### PR TITLE
firebird: 2.5.2.26540-0 -> 2.5.6.27020-0

### DIFF
--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, libedit, ncurses, automake, autoconf, libtool
-, 
+,
   # icu = null: use icu which comes with firebird
 
   # icu = pkgs.icu => you may have trouble sharing database files with windows
@@ -38,7 +38,7 @@
 */
 
 stdenv.mkDerivation rec {
-  version = "2.5.2.26540-0";
+  version = "2.5.6.27020-0";
   name = "firebird-${version}";
 
   # enableParallelBuilding = false; build fails


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/18856
https://lwn.net/Vulnerabilities/675227/
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
