### PR TITLE
snapraid: 8.1 -> 10.0

### DIFF
--- a/pkgs/tools/filesystems/snapraid/default.nix
+++ b/pkgs/tools/filesystems/snapraid/default.nix
@@ -2,12 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "snapraid-${version}";
-  version = "8.1";
+  version = "10.0";
 
   src = fetchurl {
     url = "https://github.com/amadvance/snapraid/releases/download/v${version}/snapraid-${version}.tar.gz";
-    sha256 = "0pafqn9ismn4j3fsx8fgf008qwh2c6f8mjfjijah6d5c349rmy3b";
+    sha256 = "1mhs0gl285a5y2bw6k04lrnyg1pp2am7dfcsvg0w4vr5h2ag3p7p";
   };
+
+  doCheck = true;
 
   meta = {
     homepage = http://www.snapraid.it/;


### PR DESCRIPTION
###### Motivation for this change

bump snapraid to the newest version. 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
