### PR TITLE
libui: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/libui/default.nix
+++ b/pkgs/development/libraries/libui/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchgit, cmake, pkgconfig, gtk3 }:
+{ stdenv, fetchgit, cmake, pkgconfig, gtk3, darwin }:
 
 let
   shortName = "libui";
   version   = "3.1a";
+  backend   = if stdenv.isDarwin then "darwin" else "unix";
 in
   stdenv.mkDerivation rec {
     name = "${shortName}-${version}";
@@ -12,27 +13,42 @@ in
       sha256 = "1lpbfa298c61aarlzgp7vghrmxg1274pzxh1j9isv8x758gk6mfn";
     };
 
-    buildInputs = [ cmake pkgconfig gtk3 ];
+    buildInputs = [ cmake pkgconfig ] ++
+      (if stdenv.isDarwin then [darwin.apple_sdk.frameworks.Cocoa] else [gtk3]);
+
+    preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+      sed -i 's/set(CMAKE_OSX_DEPLOYMENT_TARGET "10.8")//' ./CMakeLists.txt
+    '';
+    cmakeFlags = stdenv.lib.optionals stdenv.isDarwin [
+      "-DCMAKE_OSX_SYSROOT="
+      "-DCMAKE_OSX_DEPLOYMENT_TARGET="
+    ];
 
     installPhase = ''
       mkdir -p $out/{include,lib}
       mkdir -p $out/lib/pkgconfig
-
+    '' + stdenv.lib.optionalString stdenv.isLinux ''
       mv ./out/${shortName}.so.0 $out/lib/
       ln -s $out/lib/${shortName}.so.0 $out/lib/${shortName}.so
-
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+      mv ./out/${shortName}.A.dylib $out/lib/
+      ln -s $out/lib/${shortName}.A.dylib $out/lib/${shortName}.dylib
+    '' + ''
       cp $src/ui.h $out/include
-      cp $src/ui_unix.h $out/include
+      cp $src/ui_${backend}.h $out/include
 
       cp ${./libui.pc} $out/lib/pkgconfig/${shortName}.pc
       substituteInPlace $out/lib/pkgconfig/${shortName}.pc \
         --subst-var-by out $out \
         --subst-var-by version "${version}"
     '';
+    postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+      install_name_tool -id $out/lib/${shortName}.A.dylib $out/lib/${shortName}.A.dylib
+    '';
 
     meta = {
       homepage    = https://github.com/andlabs/libui;
       description = "Simple and portable (but not inflexible) GUI library in C that uses the native GUI technologies of each platform it supports.";
-      platforms   = stdenv.lib.platforms.linux;
+      platforms   = stdenv.lib.platforms.unix;
     };
   }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
