### PR TITLE
ibus: explain ibus-table in the docs

### DIFF
--- a/nixos/modules/i18n/input-method/default.xml
+++ b/nixos/modules/i18n/input-method/default.xml
@@ -56,8 +56,18 @@ i18n.inputMethod = {
   <listitem><para>Table (<literal>ibus-engines.table</literal>): An input method 
       that load tables of input methods.</para></listitem>
   <listitem><para>table-others (<literal>ibus-engines.table-others</literal>): 
-      Various table-based input methods.</para></listitem>
+      Various table-based input methods. To use this, and any other table-based
+      input methods, it must appear in the list of engines along with
+      <literal>table</literal>. For example:
+<programlisting>
+ibus.engines = with pkgs.ibus-engines; [ table table-others ];
+</programlisting>
+  </para></listitem>
 </itemizedlist>
+
+<para>To use any input method, the package must be added in the configuration,
+  as shown above, and also (after running <literal>nixos-rebuild</literal>) the
+  input method must be added from IBus' preference dialog.</para>
 </section>
 
 <section><title>Fcitx</title>


### PR DESCRIPTION
###### Motivation for this change

How to use table-based input methods for IBus was previously not clear.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ericsagnes, following from our discussion on #19116.
