### PR TITLE
i3lock-fancy: 2016-05-05 -> 2016-10-13

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -3,13 +3,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  rev = "b7196aaff72b90bb6ea0464a9f7b37d140db3230";
-  name = "i3lock-fancy-2016-05-05_rev${builtins.substring 0 7 rev}";
+  rev = "546ce2e71bd2339f2134904c7d22062e86105b46";
+  name = "i3lock-fancy-2016-10-13_rev${builtins.substring 0 7 rev}";
   src = fetchFromGitHub {
     owner = "meskarune";
     repo = "i3lock-fancy";
     inherit rev;
-    sha256 = "0az43nqhmbniih3yw9kz5lnky0n7mxylvklsib76s4l2alf6i3ps";
+    sha256 = "1pbxydwdfd7jlw3b8cnlwlrkqlyh5jyanfhjybndqmacd3y8vplb";
   };
   patchPhase = ''
     sed -i -e "s|(mktemp)|(${coreutils}/bin/mktemp)|" lock
@@ -19,15 +19,16 @@ stdenv.mkDerivation rec {
     sed -i -e "s|awk -F|${gawk}/bin/awk -F|" lock
     sed -i -e "s| awk | ${gawk}/bin/awk |" lock
     sed -i -e "s|i3lock -n |${i3lock-color}/bin/i3lock-color -n |" lock
-    sed -i -e 's|ICON="$SCRIPTPATH/lockdark.png"|ICON="'$out'/share/i3lock-fancy/lockdark.png"|' lock
-    sed -i -e 's|ICON="$SCRIPTPATH/lock.png"|ICON="'$out'/share/i3lock-fancy/lock.png"|' lock
+    sed -i -e 's|ICON="$SCRIPTPATH/icons/lockdark.png"|ICON="'$out'/share/i3lock-fancy/icons/lockdark.png"|' lock
+    sed -i -e 's|ICON="$SCRIPTPATH/icons/lock.png"|ICON="'$out'/share/i3lock-fancy/icons/lock.png"|' lock
     sed -i -e "s|getopt |${getopt}/bin/getopt |" lock
     sed -i -e "s|fc-match |${fontconfig.bin}/bin/fc-match |" lock
+    sed -i -e "s|SHOT=(import -window root)|SHOT=(${scrot}/bin/scrot -z)|" lock
   '';
   installPhase = ''
-    mkdir -p $out/bin $out/share/i3lock-fancy
+    mkdir -p $out/bin $out/share/i3lock-fancy/icons
     cp lock $out/bin/i3lock-fancy
-    cp lock*.png $out/share/i3lock-fancy
+    cp icons/lock*.png $out/share/i3lock-fancy/icons
   '';
   meta = with stdenv.lib; {
     description = "i3lock is a bash script that takes a screenshot of the desktop, blurs the background and adds a lock icon and text.";


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
