### PR TITLE
libxslt: 1.1.28 -> 1.1.29

### DIFF
--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, fetchpatch, libxml2, findXMLCatalogs }:
 
 stdenv.mkDerivation rec {
-  name = "libxslt-1.1.28";
+  name = "libxslt-1.1.29";
 
   src = fetchurl {
     url = "http://xmlsoft.org/sources/${name}.tar.gz";
-    sha256 = "13029baw9kkyjgr7q3jccw2mz38amq7mmpr5p3bh775qawd1bisz";
+    sha256 = "1klh81xbm9ppzgqk339097i39b7fnpmlj8lzn8bpczl3aww6x5xm";
   };
 
   patches = stdenv.lib.optional stdenv.isSunOS ./patch-ah.patch
@@ -14,14 +14,7 @@ stdenv.mkDerivation rec {
           name = "mingw.patch";
           url = "http://git.gnome.org/browse/libxslt/patch/?id=ab5810bf27cd63";
           sha256 = "0kkqq3fv2k3q86al38vp6zwxazpvp5kslcjnmrq4ax5cm2zvsjk3";
-        })
-    ++ [
-      (fetchpatch {
-        name = "CVE-2015-7995.patch";
-        url = "http://git.gnome.org/browse/libxslt/patch/?id=7ca19df892ca22";
-        sha256 = "1xzg0q94dzbih9nvqp7g9ihz0a3qb0w23l1158m360z9smbi8zbd";
-      })
-    ];
+        });
 
   outputs = [ "bin" "dev" "out" "doc" ];
 


### PR DESCRIPTION
###### Motivation for this change

includes the already security patch by default + bugfixes
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
