### PR TITLE
lf: init at 2016-10-02

### DIFF
--- a/pkgs/tools/misc/lf/default.nix
+++ b/pkgs/tools/misc/lf/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "lf-unstable-${version}";
+  version = "2016-10-02";
+
+  goPackagePath = "github.com/gokcehan/lf";
+
+  src = fetchFromGitHub {
+    owner = "gokcehan";
+    repo = "lf";
+    rev = "7a851f6c720380a6b9f715542906a56334e7e98b"; # nightly
+    sha256 = "0hdxcibly3algz0hgy65xr3dxchf4aarpxdgxsgc67m1knizksjr";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "A terminal file manager written in Go and heavily inspired by ranger";
+    longDescription = ''
+      lf (as in "list files") is a terminal file manager written in Go. It is
+      heavily inspired by ranger with some missing and extra features. Some of
+      the missing features are deliberately omitted since it is better if they
+      are handled by external tools.
+    '';
+    homepage = "https://godoc.org/github.com/gokcehan/lf";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/tools/misc/lf/deps.nix
+++ b/pkgs/tools/misc/lf/deps.nix
@@ -1,0 +1,20 @@
+[
+  {
+    goPackagePath = "github.com/nsf/termbox-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nsf/termbox-go";
+      rev = "b6acae516ace002cb8105a89024544a1480655a5"; # master
+      sha256 = "0zf95qdd5bif9rw03hqk87x7d905p373bvsj0bl4gi16spqjbdil";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "d6bea18f789704b5f83375793155289da36a3c7f"; # v0.0.1
+      sha256 = "1hnigpn7rjbwd1ircxkyx9hvi0xmxr32b2jdy2jzw6b3jmcnz1fs";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2296,6 +2296,8 @@ in
 
   less = callPackage ../tools/misc/less { };
 
+  lf = callPackage ../tools/misc/lf {};
+
   libcpuid = callPackage ../tools/misc/libcpuid { };
 
   lesspipe = callPackage ../tools/misc/lesspipe { };


### PR DESCRIPTION
###### Motivation for this change

Adding a new package called lf ("A terminal file manager written in Go and
heavily inspired by ranger").
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add the package "lf" (as in "list files") at version 2016-10-02
(nightly) under the category "tools/misc", add it to the top-level
package collection and set myself as the maintainer.

I have tested this package under NixOS and Gentoo+Nix.
