### PR TITLE
styx: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/applications/misc/styx/default.nix
+++ b/pkgs/applications/misc/styx/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name    = "styx-${version}";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner  = "styx-static";
     repo   = "styx";
     rev    = "v${version}";
-    sha256 = "0lz6mfawschfjg4mvfsqz9dv884x2lcg787zjdlnhdi5yqmjx29r";
+    sha256 = "1bcd0ss628mhchrl85fy6acxcxqvm1d3qywfaxhikahl1r7inpwg";
   };
 
   server = caddy.bin;
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
     asciidoctor $sourceRoot/doc/manual.doc -o $out/share/doc/styx/index.html
 
     substituteAllInPlace $out/bin/styx
-    substituteAllInPlace $out/share/styx/sample/templates/feed.nix
     substituteAllInPlace $out/share/doc/styx/index.html
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Update styx to the latest version.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
