### PR TITLE
pgpdump: init at v0.31

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -335,6 +335,7 @@
   pmahoney = "Patrick Mahoney <pat@polycrystal.org>";
   pmiddend = "Philipp Middendorf <pmidden@secure.mailbox.org>";
   prikhi = "Pavan Rikhi <pavan.rikhi@gmail.com>";
+  primeos = "Michael Weiss <dev.primeos@gmail.com>";
   profpatsch = "Profpatsch <mail@profpatsch.de>";
   proglodyte = "Proglodyte <proglodyte23@gmail.com>";
   pshendry = "Paul Hendry <paul@pshendry.com>";

--- a/pkgs/tools/security/pgpdump/default.nix
+++ b/pkgs/tools/security/pgpdump/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "pgpdump-${version}";
+  version = "0.31";
+
+  src = fetchFromGitHub {
+    owner = "kazu-yamamoto";
+    repo = "pgpdump";
+    rev = "v${version}";
+    sha256 = "05ywdgxzq3976dsy95vgdx3nnhd9i9vypzyrkabpmnxphfnjfrb4";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A PGP packet visualizer";
+    longDescription = ''
+      pgpdump is a PGP packet visualizer which displays the packet format of
+      OpenPGP (RFC 4880) and PGP version 2 (RFC 1991).
+    '';
+    homepage = "http://www.mew.org/~kazu/proj/pgpdump/en/";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7093,6 +7093,8 @@ in
     gnupg1 = gnupg1orig;
   };
 
+  pgpdump = callPackage ../tools/security/pgpdump { };
+
   gpgstats = callPackage ../tools/security/gpgstats { };
 
   gpshell = callPackage ../development/tools/misc/gpshell { };


### PR DESCRIPTION
###### Motivation for this change

Add a new package that will help analyzing OpenPGP packets.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add the package "pgpdump" at version v0.31 under the category
"tools/security", add it to the top-level package collection and set
myself as the maintainer (I added myself to lib/maintainers.nix).

I have tested this package under NixOS and Gentoo+Nix.
