### PR TITLE
go2nix: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/development/tools/go2nix/default.nix
+++ b/pkgs/development/tools/go2nix/default.nix
@@ -3,7 +3,7 @@
 
 buildGoPackage rec {
   name = "go2nix-${version}";
-  version = "1.1.0";
+  version = "1.1.1";
   rev = "v${version}";
 
   goPackagePath = "github.com/kamilchm/go2nix";
@@ -12,7 +12,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "kamilchm";
     repo = "go2nix";
-    sha256 = "0asbbcyf1hh8khakych0y09rjarjiywr8pyy1v8ghpr1vvg43a09";
+    sha256 = "1idxgn9yf8shw4mq4d7rhf8fvb2s1lli4r4ck0h8ddf1s9q8p63s";
   };
 
   goDeps = ./deps.nix;
@@ -27,4 +27,11 @@ buildGoPackage rec {
   '';
 
   allowGoReference = true;
+
+  meta = with stdenv.lib; {
+    description = "Go apps packaging for Nix";
+    homepage = https://github.com/kamilchm/go2nix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kamilchm ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/kamilchm/go2nix/releases/tag/v1.1.1
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
