### PR TITLE
flake8: 2.5.4 -> 3.0.4

### DIFF
--- a/pkgs/development/python-modules/flake8/move-pytest-config-to-pytest-ini.patch
+++ b/pkgs/development/python-modules/flake8/move-pytest-config-to-pytest-ini.patch
@@ -1,0 +1,22 @@
+diff -r ad8325924f04 pytest.ini
+--- /dev/null	Thu Jan 01 00:00:00 1970 +0000
++++ b/pytest.ini	Fri Sep 30 12:28:39 2016 +0200
+@@ -0,0 +1,4 @@
++[pytest]
++-norecursedirs = .git .* *.egg* old docs dist build
++-addopts = -rwv
++
+diff -r ad8325924f04 setup.cfg
+--- a/setup.cfg	Fri Sep 30 09:22:39 2016 +0200
++++ b/setup.cfg	Fri Sep 30 12:28:39 2016 +0200
+@@ -12,10 +12,6 @@
+ 	pycodestyle >= 2.0.0, < 2.1.0
+ 	mccabe >= 0.5.0, < 0.6.0
+ 
+-[pytest]
+-norecursedirs = .git .* *.egg* old docs dist build
+-addopts = -rw
+-
+ [egg_info]
+ tag_build = 
+ tag_date = 0

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10517,7 +10517,7 @@ in modules // {
       sha256 = "03cpdrjxh0fyi2qpdxbbrmxw7whiq3xr3p958gr6yzghk34i1hml";
     };
 
-    buildInputs = with self; [ nose mock ];
+    buildInputs = with self; [ nose mock pytestrunner pytest ];
     propagatedBuildInputs = with self; [ pyflakes pep8 mccabe enum34 configparser pycodestyle ];
 
     patches = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10489,6 +10489,23 @@ in modules // {
     };
   };
 
+  pycodestyle = buildPythonPackage rec {
+    name = "pycodestyle-${version}";
+    version = "2.0.0";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/p/pycodestyle/${name}.tar.gz";
+      sha256 = "1rz2v8506mdjdyxcnv9ygiw6v0d4dqx8z5sjyjm0w2v32h5l5w1p";
+    };
+
+    meta = {
+      description = "Python style guide checker (formerly called pep8)";
+      homepage = https://pycodestyle.readthedocs.io;
+      license = licenses.mit;
+      maintainers = with maintainers; [ garbas ];
+    };
+  };
+
   flake8 = buildPythonPackage rec {
     name = "flake8-${version}";
     version = "2.5.4";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10506,6 +10506,8 @@ in modules // {
     };
   };
 
+  pep8 = self.pycodestyle;
+
   flake8 = buildPythonPackage rec {
     name = "flake8-${version}";
     version = "2.5.4";
@@ -17565,23 +17567,6 @@ in modules // {
       homepage = "http://getpelican.com/";
       license = licenses.agpl3;
       maintainers = with maintainers; [ offline prikhi garbas ];
-    };
-  };
-
-  pep8 = buildPythonPackage rec {
-    name = "pep8-${version}";
-    version = "1.7.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pep8/${name}.tar.gz";
-      sha256 = "a113d5f5ad7a7abacef9df5ec3f2af23a20a28005921577b15dd584d099d5900";
-    };
-
-    meta = {
-      homepage = "http://pep8.readthedocs.org/";
-      description = "Python style guide checker";
-      license = licenses.mit;
-      maintainers = with maintainers; [ garbas ];
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13414,21 +13414,12 @@ in modules // {
 
 
   mccabe = buildPythonPackage (rec {
-    name = "mccabe-0.4.0";
+    name = "mccabe-0.5.2";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/m/mccabe/${name}.tar.gz";
-      sha256 = "0yr08a36h8lqlif10l4xcikbbig7q8f41gqywir7rrvnv3mi4aws";
+      sha256 = "1zss8c5cn8wvxsbjzv70dxymybh3cjzrjl19vxfbnyvmidng0wrl";
     };
-
-    # See https://github.com/flintwork/mccabe/issues/31
-    postPatch = ''
-      cp "${pkgs.fetchurl {
-        url = "https://raw.githubusercontent.com/flintwork/mccabe/"
-            + "e8aea16d28e92bd3c62601275762fc9c16808f6c/test_mccabe.py";
-        sha256 = "0xhjxpnaxvbpi4myj9byrban7a5nrw931br9sgvfk42ayg4sn6lm";
-      }}" test_mccabe.py
-    '';
 
     buildInputs = with self; [ pytestrunner pytest ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10510,15 +10510,24 @@ in modules // {
 
   flake8 = buildPythonPackage rec {
     name = "flake8-${version}";
-    version = "2.5.4";
+    version = "3.0.4";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/f/flake8/${name}.tar.gz";
-      sha256 = "0bs9cz4fr99r2rwig1b8jwaadl1nan7kgpdzqwj0bwbckwbmh7nc";
+      sha256 = "03cpdrjxh0fyi2qpdxbbrmxw7whiq3xr3p958gr6yzghk34i1hml";
     };
 
     buildInputs = with self; [ nose mock ];
-    propagatedBuildInputs = with self; [ pyflakes pep8 mccabe ];
+    propagatedBuildInputs = with self; [ pyflakes pep8 mccabe enum34 configparser pycodestyle ];
+
+    patches = [
+      ../development/python-modules/flake8/move-pytest-config-to-pytest-ini.patch
+    ];
+
+    # Tests fail due to missing ini file.
+    preCheck = ''
+      touch tox.ini
+    '';
 
     meta = {
       description = "Code checking using pep8 and pyflakes";


### PR DESCRIPTION
###### Motivation for this change

I need a recent version of flake8 to run the current version of spacemacs (python layer).
###### Things done

I replaced/aliased the pep8 package because it is renamed to pycodestyle now. Not sure if this is the right way to keep backwards compatibility until all other packages are referencing pycodestyle instead of pep8.
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
