### PR TITLE
esqueleto: fix compilation with ghc-8.0.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -766,6 +766,17 @@ self: super: {
     '';
   });
 
+  # no official release of esqueleto builds
+  # use fork of master that has build fixes
+  esqueleto = overrideCabal super.esqueleto (drv: {
+    src = pkgs.fetchFromGitHub {
+      owner = "tebello-thejane";
+      repo = "esqueleto";
+      sha256 = "0fngapza6cd1gwq2cl4520yv1rqibdd39ljamqmnkq4wikg8s7cb";
+      rev = "ea00e73e0496464500d4e35d1c9108b55fe186a5";
+    };
+  });
+
   # Fine-tune the build.
   structured-haskell-mode = (overrideCabal super.structured-haskell-mode (drv: {
     # Bump version to latest git-version to get support for Emacs 25.x.


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/19247
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
