### PR TITLE
elasticsearch2: 2.3.4 -> 2.4.0

### DIFF
--- a/pkgs/servers/search/elasticsearch/2.x.nix
+++ b/pkgs/servers/search/elasticsearch/2.x.nix
@@ -3,12 +3,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "2.3.4";
+  version = "2.4.0";
   name = "elasticsearch-${version}";
 
   src = fetchurl {
     url = "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${version}/${name}.tar.gz";
-    sha256 = "0vphyqhna510y8bcihlmz3awzszgyfpmzrfcy548a2pd9mghq7ip";
+    sha256 = "1jglmj1dnh1n2niyds6iyrpf6x6ppqgkivzy6qabkjvvmr013q1s";
   };
 
   patches = [ ./es-home-2.x.patch ];


### PR DESCRIPTION
###### Motivation for this change

Kibana 4.6.0 (#18277) requires ElasticSearch 2.4.x
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested in production together with Kibana 4.6.0 (#18277)

---
