### PR TITLE
thin-provisioning-tools: init at 0.6.3

### DIFF
--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, expat, libaio, boost }:
+
+stdenv.mkDerivation rec {
+  name = "thin-provisioning-tools-${version}";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "jthornber";
+    repo = "thin-provisioning-tools";
+    rev = "v${version}";
+    sha256 = "0glwhfzwj9afbqdv59ppgfqy7rik8m0vcap7279fpnvwpr1c2p5n";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ expat libaio boost ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jthornber/thin-provisioning-tools/;
+    description = "A suite of tools for manipulating the metadata of the dm-thin device-mapper target";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ globin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3790,6 +3790,8 @@ in
 
   thc-hydra = callPackage ../tools/security/thc-hydra { };
 
+  thin-provisioning-tools = callPackage ../tools/misc/thin-provisioning-tools {  };
+
   tiled = qt5.callPackage ../applications/editors/tiled { };
 
   timemachine = callPackage ../applications/audio/timemachine { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
