### PR TITLE
nextcloud: 10.0.0 -> 10.0.1

### DIFF
--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -2,20 +2,12 @@
 
 stdenv.mkDerivation rec {
   name= "nextcloud-${version}";
-  version = "10.0.0";
+  version = "10.0.1";
 
   src = fetchurl {
     url = "https://download.nextcloud.com/server/releases/${name}.tar.bz2";
-    sha256 = "07vnhw3xrady7p7y2hc3sm9bcdj21gxyx9rwgawmy28019y1gahs";
+    sha256 = "09cbjxsr6sdjrq37rmwmg6r1x3625bqcrd37ja6cmmrgy0l2lh9r";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "env-variable.patch";
-      url = "https://github.com/nextcloud/server/commit/4277051442c2b6025da936493cb674dcf754d34c.patch";
-      sha256 = "1r1xcka9j9n0mkvj2nnhlwvhzicv9jjnxcszxs5g5ji88i1y0md2";
-    }) # exposes $NEXTCLOUD_CONFIG_DIR for Nextcloud 10 and below
-  ];
 
   installPhase = ''
     mkdir -p $out/


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
