### PR TITLE
f2fs-tools: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/tools/filesystems/f2fs-tools/default.nix
+++ b/pkgs/tools/filesystems/f2fs-tools/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchurl, autoreconfHook, libuuid, pkgconfig }:
+{ stdenv, fetchurl, autoreconfHook, libselinux, libuuid, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "f2fs-tools-${version}";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "http://git.kernel.org/cgit/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/${name}.tar.gz";
-    sha256 = "1fkq1iqr5kxs6ihhbmjk4i19q395azcl60mnslqwfrlbrd3p40gm";
+    sha256 = "1m6bn1ibq0p53m0n97il91xqgjgn2pzlz74lb5bfzassx7159m1k";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ libuuid pkgconfig ];
+  buildInputs = [ libselinux libuuid pkgconfig ];
 
   meta = with stdenv.lib; {
     homepage = "http://git.kernel.org/cgit/linux/kernel/git/jaegeuk/f2fs-tools.git/";


### PR DESCRIPTION
###### Motivation for this change

This version introduces a dependency on libselinux.

Does anybody have any great ideas on a test script/process for file system tools that should get a real pounding before being upgraded?
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
