### PR TITLE
guile: Populate LD_LIBRARY_PATH to load shared libraries

### DIFF
--- a/pkgs/development/interpreters/guile/setup-hook-2.0.sh
+++ b/pkgs/development/interpreters/guile/setup-hook-2.0.sh
@@ -8,6 +8,10 @@ addGuileLibPath () {
         export GUILE_LOAD_PATH="${GUILE_LOAD_PATH}${GUILE_LOAD_PATH:+:}$1/share/guile/site"
         export GUILE_LOAD_COMPILED_PATH="${GUILE_LOAD_COMPILED_PATH}${GUILE_LOAD_COMPILED_PATH:+:}$1/share/guile/site"
     fi
+    if test -d "$1/lib"
+    then
+        export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}$1/lib"
+    fi
 }
 
 envHooks+=(addGuileLibPath)

--- a/pkgs/development/interpreters/guile/setup-hook.sh
+++ b/pkgs/development/interpreters/guile/setup-hook.sh
@@ -3,6 +3,10 @@ addGuileLibPath () {
     then
         export GUILE_LOAD_PATH="${GUILE_LOAD_PATH}${GUILE_LOAD_PATH:+:}$1/share/guile/site"
     fi
+    if test -d "$1/lib"
+    then
+        export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}$1/lib"
+    fi
 }
 
 envHooks+=(addGuileLibPath)


### PR DESCRIPTION
###### Motivation for this change

Guile modules rely on `LD_LIBRARY_PATH` to find any DLL components they use.
As it stands, `guile_ncurses` (and any other library bindings for Guile, such as `guileCairo` and `guileGnome`, though these are untested) will fail to load as they cannot find their own libraries.

This patch populates `LD_LIBRARY_PATH` with the `/lib` paths of loaded Nix packages, in the same way that it already populates `GUILE_LOAD_PATH`.

Motivating example:

```
$ nix-shell -p guile -p guile_ncurses --run "guile -c '(use-modules (ncurses curses))'"
[...]
ERROR: In procedure load-extension:
ERROR: In procedure dynamic-link: file: "libguile-ncurses", message: "file not found"
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
