### PR TITLE
stdenv/stripHash: print to stdout, not to variable

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1231,13 +1231,12 @@ echo @foo@
     <term><function>stripHash</function>
     <replaceable>path</replaceable></term>
     <listitem><para>Strips the directory and hash part of a store
-    path, storing the name part in the environment variable
-    <literal>strippedName</literal>. For example:
+    path, outputting the name part to <literal>stdout</literal>.
+    For example:
     
 <programlisting>
-stripHash "/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
 # prints coreutils-8.24
-echo $strippedName
+stripHash "/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
 </programlisting>
 
     If you wish to store the result in another variable, then the
@@ -1245,7 +1244,7 @@ echo $strippedName
     
 <programlisting>
 name="/nix/store/9s9r019176g7cvn2nvcw41gsp862y6b4-coreutils-8.24"
-someVar=$(stripHash $name; echo $strippedName)
+someVar=$(stripHash $name)
 </programlisting>
 
     </para></listitem>

--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -43,6 +43,15 @@ following incompatible changes:</para>
       <literal>radicale</literal>.
     </para>
   </listitem>
+
+  <listitem>
+    <para>
+      The <literal>stripHash</literal> bash function in <literal>stdenv</literal>
+      changed according to its documentation; it now outputs the stripped name to
+      <literal>stdout</literal> instead of putting it in the variable
+      <literal>strippedName</literal>.
+    </para>
+  </listitem>
 </itemizedlist>
 
 

--- a/nixos/modules/services/networking/ircd-hybrid/builder.sh
+++ b/nixos/modules/services/networking/ircd-hybrid/builder.sh
@@ -12,7 +12,7 @@ for i in $scripts; do
     if test "$(echo $i | cut -c1-2)" = "=>"; then
         subDir=$(echo $i | cut -c3-)
     else
-        dst=$out/$subDir/$((stripHash $i; echo $strippedName) | sed 's/\.in//')
+        dst=$out/$subDir/$(stripHash $i | sed 's/\.in//')
         doSub $i $dst
         chmod +x $dst # !!!
     fi
@@ -23,7 +23,7 @@ for i in $substFiles; do
     if test "$(echo $i | cut -c1-2)" = "=>"; then
         subDir=$(echo $i | cut -c3-)
     else
