### PR TITLE
Fix termite-with-config's terminfo

### DIFF
--- a/pkgs/applications/misc/termite/default.nix
+++ b/pkgs/applications/misc/termite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, vte, gtk3, ncurses, makeWrapper
+{ stdenv, fetchgit, pkgconfig, vte, gtk3, ncurses, makeWrapper, symlinkJoin
 , configFile ? null
 }:
 
@@ -37,13 +37,13 @@ let
       platforms = platforms.all;
     };
   };
-in if configFile == null then termite else stdenv.mkDerivation {
+in if configFile == null then termite else symlinkJoin {
   name = "termite-with-config-${version}";
+  paths = [ termite ];
   nativeBuildInputs = [ makeWrapper ];
-  buildCommand = ''
-    mkdir -p $out/etc/xdg/termite/ $out/bin
-    ln -s ${termite}/bin/termite $out/bin/termite
-    wrapProgram $out/bin/termite --add-flags "--config ${configFile}"
+  postBuild = ''
+    wrapProgram $out/bin/termite \
+      --add-flags "--config ${configFile}"
   '';
   passthru.terminfo = termite.terminfo;
 }


### PR DESCRIPTION
###### Motivation for this change

The level of indirection introduced by termite-with-config didn't mesh
well with the terminfo database. The shell complained loudly and zsh was unsusable.
This is solved by using symlinkJoin so the environment is properly propagated.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
