### PR TITLE
urxvtd service: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -515,6 +515,7 @@
   ./services/x11/hardware/synaptics.nix
   ./services/x11/hardware/wacom.nix
   ./services/x11/redshift.nix
+  ./services/x11/urxvtd.nix
   ./services/x11/window-managers/awesome.nix
   #./services/x11/window-managers/compiz.nix
   ./services/x11/window-managers/default.nix

--- a/nixos/modules/services/x11/urxvtd.nix
+++ b/nixos/modules/services/x11/urxvtd.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+# maintainer: siddharthist
+
+with lib;
+
+let
+  cfg = config.services.urxvtd;
+in {
+
+  options.services.urxvtd.enable = mkOption {
+    type = types.bool;
+    default = false;
+    example = true;
+    description = ''
+      Enable urxvtd, the urxvt terminal daemon. To use urxvtd, run
+      "urxvtc".
+    '';
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user = {
+      sockets.urxvtd = {
+        description = "socket for urxvtd, the urxvt terminal daemon";
+        after = [ "graphical.target" ];
+        wants = [ "graphical.target" ];
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = "%t/urxvtd-socket";
+        };
+      };
+
+      services.urxvtd = {
+        description = "urxvt terminal daemon";
+        serviceConfig = {
+          ExecStart = "${pkgs.rxvt_unicode-with-plugins}/bin/urxvtd -o";
+          Environment = "RXVT_SOCKET=%t/urxvtd-socket";
+          Restart = "on-failure";
+          RestartSec = "5s";
+        };
+      };
+
+    };
+
+    environment.systemPackages = [ pkgs.rxvt_unicode-with-plugins ];
+    environment.variables.RXVT_SOCKET = "/run/user/$(id -u)/urxvtd-socket";
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

Lower resource usage! See [the ArchWiki for details](https://wiki.archlinux.org/index.php/Rxvt-unicode/Tips_and_tricks#Daemon-client).

I'm not 100% sure how to document this best. Any suggestions? Should I add some XML tags in the description?
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
