### PR TITLE
bean-add: init at 76945c320e6f028223e4420956c80c421c4fe74a

### DIFF
--- a/pkgs/applications/office/beancount/bean-add.nix
+++ b/pkgs/applications/office/beancount/bean-add.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, python3Packages }:
+
+stdenv.mkDerivation rec {
+  name = "bean-add-2016-10-01";
+
+  src = fetchFromGitHub {
+    owner = "simon-v";
+    repo = "bean-add";
+    rev = "ea0c21090a9af171e60f325a3a4de810a565aba7";
+    sha256 = "11xx3p29z40xwc9m9ajn1lrkphyyi6kr9ww7f761lj3y8h7q5jcr";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ python readline ];
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    cp bean-add $out/bin/bean-add
+    chmod +x $out/bin/bean-add
+  '';
+
+  meta = {
+    homepage = https://github.com/simon-v/bean-add/;
+    description = "beancount transaction entry assistant";
+
+    # The (only) source file states:
+    #   License: "Do what you feel is right, but don't be a jerk" public license.
+
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15184,6 +15184,8 @@ in
       pythonPackages = python3Packages;
   };
 
+  bean-add = callPackage ../applications/office/beancount/bean-add.nix { };
+
   beret = callPackage ../games/beret { };
 
   bitsnbots = callPackage ../games/bitsnbots {


### PR DESCRIPTION
###### Motivation for this change

Utility for `beancount` which helps entering entries.

We should propably wait for https://github.com/simon-v/bean-add/issues/2 to be solved before merging this PR,...
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
