### PR TITLE
Mark packages as broken: asterisk, cryptopp, redmine, moodle, opera, openstack-neutron, mesos

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/moodle.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/moodle.nix
@@ -63,6 +63,10 @@ let
         cp -r * $out
         cp ${moodleConfig} $out/config.php
       '';
+    # Marked as broken due to needing an update for security issues.
+    # See: https://github.com/NixOS/nixpkgs/issues/18856
+    meta.broken = true;
+
   };
 
 in

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -84,5 +84,8 @@ stdenv.mkDerivation rec {
     homepage = http://www.opera.com;
     description = "Web browser";
     license = stdenv.lib.licenses.unfree;
+    # Marked as broken due to needing an update for security issues.
+    # See: https://github.com/NixOS/nixpkgs/issues/18856
+    broken = true;
   };
 }

--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace src/Makefile.am --subst-var-by mavenRepo ${mavenRepo}
-    
+
     substituteInPlace 3rdparty/libprocess/include/process/subprocess.hpp \
       --replace '"sh"' '"${bash}/bin/bash"'
 
@@ -64,7 +64,7 @@ in stdenv.mkDerivation rec {
 
     substituteInPlace src/launcher/executor.cpp \
       --replace '"sh"' '"${bash}/bin/bash"'
-    
+
     substituteInPlace src/launcher/fetcher.cpp \
       --replace '"gzip' '"${gzip}/bin/gzip'    \
       --replace '"tar' '"${gnutar}/bin/tar'    \
@@ -72,7 +72,7 @@ in stdenv.mkDerivation rec {
 
     substituteInPlace src/python/cli/src/mesos/cli.py \
      --replace "['mesos-resolve'" "['$out/bin/mesos-resolve'"
-    
+
     substituteInPlace src/slave/containerizer/mesos/launch.cpp \
       --replace '"sh"' '"${bash}/bin/bash"'
 
@@ -83,7 +83,7 @@ in stdenv.mkDerivation rec {
 
     substituteInPlace src/linux/perf.cpp       \
       --replace '"perf ' '"${perf}/bin/perf '
-    
+
     substituteInPlace src/linux/systemd.cpp \
       --replace 'os::realpath("/sbin/init")' '"${systemd}/lib/systemd/systemd"'
 
@@ -180,5 +180,8 @@ in stdenv.mkDerivation rec {
     description = "A cluster manager that provides efficient resource isolation and sharing across distributed applications, or frameworks";
     maintainers = with maintainers; [ cstrahan kevincox offline rushmorem ];
     platforms   = platforms.linux;
+    # Marked as broken due to needing an update for security issues.
+    # See: https://github.com/NixOS/nixpkgs/issues/18856
+    broken = true;
   };
 }

--- a/pkgs/applications/version-management/redmine/default.nix
+++ b/pkgs/applications/version-management/redmine/default.nix
@@ -67,5 +67,8 @@ in stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ maintainers.garbas ];
     license = licenses.gpl2;
+    # Marked as broken due to needing an update for security issues.
+    # See: https://github.com/NixOS/nixpkgs/issues/18856
+    broken = true;
   };
 }

--- a/pkgs/applications/virtualization/openstack/neutron.nix
+++ b/pkgs/applications/virtualization/openstack/neutron.nix
@@ -62,5 +62,8 @@ pythonPackages.buildPythonApplication rec {
     description = "Virtual network service for Openstack";
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.linux;
+    # Marked as broken due to needing an update for security issues.
+    # See: https://github.com/NixOS/nixpkgs/issues/18856
+    broken = true;
   };
 }

--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -45,6 +45,8 @@ stdenv.mkDerivation rec {
     license = licenses.boost;
     platforms = platforms.all;
     maintainers = [ ];
+    # Marked as broken due to needing an update for security issues.
+    # See: https://github.com/NixOS/nixpkgs/issues/18856
+    broken = true;
   };
 }
-

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -57,5 +57,8 @@ stdenv.mkDerivation rec {
     homepage = http://www.asterisk.org/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ auntie ];
+    # Marked as broken due to needing an update for security issues.
+    # See: https://github.com/NixOS/nixpkgs/issues/18856
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

These are packages that were difficult to upgrade and have outstanding security issues.

See: https://github.com/NixOS/nixpkgs/issues/18856

Note: if a maintainer fixes the bug, we'd rather not mark them broken :)

Maintainers / Contributors:
- @auntieNeo 
- @dasjoe
- @civodul
- @garbas
- @domenkozar 
- @cstrahan 
- @kevincox 
- @offlinehacker 
- @rushmorem 
- @edolstra 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
