### PR TITLE
albert: 0.8.10 -> 0.8.11

### DIFF
--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name    = "albert-${version}";
-  version = "0.8.10";
+  version = "0.8.11";
 
   src = fetchFromGitHub {
     owner  = "manuelschneid3r";
     repo   = "albert";
     rev    = "v${version}";
-    sha256 = "1x8fpc6rnjifh405p385avdaww4v8ld6qwczqwmkzgbcn15gman7";
+    sha256 = "12ag30l3dd05hg0d08ax4c8dvp24lgd677szkq445xzvvhggxr37";
   };
 
   nativeBuildInputs = [ cmake makeQtWrapper ];
@@ -21,11 +21,11 @@ stdenv.mkDerivation rec {
     wrapQtProgram $out/bin/albert
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage    = https://github.com/manuelSchneid3r/albert;
     description = "Desktop agnostic launcher";
-    license     = stdenv.lib.licenses.gpl3Plus;
-    maintainers = [ stdenv.lib.maintainers.ericsagnes ];
-    platforms = stdenv.lib.platforms.linux;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ericsagnes ];
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update albert to latest version.
Include also a small `meta` cleanup.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
