### PR TITLE
idris modules: don't remove gnome packages from scope

### DIFF
--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -6,7 +6,7 @@
     overrideScope = f: callPackageWithScope (mkScope (fix' (extends f scope.__unfix__))) drv args;
   };
 
-  mkScope = scope : pkgs // pkgs.xorg // pkgs.gnome // scope;
+  mkScope = scope : pkgs // pkgs.xorg // scope;
 
   idrisPackages = self: let
     defaultScope = mkScope self;


### PR DESCRIPTION
###### Motivation for this change

To be clear: I don't understand why `gnome` was subtracted, nor why this works. But, it works!
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

fixes #18998
