### PR TITLE
vtk: fix darwin impurity

### DIFF
--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchpatch, cmake, mesa, libX11, xproto, libXt
 , qtLib ? null
 # Darwin support
-, Cocoa, CoreServices, DiskArbitration, IOKit, CFNetwork, Security, GLUT
+, Cocoa, CoreServices, DiskArbitration, IOKit, CFNetwork, Security, GLUT, OpenGL
 , ApplicationServices, CoreText, IOSurface, cf-private, ImageIO, xpc, libobjc }:
 
 with stdenv.lib;
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     then [ cmake mesa libX11 xproto libXt ] ++ optional (qtLib != null) qtLib
     else [ cmake qtLib xpc CoreServices DiskArbitration IOKit cf-private
            CFNetwork Security ApplicationServices CoreText IOSurface ImageIO
-           GLUT ];
+           OpenGL GLUT ];
   propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin [ Cocoa libobjc ];
 
 
@@ -42,7 +42,8 @@ stdenv.mkDerivation rec {
     ++ optional (qtLib != null) [ "-DVTK_USE_QT:BOOL=ON" ]
     ++ optional stdenv.isDarwin [ "-DBUILD_TESTING:BOOL=OFF"
                                   "-DCMAKE_OSX_SYSROOT="
-                                  "-DCMAKE_OSX_DEPLOYMENT_TARGET=" ];
+                                  "-DCMAKE_OSX_DEPLOYMENT_TARGET="
+                                  "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks" ];
 
   doCheck = !stdenv.isDarwin;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9263,7 +9263,7 @@ in
     inherit (darwin.apple_sdk.libs) xpc;
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices DiskArbitration
                                           IOKit CFNetwork Security ApplicationServices
-                                          CoreText IOSurface ImageIO GLUT;
+                                          CoreText IOSurface ImageIO OpenGL GLUT;
   };
 
   vtkWithQt4 = vtk.override { qtLib = qt4; };


### PR DESCRIPTION
###### Motivation for this change

Address a build failure on hydra. Part of the `vtk` build had trouble finding the OpenGL headers from the OpenGL framework on darwin.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
