### PR TITLE
audit: only enable the service if needed

### DIFF
--- a/nixos/modules/security/audit.nix
+++ b/nixos/modules/security/audit.nix
@@ -100,7 +100,7 @@ in {
   };
 
   config = {
-    systemd.services.audit = {
+    systemd.services.audit = mkIf cfg.enable {
       description = "Kernel Auditing";
       wantedBy = [ "basic.target" ];
 


### PR DESCRIPTION
###### Motivation for this change

Seems pointless to run the audit service, if the user has chosen not to use the audit subsystem.

I'm running with this PR applied here and the only difference is a lack of errors when running `systemctl --failed`.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
