### PR TITLE
pythonPackages.pypoppler: init at 0.12.2

### DIFF
--- a/pkgs/development/python-modules/pypoppler-0.39.0.patch
+++ b/pkgs/development/python-modules/pypoppler-0.39.0.patch
@@ -1,0 +1,23 @@
+diff --git a/poppler.defs b/poppler.defs
+index 8b12e03..2b8fc16 100644
+--- a/poppler.defs
++++ b/poppler.defs
+@@ -570,18 +570,6 @@
+   )
+ )
+ 
+-(define-enum Orientation
+-  (in-module "Poppler")
+-  (c-name "PopplerOrientation")
+-  (gtype-id "POPPLER_TYPE_ORIENTATION")
+-  (values
+-    '("portrait" "POPPLER_ORIENTATION_PORTRAIT")
+-    '("landscape" "POPPLER_ORIENTATION_LANDSCAPE")
+-    '("upsidedown" "POPPLER_ORIENTATION_UPSIDEDOWN")
+-    '("seascape" "POPPLER_ORIENTATION_SEASCAPE")
+-  )
+-)
+-
+ (define-enum PageTransitionType
+   (in-module "Poppler")
+   (c-name "PopplerPageTransitionType")

--- a/pkgs/development/python-modules/pypoppler-poppler.c.patch
+++ b/pkgs/development/python-modules/pypoppler-poppler.c.patch
@@ -1,0 +1,12 @@
+diff --git a/poppler.c b/poppler.c
+index 31b4489..16d0838 100644
+--- a/poppler.c
++++ b/poppler.c
+@@ -4501,7 +4501,6 @@ py_poppler_add_constants(PyObject *module, const gchar *strip_prefix)
+   pyg_enum_add(module, "FormTextType", strip_prefix, POPPLER_TYPE_FORM_TEXT_TYPE);
+   pyg_enum_add(module, "FormChoiceType", strip_prefix, POPPLER_TYPE_FORM_CHOICE_TYPE);
+   pyg_enum_add(module, "Error", strip_prefix, POPPLER_TYPE_ERROR);
+-  pyg_enum_add(module, "Orientation", strip_prefix, POPPLER_TYPE_ORIENTATION);
+   pyg_enum_add(module, "PageTransitionType", strip_prefix, POPPLER_TYPE_PAGE_TRANSITION_TYPE);
+   pyg_enum_add(module, "PageTransitionAlignment", strip_prefix, POPPLER_TYPE_PAGE_TRANSITION_ALIGNMENT);
+   pyg_enum_add(module, "PageTransitionDirection", strip_prefix, POPPLER_TYPE_PAGE_TRANSITION_DIRECTION);

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8214,6 +8214,37 @@ in modules // {
     inherit pythonOlder;
   };
 
+  pypoppler = buildPythonPackage rec {
+    name = "pypoppler-${version}";
+    version = "0.12.2";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/p/pypoppler/${name}.tar.gz";
+      sha256 = "47e6ac99e5b114b9abf2d1dd1bca06f22c028d025432512989f659142470810f";
+    };
+
+    NIX_CFLAGS_COMPILE="-I${pkgs.poppler.dev}/include/poppler/";
+    buildInputs = [ pkgs.pkgconfig pkgs.poppler.dev ];
+    propagatedBuildInputs = with self; [ pycairo pygobject2 ];
+
+    patches = [
+      ../development/python-modules/pypoppler-0.39.0.patch
+      ../development/python-modules/pypoppler-poppler.c.patch
+    ];
+
+    # Not supported.
+    disabled = isPy3k;
+
+    # No tests in archive
+    doCheck = false;
+
+    meta = {
+      homepage = https://code.launchpad.net/~mriedesel/poppler-python/main;
+      description = "Python bindings for poppler-glib, unofficial branch including bug fixes, and removal of gtk dependencies";
+      license = licenses.gpl2;
+    };
+  };
+
   python-axolotl = buildPythonPackage rec {
     name = "python-axolotl-${version}";
     version = "0.1.7";


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
