### PR TITLE
tinyfugue: init at 50b8

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -213,6 +213,7 @@
   kampfschlaefer = "Arnold Krille <arnold@arnoldarts.de>";
   kevincox = "Kevin Cox <kevincox@kevincox.ca>";
   khumba = "Bryan Gardiner <bog@khumba.net>";
+  KibaFox = "Kiba Fox <kiba.fox@foxypossibilities.com>";
   kkallio = "Karn Kallio <tierpluspluslists@gmail.com>";
   koral = "Koral <koral@mailoo.org>";
   kovirobi = "Kovacsics Robert <kovirobi@gmail.com>";

--- a/pkgs/games/tinyfugue/default.nix
+++ b/pkgs/games/tinyfugue/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, ncurses, zlib
+, openssl ? null
+, sslSupport ? true
+}:
+
+with stdenv.lib;
+
+assert sslSupport -> openssl != null;
+
+stdenv.mkDerivation rec {
+  name = "tinyfugue-${version}";
+  version = "50b8";
+  verUrl = "5.0%20beta%208";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/tinyfugue/tinyfugue/${verUrl}/tf-${version}.tar.gz";
+    sha256 = "12fra2fdwqj6ilv9wdkc33rkj343rdcf5jyff4yiwywlrwaa2l1p";
+  };
+
+  configureFlags = optional (!sslSupport) "--disable-ssl";
+
+  buildInputs =
+    [ ncurses zlib ]
+    ++ optional sslSupport openssl;
+
+  meta = {
+    homepage = http://tinyfugue.sourceforge.net/;
+    description = "A terminal UI, screen-oriented MUD client";
+    longDescription = ''
+      TinyFugue, aka "tf", is a flexible, screen-oriented MUD client, for use
+      with any type of text MUD.
+    '';
+    license = licenses.gpl2;
+    platforms = ncurses.meta.platforms;
+    maintainers = [ maintainers.KibaFox ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15667,6 +15667,8 @@ in
 
   tintin = callPackage ../games/tintin { };
 
+  tinyfugue = callPackage ../games/tinyfugue { };
+
   tome4 = callPackage ../games/tome4 { };
 
   trackballs = callPackage ../games/trackballs {


### PR DESCRIPTION
###### Motivation for this change

Add tinyfugue, a terminal UI, screen oriented, MUD client.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
