### PR TITLE
thunderbird: disable PaX mprotect() hardening

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -113,6 +113,11 @@ stdenv.mkDerivation rec {
       EOF
     '';
 
+    postFixup =
+      ''
+        paxmark m $out/lib/thunderbird-${version}/thunderbird
+      '';
+
   meta = with stdenv.lib; {
     description = "A full-featured e-mail client";
     homepage = http://www.mozilla.org/thunderbird/;


### PR DESCRIPTION
Otherwise, thunderbird crashes at startup due to a PaX mprotect()
violation.

Fixes https://github.com/NixOS/nixpkgs/issues/19403
