### PR TITLE
ibus: 1.5.13 -> 1.5.14

### DIFF
--- a/pkgs/development/node-packages/node-packages-v4.nix
+++ b/pkgs/development/node-packages/node-packages-v4.nix
@@ -391,13 +391,13 @@ let
         sha1 = "6c9edcb11ced4f0dd2f2d40db0d49a109c088aab";
       };
     };
-    "azure-common-0.9.17" = {
+    "azure-common-0.9.18" = {
       name = "azure-common";
       packageName = "azure-common";
-      version = "0.9.17";
+      version = "0.9.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-common/-/azure-common-0.9.17.tgz";
-        sha1 = "8f8df41ccb4a026b670645f223e41e1a7f42f33f";
+        url = "https://registry.npmjs.org/azure-common/-/azure-common-0.9.18.tgz";
+        sha1 = "38b960f4ddadd44d34f52e8b85d5d1e0226440fd";
       };
     };
     "azure-arm-authorization-2.0.0" = {
@@ -481,13 +481,13 @@ let
         sha1 = "937f87a8aeceb641a8210a9ba837323f0206eb47";
       };
     };
-    "azure-arm-network-0.16.0" = {
+    "azure-arm-network-0.17.0" = {
       name = "azure-arm-network";
       packageName = "azure-arm-network";
-      version = "0.16.0";
+      version = "0.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-network/-/azure-arm-network-0.16.0.tgz";
-        sha1 = "df1bd296fb52742af7596db025cbdd1491391f3d";
+        url = "https://registry.npmjs.org/azure-arm-network/-/azure-arm-network-0.17.0.tgz";
+        sha1 = "97371f42301b40d56757f340c0dd0ed34984cdd6";
       };
     };
     "azure-arm-powerbiembedded-0.1.0" = {
@@ -562,13 +562,13 @@ let
         sha1 = "76604b8d2ad7b881f6ff53a37e37365481ca8c40";
       };
     };
-    "azure-graph-1.0.1" = {
+    "azure-graph-1.1.1" = {
       name = "azure-graph";
       packageName = "azure-graph";
-      version = "1.0.1";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-graph/-/azure-graph-1.0.1.tgz";
-        sha1 = "a2eda330ccd336832b190da0caba9735a73aee97";
+        url = "https://registry.npmjs.org/azure-graph/-/azure-graph-1.1.1.tgz";
+        sha1 = "5277e750d223aec0fd2559e49149777fe1371708";
       };
     };
     "azure-gallery-2.0.0-pre.18" = {
@@ -706,13 +706,13 @@ let
         sha1 = "bfd0c01a8ae6afd90eaa13360976242e28459650";
       };
     };
-    "azure-storage-1.1.0" = {
+    "azure-storage-1.3.0" = {
       name = "azure-storage";
       packageName = "azure-storage";
-      version = "1.1.0";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-storage/-/azure-storage-1.1.0.tgz";
-        sha1 = "45de61074dbddf44f9245ad287c929541ae971ab";
+        url = "https://registry.npmjs.org/azure-storage/-/azure-storage-1.3.0.tgz";
+        sha1 = "314c66699211cd065bb4f7ec98f27b2e533b48ce";
       };
     };
     "azure-arm-batch-0.2.0" = {
@@ -724,13 +724,22 @@ let
         sha1 = "4093c10422565b9b2564db449b5b2d6bb3e2646d";
       };
     };
-    "azure-batch-0.5.0" = {
+    "azure-batch-0.5.2" = {
       name = "azure-batch";
       packageName = "azure-batch";
-      version = "0.5.0";
+      version = "0.5.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-batch/-/azure-batch-0.5.0.tgz";
-        sha1 = "1fbc1ab0f976ad3f16c5879ba95d4751e9d5bf56";
+        url = "https://registry.npmjs.org/azure-batch/-/azure-batch-0.5.2.tgz";
+        sha1 = "21b23f9db7f42734e97f35bd703818a1cf2492eb";
+      };
+    };
+    "azure-servicefabric-0.1.4" = {
+      name = "azure-servicefabric";
+      packageName = "azure-servicefabric";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/azure-servicefabric/-/azure-servicefabric-0.1.4.tgz";
+        sha1 = "7f8d7e7949202e599638fd8abba8f1dc1a89f79e";
       };
     };
     "applicationinsights-0.15.12" = {
@@ -832,6 +841,15 @@ let
         sha1 = "5737045085f55eb455c68b1ff4ebc01bd50e8830";
       };
     };
+    "jsonminify-0.4.1" = {
+      name = "jsonminify";
+      packageName = "jsonminify";
+      version = "0.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsonminify/-/jsonminify-0.4.1.tgz";
+        sha1 = "805dafbb39395188cee9ab582c81ef959d7e710c";
+      };
+    };
     "jsrsasign-4.8.2" = {
       name = "jsrsasign";
       packageName = "jsrsasign";
@@ -850,13 +868,13 @@ let
         sha1 = "412beb19e5cf7937b461bb7897fd98c2b95d4e10";
       };
     };
-    "moment-2.15.0" = {
+    "moment-2.15.1" = {
       name = "moment";
       packageName = "moment";
-      version = "2.15.0";
+      version = "2.15.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/moment/-/moment-2.15.0.tgz";
-        sha1 = "cc9e33958bf4a99dea7111d5e62ed3c13fc96440";
+        url = "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz";
+        sha1 = "e979c2a29e22888e60f396f2220a6118f85cd94c";
       };
     };
     "ms-rest-1.15.0" = {
@@ -1345,15 +1363,6 @@ let
         sha1 = "b0220c02de98617433b72851cf47de3df2cdbee9";
       };
     };
-    "request-2.72.0" = {
-      name = "request";
-      packageName = "request";
-      version = "2.72.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.72.0.tgz";
-        sha1 = "0ce3a179512620b10441f14c82e21c12c0ddb4e1";
-      };
-    };
     "validator-3.22.2" = {
       name = "validator";
       packageName = "validator";
@@ -1388,591 +1397,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sax/-/sax-0.5.2.tgz";
         sha1 = "735ffaa39a1cff8ffb9598f0223abdb03a9fb2ea";
-      };
-    };
-    "aws-sign2-0.6.0" = {
-      name = "aws-sign2";
-      packageName = "aws-sign2";
-      version = "0.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz";
-        sha1 = "14342dd38dbcc94d0e5b87d763cd63612c0e794f";
-      };
-    };
-    "aws4-1.4.1" = {
-      name = "aws4";
-      packageName = "aws4";
-      version = "1.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz";
-        sha1 = "fde7d5292466d230e5ee0f4e038d9dfaab08fc61";
-      };
-    };
-    "bl-1.1.2" = {
-      name = "bl";
-      packageName = "bl";
-      version = "1.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz";
-        sha1 = "fdca871a99713aa00d19e3bbba41c44787a65398";
-      };
-    };
-    "caseless-0.11.0" = {
-      name = "caseless";
-      packageName = "caseless";
-      version = "0.11.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz";
-        sha1 = "715b96ea9841593cc33067923f5ec60ebda4f7d7";
-      };
-    };
-    "combined-stream-1.0.5" = {
-      name = "combined-stream";
-      packageName = "combined-stream";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz";
-        sha1 = "938370a57b4a51dea2c77c15d5c5fdf895164009";
-      };
-    };
-    "extend-3.0.0" = {
-      name = "extend";
-      packageName = "extend";
-      version = "3.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz";
-        sha1 = "5a474353b9f3353ddd8176dfd37b91c83a46f1d4";
-      };
-    };
-    "forever-agent-0.6.1" = {
-      name = "forever-agent";
-      packageName = "forever-agent";
-      version = "0.6.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz";
-        sha1 = "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91";
-      };
-    };
-    "form-data-1.0.1" = {
-      name = "form-data";
-      packageName = "form-data";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz";
-        sha1 = "ae315db9a4907fa065502304a66d7733475ee37c";
-      };
-    };
-    "har-validator-2.0.6" = {
-      name = "har-validator";
-      packageName = "har-validator";
-      version = "2.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz";
-        sha1 = "cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d";
-      };
-    };
-    "hawk-3.1.3" = {
-      name = "hawk";
-      packageName = "hawk";
-      version = "3.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz";
-        sha1 = "078444bd7c1640b0fe540d2c9b73d59678e8e1c4";
-      };
-    };
-    "http-signature-1.1.1" = {
-      name = "http-signature";
-      packageName = "http-signature";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz";
-        sha1 = "df72e267066cd0ac67fb76adf8e134a8fbcf91bf";
-      };
-    };
-    "is-typedarray-1.0.0" = {
-      name = "is-typedarray";
-      packageName = "is-typedarray";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz";
-        sha1 = "e479c80858df0c1b11ddda6940f96011fcda4a9a";
-      };
-    };
-    "isstream-0.1.2" = {
-      name = "isstream";
-      packageName = "isstream";
-      version = "0.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz";
-        sha1 = "47e63f7af55afa6f92e1500e690eb8b8529c099a";
-      };
-    };
-    "json-stringify-safe-5.0.1" = {
-      name = "json-stringify-safe";
-      packageName = "json-stringify-safe";
-      version = "5.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz";
-        sha1 = "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb";
-      };
-    };
-    "mime-types-2.1.11" = {
-      name = "mime-types";
-      packageName = "mime-types";
-      version = "2.1.11";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz";
-        sha1 = "c259c471bda808a85d6cd193b430a5fae4473b3c";
-      };
-    };
-    "oauth-sign-0.8.2" = {
-      name = "oauth-sign";
-      packageName = "oauth-sign";
-      version = "0.8.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz";
-        sha1 = "46a6ab7f0aead8deae9ec0565780b7d4efeb9d43";
-      };
-    };
-    "qs-6.1.0" = {
-      name = "qs";
-      packageName = "qs";
-      version = "6.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz";
-        sha1 = "ec1d1626b24278d99f0fdf4549e524e24eceeb26";
-      };
-    };
-    "stringstream-0.0.5" = {
-      name = "stringstream";
-      packageName = "stringstream";
-      version = "0.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz";
-        sha1 = "4e484cd4de5a0bbbee18e46307710a8a81621878";
-      };
-    };
-    "tough-cookie-2.2.2" = {
-      name = "tough-cookie";
-      packageName = "tough-cookie";
-      version = "2.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz";
-        sha1 = "c83a1830f4e5ef0b93ef2a3488e724f8de016ac7";
-      };
-    };
-    "tunnel-agent-0.4.3" = {
-      name = "tunnel-agent";
-      packageName = "tunnel-agent";
-      version = "0.4.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz";
-        sha1 = "6373db76909fe570e08d73583365ed828a74eeeb";
-      };
-    };
-    "readable-stream-2.0.6" = {
-      name = "readable-stream";
-      packageName = "readable-stream";
-      version = "2.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz";
-        sha1 = "8f90341e68a53ccc928788dacfcd11b36eb9b78e";
-      };
-    };
-    "isarray-1.0.0" = {
-      name = "isarray";
-      packageName = "isarray";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz";
-        sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
-      };
-    };
-    "process-nextick-args-1.0.7" = {
-      name = "process-nextick-args";
-      packageName = "process-nextick-args";
-      version = "1.0.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz";
-        sha1 = "150e20b756590ad3f91093f25a4f2ad8bff30ba3";
-      };
-    };
-    "util-deprecate-1.0.2" = {
-      name = "util-deprecate";
-      packageName = "util-deprecate";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
-        sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
-      };
-    };
-    "delayed-stream-1.0.0" = {
-      name = "delayed-stream";
-      packageName = "delayed-stream";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz";
-        sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
-      };
-    };
-    "async-2.0.1" = {
-      name = "async";
-      packageName = "async";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/async/-/async-2.0.1.tgz";
-        sha1 = "b709cc0280a9c36f09f4536be823c838a9049e25";
-      };
-    };
-    "lodash-4.15.0" = {
-      name = "lodash";
-      packageName = "lodash";
-      version = "4.15.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz";
-        sha1 = "3162391d8f0140aa22cf8f6b3c34d6b7f63d3aa9";
-      };
-    };
-    "chalk-1.1.3" = {
-      name = "chalk";
-      packageName = "chalk";
-      version = "1.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz";
-        sha1 = "a8115c55e4a702fe4d150abd3872822a7e09fc98";
-      };
-    };
-    "commander-2.9.0" = {
-      name = "commander";
-      packageName = "commander";
-      version = "2.9.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz";
-        sha1 = "9c99094176e12240cb22d6c5146098400fe0f7d4";
-      };
-    };
-    "is-my-json-valid-2.13.1" = {
-      name = "is-my-json-valid";
-      packageName = "is-my-json-valid";
-      version = "2.13.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz";
-        sha1 = "d55778a82feb6b0963ff4be111d5d1684e890707";
-      };
-    };
-    "pinkie-promise-2.0.1" = {
-      name = "pinkie-promise";
-      packageName = "pinkie-promise";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz";
-        sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
-      };
-    };
-    "ansi-styles-2.2.1" = {
-      name = "ansi-styles";
-      packageName = "ansi-styles";
-      version = "2.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz";
-        sha1 = "b432dd3358b634cf75e1e4664368240533c1ddbe";
-      };
-    };
-    "escape-string-regexp-1.0.5" = {
-      name = "escape-string-regexp";
-      packageName = "escape-string-regexp";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
-        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
-      };
-    };
-    "has-ansi-2.0.0" = {
-      name = "has-ansi";
-      packageName = "has-ansi";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz";
-        sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
-      };
-    };
-    "strip-ansi-3.0.1" = {
-      name = "strip-ansi";
-      packageName = "strip-ansi";
-      version = "3.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz";
-        sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
-      };
-    };
-    "supports-color-2.0.0" = {
-      name = "supports-color";
-      packageName = "supports-color";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz";
-        sha1 = "535d045ce6b6363fa40117084629995e9df324c7";
-      };
-    };
-    "ansi-regex-2.0.0" = {
-      name = "ansi-regex";
-      packageName = "ansi-regex";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz";
-        sha1 = "c5061b6e0ef8a81775e50f5d66151bf6bf371107";
-      };
-    };
-    "graceful-readlink-1.0.1" = {
-      name = "graceful-readlink";
-      packageName = "graceful-readlink";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz";
-        sha1 = "4cafad76bc62f02fa039b2f94e9a3dd3a391a725";
-      };
-    };
-    "generate-function-2.0.0" = {
-      name = "generate-function";
-      packageName = "generate-function";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz";
-        sha1 = "6858fe7c0969b7d4e9093337647ac79f60dfbe74";
-      };
-    };
-    "generate-object-property-1.2.0" = {
-      name = "generate-object-property";
-      packageName = "generate-object-property";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz";
-        sha1 = "9c0e1c40308ce804f4783618b937fa88f99d50d0";
-      };
-    };
-    "jsonpointer-2.0.0" = {
-      name = "jsonpointer";
-      packageName = "jsonpointer";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz";
-        sha1 = "3af1dd20fe85463910d469a385e33017d2a030d9";
-      };
-    };
-    "xtend-4.0.1" = {
-      name = "xtend";
-      packageName = "xtend";
-      version = "4.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz";
-        sha1 = "a5c6d532be656e23db820efb943a1f04998d63af";
-      };
-    };
-    "is-property-1.0.2" = {
-      name = "is-property";
-      packageName = "is-property";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz";
-        sha1 = "57fe1c4e48474edd65b09911f26b1cd4095dda84";
-      };
-    };
-    "pinkie-2.0.4" = {
-      name = "pinkie";
-      packageName = "pinkie";
-      version = "2.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz";
-        sha1 = "72556b80cfa0d48a974e80e77248e80ed4f7f870";
-      };
-    };
-    "hoek-2.16.3" = {
-      name = "hoek";
-      packageName = "hoek";
-      version = "2.16.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz";
-        sha1 = "20bb7403d3cea398e91dc4710a8ff1b8274a25ed";
-      };
-    };
-    "boom-2.10.1" = {
-      name = "boom";
-      packageName = "boom";
-      version = "2.10.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz";
-        sha1 = "39c8918ceff5799f83f9492a848f625add0c766f";
-      };
-    };
-    "cryptiles-2.0.5" = {
-      name = "cryptiles";
-      packageName = "cryptiles";
-      version = "2.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz";
-        sha1 = "3bdfecdc608147c1c67202fa291e7dca59eaa3b8";
-      };
-    };
-    "sntp-1.0.9" = {
-      name = "sntp";
-      packageName = "sntp";
-      version = "1.0.9";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz";
-        sha1 = "6541184cc90aeea6c6e7b35e2659082443c66198";
-      };
-    };
-    "assert-plus-0.2.0" = {
-      name = "assert-plus";
-      packageName = "assert-plus";
-      version = "0.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz";
-        sha1 = "d74e1b87e7affc0db8aadb7021f3fe48101ab234";
-      };
-    };
-    "jsprim-1.3.1" = {
-      name = "jsprim";
-      packageName = "jsprim";
-      version = "1.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz";
-        sha1 = "2a7256f70412a29ee3670aaca625994c4dcff252";
-      };
-    };
-    "sshpk-1.10.0" = {
-      name = "sshpk";
-      packageName = "sshpk";
-      version = "1.10.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz";
-        sha1 = "104d6ba2afb2ac099ab9567c0d193977f29c6dfa";
-      };
-    };
-    "extsprintf-1.0.2" = {
-      name = "extsprintf";
-      packageName = "extsprintf";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz";
-        sha1 = "e1080e0658e300b06294990cc70e1502235fd550";
-      };
-    };
-    "json-schema-0.2.3" = {
-      name = "json-schema";
-      packageName = "json-schema";
-      version = "0.2.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz";
-        sha1 = "b480c892e59a2f05954ce727bd3f2a4e882f9e13";
-      };
-    };
-    "verror-1.3.6" = {
-      name = "verror";
-      packageName = "verror";
-      version = "1.3.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz";
-        sha1 = "cff5df12946d297d2baaefaa2689e25be01c005c";
-      };
-    };
-    "asn1-0.2.3" = {
-      name = "asn1";
-      packageName = "asn1";
-      version = "0.2.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz";
-        sha1 = "dac8787713c9966849fc8180777ebe9c1ddf3b86";
-      };
-    };
-    "assert-plus-1.0.0" = {
-      name = "assert-plus";
-      packageName = "assert-plus";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz";
-        sha1 = "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525";
-      };
-    };
-    "dashdash-1.14.0" = {
-      name = "dashdash";
-      packageName = "dashdash";
-      version = "1.14.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz";
-        sha1 = "29e486c5418bf0f356034a993d51686a33e84141";
-      };
-    };
-    "getpass-0.1.6" = {
-      name = "getpass";
-      packageName = "getpass";
-      version = "0.1.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz";
-        sha1 = "283ffd9fc1256840875311c1b60e8c40187110e6";
-      };
-    };
-    "jsbn-0.1.0" = {
-      name = "jsbn";
-      packageName = "jsbn";
-      version = "0.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz";
-        sha1 = "650987da0dd74f4ebf5a11377a2aa2d273e97dfd";
-      };
-    };
-    "tweetnacl-0.13.3" = {
-      name = "tweetnacl";
-      packageName = "tweetnacl";
-      version = "0.13.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz";
-        sha1 = "d628b56f3bcc3d5ae74ba9d4c1a704def5ab4b56";
-      };
-    };
-    "jodid25519-1.0.2" = {
-      name = "jodid25519";
-      packageName = "jodid25519";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz";
-        sha1 = "06d4912255093419477d425633606e0e90782967";
-      };
-    };
-    "ecc-jsbn-0.1.1" = {
-      name = "ecc-jsbn";
-      packageName = "ecc-jsbn";
-      version = "0.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz";
-        sha1 = "0fc73a9ed5f0d53c38193398523ef7e543777505";
-      };
-    };
-    "bcrypt-pbkdf-1.0.0" = {
-      name = "bcrypt-pbkdf";
-      packageName = "bcrypt-pbkdf";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz";
-        sha1 = "3ca76b85241c7170bf7d9703e7b9aa74630040d4";
-      };
-    };
-    "tweetnacl-0.14.3" = {
-      name = "tweetnacl";
-      packageName = "tweetnacl";
-      version = "0.14.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz";
-        sha1 = "3da382f670f25ded78d7b3d1792119bca0b7132d";
-      };
-    };
-    "mime-db-1.23.0" = {
-      name = "mime-db";
-      packageName = "mime-db";
-      version = "1.23.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz";
-        sha1 = "a31b4070adaea27d732ea333740a64d0ec9a6659";
       };
     };
     "moment-2.6.0" = {
@@ -2020,13 +1444,13 @@ let
         sha1 = "1e60b0fef1bc0af67bc0d146dfdde5486cd615b4";
       };
     };
-    "request-2.69.0" = {
-      name = "request";
-      packageName = "request";
-      version = "2.69.0";
+    "readable-stream-2.0.6" = {
+      name = "readable-stream";
+      packageName = "readable-stream";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.69.0.tgz";
-        sha1 = "cf91d2e000752b1217155c005241911991a2346a";
+        url = "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz";
+        sha1 = "8f90341e68a53ccc928788dacfcd11b36eb9b78e";
       };
     };
     "jsonparse-1.2.0" = {
@@ -2038,22 +1462,31 @@ let
         sha1 = "5c0c5685107160e72fe7489bddea0b44c2bc67bd";
       };
     };
-    "bl-1.0.3" = {
-      name = "bl";
-      packageName = "bl";
-      version = "1.0.3";
+    "isarray-1.0.0" = {
+      name = "isarray";
+      packageName = "isarray";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz";
-        sha1 = "fc5421a28fd4226036c3b3891a66a25bc64d226e";
+        url = "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz";
+        sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
       };
     };
-    "qs-6.0.2" = {
-      name = "qs";
-      packageName = "qs";
-      version = "6.0.2";
+    "process-nextick-args-1.0.7" = {
+      name = "process-nextick-args";
+      packageName = "process-nextick-args";
+      version = "1.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz";
-        sha1 = "88c68d590e8ed56c76c79f352c17b982466abfcd";
+        url = "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz";
+        sha1 = "150e20b756590ad3f91093f25a4f2ad8bff30ba3";
+      };
+    };
+    "util-deprecate-1.0.2" = {
+      name = "util-deprecate";
+      packageName = "util-deprecate";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
+        sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
       };
     };
     "stack-trace-0.0.9" = {
@@ -2272,13 +1705,13 @@ let
         sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
       };
     };
-    "glob-7.0.6" = {
+    "glob-7.1.0" = {
       name = "glob";
       packageName = "glob";
-      version = "7.0.6";
+      version = "7.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz";
-        sha1 = "211bafaf49e525b8cd93260d14ab136152b3f57a";
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz";
+        sha1 = "36add856d746d0d99e4cc2797bba1ae2c67272fd";
       };
     };
     "fs.realpath-1.0.0" = {
@@ -2380,6 +1813,15 @@ let
         sha1 = "21e80b2be8580f98b468f379430662b046c34ad2";
       };
     };
+    "isstream-0.1.2" = {
+      name = "isstream";
+      packageName = "isstream";
+      version = "0.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz";
+        sha1 = "47e63f7af55afa6f92e1500e690eb8b8529c099a";
+      };
+    };
     "pkginfo-0.3.1" = {
       name = "pkginfo";
       packageName = "pkginfo";
@@ -2387,6 +1829,141 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz";
         sha1 = "5b29f6a81f70717142e09e765bbeab97b4f81e21";
+      };
+    };
+    "aws-sign2-0.6.0" = {
+      name = "aws-sign2";
+      packageName = "aws-sign2";
+      version = "0.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz";
+        sha1 = "14342dd38dbcc94d0e5b87d763cd63612c0e794f";
+      };
+    };
+    "aws4-1.4.1" = {
+      name = "aws4";
+      packageName = "aws4";
+      version = "1.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz";
+        sha1 = "fde7d5292466d230e5ee0f4e038d9dfaab08fc61";
+      };
+    };
+    "bl-1.1.2" = {
+      name = "bl";
+      packageName = "bl";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz";
+        sha1 = "fdca871a99713aa00d19e3bbba41c44787a65398";
+      };
+    };
+    "caseless-0.11.0" = {
+      name = "caseless";
+      packageName = "caseless";
+      version = "0.11.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz";
+        sha1 = "715b96ea9841593cc33067923f5ec60ebda4f7d7";
+      };
+    };
+    "combined-stream-1.0.5" = {
+      name = "combined-stream";
+      packageName = "combined-stream";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz";
+        sha1 = "938370a57b4a51dea2c77c15d5c5fdf895164009";
+      };
+    };
+    "extend-3.0.0" = {
+      name = "extend";
+      packageName = "extend";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz";
+        sha1 = "5a474353b9f3353ddd8176dfd37b91c83a46f1d4";
+      };
+    };
+    "forever-agent-0.6.1" = {
+      name = "forever-agent";
+      packageName = "forever-agent";
+      version = "0.6.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz";
+        sha1 = "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91";
+      };
+    };
+    "form-data-1.0.1" = {
+      name = "form-data";
+      packageName = "form-data";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz";
+        sha1 = "ae315db9a4907fa065502304a66d7733475ee37c";
+      };
+    };
+    "har-validator-2.0.6" = {
+      name = "har-validator";
+      packageName = "har-validator";
+      version = "2.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz";
+        sha1 = "cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d";
+      };
+    };
+    "hawk-3.1.3" = {
+      name = "hawk";
+      packageName = "hawk";
+      version = "3.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz";
+        sha1 = "078444bd7c1640b0fe540d2c9b73d59678e8e1c4";
+      };
+    };
+    "http-signature-1.1.1" = {
+      name = "http-signature";
+      packageName = "http-signature";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz";
+        sha1 = "df72e267066cd0ac67fb76adf8e134a8fbcf91bf";
+      };
+    };
+    "is-typedarray-1.0.0" = {
+      name = "is-typedarray";
+      packageName = "is-typedarray";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz";
+        sha1 = "e479c80858df0c1b11ddda6940f96011fcda4a9a";
+      };
+    };
+    "json-stringify-safe-5.0.1" = {
+      name = "json-stringify-safe";
+      packageName = "json-stringify-safe";
+      version = "5.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz";
+        sha1 = "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb";
+      };
+    };
+    "mime-types-2.1.12" = {
+      name = "mime-types";
+      packageName = "mime-types";
+      version = "2.1.12";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz";
+        sha1 = "152ba256777020dd4663f54c2e7bc26381e71729";
+      };
+    };
+    "oauth-sign-0.8.2" = {
+      name = "oauth-sign";
+      packageName = "oauth-sign";
+      version = "0.8.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz";
+        sha1 = "46a6ab7f0aead8deae9ec0565780b7d4efeb9d43";
       };
     };
     "qs-6.2.1" = {
@@ -2398,6 +1975,15 @@ let
         sha1 = "ce03c5ff0935bc1d9d69a9f14cbd18e568d67625";
       };
     };
+    "stringstream-0.0.5" = {
+      name = "stringstream";
+      packageName = "stringstream";
+      version = "0.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz";
+        sha1 = "4e484cd4de5a0bbbee18e46307710a8a81621878";
+      };
+    };
     "tough-cookie-2.3.1" = {
       name = "tough-cookie";
       packageName = "tough-cookie";
@@ -2405,6 +1991,375 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz";
         sha1 = "99c77dfbb7d804249e8a299d4cb0fd81fef083fd";
+      };
+    };
+    "tunnel-agent-0.4.3" = {
+      name = "tunnel-agent";
+      packageName = "tunnel-agent";
+      version = "0.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz";
+        sha1 = "6373db76909fe570e08d73583365ed828a74eeeb";
+      };
+    };
+    "delayed-stream-1.0.0" = {
+      name = "delayed-stream";
+      packageName = "delayed-stream";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz";
+        sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
+      };
+    };
+    "async-2.0.1" = {
+      name = "async";
+      packageName = "async";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async/-/async-2.0.1.tgz";
+        sha1 = "b709cc0280a9c36f09f4536be823c838a9049e25";
+      };
+    };
+    "lodash-4.16.2" = {
+      name = "lodash";
+      packageName = "lodash";
+      version = "4.16.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz";
+        sha1 = "3e626db827048a699281a8a125226326cfc0e652";
+      };
+    };
+    "chalk-1.1.3" = {
+      name = "chalk";
+      packageName = "chalk";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz";
+        sha1 = "a8115c55e4a702fe4d150abd3872822a7e09fc98";
+      };
+    };
+    "commander-2.9.0" = {
+      name = "commander";
+      packageName = "commander";
+      version = "2.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz";
+        sha1 = "9c99094176e12240cb22d6c5146098400fe0f7d4";
+      };
+    };
+    "is-my-json-valid-2.14.0" = {
+      name = "is-my-json-valid";
+      packageName = "is-my-json-valid";
+      version = "2.14.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz";
+        sha1 = "47bf808609b2df5d48c969c74becd09fbca02725";
+      };
+    };
+    "pinkie-promise-2.0.1" = {
+      name = "pinkie-promise";
+      packageName = "pinkie-promise";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz";
+        sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
+      };
+    };
+    "ansi-styles-2.2.1" = {
+      name = "ansi-styles";
+      packageName = "ansi-styles";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz";
+        sha1 = "b432dd3358b634cf75e1e4664368240533c1ddbe";
+      };
+    };
+    "escape-string-regexp-1.0.5" = {
+      name = "escape-string-regexp";
+      packageName = "escape-string-regexp";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
+      };
+    };
+    "has-ansi-2.0.0" = {
+      name = "has-ansi";
+      packageName = "has-ansi";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz";
+        sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
+      };
+    };
+    "strip-ansi-3.0.1" = {
+      name = "strip-ansi";
+      packageName = "strip-ansi";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz";
+        sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
+      };
+    };
+    "supports-color-2.0.0" = {
+      name = "supports-color";
+      packageName = "supports-color";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz";
+        sha1 = "535d045ce6b6363fa40117084629995e9df324c7";
+      };
+    };
+    "ansi-regex-2.0.0" = {
+      name = "ansi-regex";
+      packageName = "ansi-regex";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz";
+        sha1 = "c5061b6e0ef8a81775e50f5d66151bf6bf371107";
+      };
+    };
+    "graceful-readlink-1.0.1" = {
+      name = "graceful-readlink";
+      packageName = "graceful-readlink";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz";
+        sha1 = "4cafad76bc62f02fa039b2f94e9a3dd3a391a725";
+      };
+    };
+    "generate-function-2.0.0" = {
+      name = "generate-function";
+      packageName = "generate-function";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz";
+        sha1 = "6858fe7c0969b7d4e9093337647ac79f60dfbe74";
+      };
+    };
+    "generate-object-property-1.2.0" = {
+      name = "generate-object-property";
+      packageName = "generate-object-property";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz";
+        sha1 = "9c0e1c40308ce804f4783618b937fa88f99d50d0";
+      };
+    };
+    "jsonpointer-2.0.0" = {
+      name = "jsonpointer";
+      packageName = "jsonpointer";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz";
+        sha1 = "3af1dd20fe85463910d469a385e33017d2a030d9";
+      };
+    };
+    "xtend-4.0.1" = {
+      name = "xtend";
+      packageName = "xtend";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz";
+        sha1 = "a5c6d532be656e23db820efb943a1f04998d63af";
+      };
+    };
+    "is-property-1.0.2" = {
+      name = "is-property";
+      packageName = "is-property";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz";
+        sha1 = "57fe1c4e48474edd65b09911f26b1cd4095dda84";
+      };
+    };
+    "pinkie-2.0.4" = {
+      name = "pinkie";
+      packageName = "pinkie";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz";
+        sha1 = "72556b80cfa0d48a974e80e77248e80ed4f7f870";
+      };
+    };
+    "hoek-2.16.3" = {
+      name = "hoek";
+      packageName = "hoek";
+      version = "2.16.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz";
+        sha1 = "20bb7403d3cea398e91dc4710a8ff1b8274a25ed";
+      };
+    };
+    "boom-2.10.1" = {
+      name = "boom";
+      packageName = "boom";
+      version = "2.10.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz";
+        sha1 = "39c8918ceff5799f83f9492a848f625add0c766f";
+      };
+    };
+    "cryptiles-2.0.5" = {
+      name = "cryptiles";
+      packageName = "cryptiles";
+      version = "2.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz";
+        sha1 = "3bdfecdc608147c1c67202fa291e7dca59eaa3b8";
+      };
+    };
+    "sntp-1.0.9" = {
+      name = "sntp";
+      packageName = "sntp";
+      version = "1.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz";
+        sha1 = "6541184cc90aeea6c6e7b35e2659082443c66198";
+      };
+    };
+    "assert-plus-0.2.0" = {
+      name = "assert-plus";
+      packageName = "assert-plus";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz";
+        sha1 = "d74e1b87e7affc0db8aadb7021f3fe48101ab234";
+      };
+    };
+    "jsprim-1.3.1" = {
+      name = "jsprim";
+      packageName = "jsprim";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz";
+        sha1 = "2a7256f70412a29ee3670aaca625994c4dcff252";
+      };
+    };
+    "sshpk-1.10.1" = {
+      name = "sshpk";
+      packageName = "sshpk";
+      version = "1.10.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz";
+        sha1 = "30e1a5d329244974a1af61511339d595af6638b0";
+      };
+    };
+    "extsprintf-1.0.2" = {
+      name = "extsprintf";
+      packageName = "extsprintf";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz";
+        sha1 = "e1080e0658e300b06294990cc70e1502235fd550";
+      };
+    };
+    "json-schema-0.2.3" = {
+      name = "json-schema";
+      packageName = "json-schema";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz";
+        sha1 = "b480c892e59a2f05954ce727bd3f2a4e882f9e13";
+      };
+    };
+    "verror-1.3.6" = {
+      name = "verror";
+      packageName = "verror";
+      version = "1.3.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz";
+        sha1 = "cff5df12946d297d2baaefaa2689e25be01c005c";
+      };
+    };
+    "asn1-0.2.3" = {
+      name = "asn1";
+      packageName = "asn1";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz";
+        sha1 = "dac8787713c9966849fc8180777ebe9c1ddf3b86";
+      };
+    };
+    "assert-plus-1.0.0" = {
+      name = "assert-plus";
+      packageName = "assert-plus";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz";
+        sha1 = "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525";
+      };
+    };
+    "dashdash-1.14.0" = {
+      name = "dashdash";
+      packageName = "dashdash";
+      version = "1.14.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz";
+        sha1 = "29e486c5418bf0f356034a993d51686a33e84141";
+      };
+    };
+    "getpass-0.1.6" = {
+      name = "getpass";
+      packageName = "getpass";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz";
+        sha1 = "283ffd9fc1256840875311c1b60e8c40187110e6";
+      };
+    };
+    "jsbn-0.1.0" = {
+      name = "jsbn";
+      packageName = "jsbn";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz";
+        sha1 = "650987da0dd74f4ebf5a11377a2aa2d273e97dfd";
+      };
+    };
+    "tweetnacl-0.14.3" = {
+      name = "tweetnacl";
+      packageName = "tweetnacl";
+      version = "0.14.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz";
+        sha1 = "3da382f670f25ded78d7b3d1792119bca0b7132d";
+      };
+    };
+    "jodid25519-1.0.2" = {
+      name = "jodid25519";
+      packageName = "jodid25519";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz";
+        sha1 = "06d4912255093419477d425633606e0e90782967";
+      };
+    };
+    "ecc-jsbn-0.1.1" = {
+      name = "ecc-jsbn";
+      packageName = "ecc-jsbn";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz";
+        sha1 = "0fc73a9ed5f0d53c38193398523ef7e543777505";
+      };
+    };
+    "bcrypt-pbkdf-1.0.0" = {
+      name = "bcrypt-pbkdf";
+      packageName = "bcrypt-pbkdf";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz";
+        sha1 = "3ca76b85241c7170bf7d9703e7b9aa74630040d4";
+      };
+    };
+    "mime-db-1.24.0" = {
+      name = "mime-db";
+      packageName = "mime-db";
+      version = "1.24.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz";
+        sha1 = "e2d13f939f0016c6e4e9ad25a8652f126c467f0c";
       };
     };
     "asn1-0.1.11" = {
@@ -2497,13 +2452,13 @@ let
         sha1 = "489654c692616b8aa55b0724fa809bb7db49c5bf";
       };
     };
-    "asap-2.0.4" = {
+    "asap-2.0.5" = {
       name = "asap";
       packageName = "asap";
-      version = "2.0.4";
+      version = "2.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz";
-        sha1 = "b391bf7f6bfbc65706022fec8f49c4b07fecf589";
+        url = "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz";
+        sha1 = "522765b50c3510490e52d7dcfe085ef9ba96958f";
       };
     };
     "async-1.0.0" = {
@@ -3082,13 +3037,13 @@ let
         sha1 = "59c44f7ee491da704da415da5a4070ba4f8fe441";
       };
     };
-    "graceful-fs-4.1.6" = {
+    "graceful-fs-4.1.9" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.1.6";
+      version = "4.1.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz";
-        sha1 = "514c38772b31bee2e08bedc21a0aeb3abf54c19e";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz";
+        sha1 = "baacba37d19d11f9d146d3578bc99958c3787e29";
       };
     };
     "parse-json-2.2.0" = {
@@ -3199,13 +3154,13 @@ let
         sha1 = "e9ff841418a6b2ec7a495e939984f78f163e6e31";
       };
     };
-    "jsonfile-2.3.1" = {
+    "jsonfile-2.4.0" = {
       name = "jsonfile";
       packageName = "jsonfile";
-      version = "2.3.1";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz";
-        sha1 = "28bcb29c596b5b7aafd34e662a329ba62cd842fc";
+        url = "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz";
+        sha1 = "3736a2b428b87bbda0cc83b53fa3d633a35c2ae8";
       };
     };
     "klaw-1.3.0" = {
@@ -3253,13 +3208,13 @@ let
         sha1 = "e439be2aaee327321952730f99a8929e4fc50582";
       };
     };
-    "JSONStream-1.1.4" = {
+    "JSONStream-1.2.1" = {
       name = "JSONStream";
       packageName = "JSONStream";
-      version = "1.1.4";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz";
-        sha1 = "be11a495938e882d277773d11986f3974a8ba37a";
+        url = "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz";
+        sha1 = "32aa5790e799481083b49b4b7fa94e23bae69bf9";
       };
     };
     "assert-1.3.0" = {
@@ -3685,13 +3640,13 @@ let
         sha1 = "f3f7522f4ef782348da8161bad9ecfd51bf83a75";
       };
     };
-    "base64-js-1.1.2" = {
+    "base64-js-1.2.0" = {
       name = "base64-js";
       packageName = "base64-js";
-      version = "1.1.2";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz";
-        sha1 = "d6400cac1c4c660976d90d07a04351d89395f5e8";
+        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz";
+        sha1 = "a39992d723584811982be5e290bb6a53d86700f1";
       };
     };
     "ieee754-1.1.6" = {
@@ -3766,13 +3721,13 @@ let
         sha1 = "b5835739270cfe26acf632099fded2a07f209e5e";
       };
     };
-    "pbkdf2-3.0.6" = {
+    "pbkdf2-3.0.8" = {
       name = "pbkdf2";
       packageName = "pbkdf2";
-      version = "3.0.6";
+      version = "3.0.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.6.tgz";
-        sha1 = "943d289ccd92b3dec55cc77dd696d44d6087e8bd";
+        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.8.tgz";
+        sha1 = "2f8abf16ebecc82277945d748aba1d78761f61e2";
       };
     };
     "public-encrypt-4.0.0" = {
@@ -3874,13 +3829,13 @@ let
         sha1 = "21e0abfaf6f2029cf2fafb133567a701d4135524";
       };
     };
