### PR TITLE
lightyear: init at 9420f9e

### DIFF
--- a/pkgs/development/idris-modules/lightyear.nix
+++ b/pkgs/development/idris-modules/lightyear.nix
@@ -1,0 +1,32 @@
+{ build-idris-package
+, fetchFromGitHub
+, prelude
+, base
+, effects
+, lib
+, idris
+}:
+
+let
+  date = "2016-08-01";
+in
+build-idris-package {
+  name = "lightyear-${date}";
+
+  src = fetchFromGitHub {
+    owner = "ziman";
+    repo = "lightyear";
+    rev = "9420f9e892e23a7016dea1a61d8ce43a6d4ecf15";
+    sha256 = "0xbjwq7sk4x78mi2zcqxbx7wziijlr1ayxihb1vml33lqmsgl1dn";
+  };
+
+  propagatedBuildInputs = [ prelude base effects ];
+
+  meta = {
+    description = "Parser combinators for Idris";
+    homepage = https://github.com/ziman/lightyear;
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.siddharthist ];
+    inherit (idris.meta) platforms;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Depends on/tested with #19002. Lightyear is one of the major libraries of Idris so far!
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
