### PR TITLE
lightdm: Fix regression from 29caa185a7e4aaa0d621a4f117f3e8f653261fda

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -63,7 +63,7 @@ let
     let
       dm = xcfg.desktopManager.default;
       wm = xcfg.windowManager.default;
-    in dm + optionalString (wm != "none") (" + " + wm);
+    in dm + optionalString (wm != "" && wm != "none") (" + " + wm);
 in
 {
   # Note: the order in which lightdm greeter modules are imported


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

29caa185a7e4aaa0d621a4f117f3e8f653261fda introduced a bug where when
using i3 and no desktopmanager, it would start xterm and not i3.

Example configuration:

```
services.xserver.displayManager.lightdm.enable = true;
services.xserver.windowManager.i3.enable = true;
```

when starting up you would get i3 sort of, but xterm would be started
as your user-session.

This was fixable by setting:

```
services.xserver.desktopManager.default = "none";
```

as well, but this was definitely a surprise which broke my system. I
don't think this regression was intentional, so here we are fixing it.

Note the default value of `desktopManager.default` is empty, and the example value is `none`. Not sure how those two are substantially different, so I think that justifies the change.
