### PR TITLE
Clang link time optimization for darwin

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -10,6 +10,7 @@
 , zlib ? null, extraPackages ? [], extraBuildCommands ? ""
 , dyld ? null # TODO: should this be a setup-hook on dyld?
 , isGNU ? false, isClang ? cc.isClang or false, gnugrep ? null
+, llvm ? null
 }:
 
 with stdenv.lib;
@@ -22,6 +23,8 @@ assert !nativeLibc -> libc != null;
 # For ghdl (the vhdl language provider to gcc) we need zlib in the wrapper.
 assert cc.langVhdl or false -> zlib != null;
 
+assert llvm != null -> isClang;
+
 let
 
   ccVersion = (builtins.parseDrvName cc.name).version;
@@ -30,6 +33,7 @@ let
   libc_bin = if nativeLibc then null else getBin libc;
   libc_dev = if nativeLibc then null else getDev libc;
   libc_lib = if nativeLibc then null else getLib libc;
+  llvm_lib = if llvm != null then getLib llvm else "";
   cc_solib = getLib cc;
   binutils_bin = if nativeTools then "" else getBin binutils;
   # The wrapper scripts use 'cat' and 'grep', so we may need coreutils.
@@ -43,7 +47,7 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  inherit cc shell libc_bin libc_dev libc_lib binutils_bin coreutils_bin;
+  inherit cc shell libc_bin libc_dev libc_lib llvm_lib binutils_bin coreutils_bin;
   gnugrep_bin = if nativeTools then "" else gnugrep;
 
   passthru = { inherit libc nativeTools nativeLibc nativePrefix isGNU isClang; };

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -167,6 +167,9 @@ if [ "$NIX_SET_BUILD_ID" = 1 ]; then
     fi
 fi
 
+if [ -n "@llvm_lib@" ]; then
+  export DYLD_LIBRARY_PATH="@llvm_lib@/lib:$DYLD_LIBRARY_PATH"
+fi
 
 # Optionally print debug info.
 if [ -n "$NIX_DEBUG" ]; then
@@ -178,6 +181,10 @@ if [ -n "$NIX_DEBUG" ]; then
   for i in ${extra[@]}; do
       echo "  $i" >&2
   done
+  if [ -n "@llvm_lib@" ]; then
+    echo "DYLD_LIBRARY_PATH variable for @prog@:" >&2
+    echo "  $DYLD_LIBRARY_PATH" >&2
+  fi
 fi
 
 if [ -n "$NIX_LD_WRAPPER_EXEC_HOOK" ]; then

--- a/pkgs/development/compilers/llvm/3.6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.6/clang/default.nix
@@ -42,6 +42,7 @@ let
     passthru = {
       lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
       isClang = true;
+      inherit llvm;
     } // stdenv.lib.optionalAttrs stdenv.isLinux {
       inherit gcc;
     };

--- a/pkgs/development/compilers/llvm/3.7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/clang/default.nix
@@ -42,6 +42,7 @@ let
     passthru = {
       lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
       isClang = true;
+      inherit llvm;
     } // stdenv.lib.optionalAttrs stdenv.isLinux {
       inherit gcc;
     };

--- a/pkgs/development/compilers/llvm/3.7/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.7/llvm.nix
@@ -28,6 +28,7 @@ in stdenv.mkDerivation rec {
     sourceRoot=$PWD/llvm
     unpackFile ${compiler-rt_src}
     mv compiler-rt-* $sourceRoot/projects/compiler-rt
+    sed -i 's/-compatibility_version .* -current_version/-compatibility_version 1 -current_version/g' $sourceRoot/tools/llvm-shlib/CMakeLists.txt
   '';
 
   buildInputs = [ perl groff cmake libxml2 python libffi ]
@@ -37,6 +38,7 @@ in stdenv.mkDerivation rec {
 
   # hacky fix: created binaries need to be run before installation
   preBuild = ''
+    sed -i 's/-compatibility_version .* -current_version/-compatibility_version 1 -current_version/g' $PWD/tools/lto/CMakeFiles/LTO.dir/link.txt
     mkdir -p $out/
     ln -sv $PWD/lib $out
   '';

--- a/pkgs/development/compilers/llvm/3.8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/clang/default.nix
@@ -42,6 +42,7 @@ let
     passthru = {
       lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
       isClang = true;
+      inherit llvm;
     } // stdenv.lib.optionalAttrs stdenv.isLinux {
       inherit gcc;
     };

--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -43,6 +43,7 @@ let
     passthru = {
       lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
       isClang = true;
+      inherit llvm;
     } // stdenv.lib.optionalAttrs stdenv.isLinux {
       inherit gcc;
     };

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -18,7 +18,7 @@ let
     buildInputs = [ autoconf automake libtool_2 openssl libuuid ] ++
       # Only need llvm and clang if the stdenv isn't already clang-based (TODO: just make a stdenv.cc.isClang)
       stdenv.lib.optionals (!stdenv.isDarwin) [ llvm clang ] ++
