### PR TITLE
faba-icon-theme: 2016-06-02 -> 2016-09-13

### DIFF
--- a/pkgs/data/icons/faba-icon-theme/default.nix
+++ b/pkgs/data/icons/faba-icon-theme/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
   package-name = "faba-icon-theme";
-  version = "2016-06-02";
+  version = "2016-09-13";
 
   src = fetchFromGitHub {
     owner = "moka-project";
     repo = package-name;
-    rev = "e50649d0171fd8cce42404c7c5002d77710ffcfc";
-    sha256 = "1fn969a6l58asnl9181c2z1fsj4dybl2mgbcpwig20bri6q7yz20";
+    rev = "00431894bce5fb1b8caccaee064788996be228a7";
+    sha256 = "0hif030pd4w3s851k0s65w0mf2pik10ha25ycpsv91gpbgarqcns";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
