### PR TITLE
qps: init at 1.10.16

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -61,6 +61,7 @@ in
       pkgs.lxqt.obconf-qt
       pkgs.lxqt.pavucontrol-qt
       pkgs.lxqt.pcmanfm-qt
+      pkgs.lxqt.qps
       pkgs.lxqt.qterminal
       pkgs.lxqt.qtermwidget
       pkgs.menu-cache

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -59,6 +59,7 @@ let
     compton-conf = callPackage ./optional/compton-conf { };
     obconf-qt = callPackage ./optional/obconf-qt { };
     lximage-qt = callPackage ./optional/lximage-qt { };
+    qps = callPackage ./optional/qps { };
    
   };
 

--- a/pkgs/desktops/lxqt/optional/qps/default.nix
+++ b/pkgs/desktops/lxqt/optional/qps/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, cmake, qt5, makeDesktopItem }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "qps";
+  version = "1.10.16";
+
+  srcs = fetchFromGitHub {
+    owner = "QtDesktop";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1s6hvqfv9hv1cl5pfsmghqn1zqhibr4plq3glzgd8s7swwdnsvjj";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "qps";
+    exec = "qps";
+    icon = "qps";
+    comment = "Visual process manager - Qt version of ps/top";
+    desktopName = "qps";
+    genericName = meta.description;
+    categories = "System;";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ qt5.qtbase qt5.qtx11extras ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/{man/man1,doc,icons}}
+    cp -a src/qps $out/bin/
+    cp -a ../README.md $out/share/doc/
+    cp -a ../qps.1 $out/share/man/man1/
+    cp -a ../icon/icon.xpm $out/share/icons/qps.xpm
+    ln -sv "${desktopItem}/share/applications" $out/share/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The Qt process manager";
+    homepage = https://github.com/QtDesktop/qps;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ romildo ];
+    platforms = with platforms; unix;
+  };
+}


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
