### PR TITLE
mysqltuner: init at 1.6.18

### DIFF
--- a/pkgs/tools/misc/mysqltuner/default.nix
+++ b/pkgs/tools/misc/mysqltuner/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, perl }:
+
+stdenv.mkDerivation rec {
+  name = "mysqltuner-${version}";
+  version = "1.6.18";
+
+  src = fetchFromGitHub {
+    owner  = "major";
+    repo   = "MySQLTuner-perl";
+    rev    = version;
+    sha256 = "14dblrjqciyx6k7yczfzbaflc7hdxnj0kyy6q0lqfz8imszdkpi2";
+  };
+
+  buildInputs = [ perl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m0755 mysqltuner.pl $out/bin/mysqltuner
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Make recommendations for increased performance and stability of MariaDB/MySQL";
+    homepage = http://mysqltuner.com;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2730,6 +2730,8 @@ in
 
   mysql2pgsql = callPackage ../tools/misc/mysql2pgsql { };
 
+  mysqltuner = callPackage ../tools/misc/mysqltuner { };
+
   nabi = callPackage ../tools/inputmethods/nabi { };
 
   namazu = callPackage ../tools/text/namazu { };


### PR DESCRIPTION
###### Motivation for this change

The script runs, but haven't actually used it (yet).
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
