### PR TITLE
slack: 2.1.2 -> 2.2.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -4,7 +4,7 @@
 
 let
 
-  version = "2.1.2";
+  version = "2.2.1";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -43,7 +43,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://slack-ssb-updates.global.ssl.fastly.net/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "0bmz9d0p6676lzl4qxy6xmcampr2ilkc0mhh67860kcxjaz6sms6";
+        sha256 = "1x08bmkanllv3lpi2s722xs7qia8igf6zxzkc3g7vs5jms3mdrad";
       }
     else
       throw "Slack is not supported on ${stdenv.system}";


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
