### PR TITLE
networking: enable "multi on" in resolver settings

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -29,6 +29,19 @@ in
       '';
     };
 
+    networking.hostConf = lib.mkOption {
+      type = types.lines;
+      default = "multi on";
+      example = ''
+        multi on
+        reorder on
+        trim lan
+      '';
+      description = ''
+        The contents of <filename>/etc/host.conf</filename>. See also <citerefentry><refentrytitle>host.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+      '';
+    };
+
     networking.dnsSingleRequest = lib.mkOption {
       type = types.bool;
       default = false;
@@ -170,6 +183,9 @@ in
             ''}
             ${cfg.extraHosts}
           '';
+
+        # /etc/host.conf: resolver configuration file
+        "host.conf".text = cfg.hostConf;
 
         # /etc/resolvconf.conf: Configuration for openresolv.
         "resolvconf.conf".text =


### PR DESCRIPTION
###### Motivation for this change

this allows to return ipv4/ipv6 addresses for the same host in /etc/hosts.
fixes #19148
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
