### PR TITLE
Cassandra: add procps dep only on linux

### DIFF
--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -4,7 +4,13 @@
 
 let
   libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc ];
-  binPath = stdenv.lib.makeBinPath [ bash getopt gawk procps which jre ];
+  binPath = with stdenv.lib; makeBinPath ([
+    bash
+    getopt
+    gawk
+    which
+    jre
+  ] ++ stdenv.lib.optional stdenv.isLinux procps);
 in
 
 stdenv.mkDerivation rec {
@@ -42,7 +48,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://cassandra.apache.org/;
     description = "A massively scalable open source NoSQL database";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.asl20;
     maintainers = with maintainers; [ nckx rushmorem cransom ];
   };


### PR DESCRIPTION
###### Motivation for this change

The build is currently failing on OS X with the following error : 

```
CCLD     test-schedbatch
Undefined symbols for architecture x86_64:
 "_sched_setscheduler", referenced from:
     _main in test-schedbatch.o
ld: symbol(s) not found for architecture x86_64
clang-3.7: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [Makefile:429: test-schedbatch] Error 1
make[2]: Leaving directory '/private/var/folders/4j/p6_vbx9s2x17f8zp03t0tvp40000gp/T/nix-build-procps-3.3.11.drv-0/procps-ng-3.3.11/testsuite'
make[1]: *** [Makefile:1468: all-recursive] Error 1
make[1]: Leaving directory '/private/var/folders/4j/p6_vbx9s2x17f8zp03t0tvp40000gp/T/nix-build-procps-3.3.11.drv-0/procps-ng-3.3.11'
make: *** [Makefile:765: all] Error 2
builder for ‘/nix/store/vz7ygrq5xy9674l4q0mz8pfwdgs1fgrp-procps-3.3.11.drv’ failed with exit code 2
fetching path ‘/nix/store/fkh6h1xgy2bdxh9njhjbva8ma6xjid0s-tmuxinator-0.8.1’...
cannot build derivation ‘/nix/store/zjilpyhgl7vwmp2nivw7xcx5kw85q6rm-cassandra-3.0.8.drv’: 1 dependencies couldn't be built
killing process 56550
error: build of ‘/nix/store/zjilpyhgl7vwmp2nivw7xcx5kw85q6rm-cassandra-3.0.8.drv’ failed
/Users/stn/.nix-profile/bin/nix-shell: failed to build all dependencies
```

I searched for the error and found it here : 
https://github.com/NixOS/nixpkgs/issues/18929
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The test on OS X was made by overriding the package on `~/.nixpkgs`, it still required the `allowBroken` set to true in order to successfully compile though.

cc @nckx @rushmorem @cransom
