### PR TITLE
zsh-syntax-highlighting: init at 0.4.1

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -84,6 +84,14 @@ in
         type = types.bool;
       };
 
+      enableSyntaxHighlighting = mkOption {
+        default = false;
+        description = ''
+          Enable zsh-syntax-highlighting
+        '';
+        type = types.bool;
+      };
+
     };
 
   };
@@ -119,6 +127,10 @@ in
         done
 
         ${if cfg.enableCompletion then "autoload -U compinit && compinit" else ""}
+
+        ${optionalString (cfg.enableSyntaxHighlighting)
+          "source /run/current-system/sw/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+        }
 
         HELPDIR="${pkgs.zsh}/share/zsh/$ZSH_VERSION/help"
       '';
@@ -182,7 +194,8 @@ in
     environment.etc."zinputrc".source = ./zinputrc;
 
     environment.systemPackages = [ pkgs.zsh ]
-      ++ optional cfg.enableCompletion pkgs.nix-zsh-completions;
+      ++ optional cfg.enableCompletion pkgs.nix-zsh-completions
+      ++ optional cfg.enableSyntaxHighlighting pkgs.zsh-syntax-highlighting;
 
     environment.pathsToLink = optional cfg.enableCompletion "/share/zsh";
 

--- a/pkgs/shells/zsh-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh-syntax-highlighting/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, zsh }:
+
+let
+
+  pkgName = "zsh-syntax-highlighting";
+  version = "0.4.1";
+
+in
+
+stdenv.mkDerivation rec {
+  name = "${pkgName}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/zsh-users/${pkgName}/archive/${version}.tar.gz";
+    sha256 = "15sih7blqz11d8wdybx38d91vgcq9jg3q0205r26138si0g9q6wp";
+  };
+
+  buildInputs = [ zsh ];
+
+  installFlags="PREFIX=$(out)";
+
+  meta = with stdenv.lib; {
+    description = "Fish shell like syntax highlighting for Zsh";
+    homepage = "https://github.com/zsh-users/zsh-syntax-highlighting";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.loskutov ];
+  };
+}

--- a/pkgs/shells/zsh-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh-syntax-highlighting/default.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchurl, zsh }:
 
+# To make use of this derivation, use the `programs.zsh.enableSyntaxHighlighting` option
+
 let
 
   pkgName = "zsh-syntax-highlighting";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4337,6 +4337,8 @@ in
 
   zsh-navigation-tools = callPackage ../tools/misc/zsh-navigation-tools { };
 
+  zsh-syntax-highlighting = callPackage ../shells/zsh-syntax-highlighting { };
+
   zstd = callPackage ../tools/compression/zstd { };
 
   zsync = callPackage ../tools/compression/zsync { };


### PR DESCRIPTION
###### Motivation for this change

zsh-syntax-highlighting is a popular package (available in Ubuntu, homebrew, etc.), lacking in nixpkgs.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
