### PR TITLE
pythonPackages.tornado: 4.4.1 -> 4.4.2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26720,7 +26720,7 @@ in modules // {
 
   tornado = buildPythonPackage rec {
     name = "tornado-${version}";
-    version = "4.4.1";
+    version = "4.4.2";
 
     propagatedBuildInputs = with self; [ backports_abc backports_ssl_match_hostname certifi singledispatch ];
 
@@ -26732,7 +26732,7 @@ in modules // {
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/t/tornado/${name}.tar.gz";
-      sha256 = "371d0cf3d56c47accc66116a77ad558d76eebaa8458a6b677af71ca606522146";
+      sha256 = "1k7d90afm5pivam90a37nqiz9wlmakvnsfymp3p43kcqz29gk618";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

This minor release [include a security fix](http://www.tornadoweb.org/en/stable/releases/v4.4.2.html). It should probably be backported to `release-16.09`.

Several packages fail to pass nox-review, but I also fail to build them on master.
- `python35Packages.librosa` 
- `ihaskell`
- `python35Packages.buttersink`
- `python35Packages.Pweave`
- `python35Packages.scikitimage`
- `python27Packages.mitmproxy`
- `python35Packages.oger`
- `python27Packages.thumbor`
- `python35Packages.locustio`
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
