### PR TITLE
opentracker: 2014-08-03 -> 2016-10-02

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -65,6 +65,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Boost Software License 1.0";
   };
 
+  beerware = spdx {
+    spdxId = "Beerware";
+    fullName = ''Beerware License'';
+  };
+
   bsd2 = spdx {
     spdxId = "BSD-2-Clause";
     fullName = ''BSD 2-clause "Simplified" License'';

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -1,24 +1,27 @@
 { stdenv, fetchgit, libowfat, zlib }:
 
 stdenv.mkDerivation {
-  name = "opentracker-2014-08-03";
+  name = "opentracker-2016-10-02";
+
   src = fetchgit {
-    url = "https://github.com/masroore/opentracker.git";
-    rev = "9a26b3d203755577879315ecc2b515d0e22793cb";
-    sha256 = "1ayj3j9jv6h26jfhw93wcw7lvhwyfnc20kkicvskalwzw51mpsz8";
+    url = "git://erdgeist.org/opentracker";
+    rev = "0ebc0ed6a3e3b7acc9f9e338cc23cea5f4f22f61";
+    sha256 = "0qi0a8fygjwgs3yacramfn53jdabfgrlzid7q597x9lr94anfpyl";
   };
   
   buildInputs = [ libowfat zlib ];
   
   installPhase = ''
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/share/doc
     cp opentracker $out/bin
+    cp opentracker.conf.sample $out/share/doc
   '';
   
   meta = with stdenv.lib; {
-    homepage = https://github.com/masroore/opentracker;
-    license = "beer-ware";
+    homepage = https://erdgeist.org/arts/software/opentracker/;
+    license = licenses.beerware;
     platforms = platforms.linux;
-    description = "Bittorrent tracker project aiminf for minimal resource usage and is intended to run at your wlan router";
+    description = "Bittorrent tracker project which aims for minimal resource usage and is intended to run at your wlan router";
+    maintainers = with maintainers; [ makefu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The opentracker package has not been updated for almost 2 years, didn't have a maintainer and was using a hard-coded license.
This PR adds the Beerware SPDX license and in succession bumps the opentracker revision to latest while using the new, official git repo. 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
