### PR TITLE
Python: use separate output for tkinter

### DIFF
--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -422,7 +422,7 @@ exists.
 
 #### Missing `tkinter` module standard library
 
-To reduce closure size the `Tkinter`/`tkinter` module is available as `python.tkinter`.
+To reduce closure size the `Tkinter`/`tkinter` is put in a separate output. The `tkinter` is available as `python35Packages.tkinter`.
 
 #### Attributes on interpreters packages
 

--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -416,28 +416,13 @@ aliases `python` and `python3` correspond to respectively `python27` and
 `python35`. The Nix expressions for the interpreters can be found in
 `pkgs/development/interpreters/python`.
 
-
-#### Missing modules standard library
-
-The interpreters `python26` and `python27` do not include modules that
-require external dependencies. This is done in order to reduce the closure size.
-The following modules need to be added as `buildInput` explicitly:
-
-* `python.modules.bsddb`
-* `python.modules.curses`
-* `python.modules.curses_panel`
-* `python.modules.crypt`
-* `python.modules.gdbm`
-* `python.modules.sqlite3`
-* `python.modules.tkinter`
-* `python.modules.readline`
-
-For convenience `python27Full` and `python26Full` are provided with all
-modules included.
-
 All packages depending on any Python interpreter get appended
 `out/{python.sitePackages}` to `$PYTHONPATH` if such directory
 exists.
+
+#### Missing `tkinter` module standard library
+
+To reduce closure size the `Tkinter`/`tkinter` module is available as `python.tkinter`.
 
 #### Attributes on interpreters packages
 
@@ -448,7 +433,7 @@ Each interpreter has the following attributes:
 - `buildEnv`. Function to build python interpreter environments with extra packages bundled together. See section *python.buildEnv function* for usage and documentation.
 - `withPackages`. Simpler interface to `buildEnv`. See section *python.withPackages function* for usage and documentation.
 - `sitePackages`. Alias for `lib/${libPrefix}/site-packages`.
-- `executable`. Name of the interpreter executable, ie `python3.4`.
+- `executable`. Name of the interpreter executable, e.g. `python3.4`.
 
 ### Building packages and applications
 

--- a/nixos/modules/services/web-servers/apache-httpd/trac.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/trac.nix
@@ -102,7 +102,6 @@ in
             pkgs.setuptools
             pkgs.pythonPackages.genshi
             pkgs.pythonPackages.psycopg2
-            pkgs.python.modules.sqlite3
             subversion
           ];
     };

--- a/pkgs/applications/misc/loxodo/default.nix
+++ b/pkgs/applications/misc/loxodo/default.nix
@@ -12,7 +12,7 @@ py.buildPythonApplication rec {
     sha256 = "1cg0dfcv57ps54f1a0ksib7hgkrbdi9q699w302xyyfyvjcb5dd2";
   };
 
-  propagatedBuildInputs = with py; [ wxPython python.modules.readline ];
+  propagatedBuildInputs = with py; [ wxPython ];
 
   postInstall = ''
     mv $out/bin/loxodo.py $out/bin/loxodo

--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0yaviybviwdvfg2a0pf2kk28g10k245499xmbpqlai7fv91f7xll";
   };
 
-  propagatedBuildInputs = [ pythonPackages.python.modules.curses file ];
+  propagatedBuildInputs = [ file ];
 
   preConfigure = ''
     substituteInPlace ranger/ext/img_display.py \

--- a/pkgs/applications/misc/roxterm/default.nix
+++ b/pkgs/applications/misc/roxterm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, docbook_xsl, dbus_libs, dbus_glib, expat, gettext
 , gsettings_desktop_schemas, gdk_pixbuf, gtk2, gtk3, hicolor_icon_theme
 , imagemagick, itstool, librsvg, libtool, libxslt, lockfile, makeWrapper
-, pkgconfig, pythonFull, pythonPackages, vte }:
+, pkgconfig, python, pythonPackages, vte }:
 
 # TODO: Still getting following warning.
 # WARNING **: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs =
     [ docbook_xsl expat imagemagick itstool librsvg libtool libxslt
-      makeWrapper pkgconfig pythonFull pythonPackages.lockfile ];
+      makeWrapper pkgconfig python pythonPackages.lockfile ];
 
   propagatedBuildInputs =
     [ dbus_libs dbus_glib gdk_pixbuf gettext gsettings_desktop_schemas gtk2 gtk3 hicolor_icon_theme vte ];
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
                          "-I${dbus_libs.lib}/lib/dbus-1.0/include" ];
 
   # Fix up python path so the lockfile library is on it.
