### PR TITLE
cmake: Enable parallel build during bootstrap phase.

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/2.8.nix
+++ b/pkgs/development/tools/build-managers/cmake/2.8.nix
@@ -50,9 +50,12 @@ stdenv.mkDerivation rec {
   CMAKE_PREFIX_PATH = concatStringsSep ":"
     (concatMap (p: [ (p.dev or p) (p.out or p) ]) buildInputs);
 
-  configureFlags =
-    "--docdir=/share/doc/${name} --mandir=/share/man --system-libs --no-system-libarchive"
-    + stdenv.lib.optionalString useQt4 " --qt-gui";
+  configureFlags = [
+    "--docdir=/share/doc/${name}"
+    "--mandir=/share/man"
+    "--system-libs"
+    "--no-system-libarchive"
+   ] ++ stdenv.lib.optional useQt4 "--qt-gui";
 
   setupHook = ./setup-hook.sh;
 
@@ -66,6 +69,7 @@ stdenv.mkDerivation rec {
         --subst-var-by glibc_bin ${getBin glibc} \
         --subst-var-by glibc_dev ${getDev glibc} \
         --subst-var-by glibc_lib ${getLib glibc}
+      configureFlags="--parallel=''${NIX_BUILD_CORES:-1} $configureFlags"
     '';
 
   meta = {

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
         --subst-var-by glibc_lib ${getLib glibc}
       substituteInPlace Modules/FindCxxTest.cmake \
         --replace "$""{PYTHON_EXECUTABLE}" ${stdenv.shell}
+      configureFlags="--parallel=''${NIX_BUILD_CORES:-1} $configureFlags"
     '';
   configureFlags =
     [ "--docdir=share/doc/${name}"


### PR DESCRIPTION
###### Motivation for this change

The bootstrap phase of cmake takes much less time when built in parallel,
but we weren't previously using it because it requires a flag given to 'configure'
which is not how build parallelism is normally enabled.

(configure is really a wrapper for the bootstrap script)

With this change, cmake's overall build time goes from 185s to 81s on my machine.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
- Convert cmake 2.8's configureFlags to array
- Set --parallel flag in preConfigure so NIX_BUILD_CORES is expanded.