-        dst=$out/$subDir/$((stripHash $i; echo $strippedName) | sed 's/\.in//')
+        dst=$out/$subDir/$(stripHash $i | sed 's/\.in//')
         doSub $i $dst
     fi
 done

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -537,8 +537,7 @@ rec {
 
       # Hacky: RPM looks for <basename>.spec inside the tarball, so
       # strip off the hash.
-      stripHash "$src"
-      srcName="$strippedName"
+      srcName="$(stripHash "$src")"
       cp "$src" "$srcName" # `ln' doesn't work always work: RPM requires that the file is owned by root
 
       export HOME=/tmp/home

--- a/pkgs/data/fonts/droid/default.nix
+++ b/pkgs/data/fonts/droid/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   sourceRoot = "./";
 
   unpackCmd = ''
-    ttfName=$(basename $(stripHash $curSrc; echo $strippedName))
+    ttfName=$(basename $(stripHash $curSrc))
     cp $curSrc ./$ttfName
   '';
 

--- a/pkgs/data/fonts/roboto-mono/default.nix
+++ b/pkgs/data/fonts/roboto-mono/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   sourceRoot = "./";
 
   unpackCmd = ''
-    ttfName=$(basename $(stripHash $curSrc; echo $strippedName))
+    ttfName=$(basename $(stripHash $curSrc))
     cp $curSrc ./$ttfName
   '';
 

--- a/pkgs/data/fonts/roboto-slab/default.nix
+++ b/pkgs/data/fonts/roboto-slab/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   sourceRoot = "./";
 
   unpackCmd = ''
-    ttfName=$(basename $(stripHash $curSrc; echo $strippedName))
+    ttfName=$(basename $(stripHash $curSrc))
     cp $curSrc ./$ttfName
   '';
 

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook-ebnf/builder.sh
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook-ebnf/builder.sh
@@ -3,5 +3,4 @@ source $stdenv/setup
 mkdir -p $out/xml/dtd/docbook-ebnf
 cd $out/xml/dtd/docbook-ebnf
 cp -p $dtd dbebnf.dtd
-stripHash $catalog
-cp -p $catalog $strippedName
+cp -p $catalog $(stripHash $catalog)

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -495,7 +495,7 @@ dumpVars() {
 stripHash() {
     strippedName=$(basename $1);
     if echo "$strippedName" | grep -q '^[a-z0-9]\{32\}-'; then
-        strippedName=$(echo "$strippedName" | cut -c34-)
+        echo "$strippedName" | cut -c34-
     fi
 }
 

--- a/pkgs/tools/typesetting/tex/nix/animatedot.sh
+++ b/pkgs/tools/typesetting/tex/nix/animatedot.sh
@@ -4,6 +4,6 @@ mkdir -p $out
 
 for ((i = 1; i <= $nrFrames; i++)); do
     echo "producing frame $i...";
-    targetName=$out/$(basename $(stripHash $dotGraph; echo $strippedName) .dot)-f-$i.dot
+    targetName=$out/$(basename $(stripHash $dotGraph) .dot)-f-$i.dot
     cpp -DFRAME=$i < $dotGraph > $targetName
 done

--- a/pkgs/tools/typesetting/tex/nix/default.nix
+++ b/pkgs/tools/typesetting/tex/nix/default.nix
@@ -185,7 +185,7 @@ rec {
         if test -d $postscript; then
           input=$(ls $postscript/*.ps)
         else
-          input=$(stripHash $postscript; echo $strippedName)
+          input=$(stripHash $postscript)
           ln -s $postscript $input
         fi
 

--- a/pkgs/tools/typesetting/tex/nix/dot2pdf.sh
+++ b/pkgs/tools/typesetting/tex/nix/dot2pdf.sh
@@ -4,7 +4,7 @@ mkdir -p $out
 
 dot2pdf() {
     sourceFile=$1
-    targetName=$out/$(basename $(stripHash $sourceFile; echo $strippedName) .dot).pdf
+    targetName=$out/$(basename $(stripHash $sourceFile) .dot).pdf
     echo "converting $sourceFile to $targetName..."
     export FONTCONFIG_FILE=$fontsConf
     dot -Tpdf $sourceFile > $targetName

--- a/pkgs/tools/typesetting/tex/nix/dot2ps.sh
+++ b/pkgs/tools/typesetting/tex/nix/dot2ps.sh
@@ -4,7 +4,7 @@ mkdir -p $out
 
 dot2ps() {
     sourceFile=$1
-    targetName=$out/$(basename $(stripHash $sourceFile; echo $strippedName) .dot).ps
+    targetName=$out/$(basename $(stripHash $sourceFile) .dot).ps
     echo "converting $sourceFile to $targetName..."
     dot -Tps $sourceFile > $targetName
 }

--- a/pkgs/tools/typesetting/tex/nix/lhs2tex.sh
+++ b/pkgs/tools/typesetting/tex/nix/lhs2tex.sh
@@ -10,7 +10,7 @@ cd $startDir
 
 lhstex() {
     sourceFile=$1
-    targetName=$out/$(basename $(stripHash $sourceFile; echo $strippedName) .lhs).tex
+    targetName=$out/$(basename $(stripHash $sourceFile) .lhs).tex
     echo "converting $sourceFile to $targetName..."
     lhs2TeX -o "$targetName" $flags "$sourceFile"
 }

--- a/pkgs/tools/typesetting/tex/nix/run-latex.sh
+++ b/pkgs/tools/typesetting/tex/nix/run-latex.sh
@@ -16,11 +16,11 @@ for i in $extraFiles; do
     if test -d $i; then
         ln -s $i/* .
     else
-        ln -s $i $(stripHash $i; echo $strippedName)
+        ln -s $i $(stripHash $i)
     fi
 done
 
-rootName=$(basename $(stripHash "$rootFile"; echo $strippedName))
+rootName=$(basename $(stripHash "$rootFile"))
 
 rootNameBase=$(echo "$rootName" | sed 's/\..*//')
 


### PR DESCRIPTION
`stripHash` documentation states that it prints out the stripped name to
the stdout, but the function stored the value in `strippedName`
instead.

Basically all usages did something like
`$(stripHash $foo | echo $strippedName)` which is just braindamaged.
Fixed the implementation and all invocations.

cc @fpletz 
fixes #4045
