### PR TITLE
notepadqq: init at 0.53.0

### DIFF
--- a/pkgs/applications/editors/notepadqq/default.nix
+++ b/pkgs/applications/editors/notepadqq/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, pkgconfig, which, qtbase }:
+
+let
+  version = "0.53.0";
+in stdenv.mkDerivation {
+  name = "notepadqq-${version}";
+  src = fetchgit {
+    url = "https://github.com/notepadqq/notepadqq.git";
+    rev = "3b0751277fb268ec72b466b37d0f0977c536bc1b";
+    sha256 = "0hw94mn2xg2r58afvz1xg990jinv9aa33942zgwq54qwj61r93hi";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pkgconfig which
+  ];
+
+  buildInputs = [
+    qtbase.qtsvg qtbase.qtwebkit qtbase.qttools
+  ];
+
+  preConfigure = ''
+    export LRELEASE="lrelease"
+  '';
+
+  meta = {
+    homepage = "http://notepadqq.altervista.org/";
+    description = "Notepad++-like editor for the Linux desktop";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ rszibele ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13754,6 +13754,10 @@ in
 
   nedit = callPackage ../applications/editors/nedit { };
 
+  notepadqq = callPackage ../applications/editors/notepadqq {
+    qtbase = qt55;
+  };
+
   notmuch = callPackage ../applications/networking/mailreaders/notmuch {
     # No need to build Emacs - notmuch.el works just fine without
     # byte-compilation. Use emacsPackages.notmuch if you want to


### PR DESCRIPTION
###### Motivation for this change

I was missing this package for personal use and have decided to add it.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
