### PR TITLE
mgba: git-20160325 -> 0.5.1

### DIFF
--- a/pkgs/misc/emulators/mgba/default.nix
+++ b/pkgs/misc/emulators/mgba/default.nix
@@ -1,21 +1,20 @@
-{ stdenv, fetchgit
+{ stdenv, fetchFromGitHub
 , pkgconfig, cmake, libzip, epoxy, ffmpeg, imagemagick, SDL2
 , qtbase, qtmultimedia }:
 
 stdenv.mkDerivation rec {
-  name = "mgba-git-${version}";
-  version = "20160325";
+  name = "mgba-${version}";
+  version = "0.5.1";
 
-  src = fetchgit {
-    url = "https://github.com/mgba-emu/mgba.git";
-    rev = "be2641c77b4a438e0db487bc82b43bc27a26e0c2";
-    sha256 = "1wxywfbkgqvb0j9cyz4nwsfzhxrdjcmvz1k7rljmy4bz1pjcglj1";
+  src = fetchFromGitHub {
+    owner = "mgba-emu";
+    repo = "mgba";
+    rev = version;
+    sha256 = "1ysxyy888qdwjbgsh3xdzsx8f3a5yd1gqx54xvndpv9v3zqgr2jf";
   };
 
-  buildInputs = [
-    pkgconfig cmake libzip epoxy ffmpeg imagemagick SDL2
-    qtbase qtmultimedia
-  ];
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ libzip epoxy ffmpeg imagemagick SDL2 qtbase qtmultimedia ];
 
   meta = with stdenv.lib; {
     homepage = https://mgba.io;


### PR DESCRIPTION
###### Motivation for this change

Update to 0.5.1
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