-      stdenv.lib.optionals stdenv.isDarwin [ libcxxabi libobjc ];
+      stdenv.lib.optionals stdenv.isDarwin [ llvm libcxxabi libobjc ];
 
     patches = [
       ./ld-rpath-nonfinal.patch ./ld-ignore-rpath-link.patch
@@ -83,6 +83,10 @@ in {
       #!${stdenv.shell}
       EOF
       chmod +x $out/bin/dsymutil
+      exe="$out/bin/ld"
+    '' + stdenv.lib.optionalString (stdenv.isDarwin) ''
+      install_name_tool -add_rpath ${llvm}/lib $exe
+      install_name_tool -change '@rpath/libLTO.3.7.dylib' '@rpath/libLTO.dylib' $exe
     '';
   });
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -285,6 +285,7 @@ in rec {
       inherit (pkgs.darwin) dyld;
       cc   = pkgs.llvmPackages.clang-unwrapped;
       libc = pkgs.darwin.Libsystem;
+      llvm = pkgs.llvmPackages.clang-unwrapped.llvm;
     };
 
     extraBuildInputs = with pkgs; [ darwin.CF libcxx ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5191,6 +5191,7 @@ in
     isGNU = baseCC.isGNU or false;
     isClang = baseCC.isClang or false;
     inherit libc extraBuildCommands;
+    llvm = baseCC.llvm or null;
   };
 
   wrapCC = wrapCCWith (callPackage ../build-support/cc-wrapper) stdenv.cc.libc "";


### PR DESCRIPTION
###### Motivation for this change

Clang link time optimization was not working on OSX.
Resolves #19098.

