### PR TITLE
kernel: Disable RT_GROUP_SCHED

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -395,7 +395,7 @@ with stdenv.lib;
 
   # Linux containers.
   NAMESPACES? y #  Required by 'unshare' used by 'nixos-install'
-  RT_GROUP_SCHED? y
+  RT_GROUP_SCHED n
   CGROUP_DEVICE? y
   MEMCG y
   MEMCG_SWAP y


### PR DESCRIPTION
###### Motivation for this change

Follow systemd recommendation
https://github.com/systemd/systemd/blob/fd74fa791f95433ac52520764b67e6fb4bda2c0e/README#L96-L103

I have not tested if the change compiles, I would like feedback on this first.
###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
