### PR TITLE
idrisPackages.optparse: init at 2016-06-18 [wip]

### DIFF
--- a/pkgs/development/idris-modules/bifunctors.nix
+++ b/pkgs/development/idris-modules/bifunctors.nix
@@ -1,0 +1,40 @@
+{ build-idris-package, fetchFromGitHub, lib, idris, base, prelude }:
+
+# There's another partially maintained package at
+# https://github.com/HuwCampbell/Idris-Bifunctors
+build-idris-package {
+  name = "bifunctors-2016-08-10";
+
+  src = fetchFromGitHub {
+    owner = "japesinator";
+    repo = "Idris-Bifunctors";
+    rev = "18d579341956abf240ab1470306a817e4aaf5e56";
+    sha256 = "12jrwifdc6yznf4g2qz7c8bjcp93bf8x25yadvp6ccx1vyid1a67";
+  };
+
+  propagatedBuildInputs = [ prelude base ];
+
+  buildPhase = ''
+      ${idris}/bin/idris --build bifunctors.ipkg
+  '';
+
+  checkPhase = ''
+      export PATH=$PATH:${idris}/bin
+      sh test.sh
+  '';
+
+  installPhase = ''
+      ${idris}/bin/idris --install bifunctors.ipkg
+  '';
+
+  meta = {
+    description = "A small bifunctor library for idris";
+    longDescription = ''
+      This is a bifunctor library for idris based off the excellent Haskell
+      Bifunctors package from Edward Kmett.
+    '';
+    homepage = https://github.com/japesinator/Idris-Bifunctors;
+    license = lib.licenses.bsd3;
+    inherit (idris.meta) platforms;
+  };
+}

--- a/pkgs/development/idris-modules/lens.nix
+++ b/pkgs/development/idris-modules/lens.nix
@@ -1,0 +1,21 @@
+{ build-idris-package, fetchFromGitHub, lib, idris, base, prelude, bifunctors  }:
+
+build-idris-package {
+  name = "lens-2016-10-05";
+
+  src = fetchFromGitHub {
+    owner = "HuwCampbell";
+    repo = "idris-lens";
+    rev = "6664ef62396a956ee728b3a785acf77a60c3b670";
+    sha256 = "1bcczp46p5kkqp5k07p49y08ch6m5rzkdlx5m9wpvmzwxr50wln8";
+  };
+
+  propagatedBuildInputs = [ prelude base bifunctors ];
+
+  meta = {
+    description = "Small port of Control.Lens to Idris";
+    homepage = https://github.com/HuwCampbell/idris-lens;
+    license = lib.licenses.bsd3;
+    inherit (idris.meta) platforms;
+  };
+}

--- a/pkgs/development/idris-modules/optparse.nix
+++ b/pkgs/development/idris-modules/optparse.nix
@@ -1,0 +1,32 @@
+{ build-idris-package
+, lib
+, fetchFromGitHub
+, idris
+, base
+, bifunctors
+, effects
+, prelude
+, wl-pprint
+, lens
+}:
+
+build-idris-package {
+  name = "optparse-2016-06-18";
+
+  src = fetchFromGitHub {
+    owner = "HuwCampbell";
+    repo = "optparse-idris";
+    rev = "ad0490ff0fa0e623d03cde1f49a4adffc6f9362f";
+    sha256 = "0cyk1g7nrbphrrp8q3271lkc5sw9k15bzymqy5hxxxs7i1pj140x";
+  };
+
+  propagatedBuildInputs = [ prelude base effects lens wl-pprint bifunctors ];
+
+  meta = {
+    description = "Minimal port of optparse-applicative to idris";
+    homepage = https://github.com/HuwCampbell/optparse-idris;
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.siddharthist ];
+    inherit (idris.meta) platforms;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This isn't working quite yet, I was hoping to get some help from @shlevy. This package requires `idrisPackages.wl-pprint`, but I don't know how to add it to the build. Do I need to use with-packages.nix? If so, would you mind posting some example code?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
