### PR TITLE
nextcloud-news-updater: init at 9.0.2

### DIFF
--- a/pkgs/servers/nextcloud/news-updater.nix
+++ b/pkgs/servers/nextcloud/news-updater.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, python3Packages, php }:
+
+python3Packages.buildPythonApplication rec {
+  name = "nextcloud-news-updater-${version}";
+  version = "9.0.2";
+
+  src = fetchurl {
+    url = "mirror://pypi/n/nextcloud_news_updater/nextcloud_news_updater-${version}.tar.gz";
+    sha256 = "1m6g4591zyvjl2fji4iwl9api02racgc9rqa0gf0mfsqwdr77alw";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ php ];
+
+  meta = {
+    description = "Fast parallel feed updater for the Nextcloud news app";
+    homepage = "https://github.com/nextcloud/news-updater";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ schneefux ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2807,6 +2807,8 @@ in
 
   nextcloud = callPackage ../servers/nextcloud { };
 
+  nextcloud-news-updater = callPackage ../servers/nextcloud/news-updater.nix { };
+
   ngrep = callPackage ../tools/networking/ngrep { };
 
   ngrok = callPackage ../tools/networking/ngrok { };


### PR DESCRIPTION
Added the Python updater for the Nextcloud RSS reader app.
Execute it in a cron like this:

``` nix
systemd.services.nextcloud-news-cron = {
  script = "${pkgs.nextcloud-news-updater}/bin/nextcloud-news-updater -i 30 --mode singlerun ${pkgs.nextcloud}";
  environment = { NEXTCLOUD_CONFIG_DIR = "/etc/nextcloud"; };
};
systemd.timers.nextcloud-news-cron = {
  enable = true;
  partOf = [ "nextcloud-news-cron.service" ];
  timerConfig = {
    OnCalendar = "*-*-* *:00,30:00";
    Persistent = true;
  };
};
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
