### PR TITLE
handbrake: add libx265 to LD_LIBRARY_PATH

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation rec {
     lame ffmpeg libdvdread libdvdnav libbluray mp4v2 mpeg2dec x264 x265 libvpx
   ] ++ buildInputsX;
 
-
   src = fetchurl {
     url = "http://download.handbrake.fr/releases/${version}/HandBrake-${version}.tar.bz2";
     sha256 = "1w720y3bplkz187wgvy4a4xm0vpppg45mlni55l6yi8v2bfk14pv";
@@ -73,6 +72,11 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     cd build
+  '';
+
+  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath [ x265 ];
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${LD_LIBRARY_PATH}")
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Handbrake has a runtime dependency on libx265 that isn't automatically detected by nix.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
