### PR TITLE
gthumb: 3.4.3 -> 3.4.4

### DIFF
--- a/pkgs/applications/graphics/gthumb/default.nix
+++ b/pkgs/applications/graphics/gthumb/default.nix
@@ -6,12 +6,12 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "gthumb";
-  version = "${major}.3";
+  version = "${major}.4";
   major = "3.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${major}/${name}.tar.xz";
-    sha256 = "0pc2xl6kwhi5l3d0dj6nzdcj2vpihs7y1s3l1hwir8zy7cpx23y1";
+    sha256 = "154bdc8c1940209f1e3d9c60184efef45b0d24f5f7f7f59b819e9c08e19c2981";
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     [ itstool libxml2 intltool glib gtk gsettings_desktop_schemas dconf
       exiv2 libjpeg libtiff gstreamer libraw libsoup libsecret libchamplain
       librsvg libwebp json_glib webkit lcms2 bison flex ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/gthumb;


### PR DESCRIPTION
###### Motivation for this change

Minor version update.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
