### PR TITLE
Provide `python` symlink for Python3

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -89,6 +89,9 @@ in stdenv.mkDerivation {
 
     # Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
     echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
+
+    # Use Python3 as default python
+    ln -s "$out/bin/python3" "$out/bin/python"
   '';
 
   postFixup = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -691,7 +691,6 @@ in
   caddy = callPackage ../servers/caddy { };
 
   calamares = qt5.callPackage ../tools/misc/calamares rec {
-    python = python3;
     boost = pkgs.boost.override { python=python3; };
     libyamlcpp = callPackage ../development/libraries/libyaml-cpp { boost=boost; };
   };
@@ -1022,9 +1021,7 @@ in
 
   burp = callPackage ../tools/backup/burp { };
 
-  buku = callPackage ../applications/misc/buku {
-    pythonPackages = python3Packages;
-  };
+  buku = callPackage ../applications/misc/buku {};
 
   byzanz = callPackage ../applications/video/byzanz {};
 
@@ -1379,8 +1376,7 @@ in
 
   diffoscope = callPackage ../tools/misc/diffoscope {
     jdk = jdk7;
-    pythonPackages = python3Packages;
-    rpm = rpm.override { python = python3; };
+    rpm = rpm.override;
   };
 
   diffstat = callPackage ../tools/text/diffstat { };
@@ -2890,9 +2886,7 @@ in
 
   notify-osd = callPackage ../applications/misc/notify-osd { };
 
-  nox = callPackage ../tools/package-management/nox {
-    pythonPackages = python3Packages;
-  };
+  nox = callPackage ../tools/package-management/nox {};
 
   nq = callPackage ../tools/system/nq { };
 
@@ -3743,7 +3737,6 @@ in
 
   system-config-printer = callPackage ../tools/misc/system-config-printer {
     libxml2 = libxml2Python;
-    pythonPackages = python3Packages;
    };
 
   sitecopy = callPackage ../tools/networking/sitecopy { };
@@ -5539,7 +5532,7 @@ in
 
   pythonDocs = recurseIntoAttrs (callPackage ../development/interpreters/python/cpython/docs {});
 
-  pypi2nix = callPackage ../development/tools/pypi2nix { python = python35; };
+  pypi2nix = callPackage ../development/tools/pypi2nix {};
 
   svg2tikz = python27Packages.svg2tikz;
 
@@ -6166,9 +6159,7 @@ in
 
   ninja = callPackage ../development/tools/build-managers/ninja { };
 
-  nixbang = callPackage ../development/tools/misc/nixbang {
-      pythonPackages = python3Packages;
-  };
+  nixbang = callPackage ../development/tools/misc/nixbang {};
 
   nexus = callPackage ../development/tools/repository-managers/nexus { };
 
@@ -9131,7 +9122,7 @@ in
 
   stlport = callPackage ../development/libraries/stlport { };
 
-  streamlink = callPackage ../applications/video/streamlink { pythonPackages = python3Packages; };
+  streamlink = callPackage ../applications/video/streamlink {};
 
   strigi = callPackage ../development/libraries/strigi { clucene_core = clucene_core_2; };
 
@@ -12102,7 +12093,6 @@ in
 
   blender = callPackage  ../applications/misc/blender {
     cudatoolkit = cudatoolkit75;
-    python = python35;
   };
 
   bluefish = callPackage ../applications/editors/bluefish {
@@ -12644,9 +12634,7 @@ in
 
   eq10q = callPackage ../applications/audio/eq10q { };
 
-  errbot = callPackage ../applications/networking/errbot {
-    pythonPackages = python3Packages;
-  };
+  errbot = callPackage ../applications/networking/errbot {};
 
   espeak-classic = callPackage ../applications/audio/espeak { };
 
@@ -14031,9 +14019,7 @@ in
 
   purple-facebook = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-facebook { };
 
-  pithos = callPackage ../applications/audio/pithos {
-    pythonPackages = python3Packages;
-  };
+  pithos = callPackage ../applications/audio/pithos {};
 
   pinfo = callPackage ../applications/misc/pinfo { };
 
@@ -15317,9 +15303,7 @@ in
 
   bastet = callPackage ../games/bastet {};
 
-  beancount = callPackage ../applications/office/beancount {
-      pythonPackages = python3Packages;
-  };
+  beancount = callPackage ../applications/office/beancount {};
 
   bean-add = callPackage ../applications/office/beancount/bean-add.nix { };
 
@@ -17153,9 +17137,7 @@ in
 
   webfs = callPackage ../servers/http/webfs { };
 
-  wikicurses = callPackage ../applications/misc/wikicurses {
-    pythonPackages = python3Packages;
-  };
+  wikicurses = callPackage ../applications/misc/wikicurses {};
 
   wineMinimal = callPackage ../misc/emulators/wine {
     wineRelease = config.wine.release or "stable";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5490,7 +5490,7 @@ in
   };
   purePackages = recurseIntoAttrs (callPackage ./pure-packages.nix {});
 
-  python = python2;
+  python = python3;
   python2 = python27;
   python3 = python35;
 
@@ -5500,7 +5500,7 @@ in
   pythonSmall = python.override {x11Support = false;};
 
   # pythonPackages further below, but assigned here because they need to be in sync
-  pythonPackages = python2Packages;
+  pythonPackages = python3Packages;
   python2Packages = python27Packages;
   python3Packages = python35Packages;
 


### PR DESCRIPTION
###### Motivation for this change

Part of #18185.
cc @FRidh @domenkozar 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
