### PR TITLE
mergerfs: init at 2.16.1

### DIFF
--- a/pkgs/tools/filesystems/mergerfs/default.nix
+++ b/pkgs/tools/filesystems/mergerfs/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchgit, fuse, pkgconfig, which, attr, pandoc, git }:
+
+stdenv.mkDerivation rec {
+  name = "mergerfs-${version}";
+  version = "2.16.1";
+
+  # not using fetchFromGitHub because of changelog being built with git log
+  src = fetchgit {
+    url = "https://github.com/trapexit/mergerfs";
+    rev = "refs/tags/${version}";
+    sha256 = "12fqgk54fnnibqiq82p4g2k6qnw3iy6dd64csmlf73yi67za5iwf";
+    deepClone = true;
+  };
+
+  buildInputs = [ fuse pkgconfig which attr pandoc git ];
+
+  makeFlags = [ "PREFIX=$(out)" "XATTR_AVAILABLE=1" ];
+
+  meta = {
+    description = "A FUSE based union filesystem";
+    homepage = https://github.com/trapexit/mergerfs;
+    license = stdenv.lib.licenses.isc;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8291,6 +8291,8 @@ in
 
   menu-cache = callPackage ../development/libraries/menu-cache { };
 
+  mergerfs = callPackage ../tools/filesystems/mergerfs { };
+
   mesaSupported = lib.elem system lib.platforms.mesaPlatforms;
 
   mesaDarwinOr = alternative: if stdenv.isDarwin


### PR DESCRIPTION
###### Motivation for this change

mergerfs is a modern and actively developed FUSE based union file system. For me this is the replacement for mhddfs which is no longer developed and is missing a lot of great features which only mergerfs is able to provide.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
