### PR TITLE
bareos: 15.2.1 -> 15.2.4

### DIFF
--- a/pkgs/tools/backup/bareos/default.nix
+++ b/pkgs/tools/backup/bareos/default.nix
@@ -12,14 +12,14 @@ let
 in
 stdenv.mkDerivation rec {
   name = "bareos-${version}";
-  version = "15.2.1";
+  version = "15.2.4";
 
   src = fetchFromGitHub {
     owner = "bareos";
     repo = "bareos";
     rev = "Release/${version}";
     name = "${name}-src";
-    sha256 = "01vnqahzjj598jjk4y7qzfnq415jh227v40sgkrdl4qcpn76spxi";
+    sha256 = "02k6wmr2n12dc6vwda8xczmbqidg6fs8nfg9n2cwwpm3k1a21qnd";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Version bump from 15.2.1 to 15.2.4
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