-  PYTHONPATH = stdenv.lib.makeSearchPathOutput "lib" pythonFull.sitePackages [
+  PYTHONPATH = stdenv.lib.makeSearchPathOutput "lib" python.sitePackages [
     pythonPackages.curses pythonPackages.lockfile
   ];
 

--- a/pkgs/applications/misc/rtv/default.nix
+++ b/pkgs/applications/misc/rtv/default.nix
@@ -17,7 +17,6 @@ pythonPackages.buildPythonApplication rec {
     six
     praw
     kitchen
-    python.modules.curses
     praw
   ] ++ lib.optional (!pythonPackages.isPy3k) futures;
 

--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -16,7 +16,7 @@ pythonPackages.buildPythonApplication rec {
 
   propagatedBuildInputs = with pythonPackages; [
     makeWrapper pillow jinja2 spambayes pythonPackages.lxml
-    python.modules.readline pgpdump gnupg1orig
+    pgpdump gnupg1orig
   ];
 
   postInstall = ''

--- a/pkgs/applications/version-management/bazaar/default.nix
+++ b/pkgs/applications/version-management/bazaar/default.nix
@@ -10,9 +10,6 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1cysix5k3wa6y7jjck3ckq3abls4gvz570s0v0hxv805nwki4i8d";
   };
 
-  # Readline support is needed by bzrtools.
-  propagatedBuildInputs = [ pythonPackages.python.modules.readline ];
-
   doCheck = false;
 
   # Bazaar can't find the certificates alone

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, makeWrapper
-, pkgconfig, cmake, gnumake, yasm, pythonFull
+, pkgconfig, cmake, gnumake, yasm, python
 , boost, avahi, libdvdcss, lame, autoreconfHook
 , gettext, pcre-cpp, yajl, fribidi, which
 , openssl, gperf, tinyxml2, taglib, libssh, swig, jre
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
 
     buildInputs = [
       makeWrapper libxml2 gnutls
-      pkgconfig cmake gnumake yasm pythonFull
+      pkgconfig cmake gnumake yasm python
       boost libmicrohttpd autoreconfHook
       gettext pcre-cpp yajl fribidi libva
       openssl gperf tinyxml2 taglib libssh swig jre
@@ -107,7 +107,7 @@ in stdenv.mkDerivation rec {
     postInstall = ''
       for p in $(ls $out/bin/) ; do
         wrapProgram $out/bin/$p \
-          --prefix PATH ":" "${pythonFull}/bin" \
+          --prefix PATH ":" "${python}/bin" \
           --prefix PATH ":" "${glxinfo}/bin" \
           --prefix PATH ":" "${xdpyinfo}/bin" \
           --prefix LD_LIBRARY_PATH ":" "${lib.makeLibraryPath

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, libuuid, pythonFull, iasl }:
+{ stdenv, fetchgit, libuuid, python, iasl }:
 
 let
 
@@ -18,7 +18,7 @@ edk2 = stdenv.mkDerivation {
     sha256 = "0s9ywb8w7xzlnmm4kwzykxkrdaw53b7pky121cc9wjkllzqwyxrb";
   };
 
-  buildInputs = [ libuuid pythonFull ];
+  buildInputs = [ libuuid python python.tkinter ];
 
   makeFlags = "-C BaseTools";
 
@@ -40,7 +40,7 @@ edk2 = stdenv.mkDerivation {
 
   passthru = {
     setup = projectDscPath: attrs: {
-      buildInputs = [ pythonFull ] ++
+      buildInputs = [ python python.tkinter ] ++
         stdenv.lib.optionals (attrs ? buildInputs) attrs.buildInputs;
 
       configurePhase = ''

--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -28,6 +28,7 @@ let
   pythonVersion = majorVersion;
   version = "${majorVersion}.${minorVersion}${minorVersionSuffix}";
   libPrefix = "python${majorVersion}";
+  sitePackages = "lib/${libPrefix}/site-packages";
 
   buildInputs = filter (p: p != null) [
     zlib
@@ -102,8 +103,25 @@ stdenv.mkDerivation {
     echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
   '';
 
+  postFixup = ''
+    # Get rid of retained dependencies on -dev packages, and remove
+    # some $TMPDIR references to improve binary reproducibility.
+    for i in $out/lib/python${majorVersion}/_sysconfigdata.py $out/lib/python${majorVersion}/config-${majorVersion}m/Makefile; do
+      sed -i $i -e "s|-I/nix/store/[^ ']*||g" -e "s|-L/nix/store/[^ ']*||g" -e "s|$TMPDIR|/no-such-path|g"
+    done
+
+    # FIXME: should regenerate this.
+    rm $out/lib/python${majorVersion}/__pycache__/_sysconfigdata.cpython*
+
+    # tkinter goes in a separate output
+    mkdir -p $tkinter/${sitePackages}
+    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/
+  '';
+
+  outputs = ["out" "tkinter"];
+
   passthru = rec {
-    inherit libPrefix;
+    inherit libPrefix sitePackages;
     zlibSupport = zlib != null;
     sqliteSupport = sqlite != null;
     dbSupport = db != null;
@@ -116,7 +134,6 @@ stdenv.mkDerivation {
     isPy3 = true;
     isPy34 = true;
     is_py3k = true;  # deprecated
-    sitePackages = "lib/${libPrefix}/site-packages";
     interpreter = "${self}/bin/${executable}";
   };
 

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -27,6 +27,7 @@ let
   pythonVersion = majorVersion;
   version = "${majorVersion}.${minorVersion}${minorVersionSuffix}";
   libPrefix = "python${majorVersion}";
+  sitePackages = "lib/${libPrefix}/site-packages";
 
   buildInputs = filter (p: p != null) [
     zlib
@@ -102,16 +103,22 @@ stdenv.mkDerivation {
   postFixup = ''
     # Get rid of retained dependencies on -dev packages, and remove
     # some $TMPDIR references to improve binary reproducibility.
-    for i in $out/lib//python${majorVersion}/_sysconfigdata.py $out/lib/python${majorVersion}/config-${majorVersion}m/Makefile; do
+    for i in $out/lib/python${majorVersion}/_sysconfigdata.py $out/lib/python${majorVersion}/config-${majorVersion}m/Makefile; do
       sed -i $i -e "s|-I/nix/store/[^ ']*||g" -e "s|-L/nix/store/[^ ']*||g" -e "s|$TMPDIR|/no-such-path|g"
     done
 
     # FIXME: should regenerate this.
     rm $out/lib/python${majorVersion}/__pycache__/_sysconfigdata.cpython*
+
+    # tkinter goes in a separate output
+    mkdir -p $tkinter/${sitePackages}
+    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/
   '';
 
+  outputs = ["out" "tkinter"];
+
   passthru = rec {
-    inherit libPrefix;
+    inherit libPrefix sitePackages;
     zlibSupport = zlib != null;
     sqliteSupport = sqlite != null;
     dbSupport = false;
@@ -124,7 +131,6 @@ stdenv.mkDerivation {
     isPy3 = true;
     isPy35 = true;
     is_py3k = true;  # deprecated
-    sitePackages = "lib/${libPrefix}/site-packages";
     interpreter = "${self}/bin/${executable}";
   };
 

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -29,6 +29,7 @@ let
   pythonVersion = majorVersion;
   version = "${majorVersion}.${minorVersion}${minorVersionSuffix}";
   libPrefix = "python${majorVersion}";
+  sitePackages = "lib/${libPrefix}/site-packages";
 
   buildInputs = filter (p: p != null) [
     glibc
@@ -103,8 +104,16 @@ stdenv.mkDerivation {
     echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
   '';
 
+  postFixup = ''
+    # tkinter goes in a separate output
+    mkdir -p $tkinter/${sitePackages}
+    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/
+  '';
+
+  outputs = ["out" "tkinter"];
+
   passthru = rec {
-    inherit libPrefix;
+    inherit libPrefix sitePackages;
     zlibSupport = zlib != null;
     sqliteSupport = sqlite != null;
     dbSupport = db != null;
@@ -117,7 +126,6 @@ stdenv.mkDerivation {
     isPy3 = true;
     isPy35 = true;
     is_py3k = true;  # deprecated
-    sitePackages = "lib/${libPrefix}/site-packages";
     interpreter = "${self}/bin/${executable}";
   };
 

--- a/pkgs/development/interpreters/python/pypy/2.7/default.nix
+++ b/pkgs/development/interpreters/python/pypy/2.7/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, zlib ? null, zlibSupport ? true, bzip2, pkgconfig, libffi
-, sqlite, openssl, ncurses, pythonFull, expat, tcl, tk, xlibsWrapper, libX11
+, sqlite, openssl, ncurses, python, expat, tcl, tk, xlibsWrapper, libX11
 , makeWrapper, callPackage, self, pypyPackages, gdbm, db }:
 
 assert zlibSupport -> zlib != null;
@@ -34,7 +34,7 @@ let
       patch lib-python/2.7/test/test_pyexpat.py < '${expatch}'
     '';
 
-    buildInputs = [ bzip2 openssl pkgconfig pythonFull libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 makeWrapper gdbm db ]
+    buildInputs = [ bzip2 openssl pkgconfig python python.tkinter libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 makeWrapper gdbm db ]
       ++ stdenv.lib.optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc
       ++ stdenv.lib.optional zlibSupport zlib;
 
@@ -62,7 +62,7 @@ let
     '';
 
     buildPhase = ''
-      ${pythonFull.interpreter} rpython/bin/rpython --make-jobs="$NIX_BUILD_CORES" -Ojit --batch pypy/goal/targetpypystandalone.py --withmod-_minimal_curses --withmod-unicodedata --withmod-thread --withmod-bz2 --withmod-_multiprocessing
+      ${python.interpreter} rpython/bin/rpython --make-jobs="$NIX_BUILD_CORES" -Ojit --batch pypy/goal/targetpypystandalone.py --withmod-_minimal_curses --withmod-unicodedata --withmod-thread --withmod-bz2 --withmod-_multiprocessing
     '';
 
     setupHook = ./setup-hook.sh;

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     ]
     ++ stdenv.lib.optional enableGtk2 pygtk
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ]
-    ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ];
+    ++ stdenv.lib.optionals enableTk [ python.tkinter tcl tk tkinter libX11 ];
 
   patches =
     [ ./basedirlist.patch ] ++

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -26,7 +26,7 @@ in pythonPackages.buildPythonApplication rec {
     blist canonicaljson daemonize dateutil frozendict pillow pybcrypt pyasn1
     pydenticon pymacaroons-pynacl pynacl pyopenssl pysaml2 pytz requests2
     service-identity signedjson systemd twisted ujson unpaddedbase64 pyyaml
-    matrix-angular-sdk bleach netaddr jinja2 psycopg2 python.modules.curses
+    matrix-angular-sdk bleach netaddr jinja2 psycopg2
     ldap3 psutil msgpack
   ];
 

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, python, par2cmdline, unzip, unrar, p7zip, makeWrapper}:
 
 let
-  pythonEnv = python.withPackages(ps: with ps; [ pyopenssl python.modules.sqlite3 cheetah]);
+  pythonEnv = python.withPackages(ps: with ps; [ pyopenssl cheetah]);
   path = stdenv.lib.makeBinPath [ par2cmdline unrar unzip p7zip ];
 in stdenv.mkDerivation rec {
   version = "1.1.0";

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -92,8 +92,6 @@ in pythonPackages.buildPythonApplication rec {
     pythonPackages.pathlib
     pythonPackages.pyyaml
     pythonPackages.unidecode
-    pythonPackages.python.modules.sqlite3
-    pythonPackages.python.modules.readline
   ] ++ optional enableAcoustid     pythonPackages.pyacoustid
     ++ optional (enableFetchart
               || enableEmbyupdate

--- a/pkgs/tools/audio/mpdris2/default.nix
+++ b/pkgs/tools/audio/mpdris2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoreconfHook, intltool
-, pythonPackages, pythonFull
+, pythonPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ intltool autoreconfHook pythonPackages.wrapPython ];
-  propagatedBuildInputs = with pythonPackages; [ pythonFull  pygtk dbus-python ];
+  propagatedBuildInputs = with pythonPackages; [ python pygtk dbus-python ];
   pythonPath = with pythonPackages; [ mpd pygtk dbus-python notify ];
   postInstall = "wrapPythonPrograms";
 

--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -99,7 +99,6 @@ let
   };
 
   wrapArgs = "--set PYTHONPATH \"$(toPythonPath $lib)\""
-    + " --prefix PYTHONPATH : \"$(toPythonPath ${python.modules.readline})\""
     + " --prefix PYTHONPATH : \"$(toPythonPath ${pythonPackages.flask})\""
     + " --set PATH \"$out/bin\"";
 in

--- a/pkgs/tools/misc/openopc/default.nix
+++ b/pkgs/tools/misc/openopc/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, fetchurl, pythonFull }:
+{ stdenv, fetchurl, python }:
 
-stdenv.mkDerivation rec {
+let
+  pythonEnv = python.withPackages(ps: [ps.pyro3]);
+in stdenv.mkDerivation rec {
   name = "openopc-${version}";
   version = "1.2.0";
 
@@ -13,16 +15,16 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin"
     mkdir -p "$out/share/doc/openopc"
-    mkdir -p "$out/${pythonFull.python.sitePackages}"
+    mkdir -p "$out/${pythonEnv.python.sitePackages}"
     mkdir -p "$out/libexec/opc"
 
-    cp src/OpenOPC.py "$out/${pythonFull.python.sitePackages}"
+    cp src/OpenOPC.py "$out/${pythonEnv.python.sitePackages}"
     cp src/opc.py "$out/libexec/opc/"
 
     cat > "$out/bin/opc" << __EOF__
     #!${stdenv.shell}
-    export PYTHONPATH="$out/${pythonFull.python.sitePackages}"
-    exec ${pythonFull}/bin/${pythonFull.python.executable} "$out/libexec/opc/opc.py" "\$@"
+    export PYTHONPATH="$out/${pythonEnv.python.sitePackages}"
+    exec ${pythonEnv}/bin/${pythonEnv.python.executable} "$out/libexec/opc/opc.py" "\$@"
     __EOF__
     chmod a+x "$out/bin/opc"
 

--- a/pkgs/tools/misc/venus/default.nix
+++ b/pkgs/tools/misc/venus/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkPhase = "python runtests.py";
 
-  buildInputs = [ python python.modules.bsddb libxslt
+  buildInputs = [ python libxslt
     libxml2 pythonPackages.genshi pythonPackages.lxml makeWrapper ];
 
   installPhase = ''

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication {
     sha256 = "1m8gqj35kwrn30rqwd488sgakaisz22xa5v9llvz6gwf4f7ps0a9";
   };
 
-  propagatedBuildInputs = [ python.modules.sqlite3 gamin ]
+  propagatedBuildInputs = [ gamin ]
     ++ (stdenv.lib.optional stdenv.isLinux pythonPackages.systemd);
 
   preConfigure = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1659,6 +1659,7 @@ in
 
   fontforge = lowPrio (callPackage ../tools/misc/fontforge {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    python = pythonSmall;
   });
   fontforge-gtk = callPackage ../tools/misc/fontforge {
     withGTK = true;
@@ -5494,6 +5495,11 @@ in
   python2 = python27;
   python3 = python35;
 
+  # Python uses multiple outputs, and by default `python` is without X11/tkinter.
+  # This package only exists to prevent an infinite recursion and should only be used
+  # for packages Python itself depends on.
+  pythonSmall = python.override {x11Support = false;};
+
   # pythonPackages further below, but assigned here because they need to be in sync
   pythonPackages = python2Packages;
   python2Packages = python27Packages;
@@ -7143,7 +7149,9 @@ in
 
   gtkmathview = callPackage ../development/libraries/gtkmathview { };
 
-  glib = callPackage ../development/libraries/glib { };
+  glib = callPackage ../development/libraries/glib {
+    python = pythonSmall;
+  };
   glib-tested = glib.override { # checked version separate to break cycles
     doCheck = true;
     libffi = libffi.override { doCheck = true; };
@@ -8262,7 +8270,9 @@ in
 
   libxmi = callPackage ../development/libraries/libxmi { };
 
-  libxml2 = callPackage ../development/libraries/libxml2 { };
+  libxml2 = callPackage ../development/libraries/libxml2 {
+    python = pythonSmall;
+  };
   libxml2Python = pkgs.buildEnv { # slightly hacky
     name = "libxml2+py-${self.libxml2.version}";
     paths = with libxml2; [ dev bin py ];
@@ -10345,11 +10355,12 @@ in
     inherit clangStdenv fetchurl fetchgit fetchpatch stdenv pkgconfig intltool freetype fontconfig
       libxslt expat libpng zlib perl mesa_drivers spice_protocol libunwind
       dbus libuuid openssl gperf m4 libevdev tradcpp libinput mcpp makeWrapper autoreconfHook
-      autoconf automake libtool xmlto asciidoc flex bison python mtdev pixman
+      autoconf automake libtool xmlto asciidoc flex bison mtdev pixman
       cairo epoxy;
     inherit (darwin) apple_sdk cf-private libobjc;
     bootstrap_cmds = if stdenv.isDarwin then darwin.bootstrap_cmds else null;
     mesa = mesa_noglu;
+    python = pythonSmall;
     udev = if stdenv.isLinux then udev else null;
     libdrm = if stdenv.isLinux then libdrm else null;
     fglrxCompat = config.xorg.fglrxCompat or false; # `config` because we have no `xorg.override`
@@ -11502,7 +11513,9 @@ in
 
   bgnet = callPackage ../data/documentation/bgnet { };
 
-  cacert = callPackage ../data/misc/cacert { };
+  cacert = callPackage ../data/misc/cacert {
+    python = pythonSmall;
+  };
 
   caladea = callPackage ../data/fonts/caladea {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2153,7 +2153,7 @@ in
   ihaskell = callPackage ../development/tools/haskell/ihaskell/wrapper.nix {
     inherit (haskellPackages) ihaskell ghcWithPackages;
 
-    ipython = pythonFull.buildEnv.override {
+    ipython = python.buildEnv.override {
       extraLibs = with pythonPackages; [ ipython ipykernel jupyter_client notebook ];
     };
 
@@ -2978,11 +2978,7 @@ in
 
   openobex = callPackage ../tools/bluetooth/openobex { };
 
-  openopc = callPackage ../tools/misc/openopc {
-    pythonFull = python27.buildEnv.override {
-      extraLibs = [ python27Packages.pyro3 ];
-    };
-  };
+  openopc = callPackage ../tools/misc/openopc { };
 
   openresolv = callPackage ../tools/networking/openresolv { };
 
@@ -5533,17 +5529,6 @@ in
 
   pypy27 = callPackage ../development/interpreters/python/pypy/2.7 {
     self = pypy27;
-  };
-
-  pythonFull = python2Full;
-  python2Full = python27Full;
-  python26Full = python26.override {
-    includeModules = true;
-    self = python26Full;
-  };
-  python27Full = python27.override {
-    includeModules = true;
-    self = python27Full;
   };
 
   python2nix = callPackage ../tools/package-management/python2nix { };
@@ -10542,11 +10527,7 @@ in
 
   drbd = callPackage ../os-specific/linux/drbd { };
 
-  dstat = callPackage ../os-specific/linux/dstat {
-    # pythonFull includes the "curses" standard library module, for pretty
-    # dstat color output
-    python = pythonFull;
-  };
+  dstat = callPackage ../os-specific/linux/dstat { };
 
   libossp_uuid = callPackage ../development/libraries/libossp-uuid { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27,15 +27,7 @@ let
 
   buildPythonApplication = args: buildPythonPackage ({namePrefix="";} // args );
 
-  modules = python.modules or {
-    readline = null;
-    sqlite3 = null;
-    curses = null;
-    curses_panel = null;
-    crypt = null;
-  };
-
-in modules // {
+in {
 
   inherit python bootstrapped-pip isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k mkPythonDerivation buildPythonPackage buildPythonApplication;
 
@@ -2014,7 +2006,7 @@ in modules // {
       sha256 = "0grid93yz6i6jb2zggrqncp5awdf7qi88j5y2k7dq0k9r6b8zydw";
     };
 
-    propagatedBuildInputs = with stdenv.lib; with pkgs; [ modules.curses zlib xz ncompress gzip bzip2 gnutar p7zip cabextract lzma self.pycrypto ]
+    propagatedBuildInputs = with stdenv.lib; with pkgs; [ zlib xz ncompress gzip bzip2 gnutar p7zip cabextract lzma self.pycrypto ]
       ++ optional visualizationSupport pyqtgraph;
 
     meta = with stdenv.lib; {
@@ -2776,7 +2768,7 @@ in modules // {
        sha256 = "1ilf58qq7sazmcgg4f1wswbhcn2gb8qbbrpgm6gf0j2lbm60gabl";
      };
 
-     propagatedBuildInputs = with self; [ modules.curses pygments ];
+     propagatedBuildInputs = with self; [ pygments ];
      doCheck = false;
 
      meta = {
@@ -3962,7 +3954,6 @@ in modules // {
 
     propagatedBuildInputs = with self; [
       pyparsing
-      modules.readline
       urwid
     ];
 
@@ -4178,7 +4169,7 @@ in modules // {
     name = "cryptacular-1.4.1";
 
     buildInputs = with self; [ coverage nose ];
-    propagatedBuildInputs = with self; [ pbkdf2 modules.crypt ];
+    propagatedBuildInputs = with self; [ pbkdf2 ];
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/c/cryptacular/${name}.tar.gz";
@@ -4206,7 +4197,7 @@ in modules // {
     buildInputs = [ pkgs.openssl self.pretend self.cryptography_vectors
                     self.iso8601 self.pyasn1 self.pytest_29 self.py self.hypothesis self.pytz ]
                ++ optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Security;
-    propagatedBuildInputs = with self; [ six idna ipaddress pyasn1 cffi pyasn1-modules modules.sqlite3 pytz ]
+    propagatedBuildInputs = with self; [ six idna ipaddress pyasn1 cffi pyasn1-modules pytz ]
      ++ optional (pythonOlder "3.4") self.enum34;
 
     # IOKit's dependencies are inconsistent between OSX versions, so this is the best we
@@ -5660,7 +5651,7 @@ in modules // {
       make -f Makefile.prep synctus/ddar_pb2.py
     '';
 
-    propagatedBuildInputs = with self; [ protobuf modules.sqlite3 ];
+    propagatedBuildInputs = with self; [ protobuf ];
 
     meta = {
       description = "Unix de-duplicating archiver";
@@ -6602,7 +6593,7 @@ in modules // {
       sha256 = "105swvzshgn3g6bjwk67xd8pslnhpxwa63mdsw6cl4c7cjp2blx9";
     };
 
-    propagatedBuildInputs = with self; [ python_fedora modules.sqlite3 pyopenssl ];
+    propagatedBuildInputs = with self; [ python_fedora pyopenssl ];
     postInstall = "mv $out/bin/fedpkg $out/bin/fedora-cert-fedpkg";
     doCheck = false;
   };
@@ -7445,7 +7436,6 @@ in modules // {
       pyyaml
       redis
       six
-      modules.sqlite3
       pkgs.zlib
     ];
 
@@ -7839,8 +7829,7 @@ in modules // {
       sha256 = "1dnmnkc21zdfaypskbpvkwl0wpkpn0nagj1fc338w64mbxrk8ny7";
     };
 
-    propagatedBuildInputs = with self;
-      [
+    propagatedBuildInputs = with self; [
         apipkg
         bottle
         gevent
@@ -7855,7 +7844,7 @@ in modules // {
         simplejson
         sqlite3dbm
         timelib
-      ] ++ optionals (!isPy3k) [ modules.sqlite3 ];
+    ];
 
     meta = {
       description = "Library for parsing MediaWiki articles and converting them to different output formats";
@@ -9480,7 +9469,7 @@ in modules // {
     };
 
     propagatedBuildInputs = with self; [
-      pyGtkGlade pkgs.libtorrentRasterbar_1_0 twisted Mako chardet pyxdg self.pyopenssl modules.curses service-identity
+      pyGtkGlade pkgs.libtorrentRasterbar_1_0 twisted Mako chardet pyxdg self.pyopenssl service-identity
     ];
 
     nativeBuildInputs = [ pkgs.intltool ];
@@ -11694,7 +11683,7 @@ in modules // {
     doCheck = false;
 
     buildInputs = with self; [ unittest2 ];
-    propagatedBuildInputs = with self; [ modules.curses modules.curses_panel psutil setuptools bottle batinfo pkgs.hddtemp pysnmp ];
+    propagatedBuildInputs = with self; [ psutil setuptools bottle batinfo pkgs.hddtemp pysnmp ];
 
     preConfigure = ''
       sed -i 's/data_files\.append((conf_path/data_files.append(("etc\/glances"/' setup.py;
@@ -12136,7 +12125,7 @@ in modules // {
     };
 
     buildInputs = with self; [ flake8 pytest flaky ];
-    propagatedBuildInputs = with self; ([ uncompyle6 ] ++ optionals isPy27 [ enum34 modules.sqlite3 ]);
+    propagatedBuildInputs = with self; ([ uncompyle6 ] ++ optionals isPy27 [ enum34  ]);
 
     # https://github.com/DRMacIver/hypothesis/issues/300
     checkPhase = ''
@@ -12817,7 +12806,7 @@ in modules // {
     };
 
     propagatedBuildInputs = with self; [
-      pytz six tzlocal keyring modules.readline argparse dateutil_1_5
+      pytz six tzlocal keyring argparse dateutil_1_5
       parsedatetime
     ];
 
@@ -13226,7 +13215,7 @@ in modules // {
       sed -i 's/version=version/version="${version}"/' setup.py
     '';
     buildInputs = with self; [ pkgs.git ];
-    propagatedBuildInputs = with self; [ modules.sqlite3 ];
+    propagatedBuildInputs = with self; [  ];
 
     doCheck = false;
 
@@ -13826,7 +13815,7 @@ in modules // {
     buildInputs = with self; [ pyflakes pep8 ];
     propagatedBuildInputs = with self; [
       django_1_6 filebrowser_safe grappelli_safe bleach tzlocal beautifulsoup4
-      requests2 requests_oauthlib future pillow modules.sqlite3
+      requests2 requests_oauthlib future pillow
     ];
 
     # Tests Fail Due to Syntax Warning, Fixed for v3.1.11+
@@ -13965,7 +13954,7 @@ in modules // {
 
     buildInputs = with self; [
       pkgs.libjpeg pkgs.freetype pkgs.zlib pkgs.glibcLocales
-      pillow twitter pyfiglet requests2 arrow dateutil modules.readline pysocks
+      pillow twitter pyfiglet requests2 arrow dateutil pysocks
       pocket
     ];
 
@@ -14281,7 +14270,7 @@ in modules // {
 
     LC_ALL="en_US.UTF-8";
 
-    propagatedBuildInputs = with self; [ argparse jinja2 six modules.readline ] ++
+    propagatedBuildInputs = with self; [ argparse jinja2 six ] ++
                             (optionals isPy26 [ importlib ordereddict ]);
 
     meta = {
@@ -14999,7 +14988,6 @@ in modules // {
     propagatedBuildInputs = with self; [
       numpy
       nose
-      modules.sqlite3
     ];
 
     # Failing tests
@@ -17345,7 +17333,6 @@ in modules // {
       sqlalchemy
       lxml
       html5lib
-      modules.sqlite3
       beautifulsoup4
       openpyxl
       tables
@@ -17863,7 +17850,7 @@ in modules // {
       sha256 = "169s5mhw1s60qbsd6pkf9bb2x6wfgx8hn8nw9d4qgc68qnnpp2cj";
     };
 
-    propagatedBuildInputs = with self; [ modules.curses ];
+    propagatedBuildInputs = with self; [ ];
 
     meta = {
       homepage = https://github.com/mooz/percol;
@@ -20184,7 +20171,7 @@ in modules // {
       sha256 = "0jgyhkkq36wn36rymn4jiyqh2vdslmradq4a2mjkxfbk2cz6wpi5";
     };
 
-    buildInputs = with self; [ six pytest hypothesis ] ++ optional (!isPy3k) modules.sqlite3;
+    buildInputs = with self; [ six pytest hypothesis ];
 
     checkPhase = ''
       py.test
@@ -21182,7 +21169,7 @@ in modules // {
     };
 
     buildInputs = with self; [ nose ];
-    propagatedBuildInputs = with self; [ modules.sqlite3 six ];
+    propagatedBuildInputs = with self; [ six ];
 
     checkPhase = "nosetests";
 
@@ -21725,7 +21712,7 @@ in modules // {
 
     propagatedBuildInputs = with self;
       [ django_1_6 recaptcha_client pytz memcached dateutil_1_5 paramiko flup
-        pygments djblets django_evolution pycrypto modules.sqlite3 pysvn pillow
+        pygments djblets django_evolution pycrypto pysvn pillow
         psycopg2 django-haystack python_mimeparse markdown django-multiselectfield
       ];
   };
@@ -21893,7 +21880,7 @@ in modules // {
       sha256 = "1lf5f4x80f7d983bmkx12sxcizzii21kghs8kf63a1mj022a5x5j";
     };
 
-    propagatedBuildInputs = with self; [ pygments wxPython modules.sqlite3 ];
+    propagatedBuildInputs = with self; [ pygments wxPython ];
 
     # ride_postinstall.py checks that needed deps are installed and creates a
     # desktop shortcut. We don't really need it and it clutters up bin/ so
@@ -22322,8 +22309,6 @@ in modules // {
       url = "http://www.secdev.org/projects/scapy/files/${name}.tar.gz";
       sha256 = "1bqmp0xglkndrqgmybpwmzkv462mir8qlkfwsxwbvvzh9li3ndn5";
     };
-
-    propagatedBuildInputs = [ modules.readline ];
 
     meta = {
       description = "Powerful interactive network packet manipulation program";
@@ -22793,8 +22778,6 @@ in modules // {
       sha256 = "4721607e0b817b89efdba7e79cab881a03164b94777f4cf796ad5dd59a7612c5";
     };
 
-    buildInputs = with self; [ modules.sqlite3 ];
-
     meta = {
       description = "sqlite-backed dictionary";
       homepage = "http://github.com/Yelp/sqlite3dbm";
@@ -22826,8 +22809,6 @@ in modules // {
       url = "mirror://pypi/s/sqlmap/sqlmap-1.0.9.post5.tar.gz";
       sha256 = "0g8sjky8anrmcisc697b5qndp88qmay35kng9sz9x46wd3agm9pa";
     };
-
-		propagatedBuildInputs = with self; [ modules.sqlite3 ];
 
     meta = with pkgs.stdenv.lib; {
       homepage = "http://sqlmap.org";
@@ -23289,7 +23270,7 @@ in modules // {
     # 4 failing tests, 2to3
     doCheck = false;
 
-    propagatedBuildInputs = with self; [ modules.curses ];
+    propagatedBuildInputs = with self; [ ];
 
     meta = {
       maintainers = with maintainers; [ domenkozar ];
@@ -23885,7 +23866,6 @@ in modules // {
 
     buildInputs = with self; [ nose mock ]
       ++ stdenv.lib.optional doCheck pysqlite;
-    propagatedBuildInputs = with self; [ modules.sqlite3 ];
 
     checkPhase = ''
       ${python.executable} sqla_nose.py
@@ -23911,7 +23891,6 @@ in modules // {
 
     buildInputs = with self; [ pytest mock pytest_xdist ]
       ++ stdenv.lib.optional (!isPy3k) pysqlite;
-    propagatedBuildInputs = with self; [ modules.sqlite3 ];
 
     # Test-only dependency pysqlite doesn't build on Python 3. This isn't an
     # acceptable reason to make all dependents unavailable on Python 3 as well
@@ -24840,7 +24819,7 @@ in modules // {
 
     PYTHON_EGG_CACHE = "`pwd`/.egg-cache";
 
-    propagatedBuildInputs = with self; [ genshi setuptools modules.sqlite3 ];
+    propagatedBuildInputs = with self; [ genshi ];
 
     meta = {
       description = "Enhanced wiki and issue tracking system for software development projects";
@@ -25425,7 +25404,7 @@ in modules // {
 
     patches = [ ../development/python-modules/virtualenv-change-prefix.patch ];
 
-    propagatedBuildInputs = with self; [ modules.readline modules.sqlite3 modules.curses ];
+    propagatedBuildInputs = with self; [ ];
 
     # Tarball doesn't contain tests
     doCheck = false;
@@ -25846,7 +25825,7 @@ in modules // {
       sha256 = "e03dd26ea694b877a2b3b7b4dcca8e79420e7f346abab34292bff43d992a8cc5";
     };
 
-    buildInputs = with self; [ pytest modules.sqlite3 ];
+    buildInputs = with self; [ pytest ];
     propagatedBuildInputs = with self; [ feedparser pytz lxml praw pyenchant pygeoip backports_ssl_match_hostname ];
     checkPhase = ''
       py.test test
@@ -26888,7 +26867,7 @@ in modules // {
     };
 
     buildInputs = with self; [ unittest2 nose mock ];
-    propagatedBuildInputs = with self; [ modules.curses libarchive ];
+    propagatedBuildInputs = with self; [ libarchive ];
 
     # tests are still failing
     doCheck = false;
@@ -27430,7 +27409,7 @@ in modules // {
       sha256 = "472a4403fd5b5364939aee10e78f171b1489e5f6bfe6f150ed9cae8476410114";
     };
 
-    propagatedBuildInputs = with self; [ django_1_5 django_tagging modules.sqlite3 whisper pycairo ldap memcached ];
+    propagatedBuildInputs = with self; [ django_1_5 django_tagging whisper pycairo ldap memcached ];
 
     postInstall = ''
       wrapProgram $out/bin/run-graphite-devel-server.py \

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24655,6 +24655,23 @@ in {
     };
   };
 
+  # Tkinter/tkinter is part of the Python standard library.
+  # To reduce closure size its put in a separate output, `python.tkinter`.
+  # This alias was added to make this output work like any other Python package.
+  tkinter = mkPythonDerivation rec {
+    name = "tkinter-${python.version}";
+    src = python.tkinter;
+
+    disabled = isPy26 || isPyPy;
+
+    installPhase = ''
+      mkdir -p $out
+      cp -R ${python.tkinter}/* $out
+    '';
+
+    inherit (python) meta;
+  };
+
   tlslite = buildPythonPackage rec {
     name = "tlslite-${version}";
     version = "0.4.8";

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -130,7 +130,6 @@ with import ./release-lib.nix { inherit supportedSystems; };
   portmap = linux;
   procps = linux;
   python = allBut cygwin;
-  pythonFull = linux;
   readline = all;
   rlwrap = all;
   rpm = linux;


### PR DESCRIPTION
###### Motivation for this change

See issue #19255 and #1819.
- Unify expressions of different interpreters
- Reduce closure size of Python 3.x interpreters
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
