### PR TITLE
httpstat: init at 1.2.0

### DIFF
--- a/pkgs/tools/networking/httpstat/default.nix
+++ b/pkgs/tools/networking/httpstat/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, curl, python, pythonPackages, ... }:
+
+pythonPackages.buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "httpstat";
+    version = "1.2.0";
+    src = fetchFromGitHub {
+      owner = "reorx";
+      repo = pname;
+      rev = "${version}";
+      sha256 = "1zfbv3fz3g3wwvsgrcyrk2cp7pjhkpf7lmx57ry9b43c62gcd7yh";
+    };
+    doCheck = false;
+    propagatedBuildInputs = [ ];
+    runtimeDeps = [ curl ];
+
+    installPhase = ''
+      mkdir -p $out/${python.sitePackages}/
+      cp httpstat.py $out/${python.sitePackages}/
+      mkdir -p $out/bin
+      ln -s $out/${python.sitePackages}/httpstat.py $out/bin/httpstat
+      chmod +x $out/bin/httpstat
+    '';
+
+    meta = {
+      description = "curl statistics made simple";
+      homepage = https://github.com/reorx/httpstat;
+      license = stdenv.lib.licenses.mit;
+      maintainers = with stdenv.lib.maintainers; [ nequissimus ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2095,6 +2095,8 @@ in
 
   httpfs2 = callPackage ../tools/filesystems/httpfs { };
 
+  httpstat = callPackage ../tools/networking/httpstat { };
+
   httptunnel = callPackage ../tools/networking/httptunnel { };
 
   hubicfuse = callPackage ../tools/filesystems/hubicfuse { };


### PR DESCRIPTION
###### Motivation for this change

Useful tool for curl statistics
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
