### PR TITLE
searx: fix pyopenssl version

### DIFF
--- a/pkgs/development/python-modules/searx.patch
+++ b/pkgs/development/python-modules/searx.patch
@@ -16,7 +16,8 @@ index 0d2f61b..46481b3 100644
  pyasn1-modules==0.0.8
 -pygments==2.1.3
 +pygments==2.*
- pyopenssl==0.15.1
+-pyopenssl==0.15.1
++pyopenssl==16.*
 -python-dateutil==2.5.3
 +python-dateutil==2.*
 -pyyaml==3.11

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27685,11 +27685,6 @@ in modules // {
     };
 
     patches = [ ../development/python-modules/searx.patch ];
-    postPatch = ''
-      substituteInPlace requirements.txt \
-        --replace 'certifi==2015.11.20.1' 'certifi==2016.2.28' \
-        --replace 'pyopenssl==0.15.1' 'pyopenssl==16.0.0'
-    '';
 
     propagatedBuildInputs = with self; [
       pyyaml lxml_3_5 grequests flaskbabel flask requests2


### PR DESCRIPTION
The version changed in nixpkgs and the searx build failed.
- [x] service builds & runs
