### PR TITLE
libpointmatcher: only build on linux 64bit platform

### DIFF
--- a/pkgs/development/libraries/libpointmatcher/default.nix
+++ b/pkgs/development/libraries/libpointmatcher/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     description = "An \"Iterative Closest Point\" library for 2-D/3-D mapping in robotic";
     license = licenses.bsd3;
-    platforms   = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ cryptix ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Hydra [pointed out to me](https://hydra.nixos.org/build/41344008/nixlog/3#line-32) that this library is only supported on 64bit systems.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
