### PR TITLE
Cherry-pick 16.09 README.md in master

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ build daemon as so-called channels. To get channel information via git, add
 ```
 
 For stability and maximum binary package support, it is recommended to maintain
-custom changes on top of one of the channels, e.g. `nixos-16.03` for the latest
+custom changes on top of one of the channels, e.g. `nixos-16.09` for the latest
 release and `nixos-unstable` for the latest successful build of master:
 
 ```
 % git remote update channels
-% git rebase channels/nixos-16.03
+% git rebase channels/nixos-16.09
 ```
 
 For pull-requests, please rebase onto nixpkgs `master`.
@@ -32,9 +32,9 @@ For pull-requests, please rebase onto nixpkgs `master`.
 * [Manual (NixOS)](https://nixos.org/nixos/manual/)
 * [Nix Wiki](https://nixos.org/wiki/) (deprecated, see milestone ["Move the Wiki!"](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22Move+the+wiki%21%22))
 * [Continuous package builds for unstable/master](https://hydra.nixos.org/jobset/nixos/trunk-combined)
-* [Continuous package builds for 16.03 release](https://hydra.nixos.org/jobset/nixos/release-16.03)
+* [Continuous package builds for 16.09 release](https://hydra.nixos.org/jobset/nixos/release-16.09)
 * [Tests for unstable/master](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents)
-* [Tests for 16.03 release](https://hydra.nixos.org/job/nixos/release-16.03/tested#tabs-constituents)
+* [Tests for 16.09 release](https://hydra.nixos.org/job/nixos/release-16.09/tested#tabs-constituents)
 
 Communication:
 


### PR DESCRIPTION
###### Motivation for this change

`README.md` should refer to 16.09 as the stable branch.
###### Things done
- Cherry-picked #18216

I hope it's fine that I created a separate pull request for that :confused: 
