### PR TITLE
guile: add libiconv as buildInput on darwin

### DIFF
--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -1,5 +1,9 @@
-{ fetchurl, stdenv, libtool, readline, gmp, pkgconfig, boehmgc, libunistring
-, libffi, gawk, makeWrapper, coverageAnalysis ? null, gnu ? null }:
+{ fetchurl, stdenv, libtool, readline, gmp, pkgconfig
+, boehmgc, libunistring, libffi, gawk, makeWrapper
+, coverageAnalysis ? null
+, gnu ? null
+, libiconv # darwin
+}:
 
 # Do either a coverage analysis build or a standard build.
 (if coverageAnalysis != null
@@ -15,7 +19,9 @@
   };
 
   nativeBuildInputs = [ makeWrapper gawk pkgconfig ];
-  buildInputs = [ readline libtool libunistring libffi ];
+  buildInputs = [ readline libtool libunistring libffi ]
+    ++ stdenv.lib.optional stdenv.isDarwin libiconv;
+
   propagatedBuildInputs = [ gmp boehmgc ]
 
     # XXX: These ones aren't normally needed here, but since


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] OS X
  - [x] Np changes on other platforms
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
