### PR TITLE
gpshell: wrap with gppcscconnectionplugin

### DIFF
--- a/pkgs/development/tools/misc/gpshell/default.nix
+++ b/pkgs/development/tools/misc/gpshell/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, globalplatform, pcsclite }:
+{ stdenv, fetchurl, pkgconfig, globalplatform, pcsclite, gppcscconnectionplugin
+, makeWrapper
+}:
 
 stdenv.mkDerivation rec {
   name = "gpshell-${version}";
@@ -9,7 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "19a77zvyf2vazbv17185s4pynhylk2ky8vhl4i8pg9zww29sicqi";
   };
 
-  buildInputs = [ pkgconfig globalplatform pcsclite ];
+  buildInputs = [ pkgconfig globalplatform pcsclite makeWrapper ];
+
+  postFixup = ''
+    wrapProgram "$out/bin/gpshell" --prefix LD_LIBRARY_PATH : "${gppcscconnectionplugin}/lib"
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/p/globalplatform/wiki/Home/;


### PR DESCRIPTION
###### Motivation for this change

Fixes this:

```
  $ echo establish_context | gpshell
  establish_context
  establish_context failed with error 0xFFFFFFFFFFFFFFFF (libgppcscconnectionplugin.so.1.0.1: cannot open shared object file: No such file or directory)
```

~~(If patchelf had a --prefix-rpath flag I'd prefer that over the current
use of makeWrapper + LD_LIBRARY_PATH.)~~ Actually, we have to use LD_PRELOAD_PATH, see commit message.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @mbakke 
