### PR TITLE
ocaml: use ocaml.version instead of parseDrvName and ocaml_version

### DIFF
--- a/pkgs/applications/science/logic/matita/130312.nix
+++ b/pkgs/applications/science/logic/matita/130312.nix
@@ -1,10 +1,8 @@
 {stdenv, fetchurl, ocaml, findlib, gdome2, ocaml_expat, gmetadom, ocaml_http, lablgtk, ocaml_mysql, ocamlnet, ulex08, camlzip, ocaml_pcre, automake, autoconf }:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   version = "0.99.1pre130312";
   pname = "matita";
-
 in
 
 stdenv.mkDerivation {

--- a/pkgs/applications/science/logic/matita/default.nix
+++ b/pkgs/applications/science/logic/matita/default.nix
@@ -1,10 +1,8 @@
 {stdenv, fetchurl, ocaml, findlib, gdome2, ocaml_expat, gmetadom, ocaml_http, lablgtk, lablgtkmathview, ocaml_mysql, ocaml_sqlite3, ocamlnet, ulex08, camlzip, ocaml_pcre }:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   version = "0.5.8";
   pname = "matita";
-
 in
 
 stdenv.mkDerivation {

--- a/pkgs/applications/science/math/glsurf/default.nix
+++ b/pkgs/applications/science/math/glsurf/default.nix
@@ -1,9 +1,5 @@
 { stdenv, fetchdarcs, ocaml, findlib,  lablgl, camlimages, mesa, freeglut, ocaml_mysql, mysql, mlgmp, mpfr, gmp, libtiff, libjpeg, libpng, giflib }:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
 stdenv.mkDerivation {
   name = "glsurf-3.3";
 

--- a/pkgs/build-support/ocaml/default.nix
+++ b/pkgs/build-support/ocaml/default.nix
@@ -9,13 +9,12 @@
   meta ? {}, ...
 }@args:
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   defaultMeta = {
     platforms = ocaml.meta.platforms or [];
   };
 in
   assert minimumSupportedOcamlVersion != null ->
-          stdenv.lib.versionOlder minimumSupportedOcamlVersion ocaml_version;
+          stdenv.lib.versionOlder minimumSupportedOcamlVersion ocaml.version;
 
 stdenv.mkDerivation (args // {
   name = "ocaml-${name}-${version}";
@@ -24,11 +23,10 @@ stdenv.mkDerivation (args // {
 
   setupHook = if setupHook == null && hasSharedObjects
   then writeText "setupHook.sh" ''
-    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml_version}/site-lib/${name}/"
+    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${name}/"
     ''
   else setupHook;
 
-  inherit ocaml_version;
   inherit createFindlibDestdir;
   inherit dontStrip;
 

--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -1,9 +1,8 @@
 {stdenv, fetchurl, zlib, ocaml, findlib}:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   param =
-    if stdenv.lib.versionAtLeast ocaml_version "4.02"
+    if stdenv.lib.versionAtLeast ocaml.version "4.02"
     then {
       version = "1.06";
       url = "1616";
@@ -45,7 +44,7 @@ stdenv.mkDerivation {
   inherit (param) installTargets;
 
   postInstall = ''
-    ln -s $out/lib/ocaml/${ocaml_version}/site-lib/{,caml}zip
+    ln -s $out/lib/ocaml/${ocaml.version}/site-lib/{,caml}zip
   '';
 
   meta = {

--- a/pkgs/development/ocaml-modules/camomile/0.8.2.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.2.nix
@@ -1,12 +1,8 @@
 {stdenv, fetchurl, ocaml, findlib, camlp4}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "0.8.2";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "camomile-${version}";
+  version = "0.8.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/camomile/camomile-${version}.tar.bz2";

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,11 +1,8 @@
 {stdenv, fetchurl, ocaml, findlib, camlp4}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
-stdenv.mkDerivation {
-  name = "camomile-0.8.5";
+stdenv.mkDerivation rec {
+  name = "camomile-${version}";
+  version = "0.8.5";
 
   src = fetchurl {
     url = https://github.com/yoriyuki/Camomile/releases/download/rel-0.8.5/camomile-0.8.5.tar.bz2;

--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -2,15 +2,14 @@
 
 let
   pname = "cmdliner";
-  version = "0.9.8";
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
 in
 
-assert stdenv.lib.versionAtLeast ocaml_version "3.12";
+assert stdenv.lib.versionAtLeast ocaml.version "3.12";
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
 
   name = "ocaml-${pname}-${version}";
+  version = "0.9.8";
 
   src = fetchurl {
     url = "http://erratique.ch/software/${pname}/releases/${pname}-${version}.tbz";
@@ -27,7 +26,7 @@ stdenv.mkDerivation {
   installPhase   = ''
     opam-installer --script --prefix=$out ${pname}.install > install.sh
     sh install.sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/cryptgps/default.nix
+++ b/pkgs/development/ocaml-modules/cryptgps/default.nix
@@ -1,12 +1,8 @@
 {stdenv, fetchurl, ocaml, findlib}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "0.2.1";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "ocaml-cryptgps-${version}";
+  version = "0.2.1";
 
   src = fetchurl {
     url = "http://download.camlcity.org/download/cryptgps-0.2.1.tar.gz";

--- a/pkgs/development/ocaml-modules/cryptokit/default.nix
+++ b/pkgs/development/ocaml-modules/cryptokit/default.nix
@@ -1,13 +1,10 @@
 {stdenv, fetchurl, zlib, ocaml, findlib, ncurses}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
+assert stdenv.lib.versionAtLeast ocaml.version "3.12";
 
-assert stdenv.lib.versionAtLeast ocaml_version "3.12";
-
-stdenv.mkDerivation {
-  name = "cryptokit-1.10";
+stdenv.mkDerivation rec {
+  name = "cryptokit-${version}";
+  version = "1.10";
 
   src = fetchurl {
     url = http://forge.ocamlcore.org/frs/download.php/1493/cryptokit-1.10.tar.gz;
@@ -18,7 +15,7 @@ stdenv.mkDerivation {
 
   buildFlags = "setup.data build";
 
-  preBuild = "mkdir -p $out/lib/ocaml/${ocaml_version}/site-lib/cryptokit";
+  preBuild = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/cryptokit";
 
   meta = {
     homepage = "http://pauillac.inria.fr/~xleroy/software.html";

--- a/pkgs/development/ocaml-modules/dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/dypgen/default.nix
@@ -1,13 +1,12 @@
 {stdenv, fetchurl, ocaml, findlib}:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "dypgen";
-  version = "20120619-1";
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "20120619-1";
 
   src = fetchurl {
     url = "http://dypgen.free.fr/dypgen-20120619-1.tar.bz2";
@@ -22,7 +21,7 @@ stdenv.mkDerivation {
     make
   '';
 
-  makeFlags = "BINDIR=$(out)/bin  MANDIR=$(out)/usr/share/man/man1 DYPGENLIBDIR=$(out)/lib/ocaml/${ocaml_version}/site-lib";
+  makeFlags = "BINDIR=$(out)/bin  MANDIR=$(out)/usr/share/man/man1 DYPGENLIBDIR=$(out)/lib/ocaml/${ocaml.version}/site-lib";
 
   meta = {
     homepage = http://dypgen.free.fr;

--- a/pkgs/development/ocaml-modules/expat/default.nix
+++ b/pkgs/development/ocaml-modules/expat/default.nix
@@ -1,8 +1,6 @@
 {stdenv, fetchurl, ocaml, findlib, ounit, expat}:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "0.9.1";
   pname = "ocaml-expat";
   testcase = fetchurl {
     url = "http://www.w3.org/TR/1998/REC-xml-19980210.xml";
@@ -11,8 +9,9 @@ let
 
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "0.9.1";
 
   src = fetchurl {
     url = "http://www.xs4all.nl/~mmzeeman/ocaml/${pname}-${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/gmetadom/default.nix
+++ b/pkgs/development/ocaml-modules/gmetadom/default.nix
@@ -1,14 +1,12 @@
 {stdenv, fetchurl, ocaml, findlib, gdome2, libxslt, pkgconfig}:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "0.2.6";
   pname = "gmetadom";
-
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "0.2.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/${pname}/${pname}/${version}/${pname}-${version}.tar.gz";
@@ -20,7 +18,7 @@ stdenv.mkDerivation {
   dontDisableStatic = true;
 
   preConfigure=''
-    configureFlags="--with-ocaml-lib-prefix=$out/lib/ocaml/${ocaml_version}/site-lib"
+    configureFlags="--with-ocaml-lib-prefix=$out/lib/ocaml/${ocaml.version}/site-lib"
   '';
 
 

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -1,13 +1,12 @@
 {stdenv, fetchurl, which, ocaml, findlib, camlzip, extlib, camlp4}:
+
 let
   pname = "javalib";
-  version = "2.3";
   webpage = "http://sawja.inria.fr/";
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
 in
 stdenv.mkDerivation rec {
-
   name = "ocaml-${pname}-${version}";
+  version = "2.3";
 
   src = fetchurl {
     url = "https://gforge.inria.fr/frs/download.php/33090/${pname}-${version}.tar.bz2";
@@ -28,7 +27,7 @@ stdenv.mkDerivation rec {
   preBuild = ''
     make ptrees;
     make installptrees;
-    export OCAMLPATH=$out/lib/ocaml/${ocaml_version}/site-lib/:$OCAMLPATH;
+    export OCAMLPATH=$out/lib/ocaml/${ocaml.version}/site-lib/:$OCAMLPATH;
   '';
 
   propagatedBuildInputs = [ camlzip extlib ];

--- a/pkgs/development/ocaml-modules/lablgl/default.nix
+++ b/pkgs/development/ocaml-modules/lablgl/default.nix
@@ -1,13 +1,12 @@
 {stdenv, fetchurl, ocaml, lablgtk, findlib, mesa, freeglut, camlp4 } :
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "lablgl";
-  version = "1.05";
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "1.05";
 
   src = fetchurl { 
     url = "http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/dist/lablgl-${version}.tar.gz";
@@ -22,8 +21,8 @@ stdenv.mkDerivation {
   preConfigure = ''
     substituteInPlace Makefile.config \
       --subst-var-by BINDIR $out/bin \
-      --subst-var-by INSTALLDIR $out/lib/ocaml/${ocaml_version}/site-lib/lablgl \
-      --subst-var-by DLLDIR $out/lib/ocaml/${ocaml_version}/site-lib/lablgl \
+      --subst-var-by INSTALLDIR $out/lib/ocaml/${ocaml.version}/site-lib/lablgl \
+      --subst-var-by DLLDIR $out/lib/ocaml/${ocaml.version}/site-lib/lablgl \
       --subst-var-by TKINCLUDES "" \
       --subst-var-by XINCLUDES ""
   '';
@@ -33,7 +32,7 @@ stdenv.mkDerivation {
   buildFlags = "lib libopt glut glutopt";
 
   postInstall = ''
-    cp ./META $out/lib/ocaml/${ocaml_version}/site-lib/lablgl
+    cp ./META $out/lib/ocaml/${ocaml.version}/site-lib/lablgl
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
@@ -1,13 +1,12 @@
 { stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk2, libgnomecanvas, libglade, gtksourceview, camlp4 }:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "lablgtk";
-  version = "2.14.0";
 in
 
 stdenv.mkDerivation (rec {
   name = "${pname}-${version}";
+  version = "2.14.0";
 
   src = fetchurl {
     url = "https://forge.ocamlcore.org/frs/download.php/561/${name}.tar.gz";
@@ -16,12 +15,12 @@ stdenv.mkDerivation (rec {
 
   buildInputs = [ ocaml findlib pkgconfig gtk2 libgnomecanvas libglade gtksourceview camlp4 ];
 
-  configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml_version}/site-lib";
+  configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib";
   buildFlags = "world";
 
   preInstall = ''
-    mkdir -p $out/lib/ocaml/${ocaml_version}/site-lib
-    export OCAMLPATH=$out/lib/ocaml/${ocaml_version}/site-lib/:$OCAMLPATH
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib
+    export OCAMLPATH=$out/lib/ocaml/${ocaml.version}/site-lib/:$OCAMLPATH
   '';
 
   meta = {

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -1,15 +1,15 @@
 {stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk2, libgnomecanvas, libglade, gtksourceview, camlp4}:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "lablgtk";
-  version = "2.18.3";
 in
 
-assert stdenv.lib.versionAtLeast ocaml_version "3.12";
+assert stdenv.lib.versionAtLeast ocaml.version "3.12";
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "2.18.3";
+
   src = fetchurl {
     url = https://forge.ocamlcore.org/frs/download.php/1479/lablgtk-2.18.3.tar.gz;
     sha256 = "1bybn3jafxf4cx25zvn8h2xj9agn1xjbn7j3ywxxqx6az7rfnnwp";
@@ -17,12 +17,12 @@ stdenv.mkDerivation {
 
   buildInputs = [ocaml findlib pkgconfig gtk2 libgnomecanvas libglade gtksourceview camlp4];
 
-  configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml_version}/site-lib";
+  configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib";
   buildFlags = "world";
 
   preInstall = ''
-    mkdir -p $out/lib/ocaml/${ocaml_version}/site-lib
-    export OCAMLPATH=$out/lib/ocaml/${ocaml_version}/site-lib/:$OCAMLPATH
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib
+    export OCAMLPATH=$out/lib/ocaml/${ocaml.version}/site-lib/:$OCAMLPATH
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/lablgtkmathview/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtkmathview/default.nix
@@ -1,14 +1,12 @@
 {stdenv, fetchurl, pkgconfig, ocaml, findlib, gmetadom, gtkmathview, lablgtk }:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "0.7.2";
   pname = "lablgtkmathview";
-
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "0.7.2";
 
   src = fetchurl {
     url = "http://helm.cs.unibo.it/mml-widget/sources/${pname}-${version}.tar.gz";
@@ -22,7 +20,7 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [gtkmathview];
 
   prePatch = ''
-    substituteInPlace Makefile.in --replace "PROPCC = @OCAML_LIB_DIR@" "PROPCC = ${lablgtk}/lib/ocaml/${ocaml_version}/site-lib"
+    substituteInPlace Makefile.in --replace "PROPCC = @OCAML_LIB_DIR@" "PROPCC = ${lablgtk}/lib/ocaml/${ocaml.version}/site-lib"
   '';
 
   buildPhase = ''

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -1,15 +1,12 @@
 { stdenv, fetchzip, which, cryptopp, ocaml, findlib, ocaml_react, ocaml_ssl, libev, pkgconfig, ncurses, ocaml_oasis, ocaml_text, glib, camlp4, ppx_tools }:
 
 let
-  version = "2.5.2";
   inherit (stdenv.lib) optional getVersion versionAtLeast;
-  ocaml_version = getVersion ocaml;
 in
 
-stdenv.mkDerivation {
-
-
+stdenv.mkDerivation rec {
   name = "ocaml-lwt-${version}";
+  version = "2.5.2";
 
   src = fetchzip {
     url = "https://github.com/ocsigen/lwt/archive/${version}.tar.gz";
@@ -21,7 +18,7 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [ ocaml_react ocaml_ssl ocaml_text libev ];
 
   configureFlags = [ "--enable-glib" "--enable-ssl" "--enable-react" "--enable-camlp4"]
-  ++ [ (if versionAtLeast ocaml_version "4.02" then "--enable-ppx" else "--disable-ppx") ];
+  ++ [ (if versionAtLeast ocaml.version "4.02" then "--enable-ppx" else "--disable-ppx") ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/mlgmp/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmp/default.nix
@@ -1,13 +1,12 @@
 {stdenv, fetchurl, ocaml, findlib, gmp, mpfr, ncurses }:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "mlgmp";
-  version = "20120224";
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "20120224";
 
   src = fetchurl {
     url = "http://www-verimag.imag.fr/~monniaux/download/${pname}_${version}.tar.gz";
@@ -15,7 +14,7 @@ stdenv.mkDerivation {
   };
 
   makeFlags = [ 
-    "DESTDIR=$(out)/lib/ocaml/${ocaml_version}/site-lib/gmp"
+    "DESTDIR=$(out)/lib/ocaml/${ocaml.version}/site-lib/gmp"
   ];
 
   preConfigure = "make clean";
@@ -26,7 +25,7 @@ stdenv.mkDerivation {
   propagatedbuildInputs = [gmp mpfr ncurses];
 
   postInstall  = ''
-     cp ${./META} $out/lib/ocaml/${ocaml_version}/site-lib/gmp/META
+     cp ${./META} $out/lib/ocaml/${ocaml.version}/site-lib/gmp/META
   '';
 
   meta = {

--- a/pkgs/development/ocaml-modules/mysql/default.nix
+++ b/pkgs/development/ocaml-modules/mysql/default.nix
@@ -5,13 +5,12 @@
 # TODO: compilazione di moduli dipendenti da zip, ssl, tcl, gtk, gtk2
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "ocaml-mysql";
-  version = "1.1.1";
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "1.1.1";
 
   src = fetchurl {
     url = "https://forge.ocamlcore.org/frs/download.php/870/${pname}-${version}.tar.gz";
@@ -20,7 +19,7 @@ stdenv.mkDerivation {
 
   configureFlags = [ 
      "--prefix=$out" 
-     "--libdir=$out/lib/ocaml/${ocaml_version}/site-lib/mysql"
+     "--libdir=$out/lib/ocaml/${ocaml.version}/site-lib/mysql"
   ];
 
   buildInputs = [ocaml findlib camlp4 ];

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -1,14 +1,10 @@
 { stdenv, fetchzip, ocaml, findlib, cstruct, type_conv, zarith, ounit }:
 
-let
-  version = "0.5.1";
-  ocaml_version = stdenv.lib.getVersion ocaml;
-in
+assert stdenv.lib.versionAtLeast ocaml.version "4.01";
 
-assert stdenv.lib.versionAtLeast ocaml_version "4.01";
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "ocaml-nocrypto-${version}";
+  version = "0.5.1";
 
   src = fetchzip {
     url = "https://github.com/mirleft/ocaml-nocrypto/archive/${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -1,13 +1,12 @@
 {stdenv, fetchurl, automake, ocaml, autoconf, gnum4, pkgconfig, freetype, lablgtk, unzip, cairo, findlib, gdk_pixbuf, glib, gtk2, pango }:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "ocaml-cairo";
-  version = "1.2.0";
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "http://cgit.freedesktop.org/cairo-ocaml/snapshot/cairo-ocaml-${version}.zip";
@@ -25,16 +24,16 @@ stdenv.mkDerivation {
    aclocal -I support
    autoconf
    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE `pkg-config --cflags cairo gdk-pixbuf glib gtk+ pango`"
-   export LABLGTKDIR=${lablgtk}/lib/ocaml/${ocaml_version}/site-lib/lablgtk2
-   cp ${lablgtk}/lib/ocaml/${ocaml_version}/site-lib/lablgtk2/pango.ml ./src
-   cp ${lablgtk}/lib/ocaml/${ocaml_version}/site-lib/lablgtk2/gaux.ml ./src
+   export LABLGTKDIR=${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2
+   cp ${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2/pango.ml ./src
+   cp ${lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2/gaux.ml ./src
   '';
 
   postInstall = ''
-    cp META $out/lib/ocaml/${ocaml_version}/site-lib/cairo/
+    cp META $out/lib/ocaml/${ocaml.version}/site-lib/cairo/
   '';
 
-  makeFlags = "INSTALLDIR=$(out)/lib/ocaml/${ocaml_version}/site-lib/cairo";
+  makeFlags = "INSTALLDIR=$(out)/lib/ocaml/${ocaml.version}/site-lib/cairo";
 
   meta = {
     homepage = http://cairographics.org/cairo-ocaml;

--- a/pkgs/development/ocaml-modules/ocamlfuse/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlfuse/default.nix
@@ -1,9 +1,5 @@
 { stdenv, fetchFromGitHub, ocaml, camlidl, fuse, findlib }:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
 stdenv.mkDerivation rec {
   name = "ocamlfuse-2.7-3";
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/ocamlgraph/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlgraph/default.nix
@@ -1,12 +1,8 @@
 {stdenv, fetchurl, ocaml, findlib, ocamlPackages }:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "1.8.5";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "ocamlgraph-${version}";
+  version = "1.8.5";
 
   src = fetchurl {
     url = "http://ocamlgraph.lri.fr/download/ocamlgraph-${version}.tar.gz";
@@ -22,9 +18,9 @@ stdenv.mkDerivation {
   # * configure looked in the wrong path
   # * ocaml needs that directory and the stubs directory as -I flag
   postPatch = ''
-    sed -i 's@$(DESTDIR)$(OCAMLLIB)/ocamlgraph@$(DESTDIR)/lib/ocaml/${ocaml_version}/site-lib/ocamlgraph@' Makefile.in
-    sed -i 's@$OCAMLLIB/lablgtk2@${ocamlPackages.lablgtk}/lib/ocaml/${ocaml_version}/site-lib/lablgtk2@' configure Makefile.in
-    sed -i 's@+lablgtk2@${ocamlPackages.lablgtk}/lib/ocaml/${ocaml_version}/site-lib/lablgtk2 -I ${ocamlPackages.lablgtk}/lib/ocaml/${ocaml_version}/site-lib/stublibs@' configure Makefile.in editor/Makefile
+    sed -i 's@$(DESTDIR)$(OCAMLLIB)/ocamlgraph@$(DESTDIR)/lib/ocaml/${ocaml.version}/site-lib/ocamlgraph@' Makefile.in
+    sed -i 's@$OCAMLLIB/lablgtk2@${ocamlPackages.lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2@' configure Makefile.in
+    sed -i 's@+lablgtk2@${ocamlPackages.lablgtk}/lib/ocaml/${ocaml.version}/site-lib/lablgtk2 -I ${ocamlPackages.lablgtk}/lib/ocaml/${ocaml.version}/site-lib/stublibs@' configure Makefile.in editor/Makefile
   '';
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -1,10 +1,6 @@
 { stdenv, fetchurl, pkgconfig, ncurses, ocaml, findlib, ocaml_pcre, camlzip
 , gnutls, nettle }:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
 stdenv.mkDerivation {
   name = "ocamlnet-4.1.1";
 
@@ -27,7 +23,7 @@ stdenv.mkDerivation {
       -enable-pcre
       -disable-gtk2
       -with-nethttpd
-      -datadir $out/lib/ocaml/${ocaml_version}/ocamlnet
+      -datadir $out/lib/ocaml/${ocaml.version}/ocamlnet
     )
   '';
 

--- a/pkgs/development/ocaml-modules/ocamlsdl/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlsdl/default.nix
@@ -1,13 +1,12 @@
 {stdenv, fetchurl, ocaml, pkgconfig, findlib, SDL, SDL_image, SDL_mixer, SDL_ttf, SDL_gfx, lablgl }: 
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "ocamlsdl";
-  version = "0.9.1";
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "0.9.1";
 
   src = fetchurl { 
     url = "mirror://sourceforge/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz";

--- a/pkgs/development/ocaml-modules/ounit/default.nix
+++ b/pkgs/development/ocaml-modules/ounit/default.nix
@@ -1,9 +1,5 @@
 {stdenv, fetchurl, ocaml, findlib, camlp4}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
 stdenv.mkDerivation {
   name = "ounit-2.0.0";
 

--- a/pkgs/development/ocaml-modules/sexplib/108.08.00.nix
+++ b/pkgs/development/ocaml-modules/sexplib/108.08.00.nix
@@ -1,10 +1,6 @@
 {stdenv, fetchurl, ocaml, findlib, type_conv, camlp4}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
-assert stdenv.lib.versionOlder "3.12" ocaml_version;
+assert stdenv.lib.versionOlder "3.12" ocaml.version;
 
 stdenv.mkDerivation {
   name = "ocaml-sexplib-108.08.00";

--- a/pkgs/development/ocaml-modules/sexplib/111.25.00.nix
+++ b/pkgs/development/ocaml-modules/sexplib/111.25.00.nix
@@ -1,10 +1,6 @@
 {stdenv, fetchurl, ocaml, findlib, type_conv, camlp4}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
-assert stdenv.lib.versionOlder "4.00" ocaml_version;
+assert stdenv.lib.versionOlder "4.00" ocaml.version;
 
 stdenv.mkDerivation {
   name = "ocaml-sexplib-111.25.00";

--- a/pkgs/development/ocaml-modules/ssl/default.nix
+++ b/pkgs/development/ocaml-modules/ssl/default.nix
@@ -1,12 +1,8 @@
 {stdenv, fetchurl, which, openssl, ocaml, findlib}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "0.5.2";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "ocaml-ssl-${version}";
+  version = "0.5.2";
 
   src = fetchurl {
   url = "mirror://sourceforge/project/savonet/ocaml-ssl/0.5.2/ocaml-ssl-0.5.2.tar.gz";

--- a/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
+++ b/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
@@ -1,10 +1,6 @@
 {stdenv, fetchurl, ocaml, findlib, camlp4}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
-assert stdenv.lib.versionOlder "3.12" ocaml_version;
+assert stdenv.lib.versionOlder "3.12" ocaml.version;
 
 stdenv.mkDerivation {
   name = "ocaml-type_conv-108.08.00";

--- a/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
@@ -1,10 +1,6 @@
 {stdenv, fetchurl, ocaml, findlib, camlp4}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
-assert stdenv.lib.versionOlder "4.00" ocaml_version;
+assert stdenv.lib.versionOlder "4.00" ocaml.version;
 
 stdenv.mkDerivation {
   name = "ocaml-type_conv-109.60.01";

--- a/pkgs/development/ocaml-modules/ulex/0.8/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/0.8/default.nix
@@ -1,14 +1,12 @@
 {stdenv, fetchurl, ocaml, findlib, camlp5 }:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "0.8";
   pname = "ulex";
-
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "0.8";
 
   src = fetchurl {
     url = "http://www.cduce.org/download/old/${pname}-${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -1,14 +1,12 @@
 { stdenv, fetchurl, ocaml, findlib, camlp4 }:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "1.1";
   pname = "ulex";
-
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "1.1";
 
   src = fetchurl {
     url = "http://www.cduce.org/download/${pname}-${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/uucd/default.nix
+++ b/pkgs/development/ocaml-modules/uucd/default.nix
@@ -1,13 +1,12 @@
 { stdenv, fetchurl, ocaml, findlib, opam, xmlm, topkg }:
+
 let
   pname = "uucd";
-  version = "4.0.0";
   webpage = "http://erratique.ch/software/${pname}";
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
 in
 stdenv.mkDerivation rec {
-
   name = "ocaml-${pname}-${version}";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
@@ -25,7 +24,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     opam-installer --script --prefix=$out ${pname}.install > install.sh
     sh install.sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
   '';
 
   propagatedBuildInputs = [ xmlm ];

--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -1,16 +1,14 @@
 {stdenv, fetchurl, ocaml, findlib, opam}:
 let
   pname = "uunf";
-  version = "0.9.3";
   webpage = "http://erratique.ch/software/${pname}";
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
 in
 
-assert stdenv.lib.versionAtLeast ocaml_version "3.12";
+assert stdenv.lib.versionAtLeast ocaml.version "3.12";
 
 stdenv.mkDerivation rec {
-
   name = "ocaml-${pname}-${version}";
+  version = "0.9.3";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     opam-installer --script --prefix=$out ${pname}.install > install.sh
     sh install.sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/uutf/default.nix
+++ b/pkgs/development/ocaml-modules/uutf/default.nix
@@ -1,16 +1,14 @@
 {stdenv, fetchurl, ocaml, findlib, opam}:
 let
   pname = "uutf";
-  version = "0.9.3";
   webpage = "http://erratique.ch/software/${pname}";
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
 in
 
-assert stdenv.lib.versionAtLeast ocaml_version "3.12";
+assert stdenv.lib.versionAtLeast ocaml.version "3.12";
 
 stdenv.mkDerivation rec {
-
   name = "ocaml-${pname}-${version}";
+  version = "0.9.3";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     opam-installer --script --prefix=$out ${pname}.install > install.sh
     sh install.sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/xmlm/default.nix
+++ b/pkgs/development/ocaml-modules/xmlm/default.nix
@@ -1,16 +1,14 @@
 {stdenv, fetchurl, ocaml, findlib, opam}:
 let
   pname = "xmlm";
-  version = "1.2.0";
   webpage = "http://erratique.ch/software/${pname}";
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
 in
 
-assert stdenv.lib.versionAtLeast ocaml_version "3.12";
+assert stdenv.lib.versionAtLeast ocaml.version "3.12";
 
 stdenv.mkDerivation rec {
-
   name = "ocaml-${pname}-${version}";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     opam-installer --script --prefix=$out ${pname}.install > install.sh
     sh install.sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml_version}/site-lib/
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -1,10 +1,6 @@
 { stdenv, fetchurl, ocaml, findlib, pkgconfig, gmp, perl }:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
-assert stdenv.lib.versionAtLeast ocaml_version "3.12.1";
+assert stdenv.lib.versionAtLeast ocaml.version "3.12.1";
 
 stdenv.mkDerivation rec {
   name = "zarith-${version}";
@@ -22,9 +18,9 @@ stdenv.mkDerivation rec {
     substituteInPlace ./z_pp.pl --replace '/usr/bin/perl' '${perl}/bin/perl'
   '';
   configurePhase = ''
-    ./configure -installdir $out/lib/ocaml/${ocaml_version}/site-lib
+    ./configure -installdir $out/lib/ocaml/${ocaml.version}/site-lib
   '';
-  preInstall = "mkdir -p $out/lib/ocaml/${ocaml_version}/site-lib";
+  preInstall = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib";
 
   meta = with stdenv.lib; {
     description = "Fast, arbitrary precision OCaml integers";

--- a/pkgs/development/tools/misc/trv/default.nix
+++ b/pkgs/development/tools/misc/trv/default.nix
@@ -2,15 +2,11 @@
 , re2_p4, async_extra_p4, sexplib_p4, async_shell, core_extended_p4, async_find
 , cohttp, uri, tzdata}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-  version = "0.1.3";
-in
+assert stdenv.lib.versionOlder "4.02" ocaml.version;
 
-assert stdenv.lib.versionOlder "4.02" ocaml_version;
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "trv-${version}";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "afiniate";

--- a/pkgs/development/tools/ocaml/camlidl/default.nix
+++ b/pkgs/development/tools/ocaml/camlidl/default.nix
@@ -1,13 +1,12 @@
 {stdenv, fetchurl, makeWrapper, gcc, ocaml, ncurses}:
+
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "camlidl";
-  version = "1.05";
   webpage = "http://caml.inria.fr/pub/old_caml_site/camlidl/";
 in
-stdenv.mkDerivation {
-
+stdenv.mkDerivation rec {
   name = "${pname}-${version}";
+  version = "1.05";
 
   src = fetchurl {
     url = "http://caml.inria.fr/pub/old_caml_site/distrib/bazar-ocaml/${pname}-${version}.tar.gz";
@@ -19,13 +18,13 @@ stdenv.mkDerivation {
   preBuild = ''
     mv config/Makefile.unix config/Makefile
     substituteInPlace config/Makefile --replace BINDIR=/usr/local/bin BINDIR=$out
-    substituteInPlace config/Makefile --replace OCAMLLIB=/usr/local/lib/ocaml OCAMLLIB=$out/lib/ocaml/${ocaml_version}/site-lib/camlidl
+    substituteInPlace config/Makefile --replace OCAMLLIB=/usr/local/lib/ocaml OCAMLLIB=$out/lib/ocaml/${ocaml.version}/site-lib/camlidl
     substituteInPlace config/Makefile --replace CPP=/lib/cpp CPP=${gcc}/bin/cpp
-    mkdir -p $out/lib/ocaml/${ocaml_version}/site-lib/camlidl/caml
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/camlidl/caml
   '';
 
   postInstall = ''
-    cat >$out/lib/ocaml/${ocaml_version}/site-lib/camlidl/META <<EOF
+    cat >$out/lib/ocaml/${ocaml.version}/site-lib/camlidl/META <<EOF
     # Courtesy of GODI
     description = "Stub generator"
     version = "${version}"

--- a/pkgs/development/tools/ocaml/camlp4/4_03.nix
+++ b/pkgs/development/tools/ocaml/camlp4/4_03.nix
@@ -1,14 +1,11 @@
 {stdenv, fetchzip, which, ocaml, ocamlbuild}:
-let
-  ocaml_version = (stdenv.lib.getVersion ocaml);
-  version = "4.03+1";
 
-in
-
-assert stdenv.lib.versionAtLeast ocaml_version "4.02";
+assert stdenv.lib.versionAtLeast ocaml.version "4.02";
 
 stdenv.mkDerivation {
   name = "camlp4-${version}";
+  version = "4.03+1";
+
   src = fetchzip {
     url = "https://github.com/ocaml/camlp4/archive/${version}.tar.gz";
     sha256 = "1f2ndch6f1m4fgnxsjb94qbpwjnjgdlya6pard44y6n0dqxi1wsq";
@@ -21,14 +18,14 @@ stdenv.mkDerivation {
   preConfigure = ''
     configureFlagsArray=(
       --bindir=$out/bin
-      --libdir=$out/lib/ocaml/${ocaml_version}/site-lib
-      --pkgdir=$out/lib/ocaml/${ocaml_version}/site-lib
+      --libdir=$out/lib/ocaml/${ocaml.version}/site-lib
+      --pkgdir=$out/lib/ocaml/${ocaml.version}/site-lib
     )
   '';
 
   postConfigure = ''
     substituteInPlace camlp4/META.in \
-    --replace +camlp4 $out/lib/ocaml/${ocaml_version}/site-lib/camlp4
+    --replace +camlp4 $out/lib/ocaml/${ocaml.version}/site-lib/camlp4
   '';
 
 

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -1,14 +1,11 @@
 {stdenv, fetchzip, which, ocaml}:
-let
-  ocaml_version = (stdenv.lib.getVersion ocaml);
+
+assert stdenv.lib.versionAtLeast ocaml.version "4.02";
+
+stdenv.mkDerivation rec {
+  name = "camlp4-${version}";
   version = "4.02+6";
 
-in
-
-assert stdenv.lib.versionAtLeast ocaml_version "4.02";
-
-stdenv.mkDerivation {
-  name = "camlp4-${version}";
   src = fetchzip {
     url = "https://github.com/ocaml/camlp4/archive/${version}.tar.gz";
     sha256 = "06yl4q0qazl7g25b0axd1gdkfd4qpqzs1gr5fkvmkrcbz113h1hj";
@@ -21,14 +18,14 @@ stdenv.mkDerivation {
   preConfigure = ''
     configureFlagsArray=(
       --bindir=$out/bin
-      --libdir=$out/lib/ocaml/${ocaml_version}/site-lib
-      --pkgdir=$out/lib/ocaml/${ocaml_version}/site-lib
+      --libdir=$out/lib/ocaml/${ocaml.version}/site-lib
+      --pkgdir=$out/lib/ocaml/${ocaml.version}/site-lib
     )
   '';
 
   postConfigure = ''
     substituteInPlace camlp4/META.in \
-    --replace +camlp4 $out/lib/ocaml/${ocaml_version}/site-lib/camlp4
+    --replace +camlp4 $out/lib/ocaml/${ocaml.version}/site-lib/camlp4
   '';
 
 

--- a/pkgs/development/tools/ocaml/camlp5/5.15.nix
+++ b/pkgs/development/tools/ocaml/camlp5/5.15.nix
@@ -1,18 +1,17 @@
 {stdenv, fetchurl, ocaml, transitional ? false}:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   pname = "camlp5";
-  version = "5.15";
   webpage = http://pauillac.inria.fr/~ddr/camlp5/;
   metafile = ./META;
 in
 
-assert !stdenv.lib.versionOlder "4.00" ocaml_version;
+assert !stdenv.lib.versionOlder "4.00" ocaml.version;
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
 
   name = "${pname}${if transitional then "_transitional" else ""}-${version}";
+  version = "5.15";
 
   src = fetchurl {
     url = "${webpage}/distrib/src/${pname}-${version}.tgz";
@@ -24,11 +23,11 @@ stdenv.mkDerivation {
   prefixKey = "-prefix ";
 
   preConfigure = "configureFlagsArray=(" +  (if transitional then "--transitional" else "--strict") +
-                  " --libdir $out/lib/ocaml/${ocaml_version}/site-lib)";
+                  " --libdir $out/lib/ocaml/${ocaml.version}/site-lib)";
 
   buildFlags = "world.opt";
 
-  postInstall = "cp ${metafile} $out/lib/ocaml/${ocaml_version}/site-lib/camlp5/META";
+  postInstall = "cp ${metafile} $out/lib/ocaml/${ocaml.version}/site-lib/camlp5/META";
 
   meta = {
     description = "Preprocessor-pretty-printer for OCaml";

--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -1,7 +1,6 @@
 {stdenv, fetchurl, ocaml, transitional ? false}:
 
 let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
   metafile = ./META;
 in
 
@@ -19,11 +18,11 @@ stdenv.mkDerivation {
   prefixKey = "-prefix ";
 
   preConfigure = "configureFlagsArray=(" +  (if transitional then "--transitional" else "--strict") +
-                  " --libdir $out/lib/ocaml/${ocaml_version}/site-lib)";
+                  " --libdir $out/lib/ocaml/${ocaml.version}/site-lib)";
 
   buildFlags = "world.opt";
 
-  postInstall = "cp ${metafile} $out/lib/ocaml/${ocaml_version}/site-lib/camlp5/META";
+  postInstall = "cp ${metafile} $out/lib/ocaml/${ocaml.version}/site-lib/camlp5/META";
 
   meta = with stdenv.lib; {
     description = "Preprocessor-pretty-printer for OCaml";

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -1,9 +1,5 @@
 {stdenv, fetchurl, m4, ncurses, ocaml, writeText}:
 
-let
-  ocaml_version = (builtins.parseDrvName ocaml.name).version;
-in
-
 stdenv.mkDerivation rec {
   name = "ocaml-findlib-${version}";
   version = "1.6.1";
@@ -23,7 +19,7 @@ stdenv.mkDerivation rec {
     configureFlagsArray=(
       -bindir $out/bin
       -mandir $out/share/man
-      -sitelib $out/lib/ocaml/${ocaml_version}/site-lib
+      -sitelib $out/lib/ocaml/${ocaml.version}/site-lib
       -config $out/etc/findlib.conf
     )
   '';
@@ -35,10 +31,10 @@ stdenv.mkDerivation rec {
 
   setupHook = writeText "setupHook.sh" ''
     addOCamlPath () {
-        if test -d "''$1/lib/ocaml/${ocaml_version}/site-lib"; then
-            export OCAMLPATH="''${OCAMLPATH}''${OCAMLPATH:+:}''$1/lib/ocaml/${ocaml_version}/site-lib/"
+        if test -d "''$1/lib/ocaml/${ocaml.version}/site-lib"; then
+            export OCAMLPATH="''${OCAMLPATH}''${OCAMLPATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/"
         fi
-        export OCAMLFIND_DESTDIR="''$out/lib/ocaml/${ocaml_version}/site-lib/"
+        export OCAMLFIND_DESTDIR="''$out/lib/ocaml/${ocaml.version}/site-lib/"
         if test -n "$createFindlibDestdir"; then
           mkdir -p $OCAMLFIND_DESTDIR
         fi

--- a/pkgs/development/tools/ocaml/ocp-index/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-index/default.nix
@@ -8,7 +8,6 @@ assert versionAtLeast (getVersion ocpIndent) "1.4.2";
 
 let
   version = "1.1.4";
-  ocaml_version = getVersion ocaml;
   srcs = {
     "4.03.0" = {
       rev = "${version}-4.03";
@@ -27,7 +26,7 @@ let
   src = fetchFromGitHub ({
     owner = "OCamlPro";
     repo = "ocp-index";
-  } // srcs."${ocaml_version}");
+  } // srcs."${ocaml.version}");
 in
 
 stdenv.mkDerivation {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -6,8 +6,6 @@ let
       packageSet = self:
         with self; let inherit (self) callPackage; in
   {
-    ocaml_version = self.ocaml.version; #TODO: remove all mentions of ocaml_version
-
     callPackage = newScope self;
 
     inherit ocaml;
@@ -37,7 +35,7 @@ let
     async_unix_p4 = callPackage ../development/ocaml-modules/async_unix { };
 
     async_p4 =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/async { }
       else null;
 
@@ -53,26 +51,26 @@ let
     bitstring_git   = callPackage ../development/ocaml-modules/bitstring { };
 
     bitstring =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then bitstring_git
       else bitstring_2_0_4;
 
     camlidl = callPackage ../development/tools/ocaml/camlidl { };
 
     camlp4 =
-      if lib.versionOlder "4.03" ocaml_version
+      if lib.versionOlder "4.03" ocaml.version
       then callPackage ../development/tools/ocaml/camlp4/4_03.nix { }
-      else if lib.versionOlder "4.02" ocaml_version
+      else if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/tools/ocaml/camlp4 { }
       else null;
 
     camlp5_old_strict =
-      if lib.versionOlder "4.00" ocaml_version
+      if lib.versionOlder "4.00" ocaml.version
       then camlp5_6_strict
       else callPackage ../development/tools/ocaml/camlp5/5.15.nix { };
 
     camlp5_old_transitional =
-      if lib.versionOlder "4.00" ocaml_version
+      if lib.versionOlder "4.00" ocaml.version
       then camlp5_6_transitional
       else callPackage ../development/tools/ocaml/camlp5/5.15.nix {
         transitional = true;
@@ -227,7 +225,7 @@ let
     };
 
     lablgtk-extras =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/lablgtk-extras { }
       else callPackage ../development/ocaml-modules/lablgtk-extras/1.4.nix { };
 
@@ -237,7 +235,7 @@ let
 
     lambdaTerm-1_6 = callPackage ../development/ocaml-modules/lambda-term/1.6.nix { };
     lambdaTerm =
-      if lib.versionOlder "4.01" ocaml_version
+      if lib.versionOlder "4.01" ocaml.version
       then callPackage ../development/ocaml-modules/lambda-term { }
       else lambdaTerm-1_6;
 
@@ -274,7 +272,7 @@ let
     core_p4 = callPackage ../development/ocaml-modules/core { };
 
     ocamlbuild =
-    if lib.versionOlder "4.03" ocaml_version then
+    if lib.versionOlder "4.03" ocaml.version then
     callPackage ../development/tools/ocaml/ocamlbuild { }
     else
     null;
@@ -368,11 +366,11 @@ let
     type_conv_109_60_01 = callPackage ../development/ocaml-modules/type_conv/109.60.01.nix { };
     type_conv_112_01_01 = callPackage ../development/ocaml-modules/type_conv/112.01.01.nix { };
     type_conv =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then type_conv_112_01_01
-      else if lib.versionOlder "4.00" ocaml_version
+      else if lib.versionOlder "4.00" ocaml.version
       then type_conv_109_60_01
-      else if lib.versionOlder "3.12" ocaml_version
+      else if lib.versionOlder "3.12" ocaml.version
       then type_conv_108_08_00
       else null;
 
@@ -381,11 +379,11 @@ let
     sexplib_112_24_01 = callPackage ../development/ocaml-modules/sexplib/112.24.01.nix { };
 
     sexplib_p4 =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then sexplib_112_24_01
-      else if lib.versionOlder "4.00" ocaml_version
+      else if lib.versionOlder "4.00" ocaml.version
       then sexplib_111_25_00
-      else if lib.versionOlder "3.12" ocaml_version
+      else if lib.versionOlder "3.12" ocaml.version
       then sexplib_108_08_00
       else null;
 
@@ -407,17 +405,17 @@ let
     pprint = callPackage ../development/ocaml-modules/pprint { };
 
     ppx_blob =
-      if lib.versionAtLeast ocaml_version "4.02"
+      if lib.versionAtLeast ocaml.version "4.02"
       then callPackage ../development/ocaml-modules/ppx_blob {}
       else null;
 
     ppx_deriving =
-      if lib.versionAtLeast ocaml_version "4.02"
+      if lib.versionAtLeast ocaml.version "4.02"
       then callPackage ../development/ocaml-modules/ppx_deriving {}
       else null;
 
     ppx_tools =
-      if lib.versionAtLeast ocaml_version "4.02"
+      if lib.versionAtLeast ocaml.version "4.02"
       then callPackage ../development/ocaml-modules/ppx_tools {}
       else null;
 
@@ -534,74 +532,74 @@ let
 
     # Core sublibs
     typerep =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/typerep.nix {}
       else typerep_p4;
 
     fieldslib =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/fieldslib.nix {}
       else fieldslib_p4;
 
     sexplib =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/sexplib.nix {}
       else sexplib_p4;
 
     variantslib =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/variantslib.nix {}
       else variantslib_p4;
 
     bin_prot =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/bin_prot.nix {}
       else bin_prot_p4;
 
     core_kernel =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/core_kernel.nix {}
       else core_kernel_p4;
 
     core =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/core.nix {}
       else core_p4;
 
     re2 =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/re2.nix {}
       else re2_p4;
 
     textutils =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/textutils.nix {}
       else textutils_p4;
 
     core_extended =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/core-extended.nix {}
       else core_extended_p4;
 
     async_kernel =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/async-kernel.nix {}
       else async_kernel_p4;
 
     async_rpc_kernel = callPackage ../development/ocaml-modules/janestreet/async-rpc-kernel.nix {};
 
     async_unix =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/async-unix.nix {}
       else async_unix_p4;
 
     async_extra =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/async-extra.nix {}
       else async_extra_p4;
 
     async =
-      if lib.versionOlder "4.02" ocaml_version
+      if lib.versionOlder "4.02" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/async.nix {}
       else async_p4;
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
