### PR TITLE
libreswan: ignore sign-compare errors

### DIFF
--- a/pkgs/tools/networking/libreswan/default.nix
+++ b/pkgs/tools/networking/libreswan/default.nix
@@ -42,14 +42,15 @@ stdenv.mkDerivation {
     # Fix python script to use the correct python
     sed -i -e 's|#!/usr/bin/python|#!/usr/bin/env python|' -e 's/^\(\W*\)installstartcheck()/\1sscmd = "ss"\n\0/' programs/verify/verify.in
   '';
-  
+
   # Set appropriate paths for build
   preBuild = "export INC_USRLOCAL=\${out}";
 
-  makeFlags = [ 
+  makeFlags = [
     "INITSYSTEM=systemd"
     (if docs then "all" else "base")
   ];
+  CFLAGS = "-Wno-error=sign-compare";
 
   installTargets = [ (if docs then "install" else "install-base") ];
   # Hack to make install work


### PR DESCRIPTION
###### Motivation for this change

Fixes evaluation: http://hydra.nixos.org/build/41496695
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
