### PR TITLE
sit interfaces: fix dependency tracking

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -50,7 +50,7 @@ in
           if (config.boot.isContainer == false)
           then
             # Trust udev when not in the container
-            [ (subsystemDevice dev) ]
+            optional (dev != null) (subsystemDevice dev)
           else
             # When in the container, check whether the interface is built from other definitions
             if (hasAttr dev cfg.bridges) ||
@@ -333,7 +333,7 @@ in
 
         createSitDevice = n: v: nameValuePair "${n}-netdev"
           (let
-            deps = optionals (v.dev != null) (deviceDependency v.dev);
+            deps = deviceDependency v.dev;
           in
           { description = "6-to-4 Tunnel Interface ${n}";
             wantedBy = [ "network-setup.service" (subsystemDevice n) ];


### PR DESCRIPTION
###### Motivation for this change

I broke the evaluation of nixos in #19128. This should fix the dependencies of sit-devices.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
