### PR TITLE
ps3netsrv: init at 1.1.0

### DIFF
--- a/pkgs/servers/ps3netsrv/default.nix
+++ b/pkgs/servers/ps3netsrv/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation rec {
+  name = "ps3netsrv-${version}";
+  version = "1.1.0";
+
+  enableParallelBuilding = true;
+
+  src = fetchgit {
+    url = "https://github.com/dirkvdb/ps3netsrv--";
+    fetchSubmodules = true;
+    rev = "e54a66cbf142b86e2cffc1701984b95adb921e81";
+    sha256 = "09hvmfzqy2jckpsml0z1gkcnar8sigmgs1q66k718fph2d3g54sa";
+  };
+
+  buildPhase = "make CXX=$CXX";
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ps3netsrv++ $out/bin
+  '';
+
+  meta = {
+    description = "C++ implementation of the ps3netsrv server";
+    homepage = https://github.com/dirkvdb/ps3netsrv--;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3258,6 +3258,8 @@ in
 
   progress = callPackage ../tools/misc/progress { };
 
+  ps3netsrv = callPackage ../servers/ps3netsrv { };
+
   psmisc = callPackage ../os-specific/linux/psmisc { };
 
   pstoedit = callPackage ../tools/graphics/pstoedit { };


### PR DESCRIPTION
###### Motivation for this change

Tool was not yet available in nixpkgs and requires a few non-standard quirks to install correctly.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
