### PR TITLE
openssh: always enable with-kerberos on darwin

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2984,7 +2984,7 @@ in
   openssh =
     callPackage ../tools/networking/openssh {
       hpnSupport = false;
-      withKerberos = false;
+      withKerberos = if stdenv.isDarwin then true else false;
       etcDir = "/etc/ssh";
       pam = if stdenv.isLinux then pam else null;
     };


### PR DESCRIPTION
###### Motivation for this change

On darwin, /etc/ssh/ssh_config uses GSSAPIAuthentication and GSSAPIDelegateCredential, which is enabled by kerberos optional feature. Enabling this feature by default on darwin makes all packages depending on "openssh" (e.g. git) work on darwin without editing this system file.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
