### PR TITLE
cbfstool: Disable sign-compare error in compile

### DIFF
--- a/pkgs/applications/virtualization/cbfstool/default.nix
+++ b/pkgs/applications/virtualization/cbfstool/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ iasl flex bison ];
 
   hardeningDisable = [ "fortify" ];
+  CFLAGS = "-Wno-error=sign-compare";
 
   buildPhase = ''
     export LEX=${flex}/bin/flex
@@ -34,4 +35,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
