### PR TITLE
openjpeg: 2.1.1 -> 2.1.2 for CVE-2016-7163

### DIFF
--- a/pkgs/development/libraries/openjpeg/2.1.nix
+++ b/pkgs/development/libraries/openjpeg/2.1.nix
@@ -1,8 +1,8 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "2.1.1";
+  version = "2.1.2";
   branch = "2.1";
-  revision = "v2.1.1";
-  sha256 = "1hrn10byrlw7hb7hwv2zvff89rxy3bsbn0im5ki4kdk63jw5p601";
+  revision = "v2.1.2";
+  sha256 = "0kdcl9sqjz0vagli4ad6bxq1r8ma086m0prpkm5x3dxp37hpjp8h";
 })


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/702317/
https://github.com/NixOS/nixpkgs/issues/19253
https://github.com/uclouvain/openjpeg/blob/openjpeg-2.1/CHANGELOG.md
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
