### PR TITLE
elementary-icon-theme: 3.2.2 -> 4.0.1

### DIFF
--- a/pkgs/data/icons/elementary-icon-theme/default.nix
+++ b/pkgs/data/icons/elementary-icon-theme/default.nix
@@ -1,29 +1,32 @@
-{ stdenv, fetchzip }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "3.2.2";
+  version = "4.0.1";
 
   package-name = "elementary-icon-theme";
 
   name = "${package-name}-${version}";
 
-  src = fetchzip {
-    url = "https://launchpad.net/elementaryicons/3.x/${version}/+download/elementary-icon-theme-${version}.tar.xz";
-    sha256 = "0b6sgvkzc5h9zm3la6f0ngs9pfjrsj318qcynxd3yydb50cd3hnf";
+  src = fetchurl {
+    url = "https://launchpad.net/elementaryicons/4.x/${version}/+download/${name}.tar.xz";
+    sha256 = "0cbgbd9fqxk6rbsrj0gbh1rcapkkdlaig79kilq798v94jfdskrl";
   };
 
   dontBuild = true;
 
   installPhase = ''
-    install -dm 755 $out/share/icons
+    install -dm 755 $out/share/{icons,doc/$name}
     cp -dr --no-preserve='ownership' . $out/share/icons/Elementary/
+    mv $out/share/icons/Elementary/{AUTHORS,CONTRIBUTORS,README.md} \
+      $out/share/doc/$name/
+    rm $out/share/icons/Elementary/{COPYING,pre-commit}
   '';
 
   meta = with stdenv.lib; {
-  description = "Elementary icon theme";
-  homepage = "https://launchpad.net/elementaryicons";
-  license = licenses.gpl3;
-  platforms = platforms.all;
-  maintainers = with maintainers; [ simonvandel ];
+    description = "Elementary icon theme";
+    homepage = "https://launchpad.net/elementaryicons";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ simonvandel ];
   };
 }


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
