### PR TITLE
jre8: minimize minimal build and add more GUI dependencies to the regular one

### DIFF
--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -1,8 +1,11 @@
-{ stdenv, fetchurl, cpio, pkgconfig, file, which, unzip, zip, xorg, cups, freetype
-, alsaLib, bootjdk, cacert, perl, liberation_ttf, fontconfig, zlib
+{ stdenv, lib, fetchurl, cpio, pkgconfig, file, which, unzip, zip, cups, freetype
+, alsaLib, bootjdk, cacert, perl, liberation_ttf, fontconfig, zlib, lndir
+, libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor
+, libjpeg, giflib
 , setJavaClassPath
 , minimal ? false
 , enableInfinality ? true # font rendering patch
+, enableGnome2 ? true, gtk2, gnome_vfs, glib, GConf
 }:
 
 let
@@ -65,10 +68,11 @@ let
 
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [
-      cpio file which unzip zip
-      xorg.libX11 xorg.libXt xorg.libXext xorg.libXrender xorg.libXtst
-      xorg.libXi xorg.libXinerama xorg.libXcursor xorg.lndir
-      cups freetype alsaLib perl liberation_ttf fontconfig bootjdk zlib
+      cpio file which unzip zip perl bootjdk zlib cups freetype alsaLib
+      libjpeg giflib libX11 libICE libXext libXrender libXtst libXt libXtst
+      libXi libXinerama libXcursor lndir fontconfig
+    ] ++ lib.optionals (!minimal && enableGnome2) [
+      gtk2 gnome_vfs GConf glib
     ];
 
     prePatch = ''
@@ -82,10 +86,10 @@ let
       ./fix-java-home-jdk8.patch
       ./read-truststore-from-env-jdk8.patch
       ./currency-date-range-jdk8.patch
-    ] ++ (if enableInfinality then [
+    ] ++ lib.optionals (!minimal && enableInfinality) [
       ./004_add-fontconfig.patch
       ./005_enable-infinality.patch
-    ] else []);
+    ];
 
     preConfigure = ''
       chmod +x configure
@@ -101,21 +105,22 @@ let
       "--enable-unlimited-crypto"
       "--disable-debug-symbols"
       "--disable-freetype-bundling"
+      "--with-zlib=system"
+      "--with-giflib=system"
+      "--with-stdc++lib=dynamic"
 
       # glibc 2.24 deprecated readdir_r so we need this
       # See https://www.mail-archive.com/openembedded-devel@lists.openembedded.org/msg49006.html
       "--with-extra-cflags=\"-Wno-error=deprecated-declarations\""
-    ] ++ (if minimal then [
-      "--disable-headful"
-      "--with-zlib=bundled"
-      "--with-giflib=bundled"
-    ] else [
-      "--with-zlib=system"
-    ]);
+    ] ++ lib.optional minimal "--disable-headful";
 
-    NIX_LDFLAGS= if minimal then null else "-lfontconfig";
+    NIX_LDFLAGS= lib.optionals (!minimal) [
+      "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"
+    ] ++ lib.optionals (!minimal && enableGnome2) [
+      "-lgtk-x11-2.0" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
+    ];
 
-    buildFlags = "all";
+    buildFlags = [ "all" ];
 
     installPhase = ''
       mkdir -p $out/lib/openjdk $out/share $jre/lib/openjdk
@@ -135,12 +140,19 @@ let
 
       # Remove crap from the installation.
       rm -rf $out/lib/openjdk/demo $out/lib/openjdk/sample
+      ${lib.optionalString minimal ''
+        rm $out/lib/openjdk/jre/lib/${architecture}/{libjsound,libjsoundalsa,libsplashscreen,libawt*,libfontmanager}.so
+        rm $out/lib/openjdk/jre/bin/policytool
+        rm $out/lib/openjdk/bin/{policytool,appletviewer}
+      ''}
 
       # Move the JRE to a separate output and setup fallback fonts
       mv $out/lib/openjdk/jre $jre/lib/openjdk/
       mkdir $out/lib/openjdk/jre
