### PR TITLE
rtl8812au: 4.2.2-1 -> 4.3.20

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "rtl8812au-${kernel.version}-${version}";
-  version = "4.2.2-1";
+  version = "4.3.20";
 
   src = fetchFromGitHub {
-    owner = "csssuf";
-    repo = "rtl8812au";
-    rev = "874906aec694c800bfc29b146737b88dae767832";
-    sha256 = "14ifhplawipfd6971mxw76dv3ygwc0n8sbz2l3f0vvkin6x88bsj";
+    owner = "Grawp";
+    repo = "rtl8812au_rtl8821au";
+    rev = "9c5b2978ab079081dd1e981353be681a1cf495de";
+    sha256 = "0bx1vgs2qldwwhdgklbqz2vy9x4jg7cj3d6w6cpkndkcr7h0m5vz";
   };
 
   hardeningDisable = [ "pic" ];
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Driver for Realtek 802.11ac, rtl8812au, provides the 8812au mod";
-    homepage = "https://github.com/csssuf/rtl8812au";
+    homepage = "https://github.com/Grawp/rtl8812au_rtl8821au";
     license = stdenv.lib.licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
     broken = (kernel.features.grsecurity or false);


### PR DESCRIPTION
###### Motivation for this change

The current version is not working with newer kernels.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Moved the package to use AUR's package, which is being maintained and has support for newer kernels.