-    "elliptic-6.3.1" = {
+    "elliptic-6.3.2" = {
       name = "elliptic";
       packageName = "elliptic";
-      version = "6.3.1";
+      version = "6.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/elliptic/-/elliptic-6.3.1.tgz";
-        sha1 = "17781f2109ab0ec686b146bdcff5d2e8c6aeceda";
+        url = "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz";
+        sha1 = "e4c81e0829cf0a65ab70e998b8232723b5c1bc48";
       };
     };
     "parse-asn1-5.0.0" = {
@@ -3910,13 +3865,13 @@ let
         sha1 = "1332ff00156c0a0ffdd8236013d07b77a0451573";
       };
     };
-    "asn1.js-4.8.0" = {
+    "asn1.js-4.8.1" = {
       name = "asn1.js";
       packageName = "asn1.js";
-      version = "4.8.0";
+      version = "4.8.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.0.tgz";
-        sha1 = "e0e04e9923319163be46aed9e5378973b161ef13";
+        url = "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.1.tgz";
+        sha1 = "3949b7f5fd1e8bedc13be3abebf477f93490c810";
       };
     };
     "ripemd160-1.0.1" = {
@@ -4657,6 +4612,15 @@ let
         sha1 = "394288bf07c8fe16cf36bb2e40a3bb947ed24963";
       };
     };
+    "base64-js-1.1.2" = {
+      name = "base64-js";
+      packageName = "base64-js";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz";
+        sha1 = "d6400cac1c4c660976d90d07a04351d89395f5e8";
+      };
+    };
     "xmlbuilder-8.2.2" = {
       name = "xmlbuilder";
       packageName = "xmlbuilder";
@@ -4810,13 +4774,13 @@ let
         sha1 = "dabb4b17b9f06a4bbf0174b3b4b3a2cdd8e2785f";
       };
     };
-    "rusha-0.8.3" = {
+    "rusha-0.8.4" = {
       name = "rusha";
       packageName = "rusha";
-      version = "0.8.3";
+      version = "0.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rusha/-/rusha-0.8.3.tgz";
-        sha1 = "63cafec9e626ae09565ab0c4ab2cbc1f2f69b71f";
+        url = "https://registry.npmjs.org/rusha/-/rusha-0.8.4.tgz";
+        sha1 = "006599181ab437e53f3ca6bb5340f96c7a533c7b";
       };
     };
     "unzip-response-1.0.1" = {
@@ -6844,13 +6808,22 @@ let
         sha1 = "7dd79330d2abe69c10c2cef79714c97215791dfa";
       };
     };
-    "lockfile-1.0.1" = {
+    "glob-7.0.6" = {
+      name = "glob";
+      packageName = "glob";
+      version = "7.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz";
+        sha1 = "211bafaf49e525b8cd93260d14ab136152b3f57a";
+      };
+    };
+    "lockfile-1.0.2" = {
       name = "lockfile";
       packageName = "lockfile";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz";
-        sha1 = "9d353ecfe3f54d150bb57f89d51746935a39c4f5";
+        url = "https://registry.npmjs.org/lockfile/-/lockfile-1.0.2.tgz";
+        sha1 = "97e1990174f696cbe0a3acd58a43b84aa30c7c83";
       };
     };
     "lru-cache-4.0.1" = {
@@ -7564,13 +7537,13 @@ let
         sha1 = "56970fb1c38558e9e70b728bf3de269ac45adfac";
       };
     };
-    "uuid-2.0.2" = {
+    "uuid-2.0.3" = {
       name = "uuid";
       packageName = "uuid";
-      version = "2.0.2";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz";
-        sha1 = "48bd5698f0677e3c7901a1c46ef15b1643794726";
+        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz";
+        sha1 = "67e2e863797215530dff318e5bf9dcebfd47b21a";
       };
     };
     "write-file-atomic-1.2.0" = {
@@ -7699,6 +7672,15 @@ let
         sha1 = "1b379f64835af7c5a7f498b357cb95215c159edf";
       };
     };
+    "request-2.75.0" = {
+      name = "request";
+      packageName = "request";
+      version = "2.75.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/request/-/request-2.75.0.tgz";
+        sha1 = "d2b8268a286da13eaa5d01adf5d18cc90f657d93";
+      };
+    };
     "ansi-escapes-1.4.0" = {
       name = "ansi-escapes";
       packageName = "ansi-escapes";
@@ -7823,6 +7805,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz";
         sha1 = "5fa55e02be7ca934edfc12665632e849b72e5209";
+      };
+    };
+    "form-data-2.0.0" = {
+      name = "form-data";
+      packageName = "form-data";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz";
+        sha1 = "6f0aebadcc5da16c13e1ecc11137d85f9b883b25";
+      };
+    };
+    "asynckit-0.4.0" = {
+      name = "asynckit";
+      packageName = "asynckit";
+      version = "0.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz";
+        sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
       };
     };
     "bluebird-2.9.9" = {
@@ -8531,13 +8531,13 @@ let
         sha1 = "e1a3f4cad65fc02e25070a47d63d7b527361c1cf";
       };
     };
-    "level-sublevel-6.5.4" = {
+    "level-sublevel-6.6.0" = {
       name = "level-sublevel";
       packageName = "level-sublevel";
-      version = "6.5.4";
+      version = "6.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.5.4.tgz";
-        sha1 = "92e6534e7ac3fa35c8bdb121b8a8094a8d1c0826";
+        url = "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.0.tgz";
+        sha1 = "675f2f6a3d437b10700e840069bcb331a5c8362f";
       };
     };
     "leveldown-0.10.6" = {
@@ -8873,6 +8873,15 @@ let
         sha1 = "80ab4e919749351263ef14500d684e57c4202840";
       };
     };
+    "JSONStream-1.1.4" = {
+      name = "JSONStream";
+      packageName = "JSONStream";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz";
+        sha1 = "be11a495938e882d277773d11986f3974a8ba37a";
+      };
+    };
     "got-6.5.0" = {
       name = "got";
       packageName = "got";
@@ -8999,13 +9008,13 @@ let
         sha1 = "e01975e812781a163a6dadfdd80398dc64c889c3";
       };
     };
-    "espree-3.1.7" = {
+    "espree-3.3.2" = {
       name = "espree";
       packageName = "espree";
-      version = "3.1.7";
+      version = "3.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz";
-        sha1 = "fd5deec76a97a5120a9cd3a7cb1177a0923b11d2";
+        url = "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz";
+        sha1 = "dbf3fadeb4ecb4d4778303e50103b3d36c88b89c";
       };
     };
     "estraverse-4.2.0" = {
@@ -9107,13 +9116,13 @@ let
         sha1 = "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7";
       };
     };
-    "optionator-0.8.1" = {
+    "optionator-0.8.2" = {
       name = "optionator";
       packageName = "optionator";
-      version = "0.8.1";
+      version = "0.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz";
-        sha1 = "e31b4932cdd5fb862a8b0d10bc63d3ee1ec7d78b";
+        url = "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz";
+        sha1 = "364c5e409d3f4d6301d6c0b4c05bba50180aeb64";
       };
     };
     "pluralize-1.2.1" = {
@@ -9152,13 +9161,13 @@ let
         sha1 = "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3";
       };
     };
-    "table-3.7.8" = {
+    "table-3.8.0" = {
       name = "table";
       packageName = "table";
-      version = "3.7.8";
+      version = "3.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/table/-/table-3.7.8.tgz";
-        sha1 = "b424433ef596851922b2fd77224a69a1951618eb";
+        url = "https://registry.npmjs.org/table/-/table-3.8.0.tgz";
+        sha1 = "252166c7f3286684a9d561b0f3a8929caf3a997b";
       };
     };
     "es6-map-0.1.4" = {
@@ -9215,13 +9224,13 @@ let
         sha1 = "f6caca728933a850ef90661d0e17982ba47111a2";
       };
     };
-    "acorn-3.3.0" = {
+    "acorn-4.0.3" = {
       name = "acorn";
       packageName = "acorn";
-      version = "3.3.0";
+      version = "4.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz";
-        sha1 = "45e37fb39e8da3f25baee3ff5369e2bb5f22017a";
+        url = "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz";
+        sha1 = "1a3e850b428e73ba6b09d1cc527f5aaad4d03ef1";
       };
     };
     "acorn-jsx-3.0.1" = {
@@ -9231,6 +9240,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz";
         sha1 = "afdf9488fb1ecefc8348f6fb22f464e32a58b36b";
+      };
+    };
+    "acorn-3.3.0" = {
+      name = "acorn";
+      packageName = "acorn";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz";
+        sha1 = "45e37fb39e8da3f25baee3ff5369e2bb5f22017a";
       };
     };
     "flat-cache-1.2.1" = {
@@ -9359,13 +9377,13 @@ let
         sha1 = "c196b0073e6b1c595d93c9c830855b7acc32a453";
       };
     };
-    "argparse-1.0.7" = {
+    "argparse-1.0.9" = {
       name = "argparse";
       packageName = "argparse";
-      version = "1.0.7";
+      version = "1.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz";
-        sha1 = "c289506480557810f14a8bc62d7a06f63ed7f951";
+        url = "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz";
+        sha1 = "73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86";
       };
     };
     "esprima-2.7.3" = {
@@ -9413,13 +9431,13 @@ let
         sha1 = "27584810891456a4171c8d0226441ade90cbcaeb";
       };
     };
-    "fast-levenshtein-1.1.4" = {
+    "fast-levenshtein-2.0.5" = {
       name = "fast-levenshtein";
       packageName = "fast-levenshtein";
-      version = "1.1.4";
+      version = "2.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz";
-        sha1 = "e6a754cc8f15e58987aa9cbd27af66fd6f4e5af9";
+        url = "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz";
+        sha1 = "bd33145744519ab1c36c3ee9f31f08e9079b67f2";
       };
     };
     "caller-path-0.1.0" = {
@@ -9449,13 +9467,22 @@ let
         sha1 = "afab96262910a7f33c19a5775825c69f34e350ca";
       };
     };
-    "bluebird-3.4.6" = {
-      name = "bluebird";
-      packageName = "bluebird";
-      version = "3.4.6";
+    "ajv-4.7.5" = {
+      name = "ajv";
+      packageName = "ajv";
+      version = "4.7.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz";
-        sha1 = "01da8d821d87813d158967e743d5fe6c62cf8c0f";
+        url = "https://registry.npmjs.org/ajv/-/ajv-4.7.5.tgz";
+        sha1 = "f44172aec18514e6ba6350cc5fae0ee9b142e68c";
+      };
+    };
+    "ajv-keywords-1.1.1" = {
+      name = "ajv-keywords";
+      packageName = "ajv-keywords";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.1.1.tgz";
+        sha1 = "02550bc605a3e576041565628af972e06c549d50";
       };
     };
     "slice-ansi-0.0.4" = {
@@ -9467,22 +9494,13 @@ let
         sha1 = "edbf8903f66f7ce2f8eafd6ceed65e264c831b35";
       };
     };
-    "tv4-1.2.7" = {
-      name = "tv4";
-      packageName = "tv4";
-      version = "1.2.7";
+    "co-4.6.0" = {
+      name = "co";
+      packageName = "co";
+      version = "4.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz";
-        sha1 = "bd29389afc73ade49ae5f48142b5d544bf68d120";
-      };
-    };
-    "xregexp-3.1.1" = {
-      name = "xregexp";
-      packageName = "xregexp";
-      version = "3.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz";
-        sha1 = "8ee18d75ef5c7cb3f9967f8d29414a6ca5b1a184";
+        url = "https://registry.npmjs.org/co/-/co-4.6.0.tgz";
+        sha1 = "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184";
       };
     };
     "glob-3.2.11" = {
@@ -10188,13 +10206,13 @@ let
         sha1 = "a4274eeb32fa765da5a7a3b1712617ce3b144149";
       };
     };
-    "coffee-script-1.10.0" = {
+    "coffee-script-1.11.0" = {
       name = "coffee-script";
       packageName = "coffee-script";
-      version = "1.10.0";
+      version = "1.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz";
-        sha1 = "12938bcf9be1948fa006f92e0c4c9e81705108c0";
+        url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.0.tgz";
+        sha1 = "591e87f7447a53dfde33dc892db1d15b14ddd92d";
       };
     };
     "jade-1.11.0" = {
@@ -10233,13 +10251,13 @@ let
         sha1 = "c0dde4ab182713b919b970959a123ecc1a30fcd6";
       };
     };
-    "clean-css-3.4.19" = {
+    "clean-css-3.4.20" = {
       name = "clean-css";
       packageName = "clean-css";
-      version = "3.4.19";
+      version = "3.4.20";
       src = fetchurl {
-        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.19.tgz";
-        sha1 = "c32a8a13ca3b824609b14306a5da76d8793c7874";
+        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz";
+        sha1 = "c0d8963b5448e030f0bcd3ddd0dac4dfe3dea501";
       };
     };
     "commander-2.6.0" = {
@@ -11223,13 +11241,13 @@ let
         sha1 = "1fddad938aae1263ce138680be1b3f591c0ab41c";
       };
     };
-    "eventemitter3-2.0.0" = {
+    "eventemitter3-2.0.1" = {
       name = "eventemitter3";
       packageName = "eventemitter3";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.0.tgz";
-        sha1 = "605f34e75ea702681fcd06b2f4ee2e7b4e019006";
+        url = "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.1.tgz";
+        sha1 = "59c8930b1d8f4da54ad752854948f44330e7f39c";
       };
     };
     "escodegen-1.8.1" = {
@@ -11392,6 +11410,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz";
         sha1 = "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0";
+      };
+    };
+    "bluebird-3.4.6" = {
+      name = "bluebird";
+      packageName = "bluebird";
+      version = "3.4.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz";
+        sha1 = "01da8d821d87813d158967e743d5fe6c62cf8c0f";
       };
     };
     "body-parser-1.15.2" = {
@@ -13653,6 +13680,15 @@ let
         sha1 = "aaa128e62c9b3c358094568c219ff64fe489d42a";
       };
     };
+    "bl-1.0.3" = {
+      name = "bl";
+      packageName = "bl";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz";
+        sha1 = "fc5421a28fd4226036c3b3891a66a25bc64d226e";
+      };
+    };
     "qs-5.2.1" = {
       name = "qs";
       packageName = "qs";
@@ -13660,6 +13696,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz";
         sha1 = "801fee030e0b9450d6385adc48a4cc55b44aedfc";
+      };
+    };
+    "tough-cookie-2.2.2" = {
+      name = "tough-cookie";
+      packageName = "tough-cookie";
+      version = "2.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz";
+        sha1 = "c83a1830f4e5ef0b93ef2a3488e724f8de016ac7";
       };
     };
     "http-signature-0.11.0" = {
@@ -13698,13 +13743,13 @@ let
         sha1 = "3de4db3f4a90c160c06d8cb8b825a7f1c6f6a7c3";
       };
     };
-    "imap-0.8.17" = {
+    "imap-0.8.18" = {
       name = "imap";
       packageName = "imap";
-      version = "0.8.17";
+      version = "0.8.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/imap/-/imap-0.8.17.tgz";
-        sha1 = "e70ff1d1def0456af8bf1d96164d36176662172a";
+        url = "https://registry.npmjs.org/imap/-/imap-0.8.18.tgz";
+        sha1 = "4a7cdd0ff276efa0298708bb2c6d0db0b77f7a3f";
       };
     };
     "libmime-1.2.0" = {
@@ -13842,13 +13887,13 @@ let
         sha1 = "07af69344defa9851b7b845c1c18110b8264e51e";
       };
     };
-    "utf7-1.0.0" = {
+    "utf7-1.0.2" = {
       name = "utf7";
       packageName = "utf7";
-      version = "1.0.0";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/utf7/-/utf7-1.0.0.tgz";
-        sha1 = "70c895de9d85b8ee7ef5a1fa8e169241c46e72cc";
+        url = "https://registry.npmjs.org/utf7/-/utf7-1.0.2.tgz";
+        sha1 = "955f490aae653ba220b9456a0a8776c199360991";
       };
     };
     "twitter-ng-0.6.2" = {
@@ -14517,6 +14562,15 @@ let
         sha1 = "8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b";
       };
     };
+    "fstream-npm-1.2.0" = {
+      name = "fstream-npm";
+      packageName = "fstream-npm";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz";
+        sha1 = "d2c3c89101346982d64e57091c38487bda916fce";
+      };
+    };
     "lodash._baseuniq-4.6.0" = {
       name = "lodash._baseuniq";
       packageName = "lodash._baseuniq";
@@ -14526,40 +14580,40 @@ let
         sha1 = "0ebb44e456814af7905c6212fa2c9b2d51b841e8";
       };
     };
-    "lodash.clonedeep-4.4.1" = {
+    "lodash.clonedeep-4.5.0" = {
       name = "lodash.clonedeep";
       packageName = "lodash.clonedeep";
-      version = "4.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.4.1.tgz";
-        sha1 = "8adb0621f7e69682af808fe8dbccaa2ba7a8b3ea";
-      };
-    };
-    "lodash.union-4.5.0" = {
-      name = "lodash.union";
-      packageName = "lodash.union";
       version = "4.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.union/-/lodash.union-4.5.0.tgz";
-        sha1 = "d273848d9bc556780a6b4fcfed822a79a685a683";
+        url = "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz";
+        sha1 = "e23f3f9c4f8fbdde872529c1071857a086e5ccef";
       };
     };
-    "lodash.uniq-4.4.0" = {
+    "lodash.union-4.6.0" = {
+      name = "lodash.union";
+      packageName = "lodash.union";
+      version = "4.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz";
+        sha1 = "48bb5088409f16f1821666641c44dd1aaae3cd88";
+      };
+    };
+    "lodash.uniq-4.5.0" = {
       name = "lodash.uniq";
       packageName = "lodash.uniq";
-      version = "4.4.0";
+      version = "4.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.4.0.tgz";
-        sha1 = "42cdcd09e35eb0a07abe1da9c06c850f6afa55c7";
+        url = "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz";
+        sha1 = "d0225373aeb652adc1bc82e4945339a842754773";
       };
     };
-    "lodash.without-4.3.0" = {
+    "lodash.without-4.4.0" = {
       name = "lodash.without";
       packageName = "lodash.without";
-      version = "4.3.0";
+      version = "4.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.without/-/lodash.without-4.3.0.tgz";
-        sha1 = "b4e5c92c4e1fd1c2f4a9359993716e51ce12a2ba";
+        url = "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz";
+        sha1 = "3cd4574a00b67bae373a94b748772640507b7aac";
       };
     };
     "npm-install-checks-3.0.0" = {
@@ -14596,15 +14650,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.5.tgz";
         sha1 = "ace7e6381c7684f970aaa98fc7c5d2b666addab6";
-      };
-    };
-    "retry-0.9.0" = {
-      name = "retry";
-      packageName = "retry";
-      version = "0.9.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz";
-        sha1 = "6f697e50a0e4ddc8c8f7fb547a9b60dead43678d";
       };
     };
     "unique-filename-1.1.0" = {
@@ -14922,51 +14967,6 @@ let
         sha1 = "d4113ad6582445d076d1099997f0b250d7ddbaac";
       };
     };
-    "fstream-npm-1.2.0" = {
-      name = "fstream-npm";
-      packageName = "fstream-npm";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz";
-        sha1 = "d2c3c89101346982d64e57091c38487bda916fce";
-      };
-    };
-    "lodash.clonedeep-4.5.0" = {
-      name = "lodash.clonedeep";
-      packageName = "lodash.clonedeep";
-      version = "4.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz";
-        sha1 = "e23f3f9c4f8fbdde872529c1071857a086e5ccef";
-      };
-    };
-    "lodash.union-4.6.0" = {
-      name = "lodash.union";
-      packageName = "lodash.union";
-      version = "4.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz";
-        sha1 = "48bb5088409f16f1821666641c44dd1aaae3cd88";
-      };
-    };
-    "lodash.uniq-4.5.0" = {
-      name = "lodash.uniq";
-      packageName = "lodash.uniq";
-      version = "4.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz";
-        sha1 = "d0225373aeb652adc1bc82e4945339a842754773";
-      };
-    };
-    "lodash.without-4.4.0" = {
-      name = "lodash.without";
-      packageName = "lodash.without";
-      version = "4.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz";
-        sha1 = "3cd4574a00b67bae373a94b748772640507b7aac";
-      };
-    };
     "airplayer-2.0.0" = {
       name = "airplayer";
       packageName = "airplayer";
@@ -15066,13 +15066,13 @@ let
         sha1 = "1cbc691c45cdf6d6c1dc63bf368b2505f56ef839";
       };
     };
-    "buffer-indexof-1.0.2" = {
+    "buffer-indexof-1.1.0" = {
       name = "buffer-indexof";
       packageName = "buffer-indexof";
-      version = "1.0.2";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.0.2.tgz";
-        sha1 = "7fff11985ce51fe9ff07c40121ad301781587cdf";
+        url = "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.0.tgz";
+        sha1 = "f54f647c4f4e25228baa656a2e57e43d5f270982";
       };
     };
     "next-line-1.1.0" = {
@@ -16030,13 +16030,13 @@ let
         sha1 = "4d26ddc485c32e5a1cf1b35854823b4720d25a52";
       };
     };
-    "openid-2.0.4" = {
+    "openid-2.0.6" = {
       name = "openid";
       packageName = "openid";
-      version = "2.0.4";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/openid/-/openid-2.0.4.tgz";
-        sha1 = "73486f2862b080cc1a582cfd5d4df61d0274ef60";
+        url = "https://registry.npmjs.org/openid/-/openid-2.0.6.tgz";
+        sha1 = "707375e59ab9f73025899727679b20328171c9aa";
       };
     };
     "node-swt-0.1.1" = {
@@ -17398,6 +17398,24 @@ let
         sha1 = "80f7b6d7c2f9c0495ba42c518a670c99bdf6e4a0";
       };
     };
+    "request-2.72.0" = {
+      name = "request";
+      packageName = "request";
+      version = "2.72.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/request/-/request-2.72.0.tgz";
+        sha1 = "0ce3a179512620b10441f14c82e21c12c0ddb4e1";
+      };
+    };
+    "retry-0.9.0" = {
+      name = "retry";
+      packageName = "retry";
+      version = "0.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz";
+        sha1 = "6f697e50a0e4ddc8c8f7fb547a9b60dead43678d";
+      };
+    };
     "lodash._baseclone-4.5.7" = {
       name = "lodash._baseclone";
       packageName = "lodash._baseclone";
@@ -17423,6 +17441,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-4.5.0.tgz";
         sha1 = "56ea7d601367bfa46cd7de115dc3daeb18837938";
+      };
+    };
+    "qs-6.1.0" = {
+      name = "qs";
+      packageName = "qs";
+      version = "6.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz";
+        sha1 = "ec1d1626b24278d99f0fdf4549e524e24eceeb26";
       };
     };
     "lsmod-1.0.0" = {
@@ -17585,6 +17612,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.20.tgz";
         sha1 = "4424aca20e14d255c0b0889af6f6b8973da10e0d";
+      };
+    };
+    "tmp-0.0.29" = {
+      name = "tmp";
+      packageName = "tmp";
+      version = "0.0.29";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz";
+        sha1 = "f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0";
       };
     };
     "follow-redirects-0.0.3" = {
@@ -17887,10 +17923,10 @@ in
   azure-cli = nodeEnv.buildNodePackage {
     name = "azure-cli";
     packageName = "azure-cli";
-    version = "0.10.4";
+    version = "0.10.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.4.tgz";
-      sha1 = "0f5e9a8a529ac30f0fc8e754513ace91df6b5dae";
+      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.5.tgz";
+      sha1 = "7e7490d92521818ab57c561f48e5d6058d9f1583";
     };
     dependencies = [
       (sources."adal-node-0.1.21" // {
@@ -17959,7 +17995,7 @@ in
         ];
       })
       sources."async-1.4.2"
-      (sources."azure-common-0.9.17" // {
+      (sources."azure-common-0.9.18" // {
         dependencies = [
           (sources."xml2js-0.2.7" // {
             dependencies = [
@@ -17967,137 +18003,6 @@ in
             ];
           })
           sources."dateformat-1.0.2-1.2.3"
-          (sources."request-2.72.0" // {
-            dependencies = [
-              sources."aws-sign2-0.6.0"
-              sources."aws4-1.4.1"
-              (sources."bl-1.1.2" // {
-                dependencies = [
-                  (sources."readable-stream-2.0.6" // {
-                    dependencies = [
-                      sources."core-util-is-1.0.2"
-                      sources."inherits-2.0.3"
-                      sources."isarray-1.0.0"
-                      sources."process-nextick-args-1.0.7"
-                      sources."string_decoder-0.10.31"
-                      sources."util-deprecate-1.0.2"
-                    ];
-                  })
-                ];
-              })
-              sources."caseless-0.11.0"
-              (sources."combined-stream-1.0.5" // {
-                dependencies = [
-                  sources."delayed-stream-1.0.0"
-                ];
-              })
-              sources."extend-3.0.0"
-              sources."forever-agent-0.6.1"
-              (sources."form-data-1.0.1" // {
-                dependencies = [
-                  (sources."async-2.0.1" // {
-                    dependencies = [
-                      sources."lodash-4.15.0"
-                    ];
-                  })
-                ];
-              })
-              (sources."har-validator-2.0.6" // {
-                dependencies = [
-                  (sources."chalk-1.1.3" // {
-                    dependencies = [
-                      sources."ansi-styles-2.2.1"
-                      sources."escape-string-regexp-1.0.5"
-                      (sources."has-ansi-2.0.0" // {
-                        dependencies = [
-                          sources."ansi-regex-2.0.0"
-                        ];
-                      })
-                      (sources."strip-ansi-3.0.1" // {
-                        dependencies = [
-                          sources."ansi-regex-2.0.0"
-                        ];
-                      })
-                      sources."supports-color-2.0.0"
-                    ];
-                  })
-                  (sources."commander-2.9.0" // {
-                    dependencies = [
-                      sources."graceful-readlink-1.0.1"
-                    ];
-                  })
-                  (sources."is-my-json-valid-2.13.1" // {
-                    dependencies = [
-                      sources."generate-function-2.0.0"
-                      (sources."generate-object-property-1.2.0" // {
-                        dependencies = [
-                          sources."is-property-1.0.2"
-                        ];
-                      })
-                      sources."jsonpointer-2.0.0"
-                      sources."xtend-4.0.1"
-                    ];
-                  })
-                  (sources."pinkie-promise-2.0.1" // {
-                    dependencies = [
-                      sources."pinkie-2.0.4"
-                    ];
-                  })
-                ];
-              })
-              (sources."hawk-3.1.3" // {
-                dependencies = [
-                  sources."hoek-2.16.3"
-                  sources."boom-2.10.1"
-                  sources."cryptiles-2.0.5"
-                  sources."sntp-1.0.9"
-                ];
-              })
-              (sources."http-signature-1.1.1" // {
-                dependencies = [
-                  sources."assert-plus-0.2.0"
-                  (sources."jsprim-1.3.1" // {
-                    dependencies = [
-                      sources."extsprintf-1.0.2"
-                      sources."json-schema-0.2.3"
-                      sources."verror-1.3.6"
-                    ];
-                  })
-                  (sources."sshpk-1.10.0" // {
-                    dependencies = [
-                      sources."asn1-0.2.3"
-                      sources."assert-plus-1.0.0"
-                      sources."dashdash-1.14.0"
-                      sources."getpass-0.1.6"
-                      sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
-                      sources."jodid25519-1.0.2"
-                      sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
-                    ];
-                  })
-                ];
-              })
-              sources."is-typedarray-1.0.0"
-              sources."isstream-0.1.2"
-              sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
-                dependencies = [
-                  sources."mime-db-1.23.0"
-                ];
-              })
-              sources."node-uuid-1.4.7"
-              sources."oauth-sign-0.8.2"
-              sources."qs-6.1.0"
-              sources."stringstream-0.0.5"
-              sources."tough-cookie-2.2.2"
-              sources."tunnel-agent-0.4.3"
-            ];
-          })
           sources."validator-3.22.2"
           sources."envconf-0.0.4"
           sources."duplexer-0.1.1"
@@ -18112,7 +18017,7 @@ in
       sources."azure-arm-insights-0.11.3"
       sources."azure-arm-iothub-0.1.1"
       sources."azure-arm-servermanagement-0.1.2"
-      sources."azure-arm-network-0.16.0"
+      sources."azure-arm-network-0.17.0"
       sources."azure-arm-powerbiembedded-0.1.0"
       sources."azure-arm-trafficmanager-0.10.5"
       sources."azure-arm-dns-0.11.1"
@@ -18121,7 +18026,7 @@ in
       sources."azure-arm-datalake-analytics-0.4.3"
       sources."azure-arm-datalake-store-0.4.2"
       sources."azure-arm-devtestlabs-0.1.0"
-      sources."azure-graph-1.0.1"
+      sources."azure-graph-1.1.1"
       sources."azure-gallery-2.0.0-pre.18"
       sources."azure-keyvault-0.10.2"
       sources."azure-asm-compute-0.17.0"
@@ -18145,7 +18050,7 @@ in
           sources."moment-2.14.1"
         ];
       })
-      (sources."azure-storage-1.1.0" // {
+      (sources."azure-storage-1.3.0" // {
         dependencies = [
           sources."extend-1.2.1"
           sources."browserify-mime-1.2.9"
@@ -18165,123 +18070,6 @@ in
               sources."util-deprecate-1.0.2"
             ];
           })
-          (sources."request-2.69.0" // {
-            dependencies = [
-              sources."aws-sign2-0.6.0"
-              sources."aws4-1.4.1"
-              sources."bl-1.0.3"
-              sources."caseless-0.11.0"
-              (sources."combined-stream-1.0.5" // {
-                dependencies = [
-                  sources."delayed-stream-1.0.0"
-                ];
-              })
-              sources."extend-3.0.0"
-              sources."forever-agent-0.6.1"
-              (sources."form-data-1.0.1" // {
-                dependencies = [
-                  (sources."async-2.0.1" // {
-                    dependencies = [
-                      sources."lodash-4.15.0"
-                    ];
-                  })
-                ];
-              })
-              (sources."har-validator-2.0.6" // {
-                dependencies = [
-                  (sources."chalk-1.1.3" // {
-                    dependencies = [
-                      sources."ansi-styles-2.2.1"
-                      sources."escape-string-regexp-1.0.5"
-                      (sources."has-ansi-2.0.0" // {
-                        dependencies = [
-                          sources."ansi-regex-2.0.0"
-                        ];
-                      })
-                      (sources."strip-ansi-3.0.1" // {
-                        dependencies = [
-                          sources."ansi-regex-2.0.0"
-                        ];
-                      })
-                      sources."supports-color-2.0.0"
-                    ];
-                  })
-                  (sources."commander-2.9.0" // {
-                    dependencies = [
-                      sources."graceful-readlink-1.0.1"
-                    ];
-                  })
-                  (sources."is-my-json-valid-2.13.1" // {
-                    dependencies = [
-                      sources."generate-function-2.0.0"
-                      (sources."generate-object-property-1.2.0" // {
-                        dependencies = [
-                          sources."is-property-1.0.2"
-                        ];
-                      })
-                      sources."jsonpointer-2.0.0"
-                      sources."xtend-4.0.1"
-                    ];
-                  })
-                  (sources."pinkie-promise-2.0.1" // {
-                    dependencies = [
-                      sources."pinkie-2.0.4"
-                    ];
-                  })
-                ];
-              })
-              (sources."hawk-3.1.3" // {
-                dependencies = [
-                  sources."hoek-2.16.3"
-                  sources."boom-2.10.1"
-                  sources."cryptiles-2.0.5"
-                  sources."sntp-1.0.9"
-                ];
-              })
-              (sources."http-signature-1.1.1" // {
-                dependencies = [
-                  sources."assert-plus-0.2.0"
-                  (sources."jsprim-1.3.1" // {
-                    dependencies = [
-                      sources."extsprintf-1.0.2"
-                      sources."json-schema-0.2.3"
-                      sources."verror-1.3.6"
-                    ];
-                  })
-                  (sources."sshpk-1.10.0" // {
-                    dependencies = [
-                      sources."asn1-0.2.3"
-                      sources."assert-plus-1.0.0"
-                      sources."dashdash-1.14.0"
-                      sources."getpass-0.1.6"
-                      sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
-                      sources."jodid25519-1.0.2"
-                      sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
-                    ];
-                  })
-                ];
-              })
-              sources."is-typedarray-1.0.0"
-              sources."isstream-0.1.2"
-              sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
-                dependencies = [
-                  sources."mime-db-1.23.0"
-                ];
-              })
-              sources."oauth-sign-0.8.2"
-              sources."qs-6.0.2"
-              sources."stringstream-0.0.5"
-              sources."tough-cookie-2.2.2"
-              sources."tunnel-agent-0.4.3"
-            ];
-          })
           sources."validator-3.22.2"
           (sources."xml2js-0.2.7" // {
             dependencies = [
@@ -18291,7 +18079,8 @@ in
         ];
       })
       sources."azure-arm-batch-0.2.0"
-      sources."azure-batch-0.5.0"
+      sources."azure-batch-0.5.2"
+      sources."azure-servicefabric-0.1.4"
       sources."applicationinsights-0.15.12"
       (sources."caller-id-0.1.0" // {
         dependencies = [
@@ -18336,6 +18125,7 @@ in
           sources."JSV-4.0.2"
         ];
       })
+      sources."jsonminify-0.4.1"
       sources."jsrsasign-4.8.2"
       (sources."kuduscript-1.0.8" // {
         dependencies = [
@@ -18347,7 +18137,7 @@ in
           sources."streamline-0.4.11"
         ];
       })
-      sources."moment-2.15.0"
+      sources."moment-2.15.1"
       (sources."ms-rest-1.15.0" // {
         dependencies = [
           sources."duplexer-0.1.1"
@@ -18387,7 +18177,7 @@ in
               sources."ncp-0.4.2"
               (sources."rimraf-2.5.4" // {
                 dependencies = [
-                  (sources."glob-7.0.6" // {
+                  (sources."glob-7.1.0" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.5" // {
@@ -18468,7 +18258,7 @@ in
             dependencies = [
               (sources."async-2.0.1" // {
                 dependencies = [
-                  sources."lodash-4.15.0"
+                  sources."lodash-4.16.2"
                 ];
               })
             ];
@@ -18497,7 +18287,7 @@ in
                   sources."graceful-readlink-1.0.1"
                 ];
               })
-              (sources."is-my-json-valid-2.13.1" // {
+              (sources."is-my-json-valid-2.14.0" // {
                 dependencies = [
                   sources."generate-function-2.0.0"
                   (sources."generate-object-property-1.2.0" // {
@@ -18534,21 +18324,17 @@ in
                   sources."verror-1.3.6"
                 ];
               })
-              (sources."sshpk-1.10.0" // {
+              (sources."sshpk-1.10.1" // {
                 dependencies = [
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.0"
                   sources."getpass-0.1.6"
                   sources."jsbn-0.1.0"
-                  sources."tweetnacl-0.13.3"
+                  sources."tweetnacl-0.14.3"
                   sources."jodid25519-1.0.2"
                   sources."ecc-jsbn-0.1.1"
-                  (sources."bcrypt-pbkdf-1.0.0" // {
-                    dependencies = [
-                      sources."tweetnacl-0.14.3"
-                    ];
-                  })
+                  sources."bcrypt-pbkdf-1.0.0"
                 ];
               })
             ];
@@ -18556,9 +18342,9 @@ in
           sources."is-typedarray-1.0.0"
           sources."isstream-0.1.2"
           sources."json-stringify-safe-5.0.1"
-          (sources."mime-types-2.1.11" // {
+          (sources."mime-types-2.1.12" // {
             dependencies = [
-              sources."mime-db-1.23.0"
+              sources."mime-db-1.24.0"
             ];
           })
           sources."node-uuid-1.4.7"
@@ -18611,7 +18397,7 @@ in
               sources."http-basic-2.5.1"
               (sources."promise-7.1.1" // {
                 dependencies = [
-                  sources."asap-2.0.4"
+                  sources."asap-2.0.5"
                 ];
               })
               sources."qs-6.2.1"
