### PR TITLE
libqmi: 1.12.6 -> 1.16.0

### DIFF
--- a/pkgs/development/libraries/libqmi/default.nix
+++ b/pkgs/development/libraries/libqmi/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, python }:
 
 stdenv.mkDerivation rec {
-  name = "libqmi-1.12.6";
+  name = "libqmi-1.16.0";
 
   src = fetchurl {
-    url = "http://www.freedesktop.org/software/libqmi/${name}.tar.xz";
-    sha256 = "101ppan2q1h4pyp2zbn9b8sdwy2c7fk9rp91yykxz3afrvzbymq8";
+    url = "https://www.freedesktop.org/software/libqmi/${name}.tar.xz";
+    sha256 = "0amshs06qc8zy8jz3r2yksqhhbamll7f893ll4zlvgr3zm3vpdks";
   };
 
   outputs = [ "out" "dev" "devdoc" ];


### PR DESCRIPTION
###### Motivation for this change

new version, needed for networkmanager update
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
