### PR TITLE
factorio: Don't set argv[0]

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -114,6 +114,7 @@ let
       wrapProgram $out/bin/factorio                                \
         --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:$libPath \
         --run "$out/share/factorio/update-config.sh"               \
+        --argv0 "" \
         --add-flags "-c \$HOME/.factorio/config.cfg ${optionalString (mods != []) "--mod-directory=${modDir}"}"
 
         # TODO Currently, every time a mod is changed/added/removed using the


### PR DESCRIPTION
###### Motivation for this change

This stops factorio from crashing when you modify the mod configuration.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is needed to let its auto-restart function work, e.g. when changing the mod
setup.
