### PR TITLE
gnome-maps: add webkitgtk to buildInputs

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/apps/gnome-maps/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, intltool, pkgconfig, gnome3, gtk3
 , gobjectIntrospection, gdk_pixbuf, librsvg, autoreconfHook
-, geoclue2, wrapGAppsHook, folks, libchamplain, gfbgraph, file, libsoup }:
+, geoclue2, wrapGAppsHook, folks, libchamplain, gfbgraph, file, libsoup
+, webkitgtk }:
 
 stdenv.mkDerivation rec {
   inherit (import ./src.nix fetchurl) name src;
@@ -12,7 +13,8 @@ stdenv.mkDerivation rec {
                   gnome3.geocode_glib libchamplain file libsoup
                   gdk_pixbuf librsvg autoreconfHook
                   gnome3.gsettings_desktop_schemas gnome3.evolution_data_server
-                  gnome3.gnome_online_accounts gnome3.defaultIconTheme ];
+                  gnome3.gnome_online_accounts gnome3.defaultIconTheme
+                  webkitgtk ];
 
   patches = [ ./soup.patch ];
 


### PR DESCRIPTION
###### Motivation for this change

Per #17143 on GitHub, `gnome-maps` currently fails due to missing
Webkit2. Adding `webkitgtk` to `buildInputs` fixes the issue. Fixes #17143.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
