### PR TITLE
faba-mono-icons: fix repository name

### DIFF
--- a/pkgs/data/icons/faba-mono-icons/default.nix
+++ b/pkgs/data/icons/faba-mono-icons/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "2016-04-30";
 
   src = fetchFromGitHub {
-    owner = "moka-project";
+    owner = "snwh";
     repo = package-name;
     rev = "2006c5281eb988c799068734f289a85443800cda";
     sha256 = "0nisfl92y6hrbakp9qxi0ygayl6avkzrhwirg6854bwqjy2dvjv9";


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
