### PR TITLE
styx: init at 0.1.0

### DIFF
--- a/pkgs/applications/misc/styx/default.nix
+++ b/pkgs/applications/misc/styx/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, caddy, asciidoctor }:
+
+stdenv.mkDerivation rec {
+  name    = "styx-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner  = "styx-static";
+    repo   = "styx";
+    rev    = "v${version}";
+    sha256 = "0lz6mfawschfjg4mvfsqz9dv884x2lcg787zjdlnhdi5yqmjx29r";
+  };
+
+  server = caddy.bin;
+
+  nativeBuildInputs = [ asciidoctor ];
+
+  setSourceRoot = "cd styx-*/src; export sourceRoot=`pwd`";
+
+  installPhase = ''
+    mkdir $out
+    install -D -m 777 $sourceRoot/styx.sh $out/bin/styx
+
+    mkdir -p $out/share/styx
+    cp -r $sourceRoot/sample $out/share/styx
+
+    mkdir -p $out/share/doc/styx
+    asciidoctor $sourceRoot/doc/manual.doc -o $out/share/doc/styx/index.html
+
+    substituteAllInPlace $out/bin/styx
+    substituteAllInPlace $out/share/styx/sample/templates/feed.nix
+    substituteAllInPlace $out/share/doc/styx/index.html
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Nix based static site generator";
+    maintainers = with maintainers; [ ericsagnes ];
+    homepage = https://styx-static.github.io/styx-site/;
+    downloadPage = https://github.com/styx-static/styx/;
+    platforms = platforms.all;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14315,6 +14315,8 @@ in
 
   ssvnc = callPackage ../applications/networking/remote/ssvnc { };
 
+  styx = callPackage ../applications/misc/styx { };
+
   tecoc = callPackage ../applications/editors/tecoc { };
 
   viber = callPackage ../applications/networking/instant-messengers/viber { };


### PR DESCRIPTION
###### Motivation for this change

Add the Styx static site generator. (based on Nix!)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
