### PR TITLE
Python: move tkinter into separate output

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -27,6 +27,7 @@ let
   pythonVersion = majorVersion;
   version = "${majorVersion}.${minorVersion}${minorVersionSuffix}";
   libPrefix = "python${majorVersion}";
+  sitePackages = "lib/${libPrefix}/site-packages";
 
   src = fetchurl {
     url = "https://www.python.org/ftp/python/${majorVersion}.${minorVersion}/Python-${version}.tar.xz";
@@ -113,10 +114,8 @@ let
     optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc ++
     [ bzip2 openssl ]
     ++ optionals stdenv.isCygwin [ expat libffi ]
-    ++ optionals includeModules (
-        [ db gdbm ncurses sqlite readline
-        ] ++ optionals x11Support [ tcl tk xlibsWrapper libX11 ]
-    )
+    ++ [ db gdbm ncurses sqlite readline ]
+    ++ optionals x11Support [ tcl tk xlibsWrapper libX11 ]
     ++ optional zlibSupport zlib
     ++ optional stdenv.isDarwin CF;
 
@@ -129,7 +128,8 @@ let
 
   # Build the basic Python interpreter without modules that have
   # external dependencies.
-  python = stdenv.mkDerivation {
+
+in stdenv.mkDerivation {
     name = "python-${version}";
     pythonVersion = majorVersion;
 
@@ -165,20 +165,26 @@ let
         # Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
         echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
 
-        ${optionalString includeModules "$out/bin/python ./setup.py build_ext"}
-
         rm "$out"/lib/python*/plat-*/regen # refers to glibc.dev
       '';
 
+    postFixup = optionalString x11Support ''
+      # tkinter goes in a separate output
+      mkdir -p $tkinter/${sitePackages}
+      mv $out/lib/${libPrefix}/tkinter $tkinter/${sitePackages}/
+      mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/tkinter
+    '';
+
+    outputs = ["out"] ++ optional x11Support "tkinter";
+
     passthru = rec {
-      inherit libPrefix;
+      inherit libPrefix sitePackages;
       inherit zlibSupport;
       isPy2 = true;
       isPy27 = true;
       buildEnv = callPackage ../../wrapper.nix { python = self; };
       withPackages = import ../../with-packages.nix { inherit buildEnv; pythonPackages = python27Packages; };
       executable = libPrefix;
-      sitePackages = "lib/${libPrefix}/site-packages";
       interpreter = "${self}/bin/${executable}";
     };
 
@@ -200,99 +206,4 @@ let
       platforms = stdenv.lib.platforms.all;
       maintainers = with stdenv.lib.maintainers; [ chaoflow domenkozar ];
     };
-  };
-
-
-  # This function builds a Python module included in the main Python
-  # distribution in a separate derivation.
-  buildInternalPythonModule =
-    { moduleName
-    , internalName ? "_" + moduleName
-    , deps
-    }:
-    if includeModules then null else stdenv.mkDerivation rec {
-      name = "python-${moduleName}-${python.version}";
-
-      inherit src patches preConfigure postConfigure configureFlags;
-
-      buildInputs = [ python ] ++ deps;
-
-      # We need to set this for python.buildEnv
-      pythonPath = [];
-
-      inherit (mkPaths buildInputs) C_INCLUDE_PATH LIBRARY_PATH;
-
-      # non-python gdbm has a libintl dependency on i686-cygwin, not on x86_64-cygwin
-      buildPhase = (if (stdenv.system == "i686-cygwin" && moduleName == "gdbm") then ''
-          sed -i setup.py -e "s:libraries = \['gdbm'\]:libraries = ['gdbm', 'intl']:"
-      '' else '''') + ''
-          substituteInPlace setup.py --replace 'self.extensions = extensions' \
-            'self.extensions = [ext for ext in self.extensions if ext.name in ["${internalName}"]]'
-
-          python ./setup.py build_ext
-          [ -z "$(find build -name '*_failed.so' -print)" ]
-        '';
-
-      installPhase =
-        ''
-          dest=$out/lib/${python.libPrefix}/site-packages
-          mkdir -p $dest
-          cp -p $(find . -name "*.${if stdenv.isCygwin then "dll" else "so"}") $dest/
-        '';
-    };
-
-
-  # The Python modules included in the main Python distribution, built
-  # as separate derivations.
-  modules = {
-
-    bsddb = buildInternalPythonModule {
-      moduleName = "bsddb";
-      deps = [ db ];
-    };
-
-    curses = buildInternalPythonModule {
-      moduleName = "curses";
-      deps = [ ncurses ];
-    };
-
-    curses_panel = buildInternalPythonModule {
-      moduleName = "curses_panel";
-      deps = [ ncurses modules.curses ];
-    };
-
-    crypt = buildInternalPythonModule {
-      moduleName = "crypt";
-      internalName = "crypt";
-      deps = optional (stdenv ? glibc) stdenv.glibc;
-    };
-
-    gdbm = buildInternalPythonModule {
-      moduleName = "gdbm";
-      internalName = "gdbm";
-      deps = [ gdbm ] ++ stdenv.lib.optional stdenv.isCygwin gettext;
-    };
-
-    sqlite3 = buildInternalPythonModule {
-      moduleName = "sqlite3";
-      deps = [ sqlite ];
-    };
-
-  } // optionalAttrs x11Support {
-
-    tkinter = if stdenv.isCygwin then null else (buildInternalPythonModule {
-      moduleName = "tkinter";
-      deps = [ tcl tk xlibsWrapper libX11 ];
-    });
-
-  } // {
-
-    readline = buildInternalPythonModule {
-      moduleName = "readline";
-      internalName = "readline";
-      deps = [ readline ];
-    };
-
-  };
-
-in python // { inherit modules; }
+  }

--- a/pkgs/development/interpreters/python/cpython/3.3/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.3/default.nix
@@ -26,6 +26,7 @@ let
   pythonVersion = majorVersion;
   version = "${majorVersion}.${minorVersion}${minorVersionSuffix}";
   libPrefix = "python${majorVersion}";
+  sitePackages = "lib/${libPrefix}/site-packages";
 
   buildInputs = filter (p: p != null) [
     zlib bzip2 lzma gdbm sqlite db readline ncurses openssl tcl tk libX11 xproto
@@ -79,8 +80,26 @@ stdenv.mkDerivation {
     echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
   '';
 
+  postFixup = ''
+    # Get rid of retained dependencies on -dev packages, and remove
+    # some $TMPDIR references to improve binary reproducibility.
+    for i in $out/lib//python${majorVersion}/_sysconfigdata.py $out/lib/python${majorVersion}/config-${majorVersion}m/Makefile; do
+      sed -i $i -e "s|-I/nix/store/[^ ']*||g" -e "s|-L/nix/store/[^ ']*||g" -e "s|$TMPDIR|/no-such-path|g"
+    done
+
+    # FIXME: should regenerate this.
+    rm $out/lib/python${majorVersion}/__pycache__/_sysconfigdata.cpython*
+
+    # tkinter goes in a separate output
+    mkdir -p $tkinter/${sitePackages}
+    mv $out/lib/${libPrefix}/tkinter $tkinter/${sitePackages}/
+    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/tkinter
+  '';
+
+  outputs = ["out" "tkinter"];
+
   passthru = rec {
-    inherit libPrefix;
+    inherit libPrefix sitePackages;
     zlibSupport = zlib != null;
     sqliteSupport = sqlite != null;
     dbSupport = db != null;
@@ -93,7 +112,6 @@ stdenv.mkDerivation {
     isPy3 = true;
     isPy33 = true;
     is_py3k = true;  # deprecated
-    sitePackages = "lib/${libPrefix}/site-packages";
     interpreter = "${self}/bin/${executable}";
   };
 

--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -28,6 +28,7 @@ let
   pythonVersion = majorVersion;
   version = "${majorVersion}.${minorVersion}${minorVersionSuffix}";
   libPrefix = "python${majorVersion}";
+  sitePackages = "lib/${libPrefix}/site-packages";
 
   buildInputs = filter (p: p != null) [
     zlib
@@ -102,8 +103,26 @@ stdenv.mkDerivation {
     echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
   '';
 
+  postFixup = ''
+    # Get rid of retained dependencies on -dev packages, and remove
+    # some $TMPDIR references to improve binary reproducibility.
+    for i in $out/lib//python${majorVersion}/_sysconfigdata.py $out/lib/python${majorVersion}/config-${majorVersion}m/Makefile; do
+      sed -i $i -e "s|-I/nix/store/[^ ']*||g" -e "s|-L/nix/store/[^ ']*||g" -e "s|$TMPDIR|/no-such-path|g"
+    done
+
+    # FIXME: should regenerate this.
+    rm $out/lib/python${majorVersion}/__pycache__/_sysconfigdata.cpython*
+
+    # tkinter goes in a separate output
+    mkdir -p $tkinter/${sitePackages}
+    mv $out/lib/${libPrefix}/tkinter $tkinter/${sitePackages}/
+    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/tkinter
+  '';
+
+  outputs = ["out" "tkinter"];
+
   passthru = rec {
-    inherit libPrefix;
+    inherit libPrefix sitePackages;
     zlibSupport = zlib != null;
     sqliteSupport = sqlite != null;
     dbSupport = db != null;
@@ -116,7 +135,6 @@ stdenv.mkDerivation {
     isPy3 = true;
     isPy34 = true;
     is_py3k = true;  # deprecated
-    sitePackages = "lib/${libPrefix}/site-packages";
     interpreter = "${self}/bin/${executable}";
   };
 

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -27,6 +27,7 @@ let
   pythonVersion = majorVersion;
   version = "${majorVersion}.${minorVersion}${minorVersionSuffix}";
   libPrefix = "python${majorVersion}";
+  sitePackages = "lib/${libPrefix}/site-packages";
 
   buildInputs = filter (p: p != null) [
     zlib
@@ -108,10 +109,17 @@ stdenv.mkDerivation {
 
     # FIXME: should regenerate this.
     rm $out/lib/python${majorVersion}/__pycache__/_sysconfigdata.cpython*
+
+    # tkinter goes in a separate output
+    mkdir -p $tkinter/${sitePackages}
+    mv $out/lib/${libPrefix}/tkinter $tkinter/${sitePackages}/
+    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/tkinter
   '';
 
+  outputs = ["out" "tkinter"];
+
   passthru = rec {
-    inherit libPrefix;
+    inherit libPrefix sitePackages;
     zlibSupport = zlib != null;
     sqliteSupport = sqlite != null;
     dbSupport = false;
@@ -124,7 +132,6 @@ stdenv.mkDerivation {
     isPy3 = true;
     isPy35 = true;
     is_py3k = true;  # deprecated
-    sitePackages = "lib/${libPrefix}/site-packages";
     interpreter = "${self}/bin/${executable}";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1655,6 +1655,7 @@ in
 
   fontforge = lowPrio (callPackage ../tools/misc/fontforge {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    python = pythonWithoutX11;
   });
   fontforge-gtk = callPackage ../tools/misc/fontforge {
     withGTK = true;
@@ -5474,6 +5475,11 @@ in
   python2 = python27;
   python3 = python35;
 
+  # Python uses multiple outputs, and by default `python` is without X11/tkinter.
+  # This package only exists to prevent an infinite recursion and should only be used
+  # for packages Python itself depends on.
+  pythonWithoutX11 = python.override {x11Support = false;};
+
   # pythonPackages further below, but assigned here because they need to be in sync
   pythonPackages = python2Packages;
   python2Packages = python27Packages;
@@ -7123,7 +7129,9 @@ in
 
   gtkmathview = callPackage ../development/libraries/gtkmathview { };
 
-  glib = callPackage ../development/libraries/glib { };
+  glib = callPackage ../development/libraries/glib {
+    python = pythonWithoutX11;
+  };
   glib-tested = glib.override { # checked version separate to break cycles
     doCheck = true;
     libffi = libffi.override { doCheck = true; };
@@ -8242,7 +8250,9 @@ in
 
   libxmi = callPackage ../development/libraries/libxmi { };
 
-  libxml2 = callPackage ../development/libraries/libxml2 { };
+  libxml2 = callPackage ../development/libraries/libxml2 {
+    python = pythonWithoutX11;
+  };
   libxml2Python = pkgs.buildEnv { # slightly hacky
     name = "libxml2+py-${self.libxml2.version}";
     paths = with libxml2; [ dev bin py ];
@@ -10322,11 +10332,12 @@ in
     inherit clangStdenv fetchurl fetchgit fetchpatch stdenv pkgconfig intltool freetype fontconfig
       libxslt expat libpng zlib perl mesa_drivers spice_protocol libunwind
       dbus libuuid openssl gperf m4 libevdev tradcpp libinput mcpp makeWrapper autoreconfHook
-      autoconf automake libtool xmlto asciidoc flex bison python mtdev pixman
+      autoconf automake libtool xmlto asciidoc flex bison mtdev pixman
       cairo epoxy;
     inherit (darwin) apple_sdk cf-private libobjc;
     bootstrap_cmds = if stdenv.isDarwin then darwin.bootstrap_cmds else null;
     mesa = mesa_noglu;
+    python = python27.override {x11Support = false;};
     udev = if stdenv.isLinux then udev else null;
     libdrm = if stdenv.isLinux then libdrm else null;
     fglrxCompat = config.xorg.fglrxCompat or false; # `config` because we have no `xorg.override`


### PR DESCRIPTION
###### Motivation for this change

See issue #19255 and #1819.
- Unify expressions of different interpreters
- Reduce closure size of Python 3.x interpreters
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
## To do
- [ ] fix expressions that use the modules that were removed
- [ ] update docs
