### PR TITLE
nix-optimise.service: nix.optimise.dates should be list

### DIFF
--- a/nixos/modules/services/misc/nix-optimise.nix
+++ b/nixos/modules/services/misc/nix-optimise.nix
@@ -21,7 +21,7 @@ in
       };
 
       dates = mkOption {
-        default = "03:45";
+        default = ["03:45"];
         type = types.listOf types.str;
         description = ''
           Specification (in the format described by


### PR DESCRIPTION
###### Motivation for this change

```
building Nix...
building the system configuration...
error: The option value `nix.optimise.dates' in `/nix/var/nix/profiles/per-user/root/channels/nixos/nixpkgs/nixos/modules/services/misc/nix-optimise.nix' is not a list of strings.
```

Setting the time in `/etc/nixos/configuration.nix` with surrounding square brackets fixed the error. 

```
nix = {
    optimise = {
      automatic = true;
      dates = ["3:45"];
    };
};
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
