### PR TITLE
rtkit: add patch from debian to remove ControlGroup stanza

### DIFF
--- a/pkgs/os-specific/linux/rtkit/default.nix
+++ b/pkgs/os-specific/linux/rtkit/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, dbus, libcap }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, dbus, libcap }:
 
 stdenv.mkDerivation rec {
   name = "rtkit-0.11";
-  
+
   src = fetchurl {
     url = "http://0pointer.de/public/${name}.tar.xz";
     sha256 = "1l5cb1gp6wgpc9vq6sx021qs6zb0nxg3cn1ba00hjhgnrw4931b8";
@@ -10,6 +10,13 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
+  ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://anonscm.debian.org/cgit/pkg-multimedia/rtkit.git/plain/debian/patches/0002-Drop-Removed-ControlGroup-stanza.patch?id=21f2c6be6985c777cbf113c67043353406744050";
+      sha256 = "0lsxk5nv08i1wjb4xh20i5fcwg3x0qq0k4f8bc0r9cczph2sv7ck";
+    })
   ];
 
   buildInputs = [ pkgconfig dbus libcap ];


### PR DESCRIPTION
###### Motivation for this change

The support was removed in systemd 205, and since then our journal is cluttered.  
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

fixes log clutter:
systemd[1]: [/nix/store/....-rtkit-0.11/etc/systemd/system/rtkit-daemon.service:32] Unknown lvalue 'ControlGroup' in section 'Service'
