### PR TITLE
simple-scan: 3.21 -> 3.22

### DIFF
--- a/pkgs/applications/graphics/simple-scan/default.nix
+++ b/pkgs/applications/graphics/simple-scan/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchurl, cairo, colord, glib, gtk3, gusb, intltool, itstool
-, libusb1, libxml2, pkgconfig, sane-backends, vala_0_23, wrapGAppsHook
+, libusb1, libxml2, pkgconfig, sane-backends, vala_0_32, wrapGAppsHook
 , gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "simple-scan-${version}";
-  version = "3.21.1";
+  version = "${major_version}.0.1";
+  major_version = "3.22";
 
   src = fetchurl {
-    sha256 = "00w206isni8m8qd9m8x0644s1gqg11pvgnw6zav33b0bs2h2kk79";
-    url = "https://launchpad.net/simple-scan/3.21/${version}/+download/${name}.tar.xz";
+    url = "https://launchpad.net/simple-scan/${major_version}/${version}/+download/${name}.tar.xz";
+    sha256 = "0l1b3llkdlqq0bcjx1cadba67l2zb4zfykdaprpjbjbr6gkbc1f5";
   };
 
-  buildInputs = [ cairo colord glib gusb gtk3 libusb1 libxml2 sane-backends
-    vala_0_23 ];
+  buildInputs = [ cairo colord glib gnome3.defaultIconTheme gusb gtk3 libusb1 libxml2 sane-backends vala_0_32 ];
   nativeBuildInputs = [ intltool itstool pkgconfig wrapGAppsHook ];
 
   configureFlags = [ "--disable-packagekit" ];
@@ -27,18 +27,8 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    (
-    cd ${gnome3.defaultIconTheme}/share/icons/Adwaita
-
-    for f in `find . | grep 'scanner\.'` 
-    do
-      local outFile="`echo "$out/share/icons/hicolor/$f" | sed \
-        -e 's#/devices/#/apps/#g' \
-        -e 's#scanner\.#simple-scan\.#g'`"
-      mkdir -p "`realpath -m "$outFile/.."`"
-      cp "$f" "$outFile"
-    done
-    )
+    mkdir -p $out/share/icons
+    mv $out/share/simple-scan/icons/* $out/share/icons/
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Additionally, fix the icons and use a newer version of vala.

Fixes: #19423
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
