### PR TITLE
clipit: hicolor_icon_theme dependency

### DIFF
--- a/pkgs/applications/misc/clipit/default.nix
+++ b/pkgs/applications/misc/clipit/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, intltool, pkgconfig, gtk2, xdotool }:
+{ fetchurl, stdenv, intltool, pkgconfig, gtk2, xdotool, hicolor_icon_theme }:
 
 stdenv.mkDerivation rec {
   name = "clipit-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jrwn8qfgb15rwspdp1p8hb1nc0ngmpvgr87d4k3lhlvqg2cfqva";
   };
 
-  buildInputs = [ intltool pkgconfig gtk2 xdotool  ];
+  buildInputs = [ intltool pkgconfig gtk2 xdotool hicolor_icon_theme ];
 
   meta = with stdenv.lib; {
     description = "Lightweight GTK+ Clipboard Manager";


### PR DESCRIPTION
###### Motivation for this change

clipit conflicts with other packages that use `hicolor_icon_theme`
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
