### PR TITLE
redprl: remove explicit builder

### DIFF
--- a/pkgs/applications/science/logic/redprl/default.nix
+++ b/pkgs/applications/science/logic/redprl/default.nix
@@ -11,12 +11,11 @@ stdenv.mkDerivation {
   patchPhase = ''
     patchShebangs ./script/
   '';
-  builder = builtins.toFile "builder.sh" ''
-    source $stdenv/setup
-    mkdir -p $out/bin
-    cp -r $src/* .
-    chmod -R +w src
+  buildPhase = ''
     ./script/mlton.sh
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
     mv ./bin/redprl $out/bin
   '';
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Couldn't compile RedPRL due to uses of /bin/bash and no patchShebangs being called.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

patchPhase wasn't being called for me so I've switched out the explicit
builder for the generic form. I can now build RedPRL on locally on
NixOS.
