### PR TITLE
mfcj6510dw: init at 3.0.0-1

### DIFF
--- a/pkgs/misc/cups/drivers/mfcj6510dwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj6510dwcupswrapper/default.nix
@@ -1,0 +1,65 @@
+{ stdenv, fetchurl, mfcj6510dwlpr, makeWrapper}:
+
+stdenv.mkDerivation rec {
+  name = "mfcj6510dw-cupswrapper-${version}";
+  version = "3.0.0-1";
+
+  src = fetchurl {
+    url = "http://download.brother.com/welcome/dlf006814/mfcj6510dw_cupswrapper_GPL_source_${version}.tar.gz";
+    sha256 = "0y5iffybxjin8injrdmc9n9hl4s6b8n6ck76m1z78bzi88vwmhai";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ mfcj6510dwlpr ];
+
+  buildPhase = ''
+    cd brcupsconfig
+    make all
+    cd ..
+    '';
+
+  installPhase = ''
+    TARGETFOLDER=$out/opt/brother/Printers/mfcj6510dw/cupswrapper
+    mkdir -p $TARGETFOLDER
+    cp PPD/brother_mfcj6510dw_printer_en.ppd $TARGETFOLDER
+    cp brcupsconfig/brcupsconfpt1 $TARGETFOLDER
+    cp scripts/cupswrappermfcj6510dw $TARGETFOLDER
+    sed -i -e '26,304d' $TARGETFOLDER/cupswrappermfcj6510dw
+    substituteInPlace $TARGETFOLDER/cupswrappermfcj6510dw \
+      --replace "\$ppd_file_name" "$TARGETFOLDER/brother_mfcj6510dw_printer_en.ppd"
+
+    CPUSFILTERFOLDER=$out/lib/cups/filter
+    mkdir -p $TARGETFOLDER $CPUSFILTERFOLDER
+    ln -s ${mfcj6510dwlpr}/lib/cups/filter/brother_lpdwrapper_mfcj6510dw $out/lib/cups/filter/brother_lpdwrapper_mfcj6510dw
+    ##TODO: Use the cups filter instead of the LPR one.
+    #cp scripts/cupswrappermfcj6510dw $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj6510dw
+    #sed -i -e '110,258!d' $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj6510dw
+    #sed -i -e '33,40d' $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj6510dw
+    #sed -i -e '34,35d' $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj6510dw
+    #substituteInPlace $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj6510dw \
+    #  --replace "/opt/brother/$``{device_model``}/$``{printer_model``}/lpd/filter$``{printer_model``}" \
+    #    "${mfcj6510dwlpr}/opt/brother/Printers/mfcj6510dw/lpd/filtermfcj6510dw" \
+    #  --replace "/opt/brother/Printers/$``{printer_model``}/inf/br$``{printer_model``}rc" \
+    #    "${mfcj6510dwlpr}/opt/brother/Printers/mfcj6510dw/inf/brmfcj6510dwrc" \
+    #  --replace "/opt/brother/$``{device_model``}/$``{printer_model``}/cupswrapper/brcupsconfpt1" \
+    #    "$out/opt/brother/Printers/mfcj6510dw/cupswrapper/brcupsconfpt1" \
+    #  --replace "/usr/share/cups/model/Brother/brother_" "$out/opt/brother/Printers/mfcj6510dw/cupswrapper/brother_"
+    #substituteInPlace $CPUSFILTERFOLDER/brother_lpdwrapper_mfcj6510dw \
+    #  --replace "$``{printer_model``}" "mfcj6510dw" \
+    #  --replace "$``{printer_name``}" "MFCJ6510DW"
+    '';
+
+  cleanPhase = ''
+    cd brcupsconfpt1
+    make clean
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.brother.com/;
+    description = "Brother MFC-J6510DW CUPS wrapper driver";
+    license = with licenses; gpl2;
+    platforms = with platforms; linux;
+    downloadPage = http://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj6510dw_all&os=128;
+    maintainers = with maintainers; [ ramkromberg ];
+  };
+}

