### PR TITLE
redprl: patch install script shebangs

### DIFF
--- a/pkgs/applications/science/logic/redprl/default.nix
+++ b/pkgs/applications/science/logic/redprl/default.nix
@@ -8,6 +8,9 @@ stdenv.mkDerivation {
     fetchSubmodules = true;
   };
   buildInputs = [ mlton ];
+  patchPhase = ''
+    patchShebangs ./script/
+  '';
   builder = builtins.toFile "builder.sh" ''
     source $stdenv/setup
     mkdir -p $out/bin


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The source installation scripts use `/bin/bash` as an interpreter.
