### PR TITLE
c-ares: 1.10.0 -> 1.12.0 for CVE-2016-5180

### DIFF
--- a/pkgs/development/libraries/c-ares/default.nix
+++ b/pkgs/development/libraries/c-ares/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "c-ares-1.10.0";
+  name = "c-ares-1.12.0";
 
   src = fetchurl {
     url = "http://c-ares.haxx.se/download/${name}.tar.gz";
-    sha256 = "1nyka87yf2jfd0y6sspll0yxwb8zi7kyvajrdbjmh4axc5s1cw1x";
+    sha256 = "1yv5ygkd813glz8hbagykgp1hlb6450chig061hr7pyw7i0gk4l6";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/19253
https://lwn.net/Alerts/702291/
https://c-ares.haxx.se/changelog.html
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