--- a/pkgs/misc/cups/drivers/mfcj6510dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcj6510dwlpr/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, fetchurl, pkgsi686Linux, dpkg, makeWrapper, coreutils, gnused, gawk, file, cups, patchelf, utillinux, vimNox
+, ghostscript, a2ps }:
+
+# Why:
+# The executable "brprintconf_mfcj6510dw" binary is looking for "/opt/brother/Printers/%s/inf/br%sfunc" and "/opt/brother/Printers/%s/inf/br%src".
+# Whereby, %s is printf(3) string substitution for stdin's arg0 (the command's own filename) from the 10th char forwards, as a runtime dependency.
+# e.g. Say the filename is "0123456789ABCDE", the runtime will be looking for /opt/brother/Printers/ABCDE/inf/brABCDEfunc.
+# Presumably, the binary was designed to be deployed under the filename "printconf_mfcj6510dw", whereby it will search for "/opt/brother/Printers/mfcj6510dw/inf/brmfcj6510dwfunc".
+# For NixOS, we want to change the string to the store path of brmfcj6510dwfunc and brmfcj6510dwrc but we're faced with two complications:
+# 1. Too little room to specify the nix store path. We can't even take advantage of %s by renaming the file to the store path hash since the variable is too short and can't contain the whole hash.
+# 2. The binary needs the directory it's running from to be r/w.
+# What:
+# As such, we strip the path and substitution altogether, leaving only "brmfcj6510dwfunc" and "brmfcj6510dwrc", while filling the leftovers with nulls.
+# Fully null terminating the cstrings is necessary to keep the array the same size and preventing overflows.
+# We then use a shell script to link and execute the binary, func and rc files in a temporary directory.
+# How:
+# In the package, we dump the raw binary as a string of search-able hex values using hexdump. We execute the substitution with sed. We then convert the hex values back to binary form using xxd.
+# We also write a shell script that invoked "mktemp -d" to produce a r/w temporary directory and link what we need in the temporary directory.
+# Result:
+# The user can run brprintconf_mfcj6510dw in the shell.
+
+stdenv.mkDerivation rec {
+  name = "mfcj6510dwlpr-${version}";
+  version = "3.0.0-1";
+
+  src = fetchurl {
+    url = "http://download.brother.com/welcome/dlf006614/mfcj6510dwlpr-${version}.i386.deb";
+    sha256 = "1ccvx393pqavsgzd8igrzlin5jrsf01d3acyvwqd1d0yz5jgqy6d";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ cups ghostscript dpkg a2ps ];
+
+  unpackPhase = "true";
+
+  brprintconf_mfcj6510dw_script = ''
+    #!/bin/sh
+    cd $(mktemp -d)
+    ln -s @out@/usr/bin/brprintconf_mfcj6510dw_patched brprintconf_mfcj6510dw_patched
+    ln -s @out@/opt/brother/Printers/mfcj6510dw/inf/brmfcj6510dwfunc brmfcj6510dwfunc
+    ln -s @out@/opt/brother/Printers/mfcj6510dw/inf/brmfcj6510dwrc brmfcj6510dwrc
+    ./brprintconf_mfcj6510dw_patched "$@"
+  '';
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+    substituteInPlace $out/opt/brother/Printers/mfcj6510dw/lpd/filtermfcj6510dw \
+      --replace /opt "$out/opt"
+    substituteInPlace $out/opt/brother/Printers/mfcj6510dw/lpd/psconvertij2 \
+      --replace "GHOST_SCRIPT=`which gs`" "GHOST_SCRIPT=${ghostscript}/bin/gs"
+    substituteInPlace $out/opt/brother/Printers/mfcj6510dw/inf/setupPrintcapij \
+      --replace "/opt/brother/Printers" "$out/opt/brother/Printers" \
+      --replace "printcap.local" "printcap"
+
+    patchelf --set-interpreter ${pkgsi686Linux.stdenv.cc.libc.out}/lib/ld-linux.so.2 \
+      --set-rpath $out/opt/brother/Printers/mfcj6510dw/inf:$out/opt/brother/Printers/mfcj6510dw/lpd \
+      $out/opt/brother/Printers/mfcj6510dw/lpd/brmfcj6510dwfilter
+    patchelf --set-interpreter ${pkgsi686Linux.stdenv.cc.libc.out}/lib/ld-linux.so.2 $out/usr/bin/brprintconf_mfcj6510dw
+
+    #stripping the hardcoded path.
+    ${utillinux}/bin/hexdump -ve '1/1 "%.2X"' $out/usr/bin/brprintconf_mfcj6510dw | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F6272257366756E63.62726d66636a36353130647766756e63000000000000000000000000000000000000000000.' | \
+    sed 's.2F6F70742F62726F746865722F5072696E746572732F25732F696E662F627225737263.62726D66636A3635313064777263000000000000000000000000000000000000000000.' | \
+    ${vimNox}/bin/xxd -r -p > $out/usr/bin/brprintconf_mfcj6510dw_patched
+    chmod +x $out/usr/bin/brprintconf_mfcj6510dw_patched
+    #executing from current dir. segfaults if it's not r\w.
+    mkdir -p $out/bin
+    echo -n "$brprintconf_mfcj6510dw_script" > $out/bin/brprintconf_mfcj6510dw
+    chmod +x $out/bin/brprintconf_mfcj6510dw
+    substituteInPlace $out/bin/brprintconf_mfcj6510dw --replace @out@ $out
+
+    mkdir -p $out/lib/cups/filter/
+    ln -s $out/opt/brother/Printers/mfcj6510dw/lpd/filtermfcj6510dw $out/lib/cups/filter/brother_lpdwrapper_mfcj6510dw
+
+    wrapProgram $out/opt/brother/Printers/mfcj6510dw/lpd/psconvertij2 \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ coreutils gnused gawk ] }
+    wrapProgram $out/opt/brother/Printers/mfcj6510dw/lpd/filtermfcj6510dw \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ coreutils gnused file ghostscript a2ps ] }
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.brother.com/;
+    description = "Brother MFC-J6510DW LPR driver";
+    license = with licenses; unfree;
+    platforms = with platforms; linux;
+    downloadPage = http://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=mfcj6510dw_all&os=128;
+    maintainers = with maintainers; [ ramkromberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17042,6 +17042,9 @@ in
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };
   mfcj470dwlpr = callPackage_i686 ../misc/cups/drivers/mfcj470dwlpr { };
 
