### PR TITLE
guile_ncurses: Fix failure to load module

### DIFF
--- a/pkgs/development/guile-modules/guile-ncurses/default.nix
+++ b/pkgs/development/guile-modules/guile-ncurses/default.nix
@@ -13,6 +13,13 @@ stdenv.mkDerivation rec {
   preConfigure =
     '' configureFlags="$configureFlags --with-guilesitedir=$out/share/guile/site" '';
 
+  postFixup =
+    '' for f in $out/share/guile/site/ncurses/**.scm; do \
+           substituteInPlace $f \
+             --replace "libguile-ncurses" "$out/lib/libguile-ncurses"; \
+       done
+    '';
+
   doCheck = false;  # XXX: 1 of 65 tests failed
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

The `guile_ncurses` package does not work, as it cannot find its own shared library. This patch updates every reference to the shared library name (`libguile-ncurses`) to use its absolute path.

(RE #19493: the only other module with this problem is `guile-opengl`).

Motivating example:

```
$ nix-shell -p guile -p guile_ncurses --run "guile -c '(use-modules (ncurses curses))'"
[...]
ERROR: In procedure load-extension:
ERROR: In procedure dynamic-link: file: "libguile-ncurses", message: "file not found"
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
