### PR TITLE
libhttpseverywhere: build api documentation

### DIFF
--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -22,7 +22,10 @@ stdenv.mkDerivation rec {
     meson.py --prefix "$out" ..
   '';
 
-  buildPhase = "ninja";
+  buildPhase = ''
+    ninja
+    ninja devhelp
+  '';
 
   installPhase = "ninja install";
 


### PR DESCRIPTION
###### Motivation for this change

The devhelp is not built with the previous package.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This is a workaround for a bug in meson (https://github.com/mesonbuild/meson/issues/894)
