### PR TITLE
lximage-qt: init at 0.5.0

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -42,6 +42,7 @@ in
       pkgs.lxqt.liblxqt
       pkgs.lxqt.libqtxdg
       pkgs.lxqt.libsysstat
+      pkgs.lxqt.lximage-qt
       pkgs.lxqt.lxqt-about
       pkgs.lxqt.lxqt-admin
       pkgs.lxqt.lxqt-common

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -58,6 +58,7 @@ let
     qterminal = callPackage ./optional/qterminal { };
     compton-conf = callPackage ./optional/compton-conf { };
     obconf-qt = callPackage ./optional/obconf-qt { };
+    lximage-qt = callPackage ./optional/lximage-qt { };
    
   };
 

--- a/pkgs/desktops/lxqt/optional/lximage-qt/default.nix
+++ b/pkgs/desktops/lxqt/optional/lximage-qt/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, qt5, kde5, xorg, lxqt,
+ libfm, menu-cache, libexif }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "lximage-qt";
+  version = "0.5.0";
+
+  srcs = fetchFromGitHub {
+    owner = "lxde";
+    repo = pname;
+    rev = version;
+    sha256 = "0c5s0c2y73hp7mcxwg31bpn0kmjyhv519d0dxzp3na56n0xk9vl0";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [
+    qt5.qtbase
+    qt5.qttools
+    qt5.qtx11extras
+    qt5.qtsvg
+    kde5.kwindowsystem
+    lxqt.liblxqt
+    lxqt.libqtxdg
+    lxqt.libfm-qt
+    xorg.libpthreadstubs
+    xorg.libXdmcp
+    libfm
+    menu-cache
+    libexif
+  ];
+
+  cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];
+
+  meta = with stdenv.lib; {
+    description = "The image viewer and screenshot tool for lxqt";
+    homepage = https://github.com/lxde/lximage-qt;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ romildo ];
+    platforms = with platforms; unix;
+  };
+}


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
