### PR TITLE
smokeping module: fix missing js, broken alerts

### DIFF
--- a/nixos/tests/smokeping.nix
+++ b/nixos/tests/smokeping.nix
@@ -11,9 +11,10 @@ import ./make-test.nix ({ pkgs, ...} : {
         services.smokeping = {
           enable = true;
           port = 8081;
+          mailHost = "127.0.0.2";
           probeConfig = ''
             + FPing
-            binary = ${pkgs.fping}/bin/fping
+            binary = /var/setuid-wrappers/fping
             offset = 0%
           '';
         };
@@ -27,5 +28,6 @@ import ./make-test.nix ({ pkgs, ...} : {
     $sm->waitForFile("/var/lib/smokeping/data/Local/LocalMachine.rrd");
     $sm->succeed("curl -s -f localhost:8081/smokeping.fcgi?target=Local");
     $sm->succeed("ls /var/lib/smokeping/cache/Local/LocalMachine_mini.png");
+    $sm->succeed("ls /var/lib/smokeping/cache/index.html");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Address bugs for missing cropper JS scripts so that detailed zooms on graphs, alert configuration, and static html generation work properly. 
Additionally, fping requires setuid root and set the defaults to provide that.
Add a config statement that allows you to supply a full config rather than breaking the configuration into pieces if you have a previous config and just want to supply it.

This should fix problems reported by @kvz 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The initial commit accidentally left in some commented code and if you were
using alerts, they simply didn't work.

Smokeping also includes some JS code for the webui allowing you to zoom into
graphs and it was not passed into the homedir. Additionally, generate
static html pages for other webservers to serve the cache directory.

Add additional options to specify sendmail path or mailhost and verify that both
are not set.

Add one extra config hook that allows you to bypass all of the invidual config
stanzas and just hand it a string.
