### PR TITLE
networkmanager{,applet,plugins}, modemmanager: update

### DIFF
--- a/pkgs/tools/networking/modemmanager/default.nix
+++ b/pkgs/tools/networking/modemmanager/default.nix
@@ -1,17 +1,18 @@
-{ stdenv, fetchurl, udev, libgudev, polkit, dbus_glib, ppp, intltool, pkgconfig, libmbim, libqmi }:
+{ stdenv, fetchurl, udev, libgudev, polkit, dbus_glib, ppp, intltool, pkgconfig
+, libmbim, libqmi, systemd }:
 
 stdenv.mkDerivation rec {
   name = "ModemManager-${version}";
-  version = "1.4.6";
+  version = "1.6.2";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/ModemManager/${name}.tar.xz";
-    sha256 = "1kd5nn5rm88c8rgmzwy2fsf3cr7fai7r85mi61kcby0hcgsapv8c";
+    sha256 = "14v31j916h63z7af107rias1zbb2y94p3jg77zhzhrn1v6c46m74";
   };
 
   nativeBuildInputs = [ intltool pkgconfig ];
 
-  buildInputs = [ udev libgudev polkit dbus_glib ppp libmbim libqmi ];
+  buildInputs = [ udev libgudev polkit dbus_glib ppp libmbim libqmi systemd ];
 
   configureFlags = [
     "--with-polkit"
@@ -19,6 +20,7 @@ stdenv.mkDerivation rec {
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--sysconfdir=/etc"
     "--localstatedir=/var"
+    "--with-suspend-resume=systemd"
   ];
 
   installFlags = [ "DESTDIR=\${out}" ];

--- a/pkgs/tools/networking/network-manager-applet/default.nix
+++ b/pkgs/tools/networking/network-manager-applet/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, intltool, pkgconfig, libglade, networkmanager, gnome3
-, libnotify, libsecret, polkit, isocodes
+, libnotify, libsecret, polkit, isocodes, modemmanager
 , mobile_broadband_provider_info, glib_networking, gsettings_desktop_schemas
-, makeWrapper, udev, libgudev, hicolor_icon_theme }:
+, makeWrapper, udev, libgudev, hicolor_icon_theme, jansson }:
 
 stdenv.mkDerivation rec {
   name    = "${pname}-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${networkmanager.major}/${name}.tar.xz";
-    sha256 = "02b42e7c17c9cd6c840563750da92ce58da1ec621df7f0c2402016026e727756";
+    sha256 = "431b7b4876638c6a537c8bf9c91a9250532b3d960b22b056df554695a81e4499";
   };
 
   configureFlags = [ "--sysconfdir=/etc" ];
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gnome3.gtk libglade networkmanager libnotify libsecret gsettings_desktop_schemas
     polkit isocodes makeWrapper udev libgudev gnome3.gconf gnome3.libgnome_keyring
+    modemmanager jansson
   ];
 
   nativeBuildInputs = [ intltool pkgconfig ];

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -7,12 +7,12 @@
 stdenv.mkDerivation rec {
   name    = "network-manager-${version}";
   pname   = "NetworkManager";
-  major   = "1.2";
+  major   = "1.4";
   version = "${major}.2";
 
   src = fetchurl {
     url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
-    sha256 = "41d8082e027f58bb5fa4181f93742606ab99c659794a18e2823eff22df0eecd9";
+    sha256 = "a864e347ddf6da8dabd40e0185b8c10a655d4a94b45cbaa2b3bb4b5e8360d204";
   };
 
   preConfigure = ''

--- a/pkgs/tools/networking/network-manager/openconnect.nix
+++ b/pkgs/tools/networking/network-manager/openconnect.nix
@@ -4,10 +4,11 @@
 stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname   = "NetworkManager-openconnect";
-  version = networkmanager.version;
+  major   = "1.2";
+  version = "${major}.2";
 
   src = fetchurl {
-    url    = "mirror://gnome/sources/${pname}/${networkmanager.major}/${pname}-${version}.tar.xz";
+    url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
     sha256 = "522979593e21b4e884112816708db9eb66148b3491580dacfad53472b94aafec";
   };
 

--- a/pkgs/tools/networking/network-manager/openvpn.nix
+++ b/pkgs/tools/networking/network-manager/openvpn.nix
@@ -4,11 +4,12 @@
 stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname   = "NetworkManager-openvpn";
-  version = networkmanager.version;
+  major   = "1.2";
+  version = "${major}.6";
 
   src = fetchurl {
-    url    = "mirror://gnome/sources/${pname}/${networkmanager.major}/${pname}-${version}.tar.xz";
-    sha256 = "47a6d219a781eff8491c7876b7fb95b12dcfb8f8a05f916f95afc65c7babddef";
+    url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
+    sha256 = "2373e2bb0a8a876cb2997cd8b0e3d6e10012d9bef3705ea3ac21f6394b3f1fb0";
   };
 
   buildInputs = [ openvpn networkmanager libsecret ]

--- a/pkgs/tools/networking/network-manager/pptp.nix
+++ b/pkgs/tools/networking/network-manager/pptp.nix
@@ -4,11 +4,12 @@
 stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname   = "NetworkManager-pptp";
-  version = networkmanager.version;
+  major   = "1.2";
+  version = "${major}.4";
 
   src = fetchurl {
-    url    = "mirror://gnome/sources/${pname}/${networkmanager.major}/${pname}-${version}.tar.xz";
-    sha256 = "a72cb88ecc0a9edec836e8042c592d68b8b290c0d78082e6b25cf08b46c6be5d";
+    url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
+    sha256 = "bd97ce768c34cce6d5b5d43681149a8300bec754397a3f46a0d8d0aea7030c5e";
   };
 
   buildInputs = [ networkmanager pptp ppp libsecret ]

--- a/pkgs/tools/networking/network-manager/vpnc.nix
+++ b/pkgs/tools/networking/network-manager/vpnc.nix
@@ -4,11 +4,12 @@
 stdenv.mkDerivation rec {
   name    = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname   = "NetworkManager-vpnc";
-  version = networkmanager.version;
+  major   = "1.2";
+  version = "${major}.4";
 
   src = fetchurl {
-    url    = "mirror://gnome/sources/${pname}/${networkmanager.major}/${pname}-${version}.tar.xz";
-    sha256 = "e900f6500026f8c3ee4feb92e1d0a0c0abbee9ba507dad915b47a8ab7df9e1f3";
+    url    = "mirror://gnome/sources/${pname}/${major}/${pname}-${version}.tar.xz";
+    sha256 = "39c7516418e90208cb534c19628ce40fd50eba0a08b2ebaef8da85720b10fb05";
   };
 
   buildInputs = [ vpnc networkmanager libsecret ]


### PR DESCRIPTION
###### Motivation for this change

new versions everywhere

**depends on #19304 and #19305**
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested with gnome 3.22 only. Plugins not tested for functionality since i dont have any of the required remotes.
#### I can report back when nox-review finishes.
