### PR TITLE
r-modules: fix and use nix-shell --pure to generate package lists [wip]

### DIFF
--- a/pkgs/development/r-modules/README.md
+++ b/pkgs/development/r-modules/README.md
@@ -31,18 +31,15 @@ output is the name that has to be passed to rWrapper in the code snipped above.
 
 ## Updating the package set
 
+To update the three main package sets, run the following commands:
 ```bash
-Rscript generate-r-packages.R cran  > cran-packages.nix.new
-mv cran-packages.nix.new cran-packages.nix
+nix-shell --pure generate-shell.nix --command "Rscript generate-r-packages.R cran > cran-packages.nix.new && mv cran-packages.nix.new cran-packages.nix"
 
-Rscript generate-r-packages.R bioc  > bioc-packages.nix.new
-mv bioc-packages.nix.new bioc-packages.nix
+nix-shell --pure generate-shell.nix --command "Rscript generate-r-packages.R bioc > bioc-packages.nix.new && mv bioc-packages.nix.new bioc-packages.nix"
 
-Rscript generate-r-packages.R irkernel  > irkernel-packages.nix.new
-mv irkernel-packages.nix.new irkernel-packages.nix
+nix-shell --pure generate-shell.nix --command "Rscript generate-r-packages.R irkernel > irkernel-packages.nix.new && mv irkernel-packages.nix.new irkernel-packages.nix"
 ```
-
-`generate-r-packages.R <repo>` reads  `<repo>-packages.nix`, therefor the renaming.
+`generate-r-packages.R <repo>` reads  `<repo>-packages.nix`, which makes the redirection/renaming necessary.
 
 
 ## Testing if the Nix-expression could be evaluated

--- a/pkgs/development/r-modules/generate-shell.nix
+++ b/pkgs/development/r-modules/generate-shell.nix
@@ -5,7 +5,8 @@ stdenv.mkDerivation {
 
   buildCommand = "exit 1";
 
-  nativeBuildInputs = [ 
+  buildInputs = [ wget ];
+  nativeBuildInputs = [
     (rWrapper.override {
       packages = with rPackages; [
         data_table


### PR DESCRIPTION
###### Motivation for this change

see commit message
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Encourage use of `nix-shell --pure` to increase reproducibility

Add required wget dependency to nix shell definition

Fixes #19530
