### PR TITLE
openshot-qt: 2.0.7 -> 2.1.0

### DIFF
--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -8,13 +8,13 @@ let
 in
 stdenv.mkDerivation rec {
   name = "openshot-qt-${version}";
-  version = "2.0.7";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "openshot-qt";
     rev = "v${version}";
-    sha256 = "1s4b61fd8cyjy8kvc25mqd97dkxx6gqmz02i42rrcriz51pw8wgh";
+    sha256 = "1cyr5m1n6qcb9bzkhh3v6ka91a6x9c50dl5j0ilrc8vj0mb43g8c";
   };
 
   buildInputs = [doxygen python3Packages.python makeWrapper ffmpeg];
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     echo "exec ${python3Packages.python.interpreter} $(toPythonPath $out)/launch.py" >>$out/bin/openshot-qt
     chmod +x $out/bin/openshot-qt
     wrapProgram $out/bin/openshot-qt \
-      --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${libopenshot}):$(toPythonPath ${python3Packages.pyqt5}):$(toPythonPath ${python3Packages.sip}):$(toPythonPath ${python3Packages.httplib2}):$PYTHONPATH"
+      --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${libopenshot}):$(toPythonPath ${python3Packages.pyqt5}):$(toPythonPath ${python3Packages.sip}):$(toPythonPath ${python3Packages.httplib2}):$(toPythonPath ${python3Packages.pyzmq}):$PYTHONPATH"
   '';
 
   doCheck = false;

--- a/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot-audio.nix
@@ -5,13 +5,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "libopenshot-audio-${version}";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot-audio";
     rev = "v${version}";
-    sha256 = "0pgw7vzx3znglwm58187ybhg5maa13n4xcy5hrhzfsp8bqhrwkc7";
+    sha256 = "0dxyhnqkjc5y4hra8s17q9lafll6fx0pgibmmjznjm70whqcj8a6";
   };
 
   buildInputs = [

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -1,5 +1,7 @@
 {stdenv, fetchurl, fetchFromGitHub, callPackage, cmake, doxygen
-, imagemagick, ffmpeg, qt55, swig, python3, ruby, unittest-cpp}:
+, imagemagick, ffmpeg, qt55, swig, python3, ruby, unittest-cpp
+, cppzmq, czmqpp
+}:
 
 with stdenv.lib;
 
@@ -8,13 +10,13 @@ let
 in
 stdenv.mkDerivation rec {
   name = "libopenshot-${version}";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot";
     rev = "v${version}";
-    sha256 = "12nfkris7spn8n4s8fvy2f6yk1hqh97wzh1z3fsdxldg4gppi903";
+    sha256 = "00051ipb8y4z9j5m5smwm1ahv755k0glarwic8fv5b9fzryfbrdm";
   };
 
   patchPhase = ''
@@ -28,7 +30,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     cmake doxygen
     imagemagick ffmpeg qt55.qtbase qt55.qtmultimedia swig python3 ruby
-    unittest-cpp
+    unittest-cpp cppzmq czmqpp
   ];
 
   LIBOPENSHOT_AUDIO_DIR = "${libopenshot_audio}";


### PR DESCRIPTION
###### Motivation for this change

Use the latest version.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
