### PR TITLE
[16.09] wayland: revert global version back to 1.9 [-> staging]

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8785,7 +8785,6 @@ in
   mesa_drivers = mesaDarwinOr (
     let mo = mesa_noglu.override {
       grsecEnabled = config.grsecurity or false;
-      wayland = wayland_1_9; # work-around for #16779
     };
     in mo.drivers
   );
@@ -9731,7 +9730,9 @@ in
     inherit (darwin) libiconv;
   };
 
-  wayland = callPackage ../development/libraries/wayland {
+  wayland = wayland_1_9; # work around #16779
+
+  wayland_latest = callPackage ../development/libraries/wayland {
     graphviz = graphviz-nox;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Using an old wayland only for mesa breaks stuff at runtime (kde for example).
It's better to have a consistent wayland for every package including mesa.

I would be _very_ surprised if this breaks stuff that worked before.

CC @vcunat (original change) @ttuegel (kde) @domenkozar (release) 

ref comments https://github.com/NixOS/nixpkgs/commit/7a003eb9d52bc0210308af473e706c065a21aa40
ref #16779 

I filed this against staging because it causes a bigger rebuild and release is very near. Imo it should be merged into staging as soon as possible. Merging into release-16.09 could still be discussed, but we would get a full evaluation sooner.
###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
