### PR TITLE
fzy: 0.4 -> 0.7

### DIFF
--- a/pkgs/tools/misc/fzy/default.nix
+++ b/pkgs/tools/misc/fzy/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "fzy-${version}";
-  version = "0.4";
+  version = "0.7";
 
   src = fetchFromGitHub {
     owner = "jhawthorn";
     repo = "fzy";
     rev = version;
-    sha256 = "1sbwy4v5kz0fcl7kzf414phxv9cppvjvfq9jqkcda4bkzqh2xgia";
+    sha256 = "11sc92j9fx23byxv5y4rq0jxp55vc9mrn5hx9lb162vdrl8a4222";
   };
 
   makeFlags = "PREFIX=$(out)";


### PR DESCRIPTION
###### Motivation for this change

I use the tool, and 0.7 fixes a crash bug I encountered.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- ~~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
