### PR TITLE
r10k: init at 2.4.3

### DIFF
--- a/pkgs/tools/system/r10k/Gemfile
+++ b/pkgs/tools/system/r10k/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# A sample Gemfile
+source "https://rubygems.org"
+
+gem "r10k"

--- a/pkgs/tools/system/r10k/Gemfile.lock
+++ b/pkgs/tools/system/r10k/Gemfile.lock
@@ -1,0 +1,49 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colored (1.2)
+    cri (2.6.1)
+      colored (~> 1.2)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    fast_gettext (1.1.0)
+    gettext (3.2.2)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.7)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
+    locale (2.1.2)
+    log4r (1.1.10)
+    minitar (0.5.4)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    puppet_forge (2.2.2)
+      faraday (~> 0.9.0)
+      faraday_middleware (>= 0.9.0, < 0.11.0)
+      gettext-setup (>= 0.3)
+      minitar
+      semantic_puppet (~> 0.1.0)
+    r10k (2.4.3)
+      colored (= 1.2)
+      cri (~> 2.6.1)
+      gettext-setup (~> 0.5)
+      log4r (= 1.1.10)
+      minitar
+      multi_json (~> 1.10)
+      puppet_forge (~> 2.2)
+      semantic_puppet (~> 0.1.0)
+    semantic_puppet (0.1.4)
+      gettext-setup (>= 0.3)
+    text (1.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  r10k
+
+BUNDLED WITH
+   1.12.5

--- a/pkgs/tools/system/r10k/default.nix
+++ b/pkgs/tools/system/r10k/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, bundlerEnv, makeWrapper, docker, git, gnutar, gzip, ruby }:
+
+stdenv.mkDerivation rec {
+  name = "r10k-${version}";
+
+  version = "2.4.3";
+
+  env = bundlerEnv {
+    name = "${name}-gems";
+
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+    inherit ruby;
+  };
+
+  phases = ["installPhase"];
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${env}/bin/r10k $out/bin/r10k \
+      --set PATH ${stdenv.lib.makeBinPath [ docker git gnutar gzip ]}
+  '';
+
+  meta = with lib; {
+    description = "Puppet environment and module deployment";
+    homepage    = https://github.com/puppetlabs/r10k;
+    license 	= licenses.asl20;
+    maintainers = with maintainers; [ zimbatm ];
+    platforms 	= docker.meta.platforms;
+  };
+}

--- a/pkgs/tools/system/r10k/gemset.nix
+++ b/pkgs/tools/system/r10k/gemset.nix
@@ -1,0 +1,130 @@
+{
+  colored = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0b0x5jmsyi0z69bm6sij1k89z7h0laag3cb4mdn7zkl9qmxb90lx";
+      type = "gem";
+    };
+    version = "1.2";
+  };
+  cri = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zzwvwzrrlmx6c5j7bqc63ib952h37i357xn97m3h8bjd7zyv79l";
+      type = "gem";
+    };
+    version = "2.6.1";
+  };
+  faraday = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1kplqkpn2s2yl3lxdf6h7sfldqvkbkpxwwxhyk7mdhjplb5faqh6";
+      type = "gem";
+    };
+    version = "0.9.2";
+  };
+  faraday_middleware = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nxia26xzy8i56qfyz1bg8dg9yb26swpgci8n5jry8mh4bnx5r5h";
+      type = "gem";
+    };
+    version = "0.10.0";
+  };
+  fast_gettext = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mxahyywhml3c206am11h6d93rk358l2vl0j764i8ndzir5z5h75";
+      type = "gem";
+    };
+    version = "1.1.0";
+  };
+  gettext = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d2i1zfqvaxqi01g9vvkfkf5r85c5nfj2zwpd2ib9vvkjavhn9cx";
+      type = "gem";
+    };
+    version = "3.2.2";
+  };
+  gettext-setup = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "116frghrvcpzqhgi6skpmr56lzk35z44sbjkjn3lnlpr33sav03l";
+      type = "gem";
+    };
+    version = "0.7";
+  };
+  locale = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sls9bq4krx0fmnzmlbn64dw23c4d6pz46ynjzrn9k8zyassdd0x";
+      type = "gem";
+    };
+    version = "2.1.2";
+  };
+  log4r = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ri90q0frfmigkirqv5ihyrj59xm8pq5zcmf156cbdv4r4l2jicv";
+      type = "gem";
+    };
+    version = "1.1.10";
+  };
+  minitar = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vpdjfmdq1yc4i620frfp9af02ia435dnpj8ybsd7dc3rypkvbka";
+      type = "gem";
+    };
+    version = "0.5.4";
+  };
+  multi_json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wpc23ls6v2xbk3l1qncsbz16npvmw8p0b38l8czdzri18mp51xk";
+      type = "gem";
+    };
+    version = "1.12.1";
+  };
+  multipart-post = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09k0b3cybqilk1gwrwwain95rdypixb2q9w65gd44gfzsd84xi1x";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  puppet_forge = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1m2npid04dvli2r9h5cm2ccjmq0275xn4swi3x8wx5yzrixw98wv";
+      type = "gem";
+    };
+    version = "2.2.2";
+  };
+  r10k = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cqwci30r2566xcf8wz7dgamj6i4q9cblgkgmmdm9w2klqzx30j7";
+      type = "gem";
+    };
+    version = "2.4.3";
+  };
+  semantic_puppet = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zs19rsyv3f2zwhqi8cqbs87a6fzyl30aw2zqcxb8iz5m7xkd4kc";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+  text = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1x6kkmsr49y3rnrin91rv8mpc3dhrf3ql08kbccw8yffq61brfrg";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6188,6 +6188,8 @@ in
     withDocumentation = false; # 'true' is currently broken with qt>=5.5
   };
 
+  r10k = callPackage ../tools/system/r10k { };
+
   radare = callPackage ../development/tools/analysis/radare {
     inherit (gnome2) vte;
     lua = lua5;


### PR DESCRIPTION
###### Motivation for this change

[`r10k`](https://github.com/puppetlabs/r10k) wasn't packaged even though it is a popular tool.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
