### PR TITLE
screengrab: init at 2016-02-24

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -64,6 +64,7 @@ in
       pkgs.lxqt.qps
       pkgs.lxqt.qterminal
       pkgs.lxqt.qtermwidget
+      pkgs.lxqt.screengrab
       pkgs.menu-cache
       pkgs.openbox # default window manager
       pkgs.qt5.qtsvg # provides QT5 plugins for svg icons

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -60,7 +60,8 @@ let
     obconf-qt = callPackage ./optional/obconf-qt { };
     lximage-qt = callPackage ./optional/lximage-qt { };
     qps = callPackage ./optional/qps { };
-   
+    screengrab = callPackage ./optional/screengrab { };
+
   };
 
 in self

--- a/pkgs/desktops/lxqt/optional/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/optional/screengrab/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, qt5, kde5, lxqt, xorg }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "screengrab";
+  version = "2016-09-12";
+
+  srcs = fetchFromGitHub {
+    owner = "QtDesktop";
+    repo = pname;
+    rev = "3dbacb9d6f52825689846c798a6c4c95e3815bf6";
+    sha256 = "0rflb1q5b1mik8sm1wm63hwpyaah8liizxq1f5q33zapl1qafzi5";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [
+    qt5.qtbase
+    qt5.qttools
+    qt5.qtx11extras
+    qt5.qtsvg
+    kde5.kwindowsystem
+    lxqt.libqtxdg
+    xorg.libpthreadstubs
+    xorg.libXdmcp    
+  ];
+
+  cmakeFlags = [ "-DSG_USE_SYSTEM_QXT=ON" "-DCMAKE_INSTALL_LIBDIR=lib" ];
+
+  meta = with stdenv.lib; {
+    description = "Crossplatform tool for fast making screenshots";
+    homepage = https://github.com/lxde/screengrab;
+    license = licenses.gpl2;
+    platforms = with platforms; unix;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
