### PR TITLE
Re-enable support for OS X 10.10 for darwin.

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_c_symbols
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_c_symbols
@@ -234,8 +234,6 @@ __os_assert_log_ctx
 __os_assumes_log
 __os_assumes_log_ctx
 __os_avoid_tail_call
-__os_crash
-__os_crash_callback
 __os_debug_log
 __os_debug_log_error_str
 __putenvp
@@ -267,7 +265,6 @@ __unsetenvp
 __utmpxname
 _a64l
 _abort
-_abort_report_np
 _abs
 _acl_add_flag_np
 _acl_add_perm

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_kernel_symbols
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_kernel_symbols
@@ -57,7 +57,6 @@ ___ioctl
 ___iopolicysys
 ___kdebug_trace
 ___kdebug_trace64
-___kdebug_trace_string
 ___kernelVersionNumber
 ___kernelVersionString
 ___kill
@@ -82,7 +81,6 @@ ___mac_set_file
 ___mac_set_link
 ___mac_set_proc
 ___mac_syscall
-___microstackshot
 ___mkdir_extended
 ___mkfifo_extended
 ___mmap
@@ -107,8 +105,6 @@ ___posix_spawn
 ___pread_nocancel
 ___proc_info
 ___process_policy
-___pselect
-___pselect_nocancel
 ___psynch_cvbroad
 ___psynch_cvclrprepost
 ___psynch_cvsignal
@@ -181,7 +177,6 @@ ___sigsuspend
 ___sigsuspend_nocancel
 ___sigwait
 ___socketpair
-___stack_snapshot_with_config
 ___stat64_extended
 ___stat_extended
 ___syscall
@@ -198,7 +193,6 @@ ___vfork
 ___wait4
 ___wait4_nocancel
 ___waitid_nocancel
-___work_interval_ctl
 ___workq_kernreturn
 ___workq_open
 ___write_nocancel
@@ -418,7 +412,6 @@ _getsockopt
 _getuid
 _getwgroups_np
 _getxattr
-_grab_pgo_data
 _guarded_close_np
 _guarded_kqueue_np
 _guarded_open_dprotected_np
@@ -429,7 +422,6 @@ _guarded_writev_np
 _host_create_mach_voucher
 _host_default_memory_manager
 _host_get_UNDServer
-_host_get_atm_diagnostic_flag
 _host_get_boot_info
 _host_get_clock_control
 _host_get_clock_service
@@ -454,7 +446,6 @@ _host_security_set_task_token
 _host_self
 _host_self_trap
 _host_set_UNDServer
-_host_set_atm_diagnostic_flag
 _host_set_exception_ports
 _host_set_special_port
 _host_statistics
@@ -470,10 +461,8 @@ _ioctl
 _issetugid
 _kas_info
 _kdebug_trace
-_kdebug_trace_string
 _kevent
 _kevent64
-_kevent_qos
 _kext_request
 _kill
 _kmod_control
@@ -510,7 +499,6 @@ _mach_host_self
 _mach_init
 _mach_make_memory_entry
 _mach_make_memory_entry_64
-_mach_memory_info
 _mach_memory_object_memory_entry
 _mach_memory_object_memory_entry_64
 _mach_msg
@@ -647,7 +635,6 @@ _munlock
 _munlockall
 _munmap
 _necp_match_policy
-_netagent_trigger
 _netname_check_in
 _netname_check_out
 _netname_look_up
@@ -686,7 +673,6 @@ _posix_spawn_file_actions_addopen
 _posix_spawn_file_actions_destroy
 _posix_spawn_file_actions_init
 _posix_spawnattr_destroy
-_posix_spawnattr_get_darwin_role_np
 _posix_spawnattr_get_qos_clamp_np
 _posix_spawnattr_getbinpref_np
 _posix_spawnattr_getcpumonitor
@@ -698,7 +684,6 @@ _posix_spawnattr_getprocesstype_np
 _posix_spawnattr_getsigdefault
 _posix_spawnattr_getsigmask
 _posix_spawnattr_init
-_posix_spawnattr_set_darwin_role_np
 _posix_spawnattr_set_importancewatch_port_np
 _posix_spawnattr_set_qos_clamp_np
 _posix_spawnattr_setauditsessionport_np
@@ -734,10 +719,8 @@ _proc_importance_assertion_begin_with_msg
 _proc_importance_assertion_complete
 _proc_kmsgbuf
 _proc_libversion
-_proc_list_uptrs
 _proc_listallpids
 _proc_listchildpids
-_proc_listcoalitions
 _proc_listpgrppids
 _proc_listpids
 _proc_listpidspath
@@ -898,15 +881,6 @@ _sigsuspend$NOCANCEL
 _socket
 _socket_delegate
 _socketpair
-_stackshot_capture_with_config
-_stackshot_config_create
-_stackshot_config_dealloc
-_stackshot_config_dealloc_buffer
-_stackshot_config_get_stackshot_buffer
-_stackshot_config_get_stackshot_size
-_stackshot_config_set_flags
-_stackshot_config_set_pid
-_stackshot_config_set_size_hint
 _stat
 _stat$INODE64
 _stat64
@@ -973,7 +947,6 @@ _thread_depress_abort
 _thread_get_assignment
 _thread_get_exception_ports
 _thread_get_mach_voucher
-_thread_get_register_pointer_values
 _thread_get_special_port
 _thread_get_state
 _thread_info
@@ -1040,10 +1013,6 @@ _waitevent
 _waitid
 _waitid$NOCANCEL
 _watchevent
-_work_interval_create
-_work_interval_destroy
-_work_interval_notify
-_work_interval_notify_simple
 _write
 _write$NOCANCEL
 _writev


### PR DESCRIPTION
###### Motivation for this change

Re-enable support for OS X 10.10 for darwin as PR #19470 only works for 10.11 and 10.12.

@copumpkin asked for this to be a separate PR: https://github.com/NixOS/nixpkgs/pull/19470#issuecomment-253308941
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
