### PR TITLE
xtitle: 0.2 -> 0.3

### DIFF
--- a/pkgs/tools/misc/xtitle/default.nix
+++ b/pkgs/tools/misc/xtitle/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libxcb, xcbutil, xcbutilwm, git }:
 
 stdenv.mkDerivation rec {
-   name = "xtitle-0.2";
+   name = "xtitle-0.3";
 
    src = fetchurl {
-     url = "https://github.com/baskerville/xtitle/archive/0.2.tar.gz";
-     sha256 = "1wyhfwbwqnq4rn6i789gydxlg25ylc37xjrkq758bp55sdgb8fk2";
+     url = "https://github.com/baskerville/xtitle/archive/0.3.tar.gz";
+     sha256 = "07r36f4ad1q0dpkx3ykd49xlmi24d8mjqwh40j228k81wsvzayl1";
    };
 
 


### PR DESCRIPTION
###### Motivation for this change

Updating the package to a more recent version.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
