### PR TITLE
nodejs: 6.6.0 -> 6.7.0

### DIFF
--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -8,8 +8,8 @@ let
   inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
 
 in import ./nodejs.nix (args // rec {
-  version = "6.6.0";
-  sha256 = "0cqswab9idbz5kzj50fnalg1zrircmbn9qga0cr33lvjnv98a134";
+  version = "6.7.0";
+  sha256 = "1r9vvnczjczqs29ja8gmbqgsfgkg0dph4qkaxb3yh7mb98r2ic6f";
   extraBuildInputs = stdenv.lib.optionals stdenv.isDarwin
     [ CoreServices ApplicationServices ];
   preBuild = stdenv.lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Things done
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

[Release Notes](https://nodejs.org/en/blog/release/v6.7.0/)
