### PR TITLE
ocamlnet: 4.1.1 -> 4.1.2

### DIFF
--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -2,11 +2,11 @@
 , gnutls, nettle }:
 
 stdenv.mkDerivation {
-  name = "ocamlnet-4.1.1";
+  name = "ocamlnet-4.1.2";
 
   src = fetchurl {
-    url = http://download.camlcity.org/download/ocamlnet-4.1.1.tar.gz;
-    sha256 = "1z0j542dfzfimsn4asw1ycb4ww561pv92cz6s6kxazvgx60c5rb1";
+    url = http://download.camlcity.org/download/ocamlnet-4.1.2.tar.gz;
+    sha256 = "1n0l9zlq7dc5yr43bpa4a0b6bxj3iyjkadbb41g59zlwa8hkk34i";
   };
 
   buildInputs = [ ncurses ocaml findlib ocaml_pcre camlzip gnutls pkgconfig nettle ];


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
