### PR TITLE
gtk-vnc: remove gtk2 support, 0.5.3 -> 0.6.0

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/default.nix
@@ -46,7 +46,7 @@ let
   ];
 
   inherit (pkgs) glib gtk2 webkitgtk24x webkitgtk212x gtk3 gtkmm3 libcanberra_gtk2
-    clutter clutter-gst clutter_gtk cogl;
+    clutter clutter-gst clutter_gtk cogl gtkvnc;
   inherit (pkgs.gnome2) ORBit2;
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
@@ -54,7 +54,6 @@ let
   gnome3 = self // { recurseForDerivations = false; };
   gtk = gtk3;
   gtkmm = gtkmm3;
-  gtkvnc = pkgs.gtkvnc.override { enableGTK3 = true; };
   vala = pkgs.vala_0_32;
   gegl_0_3 = pkgs.gegl_0_3.override { inherit gtk; };
   webkitgtk = webkitgtk212x;
@@ -268,7 +267,6 @@ let
   glade = callPackage ./apps/glade { };
 
   gnome-boxes = callPackage ./apps/gnome-boxes {
-    gtkvnc = pkgs.gtkvnc.override { enableGTK3 = true; };
     spice_gtk = pkgs.spice_gtk;
   };
 

--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, gobjectIntrospection
-, gtk2, gnutls, cairo, libtool, glib, pkgconfig, libtasn1
+, gnutls, cairo, libtool, glib, pkgconfig, libtasn1
 , libffi, cyrus_sasl, intltool, perl, perlPackages, libpulseaudio
 , kbproto, libX11, libXext, xextproto, libgcrypt, gtk3, vala_0_23
-, libogg, enableGTK3 ? false, libgpgerror, pythonPackages }:
+, libogg, libgpgerror, pythonPackages }:
 
 let
-  inherit (pythonPackages) pygobject3 pygobject2 pygtk python;
+  inherit (pythonPackages) pygobject3 python;
 in stdenv.mkDerivation rec {
   name = "gtk-vnc-${version}";
   version = "0.5.3";
@@ -19,17 +19,14 @@ in stdenv.mkDerivation rec {
     python gnutls cairo libtool pkgconfig glib libffi libgcrypt
     intltool cyrus_sasl libpulseaudio perl perlPackages.TextCSV
     gobjectIntrospection libogg libgpgerror
-  ] ++ (if enableGTK3 then [ gtk3 vala_0_23 pygobject3 ] else [ gtk2 pygtk pygobject2 ]);
+    gtk3 vala_0_23 pygobject3 ];
 
   NIX_CFLAGS_COMPILE = "-fstack-protector-all";
   configureFlags = [
     "--with-python"
     "--with-examples"
-    (if enableGTK3 then "--with-gtk=3.0" else "--with-gtk=2.0")
+    "--with-gtk=3.0"
   ];
-
-  makeFlags = stdenv.lib.optionalString (!enableGTK3)
-    "CODEGENDIR=${pygobject2}/share/pygobject/2.0/codegen/ DEFSDIR=${pygtk}/share/pygtk/2.0/defs/";
 
   # Fix broken .la files
   preFixup = ''

--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -1,31 +1,30 @@
 { stdenv, fetchurl, gobjectIntrospection
 , gnutls, cairo, libtool, glib, pkgconfig, libtasn1
 , libffi, cyrus_sasl, intltool, perl, perlPackages, libpulseaudio
-, kbproto, libX11, libXext, xextproto, libgcrypt, gtk3, vala_0_23
+, kbproto, libX11, libXext, xextproto, libgcrypt, gtk3, vala_0_32
 , libogg, libgpgerror, pythonPackages }:
 
 let
   inherit (pythonPackages) pygobject3 python;
 in stdenv.mkDerivation rec {
   name = "gtk-vnc-${version}";
-  version = "0.5.3";
+  version = "0.6.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gtk-vnc/0.5/${name}.tar.xz";
-    sha256 = "1bww2ihxb3zzvifdrcsy1lifr664pvikq17hmr1hsm8fyk4ad46l";
+    url = "mirror://gnome/sources/gtk-vnc/0.6/${name}.tar.xz";
+    sha256 = "9559348805e64d130dae569fee466930175dbe150d2649bb868b5c095f130433";
   };
 
   buildInputs = [
     python gnutls cairo libtool pkgconfig glib libffi libgcrypt
     intltool cyrus_sasl libpulseaudio perl perlPackages.TextCSV
     gobjectIntrospection libogg libgpgerror
-    gtk3 vala_0_23 pygobject3 ];
+    gtk3 vala_0_32 pygobject3 ];
 
   NIX_CFLAGS_COMPILE = "-fstack-protector-all";
   configureFlags = [
     "--with-python"
     "--with-examples"
-    "--with-gtk=3.0"
   ];
 
   # Fix broken .la files

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14680,7 +14680,6 @@ in
   };
 
   virt-viewer = callPackage ../applications/virtualization/virt-viewer {
-    gtkvnc = gtkvnc.override { enableGTK3 = true; };
     spice_gtk = spice_gtk;
   };
 
@@ -14688,7 +14687,6 @@ in
     inherit (gnome2) gnome_python;
     vte = gnome3.vte;
     dconf = gnome3.dconf;
-    gtkvnc = gtkvnc.override { enableGTK3 = true; };
     spice_gtk = spice_gtk;
     system-libvirt = libvirt;
   };


### PR DESCRIPTION
###### Motivation for this change

No package was using gtk-vnc with gtk2.
I'm not sure why it even causes rebuild..
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
