### PR TITLE
valadoc: use newer libgee

### DIFF
--- a/pkgs/development/tools/valadoc/default.nix
+++ b/pkgs/development/tools/valadoc/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchgit, gnome3, automake, autoconf, which, libtool, pkgconfig, graphviz, glib, libgee_0_8, gobjectIntrospection, expat}:
+{stdenv, fetchgit, gnome3, automake, autoconf, which, libtool, pkgconfig, graphviz, glib, gobjectIntrospection, expat}:
 stdenv.mkDerivation rec {
   version = "2016-10-09";
   name = "valadoc-unstable-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ automake autoconf which gnome3.vala libtool pkgconfig gobjectIntrospection ];
-  buildInputs = [ graphviz glib libgee_0_8 expat ];
+  buildInputs = [ graphviz glib gnome3.libgee expat ];
 
   preConfigure = "./autogen.sh";
 


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Actually valadoc does not depend on libgee 0.8 but on the
libgee 0.8 API as defined in a gir file. I didn't notice the
difference earlier.
