### PR TITLE
libsigcxx 2.8.0 -> 2.10.0 [-> staging]

### DIFF
--- a/pkgs/development/libraries/libsigcxx/default.nix
+++ b/pkgs/development/libraries/libsigcxx/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, gnum4 }:
 let
-  ver_maj = "2.8"; # odd major numbers are unstable
+  ver_maj = "2.10"; # odd major numbers are unstable
   ver_min = "0";
 in
 stdenv.mkDerivation rec {
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libsigc++/${ver_maj}/${name}.tar.xz";
-    sha256 = "0lcnzzdq6718znfshs1hflpwqq6awbzwdyp4kv5lfaf54z880jbp";
+    sha256 = "f843d6346260bfcb4426259e314512b99e296e8ca241d771d21ac64f28298d81";
   };
   patches = [(fetchpatch {
     url = "https://anonscm.debian.org/cgit/collab-maint/libsigc++-2.0.git/plain"


### PR DESCRIPTION
###### Motivation for this change

needed for glibmm ( #19121 )

http://hydra.nixos.org/build/41612268
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