+  mfcj6510dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj6510dwcupswrapper { };
+  mfcj6510dwlpr = callPackage_i686 ../misc/cups/drivers/mfcj6510dwlpr { };
+
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung { };
   samsung-unified-linux-driver = callPackage ../misc/cups/drivers/samsung/4.00.39 { };
 


### PR DESCRIPTION
###### Motivation for this change

Too many trees.
###### Things done

Network printing with CUPS (lpd://192.168.1.50/binary_p1) works. The usb printing is untested but should also work. The scripts and binaries were all given some attentions so most miscellanea should be fine as well.

I think most people would want to start off with $(nix-build '<nixpkgs>' --no-out-link -A mfcj6510dw-cupswrapper)/opt/brother/Printers/mfcj6510dw/cupswrapper to get the ppd and the printer in CUPS.

Network users will then want to go to http://localhost:631/ to the get the lpd address and the default paper size.

In my case, the conf ended up looking something like this following the above steps:

```
# Printer configuration file for CUPS v2.1.4
# Written by cupsd on 2016-10-13 02:12
# DO NOT EDIT THIS FILE WHEN CUPSD IS RUNNING
<Printer MFCJ6510DW>
UUID urn:uuid:11111111111111111111111111111111111
Info MFCJ6510DW
Location
MakeModel Brother MFC-J6510DW CUPS
DeviceURI lpd://192.168.1.50/binary_p1
State Idle
StateTime 1476313899
ConfigTime 1476313867
Type 8400908
Accepting Yes
Shared No
JobSheets none none
QuotaPeriod 0
PageLimit 0
KLimit 0
OpPolicy default
ErrorPolicy stop-printer
Attribute marker-colors \#000000,#FFFF00,#00FFFF,#FF00FF,none
Attribute marker-levels -1,-1,-1,-1,-1
Attribute marker-names Black Ink Cartridge,Yellow Ink Cartridge,Cyan Ink Cartridge,Magenta Ink Cartridge,Ink Absorber
Attribute marker-types ink-cartridge,ink-cartridge,ink-cartridge,ink-cartridge,waste-ink
Attribute marker-change-time 1476313899
</Printer>
```

and the printcap:

```
# This file was automatically generated by cupsd(8) from the
# /etc/cups/printers.conf file.  All changes to this file
# will be lost.
MFCJ6510DW|MFCJ6510DW:rm=HAL065:rp=MFCJ6510DW:
```

Anyhow, there's a lot of hacking around in there including some rather unusual binary work.

Thanks to @yochai for https://github.com/NixOS/nixpkgs/blob/master/pkgs/misc/cups/drivers/mfcj470dwlpr/default.nix .
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