@@ -18681,7 +18467,7 @@ in
     version = "3.1.1";
     src = fetchurl {
       url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.1.tgz";
-      sha1 = "wfzj1k6jkfnk1bkgbmpni59mdab8zk3p";
+      sha1 = "77cc8f966a3595686f5d6fae30ad9bd2cc20bfe3";
     };
     dependencies = [
       (sources."argparse-1.0.4" // {
@@ -18814,7 +18600,7 @@ in
                         dependencies = [
                           (sources."load-json-file-1.1.0" // {
                             dependencies = [
-                              sources."graceful-fs-4.1.6"
+                              sources."graceful-fs-4.1.9"
                               (sources."parse-json-2.2.0" // {
                                 dependencies = [
                                   (sources."error-ex-1.3.0" // {
@@ -18839,7 +18625,7 @@ in
                           })
                           (sources."path-type-1.1.0" // {
                             dependencies = [
-                              sources."graceful-fs-4.1.6"
+                              sources."graceful-fs-4.1.9"
                               sources."pify-2.3.0"
                               (sources."pinkie-promise-2.0.1" // {
                                 dependencies = [
@@ -18899,13 +18685,13 @@ in
       sources."bower-logger-0.2.1"
       (sources."fs-extra-0.26.7" // {
         dependencies = [
-          sources."graceful-fs-4.1.6"
-          sources."jsonfile-2.3.1"
+          sources."graceful-fs-4.1.9"
+          sources."jsonfile-2.4.0"
           sources."klaw-1.3.0"
           sources."path-is-absolute-1.0.0"
           (sources."rimraf-2.5.4" // {
             dependencies = [
-              (sources."glob-7.0.6" // {
+              (sources."glob-7.1.0" // {
                 dependencies = [
                   sources."fs.realpath-1.0.0"
                   (sources."inflight-1.0.5" // {
@@ -19002,7 +18788,7 @@ in
       sha1 = "d81a018e98dd7ca706ec04253d20f8a03b2af8ae";
     };
     dependencies = [
-      (sources."JSONStream-1.1.4" // {
+      (sources."JSONStream-1.2.1" // {
         dependencies = [
           sources."jsonparse-1.2.0"
           sources."through-2.3.8"
@@ -19030,7 +18816,7 @@ in
       })
       (sources."buffer-4.9.1" // {
         dependencies = [
-          sources."base64-js-1.1.2"
+          sources."base64-js-1.2.0"
           sources."ieee754-1.1.6"
           sources."isarray-1.0.0"
         ];
@@ -19081,7 +18867,7 @@ in
             dependencies = [
               sources."bn.js-4.11.6"
               sources."browserify-rsa-4.0.1"
-              (sources."elliptic-6.3.1" // {
+              (sources."elliptic-6.3.2" // {
                 dependencies = [
                   sources."brorand-1.0.6"
                   sources."hash.js-1.0.3"
@@ -19089,7 +18875,7 @@ in
               })
               (sources."parse-asn1-5.0.0" // {
                 dependencies = [
-                  (sources."asn1.js-4.8.0" // {
+                  (sources."asn1.js-4.8.1" // {
                     dependencies = [
                       sources."minimalistic-assert-1.0.0"
                     ];
@@ -19108,7 +18894,7 @@ in
           (sources."create-ecdh-4.0.0" // {
             dependencies = [
               sources."bn.js-4.11.6"
-              (sources."elliptic-6.3.1" // {
+              (sources."elliptic-6.3.2" // {
                 dependencies = [
                   sources."brorand-1.0.6"
                   sources."hash.js-1.0.3"
@@ -19134,14 +18920,14 @@ in
               })
             ];
           })
-          sources."pbkdf2-3.0.6"
+          sources."pbkdf2-3.0.8"
           (sources."public-encrypt-4.0.0" // {
             dependencies = [
               sources."bn.js-4.11.6"
               sources."browserify-rsa-4.0.1"
               (sources."parse-asn1-5.0.0" // {
                 dependencies = [
-                  (sources."asn1.js-4.8.0" // {
+                  (sources."asn1.js-4.8.1" // {
                     dependencies = [
                       sources."minimalistic-assert-1.0.0"
                     ];
@@ -19482,7 +19268,7 @@ in
                     dependencies = [
                       (sources."load-json-file-1.1.0" // {
                         dependencies = [
-                          sources."graceful-fs-4.1.6"
+                          sources."graceful-fs-4.1.9"
                           (sources."parse-json-2.2.0" // {
                             dependencies = [
                               (sources."error-ex-1.3.0" // {
@@ -19507,7 +19293,7 @@ in
                       })
                       (sources."path-type-1.1.0" // {
                         dependencies = [
-                          sources."graceful-fs-4.1.6"
+                          sources."graceful-fs-4.1.9"
                           sources."pify-2.3.0"
                           (sources."pinkie-promise-2.0.1" // {
                             dependencies = [
@@ -19619,7 +19405,7 @@ in
                   sources."bencode-0.10.0"
                   (sources."simple-sha1-2.0.8" // {
                     dependencies = [
-                      sources."rusha-0.8.3"
+                      sources."rusha-0.8.4"
                     ];
                   })
                   sources."uniq-1.0.1"
@@ -19710,7 +19496,7 @@ in
                       sources."bencode-0.7.0"
                       (sources."simple-sha1-2.0.8" // {
                         dependencies = [
-                          sources."rusha-0.8.3"
+                          sources."rusha-0.8.4"
                         ];
                       })
                     ];
@@ -19748,7 +19534,7 @@ in
               })
               (sources."rimraf-2.5.4" // {
                 dependencies = [
-                  (sources."glob-7.0.6" // {
+                  (sources."glob-7.1.0" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.5" // {
@@ -19929,7 +19715,7 @@ in
                   sources."bencode-0.7.0"
                   (sources."simple-sha1-2.0.8" // {
                     dependencies = [
-                      sources."rusha-0.8.3"
+                      sources."rusha-0.8.4"
                     ];
                   })
                 ];
@@ -20007,7 +19793,7 @@ in
           sources."sax-1.2.1"
           (sources."xmlbuilder-4.2.1" // {
             dependencies = [
-              sources."lodash-4.15.0"
+              sources."lodash-4.16.2"
             ];
           })
         ];
@@ -20025,10 +19811,10 @@ in
   coffee-script = nodeEnv.buildNodePackage {
     name = "coffee-script";
     packageName = "coffee-script";
-    version = "1.10.0";
+    version = "1.11.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz";
-      sha1 = "12938bcf9be1948fa006f92e0c4c9e81705108c0";
+      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.0.tgz";
+      sha1 = "591e87f7447a53dfde33dc892db1d15b14ddd92d";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -20074,7 +19860,7 @@ in
               sources."q-1.4.1"
               (sources."shelljs-0.7.4" // {
                 dependencies = [
-                  (sources."glob-7.0.6" // {
+                  (sources."glob-7.1.0" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.5" // {
@@ -20115,7 +19901,7 @@ in
             dependencies = [
               (sources."browserify-10.1.3" // {
                 dependencies = [
-                  (sources."JSONStream-1.1.4" // {
+                  (sources."JSONStream-1.2.1" // {
                     dependencies = [
                       sources."jsonparse-1.2.0"
                       sources."through-2.3.8"
@@ -20209,7 +19995,7 @@ in
                         dependencies = [
                           sources."bn.js-4.11.6"
                           sources."browserify-rsa-4.0.1"
-                          (sources."elliptic-6.3.1" // {
+                          (sources."elliptic-6.3.2" // {
                             dependencies = [
                               sources."brorand-1.0.6"
                               sources."hash.js-1.0.3"
@@ -20217,7 +20003,7 @@ in
                           })
                           (sources."parse-asn1-5.0.0" // {
                             dependencies = [
-                              (sources."asn1.js-4.8.0" // {
+                              (sources."asn1.js-4.8.1" // {
                                 dependencies = [
                                   sources."minimalistic-assert-1.0.0"
                                 ];
@@ -20236,7 +20022,7 @@ in
                       (sources."create-ecdh-4.0.0" // {
                         dependencies = [
                           sources."bn.js-4.11.6"
-                          (sources."elliptic-6.3.1" // {
+                          (sources."elliptic-6.3.2" // {
                             dependencies = [
                               sources."brorand-1.0.6"
                               sources."hash.js-1.0.3"
@@ -20262,14 +20048,14 @@ in
                           })
                         ];
                       })
-                      sources."pbkdf2-3.0.6"
+                      sources."pbkdf2-3.0.8"
                       (sources."public-encrypt-4.0.0" // {
                         dependencies = [
                           sources."bn.js-4.11.6"
                           sources."browserify-rsa-4.0.1"
                           (sources."parse-asn1-5.0.0" // {
                             dependencies = [
-                              (sources."asn1.js-4.8.0" // {
+                              (sources."asn1.js-4.8.1" // {
                                 dependencies = [
                                   sources."minimalistic-assert-1.0.0"
                                 ];
@@ -20484,9 +20270,9 @@ in
                 dependencies = [
                   (sources."accepts-1.3.3" // {
                     dependencies = [
-                      (sources."mime-types-2.1.11" // {
+                      (sources."mime-types-2.1.12" // {
                         dependencies = [
-                          sources."mime-db-1.23.0"
+                          sources."mime-db-1.24.0"
                         ];
                       })
                       sources."negotiator-0.6.1"
@@ -20495,7 +20281,7 @@ in
                   sources."bytes-2.3.0"
                   (sources."compressible-2.0.8" // {
                     dependencies = [
-                      sources."mime-db-1.23.0"
+                      sources."mime-db-1.24.0"
                     ];
                   })
                   (sources."debug-2.2.0" // {
@@ -20511,9 +20297,9 @@ in
                 dependencies = [
                   (sources."accepts-1.3.3" // {
                     dependencies = [
-                      (sources."mime-types-2.1.11" // {
+                      (sources."mime-types-2.1.12" // {
                         dependencies = [
-                          sources."mime-db-1.23.0"
+                          sources."mime-db-1.24.0"
                         ];
                       })
                       sources."negotiator-0.6.1"
@@ -20575,9 +20361,9 @@ in
                   (sources."type-is-1.6.13" // {
                     dependencies = [
                       sources."media-typer-0.3.0"
-                      (sources."mime-types-2.1.11" // {
+                      (sources."mime-types-2.1.12" // {
                         dependencies = [
-                          sources."mime-db-1.23.0"
+                          sources."mime-db-1.24.0"
                         ];
                       })
                     ];
@@ -20682,7 +20468,7 @@ in
                       })
                     ];
                   })
-                  sources."graceful-fs-4.1.6"
+                  sources."graceful-fs-4.1.9"
                 ];
               })
               (sources."validate-npm-package-license-3.0.1" // {
@@ -20740,7 +20526,7 @@ in
               })
               (sources."dezalgo-1.0.3" // {
                 dependencies = [
-                  sources."asap-2.0.4"
+                  sources."asap-2.0.5"
                 ];
               })
               sources."editor-1.0.0"
@@ -20764,12 +20550,12 @@ in
                   sources."path-is-absolute-1.0.0"
                 ];
               })
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
               sources."hosted-git-info-2.1.5"
               sources."inflight-1.0.5"
               sources."inherits-2.0.3"
               sources."ini-1.3.4"
-              sources."lockfile-1.0.1"
+              sources."lockfile-1.0.2"
               (sources."lru-cache-4.0.1" // {
                 dependencies = [
                   sources."pseudomap-1.0.2"
@@ -20941,7 +20727,7 @@ in
                     dependencies = [
                       (sources."async-2.0.1" // {
                         dependencies = [
-                          sources."lodash-4.15.0"
+                          sources."lodash-4.16.2"
                         ];
                       })
                     ];
@@ -20961,7 +20747,7 @@ in
                           sources."graceful-readlink-1.0.1"
                         ];
                       })
-                      (sources."is-my-json-valid-2.13.1" // {
+                      (sources."is-my-json-valid-2.14.0" // {
                         dependencies = [
                           sources."generate-function-2.0.0"
                           (sources."generate-object-property-1.2.0" // {
@@ -20998,21 +20784,17 @@ in
                           sources."verror-1.3.6"
                         ];
                       })
-                      (sources."sshpk-1.10.0" // {
+                      (sources."sshpk-1.10.1" // {
                         dependencies = [
                           sources."asn1-0.2.3"
                           sources."assert-plus-1.0.0"
                           sources."dashdash-1.14.0"
                           sources."getpass-0.1.6"
                           sources."jsbn-0.1.0"
-                          sources."tweetnacl-0.13.3"
+                          sources."tweetnacl-0.14.3"
                           sources."jodid25519-1.0.2"
                           sources."ecc-jsbn-0.1.1"
-                          (sources."bcrypt-pbkdf-1.0.0" // {
-                            dependencies = [
-                              sources."tweetnacl-0.14.3"
-                            ];
-                          })
+                          sources."bcrypt-pbkdf-1.0.0"
                         ];
                       })
                     ];
@@ -21020,9 +20802,9 @@ in
                   sources."is-typedarray-1.0.0"
                   sources."isstream-0.1.2"
                   sources."json-stringify-safe-5.0.1"
-                  (sources."mime-types-2.1.11" // {
+                  (sources."mime-types-2.1.12" // {
                     dependencies = [
-                      sources."mime-db-1.23.0"
+                      sources."mime-db-1.24.0"
                     ];
                   })
                   sources."node-uuid-1.4.7"
@@ -21141,7 +20923,7 @@ in
               sources."block-stream-0.0.9"
               (sources."fstream-1.0.10" // {
                 dependencies = [
-                  sources."graceful-fs-4.1.6"
+                  sources."graceful-fs-4.1.9"
                   (sources."mkdirp-0.5.1" // {
                     dependencies = [
                       sources."minimist-0.0.8"
@@ -21149,7 +20931,7 @@ in
                   })
                   (sources."rimraf-2.5.4" // {
                     dependencies = [
-                      (sources."glob-7.0.6" // {
+                      (sources."glob-7.1.0" // {
                         dependencies = [
                           sources."fs.realpath-1.0.0"
                           (sources."inflight-1.0.5" // {
@@ -21295,7 +21077,7 @@ in
           })
           (sources."configstore-1.4.0" // {
             dependencies = [
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
               (sources."mkdirp-0.5.1" // {
                 dependencies = [
                   sources."minimist-0.0.8"
@@ -21308,7 +21090,7 @@ in
                   sources."os-homedir-1.0.1"
                 ];
               })
-              sources."uuid-2.0.2"
+              sources."uuid-2.0.3"
               (sources."write-file-atomic-1.2.0" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
@@ -21451,7 +21233,7 @@ in
           })
           (sources."configstore-1.4.0" // {
             dependencies = [
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
               (sources."mkdirp-0.5.1" // {
                 dependencies = [
                   sources."minimist-0.0.8"
@@ -21463,7 +21245,7 @@ in
                   sources."os-homedir-1.0.1"
                 ];
               })
-              sources."uuid-2.0.2"
+              sources."uuid-2.0.3"
               (sources."write-file-atomic-1.2.0" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
@@ -21548,7 +21330,7 @@ in
               })
             ];
           })
-          (sources."request-2.74.0" // {
+          (sources."request-2.75.0" // {
             dependencies = [
               sources."aws-sign2-0.6.0"
               sources."aws4-1.4.1"
@@ -21574,13 +21356,9 @@ in
               })
               sources."extend-3.0.0"
               sources."forever-agent-0.6.1"
-              (sources."form-data-1.0.1" // {
+              (sources."form-data-2.0.0" // {
                 dependencies = [
-                  (sources."async-2.0.1" // {
-                    dependencies = [
-                      sources."lodash-4.15.0"
-                    ];
-                  })
+                  sources."asynckit-0.4.0"
                 ];
               })
               (sources."har-validator-2.0.6" // {
@@ -21590,7 +21368,7 @@ in
                       sources."graceful-readlink-1.0.1"
                     ];
                   })
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -21627,21 +21405,17 @@ in
                       sources."verror-1.3.6"
                     ];
                   })
-                  (sources."sshpk-1.10.0" // {
+                  (sources."sshpk-1.10.1" // {
                     dependencies = [
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.0"
                       sources."getpass-0.1.6"
                       sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
+                      sources."tweetnacl-0.14.3"
                       sources."jodid25519-1.0.2"
                       sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
+                      sources."bcrypt-pbkdf-1.0.0"
                     ];
                   })
                 ];
@@ -21649,9 +21423,9 @@ in
               sources."is-typedarray-1.0.0"
               sources."isstream-0.1.2"
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."oauth-sign-0.8.2"
@@ -21697,9 +21471,9 @@ in
         dependencies = [
           (sources."accepts-1.2.13" // {
             dependencies = [
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."negotiator-0.5.3"
@@ -21998,7 +21772,7 @@ in
           sources."level-packager-0.18.0"
         ];
       })
-      (sources."level-sublevel-6.5.4" // {
+      (sources."level-sublevel-6.6.0" // {
         dependencies = [
           (sources."pull-stream-2.21.0" // {
             dependencies = [
@@ -22233,7 +22007,7 @@ in
       })
       (sources."async-2.0.1" // {
         dependencies = [
-          sources."lodash-4.15.0"
+          sources."lodash-4.16.2"
         ];
       })
       sources."aws4-1.4.1"
@@ -22243,7 +22017,7 @@ in
           sources."minimist-0.0.10"
         ];
       })
-      (sources."request-2.74.0" // {
+      (sources."request-2.75.0" // {
         dependencies = [
           sources."aws-sign2-0.6.0"
           (sources."bl-1.1.2" // {
@@ -22268,7 +22042,11 @@ in
           })
           sources."extend-3.0.0"
           sources."forever-agent-0.6.1"
-          sources."form-data-1.0.1"
+          (sources."form-data-2.0.0" // {
+            dependencies = [
+              sources."asynckit-0.4.0"
+            ];
+          })
           (sources."har-validator-2.0.6" // {
             dependencies = [
               (sources."chalk-1.1.3" // {
@@ -22293,7 +22071,7 @@ in
                   sources."graceful-readlink-1.0.1"
                 ];
               })
-              (sources."is-my-json-valid-2.13.1" // {
+              (sources."is-my-json-valid-2.14.0" // {
                 dependencies = [
                   sources."generate-function-2.0.0"
                   (sources."generate-object-property-1.2.0" // {
@@ -22330,21 +22108,17 @@ in
                   sources."verror-1.3.6"
                 ];
               })
-              (sources."sshpk-1.10.0" // {
+              (sources."sshpk-1.10.1" // {
                 dependencies = [
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.0"
                   sources."getpass-0.1.6"
                   sources."jsbn-0.1.0"
-                  sources."tweetnacl-0.13.3"
+                  sources."tweetnacl-0.14.3"
                   sources."jodid25519-1.0.2"
                   sources."ecc-jsbn-0.1.1"
-                  (sources."bcrypt-pbkdf-1.0.0" // {
-                    dependencies = [
-                      sources."tweetnacl-0.14.3"
-                    ];
-                  })
+                  sources."bcrypt-pbkdf-1.0.0"
                 ];
               })
             ];
@@ -22352,9 +22126,9 @@ in
           sources."is-typedarray-1.0.0"
           sources."isstream-0.1.2"
           sources."json-stringify-safe-5.0.1"
-          (sources."mime-types-2.1.11" // {
+          (sources."mime-types-2.1.12" // {
             dependencies = [
-              sources."mime-db-1.23.0"
+              sources."mime-db-1.24.0"
             ];
           })
           sources."node-uuid-1.4.7"
@@ -22507,7 +22281,7 @@ in
                 dependencies = [
                   (sources."load-json-file-1.1.0" // {
                     dependencies = [
-                      sources."graceful-fs-4.1.6"
+                      sources."graceful-fs-4.1.9"
                       (sources."parse-json-2.2.0" // {
                         dependencies = [
                           (sources."error-ex-1.3.0" // {
@@ -22532,7 +22306,7 @@ in
                   })
                   (sources."path-type-1.1.0" // {
                     dependencies = [
-                      sources."graceful-fs-4.1.6"
+                      sources."graceful-fs-4.1.9"
                       sources."pify-2.3.0"
                       (sources."pinkie-promise-2.0.1" // {
                         dependencies = [
@@ -22582,10 +22356,10 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "3.5.0";
+    version = "3.6.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-3.5.0.tgz";
-      sha1 = "22fc9f780ea5bca1306fab2b6d3336b0fa62c754";
+      url = "https://registry.npmjs.org/eslint/-/eslint-3.6.1.tgz";
+      sha1 = "39eeabcfd8d2fe046fb8754b4cf97182abde0d9d";
     };
     dependencies = [
       (sources."chalk-1.1.3" // {
@@ -22658,10 +22432,14 @@ in
           })
         ];
       })
-      (sources."espree-3.1.7" // {
+      (sources."espree-3.3.2" // {
         dependencies = [
-          sources."acorn-3.3.0"
-          sources."acorn-jsx-3.0.1"
+          sources."acorn-4.0.3"
+          (sources."acorn-jsx-3.0.1" // {
+            dependencies = [
+              sources."acorn-3.3.0"
+            ];
+          })
         ];
       })
       sources."estraverse-4.2.0"
@@ -22698,14 +22476,14 @@ in
                   sources."rimraf-2.5.4"
                 ];
               })
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
               sources."write-0.2.1"
             ];
           })
           sources."object-assign-4.1.0"
         ];
       })
-      (sources."glob-7.0.6" // {
+      (sources."glob-7.1.0" // {
         dependencies = [
           sources."fs.realpath-1.0.0"
           (sources."inflight-1.0.5" // {
@@ -22799,7 +22577,7 @@ in
           sources."through-2.3.8"
         ];
       })
-      (sources."is-my-json-valid-2.13.1" // {
+      (sources."is-my-json-valid-2.14.0" // {
         dependencies = [
           sources."generate-function-2.0.0"
           (sources."generate-object-property-1.2.0" // {
@@ -22818,7 +22596,7 @@ in
       })
       (sources."js-yaml-3.6.1" // {
         dependencies = [
-          (sources."argparse-1.0.7" // {
+          (sources."argparse-1.0.9" // {
             dependencies = [
               sources."sprintf-js-1.0.3"
             ];
@@ -22837,20 +22615,20 @@ in
           sources."type-check-0.3.2"
         ];
       })
-      sources."lodash-4.15.0"
+      sources."lodash-4.16.2"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
         ];
       })
       sources."natural-compare-1.4.0"
-      (sources."optionator-0.8.1" // {
+      (sources."optionator-0.8.2" // {
         dependencies = [
           sources."prelude-ls-1.1.2"
           sources."deep-is-0.1.3"
           sources."wordwrap-1.0.0"
           sources."type-check-0.3.2"
-          sources."fast-levenshtein-1.1.4"
+          sources."fast-levenshtein-2.0.5"
         ];
       })
       sources."path-is-inside-1.0.2"
@@ -22869,9 +22647,14 @@ in
       sources."shelljs-0.6.1"
       sources."strip-bom-3.0.0"
       sources."strip-json-comments-1.0.4"
-      (sources."table-3.7.8" // {
+      (sources."table-3.8.0" // {
         dependencies = [
-          sources."bluebird-3.4.6"
+          (sources."ajv-4.7.5" // {
+            dependencies = [
+              sources."co-4.6.0"
+            ];
+          })
+          sources."ajv-keywords-1.1.1"
           sources."slice-ansi-0.0.4"
           (sources."string-width-1.0.2" // {
             dependencies = [
@@ -22885,15 +22668,13 @@ in
                   sources."number-is-nan-1.0.0"
                 ];
               })
+              (sources."strip-ansi-3.0.1" // {
+                dependencies = [
+                  sources."ansi-regex-2.0.0"
+                ];
+              })
             ];
           })
-          (sources."strip-ansi-3.0.1" // {
-            dependencies = [
-              sources."ansi-regex-2.0.0"
-            ];
-          })
-          sources."tv4-1.2.7"
-          sources."xregexp-3.1.1"
         ];
       })
       sources."text-table-0.2.0"
@@ -22908,6 +22689,21 @@ in
       description = "An AST-based pattern checker for JavaScript.";
       homepage = http://eslint.org/;
       license = "MIT";
+    };
+    production = true;
+  };
+  emojione = nodeEnv.buildNodePackage {
+    name = "emojione";
+    packageName = "emojione";
+    version = "2.2.6";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/emojione/-/emojione-2.2.6.tgz";
+      sha1 = "67dec452937d5b14ee669207ea41cdb1f69fb8f6";
+    };
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Emoji One is a complete set of emojis designed for the web. It includes libraries to easily convert unicode characters to shortnames (:smile:) and shortnames to our custom emoji images. PNG and SVG formats provided for the emoji images.";
+      homepage = http://www.emojione.com/;
     };
     production = true;
   };
@@ -23111,7 +22907,7 @@ in
               })
               (sources."readdirp-2.1.0" // {
                 dependencies = [
-                  sources."graceful-fs-4.1.6"
+                  sources."graceful-fs-4.1.9"
                   (sources."minimatch-3.0.3" // {
                     dependencies = [
                       (sources."brace-expansion-1.1.6" // {
@@ -23208,7 +23004,7 @@ in
                           sources."strip-json-comments-1.0.4"
                         ];
                       })
-                      (sources."request-2.74.0" // {
+                      (sources."request-2.75.0" // {
                         dependencies = [
                           sources."aws-sign2-0.6.0"
                           sources."aws4-1.4.1"
@@ -23233,13 +23029,9 @@ in
                           })
                           sources."extend-3.0.0"
                           sources."forever-agent-0.6.1"
-                          (sources."form-data-1.0.1" // {
+                          (sources."form-data-2.0.0" // {
                             dependencies = [
-                              (sources."async-2.0.1" // {
-                                dependencies = [
-                                  sources."lodash-4.15.0"
-                                ];
-                              })
+                              sources."asynckit-0.4.0"
                             ];
                           })
                           (sources."har-validator-2.0.6" // {
@@ -23266,7 +23058,7 @@ in
                                   sources."graceful-readlink-1.0.1"
                                 ];
                               })
-                              (sources."is-my-json-valid-2.13.1" // {
+                              (sources."is-my-json-valid-2.14.0" // {
                                 dependencies = [
                                   sources."generate-function-2.0.0"
                                   (sources."generate-object-property-1.2.0" // {
@@ -23303,21 +23095,17 @@ in
                                   sources."verror-1.3.6"
                                 ];
                               })
-                              (sources."sshpk-1.10.0" // {
+                              (sources."sshpk-1.10.1" // {
                                 dependencies = [
                                   sources."asn1-0.2.3"
                                   sources."assert-plus-1.0.0"
                                   sources."dashdash-1.14.0"
                                   sources."getpass-0.1.6"
                                   sources."jsbn-0.1.0"
-                                  sources."tweetnacl-0.13.3"
+                                  sources."tweetnacl-0.14.3"
                                   sources."jodid25519-1.0.2"
                                   sources."ecc-jsbn-0.1.1"
-                                  (sources."bcrypt-pbkdf-1.0.0" // {
-                                    dependencies = [
-                                      sources."tweetnacl-0.14.3"
-                                    ];
-                                  })
+                                  sources."bcrypt-pbkdf-1.0.0"
                                 ];
                               })
                             ];
@@ -23325,9 +23113,9 @@ in
                           sources."is-typedarray-1.0.0"
                           sources."isstream-0.1.2"
                           sources."json-stringify-safe-5.0.1"
-                          (sources."mime-types-2.1.11" // {
+                          (sources."mime-types-2.1.12" // {
                             dependencies = [
-                              sources."mime-db-1.23.0"
+                              sources."mime-db-1.24.0"
                             ];
                           })
                           sources."node-uuid-1.4.7"
@@ -23340,7 +23128,7 @@ in
                       })
                       (sources."rimraf-2.5.4" // {
                         dependencies = [
-                          (sources."glob-7.0.6" // {
+                          (sources."glob-7.1.0" // {
                             dependencies = [
                               sources."fs.realpath-1.0.0"
                               (sources."inflight-1.0.5" // {
@@ -23373,7 +23161,7 @@ in
                           sources."block-stream-0.0.9"
                           (sources."fstream-1.0.10" // {
                             dependencies = [
-                              sources."graceful-fs-4.1.6"
+                              sources."graceful-fs-4.1.9"
                             ];
                           })
                         ];
@@ -23387,7 +23175,7 @@ in
                           })
                           (sources."fstream-1.0.10" // {
                             dependencies = [
-                              sources."graceful-fs-4.1.6"
+                              sources."graceful-fs-4.1.9"
                             ];
                           })
                           (sources."fstream-ignore-1.0.5" // {
@@ -23518,7 +23306,7 @@ in
           sources."ncp-0.4.2"
           (sources."rimraf-2.5.4" // {
             dependencies = [
-              (sources."glob-7.0.6" // {
+              (sources."glob-7.1.0" // {
                 dependencies = [
                   sources."fs.realpath-1.0.0"
                   (sources."inflight-1.0.5" // {
@@ -23656,11 +23444,11 @@ in
       sha256 = "a51a5beef55c14c68630275d51cf66c44a4462d1b20c0f08aef6d88a62ca077c";
     };
     dependencies = [
-      sources."coffee-script-1.10.0"
+      sources."coffee-script-1.11.0"
       (sources."jade-1.11.0" // {
         dependencies = [
           sources."character-parser-1.2.1"
-          (sources."clean-css-3.4.19" // {
+          (sources."clean-css-3.4.20" // {
             dependencies = [
               (sources."commander-2.8.1" // {
                 dependencies = [
@@ -23789,7 +23577,7 @@ in
       })
       (sources."q-2.0.3" // {
         dependencies = [
-          sources."asap-2.0.4"
+          sources."asap-2.0.5"
           sources."pop-iterate-1.0.1"
           sources."weak-map-1.0.5"
         ];
@@ -23799,7 +23587,7 @@ in
           sources."sax-1.2.1"
           (sources."xmlbuilder-4.2.1" // {
             dependencies = [
-              sources."lodash-4.15.0"
+              sources."lodash-4.16.2"
             ];
           })
         ];
@@ -23909,7 +23697,7 @@ in
                         dependencies = [
                           (sources."load-json-file-1.1.0" // {
                             dependencies = [
-                              sources."graceful-fs-4.1.6"
+                              sources."graceful-fs-4.1.9"
                               (sources."parse-json-2.2.0" // {
                                 dependencies = [
                                   (sources."error-ex-1.3.0" // {
@@ -23934,7 +23722,7 @@ in
                           })
                           (sources."path-type-1.1.0" // {
                             dependencies = [
-                              sources."graceful-fs-4.1.6"
+                              sources."graceful-fs-4.1.9"
                               sources."pify-2.3.0"
                               (sources."pinkie-promise-2.0.1" // {
                                 dependencies = [
@@ -24373,7 +24161,7 @@ in
     dependencies = [
       (sources."http-proxy-1.0.2" // {
         dependencies = [
-          sources."eventemitter3-2.0.0"
+          sources."eventemitter3-2.0.1"
         ];
       })
       sources."redis-0.10.3"
@@ -24403,13 +24191,13 @@ in
         dependencies = [
           sources."estraverse-1.9.3"
           sources."esutils-2.0.2"
-          (sources."optionator-0.8.1" // {
+          (sources."optionator-0.8.2" // {
             dependencies = [
               sources."prelude-ls-1.1.2"
               sources."deep-is-0.1.3"
               sources."type-check-0.3.2"
               sources."levn-0.3.0"
-              sources."fast-levenshtein-1.1.4"
+              sources."fast-levenshtein-2.0.5"
             ];
           })
           (sources."source-map-0.2.0" // {
@@ -24508,7 +24296,7 @@ in
       })
       (sources."js-yaml-3.6.1" // {
         dependencies = [
-          (sources."argparse-1.0.7" // {
+          (sources."argparse-1.0.9" // {
             dependencies = [
               sources."sprintf-js-1.0.3"
             ];
@@ -24577,7 +24365,7 @@ in
     dependencies = [
       (sources."cli-1.0.0" // {
         dependencies = [
-          (sources."glob-7.0.6" // {
+          (sources."glob-7.1.0" // {
             dependencies = [
               sources."fs.realpath-1.0.0"
               (sources."inflight-1.0.5" // {
@@ -24688,7 +24476,7 @@ in
       sha1 = "6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30";
     };
     dependencies = [
-      (sources."argparse-1.0.7" // {
+      (sources."argparse-1.0.9" // {
         dependencies = [
           sources."sprintf-js-1.0.3"
         ];
@@ -24745,9 +24533,9 @@ in
           (sources."type-is-1.6.13" // {
             dependencies = [
               sources."media-typer-0.3.0"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
             ];
@@ -24931,7 +24719,7 @@ in
                       sources."strip-json-comments-1.0.4"
                     ];
                   })
-                  (sources."request-2.74.0" // {
+                  (sources."request-2.75.0" // {
                     dependencies = [
                       sources."aws-sign2-0.6.0"
                       sources."aws4-1.4.1"
@@ -24956,13 +24744,9 @@ in
                       })
                       sources."extend-3.0.0"
                       sources."forever-agent-0.6.1"
-                      (sources."form-data-1.0.1" // {
+                      (sources."form-data-2.0.0" // {
                         dependencies = [
-                          (sources."async-2.0.1" // {
-                            dependencies = [
-                              sources."lodash-4.15.0"
-                            ];
-                          })
+                          sources."asynckit-0.4.0"
                         ];
                       })
                       (sources."har-validator-2.0.6" // {
@@ -24989,7 +24773,7 @@ in
                               sources."graceful-readlink-1.0.1"
                             ];
                           })
-                          (sources."is-my-json-valid-2.13.1" // {
+                          (sources."is-my-json-valid-2.14.0" // {
                             dependencies = [
                               sources."generate-function-2.0.0"
                               (sources."generate-object-property-1.2.0" // {
@@ -25026,21 +24810,17 @@ in
                               sources."verror-1.3.6"
                             ];
                           })
-                          (sources."sshpk-1.10.0" // {
+                          (sources."sshpk-1.10.1" // {
                             dependencies = [
                               sources."asn1-0.2.3"
                               sources."assert-plus-1.0.0"
                               sources."dashdash-1.14.0"
                               sources."getpass-0.1.6"
                               sources."jsbn-0.1.0"
-                              sources."tweetnacl-0.13.3"
+                              sources."tweetnacl-0.14.3"
                               sources."jodid25519-1.0.2"
                               sources."ecc-jsbn-0.1.1"
-                              (sources."bcrypt-pbkdf-1.0.0" // {
-                                dependencies = [
-                                  sources."tweetnacl-0.14.3"
-                                ];
-                              })
+                              sources."bcrypt-pbkdf-1.0.0"
                             ];
                           })
                         ];
@@ -25048,9 +24828,9 @@ in
                       sources."is-typedarray-1.0.0"
                       sources."isstream-0.1.2"
                       sources."json-stringify-safe-5.0.1"
-                      (sources."mime-types-2.1.11" // {
+                      (sources."mime-types-2.1.12" // {
                         dependencies = [
-                          sources."mime-db-1.23.0"
+                          sources."mime-db-1.24.0"
                         ];
                       })
                       sources."node-uuid-1.4.7"
@@ -25104,7 +24884,7 @@ in
       sources."colors-1.1.2"
       (sources."combine-lists-1.0.1" // {
         dependencies = [
-          sources."lodash-4.15.0"
+          sources."lodash-4.16.2"
         ];
       })
       (sources."connect-3.5.0" // {
@@ -25156,7 +24936,7 @@ in
           })
         ];
       })
-      (sources."glob-7.0.6" // {
+      (sources."glob-7.1.0" // {
         dependencies = [
           sources."fs.realpath-1.0.0"
           (sources."inflight-1.0.5" // {
@@ -25173,7 +24953,7 @@ in
           sources."path-is-absolute-1.0.0"
         ];
       })
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       (sources."http-proxy-1.15.1" // {
         dependencies = [
           sources."eventemitter3-1.2.0"
@@ -25410,9 +25190,9 @@ in
                 dependencies = [
                   (sources."accepts-1.2.13" // {
                     dependencies = [
-                      (sources."mime-types-2.1.11" // {
+                      (sources."mime-types-2.1.12" // {
                         dependencies = [
-                          sources."mime-db-1.23.0"
+                          sources."mime-db-1.24.0"
                         ];
                       })
                       sources."negotiator-0.5.3"
@@ -25420,7 +25200,7 @@ in
                   })
                   (sources."compressible-2.0.8" // {
                     dependencies = [
-                      sources."mime-db-1.23.0"
+                      sources."mime-db-1.24.0"
                     ];
                   })
                 ];
@@ -25450,9 +25230,9 @@ in
                 dependencies = [
                   (sources."accepts-1.3.3" // {
                     dependencies = [
-                      (sources."mime-types-2.1.11" // {
+                      (sources."mime-types-2.1.12" // {
                         dependencies = [
-                          sources."mime-db-1.23.0"
+                          sources."mime-db-1.24.0"
                         ];
                       })
                       sources."negotiator-0.6.1"
@@ -25532,9 +25312,9 @@ in
                   })
                   sources."batch-0.5.3"
                   sources."escape-html-1.0.3"
-                  (sources."mime-types-2.1.11" // {
+                  (sources."mime-types-2.1.12" // {
                     dependencies = [
-                      sources."mime-db-1.23.0"
+                      sources."mime-db-1.24.0"
                     ];
                   })
                 ];
@@ -25561,9 +25341,9 @@ in
               (sources."type-is-1.6.13" // {
                 dependencies = [
                   sources."media-typer-0.3.0"
-                  (sources."mime-types-2.1.11" // {
+                  (sources."mime-types-2.1.12" // {
                     dependencies = [
-                      sources."mime-db-1.23.0"
+                      sources."mime-db-1.24.0"
                     ];
                   })
                 ];
@@ -25660,7 +25440,7 @@ in
           sources."sax-1.2.1"
           (sources."xmlbuilder-4.2.1" // {
             dependencies = [
-              sources."lodash-4.15.0"
+              sources."lodash-4.16.2"
             ];
           })
         ];
@@ -25870,7 +25650,7 @@ in
               })
             ];
           })
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
           (sources."gulp-sourcemaps-1.6.0" // {
             dependencies = [
               sources."convert-source-map-1.3.0"
@@ -26020,7 +25800,7 @@ in
               })
             ];
           })
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
           (sources."mkdirp-0.5.1" // {
             dependencies = [
               sources."minimist-0.0.8"
@@ -26057,7 +25837,7 @@ in
               sources."wrappy-1.0.2"
             ];
           })
-          (sources."request-2.74.0" // {
+          (sources."request-2.75.0" // {
             dependencies = [
               sources."aws-sign2-0.6.0"
               sources."aws4-1.4.1"
@@ -26083,13 +25863,9 @@ in
               })
               sources."extend-3.0.0"
               sources."forever-agent-0.6.1"
-              (sources."form-data-1.0.1" // {
+              (sources."form-data-2.0.0" // {
                 dependencies = [
-                  (sources."async-2.0.1" // {
-                    dependencies = [
-                      sources."lodash-4.15.0"
-                    ];
-                  })
+                  sources."asynckit-0.4.0"
                 ];
               })
               (sources."har-validator-2.0.6" // {
@@ -26116,7 +25892,7 @@ in
                       sources."graceful-readlink-1.0.1"
                     ];
                   })
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -26153,21 +25929,17 @@ in
                       sources."verror-1.3.6"
                     ];
                   })
-                  (sources."sshpk-1.10.0" // {
+                  (sources."sshpk-1.10.1" // {
                     dependencies = [
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.0"
                       sources."getpass-0.1.6"
                       sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
+                      sources."tweetnacl-0.14.3"
                       sources."jodid25519-1.0.2"
                       sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
+                      sources."bcrypt-pbkdf-1.0.0"
                     ];
                   })
                 ];
@@ -26175,9 +25947,9 @@ in
               sources."is-typedarray-1.0.0"
               sources."isstream-0.1.2"
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."node-uuid-1.4.7"
@@ -26191,7 +25963,7 @@ in
           sources."retry-0.8.0"
           (sources."rimraf-2.5.4" // {
             dependencies = [
-              (sources."glob-7.0.6" // {
+              (sources."glob-7.1.0" // {
                 dependencies = [
                   sources."fs.realpath-1.0.0"
                   (sources."inflight-1.0.5" // {
@@ -26308,7 +26080,7 @@ in
           sources."block-stream-0.0.9"
           (sources."fstream-1.0.10" // {
             dependencies = [
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
               (sources."mkdirp-0.5.1" // {
                 dependencies = [
                   sources."minimist-0.0.8"
@@ -26316,7 +26088,7 @@ in
               })
               (sources."rimraf-2.5.4" // {
                 dependencies = [
-                  (sources."glob-7.0.6" // {
+                  (sources."glob-7.1.0" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.5" // {
@@ -26401,7 +26173,7 @@ in
           sources."inherits-2.0.3"
         ];
       })
-      (sources."glob-7.0.6" // {
+      (sources."glob-7.1.0" // {
         dependencies = [
           sources."fs.realpath-1.0.0"
           (sources."inflight-1.0.5" // {
@@ -26418,7 +26190,7 @@ in
           sources."path-is-absolute-1.0.0"
         ];
       })
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       (sources."minimatch-3.0.3" // {
         dependencies = [
           (sources."brace-expansion-1.1.6" // {
@@ -26519,7 +26291,7 @@ in
           })
         ];
       })
-      (sources."request-2.74.0" // {
+      (sources."request-2.75.0" // {
         dependencies = [
           sources."aws-sign2-0.6.0"
           sources."aws4-1.4.1"
@@ -26545,13 +26317,9 @@ in
           })
           sources."extend-3.0.0"
           sources."forever-agent-0.6.1"
-          (sources."form-data-1.0.1" // {
+          (sources."form-data-2.0.0" // {
             dependencies = [
-              (sources."async-2.0.1" // {
-                dependencies = [
-                  sources."lodash-4.15.0"
-                ];
-              })
+              sources."asynckit-0.4.0"
             ];
           })
           (sources."har-validator-2.0.6" // {
@@ -26578,7 +26346,7 @@ in
                   sources."graceful-readlink-1.0.1"
                 ];
               })
-              (sources."is-my-json-valid-2.13.1" // {
+              (sources."is-my-json-valid-2.14.0" // {
                 dependencies = [
                   sources."generate-function-2.0.0"
                   (sources."generate-object-property-1.2.0" // {
@@ -26615,21 +26383,17 @@ in
                   sources."verror-1.3.6"
                 ];
               })
-              (sources."sshpk-1.10.0" // {
+              (sources."sshpk-1.10.1" // {
                 dependencies = [
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.0"
                   sources."getpass-0.1.6"
                   sources."jsbn-0.1.0"
-                  sources."tweetnacl-0.13.3"
+                  sources."tweetnacl-0.14.3"
                   sources."jodid25519-1.0.2"
                   sources."ecc-jsbn-0.1.1"
-                  (sources."bcrypt-pbkdf-1.0.0" // {
-                    dependencies = [
-                      sources."tweetnacl-0.14.3"
-                    ];
-                  })
+                  sources."bcrypt-pbkdf-1.0.0"
                 ];
               })
             ];
@@ -26637,9 +26401,9 @@ in
           sources."is-typedarray-1.0.0"
           sources."isstream-0.1.2"
           sources."json-stringify-safe-5.0.1"
-          (sources."mime-types-2.1.11" // {
+          (sources."mime-types-2.1.12" // {
             dependencies = [
-              sources."mime-db-1.23.0"
+              sources."mime-db-1.24.0"
             ];
           })
           sources."node-uuid-1.4.7"
@@ -26788,7 +26552,7 @@ in
                             dependencies = [
                               (sources."load-json-file-1.1.0" // {
                                 dependencies = [
-                                  sources."graceful-fs-4.1.6"
+                                  sources."graceful-fs-4.1.9"
                                   (sources."parse-json-2.2.0" // {
                                     dependencies = [
                                       (sources."error-ex-1.3.0" // {
@@ -26813,7 +26577,7 @@ in
                               })
                               (sources."path-type-1.1.0" // {
                                 dependencies = [
-                                  sources."graceful-fs-4.1.6"
+                                  sources."graceful-fs-4.1.9"
                                   sources."pify-2.3.0"
                                   (sources."pinkie-promise-2.0.1" // {
                                     dependencies = [
@@ -26871,9 +26635,9 @@ in
         dependencies = [
           (sources."accepts-1.3.3" // {
             dependencies = [
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."negotiator-0.6.1"
@@ -26930,9 +26694,9 @@ in
           (sources."type-is-1.6.13" // {
             dependencies = [
               sources."media-typer-0.3.0"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
             ];
@@ -27055,7 +26819,7 @@ in
                   sources."set-blocking-2.0.0"
                 ];
               })
-              (sources."request-2.74.0" // {
+              (sources."request-2.75.0" // {
                 dependencies = [
                   sources."aws-sign2-0.6.0"
                   sources."aws4-1.4.1"
@@ -27081,13 +26845,9 @@ in
                   })
                   sources."extend-3.0.0"
                   sources."forever-agent-0.6.1"
-                  (sources."form-data-1.0.1" // {
+                  (sources."form-data-2.0.0" // {
                     dependencies = [
-                      (sources."async-2.0.1" // {
-                        dependencies = [
-                          sources."lodash-4.15.0"
-                        ];
-                      })
+                      sources."asynckit-0.4.0"
                     ];
                   })
                   (sources."har-validator-2.0.6" // {
@@ -27114,7 +26874,7 @@ in
                           sources."graceful-readlink-1.0.1"
                         ];
                       })
-                      (sources."is-my-json-valid-2.13.1" // {
+                      (sources."is-my-json-valid-2.14.0" // {
                         dependencies = [
                           sources."generate-function-2.0.0"
                           (sources."generate-object-property-1.2.0" // {
@@ -27151,21 +26911,17 @@ in
                           sources."verror-1.3.6"
                         ];
                       })
-                      (sources."sshpk-1.10.0" // {
+                      (sources."sshpk-1.10.1" // {
                         dependencies = [
                           sources."asn1-0.2.3"
                           sources."assert-plus-1.0.0"
                           sources."dashdash-1.14.0"
                           sources."getpass-0.1.6"
                           sources."jsbn-0.1.0"
-                          sources."tweetnacl-0.13.3"
+                          sources."tweetnacl-0.14.3"
                           sources."jodid25519-1.0.2"
                           sources."ecc-jsbn-0.1.1"
-                          (sources."bcrypt-pbkdf-1.0.0" // {
-                            dependencies = [
-                              sources."tweetnacl-0.14.3"
-                            ];
-                          })
+                          sources."bcrypt-pbkdf-1.0.0"
                         ];
                       })
                     ];
@@ -27173,9 +26929,9 @@ in
                   sources."is-typedarray-1.0.0"
                   sources."isstream-0.1.2"
                   sources."json-stringify-safe-5.0.1"
-                  (sources."mime-types-2.1.11" // {
+                  (sources."mime-types-2.1.12" // {
                     dependencies = [
-                      sources."mime-db-1.23.0"
+                      sources."mime-db-1.24.0"
                     ];
                   })
                   sources."node-uuid-1.4.7"
@@ -27188,7 +26944,7 @@ in
               })
               (sources."rimraf-2.5.4" // {
                 dependencies = [
-                  (sources."glob-7.0.6" // {
+                  (sources."glob-7.1.0" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.5" // {
@@ -27222,7 +26978,7 @@ in
                   sources."block-stream-0.0.9"
                   (sources."fstream-1.0.10" // {
                     dependencies = [
-                      sources."graceful-fs-4.1.6"
+                      sources."graceful-fs-4.1.9"
                     ];
                   })
                   sources."inherits-2.0.3"
@@ -27232,7 +26988,7 @@ in
                 dependencies = [
                   (sources."fstream-1.0.10" // {
                     dependencies = [
-                      sources."graceful-fs-4.1.6"
+                      sources."graceful-fs-4.1.9"
                       sources."inherits-2.0.3"
                     ];
                   })
@@ -27340,7 +27096,7 @@ in
                   sources."set-blocking-2.0.0"
                 ];
               })
-              (sources."request-2.74.0" // {
+              (sources."request-2.75.0" // {
                 dependencies = [
                   sources."aws-sign2-0.6.0"
                   sources."aws4-1.4.1"
@@ -27366,13 +27122,9 @@ in
                   })
                   sources."extend-3.0.0"
                   sources."forever-agent-0.6.1"
-                  (sources."form-data-1.0.1" // {
+                  (sources."form-data-2.0.0" // {
                     dependencies = [
-                      (sources."async-2.0.1" // {
-                        dependencies = [
-                          sources."lodash-4.15.0"
-                        ];
-                      })
+                      sources."asynckit-0.4.0"
                     ];
                   })
                   (sources."har-validator-2.0.6" // {
@@ -27399,7 +27151,7 @@ in
                           sources."graceful-readlink-1.0.1"
                         ];
                       })
-                      (sources."is-my-json-valid-2.13.1" // {
+                      (sources."is-my-json-valid-2.14.0" // {
                         dependencies = [
                           sources."generate-function-2.0.0"
                           (sources."generate-object-property-1.2.0" // {
@@ -27436,21 +27188,17 @@ in
                           sources."verror-1.3.6"
                         ];
                       })
-                      (sources."sshpk-1.10.0" // {
+                      (sources."sshpk-1.10.1" // {
                         dependencies = [
                           sources."asn1-0.2.3"
                           sources."assert-plus-1.0.0"
                           sources."dashdash-1.14.0"
                           sources."getpass-0.1.6"
                           sources."jsbn-0.1.0"
-                          sources."tweetnacl-0.13.3"
+                          sources."tweetnacl-0.14.3"
                           sources."jodid25519-1.0.2"
                           sources."ecc-jsbn-0.1.1"
-                          (sources."bcrypt-pbkdf-1.0.0" // {
-                            dependencies = [
-                              sources."tweetnacl-0.14.3"
-                            ];
-                          })
+                          sources."bcrypt-pbkdf-1.0.0"
                         ];
                       })
                     ];
@@ -27458,9 +27206,9 @@ in
                   sources."is-typedarray-1.0.0"
                   sources."isstream-0.1.2"
                   sources."json-stringify-safe-5.0.1"
-                  (sources."mime-types-2.1.11" // {
+                  (sources."mime-types-2.1.12" // {
                     dependencies = [
-                      sources."mime-db-1.23.0"
+                      sources."mime-db-1.24.0"
                     ];
                   })
                   sources."node-uuid-1.4.7"
@@ -27473,7 +27221,7 @@ in
               })
               (sources."rimraf-2.5.4" // {
                 dependencies = [
-                  (sources."glob-7.0.6" // {
+                  (sources."glob-7.1.0" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.5" // {
@@ -27507,7 +27255,7 @@ in
                   sources."block-stream-0.0.9"
                   (sources."fstream-1.0.10" // {
                     dependencies = [
-                      sources."graceful-fs-4.1.6"
+                      sources."graceful-fs-4.1.9"
                     ];
                   })
                   sources."inherits-2.0.3"
@@ -27517,7 +27265,7 @@ in
                 dependencies = [
                   (sources."fstream-1.0.10" // {
                     dependencies = [
-                      sources."graceful-fs-4.1.6"
+                      sources."graceful-fs-4.1.9"
                       sources."inherits-2.0.3"
                     ];
                   })
@@ -27702,7 +27450,7 @@ in
           sources."strip-json-comments-1.0.4"
         ];
       })
-      (sources."request-2.74.0" // {
+      (sources."request-2.75.0" // {
         dependencies = [
           sources."aws-sign2-0.6.0"
           sources."aws4-1.4.1"
@@ -27728,13 +27476,9 @@ in
           })
           sources."extend-3.0.0"
           sources."forever-agent-0.6.1"
-          (sources."form-data-1.0.1" // {
+          (sources."form-data-2.0.0" // {
             dependencies = [
-              (sources."async-2.0.1" // {
-                dependencies = [
-                  sources."lodash-4.15.0"
-                ];
-              })
+              sources."asynckit-0.4.0"
             ];
           })
           (sources."har-validator-2.0.6" // {
@@ -27761,7 +27505,7 @@ in
                   sources."graceful-readlink-1.0.1"
                 ];
               })
-              (sources."is-my-json-valid-2.13.1" // {
+              (sources."is-my-json-valid-2.14.0" // {
                 dependencies = [
                   sources."generate-function-2.0.0"
                   (sources."generate-object-property-1.2.0" // {
@@ -27798,21 +27542,17 @@ in
                   sources."verror-1.3.6"
                 ];
               })
-              (sources."sshpk-1.10.0" // {
+              (sources."sshpk-1.10.1" // {
                 dependencies = [
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.0"
                   sources."getpass-0.1.6"
                   sources."jsbn-0.1.0"
-                  sources."tweetnacl-0.13.3"
+                  sources."tweetnacl-0.14.3"
                   sources."jodid25519-1.0.2"
                   sources."ecc-jsbn-0.1.1"
-                  (sources."bcrypt-pbkdf-1.0.0" // {
-                    dependencies = [
-                      sources."tweetnacl-0.14.3"
-                    ];
-                  })
+                  sources."bcrypt-pbkdf-1.0.0"
                 ];
               })
             ];
@@ -27820,9 +27560,9 @@ in
           sources."is-typedarray-1.0.0"
           sources."isstream-0.1.2"
           sources."json-stringify-safe-5.0.1"
-          (sources."mime-types-2.1.11" // {
+          (sources."mime-types-2.1.12" // {
             dependencies = [
-              sources."mime-db-1.23.0"
+              sources."mime-db-1.24.0"
             ];
           })
           sources."node-uuid-1.4.7"
@@ -27835,7 +27575,7 @@ in
       })
       (sources."rimraf-2.5.4" // {
         dependencies = [
-          (sources."glob-7.0.6" // {
+          (sources."glob-7.1.0" // {
             dependencies = [
               sources."fs.realpath-1.0.0"
               (sources."inflight-1.0.5" // {
@@ -27870,7 +27610,7 @@ in
           sources."block-stream-0.0.9"
           (sources."fstream-1.0.10" // {
             dependencies = [
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
             ];
           })
           sources."inherits-2.0.3"
@@ -27885,7 +27625,7 @@ in
           })
           (sources."fstream-1.0.10" // {
             dependencies = [
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
               sources."inherits-2.0.3"
             ];
           })
@@ -28032,7 +27772,7 @@ in
           sources."path-is-absolute-1.0.0"
           (sources."readdirp-2.1.0" // {
             dependencies = [
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
               (sources."readable-stream-2.1.5" // {
                 dependencies = [
                   sources."buffer-shims-1.0.0"
@@ -28119,7 +27859,7 @@ in
                       sources."strip-json-comments-1.0.4"
                     ];
                   })
-                  (sources."request-2.74.0" // {
+                  (sources."request-2.75.0" // {
                     dependencies = [
                       sources."aws-sign2-0.6.0"
                       sources."aws4-1.4.1"
@@ -28144,13 +27884,9 @@ in
                       })
                       sources."extend-3.0.0"
                       sources."forever-agent-0.6.1"
-                      (sources."form-data-1.0.1" // {
+                      (sources."form-data-2.0.0" // {
                         dependencies = [
-                          (sources."async-2.0.1" // {
-                            dependencies = [
-                              sources."lodash-4.15.0"
-                            ];
-                          })
+                          sources."asynckit-0.4.0"
                         ];
                       })
                       (sources."har-validator-2.0.6" // {
@@ -28177,7 +27913,7 @@ in
                               sources."graceful-readlink-1.0.1"
                             ];
                           })
-                          (sources."is-my-json-valid-2.13.1" // {
+                          (sources."is-my-json-valid-2.14.0" // {
                             dependencies = [
                               sources."generate-function-2.0.0"
                               (sources."generate-object-property-1.2.0" // {
@@ -28214,21 +27950,17 @@ in
                               sources."verror-1.3.6"
                             ];
                           })
-                          (sources."sshpk-1.10.0" // {
+                          (sources."sshpk-1.10.1" // {
                             dependencies = [
                               sources."asn1-0.2.3"
                               sources."assert-plus-1.0.0"
                               sources."dashdash-1.14.0"
                               sources."getpass-0.1.6"
                               sources."jsbn-0.1.0"
-                              sources."tweetnacl-0.13.3"
+                              sources."tweetnacl-0.14.3"
                               sources."jodid25519-1.0.2"
                               sources."ecc-jsbn-0.1.1"
-                              (sources."bcrypt-pbkdf-1.0.0" // {
-                                dependencies = [
-                                  sources."tweetnacl-0.14.3"
-                                ];
-                              })
+                              sources."bcrypt-pbkdf-1.0.0"
                             ];
                           })
                         ];
@@ -28236,9 +27968,9 @@ in
                       sources."is-typedarray-1.0.0"
                       sources."isstream-0.1.2"
                       sources."json-stringify-safe-5.0.1"
-                      (sources."mime-types-2.1.11" // {
+                      (sources."mime-types-2.1.12" // {
                         dependencies = [
-                          sources."mime-db-1.23.0"
+                          sources."mime-db-1.24.0"
                         ];
                       })
                       sources."node-uuid-1.4.7"
@@ -28251,7 +27983,7 @@ in
                   })
                   (sources."rimraf-2.5.4" // {
                     dependencies = [
-                      (sources."glob-7.0.6" // {
+                      (sources."glob-7.1.0" // {
                         dependencies = [
                           sources."fs.realpath-1.0.0"
                           (sources."inflight-1.0.5" // {
@@ -28274,7 +28006,7 @@ in
                       sources."block-stream-0.0.9"
                       (sources."fstream-1.0.10" // {
                         dependencies = [
-                          sources."graceful-fs-4.1.6"
+                          sources."graceful-fs-4.1.9"
                         ];
                       })
                     ];
@@ -28283,7 +28015,7 @@ in
                     dependencies = [
                       (sources."fstream-1.0.10" // {
                         dependencies = [
-                          sources."graceful-fs-4.1.6"
+                          sources."graceful-fs-4.1.9"
                         ];
                       })
                       sources."fstream-ignore-1.0.5"
@@ -28401,7 +28133,7 @@ in
           })
           (sources."configstore-1.4.0" // {
             dependencies = [
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
               (sources."mkdirp-0.5.1" // {
                 dependencies = [
                   sources."minimist-0.0.8"
@@ -28414,7 +28146,7 @@ in
                   sources."os-homedir-1.0.1"
                 ];
               })
-              sources."uuid-2.0.2"
+              sources."uuid-2.0.3"
               (sources."write-file-atomic-1.2.0" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
@@ -28581,9 +28313,9 @@ in
           sources."qs-6.2.0"
           (sources."type-is-1.6.13" // {
             dependencies = [
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
             ];
@@ -28645,7 +28377,7 @@ in
         dependencies = [
           (sources."moment-timezone-0.3.1" // {
             dependencies = [
-              sources."moment-2.15.0"
+              sources."moment-2.15.1"
             ];
           })
         ];
@@ -28654,9 +28386,9 @@ in
         dependencies = [
           (sources."accepts-1.3.3" // {
             dependencies = [
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."negotiator-0.6.1"
@@ -28717,9 +28449,9 @@ in
           sources."serve-static-1.11.1"
           (sources."type-is-1.6.13" // {
             dependencies = [
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
             ];
@@ -28740,13 +28472,13 @@ in
       })
       (sources."fs-extra-0.30.0" // {
         dependencies = [
-          sources."graceful-fs-4.1.6"
-          sources."jsonfile-2.3.1"
+          sources."graceful-fs-4.1.9"
+          sources."jsonfile-2.4.0"
           sources."klaw-1.3.0"
           sources."path-is-absolute-1.0.0"
           (sources."rimraf-2.5.4" // {
             dependencies = [
-              (sources."glob-7.0.6" // {
+              (sources."glob-7.1.0" // {
                 dependencies = [
                   sources."fs.realpath-1.0.0"
                   (sources."inflight-1.0.5" // {
@@ -29050,7 +28782,7 @@ in
           sources."sax-1.2.1"
           (sources."xmlbuilder-4.2.1" // {
             dependencies = [
-              sources."lodash-4.15.0"
+              sources."lodash-4.16.2"
             ];
           })
         ];
@@ -29095,15 +28827,15 @@ in
                 dependencies = [
                   (sources."async-2.0.1" // {
                     dependencies = [
-                      sources."lodash-4.15.0"
+                      sources."lodash-4.16.2"
                     ];
                   })
                 ];
               })
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."node-uuid-1.4.7"
@@ -29158,7 +28890,7 @@ in
                       sources."graceful-readlink-1.0.1"
                     ];
                   })
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -29266,9 +28998,9 @@ in
               })
             ];
           })
-          (sources."imap-0.8.17" // {
+          (sources."imap-0.8.18" // {
             dependencies = [
-              sources."utf7-1.0.0"
+              sources."utf7-1.0.2"
               (sources."readable-stream-1.1.14" // {
                 dependencies = [
                   sources."core-util-is-1.0.2"
@@ -29308,15 +29040,15 @@ in
                 dependencies = [
                   (sources."async-2.0.1" // {
                     dependencies = [
-                      sources."lodash-4.15.0"
+                      sources."lodash-4.16.2"
                     ];
                   })
                 ];
               })
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."node-uuid-1.4.7"
@@ -29333,21 +29065,17 @@ in
                       sources."verror-1.3.6"
                     ];
                   })
-                  (sources."sshpk-1.10.0" // {
+                  (sources."sshpk-1.10.1" // {
                     dependencies = [
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.0"
                       sources."getpass-0.1.6"
                       sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
+                      sources."tweetnacl-0.14.3"
                       sources."jodid25519-1.0.2"
                       sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
+                      sources."bcrypt-pbkdf-1.0.0"
                     ];
                   })
                 ];
@@ -29394,7 +29122,7 @@ in
                       sources."graceful-readlink-1.0.1"
                     ];
                   })
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -29496,7 +29224,7 @@ in
                       sources."strip-json-comments-1.0.4"
                     ];
                   })
-                  (sources."request-2.74.0" // {
+                  (sources."request-2.75.0" // {
                     dependencies = [
                       sources."aws-sign2-0.6.0"
                       sources."aws4-1.4.1"
@@ -29522,13 +29250,9 @@ in
                       })
                       sources."extend-3.0.0"
                       sources."forever-agent-0.6.1"
-                      (sources."form-data-1.0.1" // {
+                      (sources."form-data-2.0.0" // {
                         dependencies = [
-                          (sources."async-2.0.1" // {
-                            dependencies = [
-                              sources."lodash-4.15.0"
-                            ];
-                          })
+                          sources."asynckit-0.4.0"
                         ];
                       })
                       (sources."har-validator-2.0.6" // {
@@ -29555,7 +29279,7 @@ in
                               sources."graceful-readlink-1.0.1"
                             ];
                           })
-                          (sources."is-my-json-valid-2.13.1" // {
+                          (sources."is-my-json-valid-2.14.0" // {
                             dependencies = [
                               sources."generate-function-2.0.0"
                               (sources."generate-object-property-1.2.0" // {
@@ -29592,21 +29316,17 @@ in
                               sources."verror-1.3.6"
                             ];
                           })
-                          (sources."sshpk-1.10.0" // {
+                          (sources."sshpk-1.10.1" // {
                             dependencies = [
                               sources."asn1-0.2.3"
                               sources."assert-plus-1.0.0"
                               sources."dashdash-1.14.0"
                               sources."getpass-0.1.6"
                               sources."jsbn-0.1.0"
-                              sources."tweetnacl-0.13.3"
+                              sources."tweetnacl-0.14.3"
                               sources."jodid25519-1.0.2"
                               sources."ecc-jsbn-0.1.1"
-                              (sources."bcrypt-pbkdf-1.0.0" // {
-                                dependencies = [
-                                  sources."tweetnacl-0.14.3"
-                                ];
-                              })
+                              sources."bcrypt-pbkdf-1.0.0"
                             ];
                           })
                         ];
@@ -29614,9 +29334,9 @@ in
                       sources."is-typedarray-1.0.0"
                       sources."isstream-0.1.2"
                       sources."json-stringify-safe-5.0.1"
-                      (sources."mime-types-2.1.11" // {
+                      (sources."mime-types-2.1.12" // {
                         dependencies = [
-                          sources."mime-db-1.23.0"
+                          sources."mime-db-1.24.0"
                         ];
                       })
                       sources."node-uuid-1.4.7"
@@ -29629,7 +29349,7 @@ in
                   })
                   (sources."rimraf-2.5.4" // {
                     dependencies = [
-                      (sources."glob-7.0.6" // {
+                      (sources."glob-7.1.0" // {
                         dependencies = [
                           sources."fs.realpath-1.0.0"
                           (sources."inflight-1.0.5" // {
@@ -29663,7 +29383,7 @@ in
                       sources."block-stream-0.0.9"
                       (sources."fstream-1.0.10" // {
                         dependencies = [
-                          sources."graceful-fs-4.1.6"
+                          sources."graceful-fs-4.1.9"
                         ];
                       })
                       sources."inherits-2.0.3"
@@ -29673,7 +29393,7 @@ in
                     dependencies = [
                       (sources."fstream-1.0.10" // {
                         dependencies = [
-                          sources."graceful-fs-4.1.6"
+                          sources."graceful-fs-4.1.9"
                           sources."inherits-2.0.3"
                         ];
                       })
@@ -29831,7 +29551,7 @@ in
       (sources."config-0.4.15" // {
         dependencies = [
           sources."js-yaml-0.3.7"
-          sources."coffee-script-1.10.0"
+          sources."coffee-script-1.11.0"
           (sources."vows-0.8.1" // {
             dependencies = [
               sources."eyes-0.1.8"
@@ -29957,10 +29677,10 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "3.10.7";
+    version = "3.10.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-3.10.7.tgz";
-      sha1 = "c27556ddd52558d0a6fbf528503695fb83a54210";
+      url = "https://registry.npmjs.org/npm/-/npm-3.10.8.tgz";
+      sha1 = "8f76ff8c6da04b61dd371d554ce40a0b8916c15e";
     };
     dependencies = [
       sources."abbrev-1.0.9"
@@ -29968,7 +29688,7 @@ in
       sources."ansistyles-0.1.3"
       sources."aproba-1.0.4"
       sources."archy-1.0.0"
-      sources."asap-2.0.4"
+      sources."asap-2.0.5"
       sources."chownr-1.0.1"
       sources."cmd-shim-2.0.2"
       (sources."columnify-1.5.4" // {
@@ -29994,7 +29714,7 @@ in
       sources."fs-vacuum-1.2.9"
       sources."fs-write-stream-atomic-1.0.8"
       sources."fstream-1.0.10"
-      (sources."fstream-npm-1.1.1" // {
+      (sources."fstream-npm-1.2.0" // {
         dependencies = [
           (sources."fstream-ignore-1.0.5" // {
             dependencies = [
@@ -30028,7 +29748,7 @@ in
           sources."path-is-absolute-1.0.0"
         ];
       })
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."has-unicode-2.0.1"
       sources."hosted-git-info-2.1.5"
       sources."iferr-0.1.5"
@@ -30055,17 +29775,17 @@ in
           sources."promzard-0.3.0"
         ];
       })
-      sources."lockfile-1.0.1"
+      sources."lockfile-1.0.2"
       (sources."lodash._baseuniq-4.6.0" // {
         dependencies = [
           sources."lodash._createset-4.0.3"
           sources."lodash._root-3.0.1"
         ];
       })
-      sources."lodash.clonedeep-4.4.1"
-      sources."lodash.union-4.5.0"
-      sources."lodash.uniq-4.4.0"
-      sources."lodash.without-4.3.0"
+      sources."lodash.clonedeep-4.5.0"
+      sources."lodash.union-4.6.0"
+      sources."lodash.uniq-4.5.0"
+      sources."lodash.without-4.4.0"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
@@ -30081,6 +29801,39 @@ in
                   sources."concat-map-0.0.1"
                 ];
               })
+            ];
+          })
+          (sources."npmlog-3.1.2" // {
+            dependencies = [
+              (sources."are-we-there-yet-1.1.2" // {
+                dependencies = [
+                  sources."delegates-1.0.0"
+                ];
+              })
+              sources."console-control-strings-1.1.0"
+              (sources."gauge-2.6.0" // {
+                dependencies = [
+                  sources."has-color-0.1.7"
+                  sources."object-assign-4.1.0"
+                  sources."signal-exit-3.0.1"
+                  (sources."string-width-1.0.2" // {
+                    dependencies = [
+                      (sources."code-point-at-1.0.0" // {
+                        dependencies = [
+                          sources."number-is-nan-1.0.0"
+                        ];
+                      })
+                      (sources."is-fullwidth-code-point-1.0.0" // {
+                        dependencies = [
+                          sources."number-is-nan-1.0.0"
+                        ];
+                      })
+                    ];
+                  })
+                  sources."wide-align-1.1.0"
+                ];
+              })
+              sources."set-blocking-2.0.0"
             ];
           })
           (sources."path-array-1.0.1" // {
@@ -30122,7 +29875,7 @@ in
       sources."npm-cache-filename-1.0.2"
       sources."npm-install-checks-3.0.0"
       sources."npm-package-arg-4.2.0"
-      (sources."npm-registry-client-7.1.2" // {
+      (sources."npm-registry-client-7.2.1" // {
         dependencies = [
           (sources."concat-stream-1.5.2" // {
             dependencies = [
@@ -30138,11 +29891,43 @@ in
               })
             ];
           })
-          sources."retry-0.8.0"
+          (sources."npmlog-3.1.2" // {
+            dependencies = [
+              (sources."are-we-there-yet-1.1.2" // {
+                dependencies = [
+                  sources."delegates-1.0.0"
+                ];
+              })
+              sources."console-control-strings-1.1.0"
+              (sources."gauge-2.6.0" // {
+                dependencies = [
+                  sources."has-color-0.1.7"
+                  sources."object-assign-4.1.0"
+                  sources."signal-exit-3.0.1"
+                  (sources."string-width-1.0.2" // {
+                    dependencies = [
+                      (sources."code-point-at-1.0.0" // {
+                        dependencies = [
+                          sources."number-is-nan-1.0.0"
+                        ];
+                      })
+                      (sources."is-fullwidth-code-point-1.0.0" // {
+                        dependencies = [
+                          sources."number-is-nan-1.0.0"
+                        ];
+                      })
+                    ];
+                  })
+                  sources."wide-align-1.1.0"
+                ];
+              })
+              sources."set-blocking-2.0.0"
+            ];
+          })
         ];
       })
       sources."npm-user-validate-0.1.5"
-      (sources."npmlog-3.1.2" // {
+      (sources."npmlog-4.0.0" // {
         dependencies = [
           (sources."are-we-there-yet-1.1.2" // {
             dependencies = [
@@ -30175,7 +29960,7 @@ in
           sources."set-blocking-2.0.0"
         ];
       })
-      sources."once-1.3.3"
+      sources."once-1.4.0"
       sources."opener-1.4.2"
       (sources."osenv-0.1.3" // {
         dependencies = [
@@ -30260,7 +30045,7 @@ in
             dependencies = [
               (sources."async-2.0.1" // {
                 dependencies = [
-                  sources."lodash-4.15.0"
+                  sources."lodash-4.16.2"
                 ];
               })
             ];
@@ -30280,7 +30065,7 @@ in
                   sources."graceful-readlink-1.0.1"
                 ];
               })
-              (sources."is-my-json-valid-2.13.1" // {
+              (sources."is-my-json-valid-2.14.0" // {
                 dependencies = [
                   sources."generate-function-2.0.0"
                   (sources."generate-object-property-1.2.0" // {
@@ -30317,21 +30102,17 @@ in
                   sources."verror-1.3.6"
                 ];
               })
-              (sources."sshpk-1.10.0" // {
+              (sources."sshpk-1.10.1" // {
                 dependencies = [
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.0"
                   sources."getpass-0.1.6"
                   sources."jsbn-0.1.0"
-                  sources."tweetnacl-0.13.3"
+                  sources."tweetnacl-0.14.3"
                   sources."jodid25519-1.0.2"
                   sources."ecc-jsbn-0.1.1"
-                  (sources."bcrypt-pbkdf-1.0.0" // {
-                    dependencies = [
-                      sources."tweetnacl-0.14.3"
-                    ];
-                  })
+                  sources."bcrypt-pbkdf-1.0.0"
                 ];
               })
             ];
@@ -30339,9 +30120,9 @@ in
           sources."is-typedarray-1.0.0"
           sources."isstream-0.1.2"
           sources."json-stringify-safe-5.0.1"
-          (sources."mime-types-2.1.11" // {
+          (sources."mime-types-2.1.12" // {
             dependencies = [
-              sources."mime-db-1.23.0"
+              sources."mime-db-1.24.0"
             ];
           })
           sources."node-uuid-1.4.7"
@@ -30352,9 +30133,9 @@ in
           sources."tunnel-agent-0.4.3"
         ];
       })
-      sources."retry-0.9.0"
+      sources."retry-0.10.0"
       sources."rimraf-2.5.4"
-      sources."semver-5.1.1"
+      sources."semver-5.3.0"
       sources."sha-2.0.1"
       sources."slide-1.1.6"
       sources."sorted-object-2.0.1"
@@ -30384,7 +30165,7 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."write-file-atomic-1.1.4"
+      sources."write-file-atomic-1.2.0"
       sources."ansi-regex-2.0.0"
       sources."debuglog-1.0.1"
       sources."imurmurhash-0.1.4"
@@ -30433,7 +30214,7 @@ in
       })
       (sources."npm-registry-client-0.2.27" // {
         dependencies = [
-          (sources."request-2.74.0" // {
+          (sources."request-2.75.0" // {
             dependencies = [
               sources."aws-sign2-0.6.0"
               sources."aws4-1.4.1"
@@ -30459,13 +30240,9 @@ in
               })
               sources."extend-3.0.0"
               sources."forever-agent-0.6.1"
-              (sources."form-data-1.0.1" // {
+              (sources."form-data-2.0.0" // {
                 dependencies = [
-                  (sources."async-2.0.1" // {
-                    dependencies = [
-                      sources."lodash-4.15.0"
-                    ];
-                  })
+                  sources."asynckit-0.4.0"
                 ];
               })
               (sources."har-validator-2.0.6" // {
@@ -30492,7 +30269,7 @@ in
                       sources."graceful-readlink-1.0.1"
                     ];
                   })
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -30529,21 +30306,17 @@ in
                       sources."verror-1.3.6"
                     ];
                   })
