### PR TITLE
slock service: init [wip]

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -468,8 +468,9 @@
   ./services/security/munge.nix
   ./services/security/oauth2_proxy.nix
   ./services/security/physlock.nix
-  ./services/security/torify.nix
+  ./services/security/slock.nix
   ./services/security/tor.nix
+  ./services/security/torify.nix
   ./services/security/torsocks.nix
   ./services/system/cloud-init.nix
   ./services/system/dbus.nix

--- a/nixos/modules/services/security/slock.nix
+++ b/nixos/modules/services/security/slock.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.slock;
+in {
+  ###### interface
+
+  options = {
+
+    services.slock = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable the <command>slock</command> screen locking
+          mechanism.
+
+          Enable this and then run <command>systemctl start slock</command> to
+          lock the screen.
+        '';
+      };
+
+      lockOn = {
+
+        suspend = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Whether to lock screen with slock just before suspend.
+          '';
+        };
+
+        hibernate = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Whether to lock screen with slock just before hibernate.
+          '';
+        };
+
+        extraTargets = mkOption {
+          type = types.listOf types.str;
+          default = [];
+          example = [ "display-manager.service" ];
+          description = ''
+            Other targets to lock the screen just before.
+
+            Useful if you want to e.g. both autologin to X11 so that
+            your <filename>~/.xsession</filename> gets executed and
+            still to have the screen locked so that the system can be
+            booted relatively unattended.
+          '';
+        };
+      };
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.slock ];
+
+    systemd.services.slock = {
+      enable = true;
+      description = "${pkgs.slock.meta.description}";
+      wantedBy = optional cfg.lockOn.suspend   "suspend.target"
+              ++ optional cfg.lockOn.hibernate "hibernate.target"
+              ++ cfg.lockOn.extraTargets;
+      before   = optional cfg.lockOn.suspend   "systemd-suspend.service"
+              ++ optional cfg.lockOn.hibernate "systemd-hibernate.service"
+              ++ cfg.lockOn.extraTargets;
+      serviceConfig.ExecStart = "${pkgs.slock}/bin/slock";
+      environment = {
+        DISPLAY = ":${toString (
+          let display = config.services.xserver.display;
+          in if display != null then display else 0
+        )}";
+      };
+    };
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

See commit message
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Currently segfaults! I don't know why and I can't find the suckless.org bug tracker. Any help is appreciated!

dmesg:

```
[32044.201974] slock[29777]: segfault at 0 ip 00007f8e33154bce sp 00007fffb4e49420 error 4 in libnss_files-2.24.so[7f8e3314f000+a000]
[32115.701816] slock[31514]: segfault at 0 ip 00007fc1d914fbce sp 00007ffce44fb900 error 4 in libnss_files-2.24.so[7fc1d914a000+a000]
[32122.491782] slock[31593]: segfault at 0 ip 00007f082f986bce sp 00007ffc1e1f3720 error 4 in libnss_files-2.24.so[7f082f981000+a000]
[32129.571144] slock[31702]: segfault at 0 ip 00007f86af449bce sp 00007fff4418d3f0 error 4 in libnss_files-2.24.so[7f86af444000+a000]
```
