### PR TITLE
llvm-3.8: Fix clang build on non-darwin.

### DIFF
--- a/pkgs/development/compilers/llvm/3.8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/clang/default.nix
@@ -39,7 +39,10 @@ let
       ln -sv $out/bin/clang $out/bin/cpp
 
       mkdir -p $python/bin $python/share/clang/
-      mv $out/bin/{git-clang-format,scan-view,set-xcode-analyzer} $python/bin
+      mv $out/bin/{git-clang-format,scan-view} $python/bin
+      if [ -e $out/bin/set-xcode-analyzer ]; then
+        mv $out/bin/set-xcode-analyzer $python/bin
+      fi
       mv $out/share/clang/*.py $python/share/clang
 
       rm $out/bin/c-index-test


### PR DESCRIPTION
###### Motivation for this change

LLVM 3.8 no longer builds on NixOS or Linux after 7b9d3f860588c5157ec9cb2a325e9e16a2ab6e17
due to the postInstall referencing something that only is created on Darwin.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

'set-xcode-analyzer' is only installed on APPLE.
