### PR TITLE
vscode: 1.5.1 -> 1.6.1

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -1,20 +1,21 @@
-{ stdenv, lib, callPackage, fetchurl, unzip, atomEnv, makeDesktopItem }:
+{ stdenv, lib, callPackage, fetchurl, unzip, atomEnv, makeDesktopItem,
+  makeWrapper, libXScrnSaver }:
 
 let
-  version = "1.5.1";
-  rev = "07d663dc1bd848161edf4cd4ce30cce410d3d877";
+  version = "1.6.1";
+  rev = "9e4e44c19e393803e2b05fe2323cf4ed7e36880e";
 
-  sha256 = if stdenv.system == "i686-linux"    then "1a2854snjdmfhzx6qwib4iw3qjhlmlf09dlsbbvh24zbrjphnd85"
-      else if stdenv.system == "x86_64-linux"  then "0gg2ad7sp02ffv7la61hh9h4vfw8qkfladbhwlh5y4axbbrx17r7"
-      else if stdenv.system == "x86_64-darwin" then "18q4ldnmm619vv8yx6rznpznpcc19zjczmcidr34552i5qfg5xsz"
+  sha256 = if stdenv.system == "i686-linux"    then "1aks84siflpjbd2s9y1f0vvvf3nas4f50cimjf25lijxzjxrlivy"
+      else if stdenv.system == "x86_64-linux"  then "05kbi081ih64fadj4k74grkk9ca3wga6ybwgs5ld0bal4ilw1q6i"
+      else if stdenv.system == "x86_64-darwin" then "00p2m8b0l3pkf5k74szw6kcql3j1fjnv3rwnhy24wfkg4b4ah2x9"
       else throw "Unsupported system: ${stdenv.system}";
 
   urlBase = "https://az764295.vo.msecnd.net/stable/${rev}/";
 
   urlStr = if stdenv.system == "i686-linux" then
-        urlBase + "code-stable-code_${version}-1473369468_i386.tar.gz"
+        urlBase + "code-stable-code_${version}-1476372351_i386.tar.gz"
       else if stdenv.system == "x86_64-linux" then
-        urlBase + "code-stable-code_${version}-1473370243_amd64.tar.gz"
+        urlBase + "code-stable-code_${version}-1476373175_amd64.tar.gz"
       else if stdenv.system == "x86_64-darwin" then
         urlBase + "VSCode-darwin-stable.zip"
       else throw "Unsupported system: ${stdenv.system}";
@@ -32,15 +33,18 @@ in
       name = "code";
       exec = "code";
       icon = "code";
-      comment = "Visual Studio Code is a code editor redefined and optimized for building and debugging modern web and cloud applications";
+      comment = ''
+        Code editor redefined and optimized for building and debugging modern
+        web and cloud applications
+      '';
       desktopName = "Visual Studio Code";
       genericName = "Text Editor";
       categories = "GNOME;GTK;Utility;TextEditor;Development;";
     };
 
     buildInputs = if stdenv.system == "x86_64-darwin"
-      then [ unzip ]
-      else [ ];
+      then [ unzip makeWrapper libXScrnSaver ]
+      else [ makeWrapper libXScrnSaver ];
 
     installPhase = ''
       mkdir -p $out/lib/vscode $out/bin
@@ -59,14 +63,22 @@ in
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "${atomEnv.libPath}:$out/lib/vscode" \
         $out/lib/vscode/code
+
+      wrapProgram $out/bin/code \
+        --prefix LD_PRELOAD : ${stdenv.lib.makeLibraryPath [ libXScrnSaver ]}/libXss.so.1
     '';
 
     meta = with stdenv.lib; {
-      description = "Visual Studio Code is an open source source code editor developed by Microsoft for Windows, Linux and OS X.";
+      description = ''
+        Open source source code editor developed by Microsoft for Windows,
+        Linux and OS X
+      '';
       longDescription = ''
-        Visual Studio Code is an open source source code editor developed by Microsoft for Windows, Linux and OS X.
-        It includes support for debugging, embedded Git control, syntax highlighting, intelligent code completion, snippets, and code refactoring.
-        It is also customizable, so users can change the editor's theme, keyboard shortcuts, and preferences.
+        Open source source code editor developed by Microsoft for Windows,
+        Linux and OS X. It includes support for debugging, embedded Git
+        control, syntax highlighting, intelligent code completion, snippets,
+        and code refactoring. It is also customizable, so users can change the
+        editor's theme, keyboard shortcuts, and preferences
       '';
       homepage = http://code.visualstudio.com/;
       downloadPage = https://code.visualstudio.com/Updates;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
