### PR TITLE
mate: update themes to release 1.16.0

### DIFF
--- a/pkgs/desktops/mate/mate-common/default.nix
+++ b/pkgs/desktops/mate/mate-common/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "mate-common-${version}";
   version = "${major-ver}.${minor-ver}";
-  major-ver = "1.15";
+  major-ver = "1.16";
   minor-ver = "0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "1r3c0i03ylrlibn4pz4j9qzbnj7b540hyhf98kkzzh680jn59iiy";
+    sha256 = "02pj5ry3c7p5sd2mp9dsshy0ij0xgv00bxr4vvmnm027hv2silrl";
   };
 
   meta = {

--- a/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "mate-icon-theme-faenza-${version}";
   version = "${major-ver}.${minor-ver}";
-  major-ver = "1.15";
-  minor-ver = "1";
+  major-ver = "1.16";
+  minor-ver = "0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "1x2jn86gcv6spnkvhjg0mzp5qhlb5dw4h8m8qp1hdgzzrzinfr3p";
+    sha256 = "0p3z3qarbvrhzj2sdw3f8dp0c7wwjkk9a749bq8rh5gm9m66hibg";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   name = "mate-icon-theme-${version}";
   version = "${major-ver}.${minor-ver}";
-  major-ver = "1.15";
+  major-ver = "1.16";
   minor-ver = "0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${major-ver}/${name}.tar.xz";
-    sha256 = "1jpz3ihmyhyiyqlqz798xgzl3qa31ghymw3yrw6abd7ww0nkwiq9";
+    sha256 = "1zldw22p1i76iss8car39pmfagpfxxlfk1fdhvr4x5r6gf36gv7d";
   };
 
   nativeBuildInputs = [ pkgconfig intltool iconnamingutils ];

--- a/pkgs/desktops/mate/mate-themes/default.nix
+++ b/pkgs/desktops/mate/mate-themes/default.nix
@@ -6,15 +6,17 @@ stdenv.mkDerivation rec {
   version = "${major-ver}.${minor-ver}";
   major-ver = gnome3.version;
   minor-ver = {
-    "3.18" = "3";
-    "3.20" = "10";
+    "3.18" = "4";
+    "3.20" = "12";
+    "3.22" = "3";
   }."${major-ver}";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/themes/${major-ver}/${name}.tar.xz";
     sha256 = {
-      "3.18" = "09vglvjnjnm95wxw5b7pn6rf5xrr3nfyqs5c3y1c72z4p3w8qqn5";
-      "3.20" = "0bhhidip8qbsq69a9n0dmxfryhvzngiy59vnms6xhya9n7y19hci";
+      "3.18" = "1h3z705jrg7gng5glf51ksszjz6v81qq83qvmfpv1v69bwn6fy4b";
+      "3.20" = "15s2xp2cq9x8iikvbywr5gl8l33i57i1xvbv4jc2qipnkn3c4yca";
+      "3.22" = "0p1rf5q2nr1vsab3pljwycclbrnwylvp88d0dhk8as0d6n6fp85k";
     }."${major-ver}";
   };
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
