### PR TITLE
corebird: 1.3.1 -> 1.3.2

### DIFF
--- a/pkgs/applications/networking/corebird/default.nix
+++ b/pkgs/applications/networking/corebird/default.nix
@@ -2,14 +2,14 @@
 , automake, autoconf, libtool, pkgconfig, gnome3, gst_all_1, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  version = "1.3.1";
+  version = "1.3.2";
   name = "corebird-${version}";
 
   src = fetchFromGitHub {
     owner = "baedert";
     repo = "corebird";
     rev = version;
-    sha256 = "1a7b6hinl5p7yanf75a0khki2fvd04km1xlkwnspgx75cmnbnn5z";
+    sha256 = "1ps4l37dyj2pmzcly9jb95y7cqa8zm8hyfja5prsqj7pbka1fibn";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

Upgrade corebird to the latest release to address new Twitter character
limit rules.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
