### PR TITLE
ardour: 4.7 -> 5.4

### DIFF
--- a/pkgs/applications/audio/ardour/ardour4.nix
+++ b/pkgs/applications/audio/ardour/ardour4.nix
@@ -1,10 +1,9 @@
-{ stdenv, fetchgit, alsaLib, aubio, boost, cairomm, curl, doxygen
+{ stdenv, fetchFromGitHub, alsaLib, aubio, boost, cairomm, curl, doxygen, dbus, fftw
 , fftwSinglePrec, flac, glibc, glibmm, graphviz, gtkmm2, libjack2
 , libgnomecanvas, libgnomecanvasmm, liblo, libmad, libogg, librdf
 , librdf_raptor, librdf_rasqal, libsamplerate, libsigcxx, libsndfile
-, libusb, libuuid, libxml2, libxslt, lilv-svn, lv2, makeWrapper
-, perl, pkgconfig, python, rubberband, serd, sord-svn, sratom
-, taglib, vampSDK, dbus, fftw, pango, suil, libarchive }:
+, libusb, libuuid, libxml2, libxslt, lilv-svn, lv2, makeWrapper, pango
+, perl, pkgconfig, python, rubberband, serd, sord-svn, sratom, suil, taglib, vampSDK }:
 
 let
 
@@ -16,17 +15,18 @@ let
   # "git describe" when _not_ on an annotated tag(!): MAJOR.MINOR-REV-HASH.
 
   # Version to build.
-  tag = "5.4";
+  tag = "4.7";
 
 in
 
 stdenv.mkDerivation rec {
   name = "ardour-${tag}";
 
-  src = fetchgit {
-    url = "git://git.ardour.org/ardour/ardour.git";
-    rev = "bb3312c3bb9c6ed9b75ac6739a6ee720ddf86c86";
-    sha256 = "1yrg0d86k9fqw7lmzjglilbadb4cjqxqkf6ii4bjs6rihj6b0qrf";
+  src = fetchFromGitHub {
+    owner = "Ardour";
+    repo = "ardour";
+    rev = "d84a8222f2b6dab5028b2586f798535a8766670e";
+    sha256 = "149gswphz77m3pkzsn2nqbm6yvcfa3fva560bcvjzlgb73f64q5l";
   };
 
   buildInputs =
@@ -34,8 +34,7 @@ stdenv.mkDerivation rec {
       glibmm graphviz gtkmm2 libjack2 libgnomecanvas libgnomecanvasmm liblo
       libmad libogg librdf librdf_raptor librdf_rasqal libsamplerate
       libsigcxx libsndfile libusb libuuid libxml2 libxslt lilv-svn lv2
-      makeWrapper pango perl pkgconfig python rubberband serd sord-svn
-      sratom suil taglib vampSDK libarchive
+      makeWrapper pango perl pkgconfig python rubberband serd sord-svn sratom suil taglib vampSDK
     ];
 
   # ardour's wscript has a "tarball" target but that required the git revision
@@ -53,16 +52,15 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     python waf install
-
     # Install desktop file
     mkdir -p "$out/share/applications"
     cat > "$out/share/applications/ardour.desktop" << EOF
     [Desktop Entry]
-    Name=Ardour 5
+    Name=Ardour 4
     GenericName=Digital Audio Workstation
     Comment=Multitrack harddisk recorder
-    Exec=$out/bin/ardour5
-    Icon=$out/share/ardour5/icons/ardour_icon_256px.png
+    Exec=$out/bin/ardour4
+    Icon=$out/share/ardour4/icons/ardour_icon_256px.png
     Terminal=false
     Type=Application
     X-MultipleArgs=false
@@ -77,7 +75,6 @@ stdenv.mkDerivation rec {
       record, edit and mix multi-track audio and midi. Produce your
       own CDs. Mix video soundtracks. Experiment with new ideas about
       music and sound.
-
       Please consider supporting the ardour project financially:
       https://community.ardour.org/node/8288
     '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11893,14 +11893,19 @@ in
 
   ao = callPackage ../applications/graphics/ao {};
 
-  ardour = ardour4;
+  ardour = ardour5;
 
   ardour3 =  callPackage ../applications/audio/ardour/ardour3.nix {
     inherit (gnome2) libgnomecanvas libgnomecanvasmm;
     inherit (vamp) vampSDK;
   };
 
-  ardour4 =  callPackage ../applications/audio/ardour {
+  ardour4 =  callPackage ../applications/audio/ardour/ardour4.nix {
+    inherit (gnome2) libgnomecanvas libgnomecanvasmm;
+    inherit (vamp) vampSDK;
+  };
+
+  ardour5 =  callPackage ../applications/audio/ardour {
     inherit (gnome2) libgnomecanvas libgnomecanvasmm;
     inherit (vamp) vampSDK;
   };


### PR DESCRIPTION
###### Motivation for this change

There was a new major release and a few minor ones.
`fetchFromGitHub` had to be exchanged with `fetchgit`, because GitHub fails to generate
new releases for Ardour since a few releases. It seems like that will stay like that for quite some
time. Since there are no alternative tarball mirrors, I believe its best to fetch the sources with `fetchgit`,
until there is some supported tarball mirror available again.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
