### PR TITLE
textadept: 8.7 -> 9.0

### DIFF
--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -43,22 +43,23 @@ let
 
 
   # These lists are taken from the Makefile.
-  scintilla_tgz  = "scintilla365.tgz";
+  scintilla_tgz  = "scintilla367.tgz";
+  tre_zip        = "cdce45e8dd7a3b36954022b4a4d3570e1ac5a4f8.zip";
   scinterm_zip   = "scinterm_1.8.zip";
-  scintillua_zip = "scintillua_3.6.5-1.zip";
-  lua_tgz        = "lua-5.3.2.tar.gz";
+  scintillua_zip = "scintillua_3.6.7-1.zip";
+  lua_tgz        = "lua-5.3.3.tar.gz";
   lpeg_tgz       = "lpeg-1.0.0.tar.gz";
   lfs_zip        = "v_1_6_3.zip";
-  luautf8_zip    = "0.1.1.zip";
   lspawn_zip     = "lspawn_1.5.zip";
   luajit_tgz     = "LuaJIT-2.0.3.tar.gz";
   libluajit_tgz  = "libluajit_2.0.3.x86_64.tgz";
-  gtdialog_zip   = "gtdialog_1.2.zip";
+  gtdialog_zip   = "gtdialog_1.3.zip";
   cdk_tgz        = "cdk-5.0-20150928.tgz";
   termkey_tgz    = "libtermkey-0.17.tar.gz";
   bombay_zip     = "bombay.zip";
 
   scinterm_url   = "http://foicica.com/scinterm/download/" + scinterm_zip;
+  tre_url        = "https://github.com/laurikari/tre/archive/" + tre_zip;
   scintillua_url = "http://foicica.com/scintillua/download/" + scintillua_zip;
   gtdialog_url   = "http://foicica.com/gtdialog/download/" + gtdialog_zip;
   lspawn_url     = "http://foicica.com/lspawn/download/" + lspawn_zip;
@@ -67,7 +68,6 @@ let
   lua_url        = "http://www.lua.org/ftp/" + lua_tgz;
   lpeg_url       = "http://www.inf.puc-rio.br/~roberto/lpeg/" + lpeg_tgz;
   lfs_url        = "https://github.com/keplerproject/luafilesystem/archive/" + lfs_zip;
-  luautf8_url    = "https://github.com/starwing/luautf8/archive/" + luautf8_zip;
   luajit_url     = "http://luajit.org/download/" + luajit_tgz;
   libluajit_url  = "http://foicica.com/textadept/download/" + libluajit_tgz;
   cdk_url        = "http://invisible-mirror.net/archives/cdk/" + cdk_tgz;
@@ -75,13 +75,13 @@ let
   termkey_url    = "http://www.leonerd.org.uk/code/libtermkey/" + termkey_tgz;
 
 
-  get_scintilla   = get_url scintilla_url   "1s5zbkn5f3vs8gbnjlkfzw4b137y12m3c89lyc4pmvqvrvxgyalj";
+  get_scintilla   = get_url scintilla_url   "0rh1xgd06qcnj4l0vi8g4i94vi63s76366b8hhqky3iqdjgwsxpi";
+  get_tre         = get_url tre_url         "0mw8npwk5nnhc33352j4akannhpx77kqvfam8jdq1n4yf8js1gi7";
   get_scinterm    = get_url scinterm_url    "02ax6cjpxylfz7iqp1cjmsl323in066a38yklmsyzdl3w7761nxi";
-  get_scintillua  = get_url scintillua_url  "0s4q7a9mgvxh0msi18llkczhcgafaiizw9qm1p9w18r2a7wjq9wc";
-  get_lua         = get_url lua_url         "13x6knpv5xsli0n2bib7g1nrga2iacy7qfy63i798dm94fxwfh67";
+  get_scintillua  = get_url scintillua_url  "0fhyjrkfj2cvxnql65687nx1d0sfyg5lbrxmylyzhnfh4s4jnwmq";
+  get_lua         = get_url lua_url         "18mcfbbmjyp8f2l9yy7n6dzk066nq6man0kpwly4bppphilc04si";
   get_lpeg        = get_url lpeg_url        "13mz18s359wlkwm9d9iqlyyrrwjc6iqfpa99ai0icam2b3khl68h";
   get_lfs         = get_url_zip lfs_url     "1hxcnqj53540ysyw8fzax7f09pl98b8f55s712gsglcdxp2g2pri";
-  get_luautf8_zip = get_url_zip luautf8_url "1dgmxdk88njpic4d4sn2wzlni4b6sfqcsmh2hrraxivpqf9ps7f7";
   get_lspawn      = get_url lspawn_url      "09c6v9irblay2kv1n7i59pyj9g4xb43c6rfa7ba5m353lymcwwqi";
   get_luajit      = get_url luajit_url      "0ydxpqkmsn2c341j4r2v6r5r0ig3kbwv3i9jran3iv81s6r6rgjm";
   get_libluajit   = get_url libluajit_url   "1nhvcdjpqrhd5qbihdm3bxpw84irfvnw2vmfqnsy253ay3dxzrgy";
@@ -93,12 +93,12 @@ let
 
 
   get_deps = get_scintilla
+    + get_tre
     + get_scinterm
     + get_scintillua
     + get_lua
     + get_lpeg
     + get_lfs
-    + get_luautf8_zip
     + get_lspawn
     + get_luajit
     + get_libluajit
@@ -108,7 +108,7 @@ let
     + get_termkey;
 in
 stdenv.mkDerivation rec {
-  version = "8.7";
+  version = "9.0";
   name = "textadept-${version}";
 
   buildInputs = [
@@ -118,7 +118,7 @@ stdenv.mkDerivation rec {
   src = fetchhg {
     url = http://foicica.com/hg/textadept;
     rev = "textadept_${version}";
-    sha256 = "1gi73wk11w3rbkxqqdp8z9g83qiyhx6gxry221vxjxpqsl9pvhlf";
+    sha256 = "1fkxblf2db4i0kbfww94xwps7nbn88qc4fwghrm4dcszcq32jlfi";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
