### PR TITLE
wallabag: init at 2.1.1

### DIFF
--- a/pkgs/servers/web-apps/wallabag/default.nix
+++ b/pkgs/servers/web-apps/wallabag/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "wallabag-${version}";
+  version = "2.1.2";
+
+  # remember to rm -r var/cache/* after a rebuild or unexpected errors will occur
+
+  src = fetchurl {
+    url = "https://framabag.org/wallabag-release-${version}.tar.gz";
+    sha256 = "01i4xdzw126wwwkxy0d97dizrikvawpzqj95bykd1g25m7jzvb7k";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  patchPhase = ''
+    rm Makefile # use the "shared hosting" package with bundled dependencies
+    substituteInPlace app/AppKernel.php \
+      --replace "__DIR__" "getenv('WALLABAG_DATA')"
+    substituteInPlace var/bootstrap.php.cache \
+      --replace "\$this->rootDir = \$this->getRootDir()" "\$this->rootDir = getenv('WALLABAG_DATA')"
+  ''; # exposes $WALLABAG_DATA
+
+  installPhase = ''
+    mv docs $doc/
+    mkdir $out/
+    cp -R * $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Web page archiver";
+    longDescription = ''
+      wallabag is a self hostable application for saving web pages.
+
+      To use, point the environment variable $WALLABAG_DATA to a directory called `app` that contains the folder `config` with wallabag's configuration files. These need to be updated every package upgrade. In `app`'s parent folder, a directory called `var` containing wallabag's data will be created.
+      After a package upgrade, empty the `var/cache` folder.
+    '';
+    license = licenses.mit;
+    homepage = http://wallabag.org;
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10301,6 +10301,8 @@ in
 
   vsftpd = callPackage ../servers/ftp/vsftpd { };
 
+  wallabag = callPackage ../servers/web-apps/wallabag { };
+
   winstone = callPackage ../servers/http/winstone { };
 
   xinetd = callPackage ../servers/xinetd { };


### PR DESCRIPTION
###### Motivation for this change

Added the [wallabag](https://wallabag.org) read it later PHP web app.

---

To use, set `$WALLABAG_DATA` to for example to `/var/lib/wallabag/app`. Inside that directory, put the [configuration files](https://github.com/wallabag/wallabag/tree/master/app/config) in `config/`. Data will be written to `$WALLABAG_DATA/../var/` (`/var/lib/wallabag/var/`).

So the directory structure is

```
/var/lib/wallabag
 - /app (<- $WALLABAG_DATA)
 - - /config
 - - - *.yml
 - /var
 - - /cache/*
 - - /logs/*
 - - /sessions/*
```

Due to hard-coded relative paths in the Symfony framework there is no simpler solution.

Tested:
- [x] existing installation with MySQL database
- [ ] fresh install
- [ ] file import
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
