### PR TITLE
EditorConfig: init at 0.12.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6185,7 +6185,7 @@ in modules // {
     name = "EditorConfig-0.12.0";
 
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/89/b9/29a4d312d958d298cedf0019b60168dc680f79d7ca394664dd82cf4f66a3/${name}.tar.gz";
+      url = "mirror://pypi/E/EditorConfig/${name}.tar.gz";
       sha256 = "1ah5hnrjw8r3pq586rh1w1ykqpb2dwzhhjc04d0n95fza1a3k9zd";
     };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6181,6 +6181,21 @@ in modules // {
     };
   };
 
+  EditorConfig = buildPythonPackage rec {
+    name = "EditorConfig-0.12.0";
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/89/b9/29a4d312d958d298cedf0019b60168dc680f79d7ca394664dd82cf4f66a3/${name}.tar.gz";
+      sha256 = "1ah5hnrjw8r3pq586rh1w1ykqpb2dwzhhjc04d0n95fza1a3k9zd";
+    };
+
+    meta = {
+      homepage = "http://editorconfig.org";
+      description = "EditorConfig File Locator and Interpreter for Python";
+      license = stdenv.lib.licenses.psfl;
+    };
+  };
+
   elasticsearch = buildPythonPackage (rec {
     name = "elasticsearch-1.9.0";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6182,12 +6182,22 @@ in modules // {
   };
 
   EditorConfig = buildPythonPackage rec {
-    name = "EditorConfig-0.12.0";
+    name = "EditorConfig-${version}";
+    version = "0.12.0";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/E/EditorConfig/${name}.tar.gz";
-      sha256 = "1ah5hnrjw8r3pq586rh1w1ykqpb2dwzhhjc04d0n95fza1a3k9zd";
+    # fetchgit used to ensure test submodule is available
+    src = pkgs.fetchgit {
+      url = "https://github.com/editorconfig/editorconfig-core-py";
+      rev = "refs/tags/v${version}";
+      sha256 = "0svk7id7ncygj2rnxhm7602xizljyidk4xgrl6i0xgq3829cz4bl";
     };
+
+    buildInputs = [ pkgs.cmake ];
+    checkPhase = ''
+      cmake .
+      # utf_8_char fails with python3
+      ctest -E "utf_8_char" .
+    '';
 
     meta = {
       homepage = "http://editorconfig.org";


### PR DESCRIPTION
###### Motivation for this change

Following #18958 EditorConfig makes it easy to maintain the correct coding style when switching between different text editors and between different projects. The EditorConfig project maintains a file format and plugins for various text editors which allow this file format to be read and used by those editors. http://editorconfig.org/
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
