### PR TITLE
theme-vertex: revert package renaming

### DIFF
--- a/pkgs/misc/themes/vertex/default.nix
+++ b/pkgs/misc/themes/vertex/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  pname = "vertex-theme";
+  pname = "theme-vertex";
   version = "20161009";
 
   src = fetchFromGitHub {
     owner = "horst3180";
-    repo = pname;
+    repo = "vertex-theme";
     rev = "c861918a7fccf6d0768d45d790a19a13bb23485e";
     sha256 = "13abgl18m04sj44gqipxbagpan4jqral65w59rgnhb6ldxgnhg33";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16181,7 +16181,7 @@ in
     in
       recurseIntoAttrs (lib.makeScope qt5.newScope merged);
 
-  vertex-theme = callPackage ../misc/themes/vertex { };
+  theme-vertex = callPackage ../misc/themes/vertex { };
 
   xfce = xfce4-12;
   xfce4-12 = recurseIntoAttrs (callPackage ../desktops/xfce { });


### PR DESCRIPTION
###### Motivation for this change

There is a discussion at https://github.com/NixOS/nixpkgs/pull/19541#pullrequestreview-4303982 about the package name for themes. This PR reverts to previous name `theme-vertex` instead of the actual `vertex-theme`.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
