### PR TITLE
kibana: fix 4.6.0 for i686

### DIFF
--- a/pkgs/development/tools/misc/kibana/default.nix
+++ b/pkgs/development/tools/misc/kibana/default.nix
@@ -3,8 +3,12 @@
 with stdenv.lib;
 let
   inherit (builtins) elemAt;
+  archOverrides = {
+    "i686" = "x86";
+  };
   info = splitString "-" stdenv.system;
-  arch = elemAt info 0;
+  arch = (elemAt info 0);
+  elasticArch = archOverrides."${arch}" or arch;
   plat = elemAt info 1;
   shas = {
     "x86_64-linux"  = "1md3y3a8rxvf37lnfc56kbirv2rjl68pa5672yxhfmjngrr20rcw";
@@ -16,7 +20,7 @@ in stdenv.mkDerivation rec {
   version = "4.6.0";
 
   src = fetchurl {
-    url = "https://download.elastic.co/kibana/kibana/${name}-${plat}-${arch}.tar.gz";
+    url = "https://download.elastic.co/kibana/kibana/${name}-${plat}-${elasticArch}.tar.gz";
     sha256 = shas."${stdenv.system}";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes problem reported in common on #18277 w.r.t. i686 build.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS

```
$ nixos-version
16.09beta430.c4469ed (Flounder)
```
- [ ] OS X
- [ ] Linux
  - [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  - [X] Tested execution of all binary files (usually in `./result/bin/`)

```
$ env BABEL_CACHE_PATH=./.babelcache.json ./result/bin/kibana -e localhost:9200 -p 5601 --verbose -l . ser
  log   [14:51:48.333] [info][listening] Server running at http://0.0.0.0:5601
^Z

$ curl -i localhost:5601
HTTP/1.1 200 OK
kbn-name: kibana
kbn-version: 4.6.0
cache-control: no-cache
content-type: text/html
content-length: 217
accept-ranges: bytes
Date: Sat, 01 Oct 2016 19:52:04 GMT
Connection: keep-alive

<script>var hashRoute = '/app/kibana';
var defaultRoute = '/app/kibana';

var hash = window.location.hash;
if (hash.length) {
  window.location = hashRoute + hash;
} else {
  window.location = defaultRoute;
}</script>
```
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also simple test of logic in REPL since I am on x86_64 not i686:

```
$ nix-repl
Welcome to Nix version 1.11.4. Type :? for help.

nix-repl> { "i686" = "x68"; }."i686" or "bla"
"x68"

nix-repl> { "i686" = "x68"; }."x86_64" or "bla"
"bla"
```

---
