### PR TITLE
facetimehd: 2016-05-02 -> 2016-10-09

### DIFF
--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -3,25 +3,40 @@
 # facetimehd is not supported for kernels older than 3.19";
 assert stdenv.lib.versionAtLeast kernel.version "3.19";
 
+let
+  # Note: When updating this revision:
+  # 1. Also update pkgs/os-specific/linux/firmware/facetimehd-firmware/
+  # 2. Test the module and firmware change via:
+  #    a. Give some applications a try (Skype, Hangouts, Cheese, etc.)
+  #    b. Run: journalctl -f
+  #    c. Then close the lid
+  #    d. Then open the lid (and maybe press a key to wake it up)
+  #    e. see if the module loads back (apps using the camera won't
+  #       recover and will have to be restarted) and the camera
+  #       still works.
+  srcParams = if (stdenv.lib.versionAtLeast kernel.version "4.8") then
+    { # Use mainline branch
+      version = "unstable-2016-10-09";
+      rev = "887d0f531ef7b91457be519474136c3355c5132b";
+      sha256 = "0bayahnxar1q6wvf9cb6p8gsfw98w0wqp715hs4r7apmddwk9v7n";
+    }
+  else
+    { # Use master branch (broken on 4.8)
+      version = "unstable-2016-05-02";
+      rev = "5a7083bd98b38ef3bd223f7ee531d58f4fb0fe7c";
+      sha256 = "0d455kajvn5xav9iilqy7s1qvsy4yb8vzjjxx7bvcgp7aj9ljvdp";
+    }
+  ;
+in
+
 stdenv.mkDerivation rec {
   name = "facetimehd-${version}-${kernel.version}";
-  version = "git-20160503";
+  version = srcParams.version;
 
   src = fetchFromGitHub {
     owner = "patjak";
     repo = "bcwc_pcie";
-    # Note: When updating this revision:
-    # 1. Also update pkgs/os-specific/linux/firmware/facetimehd-firmware/
-    # 2. Test the module and firmware change via:
-    #    a. Give some applications a try (Skype, Hangouts, Cheese, etc.)
-    #    b. Run: journalctl -f
-    #    c. Then close the lid
-    #    d. Then open the lid (and maybe press a key to wake it up)
-    #    e. see if the module loads back (apps using the camera won't
-    #       recover and will have to be restarted) and the camera
-    #       still works.
-    rev = "5a7083bd98b38ef3bd223f7ee531d58f4fb0fe7c";
-    sha256 = "0d455kajvn5xav9iilqy7s1qvsy4yb8vzjjxx7bvcgp7aj9ljvdp";
+    inherit (srcParams) rev sha256;
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

facetimehd doesn't work on 4.8 without the newer version, and the newer version doesn't work on anything older than 4.8. any idea on a better way to fix this? I'd like this in 16.09 too.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
