### PR TITLE
vim module: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -84,6 +84,7 @@
   ./programs/ssmtp.nix
   ./programs/tmux.nix
   ./programs/venus.nix
+  ./programs/vim.nix
   ./programs/wvdial.nix
   ./programs/xfs_quota.nix
   ./programs/xonsh.nix

--- a/nixos/modules/programs/vim.nix
+++ b/nixos/modules/programs/vim.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.vim;
+in {
+  options.programs.vim = {
+    defaultEditor = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        When enabled, installs vim and configures vim to be the default editor
+        using the EDITOR environment variable.
+      '';
+    };
+  };
+
+  config = mkIf cfg.defaultEditor {
+        environment.systemPackages = [ pkgs.vim ];
+        environment.variables = { EDITOR = mkOverride 900 "vim"; };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

My main motivation is to provide the `services.vim.defaultEditor` wich a user could set in order to make vim (instead of nano) the system wide default text editor via the `EDITOR` environment variable (and it'll install vim if that isn't already the case). I don't know if the `services.vim.install` option makes sense since the same effect can be achieved by simply adding vim to the systemPackages.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: If both `services.vim.defaultEditor` and `services.emacs.defaultEditor` are set vim will be the default editor (not tested...) since the priority is lower (`mkForce` / `mkOverride 10` vs `mkOverride 900`). Is that ok or should I also use 900? I just thought mkForce (which apparently uses 10) would fit better. I must also admit that this probably isn't the best solution due to the emacs collision, however the user should avoid that anyway. An alternative would be to introduce a generic `defaultEditor` option.
