### PR TITLE
maintainers: change smironov email

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -383,8 +383,8 @@
   skeidel = "Sven Keidel <svenkeidel@gmail.com>";
   skrzyp = "Jakub Skrzypnik <jot.skrzyp@gmail.com>";
   sleexyz = "Sean Lee <freshdried@gmail.com>";
-  smironov = "Sergey Mironov <ierton@gmail.com>";
   solson = "Scott Olson <scott@solson.me>";
+  smironov = "Sergey Mironov <grrwlf@gmail.com>";
   spacefrogg = "Michael Raitza <spacefrogg-nixos@meterriblecrew.net>";
   spencerjanssen = "Spencer Janssen <spencerjanssen@gmail.com>";
   spinus = "Tomasz Czyż <tomasz.czyz@gmail.com>";


### PR DESCRIPTION
###### Motivation for this change

Patch changes my email in maintainers.nix
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
