### PR TITLE
libcaca: fix missing darwin inputs

### DIFF
--- a/pkgs/development/libraries/libcaca/default.nix
+++ b/pkgs/development/libraries/libcaca/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, zlib, imlib2, pkgconfig, libX11 }:
+{ stdenv, fetchurl, ncurses, zlib, imlib2, pkgconfig, libX11, libXext }:
 
 stdenv.mkDerivation rec {
   name = "libcaca-0.99.beta19";
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "man" ];
 
-  propagatedBuildInputs = [ ncurses zlib imlib2 pkgconfig libX11 ];
+  propagatedBuildInputs = [ ncurses zlib imlib2 pkgconfig libX11 ]
+   ++ stdenv.lib.optional stdenv.isDarwin libXext;
 
   postInstall = ''
     mkdir -p $dev/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7477,7 +7477,7 @@ in
   libburn = callPackage ../development/libraries/libburn { };
 
   libcaca = callPackage ../development/libraries/libcaca {
-    inherit (xlibs) libX11;
+    inherit (xlibs) libX11 libXext;
   };
 
   libcanberra_gtk3 = callPackage ../development/libraries/libcanberra {


### PR DESCRIPTION
###### Motivation for this change

http://hydra.nixos.org/build/41806046/log
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] OS X
  - [x] No changes on other platforms
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
