### PR TITLE
openssh: apply patch to fix NEWKEYS null pointer deref

### DIFF
--- a/pkgs/tools/networking/openssh/RH-1380296-NEWKEYS-null-pointer-deref.patch
+++ b/pkgs/tools/networking/openssh/RH-1380296-NEWKEYS-null-pointer-deref.patch
@@ -1,0 +1,37 @@
+diff --git a/kex.c b/kex.c
+index 50c7a0f..823668b 100644
+--- a/kex.c
++++ b/kex.c
+@@ -419,6 +419,8 @@ kex_input_newkeys(int type, u_int32_t seq, void *ctxt)
+ 	ssh_dispatch_set(ssh, SSH2_MSG_NEWKEYS, &kex_protocol_error);
+ 	if ((r = sshpkt_get_end(ssh)) != 0)
+ 		return r;
++        if ((r = ssh_set_newkeys(ssh, MODE_IN)) != 0)
++          return r;
+ 	kex->done = 1;
+ 	sshbuf_reset(kex->peer);
+ 	/* sshbuf_reset(kex->my); */
+diff --git a/packet.c b/packet.c
+index d6dad2d..f96566b 100644
+--- a/packet.c
++++ b/packet.c
+@@ -38,7 +38,7 @@
+  */
+ 
+ #include "includes.h"
+- 
++
+ #include <sys/param.h>	/* MIN roundup */
+ #include <sys/types.h>
+ #include "openbsd-compat/sys-queue.h"
+@@ -1907,9 +1907,7 @@ ssh_packet_read_poll2(struct ssh *ssh, u_char *typep, u_int32_t *seqnr_p)
+ 			return r;
+ 		return SSH_ERR_PROTOCOL_ERROR;
+ 	}
+-	if (*typep == SSH2_MSG_NEWKEYS)
+-		r = ssh_set_newkeys(ssh, MODE_IN);
+-	else if (*typep == SSH2_MSG_USERAUTH_SUCCESS && !state->server_side)
++	if (*typep == SSH2_MSG_USERAUTH_SUCCESS && !state->server_side)
+ 		r = ssh_packet_enable_delayed_compress(ssh);
+ 	else
+ 		r = 0;

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
 
   patches =
     [
+      ./RH-1380296-NEWKEYS-null-pointer-deref.patch
       ./locale_archive.patch
       ./fix-host-key-algorithms-plus.patch
 


### PR DESCRIPTION
###### Motivation for this change

Fix:
- https://lwn.net/Vulnerabilities/702477/
- https://lwn.net/Alerts/702464/
- https://bugzilla.redhat.com/show_bug.cgi?id=1380296
- https://github.com/NixOS/nixpkgs/issues/19253

based off of https://anongit.mindrot.org/openssh.git/commit/?id=28652bca29046f62c7045e933e6b931de1d16737
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
