### PR TITLE
rancher-compose: init at 0.10.0

### DIFF
--- a/pkgs/applications/virtualization/rancher-compose/default.nix
+++ b/pkgs/applications/virtualization/rancher-compose/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+let
+  generic = { version, sha256 }: buildGoPackage rec {
+    name = "rancher-compose-${version}";
+
+    goPackagePath = "github.com/rancher/rancher-compose";
+
+    src = fetchFromGitHub {
+      owner = "rancher";
+      repo = "rancher-compose";
+      rev = "v${version}";
+      inherit sha256;
+    };
+
+    excludedPackages = "scripts";
+
+    meta = with lib; {
+      description = "Docker compose compatible client to deploy to Rancher";
+      homepage = "https://docs.rancher.com/rancher/rancher-compose/";
+      license = licenses.asl20;
+      platforms = platforms.unix;
+      maintainers = [maintainers.mic92];
+    };
+  };
+in {
+  # should point to a version compatible
+  # with the latest stable release of rancher
+  rancher-compose = generic {
+    version = "0.9.2";
+    sha256 = "1wlsdjaa4j2b3c034hb6zci5h900b1msimmshz5h4g5hiaqb3khq";
+  };
+
+  # for rancher v1.2.0-pre3+
+  rancher-compose_0_10 = generic {
+    version = "0.10.0";
+    sha256 = "17f3ya4qq0dzk4wvhgxp0lh9p8c87kpq7hmh3g21ashzqwmcflxl";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2305,7 +2305,7 @@ in
   less = callPackage ../tools/misc/less { };
 
   lf = callPackage ../tools/misc/lf {};
-  
+
   lhasa = callPackage ../tools/compression/lhasa {};
 
   libcpuid = callPackage ../tools/misc/libcpuid { };
@@ -14173,6 +14173,10 @@ in
   rakarrack = callPackage ../applications/audio/rakarrack {
     fltk = fltk13;
   };
+
+  inherit (callPackage ../applications/virtualization/rancher-compose {})
+    rancher-compose
+    rancher-compose_0_10;
 
   renoise = callPackage ../applications/audio/renoise {
     demo = false;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
