### PR TITLE
camingo-code: init at 1.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -110,6 +110,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Creative Commons Attribution Non Commercial Share Alike 4.0";
   };
 
+  cc-by-nd-30 = spdx {
+    spdxId = "CC-BY-ND-3.0";
+    fullName = "Creative Commons Attribution-No Derivative Works v3.00";
+  };
+
   cc-by-sa-25 = spdx {
     spdxId = "CC-BY-SA-2.5";
     fullName = "Creative Commons Attribution Share Alike 2.5";

--- a/pkgs/data/fonts/camingo-code/default.nix
+++ b/pkgs/data/fonts/camingo-code/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "camingo-code-${version}";
+  version = "1.0";
+
+  src = fetchurl {
+    url = https://github.com/chrissimpkins/codeface/releases/download/font-collection/codeface-fonts.zip;
+    sha256 = "1gbpfa5mqyhi5yrb6dl708pggiwp002b532fn3axiagb0cxxf02s";
+  };
+
+  buildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/doc/${name}
+    cp -v camingo-code/*.ttf $out/share/fonts/truetype/
+    cp -v camingo-code/*.txt $out/share/doc/${name}/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.myfonts.com/fonts/jan-fromm/camingo-code/;
+    description = "A monospaced typeface designed for source-code editors";
+    platforms = platforms.all;
+    license = licenses.cc-by-nd-30;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11549,6 +11549,8 @@ in
 
   cabin = callPackage ../data/fonts/cabin { };
 
+  camingo-code = callPackage ../data/fonts/camingo-code { };
+
   dosis = callPackage ../data/fonts/dosis { };
 
   dosemu_fonts = callPackage ../data/fonts/dosemu-fonts { };


### PR DESCRIPTION
###### Motivation for this change

Added the camingo code font
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
