### PR TITLE
maia-icon-theme: -> 2016-09-16

### DIFF
--- a/pkgs/data/icons/maia-icon-theme/default.nix
+++ b/pkgs/data/icons/maia-icon-theme/default.nix
@@ -1,21 +1,24 @@
 { stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation {
-  name = "maia-icon-theme";
+stdenv.mkDerivation rec {
+  name = "maia-icon-theme-${version}";
+  version = "2016-09-16";
 
   src = fetchFromGitHub {
     owner = "manjaro";
     repo = "artwork-maia";
-    rev = "23235fa56e6111d30e9f92576030cc855a0facbe";
-    sha256 = "1d5bv13gds1nx88pc6a9gkrz1lb8sji0wcc5h3bf4mjw0q072nfr";
+    rev = "f6718cd9c383adb77af54b694c47efa4d581f5b5";
+    sha256 = "0f9l3k9abgg8islzddrxgbxaw6vbai5bvz5qi1v2fzir7ykx7bgj";
   };
 
   dontBuild = true;
   
   installPhase = ''
     install -dm 755 $out/share/icons
-    rm icons/CMakeLists.txt
-    cp -dr --no-preserve='ownership' icons $out/share/icons/Maia
+    for f in "" "-dark"; do
+      rm icons$f/CMakeLists.txt
+      cp -dr --no-preserve='ownership' icons$f $out/share/icons/maia$f
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add versioning using the date of revision on the git repository. Also
update to the latest revision, which includes a dark version of the icon
theme.

The cmake scripts install the icons at subdirectories 'maia' and
'maia-dark'. Also use these names. The difference is in the
capitalization of the names.
