### PR TITLE
timezone service: use /etc/zoneinfo instead of tzinfo directly

### DIFF
--- a/nixos/modules/config/timezone.nix
+++ b/nixos/modules/config/timezone.nix
@@ -37,14 +37,15 @@ in
 
     environment.sessionVariables.TZDIR = "/etc/zoneinfo";
 
+    # This way services are restarted when tzdata changes.
     systemd.globalEnvironment.TZDIR = tzdir;
 
     environment.etc.localtime =
-      { source = "${tzdir}/${config.time.timeZone}";
+      { source = "/etc/zoneinfo/${config.time.timeZone}";
         mode = "direct-symlink";
       };
 
-    environment.etc.zoneinfo.source = "${pkgs.tzdata}/share/zoneinfo";
+    environment.etc.zoneinfo.source = tzdir;
 
   };
 

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -89,6 +89,7 @@ let
 
       # symlink other core stuff
       ln -s /host/etc/localtime localtime
+      ln -s /host/etc/zoneinfo zoneinfo
       ln -s /host/etc/machine-id machine-id
       ln -s /host/etc/os-release os-release
 


### PR DESCRIPTION
###### Motivation for this change

Partially fixes #19339. Also probably fixes some other uses of timezones in systemd. Needs https://github.com/NixOS/systemd/pull/7 to fully fix the bug, but can be merged separately.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested in a VM with https://github.com/NixOS/systemd/pull/7 applied to systemd. `timedatectl` now works properly.
