### PR TITLE
glib{mm,-networking} -> 2.50.0 [-> staging]

### DIFF
--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -2,15 +2,15 @@
 , gsettings_desktop_schemas }:
 
 let
-  ver_maj = "2.46";
-  ver_min = "1";
+  ver_maj = "2.50";
+  ver_min = "0";
 in
 stdenv.mkDerivation rec {
   name = "glib-networking-${ver_maj}.${ver_min}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib-networking/${ver_maj}/${name}.tar.xz";
-    sha256 = "1cchmi08jpjypgmm9i7xzh5qfg2q5k61kry9ns8mhw3z44a440ym";
+    sha256 = "3f1a442f3c2a734946983532ce59ed49120319fdb10c938447c373d5e5286bee";
   };
 
   outputs = [ "out" "dev" ]; # to deal with propagatedBuildInputs

--- a/pkgs/development/libraries/glibmm/default.nix
+++ b/pkgs/development/libraries/glibmm/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, pkgconfig, gnum4, glib, libsigcxx }:
 
 let
-  ver_maj = "2.48";
-  ver_min = "1";
+  ver_maj = "2.50";
+  ver_min = "0";
 in
 stdenv.mkDerivation rec {
   name = "glibmm-${ver_maj}.${ver_min}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glibmm/${ver_maj}/${name}.tar.xz";
-    sha256 = "1pvw2mrm03p51p03179rb6fk9p42iykkwj1jcdv7jr265xymy8nw";
+    sha256 = "df726e3c6ef42b7621474b03b644a2e40ec4eef94a1c5a932c1e740a78f95e94";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

glib was already updated to 2.50.0 in staging with #18849 
these two libraries should probably match the glib version.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
