### PR TITLE
shaarli: init at 0.7.0

### DIFF
--- a/pkgs/servers/web-apps/shaarli/default.nix
+++ b/pkgs/servers/web-apps/shaarli/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "shaarli-${version}";
+  version = "0.8.0";
+
+  src = fetchurl {
+    url = "https://github.com/shaarli/Shaarli/releases/download/v0.8.0/shaarli-v0.8.0-full.tar.gz";
+    sha256 = "04151fl62rs8vxsmdyq4qm8fi7fr7i6x0zhrg1zgssv8w8lfx1ww";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  patchPhase = ''
+    substituteInPlace index.php \
+      --replace "new ConfigManager();" "new ConfigManager(getenv('SHAARLI_CONFIG'));"
+  '';
+
+#    Point $SHAARLI_CONFIG to your configuration file, see https://github.com/shaarli/Shaarli/wiki/Shaarli-configuration.
+#    For example:
+#      <?php /*
+#      {
+#          "credentials": {
+#              "login": "user",
+#              "hash": "(password hash)",
+#              "salt": "(password salt)"
+#          },
+#          "resource": {
+#              "data_dir": "\/var\/lib\/shaarli",
+#              "config": "\/var\/lib\/shaarli\/config.json.php",
+#              "datastore": "\/var\/lib\/shaarli\/datastore.php",
+#              "ban_file": "\/var\/lib\/shaarli\/ipbans.php",
+#              "updates": "\/var\/lib\/shaarli\/updates.txt",
+#              "log": "\/var\/lib\/shaarli\/log.txt",
+#              "update_check": "\/var\/lib\/shaarli\/lastupdatecheck.txt",
+#              "raintpl_tmp": "\/var\/lib\/shaarli\/tmp",
+#              "thumbnails_cache": "\/var\/lib\/shaarli\/cache",
+#              "page_cache": "\/var\/lib\/shaarli\/pagecache"
+#          },
+#          "updates": {
+#              "check_updates": false
+#          }
+#      }
+#      */ ?>
+
+  installPhase = ''
+    rm -r {cache,pagecache,tmp,data}/
+    mv doc/ $doc/
+    mkdir $out/
+    cp -R ./* $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The personal, minimalist, super-fast, database free, bookmarking service";
+    license = licenses.gpl3Plus;
+    homepage = https://github.com/shaarli/Shaarli;
+    maintainers = with maintainers; [ schneefux ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10304,6 +10304,8 @@ in
 
   selfoss = callPackage ../servers/web-apps/selfoss { };
 
+  shaarli = callPackage ../servers/web-apps/shaarli { };
+
   axis2 = callPackage ../servers/http/tomcat/axis2 { };
 
   unifi = callPackage ../servers/unifi { };


### PR DESCRIPTION
###### Motivation for this change

Added the [Shaarli](https://github.com/shaarli/Shaarli) PHP web app.

---

Exposes `$SHAARLI_CONFIG` for configuration. Example configuration (without credentials):

``` json
<?php /*
{
    "resource": {
        "data_dir": "\/var\/lib\/shaarli",
        "config": "\/var\/lib\/shaarli\/config.json.php",
        "datastore": "\/var\/lib\/shaarli\/datastore.php",
        "ban_file": "\/var\/lib\/shaarli\/ipbans.php",
        "updates": "\/var\/lib\/shaarli\/updates.txt",
        "log": "\/var\/lib\/shaarli\/log.txt",
        "update_check": "\/var\/lib\/shaarli\/lastupdatecheck.txt",
        "raintpl_tmp": "\/var\/lib\/shaarli\/tmp",
        "thumbnails_cache": "\/var\/lib\/shaarli\/cache",
        "page_cache": "\/var\/lib\/shaarli\/pagecache"
    },
    "updates": {
        "check_updates": false
    }
}
*/ ?>
```

---

To use a custom template, set `"raintpl_tpl"`, rewrite the templates `includes.html` to use absolute URLs by appending a `#` and configure your web server to serve `${pkgs.shaarli}/inc`.
For example:
`<link type="text/css" rel="stylesheet" href="/material/styles.min.css#" />` and `find -name "*.html" | xargs sed -i 's,png",png#",g'`

``` nginx
location ^~ /material {
  root /var/lib/shaarli/material-theme/build;
}
location ^~ /images {
  alias /var/lib/shaarli/material-theme/images;
}
```

---
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
