### PR TITLE
meson: 0.32 -> 0.35

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,10 +1,11 @@
 { lib, python3Packages, fetchurl }:
 python3Packages.buildPythonPackage rec {
-  name = "meson-0.32.0";
+  version = "0.35.0";
+  name = "meson-${version}";
 
   src = fetchurl {
     url = "mirror://pypi/m/meson/${name}.tar.gz";
-    sha256 = "1i5m4q53sr55aw8kx761kh0rsfwkpq0gfa0c0k3jf66y4aml6n54";
+    sha256 = "0w4vian55cwcv2m5qzn73aznf9a0y24cszqb7dkpahrb9yrg25l3";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
