### PR TITLE
Revert "mesa_drivers: work around #16779"

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8321,7 +8321,6 @@ in
   mesa_drivers = mesaDarwinOr (
     let mo = mesa_noglu.override {
       grsecEnabled = config.grsecurity or false;
-      wayland = wayland_1_9; # work-around for #16779
     };
     in mo.drivers
   );


### PR DESCRIPTION
This reverts commit 7a003eb9d52bc0210308af473e706c065a21aa40.

This reversion is already present in 16.09.

This is a mass-rebuild, but the channel is currently broken because the succeeding builds produce broken binaries. Therefore, I think it should go directly into master.

This is a stop-gap measure to keep the channel building until a [comprehensive solution](https://github.com/NixOS/nixpkgs/commit/7a003eb9d52bc0210308af473e706c065a21aa40#commitcomment-19259773) is available.

Attn. @vcunat @domenkozar
