### PR TITLE
gthumb: hicolor_icon_theme dependency

### DIFF
--- a/pkgs/applications/graphics/gthumb/default.nix
+++ b/pkgs/applications/graphics/gthumb/default.nix
@@ -1,7 +1,7 @@
 { stdenv,  fetchurl, gnome3, itstool, libxml2, pkgconfig, intltool,
   exiv2, libjpeg, libtiff, gstreamer, libraw, libsoup, libsecret,
   libchamplain, librsvg, libwebp, json_glib, webkit, lcms2, bison,
-  flex, wrapGAppsHook }:
+  flex, hicolor_icon_theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = with gnome3;
     [ itstool libxml2 intltool glib gtk gsettings_desktop_schemas dconf
       exiv2 libjpeg libtiff gstreamer libraw libsoup libsecret libchamplain
-      librsvg libwebp json_glib webkit lcms2 bison flex ];
+      librsvg libwebp json_glib webkit lcms2 bison flex hicolor_icon_theme ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

gthumb conflicts with other packages that use hicolor_icon_theme
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
