### PR TITLE
lastpass-cli: 0.9.0 -> 1.0.0

### DIFF
--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "lastpass-cli-${version}";
 
-  version = "0.9.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "lastpass";
     repo = "lastpass-cli";
     rev = "v${version}";
-    sha256 = "1iaz36bcyss2kahhlm92l7yh26rxvs12wnkkh1289yarl5wi0yld";
+    sha256 = "0hidx2qfr52bwjb6as4fbfa34jqh3zwvrcx590vbsji3bq4g7avb";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

`lastpass-cli` version update from 0.9.0 to 1.0.0. Released in July 2016. Changelog located here: https://github.com/lastpass/lastpass-cli/releases/tag/v1.0.0
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
