### PR TITLE
bspwm-unstable: init at 2016-09-30

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -523,6 +523,7 @@
   ./services/x11/window-managers/fluxbox.nix
   ./services/x11/window-managers/icewm.nix
   ./services/x11/window-managers/bspwm.nix
+  ./services/x11/window-managers/bspwm-unstable.nix
   ./services/x11/window-managers/metacity.nix
   ./services/x11/window-managers/none.nix
   ./services/x11/window-managers/twm.nix

--- a/nixos/modules/services/x11/window-managers/bspwm-unstable.nix
+++ b/nixos/modules/services/x11/window-managers/bspwm-unstable.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.windowManager.bspwm-unstable;
+in
+
+{
+  options = {
+    services.xserver.windowManager.bspwm-unstable = {
+        enable = mkEnableOption "bspwm-unstable";
+        startThroughSession = mkOption {
+            type = with types; bool;
+            default = false;
+            description = "
+                Start the window manager through the script defined in 
+                sessionScript. Defaults to the the bspwm-session script
+                provided by bspwm
+            ";
+        };
+        sessionScript = mkOption {
+            default = "${pkgs.bspwm-unstable}/bin/bspwm-session";
+            defaultText = "(pkgs.bspwm-unstable)/bin/bspwm-session";
+            description = "
+                The start-session script to use. Defaults to the
+                provided bspwm-session script from the bspwm package.
+
+                Does nothing unless `bspwm.startThroughSession` is enabled
+            ";
+        };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.xserver.windowManager.session = singleton {
+      name = "bspwm-unstable";
+      start = if cfg.startThroughSession
+        then cfg.sessionScript
+        else ''
+            export _JAVA_AWT_WM_NONREPARENTING=1
+            SXHKD_SHELL=/bin/sh ${pkgs.sxhkd-unstable}/bin/sxhkd -f 100 &
+            ${pkgs.bspwm-unstable}/bin/bspwm
+        '';
+    };
+    environment.systemPackages = [ pkgs.bspwm-unstable ];
+  };
+}

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -10,6 +10,7 @@ in
   imports = [
     ./afterstep.nix
     ./bspwm.nix
+    ./bspwm-unstable.nix
     ./compiz.nix
     ./dwm.nix
     ./exwm.nix

--- a/pkgs/applications/window-managers/bspwm/unstable.nix
+++ b/pkgs/applications/window-managers/bspwm/unstable.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, libxcb, libXinerama, sxhkd, xcbutil, xcbutilkeysyms, xcbutilwm }:
+
+stdenv.mkDerivation rec {
+  name = "bspwm-unstable-2016-09-30";
+
+
+  src = fetchFromGitHub {
+    owner   = "baskerville";
+    repo    = "bspwm";
+    rev     = "8664c007e44de162c1597fd7e163635b274fb747";
+    sha256  = "0clvpz32z38i8kr10hqlifa661szpfn93c63m2aq2h4dwmr44slz";
+  };
+
+  buildInputs = [ libxcb libXinerama xcbutil xcbutilkeysyms xcbutilwm ];
+
+  buildPhase = ''
+    make PREFIX=$out
+  '';
+
+  installPhase = ''
+    make PREFIX=$out install
+  '';
+
+  meta = {
+    description = "A tiling window manager based on binary space partitioning (git version)";
+    homepage = https://github.com/baskerville/bspwm;
+    maintainers = [ stdenv.lib.maintainers.meisternu stdenv.lib.maintainers.epitrochoid ];
+    license = stdenv.lib.licenses.bsd2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12096,6 +12096,8 @@ in
 
   bspwm = callPackage ../applications/window-managers/bspwm { };
 
+  bspwm-unstable = callPackage ../applications/window-managers/bspwm/unstable.nix { };
+
   bvi = callPackage ../applications/editors/bvi { };
 
   bviplus = callPackage ../applications/editors/bviplus { };


### PR DESCRIPTION
###### Motivation for this change

Adding the git version of bspwm.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
