### PR TITLE
lxqt: Add xscreensaver to systemPackages

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -66,6 +66,7 @@ in
       pkgs.menu-cache
       pkgs.openbox # default window manager
       pkgs.qt5.qtsvg # provides QT5 plugins for svg icons
+      pkgs.xscreensaver
     ];
 
     # Link some extra directories in /run/current-system/software/share


### PR DESCRIPTION
###### Motivation for this change

Lock screen does not work without xscreensaver. See https://github.com/NixOS/nixpkgs/pull/19212#issuecomment-252443790.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
