### PR TITLE
imagemagick: 6.9.5-10 -> 6.9.6-2 for CVEs (and other fixing from the subsequent breakage.)

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -11,8 +11,8 @@ let
     else throw "ImageMagick is not supported on this platform.";
 
   cfg = {
-    version = "6.9.5-10";
-    sha256 = "0cxjzqzca80vf6sfx4z9zq4wq2w0vy9ajp9kf88jb4na8mwsn198";
+    version = "6.9.6-2";
+    sha256 = "139h9lycxw3lszn052m34xm0rqyanin4nb529vxjcrkkzqilh91r";
     patches = [];
   }
     # Freeze version on mingw so we don't need to port the patch too often.

--- a/pkgs/applications/graphics/PythonMagick/default.nix
+++ b/pkgs/applications/graphics/PythonMagick/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "0.9.12";
+  version = "0.9.14";
 
 in
 
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   name = "pythonmagick-${version}";
 
   src = fetchurl {
-    url = "http://www.imagemagick.org/download/python/releases/PythonMagick-${version}.tar.xz";
-    sha256 = "1l1kr3d7l40fkxgs6mrlxj65alv2jizm9hhgg9i9g90a8qj8642b";
+    url = "mirror://imagemagick/python/releases/PythonMagick-${version}.tar.xz";
+    sha256 = "1flkdfi3c19wy2qcfzax1cqvmmri10rvmhc2y85gmagqvv01zz22";
   };
 
   buildInputs = [python boost pkgconfig imagemagick];

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -57,6 +57,7 @@ rec {
       sed -e 's,^\(GIMP_PLUGIN_DIR=\).*,\1'"$out/${gimp.name}-plugins", \
        -e 's,^\(GIMP_DATA_DIR=\).*,\1'"$out/share/${gimp.name}", -i configure
     '';
+    hardeningDisable = [ "format" ];
     meta = with stdenv.lib; {
       description = "The GIMP Animation Package";
       homepage = http://www.gimp.org;

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -23,20 +23,11 @@ let
     sha256 = "0r5pfbjbmdj46h20jm3iqmy969qd27ajyf0phjhgykv6j0cqjlgd";
   };
 
-  imagick = if isPhp7 then imagick34 else imagick31;
-
-  imagick31 = assert !isPhp7; buildPecl {
-    name = "imagick-3.1.2";
-    sha256 = "14vclf2pqcgf3w8nzqbdw0b9v30q898344c84jdbw2sa62n6k1sj";
+  imagick = buildPecl {
+    name = "imagick-3.4.3RC1";
+    sha256 = "0siyxpszjz6s095s2g2854bhprjq49rf22v6syjiwvndg1pc9fsh";
     configureFlags = "--with-imagick=${pkgs.imagemagick.dev}";
-    buildInputs = [ pkgs.pkgconfig ];
-  };
-
-  imagick34 = buildPecl {
-    name = "imagick-3.4.0RC4";
-    sha256 = "0fdkzdv3r8sm6y1x11kp3rxsimq6zf15xvi0mhn57svmnan4zh0i";
-    configureFlags = "--with-imagick=${pkgs.imagemagick.dev}";
-    buildInputs = [ pkgs.pkgconfig ];
+    nativeBuildInputs = [ pkgs.pkgconfig ];
   };
 
   # No support for PHP 7 yet


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
