### PR TITLE
tevent, samba4: use tevent 0.9.29 for samba4

### DIFF
--- a/pkgs/development/libraries/tevent/0.9.29.nix
+++ b/pkgs/development/libraries/tevent/0.9.29.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, python, pkgconfig, readline, talloc
+, libxslt, docbook_xsl, docbook_xml_dtd_42
+}:
+
+stdenv.mkDerivation rec {
+  name = "tevent-0.9.29";
+
+  src = fetchurl {
+    url = "mirror://samba/tevent/${name}.tar.gz";
+    sha256 = "0ay4l6x7p3p33d9q1vy251gng6fiwhg03sdyflhzw65ppfq1kxd4";
+  };
+
+  buildInputs = [
+    python pkgconfig readline talloc libxslt docbook_xsl docbook_xml_dtd_42
+  ];
+
+  preConfigure = ''
+    sed -i 's,#!/usr/bin/env python,#!${python}/bin/python,g' buildtools/bin/waf
+  '';
+
+  configureFlags = [
+    "--bundled-libraries=NONE"
+    "--builtin-libraries=replace"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "An event system based on the talloc memory management library";
+    homepage = http://tevent.samba.org/;
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ wkennington ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9128,6 +9128,10 @@ in
     python = python2;
   };
 
+  tevent_0_9_29 = callPackage ../development/libraries/tevent/0.9.29.nix {
+    python = python2;
+  };
+
   tet = callPackage ../development/tools/misc/tet { };
 
   thrift = callPackage ../development/libraries/thrift {
@@ -10165,6 +10169,8 @@ in
 
   samba4 = callPackage ../servers/samba/4.x.nix {
     python = python2;
+    # Samba 4 crashes with tevent 0.9.30
+    tevent =  tevent_0_9_29;
     # enableLDAP
   };
 


### PR DESCRIPTION
###### Motivation for this change

Samba 4 currently crashes with 0.9.30.
See #19013 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Tested on real system using nixos-rebuild switch
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
