### PR TITLE
Emacs all the icons fonts

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12972,7 +12972,8 @@ in
     external = {
       inherit (haskellPackages) ghc-mod structured-haskell-mode Agda hindent;
       inherit (pythonPackages) elpy;
-      inherit rtags libffi autoconf automake libpng zlib poppler pkgconfig;
+      inherit rtags libffi autoconf automake libpng zlib poppler pkgconfig
+      inherit font-awesome-ttf;
     };
   };
 

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -75,6 +75,25 @@ let
 
   ## START HERE
 
+  all-the-icons = melpaBuild rec {
+    pname = "all-the-icons";
+    version = "2.0.0";
+    src = fetchFromGitHub {
+      owner = "domtronn";
+      repo = "${pname}.el";
+      rev = version;
+      sha256 = "1zw6mkayf9dqxkk6pfb6niarkxk1jcwdln45jp7q7n8vq3cqg6rp";
+    };
+    propagatedBuildInputs = with external; [ font-awesome-ttf atom-file-icons ];
+    fileSpecs = [ "*.el" "data" ];
+    packageRequires = [ dash ];
+    meta = {
+      description = "A utility package to collect various Icon Fonts and propertize them within Emacs";
+      license = mit;
+    };
+  };
+
+
   tablist = melpaBuild rec {
     pname = "tablist";
     inherit (pdf-tools) src version;


### PR DESCRIPTION
###### Motivation for this change

`all-the-icons` is an Emacs package which needs some fonts to work. This PR adds the necessary fonts as propagated build inputs of this package.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
