### PR TITLE
groonga: 6.0.8 -> 6.0.9

### DIFF
--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -7,11 +7,11 @@
 stdenv.mkDerivation rec {
 
   name    = "groonga-${version}";
-  version = "6.0.8";
+  version = "6.0.9";
 
   src = fetchurl {
     url    = "http://packages.groonga.org/source/groonga/${name}.tar.gz";
-    sha256 = "05mp6zkavxj87nbx0jr48rpjjcf7fzdczxa93sxp4zq2dsnn5s5r";
+    sha256 = "1n7kf25yimgy9wy04hv5qvp4rzdzdr0ar92lhwms812qkhp3i4mq";
   };
 
   buildInputs = with stdenv.lib; [ pkgconfig mecab kytea libedit ] ++
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
     ${optionalString zlibSupport "--with-zlib"}
     ${optionalString lz4Support "--with-lz4"}
   '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = "$out/bin/groonga --version";
 
   meta = with stdenv.lib; {
     homepage = http://groonga.org/;


### PR DESCRIPTION
###### Motivation for this change

Update groonga to latest version. ([release notes](http://groonga.org/en/blog/2016/09/29/groonga-6.0.9.html))

Also added an `installCheck` basic test.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
