### PR TITLE
f3: init at 6.0

### DIFF
--- a/pkgs/tools/filesystems/f3/default.nix
+++ b/pkgs/tools/filesystems/f3/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "f3-${version}";
+  version = "6.0";
+
+  enableParallelBuilding = true;
+
+  src = fetchFromGitHub {
+    owner = "AltraMayor";
+    repo = "f3";
+    rev = "v${version}";
+    sha256 = "1azi10ba0h9z7m0gmfnyymmfqb8380k9za8hn1rrw1s442hzgnz2";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+  patchPhase = "sed -i 's/-oroot -groot//' Makefile";
+
+  meta = {
+    description = "Fight Flash Fraud";
+    homepage = http://oss.digirati.com.br/f3/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -815,6 +815,8 @@ in
 
   ent = callPackage ../tools/misc/ent { };
 
+  f3 = callPackage ../tools/filesystems/f3 { };
+
   facter = callPackage ../tools/system/facter {
     ruby = ruby_2_1;
   };


### PR DESCRIPTION
###### Motivation for this change

The tool can check read/write performance of your flash drive as well as if the stick you might have bought from china really provides the disk space it suggests. 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
