### PR TITLE
wl-pprint: update to 2016-09-28

### DIFF
--- a/pkgs/development/idris-modules/wl-pprint.nix
+++ b/pkgs/development/idris-modules/wl-pprint.nix
@@ -4,25 +4,27 @@
 , base
 , lib
 , idris
-}: build-idris-package {
-  name = "wl-pprint";
+}:
+build-idris-package {
+  name = "wl-pprint-2016-09-28";
 
   src = fetchFromGitHub {
     owner = "shayan-najd";
     repo = "wl-pprint";
-    rev = "120f654b0b9838b57e10b163d3562d959439fb07";
-    sha256 = "1yymdl251zla6hv9rcg06x73gbp6xb0n6f6a02bsy5fqfmrfngcl";
+    rev = "4cc88a0865620a3b997863e4167d3b98e1a41b52";
+    sha256 = "1yxxh366k5njad75r0xci2q5c554cddvzgrwk43b0xn8rq0vm11x";
   };
+
+  # The tests for this package fail. We should attempt to enable them when
+  # updating this package again.
+  doCheck = false;
 
   propagatedBuildInputs = [ prelude base ];
 
   meta = {
     description = "Wadler-Leijen pretty-printing library";
-
     homepage = https://github.com/shayan-najd/wl-pprint;
-
     license = lib.licenses.bsd2;
-
     inherit (idris.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes #19014 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
