### PR TITLE
androidenv: Add API sources

### DIFF
--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -1,8 +1,9 @@
 { stdenv, stdenv_32bit, fetchurl, unzip, makeWrapper
-, platformTools, buildTools, support, supportRepository, platforms, sysimages, addons
+, platformTools, buildTools, support, supportRepository, platforms, sysimages, addons, sources
 , libX11, libXext, libXrender, libxcb, libXau, libXdmcp, libXtst, mesa, alsaLib
 , freetype, fontconfig, glib, gtk2, atk, file, jdk, coreutils, libpulseaudio, dbus
 , zlib, glxinfo, xkeyboardconfig
+, includeSources
 }:
 { platformVersions, abiVersions, useGoogleAPIs, useExtraSupportLibs ? false, useGooglePlayServices ? false }:
 
@@ -164,6 +165,22 @@ stdenv.mkDerivation rec {
      else ""}
       
     cd ../..
+
+    # Symlink required sources
+    mkdir -p sources
+    cd sources
+
+    ${if includeSources then
+        stdenv.lib.concatMapStrings (platformVersion:
+        if (builtins.hasAttr ("source_"+platformVersion) sources) then
+          let
+            source = builtins.getAttr ("source_"+platformVersion) sources;
+          in
+          "ln -s ${source}/* android-${platformVersion}\n"
+        else "") platformVersions
+      else ""}
+
+    cd ..
 
     # Symlink required platforms
    

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -1,4 +1,4 @@
-{pkgs, pkgs_i686}:
+{pkgs, pkgs_i686, includeSources ? true}:
 
 rec {
   platformTools = import ./platform-tools.nix {
@@ -39,12 +39,16 @@ rec {
     inherit (pkgs) stdenv fetchurl unzip;
   };
 
+  sources = import ./sources.nix {
+    inherit (pkgs) stdenv fetchurl unzip;
+  };
+
   androidsdk = import ./androidsdk.nix {
     inherit (pkgs) stdenv fetchurl unzip makeWrapper;
     inherit (pkgs) zlib glxinfo freetype fontconfig glib gtk2 atk mesa file alsaLib jdk coreutils libpulseaudio dbus;
     inherit (pkgs.xorg) libX11 libXext libXrender libxcb libXau libXdmcp libXtst xkeyboardconfig;
     
-    inherit platformTools buildTools support supportRepository platforms sysimages addons;
+    inherit platformTools buildTools support supportRepository platforms sysimages addons sources includeSources;
     
     stdenv_32bit = pkgs_i686.stdenv;
   };

--- a/pkgs/development/mobile/androidenv/fetch.sh
+++ b/pkgs/development/mobile/androidenv/fetch.sh
@@ -12,3 +12,4 @@ curl -o sys-img.xml       https://dl.google.com/android/repository/sys-img/andro
 ./generate-addons.sh
 ./generate-platforms.sh
 ./generate-sysimages.sh
+./generate-sources.sh

--- a/pkgs/development/mobile/androidenv/generate-sources.sh
+++ b/pkgs/development/mobile/androidenv/generate-sources.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+xsltproc generate-sources.xsl repository-11.xml > sources.nix

--- a/pkgs/development/mobile/androidenv/generate-sources.xsl
+++ b/pkgs/development/mobile/androidenv/generate-sources.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:sdk="http://schemas.android.com/sdk/android/repository/11">
+
+  <xsl:output omit-xml-declaration="yes" indent="no" />
+
+  <xsl:template name="repository-url">
+    <xsl:variable name="raw-url" select="sdk:archives/sdk:archive/sdk:url"/>
+    <xsl:choose>
+      <xsl:when test="starts-with($raw-url, 'http')">
+        <xsl:value-of select="$raw-url"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>https://dl.google.com/android/repository/</xsl:text>
+        <xsl:value-of select="$raw-url"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="/sdk:sdk-repository">
+# This file is generated from generate-sources.sh. DO NOT EDIT.
+# Execute generate-sources.sh or fetch.sh to update the file.
+{stdenv, fetchurl, unzip}:
+
+let
+  buildSource = args:
+    stdenv.mkDerivation (args // {
+      buildInputs = [ unzip ];
+      buildCommand = ''
+        mkdir -p $out
+        cd $out
+        unzip $src
+    '';
+  });
+in
+{
+<xsl:for-each select="sdk:source"><xsl:sort select="sdk:api-level" data-type="number"/>
+  source_<xsl:value-of select="sdk:api-level" /> = buildSource {
+    name = "android-source-<xsl:value-of select="sdk:api-level" />";
+    src = fetchurl {
+      url = <xsl:call-template name="repository-url"/>;
+      sha1 = "<xsl:value-of select="sdk:archives/sdk:archive/sdk:checksum[@type='sha1']" />";
+    };
+    meta = {
+      description = "Source code for Android API <xsl:value-of select="sdk:api-level" />";
+    };
+  };
+</xsl:for-each>
+}
+</xsl:template>
+</xsl:stylesheet>

--- a/pkgs/development/mobile/androidenv/sources.nix
+++ b/pkgs/development/mobile/androidenv/sources.nix
@@ -1,0 +1,140 @@
+
+# This file is generated from generate-sources.sh. DO NOT EDIT.
+# Execute generate-sources.sh or fetch.sh to update the file.
+{stdenv, fetchurl, unzip}:
+
+let
+  buildSource = args:
+    stdenv.mkDerivation (args // {
+      buildInputs = [ unzip ];
+      buildCommand = ''
+        mkdir -p $out
+        cd $out
+        unzip $src
+    '';
+  });
+in
+{
+
+  source_14 = buildSource {
+    name = "android-source-14";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-14_r01.zip;
+      sha1 = "eaf4ed7dcac46e68516a1b4aa5b0d9e5a39a7555";
+    };
+    meta = {
+      description = "Source code for Android API 14";
+    };
+  };
+
+  source_15 = buildSource {
+    name = "android-source-15";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-15_r02.zip;
+      sha1 = "e5992a5747c9590783fbbdd700337bf0c9f6b1fa";
+    };
+    meta = {
+      description = "Source code for Android API 15";
+    };
+  };
+
+  source_16 = buildSource {
+    name = "android-source-16";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-16_r02.zip;
+      sha1 = "0f83c14ed333c45d962279ab5d6bc98a0269ef84";
+    };
+    meta = {
+      description = "Source code for Android API 16";
+    };
+  };
+
+  source_17 = buildSource {
+    name = "android-source-17";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-17_r01.zip;
+      sha1 = "6f1f18cd2d2b1852d7f6892df9cee3823349d43a";
+    };
+    meta = {
+      description = "Source code for Android API 17";
+    };
+  };
+
+  source_18 = buildSource {
+    name = "android-source-18";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-18_r01.zip;
+      sha1 = "8b49fdf7433f4881a2bfb559b5dd05d8ec65fb78";
+    };
+    meta = {
+      description = "Source code for Android API 18";
+    };
+  };
+
+  source_19 = buildSource {
+    name = "android-source-19";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-19_r02.zip;
+      sha1 = "433a1d043ef77561571250e94cb7a0ef24a202e7";
+    };
+    meta = {
+      description = "Source code for Android API 19";
+    };
+  };
+
+  source_20 = buildSource {
+    name = "android-source-20";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-20_r01.zip;
+      sha1 = "8da3e40f2625f9f7ef38b7e403f49f67226c0d76";
+    };
+    meta = {
+      description = "Source code for Android API 20";
+    };
+  };
+
+  source_21 = buildSource {
+    name = "android-source-21";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-21_r01.zip;
+      sha1 = "137a5044915d32bea297a8c1552684802bbc2e25";
+    };
+    meta = {
+      description = "Source code for Android API 21";
+    };
+  };
+
+  source_22 = buildSource {
+    name = "android-source-22";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-22_r01.zip;
+      sha1 = "98320e13976d11597a4a730a8d203ac9a03ed5a6";
+    };
+    meta = {
+      description = "Source code for Android API 22";
+    };
+  };
+
+  source_23 = buildSource {
+    name = "android-source-23";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-23_r01.zip;
+      sha1 = "b0f15da2762b42f543c5e364c2b15b198cc99cc2";
+    };
+    meta = {
+      description = "Source code for Android API 23";
+    };
+  };
+
+  source_24 = buildSource {
+    name = "android-source-24";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-24_r01.zip;
+      sha1 = "6b96115830a83d654479f32ce4b724ca9011148b";
+    };
+    meta = {
+      description = "Source code for Android API 24";
+    };
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

Installing API sources of Android SDK. This enables looking up symbol definitions from Android Studio.

This fixes #18918.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
