### PR TITLE
bash: fix CVE-2016-7543 in 16.09

### DIFF
--- a/pkgs/shells/bash/bash-4.3-patches.nix
+++ b/pkgs/shells/bash/bash-4.3-patches.nix
@@ -47,4 +47,6 @@ patch: [
 (patch "044" "16bzaq9fs2kaw2n2k6vvljkjw5k5kx06isnq8hxkfrxz60384f4k")
 (patch "045" "08q02mj9imp2njpgm6f5q5m61i7qzp33rbxxzarixalyisbw6vms")
 (patch "046" "13v8dymwj83wcvrfayjqrs5kqar05bcj4zpiacrjkkchnsk5dd5k")
+(patch "047" "0jkwqviwkqdc13wv3q0g0kapjr68ggs1xzhqy696pfkqgvg4i4n6")
+(patch "048" "18nzlk1idwkq0xd54s83lx8kam8kcvz7yc0mw6hnq2ax3i2ib0jv")
 ]


### PR DESCRIPTION
###### Motivation for this change

patch level 47 + 48 brings security fixes
related to #19253
for master I will update to bash 4.4
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
