### PR TITLE
Init docker registry service and package

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -235,6 +235,7 @@
   ./services/misc/dictd.nix
   ./services/misc/dysnomia.nix
   ./services/misc/disnix.nix
+  ./services/misc/docker-registry.nix
   ./services/misc/emby.nix
   ./services/misc/errbot.nix
   ./services/misc/etcd.nix

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -156,7 +156,5 @@ with lib;
       "See the 16.09 release notes for more information.")
     (mkRemovedOptionModule [ "services" "phpfpm" "phpIni" ] "")
     (mkRemovedOptionModule [ "services" "dovecot2" "package" ] "")
-    (mkRemovedOptionModule [ "services" "dockerRegistry" ]
-      "docker-registry has been deprecated upstream since a long time.")
   ];
 }

--- a/nixos/modules/services/misc/docker-registry.nix
+++ b/nixos/modules/services/misc/docker-registry.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.dockerRegistry;
+
+in {
+  options.services.dockerRegistry = {
+    enable = mkEnableOption "Docker Registry";
+
+    listenAddress = mkOption {
+      description = "Docker registry host or ip to bind to.";
+      default = "127.0.0.1";
+      type = types.str;
+    };
+
+    port = mkOption {
+      description = "Docker registry port to bind to.";
+      default = 5000;
+      type = types.int;
+    };
+
+    storagePath = mkOption {
+      type = types.path;
+      default = "/var/lib/docker-registry";
+      description = "Docker registry storage path.";
+    };
+
+    extraConfig = mkOption {
+      description = ''
+        Docker extra registry configuration via environment variables.
+      '';
+      default = {};
+      type = types.attrsOf types.str;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.docker-registry = {
+      description = "Docker Container Registry";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment = {
+        REGISTRY_HTTP_ADDR = "${cfg.listenAddress}:${toString cfg.port}";
+        REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY = cfg.storagePath;
+      } // cfg.extraConfig;
+
+      script = ''
+        ${pkgs.docker-distribution}/bin/registry serve \
+          ${pkgs.docker-distribution.out}/share/go/src/github.com/docker/distribution/cmd/registry/config-example.yml
+      '';
+
+      serviceConfig = {
+        User = "docker-registry";
+        WorkingDirectory = cfg.storagePath;
+      };
+    };
+
+    users.extraUsers.docker-registry = {
+      createHome = true;
+      home = cfg.storagePath;
+    };
+  };
+}

--- a/nixos/tests/docker-registry.nix
+++ b/nixos/tests/docker-registry.nix
@@ -1,0 +1,45 @@
+# This test runs docker-registry and check if it works
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "docker-registry";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ globin ];
+  };
+
+  nodes = {
+    registry = { config, pkgs, ... }: {
+      services.dockerRegistry.enable = true;
+      services.dockerRegistry.port = 8080;
+      services.dockerRegistry.listenAddress = "0.0.0.0";
+      networking.firewall.allowedTCPPorts = [ 8080 ];
+    };
+
+    client1 = { config, pkgs, ...}: {
+      virtualisation.docker.enable = true;
+      virtualisation.docker.socketActivation = false;
+      virtualisation.docker.extraOptions = "--insecure-registry registry:8080";
+    };
+
+    client2 = { config, pkgs, ...}: {
+      virtualisation.docker.enable = true;
+      virtualisation.docker.socketActivation = false;
+      virtualisation.docker.extraOptions = "--insecure-registry registry:8080";
+    };
+  };
+
+  testScript = ''
+    $client1->start();
+    $client1->waitForUnit("docker.service");
+    $client1->succeed("tar cv --files-from /dev/null | docker import - scratch");
+    $client1->succeed("docker tag scratch registry:8080/scratch");
+
+    $registry->start();
+    $registry->waitForUnit("docker-registry.service");
+    $client1->succeed("docker push registry:8080/scratch");
+
+    $client2->start();
+    $client2->waitForUnit("docker.service");
+    $client2->succeed("docker pull registry:8080/scratch");
+    $client2->succeed("docker images | grep scratch");
+  '';
+})

--- a/pkgs/applications/virtualization/docker-distribution/default.nix
+++ b/pkgs/applications/virtualization/docker-distribution/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "distribution-${version}";
+  version = "2.5.1";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/docker/distribution";
+
+  src = fetchFromGitHub {
+    owner = "docker";
+    repo = "distribution";
+    inherit rev;
+    sha256 = "08nxcsl9bc3k9gav2mkqccm5byrlfcgy6qaqaywiyza0b0cn4kdc";
+  };
+
+  meta = with stdenv.lib; {
+    description = "The Docker toolset to pack, ship, store, and deliver content";
+    license = licenses.asl20;
+    maintainers = [ maintainers.globin ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12377,6 +12377,8 @@ in
 
   docker-machine = callPackage ../applications/networking/cluster/docker-machine { };
 
+  docker-distribution = callPackage ../applications/virtualization/docker-distribution { };
+
   doodle = callPackage ../applications/search/doodle { };
 
   drumgizmo = callPackage ../applications/audio/drumgizmo { };


### PR DESCRIPTION
###### Motivation for this change

Re-adding the docker registry service with their new software.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
