### PR TITLE
epson-escpr: 1.6.5 -> 1.6.8

### DIFF
--- a/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
+++ b/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
@@ -1,5 +1,5 @@
 diff --git a/configure b/configure_new
-index 3d6f68c..c2b10ff 100755
+index 699bcb5..89a1832 100755
 --- a/configure
 +++ b/configure_new
 @@ -11585,55 +11585,8 @@ else

--- a/pkgs/misc/drivers/epson-escpr/default.nix
+++ b/pkgs/misc/drivers/epson-escpr/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, cups }:
 
 let
-  version = "1.6.5";
+  version = "1.6.8";
 in
   stdenv.mkDerivation {
 
     name = "epson-escpr-${version}";
   
     src = fetchurl {
-      url = "https://download3.ebz.epson.net/dsc/f/03/00/04/54/27/b73564748bfde7b7ce625e20d4a3257d447bec79/epson-inkjet-printer-escpr-1.6.5-1lsb3.2.tar.gz"; 
-      sha256 = "1cd9e0506bf181e1476bd8305f1c6b8dbc4354eab9415d0d5529850856129e4c"; 
+      url = "https://download3.ebz.epson.net/dsc/f/03/00/05/10/61/125006df4ffc84861395c1158a02f1f73e6f1753/epson-inkjet-printer-escpr-1.6.8-1lsb3.2.tar.gz";
+      sha256 = "02v8ljzw6xhfkz1x8m50mblcckgfbpa89fc902wcmi2sy8fihgh4";
     }; 
 
     patches = [ ./cups-filter-ppd-dirs.patch ]; 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
