### PR TITLE
blueman: hicolor_icon_theme dependency

### DIFF
--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, intltool, pkgconfig, pythonPackages, bluez, polkit, gtk3
 , obex_data_server, xdg_utils, libnotify, dconf, gsettings_desktop_schemas, dnsmasq, dhcp
-, withPulseAudio ? true, libpulseaudio }:
+, hicolor_icon_theme , withPulseAudio ? true, libpulseaudio }:
 
 let
   binPath = lib.makeBinPath [ xdg_utils dnsmasq dhcp ];
@@ -16,7 +16,8 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ intltool pkgconfig pythonPackages.wrapPython pythonPackages.cython ];
 
-  buildInputs = [ bluez gtk3 pythonPackages.python libnotify dconf gsettings_desktop_schemas ]
+  buildInputs = [ bluez gtk3 pythonPackages.python libnotify dconf
+                  gsettings_desktop_schemas hicolor_icon_theme ]
                 ++ pythonPath
                 ++ lib.optional withPulseAudio libpulseaudio;
 


### PR DESCRIPTION
###### Motivation for this change

blueman conflicts with other packages that use hicolor_icon_theme
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
