### PR TITLE
ibus-libpinyin: 1.7.4 -> 1.8.0

### DIFF
--- a/pkgs/development/libraries/libpinyin/default.nix
+++ b/pkgs/development/libraries/libpinyin/default.nix
@@ -1,19 +1,34 @@
-{ stdenv, fetchurl, glib, db, pkgconfig }:
+{ stdenv, fetchurl, fetchFromGitHub, autoreconfHook, glib, db, pkgconfig }:
 
-stdenv.mkDerivation {
-  name = "libpinyin-1.3.0";
+let
+  modelData = fetchurl {
+    url    = "mirror://sourceforge/libpinyin/models/model12.text.tar.gz";
+    sha256 = "1fijhhnjgj8bj1xr5pp7c4qxf11cqybgfqg7v36l3x780d84hfnd";
+  };
+in
+
+stdenv.mkDerivation rec {
+  name = "libpinyin-${version}";
+  version = "1.6.0";
+
+  nativeBuildInputs = [ autoreconfHook glib db pkgconfig ];
+
+  postUnpack = ''
+    tar -xzf ${modelData} -C $sourceRoot/data
+  '';
+
+  src = fetchFromGitHub {
+    owner  = "libpinyin";
+    repo   = "libpinyin";
+    rev    = version;
+    sha256 = "0k40a7wfp8zj9d426afv0am5sr3m2i2p309fq0vf8qrb050hj17f";
+  };
 
   meta = with stdenv.lib; {
     description = "Library for intelligent sentence-based Chinese pinyin input method";
     homepage    = https://sourceforge.net/projects/libpinyin;
     license     = licenses.gpl2;
+    maintainers = with maintainers; [ ericsagnes ];
     platforms   = platforms.linux;
-  };
-
-  buildInputs = [ glib db pkgconfig ];
-
-  src = fetchurl {
-    url = "mirror://sourceforge/project/libpinyin/libpinyin/libpinyin-1.3.0.tar.gz";
-    sha256 = "e105c443b01cd67b9db2a5236435d5441cf514b997b891215fa65f16030cf1f2";
   };
 }

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
@@ -1,29 +1,31 @@
-{ stdenv, fetchurl, intltool, pkgconfig, sqlite, libpinyin, db
+{ stdenv, fetchFromGitHub, autoreconfHook
+, intltool, pkgconfig, sqlite, libpinyin, db
 , ibus, glib, gtk3, python3, pygobject3
 }:
 
 stdenv.mkDerivation rec {
   name = "ibus-libpinyin-${version}";
-  version = "1.7.4";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner  = "libpinyin";
+    repo   = "ibus-libpinyin";
+    rev    = version;
+    sha256 = "1d85kzlhav0ay798i88yqyrjbkv3y7w2aiadpmcjgscyd5ccsnnz";
+  };
+
+  buildInputs = [ ibus glib sqlite libpinyin python3 gtk3 db ];
+  nativeBuildInputs = [ autoreconfHook intltool pkgconfig ];
+
+  postAutoreconf = ''
+    intltoolize
+  '';
 
   meta = with stdenv.lib; {
     isIbusEngine = true;
     description  = "IBus interface to the libpinyin input method";
-    homepage     = https://github.com/libpinyin/ibus-libpinyin;
     license      = licenses.gpl2;
+    maintainers  = with maintainers; [ ericsagnes ];
     platforms    = platforms.linux;
-  };
-
-  #configureFlags = "--with-anthy-zipcode=${anthy}/share/anthy/zipcode.t";
-
-  buildInputs = [
-  ibus glib sqlite libpinyin python3 gtk3 db
-  ];
-
-  nativeBuildInputs = [ intltool pkgconfig ];
-
-  src = fetchurl {
-    url = "mirror://sourceforge/project/libpinyin/ibus-libpinyin/ibus-libpinyin-${version}.tar.gz";
-    sha256 = "c2085992f76ca669ebe4b7e7c0170433bbfb61f764f8336b3b17490b9fb1c334";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update ibus-libpinyin to the latest version.

This also update libpinyin as a requirement, but ibus-libpinyin is the only package using libpinyin as a dependency.

Additional changes:
- sources are fetched from github (main repo)
- few cosmetic changes
- added maintainer
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
