### PR TITLE
input-fonts: fix license

### DIFF
--- a/pkgs/data/fonts/input-fonts/default.nix
+++ b/pkgs/data/fonts/input-fonts/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       characters — but without the limitations of a fixed width.
     '';
     homepage = http://input.fontbureau.com;
-    license = licenses.proprietary;
+    license = licenses.unfree;
     maintainers = with maintainers; [ romildo ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Motivation for this change

License `proprietary` is not valid. Change to `unfree`. See https://github.com/NixOS/nixpkgs/pull/19080#pullrequestreview-3417039.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
