### PR TITLE
fetch*: print a trace warning about md5 deprecation

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -113,4 +113,7 @@ rec {
   */
   warn = msg: builtins.trace "WARNING: ${msg}";
   info = msg: builtins.trace "INFO: ${msg}";
+
+  fetchMD5warn = name: context : data : warn
+    "Deprecated use of MD5 hash in ${name} to fetch ${context}" data;
 }

--- a/pkgs/build-support/fetchdarcs/default.nix
+++ b/pkgs/build-support/fetchdarcs/default.nix
@@ -7,7 +7,8 @@ stdenv.mkDerivation {
 
   outputHashAlgo = if sha256 == "" then "md5" else "sha256";
   outputHashMode = "recursive";
-  outputHash = if sha256 == "" then md5 else sha256;
+  outputHash = if sha256 == "" then
+    (stdenv.lib.fetchMD5warn "fetchdarcs" url md5) else sha256;
   
   inherit url rev context;
 }

--- a/pkgs/build-support/fetchegg/default.nix
+++ b/pkgs/build-support/fetchegg/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation {
 
   outputHashAlgo = if sha256 == "" then "md5" else "sha256";
   outputHashMode = "recursive";
-  outputHash = if sha256 == "" then md5 else sha256;
+  outputHash = if sha256 == "" then
+    (stdenv.lib.fetchMD5warn "fetchegg" name md5) else sha256;
 
   inherit version;
 

--- a/pkgs/build-support/fetchfile/default.nix
+++ b/pkgs/build-support/fetchfile/default.nix
@@ -1,7 +1,11 @@
-{stdenv}: {pathname, md5}: stdenv.mkDerivation {
+{stdenv}: {pathname, md5 ? "", sha256 ? ""}: stdenv.mkDerivation {
   name = baseNameOf (toString pathname);
   builder = ./builder.sh;
   pathname = pathname;
-  md5 = md5;
+} // if (sha256 == "") then {
+  md5 = (stdenv.lib.fetchMD5warn "fetchfile" pathname md5);
   id = md5;
+} else {
+  sha256 = sha256;
+  id = sha256;
 }

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -50,7 +50,8 @@ stdenv.mkDerivation {
 
   outputHashAlgo = if sha256 == "" then "md5" else "sha256";
   outputHashMode = "recursive";
-  outputHash = if sha256 == "" then md5 else sha256;
+  outputHash = if sha256 == "" then
+    (stdenv.lib.fetchMD5warn "fetchgit" url md5) else sha256;
 
   inherit url rev leaveDotGit fetchSubmodules deepClone branchName;
 

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation {
 
   outputHashAlgo = if md5 != null then "md5" else "sha256";
   outputHashMode = "recursive";
-  outputHash = if md5 != null then md5 else sha256;
+  outputHash = if md5 != null then
+    (stdenv.lib.fetchMD5warn "fetchhg" url md5) else sha256;
 
   inherit url rev;
   preferLocalBuild = true;

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation {
 
   outputHashAlgo = if sha256 == "" then "md5" else "sha256";
   outputHashMode = "recursive";
-  outputHash = if sha256 == "" then md5 else sha256;
+  outputHash = if sha256 == "" then
+    (stdenv.lib.fetchMD5warn "fetchsvn" url md5) else sha256;
   
   inherit url rev sshSupport openssh ignoreExternals;
 

--- a/pkgs/build-support/fetchsvnssh/default.nix
+++ b/pkgs/build-support/fetchsvnssh/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation {
 
   outputHashAlgo = if sha256 == "" then "md5" else "sha256";
   outputHashMode = "recursive";
-  outputHash = if sha256 == "" then md5 else sha256;
+  outputHash = if sha256 == "" then
+    (stdenv.lib.fetchMD5warn "fetchsvnssh" url md5) else sha256;
   
   sshSubversion = ./sshsubversion.exp;
   

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -112,7 +112,8 @@ if (!hasHash) then throw "Specify hash for fetchurl fixed-output derivation: ${s
   outputHashAlgo = if outputHashAlgo != "" then outputHashAlgo else
       if sha512 != "" then "sha512" else if sha256 != "" then "sha256" else if sha1 != "" then "sha1" else "md5";
   outputHash = if outputHash != "" then outputHash else
-      if sha512 != "" then sha512 else if sha256 != "" then sha256 else if sha1 != "" then sha1 else md5;
+      if sha512 != "" then sha512 else if sha256 != "" then sha256 else if sha1 != "" then sha1 else
+        (stdenv.lib.fetchMD5warn "fetchurl" (builtins.head urls_) md5);
 
   outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
 

--- a/pkgs/development/libraries/libnfnetlink/default.nix
+++ b/pkgs/development/libraries/libnfnetlink/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.netfilter.org/projects/libnfnetlink/files/${name}.tar.bz2";
-    md5 = "98927583d2016a9fb1936fed992e2c5e";
+    sha256 = "06mm2x4b01k3m7wnrxblk9j0mybyr4pfz28ml7944xhjx6fy2w7j";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

The issue #4491 seeks to avoid usage of MD5 as a checksum inside NixPkgs.

This change adds a warning to all `fetch*` functions currently capable of processing md5.

In the process, I found `fetchfile` that was unable to handle SHA-256. This is now fixed.
###### Things done
- Tested `test-eval-release.sh` — seems fine.
- A random package (for the record: `libnfnetlink`) affected by the warnings prints a warning but doesn't get a new hash (as intended), i.e. gets fetched from the binary cache.
###### # PR status

This is a small patch that has global and (intentionally) annoying effects.

I think it is fine (given nobody currently objects to removal of MD5 use from NixPkgs), and I intend to merge it myself next week. If there are some suggestions or objections, I will delay the merge (or fix small things before merging)

Cc @domenkozar as the MD5-removal leader
