### PR TITLE
audit module: only enable service if kernel has audit

### DIFF
--- a/nixos/modules/security/audit.nix
+++ b/nixos/modules/security/audit.nix
@@ -104,7 +104,11 @@ in {
       description = "Kernel Auditing";
       wantedBy = [ "basic.target" ];
 
-      unitConfig.ConditionVirtualization = "!container";
+      unitConfig = {
+        ConditionVirtualization = "!container";
+        ConditionSecurity = [ "audit" ];
+      };
+
 
       path = [ pkgs.audit ];
 


### PR DESCRIPTION
###### Motivation for this change

Just came across `ConditionSecurity` and thought it fits here:
superseedes #19038 (not sure why it was closed without a resolution)

cc @fpletz @peterhoeg 
Can someone who has audit disabled and sees errors in journal please test this and see if it works as intended? :wink: 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
