### PR TITLE
ocamlPackages.ppx-variants-conv : add variantslib in propagatedBuildInputs

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
@@ -1,10 +1,10 @@
 {stdenv, buildOcamlJane,
- ppx_core, ppx_tools, ppx_type_conv, sexplib}:
+ ppx_core, ppx_tools, ppx_type_conv, sexplib, variantslib}:
 
 buildOcamlJane rec {
   name = "ppx_variants_conv";
   hash = "0kgal8b9yh7wrd75hllb9fyl6zbksfnr9k7pykpzdm3js98dirhn";
-  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib];
+  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib variantslib ];
 
   meta = with stdenv.lib; {
     description = "Generation of accessor and iteration functions for ocaml variant types";


### PR DESCRIPTION
ocamlPackages.ppx-variants-conv builds fine without variantslib, but
can't be used without, so it makes sense to have it in propagatedBuildInputs.
