### PR TITLE
nimble: Do not use patchelf.

### DIFF
--- a/pkgs/development/tools/nimble/default.nix
+++ b/pkgs/development/tools/nimble/default.nix
@@ -12,22 +12,22 @@ stdenv.mkDerivation rec {
     sha256 = "12znxzj1j5fflw2mkkrns9n7qg6sf207652zrdyf7h2jdyzzb73x";
   };
 
-  buildInputs = [ nim ];
+  buildInputs = [ nim openssl ];
 
   patchPhase = ''
     substituteInPlace src/nimble.nim.cfg --replace "./vendor/nim" "${nim}/share"
+    cat >>src/nimble.nim.cfg <<END
+--clib:crypto
+END
   '';
 
   buildPhase = ''
-    nim c src/nimble
+    cd src && nim c -d:release nimble
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    cp src/nimble $out/bin
-    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [stdenv.cc.libc openssl]}" \
-        --add-needed libcrypto.so \
-        "$out/bin/nimble"
+    cp nimble $out/bin
   '';
 
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
