### PR TITLE
container: fix extraVeth submodule usage

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -473,7 +473,7 @@ in
             };
 
             extraVeths = mkOption {
-              type = with types; attrsOf (submodule networkOptions);
+              type = with types; attrsOf (submodule { options = networkOptions; });
               default = {};
               description = ''
                 Extra veth-pairs to be created for the container


### PR DESCRIPTION
###### Motivation for this change

The obsolescence for the optionset was not done correctly here. Fix the extraVeth and the test for it.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

the submodule needs options, not a plain set.
