### PR TITLE
sddm service: Install SDDM when enabling it as a display manager

### DIFF
--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -251,6 +251,7 @@ in
     };
 
     environment.etc."sddm.conf".source = cfgFile;
+    environment.systemPackages = [ pkgs.sddm ];
 
     users.extraGroups.sddm.gid = config.ids.gids.sddm;
 


### PR DESCRIPTION
###### Motivation for this change

SDDM was not installed when it was enabled as a display manager. This resulted in an empty text mode screen when display-manager.service was started.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
