### PR TITLE
jre8_headless: 'minimal' attribute is added to 'openjdk-darwin/8.nix'…

### DIFF
--- a/pkgs/development/compilers/openjdk-darwin/8.nix
+++ b/pkgs/development/compilers/openjdk-darwin/8.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, setJavaClassPath }:
+{ stdenv, fetchurl, unzip, setJavaClassPath, minimal ? false }:
 let
   jdk = stdenv.mkDerivation {
     name = "zulu1.8.0_66-8.11.0.1";


### PR DESCRIPTION
###### Motivation for this change

jre8_headless introduced in #19167 overrides 'minimal' attribute in openjdk8 to true, but such attribute has never been set in darwin ('openjdk-darwin/8.nix'). Despite of being very minor issue, it seems to result in many travis-ci build failure right now.

---

… so that jre8_headless can be evaluated without an error
