### PR TITLE
sxhkd-git: init at revision from 2016-08-29

### DIFF
--- a/pkgs/applications/window-managers/sxhkd/git.nix
+++ b/pkgs/applications/window-managers/sxhkd/git.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, asciidoc, libxcb, xcbutil, xcbutilkeysyms, xcbutilwm }:
+
+stdenv.mkDerivation rec {
+  name = "sxhkd-git-2016-08-29";
+
+  src = fetchFromGitHub {
+    owner  = "baskerville";
+    repo   = "sxhkd";
+    rev    = "69b6acc7831bd333b39286c37188e5638ad0de27";
+    sha256 = "11i451hz0icsbxnvbq2bdl6r5kacxf6ps0yvi9ix3vkpxn4zcanh";
+  };
+
+  buildInputs = [ asciidoc libxcb xcbutil xcbutilkeysyms xcbutilwm ];
+
+  makeFlags = ''PREFIX=$(out)'';
+
+  meta = {
+    description = "Simple X hotkey daemon (git version)";
+    homepage = http://github.com/baskerville/sxhkd/;
+    license = stdenv.lib.licenses.bsd2;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}
+{
+  "url": "https://github.com/baskerville/sxhkd",
+  "date": "2016-08-29T20:45:21+02:00",
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13774,6 +13774,8 @@ in
 
   sxhkd = callPackage ../applications/window-managers/sxhkd { };
 
+  sxhkd-git = callPackage ../applications/window-managers/sxhkd/git.nix { };
+
   mpop = callPackage ../applications/networking/mpop {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

Added git version of sxhkd, a simple hotkey daemon for X.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
