### PR TITLE
logstash: wrapProgram to provide jre at runtime

### DIFF
--- a/pkgs/tools/misc/logstash/default.nix
+++ b/pkgs/tools/misc/logstash/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, makeWrapper, jre  }:
 
 stdenv.mkDerivation rec {
   version = "2.3.4";
@@ -14,10 +14,22 @@ stdenv.mkDerivation rec {
   dontStrip         = true;
   dontPatchShebangs = true;
 
+  buildInputs = [
+    makeWrapper jre
+  ];
+  
   installPhase = ''
     mkdir -p $out
     cp -r {Gemfile*,vendor,lib,bin} $out
-    mv $out/bin/plugin $out/bin/logstash-plugin
+	
+    wrapProgram $out/bin/logstash \
+       --set JAVA_HOME "${jre}"
+	   
+    wrapProgram $out/bin/rspec \
+       --set JAVA_HOME "${jre}"
+	
+    wrapProgram $out/bin/logstash-plugin \
+       --set JAVA_HOME "${jre}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

logstash complains when executing it from CLI if it does not have access to the JRE

``` bash
[root@nixos:~/nixpkgs]# logstash
Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME.
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS - 16.03
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
