### PR TITLE
php: build embedded, uwsgi: enable php plugin

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5720,6 +5720,14 @@ in
     php70
     php71;
 
+  php-embed = php71-embed;
+
+  php71-embed = php71.override {
+    config.php.embed = true;
+    config.php.apxs2 = false;
+  };
+
+
   picoc = callPackage ../development/interpreters/picoc {};
 
   picolisp = callPackage ../development/interpreters/picolisp {};


### PR DESCRIPTION
Allows to run uwsgi with the PHP plugin.
The plugin needs embedded PHP, so I added php70-embed. (@globin)

Usage example:

``` nginx
location ~ (index)\.php$ {
  include ${pkgs.nginx}/conf/uwsgi_params;
  uwsgi_modifier1 14;
  uwsgi_pass unix:/run/uwsgi/php.sock;
}
```

``` nix
services.uwsgi = {
  enable = true;
  user = "nginx";
  group = "nginx";
  instance = {
    type = "emperor";
    vassals = {
      php = {
        type = "normal";
        socket = "/run/uwsgi/php.sock";
        master = true;

        processes = 16;
        cheaper = 1;
        php-sapi-name = "apache";
        php-allowed-ext = [ ".php" ".inc" ];
        socket-modifier1 = 14;
        php-index = "index.php";

        php-set = "date.timezone=Europe/Berlin";
        env = "NEXTCLOUD_CONFIG_DIR=/var/www/nextcloud/config";

        plugins = [ "php" ];
      };
    };
  };
  plugins = [ "php" ];
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
