### PR TITLE
shellcheck: renamed without camelCase

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -1553,7 +1553,7 @@ default-package-overrides:
   - shake-language-c ==0.10.0
   - shakespeare ==2.0.11.1
   - shell-conduit ==4.5.2
-  - ShellCheck ==0.4.4
+  - shellcheck ==0.4.4
   - shelly ==1.6.8
   - shortcut-links ==0.4.2.0
   - should-not-typecheck ==2.1.0

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6293,7 +6293,7 @@ in
   sbt = callPackage ../development/tools/build-managers/sbt { };
   simpleBuildTool = sbt;
 
-  shellcheck = self.haskellPackages.ShellCheck;
+  shellcheck = self.haskellPackages.shellcheck;
 
   shncpd = callPackage ../tools/networking/shncpd { };
 


### PR DESCRIPTION
###### Motivation for this change

I started to package this program because i coulnd find it,
I expected the package to have a non camelCase name.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I started to package this program because i coulnd find it,
I expected the package to have a non camelCase name.

In the Contributors Guide 10.2 states the name shouldnt be in uppercase.
