### PR TITLE
uwsgi: enable cgi plugin

### DIFF
--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -25,6 +25,10 @@ let pythonPlugin = pkg : lib.nameValuePair "python${if pkg ? isPy2 then "2" else
                     path = "plugins/rack";
                     inputs = [ ruby ];
                   })
+                  (lib.nameValuePair "cgi" {
+                    path = "plugins/cgi";
+                    inputs = [ ];
+                  })
                 ];
 
     getPlugin = name:


### PR DESCRIPTION
How to use it with nginx and PHP:

``` nginx
location ~ (index)\.php$ {
  include ${pkgs.nginx}/conf/uwsgi_params;
  uwsgi_modifier1 9;
  uwsgi_pass unix:/run/uwsgi/cgi.sock;
}
```

``` nix
services.uwsgi = {
  enable = true;
  user = "nginx";
  group = "nginx";
  instance = {
    type = "emperor";
    vassals = {
      mycgi = {
        type = "normal";
        socket = "/run/uwsgi/cgi.sock";
        async = 50;
        ugreen = true;
        cgi = "/var/www/webapp";
        cgi-allowed-ext = ".php";
        cgi-helper = ".php=${pkgs.php}/bin/php-cgi";
        plugins = [ "cgi" ];
      };
    };
  };
  plugins = [ "cgi" ];
};
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
