### PR TITLE
afpfs-ng: init at 0.8.2

### DIFF
--- a/pkgs/tools/filesystems/afpfs-ng/default.nix
+++ b/pkgs/tools/filesystems/afpfs-ng/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, fuse, readline, libgcrypt, gmp }:
+
+stdenv.mkDerivation rec {
+  name = "afpfs-ng-${version}";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner  = "simonvetter";
+    repo   = "afpfs-ng";
+    rev    = "f6e24eb73c9283732c3b5d9cb101a1e2e4fade3e";
+    sha256 = "125jx1rsqkiifcffyjb05b2s36rllckdgjaf1bay15k9gzhwwldz";
+  };
+
+  buildInputs = [ fuse readline libgcrypt gmp ];
+
+  meta = with stdenv.lib; {
+    homepage    = https://github.com/simonvetter/afpfs-ng;
+    description = "A client implementation of the Apple Filing Protocol";
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ rnhmjoj ];
+    platform    = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -377,6 +377,8 @@ in
 
   afl = callPackage ../tools/security/afl { };
 
+  afpfs-ng = callPackage ../tools/filesystems/afpfs-ng/default.nix { };
+
   aha = callPackage ../tools/text/aha { };
 
   ahcpd = callPackage ../tools/networking/ahcpd { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using (new package)
- [x] Tested execution of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
