### PR TITLE
pythonPackages.matplotlib: 1.5.1 -> 1.5.3

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -18,11 +18,11 @@ assert enableTk -> (tcl != null)
 
 buildPythonPackage rec {
   name = "matplotlib-${version}";
-  version = "1.5.1";
+  version = "1.5.3";
 
   src = fetchurl {
     url = "mirror://pypi/m/matplotlib/${name}.tar.gz";
-    sha256 = "3ab8d968eac602145642d0db63dd8d67c85e9a5444ce0e2ecb2a8fedc7224d40";
+    sha256 = "1g7bhr6v3wdxyx29rfxgf57l9w19s79cdlpyi0h4y0c5ywwxr9d0";
   };
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";


### PR DESCRIPTION
###### Motivation for this change

The following still fail on `nox-review`, but they also fail on master:
- `python35Packages.scikitimage`
- `python35Packages.librosa`
- `python35Packages.oger`
- `python35Packages-Pweave`
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
