### PR TITLE
rtkit: apply security relevant patch

### DIFF
--- a/pkgs/os-specific/linux/rtkit/default.nix
+++ b/pkgs/os-specific/linux/rtkit/default.nix
@@ -13,9 +13,16 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
+    # Drop removed ControlGroup stanza
     (fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-multimedia/rtkit.git/plain/debian/patches/0002-Drop-Removed-ControlGroup-stanza.patch?id=21f2c6be6985c777cbf113c67043353406744050";
+      url = "http://git.0pointer.net/rtkit.git/patch/?id=6c28e20c0be2f616a025059fda0ffac84e7f4f17";
       sha256 = "0lsxk5nv08i1wjb4xh20i5fcwg3x0qq0k4f8bc0r9cczph2sv7ck";
+    })
+
+    # security patch: Pass uid of caller to polkit
+    (fetchpatch {
+      url = "http://git.0pointer.net/rtkit.git/patch/?id=88d4082ef6caf6b071d749dca1c50e7edde914cc";
+      sha256 = "0hp1blbi359qz8fmr6nj4w9yc0jf3dd176f8pn25wdj38n13qkix";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Pass uid of caller to polkit: Otherwise, we force polkit to look up the uid
itself in /proc, which is racy if they execve() a setuid binary.
