### PR TITLE
Add libgee_0_8 and valadoc-unstable

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -240,7 +240,7 @@
   lucas8 = "Luc Chabassier <luc.linux@mailoo.org>";
   ludo = "Ludovic Courtès <ludo@gnu.org>";
   luispedro = "Luis Pedro Coelho <luis@luispedro.org>";
-  lukasepple = "Lukas Epple <post@lukasepple.de>";
+  sternenseemann = "Lukas Epple <post@lukasepple.de>";
   lukego = "Luke Gorrie <luke@snabb.co>";
   lw = "Sergey Sofeychuk <lw@fmap.me>";
   madjar = "Georges Dubus <georges.dubus@compiletoi.net>";

--- a/pkgs/development/libraries/libgee/0.8.nix
+++ b/pkgs/development/libraries/libgee/0.8.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pkgconfig, glib }:
+
+let
+  ver_maj = "0.8";
+  ver_min = "6";
+in
+stdenv.mkDerivation rec {
+  name = "libgee-${ver_maj}.${ver_min}";
+
+  src = fetchurl {
+    url = "https://download.gnome.org/sources/libgee/${ver_maj}/${name}.tar.xz";
+    sha256 = "1mp3bfghc8qh2v8h2pfhksda22mgy2d5ygm1jr3bir544nr8i4fg";
+  };
+
+  buildInputs = [ glib ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Utility library providing GObject-based interfaces and classes for commonly used data structures";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    homepage = "http://live.gnome.org/Libgee";
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/development/libraries/libgee/0.8.nix
+++ b/pkgs/development/libraries/libgee/0.8.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     homepage = "http://live.gnome.org/Libgee";
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ sternenseemann ];
   };
 }

--- a/pkgs/development/tools/valadoc/default.nix
+++ b/pkgs/development/tools/valadoc/default.nix
@@ -1,0 +1,24 @@
+{stdenv, fetchgit, gnome3, automake, autoconf, which, libtool, pkgconfig, graphviz, glib, libgee_0_8, gobjectIntrospection, expat}:
+stdenv.mkDerivation rec {
+  version = "2016-10-09";
+  name = "valadoc-unstable-${version}";
+
+  src = fetchgit {
+    url = "git://git.gnome.org/valadoc";
+    rev = "37756970379d1363453562e9f2af2c354d172fb4";
+    sha256 = "1s9sf6f0srh5sqqikswnb3bgwv5s1r9bd4n10hs2lzfmh7z227qb";
+  };
+
+  nativeBuildInputs = [ automake autoconf which gnome3.vala libtool pkgconfig gobjectIntrospection ];
+  buildInputs = [ graphviz glib libgee_0_8 expat ];
+
+  preConfigure = "./autogen.sh";
+
+  meta = with stdenv.lib; {
+    description = "valadoc is a documentation generator for generating API documentation from Vala source code";
+    homepage = http://valadoc.org;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with maintainers; [ sternenseemann ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     description = "Firmware for Intel 2200BG cards";
     homepage = http://ipw2200.sourceforge.net/firmware.php;
     license = stdenv.lib.licenses.unfreeRedistributableFirmware;
-    maintainers = with maintainers; [ lukasepple ];
+    maintainers = with maintainers; [ sternenseemann ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/tools/backup/rdup/default.nix
+++ b/pkgs/tools/backup/rdup/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/miekg/rdup";
     license    = stdenv.lib.licenses.gpl3;
     platforms   = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ lukasepple ];
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5200,6 +5200,8 @@ in
 
   vala_0_32 = callPackage ../development/compilers/vala/0.32.nix { };
 
+  valadoc = callPackage ../development/tools/valadoc { };
+
   vs90wrapper = callPackage ../development/compilers/vs90wrapper { };
 
   wla-dx = callPackage ../development/compilers/wla-dx { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7646,6 +7646,8 @@ in
 
   libgee_0_6 = callPackage ../development/libraries/libgee/0.6.nix { };
 
+  libgee_0_8 = callPackage ../development/libraries/libgee/0.8.nix { };
+
   libgig = callPackage ../development/libraries/libgig { };
 
   libgnome_keyring = callPackage ../development/libraries/libgnome-keyring { };


### PR DESCRIPTION
###### Motivation for this change
- libhttpseverywhere and valadoc which I am currently packaging require this specific version of libgee.
- valadoc is needed by libhttpseverywhere as well
  ###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
