### PR TITLE
Update the packaged Bazel to 0.3.2, and also make it actually work.

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -1,35 +1,70 @@
-{ stdenv, fetchFromGitHub, jdk, zip, zlib, protobuf3_0, pkgconfig, libarchive, unzip, which, makeWrapper }:
-stdenv.mkDerivation rec {
-  version = "0.3.1";
-  name = "bazel-${version}";
+{ stdenv, fetchFromGitHub, buildFHSUserEnv, writeScript, jdk, zip, unzip,
+  which, makeWrapper, binutils }:
 
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "bazel";
-    rev = version;
-    sha256 = "1cm8zjxf8y3ai6h9wndxvflfsijjqhg87fll9ar7ff0hbbbdf6l5";
-  };
+let
 
-  buildInputs = [ pkgconfig protobuf3_0 zlib zip libarchive unzip which makeWrapper jdk ];
+  version = "0.3.2";
 
-  buildPhase = ''
-    export LD_LIBRARY_PATH="${stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
-
-    bash compile.sh
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin $out/share
-    cp -R output $out/share/bazel
-    ln -s $out/share/bazel/bazel $out/bin/bazel
-    wrapProgram $out/bin/bazel --set JAVA_HOME "${jdk.home}"
-  '';
-
-  meta = {
-    homepage = http://github.com/google/bazel/;
+  meta = with stdenv.lib; {
+    homepage = http://github.com/bazelbuild/bazel/;
     description = "Build tool that builds code quickly and reliably";
-    license = stdenv.lib.licenses.asl20;
-    maintainers = [ stdenv.lib.maintainers.philandstuff ];
+    license = licenses.asl20;
+    maintainers = [ maintainers.philandstuff ];
     platforms = [ "x86_64-linux" ];
   };
-}
+
+  bootstrapEnv = buildFHSUserEnv {
+    name = "bazel-bootstrap-env";
+
+    targetPkgs = pkgs: [ ];
+
+    inherit meta;
+  };
+
+  bazelBinary = stdenv.mkDerivation rec {
+    name = "bazel-${version}";
+  
+    src = fetchFromGitHub {
+      owner = "bazelbuild";
+      repo = "bazel";
+      rev = version;
+      sha256 = "085cjz0qhm4a12jmhkjd9w3ic4a67035j01q111h387iklvgn6xg";
+    };
+    patches = [ ./java_stub_template.patch ];
+
+    packagesNotFromEnv = [
+        stdenv.cc stdenv.cc.cc.lib jdk which zip unzip binutils ];
+    buildInputs = packagesNotFromEnv ++ [ bootstrapEnv makeWrapper ];
+
+    buildTimeBinPath = stdenv.lib.makeBinPath packagesNotFromEnv;
+    buildTimeLibPath = stdenv.lib.makeLibraryPath packagesNotFromEnv;
+
+    runTimeBinPath = stdenv.lib.makeBinPath [ jdk stdenv.cc.cc ];
+    runTimeLibPath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib ];
+
+    buildWrapper = writeScript "build-wrapper.sh" ''
+      #! ${stdenv.shell} -e
+      export PATH="${buildTimeBinPath}:$PATH"
+      export LD_LIBRARY_PATH="${buildTimeLibPath}:$LD_LIBRARY_PATH"
+      ./compile.sh
+    '';
+  
+    buildPhase = ''
+      bazel-bootstrap-env ${buildWrapper}
+    '';
+  
+    installPhase = ''
+      mkdir -p $out/bin
+      cp output/bazel $out/bin/
+      wrapProgram $out/bin/bazel \
+          --suffix PATH ":" "${runTimeBinPath}" \
+          --suffix LD_LIBRARY_PATH ":" "${runTimeLibPath}"
+    '';
+  
+    dontStrip = true;
+    dontPatchELF = true;
+  
+    inherit meta;
+  };
+
+in bazelBinary

--- a/pkgs/development/tools/build-managers/bazel/java_stub_template.patch
+++ b/pkgs/development/tools/build-managers/bazel/java_stub_template.patch
@@ -1,0 +1,16 @@
+commit 5525326e3287243e0e7417de96bf7d58d04b4c8b
+Author: Irene Knapp <ireneista@google.com>
+Date:   Sat Oct 8 19:36:12 2016 -0700
+
+    Change #!/bin/bash to #!/usr/bin/env bash.
+
+diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+index f77051f..fbf367a 100644
+--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
++++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+@@ -1,4 +1,4 @@
+-#!/bin/bash --posix
++#!/usr/bin/env bash
+ # Copyright 2014 The Bazel Authors. All rights reserved.
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
###### Motivation for this change

I completely rewrote the nix file for the Bazel build tool, which I don't think had ever resulted in an output that could be used to build things, although it at least compiled without error. It is now referring to the latest upstream.

I have manually tested that at least the cc_binary, cc_library, java_binary, and java_library rules work as they should; I don't have toolchains for things like Android or iOS installed here, so I leave it as future work to make sure everything else is usable.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
