### PR TITLE
DONT-MERGE kodi: 16.1 -> 17.0

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, makeWrapper
 , pkgconfig, cmake, gnumake, yasm, python2
-, boost, avahi, libdvdcss, lame, autoreconfHook
+, boost, avahi, libdvdcss, libdvdnav, libdvdread, lame, autoreconfHook
 , gettext, pcre-cpp, yajl, fribidi, which
 , openssl, gperf, tinyxml2, taglib, libssh, swig, jre
 , libX11, xproto, inputproto, libxml2
@@ -38,18 +38,18 @@ assert pulseSupport -> libpulseaudio != null;
 assert rtmpSupport  -> rtmpdump != null;
 
 let
-  rel = "Jarvis";
-  ffmpeg_2_8_6 = fetchurl {
-    url = "https://github.com/xbmc/FFmpeg/archive/2.8.6-${rel}-16.1.tar.gz";
-    sha256 = "1qp8b97298l2pnhhcp7xczdfwr7q7ibxlk4vp8pfmxli2h272wan";
+  rel = "Krypton";
+  ffmpeg_3_1_6 = fetchurl {
+    url = "https://github.com/xbmc/FFmpeg/archive/3.1.6-${rel}-Beta6.tar.gz";
+    sha256 = "0vqm9gjmc8hj71glk4g6xklaks1041nv8y0m6k9av1zbps22p75b";
   };
 in stdenv.mkDerivation rec {
     name = "kodi-" + version;
-    version = "16.1";
+    version = "17.0b6";
 
     src = fetchurl {
       url = "https://github.com/xbmc/xbmc/archive/${version}-${rel}.tar.gz";
-      sha256 = "047xpmz78k3d6nhk1x9s8z0bw1b1w9kca46zxkg86p3iyapwi0kx";
+      sha256 = "0jzswvfs4hqag4mn5xsbl91vdnk9i2sjj3x0b1nkly9kp3h304wn";
     };
 
     buildInputs = [
@@ -90,7 +90,10 @@ in stdenv.mkDerivation rec {
         --replace 'usr/share/zoneinfo' 'etc/zoneinfo'
       substituteInPlace tools/depends/target/ffmpeg/autobuild.sh \
         --replace "/bin/bash" "${bash}/bin/bash -ex"
-      cp ${ffmpeg_2_8_6} tools/depends/target/ffmpeg/ffmpeg-2.8.6-${rel}-16.0.tar.gz
+      cp ${ffmpeg_3_1_6} tools/depends/target/ffmpeg/ffmpeg-3.1.6-${rel}-Beta6.tar.gz
+      ln -s ${libdvdcss.src} tools/depends/target/libdvdcss/libdvdcss-master.tar.gz
+      ln -s ${libdvdnav.src} tools/depends/target/libdvdnav/libdvdnav-master.tar.gz
+      ln -s ${libdvdread.src} tools/depends/target/libdvdread/libdvdread-master.tar.gz
     '';
 
     preConfigure = ''

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -6,14 +6,14 @@ let
 
   kodi-platform = stdenv.mkDerivation rec {
     project = "kodi-platform";
-    version = "15.2";
+    version = "17.1";
     name = "${project}-${version}";
 
     src = fetchFromGitHub {
       owner = "xbmc";
       repo = project;
-      rev = "45d6ad1984fdb1dc855076ff18484dbec33939d1";
-      sha256 = "1fai33mwyv5ab47b16i692g7a3vcnmxavx13xin2gh16y0qm62hi";
+      rev = "c8188d82678fec6b784597db69a68e74ff4986b5";
+      sha256 = "1r3gs3c6zczmm66qcxh9mr306clwb3p7ykzb70r3jv5jqggiz199";
     };
 
     buildInputs = [ cmake kodi libcec_platform tinyxml ];
@@ -219,13 +219,13 @@ in
   pvr-hts = (mkKodiPlugin rec {
     plugin = "pvr-hts";
     namespace = "pvr.hts";
-    version = "2.2.13";
+    version = "3.4.4";
 
     src = fetchFromGitHub {
       owner = "kodi-pvr";
       repo = "pvr.hts";
-      rev = "3274354511e970e2101c2aa437001b2f245f80da";
-      sha256 = "0i7cb61pjv6vbj3x96cm1n4w91mvc8z6lxa8ykjasrrbi95ph7ld";
+      rev = "343ca980982d87c778696e42e52eff763cadee4a";
+      sha256 = "03jk45nk1c5j7zwj6l8s8jyf6ijhisp1r16xg6n5561bm3cfk0b9";
     };
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, cmake, kodi, steam, libcec_platform, tinyxml, unzip }:
+{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, lib
+, unzip, cmake, kodi, steam, libcec_platform, tinyxml }:
 
 let
 
@@ -19,9 +20,9 @@ let
     buildInputs = [ cmake kodi libcec_platform tinyxml ];
   };
 
-  mkKodiPlugin = { plugin, namespace, version, src, meta, ... }:
+  mkKodiPlugin = { plugin, namespace, version, src, meta, sourceDir ? null, ... }:
   stdenv.lib.makeOverridable stdenv.mkDerivation rec {
-    inherit src meta;
+    inherit src meta sourceDir;
     name = "kodi-plugin-${plugin}-${version}";
     passthru = {
       kodiPlugin = pluginDir;
@@ -29,6 +30,7 @@ let
     };
     dontStrip = true;
     installPhase = ''
+      ${if isNull sourceDir then "" else "cd $src/$sourceDir"}
       d=$out${pluginDir}/${namespace}
       mkdir -p $d
       sauce="."
@@ -70,34 +72,69 @@ in
 
   };
 
-  genesis = (mkKodiPlugin rec {
+  controllers = let
+    pname = "game-controller";
+    version = "1.0.3";
 
-    plugin = "genesis";
-    namespace = "plugin.video.genesis";
-    version = "5.1.4";
-
-    src = fetchurl {
-      url = "https://offshoregit.com/lambda81/lambda-repo/${namespace}/${namespace}-${version}.zip";
-      sha256 = "0b0pdzgg42mgxgkb6sb83rldh4k19c3l9z7g2wnvxm3s2p6rjy3v";
+    src = fetchFromGitHub {
+      owner = "kodi-game";
+      repo = "kodi-game-controllers";
+      rev = "01acb5b6e8b85392b3cb298b034aadb1b24ccf18";
+      sha256 = "0sbc0w0fwbp7rbmbgb6a1kglhnn5g85hijcbbvf5x6jdq9v3f1qb";
     };
 
     meta = with stdenv.lib; {
-      homepage = "http://forums.tvaddons.ag/forums/148-lambda-s-kodi-addons";
-      description = "The origins of streaming";
+      description = "Add support for different gaming controllers.";
       platforms = platforms.all;
       maintainers = with maintainers; [ edwtjo ];
     };
+
+    mkController = controller: {
+        "${controller}" = mkKodiPlugin rec {
+          plugin = pname + "-" + controller;
+          namespace = "game.controller." + controller;
+          sourceDir = "addons/" + namespace;
+          inherit version src meta;
+        };
+      };
+    in (mkController "default")
+    // (mkController "dreamcast")
+    // (mkController "gba")
+    // (mkController "genesis")
+    // (mkController "mouse")
+    // (mkController "n64")
+    // (mkController "nes")
+    // (mkController "ps")
+    // (mkController "snes");
+
+  exodus = (mkKodiPlugin rec {
+
+    plugin = "exodus";
+    namespace = "plugin.video.exodus";
+    version = "2.0.12";
+
+    src = fetchurl {
+      url = "https://offshoregit.com/${plugin}/${namespace}/${namespace}-${version}.zip";
+      sha256 = "02cdyvyxay6jiw9xj8hqnkp5w6drqj67pkh243znrsc06f26qkql";
+    };
+
+    meta = with stdenv.lib; {
+      description = "A streaming plugin for Kodi";
+      platforms = platforms.all;
+      maintainers = with maintainers; [ edwtjo ];
+    };
+
   }).override { buildInputs = [ unzip ]; };
 
   hyper-launcher = let
     pname = "hyper-launcher";
-    version = "1.2.0";
+    version = "1.5.2";
     src = fetchFromGitHub rec {
       name = pname + "-" + version + ".tar.gz";
       owner = "teeedubb";
       repo = owner + "-xbmc-repo";
-      rev = "9bd170407436e736d2d709f8af9968238594669c";
-      sha256 = "019nqf7kixicnrzkg671x4yq723igjkhfl8hz5bifi9gx2qcy8hy";
+      rev = "f958ba93fe85b9c9025b1745d89c2db2e7dd9bf6";
+      sha256 = "1dvff24fbas25k5kvca4ssks9l1g5rfa3hl8lqxczkaqi3pp41j5";
     };
     meta = with stdenv.lib; {
       homepage = http://forum.kodi.tv/showthread.php?tid=258159;
@@ -107,8 +144,9 @@ in
   in {
     service = mkKodiPlugin {
       plugin = pname + "-service";
+      version = "1.2.1";
       namespace = "service.hyper.launcher";
-      inherit version src meta;
+      inherit src meta;
     };
     plugin = mkKodiPlugin {
       plugin = pname;
@@ -117,39 +155,18 @@ in
     };
   };
 
-  salts = mkKodiPlugin rec {
-
-    plugin = "salts";
-    namespace = "plugin.video.salts";
-    version = "2.0.19";
-
-    src = fetchFromGitHub {
-      name = plugin + "-" + version + ".tar.gz";
-      owner = "tknorris";
-      repo = plugin;
-      rev = "9c1882bad35cab9e62687847e097c37a576b900d";
-      sha256 = "0saq578xsxvyg1v8jg2m3131hfrr95gv74b2npxr7g715yyx5bjq";
-    };
-
-    meta = with stdenv.lib; {
-      homepage = "https://github.com/tknorris/salts";
-      description = "Stream All The Sources";
-      maintainers = with maintainers; [ edwtjo ];
-    };
-  };
-
   svtplay = mkKodiPlugin rec {
 
     plugin = "svtplay";
     namespace = "plugin.video.svtplay";
-    version = "4.0.24";
+    version = "4.0.37";
 
     src = fetchFromGitHub {
       name = plugin + "-" + version + ".tar.gz";
       owner = "nilzen";
       repo = "xbmc-" + plugin;
-      rev = "e66e2af6529e3ffd030ad486c849894a9ffdeb45";
-      sha256 = "01nq6gac83q6ayhqcj1whvk58pzrm1haw801s321f4vc8gswag56";
+      rev = "751412f4d117008643dbf2cce490561b47b41b83";
+      sha256 = "1y5f1nymvlq9fsb20sik61mnw1h59if5jw075mpbmviyfip4q1dd";
     };
 
     meta = with stdenv.lib; {
@@ -247,49 +264,5 @@ in
       make install
       ln -s $out/lib/addons/pvr.hts/pvr.hts.so* $out/share/kodi/addons/pvr.hts
     '';
-  };
-
-  t0mm0-common = mkKodiPlugin rec {
-
-    plugin = "t0mm0-common";
-    namespace = "script.module.t0mm0.common";
-    version = "0.0.1";
-
-    src = fetchFromGitHub {
-      name = plugin + "-" + version + ".tar.gz";
-      owner = "t0mm0";
-      repo = "xbmc-urlresolver";
-      rev = "ab16933a996a9e77b572953c45e70900c723d6e1";
-      sha256 = "1yd00md8iirizzaiqy6fv1n2snydcpqvp2f9irzfzxxi3i9asb93";
-    };
-
-    meta = with stdenv.lib; {
-      homepage = "https://github.com/t0mm0/xbmc-urlresolver/";
-      description = "t0mm0's common stuff";
-      maintainers = with maintainers; [ edwtjo ];
-    };
-  };
-
-  urlresolver = (mkKodiPlugin rec {
-
-    plugin = "urlresolver";
-    namespace = "script.module.urlresolver";
-    version = "2.10.0";
-
-    src = fetchFromGitHub {
-      name = plugin + "-" + version + ".tar.gz";
-      owner = "Eldorados";
-      repo = namespace;
-      rev = "72b9d978d90d54bb7a0224a1fd2407143e592984";
-      sha256 = "0r5glfvgy9ri3ar9zdkvix8lalr1kfp22fap2pqp739b6k2iqir6";
-    };
-
-    meta = with stdenv.lib; {
-      homepage = "https://github.com/Eldorados/urlresolver";
-      description = "Resolve common video host URL's to be playable in XBMC/Kodi";
-      maintainers = with maintainers; [ edwtjo ];
-    };
-  }).override {
-    postPatch = "sed -i -e 's,settings_file = os.path.join(addon_path,settings_file = os.path.join(profile_path,g' lib/urlresolver/common.py";
   };
 }

--- a/pkgs/development/libraries/libcec/default.nix
+++ b/pkgs/development/libraries/libcec/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, cmake, pkgconfig, udev, libcec_platform }:
 
-let version = "3.0.1"; in
+let version = "3.1.0"; in
 
 stdenv.mkDerivation {
   name = "libcec-${version}";
 
   src = fetchurl {
     url = "https://github.com/Pulse-Eight/libcec/archive/libcec-${version}.tar.gz";
-    sha256 = "0gi5gq8pz6vfdx80pimx23d5g243zzgmc7s8wpb686csjk470dky";
+    sha256 = "08gr4rhx7qh8ajkry9j0sqw11i74y802dla1wg4l4gxhl4hrs409";
   };
 
   buildInputs = [ cmake pkgconfig udev libcec_platform ];

--- a/pkgs/development/libraries/libcec/platform.nix
+++ b/pkgs/development/libraries/libcec/platform.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, cmake }:
 
-let version = "1.0.10"; in
+let version = "2.0.1"; in
 
 stdenv.mkDerivation {
-  name = "libcec-${version}";
+  name = "p8-platform-${version}";
 
   src = fetchurl {
-    url = "https://github.com/Pulse-Eight/platform/archive/${version}.tar.gz";
-    sha256 = "1kdmi9b62nky4jrb5519ddnw5n7s7m6qyj7rzhg399f0n6f278vb";
+    url = "https://github.com/Pulse-Eight/platform/archive/p8-platform-${version}.tar.gz";
+    sha256 = "1kslq24p2zams92kc247qcczbxb2n89ykk9jfyiilmwh7qklazp9";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "Platform library for libcec and Kodi addons";
     homepage = "https://github.com/Pulse-Eight/platform";
-    repositories.git = "https://github.com/Pulse-Eight/libcec.git";
+    repositories.git = "https://github.com/Pulse-Eight/platform.git";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.titanous ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15247,10 +15247,12 @@ in
     plugins = let inherit (lib) optional optionals; in with kodiPlugins;
       ([]
       ++ optional (config.kodi.enableAdvancedLauncher or false) advanced-launcher
-      ++ optional (config.kodi.enableGenesis or false) genesis
+      ++ optionals (config.kodi.enableControllers or false)
+        (with controllers;
+          [ default dreamcast gba genesis mouse n64 nes ps snes ])
+      ++ optional (config.kodi.enableExodus or false) exodus
       ++ optionals (config.kodi.enableHyperLauncher or false)
            (with hyper-launcher; [ plugin service pdfreader ])
-      ++ optionals (config.kodi.enableSALTS or false) [salts urlresolver t0mm0-common]
       ++ optional (config.kodi.enableSVTPlay or false) svtplay
       ++ optional (config.kodi.enableSteamLauncher or false) steam-launcher
       ++ optional (config.kodi.enablePVRHTS or false) pvr-hts


### PR DESCRIPTION
###### Motivation for this change

Test uppcoming Kodi, [changelog](http://kodi.wiki/view/Kodi_v17_%28Krypton%29_changelog). @cpages reading the changelog it seems that pvr-hts might need special care, I don't use that feature.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