-                  (sources."sshpk-1.10.0" // {
+                  (sources."sshpk-1.10.1" // {
                     dependencies = [
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.0"
                       sources."getpass-0.1.6"
                       sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
+                      sources."tweetnacl-0.14.3"
                       sources."jodid25519-1.0.2"
                       sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
+                      sources."bcrypt-pbkdf-1.0.0"
                     ];
                   })
                 ];
@@ -30551,9 +30324,9 @@ in
               sources."is-typedarray-1.0.0"
               sources."isstream-0.1.2"
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."node-uuid-1.4.7"
@@ -30571,7 +30344,7 @@ in
           sources."mkdirp-0.3.5"
           (sources."rimraf-2.5.4" // {
             dependencies = [
-              (sources."glob-7.0.6" // {
+              (sources."glob-7.1.0" // {
                 dependencies = [
                   sources."fs.realpath-1.0.0"
                   (sources."inflight-1.0.5" // {
@@ -30699,7 +30472,7 @@ in
               })
               (sources."rimraf-2.5.4" // {
                 dependencies = [
-                  (sources."glob-7.0.6" // {
+                  (sources."glob-7.1.0" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.5" // {
@@ -30759,7 +30532,7 @@ in
         ];
       })
       sources."findit-1.2.0"
-      sources."coffee-script-1.10.0"
+      sources."coffee-script-1.11.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -30826,7 +30599,7 @@ in
       sources."lodash-3.10.1"
       (sources."node-alias-1.0.4" // {
         dependencies = [
-          sources."lodash-4.15.0"
+          sources."lodash-4.16.2"
         ];
       })
       (sources."npm-3.10.8" // {
@@ -30836,7 +30609,7 @@ in
           sources."ansistyles-0.1.3"
           sources."aproba-1.0.4"
           sources."archy-1.0.0"
-          sources."asap-2.0.4"
+          sources."asap-2.0.5"
           sources."chownr-1.0.1"
           sources."cmd-shim-2.0.2"
           (sources."columnify-1.5.4" // {
@@ -30896,7 +30669,7 @@ in
               sources."path-is-absolute-1.0.0"
             ];
           })
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
           sources."has-unicode-2.0.1"
           sources."hosted-git-info-2.1.5"
           sources."iferr-0.1.5"
@@ -30923,7 +30696,7 @@ in
               sources."promzard-0.3.0"
             ];
           })
-          sources."lockfile-1.0.1"
+          sources."lockfile-1.0.2"
           (sources."lodash._baseuniq-4.6.0" // {
             dependencies = [
               sources."lodash._createset-4.0.3"
@@ -31188,14 +30961,14 @@ in
                 dependencies = [
                   (sources."async-2.0.1" // {
                     dependencies = [
-                      sources."lodash-4.15.0"
+                      sources."lodash-4.16.2"
                     ];
                   })
                 ];
               })
               (sources."har-validator-2.0.6" // {
                 dependencies = [
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -31232,21 +31005,17 @@ in
                       sources."verror-1.3.6"
                     ];
                   })
-                  (sources."sshpk-1.10.0" // {
+                  (sources."sshpk-1.10.1" // {
                     dependencies = [
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.0"
                       sources."getpass-0.1.6"
                       sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
+                      sources."tweetnacl-0.14.3"
                       sources."jodid25519-1.0.2"
                       sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
+                      sources."bcrypt-pbkdf-1.0.0"
                     ];
                   })
                 ];
