### PR TITLE
clang-tools: New package

### DIFF
--- a/pkgs/development/tools/clang-tools/default.nix
+++ b/pkgs/development/tools/clang-tools/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, makeWrapper, writeScript, llvmPackages }:
+
+let
+  clang = llvmPackages.clang-unwrapped;
+  version = stdenv.lib.getVersion clang;
+in
+
+stdenv.mkDerivation {
+  name = "clang-tools-${version}";
+  builder = writeScript "builder" ''
+    source $stdenv/setup
+    for tool in \
+      clang-apply-replacements \
+      clang-check \
+      clang-format \
+      clang-rename \
+      clang-tidy
+    do
+      makeWrapper $clang/bin/$tool $out/bin/$tool --argv0 $tool
+    done
+  '';
+  buildInputs = [ makeWrapper ];
+  inherit clang;
+  meta = clang.meta // {
+    description = "Standalone command line tools for C++ development";
+    maintainers = with stdenv.lib.maintainers; [ aherrmann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4424,6 +4424,8 @@ in
   clang_35 = wrapCC llvmPackages_35.clang;
   clang_34 = wrapCC llvmPackages_34.clang;
 
+  clang-tools = callPackage ../development/tools/clang-tools { };
+
   clang-analyzer = callPackage ../development/tools/analysis/clang-analyzer { };
 
   clangUnwrapped = llvm: pkg: callPackage pkg { inherit llvm; };


### PR DESCRIPTION
###### Motivation for this change

Fixes #9214

Allows to install clang-tools for C++ development without also installing the
clang compiler and its tool-chain. This way it is possible to use e.g.
`clang-format` without conflicting with e.g. GCC's tool-chain, or the global
system tool-chain.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
