### PR TITLE
zk-shell:: init at 1.0.0

### DIFF
--- a/pkgs/applications/misc/zk-shell/default.nix
+++ b/pkgs/applications/misc/zk-shell/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, pythonPackages }:
+
+buildPythonApplication rec {
+  version = "1.0.0";
+  name = "zk-shell-" + version;
+
+  src = fetchFromGitHub {
+    owner = "rgs1";
+    repo = "zk_shell";
+    rev = "v${version}";
+    sha256 = "0zisvvlclsf4sdh7dpqcl1149xbxw6pi1aqcwjbqblgf8m4nm0c7";
+  };
+
+  propagatedBuildInputs = (with pythonPackages; [
+    ansi kazoo nose six tabulate twitter readline
+  ]);
+
+  #requires a running zookeeper, don't know how to fix that for the moment
+  doCheck = false;
+
+  meta = {
+    description = "A powerful & scriptable shell for Apache ZooKeeper";
+    homepage = https://github.com/rgs1/zk_shell;
+    license = stdenv.lib.licenses.apache2;
+    maintainers = [ stdenv.lib.maintainers.mahe ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17335,6 +17335,10 @@ in
 
   zimg = callPackage ../development/libraries/zimg { };
 
+  zk-shell = callPackage ../applications/misc/zk-shell {
+    inherit (pythonPackages) buildPythonApplication;
+  };
+
   zuki-themes = callPackage ../misc/themes/zuki { };
 
   zoom-us = qt55.callPackage ../applications/networking/instant-messengers/zoom-us {};


### PR DESCRIPTION
###### Motivation for this change

zk-shell is a handy tool for zk
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
