### PR TITLE
lib: deprecation, warnRenamed, release constants

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -24,10 +24,12 @@ let
   licenses = import ./licenses.nix;
   platforms = import ./platforms.nix;
   systems = import ./systems.nix;
+  releases = import ./releases.nix;
 
   # misc
   debug = import ./debug.nix;
   misc = import ./deprecated.nix;
+  deprecate = import ./deprecate.nix;
 
   # domain-specific
   sandbox = import ./sandbox.nix;
@@ -38,8 +40,8 @@ in
             attrsets lists strings stringsWithDeps
             customisation maintainers meta sources
             modules options types
-            licenses platforms systems
-            debug misc
+            licenses platforms systems releases
+            debug misc deprecate
             sandbox fetchers;
   }
   # !!! don't include everything at top-level; perhaps only the most

--- a/lib/deprecate.nix
+++ b/lib/deprecate.nix
@@ -1,0 +1,19 @@
+# deprecation functions
+
+let
+  releases = import ./releases.nix;
+  trivial  = import ./trivial.nix;
+
+in
+{
+    warnRenamed = {
+      oldName
+    , newName
+    , reason
+    , removedAt ? releases.next
+    }: trivial.warn ''
+      "${oldName}" has been renamed to "${newName}".
+      It will be removed in ${releases.asString removedAt}.
+      Reason: ${reason}
+    '';
+}

--- a/lib/releases.nix
+++ b/lib/releases.nix
@@ -1,0 +1,22 @@
+# nixpkgs/nixos release information
+rec {
+
+  # formatting releases
+  asString = {
+    name
+  , releaseDate
+  }: "${name} (release date ${releaseDate})";
+
+  next = nixos-17-first;
+
+  nixos-17-first = {
+    name = "NixOS 17.?";
+    releaseDate = "early 2017";
+  };
+
+  "nixos-16.09" = {
+    name = "NixOS 16.09";
+    releaseDate = "2016-10-03";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13838,7 +13838,13 @@ in
 
   opusfile = callPackage ../applications/audio/opusfile { };
 
-  opusTools = callPackage ../applications/audio/opus-tools { };
+  opusTools = lib.deprecate.warnRenamed {
+    oldName   = "opusTools";
+    newName   = "opus-tools";
+    removedAt = lib.releases.next;
+    reason    = "Consistency with vorbis-tools";
+  } opus-tools;
+  opus-tools = callPackage ../applications/audio/opus-tools { };
 
   orpie = callPackage ../applications/misc/orpie { gsl = gsl_1; };
 


### PR DESCRIPTION
Introduce the concept of attribute deprecation.
A new library contains deprecation functions (for now only
`renamedWarning`) that annotate functions and print a deprecation
warning.

In order to manage time until a symbol is removed, we introduce release
constants that are used in the warning messages and contain release
names and dates.

The printed warning only uses a trace message at the moment, this should
be improved.

As an example, `opusTools` is renamed to `opus-tools`, with the
reasoning that the related `vorbis-tools` uses a different naming
scheme. Users on master will immediately get a warning, users of stable
channels can find out about the changed attribute from the changelog
when they update to a new release.

cc @edolstra @aszlig @vcunat 
