### PR TITLE
nixos.acme: make timer persistent

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -282,6 +282,7 @@ in
           timerConfig = {
             OnCalendar = cfg.renewInterval;
             Unit = "acme-${cert}.service";
+            Persistent = "yes";
           };
         })
       );


### PR DESCRIPTION
###### Motivation for this change

This makes sure that if the system was powered off when the timer was supposed to trigger, it will run the next time the system boots up.

Without this change it wouldn't trigger until the next timer interval (another week, by default), which again could be missed if the system is powered off at that exact time.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
## 
