### PR TITLE
ocaml-react: fix hash

### DIFF
--- a/pkgs/development/ocaml-modules/react/default.nix
+++ b/pkgs/development/ocaml-modules/react/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = http://erratique.ch/software/react/releases/react-1.2.0.tbz;
-    sha256 = "1gymn8hy7ga0l9qymmb1jcnnkqvy7l2zr87xavzqz0dfi9ci8dm7";
+    sha256 = "0knhgbngphv5sp1yskfd97crf169qhpc0igr6w7vqw0q36lswyl8";
   };
 
   unpackCmd = "tar xjf $src";


### PR DESCRIPTION
###### Motivation for this change

Wrong hash - the package had been updated but the hash hadn't.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The package had been updated from 1.1.0 -> 1.2.0 but the hash hadn't.
