### PR TITLE
bup-0.28.1: A fix for darwin. Unmatched patch removed (already merged…

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-    version = "2.0.35";
+    version = "2.0.36";
 in
 stdenv.mkDerivation rec {
     name = "anki-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
         "http://ankisrs.net/download/mirror/${name}.tgz"
         "http://ankisrs.net/download/mirror/archive/${name}.tgz"
       ];
-      sha256 = "1d7k38xzw1nbg83d1aqxf2f76fv3hn2fry99k3vf4lgmhndj52mv";
+      sha256 = "070p0jmx6cy7kp9bfcgpgkzpyqkcj81wy8gmacns03n5rlq8487v";
     };
 
     pythonPath = [ pyqt4 pysqlite sqlalchemy pyaudio beautifulsoup httplib2 ]

--- a/pkgs/tools/backup/bup/default.nix
+++ b/pkgs/tools/backup/bup/default.nix
@@ -22,12 +22,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ git pythonPackages.python ];
   nativeBuildInputs = [ pandoc perl makeWrapper ];
 
-  patches = optional stdenv.isDarwin (fetchurl {
-    url = "https://github.com/bup/bup/commit/75d089e7cdb7a7eb4d69c352f56dad5ad3aa1f97.diff";
-    sha256 = "05kp47p30a45ip0fg090vijvzc7ijr0alc3y8kjl6bvv3gliails";
-    name = "darwin_10_10.patch";
-  });
-
   postPatch = ''
     patchShebangs .
     substituteInPlace Makefile --replace "-Werror" ""
@@ -49,7 +43,9 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/bup \
       --prefix PATH : ${git}/bin \
       --prefix PYTHONPATH : ${concatStringsSep ":" (map (x: "$(toPythonPath ${x})")
-        (with pythonPackages; [ pyxattr pylibacl setuptools fuse tornado ]))}
+        (with pythonPackages;
+         [ setuptools tornado ]
+         ++ stdenv.lib.optional (!stdenv.isDarwin) [ pyxattr pylibacl fuse ]))}
   '';
 
   meta = {

--- a/pkgs/tools/backup/bup/default.nix
+++ b/pkgs/tools/backup/bup/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       --prefix PYTHONPATH : ${concatStringsSep ":" (map (x: "$(toPythonPath ${x})")
         (with pythonPackages;
          [ setuptools tornado ]
-         ++ stdenv.lib.optional (!stdenv.isDarwin) [ pyxattr pylibacl fuse ]))}
+         ++ stdenv.lib.optionals (!stdenv.isDarwin) [ pyxattr pylibacl fuse ]))}
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

To fix broken build in osx. {acl,pyxattr,fuse} are removed for OS X. Previously added obsolete patch for darwin system is removed.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

… in the current release). {pyxattr,acl,fuse} are removed from the dependencies for OSX
