### PR TITLE
get_iplayer: 2.94 -> 2.97

### DIFF
--- a/pkgs/applications/misc/get_iplayer/default.nix
+++ b/pkgs/applications/misc/get_iplayer/default.nix
@@ -1,30 +1,33 @@
-{stdenv, fetchurl, flvstreamer, ffmpeg, makeWrapper, perl, buildPerlPackage, perlPackages, vlc, rtmpdump}:
-buildPerlPackage {
-  name = "get_iplayer-2.94";
+{stdenv, fetchurl, atomicparsley, flvstreamer, ffmpeg, makeWrapper, perl, buildPerlPackage, perlPackages, rtmpdump}:
+buildPerlPackage rec {
+  name = "get_iplayer-${version}";
+  version = "2.97";
 
   buildInputs = [makeWrapper perl];
-  propagatedBuildInputs = with perlPackages; [HTMLParser HTTPCookies LWP XMLSimple];
+  propagatedBuildInputs = with perlPackages; [HTMLParser HTTPCookies LWP XMLLibXML XMLSimple];
 
   preConfigure = "touch Makefile.PL";
   doCheck = false;
   outputs = [ "out" "man" ];
 
-  patchPhase = ''
-    sed -e 's|^update_script|#update_script|' \
-        -e '/WARNING.*updater/d' \
-        -i get_iplayer
-  '';
-
-  installPhase = '' 
+  installPhase = ''
     mkdir -p $out/bin $out/share/man/man1
     cp get_iplayer $out/bin
-    wrapProgram $out/bin/get_iplayer --suffix PATH : ${stdenv.lib.makeBinPath [ ffmpeg flvstreamer vlc rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
+    wrapProgram $out/bin/get_iplayer --suffix PATH : ${stdenv.lib.makeBinPath [ atomicparsley ffmpeg flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
     cp get_iplayer.1 $out/share/man/man1
   '';
   
   src = fetchurl {
-    url = ftp://ftp.infradead.org/pub/get_iplayer/get_iplayer-2.94.tar.gz;
-    sha256 = "16p0bw879fl8cs6rp37g1hgrcai771z6rcqk2nvm49kk39dx1zi4";
+    url = "https://github.com/get-iplayer/get_iplayer/archive/v${version}.tar.gz";
+    sha256 = "0bb6kmzjmazwfxq5ip7yxm39vssfgz3v5vfx1114wfssp6pw0r44";
+  };
+
+  meta = {
+    description = "Downloads TV and radio from BBC iPlayer";
+    license = stdenv.lib.licenses.gpl3Plus;
+    homepage = https://squarepenguin.co.uk/;
+    downloadPage = https://github.com/get-iplayer/get_iplayer/releases;
+    platforms = stdenv.lib.platforms.all;
   };
   
 }


### PR DESCRIPTION
###### Motivation for this change

New version. Also add metadata and add dependence on atomicparsley (recommended by upstream and used by default if available).

Removed VLC dependency and `patchPhase`. VLC is no longer used as of 2.95; the `patchPhase` formerly fixed get_iplayer's updater script, which was removed.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
