### PR TITLE
powerdns: removed PrivateTmp=true in serviceConfig

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -290,6 +290,7 @@
   nckx = "Tobias Geerinckx-Rice <tobias.geerinckx.rice@gmail.com>";
   nequissimus = "Tim Steinbach <tim@nequissimus.com>";
   nfjinjing = "Jinjing Wang <nfjinjing@gmail.com>";
+  nhooyr = "Anmol Sethi <anmol@aubble.com>";
   nico202 = "Nicolò Balzarotti <anothersms@gmail.com>";
   notthemessiah = "Brian Cohen <brian.cohen.88@gmail.com>";
   NikolaMandic = "Ratko Mladic <nikola@mandic.email>";

--- a/nixos/modules/services/networking/powerdns.nix
+++ b/nixos/modules/services/networking/powerdns.nix
@@ -35,7 +35,6 @@ in {
         Restart="on-failure";
         RestartSec="1";
         StartLimitInterval="0";
-        PrivateTmp=true;
         PrivateDevices=true;
         CapabilityBoundingSet="CAP_CHOWN CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT";
         NoNewPrivileges=true;

--- a/pkgs/servers/dns/powerdns/default.nix
+++ b/pkgs/servers/dns/powerdns/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     # cannot find postgresql libs on macos x
     license = licenses.gpl2;
-    maintainers = [ maintainers.mic92 ];
+    maintainers = [ maintainers.mic92 maintainers.nhooyr ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

As discussed in #18187 (sorry I meant #18718) PrivateTmp is unnecessary because powerdns is
chrooted to /var/lib/powerdns.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
