### PR TITLE
llvm3.9: Remove -DCMAKE_BUILD_TYPE=Release flags

### DIFF
--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -16,7 +16,6 @@ let
     buildInputs = [ cmake libedit libxml2 llvm python ];
 
     cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
       "-DCMAKE_CXX_FLAGS=-std=c++11"
     ] ++
     # Maybe with compiler-rt this won't be needed?

--- a/pkgs/development/compilers/llvm/3.9/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/libc++/default.nix
@@ -18,8 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  cmakeFlags =
-    [ "-DCMAKE_BUILD_TYPE=Release"
+  cmakeFlags = [
       "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
       "-DLIBCXX_LIBCPPABI_VERSION=2"
       "-DLIBCXX_CXX_ABI=libcxxabi"

--- a/pkgs/development/compilers/llvm/3.9/lldb.nix
+++ b/pkgs/development/compilers/llvm/3.9/lldb.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation {
   hardeningDisable = [ "format" ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DLLVM_MAIN_INCLUDE_DIR=${llvm}/include"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

LLVM 3.9 seems to have gotten added after I made the previous PR #18000.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Since commit 183d05a in 2012, this is the default.
cc @Mic92 
