### PR TITLE
buildbot: 0.9.0rc3 -> 0.9.0rc4

### DIFF
--- a/pkgs/development/tools/build-managers/buildbot/plugins.nix
+++ b/pkgs/development/tools/build-managers/buildbot/plugins.nix
@@ -1,17 +1,14 @@
-{ stdenv
-, fetchurl
-, pythonPackages
-}:
+{ stdenv, fetchurl, pythonPackages }:
 
 let
   buildbot-pkg = pythonPackages.buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "buildbot-pkg";
-    version = "0.9.0rc3";
+    version = "0.9.0rc4";
 
     src = fetchurl {
       url = "mirror://pypi/b/${pname}/${name}.tar.gz";
-      sha256 = "0a05dgc5nn6sx3nicfvqwar9iy8yxhq92688dhs5p6mzjxaprlxm";
+      sha256 = "0dfdyc3x0926dynzdl9w7z0p84w287l362mxdl3r6wl87gkisr10";
     };
 
     propagatedBuildInputs = with pythonPackages; [ setuptools ];
@@ -21,6 +18,7 @@ let
       description = "Buildbot Packaging Helper";
       maintainers = with maintainers; [ nand0p ryansydnor ];
       platforms = platforms.all;
+      license = licenses.gpl2;
     };
   };
 
@@ -29,13 +27,14 @@ in {
   www = pythonPackages.buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "buildbot_www";
-    version = "0.9.0rc3";
+    version = "0.9.0rc4";
 
     # NOTE: wheel is used due to buildbot circular dependency
     format = "wheel";
+
     src = fetchurl {
-      url = "https://pypi.python.org/packages/93/1e/09e329fc831ae4f5be05eb3363c9028ab7e26e9c7e5d89e3aa66c3f25d9d/${name}-py2-none-any.whl";
-      sha256 = "0fy2v7y1kc53zm67ddx85yz5qh4b7hmcbfzmsziiv9n83a0qh1i6";
+      url = "https://pypi.python.org/packages/78/45/b43bd85695cd0178f8bac9c3b394062e9eb46f489b655c11e950e54278a2/${name}-py2-none-any.whl";
+      sha256 = "0ixi0y0jhbql55swsvy0jin1v6xf4q4mw9p5n9sll2h10lyp9h0p";
     };
 
     propagatedBuildInputs = [ buildbot-pkg ];
@@ -45,17 +44,18 @@ in {
       description = "Buildbot UI";
       maintainers = with maintainers; [ nand0p ryansydnor ];
       platforms = platforms.all;
+      license = licenses.gpl2;
     };
   };
 
   console-view = pythonPackages.buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "buildbot-console-view";
-    version = "0.9.0rc3";
+    version = "0.9.0rc4";
 
     src = fetchurl {
       url = "mirror://pypi/b/${pname}/${name}.tar.gz";
-      sha256 = "09yfqrnwfambg1j4x7ywnjg4xfhvv6f242zzh35fwj64cnqmqx07";
+      sha256 = "1fig635yg5dgn239g9wzfpw9wc3p91lcl9nnig9k7fijz85pwrva";
     };
 
     propagatedBuildInputs = [ buildbot-pkg ];
@@ -65,17 +65,18 @@ in {
       description = "Buildbot Console View Plugin";
       maintainers = with maintainers; [ nand0p ryansydnor ];
       platforms = platforms.all;
+      license = licenses.gpl2;
     };
   };
 
   waterfall-view = pythonPackages.buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "buildbot-waterfall-view";
-    version = "0.9.0rc3";
+    version = "0.9.0rc4";
 
     src = fetchurl {
       url = "mirror://pypi/b/${pname}/${name}.tar.gz";
-      sha256 = "0xpqxj3mmwl5xdhm3p52shl24d85qapdk4v66f9hrb9pnk5k4a81";
+      sha256 = "08kh966grj9b4mif337vv7bqy5ixz8xz31ml63wysjb65djnjbk8";
     };
 
     propagatedBuildInputs = [ buildbot-pkg ];
@@ -85,6 +86,7 @@ in {
       description = "Buildbot Waterfall View Plugin";
       maintainers = with maintainers; [ nand0p ryansydnor ];
       platforms = platforms.all;
+      license = licenses.gpl2;
     };
   };
 }

--- a/pkgs/development/tools/build-managers/buildbot/worker.nix
+++ b/pkgs/development/tools/build-managers/buildbot/worker.nix
@@ -1,16 +1,13 @@
-{ stdenv
-, fetchurl
-, pythonPackages
-}:
+{ stdenv, fetchurl, pythonPackages }:
 
 pythonPackages.buildPythonApplication (rec {
   name = "${pname}-${version}";
   pname = "buildbot-worker";
-  version = "0.9.0rc3";
+  version = "0.9.0rc4";
 
   src = fetchurl {
     url = "mirror://pypi/b/${pname}/${name}.tar.gz";
-    sha256 = "0wqn2176rk7hc27r4hfy5qnxp0nr9iis5nyzg5x07xljnsspnhy1";
+    sha256 = "1fv40pki1awv5f2z9vd7phjk7dlsy1cp4blsy2vdhqwbc7112a8c";
   };
 
   buildInputs = with pythonPackages; [ setuptoolsTrial mock ];
@@ -21,5 +18,6 @@ pythonPackages.buildPythonApplication (rec {
     description = "Buildbot Worker Daemon";
     maintainers = with maintainers; [ nand0p ryansydnor ];
     platforms = platforms.all;
+    license = licenses.gpl2;
   };
 })


### PR DESCRIPTION
buildbot: 0.9.0rc3 -> 0.9.0rc4
- upgrade to rc4
- un-hardcode path in logwatcher
- fix shebang in wrapper
- add gpl2 license
- remove duplicate wrapper
