### PR TITLE
gnu global: 6.5.4 -> 6.5.5

### DIFF
--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -3,11 +3,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "global-6.5.4";
+  name = "global-${version}";
+  version = "6.5.5";
 
   src = fetchurl {
     url = "mirror://gnu/global/${name}.tar.gz";
-    sha256 = "19hxajpwld6qx0faz4rzyh1hfs25ycjmws6bas8pavx4hskf05mg";
+    sha256 = "0yyg91qw8399lnxfai4bxkh9yq71qdwp9kvadgzp05cdqni44nxw";
   };
 
   nativeBuildInputs = [ libtool makeWrapper ];
@@ -51,7 +52,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.gnu.org/software/global/;
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ pSub ];
+    maintainers = with maintainers; [ pSub peterhoeg ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Because clearly 6.5.5 is 0.0.1 better than 6.5.4.

`nox-review wip` ftw, thanks @fridh!
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
