### PR TITLE
opentyrian: 0.0.955 -> 2.1.20130907

### DIFF
--- a/pkgs/games/opentyrian/default.nix
+++ b/pkgs/games/opentyrian/default.nix
@@ -1,21 +1,20 @@
-{stdenv, fetchhg, fetchurl, unzip, SDL, SDL_net}:
+{stdenv, fetchurl, fetchzip, SDL, SDL_net}:
 
 stdenv.mkDerivation rec {
   name = "opentyrian-${version}";
-  version = "0.0.955";
+  version = "2.1.20130907";
 
-  src = fetchhg {
-    url = "https://opentyrian.googlecode.com/hg/";
-    rev = "13ef8ce47362";
-    md5 = "95c8f9e7ff3d4207f1c692c7cec6c9b0";
+  src = fetchurl {
+    url = "https://bitbucket.org/opentyrian/opentyrian/get/${version}.tar.gz";
+    sha256 = "1jnrkq616pc4dhlbd4n30d65vmn25q84w6jfv9383l9q20cqf2ph";
   };
 
-  data = fetchurl {
+  data = fetchzip {
     url = http://sites.google.com/a/camanis.net/opentyrian/tyrian/tyrian21.zip;
-    md5 = "2a3b206a6de25ed4b771af073f8ca904";
+    sha256 = "1biz6hf6s7qrwn8ky0g6p8w7yg715w7yklpn6258bkks1s15hpdb";
   };
 
-  buildInputs = [SDL SDL_net unzip];
+  buildInputs = [SDL SDL_net];
 
   patchPhase = "
     substituteInPlace src/file.c --replace /usr/share $out/share
@@ -25,12 +24,12 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp ./opentyrian $out/bin
     mkdir -p $out/share/opentyrian/data
-    unzip -j $data -d $out/share/opentyrian/data
+    cp -r $data/* $out/share/opentyrian/data
   ";
 
   meta = {
     description = ''Open source port of the game "Tyrian"'';
-    homepage = https://opentyrian.googlecode.com/;
+    homepage = https://bitbucket.org/opentyrian/opentyrian;
     # This does not account of Tyrian data.
     # license = stdenv.lib.licenses.gpl2;
   };


### PR DESCRIPTION
###### Motivation for this change

md5 checksum
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
