### PR TITLE
gdal: disable python support on darwin

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -3,7 +3,8 @@
 , libpng
 , netcdf, hdf5 , curl
 , netcdfSupport ? true
- }:
+, pythonSupport ? !stdenv.isDarwin
+}:
 
 composableDerivation.composableDerivation {} (fixed: rec {
   version = "2.1.1";
@@ -33,7 +34,7 @@ composableDerivation.composableDerivation {} (fixed: rec {
     "--with-pg=${postgresql}/bin/pg_config"
     "--with-mysql=${mysql.lib.dev}/bin/mysql_config"
     "--with-geotiff=${libgeotiff}"
-    "--with-python"               # optional
+    "--with-python${if pythonSupport then "" else "=no"}"
     "--with-static-proj4=${proj}" # optional
     "--with-geos=${geos}/bin/geos-config"# optional
     (if netcdfSupport then "--with-netcdf=${netcdf}" else "")
@@ -60,6 +61,6 @@ composableDerivation.composableDerivation {} (fixed: rec {
     homepage = http://www.gdal.org/;
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 })


### PR DESCRIPTION
###### Motivation for this change

Enabling python support on darwin results in a build failure.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
