### PR TITLE
goDeps: support fetchFromGitHub to fetch Go libs

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -1,4 +1,5 @@
-{ go, govers, parallel, lib, fetchgit, fetchhg, fetchbzr, rsync, removeReferencesTo }:
+{ go, govers, parallel, lib, fetchgit, fetchhg, fetchbzr, rsync
+, removeReferencesTo, fetchFromGitHub }:
 
 { name, buildInputs ? [], nativeBuildInputs ? [], passthru ? {}, preFixup ? ""
 
@@ -57,6 +58,10 @@ let
       else if goDep.fetch.type == "bzr" then
         fetchbzr {
           inherit (goDep.fetch) url rev sha256;
+        }
+      else if goDep.fetch.type == "FromGitHub" then
+        fetchFromGitHub {
+          inherit (goDep.fetch) owner repo rev sha256;
         }
       else abort "Unrecognized package fetch type: ${goDep.fetch.type}";
     };


### PR DESCRIPTION
###### Motivation for this change

It's more like a proposal than a real change.
I can convert all github `goDeps` from `fetchgit` to `fetchFromGitHub` so they will look like:

```
{
  goPackagePath = "github.com/Masterminds/vcs";
  fetch = {
    type = "FromGitHub"; # <- this is the new thing
    owner = "Masterminds";
    repo = "vcs";
    rev = "fbe9fb6ad5b5f35b3e82a7c21123cfc526cbf895";
    sha256 = "09rdq8k2smwgy6wdslddcq13wg3lzd4amzpy0f8kd0hlxxvas89c";
  };
}
```

So let me know is it ok and after we merge `fetchFromGitHub` support I'll convert all `goDeps` that can use it and add `fetchFromGitHub` to `go2nix`.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @copumpkin, @edolstra, @rushmorem, @zimbatm, @cstrahan  

https://github.com/NixOS/nixpkgs/pull/16017#issuecomment-246252087
https://github.com/NixOS/nixpkgs/pull/17254#issuecomment-245297782