@@ -31254,9 +31023,9 @@ in
               sources."is-typedarray-1.0.0"
               sources."isstream-0.1.2"
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."node-uuid-1.4.7"
@@ -31334,7 +31103,7 @@ in
         dependencies = [
           (sources."configstore-1.4.0" // {
             dependencies = [
-              sources."graceful-fs-4.1.6"
+              sources."graceful-fs-4.1.9"
               (sources."mkdirp-0.5.1" // {
                 dependencies = [
                   sources."minimist-0.0.8"
@@ -31347,7 +31116,7 @@ in
                   sources."os-homedir-1.0.1"
                 ];
               })
-              sources."uuid-2.0.2"
+              sources."uuid-2.0.3"
               (sources."write-file-atomic-1.2.0" // {
                 dependencies = [
                   sources."imurmurhash-0.1.4"
@@ -31529,7 +31298,7 @@ in
                     dependencies = [
                       (sources."consume-until-1.0.0" // {
                         dependencies = [
-                          sources."buffer-indexof-1.0.2"
+                          sources."buffer-indexof-1.1.0"
                         ];
                       })
                       (sources."http-headers-3.0.1" // {
@@ -31599,7 +31368,7 @@ in
               sources."dns-equal-1.0.0"
               (sources."dns-txt-2.0.2" // {
                 dependencies = [
-                  sources."buffer-indexof-1.0.2"
+                  sources."buffer-indexof-1.1.0"
                 ];
               })
               (sources."multicast-dns-6.1.0" // {
@@ -31674,7 +31443,7 @@ in
                         dependencies = [
                           (sources."load-json-file-1.1.0" // {
                             dependencies = [
-                              sources."graceful-fs-4.1.6"
+                              sources."graceful-fs-4.1.9"
                               (sources."parse-json-2.2.0" // {
                                 dependencies = [
                                   (sources."error-ex-1.3.0" // {
@@ -31699,7 +31468,7 @@ in
                           })
                           (sources."path-type-1.1.0" // {
                             dependencies = [
-                              sources."graceful-fs-4.1.6"
+                              sources."graceful-fs-4.1.9"
                               sources."pify-2.3.0"
                               (sources."pinkie-promise-2.0.1" // {
                                 dependencies = [
@@ -31808,7 +31577,7 @@ in
               sources."bencode-0.10.0"
               (sources."simple-sha1-2.0.8" // {
                 dependencies = [
-                  sources."rusha-0.8.3"
+                  sources."rusha-0.8.4"
                 ];
               })
               sources."uniq-1.0.1"
@@ -31900,7 +31669,7 @@ in
                   sources."bencode-0.7.0"
                   (sources."simple-sha1-2.0.8" // {
                     dependencies = [
-                      sources."rusha-0.8.3"
+                      sources."rusha-0.8.4"
                     ];
                   })
                 ];
@@ -31938,7 +31707,7 @@ in
           })
           (sources."rimraf-2.5.4" // {
             dependencies = [
-              (sources."glob-7.0.6" // {
+              (sources."glob-7.1.0" // {
                 dependencies = [
                   sources."fs.realpath-1.0.0"
                   (sources."inflight-1.0.5" // {
@@ -32270,7 +32039,7 @@ in
                   sources."bencode-0.7.0"
                   (sources."simple-sha1-2.0.8" // {
                     dependencies = [
-                      sources."rusha-0.8.3"
+                      sources."rusha-0.8.4"
                     ];
                   })
                 ];
@@ -32456,7 +32225,7 @@ in
                   sources."bencode-0.7.0"
                   (sources."simple-sha1-2.0.8" // {
                     dependencies = [
-                      sources."rusha-0.8.3"
+                      sources."rusha-0.8.4"
                     ];
                   })
                 ];
@@ -32490,7 +32259,7 @@ in
           sources."random-access-file-0.3.2"
           (sources."rimraf-2.5.4" // {
             dependencies = [
-              (sources."glob-7.0.6" // {
+              (sources."glob-7.1.0" // {
                 dependencies = [
                   sources."fs.realpath-1.0.0"
                   (sources."inflight-1.0.5" // {
@@ -32526,7 +32295,7 @@ in
         dependencies = [
           (sources."async-2.0.1" // {
             dependencies = [
-              sources."lodash-4.15.0"
+              sources."lodash-4.16.2"
             ];
           })
           (sources."which-1.2.11" // {
@@ -32590,13 +32359,13 @@ in
       })
       (sources."fs-extra-0.26.7" // {
         dependencies = [
-          sources."graceful-fs-4.1.6"
-          sources."jsonfile-2.3.1"
+          sources."graceful-fs-4.1.9"
+          sources."jsonfile-2.4.0"
           sources."klaw-1.3.0"
           sources."path-is-absolute-1.0.0"
           (sources."rimraf-2.5.4" // {
             dependencies = [
-              (sources."glob-7.0.6" // {
+              (sources."glob-7.1.0" // {
                 dependencies = [
                   sources."fs.realpath-1.0.0"
                   (sources."inflight-1.0.5" // {
@@ -32661,15 +32430,15 @@ in
             dependencies = [
               (sources."async-2.0.1" // {
                 dependencies = [
-                  sources."lodash-4.15.0"
+                  sources."lodash-4.16.2"
                 ];
               })
             ];
           })
           sources."json-stringify-safe-5.0.1"
-          (sources."mime-types-2.1.11" // {
+          (sources."mime-types-2.1.12" // {
             dependencies = [
-              sources."mime-db-1.23.0"
+              sources."mime-db-1.24.0"
             ];
           })
           sources."node-uuid-1.4.7"
@@ -32686,21 +32455,17 @@ in
                   sources."verror-1.3.6"
                 ];
               })
-              (sources."sshpk-1.10.0" // {
+              (sources."sshpk-1.10.1" // {
                 dependencies = [
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.0"
                   sources."getpass-0.1.6"
                   sources."jsbn-0.1.0"
-                  sources."tweetnacl-0.13.3"
+                  sources."tweetnacl-0.14.3"
                   sources."jodid25519-1.0.2"
                   sources."ecc-jsbn-0.1.1"
-                  (sources."bcrypt-pbkdf-1.0.0" // {
-                    dependencies = [
-                      sources."tweetnacl-0.14.3"
-                    ];
-                  })
+                  sources."bcrypt-pbkdf-1.0.0"
                 ];
               })
             ];
@@ -32747,7 +32512,7 @@ in
                   sources."graceful-readlink-1.0.1"
                 ];
               })
-              (sources."is-my-json-valid-2.13.1" // {
+              (sources."is-my-json-valid-2.14.0" // {
                 dependencies = [
                   sources."generate-function-2.0.0"
                   (sources."generate-object-property-1.2.0" // {
@@ -32835,7 +32600,7 @@ in
               sources."path-is-absolute-1.0.0"
             ];
           })
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
           sources."iconv-lite-0.4.13"
           (sources."mkdirp-0.5.1" // {
             dependencies = [
@@ -32969,9 +32734,9 @@ in
               sources."fresh-0.1.0"
             ];
           })
-          (sources."openid-2.0.4" // {
+          (sources."openid-2.0.6" // {
             dependencies = [
-              (sources."request-2.74.0" // {
+              (sources."request-2.75.0" // {
                 dependencies = [
                   sources."aws-sign2-0.6.0"
                   sources."aws4-1.4.1"
@@ -32997,13 +32762,9 @@ in
                   })
                   sources."extend-3.0.0"
                   sources."forever-agent-0.6.1"
-                  (sources."form-data-1.0.1" // {
+                  (sources."form-data-2.0.0" // {
                     dependencies = [
-                      (sources."async-2.0.1" // {
-                        dependencies = [
-                          sources."lodash-4.15.0"
-                        ];
-                      })
+                      sources."asynckit-0.4.0"
                     ];
                   })
                   (sources."har-validator-2.0.6" // {
@@ -33030,7 +32791,7 @@ in
                           sources."graceful-readlink-1.0.1"
                         ];
                       })
-                      (sources."is-my-json-valid-2.13.1" // {
+                      (sources."is-my-json-valid-2.14.0" // {
                         dependencies = [
                           sources."generate-function-2.0.0"
                           (sources."generate-object-property-1.2.0" // {
@@ -33067,21 +32828,17 @@ in
                           sources."verror-1.3.6"
                         ];
                       })
-                      (sources."sshpk-1.10.0" // {
+                      (sources."sshpk-1.10.1" // {
                         dependencies = [
                           sources."asn1-0.2.3"
                           sources."assert-plus-1.0.0"
                           sources."dashdash-1.14.0"
                           sources."getpass-0.1.6"
                           sources."jsbn-0.1.0"
-                          sources."tweetnacl-0.13.3"
+                          sources."tweetnacl-0.14.3"
                           sources."jodid25519-1.0.2"
                           sources."ecc-jsbn-0.1.1"
-                          (sources."bcrypt-pbkdf-1.0.0" // {
-                            dependencies = [
-                              sources."tweetnacl-0.14.3"
-                            ];
-                          })
+                          sources."bcrypt-pbkdf-1.0.0"
                         ];
                       })
                     ];
@@ -33089,9 +32846,9 @@ in
                   sources."is-typedarray-1.0.0"
                   sources."isstream-0.1.2"
                   sources."json-stringify-safe-5.0.1"
-                  (sources."mime-types-2.1.11" // {
+                  (sources."mime-types-2.1.12" // {
                     dependencies = [
-                      sources."mime-db-1.23.0"
+                      sources."mime-db-1.24.0"
                     ];
                   })
                   sources."node-uuid-1.4.7"
@@ -33109,7 +32866,7 @@ in
               sources."sax-1.2.1"
               (sources."xmlbuilder-4.2.1" // {
                 dependencies = [
-                  sources."lodash-4.15.0"
+                  sources."lodash-4.16.2"
                 ];
               })
             ];
@@ -33161,9 +32918,9 @@ in
         dependencies = [
           (sources."accepts-1.2.13" // {
             dependencies = [
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."negotiator-0.5.3"
@@ -33248,9 +33005,9 @@ in
           (sources."type-is-1.6.13" // {
             dependencies = [
               sources."media-typer-0.3.0"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
             ];
@@ -33294,9 +33051,9 @@ in
           (sources."type-is-1.6.13" // {
             dependencies = [
               sources."media-typer-0.3.0"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
             ];
@@ -33307,9 +33064,9 @@ in
         dependencies = [
           (sources."accepts-1.3.3" // {
             dependencies = [
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."negotiator-0.6.1"
@@ -33318,7 +33075,7 @@ in
           sources."bytes-2.3.0"
           (sources."compressible-2.0.8" // {
             dependencies = [
-              sources."mime-db-1.23.0"
+              sources."mime-db-1.24.0"
             ];
           })
           (sources."debug-2.2.0" // {
@@ -33337,7 +33094,7 @@ in
       })
       (sources."js-yaml-3.6.1" // {
         dependencies = [
-          (sources."argparse-1.0.7" // {
+          (sources."argparse-1.0.9" // {
             dependencies = [
               sources."sprintf-js-1.0.3"
             ];
@@ -33351,7 +33108,7 @@ in
           sources."keygrip-1.0.1"
         ];
       })
-      (sources."request-2.74.0" // {
+      (sources."request-2.75.0" // {
         dependencies = [
           sources."aws-sign2-0.6.0"
           sources."aws4-1.4.1"
@@ -33377,13 +33134,9 @@ in
           })
           sources."extend-3.0.0"
           sources."forever-agent-0.6.1"
-          (sources."form-data-1.0.1" // {
+          (sources."form-data-2.0.0" // {
             dependencies = [
-              (sources."async-2.0.1" // {
-                dependencies = [
-                  sources."lodash-4.15.0"
-                ];
-              })
+              sources."asynckit-0.4.0"
             ];
           })
           (sources."har-validator-2.0.6" // {
@@ -33405,7 +33158,7 @@ in
                   sources."supports-color-2.0.0"
                 ];
               })
-              (sources."is-my-json-valid-2.13.1" // {
+              (sources."is-my-json-valid-2.14.0" // {
                 dependencies = [
                   sources."generate-function-2.0.0"
                   (sources."generate-object-property-1.2.0" // {
@@ -33442,21 +33195,17 @@ in
                   sources."verror-1.3.6"
                 ];
               })
-              (sources."sshpk-1.10.0" // {
+              (sources."sshpk-1.10.1" // {
                 dependencies = [
                   sources."asn1-0.2.3"
                   sources."assert-plus-1.0.0"
                   sources."dashdash-1.14.0"
                   sources."getpass-0.1.6"
                   sources."jsbn-0.1.0"
-                  sources."tweetnacl-0.13.3"
+                  sources."tweetnacl-0.14.3"
                   sources."jodid25519-1.0.2"
                   sources."ecc-jsbn-0.1.1"
-                  (sources."bcrypt-pbkdf-1.0.0" // {
-                    dependencies = [
-                      sources."tweetnacl-0.14.3"
-                    ];
-                  })
+                  sources."bcrypt-pbkdf-1.0.0"
                 ];
               })
             ];
@@ -33464,9 +33213,9 @@ in
           sources."is-typedarray-1.0.0"
           sources."isstream-0.1.2"
           sources."json-stringify-safe-5.0.1"
-          (sources."mime-types-2.1.11" // {
+          (sources."mime-types-2.1.12" // {
             dependencies = [
-              sources."mime-db-1.23.0"
+              sources."mime-db-1.24.0"
             ];
           })
           sources."node-uuid-1.4.7"
@@ -33529,7 +33278,7 @@ in
             ];
           })
           sources."safe-json-stringify-1.0.3"
-          sources."moment-2.15.0"
+          sources."moment-2.15.1"
         ];
       })
       (sources."handlebars-2.0.0" // {
@@ -33557,7 +33306,7 @@ in
         dependencies = [
           (sources."markdown-it-4.4.0" // {
             dependencies = [
-              (sources."argparse-1.0.7" // {
+              (sources."argparse-1.0.9" // {
                 dependencies = [
                   sources."sprintf-js-1.0.3"
                 ];
@@ -33604,7 +33353,7 @@ in
         ];
       })
       sources."jju-1.3.0"
-      (sources."JSONStream-1.1.4" // {
+      (sources."JSONStream-1.2.1" // {
         dependencies = [
           sources."jsonparse-1.2.0"
           sources."through-2.3.8"
@@ -33675,7 +33424,7 @@ in
       })
       (sources."readdirp-2.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
           (sources."minimatch-3.0.3" // {
             dependencies = [
               (sources."brace-expansion-1.1.6" // {
@@ -33992,10 +33741,10 @@ in
   svgo = nodeEnv.buildNodePackage {
     name = "svgo";
     packageName = "svgo";
-    version = "0.7.0";
+    version = "0.7.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/svgo/-/svgo-0.7.0.tgz";
-      sha1 = "51a95c5f7aaa98824f92857ac14c2cdbe81537aa";
+      url = "https://registry.npmjs.org/svgo/-/svgo-0.7.1.tgz";
+      sha1 = "287320fed972cb097e72c2bb1685f96fe08f8034";
     };
     dependencies = [
       sources."sax-1.2.1"
@@ -34006,7 +33755,7 @@ in
       })
       (sources."js-yaml-3.6.1" // {
         dependencies = [
-          (sources."argparse-1.0.7" // {
+          (sources."argparse-1.0.9" // {
             dependencies = [
               sources."sprintf-js-1.0.3"
             ];
@@ -34059,10 +33808,10 @@ in
   titanium = nodeEnv.buildNodePackage {
     name = "titanium";
     packageName = "titanium";
-    version = "5.0.9";
+    version = "5.0.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.9.tgz";
-      sha1 = "113f5f986b5e39e92db0d5d0ba5b2b1f237504e7";
+      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.10.tgz";
+      sha1 = "9bbae581957b33265a71774e8fd9f4766441bf1d";
     };
     dependencies = [
       sources."async-1.4.2"
@@ -34122,15 +33871,15 @@ in
                 dependencies = [
                   (sources."async-2.0.1" // {
                     dependencies = [
-                      sources."lodash-4.15.0"
+                      sources."lodash-4.16.2"
                     ];
                   })
                 ];
               })
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."qs-4.0.0"
@@ -34185,7 +33934,7 @@ in
                       sources."graceful-readlink-1.0.1"
                     ];
                   })
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -34247,15 +33996,15 @@ in
             dependencies = [
               (sources."async-2.0.1" // {
                 dependencies = [
-                  sources."lodash-4.15.0"
+                  sources."lodash-4.16.2"
                 ];
               })
             ];
           })
           sources."json-stringify-safe-5.0.1"
-          (sources."mime-types-2.1.11" // {
+          (sources."mime-types-2.1.12" // {
             dependencies = [
-              sources."mime-db-1.23.0"
+              sources."mime-db-1.24.0"
             ];
           })
           sources."node-uuid-1.4.7"
@@ -34311,7 +34060,7 @@ in
                   sources."graceful-readlink-1.0.1"
                 ];
               })
-              (sources."is-my-json-valid-2.13.1" // {
+              (sources."is-my-json-valid-2.14.0" // {
                 dependencies = [
                   sources."generate-function-2.0.0"
                   (sources."generate-object-property-1.2.0" // {
@@ -34359,10 +34108,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "1.8.10";
+    version = "2.0.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz";
-      sha1 = "b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e";
+      url = "https://registry.npmjs.org/typescript/-/typescript-2.0.3.tgz";
+      sha1 = "33dec9eae86b8eee327dd419ca050c853cabd514";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -34480,9 +34229,9 @@ in
           (sources."type-is-1.6.13" // {
             dependencies = [
               sources."media-typer-0.3.0"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
             ];
@@ -34516,9 +34265,9 @@ in
         dependencies = [
           (sources."accepts-1.2.13" // {
             dependencies = [
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."negotiator-0.5.3"
@@ -34576,9 +34325,9 @@ in
           (sources."type-is-1.6.13" // {
             dependencies = [
               sources."media-typer-0.3.0"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
             ];
@@ -34775,7 +34524,7 @@ in
           })
           (sources."dezalgo-1.0.3" // {
             dependencies = [
-              sources."asap-2.0.4"
+              sources."asap-2.0.5"
             ];
           })
           sources."editor-1.0.0"
@@ -34816,7 +34565,7 @@ in
               sources."path-is-absolute-1.0.0"
             ];
           })
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
           sources."has-unicode-2.0.1"
           sources."hosted-git-info-2.1.5"
           sources."iferr-0.1.5"
@@ -34843,7 +34592,7 @@ in
               sources."promzard-0.3.0"
             ];
           })
-          sources."lockfile-1.0.1"
+          sources."lockfile-1.0.2"
           (sources."lodash._baseuniq-4.6.0" // {
             dependencies = [
               sources."lodash._createset-4.0.3"
@@ -35047,7 +34796,7 @@ in
                       sources."graceful-readlink-1.0.1"
                     ];
                   })
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -35084,21 +34833,17 @@ in
                       sources."verror-1.3.6"
                     ];
                   })
-                  (sources."sshpk-1.10.0" // {
+                  (sources."sshpk-1.10.1" // {
                     dependencies = [
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.0"
                       sources."getpass-0.1.6"
                       sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
+                      sources."tweetnacl-0.14.3"
                       sources."jodid25519-1.0.2"
                       sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
+                      sources."bcrypt-pbkdf-1.0.0"
                     ];
                   })
                 ];
@@ -35106,9 +34851,9 @@ in
               sources."is-typedarray-1.0.0"
               sources."isstream-0.1.2"
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."node-uuid-1.4.7"
@@ -35190,7 +34935,7 @@ in
               })
             ];
           })
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
           (sources."normalize-package-data-2.3.5" // {
             dependencies = [
               sources."hosted-git-info-2.1.5"
@@ -35221,7 +34966,7 @@ in
               sources."wrappy-1.0.2"
             ];
           })
-          (sources."request-2.74.0" // {
+          (sources."request-2.75.0" // {
             dependencies = [
               sources."aws-sign2-0.6.0"
               sources."aws4-1.4.1"
@@ -35247,7 +34992,11 @@ in
               })
               sources."extend-3.0.0"
               sources."forever-agent-0.6.1"
-              sources."form-data-1.0.1"
+              (sources."form-data-2.0.0" // {
+                dependencies = [
+                  sources."asynckit-0.4.0"
+                ];
+              })
               (sources."har-validator-2.0.6" // {
                 dependencies = [
                   (sources."chalk-1.1.3" // {
@@ -35272,7 +35021,7 @@ in
                       sources."graceful-readlink-1.0.1"
                     ];
                   })
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -35309,21 +35058,17 @@ in
                       sources."verror-1.3.6"
                     ];
                   })
-                  (sources."sshpk-1.10.0" // {
+                  (sources."sshpk-1.10.1" // {
                     dependencies = [
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.0"
                       sources."getpass-0.1.6"
                       sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
+                      sources."tweetnacl-0.14.3"
                       sources."jodid25519-1.0.2"
                       sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
+                      sources."bcrypt-pbkdf-1.0.0"
                     ];
                   })
                 ];
@@ -35331,9 +35076,9 @@ in
               sources."is-typedarray-1.0.0"
               sources."isstream-0.1.2"
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."node-uuid-1.4.7"
@@ -35431,7 +35176,7 @@ in
       })
       (sources."rimraf-2.5.4" // {
         dependencies = [
-          (sources."glob-7.0.6" // {
+          (sources."glob-7.1.0" // {
             dependencies = [
               sources."fs.realpath-1.0.0"
               (sources."inflight-1.0.5" // {
@@ -35722,7 +35467,7 @@ in
               })
               (sources."load-json-file-1.1.0" // {
                 dependencies = [
-                  sources."graceful-fs-4.1.6"
+                  sources."graceful-fs-4.1.9"
                   (sources."parse-json-2.2.0" // {
                     dependencies = [
                       (sources."error-ex-1.3.0" // {
@@ -35765,7 +35510,7 @@ in
                 dependencies = [
                   (sources."load-json-file-1.1.0" // {
                     dependencies = [
-                      sources."graceful-fs-4.1.6"
+                      sources."graceful-fs-4.1.9"
                       (sources."parse-json-2.2.0" // {
                         dependencies = [
                           (sources."error-ex-1.3.0" // {
@@ -35810,7 +35555,7 @@ in
                   })
                   (sources."path-type-1.1.0" // {
                     dependencies = [
-                      sources."graceful-fs-4.1.6"
+                      sources."graceful-fs-4.1.9"
                       sources."pify-2.3.0"
                       (sources."pinkie-promise-2.0.1" // {
                         dependencies = [
@@ -35932,13 +35677,13 @@ in
           })
           (sources."fs-extra-0.26.7" // {
             dependencies = [
-              sources."graceful-fs-4.1.6"
-              sources."jsonfile-2.3.1"
+              sources."graceful-fs-4.1.9"
+              sources."jsonfile-2.4.0"
               sources."klaw-1.3.0"
               sources."path-is-absolute-1.0.0"
               (sources."rimraf-2.5.4" // {
                 dependencies = [
-                  (sources."glob-7.0.6" // {
+                  (sources."glob-7.1.0" // {
                     dependencies = [
                       sources."fs.realpath-1.0.0"
                       (sources."inflight-1.0.5" // {
@@ -36003,15 +35748,15 @@ in
                 dependencies = [
                   (sources."async-2.0.1" // {
                     dependencies = [
-                      sources."lodash-4.15.0"
+                      sources."lodash-4.16.2"
                     ];
                   })
                 ];
               })
               sources."json-stringify-safe-5.0.1"
-              (sources."mime-types-2.1.11" // {
+              (sources."mime-types-2.1.12" // {
                 dependencies = [
-                  sources."mime-db-1.23.0"
+                  sources."mime-db-1.24.0"
                 ];
               })
               sources."node-uuid-1.4.7"
@@ -36028,21 +35773,17 @@ in
                       sources."verror-1.3.6"
                     ];
                   })
-                  (sources."sshpk-1.10.0" // {
+                  (sources."sshpk-1.10.1" // {
                     dependencies = [
                       sources."asn1-0.2.3"
                       sources."assert-plus-1.0.0"
                       sources."dashdash-1.14.0"
                       sources."getpass-0.1.6"
                       sources."jsbn-0.1.0"
-                      sources."tweetnacl-0.13.3"
+                      sources."tweetnacl-0.14.3"
                       sources."jodid25519-1.0.2"
                       sources."ecc-jsbn-0.1.1"
-                      (sources."bcrypt-pbkdf-1.0.0" // {
-                        dependencies = [
-                          sources."tweetnacl-0.14.3"
-                        ];
-                      })
+                      sources."bcrypt-pbkdf-1.0.0"
                     ];
                   })
                 ];
@@ -36089,7 +35830,7 @@ in
                       sources."graceful-readlink-1.0.1"
                     ];
                   })
-                  (sources."is-my-json-valid-2.13.1" // {
+                  (sources."is-my-json-valid-2.14.0" // {
                     dependencies = [
                       sources."generate-function-2.0.0"
                       (sources."generate-object-property-1.2.0" // {
@@ -36122,7 +35863,7 @@ in
           })
         ];
       })
-      (sources."tmp-0.0.28" // {
+      (sources."tmp-0.0.29" // {
         dependencies = [
           sources."os-tmpdir-1.0.1"
         ];
@@ -36155,7 +35896,7 @@ in
       (sources."enhanced-resolve-0.9.1" // {
         dependencies = [
           sources."memory-fs-0.2.0"
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
         ];
       })
       sources."acorn-3.3.0"
@@ -36203,7 +35944,7 @@ in
           })
           (sources."buffer-4.9.1" // {
             dependencies = [
-              sources."base64-js-1.1.2"
+              sources."base64-js-1.2.0"
               sources."ieee754-1.1.6"
               sources."isarray-1.0.0"
             ];
@@ -36515,7 +36256,7 @@ in
                           sources."strip-json-comments-1.0.4"
                         ];
                       })
-                      (sources."request-2.74.0" // {
+                      (sources."request-2.75.0" // {
                         dependencies = [
                           sources."aws-sign2-0.6.0"
                           sources."aws4-1.4.1"
@@ -36540,13 +36281,9 @@ in
                           })
                           sources."extend-3.0.0"
                           sources."forever-agent-0.6.1"
-                          (sources."form-data-1.0.1" // {
+                          (sources."form-data-2.0.0" // {
                             dependencies = [
-                              (sources."async-2.0.1" // {
-                                dependencies = [
-                                  sources."lodash-4.15.0"
-                                ];
-                              })
+                              sources."asynckit-0.4.0"
                             ];
                           })
                           (sources."har-validator-2.0.6" // {
@@ -36573,7 +36310,7 @@ in
                                   sources."graceful-readlink-1.0.1"
                                 ];
                               })
-                              (sources."is-my-json-valid-2.13.1" // {
+                              (sources."is-my-json-valid-2.14.0" // {
                                 dependencies = [
                                   sources."generate-function-2.0.0"
                                   (sources."generate-object-property-1.2.0" // {
@@ -36610,21 +36347,17 @@ in
                                   sources."verror-1.3.6"
                                 ];
                               })
-                              (sources."sshpk-1.10.0" // {
+                              (sources."sshpk-1.10.1" // {
                                 dependencies = [
                                   sources."asn1-0.2.3"
                                   sources."assert-plus-1.0.0"
                                   sources."dashdash-1.14.0"
                                   sources."getpass-0.1.6"
                                   sources."jsbn-0.1.0"
-                                  sources."tweetnacl-0.13.3"
+                                  sources."tweetnacl-0.14.3"
                                   sources."jodid25519-1.0.2"
                                   sources."ecc-jsbn-0.1.1"
-                                  (sources."bcrypt-pbkdf-1.0.0" // {
-                                    dependencies = [
-                                      sources."tweetnacl-0.14.3"
-                                    ];
-                                  })
+                                  sources."bcrypt-pbkdf-1.0.0"
                                 ];
                               })
                             ];
@@ -36632,9 +36365,9 @@ in
                           sources."is-typedarray-1.0.0"
                           sources."isstream-0.1.2"
                           sources."json-stringify-safe-5.0.1"
-                          (sources."mime-types-2.1.11" // {
+                          (sources."mime-types-2.1.12" // {
                             dependencies = [
-                              sources."mime-db-1.23.0"
+                              sources."mime-db-1.24.0"
                             ];
                           })
                           sources."node-uuid-1.4.7"
@@ -36647,7 +36380,7 @@ in
                       })
                       (sources."rimraf-2.5.4" // {
                         dependencies = [
-                          (sources."glob-7.0.6" // {
+                          (sources."glob-7.1.0" // {
                             dependencies = [
                               sources."fs.realpath-1.0.0"
                               (sources."inflight-1.0.5" // {
@@ -36727,7 +36460,7 @@ in
               })
             ];
           })
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
         ];
       })
       (sources."webpack-core-0.6.8" // {

--- a/pkgs/development/node-packages/node-packages-v5.nix
+++ b/pkgs/development/node-packages/node-packages-v5.nix
@@ -391,13 +391,13 @@ let
         sha1 = "6c9edcb11ced4f0dd2f2d40db0d49a109c088aab";
       };
     };
-    "azure-common-0.9.17" = {
+    "azure-common-0.9.18" = {
       name = "azure-common";
       packageName = "azure-common";
-      version = "0.9.17";
+      version = "0.9.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-common/-/azure-common-0.9.17.tgz";
-        sha1 = "8f8df41ccb4a026b670645f223e41e1a7f42f33f";
+        url = "https://registry.npmjs.org/azure-common/-/azure-common-0.9.18.tgz";
+        sha1 = "38b960f4ddadd44d34f52e8b85d5d1e0226440fd";
       };
     };
     "azure-arm-authorization-2.0.0" = {
@@ -481,13 +481,13 @@ let
         sha1 = "937f87a8aeceb641a8210a9ba837323f0206eb47";
       };
     };
-    "azure-arm-network-0.16.0" = {
+    "azure-arm-network-0.17.0" = {
       name = "azure-arm-network";
       packageName = "azure-arm-network";
-      version = "0.16.0";
+      version = "0.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-network/-/azure-arm-network-0.16.0.tgz";
-        sha1 = "df1bd296fb52742af7596db025cbdd1491391f3d";
+        url = "https://registry.npmjs.org/azure-arm-network/-/azure-arm-network-0.17.0.tgz";
+        sha1 = "97371f42301b40d56757f340c0dd0ed34984cdd6";
       };
     };
     "azure-arm-powerbiembedded-0.1.0" = {
@@ -562,13 +562,13 @@ let
         sha1 = "76604b8d2ad7b881f6ff53a37e37365481ca8c40";
       };
     };
-    "azure-graph-1.0.1" = {
+    "azure-graph-1.1.1" = {
       name = "azure-graph";
       packageName = "azure-graph";
-      version = "1.0.1";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-graph/-/azure-graph-1.0.1.tgz";
-        sha1 = "a2eda330ccd336832b190da0caba9735a73aee97";
+        url = "https://registry.npmjs.org/azure-graph/-/azure-graph-1.1.1.tgz";
+        sha1 = "5277e750d223aec0fd2559e49149777fe1371708";
       };
     };
     "azure-gallery-2.0.0-pre.18" = {
@@ -706,13 +706,13 @@ let
         sha1 = "bfd0c01a8ae6afd90eaa13360976242e28459650";
       };
     };
-    "azure-storage-1.1.0" = {
+    "azure-storage-1.3.0" = {
       name = "azure-storage";
       packageName = "azure-storage";
-      version = "1.1.0";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-storage/-/azure-storage-1.1.0.tgz";
-        sha1 = "45de61074dbddf44f9245ad287c929541ae971ab";
+        url = "https://registry.npmjs.org/azure-storage/-/azure-storage-1.3.0.tgz";
+        sha1 = "314c66699211cd065bb4f7ec98f27b2e533b48ce";
       };
     };
     "azure-arm-batch-0.2.0" = {
@@ -724,13 +724,22 @@ let
         sha1 = "4093c10422565b9b2564db449b5b2d6bb3e2646d";
       };
     };
-    "azure-batch-0.5.0" = {
+    "azure-batch-0.5.2" = {
       name = "azure-batch";
       packageName = "azure-batch";
-      version = "0.5.0";
+      version = "0.5.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-batch/-/azure-batch-0.5.0.tgz";
-        sha1 = "1fbc1ab0f976ad3f16c5879ba95d4751e9d5bf56";
+        url = "https://registry.npmjs.org/azure-batch/-/azure-batch-0.5.2.tgz";
+        sha1 = "21b23f9db7f42734e97f35bd703818a1cf2492eb";
+      };
+    };
+    "azure-servicefabric-0.1.4" = {
+      name = "azure-servicefabric";
+      packageName = "azure-servicefabric";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/azure-servicefabric/-/azure-servicefabric-0.1.4.tgz";
+        sha1 = "7f8d7e7949202e599638fd8abba8f1dc1a89f79e";
       };
     };
     "applicationinsights-0.15.12" = {
@@ -832,6 +841,15 @@ let
         sha1 = "5737045085f55eb455c68b1ff4ebc01bd50e8830";
       };
     };
+    "jsonminify-0.4.1" = {
+      name = "jsonminify";
+      packageName = "jsonminify";
+      version = "0.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsonminify/-/jsonminify-0.4.1.tgz";
+        sha1 = "805dafbb39395188cee9ab582c81ef959d7e710c";
+      };
+    };
     "jsrsasign-4.8.2" = {
       name = "jsrsasign";
       packageName = "jsrsasign";
@@ -850,13 +868,13 @@ let
         sha1 = "412beb19e5cf7937b461bb7897fd98c2b95d4e10";
       };
     };
-    "moment-2.15.0" = {
+    "moment-2.15.1" = {
       name = "moment";
       packageName = "moment";
-      version = "2.15.0";
+      version = "2.15.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/moment/-/moment-2.15.0.tgz";
-        sha1 = "cc9e33958bf4a99dea7111d5e62ed3c13fc96440";
+        url = "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz";
+        sha1 = "e979c2a29e22888e60f396f2220a6118f85cd94c";
       };
     };
     "ms-rest-1.15.0" = {
@@ -1345,15 +1363,6 @@ let
         sha1 = "b0220c02de98617433b72851cf47de3df2cdbee9";
       };
     };
-    "request-2.72.0" = {
-      name = "request";
-      packageName = "request";
-      version = "2.72.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.72.0.tgz";
-        sha1 = "0ce3a179512620b10441f14c82e21c12c0ddb4e1";
-      };
-    };
     "validator-3.22.2" = {
       name = "validator";
       packageName = "validator";
@@ -1388,591 +1397,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sax/-/sax-0.5.2.tgz";
         sha1 = "735ffaa39a1cff8ffb9598f0223abdb03a9fb2ea";
-      };
-    };
-    "aws-sign2-0.6.0" = {
-      name = "aws-sign2";
-      packageName = "aws-sign2";
-      version = "0.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz";
-        sha1 = "14342dd38dbcc94d0e5b87d763cd63612c0e794f";
-      };
-    };
-    "aws4-1.4.1" = {
-      name = "aws4";
-      packageName = "aws4";
-      version = "1.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz";
-        sha1 = "fde7d5292466d230e5ee0f4e038d9dfaab08fc61";
-      };
-    };
-    "bl-1.1.2" = {
-      name = "bl";
-      packageName = "bl";
-      version = "1.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz";
-        sha1 = "fdca871a99713aa00d19e3bbba41c44787a65398";
-      };
-    };
-    "caseless-0.11.0" = {
-      name = "caseless";
-      packageName = "caseless";
-      version = "0.11.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz";
-        sha1 = "715b96ea9841593cc33067923f5ec60ebda4f7d7";
-      };
-    };
-    "combined-stream-1.0.5" = {
-      name = "combined-stream";
-      packageName = "combined-stream";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz";
-        sha1 = "938370a57b4a51dea2c77c15d5c5fdf895164009";
-      };
-    };
-    "extend-3.0.0" = {
-      name = "extend";
-      packageName = "extend";
-      version = "3.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz";
-        sha1 = "5a474353b9f3353ddd8176dfd37b91c83a46f1d4";
-      };
-    };
-    "forever-agent-0.6.1" = {
-      name = "forever-agent";
-      packageName = "forever-agent";
-      version = "0.6.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz";
-        sha1 = "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91";
-      };
-    };
-    "form-data-1.0.1" = {
-      name = "form-data";
-      packageName = "form-data";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz";
-        sha1 = "ae315db9a4907fa065502304a66d7733475ee37c";
-      };
-    };
-    "har-validator-2.0.6" = {
-      name = "har-validator";
-      packageName = "har-validator";
-      version = "2.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz";
-        sha1 = "cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d";
-      };
-    };
-    "hawk-3.1.3" = {
-      name = "hawk";
-      packageName = "hawk";
-      version = "3.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz";
-        sha1 = "078444bd7c1640b0fe540d2c9b73d59678e8e1c4";
-      };
-    };
-    "http-signature-1.1.1" = {
-      name = "http-signature";
-      packageName = "http-signature";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz";
-        sha1 = "df72e267066cd0ac67fb76adf8e134a8fbcf91bf";
-      };
-    };
-    "is-typedarray-1.0.0" = {
-      name = "is-typedarray";
-      packageName = "is-typedarray";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz";
-        sha1 = "e479c80858df0c1b11ddda6940f96011fcda4a9a";
-      };
-    };
-    "isstream-0.1.2" = {
-      name = "isstream";
-      packageName = "isstream";
-      version = "0.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz";
-        sha1 = "47e63f7af55afa6f92e1500e690eb8b8529c099a";
-      };
-    };
-    "json-stringify-safe-5.0.1" = {
-      name = "json-stringify-safe";
-      packageName = "json-stringify-safe";
-      version = "5.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz";
-        sha1 = "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb";
-      };
-    };
-    "mime-types-2.1.11" = {
-      name = "mime-types";
-      packageName = "mime-types";
-      version = "2.1.11";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz";
-        sha1 = "c259c471bda808a85d6cd193b430a5fae4473b3c";
-      };
-    };
-    "oauth-sign-0.8.2" = {
-      name = "oauth-sign";
-      packageName = "oauth-sign";
-      version = "0.8.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz";
-        sha1 = "46a6ab7f0aead8deae9ec0565780b7d4efeb9d43";
-      };
-    };
-    "qs-6.1.0" = {
-      name = "qs";
-      packageName = "qs";
-      version = "6.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz";
-        sha1 = "ec1d1626b24278d99f0fdf4549e524e24eceeb26";
-      };
-    };
-    "stringstream-0.0.5" = {
-      name = "stringstream";
-      packageName = "stringstream";
-      version = "0.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz";
-        sha1 = "4e484cd4de5a0bbbee18e46307710a8a81621878";
-      };
-    };
-    "tough-cookie-2.2.2" = {
-      name = "tough-cookie";
-      packageName = "tough-cookie";
-      version = "2.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz";
-        sha1 = "c83a1830f4e5ef0b93ef2a3488e724f8de016ac7";
-      };
-    };
-    "tunnel-agent-0.4.3" = {
-      name = "tunnel-agent";
-      packageName = "tunnel-agent";
-      version = "0.4.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz";
-        sha1 = "6373db76909fe570e08d73583365ed828a74eeeb";
-      };
-    };
-    "readable-stream-2.0.6" = {
-      name = "readable-stream";
-      packageName = "readable-stream";
-      version = "2.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz";
-        sha1 = "8f90341e68a53ccc928788dacfcd11b36eb9b78e";
-      };
-    };
-    "isarray-1.0.0" = {
-      name = "isarray";
-      packageName = "isarray";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz";
-        sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
-      };
-    };
-    "process-nextick-args-1.0.7" = {
-      name = "process-nextick-args";
-      packageName = "process-nextick-args";
-      version = "1.0.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz";
-        sha1 = "150e20b756590ad3f91093f25a4f2ad8bff30ba3";
-      };
-    };
-    "util-deprecate-1.0.2" = {
-      name = "util-deprecate";
-      packageName = "util-deprecate";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
-        sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
-      };
-    };
-    "delayed-stream-1.0.0" = {
-      name = "delayed-stream";
-      packageName = "delayed-stream";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz";
-        sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
-      };
-    };
-    "async-2.0.1" = {
-      name = "async";
-      packageName = "async";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/async/-/async-2.0.1.tgz";
-        sha1 = "b709cc0280a9c36f09f4536be823c838a9049e25";
-      };
-    };
-    "lodash-4.15.0" = {
-      name = "lodash";
-      packageName = "lodash";
-      version = "4.15.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz";
-        sha1 = "3162391d8f0140aa22cf8f6b3c34d6b7f63d3aa9";
-      };
-    };
-    "chalk-1.1.3" = {
-      name = "chalk";
-      packageName = "chalk";
-      version = "1.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz";
-        sha1 = "a8115c55e4a702fe4d150abd3872822a7e09fc98";
-      };
-    };
-    "commander-2.9.0" = {
-      name = "commander";
-      packageName = "commander";
-      version = "2.9.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz";
-        sha1 = "9c99094176e12240cb22d6c5146098400fe0f7d4";
-      };
-    };
-    "is-my-json-valid-2.13.1" = {
-      name = "is-my-json-valid";
-      packageName = "is-my-json-valid";
-      version = "2.13.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz";
-        sha1 = "d55778a82feb6b0963ff4be111d5d1684e890707";
-      };
-    };
-    "pinkie-promise-2.0.1" = {
-      name = "pinkie-promise";
-      packageName = "pinkie-promise";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz";
-        sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
-      };
-    };
-    "ansi-styles-2.2.1" = {
-      name = "ansi-styles";
-      packageName = "ansi-styles";
-      version = "2.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz";
-        sha1 = "b432dd3358b634cf75e1e4664368240533c1ddbe";
-      };
-    };
-    "escape-string-regexp-1.0.5" = {
-      name = "escape-string-regexp";
-      packageName = "escape-string-regexp";
-      version = "1.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
-        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
-      };
-    };
-    "has-ansi-2.0.0" = {
-      name = "has-ansi";
-      packageName = "has-ansi";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz";
-        sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
-      };
-    };
-    "strip-ansi-3.0.1" = {
-      name = "strip-ansi";
-      packageName = "strip-ansi";
-      version = "3.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz";
-        sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
-      };
-    };
-    "supports-color-2.0.0" = {
-      name = "supports-color";
-      packageName = "supports-color";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz";
-        sha1 = "535d045ce6b6363fa40117084629995e9df324c7";
-      };
-    };
-    "ansi-regex-2.0.0" = {
-      name = "ansi-regex";
-      packageName = "ansi-regex";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz";
-        sha1 = "c5061b6e0ef8a81775e50f5d66151bf6bf371107";
-      };
-    };
-    "graceful-readlink-1.0.1" = {
-      name = "graceful-readlink";
-      packageName = "graceful-readlink";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz";
-        sha1 = "4cafad76bc62f02fa039b2f94e9a3dd3a391a725";
-      };
-    };
-    "generate-function-2.0.0" = {
-      name = "generate-function";
-      packageName = "generate-function";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz";
-        sha1 = "6858fe7c0969b7d4e9093337647ac79f60dfbe74";
-      };
-    };
-    "generate-object-property-1.2.0" = {
-      name = "generate-object-property";
-      packageName = "generate-object-property";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz";
-        sha1 = "9c0e1c40308ce804f4783618b937fa88f99d50d0";
-      };
-    };
-    "jsonpointer-2.0.0" = {
-      name = "jsonpointer";
-      packageName = "jsonpointer";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz";
-        sha1 = "3af1dd20fe85463910d469a385e33017d2a030d9";
-      };
-    };
-    "xtend-4.0.1" = {
-      name = "xtend";
-      packageName = "xtend";
-      version = "4.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz";
-        sha1 = "a5c6d532be656e23db820efb943a1f04998d63af";
-      };
-    };
-    "is-property-1.0.2" = {
-      name = "is-property";
-      packageName = "is-property";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz";
-        sha1 = "57fe1c4e48474edd65b09911f26b1cd4095dda84";
-      };
-    };
-    "pinkie-2.0.4" = {
-      name = "pinkie";
-      packageName = "pinkie";
-      version = "2.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz";
-        sha1 = "72556b80cfa0d48a974e80e77248e80ed4f7f870";
-      };
-    };
-    "hoek-2.16.3" = {
-      name = "hoek";
-      packageName = "hoek";
-      version = "2.16.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz";
-        sha1 = "20bb7403d3cea398e91dc4710a8ff1b8274a25ed";
-      };
-    };
-    "boom-2.10.1" = {
-      name = "boom";
-      packageName = "boom";
-      version = "2.10.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz";
-        sha1 = "39c8918ceff5799f83f9492a848f625add0c766f";
-      };
-    };
-    "cryptiles-2.0.5" = {
-      name = "cryptiles";
-      packageName = "cryptiles";
-      version = "2.0.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz";
-        sha1 = "3bdfecdc608147c1c67202fa291e7dca59eaa3b8";
-      };
-    };
-    "sntp-1.0.9" = {
-      name = "sntp";
-      packageName = "sntp";
-      version = "1.0.9";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz";
-        sha1 = "6541184cc90aeea6c6e7b35e2659082443c66198";
-      };
-    };
-    "assert-plus-0.2.0" = {
-      name = "assert-plus";
-      packageName = "assert-plus";
-      version = "0.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz";
-        sha1 = "d74e1b87e7affc0db8aadb7021f3fe48101ab234";
-      };
-    };
-    "jsprim-1.3.1" = {
-      name = "jsprim";
-      packageName = "jsprim";
-      version = "1.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz";
-        sha1 = "2a7256f70412a29ee3670aaca625994c4dcff252";
-      };
-    };
-    "sshpk-1.10.0" = {
-      name = "sshpk";
-      packageName = "sshpk";
-      version = "1.10.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz";
-        sha1 = "104d6ba2afb2ac099ab9567c0d193977f29c6dfa";
-      };
-    };
-    "extsprintf-1.0.2" = {
-      name = "extsprintf";
-      packageName = "extsprintf";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz";
-        sha1 = "e1080e0658e300b06294990cc70e1502235fd550";
-      };
-    };
-    "json-schema-0.2.3" = {
-      name = "json-schema";
-      packageName = "json-schema";
-      version = "0.2.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz";
-        sha1 = "b480c892e59a2f05954ce727bd3f2a4e882f9e13";
-      };
-    };
-    "verror-1.3.6" = {
-      name = "verror";
-      packageName = "verror";
-      version = "1.3.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz";
-        sha1 = "cff5df12946d297d2baaefaa2689e25be01c005c";
-      };
-    };
-    "asn1-0.2.3" = {
-      name = "asn1";
-      packageName = "asn1";
-      version = "0.2.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz";
-        sha1 = "dac8787713c9966849fc8180777ebe9c1ddf3b86";
-      };
-    };
-    "assert-plus-1.0.0" = {
-      name = "assert-plus";
-      packageName = "assert-plus";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz";
-        sha1 = "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525";
-      };
-    };
-    "dashdash-1.14.0" = {
-      name = "dashdash";
-      packageName = "dashdash";
-      version = "1.14.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz";
-        sha1 = "29e486c5418bf0f356034a993d51686a33e84141";
-      };
-    };
-    "getpass-0.1.6" = {
-      name = "getpass";
-      packageName = "getpass";
-      version = "0.1.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz";
-        sha1 = "283ffd9fc1256840875311c1b60e8c40187110e6";
-      };
-    };
-    "jsbn-0.1.0" = {
-      name = "jsbn";
-      packageName = "jsbn";
-      version = "0.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz";
-        sha1 = "650987da0dd74f4ebf5a11377a2aa2d273e97dfd";
-      };
-    };
-    "tweetnacl-0.13.3" = {
-      name = "tweetnacl";
-      packageName = "tweetnacl";
-      version = "0.13.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz";
-        sha1 = "d628b56f3bcc3d5ae74ba9d4c1a704def5ab4b56";
-      };
-    };
-    "jodid25519-1.0.2" = {
-      name = "jodid25519";
-      packageName = "jodid25519";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz";
-        sha1 = "06d4912255093419477d425633606e0e90782967";
-      };
-    };
-    "ecc-jsbn-0.1.1" = {
-      name = "ecc-jsbn";
-      packageName = "ecc-jsbn";
-      version = "0.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz";
-        sha1 = "0fc73a9ed5f0d53c38193398523ef7e543777505";
-      };
-    };
-    "bcrypt-pbkdf-1.0.0" = {
-      name = "bcrypt-pbkdf";
-      packageName = "bcrypt-pbkdf";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz";
-        sha1 = "3ca76b85241c7170bf7d9703e7b9aa74630040d4";
-      };
-    };
-    "tweetnacl-0.14.3" = {
-      name = "tweetnacl";
-      packageName = "tweetnacl";
-      version = "0.14.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz";
-        sha1 = "3da382f670f25ded78d7b3d1792119bca0b7132d";
-      };
-    };
-    "mime-db-1.23.0" = {
-      name = "mime-db";
-      packageName = "mime-db";
-      version = "1.23.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz";
-        sha1 = "a31b4070adaea27d732ea333740a64d0ec9a6659";
       };
     };
     "moment-2.6.0" = {
@@ -2020,13 +1444,13 @@ let
         sha1 = "1e60b0fef1bc0af67bc0d146dfdde5486cd615b4";
       };
     };
