### PR TITLE
ranger: patch default pager

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, w3m, file }:
+{ stdenv, fetchurl, pythonPackages, w3m, file, less }:
 
 pythonPackages.buildPythonApplication rec {
   name = "ranger-1.7.2";
@@ -20,6 +20,8 @@ pythonPackages.buildPythonApplication rec {
   preConfigure = ''
     substituteInPlace ranger/ext/img_display.py \
       --replace /usr/lib/w3m ${w3m}/libexec/w3m
+    substituteInPlace ranger/__init__.py \
+      --replace "DEFAULT_PAGER = 'less'" "DEFAULT_PAGER = '${stdenv.lib.getBin less}/bin/less'"
 
     for i in ranger/config/rc.conf doc/config/rc.conf ; do
       substituteInPlace $i --replace /usr/share $out/share


### PR DESCRIPTION
- [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
