### PR TITLE
broadcom-sta: Support linux-4.8

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, kernel }:
+{ stdenv, fetchurl, fetchpatch, kernel }:
 
 let
   version = "6.30.223.271";
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.broadcom.com/docs/linux_sta/${tarball}";
-    sha256 = hashes.${stdenv.system};
+    sha256 = hashes."${stdenv.system}";
   };
 
   hardeningDisable = [ "pic" ];
@@ -27,6 +27,11 @@ stdenv.mkDerivation {
     ./linux-4.7.patch
     ./null-pointer-fix.patch
     ./gcc.patch
+    (fetchpatch {
+      name = "linux-4.8.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/004-linux48.patch?h=broadcom-wl-dkms";
+      sha256 = "0s8apf6l3qm9kln451g4z0pr13f4jdgyval1vfl2abg0dqc5xfhs";
+    })
   ];
 
   makeFlags = "KBASE=${kernel.dev}/lib/modules/${kernel.modDirVersion}";


### PR DESCRIPTION
###### Motivation for this change

Without this patch the wl kernel module causes null pointer dereferences.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
