### PR TITLE
rust: 1.11.0 -> 1.12.0, cargo: 0.12.0 -> 0.13.0

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -17,13 +17,13 @@ let
   # fetch hashes by running `print-hashes.sh 1.9.0`
   bootstrapHash =
     if stdenv.system == "i686-linux"
-    then "be93dd2b80a97f2877679950d56990628c6547b953294f16bf6d69c18a39edc0"
+    then "f5a3f5d53defe827a71447b1a0e7a656394b87ee23e009d7bf73a0277c1b5ac2"
     else if stdenv.system == "x86_64-linux"
-    then "f189303d52b37c8bb694b9d9739ae73ffa926cbdeffde1d5d6a5c6e811940293"
+    then "f4ebbd6d9494cb8fa6c410cb58954e1913546c2bca8963faebc424591547d83f"
     else if stdenv.system == "i686-darwin"
-    then "40d4782a58dd5bef22dbbaa7a363f3b42f844628db07205f6435ac934f350061"
+    then "bf07182bc362985fcdd48af905cdb559e20c68518cd71dabec3c30b78ca8a94a"
     else if stdenv.system == "x86_64-darwin"
-    then "4bb71249f4afd7cee07f63d681f9fcb1b525ee3dfd49722adab7a40024e45af7"
+    then "2cdbc47438dc86ecaf35298317b77d735956eb160862e3f6d0fda0da656ecc35"
     else throw "missing boostrap hash for platform ${stdenv.system}";
 
   needsPatchelf = stdenv.isLinux;
@@ -33,7 +33,7 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "1.10.0";
+  version = "1.11.0";
 in
 
 rec {

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -7,12 +7,12 @@ in
 
 rec {
   rustc = callPackage ./rustc.nix {
-    shortVersion = "1.11.0";
+    shortVersion = "1.12.0";
     isRelease = true;
     forceBundledLLVM = false;
     configureFlags = [ "--release-channel=stable" ];
-    srcRev = "9b21dcd6a89f38e8ceccb2ede8c9027cb409f6e3";
-    srcSha = "12djpxhwqvq3262ai9vd096bvriynci2mrwn0dfjrd0w6s0i8viy";
+    srcRev = "3191fbae9da539442351f883bdabcad0d72efcb6";
+    srcSha = "1mpw6c5jfxy60g786wl8g0ncwikqfbcj67jrdpj3jacywxsxzlby";
 
     patches = [
       ./patches/disable-lockfile-check.patch
@@ -25,10 +25,10 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.12.0";
-    srcRev = "6b98d1f8abf5b33c1ca2771d3f5f3bafc3407b93";
-    srcSha = "0pq6l3yzmh2il6320f6501hvp9iikdxzl34i5b52v93ncpim36bk";
-    depsSha256 = "1jrwzm9fd15kf2d5zb17q901hx32h711ivcwdpxpmzwq08sjlcvl";
+    version = "0.13.0";
+    srcRev = "109cb7c33d426044d141457049bd0fffaca1327c";
+    srcSha = "0p79m7hpzjh36l4fc6a59h6r8yz6qafjcdg5v1yb7bac9m2wi7vs";
+    depsSha256 = "1cwp4p8b985fj8j2qmgsi2mpp51rdpwzm9qa60760nrry1fy624z";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -90,6 +90,9 @@ stdenv.mkDerivation {
     # Disable fragile linker-output-non-utf8 test
     rm -vr src/test/run-make/linker-output-non-utf8/
 
+    # Remove test targeted at LLVM 3.9 - https://github.com/rust-lang/rust/issues/36835
+    rm -vr src/test/run-pass/issue-36023.rs
+
     # Useful debugging parameter
     # export VERBOSE=1
   '' +


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #19428

As per rust-lang/rust#36835 I am skipping one of the tests
