### PR TITLE
gdb: disable format hardening

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -43,6 +43,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # darwin build fails with format hardening since v7.12
+  hardeningDisable = stdenv.lib.optionals stdenv.isDarwin [ "format" ];
+
   configureFlags = with stdenv.lib;
     [ "--with-gmp=${gmp.dev}" "--with-mpfr=${mpfr.dev}" "--with-system-readline"
       "--with-system-zlib" "--with-expat" "--with-libexpat-prefix=${expat.dev}"


### PR DESCRIPTION
###### Motivation for this change

fixes darwin build for v7.12 (https://github.com/NixOS/nixpkgs/pull/19416)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
i387-tdep.c:1291:3: warning: format string is not a string literal [-Wformat-nonliteral]
  gdb_assert (tdep->num_xmm_regs > 0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./common/gdb_assert.h:35:6: note: expanded from macro 'gdb_assert'
           (gdb_assert_fail (#expr, __FILE__, __LINE__, FUNCTION_NAME), 0)))
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./common/gdb_assert.h:41:31: note: expanded from macro 'gdb_assert_fail'
  internal_error (file, line, _("%s: Assertion `%s' failed."),                \
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./common/gdb_locale.h:28:20: note: expanded from macro '_'
# define _(String) gettext (String)
                   ^~~~~~~~~~~~~~~~
i387-tdep.c:1526:10: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
                              _("invalid i387 regclass"));
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
./common/gdb_locale.h:28:20: note: expanded from macro '_'
# define _(String) gettext (String)
                   ^~~~~~~~~~~~~~~~
i387-tdep.c:1629:10: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
                              _("invalid i387 regclass"));
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
./common/gdb_locale.h:28:20: note: expanded from macro '_'
# define _(String) gettext (String)
                   ^~~~~~~~~~~~~~~~
256 warnings and 4 errors generated.
make[2]: *** [Makefile:1135: i387-tdep.o] Error 1
make[2]: Leaving directory '/private/var/tmp/nix-build-gdb-7.12.drv-0/gdb-7.12/gdb'
make[1]: *** [Makefile:8554: all-gdb] Error 2
make[1]: Leaving directory '/private/var/tmp/nix-build-gdb-7.12.drv-0/gdb-7.12'
make: *** [Makefile:879: all] Error 2
builder for /nix/store/84940xgvzpz55cc9s602pachzdjdnn4s-gdb-7.12.drv failed with exit code 2
```
