### PR TITLE
sonic-pi: 2.9.0 -> 2.10.0

### DIFF
--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -11,14 +11,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.9.0";
+  version = "2.10.0";
   name = "sonic-pi-${version}";
 
   src = fetchFromGitHub {
     owner = "samaaron";
     repo = "sonic-pi";
     rev = "v${version}";
-    sha256 = "19db5dxrf6h1v2w3frds5g90nb6izd9ppp7cs2xi6i0m67l6jrwb";
+    sha256 = "01778znilsax01j1nwnmvgnn7rsfdhcbnpmqi98mryf8w2j2i3c4";
   };
 
   buildInputs = [

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,9 +1,8 @@
-{ stdenv, fetchurl, cmake, pkgconfig
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
 , libjack2, libsndfile, fftw, curl, gcc
 , libXt, qt55, readline
 , useSCEL ? false, emacs
 }:
-
 let optional = stdenv.lib.optional;
 in
 
@@ -11,10 +10,11 @@ stdenv.mkDerivation rec {
   name = "supercollider-${version}";
   version = "3.7.2";
 
-
-  src = fetchurl {
-    url = "https://github.com/supercollider/supercollider/releases/download/Version-${version}/SuperCollider-${version}-Source-linux.tar.bz2";
-    sha256 = "1mybxcnl7flliz74kdfnvh18v5dwd9zbdsw2kc7wpl4idcly1n0s";
+  src = fetchFromGitHub {
+    owner = "supercollider";
+    repo = "supercollider";
+    rev = "Version-${version}";
+    sha256 = "11khrv6jchs0vv0lv43am8lp0x1rr3h6l2xj9dmwrxcpdayfbalr";
   };
 
   hardeningDisable = [ "stackprotector" ];


### PR DESCRIPTION
###### Motivation for this change

Update sonic-pi and supercollider.

Build fails by now, because supercollider cannot find Qt - don't know why, though.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
