### PR TITLE
pass: add procps dep only on linux

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -68,11 +68,11 @@ stdenv.mkDerivation rec {
     git
     gnupg
     gnused
-    procps
     pwgen
     tree
     which
-  ] ++ ifEnable x11Support [ dmenu xclip xdotool ]);
+  ] ++ stdenv.lib.optional stdenv.isLinux procps
+    ++ ifEnable x11Support [ dmenu xclip xdotool ]);
 
   postFixup = ''
     # Fix program name in --help


### PR DESCRIPTION
###### Motivation for this change

fixes #18929
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
