### PR TITLE
purple-facebook: init at 66ee77378d82

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -107,6 +107,7 @@
   danbst = "Danylo Hlynskyi <abcz2.uprola@gmail.com>";
   davidak = "David Kleuker <post@davidak.de>";
   davidrusu = "David Rusu <davidrusu.me@gmail.com>";
+  davorb = "Davor Babic <davor@davor.se>";
   dbohdan = "Danyil Bohdan <danyil.bohdan@gmail.com>";
   dbrock = "Daniel Brockman <daniel@brockman.se>";
   deepfire = "Kosyrev Serge <_deepfire@feelingofgreen.ru>";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-facebook/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-facebook/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pidgin, glib, json_glib, mercurial, autoreconfHook } :
+
+stdenv.mkDerivation rec {
+  name = "purple-facebook-${version}";
+  version = "2016-04-09";
+
+  src = fetchFromGitHub {
+    owner = "dequis";
+    repo = "purple-facebook";
+    rev = "66ee77378d82";
+    sha256 = "0kr9idl79h70lacd3cvpmzvfd6il3b5xm2fj1sj96l7bjhiw9s3y";
+  };
+
+  preAutoreconf = "./autogen.sh";
+
+  makeFlags = [
+    "PLUGIN_DIR_PURPLE=/lib/pidgin/"
+    "DATA_ROOT_DIR_PURPLE=/share"
+    "DESTDIR=$(out)"
+  ];
+
+  postInstall =  ''
+    mkdir -p $out/lib/purple-2
+    cp pidgin/libpurple/protocols/facebook/.libs/*.so $out/lib/purple-2/
+  '';
+
+  buildInputs = [ pidgin glib json_glib mercurial autoreconfHook];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Facebook protocol plugin for libpurple";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ davorb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13999,6 +13999,8 @@ in
 
   pidgin-opensteamworks = callPackage ../applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks { };
 
+  purple-facebook = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-facebook { };
+
   pithos = callPackage ../applications/audio/pithos {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

Adds a package that didn't exist before.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
