### PR TITLE
fetchdata and fetchmulti

### DIFF
--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -1,36 +1,36 @@
-{ stdenv, lib, requireFile, demo, fetchurl, libX11, libXext, libXcursor, libXrandr, libjack2, alsaLib, ... }:
-
+{ stdenv, lib, fetchOneOf, demo
+, libX11, libXext, libXcursor, libXrandr, libjack2, alsaLib, ...
+}:
+let
+  demoStr = if demo then "-demo" else "";
+in
 stdenv.mkDerivation rec {
   name = "renoise";
 
   buildInputs = [ libX11 libXext libXcursor libXrandr alsaLib libjack2 ];
 
-  src =
-    if stdenv.system == "x86_64-linux" then
-        if demo then
-        fetchurl {
-            url = "http://files.renoise.com/demo/Renoise_3_0_1_Demo_x86_64.tar.bz2";
-            sha256 = "1q7f94wz2dbz659kpp53a3n1qyndsk0pkb29lxdff4pc3ddqwykg";
-        }
-        else
-        requireFile {
-            url = "http://backstage.renoise.com/frontend/app/index.html#/login";
-            name = "rns_3_0_1_linux_x86_64.tar.gz";
-            sha256 = "1yb5w5jrg9dk9fg5rfvfk6p0rxn4r4i32vxp2l9lzhbs02pv15wd";
-        }
-    else if stdenv.system == "i686-linux" then
-        if demo then
-        fetchurl {
-            url = "http://files.renoise.com/demo/Renoise_3_0_1_Demo_x86.tar.bz2";
-            sha256 = "0dgqvib4xh2yhgh2wajj11wsb6xiiwgfkhyz32g8vnyaij5q8f58";
-        }
-        else
-        requireFile {
-            url = "http://backstage.renoise.com/frontend/app/index.html#/login";
-            name = "rns_3_0_1_reg_x86.tar.gz";
-            sha256 = "1swax2jz0gswdpzz8alwjfd8rhigc2yfspj7p8wvdvylqrf7n8q7";
-        }
-    else throw "platform is not suppored by Renoise";
+  src = fetchOneOf "${stdenv.system}${demoStr}" {
+    "x86_64-linux-demo" = {
+      url = "http://files.renoise.com/demo/Renoise_3_0_1_Demo_x86_64.tar.bz2";
+      sha256 = "1q7f94wz2dbz659kpp53a3n1qyndsk0pkb29lxdff4pc3ddqwykg";
+    };
+    "x86_64-linux" = {
+      fetcher = "requireFile";
+      url = "http://backstage.renoise.com/frontend/app/index.html#/login";
+      name = "rns_3_0_1_linux_x86_64.tar.gz";
+      sha256 = "1yb5w5jrg9dk9fg5rfvfk6p0rxn4r4i32vxp2l9lzhbs02pv15wd";
+    };
+    "i686-linux-demo" = {
+      url = "http://files.renoise.com/demo/Renoise_3_0_1_Demo_x86.tar.bz2";
+      sha256 = "0dgqvib4xh2yhgh2wajj11wsb6xiiwgfkhyz32g8vnyaij5q8f58";
+    };
+    "i686-linux" = {
+      fetcher = "requireFile";
+      url = "http://backstage.renoise.com/frontend/app/index.html#/login";
+      name = "rns_3_0_1_reg_x86.tar.gz";
+      sha256 = "1swax2jz0gswdpzz8alwjfd8rhigc2yfspj7p8wvdvylqrf7n8q7";
+    };
+  };
 
   installPhase = ''
     cp -r Resources $out

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -1,32 +1,27 @@
-{ stdenv, lib, callPackage, fetchurl, unzip, atomEnv, makeDesktopItem,
-  makeWrapper, libXScrnSaver }:
+{ stdenv, lib, callPackage, fetchOneOf, unzip, atomEnv, makeDesktopItem }:
 
 let
   version = "1.6.1";
   rev = "9e4e44c19e393803e2b05fe2323cf4ed7e36880e";
-
-  sha256 = if stdenv.system == "i686-linux"    then "1aks84siflpjbd2s9y1f0vvvf3nas4f50cimjf25lijxzjxrlivy"
-      else if stdenv.system == "x86_64-linux"  then "05kbi081ih64fadj4k74grkk9ca3wga6ybwgs5ld0bal4ilw1q6i"
-      else if stdenv.system == "x86_64-darwin" then "00p2m8b0l3pkf5k74szw6kcql3j1fjnv3rwnhy24wfkg4b4ah2x9"
-      else throw "Unsupported system: ${stdenv.system}";
-
   urlBase = "https://az764295.vo.msecnd.net/stable/${rev}/";
-
-  urlStr = if stdenv.system == "i686-linux" then
-        urlBase + "code-stable-code_${version}-1476372351_i386.tar.gz"
-      else if stdenv.system == "x86_64-linux" then
-        urlBase + "code-stable-code_${version}-1476373175_amd64.tar.gz"
-      else if stdenv.system == "x86_64-darwin" then
-        urlBase + "VSCode-darwin-stable.zip"
-      else throw "Unsupported system: ${stdenv.system}";
 in
   stdenv.mkDerivation rec {
     name = "vscode-${version}";
     inherit version;
 
-    src = fetchurl {
-      url = urlStr;
-      inherit sha256;
+    src = fetchOneOf stdenv.system {
+      "i686-linux" = {
+        url = "${urlBase}/code-stable-code_${version}-1476372351_i386.tar.gz";
+        sha256 = "1aks84siflpjbd2s9y1f0vvvf3nas4f50cimjf25lijxzjxrlivy";
+      };
+      "x86_64-linux" = {
+        url = "${urlBase}/code-stable-code_${version}-1476373175_amd64.tar.gz";
+        sha256 = "05kbi081ih64fadj4k74grkk9ca3wga6ybwgs5ld0bal4ilw1q6i";
+      };
+      "x86_64-darwin" = {
+        url = "${urlBase}/VSCode-darwin-stable.zip";
+        sha256 = "00p2m8b0l3pkf5k74szw6kcql3j1fjnv3rwnhy24wfkg4b4ah2x9";
+      };
     };
 
     desktopItem = makeDesktopItem {

--- a/pkgs/build-support/fetchdata/default.nix
+++ b/pkgs/build-support/fetchdata/default.nix
@@ -1,0 +1,46 @@
+{ fetchers }:
+
+# One fetcher to rule them all.
+#
+# The input should only be pure nix data, no function calls.
+#
+# Example usage:
+#
+#    fetchurl {
+#      url = "http://example.com/archive.tar.gz";
+#      sha256 = "...";
+#    };
+#
+# Becomes:
+#
+#    fetchdata {
+#      url = "http://example.com/archive.tar.gz";
+#      sha256 = "...";
+#    }
+#
+# If the data is not for fetchurl, it's possible to pass a "fetcher"
+# attribute:
+#
+#    fetchdata {
+#      fetcher = "fetchFromGitHub";
+#      repo    = "someone";
+#      repo    = "something";
+#      rev     = "v1.0";
+#      sha256  = "...";
+#    }
+#
+# Which means that the attributes can now be imported
+#
+#    fetchdata (import ./source.nix);
+#
+# That's the whole point of this function.
+#
+{ fetcher ? "fetchurl", ... }@attrs:
+  let
+    # TODO: add heuristic based on the input data instead
+    fetcher' =
+      fetchers."${fetcher}" or
+        (throw "fetcher of type `${fetcher}' not supported");
+    attrs' = builtins.removeAttrs attrs ["fetcher"];
+  in
+    fetcher' attrs'

--- a/pkgs/build-support/fetchdata/one-of.nix
+++ b/pkgs/build-support/fetchdata/one-of.nix
@@ -1,0 +1,36 @@
+{ lib, fetchdata }:
+
+# Similar to fetchdata but allows to switch on an attribute
+#
+# Example usage:
+#
+#     fetchmulti stdenv.system {
+#        "x86_64-linux" = {
+#          url = "http://example.com/x86-linux.tar.gz";
+#          sha256 = "...";
+#        };
+#        "i686-linux" = {
+#          url = "http://example.com/i686-linux.tar.gz";
+#          sha256 = "...";
+#        };
+#     }
+#
+# All the urls are exposed on the `all' attribute which allows to run
+# `nix-fetchetch-url -A mypackage.src.all` to calculate the checksums of the:q
+#
+# FIXME: right now nix-prefetch-url only work if one of the keys match the
+#        current plaform
+#
+key: data:
+let
+  attrs = data."${key}" or (throw "`${key}' is not available as a source");
+
+  # A list of all the fetcher urls
+  urls = lib.foldl
+    (sum: v: ((fetchdata v).urls or []) ++ sum)
+    []
+    (builtins.attrValues data);
+in
+  (fetchdata attrs) // { all = { inherit urls; }; }
+
+

--- a/pkgs/development/compilers/openjdk/bootstrap.nix
+++ b/pkgs/development/compilers/openjdk/bootstrap.nix
@@ -1,35 +1,28 @@
-{ stdenv, runCommand, glibc, fetchurl, file
+{ stdenv, runCommand, glibc, fetchOneOf, file
 
 , version
 }:
 
 let
   # !!! These should be on nixos.org
-  src = if glibc.system == "x86_64-linux" then
-    (if version == "8" then
-      fetchurl {
-        url = "https://www.dropbox.com/s/a0lsq2ig4uguky5/openjdk8-bootstrap-x86_64-linux.tar.xz?dl=1";
-        sha256 = "18zqx6jhm3lizn9hh6ryyqc9dz3i96pwaz8f6nxfllk70qi5gvks";
-      }
-    else if version == "7" then
-      fetchurl {
-        url = "https://www.dropbox.com/s/rssfbeommrfbsjf/openjdk7-bootstrap-x86_64-linux.tar.xz?dl=1";
-        sha256 = "024gg2sgg4labxbc1nhn8lxls2p7d9h3b82hnsahwaja2pm1hbra";
-      }
-    else throw "No bootstrap for version")
-  else if glibc.system == "i686-linux" then
-    (if version == "8" then
-      fetchurl {
-        url = "https://www.dropbox.com/s/rneqjhlerijsw74/openjdk8-bootstrap-i686-linux.tar.xz?dl=1";
-        sha256 = "1yx04xh8bqz7amg12d13rw5vwa008rav59mxjw1b9s6ynkvfgqq9";
-      }
-    else if version == "7" then
-      fetchurl {
-        url = "https://www.dropbox.com/s/6xe64td7eg2wurs/openjdk7-bootstrap-i686-linux.tar.xz?dl=1";
-        sha256 = "0xwqjk1zx8akziw8q9sbjc1rs8s7c0w6mw67jdmmi26cwwp8ijnx";
-      }
-    else throw "No bootstrap for version")
-  else throw "No bootstrap for system";
+  src = fetchOneOf "${glibc.system}-jdk${version}" {
+    "x86_64-linux-jdk7" = {
+      url = "https://www.dropbox.com/s/rssfbeommrfbsjf/openjdk7-bootstrap-x86_64-linux.tar.xz?dl=1";
+      sha256 = "024gg2sgg4labxbc1nhn8lxls2p7d9h3b82hnsahwaja2pm1hbra";
+    };
+    "x86_64-linux-jdk8" = {
+      url = "https://www.dropbox.com/s/a0lsq2ig4uguky5/openjdk8-bootstrap-x86_64-linux.tar.xz?dl=1";
+      sha256 = "18zqx6jhm3lizn9hh6ryyqc9dz3i96pwaz8f6nxfllk70qi5gvks";
+    };
+    "i686-linux-jdk7" = {
+      url = "https://www.dropbox.com/s/6xe64td7eg2wurs/openjdk7-bootstrap-i686-linux.tar.xz?dl=1";
+      sha256 = "0xwqjk1zx8akziw8q9sbjc1rs8s7c0w6mw67jdmmi26cwwp8ijnx";
+    };
+    "i686-linux-jdk8" = {
+      url = "https://www.dropbox.com/s/rneqjhlerijsw74/openjdk8-bootstrap-i686-linux.tar.xz?dl=1";
+      sha256 = "1yx04xh8bqz7amg12d13rw5vwa008rav59mxjw1b9s6ynkvfgqq9";
+    };
+  };
 
   bootstrap = runCommand "openjdk-bootstrap" {
     passthru.home = "${bootstrap}/lib/openjdk";

--- a/pkgs/tools/typesetting/kindlegen/default.nix
+++ b/pkgs/tools/typesetting/kindlegen/default.nix
@@ -1,34 +1,40 @@
-{ fetchurl, stdenv }:
+{ stdenv, fetchOneOf }:
 
 let
   version = "2.9";
   fileVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
-
-  sha256 = {
-    "x86_64-linux"  = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
-    "i686-linux"    = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
-    "x86_64-darwin" = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
-    "i686-darwin"   = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
-    "x86_64-cygwin" = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
-    "i686-cygwin"   = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
-  }."${stdenv.system}" or (throw "system #{stdenv.system.} is not supported");
-
-  url = {
-    "x86_64-linux"  = "http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
-    "i686-linux"    = "http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
-    "x86_64-darwin" = "http://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v${fileVersion}.zip";
-    "i686-darwin"   = "http://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v${fileVersion}.zip";
-    "x86_64-cygwin" = "http://kindlegen.s3.amazonaws.com/kindlegen_win32_v${fileVersion}.zip";
-    "i686-cygwin"   = "http://kindlegen.s3.amazonaws.com/kindlegen_win32_v${fileVersion}.zip";
-  }."${stdenv.system}" or (throw "system #{stdenv.system.} is not supported");
+  baseURL = "http://kindlegen.s3.amazonaws.com";
+  src = fetchOneOf stdenv.system {
+    "x86_64-linux"  = {
+      url = "${baseURL}/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
+      sha256 = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
+    };
+    "i686-linux"    = {
+      url = "${baseURL}/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
+      sha256 = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
+    };
+    "x86_64-darwin" = {
+      url = "${baseURL}/KindleGen_Mac_i386_v${fileVersion}.zip";
+      sha256 = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
+    };
+    "i686-darwin"   = {
+      url = "${baseURL}/KindleGen_Mac_i386_v${fileVersion}.zip";
+      sha256 = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
+    };
+    "x86_64-cygwin" = {
+      url = "${baseURL}/kindlegen_win32_v${fileVersion}.zip";
+      sha256 = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
+    };
+    "i686-cygwin"   = {
+      url = "${baseURL}/kindlegen_win32_v${fileVersion}.zip";
+      sha256 = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
+    };
+  };
 
 in stdenv.mkDerivation rec {
   name = "kindlegen-${version}";
 
-  src = fetchurl {
-    inherit url;
-    inherit sha256;
-  };
+  inherit src;
 
   sourceRoot = ".";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -262,6 +262,11 @@ in
   } // removeAttrs args [ "repo" "rev" ]) // { inherit rev; };
 
   fetchNuGet = callPackage ../build-support/fetchnuget { };
+
+  fetchdata = callPackage ../build-support/fetchdata {
+    fetchers = pkgs;
+  };
+
   buildDotnetPackage = callPackage ../build-support/build-dotnet-package { };
 
   resolveMirrorURLs = {url}: fetchurl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -267,6 +267,8 @@ in
     fetchers = pkgs;
   };
 
+  fetchOneOf = callPackage ../build-support/fetchdata/one-of.nix { };
+
   buildDotnetPackage = callPackage ../build-support/build-dotnet-package { };
 
   resolveMirrorURLs = {url}: fetchurl {


### PR DESCRIPTION
###### Motivation for this change

Moving the fetch data into pure NIXON code means we can more easily write update scripts. The updating part is still missing though.

The second motivation is that it's currently painful to update sha256s with multi-arch sources (binary packages). With `fetchmulti` it's possible to do `nix-prefetch-url . -A mypackage.src.all` and get all the hashes out.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @garbas @kamilchm @domenkozar 
