### PR TITLE
r10k: remove unused docker dependency

### DIFF
--- a/pkgs/tools/system/r10k/default.nix
+++ b/pkgs/tools/system/r10k/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, bundlerEnv, makeWrapper, docker, git, gnutar, gzip, ruby }:
+{ stdenv, lib, bundlerEnv, makeWrapper, git, gnutar, gzip, ruby }:
 
 stdenv.mkDerivation rec {
   name = "r10k-${version}";
@@ -21,14 +21,13 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     makeWrapper ${env}/bin/r10k $out/bin/r10k \
-      --set PATH ${stdenv.lib.makeBinPath [ docker git gnutar gzip ]}
+      --set PATH ${stdenv.lib.makeBinPath [ git gnutar gzip ]}
   '';
 
   meta = with lib; {
     description = "Puppet environment and module deployment";
     homepage    = https://github.com/puppetlabs/r10k;
-    license 	= licenses.asl20;
+    license     = licenses.asl20;
     maintainers = with maintainers; [ zimbatm ];
-    platforms 	= docker.meta.platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`r10k` had a dependency on docker even though it doesn't use it. (bad copy paste)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
