### PR TITLE
oraclejdk7: mark as broken since it is end of life (16.09)

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -6,6 +6,7 @@
 , jceName
 , jceDownloadUrl
 , sha256JCE
+, broken ? false
 }:
 
 { swingSupport ? true
@@ -193,6 +194,7 @@ let result = stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     license = licenses.unfree;
     platforms = [ "i686-linux" "x86_64-linux" ]; # some inherit jre.meta.platforms
+    broken = broken;
   };
 
 }; in result

--- a/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7-linux.nix
@@ -7,4 +7,5 @@ import ./jdk-linux-base.nix {
   jceName = "UnlimitedJCEPolicyJDK7.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";
+  broken = true;
 }

--- a/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk7psu-linux.nix
@@ -7,4 +7,5 @@ import ./jdk-linux-base.nix {
   jceName = "UnlimitedJCEPolicyJDK7.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html;
   sha256JCE = "7a8d790e7bd9c2f82a83baddfae765797a4a56ea603c9150c87b7cdb7800194d";
+  broken = true;
 }


### PR DESCRIPTION
###### Motivation for this change

RE: https://github.com/NixOS/nixpkgs/issues/18856
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
