### PR TITLE
jasper: 1.900.1 -> 1.900.2

### DIFF
--- a/pkgs/development/libraries/jasper/default.nix
+++ b/pkgs/development/libraries/jasper/default.nix
@@ -1,37 +1,17 @@
-{ stdenv, fetchurl, fetchpatch, unzip, libjpeg, autoreconfHook }:
+{ stdenv, fetchurl, fetchpatch, libjpeg, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "jasper-1.900.1";
+  name = "jasper-1.900.2";
 
   src = fetchurl {
-    url = "http://www.ece.uvic.ca/~mdadams/jasper/software/${name}.zip";
-    sha256 = "154l7zk7yh3v8l2l6zm5s2alvd2fzkp6c9i18iajfbna5af5m43b";
+    url = "http://www.ece.uvic.ca/~mdadams/jasper/software/${name}.tar.gz";
+    sha256 = "0bkibjhq3js2ldxa2f9pss84lcx4f5d3v0qis3ifi11ciy7a6c9a";
   };
 
   patches = [
-    ./jasper-CVE-2016-1867.diff
     ./jasper-CVE-2014-8137-variant2.diff
     ./jasper-CVE-2014-8137-noabort.diff
-    ./jasper-CVE-2014-8138.diff
-    ./jasper-CVE-2014-8157.diff
-    ./jasper-CVE-2014-8158.diff
-    ./jasper-CVE-2014-9029.diff
-    (fetchpatch { # CVE-2016-2116
-      url = "https://github.com/mdadams/jasper/commit/142245b9bbb33274a7c620aa7a8f85bc00b2d68e.patch";
-      sha256 = "06dkplqfb3swmdfqb9i2m6r13q0ivn538xfvinxz0agandxyc9yr";
-    })
-    (fetchpatch { # CVE-2016-1577
-      url = "https://github.com/mdadams/jasper/commit/74ea22a7a4fe186e0a0124df25e19739b77c4a29.patch";
-      sha256 = "1xgvhfhv8r77z0a07ick2w3217mypnkaqjwzxbk1g1ym8lsy5r13";
-    })
-    (fetchpatch { # CVE-2015-5221
-      url = "https://github.com/mdadams/jasper/commit/df5d2867e8004e51e18b89865bc4aa69229227b3.patch";
-      sha256 = "0qsiymm59dkj843dbi43ijqdyy3rrzf193ndm9ynj3cfhqghi10l";
-    })
-    (fetchpatch { # CVE-2008-3522
-      url = "https://github.com/mdadams/jasper/commit/d678ccd27b8a062e3bfd4c80d8ce2676a8166a27.patch";
-      sha256 = "0dapf8h4s3zijbgd8vmap3blpnc78h7jqm5ydv8j0krrs5dv5672";
-    })
+
     (fetchpatch { # CVE-2016-2089
       url = "https://github.com/mdadams/jasper/commit/aa6d9c2bbae9155f8e1466295373a68fa97291c3.patch";
       sha256 = "1pxnm86zmbq6brfwsm5wx3iv7s92n4xilc52lzp61q266jmlggrf";
@@ -43,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   # newer reconf to recognize a multiout flag
-  nativeBuildInputs = [ unzip autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook ];
   propagatedBuildInputs = [ libjpeg ];
 
   configureFlags = "--enable-shared";


### PR DESCRIPTION
###### Motivation for this change

Upstream jasper did a release, packaging about 10 CVE patches and many others improving the security and code quality. The jasper we have should be secure against all the known CVEs, so I don't think we need a backport.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
