### PR TITLE
md2man: enable for darwin

### DIFF
--- a/pkgs/development/tools/misc/md2man/default.nix
+++ b/pkgs/development/tools/misc/md2man/default.nix
@@ -20,6 +20,6 @@ buildGoPackage rec {
     license = licenses.mit;
     homepage = https://github.com/cpuguy83/go-md2man;
     maintainers = with maintainers; [offline];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
