### PR TITLE
clerk: init at 875963b

### DIFF
--- a/pkgs/applications/audio/clerk/default.nix
+++ b/pkgs/applications/audio/clerk/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, makeWrapper, rofi, mpc_cli, perl,
+utillinux, pythonPackages, libnotify }:
+
+stdenv.mkDerivation {
+  name = "clerk-unstable-15-08-2016";
+
+  src = fetchFromGitHub {
+    owner = "carnager";
+    repo = "clerk";
+    rev = "875963bcae095ac1db174627183c76ebe165f787";
+    sha256 = "0y045my65hr3hjyx13jrnyg6g3wb41phqb1m7azc4l6vx6r4124b";
+  };
+
+  buildInputs = [ makeWrapper pythonPackages.mpd2 ];
+
+  buildPhase = ''
+    echo skipping build phase...
+  '';
+
+  installPhase = ''
+    DESTDIR=$out PREFIX=/ make install
+    wrapProgram $out/bin/clerk $out/bin/clerk \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ rofi mpc_cli perl utillinux libnotify ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An MPD client built on top of rofi";
+    homepage    = https://github.com/carnager/clerk;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ anderspapitto ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13677,6 +13677,8 @@ in
 
   mpc_cli = callPackage ../applications/audio/mpc { };
 
+  clerk = callPackage ../applications/audio/clerk { };
+
   ncmpc = callPackage ../applications/audio/ncmpc { };
 
   ncmpcpp = callPackage ../applications/audio/ncmpcpp { };


### PR DESCRIPTION
- Built on platform(s)
  - [ x] NixOS
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
