### PR TITLE
ponyc: 2016-07-26 -> 0.5.1

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -1,16 +1,19 @@
-{stdenv, glibc, fetchFromGitHub, llvm, makeWrapper, openssl, pcre2, coreutils }:
+{ stdenv, fetchFromGitHub, llvm, makeWrapper, pcre2, coreutils, which, libressl,
+  cc ? stdenv.cc, lto ? !stdenv.isDarwin }:
 
-stdenv.mkDerivation {
-  name = "ponyc-2016-07-26";
+stdenv.mkDerivation ( rec {
+  name = "ponyc-${version}";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
-    rev = "4eec8a9b0d9936b2a0249bd17fd7a2caac6aaa9c";
-    sha256 = "184x2jivp7826i60rf0dpx0a9dg5rsj56dv0cll28as4nyqfmna2";
+    rev = version;
+    sha256 = "14c6qs3cqn9hk2hrq2d5rd4cmwzzz2fcb02dg5q1blq17pj7mcxa";
   };
 
-  buildInputs = [ llvm makeWrapper ];
+  buildInputs = [ llvm makeWrapper which ];
+  propagatedBuildInputs = [ cc ];
 
   # Disable problematic networking tests
   patches = [ ./disable-tests.patch ];
@@ -18,37 +21,69 @@ stdenv.mkDerivation {
   preBuild = ''
     # Fix tests
     substituteInPlace packages/process/_test.pony \
-        --replace "/bin/cat" "${coreutils}/bin/cat"
+        --replace '"/bin/' '"${coreutils}/bin/'
+    substituteInPlace packages/process/_test.pony \
+        --replace '=/bin' "${coreutils}/bin"
+
+
+    # Fix llvm-ar check for darwin
+    substituteInPlace Makefile \
+        --replace "llvm-ar-3.8" "llvm-ar"
+
+    # Remove impure system refs
+    substituteInPlace src/libponyc/pkg/package.c \
+        --replace "/usr/local/lib" ""
+    substituteInPlace src/libponyc/pkg/package.c \
+        --replace "/opt/local/lib" ""
+
+    for file in `grep -irl '/usr/local/opt/libressl/lib' ./*`; do
+      substituteInPlace $file  --replace '/usr/local/opt/libressl/lib' "${stdenv.lib.getLib libressl}/lib"
+    done
+
+    # Fix ponypath issue
+    substituteInPlace Makefile \
+        --replace "PONYPATH=." "PONYPATH=.:\$(PONYPATH)"
 
     export LLVM_CONFIG=${llvm}/bin/llvm-config
+  '' + stdenv.lib.optionalString ((!stdenv.isDarwin) && (!cc.isClang) && lto) ''
+    export LTO_PLUGIN=`find ${cc.cc}/ -name liblto_plugin.so`
+  '' + stdenv.lib.optionalString ((!stdenv.isDarwin) && (cc.isClang) && lto) ''
+    export LTO_PLUGIN=`find ${cc.cc}/ -name LLVMgold.so`
   '';
 
-  makeFlags = [ "config=release" ];
+  makeFlags = [ "config=release" ] ++ stdenv.lib.optionals stdenv.isDarwin [ "bits=64" ]
+              ++ stdenv.lib.optionals (stdenv.isDarwin && (!lto)) [ "lto=no" ];
 
   enableParallelBuilding = true;
 
   doCheck = true;
 
-  checkTarget = "test";
+  checkTarget = "test-ci";
 
   preCheck = ''
-    export LIBRARY_PATH="$out/lib:${stdenv.lib.makeLibraryPath [ openssl pcre2 ]}"
+    export PONYPATH="$out/lib:${stdenv.lib.makeLibraryPath [ pcre2 libressl ]}"
   '';
 
   installPhase = ''
-    make config=release prefix=$out install
+    make config=release prefix=$out ''
+    + stdenv.lib.optionalString stdenv.isDarwin '' bits=64 ''
+    + stdenv.lib.optionalString (stdenv.isDarwin && (!lto)) '' lto=no ''
+    + '' install
     mv $out/bin/ponyc $out/bin/ponyc.wrapped
     makeWrapper $out/bin/ponyc.wrapped $out/bin/ponyc \
-      --prefix LIBRARY_PATH : "$out/lib" \
-      --prefix LIBRARY_PATH : "${openssl.out}/lib" \
-      --prefix LIBRARY_PATH : "${pcre2}/lib"
+      --prefix PONYPATH : "$out/lib" \
+      --prefix PONYPATH : "${stdenv.lib.getLib pcre2}/lib" \
+      --prefix PONYPATH : "${stdenv.lib.getLib libressl}/lib"
   '';
+
+  # Stripping breaks linking for ponyc
+  dontStrip = true;
 
   meta = {
     description = "Pony is an Object-oriented, actor-model, capabilities-secure, high performance programming language";
     homepage = http://www.ponylang.org;
     license = stdenv.lib.licenses.bsd2;
     maintainers = [ stdenv.lib.maintainers.doublec ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/compilers/ponyc/disable-tests.patch
+++ b/pkgs/development/compilers/ponyc/disable-tests.patch
@@ -1,16 +1,17 @@
 diff --git a/packages/net/_test.pony b/packages/net/_test.pony
-index d6c3e56..dc37dd9 100644
+index ce26bd7..9a98cc7 100644
 --- a/packages/net/_test.pony
 +++ b/packages/net/_test.pony
-@@ -7,11 +7,6 @@ actor Main is TestList
+@@ -5,11 +5,7 @@ actor Main is TestList
+   new make() => None
+
    fun tag tests(test: PonyTest) =>
-     test(_TestReadBuffer)
-     test(_TestWriteBuffer)
 -    test(_TestBroadcast)
+-    test(_TestTCPWritev)
 -    ifdef not windows then
 -      test(_TestTCPExpect)
--      test(_TestTCPWritev)
 -    end
- 
- class iso _TestReadBuffer is UnitTest
-   """
++    None
+
+ class _TestPing is UDPNotify
+   let _h: TestHelper

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5099,7 +5099,9 @@ in
     stdenv = overrideCC stdenv gcc49;
   };
 
-  ponyc = callPackage ../development/compilers/ponyc { };
+  ponyc = callPackage ../development/compilers/ponyc {
+    llvm = llvm_38;
+  };
 
   rgbds = callPackage ../development/compilers/rgbds { };
 


### PR DESCRIPTION
###### Motivation for this change

Update to latest ponyc release
- add more package options for compiling
- enable for darwin
- enable LTO by default on linux
- disable LTO by default on darwin until #19312 is merged
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
