### PR TITLE
r-modules: add more nix-shell documentation

### DIFF
--- a/pkgs/development/r-modules/README.md
+++ b/pkgs/development/r-modules/README.md
@@ -29,6 +29,30 @@ profile. The set of available libraries can be discovered by running the
 command `nix-env -f "<nixpkgs>" -qaP -A rPackages`. The first column from that
 output is the name that has to be passed to rWrapper in the code snipped above.
 
+However, if you'd like to add a file to your project source to make the
+environment available for other contributors, you can create a `default.nix`
+file like so:
+```nix
+let
+  pkgs = import <nixpkgs> {};
+  stdenv = pkgs.stdenv;
+in with pkgs; {
+  myProject = stdenv.mkDerivation {
+    name = "myProject";
+    version = "1";
+    src = if pkgs.lib.inNixShell then null else nix;
+
+    buildInputs = with rPackages; [
+      R
+      ggplot2
+      knitr
+    ];
+  };
+}
+```
+and then run `nix-shell .` to be dropped into a shell with those packages
+available.
+
 ## Updating the package set
 
 ```bash


### PR DESCRIPTION
###### Motivation for this change

A lot of the time, I'd like to share my environments with others. This just adds instructions on how to do that! Essentially taken from https://github.com/NixOS/nixpkgs/issues/13204. 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Use nix-shell with a `default.nix` rather than using config.nix
