### PR TITLE
Nim

### DIFF
--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
-  name = "nim-0.14.2";
+  name = "nim-0.15.0";
 
   src = fetchurl {
     url = "http://nim-lang.org/download/${name}.tar.xz";
-    sha256 = "14jy7wza54jawja21r6v676qyj0i9kg1jpn5bxwn8wfm1vbki3cg";
+    sha256 = "1yv9qvc1r7m0m4gwi8mgnabdjz70mwxf5rmv8xhibcmja1856565";
   };
 
   buildPhase   = "sh build.sh";

--- a/pkgs/development/tools/nimble/default.nix
+++ b/pkgs/development/tools/nimble/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "nimble-${version}";
 
-  version = "0.7.4";
+  version = "0.7.8";
 
   src = fetchFromGitHub {
     owner = "nim-lang";
     repo = "nimble";
     rev = "v${version}";
-    sha256 = "1l477f1zlqpc738jg47pz599cwjasgy9jqdsplj3ywd12xfqpc96";
+    sha256 = "12znxzj1j5fflw2mkkrns9n7qg6sf207652zrdyf7h2jdyzzb73x";
   };
 
   buildInputs = [ nim ];


### PR DESCRIPTION
###### Motivation for this change

Upgrade Nim to the latest version 0.15.
Upgrade Nim package manager Nimble to the latest version 0.7.8.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