-      mkdir -p $jre/lib/openjdk/jre/lib/fonts/fallback
-      lndir ${liberation_ttf}/share/fonts/truetype $jre/lib/openjdk/jre/lib/fonts/fallback
+      ${lib.optionalString (!minimal) ''
+        mkdir -p $jre/lib/openjdk/jre/lib/fonts/fallback
+        lndir ${liberation_ttf}/share/fonts/truetype $jre/lib/openjdk/jre/lib/fonts/fallback
+      ''}
       lndir $jre/lib/openjdk/jre $out/lib/openjdk/jre
 
       rm -rf $out/lib/openjdk/jre/bina

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -89,6 +89,8 @@ let
     ] ++ lib.optionals (!minimal && enableInfinality) [
       ./004_add-fontconfig.patch
       ./005_enable-infinality.patch
+    ] ++ lib.optionals (!minimal && enableGnome2) [
+      ./swing-use-gtk.patch
     ];
 
     preConfigure = ''

--- a/pkgs/development/compilers/openjdk/swing-use-gtk.patch
+++ b/pkgs/development/compilers/openjdk/swing-use-gtk.patch
@@ -1,0 +1,26 @@
+diff -ru3 a/jdk/src/share/classes/javax/swing/UIManager.java b/jdk/src/share/classes/javax/swing/UIManager.java
+--- a/jdk/src/share/classes/javax/swing/UIManager.java	2016-07-26 00:41:37.000000000 +0300
++++ b/jdk/src/share/classes/javax/swing/UIManager.java	2016-10-02 22:46:01.890071761 +0300
+@@ -607,11 +607,9 @@
+         if (osType == OSInfo.OSType.WINDOWS) {
+             return "com.sun.java.swing.plaf.windows.WindowsLookAndFeel";
+         } else {
+-            String desktop = AccessController.doPrivileged(new GetPropertyAction("sun.desktop"));
+             Toolkit toolkit = Toolkit.getDefaultToolkit();
+-            if ("gnome".equals(desktop) &&
+-                    toolkit instanceof SunToolkit &&
+-                    ((SunToolkit) toolkit).isNativeGTKAvailable()) {
++            if (toolkit instanceof SunToolkit &&
++                    ((SunToolkit) toolkit).isNativeGTKAvailable()) {
+                 // May be set on Linux and Solaris boxs.
+                 return "com.sun.java.swing.plaf.gtk.GTKLookAndFeel";
+             }
+@@ -1341,7 +1339,7 @@
+             lafName = (String) lafData.remove("defaultlaf");
+         }
+         if (lafName == null) {
+-            lafName = getCrossPlatformLookAndFeelClassName();
++            lafName = getSystemLookAndFeelClassName();
+         }
+         lafName = swingProps.getProperty(defaultLAFKey, lafName);
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4862,6 +4862,7 @@ in
     else
       callPackage ../development/compilers/openjdk/8.nix {
         bootjdk = callPackage ../development/compilers/openjdk/bootstrap.nix { version = "8"; };
+        inherit (gnome2) GConf gnome_vfs;
       };
 
   openjdk = if stdenv.isDarwin then openjdk7 else openjdk8;
@@ -4875,6 +4876,9 @@ in
   jre8 = lib.setName "openjre-${lib.getVersion pkgs.openjdk8.jre}"
     (lib.addMetaAttrs { outputsToInstall = [ "jre" ]; }
       (openjdk8.jre // { outputs = [ "jre" ]; }));
+  jre8_headless = lib.setName "openjre-${lib.getVersion pkgs.openjdk8.jre}-headless"
+    (lib.addMetaAttrs { outputsToInstall = [ "jre" ]; }
+      ((openjdk8.override { minimal = true; }).jre // { outputs = [ "jre" ]; }));
 
   jdk = if stdenv.isDarwin then jdk7 else jdk8;
   jre = if stdenv.isDarwin then jre7 else jre8;


### PR DESCRIPTION
###### Motivation for this change

We have several issues (https://github.com/NixOS/nixpkgs/issues/17876, https://github.com/NixOS/nixpkgs/issues/12472) which arise because Java is not linked to all supported libraries. I propose to add requested and several other libraries to Java's closure, and instead make `minimal` minimal-er. The idea is that `jre8_headless` doesn't support sound, printing and GUI and is used for console and server applications. `jre8`, on the other hand, supports all kinds of GUI-related activities, and is also linked to GTK, CUPS and several GNOME libraries. This makes it much nicer to work with, especially on HighDPI displays -- GTK-2 Java backend is the only one which is DPI-aware.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
