### PR TITLE
ibus-table: 1.9.11 -> 1.9.14

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
@@ -1,13 +1,17 @@
-{ stdenv, fetchurl, pkgconfig
-, gtk3, dconf, gobjectIntrospection, ibus, python3, pygobject3 }:
+{ stdenv, fetchFromGitHub
+, autoreconfHook, docbook2x, pkgconfig
+, gtk3, dconf, gobjectIntrospection
+, ibus, python3, pygobject3 }:
 
 stdenv.mkDerivation rec {
   name = "ibus-table-${version}";
-  version = "1.9.11";
+  version = "1.9.14";
 
-  src = fetchurl {
-    url = "https://github.com/kaio/ibus-table/releases/download/${version}/${name}.tar.gz";
-    sha256 = "14sb89z1inbbhcrbsm5nww8la04ncy2lk32mxfqpi4ghl22ixxqd";
+  src = fetchFromGitHub {
+    owner  = "kaio";
+    repo   = "ibus-table";
+    rev    = version;
+    sha256 = "1mkx03iqrq5yq57y7hjqcmxfh41dsjykyyl70d41dflcgp5q2nhw";
   };
 
   postPatch = ''
@@ -28,7 +32,12 @@ stdenv.mkDerivation rec {
     dconf gtk3 gobjectIntrospection ibus python3 pygobject3
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook docbook2x pkgconfig ];
+
+  postUnpack = ''
+    substituteInPlace $sourceRoot/engine/Makefile.am \
+      --replace "docbook2man" "docbook2man --sgml"
+  '';
 
   meta = with stdenv.lib; {
     isIbusEngine = true;


### PR DESCRIPTION
###### Motivation for this change

Update ibus-table to latest version.

@laMudri 
The package is building fine, but I have no idea on how to use or test this engine.
Could you check that everything is working as it should?
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

release notes:
- https://github.com/kaio/ibus-table/releases/tag/1.9.12
- https://github.com/kaio/ibus-table/releases/tag/1.9.13
- https://github.com/kaio/ibus-table/releases/tag/1.9.14