-    "request-2.69.0" = {
-      name = "request";
-      packageName = "request";
-      version = "2.69.0";
+    "readable-stream-2.0.6" = {
+      name = "readable-stream";
+      packageName = "readable-stream";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/request/-/request-2.69.0.tgz";
-        sha1 = "cf91d2e000752b1217155c005241911991a2346a";
+        url = "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz";
+        sha1 = "8f90341e68a53ccc928788dacfcd11b36eb9b78e";
       };
     };
     "jsonparse-1.2.0" = {
@@ -2038,22 +1462,31 @@ let
         sha1 = "5c0c5685107160e72fe7489bddea0b44c2bc67bd";
       };
     };
-    "bl-1.0.3" = {
-      name = "bl";
-      packageName = "bl";
-      version = "1.0.3";
+    "isarray-1.0.0" = {
+      name = "isarray";
+      packageName = "isarray";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz";
-        sha1 = "fc5421a28fd4226036c3b3891a66a25bc64d226e";
+        url = "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz";
+        sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
       };
     };
-    "qs-6.0.2" = {
-      name = "qs";
-      packageName = "qs";
-      version = "6.0.2";
+    "process-nextick-args-1.0.7" = {
+      name = "process-nextick-args";
+      packageName = "process-nextick-args";
+      version = "1.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz";
-        sha1 = "88c68d590e8ed56c76c79f352c17b982466abfcd";
+        url = "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz";
+        sha1 = "150e20b756590ad3f91093f25a4f2ad8bff30ba3";
+      };
+    };
+    "util-deprecate-1.0.2" = {
+      name = "util-deprecate";
+      packageName = "util-deprecate";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
+        sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
       };
     };
     "stack-trace-0.0.9" = {
@@ -2272,13 +1705,13 @@ let
         sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
       };
     };
-    "glob-7.0.6" = {
+    "glob-7.1.0" = {
       name = "glob";
       packageName = "glob";
-      version = "7.0.6";
+      version = "7.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz";
-        sha1 = "211bafaf49e525b8cd93260d14ab136152b3f57a";
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz";
+        sha1 = "36add856d746d0d99e4cc2797bba1ae2c67272fd";
       };
     };
     "fs.realpath-1.0.0" = {
@@ -2380,6 +1813,15 @@ let
         sha1 = "21e80b2be8580f98b468f379430662b046c34ad2";
       };
     };
+    "isstream-0.1.2" = {
+      name = "isstream";
+      packageName = "isstream";
+      version = "0.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz";
+        sha1 = "47e63f7af55afa6f92e1500e690eb8b8529c099a";
+      };
+    };
     "pkginfo-0.3.1" = {
       name = "pkginfo";
       packageName = "pkginfo";
@@ -2387,6 +1829,141 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz";
         sha1 = "5b29f6a81f70717142e09e765bbeab97b4f81e21";
+      };
+    };
+    "aws-sign2-0.6.0" = {
+      name = "aws-sign2";
+      packageName = "aws-sign2";
+      version = "0.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz";
+        sha1 = "14342dd38dbcc94d0e5b87d763cd63612c0e794f";
+      };
+    };
+    "aws4-1.4.1" = {
+      name = "aws4";
+      packageName = "aws4";
+      version = "1.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz";
+        sha1 = "fde7d5292466d230e5ee0f4e038d9dfaab08fc61";
+      };
+    };
+    "bl-1.1.2" = {
+      name = "bl";
+      packageName = "bl";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz";
+        sha1 = "fdca871a99713aa00d19e3bbba41c44787a65398";
+      };
+    };
+    "caseless-0.11.0" = {
+      name = "caseless";
+      packageName = "caseless";
+      version = "0.11.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz";
+        sha1 = "715b96ea9841593cc33067923f5ec60ebda4f7d7";
+      };
+    };
+    "combined-stream-1.0.5" = {
+      name = "combined-stream";
+      packageName = "combined-stream";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz";
+        sha1 = "938370a57b4a51dea2c77c15d5c5fdf895164009";
+      };
+    };
+    "extend-3.0.0" = {
+      name = "extend";
+      packageName = "extend";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz";
+        sha1 = "5a474353b9f3353ddd8176dfd37b91c83a46f1d4";
+      };
+    };
+    "forever-agent-0.6.1" = {
+      name = "forever-agent";
+      packageName = "forever-agent";
+      version = "0.6.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz";
+        sha1 = "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91";
+      };
+    };
+    "form-data-1.0.1" = {
+      name = "form-data";
+      packageName = "form-data";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz";
+        sha1 = "ae315db9a4907fa065502304a66d7733475ee37c";
+      };
+    };
+    "har-validator-2.0.6" = {
+      name = "har-validator";
+      packageName = "har-validator";
+      version = "2.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz";
+        sha1 = "cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d";
+      };
+    };
+    "hawk-3.1.3" = {
+      name = "hawk";
+      packageName = "hawk";
+      version = "3.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz";
+        sha1 = "078444bd7c1640b0fe540d2c9b73d59678e8e1c4";
+      };
+    };
+    "http-signature-1.1.1" = {
+      name = "http-signature";
+      packageName = "http-signature";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz";
+        sha1 = "df72e267066cd0ac67fb76adf8e134a8fbcf91bf";
+      };
+    };
+    "is-typedarray-1.0.0" = {
+      name = "is-typedarray";
+      packageName = "is-typedarray";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz";
+        sha1 = "e479c80858df0c1b11ddda6940f96011fcda4a9a";
+      };
+    };
+    "json-stringify-safe-5.0.1" = {
+      name = "json-stringify-safe";
+      packageName = "json-stringify-safe";
+      version = "5.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz";
+        sha1 = "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb";
+      };
+    };
+    "mime-types-2.1.12" = {
+      name = "mime-types";
+      packageName = "mime-types";
+      version = "2.1.12";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz";
+        sha1 = "152ba256777020dd4663f54c2e7bc26381e71729";
+      };
+    };
+    "oauth-sign-0.8.2" = {
+      name = "oauth-sign";
+      packageName = "oauth-sign";
+      version = "0.8.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz";
+        sha1 = "46a6ab7f0aead8deae9ec0565780b7d4efeb9d43";
       };
     };
     "qs-6.2.1" = {
@@ -2398,6 +1975,15 @@ let
         sha1 = "ce03c5ff0935bc1d9d69a9f14cbd18e568d67625";
       };
     };
+    "stringstream-0.0.5" = {
+      name = "stringstream";
+      packageName = "stringstream";
+      version = "0.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz";
+        sha1 = "4e484cd4de5a0bbbee18e46307710a8a81621878";
+      };
+    };
     "tough-cookie-2.3.1" = {
       name = "tough-cookie";
       packageName = "tough-cookie";
@@ -2405,6 +1991,375 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz";
         sha1 = "99c77dfbb7d804249e8a299d4cb0fd81fef083fd";
+      };
+    };
+    "tunnel-agent-0.4.3" = {
+      name = "tunnel-agent";
+      packageName = "tunnel-agent";
+      version = "0.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz";
+        sha1 = "6373db76909fe570e08d73583365ed828a74eeeb";
+      };
+    };
+    "delayed-stream-1.0.0" = {
+      name = "delayed-stream";
+      packageName = "delayed-stream";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz";
+        sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
+      };
+    };
+    "async-2.0.1" = {
+      name = "async";
+      packageName = "async";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async/-/async-2.0.1.tgz";
+        sha1 = "b709cc0280a9c36f09f4536be823c838a9049e25";
+      };
+    };
+    "lodash-4.16.2" = {
+      name = "lodash";
+      packageName = "lodash";
+      version = "4.16.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz";
+        sha1 = "3e626db827048a699281a8a125226326cfc0e652";
+      };
+    };
+    "chalk-1.1.3" = {
+      name = "chalk";
+      packageName = "chalk";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz";
+        sha1 = "a8115c55e4a702fe4d150abd3872822a7e09fc98";
+      };
+    };
+    "commander-2.9.0" = {
+      name = "commander";
+      packageName = "commander";
+      version = "2.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz";
+        sha1 = "9c99094176e12240cb22d6c5146098400fe0f7d4";
+      };
+    };
+    "is-my-json-valid-2.14.0" = {
+      name = "is-my-json-valid";
+      packageName = "is-my-json-valid";
+      version = "2.14.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz";
+        sha1 = "47bf808609b2df5d48c969c74becd09fbca02725";
+      };
+    };
+    "pinkie-promise-2.0.1" = {
+      name = "pinkie-promise";
+      packageName = "pinkie-promise";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz";
+        sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
+      };
+    };
+    "ansi-styles-2.2.1" = {
+      name = "ansi-styles";
+      packageName = "ansi-styles";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz";
+        sha1 = "b432dd3358b634cf75e1e4664368240533c1ddbe";
+      };
+    };
+    "escape-string-regexp-1.0.5" = {
+      name = "escape-string-regexp";
+      packageName = "escape-string-regexp";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
+      };
+    };
+    "has-ansi-2.0.0" = {
+      name = "has-ansi";
+      packageName = "has-ansi";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz";
+        sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
+      };
+    };
+    "strip-ansi-3.0.1" = {
+      name = "strip-ansi";
+      packageName = "strip-ansi";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz";
+        sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
+      };
+    };
+    "supports-color-2.0.0" = {
+      name = "supports-color";
+      packageName = "supports-color";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz";
+        sha1 = "535d045ce6b6363fa40117084629995e9df324c7";
+      };
+    };
+    "ansi-regex-2.0.0" = {
+      name = "ansi-regex";
+      packageName = "ansi-regex";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz";
+        sha1 = "c5061b6e0ef8a81775e50f5d66151bf6bf371107";
+      };
+    };
+    "graceful-readlink-1.0.1" = {
+      name = "graceful-readlink";
+      packageName = "graceful-readlink";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz";
+        sha1 = "4cafad76bc62f02fa039b2f94e9a3dd3a391a725";
+      };
+    };
+    "generate-function-2.0.0" = {
+      name = "generate-function";
+      packageName = "generate-function";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz";
+        sha1 = "6858fe7c0969b7d4e9093337647ac79f60dfbe74";
+      };
+    };
+    "generate-object-property-1.2.0" = {
+      name = "generate-object-property";
+      packageName = "generate-object-property";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz";
+        sha1 = "9c0e1c40308ce804f4783618b937fa88f99d50d0";
+      };
+    };
+    "jsonpointer-2.0.0" = {
+      name = "jsonpointer";
+      packageName = "jsonpointer";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz";
+        sha1 = "3af1dd20fe85463910d469a385e33017d2a030d9";
+      };
+    };
+    "xtend-4.0.1" = {
+      name = "xtend";
+      packageName = "xtend";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz";
+        sha1 = "a5c6d532be656e23db820efb943a1f04998d63af";
+      };
+    };
+    "is-property-1.0.2" = {
+      name = "is-property";
+      packageName = "is-property";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz";
+        sha1 = "57fe1c4e48474edd65b09911f26b1cd4095dda84";
+      };
+    };
+    "pinkie-2.0.4" = {
+      name = "pinkie";
+      packageName = "pinkie";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz";
+        sha1 = "72556b80cfa0d48a974e80e77248e80ed4f7f870";
+      };
+    };
+    "hoek-2.16.3" = {
+      name = "hoek";
+      packageName = "hoek";
+      version = "2.16.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz";
+        sha1 = "20bb7403d3cea398e91dc4710a8ff1b8274a25ed";
+      };
+    };
+    "boom-2.10.1" = {
+      name = "boom";
+      packageName = "boom";
+      version = "2.10.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz";
+        sha1 = "39c8918ceff5799f83f9492a848f625add0c766f";
+      };
+    };
+    "cryptiles-2.0.5" = {
+      name = "cryptiles";
+      packageName = "cryptiles";
+      version = "2.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz";
+        sha1 = "3bdfecdc608147c1c67202fa291e7dca59eaa3b8";
+      };
+    };
+    "sntp-1.0.9" = {
+      name = "sntp";
+      packageName = "sntp";
+      version = "1.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz";
+        sha1 = "6541184cc90aeea6c6e7b35e2659082443c66198";
+      };
+    };
+    "assert-plus-0.2.0" = {
+      name = "assert-plus";
+      packageName = "assert-plus";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz";
+        sha1 = "d74e1b87e7affc0db8aadb7021f3fe48101ab234";
+      };
+    };
+    "jsprim-1.3.1" = {
+      name = "jsprim";
+      packageName = "jsprim";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz";
+        sha1 = "2a7256f70412a29ee3670aaca625994c4dcff252";
+      };
+    };
+    "sshpk-1.10.1" = {
+      name = "sshpk";
+      packageName = "sshpk";
+      version = "1.10.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz";
+        sha1 = "30e1a5d329244974a1af61511339d595af6638b0";
+      };
+    };
+    "extsprintf-1.0.2" = {
+      name = "extsprintf";
+      packageName = "extsprintf";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz";
+        sha1 = "e1080e0658e300b06294990cc70e1502235fd550";
+      };
+    };
+    "json-schema-0.2.3" = {
+      name = "json-schema";
+      packageName = "json-schema";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz";
+        sha1 = "b480c892e59a2f05954ce727bd3f2a4e882f9e13";
+      };
+    };
+    "verror-1.3.6" = {
+      name = "verror";
+      packageName = "verror";
+      version = "1.3.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz";
+        sha1 = "cff5df12946d297d2baaefaa2689e25be01c005c";
+      };
+    };
+    "asn1-0.2.3" = {
+      name = "asn1";
+      packageName = "asn1";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz";
+        sha1 = "dac8787713c9966849fc8180777ebe9c1ddf3b86";
+      };
+    };
+    "assert-plus-1.0.0" = {
+      name = "assert-plus";
+      packageName = "assert-plus";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz";
+        sha1 = "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525";
+      };
+    };
+    "dashdash-1.14.0" = {
+      name = "dashdash";
+      packageName = "dashdash";
+      version = "1.14.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz";
+        sha1 = "29e486c5418bf0f356034a993d51686a33e84141";
+      };
+    };
+    "getpass-0.1.6" = {
+      name = "getpass";
+      packageName = "getpass";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz";
+        sha1 = "283ffd9fc1256840875311c1b60e8c40187110e6";
+      };
+    };
+    "jsbn-0.1.0" = {
+      name = "jsbn";
+      packageName = "jsbn";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz";
+        sha1 = "650987da0dd74f4ebf5a11377a2aa2d273e97dfd";
+      };
+    };
+    "tweetnacl-0.14.3" = {
+      name = "tweetnacl";
+      packageName = "tweetnacl";
+      version = "0.14.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz";
+        sha1 = "3da382f670f25ded78d7b3d1792119bca0b7132d";
+      };
+    };
+    "jodid25519-1.0.2" = {
+      name = "jodid25519";
+      packageName = "jodid25519";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz";
+        sha1 = "06d4912255093419477d425633606e0e90782967";
+      };
+    };
+    "ecc-jsbn-0.1.1" = {
+      name = "ecc-jsbn";
+      packageName = "ecc-jsbn";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz";
+        sha1 = "0fc73a9ed5f0d53c38193398523ef7e543777505";
+      };
+    };
+    "bcrypt-pbkdf-1.0.0" = {
+      name = "bcrypt-pbkdf";
+      packageName = "bcrypt-pbkdf";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz";
+        sha1 = "3ca76b85241c7170bf7d9703e7b9aa74630040d4";
+      };
+    };
+    "mime-db-1.24.0" = {
+      name = "mime-db";
+      packageName = "mime-db";
+      version = "1.24.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz";
+        sha1 = "e2d13f939f0016c6e4e9ad25a8652f126c467f0c";
       };
     };
     "asn1-0.1.11" = {
@@ -2488,13 +2443,13 @@ let
         sha1 = "489654c692616b8aa55b0724fa809bb7db49c5bf";
       };
     };
-    "asap-2.0.4" = {
+    "asap-2.0.5" = {
       name = "asap";
       packageName = "asap";
-      version = "2.0.4";
+      version = "2.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz";
-        sha1 = "b391bf7f6bfbc65706022fec8f49c4b07fecf589";
+        url = "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz";
+        sha1 = "522765b50c3510490e52d7dcfe085ef9ba96958f";
       };
     };
     "async-1.0.0" = {
@@ -3064,13 +3019,13 @@ let
         sha1 = "59c44f7ee491da704da415da5a4070ba4f8fe441";
       };
     };
-    "graceful-fs-4.1.6" = {
+    "graceful-fs-4.1.9" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.1.6";
+      version = "4.1.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz";
-        sha1 = "514c38772b31bee2e08bedc21a0aeb3abf54c19e";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz";
+        sha1 = "baacba37d19d11f9d146d3578bc99958c3787e29";
       };
     };
     "parse-json-2.2.0" = {
@@ -3181,13 +3136,13 @@ let
         sha1 = "e9ff841418a6b2ec7a495e939984f78f163e6e31";
       };
     };
-    "jsonfile-2.3.1" = {
+    "jsonfile-2.4.0" = {
       name = "jsonfile";
       packageName = "jsonfile";
-      version = "2.3.1";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz";
-        sha1 = "28bcb29c596b5b7aafd34e662a329ba62cd842fc";
+        url = "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz";
+        sha1 = "3736a2b428b87bbda0cc83b53fa3d633a35c2ae8";
       };
     };
     "klaw-1.3.0" = {
@@ -3235,13 +3190,13 @@ let
         sha1 = "e439be2aaee327321952730f99a8929e4fc50582";
       };
     };
-    "JSONStream-1.1.4" = {
+    "JSONStream-1.2.1" = {
       name = "JSONStream";
       packageName = "JSONStream";
-      version = "1.1.4";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz";
-        sha1 = "be11a495938e882d277773d11986f3974a8ba37a";
+        url = "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz";
+        sha1 = "32aa5790e799481083b49b4b7fa94e23bae69bf9";
       };
     };
     "assert-1.3.0" = {
@@ -3676,13 +3631,13 @@ let
         sha1 = "f3f7522f4ef782348da8161bad9ecfd51bf83a75";
       };
     };
-    "base64-js-1.1.2" = {
+    "base64-js-1.2.0" = {
       name = "base64-js";
       packageName = "base64-js";
-      version = "1.1.2";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz";
-        sha1 = "d6400cac1c4c660976d90d07a04351d89395f5e8";
+        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz";
+        sha1 = "a39992d723584811982be5e290bb6a53d86700f1";
       };
     };
     "ieee754-1.1.6" = {
@@ -3757,13 +3712,13 @@ let
         sha1 = "b5835739270cfe26acf632099fded2a07f209e5e";
       };
     };
-    "pbkdf2-3.0.6" = {
+    "pbkdf2-3.0.8" = {
       name = "pbkdf2";
       packageName = "pbkdf2";
-      version = "3.0.6";
+      version = "3.0.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.6.tgz";
-        sha1 = "943d289ccd92b3dec55cc77dd696d44d6087e8bd";
+        url = "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.8.tgz";
+        sha1 = "2f8abf16ebecc82277945d748aba1d78761f61e2";
       };
     };
     "public-encrypt-4.0.0" = {
@@ -3865,13 +3820,13 @@ let
         sha1 = "21e0abfaf6f2029cf2fafb133567a701d4135524";
       };
     };
-    "elliptic-6.3.1" = {
+    "elliptic-6.3.2" = {
       name = "elliptic";
       packageName = "elliptic";
-      version = "6.3.1";
+      version = "6.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/elliptic/-/elliptic-6.3.1.tgz";
-        sha1 = "17781f2109ab0ec686b146bdcff5d2e8c6aeceda";
+        url = "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz";
+        sha1 = "e4c81e0829cf0a65ab70e998b8232723b5c1bc48";
       };
     };
     "parse-asn1-5.0.0" = {
@@ -3901,13 +3856,13 @@ let
         sha1 = "1332ff00156c0a0ffdd8236013d07b77a0451573";
       };
     };
-    "asn1.js-4.8.0" = {
+    "asn1.js-4.8.1" = {
       name = "asn1.js";
       packageName = "asn1.js";
-      version = "4.8.0";
+      version = "4.8.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.0.tgz";
-        sha1 = "e0e04e9923319163be46aed9e5378973b161ef13";
+        url = "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.1.tgz";
+        sha1 = "3949b7f5fd1e8bedc13be3abebf477f93490c810";
       };
     };
     "ripemd160-1.0.1" = {
@@ -4648,6 +4603,15 @@ let
         sha1 = "394288bf07c8fe16cf36bb2e40a3bb947ed24963";
       };
     };
+    "base64-js-1.1.2" = {
+      name = "base64-js";
+      packageName = "base64-js";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz";
+        sha1 = "d6400cac1c4c660976d90d07a04351d89395f5e8";
+      };
+    };
     "xmlbuilder-8.2.2" = {
       name = "xmlbuilder";
       packageName = "xmlbuilder";
@@ -4801,13 +4765,13 @@ let
         sha1 = "dabb4b17b9f06a4bbf0174b3b4b3a2cdd8e2785f";
       };
     };
-    "rusha-0.8.3" = {
+    "rusha-0.8.4" = {
       name = "rusha";
       packageName = "rusha";
-      version = "0.8.3";
+      version = "0.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rusha/-/rusha-0.8.3.tgz";
-        sha1 = "63cafec9e626ae09565ab0c4ab2cbc1f2f69b71f";
+        url = "https://registry.npmjs.org/rusha/-/rusha-0.8.4.tgz";
+        sha1 = "006599181ab437e53f3ca6bb5340f96c7a533c7b";
       };
     };
     "unzip-response-1.0.1" = {
@@ -6844,13 +6808,22 @@ let
         sha1 = "7dd79330d2abe69c10c2cef79714c97215791dfa";
       };
     };
-    "lockfile-1.0.1" = {
+    "glob-7.0.6" = {
+      name = "glob";
+      packageName = "glob";
+      version = "7.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz";
+        sha1 = "211bafaf49e525b8cd93260d14ab136152b3f57a";
+      };
+    };
+    "lockfile-1.0.2" = {
       name = "lockfile";
       packageName = "lockfile";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz";
-        sha1 = "9d353ecfe3f54d150bb57f89d51746935a39c4f5";
+        url = "https://registry.npmjs.org/lockfile/-/lockfile-1.0.2.tgz";
+        sha1 = "97e1990174f696cbe0a3acd58a43b84aa30c7c83";
       };
     };
     "lru-cache-4.0.1" = {
@@ -7175,6 +7148,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz";
         sha1 = "bd968567d61635e33c0b80727613c9cb4b096bac";
+      };
+    };
+    "request-2.75.0" = {
+      name = "request";
+      packageName = "request";
+      version = "2.75.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/request/-/request-2.75.0.tgz";
+        sha1 = "d2b8268a286da13eaa5d01adf5d18cc90f657d93";
+      };
+    };
+    "form-data-2.0.0" = {
+      name = "form-data";
+      packageName = "form-data";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz";
+        sha1 = "6f0aebadcc5da16c13e1ecc11137d85f9b883b25";
+      };
+    };
+    "asynckit-0.4.0" = {
+      name = "asynckit";
+      packageName = "asynckit";
+      version = "0.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz";
+        sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
       };
     };
     "are-we-there-yet-1.1.2" = {
@@ -7555,13 +7555,13 @@ let
         sha1 = "56970fb1c38558e9e70b728bf3de269ac45adfac";
       };
     };
-    "uuid-2.0.2" = {
+    "uuid-2.0.3" = {
       name = "uuid";
       packageName = "uuid";
-      version = "2.0.2";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz";
-        sha1 = "48bd5698f0677e3c7901a1c46ef15b1643794726";
+        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz";
+        sha1 = "67e2e863797215530dff318e5bf9dcebfd47b21a";
       };
     };
     "xdg-basedir-2.0.0" = {
@@ -8513,13 +8513,13 @@ let
         sha1 = "e1a3f4cad65fc02e25070a47d63d7b527361c1cf";
       };
     };
-    "level-sublevel-6.5.4" = {
+    "level-sublevel-6.6.0" = {
       name = "level-sublevel";
       packageName = "level-sublevel";
-      version = "6.5.4";
+      version = "6.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.5.4.tgz";
-        sha1 = "92e6534e7ac3fa35c8bdb121b8a8094a8d1c0826";
+        url = "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.0.tgz";
+        sha1 = "675f2f6a3d437b10700e840069bcb331a5c8362f";
       };
     };
     "leveldown-0.10.6" = {
@@ -8855,6 +8855,15 @@ let
         sha1 = "80ab4e919749351263ef14500d684e57c4202840";
       };
     };
+    "JSONStream-1.1.4" = {
+      name = "JSONStream";
+      packageName = "JSONStream";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.4.tgz";
+        sha1 = "be11a495938e882d277773d11986f3974a8ba37a";
+      };
+    };
     "got-6.5.0" = {
       name = "got";
       packageName = "got";
@@ -8981,13 +8990,13 @@ let
         sha1 = "e01975e812781a163a6dadfdd80398dc64c889c3";
       };
     };
-    "espree-3.1.7" = {
+    "espree-3.3.2" = {
       name = "espree";
       packageName = "espree";
-      version = "3.1.7";
+      version = "3.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz";
-        sha1 = "fd5deec76a97a5120a9cd3a7cb1177a0923b11d2";
+        url = "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz";
+        sha1 = "dbf3fadeb4ecb4d4778303e50103b3d36c88b89c";
       };
     };
     "estraverse-4.2.0" = {
@@ -9089,13 +9098,13 @@ let
         sha1 = "4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7";
       };
     };
-    "optionator-0.8.1" = {
+    "optionator-0.8.2" = {
       name = "optionator";
       packageName = "optionator";
-      version = "0.8.1";
+      version = "0.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz";
-        sha1 = "e31b4932cdd5fb862a8b0d10bc63d3ee1ec7d78b";
+        url = "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz";
+        sha1 = "364c5e409d3f4d6301d6c0b4c05bba50180aeb64";
       };
     };
     "pluralize-1.2.1" = {
@@ -9134,13 +9143,13 @@ let
         sha1 = "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3";
       };
     };
-    "table-3.7.8" = {
+    "table-3.8.0" = {
       name = "table";
       packageName = "table";
-      version = "3.7.8";
+      version = "3.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/table/-/table-3.7.8.tgz";
-        sha1 = "b424433ef596851922b2fd77224a69a1951618eb";
+        url = "https://registry.npmjs.org/table/-/table-3.8.0.tgz";
+        sha1 = "252166c7f3286684a9d561b0f3a8929caf3a997b";
       };
     };
     "es6-map-0.1.4" = {
@@ -9197,13 +9206,13 @@ let
         sha1 = "f6caca728933a850ef90661d0e17982ba47111a2";
       };
     };
-    "acorn-3.3.0" = {
+    "acorn-4.0.3" = {
       name = "acorn";
       packageName = "acorn";
-      version = "3.3.0";
+      version = "4.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz";
-        sha1 = "45e37fb39e8da3f25baee3ff5369e2bb5f22017a";
+        url = "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz";
+        sha1 = "1a3e850b428e73ba6b09d1cc527f5aaad4d03ef1";
       };
     };
     "acorn-jsx-3.0.1" = {
@@ -9213,6 +9222,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz";
         sha1 = "afdf9488fb1ecefc8348f6fb22f464e32a58b36b";
+      };
+    };
+    "acorn-3.3.0" = {
+      name = "acorn";
+      packageName = "acorn";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz";
+        sha1 = "45e37fb39e8da3f25baee3ff5369e2bb5f22017a";
       };
     };
     "flat-cache-1.2.1" = {
@@ -9341,13 +9359,13 @@ let
         sha1 = "c196b0073e6b1c595d93c9c830855b7acc32a453";
       };
     };
-    "argparse-1.0.7" = {
+    "argparse-1.0.9" = {
       name = "argparse";
       packageName = "argparse";
-      version = "1.0.7";
+      version = "1.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz";
-        sha1 = "c289506480557810f14a8bc62d7a06f63ed7f951";
+        url = "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz";
+        sha1 = "73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86";
       };
     };
     "esprima-2.7.3" = {
@@ -9395,13 +9413,13 @@ let
         sha1 = "27584810891456a4171c8d0226441ade90cbcaeb";
       };
     };
-    "fast-levenshtein-1.1.4" = {
+    "fast-levenshtein-2.0.5" = {
       name = "fast-levenshtein";
       packageName = "fast-levenshtein";
-      version = "1.1.4";
+      version = "2.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz";
-        sha1 = "e6a754cc8f15e58987aa9cbd27af66fd6f4e5af9";
+        url = "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz";
+        sha1 = "bd33145744519ab1c36c3ee9f31f08e9079b67f2";
       };
     };
     "caller-path-0.1.0" = {
@@ -9431,13 +9449,22 @@ let
         sha1 = "afab96262910a7f33c19a5775825c69f34e350ca";
       };
     };
-    "bluebird-3.4.6" = {
-      name = "bluebird";
-      packageName = "bluebird";
-      version = "3.4.6";
+    "ajv-4.7.5" = {
+      name = "ajv";
+      packageName = "ajv";
+      version = "4.7.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz";
-        sha1 = "01da8d821d87813d158967e743d5fe6c62cf8c0f";
+        url = "https://registry.npmjs.org/ajv/-/ajv-4.7.5.tgz";
+        sha1 = "f44172aec18514e6ba6350cc5fae0ee9b142e68c";
+      };
+    };
+    "ajv-keywords-1.1.1" = {
+      name = "ajv-keywords";
+      packageName = "ajv-keywords";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.1.1.tgz";
+        sha1 = "02550bc605a3e576041565628af972e06c549d50";
       };
     };
     "slice-ansi-0.0.4" = {
@@ -9449,22 +9476,13 @@ let
         sha1 = "edbf8903f66f7ce2f8eafd6ceed65e264c831b35";
       };
     };
-    "tv4-1.2.7" = {
-      name = "tv4";
-      packageName = "tv4";
-      version = "1.2.7";
+    "co-4.6.0" = {
+      name = "co";
+      packageName = "co";
+      version = "4.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz";
-        sha1 = "bd29389afc73ade49ae5f48142b5d544bf68d120";
-      };
-    };
-    "xregexp-3.1.1" = {
-      name = "xregexp";
-      packageName = "xregexp";
-      version = "3.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz";
-        sha1 = "8ee18d75ef5c7cb3f9967f8d29414a6ca5b1a184";
+        url = "https://registry.npmjs.org/co/-/co-4.6.0.tgz";
+        sha1 = "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184";
       };
     };
     "glob-3.2.11" = {
@@ -10170,13 +10188,13 @@ let
         sha1 = "a4274eeb32fa765da5a7a3b1712617ce3b144149";
       };
     };
-    "coffee-script-1.10.0" = {
+    "coffee-script-1.11.0" = {
       name = "coffee-script";
       packageName = "coffee-script";
-      version = "1.10.0";
+      version = "1.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz";
-        sha1 = "12938bcf9be1948fa006f92e0c4c9e81705108c0";
+        url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.0.tgz";
+        sha1 = "591e87f7447a53dfde33dc892db1d15b14ddd92d";
       };
     };
     "jade-1.11.0" = {
@@ -10215,13 +10233,13 @@ let
         sha1 = "c0dde4ab182713b919b970959a123ecc1a30fcd6";
       };
     };
-    "clean-css-3.4.19" = {
+    "clean-css-3.4.20" = {
       name = "clean-css";
       packageName = "clean-css";
-      version = "3.4.19";
+      version = "3.4.20";
       src = fetchurl {
-        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.19.tgz";
-        sha1 = "c32a8a13ca3b824609b14306a5da76d8793c7874";
+        url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz";
+        sha1 = "c0d8963b5448e030f0bcd3ddd0dac4dfe3dea501";
       };
     };
     "commander-2.6.0" = {
@@ -11205,13 +11223,13 @@ let
         sha1 = "1fddad938aae1263ce138680be1b3f591c0ab41c";
       };
     };
-    "eventemitter3-2.0.0" = {
+    "eventemitter3-2.0.1" = {
       name = "eventemitter3";
       packageName = "eventemitter3";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.0.tgz";
-        sha1 = "605f34e75ea702681fcd06b2f4ee2e7b4e019006";
+        url = "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.1.tgz";
+        sha1 = "59c8930b1d8f4da54ad752854948f44330e7f39c";
       };
     };
     "escodegen-1.8.1" = {
@@ -11374,6 +11392,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz";
         sha1 = "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0";
+      };
+    };
+    "bluebird-3.4.6" = {
+      name = "bluebird";
+      packageName = "bluebird";
+      version = "3.4.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz";
+        sha1 = "01da8d821d87813d158967e743d5fe6c62cf8c0f";
       };
     };
     "body-parser-1.15.2" = {
@@ -13644,6 +13671,15 @@ let
         sha1 = "aaa128e62c9b3c358094568c219ff64fe489d42a";
       };
     };
+    "bl-1.0.3" = {
+      name = "bl";
+      packageName = "bl";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz";
+        sha1 = "fc5421a28fd4226036c3b3891a66a25bc64d226e";
+      };
+    };
     "qs-5.2.1" = {
       name = "qs";
       packageName = "qs";
@@ -13651,6 +13687,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz";
         sha1 = "801fee030e0b9450d6385adc48a4cc55b44aedfc";
+      };
+    };
+    "tough-cookie-2.2.2" = {
+      name = "tough-cookie";
+      packageName = "tough-cookie";
+      version = "2.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz";
+        sha1 = "c83a1830f4e5ef0b93ef2a3488e724f8de016ac7";
       };
     };
     "http-signature-0.11.0" = {
@@ -13689,13 +13734,13 @@ let
         sha1 = "3de4db3f4a90c160c06d8cb8b825a7f1c6f6a7c3";
       };
     };
