### PR TITLE
[RFC][WIP] vim module: support pkg and vimrc specification

### DIFF
--- a/nixos/modules/programs/vim.nix
+++ b/nixos/modules/programs/vim.nix
@@ -5,20 +5,60 @@ with lib;
 let
   cfg = config.programs.vim;
 in {
+  ###### interface
   options.programs.vim = {
     defaultEditor = mkOption {
       type = types.bool;
       default = false;
       example = true;
       description = ''
-        When enabled, installs vim and configures vim to be the default editor
-        using the EDITOR environment variable.
+        When enabled, installs the selected vim derivation and sets it to be
+        the system-wide default editor using the EDITOR environment variable.
+      '';
+    };
+    vimrc = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        The system-wide vim configuration.
+      '';
+      example = ''
+        set nocompatible
+      '';
+    };
+    gvimrc = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        The system-wide gvim configuration.
+      '';
+      example = ''
+        set nocompatible
+      '';
+    };
+    package = mkOption {
+      type = types.package;
+      default = pkgs.vim;
+      defaultText = "pkgs.vim";
+      description = ''
+        Which vim derivation to use.
       '';
     };
   };
 
-  config = mkIf cfg.defaultEditor {
-        environment.systemPackages = [ pkgs.vim ];
-        environment.variables = { EDITOR = mkOverride 900 "vim"; };
-  };
+  ###### implementation
+  config = mkMerge
+    [
+      (mkIf cfg.defaultEditor {
+        environment.systemPackages = [ cfg.package ];
+        environment.variables = {
+          EDITOR = mkOverride 900 "${cfg.package}/bin/vim"; };
+      })
+      (mkIf (cfg.vimrc != "") {
+        environment.etc."vim/vimrc".text = cfg.vimrc;
+      })
+      (mkIf (cfg.gvimrc != "") {
+        environment.etc."vim/gvimrc".text = cfg.gvimrc;
+      })
+    ];
 }


### PR DESCRIPTION
###### Motivation for this change

Provide a way to select which vim derivation to use as the system-wide default editor (atm the package must contain `./bin/vim` - don't know if something like neovim (`./bin/nvim`), etc. should be supported as well - but since other options might also be incompatible `programs.neovim`, etc. would probably make more sense).

Add an option to define a default configuration which is written to `/etc/vim/vimrc` (doesn't make much sense atm since pkgs.vim doesn't parse this file (not yet, anyway)). However `vim_configurable` does source `/etc/vim/vimrc` (and `/etc/vimrc`) so that works :)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add an option for selecting which vim package to use and another one to
define a system wide vimrc (/etc/vim/vimrc - currently ignored).

TODO (WIP):
- [x] Probably add support for gvim (gvimrc) as well
- [ ] Use a modified `vimrc` for `pkgs.vim` that sources `/etc/vim/vimrc`? (we're currently using [The ArchLinux global vimrc](https://git.archlinux.org/svntogit/packages.git/plain/trunk/archlinux.vim?h=packages/vim?id=68f6d131750aa778807119e03eed70286a17b1cb))
- Use `/etc/vim/vimrc` or `/etc/vimrc`? (I personally prefer `/etc/vim/vimrc` since it keeps `/etc` cleaner if e.g. `gvimrc` is used as well)

cc @lovek323
