### PR TITLE
bitcoin: 0.12.0 -> 0.13.0 

### DIFF
--- a/pkgs/applications/altcoins/bitcoin.nix
+++ b/pkgs/applications/altcoins/bitcoin.nix
@@ -6,14 +6,14 @@ with stdenv.lib;
 stdenv.mkDerivation rec{
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-" + version;
-  core_version = "0.12.0";
+  core_version = "0.13.0";
   version = core_version;
 
   src = fetchurl {
     urls = [ "https://bitcoin.org/bin/bitcoin-core-${core_version}/bitcoin-${version}.tar.gz"
              "mirror://sourceforge/bitcoin/Bitcoin/bitcoin-${core_version}/bitcoin-${version}.tar.gz"
            ];
-    sha256 = "0f1cda66c841a548a07cc37e80b0727354b1236d9f374c7d44362acdb85eb3e1";
+    sha256 = "0c7d7049689bb17f4256f1e5ec20777f42acef61814d434b38e6c17091161cda";
   };
 
   buildInputs = [ pkgconfig autoreconfHook openssl db48 boost zlib


### PR DESCRIPTION
###### Motivation for this change

upstream update
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