-    "imap-0.8.17" = {
+    "imap-0.8.18" = {
       name = "imap";
       packageName = "imap";
-      version = "0.8.17";
+      version = "0.8.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/imap/-/imap-0.8.17.tgz";
-        sha1 = "e70ff1d1def0456af8bf1d96164d36176662172a";
+        url = "https://registry.npmjs.org/imap/-/imap-0.8.18.tgz";
+        sha1 = "4a7cdd0ff276efa0298708bb2c6d0db0b77f7a3f";
       };
     };
     "libmime-1.2.0" = {
@@ -13833,13 +13878,13 @@ let
         sha1 = "07af69344defa9851b7b845c1c18110b8264e51e";
       };
     };
-    "utf7-1.0.0" = {
+    "utf7-1.0.2" = {
       name = "utf7";
       packageName = "utf7";
-      version = "1.0.0";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/utf7/-/utf7-1.0.0.tgz";
-        sha1 = "70c895de9d85b8ee7ef5a1fa8e169241c46e72cc";
+        url = "https://registry.npmjs.org/utf7/-/utf7-1.0.2.tgz";
+        sha1 = "955f490aae653ba220b9456a0a8776c199360991";
       };
     };
     "twitter-ng-0.6.2" = {
@@ -14508,6 +14553,15 @@ let
         sha1 = "8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b";
       };
     };
+    "fstream-npm-1.2.0" = {
+      name = "fstream-npm";
+      packageName = "fstream-npm";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz";
+        sha1 = "d2c3c89101346982d64e57091c38487bda916fce";
+      };
+    };
     "lodash._baseuniq-4.6.0" = {
       name = "lodash._baseuniq";
       packageName = "lodash._baseuniq";
@@ -14517,40 +14571,40 @@ let
         sha1 = "0ebb44e456814af7905c6212fa2c9b2d51b841e8";
       };
     };
-    "lodash.clonedeep-4.4.1" = {
+    "lodash.clonedeep-4.5.0" = {
       name = "lodash.clonedeep";
       packageName = "lodash.clonedeep";
-      version = "4.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.4.1.tgz";
-        sha1 = "8adb0621f7e69682af808fe8dbccaa2ba7a8b3ea";
-      };
-    };
-    "lodash.union-4.5.0" = {
-      name = "lodash.union";
-      packageName = "lodash.union";
       version = "4.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.union/-/lodash.union-4.5.0.tgz";
-        sha1 = "d273848d9bc556780a6b4fcfed822a79a685a683";
+        url = "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz";
+        sha1 = "e23f3f9c4f8fbdde872529c1071857a086e5ccef";
       };
     };
-    "lodash.uniq-4.4.0" = {
+    "lodash.union-4.6.0" = {
+      name = "lodash.union";
+      packageName = "lodash.union";
+      version = "4.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz";
+        sha1 = "48bb5088409f16f1821666641c44dd1aaae3cd88";
+      };
+    };
+    "lodash.uniq-4.5.0" = {
       name = "lodash.uniq";
       packageName = "lodash.uniq";
-      version = "4.4.0";
+      version = "4.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.4.0.tgz";
-        sha1 = "42cdcd09e35eb0a07abe1da9c06c850f6afa55c7";
+        url = "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz";
+        sha1 = "d0225373aeb652adc1bc82e4945339a842754773";
       };
     };
-    "lodash.without-4.3.0" = {
+    "lodash.without-4.4.0" = {
       name = "lodash.without";
       packageName = "lodash.without";
-      version = "4.3.0";
+      version = "4.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.without/-/lodash.without-4.3.0.tgz";
-        sha1 = "b4e5c92c4e1fd1c2f4a9359993716e51ce12a2ba";
+        url = "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz";
+        sha1 = "3cd4574a00b67bae373a94b748772640507b7aac";
       };
     };
     "npm-install-checks-3.0.0" = {
@@ -14587,15 +14641,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.5.tgz";
         sha1 = "ace7e6381c7684f970aaa98fc7c5d2b666addab6";
-      };
-    };
-    "retry-0.9.0" = {
-      name = "retry";
-      packageName = "retry";
-      version = "0.9.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz";
-        sha1 = "6f697e50a0e4ddc8c8f7fb547a9b60dead43678d";
       };
     };
     "unique-filename-1.1.0" = {
@@ -14913,51 +14958,6 @@ let
         sha1 = "d4113ad6582445d076d1099997f0b250d7ddbaac";
       };
     };
-    "fstream-npm-1.2.0" = {
-      name = "fstream-npm";
-      packageName = "fstream-npm";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz";
-        sha1 = "d2c3c89101346982d64e57091c38487bda916fce";
-      };
-    };
-    "lodash.clonedeep-4.5.0" = {
-      name = "lodash.clonedeep";
-      packageName = "lodash.clonedeep";
-      version = "4.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz";
-        sha1 = "e23f3f9c4f8fbdde872529c1071857a086e5ccef";
-      };
-    };
-    "lodash.union-4.6.0" = {
-      name = "lodash.union";
-      packageName = "lodash.union";
-      version = "4.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz";
-        sha1 = "48bb5088409f16f1821666641c44dd1aaae3cd88";
-      };
-    };
-    "lodash.uniq-4.5.0" = {
-      name = "lodash.uniq";
-      packageName = "lodash.uniq";
-      version = "4.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz";
-        sha1 = "d0225373aeb652adc1bc82e4945339a842754773";
-      };
-    };
-    "lodash.without-4.4.0" = {
-      name = "lodash.without";
-      packageName = "lodash.without";
-      version = "4.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz";
-        sha1 = "3cd4574a00b67bae373a94b748772640507b7aac";
-      };
-    };
     "airplayer-2.0.0" = {
       name = "airplayer";
       packageName = "airplayer";
@@ -15057,13 +15057,13 @@ let
         sha1 = "1cbc691c45cdf6d6c1dc63bf368b2505f56ef839";
       };
     };
-    "buffer-indexof-1.0.2" = {
+    "buffer-indexof-1.1.0" = {
       name = "buffer-indexof";
       packageName = "buffer-indexof";
-      version = "1.0.2";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.0.2.tgz";
-        sha1 = "7fff11985ce51fe9ff07c40121ad301781587cdf";
+        url = "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.0.tgz";
+        sha1 = "f54f647c4f4e25228baa656a2e57e43d5f270982";
       };
     };
     "next-line-1.1.0" = {
@@ -16021,13 +16021,13 @@ let
         sha1 = "4d26ddc485c32e5a1cf1b35854823b4720d25a52";
       };
     };
-    "openid-2.0.4" = {
+    "openid-2.0.6" = {
       name = "openid";
       packageName = "openid";
-      version = "2.0.4";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/openid/-/openid-2.0.4.tgz";
-        sha1 = "73486f2862b080cc1a582cfd5d4df61d0274ef60";
+        url = "https://registry.npmjs.org/openid/-/openid-2.0.6.tgz";
+        sha1 = "707375e59ab9f73025899727679b20328171c9aa";
       };
     };
     "node-swt-0.1.1" = {
@@ -17389,6 +17389,24 @@ let
         sha1 = "80f7b6d7c2f9c0495ba42c518a670c99bdf6e4a0";
       };
     };
+    "request-2.72.0" = {
+      name = "request";
+      packageName = "request";
+      version = "2.72.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/request/-/request-2.72.0.tgz";
+        sha1 = "0ce3a179512620b10441f14c82e21c12c0ddb4e1";
+      };
+    };
+    "retry-0.9.0" = {
+      name = "retry";
+      packageName = "retry";
+      version = "0.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz";
+        sha1 = "6f697e50a0e4ddc8c8f7fb547a9b60dead43678d";
+      };
+    };
     "lodash._baseclone-4.5.7" = {
       name = "lodash._baseclone";
       packageName = "lodash._baseclone";
@@ -17414,6 +17432,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-4.5.0.tgz";
         sha1 = "56ea7d601367bfa46cd7de115dc3daeb18837938";
+      };
+    };
+    "qs-6.1.0" = {
+      name = "qs";
+      packageName = "qs";
+      version = "6.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz";
+        sha1 = "ec1d1626b24278d99f0fdf4549e524e24eceeb26";
       };
     };
     "lsmod-1.0.0" = {
@@ -17576,6 +17603,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.20.tgz";
         sha1 = "4424aca20e14d255c0b0889af6f6b8973da10e0d";
+      };
+    };
+    "tmp-0.0.29" = {
+      name = "tmp";
+      packageName = "tmp";
+      version = "0.0.29";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz";
+        sha1 = "f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0";
       };
     };
     "follow-redirects-0.0.3" = {
@@ -17842,10 +17878,10 @@ in
   azure-cli = nodeEnv.buildNodePackage {
     name = "azure-cli";
     packageName = "azure-cli";
-    version = "0.10.4";
+    version = "0.10.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.4.tgz";
-      sha1 = "0f5e9a8a529ac30f0fc8e754513ace91df6b5dae";
+      url = "https://registry.npmjs.org/azure-cli/-/azure-cli-0.10.5.tgz";
+      sha1 = "7e7490d92521818ab57c561f48e5d6058d9f1583";
     };
     dependencies = [
       (sources."adal-node-0.1.21" // {
@@ -17854,12 +17890,10 @@ in
         ];
       })
       sources."async-1.4.2"
-      (sources."azure-common-0.9.17" // {
+      (sources."azure-common-0.9.18" // {
         dependencies = [
           sources."xml2js-0.2.7"
-          sources."request-2.72.0"
           sources."validator-3.22.2"
-          sources."node-uuid-1.4.7"
         ];
       })
       sources."azure-arm-authorization-2.0.0"
@@ -17871,7 +17905,7 @@ in
       sources."azure-arm-insights-0.11.3"
       sources."azure-arm-iothub-0.1.1"
       sources."azure-arm-servermanagement-0.1.2"
-      sources."azure-arm-network-0.16.0"
+      sources."azure-arm-network-0.17.0"
       sources."azure-arm-powerbiembedded-0.1.0"
       sources."azure-arm-trafficmanager-0.10.5"
       sources."azure-arm-dns-0.11.1"
@@ -17880,7 +17914,7 @@ in
       sources."azure-arm-datalake-analytics-0.4.3"
       sources."azure-arm-datalake-store-0.4.2"
       sources."azure-arm-devtestlabs-0.1.0"
-      sources."azure-graph-1.0.1"
+      sources."azure-graph-1.1.1"
       sources."azure-gallery-2.0.0-pre.18"
       sources."azure-keyvault-0.10.2"
       sources."azure-asm-compute-0.17.0"
@@ -17904,25 +17938,18 @@ in
           sources."moment-2.14.1"
         ];
       })
-      (sources."azure-storage-1.1.0" // {
+      (sources."azure-storage-1.3.0" // {
         dependencies = [
-          sources."extend-1.2.1"
           sources."node-uuid-1.4.7"
           sources."readable-stream-2.0.6"
-          (sources."request-2.69.0" // {
-            dependencies = [
-              sources."extend-3.0.0"
-            ];
-          })
           sources."validator-3.22.2"
           sources."xml2js-0.2.7"
           sources."isarray-1.0.0"
-          sources."bl-1.0.3"
-          sources."qs-6.0.2"
         ];
       })
       sources."azure-arm-batch-0.2.0"
-      sources."azure-batch-0.5.0"
+      sources."azure-batch-0.5.2"
+      sources."azure-servicefabric-0.1.4"
       sources."applicationinsights-0.15.12"
       sources."caller-id-0.1.0"
       sources."colors-1.1.2"
@@ -17934,6 +17961,7 @@ in
       sources."fast-json-patch-0.5.6"
       sources."js2xmlparser-1.0.0"
       sources."jsonlint-1.6.2"
+      sources."jsonminify-0.4.1"
       sources."jsrsasign-4.8.2"
       (sources."kuduscript-1.0.8" // {
         dependencies = [
@@ -17941,7 +17969,7 @@ in
           sources."streamline-0.4.11"
         ];
       })
-      sources."moment-2.15.0"
+      sources."moment-2.15.1"
       sources."ms-rest-1.15.0"
       (sources."ms-rest-azure-1.15.0" // {
         dependencies = [
@@ -17968,9 +17996,8 @@ in
       sources."readable-stream-1.0.34"
       (sources."request-2.74.0" // {
         dependencies = [
+          sources."extend-3.0.0"
           sources."node-uuid-1.4.7"
-          sources."qs-6.2.1"
-          sources."tough-cookie-2.3.1"
         ];
       })
       (sources."ssh-key-to-pem-0.11.0" // {
@@ -18031,97 +18058,12 @@ in
       sources."envconf-0.0.4"
       sources."duplexer-0.1.1"
       sources."sax-0.5.2"
-      sources."aws-sign2-0.6.0"
-      sources."aws4-1.4.1"
-      (sources."bl-1.1.2" // {
-        dependencies = [
-          sources."readable-stream-2.0.6"
-          sources."isarray-1.0.0"
-        ];
-      })
-      sources."caseless-0.11.0"
-      sources."combined-stream-1.0.5"
-      sources."extend-3.0.0"
-      sources."forever-agent-0.6.1"
-      (sources."form-data-1.0.1" // {
-        dependencies = [
-          sources."async-2.0.1"
-        ];
-      })
-      (sources."har-validator-2.0.6" // {
-        dependencies = [
-          sources."commander-2.9.0"
-        ];
-      })
-      sources."hawk-3.1.3"
-      sources."http-signature-1.1.1"
-      sources."is-typedarray-1.0.0"
-      sources."isstream-0.1.2"
-      sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
-      sources."oauth-sign-0.8.2"
-      sources."qs-6.1.0"
-      sources."stringstream-0.0.5"
-      sources."tough-cookie-2.2.2"
-      sources."tunnel-agent-0.4.3"
-      sources."process-nextick-args-1.0.7"
-      sources."util-deprecate-1.0.2"
-      sources."delayed-stream-1.0.0"
-      sources."lodash-4.15.0"
-      sources."chalk-1.1.3"
-      sources."is-my-json-valid-2.13.1"
-      sources."pinkie-promise-2.0.1"
-      sources."ansi-styles-2.2.1"
-      sources."escape-string-regexp-1.0.5"
-      sources."has-ansi-2.0.0"
-      sources."strip-ansi-3.0.1"
-      sources."supports-color-2.0.0"
-      sources."ansi-regex-2.0.0"
-      sources."graceful-readlink-1.0.1"
-      sources."generate-function-2.0.0"
-      sources."generate-object-property-1.2.0"
-      sources."jsonpointer-2.0.0"
-      sources."xtend-4.0.1"
-      sources."is-property-1.0.2"
-      sources."pinkie-2.0.4"
-      sources."hoek-2.16.3"
-      sources."boom-2.10.1"
-      sources."cryptiles-2.0.5"
-      sources."sntp-1.0.9"
-      sources."assert-plus-0.2.0"
-      sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
-        dependencies = [
-          sources."assert-plus-1.0.0"
-        ];
-      })
-      sources."extsprintf-1.0.2"
-      sources."json-schema-0.2.3"
-      sources."verror-1.3.6"
-      sources."asn1-0.2.3"
-      (sources."dashdash-1.14.0" // {
-        dependencies = [
-          sources."assert-plus-1.0.0"
-        ];
-      })
-      (sources."getpass-0.1.6" // {
-        dependencies = [
-          sources."assert-plus-1.0.0"
-        ];
-      })
-      sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
-      sources."jodid25519-1.0.2"
-      sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
+      sources."extend-1.2.1"
       sources."browserify-mime-1.2.9"
       sources."json-edm-parser-0.1.2"
       sources."jsonparse-1.2.0"
+      sources."process-nextick-args-1.0.7"
+      sources."util-deprecate-1.0.2"
       sources."stack-trace-0.0.9"
       sources."keypress-0.1.0"
       sources."from-0.1.3"
@@ -18132,13 +18074,13 @@ in
       (sources."nomnom-1.8.1" // {
         dependencies = [
           sources."underscore-1.6.0"
-          sources."chalk-0.4.0"
-          sources."ansi-styles-1.0.0"
-          sources."strip-ansi-0.1.1"
         ];
       })
       sources."JSV-4.0.2"
+      sources."chalk-0.4.0"
       sources."has-color-0.1.7"
+      sources."ansi-styles-1.0.0"
+      sources."strip-ansi-0.1.1"
       sources."uuid-2.0.1"
       sources."debug-0.7.4"
       sources."q-0.9.7"
@@ -18158,7 +18100,7 @@ in
       })
       sources."ncp-0.4.2"
       sources."rimraf-2.5.4"
-      sources."glob-7.0.6"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -18169,6 +18111,87 @@ in
       sources."balanced-match-0.4.2"
       sources."concat-map-0.0.1"
       sources."cycle-1.0.3"
+      sources."isstream-0.1.2"
+      sources."aws-sign2-0.6.0"
+      sources."aws4-1.4.1"
+      (sources."bl-1.1.2" // {
+        dependencies = [
+          sources."readable-stream-2.0.6"
+          sources."isarray-1.0.0"
+        ];
+      })
+      sources."caseless-0.11.0"
+      sources."combined-stream-1.0.5"
+      sources."forever-agent-0.6.1"
+      (sources."form-data-1.0.1" // {
+        dependencies = [
+          sources."async-2.0.1"
+        ];
+      })
+      (sources."har-validator-2.0.6" // {
+        dependencies = [
+          sources."chalk-1.1.3"
+          sources."commander-2.9.0"
+          sources."ansi-styles-2.2.1"
+          sources."strip-ansi-3.0.1"
+        ];
+      })
+      sources."hawk-3.1.3"
+      sources."http-signature-1.1.1"
+      sources."is-typedarray-1.0.0"
+      sources."json-stringify-safe-5.0.1"
+      sources."mime-types-2.1.12"
+      sources."oauth-sign-0.8.2"
+      sources."qs-6.2.1"
+      sources."stringstream-0.0.5"
+      sources."tough-cookie-2.3.1"
+      sources."tunnel-agent-0.4.3"
+      sources."delayed-stream-1.0.0"
+      sources."lodash-4.16.2"
+      sources."is-my-json-valid-2.14.0"
+      sources."pinkie-promise-2.0.1"
+      sources."escape-string-regexp-1.0.5"
+      sources."has-ansi-2.0.0"
+      sources."supports-color-2.0.0"
+      sources."ansi-regex-2.0.0"
+      sources."graceful-readlink-1.0.1"
+      sources."generate-function-2.0.0"
+      sources."generate-object-property-1.2.0"
+      sources."jsonpointer-2.0.0"
+      sources."xtend-4.0.1"
+      sources."is-property-1.0.2"
+      sources."pinkie-2.0.4"
+      sources."hoek-2.16.3"
+      sources."boom-2.10.1"
+      sources."cryptiles-2.0.5"
+      sources."sntp-1.0.9"
+      sources."assert-plus-0.2.0"
+      sources."jsprim-1.3.1"
+      (sources."sshpk-1.10.1" // {
+        dependencies = [
+          sources."assert-plus-1.0.0"
+        ];
+      })
+      sources."extsprintf-1.0.2"
+      sources."json-schema-0.2.3"
+      sources."verror-1.3.6"
+      sources."asn1-0.2.3"
+      (sources."dashdash-1.14.0" // {
+        dependencies = [
+          sources."assert-plus-1.0.0"
+        ];
+      })
+      (sources."getpass-0.1.6" // {
+        dependencies = [
+          sources."assert-plus-1.0.0"
+        ];
+      })
+      sources."jsbn-0.1.0"
+      sources."tweetnacl-0.14.3"
+      sources."jodid25519-1.0.2"
+      sources."ecc-jsbn-0.1.1"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
       sources."ctype-0.5.2"
       sources."source-map-0.1.43"
       sources."fibers-1.0.14"
@@ -18178,7 +18201,7 @@ in
       sources."then-request-2.2.0"
       sources."http-basic-2.5.1"
       sources."promise-7.1.1"
-      sources."asap-2.0.4"
+      sources."asap-2.0.5"
       sources."os-homedir-1.0.1"
       sources."mute-stream-0.0.6"
     ];
@@ -18212,7 +18235,7 @@ in
     version = "3.1.1";
     src = fetchurl {
       url = "https://registry.npmjs.org/bower2nix/-/bower2nix-3.1.1.tgz";
-      sha1 = "wfzj1k6jkfnk1bkgbmpni59mdab8zk3p";
+      sha1 = "77cc8f966a3595686f5d6fae30ad9bd2cc20bfe3";
     };
     dependencies = [
       sources."argparse-1.0.4"
@@ -18222,7 +18245,7 @@ in
       sources."bower-logger-0.2.1"
       (sources."fs-extra-0.26.7" // {
         dependencies = [
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
         ];
       })
       sources."lodash-4.2.1"
@@ -18297,12 +18320,12 @@ in
       sources."pinkie-2.0.4"
       (sources."load-json-file-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
         ];
       })
       (sources."path-type-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.1.6"
+          sources."graceful-fs-4.1.9"
         ];
       })
       sources."parse-json-2.2.0"
@@ -18320,12 +18343,16 @@ in
       sources."sort-keys-1.1.2"
       sources."is-plain-obj-1.1.0"
       sources."natives-1.1.0"
-      sources."jsonfile-2.3.1"
+      (sources."jsonfile-2.4.0" // {
+        dependencies = [
+          sources."graceful-fs-4.1.9"
+        ];
+      })
       sources."klaw-1.3.0"
       sources."path-is-absolute-1.0.0"
       (sources."rimraf-2.5.4" // {
         dependencies = [
-          sources."glob-7.0.6"
+          sources."glob-7.1.0"
         ];
       })
       sources."fs.realpath-1.0.0"
@@ -18361,7 +18388,7 @@ in
       sha1 = "d81a018e98dd7ca706ec04253d20f8a03b2af8ae";
     };
     dependencies = [
-      sources."JSONStream-1.1.4"
+      sources."JSONStream-1.2.1"
       sources."assert-1.3.0"
       sources."browser-pack-6.0.1"
       sources."browser-resolve-1.11.2"
@@ -18440,7 +18467,7 @@ in
       sources."lodash.memoize-3.0.4"
       sources."source-map-0.5.6"
       sources."pako-0.2.9"
-      sources."base64-js-1.1.2"
+      sources."base64-js-1.2.0"
       sources."ieee754-1.1.6"
       sources."isarray-1.0.0"
       sources."typedarray-0.0.6"
@@ -18454,7 +18481,7 @@ in
       sources."create-hash-1.1.2"
       sources."create-hmac-1.1.4"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.6"
+      sources."pbkdf2-3.0.8"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -18466,11 +18493,11 @@ in
       sources."minimalistic-assert-1.0.0"
       sources."bn.js-4.11.6"
       sources."browserify-rsa-4.0.1"
-      sources."elliptic-6.3.1"
+      sources."elliptic-6.3.2"
       sources."parse-asn1-5.0.0"
       sources."brorand-1.0.6"
       sources."hash.js-1.0.3"
-      sources."asn1.js-4.8.0"
+      sources."asn1.js-4.8.1"
       sources."ripemd160-1.0.1"
       sources."sha.js-2.4.5"
       sources."miller-rabin-4.0.0"
@@ -18564,7 +18591,7 @@ in
       (sources."xml2js-0.4.17" // {
         dependencies = [
           sources."xmlbuilder-4.2.1"
-          sources."lodash-4.15.0"
+          sources."lodash-4.16.2"
         ];
       })
       sources."xtend-4.0.1"
@@ -18627,7 +18654,7 @@ in
       sources."pinkie-2.0.4"
       sources."load-json-file-1.1.0"
       sources."path-type-1.1.0"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."parse-json-2.2.0"
       sources."pify-2.3.0"
       sources."strip-bom-2.0.0"
@@ -18708,7 +18735,7 @@ in
       sources."uniq-1.0.1"
       sources."bencode-0.10.0"
       sources."simple-sha1-2.0.8"
-      sources."rusha-0.8.3"
+      sources."rusha-0.8.4"
       sources."once-1.4.0"
       sources."unzip-response-1.0.1"
       sources."wrappy-1.0.2"
@@ -18762,7 +18789,7 @@ in
       sources."isarray-0.0.1"
       sources."string_decoder-0.10.31"
       sources."cyclist-0.1.1"
-      sources."glob-7.0.6"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -18871,10 +18898,10 @@ in
   coffee-script = nodeEnv.buildNodePackage {
     name = "coffee-script";
     packageName = "coffee-script";
-    version = "1.10.0";
+    version = "1.11.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz";
-      sha1 = "12938bcf9be1948fa006f92e0c4c9e81705108c0";
+      url = "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.0.tgz";
+      sha1 = "591e87f7447a53dfde33dc892db1d15b14ddd92d";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -18914,7 +18941,7 @@ in
       (sources."insight-0.8.3" // {
         dependencies = [
           sources."async-1.5.2"
-          sources."request-2.74.0"
+          sources."request-2.75.0"
         ];
       })
       sources."aliasify-1.9.0"
@@ -18923,7 +18950,7 @@ in
         dependencies = [
           sources."q-1.4.1"
           sources."shelljs-0.7.4"
-          sources."glob-7.0.6"
+          sources."glob-7.1.0"
         ];
       })
       sources."cordova-js-4.1.4"
@@ -18955,6 +18982,7 @@ in
           sources."semver-5.1.1"
           sources."tar-2.2.1"
           sources."isarray-1.0.0"
+          sources."form-data-1.0.1"
         ];
       })
       sources."opener-1.4.1"
@@ -19023,7 +19051,7 @@ in
           sources."minimatch-2.0.10"
         ];
       })
-      sources."JSONStream-1.1.4"
+      sources."JSONStream-1.2.1"
       sources."assert-1.3.0"
       (sources."browser-pack-4.0.4" // {
         dependencies = [
@@ -19122,7 +19150,7 @@ in
       sources."create-hash-1.1.2"
       sources."create-hmac-1.1.4"
       sources."diffie-hellman-5.0.2"
-      sources."pbkdf2-3.0.6"
+      sources."pbkdf2-3.0.8"
       sources."public-encrypt-4.0.0"
       sources."randombytes-2.0.3"
       sources."browserify-aes-1.0.6"
@@ -19134,11 +19162,11 @@ in
       sources."minimalistic-assert-1.0.0"
       sources."bn.js-4.11.6"
       sources."browserify-rsa-4.0.1"
-      sources."elliptic-6.3.1"
+      sources."elliptic-6.3.2"
       sources."parse-asn1-5.0.0"
       sources."brorand-1.0.6"
       sources."hash.js-1.0.3"
-      sources."asn1.js-4.8.0"
+      sources."asn1.js-4.8.1"
       sources."ripemd160-1.0.1"
       sources."sha.js-2.4.5"
       sources."miller-rabin-4.0.0"
@@ -19179,9 +19207,9 @@ in
       sources."debug-2.2.0"
       sources."on-headers-1.0.1"
       sources."vary-1.1.0"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."negotiator-0.6.1"
-      sources."mime-db-1.23.0"
+      sources."mime-db-1.24.0"
       sources."ms-0.7.1"
       sources."array-flatten-1.1.1"
       sources."content-disposition-0.5.1"
@@ -19239,7 +19267,7 @@ in
       sources."mute-stream-0.0.6"
       sources."json-parse-helpfulerror-1.0.3"
       sources."normalize-package-data-2.3.5"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."jju-1.3.0"
       sources."is-builtin-module-1.0.0"
       sources."builtin-modules-1.1.1"
@@ -19268,7 +19296,7 @@ in
       sources."github-url-from-git-1.4.0"
       sources."github-url-from-username-repo-1.0.2"
       sources."ini-1.3.4"
-      sources."lockfile-1.0.1"
+      sources."lockfile-1.0.2"
       sources."lru-cache-4.0.1"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
@@ -19277,7 +19305,7 @@ in
       })
       (sources."node-gyp-3.4.0" // {
         dependencies = [
-          sources."glob-7.0.6"
+          sources."glob-7.1.0"
           sources."tar-2.2.1"
         ];
       })
@@ -19287,7 +19315,7 @@ in
       (sources."npm-registry-client-7.2.1" // {
         dependencies = [
           sources."concat-stream-1.5.2"
-          sources."request-2.74.0"
+          sources."request-2.75.0"
           sources."readable-stream-2.0.6"
           sources."isarray-1.0.0"
         ];
@@ -19301,7 +19329,7 @@ in
       sources."retry-0.10.0"
       (sources."rimraf-2.5.4" // {
         dependencies = [
-          sources."glob-7.0.6"
+          sources."glob-7.1.0"
         ];
       })
       (sources."sha-2.0.1" // {
@@ -19322,7 +19350,7 @@ in
       sources."defaults-1.0.3"
       sources."clone-1.0.2"
       sources."proto-list-1.2.4"
-      sources."asap-2.0.4"
+      sources."asap-2.0.5"
       sources."iferr-0.1.5"
       sources."fstream-ignore-1.0.5"
       sources."pseudomap-1.0.2"
@@ -19347,7 +19375,7 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      sources."form-data-1.0.1"
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
@@ -19360,10 +19388,9 @@ in
       sources."tough-cookie-2.3.1"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      sources."async-2.0.1"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."graceful-readlink-1.0.1"
       sources."generate-function-2.0.0"
@@ -19377,7 +19404,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -19397,14 +19424,10 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
+      sources."bcrypt-pbkdf-1.0.0"
       sources."are-we-there-yet-1.1.2"
       sources."gauge-1.2.7"
       sources."delegates-1.0.0"
@@ -19418,6 +19441,8 @@ in
       sources."readdir-scoped-modules-1.0.2"
       sources."util-extend-1.0.3"
       sources."buffer-shims-1.0.0"
+      sources."async-2.0.1"
+      sources."lodash-4.16.2"
       sources."isexe-1.1.2"
       (sources."xmlbuilder-4.0.0" // {
         dependencies = [
@@ -19443,7 +19468,7 @@ in
       })
       sources."string-length-1.0.1"
       sources."object-assign-4.1.0"
-      sources."uuid-2.0.2"
+      sources."uuid-2.0.3"
       sources."xdg-basedir-2.0.0"
       sources."package-json-1.2.0"
       (sources."got-3.3.1" // {
@@ -19599,9 +19624,9 @@ in
       sources."cookie-0.1.2"
       sources."merge-descriptors-0.0.2"
       sources."utils-merge-1.0.0"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."negotiator-0.5.3"
-      sources."mime-db-1.23.0"
+      sources."mime-db-1.24.0"
       sources."ms-0.7.0"
       sources."crc-3.2.1"
       sources."ee-first-1.1.0"
@@ -19678,7 +19703,7 @@ in
       sources."from2-1.3.0"
       sources."fs-blob-store-5.2.1"
       sources."level-0.18.0"
-      (sources."level-sublevel-6.5.4" // {
+      (sources."level-sublevel-6.6.0" // {
         dependencies = [
           (sources."levelup-0.19.1" // {
             dependencies = [
@@ -19810,10 +19835,10 @@ in
       sources."async-2.0.1"
       sources."aws4-1.4.1"
       sources."optimist-0.6.1"
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."jsonparse-1.2.0"
       sources."through-2.3.8"
-      sources."lodash-4.15.0"
+      sources."lodash-4.16.2"
       sources."wordwrap-0.0.3"
       sources."minimist-0.0.10"
       sources."aws-sign2-0.6.0"
@@ -19822,14 +19847,14 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      sources."form-data-1.0.1"
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -19844,9 +19869,10 @@ in
       sources."string_decoder-0.10.31"
       sources."util-deprecate-1.0.2"
       sources."delayed-stream-1.0.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -19867,7 +19893,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -19887,15 +19913,11 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -19973,7 +19995,7 @@ in
       sources."path-exists-2.1.0"
       sources."load-json-file-1.1.0"
       sources."path-type-1.1.0"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."parse-json-2.2.0"
       sources."pify-2.3.0"
       sources."strip-bom-2.0.0"
@@ -19998,10 +20020,10 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "3.5.0";
+    version = "3.6.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-3.5.0.tgz";
-      sha1 = "22fc9f780ea5bca1306fab2b6d3336b0fa62c754";
+      url = "https://registry.npmjs.org/eslint/-/eslint-3.6.1.tgz";
+      sha1 = "39eeabcfd8d2fe046fb8754b4cf97182abde0d9d";
     };
     dependencies = [
       sources."chalk-1.1.3"
@@ -20009,24 +20031,24 @@ in
       sources."debug-2.2.0"
       sources."doctrine-1.4.0"
       sources."escope-3.6.0"
-      sources."espree-3.1.7"
+      sources."espree-3.3.2"
       sources."estraverse-4.2.0"
       sources."esutils-2.0.2"
       sources."file-entry-cache-2.0.0"
-      sources."glob-7.0.6"
+      sources."glob-7.1.0"
       sources."globals-9.10.0"
       sources."ignore-3.1.5"
       sources."imurmurhash-0.1.4"
       sources."inquirer-0.12.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."is-resolvable-1.0.0"
       sources."js-yaml-3.6.1"
       sources."json-stable-stringify-1.0.1"
       sources."levn-0.3.0"
-      sources."lodash-4.15.0"
+      sources."lodash-4.16.2"
       sources."mkdirp-0.5.1"
       sources."natural-compare-1.4.0"
-      sources."optionator-0.8.1"
+      sources."optionator-0.8.2"
       sources."path-is-inside-1.0.2"
       sources."pluralize-1.2.1"
       sources."progress-1.1.8"
@@ -20034,7 +20056,7 @@ in
       sources."shelljs-0.6.1"
       sources."strip-bom-3.0.0"
       sources."strip-json-comments-1.0.4"
-      sources."table-3.7.8"
+      sources."table-3.8.0"
       sources."text-table-0.2.0"
       sources."user-home-2.0.0"
       sources."ansi-styles-2.2.1"
@@ -20066,12 +20088,16 @@ in
       sources."es6-symbol-3.1.0"
       sources."event-emitter-0.3.4"
       sources."object-assign-4.1.0"
-      sources."acorn-3.3.0"
-      sources."acorn-jsx-3.0.1"
+      sources."acorn-4.0.3"
+      (sources."acorn-jsx-3.0.1" // {
+        dependencies = [
+          sources."acorn-3.3.0"
+        ];
+      })
       sources."flat-cache-1.2.1"
       sources."circular-json-0.3.1"
       sources."del-2.2.2"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."write-0.2.1"
       sources."globby-5.0.0"
       sources."is-path-cwd-1.0.0"
@@ -20115,7 +20141,7 @@ in
       sources."xtend-4.0.1"
       sources."is-property-1.0.2"
       sources."tryit-1.0.2"
-      sources."argparse-1.0.7"
+      sources."argparse-1.0.9"
       sources."esprima-2.7.3"
       sources."sprintf-js-1.0.3"
       sources."jsonify-0.0.0"
@@ -20124,14 +20150,14 @@ in
       sources."minimist-0.0.8"
       sources."deep-is-0.1.3"
       sources."wordwrap-1.0.0"
-      sources."fast-levenshtein-1.1.4"
+      sources."fast-levenshtein-2.0.5"
       sources."caller-path-0.1.0"
       sources."resolve-from-1.0.1"
       sources."callsites-0.2.0"
-      sources."bluebird-3.4.6"
+      sources."ajv-4.7.5"
+      sources."ajv-keywords-1.1.1"
       sources."slice-ansi-0.0.4"
-      sources."tv4-1.2.7"
-      sources."xregexp-3.1.1"
+      sources."co-4.6.0"
       sources."os-homedir-1.0.1"
     ];
     buildInputs = globalBuildInputs;
@@ -20139,6 +20165,21 @@ in
       description = "An AST-based pattern checker for JavaScript.";
       homepage = http://eslint.org/;
       license = "MIT";
+    };
+    production = true;
+  };
+  emojione = nodeEnv.buildNodePackage {
+    name = "emojione";
+    packageName = "emojione";
+    version = "2.2.6";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/emojione/-/emojione-2.2.6.tgz";
+      sha1 = "67dec452937d5b14ee669207ea41cdb1f69fb8f6";
+    };
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Emoji One is a complete set of emojis designed for the web. It includes libraries to easily convert unicode characters to shortnames (:smile:) and shortnames to our custom emoji images. PNG and SVG formats provided for the emoji images.";
+      homepage = http://www.emojione.com/;
     };
     production = true;
   };
@@ -20281,7 +20322,7 @@ in
       sources."is-equal-shallow-0.1.3"
       sources."is-primitive-2.0.0"
       sources."binary-extensions-1.6.0"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."readable-stream-2.1.5"
       sources."set-immediate-shim-1.0.1"
       sources."brace-expansion-1.1.6"
@@ -20306,7 +20347,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."rimraf-2.5.4"
       sources."semver-5.3.0"
       sources."tar-2.2.1"
@@ -20350,18 +20391,14 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-1.0.1" // {
-        dependencies = [
-          sources."async-2.0.1"
-        ];
-      })
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -20369,10 +20406,10 @@ in
       sources."tough-cookie-2.3.1"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -20391,7 +20428,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -20411,16 +20448,12 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
-      (sources."glob-7.0.6" // {
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
+      (sources."glob-7.1.0" // {
         dependencies = [
           sources."minimatch-3.0.3"
         ];
@@ -20527,17 +20560,17 @@ in
       sha256 = "a51a5beef55c14c68630275d51cf66c44a4462d1b20c0f08aef6d88a62ca077c";
     };
     dependencies = [
-      sources."coffee-script-1.10.0"
+      sources."coffee-script-1.11.0"
       sources."jade-1.11.0"
       (sources."q-2.0.3" // {
         dependencies = [
-          sources."asap-2.0.4"
+          sources."asap-2.0.5"
         ];
       })
       sources."xml2js-0.4.17"
       sources."msgpack-1.0.2"
       sources."character-parser-1.2.1"
-      (sources."clean-css-3.4.19" // {
+      (sources."clean-css-3.4.20" // {
         dependencies = [
           sources."commander-2.8.1"
         ];
@@ -20602,7 +20635,7 @@ in
       sources."weak-map-1.0.5"
       sources."sax-1.2.1"
       sources."xmlbuilder-4.2.1"
-      sources."lodash-4.15.0"
+      sources."lodash-4.16.2"
       sources."nan-2.4.0"
     ];
     buildInputs = globalBuildInputs;
@@ -20702,7 +20735,7 @@ in
       sources."pinkie-2.0.4"
       sources."load-json-file-1.1.0"
       sources."path-type-1.1.0"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."parse-json-2.2.0"
       sources."pify-2.3.0"
       sources."strip-bom-2.0.0"
@@ -20883,7 +20916,7 @@ in
       sources."redis-0.10.3"
       sources."lru-cache-2.5.2"
       sources."minimist-0.0.8"
-      sources."eventemitter3-2.0.0"
+      sources."eventemitter3-2.0.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -20926,13 +20959,13 @@ in
       sources."wordwrap-1.0.0"
       sources."estraverse-1.9.3"
       sources."esutils-2.0.2"
-      sources."optionator-0.8.1"
+      sources."optionator-0.8.2"
       sources."source-map-0.2.0"
       sources."prelude-ls-1.1.2"
       sources."deep-is-0.1.3"
       sources."type-check-0.3.2"
       sources."levn-0.3.0"
-      sources."fast-levenshtein-1.1.4"
+      sources."fast-levenshtein-2.0.5"
       sources."amdefine-1.0.0"
       sources."inflight-1.0.5"
       sources."inherits-2.0.3"
@@ -20972,7 +21005,7 @@ in
       sources."longest-1.0.1"
       sources."repeat-string-1.5.4"
       sources."is-buffer-1.1.4"
-      sources."argparse-1.0.7"
+      sources."argparse-1.0.9"
       sources."sprintf-js-1.0.3"
       sources."has-flag-1.0.0"
       sources."isexe-1.1.2"
@@ -21021,7 +21054,7 @@ in
       sources."shelljs-0.3.0"
       sources."strip-json-comments-1.0.4"
       sources."lodash-3.7.0"
-      sources."glob-7.0.6"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."inherits-2.0.3"
@@ -21094,7 +21127,7 @@ in
       sha1 = "6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30";
     };
     dependencies = [
-      sources."argparse-1.0.7"
+      sources."argparse-1.0.9"
       sources."esprima-2.7.3"
       sources."sprintf-js-1.0.3"
     ];
@@ -21121,7 +21154,7 @@ in
       sources."colors-1.1.2"
       (sources."combine-lists-1.0.1" // {
         dependencies = [
-          sources."lodash-4.15.0"
+          sources."lodash-4.16.2"
         ];
       })
       sources."connect-3.5.0"
