### PR TITLE
Fix 3 ocaml packages on darwin (llvm, camlidl, expat)

### DIFF
--- a/pkgs/development/ocaml-modules/expat/default.nix
+++ b/pkgs/development/ocaml-modules/expat/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation rec {
     substituteInPlace "unittest.ml" \
       --replace "/home/maas/xml-samples/REC-xml-19980210.xml.txt" "${testcase}"
     substituteInPlace Makefile --replace "EXPAT_LIBDIR=/usr/local/lib" "EXPAT_LIBDIR=${expat.out}/lib" \
-    substituteInPlace Makefile --replace "EXPAT_INCDIR=/usr/local/include" "EXPAT_INCDIR=${expat.dev}/include" \
+      --replace "EXPAT_INCDIR=/usr/local/include" "EXPAT_INCDIR=${expat.dev}/include" \
+      --replace "gcc" "\$(CC)"
   '';
 
   configurePhase = "true";  	# Skip configure

--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   configurePhase = ''
     mkdir build
     cd build
-    ../configure CC=gcc CXX=g++ --disable-compiler-version-checks --prefix=$out \
+    ../configure --disable-compiler-version-checks --prefix=$out \
     --disable-doxygen --disable-docs --with-ocaml-libdir=$OCAMLFIND_DESTDIR/llvm \
     --enable-static
     '';

--- a/pkgs/development/tools/ocaml/camlidl/default.nix
+++ b/pkgs/development/tools/ocaml/camlidl/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, makeWrapper, gcc, ocaml, ncurses}:
+{ stdenv, fetchurl, makeWrapper, ocaml, ncurses }:
 
 let
   pname = "camlidl";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     mv config/Makefile.unix config/Makefile
     substituteInPlace config/Makefile --replace BINDIR=/usr/local/bin BINDIR=$out
     substituteInPlace config/Makefile --replace OCAMLLIB=/usr/local/lib/ocaml OCAMLLIB=$out/lib/ocaml/${ocaml.version}/site-lib/camlidl
-    substituteInPlace config/Makefile --replace CPP=/lib/cpp CPP=${gcc}/bin/cpp
+    substituteInPlace config/Makefile --replace CPP=/lib/cpp CPP=${stdenv.cc}/bin/cpp
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/camlidl/caml
   '';
 


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
