### PR TITLE
libhttpseverywhere: init at 0.1.0

### DIFF
--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -1,0 +1,36 @@
+{stdenv, fetchFromGitHub, gnome3, glib, json_glib, libxml2, libarchive, libsoup, gobjectIntrospection, meson, ninja, pkgconfig,  valadoc}:
+
+stdenv.mkDerivation rec {
+  name = "libhttpseverywhere-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "grindhold";
+    repo  = "libhttpseverywhere";
+    rev = "${version}";
+    sha256 = "1b8bcg4jp2h3nwk1g7jgswsipqzkjq2gb017v07wb7nvl6kdi0rc";
+  };
+
+  nativeBuildInputs = [ gnome3.vala valadoc  gobjectIntrospection meson ninja pkgconfig ];
+  buildInputs = [ glib gnome3.libgee libxml2 json_glib libsoup libarchive ];
+
+  patches = [ ./meson.patch ];
+
+  configurePhase = ''
+    mkdir build
+    cd build
+    meson.py --prefix "$out" ..
+  '';
+
+  buildPhase = "ninja";
+
+  installPhase = "ninja install";
+
+  meta = {
+    description = "library to use HTTPSEverywhere in desktop applications";
+    homepage    = https://github.com/grindhold/libhttpseverywhere;
+    license     = stdenv.lib.licenses.lgpl3;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/libraries/libhttpseverywhere/meson.patch
+++ b/pkgs/development/libraries/libhttpseverywhere/meson.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index c20c2f9..f40bb2b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -19,7 +19,7 @@
+ # If not, see http://www.gnu.org/licenses/.
+ #*********************************************************************
+ 
+-project ('httpseverywhere', ['vala','c'])
++project ('httpseverywhere', 'vala','c')
+ 
+ pkgconfig = import('pkgconfig')
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7764,6 +7764,8 @@ in
 
   libhif = callPackage ../tools/package-management/libhif { sphinx = python27Packages.sphinx; };
 
+  libhttpseverywhere = callPackage ../development/libraries/libhttpseverywhere { };
+
   libHX = callPackage ../development/libraries/libHX { };
 
   libibmad = callPackage ../development/libraries/libibmad { };


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