@@ -21136,8 +21169,8 @@ in
           sources."repeat-string-0.2.2"
         ];
       })
-      sources."glob-7.0.6"
-      sources."graceful-fs-4.1.6"
+      sources."glob-7.1.0"
+      sources."graceful-fs-4.1.9"
       sources."http-proxy-1.15.1"
       sources."isbinaryfile-3.0.1"
       sources."lodash-3.10.1"
@@ -21175,8 +21208,8 @@ in
       sources."ee-first-1.1.1"
       sources."unpipe-1.0.0"
       sources."media-typer-0.3.0"
-      sources."mime-types-2.1.11"
-      sources."mime-db-1.23.0"
+      sources."mime-types-2.1.12"
+      sources."mime-db-1.24.0"
       sources."anymatch-1.3.0"
       sources."async-each-1.0.1"
       sources."glob-parent-2.0.0"
@@ -21236,7 +21269,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."semver-5.3.0"
       sources."tar-2.2.1"
       sources."tar-pack-3.1.4"
@@ -21273,7 +21306,7 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      sources."form-data-1.0.1"
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
@@ -21286,14 +21319,10 @@ in
       sources."tough-cookie-2.3.1"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      (sources."async-2.0.1" // {
-        dependencies = [
-          sources."lodash-4.15.0"
-        ];
-      })
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -21312,7 +21341,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -21332,14 +21361,10 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
+      sources."bcrypt-pbkdf-1.0.0"
       sources."block-stream-0.0.9"
       sources."fstream-1.0.10"
       sources."fstream-ignore-1.0.5"
@@ -21546,9 +21571,9 @@ in
       sources."unpipe-1.0.0"
       sources."accepts-1.2.13"
       sources."compressible-2.0.8"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."negotiator-0.5.3"
-      sources."mime-db-1.23.0"
+      sources."mime-db-1.24.0"
       sources."ms-0.7.1"
       sources."csrf-3.0.3"
       sources."base64-url-1.2.2"
@@ -21580,7 +21605,7 @@ in
       sources."uid2-0.0.3"
       sources."sax-1.2.1"
       sources."xmlbuilder-4.2.1"
-      sources."lodash-4.15.0"
+      sources."lodash-4.16.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -21620,7 +21645,7 @@ in
           sources."isarray-0.0.1"
         ];
       })
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."gulp-sourcemaps-1.6.0"
       sources."is-valid-glob-0.3.0"
       sources."lazystream-1.0.0"
@@ -21806,7 +21831,7 @@ in
       sources."nijs-0.0.23"
       sources."chownr-1.0.1"
       sources."concat-stream-1.5.2"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."mkdirp-0.5.1"
       sources."normalize-package-data-2.3.5"
       (sources."npm-package-arg-4.2.0" // {
@@ -21815,7 +21840,7 @@ in
         ];
       })
       sources."once-1.4.0"
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."retry-0.8.0"
       sources."rimraf-2.5.4"
       sources."slide-1.1.6"
@@ -21844,14 +21869,14 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      sources."form-data-1.0.1"
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -21859,11 +21884,10 @@ in
       sources."tough-cookie-2.3.1"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      sources."async-2.0.1"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -21884,7 +21908,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -21904,16 +21928,12 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
-      sources."glob-7.0.6"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -21976,15 +21996,15 @@ in
     };
     dependencies = [
       sources."fstream-1.0.10"
-      sources."glob-7.0.6"
-      sources."graceful-fs-4.1.6"
+      sources."glob-7.1.0"
+      sources."graceful-fs-4.1.9"
       sources."minimatch-3.0.3"
       sources."mkdirp-0.5.1"
       sources."nopt-3.0.6"
       sources."npmlog-3.1.2"
       sources."osenv-0.1.3"
       sources."path-array-1.0.1"
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."rimraf-2.5.4"
       sources."semver-5.3.0"
       sources."tar-2.2.1"
@@ -22044,14 +22064,14 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      sources."form-data-1.0.1"
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -22059,11 +22079,10 @@ in
       sources."tough-cookie-2.3.1"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      sources."async-2.0.1"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -22082,7 +22101,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -22102,15 +22121,11 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
       sources."block-stream-0.0.9"
       sources."isexe-1.1.2"
     ];
@@ -22209,7 +22224,7 @@ in
       sources."pinkie-2.0.4"
       sources."load-json-file-1.1.0"
       sources."path-type-1.1.0"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."parse-json-2.2.0"
       sources."pify-2.3.0"
       sources."strip-bom-2.0.0"
@@ -22248,9 +22263,9 @@ in
       sources."type-is-1.6.13"
       sources."utils-merge-1.0.0"
       sources."vary-1.1.0"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."negotiator-0.6.1"
-      sources."mime-db-1.23.0"
+      sources."mime-db-1.24.0"
       sources."statuses-1.3.0"
       sources."unpipe-1.0.0"
       sources."ee-first-1.1.1"
@@ -22278,18 +22293,18 @@ in
         dependencies = [
           sources."rimraf-2.5.4"
           sources."semver-5.3.0"
-          sources."glob-7.0.6"
+          sources."glob-7.1.0"
         ];
       })
       sources."nopt-3.0.6"
       sources."npmlog-4.0.0"
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."tar-2.2.1"
       (sources."tar-pack-3.1.4" // {
         dependencies = [
           sources."once-1.3.3"
           sources."rimraf-2.5.4"
-          sources."glob-7.0.6"
+          sources."glob-7.1.0"
         ];
       })
       sources."abbrev-1.0.9"
@@ -22324,12 +22339,7 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-1.0.1" // {
-        dependencies = [
-          sources."async-2.0.1"
-          sources."lodash-4.15.0"
-        ];
-      })
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
@@ -22342,9 +22352,10 @@ in
       sources."tough-cookie-2.3.1"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."has-ansi-2.0.0"
@@ -22360,7 +22371,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -22380,14 +22391,10 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
+      sources."bcrypt-pbkdf-1.0.0"
       sources."fs.realpath-1.0.0"
       sources."block-stream-0.0.9"
       sources."fstream-1.0.10"
@@ -22428,7 +22435,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."rimraf-2.5.4"
       sources."semver-5.3.0"
       sources."tar-2.2.1"
@@ -22478,14 +22485,14 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      sources."form-data-1.0.1"
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -22493,11 +22500,10 @@ in
       sources."tough-cookie-2.3.1"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      sources."async-2.0.1"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -22516,7 +22522,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -22536,16 +22542,12 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
-      sources."glob-7.0.6"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -22557,7 +22559,7 @@ in
       sources."concat-map-0.0.1"
       sources."block-stream-0.0.9"
       sources."fstream-1.0.10"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."debug-2.2.0"
       sources."fstream-ignore-1.0.5"
       sources."uid-number-0.0.6"
@@ -22637,7 +22639,7 @@ in
       sources."is-equal-shallow-0.1.3"
       sources."is-primitive-2.0.0"
       sources."binary-extensions-1.6.0"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."readable-stream-2.1.5"
       sources."set-immediate-shim-1.0.1"
       sources."buffer-shims-1.0.0"
@@ -22655,7 +22657,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."rimraf-2.5.4"
       sources."semver-5.3.0"
       sources."tar-2.2.1"
@@ -22697,14 +22699,14 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      sources."form-data-1.0.1"
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -22712,11 +22714,10 @@ in
       sources."tough-cookie-2.3.1"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      sources."async-2.0.1"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -22735,7 +22736,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -22755,16 +22756,12 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
-      sources."glob-7.0.6"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."once-1.4.0"
@@ -22804,7 +22801,7 @@ in
       sources."string-length-1.0.1"
       sources."os-tmpdir-1.0.1"
       sources."osenv-0.1.3"
-      sources."uuid-2.0.2"
+      sources."uuid-2.0.3"
       sources."write-file-atomic-1.2.0"
       sources."xdg-basedir-2.0.0"
       sources."os-homedir-1.0.1"
@@ -22923,8 +22920,8 @@ in
       sources."setprototypeof-1.0.1"
       sources."statuses-1.3.0"
       sources."ee-first-1.1.1"
-      sources."mime-types-2.1.11"
-      sources."mime-db-1.23.0"
+      sources."mime-types-2.1.12"
+      sources."mime-db-1.24.0"
       sources."css-select-1.0.0"
       sources."entities-1.1.1"
       (sources."htmlparser2-3.8.3" // {
@@ -22953,7 +22950,7 @@ in
       sources."cookie-signature-1.0.6"
       sources."vary-1.1.0"
       sources."moment-timezone-0.3.1"
-      sources."moment-2.15.0"
+      sources."moment-2.15.1"
       sources."accepts-1.3.3"
       sources."array-flatten-1.1.1"
       sources."content-disposition-0.5.1"
@@ -22978,12 +22975,12 @@ in
       sources."destroy-1.0.4"
       sources."mime-1.3.4"
       sources."stream-consume-0.1.0"
-      sources."graceful-fs-4.1.6"
-      sources."jsonfile-2.3.1"
+      sources."graceful-fs-4.1.9"
+      sources."jsonfile-2.4.0"
       sources."klaw-1.3.0"
       sources."path-is-absolute-1.0.0"
       sources."rimraf-2.5.4"
-      sources."glob-7.0.6"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -23093,7 +23090,7 @@ in
       sources."sax-1.2.1"
       (sources."xmlbuilder-4.2.1" // {
         dependencies = [
-          sources."lodash-4.15.0"
+          sources."lodash-4.16.2"
         ];
       })
       (sources."feedparser-1.1.3" // {
@@ -23118,7 +23115,7 @@ in
       (sources."form-data-1.0.1" // {
         dependencies = [
           sources."async-2.0.1"
-          sources."lodash-4.15.0"
+          sources."lodash-4.16.2"
         ];
       })
       sources."json-stringify-safe-5.0.1"
@@ -23143,7 +23140,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -23160,7 +23157,7 @@ in
       sources."nodemailer-1.11.0"
       sources."poplib-0.1.7"
       sources."mailparser-0.6.1"
-      sources."imap-0.8.17"
+      sources."imap-0.8.18"
       sources."libmime-1.2.0"
       sources."mailcomposer-2.1.0"
       sources."needle-0.11.0"
@@ -23188,12 +23185,12 @@ in
       })
       sources."encoding-0.1.12"
       sources."uue-3.0.0"
-      sources."utf7-1.0.0"
+      sources."utf7-1.0.2"
       sources."twitter-ng-0.6.2"
       sources."oauth-0.9.14"
       sources."is-typedarray-1.0.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."asn1-0.2.3"
           sources."assert-plus-1.0.0"
@@ -23213,14 +23210,10 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
+      sources."bcrypt-pbkdf-1.0.0"
       (sources."serialport-2.1.2" // {
         dependencies = [
           sources."nan-2.2.1"
@@ -23346,7 +23339,7 @@ in
       sources."bytes-0.2.0"
       sources."pause-0.0.1"
       sources."mime-1.2.6"
-      sources."coffee-script-1.10.0"
+      sources."coffee-script-1.11.0"
       sources."vows-0.8.1"
       sources."eyes-0.1.8"
       sources."diff-1.0.8"
@@ -23410,10 +23403,10 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "3.10.7";
+    version = "3.10.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-3.10.7.tgz";
-      sha1 = "c27556ddd52558d0a6fbf528503695fb83a54210";
+      url = "https://registry.npmjs.org/npm/-/npm-3.10.8.tgz";
+      sha1 = "8f76ff8c6da04b61dd371d554ce40a0b8916c15e";
     };
     dependencies = [
       sources."abbrev-1.0.9"
@@ -23421,7 +23414,7 @@ in
       sources."ansistyles-0.1.3"
       sources."aproba-1.0.4"
       sources."archy-1.0.0"
-      sources."asap-2.0.4"
+      sources."asap-2.0.5"
       sources."chownr-1.0.1"
       sources."cmd-shim-2.0.2"
       sources."columnify-1.5.4"
@@ -23431,9 +23424,9 @@ in
       sources."fs-vacuum-1.2.9"
       sources."fs-write-stream-atomic-1.0.8"
       sources."fstream-1.0.10"
-      sources."fstream-npm-1.1.1"
+      sources."fstream-npm-1.2.0"
       sources."glob-7.0.6"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."has-unicode-2.0.1"
       sources."hosted-git-info-2.1.5"
       sources."iferr-0.1.5"
@@ -23445,28 +23438,32 @@ in
           sources."glob-6.0.4"
         ];
       })
-      sources."lockfile-1.0.1"
+      sources."lockfile-1.0.2"
       sources."lodash._baseuniq-4.6.0"
-      sources."lodash.clonedeep-4.4.1"
-      sources."lodash.union-4.5.0"
-      sources."lodash.uniq-4.4.0"
-      sources."lodash.without-4.3.0"
+      sources."lodash.clonedeep-4.5.0"
+      sources."lodash.union-4.6.0"
+      sources."lodash.uniq-4.5.0"
+      sources."lodash.without-4.4.0"
       sources."mkdirp-0.5.1"
-      sources."node-gyp-3.4.0"
+      (sources."node-gyp-3.4.0" // {
+        dependencies = [
+          sources."npmlog-3.1.2"
+        ];
+      })
       sources."nopt-3.0.6"
       sources."normalize-git-url-3.0.2"
       sources."normalize-package-data-2.3.5"
       sources."npm-cache-filename-1.0.2"
       sources."npm-install-checks-3.0.0"
       sources."npm-package-arg-4.2.0"
-      (sources."npm-registry-client-7.1.2" // {
+      (sources."npm-registry-client-7.2.1" // {
         dependencies = [
-          sources."retry-0.8.0"
+          sources."npmlog-3.1.2"
         ];
       })
       sources."npm-user-validate-0.1.5"
-      sources."npmlog-3.1.2"
-      sources."once-1.3.3"
+      sources."npmlog-4.0.0"
+      sources."once-1.4.0"
       sources."opener-1.4.2"
       sources."osenv-0.1.3"
       sources."path-is-inside-1.0.2"
@@ -23482,9 +23479,9 @@ in
       sources."readable-stream-2.1.5"
       sources."realize-package-specifier-3.0.3"
       sources."request-2.74.0"
-      sources."retry-0.9.0"
+      sources."retry-0.10.0"
       sources."rimraf-2.5.4"
-      sources."semver-5.1.1"
+      sources."semver-5.3.0"
       sources."sha-2.0.1"
       sources."slide-1.1.6"
       sources."sorted-object-2.0.1"
@@ -23498,7 +23495,7 @@ in
       sources."validate-npm-package-name-2.2.2"
       sources."which-1.2.11"
       sources."wrappy-1.0.2"
-      sources."write-file-atomic-1.1.4"
+      sources."write-file-atomic-1.2.0"
       sources."ansi-regex-2.0.0"
       sources."debuglog-1.0.1"
       sources."imurmurhash-0.1.4"
@@ -23526,6 +23523,19 @@ in
       sources."lodash._root-3.0.1"
       sources."minimist-0.0.8"
       sources."path-array-1.0.1"
+      sources."are-we-there-yet-1.1.2"
+      sources."console-control-strings-1.1.0"
+      sources."gauge-2.6.0"
+      sources."set-blocking-2.0.0"
+      sources."delegates-1.0.0"
+      sources."has-color-0.1.7"
+      sources."object-assign-4.1.0"
+      sources."signal-exit-3.0.1"
+      sources."string-width-1.0.2"
+      sources."wide-align-1.1.0"
+      sources."code-point-at-1.0.0"
+      sources."is-fullwidth-code-point-1.0.0"
+      sources."number-is-nan-1.0.0"
       sources."array-index-1.0.0"
       sources."debug-2.2.0"
       sources."es6-symbol-3.1.0"
@@ -23546,19 +23556,6 @@ in
       sources."process-nextick-args-1.0.7"
       sources."string_decoder-0.10.31"
       sources."util-deprecate-1.0.2"
-      sources."are-we-there-yet-1.1.2"
-      sources."console-control-strings-1.1.0"
-      sources."gauge-2.6.0"
-      sources."set-blocking-2.0.0"
-      sources."delegates-1.0.0"
-      sources."has-color-0.1.7"
-      sources."object-assign-4.1.0"
-      sources."signal-exit-3.0.1"
-      sources."string-width-1.0.2"
-      sources."wide-align-1.1.0"
-      sources."code-point-at-1.0.0"
-      sources."is-fullwidth-code-point-1.0.0"
-      sources."number-is-nan-1.0.0"
       sources."os-homedir-1.0.1"
       sources."os-tmpdir-1.0.1"
       sources."mute-stream-0.0.6"
@@ -23584,7 +23581,7 @@ in
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -23593,10 +23590,10 @@ in
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
       sources."async-2.0.1"
-      sources."lodash-4.15.0"
+      sources."lodash-4.16.2"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -23615,7 +23612,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -23635,15 +23632,11 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
       sources."block-stream-0.0.9"
       sources."unique-slug-2.0.0"
       sources."builtins-0.0.7"
@@ -23697,10 +23690,10 @@ in
       })
       sources."fs.extra-1.3.2"
       sources."findit-1.2.0"
-      sources."coffee-script-1.10.0"
+      sources."coffee-script-1.11.0"
       sources."underscore-1.4.4"
       sources."underscore.string-2.3.3"
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."graceful-fs-2.0.3"
       sources."slide-1.1.6"
       sources."chownr-0.0.2"
@@ -23716,14 +23709,14 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      sources."form-data-1.0.1"
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -23738,11 +23731,10 @@ in
       sources."string_decoder-0.10.31"
       sources."util-deprecate-1.0.2"
       sources."delayed-stream-1.0.0"
-      sources."async-2.0.1"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -23763,7 +23755,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -23783,16 +23775,12 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
-      sources."glob-7.0.6"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -23874,7 +23862,7 @@ in
       sources."lodash-3.10.1"
       (sources."node-alias-1.0.4" // {
         dependencies = [
-          sources."lodash-4.15.0"
+          sources."lodash-4.16.2"
         ];
       })
       sources."npm-3.10.8"
@@ -23905,7 +23893,7 @@ in
       sources."ansistyles-0.1.3"
       sources."aproba-1.0.4"
       sources."archy-1.0.0"
-      sources."asap-2.0.4"
+      sources."asap-2.0.5"
       sources."chownr-1.0.1"
       sources."cmd-shim-2.0.2"
       sources."columnify-1.5.4"
@@ -23917,7 +23905,7 @@ in
       sources."fstream-1.0.10"
       sources."fstream-npm-1.2.0"
       sources."glob-7.0.6"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."has-unicode-2.0.1"
       sources."hosted-git-info-2.1.5"
       sources."iferr-0.1.5"
@@ -23929,7 +23917,7 @@ in
           sources."glob-6.0.4"
         ];
       })
-      sources."lockfile-1.0.1"
+      sources."lockfile-1.0.2"
       sources."lodash._baseuniq-4.6.0"
       sources."lodash.clonedeep-4.5.0"
       sources."lodash.union-4.6.0"
@@ -24067,7 +24055,7 @@ in
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -24077,10 +24065,10 @@ in
       sources."delayed-stream-1.0.0"
       (sources."async-2.0.1" // {
         dependencies = [
-          sources."lodash-4.15.0"
+          sources."lodash-4.16.2"
         ];
       })
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."generate-function-2.0.0"
       sources."generate-object-property-1.2.0"
       sources."jsonpointer-2.0.0"
@@ -24092,7 +24080,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -24112,15 +24100,11 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
       sources."block-stream-0.0.9"
       sources."unique-slug-2.0.0"
       sources."builtins-0.0.7"
@@ -24134,7 +24118,7 @@ in
       sources."repeating-1.1.3"
       sources."semver-diff-2.1.0"
       sources."string-length-1.0.1"
-      sources."uuid-2.0.2"
+      sources."uuid-2.0.3"
       sources."xdg-basedir-2.0.0"
       sources."package-json-1.2.0"
       (sources."got-3.3.1" // {
@@ -24259,7 +24243,7 @@ in
       sources."once-1.4.0"
       sources."consume-until-1.0.0"
       sources."http-headers-3.0.1"
-      sources."buffer-indexof-1.0.2"
+      sources."buffer-indexof-1.1.0"
       sources."next-line-1.1.0"
       sources."wrappy-1.0.2"
       sources."chalk-1.1.3"
@@ -24312,7 +24296,7 @@ in
       sources."pinkie-2.0.4"
       sources."load-json-file-1.1.0"
       sources."path-type-1.1.0"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."parse-json-2.2.0"
       sources."pify-2.3.0"
       sources."strip-bom-2.0.0"
@@ -24344,7 +24328,7 @@ in
       sources."uniq-1.0.1"
       sources."bencode-0.10.0"
       sources."simple-sha1-2.0.8"
-      sources."rusha-0.8.3"
+      sources."rusha-0.8.4"
       sources."unzip-response-1.0.1"
       (sources."end-of-stream-1.0.0" // {
         dependencies = [
@@ -24392,7 +24376,7 @@ in
       sources."speedometer-0.1.4"
       sources."utp-0.0.7"
       sources."cyclist-0.1.1"
-      sources."glob-7.0.6"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -24582,7 +24566,7 @@ in
       sources."flatten-0.0.1"
       sources."bencode-0.7.0"
       sources."simple-sha1-2.0.8"
-      sources."rusha-0.8.3"
+      sources."rusha-0.8.4"
       sources."form-data-0.0.10"
       sources."hawk-0.10.2"
       sources."node-uuid-1.4.7"
@@ -24667,7 +24651,7 @@ in
       })
       sources."fifo-0.1.4"
       sources."speedometer-0.1.4"
-      sources."glob-7.0.6"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -24718,12 +24702,12 @@ in
       sources."minimist-0.0.8"
       sources."fd-slicer-1.0.1"
       sources."pend-1.2.0"
-      sources."graceful-fs-4.1.6"
-      sources."jsonfile-2.3.1"
+      sources."graceful-fs-4.1.9"
+      sources."jsonfile-2.4.0"
       sources."klaw-1.3.0"
       sources."path-is-absolute-1.0.0"
       sources."rimraf-2.5.4"
-      sources."glob-7.0.6"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -24741,7 +24725,7 @@ in
       sources."forever-agent-0.6.1"
       sources."form-data-1.0.1"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."qs-5.2.1"
       sources."tunnel-agent-0.4.3"
@@ -24756,11 +24740,11 @@ in
       sources."is-typedarray-1.0.0"
       sources."har-validator-2.0.6"
       sources."async-2.0.1"
-      sources."lodash-4.15.0"
-      sources."mime-db-1.23.0"
+      sources."lodash-4.16.2"
+      sources."mime-db-1.24.0"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -24780,14 +24764,10 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
+      sources."bcrypt-pbkdf-1.0.0"
       sources."hoek-2.16.3"
       sources."boom-2.10.1"
       sources."cryptiles-2.0.5"
@@ -24795,7 +24775,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."has-ansi-2.0.0"
@@ -24838,7 +24818,7 @@ in
       sources."commander-2.9.0"
       sources."detective-4.3.1"
       sources."glob-5.0.15"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."iconv-lite-0.4.13"
       sources."mkdirp-0.5.1"
       sources."private-0.1.6"
@@ -24940,9 +24920,9 @@ in
       sources."ms-0.7.1"
       sources."oauth-https://codeload.github.com/ciaranj/node-oauth/legacy.tar.gz/master"
       sources."request-2.9.203"
-      (sources."openid-2.0.4" // {
+      (sources."openid-2.0.6" // {
         dependencies = [
-          sources."request-2.74.0"
+          sources."request-2.75.0"
           sources."node-uuid-1.4.7"
           sources."qs-6.2.1"
         ];
@@ -24963,7 +24943,7 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      sources."form-data-1.0.1"
+      sources."form-data-2.0.0"
       (sources."har-validator-2.0.6" // {
         dependencies = [
           sources."commander-2.9.0"
@@ -24974,7 +24954,7 @@ in
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."oauth-sign-0.8.2"
       sources."stringstream-0.0.5"
       sources."tough-cookie-2.3.1"
@@ -24982,10 +24962,9 @@ in
       sources."process-nextick-args-1.0.7"
       sources."util-deprecate-1.0.2"
       sources."delayed-stream-1.0.0"
-      sources."async-2.0.1"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -25006,7 +24985,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -25026,15 +25005,11 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
       sources."events.node-0.4.9"
     ];
     buildInputs = globalBuildInputs;
@@ -25093,7 +25068,7 @@ in
           sources."depd-1.1.0"
         ];
       })
-      (sources."request-2.74.0" // {
+      (sources."request-2.75.0" // {
         dependencies = [
           sources."qs-6.2.1"
         ];
@@ -25108,7 +25083,7 @@ in
       sources."lunr-0.7.1"
       sources."render-readme-1.3.1"
       sources."jju-1.3.0"
-      sources."JSONStream-1.1.4"
+      sources."JSONStream-1.2.1"
       sources."mkdirp-0.5.1"
       sources."sinopia-htpasswd-0.4.5"
       (sources."http-errors-1.5.0" // {
@@ -25169,9 +25144,9 @@ in
       sources."type-is-1.6.13"
       sources."vary-1.0.1"
       sources."utils-merge-1.0.0"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."negotiator-0.5.3"
-      sources."mime-db-1.23.0"
+      sources."mime-db-1.24.0"
       sources."ms-0.7.1"
       sources."unpipe-1.0.0"
       sources."ee-first-1.1.1"
@@ -25189,7 +25164,7 @@ in
       sources."compressible-2.0.8"
       sources."on-headers-1.0.1"
       sources."graceful-readlink-1.0.1"
-      sources."argparse-1.0.7"
+      sources."argparse-1.0.9"
       sources."esprima-2.7.3"
       sources."sprintf-js-1.0.3"
       sources."keygrip-1.0.1"
@@ -25204,11 +25179,7 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-1.0.1" // {
-        dependencies = [
-          sources."async-2.0.1"
-        ];
-      })
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
@@ -25226,9 +25197,9 @@ in
       sources."string_decoder-0.10.31"
       sources."util-deprecate-1.0.2"
       sources."delayed-stream-1.0.0"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       sources."chalk-1.1.3"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -25248,7 +25219,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -25268,20 +25239,16 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
+      sources."bcrypt-pbkdf-1.0.0"
       sources."lru-cache-2.7.3"
       sources."sigmund-1.0.1"
       sources."dtrace-provider-0.6.0"
       sources."mv-2.1.1"
       sources."safe-json-stringify-1.0.3"
-      sources."moment-2.15.0"
+      sources."moment-2.15.1"
       sources."nan-2.4.0"
       sources."ncp-2.0.0"
       sources."rimraf-2.4.5"
@@ -25356,7 +25323,7 @@ in
       sources."readdirp-2.1.0"
       sources."colors-1.0.3"
       sources."graceful-readlink-1.0.1"
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."minimatch-3.0.3"
       sources."readable-stream-2.1.5"
       sources."set-immediate-shim-1.0.1"
@@ -25559,10 +25526,10 @@ in
   svgo = nodeEnv.buildNodePackage {
     name = "svgo";
     packageName = "svgo";
-    version = "0.7.0";
+    version = "0.7.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/svgo/-/svgo-0.7.0.tgz";
-      sha1 = "51a95c5f7aaa98824f92857ac14c2cdbe81537aa";
+      url = "https://registry.npmjs.org/svgo/-/svgo-0.7.1.tgz";
+      sha1 = "287320fed972cb097e72c2bb1685f96fe08f8034";
     };
     dependencies = [
       sources."sax-1.2.1"
@@ -25573,7 +25540,7 @@ in
       sources."mkdirp-0.5.1"
       sources."csso-2.2.1"
       sources."q-1.4.1"
-      sources."argparse-1.0.7"
+      sources."argparse-1.0.9"
       sources."esprima-2.7.3"
       sources."sprintf-js-1.0.3"
       sources."minimist-0.0.8"
@@ -25598,10 +25565,10 @@ in
   titanium = nodeEnv.buildNodePackage {
     name = "titanium";
     packageName = "titanium";
-    version = "5.0.9";
+    version = "5.0.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.9.tgz";
-      sha1 = "113f5f986b5e39e92db0d5d0ba5b2b1f237504e7";
+      url = "https://registry.npmjs.org/titanium/-/titanium-5.0.10.tgz";
+      sha1 = "9bbae581957b33265a71774e8fd9f4766441bf1d";
     };
     dependencies = [
       sources."async-1.4.2"
@@ -25662,7 +25629,7 @@ in
         ];
       })
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."qs-4.0.0"
       sources."tunnel-agent-0.4.3"
       sources."tough-cookie-2.3.1"
@@ -25681,8 +25648,8 @@ in
       sources."process-nextick-args-1.0.7"
       sources."string_decoder-0.10.31"
       sources."util-deprecate-1.0.2"
-      sources."lodash-4.15.0"
-      sources."mime-db-1.23.0"
+      sources."lodash-4.16.2"
+      sources."mime-db-1.24.0"
       sources."assert-plus-0.1.5"
       sources."asn1-0.1.11"
       sources."ctype-0.5.3"
@@ -25694,7 +25661,7 @@ in
       sources."bluebird-2.11.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."has-ansi-2.0.0"
@@ -25734,10 +25701,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "1.8.10";
+    version = "2.0.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz";
-      sha1 = "b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e";
+      url = "https://registry.npmjs.org/typescript/-/typescript-2.0.3.tgz";
+      sha1 = "33dec9eae86b8eee327dd419ca050c853cabd514";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -25842,11 +25809,11 @@ in
       })
       (sources."npm-registry-client-7.1.2" // {
         dependencies = [
-          sources."request-2.74.0"
+          sources."request-2.75.0"
           sources."retry-0.8.0"
           sources."combined-stream-1.0.5"
           sources."forever-agent-0.6.1"
-          sources."form-data-1.0.1"
+          sources."form-data-2.0.0"
           sources."hawk-3.1.3"
           sources."json-stringify-safe-5.0.1"
           sources."oauth-sign-0.8.2"
@@ -25929,8 +25896,8 @@ in
       sources."ee-first-1.1.1"
       sources."unpipe-1.0.0"
       sources."media-typer-0.3.0"
-      sources."mime-types-2.1.11"
-      sources."mime-db-1.23.0"
+      sources."mime-types-2.1.12"
+      sources."mime-db-1.24.0"
       sources."clone-1.0.2"
       sources."color-convert-1.5.0"
       sources."color-string-0.3.0"
@@ -26066,7 +26033,7 @@ in
           sources."minimatch-3.0.3"
         ];
       })
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."has-unicode-2.0.1"
       sources."hosted-git-info-2.1.5"
       sources."iferr-0.1.5"
@@ -26077,7 +26044,7 @@ in
           sources."minimatch-3.0.3"
         ];
       })
-      sources."lockfile-1.0.1"
+      sources."lockfile-1.0.2"
       sources."lodash._baseuniq-4.6.0"
       sources."lodash.clonedeep-4.3.2"
       sources."lodash.union-4.4.0"
@@ -26146,7 +26113,7 @@ in
       sources."wcwidth-1.0.1"
       sources."defaults-1.0.3"
       sources."proto-list-1.2.4"
-      sources."asap-2.0.4"
+      sources."asap-2.0.5"
       (sources."fstream-ignore-1.0.5" // {
         dependencies = [
           sources."minimatch-3.0.3"
@@ -26208,7 +26175,7 @@ in
       sources."tough-cookie-2.2.2"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -26223,7 +26190,7 @@ in
       sources."pinkie-2.0.4"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -26243,14 +26210,10 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
+      sources."bcrypt-pbkdf-1.0.0"
       sources."block-stream-0.0.9"
       sources."unique-slug-2.0.0"
       sources."builtins-0.0.7"
@@ -26264,6 +26227,7 @@ in
         ];
       })
       sources."typedarray-0.0.6"
+      sources."asynckit-0.4.0"
       sources."passport-strategy-1.0.0"
       sources."pause-0.0.1"
       sources."lsmod-1.0.0"
@@ -26403,7 +26367,7 @@ in
           sources."kew-0.7.0"
         ];
       })
-      sources."tmp-0.0.28"
+      sources."tmp-0.0.29"
       sources."follow-redirects-0.0.3"
       (sources."config-chain-1.1.10" // {
         dependencies = [
@@ -26443,12 +26407,12 @@ in
       sources."minimist-0.0.8"
       sources."fd-slicer-1.0.1"
       sources."pend-1.2.0"
-      sources."graceful-fs-4.1.6"
-      sources."jsonfile-2.3.1"
+      sources."graceful-fs-4.1.9"
+      sources."jsonfile-2.4.0"
       sources."klaw-1.3.0"
       sources."path-is-absolute-1.0.0"
       sources."rimraf-2.5.4"
-      sources."glob-7.0.6"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."minimatch-3.0.3"
@@ -26464,7 +26428,7 @@ in
       sources."forever-agent-0.6.1"
       sources."form-data-1.0.1"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."qs-5.2.1"
       sources."tunnel-agent-0.4.3"
@@ -26479,11 +26443,11 @@ in
       sources."is-typedarray-1.0.0"
       sources."har-validator-2.0.6"
       sources."async-2.0.1"
-      sources."lodash-4.15.0"
-      sources."mime-db-1.23.0"
+      sources."lodash-4.16.2"
+      sources."mime-db-1.24.0"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -26503,14 +26467,10 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
+      sources."bcrypt-pbkdf-1.0.0"
       sources."hoek-2.16.3"
       sources."boom-2.10.1"
       sources."cryptiles-2.0.5"
@@ -26518,7 +26478,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."chalk-1.1.3"
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."has-ansi-2.0.0"
@@ -26589,7 +26549,7 @@ in
           sources."source-map-0.4.4"
         ];
       })
-      sources."graceful-fs-4.1.6"
+      sources."graceful-fs-4.1.9"
       sources."big.js-3.1.3"
       sources."emojis-list-2.0.1"
       sources."json5-0.5.0"
@@ -26640,7 +26600,7 @@ in
       })
       sources."vm-browserify-0.0.4"
       sources."pako-0.2.9"
-      sources."base64-js-1.1.2"
+      sources."base64-js-1.2.0"
       sources."ieee754-1.1.6"
       sources."date-now-0.1.4"
       sources."pbkdf2-compat-2.0.1"
@@ -26723,7 +26683,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."request-2.74.0"
+      sources."request-2.75.0"
       sources."rimraf-2.5.4"
       sources."semver-5.3.0"
       sources."tar-2.2.1"
@@ -26763,18 +26723,14 @@ in
       sources."combined-stream-1.0.5"
       sources."extend-3.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-1.0.1" // {
-        dependencies = [
-          sources."async-2.0.1"
-        ];
-      })
+      sources."form-data-2.0.0"
       sources."har-validator-2.0.6"
       sources."hawk-3.1.3"
       sources."http-signature-1.1.1"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."json-stringify-safe-5.0.1"
-      sources."mime-types-2.1.11"
+      sources."mime-types-2.1.12"
       sources."node-uuid-1.4.7"
       sources."oauth-sign-0.8.2"
       sources."qs-6.2.1"
@@ -26782,14 +26738,14 @@ in
       sources."tough-cookie-2.3.1"
       sources."tunnel-agent-0.4.3"
       sources."delayed-stream-1.0.0"
-      sources."lodash-4.15.0"
+      sources."asynckit-0.4.0"
       (sources."chalk-1.1.3" // {
         dependencies = [
           sources."supports-color-2.0.0"
         ];
       })
       sources."commander-2.9.0"
-      sources."is-my-json-valid-2.13.1"
+      sources."is-my-json-valid-2.14.0"
       sources."pinkie-promise-2.0.1"
       sources."ansi-styles-2.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -26807,7 +26763,7 @@ in
       sources."sntp-1.0.9"
       sources."assert-plus-0.2.0"
       sources."jsprim-1.3.1"
-      (sources."sshpk-1.10.0" // {
+      (sources."sshpk-1.10.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -26827,16 +26783,12 @@ in
         ];
       })
       sources."jsbn-0.1.0"
-      sources."tweetnacl-0.13.3"
+      sources."tweetnacl-0.14.3"
       sources."jodid25519-1.0.2"
       sources."ecc-jsbn-0.1.1"
-      (sources."bcrypt-pbkdf-1.0.0" // {
-        dependencies = [
-          sources."tweetnacl-0.14.3"
-        ];
-      })
-      sources."mime-db-1.23.0"
-      sources."glob-7.0.6"
+      sources."bcrypt-pbkdf-1.0.0"
+      sources."mime-db-1.24.0"
+      sources."glob-7.1.0"
       sources."fs.realpath-1.0.0"
       sources."inflight-1.0.5"
       sources."once-1.4.0"

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -12,6 +12,7 @@
 , "elasticdump"
 , "emoj"
 , "eslint"
+, "emojione"
 , "fetch-bower"
 , "forever"
 , "git-run"

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchurl, makeWrapper
 , intltool, isocodes, pkgconfig
 , python3, pygobject3
-, gtk2, gtk3, atk, dconf, glib
+, gtk2, gtk3, atk, dconf, glib, json_glib
 , dbus, libnotify, gobjectIntrospection, wayland
+, nodePackages
 }:
 
 stdenv.mkDerivation rec {
   name = "ibus-${version}";
-  version = "1.5.13";
+  version = "1.5.14";
 
   src = fetchurl {
     url = "https://github.com/ibus/ibus/releases/download/${version}/${name}.tar.gz";
-    sha256 = "1wd5azlsgdih8qw6gi15rv130s6d90846n3r1ccwmp6z882xhwzd";
+    sha256 = "0g4x02d7j5w1lfn4zvmzsq93h17lajgn9d7hlvr6pws28vz40ax4";
   };
 
   postPatch = ''
@@ -29,12 +30,14 @@ stdenv.mkDerivation rec {
     "--disable-memconf"
     "--enable-ui"
     "--enable-python-library"
+    "--with-emoji-json-file=${nodePackages.emojione}/lib/node_modules/emojione/emoji.json"
   ];
 
   buildInputs = [
     python3 pygobject3
     intltool isocodes pkgconfig
     gtk2 gtk3 dconf
+    json_glib
     dbus libnotify gobjectIntrospection wayland
   ];
 
@@ -63,6 +66,9 @@ stdenv.mkDerivation rec {
         --prefix GIO_EXTRA_MODULES : "${dconf}/lib/gio/modules"
     done
   '';
+
+  doInstallCheck = true;
+  installCheckPhase = "$out/bin/ibus version";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/ibus/ibus;


### PR DESCRIPTION
###### Motivation for this change

Update ibus to latest version.
release notes: https://github.com/ibus/ibus/releases/tag/1.5.14

This add a new emoji input mode, [details](https://fedoraproject.org/wiki/Changes/IBus_Emoji_Typing).

This also contains the following changes:
- added `nodePackages.emojione` (new dependency of ibus)
- added an `installCheck` to ibus
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ttuegel 
