### PR TITLE
bge: init at 3.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -199,6 +199,7 @@
   joamaki = "Jussi Maki <joamaki@gmail.com>";
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
   joelteon = "Joel Taylor <me@joelt.io>";
+  jorgemartinezpizarro = "Jorge Martinez Pizarro <jorgemartinezpizarro@gmail.com>";
   joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
   jonafato = "Jon Banafato <jon@jonafato.com>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";
@@ -397,6 +398,7 @@
   sprock = "Roger Mason <rmason@mun.ca>";
   spwhitt = "Spencer Whitt <sw@swhitt.me>";
   SShrike = "Severen Redwood <severen@shrike.me>";
+  stefanwouldgo = "Stefan Richter <richter@cs.rwth-aachen.de>";
   stephenmw = "Stephen Weinberg <stephen@q5comm.com>";
   steveej = "Stefan Junker <mail@stefanjunker.de>";
   swarren83 = "Shawn Warren <shawn.w.warren@gmail.com>";

--- a/pkgs/servers/bge/default.nix
+++ b/pkgs/servers/bge/default.nix
@@ -1,0 +1,51 @@
+{sbt,stdenv, fetchgit,jdk, makeWrapper}:
+
+with stdenv.lib;
+ stdenv.mkDerivation {
+    name = "bge";
+
+    meta = {
+     description = "Bitcoin Graph Explorer is a blockchain analysis server";
+       homepage = "https://bitcoinprivacy.net";
+       maintainers =  with maintainers; [ jorgemartinezpizarro stefanwouldgo ];
+       license = licenses.asl20;
+    };
+
+    buildPhase = let
+      sbtBootDir = "./.sbt/boot/";
+      sbtIvyHome = "/var/tmp/`whoami`/.ivy";
+      sbtOpts = "-XX:PermSize=190m -Dsbt.boot.directory=${sbtBootDir} -Dsbt.ivy.home=${sbtIvyHome}";
+      in ''
+        mkdir -p ${sbtBootDir}
+        mkdir -p ${sbtIvyHome}
+        sbt ${sbtOpts} assembly publish-local
+        cd api
+        mkdir -p ${sbtBootDir}
+        mkdir -p ${sbtIvyHome}
+        sbt ${sbtOpts} assembly
+        cd ..
+      '';
+
+    installPhase = ''
+     mkdir -p $out
+     mkdir -p $out/bin/
+     cp  ./target/scala-2.11/bge-assembly-3.1.jar $out
+     cp bge $out/bin/
+     cp  ./api/target/scala-2.11/bgeapi-assembly-1.0.jar $out
+     cp api/bgeapi $out/bin/
+     wrapProgram $out/bin/bge --suffix LD_LIBRARY_PATH : ${stdenv.cc.cc.lib}/lib                 
+    '';
+
+    src = fetchgit {
+    url = "git://github.com/bitcoinprivacy/Bitcoin-Graph-Explorer.git";
+    rev = "080bd1f";
+    md5 = "3928c2cea051f3a505e21c396c57d054";
+    } ;
+    JAVA_HOME = "${jdk}";
+    shellHook = ''
+
+    export PS1="BGE > " '';
+#    LD_LIBRARY_PATH="${stdenv.cc.cc}/lib64";
+
+    buildInputs = [sbt makeWrapper];
+}

--- a/pkgs/servers/bge/default.nix
+++ b/pkgs/servers/bge/default.nix
@@ -1,17 +1,20 @@
-{sbt,stdenv, fetchgit,jdk, makeWrapper}:
+{sbt,stdenv, fetchFromGitHub, jdk, makeWrapper}:
 
 with stdenv.lib;
  stdenv.mkDerivation {
-    name = "bge";
+    name = "bge-3.1";
 
     meta = {
-     description = "Bitcoin Graph Explorer is a blockchain analysis server";
-       homepage = "https://bitcoinprivacy.net";
-       maintainers =  with maintainers; [ jorgemartinezpizarro stefanwouldgo ];
-       license = licenses.asl20;
+      description = "A blockchain analysis server";
+      longDescription = "Bitcoin Graph Explorer is a live bitcoin blockchain analysis server including a REST API. It is written in Scala.";
+      homepage = "https://bitcoinprivacy.net";
+      maintainers =  with maintainers; [ jorgemartinezpizarro stefanwouldgo ];
+      license = licenses.asl20;
     };
 
-    buildPhase = let
+    buildInputs = [sbt makeWrapper];
+
+    buildPhase =  let
       sbtBootDir = "./.sbt/boot/";
       sbtIvyHome = "/var/tmp/`whoami`/.ivy";
       sbtOpts = "-XX:PermSize=190m -Dsbt.boot.directory=${sbtBootDir} -Dsbt.ivy.home=${sbtIvyHome}";
@@ -27,25 +30,25 @@ with stdenv.lib;
       '';
 
     installPhase = ''
-     mkdir -p $out
-     mkdir -p $out/bin/
-     cp  ./target/scala-2.11/bge-assembly-3.1.jar $out
-     cp bge $out/bin/
-     cp  ./api/target/scala-2.11/bgeapi-assembly-1.0.jar $out
-     cp api/bgeapi $out/bin/
-     wrapProgram $out/bin/bge --suffix LD_LIBRARY_PATH : ${stdenv.cc.cc.lib}/lib                 
+      mkdir -p $out
+      mkdir -p $out/bin/
+      cp  ./target/scala-2.11/bge-assembly-3.1.jar $out
+      cp bge $out/bin/
+      cp  ./api/target/scala-2.11/bgeapi-assembly-1.0.jar $out
+      cp api/bgeapi $out/bin/
+      wrapProgram $out/bin/bge --suffix LD_LIBRARY_PATH : ${stdenv.cc.cc.lib}/lib                 
     '';
 
-    src = fetchgit {
-    url = "git://github.com/bitcoinprivacy/Bitcoin-Graph-Explorer.git";
-    rev = "080bd1f";
-    md5 = "3928c2cea051f3a505e21c396c57d054";
-    } ;
+    src = fetchFromGitHub {
+      rev = "3.1";
+      owner = "bitcoinprivacy";
+      repo = "Bitcoin-Graph-Explorer";
+      sha256 = "062dfj4vc1r9q2dcppij2k16plv26xabvabn5qa9cq39289797vd";
+    };
+
     JAVA_HOME = "${jdk}";
+
     shellHook = ''
 
     export PS1="BGE > " '';
-#    LD_LIBRARY_PATH="${stdenv.cc.cc}/lib64";
-
-    buildInputs = [sbt makeWrapper];
 }

