### PR TITLE
grub bootloader: add forceInstall option

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -53,7 +53,7 @@ let
       inherit (args) devices;
       inherit (efi) canTouchEfiVariables;
       inherit (cfg)
-        version extraConfig extraPerEntryConfig extraEntries
+        version extraConfig extraPerEntryConfig extraEntries forceInstall 
         extraEntriesBeforeNixOS extraPrepareConfig configurationLimit copyKernels
         default fsIdentifier efiSupport efiInstallAsRemovable gfxmodeEfi gfxmodeBios;
       path = (makeBinPath ([
@@ -401,6 +401,16 @@ in
         description = ''
           Enable support for encrypted partitions. GRUB should automatically
           unlock the correct encrypted partition and look for filesystems.
+        '';
+      };
+
+      forceInstall = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Whether to try and forcibly install GRUB even if problems are
+          detected. It is not recommended to enable this unless you know what
+          you are doing.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

Currently NixOS can't be installed on a partitionless disk, because grub-install will fail. GRUB recommends against installing on a paritionless disk because it can be unstable, but it will allow the installation if the '--force' option is used.

Even though the partitionless installation isn't recommended it makes sense in some situations. In particular Linode uses partitionless disks for most of its tools. When using GRUB on Linode's platform the bootloader is run on the host machine instead of the VM and the only thing that is used is the grub.cfg file. This is the main motivation for the change as I am attempting to make NixOS work better on Linode's platform

In general I think more options for NixOS is better, even if they may be potentially dangerous. As long as the user is fully informed how dangerous these options are. 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Using the --force option on GRUB isn't recommended, but there are very
specific instances where it makes sense. One example is installing on a
partitionless disk.
