### PR TITLE
purple-hangouts-hg: 2016-08-31 -> 2016-10-01

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-hangouts/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-hangouts/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "purple-hangouts-hg-${version}";
-  version = "2016-08-31";
+  version = "2016-10-01";
 
   src = fetchhg {
     url = "https://bitbucket.org/EionRobb/purple-hangouts/";
-    rev = "1c0286e48e92";
-    sha256 = "0iv1isa8brm89nvmwrvxjm5ymx4svqrz3gf5yciqzf6kpc82gnxr";
+    rev = "00e28b7";
+    sha256 = "08jllhhww3cqlw6dg9w1hli3havdfzb47grcdl184537gl2bl49d";
   };
 
   buildInputs = [ pidgin glib json_glib protobuf protobufc ];


### PR DESCRIPTION
###### Motivation for this change

Stability fixes
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
