### PR TITLE
Termite 12

### DIFF
--- a/pkgs/applications/misc/termite/default.nix
+++ b/pkgs/applications/misc/termite/default.nix
@@ -3,14 +3,14 @@
 }:
 
 let 
-  version = "11";
+  version = "12";
   termite = stdenv.mkDerivation {
     name = "termite-${version}";
 
     src = fetchgit {
       url = "https://github.com/thestinger/termite";
       rev = "refs/tags/v${version}";
-      sha256 = "1cw4yw7n9m2si8b7zcfyz9pyihncabxm5g39v1mxslfajxgwzmd8";
+      sha256 = "0s6dyg3vcqk5qcx90bs24wdnd3p56rdjdcanx4pcxvp6ksjl61jz";
     };
 
     postPatch = "sed '1i#include <math.h>' -i termite.cc";

--- a/pkgs/desktops/gnome-3/3.20/core/vte/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/vte/default.nix
@@ -39,12 +39,12 @@ let baseAttrs = rec {
 in stdenv.mkDerivation ( baseAttrs
   // stdenv.lib.optionalAttrs selectTextPatch rec {
       name = "vte-ng-${version}";
-      version = "0.42.4.a";
+      version = "0.44.1b-ng";
       src = fetchFromGitHub {
         owner = "thestinger";
         repo = "vte-ng";
         rev = version;
-        sha256 = "1w91lz30j5lrskp9ds5j3nn27m5mpdpn7nlcvf5y1w63mpmjg8k1";
+        sha256 = "0p61znma9742fd3c6b44rq7j6mhpr6gx2b9rldm3jhb62ss4vsyy";
       };
       # slightly hacky; I couldn't make it work with autoreconfHook
       configureScript = "./autogen.sh";


### PR DESCRIPTION
###### Motivation for this change

A newer version of termite was released.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
