### PR TITLE
zsh: do not export HISTFILE, HISTSIZE, SAVEHIST

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -102,9 +102,9 @@ in
 
       interactiveShellInit = ''
         # history defaults
-        export SAVEHIST=2000
-        export HISTSIZE=2000
-        export HISTFILE=$HOME/.zsh_history
+        SAVEHIST=2000
+        HISTSIZE=2000
+        HISTFILE=$HOME/.zsh_history
 
         setopt HIST_IGNORE_DUPS SHARE_HISTORY HIST_FCNTL_LOCK
 


### PR DESCRIPTION
###### Motivation for this change

Every interactive zsh sources /etc/zshrc (see STARTUP/SHUTDOWN FILES in zshautll(1))
Therefor every interactive zsh process will respect the content of these variables.
Using `export` will also lead to child processes inheriting this value.
This leads to problems, if other interactive shells are spawned such as bash,
because they use an incomptabible history format (without timestamps).
There seems to be also cases, where the local HISTSIZE in ~/.zshrc is
not sourced but /etc/zshrc, which leads to history truncation in other shells.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
