### PR TITLE
cmake: Improve build when stdenv.glibc isn't present, bootstrap in parallel

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/2.8.nix
+++ b/pkgs/development/tools/build-managers/cmake/2.8.nix
@@ -5,6 +5,8 @@
 with stdenv.lib;
 
 assert wantPS -> (ps != null);
+assert stdenv ? cc;
+assert stdenv.cc ? libc;
 
 let
   os = stdenv.lib.optionalString;
@@ -31,9 +33,8 @@ stdenv.mkDerivation rec {
       url = "http://www.cmake.org/Bug/file_download.php?file_id=4660&type=bug";
       sha256 = "136z63ff83hnwd247cq4m8m8164pklzyl5i2csf5h6wd8p01pdkj";
     })] ++
-    # Don't search in non-Nix locations such as /usr, but do search in
-    # Nixpkgs' Glibc.
-    optional (stdenv ? glibc) ./search-path.patch ++
+    # Don't search in non-Nix locations such as /usr, but do search in our libc.
+    [ ./search-path.patch ] ++
     optional (stdenv ? cross) (fetchurl {
       name = "fix-darwin-cross-compile.patch";
       url = "http://public.kitware.com/Bug/file_download.php?"
@@ -50,22 +51,24 @@ stdenv.mkDerivation rec {
   CMAKE_PREFIX_PATH = concatStringsSep ":"
     (concatMap (p: [ (p.dev or p) (p.out or p) ]) buildInputs);
 
-  configureFlags =
-    "--docdir=/share/doc/${name} --mandir=/share/man --system-libs --no-system-libarchive"
-    + stdenv.lib.optionalString useQt4 " --qt-gui";
+  configureFlags = [
+    "--docdir=/share/doc/${name}"
+    "--mandir=/share/man"
+    "--system-libs"
+    "--no-system-libarchive"
+   ] ++ stdenv.lib.optional useQt4 "--qt-gui";
 
   setupHook = ./setup-hook.sh;
 
   dontUseCmakeConfigure = true;
 
-  preConfigure = with stdenv; optionalString (stdenv ? glibc)
-    ''
+  preConfigure = with stdenv; ''
       source $setupHook
       fixCmakeFiles .
       substituteInPlace Modules/Platform/UnixPaths.cmake \
-        --subst-var-by glibc_bin ${getBin glibc} \
-        --subst-var-by glibc_dev ${getDev glibc} \
-        --subst-var-by glibc_lib ${getLib glibc}
+        --subst-var-by libc_bin ${getBin cc.libc} \
+        --subst-var-by libc_dev ${getDev cc.libc} \
+        --subst-var-by libc_lib ${getLib cc.libc}
     '';
 
   meta = {

--- a/pkgs/development/tools/build-managers/cmake/2.8.nix
+++ b/pkgs/development/tools/build-managers/cmake/2.8.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation rec {
         --subst-var-by libc_bin ${getBin cc.libc} \
         --subst-var-by libc_dev ${getDev cc.libc} \
         --subst-var-by libc_lib ${getLib cc.libc}
+      configureFlags="--parallel=''${NIX_BUILD_CORES:-1} $configureFlags"
     '';
 
   meta = {

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
         --subst-var-by libc_lib ${getLib cc.libc}
       substituteInPlace Modules/FindCxxTest.cmake \
         --replace "$""{PYTHON_EXECUTABLE}" ${stdenv.shell}
+      configureFlags="--parallel=''${NIX_BUILD_CORES:-1} $configureFlags"
     '';
   configureFlags =
     [ "--docdir=share/doc/${name}"

--- a/pkgs/development/tools/build-managers/cmake/search-path-3.2.patch
+++ b/pkgs/development/tools/build-managers/cmake/search-path-3.2.patch
@@ -25,7 +25,7 @@ diff -ru3 cmake-3.4.3/Modules/Platform/UnixPaths.cmake cmake-3.4.3-new/Modules/P
 -  /usr/pkg/include
 -  /opt/csw/include /opt/include
 -  /usr/openwin/include
-+  @glibc_dev@/include
++  @libc_dev@/include
    )
 -
  list(APPEND CMAKE_SYSTEM_LIBRARY_PATH
@@ -39,26 +39,26 @@ diff -ru3 cmake-3.4.3/Modules/Platform/UnixPaths.cmake cmake-3.4.3-new/Modules/P
 -  /usr/pkg/lib
 -  /opt/csw/lib /opt/lib
 -  /usr/openwin/lib
-+  @glibc_lib@/lib
++  @libc_lib@/lib
    )
  
  list(APPEND CMAKE_SYSTEM_PROGRAM_PATH
 -  /usr/pkg/bin
-+  @glibc_bin@/bin
++  @libc_bin@/bin
    )
  
  list(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
 -  /lib /lib32 /lib64 /usr/lib /usr/lib32 /usr/lib64
-+  @glibc_lib@/lib
++  @libc_lib@/lib
    )
  
  list(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  @glibc_dev@/include
++  @libc_dev@/include
    )
  list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  @glibc_dev@/include
++  @libc_dev@/include
    )
  
  # Enable use of lib64 search path variants by default.

--- a/pkgs/development/tools/build-managers/cmake/search-path.patch
+++ b/pkgs/development/tools/build-managers/cmake/search-path.patch
@@ -53,7 +53,7 @@ diff -ru3 cmake-2.8.12.2/Modules/Platform/UnixPaths.cmake cmake-2.8.12.2-new/Mod
 -  /usr/pkg/include
 -  /opt/csw/include /opt/include
 -  /usr/openwin/include
-+  @glibc_dev@/include
++  @libc_dev@/include
    )
  
  list(APPEND CMAKE_SYSTEM_LIBRARY_PATH
@@ -67,26 +67,26 @@ diff -ru3 cmake-2.8.12.2/Modules/Platform/UnixPaths.cmake cmake-2.8.12.2-new/Mod
 -  /usr/pkg/lib
 -  /opt/csw/lib /opt/lib
 -  /usr/openwin/lib
-+  @glibc_lib@/lib
++  @libc_lib@/lib
    )
  
  list(APPEND CMAKE_SYSTEM_PROGRAM_PATH
 -  /usr/pkg/bin
-+  @glibc_bin@/bin
++  @libc_bin@/bin
    )
  
  list(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
 -  /lib /usr/lib /usr/lib32 /usr/lib64
-+  @glibc_lib@/lib
++  @libc_lib@/lib
    )
  
  list(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  @glibc_dev@/include
++  @libc_dev@/include
    )
  list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
 -  /usr/include
-+  @glibc_dev@/include
++  @libc_dev@/include
    )
  
  # Enable use of lib64 search path variants by default.


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
