### PR TITLE
lemonbar: 1.2pre -> 1.2

### DIFF
--- a/pkgs/applications/window-managers/lemonbar/default.nix
+++ b/pkgs/applications/window-managers/lemonbar/default.nix
@@ -1,27 +1,22 @@
-{ stdenv, fetchFromGitHub, perl, libxcb }:
+{ stdenv, fetchurl, perl, libxcb }:
 
-let
-  version = "1.2pre";
-in
-  stdenv.mkDerivation rec {
-    name = "lemonbar-${version}";
+stdenv.mkDerivation rec {
+  name = "lemonbar-1.2";
   
-    src = fetchFromGitHub {
-      owner = "LemonBoy";
-      repo = "bar";
-      rev = "61985278f2af1e4e85d63a696ffedc5616b06bc0";
-      sha256 = "0a8djlayimjdg5fj50lpifsv6gkb577bca68wmk9wg9y9n27pgay";
-    };
+  src = fetchurl {
+    url    = "https://github.com/LemonBoy/bar/archive/v1.2.tar.gz";
+    sha256 = "1smz8lh930bnb6a4lrm07l3z2k071kc8p2pljk5wsrch3x2xhimq";
+  };
   
-    buildInputs = [ libxcb perl ];
+  buildInputs = [ libxcb perl ];
   
-    prePatch = ''sed -i "s@/usr@$out@" Makefile'';
+  prePatch = ''sed -i "s@/usr@$out@" Makefile'';
   
-    meta = with stdenv.lib; {
-      description = "A lightweight xcb based bar";
-      homepage = https://github.com/LemonBoy/bar;
-      maintainers = [ maintainers.meisternu ];
-      license = "Custom";   
-      platforms = platforms.linux;
-    };
+  meta = with stdenv.lib; {
+    description = "A lightweight xcb based bar";
+    homepage = https://github.com/LemonBoy/bar;
+    maintainers = [ maintainers.meisternu ];
+    license = "Custom";   
+    platforms = platforms.linux;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Updating a package to a released version.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
