### PR TITLE
pony-stable: init at 2016-10-10

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -117,6 +117,7 @@
   dezgeg = "Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>";
   dfoxfranke = "Daniel Fox Franke <dfoxfranke@gmail.com>";
   dgonyeo = "Derek Gonyeo <derek@gonyeo.com>";
+  dipinhora = "Dipin Hora <dipinhora+github@gmail.com>";
   dmalikov = "Dmitry Malikov <malikov.d.y@gmail.com>";
   dochang = "Desmond O. Chang <dochang@gmail.com>";
   doublec = "Chris Double <chris.double@double.co.nz>";

--- a/pkgs/development/compilers/ponyc/pony-stable.nix
+++ b/pkgs/development/compilers/ponyc/pony-stable.nix
@@ -1,0 +1,26 @@
+{stdenv, fetchFromGitHub, ponyc }:
+
+stdenv.mkDerivation {
+  name = "pony-stable-2016-10-10";
+
+  src = fetchFromGitHub {
+    owner = "jemc";
+    repo = "pony-stable";
+    rev = "fdefa26fed93f4ff81c323f29abd47813c515703";
+    sha256 = "16inavy697icgryyvn9gcylgh639xxs7lnbrqdzcryvh0ck15qxk";
+  };
+
+  buildInputs = [ ponyc ];
+
+  installPhase = ''
+    make prefix=$out install
+  '';
+
+  meta = {
+    description = "A simple dependency manager for the Pony language.";
+    homepage = http://www.ponylang.org;
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = [ stdenv.lib.maintainers.dipinhora ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5101,6 +5101,8 @@ in
 
   ponyc = callPackage ../development/compilers/ponyc { };
 
+  pony-stable = callPackage ../development/compilers/ponyc/pony-stable.nix { };
+
   rgbds = callPackage ../development/compilers/rgbds { };
 
   rtags = callPackage ../development/tools/rtags/default.nix {};


### PR DESCRIPTION
###### Motivation for this change

Add pony-stable for managing pony project dependencies

Depends on updated ponyc from #19457 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
