### PR TITLE
oh-my-zsh: Fix oh-my-zsh's loading of ~/.oh-my-zsh

### DIFF
--- a/pkgs/shells/oh-my-zsh/default.nix
+++ b/pkgs/shells/oh-my-zsh/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   chmod -R +w templates
 
   # Change the path to oh-my-zsh dir and disable auto-updating.
-  sed -i -e "2c\\ZSH=$outdir/" \
+  sed -i -e "s#ZSH=\$HOME/.oh-my-zsh#ZSH=$outdir#" \
          -e 's/\# \(DISABLE_AUTO_UPDATE="true"\)/\1/' \
    $template
 


### PR DESCRIPTION
###### Motivation for this change

Before the patch would cause share/oh-my-zsh/templates/zshrc.zsh-template to start with:

```
# If you come from bash you might have to change your $PATH.
ZSH=/nix/store/2r5rclvhqzzn32jp8d5ia630ydp3fzlf-oh-my-zsh-git-2016-09-24/share/oh-my-zsh/

# Path to your oh-my-zsh installation.
export ZSH=$HOME/.oh-my-zsh
```

Now it starts with:

```
# Path to your oh-my-zsh installation.
export ZSH=/nix/store/s5kbzx7mcpphm43kjvg6kdh49nfmdx9w-oh-my-zsh-git-2016-08-01/share/oh-my-zsh
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
