### PR TITLE
a2ps: fix build

### DIFF
--- a/pkgs/tools/text/a2ps/default.nix
+++ b/pkgs/tools/text/a2ps/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, libpaper, gperf, file, perl }:
+{ stdenv, fetchurl, fetchpatch, autoconf, bison, libpaper, gperf, file, perl }:
 
 stdenv.mkDerivation rec {
   name = "a2ps-4.14";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     substituteInPlace tests/defs.in --replace "/bin/rm" "rm"
   '';
 
-  nativeBuildInputs = [ file perl ];
+  nativeBuildInputs = [ autoconf file bison perl ];
   buildInputs = [ libpaper gperf ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

https://hydra.nixos.org/build/41788034

https://hydra.nixos.org/build/41788034/nixlog/3

@fpletz there something really weird with this one. Like hydra, I had build breaks with the same error. However, the problem comes and goes and sometimes it built fine. Anyhow, hydra confirmed the build breaks without autoconf and my own runs show it also breaks without yacc (unfortunately considering you went through the trouble of patching both the .y and the .c with that last patch)...
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
