### PR TITLE
trivial-builders.nix: add writeShellScriptBin builder

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -18,6 +18,7 @@ rec {
     , text
     , executable ? false # run chmod +x ?
     , destination ? ""   # relative path appended to $out eg "/bin/foo"
+    , checkPhase ? ""    # syntax checks, e.g. for scripts
     }:
     runCommand name
       { inherit text executable;
@@ -36,6 +37,8 @@ rec {
           echo -n "$text" > "$n"
         fi
 
+        ${checkPhase}
+
         (test -n "$executable" && chmod +x "$n") || true
       '';
 
@@ -46,6 +49,20 @@ rec {
   writeScript = name: text: writeTextFile {inherit name text; executable = true;};
   writeScriptBin = name: text: writeTextFile {inherit name text; executable = true; destination = "/bin/${name}";};
 
+  # Create a Shell script, check its syntax
+  writeShellScriptBin = name : text :
+    writeTextFile {
+      inherit name;
+      executable = true;
+      destination = "/bin/${name}";
+      text = ''
+        #!${stdenv.shell}
+        ${text}
+        '';
+      checkPhase = ''
+        ${stdenv.shell} -n $out
+      '';
+    };
 
   # Create a forest of symlinks to the files in `paths'.
   symlinkJoin =


### PR DESCRIPTION
###### Motivation for this change

We often use Nix to write in-place shell scripts. This patch adds writeShellScriptBin which enables basic syntax-checking for such a scripts.

More detailed, it does the following:
1. Assuming caller-supplied `text` is a shell-script, adds '#!${stdenv.shell}' header
2. Calls underlying `writeScriptBin` function
3. Calls `sh -n` to check the basic syntax
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
