### PR TITLE
c14: init at 2016-09-09

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -37,6 +37,7 @@
   andsild = "Anders Sildnes <andsild@gmail.com>";
   aneeshusa = "Aneesh Agrawal <aneeshusa@gmail.com>";
   antono = "Antono Vasiljev <self@antono.info>";
+  apeyroux = "Alexandre Peyroux <alex@px.io>";
   ardumont = "Antoine R. Dumont <eniotna.t@gmail.com>";
   aristid = "Aristid Breitkreuz <aristidb@gmail.com>";
   arobyn = "Alexei Robyn <shados@shados.net>";

--- a/pkgs/applications/networking/c14/default.nix
+++ b/pkgs/applications/networking/c14/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "c14-cli-2016-09-09";
+  goPackagePath = "github.com/online-net/c14-cli";
+  subPackages = [ "cmd/c14" ];
+
+  src = fetchFromGitHub {
+    owner = "online-net";
+    repo = "c14-cli";
+    rev = "e7c7c3cb214fd06df63530a4e861210e7a0a1b6c";
+    sha256 = "1k53lii2c04j8cy1bnyfvckl9fglprxp75cmbg15lrp9iic2w22a";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "C14 is designed for data archiving & long-term backups.";
+    homepage = "https://www.online.net/en/c14";
+    license = licenses.mit;
+    maintainers = with maintainers; [ apeyroux ];
+  };
+}

--- a/pkgs/applications/networking/c14/deps.nix
+++ b/pkgs/applications/networking/c14/deps.nix
@@ -1,0 +1,65 @@
+[
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "6d212800a42e8ab5c146b8ace3490ee17e5225f9";
+      sha256 = "01i0n1s4j7khb7n6mz2wymniz37q0vbzkgfv7rbi6p9hpg227q93";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "87d4004f2ab62d0d255e0a38f1680aa534549fe3";
+      sha256 = "0d51avdl4z38f7jd8qmzrzyh4gxkcjpxd0vvma9zfqhmqy15jqhb";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8";
+      sha256 = "034fhyqmiqmn0v9gdbdmm0ca5d0pki2q1ch1rd34p9kh9574mjyq";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8";
+      sha256 = "17lf13ndnai9a6dlmykqkdyzf1z04q7kffs0l7kvd78wpv3l6rm5";
+    };
+  }
+  {
+    goPackagePath = "github.com/online-net/c14-cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/online-net/c14-cli";
+      rev = "e7c7c3cb214fd06df63530a4e861210e7a0a1b6c";
+      sha256 = "1k53lii2c04j8cy1bnyfvckl9fglprxp75cmbg15lrp9iic2w22a";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "d77da356e56a7428ad25149ca77381849a6a5232";
+      sha256 = "11id286pkzyswxcx2xz6185fzh0nz6yzkk055dd6z02gvinl6pqa";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1197,6 +1197,8 @@ in
 
   biosdevname = callPackage ../tools/networking/biosdevname { };
 
+  c14 = callPackage ../applications/networking/c14 { };
+
   checkbashisms = callPackage ../development/tools/misc/checkbashisms { };
 
   clamav = callPackage ../tools/security/clamav { };


### PR DESCRIPTION
###### Motivation for this change

Following #18845 C14 is designed for data archiving & long-term backups and lets you store and retrieve large amounts of data.  https://www.online.net/en/c14
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
