### PR TITLE
scribus: depend on pythonFull

### DIFF
--- a/pkgs/applications/office/scribus/default.nix
+++ b/pkgs/applications/office/scribus/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, freetype, lcms, libtiff, libxml2
-, libart_lgpl, qt4, python, cups, fontconfig, libjpeg
+, libart_lgpl, qt4, pythonFull, cups, fontconfig, libjpeg
 , zlib, libpng, xorg, cairo, podofo, aspell, boost, cmake }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = with xorg;
     [ pkgconfig cmake freetype lcms libtiff libxml2 libart_lgpl qt4
-      python cups fontconfig
+      pythonFull cups fontconfig
       libjpeg zlib libpng podofo aspell cairo
       boost # for internal 2geom library
       libXaw libXext libX11 libXtst libXi libXinerama


### PR DESCRIPTION
###### Motivation for this change

fix #19292
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [*] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [*] Tested execution of all binary files (usually in `./result/bin/`)
- [*] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

tkinter is needed for some scripts and is not found by just depending on python.modules.tkinter
Fixes #19292
