### PR TITLE
sakura: 3.2.0 -> 3.3.4

### DIFF
--- a/pkgs/applications/misc/sakura/default.nix
+++ b/pkgs/applications/misc/sakura/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, cmake, pkgconfig, gtk3, perl, vte }:
+{ stdenv, fetchurl, cmake, pkgconfig, gtk3, perl, vte, pcre, glib }:
 
 stdenv.mkDerivation rec {
   name = "sakura-${version}";
-  version = "3.2.0";
+  version = "3.3.4";
 
   src = fetchurl {
     url = "http://launchpad.net/sakura/trunk/${version}/+download/${name}.tar.bz2";
-    sha256 = "1pfvc35kckrzik5wx8ywhkhclr52rfp2syg46ix2nsdm72q6dl90";
+    sha256 = "1fnkrkzf2ysav1ljgi4y4w8kvbwiwgmg1462xhizlla8jqa749r7";
   };
 
   nativeBuildInputs = [ cmake perl pkgconfig ];
 
-  buildInputs = [ gtk3 vte ];
+  buildInputs = [ gtk3 vte pcre glib ];
 
   meta = with stdenv.lib; {
     description = "A terminal emulator based on GTK and VTE";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14655,7 +14655,7 @@ in
   udevil = callPackage ../applications/misc/udevil {};
 
   sakura = callPackage ../applications/misc/sakura {
-    vte = gnome3.vte_290;
+    vte = gnome3.vte;
   };
 
   sbagen = callPackage ../applications/misc/sbagen { };


### PR DESCRIPTION
###### Motivation for this change

The current package in stable (16.09) is broken, the one in unstable (master) works.
See related issue: https://github.com/NixOS/nixpkgs/issues/16584
I think in this case it might be good to fix stable (16.09) fast so others don't have the same inconvenience, but please let me know if this is not the correct way to approach or solve this, this is my first contribution here.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
