### PR TITLE
elasticsearch: 2.3.4 -> 2.4.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -254,6 +254,7 @@
   matthiasbeyer = "Matthias Beyer <mail@beyermatthias.de>";
   maurer = "Matthew Maurer <matthew.r.maurer+nix@gmail.com>";
   mbakke = "Marius Bakke <mbakke@fastmail.com>";
+  mbbx6spp = "Susan Potter <me@susanpotter.net>";
   matthewbauer = "Matthew Bauer <mjbauer95@gmail.com>";
   mbe = "Brandon Edens <brandonedens@gmail.com>";
   mboes = "Mathieu Boespflug <mboes@tweag.net>";

--- a/pkgs/servers/search/elasticsearch/2.x.nix
+++ b/pkgs/servers/search/elasticsearch/2.x.nix
@@ -3,12 +3,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "2.3.4";
+  version = "2.4.0";
   name = "elasticsearch-${version}";
 
   src = fetchurl {
     url = "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${version}/${name}.tar.gz";
-    sha256 = "0vphyqhna510y8bcihlmz3awzszgyfpmzrfcy548a2pd9mghq7ip";
+    sha256 = "1jglmj1dnh1n2niyds6iyrpf6x6ppqgkivzy6qabkjvvmr013q1s";
   };
 
   patches = [ ./es-home-2.x.patch ];
@@ -33,9 +33,10 @@ stdenv.mkDerivation rec {
     description = "Open Source, Distributed, RESTful Search Engine";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = [
-      maintainers.offline
-      maintainers.markWot
+    maintainers = with maintainers; [
+      offline
+      markWot
+      mbbx6spp
     ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Elasticsearch 2.4.0 is the latest stable version of elasticsearch. For release announcement see:
https://www.elastic.co/blog/elasticsearch-2-4-0-released
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)

```
$ nixos-option nix.useSandbox
Value:
true

Default:
false
```
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux

```
$ nixos-version
16.09beta264.aadcffc (Flounder)
```
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)

It did require I set the `ES_HOME` env var, but this appears to be the same behavior as the current master for package `elasticsearc2`.

```
$ /nix/store/mfil35ssky14jiwjhf32sz2zawkbzinx-elasticsearch-2.4.0/bin/elasticsearch --version
Version: 2.4.0, Build: ce9f0c7/2016-08-29T09:14:17Z, JVM: 1.8.0_122
```
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