Trying to follow [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md) (hopefully I didn't make too many mistakes):
cc @copumpkin (for cctool/darwin stdenv changes)
cc @lovek323 @raskin @viric (for clang 3.6/llvm 3.7/clang 3.7/clang 3.8/clang 3.9 changes)
cc @fpletz @globin (for cc-wrapper changes)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

**NOTE: Not all tests were successful but I don't believe the issues are caused by any changes in this PR but I am not sure because I didn't do a baseline of the tests without the changes first.**

**The following is are the results of the testing combinations as represented by checkboxes above:**

_Technical details_
- System: Mac OSX 10.10.5; Output of `uname -a`:

```
Darwin Dipins-MBP.home 14.5.0 Darwin Kernel Version 14.5.0: Wed Jul 29 02:26:53 PDT 2015; root:xnu-2782.40.9~1/RELEASE_X86_64 x86_64
```
- Nix version: `nix-env (Nix) 1.11.4`
- Nixpkgs version: `"17.03pre93030.548bcd0"`

_mac:_

`NIX_PATH=nixpkgs=/Users/dipinhora/nixpkgs/ nix-shell -p llvmPackages_38.clang --pure --keep-failed`
works fine

`NIX_PATH=nixpkgs=/Users/dipinhora/nixpkgs/ nix-shell -p llvmPackages_38.clang --pure --keep-failed --option build-use-sandbox true`
error:

```
building path(s) ‘/nix/store/y9vg140f50a2zq4qsdpdavdmlrlhjjpf-clang-wrapper-9.9.9’
error: derivation ‘/nix/store/5jplsyd68iaxw6d1vrvfl0n2xqpvzh8k-clang-wrapper-9.9.9.drv’ specifies a sandbox profile, but this is only allowed when ‘build-use-sandbox’ is ‘relaxed’
```

`NIX_PATH=nixpkgs=/Users/dipinhora/nixpkgs/ nix-shell -p llvmPackages_38.clang --pure --keep-failed --option build-use-sandbox relaxed`
error: (known issue: https://github.com/NixOS/nix/issues/759)

```
building path(s) ‘/nix/store/y9vg140f50a2zq4qsdpdavdmlrlhjjpf-clang-wrapper-9.9.9’
killing process 26411
killing process 26411: Operation not permitted
note: keeping build directory ‘/private/var/folders/tw/867wzcgs2gg1zwkwn0ws8_k80000gn/T/nix-build-clang-wrapper-9.9.9.drv-1’
error: while setting up the build environment: changing into ‘/private/var/folders/tw/867wzcgs2gg1zwkwn0ws8_k80000gn/T/nix-build-clang-wrapper-9.9.9.drv-1’: No such file or directory
```

`NIX_PATH=nixpkgs=/Users/dipinhora/nixpkgs/ nix-shell -p nox --run "nox-review wip" --pure --keep-failed`
error:

```
note: keeping build directory ‘/private/var/folders/tw/867wzcgs2gg1zwkwn0ws8_k80000gn/T/nix-build-python3.5-pytest-2.9.2.drv-0’
error: opening directory ‘/private/var/folders/tw/867wzcgs2gg1zwkwn0ws8_k80000gn/T/nix-build-python3.5-pytest-2.9.2.drv-0/pytest-of-dipinhora/pytest-0/testdir/test_cache_failure_warns0/.cache’: Permission denied
/Users/dipinhora/.nix-profile/bin/nix-shell: failed to build all dependencies
```

When run a second time:

```
Traceback (most recent call last):
  File "/nix/store/q9n9wsafqp93rcv31wy1hd0l6dpg45gi-nox-0.0.4/bin/.nox-review-wrapped", line 12, in <module>
    sys.exit(cli())
  File "/nix/store/bkq3sl3kyz1rki2dv6n1wm7xs824x2s2-python3.5-click-6.6/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/bkq3sl3kyz1rki2dv6n1wm7xs824x2s2-python3.5-click-6.6/lib/python3.5/site-packages/click/core.py", line 675, in main
    _verify_python3_env()
  File "/nix/store/bkq3sl3kyz1rki2dv6n1wm7xs824x2s2-python3.5-click-6.6/lib/python3.5/site-packages/click/_unicodefun.py", line 64, in _verify_python3_env
    stderr=subprocess.PIPE).communicate()[0]
  File "/nix/store/wb7zc6hicj05kgncqkrwiv7z9r9mj21d-python3-3.5.2/lib/python3.5/subprocess.py", line 947, in __init__
    restore_signals, start_new_session)
  File "/nix/store/wb7zc6hicj05kgncqkrwiv7z9r9mj21d-python3-3.5.2/lib/python3.5/subprocess.py", line 1551, in _execute_child
    raise child_exception_type(errno_num, err_msg)
FileNotFoundError: [Errno 2] No such file or directory: 'locale'
```

_nixos: (without and with nix.useSandbox = true) (on aws: ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20160907.1 (ami-2ef48339))_

`NIX_PATH=nixpkgs=/root/nixpkgs/ nix-shell -p llvmPackages_38.clang --pure --keep-failed --max-jobs 8 --cores 8`
works fine

`NIX_PATH=nixpkgs=/root/nixpkgs/ nix-shell -p llvmPackages_38.clang --pure --keep-failed --max-jobs 8 --cores 8 --option build-use-sandbox true`
works fine

`NIX_PATH=nixpkgs=/root/nixpkgs/ nix-shell -p nox --run "nox-review wip" --pure --keep-failed --max-jobs 8 --cores 8`
error:

```
Traceback (most recent call last):
  File "/nix/store/2gaxi7l0z59gq7zya7xqi1gkynp9yy3i-nox-0.0.4/bin/.nox-review-wrapped", line 12, in <module>
    sys.exit(cli())
  File "/nix/store/pqb3555sq1anvfp1ax293xk9dw29f2vm-python3.5-click-6.6/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/pqb3555sq1anvfp1ax293xk9dw29f2vm-python3.5-click-6.6/lib/python3.5/site-packages/click/core.py", line 675, in main
    _verify_python3_env()
  File "/nix/store/pqb3555sq1anvfp1ax293xk9dw29f2vm-python3.5-click-6.6/lib/python3.5/site-packages/click/_unicodefun.py", line 119, in _verify_python3_env
    'mitigation steps.' + extra)
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Either run this under Python 2 or consult http://click.pocoo.org/python3/ for mitigation steps.

Additional information: on this system no suitable UTF-8
locales were discovered.  This most likely requires resolving
by reconfiguring the locale system.
```

_ubuntu: (on aws: nixos-16.09.666.3738950-x86_64-hvm-ebs (ami-93347684))_

`NIX_PATH=nixpkgs=/home/ubuntu/nixpkgs/ nix-shell -p llvmPackages_38.clang --pure --keep-failed --max-jobs 8 --cores 8`
works fine

`NIX_PATH=nixpkgs=/home/ubuntu/nixpkgs/ nix-shell -p llvmPackages_38.clang --pure --keep-failed --option build-use-sandbox true`
error:

```
building path(s) ‘/nix/store/g7a2yvmgs3ffy91dwppsaifrvgwz41xr-bootstrap-gcc-wrapper’
note: keeping build directory ‘/tmp/nix-build-bootstrap-gcc-wrapper.drv-3’
error: cannot change ownership of ‘/nix/store/vjirhdirwq2k84jxsds0473ik8gn1n00-bootstrap-gcc-wrapper.drv.chroot’: Operation not permitted
```

`NIX_PATH=nixpkgs=/home/ubuntu/nixpkgs/ nix-shell -p llvmPackages_38.clang --pure --keep-failed --option build-use-sandbox relaxed`
error:

```
building path(s) ‘/nix/store/g7a2yvmgs3ffy91dwppsaifrvgwz41xr-bootstrap-gcc-wrapper’
note: keeping build directory ‘/tmp/nix-build-bootstrap-gcc-wrapper.drv-2’
error: cannot change ownership of ‘/nix/store/vjirhdirwq2k84jxsds0473ik8gn1n00-bootstrap-gcc-wrapper.drv.chroot’: Operation not permitted
```

`NIX_PATH=nixpkgs=/home/ubuntu/nixpkgs/ nix-shell -p nox --run "nox-review wip" --pure --keep-failed --max-jobs 8 --cores 8`
error:

```
note: keeping build directory ‘/tmp/nix-build-python3.5-pytest-2.9.2.drv-0’
error: opening directory ‘/tmp/nix-build-python3.5-pytest-2.9.2.drv-0/pytest-of-ubuntu/pytest-0/testdir/test_cache_failure_warns0/.cache’: Permission denied
/home/ubuntu/.nix-profile/bin/nix-shell: failed to build all dependencies
```

When run a second time:

```
Traceback (most recent call last):
  File "/nix/store/2gaxi7l0z59gq7zya7xqi1gkynp9yy3i-nox-0.0.4/bin/.nox-review-wrapped", line 12, in <module>
    sys.exit(cli())
  File "/nix/store/pqb3555sq1anvfp1ax293xk9dw29f2vm-python3.5-click-6.6/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/pqb3555sq1anvfp1ax293xk9dw29f2vm-python3.5-click-6.6/lib/python3.5/site-packages/click/core.py", line 675, in main
    _verify_python3_env()
  File "/nix/store/pqb3555sq1anvfp1ax293xk9dw29f2vm-python3.5-click-6.6/lib/python3.5/site-packages/click/_unicodefun.py", line 119, in _verify_python3_env
    'mitigation steps.' + extra)
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Either run this under Python 2 or consult http://click.pocoo.org/python3/ for mitigation steps.

Additional information: on this system no suitable UTF-8
locales were discovered.  This most likely requires resolving
by reconfiguring the locale system.
```

---
