### PR TITLE
Nodejs: Upgrades for security patches

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -6,7 +6,8 @@
 , preBuild ? ""
 , extraConfigFlags ? []
 , extraBuildInputs ? []
-, ...
+, patches ? [],
+ ...
 }:
 
 assert stdenv.system != "armv5tel-linux";
@@ -44,7 +45,7 @@ in stdenv.mkDerivation {
     PATH=$out/bin:$PATH patchShebangs $out
   '';
 
-  patches = stdenv.lib.optionals stdenv.isDarwin [ ./no-xcode.patch ];
+  patches = patches ++ stdenv.lib.optionals stdenv.isDarwin [ ./no-xcode.patch ];
 
   buildInputs = extraBuildInputs
     ++ [ python which zlib libuv openssl ]

--- a/pkgs/development/web/nodejs/v4.nix
+++ b/pkgs/development/web/nodejs/v4.nix
@@ -4,9 +4,9 @@
 }@args:
 
 import ./nodejs.nix (args // rec {
-  version = "4.4.6";
+  version = "4.6.0";
   src = fetchurl {
     url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
-    sha256 = "0f6bbfbea525469c91932b1aac35e0810e6bcda96f1c720e42a433942ee66106";
+    sha256 = "1566q1kkv8j30fgqx8sm2h8323f38wwpa1hfb10gr6z46jyhv4a2";
   };
 })

--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, openssl, python, zlib, libuv, v8, utillinux, http-parser
-, pkgconfig, runCommand, which, libtool
+, pkgconfig, runCommand, which, libtool, fetchpatch
 , callPackage
 , darwin ? null
 }@args:
@@ -8,12 +8,18 @@ let
   inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
 
 in import ./nodejs.nix (args // rec {
-  version = "6.7.0";
-  sha256 = "1r9vvnczjczqs29ja8gmbqgsfgkg0dph4qkaxb3yh7mb98r2ic6f";
+  version = "6.8.0";
+  sha256 = "13arzwki13688hr1lh871y06lrk019g4hkasmg11arm8j1dcwcpq";
   extraBuildInputs = stdenv.lib.optionals stdenv.isDarwin
     [ CoreServices ApplicationServices ];
   preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i -e "s|tr1/type_traits|type_traits|g" \
       -e "s|std::tr1|std|" src/util.h
   '';
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/nodejs/node/commit/fc164acbbb700fd50ab9c04b47fc1b2687e9c0f4.patch";
+      sha256 = "1rms3n09622xmddn013yvf5c6p3s8w8s0d2h813zs8c1l15k4k1i";
+    })
+  ];
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2305,7 +2305,7 @@ in
   less = callPackage ../tools/misc/less { };
 
   lf = callPackage ../tools/misc/lf {};
-  
+
   lhasa = callPackage ../tools/compression/lhasa {};
 
   libcpuid = callPackage ../tools/misc/libcpuid { };
@@ -2417,10 +2417,6 @@ in
     libtool = darwin.cctools;
   };
 
-  nodejs-5_x = callPackage ../development/web/nodejs/v5.nix {
-    libtool = darwin.cctools;
-  };
-
   nodejs-6_x = callPackage ../development/web/nodejs/v6.nix {
     libtool = darwin.cctools;
   };
@@ -2432,10 +2428,6 @@ in
 
   nodePackages_6_x = callPackage ../development/node-packages/default-v6.nix {
     nodejs = pkgs.nodejs-6_x;
-  };
-
-  nodePackages_5_x = callPackage ../development/node-packages/default-v5.nix {
-    nodejs = pkgs.nodejs-5_x;
   };
 
   nodePackages_4_x = callPackage ../development/node-packages/default-v4.nix {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/19481
https://lwn.net/Vulnerabilities/702896/
### Note: Do not backport the removal of nodejs-5_x
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
