### PR TITLE
epiphany: fix tls support

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/epiphany/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
                   webkitgtk libsoup libsecret gnome_desktop libnotify libtool
                   sqlite isocodes nss itstool p11_kit nspr icu gnome3.yelp_tools
                   gdk_pixbuf gnome3.defaultIconTheme librsvg which gnome_common
-                  gcr avahi gnome3.gsettings_desktop_schemas gnome3.dconf ];
+                  gcr avahi gnome3.gsettings_desktop_schemas gnome3.dconf
+                  gnome3.glib_networking ];
 
   NIX_CFLAGS_COMPILE = "-I${nspr.dev}/include/nspr -I${nss.dev}/include/nss -I${glib.dev}/include/gio-unix-2.0";
 


### PR DESCRIPTION
###### Motivation for this change

Add SSL and TLS support.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
