### PR TITLE
jansson: 2.8 -> 2.9

### DIFF
--- a/pkgs/development/libraries/jansson/default.nix
+++ b/pkgs/development/libraries/jansson/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "jansson-2.8";
+  name = "jansson-2.9";
 
   src = fetchurl {
     url = "http://www.digip.org/jansson/releases/${name}.tar.gz";
-    sha256 = "0v7v82mv7x44rpcxmrpnmb8hqimx67qwsp2cz9mv3y0f37iykwnf";
+    sha256 = "19fjgfwjfj99rqa3kf96x5rssj88siazggksgrikd6h4r9sd1l0a";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
