### PR TITLE
amazon ec2 and ami fixes

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -67,21 +67,11 @@ let cfg = config.ec2; in
 
         echo "getting EC2 instance metadata..."
 
-        if ! [ -e "$metaDir/ami-manifest-path" ]; then
-          wget -q -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
-        fi
-
-        if ! [ -e "$metaDir/user-data" ]; then
-          wget -q -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
-        fi
-
-        if ! [ -e "$metaDir/hostname" ]; then
-          wget -q -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
-        fi
-
-        if ! [ -e "$metaDir/public-keys-0-openssh-key" ]; then
-          wget -q -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
-        fi
+        # fetch metadata everytime!
+        wget -q -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
+        wget -q -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
+        wget -q -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
+        wget -q -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
 
         diskNr=0
         diskForUnionfs=

--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -13,6 +13,9 @@ let
 
     userData=/etc/ec2-metadata/user-data
 
+    # set nameserver to anything, it will be later overwritten to correct entry
+    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+
     if [ -s "$userData" ]; then
 
       # If the user-data looks like it could be a nix expression,

--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -9,7 +9,7 @@ let
     echo "attempting to fetch configuration from EC2 user data..."
 
     export PATH=${pkgs.lib.makeBinPath [ config.nix.package pkgs.systemd pkgs.gnugrep pkgs.gnused config.system.build.nixos-rebuild]}:$PATH
-    export NIX_PATH=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
+    export NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
 
     userData=/etc/ec2-metadata/user-data
 


### PR DESCRIPTION
###### Motivation for this change

Launching EC2 instance from AMI image has a few problems, I fixed 3:
- I temporarily set 8.8.8.8 name server (it will be automagically set later to correct entries) so that nixos.org and cache domains are resolved during stage-2-init, that is rebuilding from user-data (nixos configuration)
  if 8.8.8.8 is not acceptable, we can use something like: `dig | grep SERVER: | awk -F# '{print $1}' | awk -F': ' '{print $2}'` which I found on some stack overflow post and it worked in my debugging process.
  Please advise on better solutions.
  PS: this fixes https://github.com/NixOS/nixpkgs/issues/19010
- set `NIX_PATH=nixpkgs=/path/to/nixpkgs:....` instead of `NIX_PATH=/path/to/nixpkgs:....` which fails because rebuild searches for `nixpkgs` folder in `/path/to/nixpkgs` which is non existant at least in latest master/unstable, prefixing nixpkgs path with `nixpkgs=` fixes this
- fetch meta-data on every boot, because at least `user-data` and `hostname` files can have dynamic content

Procedure to check:

temporarily change these variables to make build and upload process of AMI faster in the `./nixpkgs/nixos/maintainers/scripts/ec2/create-amis.sh`

```
types="hvm"
stores="ebs"
regions="eu-central-1"
```

then build and upload AMI

```
# dependencies of create-amis.sh
nix-env -iA awscli
nix-env -iA qemu
nix-env -iA ec2_api_tools
nix-env -iA jq

export AWS_ACCOUNT="#####"
export AWS_ACCESS_KEY_ID="##########"
export AWS_SECRET_ACCESS_KEY="###########"
export NIX_PATH="nixpkgs=/home/matejc/workarea/gatehub/ec2/nixpkgs"

./nixpkgs/nixos/maintainers/scripts/ec2/create-amis.sh
```

then launch instance with user-data:

```
### https://github.com/matejc/nixpkgs/archive/aws-fixes.tar.gz nixos

{
  imports = [ <nixpkgs/nixos/modules/virtualisation/amazon-image.nix> ];
  ec2.hvm = true;
  security.sudo.wheelNeedsPassword = false;
  users.extraUsers.matejc =
    { createHome      = true;
      home            = "/home/matejc";
      description     = "Matej";
      extraGroups     = [ "wheel" ];
      useDefaultShell = true;
      openssh.authorizedKeys.keys = [
        "ssh-rsa ..."
      ];
    };
}
```

note: that `https://github.com/matejc/nixpkgs/archive/aws-fixes.tar.gz` points to `aws-fixes` branch, which is revision to this pull request.

things to check: at first boot at `stage-2-init` inside `journalctl -b` should be visible rebuild procedure, then stop the instance and change user data, lets say.. add `services.redis.enable = true;` and start the instance and after booting process is done you should have redis running.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
