### PR TITLE
wol: init at 0.7.1

### DIFF
--- a/pkgs/tools/networking/wol/default.nix
+++ b/pkgs/tools/networking/wol/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "wol-${version}";
+  version = "0.7.1";
+  proj = "wake-on-lan";
+
+  enableParallelBuilding = true;
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${proj}/${name}.tar.gz";
+    sha256 = "08i6l5lr14mh4n3qbmx6kyx7vjqvzdnh3j9yfvgjppqik2dnq270";
+  };
+
+  meta = {
+    description = "Implements Wake On LAN functionality in a small program";
+    homepage = https://sourceforge.net/projects/wake-on-lan/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4175,6 +4175,8 @@ in
 
   wml = callPackage ../development/web/wml { };
 
+  wol = callPackage ../tools/networking/wol { };
+
   wring = nodePackages.wring;
 
   wrk = callPackage ../tools/networking/wrk { };


### PR DESCRIPTION
###### Motivation for this change

wol, unlike wakelan, supports the password feature of the wake-on-lan specification
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

wol, unlike wakelan, supports wake-on-lan passwords
