### PR TITLE
Fix xml validation error in NixOS releases documentation

### DIFF
--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -100,7 +100,7 @@
       <listitem>
         <para>
           Use https://lwn.net/Vulnerabilities/ and 
-          <link xlink:href="https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&q=vulnerabilities&type=Issues">triage vulnerabilities in an issue</link>.
+          <link xlink:href="https://github.com/NixOS/nixpkgs/search?utf8=%E2%9C%93&amp;q=vulnerabilities&amp;type=Issues">triage vulnerabilities in an issue</link>.
         </para>
       </listitem>
       <listitem>


### PR DESCRIPTION
###### Motivation for this change

Schema validation failes because the `&` in the url is interpreted as XML entity.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
