### PR TITLE
linenoise: init at git-2016-09-30

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -277,6 +277,7 @@
   mounium = "Katona László <muoniurn@gmail.com>";
   MP2E = "Cray Elliott <MP2E@archlinux.us>";
   mpscholten = "Marc Scholten <marc@mpscholten.de>";
+  mpsyco = "Francis St-Amour <fr.st-amour@gmail.com>";
   msackman = "Matthew Sackman <matthew@wellquite.org>";
   mschristiansen = "Mikkel Christiansen <mikkel@rheosystems.com>";
   msteen = "Matthijs Steen <emailmatthijs@gmail.com>";

--- a/pkgs/development/libraries/linenoise/create-pkg-config-file.sh
+++ b/pkgs/development/libraries/linenoise/create-pkg-config-file.sh
@@ -1,0 +1,13 @@
+cat <<EOF > linenoise.pc
+prefix=$out
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: linenoise
+Description: A minimal, zero-config, BSD licensed, readline replacement.
+Requires: 
+Version: 1.0.10
+Cflags: -I\${includedir}/ \${prefix}/src/linenoise.c
+
+EOF

--- a/pkgs/development/libraries/linenoise/default.nix
+++ b/pkgs/development/libraries/linenoise/default.nix
@@ -1,0 +1,30 @@
+  { stdenv, fetchFromGitHub }:
+
+  stdenv.mkDerivation rec {
+    name = "linenoise-${version}";
+    version = "1.0.10";  # Its version 1.0 plus 10 commits
+
+    src = fetchFromGitHub {
+      owner = "antirez";
+      repo = "linenoise";
+      rev = "c894b9e59f02203dbe4e2be657572cf88c4230c3";
+      sha256 = "0wasql7ph5g473zxhc2z47z3pjp42q0dsn4gpijwzbxawid71b4w";
+    };
+
+    buildPhase = ./create-pkg-config-file.sh;
+
+    installPhase = ''
+      mkdir -p $out/{lib/pkgconfig,src,include}
+      cp linenoise.c $out/src/
+      cp linenoise.h $out/include/
+      cp linenoise.pc $out/lib/pkgconfig/
+      '';
+
+    meta = {
+      homepage = https://github.com/antirez/linenoise;
+      description = "A minimal, zero-config, BSD licensed, readline replacement";
+      maintainers = with stdenv.lib.maintainers; [ mpsyco ];
+      platforms = stdenv.lib.platforms.unix;
+      license = stdenv.lib.licenses.free;
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8245,6 +8245,8 @@ in
   lightning = callPackage ../development/libraries/lightning { };
 
   lightlocker = callPackage ../misc/screensavers/light-locker { };
+  
+  linenoise = callPackage ../development/libraries/linenoise { };
 
   lirc = callPackage ../development/libraries/lirc { };
 


### PR DESCRIPTION
###### Motivation for this change

I needed that library in order to build another custom package. Might be useful for others.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
  - [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md) AFAIK.

---

There is place for amelioration: static and dynamic builds and corresponding pkg-config file.