--- a/pkgs/servers/bge/default.nix
+++ b/pkgs/servers/bge/default.nix
@@ -1,24 +1,24 @@
 {sbt,stdenv, fetchFromGitHub, jdk, makeWrapper}:
 
 with stdenv.lib;
- stdenv.mkDerivation {
-    name = "bge-3.1";
+stdenv.mkDerivation {
+  name = "bge-3.1";
 
-    meta = {
-      description = "A blockchain analysis server";
-      longDescription = "Bitcoin Graph Explorer is a live bitcoin blockchain analysis server including a REST API. It is written in Scala.";
-      homepage = "https://bitcoinprivacy.net";
-      maintainers =  with maintainers; [ jorgemartinezpizarro stefanwouldgo ];
-      license = licenses.asl20;
-    };
+  meta = {
+    description = "A blockchain analysis server";
+    longDescription = "Bitcoin Graph Explorer is a live bitcoin blockchain analysis server including a REST API. It is written in Scala.";
+    homepage = "https://bitcoinprivacy.net";
+    maintainers =  with maintainers; [ jorgemartinezpizarro stefanwouldgo ];
+    license = licenses.asl20;
+  };
 
-    buildInputs = [sbt makeWrapper];
+  buildInputs = [sbt makeWrapper];
 
-    buildPhase =  let
-      sbtBootDir = "./.sbt/boot/";
-      sbtIvyHome = "/var/tmp/`whoami`/.ivy";
-      sbtOpts = "-XX:PermSize=190m -Dsbt.boot.directory=${sbtBootDir} -Dsbt.ivy.home=${sbtIvyHome}";
-      in ''
+  buildPhase =  let
+    sbtBootDir = "./.sbt/boot/";
+    sbtIvyHome = "/var/tmp/`whoami`/.ivy";
+    sbtOpts = "-XX:PermSize=190m -Dsbt.boot.directory=${sbtBootDir} -Dsbt.ivy.home=${sbtIvyHome}";
+  in ''
         mkdir -p ${sbtBootDir}
         mkdir -p ${sbtIvyHome}
         sbt ${sbtOpts} assembly publish-local
@@ -29,7 +29,7 @@ with stdenv.lib;
         cd ..
       '';
 
-    installPhase = ''
+  installPhase = ''
       mkdir -p $out
       mkdir -p $out/bin/
       cp  ./target/scala-2.11/bge-assembly-3.1.jar $out
@@ -39,16 +39,16 @@ with stdenv.lib;
       wrapProgram $out/bin/bge --suffix LD_LIBRARY_PATH : ${stdenv.cc.cc.lib}/lib                 
     '';
 
-    src = fetchFromGitHub {
-      rev = "3.1";
-      owner = "bitcoinprivacy";
-      repo = "Bitcoin-Graph-Explorer";
-      sha256 = "062dfj4vc1r9q2dcppij2k16plv26xabvabn5qa9cq39289797vd";
-    };
+  src = fetchFromGitHub {
+    rev = "3.1";
+    owner = "bitcoinprivacy";
+    repo = "Bitcoin-Graph-Explorer";
+    sha256 = "062dfj4vc1r9q2dcppij2k16plv26xabvabn5qa9cq39289797vd";
+  };
 
-    JAVA_HOME = "${jdk}";
+  JAVA_HOME = "${jdk}";
 
-    shellHook = ''
+  shellHook = ''
 
     export PS1="BGE > " '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9768,6 +9768,8 @@ in
 
   sabnzbd = callPackage ../servers/sabnzbd { };
 
+  bge = callPackage ../servers/bge { };
+  
   bind = callPackage ../servers/dns/bind { };
 
   bird = callPackage ../servers/bird { };


### PR DESCRIPTION
###### Motivation for this change

Adding our nix derivation for Bitcoin Graph Explorer, a blockchain analysis server written in Scala, to nixpkgs.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
