### PR TITLE
Fetch one of

### DIFF
--- a/pkgs/applications/audio/baudline/default.nix
+++ b/pkgs/applications/audio/baudline/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libXmu, libXt, libX11, libXext, libXxf86vm, jack
+{ stdenv, fetchOneOf, libXmu, libXt, libX11, libXext, libXxf86vm, jack
 , makeWrapper
 }:
 
@@ -10,19 +10,16 @@ stdenv.mkDerivation rec {
   name = "baudline-${version}";
   version = "1.08";
 
-  src =
-    if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        url = "http://www.baudline.com/baudline_${version}_linux_x86_64.tar.gz";
-        sha256 = "09fn0046i69in1jpizkzbaq5ggij0mpflcsparyskm3wh71mbzvr";
-      }
-    else if stdenv.system == "i686-linux" then
-      fetchurl {
-        url = "http://www.baudline.com/baudline_${version}_linux_i686.tar.gz";
-        sha256 = "1waip5pmcf5ffcfvn8lf1rvsaq2ab66imrbfqs777scz7k8fhhjb";
-      }
-    else
-      throw "baudline isn't supported (yet?) on ${stdenv.system}";
+  src = fetchOneOf stdenv.system {
+    "x86_64-linux" = {
+      url = "http://www.baudline.com/baudline_${version}_linux_x86_64.tar.gz";
+      sha256 = "09fn0046i69in1jpizkzbaq5ggij0mpflcsparyskm3wh71mbzvr";
+    };
+    "i686-linux" = {
+      url = "http://www.baudline.com/baudline_${version}_linux_i686.tar.gz";
+      sha256 = "1waip5pmcf5ffcfvn8lf1rvsaq2ab66imrbfqs777scz7k8fhhjb";
+    };
+  };
 
   buildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/audio/google-musicmanager/default.nix
+++ b/pkgs/applications/audio/google-musicmanager/default.nix
@@ -1,10 +1,6 @@
-{ stdenv, fetchurl, readline, patchelf, ncurses, qt48, libidn, expat, flac
+{ stdenv, fetchOneOf, readline, patchelf, ncurses, qt48, libidn, expat, flac
 , libvorbis }:
 
-assert stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux";
-let
-  archUrl = name: arch: "http://dl.google.com/linux/musicmanager/deb/pool/main/g/google-musicmanager-beta/${name}_${arch}.deb";
-in
 stdenv.mkDerivation rec {
   version = "beta_1.0.243.1116-r0"; # friendly to nix-env version sorting algo
   product = "google-musicmanager";
@@ -16,16 +12,18 @@ stdenv.mkDerivation rec {
   # curl http://dl.google.com/linux/musicmanager/deb/dists/stable/main/binary-amd64/Packages
   # which will contain the links to all available *.debs for the arch.
 
-  src = if stdenv.system == "x86_64-linux"
-    then fetchurl {
-      url    = archUrl name "amd64";
+  src = fetchOneOf stdenv.system {
+    "x86_64-linux" = {
+      url = "http://dl.google.com/linux/musicmanager/deb/pool/main/g/google-musicmanager-beta/${name}_amd64.deb";
       sha256 = "54f97f449136e173492d36084f2c01244b84f02d6e223fb8a40661093e0bec7c";
-    }
-    else fetchurl {
-        url    = archUrl name "i386";
-        sha256 = "121a7939015e2270afa3f1c73554102e2b4f2e6a31482ff7be5e7c28dd101d3c";
     };
+    "i686-linux" = {
+      url = "http://dl.google.com/linux/musicmanager/deb/pool/main/g/google-musicmanager-beta/${name}_i386.deb";
+      sha256 = "121a7939015e2270afa3f1c73554102e2b4f2e6a31482ff7be5e7c28dd101d3c";
+    };
+  };
 
+  # FIXME: use dpkg -x
   unpackPhase = ''
     ar vx ${src}
     tar -xvf data.tar.lzma

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -1,36 +1,36 @@
-{ stdenv, lib, requireFile, demo, fetchurl, libX11, libXext, libXcursor, libXrandr, libjack2, alsaLib, ... }:
-
+{ stdenv, lib, fetchOneOf, demo
+, libX11, libXext, libXcursor, libXrandr, libjack2, alsaLib, ...
+}:
+let
+  demoStr = if demo then "-demo" else "";
+in
 stdenv.mkDerivation rec {
   name = "renoise";
 
   buildInputs = [ libX11 libXext libXcursor libXrandr alsaLib libjack2 ];
 
-  src =
-    if stdenv.system == "x86_64-linux" then
-        if demo then
-        fetchurl {
-            url = "http://files.renoise.com/demo/Renoise_3_0_1_Demo_x86_64.tar.bz2";
-            sha256 = "1q7f94wz2dbz659kpp53a3n1qyndsk0pkb29lxdff4pc3ddqwykg";
-        }
-        else
-        requireFile {
-            url = "http://backstage.renoise.com/frontend/app/index.html#/login";
-            name = "rns_3_0_1_linux_x86_64.tar.gz";
-            sha256 = "1yb5w5jrg9dk9fg5rfvfk6p0rxn4r4i32vxp2l9lzhbs02pv15wd";
-        }
-    else if stdenv.system == "i686-linux" then
-        if demo then
-        fetchurl {
-            url = "http://files.renoise.com/demo/Renoise_3_0_1_Demo_x86.tar.bz2";
-            sha256 = "0dgqvib4xh2yhgh2wajj11wsb6xiiwgfkhyz32g8vnyaij5q8f58";
-        }
-        else
-        requireFile {
-            url = "http://backstage.renoise.com/frontend/app/index.html#/login";
-            name = "rns_3_0_1_reg_x86.tar.gz";
-            sha256 = "1swax2jz0gswdpzz8alwjfd8rhigc2yfspj7p8wvdvylqrf7n8q7";
-        }
-    else throw "platform is not suppored by Renoise";
+  src = fetchOneOf "${stdenv.system}${demoStr}" {
+    "x86_64-linux-demo" = {
+      url = "http://files.renoise.com/demo/Renoise_3_0_1_Demo_x86_64.tar.bz2";
+      sha256 = "1q7f94wz2dbz659kpp53a3n1qyndsk0pkb29lxdff4pc3ddqwykg";
+    };
+    "x86_64-linux" = {
+      fetcher = "requireFile";
+      url = "http://backstage.renoise.com/frontend/app/index.html#/login";
+      name = "rns_3_0_1_linux_x86_64.tar.gz";
+      sha256 = "1yb5w5jrg9dk9fg5rfvfk6p0rxn4r4i32vxp2l9lzhbs02pv15wd";
+    };
+    "i686-linux-demo" = {
+      url = "http://files.renoise.com/demo/Renoise_3_0_1_Demo_x86.tar.bz2";
+      sha256 = "0dgqvib4xh2yhgh2wajj11wsb6xiiwgfkhyz32g8vnyaij5q8f58";
+    };
+    "i686-linux" = {
+      fetcher = "requireFile";
+      url = "http://backstage.renoise.com/frontend/app/index.html#/login";
+      name = "rns_3_0_1_reg_x86.tar.gz";
+      sha256 = "1swax2jz0gswdpzz8alwjfd8rhigc2yfspj7p8wvdvylqrf7n8q7";
+    };
+  };
 
   installPhase = ''
     cp -r Resources $out

--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -1,9 +1,13 @@
-{ stdenv, makeDesktopItem, freetype, fontconfig, libX11, libXrender, zlib, jdk, glib, gtk2, libXtst, webkitgtk2, makeWrapper, ... }:
+{ stdenv, makeDesktopItem, freetype, fontconfig, libX11, libXrender, zlib
+, jdk, glib, gtk2, libXtst, webkitgtk2, makeWrapper, fetchOneOf, ... 
+}:
 
-{ name, src ? builtins.getAttr stdenv.system sources, sources ? null, description }:
+{ name, sources, description }:
 
 stdenv.mkDerivation rec {
-  inherit name src;
+  inherit name;
+
+  src = fetchOneOf stdenv.system sources;
 
   desktopItem = makeDesktopItem {
     name = "Eclipse";

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeDesktopItem, makeWrapper
+{ stdenv, lib, fetchOneOf, makeDesktopItem, makeWrapper
 , freetype, fontconfig, libX11, libXext, libXrender, zlib
 , glib, libXtst, jdk
 , webkitgtk2 ? null  # for internal web browser
@@ -15,85 +15,80 @@ rec {
   eclipse-sdk-35 = buildEclipse {
     name = "eclipse-sdk-3.5.2";
     description = "Eclipse Classic";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.5.2-201002111343/eclipse-SDK-3.5.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "1ndvanxw62b5ywi6ww0dyimabfmjdsw9q3xpy95zd8d5ygj2qsgq";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.5.2-201002111343/eclipse-SDK-3.5.2-linux-gtk.tar.gz;
-          sha256 = "0y5n0cyr9lgjmmzkfmav7j5w66rc1jq3300hcw3vrfjiv1k6ng3w";
-        };
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.5.2-201002111343/eclipse-SDK-3.5.2-linux-gtk-x86_64.tar.gz;
+        sha256 = "1ndvanxw62b5ywi6ww0dyimabfmjdsw9q3xpy95zd8d5ygj2qsgq";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.5.2-201002111343/eclipse-SDK-3.5.2-linux-gtk.tar.gz;
+        sha256 = "0y5n0cyr9lgjmmzkfmav7j5w66rc1jq3300hcw3vrfjiv1k6ng3w";
+      };
+    };
   };
   eclipse_sdk_35 = eclipse-sdk-35; # backward compatibility, added 2016-01-30
 
   eclipse-sdk-36 = buildEclipse {
     name = "eclipse-sdk-3.6.2";
     description = "Eclipse Classic";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "0dfcfadcd6337c897fbfd5b292de481931dfce12d43289ecb93691fd27dd47f4";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk.tar.gz;
-          sha256 = "1bh8ykliqr8wbciv13vpiy50rvm7yszk7y8dslr796dbwhi5b1cj";
-        };
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz;
+        sha256 = "0dfcfadcd6337c897fbfd5b292de481931dfce12d43289ecb93691fd27dd47f4";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk.tar.gz;
+        sha256 = "1bh8ykliqr8wbciv13vpiy50rvm7yszk7y8dslr796dbwhi5b1cj";
+      };
+    };
   };
   eclipse_sdk_36 = eclipse-sdk-36; # backward compatibility, added 2016-01-30
 
   eclipse-scala-sdk-40 = buildEclipse {
     name = "eclipse-scala-sdk-4.0.0";
     description = "Eclipse IDE for Scala Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl { # tested
-          url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86_64.tar.gz;
-          sha256  = "b65c5e8160e72c8389537e9e427138e6daa2065f9df3a943a86e40dd1543dd83";
-        }
-      else
-        fetchurl { # untested
-          url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86.tar.gz;
-          sha256 = "f422aea5903c97d212264a5a43c6ebc638aecbd4ce5e6078d92618725bc5d31e";
-        };
+    sources = {
+      "x86_64-linux" = { # tested
+        url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86_64.tar.gz;
+        sha256  = "b65c5e8160e72c8389537e9e427138e6daa2065f9df3a943a86e40dd1543dd83";
+      };
+      "i686-linux" = { # untested
+        url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86.tar.gz;
+        sha256 = "f422aea5903c97d212264a5a43c6ebc638aecbd4ce5e6078d92618725bc5d31e";
+      };
+    };
   };
   eclipse_scala_sdk_40 = eclipse-scala-sdk-40; # backward compatibility, added 2016-01-30
 
   eclipse-cpp-36 = buildEclipse {
     name = "eclipse-cpp-3.6.2";
     description = "Eclipse IDE for C/C++ Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-cpp-helios-SR2-linux-gtk-x86_64.tar.gz;
-          sha1 = "6f914e11fa15a900c46825e4aa8299afd76e7e65";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-cpp-helios-SR2-linux-gtk.tar.gz;
-          sha1 = "1156e4bc0253ae3a3a4e54839e4944dc64d3108f";
-        };
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-cpp-helios-SR2-linux-gtk-x86_64.tar.gz;
+        sha1 = "6f914e11fa15a900c46825e4aa8299afd76e7e65";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-cpp-helios-SR2-linux-gtk.tar.gz;
+        sha1 = "1156e4bc0253ae3a3a4e54839e4944dc64d3108f";
+      };
+    };
   };
   eclipse_cpp_36 = eclipse-cpp-36; # backward compatibility, added 2016-01-30
 
   eclipse-modeling-36 = buildEclipse {
     name = "eclipse-modeling-3.6.2";
     description = "Eclipse Modeling Tools (includes Incubating components)";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-modeling-helios-SR2-incubation-linux-gtk-x86_64.tar.gz;
-          sha1 = "e96f5f006298f68476f4a15a2be8589158d5cc61";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-modeling-helios-SR2-incubation-linux-gtk.tar.gz;
-          sha1 = "696377895bb26445de39d82a916b7e69edb1d939";
-        };
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-modeling-helios-SR2-incubation-linux-gtk-x86_64.tar.gz;
+        sha1 = "e96f5f006298f68476f4a15a2be8589158d5cc61";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-modeling-helios-SR2-incubation-linux-gtk.tar.gz;
+        sha1 = "696377895bb26445de39d82a916b7e69edb1d939";
+      };
+    };
   };
   eclipse_modeling_36 = eclipse-modeling-36; # backward compatibility, added 2016-01-30
 
@@ -101,14 +96,14 @@ rec {
     name = "eclipse-sdk-3.7";
     description = "Eclipse Classic";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.7.2-201202080800/eclipse-SDK-3.7.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "0nf4nv7awhp1k8b1hjb7chpjyjrqnyszsjbc4dlk9phpjv3j4wg5";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.7.2-201202080800/eclipse-SDK-3.7.2-linux-gtk.tar.gz;
-          sha256 = "1isn7i45l9kyn2yx6vm88jl1gnxph8ynank0aaa218cg8kdygk7j";
-        };
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.7.2-201202080800/eclipse-SDK-3.7.2-linux-gtk-x86_64.tar.gz;
+        sha256 = "0nf4nv7awhp1k8b1hjb7chpjyjrqnyszsjbc4dlk9phpjv3j4wg5";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.7.2-201202080800/eclipse-SDK-3.7.2-linux-gtk.tar.gz;
+        sha256 = "1isn7i45l9kyn2yx6vm88jl1gnxph8ynank0aaa218cg8kdygk7j";
+      };
     };
   };
   eclipse_sdk_37 = eclipse-sdk-37; # backward compatibility, added 2016-01-30
@@ -116,135 +111,126 @@ rec {
   eclipse-cpp-37 = buildEclipse {
     name = "eclipse-cpp-3.7";
     description = "Eclipse IDE for C/C++ Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/indigo/R/eclipse-cpp-indigo-incubation-linux-gtk-x86_64.tar.gz;
-          sha256 = "14ppc9g9igzvj1pq7jl01vwhzb66nmzbl9wsdl1sf3xnwa9wnqk3";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/indigo/R/eclipse-cpp-indigo-incubation-linux-gtk.tar.gz;
-          sha256 = "1cvg1vgyazrkinwzlvlf0dpl197p4784752srqybqylyj5psdi3b";
-        };
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/indigo/R/eclipse-cpp-indigo-incubation-linux-gtk-x86_64.tar.gz;
+        sha256 = "14ppc9g9igzvj1pq7jl01vwhzb66nmzbl9wsdl1sf3xnwa9wnqk3";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/indigo/R/eclipse-cpp-indigo-incubation-linux-gtk.tar.gz;
+        sha256 = "1cvg1vgyazrkinwzlvlf0dpl197p4784752srqybqylyj5psdi3b";
+      };
+    };
   };
   eclipse_cpp_37 = eclipse-cpp-37; # backward compatibility, added 2016-01-30
 
   eclipse-cpp-42 = buildEclipse {
     name = "eclipse-cpp-4.2";
     description = "Eclipse IDE for C/C++ Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/juno/SR2/eclipse-cpp-juno-SR2-linux-gtk-x86_64.tar.gz;
-          sha256 = "1qq04926pf7v9sf3s0z53zvlbl1j0rmmjmbmhqi49473fnjikh7y";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/juno/SR2/eclipse-cpp-juno-SR2-linux-gtk.tar.gz;
-          sha256 = "1a4s9qlhfpfpdhvffyglnfdr3dq5r2ywcxqywhqi95yhq5nmsgyk";
-        };
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/juno/SR2/eclipse-cpp-juno-SR2-linux-gtk-x86_64.tar.gz;
+        sha256 = "1qq04926pf7v9sf3s0z53zvlbl1j0rmmjmbmhqi49473fnjikh7y";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/juno/SR2/eclipse-cpp-juno-SR2-linux-gtk.tar.gz;
+        sha256 = "1a4s9qlhfpfpdhvffyglnfdr3dq5r2ywcxqywhqi95yhq5nmsgyk";
+      };
+    };
   };
   eclipse_cpp_42 = eclipse-cpp-42; # backward compatibility, added 2016-01-30
 
   eclipse-cpp-43 = buildEclipse {
     name = "eclipse-cpp-4.3.2";
     description = "Eclipse IDE for C/C++ Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/kepler/SR2/eclipse-cpp-kepler-SR2-linux-gtk-x86_64.tar.gz;
-          sha256 = "16zhjm6bx78263b1clg75kfiliahkhwg0k116vp9fj039nlpc30l";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/kepler/SR2/eclipse-cpp-kepler-SR2-linux-gtk.tar.gz;
-          sha256 = "0d6jlj7hwz8blx6csrlyi2h2prql0wckbh7ihwjmgclwpcpj84g6";
-        };
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/kepler/SR2/eclipse-cpp-kepler-SR2-linux-gtk-x86_64.tar.gz;
+        sha256 = "16zhjm6bx78263b1clg75kfiliahkhwg0k116vp9fj039nlpc30l";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/kepler/SR2/eclipse-cpp-kepler-SR2-linux-gtk.tar.gz;
+        sha256 = "0d6jlj7hwz8blx6csrlyi2h2prql0wckbh7ihwjmgclwpcpj84g6";
+      };
+    };
   };
   eclipse_cpp_43 = eclipse-cpp-43; # backward compatibility, added 2016-01-30
   
   eclipse-cpp-44 = buildEclipse {
     name = "eclipse-cpp-4.4.2";
     description = "Eclipse IDE for C/C++ Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/luna/SR2/eclipse-cpp-luna-SR2-linux-gtk-x86_64.tar.gz;
-          sha256 = "1vxwj7yihgipvrb3gksmddqkarzazpwk3mh1mjnw0i5xz2y32ba4";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/luna/SR2/eclipse-cpp-luna-SR2-linux-gtk.tar.gz;
-          sha256 = "1yn7yzzx8izc199c8w4f7vrc0b08idyq0dn113i8123b0mxw5lkp";
-        };
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/luna/SR2/eclipse-cpp-luna-SR2-linux-gtk-x86_64.tar.gz;
+        sha256 = "1vxwj7yihgipvrb3gksmddqkarzazpwk3mh1mjnw0i5xz2y32ba4";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/luna/SR2/eclipse-cpp-luna-SR2-linux-gtk.tar.gz;
+        sha256 = "1yn7yzzx8izc199c8w4f7vrc0b08idyq0dn113i8123b0mxw5lkp";
+      };
+    };
   };
   eclipse_cpp_44 = eclipse-cpp-44; # backward compatibility, added 2016-01-30
 
   eclipse-cpp-45 = buildEclipse {
     name = "eclipse-cpp-4.5.1";
     description = "Eclipse IDE for C/C++ Developers, Mars release";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/mars/1/eclipse-cpp-mars-1-linux-gtk-x86_64.tar.gz;
-          sha256 = "1j6rsgr44kya2v7y34ifscajqk7lnq1w9m9fx4i0qgby84sy4xj7";
-        }
-      else if stdenv.system == "i686-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/mars/1/eclipse-cpp-mars-1-linux-gtk.tar.gz;
-          sha256 = "0qsbvjkq0ssxbnafh4gs8pfclynqis3nf7xlxx4w3k20jcjx7sr2";
-        }
-      else throw "Unsupported system: ${stdenv.system}";
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/mars/1/eclipse-cpp-mars-1-linux-gtk-x86_64.tar.gz;
+        sha256 = "1j6rsgr44kya2v7y34ifscajqk7lnq1w9m9fx4i0qgby84sy4xj7";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/mars/1/eclipse-cpp-mars-1-linux-gtk.tar.gz;
+        sha256 = "0qsbvjkq0ssxbnafh4gs8pfclynqis3nf7xlxx4w3k20jcjx7sr2";
+      };
+    };
   };
   eclipse_cpp_45 = eclipse-cpp-45; # backward compatibility, added 2016-01-30
 
   eclipse-cpp-46 = buildEclipse {
     name = "eclipse-cpp-4.6.0";
     description = "Eclipse IDE for C/C++ Developers, Neon release";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk-x86_64.tar.gz;
-          sha256 = "09fqsgvbjfdqvn7z03crkii34z4bsb34y272q68ib8741bxk0i6m";
-        }
-      else if stdenv.system == "i686-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk.tar.gz;
-          sha256 = "0a12qmqq22v7sbmwn1hjv1zcrkmp64bf0ajmdjljhs9ac79mxn5h";
-        }
-      else throw "Unsupported system: ${stdenv.system}";
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk-x86_64.tar.gz;
+        sha256 = "09fqsgvbjfdqvn7z03crkii34z4bsb34y272q68ib8741bxk0i6m";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk.tar.gz;
+        sha256 = "0a12qmqq22v7sbmwn1hjv1zcrkmp64bf0ajmdjljhs9ac79mxn5h";
+      };
+    };
   };
 
   eclipse-sdk-421 = buildEclipse {
     name = "eclipse-sdk-4.2.1";
     description = "Eclipse Classic";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.1-201209141800/eclipse-SDK-4.2.1-linux-gtk-x86_64.tar.gz;
-          sha256 = "1mlyy90lk08lb2971ynglgi3nqvqfq1k70md2kb39jk160wd1xrk";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.1-201209141800/eclipse-SDK-4.2.1-linux-gtk.tar.gz;
-          sha256 = "1av6qm9wkbyk123qqf38f0jq4jv2bj9wp6fmpnl55zg6qr463c1w";
-        };
+    sources = {
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.1-201209141800/eclipse-SDK-4.2.1-linux-gtk-x86_64.tar.gz;
+        sha256 = "1mlyy90lk08lb2971ynglgi3nqvqfq1k70md2kb39jk160wd1xrk";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.1-201209141800/eclipse-SDK-4.2.1-linux-gtk.tar.gz;
+        sha256 = "1av6qm9wkbyk123qqf38f0jq4jv2bj9wp6fmpnl55zg6qr463c1w";
+      };
     };
+  };
   eclipse_sdk_421 = eclipse-sdk-421; # backward compatibility, added 2016-01-30
 
   eclipse-sdk-422 = buildEclipse {
     name = "eclipse-sdk-4.2.2";
     description = "Eclipse Classic";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.2-201302041200/eclipse-SDK-4.2.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "0ysa6ymk4h3k1vn59dc909iy197kmx132671kbzfwbim87jmgnqb";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.2-201302041200/eclipse-SDK-4.2.2-linux-gtk.tar.gz;
-          sha256 = "038yibbrcia38wi72qrdl03g7l35mpvl5nxdfdnvpqxrkfffb826";
-        };
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.2-201302041200/eclipse-SDK-4.2.2-linux-gtk-x86_64.tar.gz;
+        sha256 = "0ysa6ymk4h3k1vn59dc909iy197kmx132671kbzfwbim87jmgnqb";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.2-201302041200/eclipse-SDK-4.2.2-linux-gtk.tar.gz;
+        sha256 = "038yibbrcia38wi72qrdl03g7l35mpvl5nxdfdnvpqxrkfffb826";
+      };
     };
   };
   eclipse_sdk_422 = eclipse-sdk-422; # backward compatibility, added 2016-01-30
@@ -253,14 +239,14 @@ rec {
     name = "eclipse-sdk-4.3.1";
     description = "Eclipse Classic";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.3.1-201309111000/eclipse-SDK-4.3.1-linux-gtk-x86_64.tar.gz;
-          sha256 = "0ncm56ylwxw9z8rk8ccgva68c2yr9yrf1kcr1zkgw6p87xh1yczd";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.3.1-201309111000/eclipse-SDK-4.3.1-linux-gtk.tar.gz;
-          sha256 = "1zxsh838khny7mvl01h28xna6xdh01yi4mvls28zj22v0340lgsg";
-        };
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.3.1-201309111000/eclipse-SDK-4.3.1-linux-gtk-x86_64.tar.gz;
+        sha256 = "0ncm56ylwxw9z8rk8ccgva68c2yr9yrf1kcr1zkgw6p87xh1yczd";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.3.1-201309111000/eclipse-SDK-4.3.1-linux-gtk.tar.gz;
+        sha256 = "1zxsh838khny7mvl01h28xna6xdh01yi4mvls28zj22v0340lgsg";
+      };
     };
   };
   eclipse_sdk_431 = eclipse-sdk-431; # backward compatibility, added 2016-01-30
@@ -269,14 +255,14 @@ rec {
     name = "eclipse-sdk-4.4";
     description = "Eclipse Classic";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-linux-gtk-x86_64.tar.gz;
-          sha256 = "14hdkijsjq0hhzi9ijpwjjkhz7wm0pry86l3dniy5snlh3l5bsb2";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-linux-gtk.tar.gz;
-          sha256 = "0hjc4zrsmik6vff851p0a4ydnx99840j2xrx8348kk6h0af8vx6z";
-        };
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-linux-gtk-x86_64.tar.gz;
+        sha256 = "14hdkijsjq0hhzi9ijpwjjkhz7wm0pry86l3dniy5snlh3l5bsb2";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-linux-gtk.tar.gz;
+        sha256 = "0hjc4zrsmik6vff851p0a4ydnx99840j2xrx8348kk6h0af8vx6z";
+      };
     };
   };
   eclipse_sdk_44 = eclipse-sdk-44; # backward compatibility, added 2016-01-30
@@ -285,14 +271,14 @@ rec {
     name = "eclipse-sdk-4.4.2";
     description = "Eclipse Classic";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "0g00alsixfaakmn4khr0m9fxvkrbhbg6qqfa27xr6a9np6gzg98l";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk.tar.gz;
-          sha256 = "1hacyjjwhhxi7r3xyhpqgjqpd5r0irw9bfkalz5s5l6shb0lq4i7";
-        };
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk-x86_64.tar.gz;
+        sha256 = "0g00alsixfaakmn4khr0m9fxvkrbhbg6qqfa27xr6a9np6gzg98l";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk.tar.gz;
+        sha256 = "1hacyjjwhhxi7r3xyhpqgjqpd5r0irw9bfkalz5s5l6shb0lq4i7";
+      };
     };
   };
   eclipse_sdk_442 = eclipse-sdk-442; # backward compatibility, added 2016-01-30
@@ -301,14 +287,14 @@ rec {
     name = "eclipse-sdk-4.5";
     description = "Eclipse Mars Classic";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-SDK-4.5-linux-gtk-x86_64.tar.gz;
-          sha256 = "0vfql4gh263ms8bg7sgn05gnjajplx304cn3nr03jlacgr3pkarf";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-SDK-4.5-linux-gtk.tar.gz;
-          sha256 = "0xv66l6hdlvxpswcqrsh398wg6xhy30f833dr7jvvz45s5437hm3";
-        };
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-SDK-4.5-linux-gtk-x86_64.tar.gz;
+        sha256 = "0vfql4gh263ms8bg7sgn05gnjajplx304cn3nr03jlacgr3pkarf";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-SDK-4.5-linux-gtk.tar.gz;
+        sha256 = "0xv66l6hdlvxpswcqrsh398wg6xhy30f833dr7jvvz45s5437hm3";
+      };
     };
   };
   eclipse_sdk_45 = eclipse-sdk-45; # backward compatibility, added 2016-01-30
@@ -317,14 +303,14 @@ rec {
     name = "eclipse-sdk-4.5.1";
     description = "Eclipse Mars Classic";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-SDK-4.5.1-linux-gtk-x86_64.tar.gz;
-          sha256 = "b56503ab4b86f54e1cdc93084ef8c32fb1eaabc6f6dad9ef636153b14c928e02";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-SDK-4.5.1-linux-gtk.tar.gz;
-          sha256 = "f2e41da52e138276f8f121fd4d57c3f98839817836b56f8424e99b63c9b1b025";
-        };
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-SDK-4.5.1-linux-gtk-x86_64.tar.gz;
+        sha256 = "b56503ab4b86f54e1cdc93084ef8c32fb1eaabc6f6dad9ef636153b14c928e02";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-SDK-4.5.1-linux-gtk.tar.gz;
+        sha256 = "f2e41da52e138276f8f121fd4d57c3f98839817836b56f8424e99b63c9b1b025";
+      };
     };
   };
   eclipse_sdk_451 = eclipse-sdk-451; # backward compatibility, added 2016-01-30
@@ -333,14 +319,14 @@ rec {
     name = "eclipse-sdk-4.5.2";
     description = "Eclipse Mars Classic";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "87f82b0c13c245ee20928557dbc4435657d1e029f72d9135683c8d585c69ba8d";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk.tar.gz;
-          sha256 = "78f7e537b34333401fc782fbd1260087c586ff93b17b88da5b177642f3aa5a02";
-        };
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz;
+        sha256 = "87f82b0c13c245ee20928557dbc4435657d1e029f72d9135683c8d585c69ba8d";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk.tar.gz;
+        sha256 = "78f7e537b34333401fc782fbd1260087c586ff93b17b88da5b177642f3aa5a02";
+      };
     };
   };
   
@@ -348,14 +334,14 @@ rec {
     name = "eclipse-sdk-4.6";
     description = "Eclipse Neon Classic";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk-x86_64.tar.gz;
-          sha256 = "4d7a39ce4e04ba1f5179f6a72926eb86ed506d97842a3bf4247814491c508e0a";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk.tar.gz;
-          sha256 = "d9e1d390cac504a17a65d4a22ebb8da6a592bcc54491912cbc29577990d77014";
-        };
+      "x86_64-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk-x86_64.tar.gz;
+        sha256 = "4d7a39ce4e04ba1f5179f6a72926eb86ed506d97842a3bf4247814491c508e0a";
+      };
+      "i686-linux" = {
+        url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk.tar.gz;
+        sha256 = "d9e1d390cac504a17a65d4a22ebb8da6a592bcc54491912cbc29577990d77014";
+      };
     };
   };
 
@@ -365,14 +351,14 @@ rec {
     name = "eclipse-platform-4.5";
     description = "Eclipse platform";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk-x86_64.tar.gz;
-          sha256 = "1510j41yr86pbzwf48kjjdd46nkpkh8zwn0hna0cqvsw1gk2vqcg";
-        };
-      "i686-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk.tar.gz;
-          sha256 = "1f97jd3qbi3830y3djk8bhwzd9whsq8gzfdk996chxc55prn0qbd";
-        };
+      "x86_64-linux" = {
+        url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk-x86_64.tar.gz;
+        sha256 = "1510j41yr86pbzwf48kjjdd46nkpkh8zwn0hna0cqvsw1gk2vqcg";
+      };
+      "i686-linux" = {
+        url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk.tar.gz;
+        sha256 = "1f97jd3qbi3830y3djk8bhwzd9whsq8gzfdk996chxc55prn0qbd";
+      };
     };
   };
 
@@ -380,14 +366,14 @@ rec {
     name = "eclipse-platform-4.5.1";
     description = "Eclipse platform";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-platform-4.5.1-linux-gtk-x86_64.tar.gz;
-          sha256 = "1m7bzyi20yss6cz74d7hvhxj1cddcpgzxjia5wcjycsvq33kkny0";
-        };
-      "i686-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-platform-4.5.1-linux-gtk.tar.gz;
-          sha256 = "17x8w4k0rba0c0v9ghxdl0zqfadla5c1aakfd5k0q9q3x3qi6rxp";
-        };
+      "x86_64-linux" = {
+        url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-platform-4.5.1-linux-gtk-x86_64.tar.gz;
+        sha256 = "1m7bzyi20yss6cz74d7hvhxj1cddcpgzxjia5wcjycsvq33kkny0";
+      };
+      "i686-linux" = {
+        url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-platform-4.5.1-linux-gtk.tar.gz;
+        sha256 = "17x8w4k0rba0c0v9ghxdl0zqfadla5c1aakfd5k0q9q3x3qi6rxp";
+      };
     };
   };
 
@@ -395,14 +381,14 @@ rec {
     name = "eclipse-platform-4.5.2";
     description = "Eclipse platform";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "13dsd5f5i39wd0sr2bgp57hd2msn8g2dnmw5j8hfwif22c62py47";
-        };
-      "i686-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk.tar.gz;
-          sha256 = "00jsmbrl4xhpbgd8hyxijgzqdic700kd3yw2qwgl0cs3ncvybxvq";
-        };
+      "x86_64-linux" = {
+        url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz;
+        sha256 = "13dsd5f5i39wd0sr2bgp57hd2msn8g2dnmw5j8hfwif22c62py47";
+      };
+      "i686-linux" = {
+        url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk.tar.gz;
+        sha256 = "00jsmbrl4xhpbgd8hyxijgzqdic700kd3yw2qwgl0cs3ncvybxvq";
+      };
     };
   };
 
@@ -410,14 +396,14 @@ rec {
     name = "eclipse-platform-4.6";
     description = "Eclipse platform";
     sources = {
-      "x86_64-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk-x86_64.tar.gz;
-          sha256 = "02lfa0f4j53q4ks3nal4jxnm1vc6xck2k9zng58izfh49v73jyjd";
-        };
-      "i686-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk.tar.gz;
-          sha256 = "053hsy87jmr9phn934a4qny959d6inxjx8nlcmxa2165ra8d7qfr";
-        };
+      "x86_64-linux" = {
+        url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk-x86_64.tar.gz;
+        sha256 = "02lfa0f4j53q4ks3nal4jxnm1vc6xck2k9zng58izfh49v73jyjd";
+      };
+      "i686-linux" = {
+        url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk.tar.gz;
+        sha256 = "053hsy87jmr9phn934a4qny959d6inxjx8nlcmxa2165ra8d7qfr";
+      };
     };
   };
 

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -1,32 +1,29 @@
-{ stdenv, lib, callPackage, fetchurl, unzip, atomEnv, makeDesktopItem,
-  makeWrapper, libXScrnSaver }:
+{ stdenv, lib, fetchOneOf, unzip, atomEnv, makeDesktopItem, makeWrapper
+, libXScrnSaver
+}:
 
 let
   version = "1.6.1";
   rev = "9e4e44c19e393803e2b05fe2323cf4ed7e36880e";
-
-  sha256 = if stdenv.system == "i686-linux"    then "1aks84siflpjbd2s9y1f0vvvf3nas4f50cimjf25lijxzjxrlivy"
-      else if stdenv.system == "x86_64-linux"  then "05kbi081ih64fadj4k74grkk9ca3wga6ybwgs5ld0bal4ilw1q6i"
-      else if stdenv.system == "x86_64-darwin" then "00p2m8b0l3pkf5k74szw6kcql3j1fjnv3rwnhy24wfkg4b4ah2x9"
-      else throw "Unsupported system: ${stdenv.system}";
-
   urlBase = "https://az764295.vo.msecnd.net/stable/${rev}/";
-
-  urlStr = if stdenv.system == "i686-linux" then
-        urlBase + "code-stable-code_${version}-1476372351_i386.tar.gz"
-      else if stdenv.system == "x86_64-linux" then
-        urlBase + "code-stable-code_${version}-1476373175_amd64.tar.gz"
-      else if stdenv.system == "x86_64-darwin" then
-        urlBase + "VSCode-darwin-stable.zip"
-      else throw "Unsupported system: ${stdenv.system}";
 in
   stdenv.mkDerivation rec {
     name = "vscode-${version}";
     inherit version;
 
-    src = fetchurl {
-      url = urlStr;
-      inherit sha256;
+    src = fetchOneOf stdenv.system {
+      "i686-linux" = {
+        url = "${urlBase}/code-stable-code_${version}-1476372351_i386.tar.gz";
+        sha256 = "1aks84siflpjbd2s9y1f0vvvf3nas4f50cimjf25lijxzjxrlivy";
+      };
+      "x86_64-linux" = {
+        url = "${urlBase}/code-stable-code_${version}-1476373175_amd64.tar.gz";
+        sha256 = "05kbi081ih64fadj4k74grkk9ca3wga6ybwgs5ld0bal4ilw1q6i";
+      };
+      "x86_64-darwin" = {
+        url = "${urlBase}/VSCode-darwin-stable.zip";
+        sha256 = "00p2m8b0l3pkf5k74szw6kcql3j1fjnv3rwnhy24wfkg4b4ah2x9";
+      };
     };
 
     desktopItem = makeDesktopItem {

--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -1,29 +1,32 @@
-{ stdenv, callPackage, overrideCC, fetchurl, makeWrapper, pkgconfig
+{ stdenv, callPackage, overrideCC, fetchurl, fetchOneOf, makeWrapper, pkgconfig
 , zip, python, zlib, which, icu, libmicrohttpd, lzma, ctpp2, aria2, wget, bc
 , libuuid, glibc, libX11, libXext, libXt, libXrender, glib, dbus, dbus_glib
 , gtk2, gdk_pixbuf, pango, cairo , freetype, fontconfig, alsaLib, atk
 }:
 
 let
-  xulrunner64_tar = fetchurl {
-    url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-x86_64.tar.bz2;
-    sha256 = "0i3m30gm5z7qmas14id6ypvbmnb2k7jhz8aby2wz5vvv49zqmx3s";
-  };
-  xulrunnersdk64_tar = fetchurl {
-    url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-x86_64.sdk.tar.bz2;
-    sha256 = "0z90v7c4mq15g5klmsj8vs2r10fbygj3qzynx4952hkv8ihw8n3a";
-  };
-  xulrunner32_tar = fetchurl {
-    url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-i686.tar.bz2;
-    sha256 = "0yln6pxz8f6b9wm9124sx049z8mgi17lgd63rcv2hnix825y8gjb";
-  };
-  xulrunnersdk32_tar = fetchurl {
-    url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-i686.sdk.tar.bz2;
-    sha256 = "1h9vcbvf8wgds6i2z20y7krpys0mqsqhv1ijyfljanp6vyll9fvi";
+  xulrunner_tar = fetchOneOf stdenv.system {
+    "x86_64-linux" = {
+      url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-x86_64.tar.bz2;
+      sha256 = "0i3m30gm5z7qmas14id6ypvbmnb2k7jhz8aby2wz5vvv49zqmx3s";
+    };
+    "i686-linux" = {
+      url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-i686.tar.bz2;
+      sha256 = "0yln6pxz8f6b9wm9124sx049z8mgi17lgd63rcv2hnix825y8gjb";
+    };
   };
 
-  xulrunner_tar = if stdenv.system == "x86_64-linux" then xulrunner64_tar else xulrunner32_tar;
-  xulrunnersdk_tar = if stdenv.system == "x86_64-linux" then xulrunnersdk64_tar else xulrunnersdk32_tar;
+  xulrunnersdk_tar = fetchOneOf stdenv.system {
+    "x86_64-linux" = {
+      url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-x86_64.sdk.tar.bz2;
+      sha256 = "0z90v7c4mq15g5klmsj8vs2r10fbygj3qzynx4952hkv8ihw8n3a";
+    };
+    "i686-linux" = {
+      url = http://download.kiwix.org/dev/xulrunner-29.0.en-US.linux-i686.sdk.tar.bz2;
+      sha256 = "1h9vcbvf8wgds6i2z20y7krpys0mqsqhv1ijyfljanp6vyll9fvi";
+    };
+  };
+
   pugixml_tar = fetchurl {
     url = http://download.kiwix.org/dev/pugixml-1.2.tar.gz;
     sha256 = "0sqk0vdwjq44jxbbkj1cy8qykrmafs1sickzldb2w2nshsnjshhg";

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, libX11, libXext, libSM, libICE
+{ stdenv, fetchOneOf, zlib, libX11, libXext, libSM, libICE
 , libXfixes, libXt, libXi, libXcursor, libXScrnSaver, libXcomposite, libXdamage, libXtst, libXrandr
 , alsaLib, dbus_libs, cups, libexif, ffmpeg, systemd
 , freetype, fontconfig, libXft, libXrender, libxcb, expat, libXau, libXdmcp
@@ -10,25 +10,24 @@
 }:
 
 let
+  pname = "vivaldi";
   version = "1.4";
   build = "589.29-1";
   fullVersion = "stable_${version}.${build}";
-
-  info = if stdenv.is64bit then {
-      arch = "amd64";
-      sha256 = "14sb58qrqnqcpkzacwnwfln558p018zargppxq21p5ic8s92v1g6";
-    } else {
-      arch = "i386";
-      sha256 = "0c4l9ji5xlxwzcjsrvxjkx53j76y777fj6hh7plfkkanlrfkryac";
-    };
+  baseURL = "https://downloads.vivaldi.com/stable/${pname}-${fullVersion}";
 
 in stdenv.mkDerivation rec {
-  product    = "vivaldi";
-  name       = "${product}-${version}";
+  name = "${pname}-${version}";
 
-  src = fetchurl {
-    inherit (info) sha256;
-    url = "https://downloads.vivaldi.com/stable/${product}-${fullVersion}_${info.arch}.deb";
+  src = fetchOneOf stdenv.system {
+    "x86_64-linux" = {
+      url = "${baseURL}_amd64.deb";
+      sha256 = "14sb58qrqnqcpkzacwnwfln558p018zargppxq21p5ic8s92v1g6";
+    };
+    "i686-linux" = {
+      url = "${baseURL}_i386.deb";
+      sha256 = "0c4l9ji5xlxwzcjsrvxjkx53j76y777fj6hh7plfkkanlrfkryac";
+    };
   };
 
   unpackPhase = ''

--- a/pkgs/build-support/fetch-one-of/default.nix
+++ b/pkgs/build-support/fetch-one-of/default.nix
@@ -4,7 +4,7 @@
 #
 # Example usage:
 #
-#     fetchmulti stdenv.system {
+#     fetchOneOf stdenv.system {
 #        "x86_64-linux" = {
 #          url = "http://example.com/x86-linux.tar.gz";
 #          sha256 = "...";

--- a/pkgs/build-support/fetch-one-of/default.nix
+++ b/pkgs/build-support/fetch-one-of/default.nix
@@ -1,0 +1,46 @@
+{ lib, fetchers }:
+
+# Similar to fetchdata but allows to switch on an attribute
+#
+# Example usage:
+#
+#     fetchmulti stdenv.system {
+#        "x86_64-linux" = {
+#          url = "http://example.com/x86-linux.tar.gz";
+#          sha256 = "...";
+#        };
+#        "i686-linux" = {
+#          url = "http://example.com/i686-linux.tar.gz";
+#          sha256 = "...";
+#        };
+#     }
+#
+# All the urls are exposed on the `all' attribute which allows to run
+# `nix-fetchetch-url -A mypackage.src.all` to calculate the checksums of the:q
+#
+# FIXME: right now nix-prefetch-url only work if one of the keys match the
+#        current plaform
+#
+key: data:
+let
+  fetchdata = { fetcher ? "fetchurl", ... }@attrs:
+    let
+      # TODO: add heuristic based on the input data instead
+      fetcher' =
+        fetchers."${fetcher}" or
+          (throw "fetcher of type `${fetcher}' not supported");
+      attrs' = builtins.removeAttrs attrs ["fetcher"];
+    in
+      fetcher' attrs';
+
+  attrs = data."${key}" or (throw "source for `${key}' is not available");
+
+  # A list of all the fetcher urls
+  urls = lib.foldl
+    (sum: v: ((fetchdata v).urls or []) ++ sum)
+    []
+    (builtins.attrValues data);
+in
+  (fetchdata attrs) // { all = { inherit urls; }; }
+
+

--- a/pkgs/development/compilers/fpc/binary.nix
+++ b/pkgs/development/compilers/fpc/binary.nix
@@ -1,20 +1,18 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchOneOf }:
 
 stdenv.mkDerivation {
   name = "fpc-2.6.0-binary";
 
-  src =
-    if stdenv.system == "i686-linux" then
-      fetchurl {
-        url = "mirror://sourceforge/project/freepascal/Linux/2.6.0/fpc-2.6.0.i386-linux.tar";
-        sha256 = "08yklvrfxvk59bxsd4rh1i6s3cjn0q06dzjs94h9fbq3n1qd5zdf";
-      }
-    else if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        url = "mirror://sourceforge/project/freepascal/Linux/2.6.0/fpc-2.6.0.x86_64-linux.tar";
-        sha256 = "0k9vi75k39y735fng4jc2vppdywp82j4qhzn7x4r6qjkad64d8lx";
-      }
-    else throw "Not supported on ${stdenv.system}.";
+  src = fetchOneOf stdenv.system {
+    "i686-linux" = {
+      url = "mirror://sourceforge/project/freepascal/Linux/2.6.0/fpc-2.6.0.i386-linux.tar";
+      sha256 = "08yklvrfxvk59bxsd4rh1i6s3cjn0q06dzjs94h9fbq3n1qd5zdf";
+    };
+    "x86_64-linux" = {
+      url = "mirror://sourceforge/project/freepascal/Linux/2.6.0/fpc-2.6.0.x86_64-linux.tar";
+      sha256 = "0k9vi75k39y735fng4jc2vppdywp82j4qhzn7x4r6qjkad64d8lx";
+    };
+  };
 
   builder = ./binary-builder.sh;
 

--- a/pkgs/development/compilers/fpc/default.nix
+++ b/pkgs/development/compilers/fpc/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, gawk }:
+{ stdenv, fetchurl, fetchOneOf, gawk }:
 
-let startFPC = import ./binary.nix { inherit stdenv fetchurl; }; in
+let startFPC = import ./binary.nix { inherit stdenv fetchOneOf; }; in
 
 stdenv.mkDerivation rec {
   version = "3.0.0";

--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -1,24 +1,22 @@
-{stdenv, lib, fetchurl, perl, libedit, ncurses5, gmp}:
+{stdenv, lib, fetchOneOf, perl, libedit, ncurses5, gmp}:
 
 stdenv.mkDerivation rec {
   version = "6.10.2";
 
   name = "ghc-${version}-binary";
 
-  src =
-    if stdenv.system == "i686-linux" then
-      fetchurl {
-        # This binary requires libedit.so.0 (rather than libedit.so.2).
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
-        sha256 = "1fw0zr2qshlpk8s0d16k27zcv5263nqdg2xds5ymw8ff6qz9rz9b";
-      }
-    else if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        # Idem.
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
-        sha256 = "1rd2j7lmcfsm2rdfb5g6q0l8dz3sxadk5m3d2f69d4a6g4p4h7jj";
-      }
-    else throw "cannot bootstrap GHC on this platform";
+  src = fetchOneOf stdenv.system {
+    "i686-linux" = {
+      # This binary requires libedit.so.0 (rather than libedit.so.2).
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
+      sha256 = "1fw0zr2qshlpk8s0d16k27zcv5263nqdg2xds5ymw8ff6qz9rz9b";
+    };
+    "x86_64-linux" = {
+      # Idem.
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
+      sha256 = "1rd2j7lmcfsm2rdfb5g6q0l8dz3sxadk5m3d2f69d4a6g4p4h7jj";
+    };
+  };
 
   buildInputs = [perl];
 

--- a/pkgs/development/compilers/ghc/7.0.4-binary.nix
+++ b/pkgs/development/compilers/ghc/7.0.4-binary.nix
@@ -1,32 +1,28 @@
-{stdenv, fetchurl, perl, ncurses5, gmp, libiconv}:
+{stdenv, fetchOneOf, perl, ncurses5, gmp, libiconv}:
 
 stdenv.mkDerivation rec {
   version = "7.0.4";
 
   name = "ghc-${version}-binary";
 
-  src =
-    if stdenv.system == "i686-linux" then
-      fetchurl {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
-        sha256 = "0mfnihiyjl06f5w1yrjp36sw9g67g2ymg5sdl0g23h1pab99jx63";
-      }
-    else if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
-        sha256 = "0mc4rhqcxz427wq4zgffmnn0d2yjqvy6af4x9mha283p1gdj5q99";
-      }
-    else if stdenv.system == "i686-darwin" then
-      fetchurl {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
-        sha256 = "0qj45hslrrr8zfks8m1jcb3awwx9rh35ndnpfmb0gwb6j7azq5n3";
-      }
-    else if stdenv.system == "x86_64-darwin" then
-      fetchurl {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
-        sha256 = "1m2ml88p1swf4dnv2vq8hz4drcp46n3ahpfi05wh01ajkf8hnn3l";
-      }
-    else throw "cannot bootstrap GHC on this platform";
+  src = fetchOneOf stdenv.system {
+    "i686-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
+      sha256 = "0mfnihiyjl06f5w1yrjp36sw9g67g2ymg5sdl0g23h1pab99jx63";
+    };
+    "x86_64-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
+      sha256 = "0mc4rhqcxz427wq4zgffmnn0d2yjqvy6af4x9mha283p1gdj5q99";
+    };
+    "i686-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
+      sha256 = "0qj45hslrrr8zfks8m1jcb3awwx9rh35ndnpfmb0gwb6j7azq5n3";
+    };
+    "x86_64-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
+      sha256 = "1m2ml88p1swf4dnv2vq8hz4drcp46n3ahpfi05wh01ajkf8hnn3l";
+    };
+  };
 
   buildInputs = [perl];
 

--- a/pkgs/development/compilers/ghc/7.4.2-binary.nix
+++ b/pkgs/development/compilers/ghc/7.4.2-binary.nix
@@ -1,32 +1,28 @@
-{stdenv, fetchurl, perl, ncurses5, gmp, libiconv, makeWrapper}:
+{stdenv, fetchOneOf, perl, ncurses5, gmp, libiconv, makeWrapper}:
 
 stdenv.mkDerivation rec {
   version = "7.4.2";
 
   name = "ghc-${version}-binary";
 
-  src =
-    if stdenv.system == "i686-linux" then
-      fetchurl {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
-        sha256 = "0gny7knhss0w0d9r6jm1gghrcb8kqjvj94bb7hxf9syrk4fxlcxi";
-      }
-    else if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
-        sha256 = "043jabd0lh6n1zlqhysngbpvlsdznsa2mmsj08jyqgahw9sjb5ns";
-      }
-    else if stdenv.system == "i686-darwin" then
-      fetchurl {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
-        sha256 = "1vrbs3pzki37hzym1f1nh07lrqh066z3ypvm81fwlikfsvk4djc0";
-      }
-    else if stdenv.system == "x86_64-darwin" then
-      fetchurl {
-        url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
-        sha256 = "1imzqc0slpg0r6p40n5a9m18cbcm0m86z8dgyhfxcckksw54mzwf";
-      }
-    else throw "cannot bootstrap GHC on this platform";
+  src = fetchOneOf stdenv.system {
+    "i686-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-unknown-linux.tar.bz2";
+      sha256 = "0gny7knhss0w0d9r6jm1gghrcb8kqjvj94bb7hxf9syrk4fxlcxi";
+    };
+    "x86_64-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-unknown-linux.tar.bz2";
+      sha256 = "043jabd0lh6n1zlqhysngbpvlsdznsa2mmsj08jyqgahw9sjb5ns";
+    };
+    "i686-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-apple-darwin.tar.bz2";
+      sha256 = "1vrbs3pzki37hzym1f1nh07lrqh066z3ypvm81fwlikfsvk4djc0";
+    };
+    "x86_64-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.bz2";
+      sha256 = "1imzqc0slpg0r6p40n5a9m18cbcm0m86z8dgyhfxcckksw54mzwf";
+    };
+  };
 
   buildInputs = [perl];
 

--- a/pkgs/development/compilers/nvidia-cg-toolkit/default.nix
+++ b/pkgs/development/compilers/nvidia-cg-toolkit/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, patchelf }:
+{ lib, stdenv, fetchOneOf, patchelf }:
 
 assert stdenv ? glibc;
 
@@ -9,18 +9,16 @@ stdenv.mkDerivation rec {
 
   name = "nvidia-cg-toolkit-${version}";
 
-  src =
-    if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        url = "http://developer.download.nvidia.com/cg/Cg_${version}/Cg-${version}_${date}_x86_64.tgz";
-        sha256 = "e8ff01e6cc38d1b3fd56a083f5860737dbd2f319a39037528fb1a74a89ae9878";
-      }
-    else if stdenv.system == "i686-linux" then
-      fetchurl {
-        url = "http://developer.download.nvidia.com/cg/Cg_${version}/Cg-${version}_${date}_x86.tgz";
-        sha256 = "cef3591e436f528852db0e8c145d3842f920e0c89bcfb219c466797cb7b18879";
-      }
-    else throw "nvidia-cg-toolkit does not support platform ${stdenv.system}";
+  src = fetchOneOf stdenv.system {
+    "x86_64-linux" = {
+      url = "http://developer.download.nvidia.com/cg/Cg_${version}/Cg-${version}_${date}_x86_64.tgz";
+      sha256 = "e8ff01e6cc38d1b3fd56a083f5860737dbd2f319a39037528fb1a74a89ae9878";
+    };
+    "i686-linux" = {
+      url = "http://developer.download.nvidia.com/cg/Cg_${version}/Cg-${version}_${date}_x86.tgz";
+      sha256 = "cef3591e436f528852db0e8c145d3842f920e0c89bcfb219c466797cb7b18879";
+    };
+  };
 
   installPhase = ''
     for b in cgc cgfxcat cginfo

--- a/pkgs/development/compilers/opendylan/bin.nix
+++ b/pkgs/development/compilers/opendylan/bin.nix
@@ -1,19 +1,20 @@
 # Binaries provided by Open Dylan to be used to bootstrap from source.
 # The binaries can also be used as is.
-{stdenv, fetchurl, patchelf, boehmgc, gnused, gcc, makeWrapper}:
+{stdenv, fetchOneOf, patchelf, boehmgc, gnused, gcc, makeWrapper}:
 
 stdenv.mkDerivation {
   name = "opendylan-2013.2";
 
-  src = if stdenv.system == "x86_64-linux" then fetchurl {
+  src = fetchOneOf stdenv.system {
+    "x86_64-linux" = {
       url = http://opendylan.org/downloads/opendylan/2013.2/opendylan-2013.2-x86_64-linux.tar.bz2;
       sha256 = "035brbw3hm7zrs593q4zc42yglj1gmmkw3b1r7zzlw3ks4i2lg7h";
-    }
-    else if stdenv.system == "i686-linux" then fetchurl {
+    };
+    "i686-linux" = {
       url = http://opendylan.org/downloads/opendylan/2013.2/opendylan-2013.2-x86-linux.tar.bz2;
       sha256 = "0c61ihvblcsjrw6ncr8x8ylhskcrqs8pajs4mg5di36cvqw12nq5";
-    }
-    else throw "platform ${stdenv.system} not supported.";
+    };
+  };
 
   buildInputs = [ patchelf boehmgc gnused makeWrapper ];
 

--- a/pkgs/development/compilers/openjdk/bootstrap.nix
+++ b/pkgs/development/compilers/openjdk/bootstrap.nix
@@ -1,35 +1,28 @@
-{ stdenv, runCommand, glibc, fetchurl, file
+{ stdenv, runCommand, glibc, fetchOneOf, file
 
 , version
 }:
 
 let
   # !!! These should be on nixos.org
-  src = if glibc.system == "x86_64-linux" then
-    (if version == "8" then
-      fetchurl {
-        url = "https://www.dropbox.com/s/a0lsq2ig4uguky5/openjdk8-bootstrap-x86_64-linux.tar.xz?dl=1";
-        sha256 = "18zqx6jhm3lizn9hh6ryyqc9dz3i96pwaz8f6nxfllk70qi5gvks";
-      }
-    else if version == "7" then
-      fetchurl {
-        url = "https://www.dropbox.com/s/rssfbeommrfbsjf/openjdk7-bootstrap-x86_64-linux.tar.xz?dl=1";
-        sha256 = "024gg2sgg4labxbc1nhn8lxls2p7d9h3b82hnsahwaja2pm1hbra";
-      }
-    else throw "No bootstrap for version")
-  else if glibc.system == "i686-linux" then
-    (if version == "8" then
-      fetchurl {
-        url = "https://www.dropbox.com/s/rneqjhlerijsw74/openjdk8-bootstrap-i686-linux.tar.xz?dl=1";
-        sha256 = "1yx04xh8bqz7amg12d13rw5vwa008rav59mxjw1b9s6ynkvfgqq9";
-      }
-    else if version == "7" then
-      fetchurl {
-        url = "https://www.dropbox.com/s/6xe64td7eg2wurs/openjdk7-bootstrap-i686-linux.tar.xz?dl=1";
-        sha256 = "0xwqjk1zx8akziw8q9sbjc1rs8s7c0w6mw67jdmmi26cwwp8ijnx";
-      }
-    else throw "No bootstrap for version")
-  else throw "No bootstrap for system";
+  src = fetchOneOf "${glibc.system}-jdk${version}" {
+    "x86_64-linux-jdk7" = {
+      url = "https://www.dropbox.com/s/rssfbeommrfbsjf/openjdk7-bootstrap-x86_64-linux.tar.xz?dl=1";
+      sha256 = "024gg2sgg4labxbc1nhn8lxls2p7d9h3b82hnsahwaja2pm1hbra";
+    };
+    "x86_64-linux-jdk8" = {
+      url = "https://www.dropbox.com/s/a0lsq2ig4uguky5/openjdk8-bootstrap-x86_64-linux.tar.xz?dl=1";
+      sha256 = "18zqx6jhm3lizn9hh6ryyqc9dz3i96pwaz8f6nxfllk70qi5gvks";
+    };
+    "i686-linux-jdk7" = {
+      url = "https://www.dropbox.com/s/6xe64td7eg2wurs/openjdk7-bootstrap-i686-linux.tar.xz?dl=1";
+      sha256 = "0xwqjk1zx8akziw8q9sbjc1rs8s7c0w6mw67jdmmi26cwwp8ijnx";
+    };
+    "i686-linux-jdk8" = {
+      url = "https://www.dropbox.com/s/rneqjhlerijsw74/openjdk8-bootstrap-i686-linux.tar.xz?dl=1";
+      sha256 = "1yx04xh8bqz7amg12d13rw5vwa008rav59mxjw1b9s6ynkvfgqq9";
+    };
+  };
 
   bootstrap = runCommand "openjdk-bootstrap" {
     passthru.home = "${bootstrap}/lib/openjdk";

--- a/pkgs/development/libraries/libspotify/default.nix
+++ b/pkgs/development/libraries/libspotify/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libspotify, alsaLib, readline, pkgconfig, apiKey, unzip, gnused }:
+{ stdenv, fetchOneOf, libspotify, alsaLib, readline, pkgconfig, apiKey, unzip, gnused }:
 
 let
   version = "12.1.51";
@@ -10,24 +10,20 @@ then throw "Check https://developer.spotify.com/technologies/libspotify/ for a t
 else stdenv.mkDerivation {
   name = "libspotify-${version}";
 
-  src =
-    if stdenv.system == "x86_64-linux" then
-      fetchurl {
-        url    = "https://developer.spotify.com/download/libspotify/libspotify-${version}-Linux-x86_64-release.tar.gz";
-        sha256 = "0n0h94i4xg46hfba95n3ypah93crwb80bhgsg00f6sms683lx8a3";
-      }
-    else if stdenv.system == "x86_64-darwin" then
-      fetchurl {
-        url    = "https://developer.spotify.com/download/libspotify/libspotify-${version}-Darwin-universal.zip";
-        sha256 = "1gcgrc8arim3hnszcc886lmcdb4iigc08abkaa02l6gng43ky1c0";
-      }
-    else if stdenv.system == "i686-linux" then
-      fetchurl {
-        url    = "https://developer.spotify.com/download/libspotify/libspotify-${version}-Linux-i686-release.tar.gz";
-        sha256 = "1bjmn64gbr4p9irq426yap4ipq9rb84zsyhjjr7frmmw22xb86ll";
-      }
-    else
-      null;
+  src = fetchOneOf stdenv.system {
+    "x86_64-linux" = {
+      url    = "https://developer.spotify.com/download/libspotify/libspotify-${version}-Linux-x86_64-release.tar.gz";
+      sha256 = "0n0h94i4xg46hfba95n3ypah93crwb80bhgsg00f6sms683lx8a3";
+    };
+    "x86_64-darwin" = {
+      url    = "https://developer.spotify.com/download/libspotify/libspotify-${version}-Darwin-universal.zip";
+      sha256 = "1gcgrc8arim3hnszcc886lmcdb4iigc08abkaa02l6gng43ky1c0";
+    };
+    "i686-linux" = {
+      url    = "https://developer.spotify.com/download/libspotify/libspotify-${version}-Linux-i686-release.tar.gz";
+      sha256 = "1bjmn64gbr4p9irq426yap4ipq9rb84zsyhjjr7frmmw22xb86ll";
+    };
+  };
 
   dontBuild = true;
 

--- a/pkgs/development/tools/phantomjs/default.nix
+++ b/pkgs/development/tools/phantomjs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, freetype, fontconfig, openssl, unzip }:
+{ stdenv, lib, fetchOneOf, freetype, fontconfig, openssl, unzip }:
 
 let
   platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
@@ -13,22 +13,20 @@ stdenv.mkDerivation rec {
   # because it has bundled a lot of external libraries (like QT and Webkit)
   # and no easy/nice way to use the system versions of these
 
-  src = if stdenv.system == "i686-linux" then
-          fetchurl {
-            url = "https://bitbucket.org/ariya/phantomjs/downloads/${name}-linux-i686.tar.bz2";
-            sha256 = "11fzmssz9pqf3arh4f36w06sl2nyz8l9h8iyxyd7w5aqnq5la0j1";
-          }
-        else
-          if stdenv.system == "x86_64-linux" then
-            fetchurl {
-              url = "https://bitbucket.org/ariya/phantomjs/downloads/${name}-linux-x86_64.tar.bz2";
-              sha256 = "0fhnqxxsxhy125fmif1lwgnlhfx908spy7fx9mng4w72320n5nd1";
-            }
-          else # x86_64-darwin
-            fetchurl {
-              url = "https://bitbucket.org/ariya/phantomjs/downloads/${name}-macosx.zip";
-              sha256 = "0j0aq8dgzmb210xdrh0v3d4nblskl3zsckl8bzf1a603wcx085cg";
-            };
+  src = fetchOneOf stdenv.system {
+    "i686-linux" = {
+      url = "https://bitbucket.org/ariya/phantomjs/downloads/${name}-linux-i686.tar.bz2";
+      sha256 = "11fzmssz9pqf3arh4f36w06sl2nyz8l9h8iyxyd7w5aqnq5la0j1";
+    };
+    "x86_64-linux" = {
+      url = "https://bitbucket.org/ariya/phantomjs/downloads/${name}-linux-x86_64.tar.bz2";
+      sha256 = "0fhnqxxsxhy125fmif1lwgnlhfx908spy7fx9mng4w72320n5nd1";
+    };
+    "x86_64-darwin" = {
+      url = "https://bitbucket.org/ariya/phantomjs/downloads/${name}-macosx.zip";
+      sha256 = "0j0aq8dgzmb210xdrh0v3d4nblskl3zsckl8bzf1a603wcx085cg";
+    };
+  };
 
   buildInputs = lib.optional stdenv.isDarwin unzip;
 

--- a/pkgs/tools/typesetting/kindlegen/default.nix
+++ b/pkgs/tools/typesetting/kindlegen/default.nix
@@ -1,34 +1,40 @@
-{ fetchurl, stdenv }:
+{ stdenv, fetchOneOf }:
 
 let
   version = "2.9";
   fileVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
-
-  sha256 = {
-    "x86_64-linux"  = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
-    "i686-linux"    = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
-    "x86_64-darwin" = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
-    "i686-darwin"   = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
-    "x86_64-cygwin" = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
-    "i686-cygwin"   = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
-  }."${stdenv.system}" or (throw "system #{stdenv.system.} is not supported");
-
-  url = {
-    "x86_64-linux"  = "http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
-    "i686-linux"    = "http://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
-    "x86_64-darwin" = "http://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v${fileVersion}.zip";
-    "i686-darwin"   = "http://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v${fileVersion}.zip";
-    "x86_64-cygwin" = "http://kindlegen.s3.amazonaws.com/kindlegen_win32_v${fileVersion}.zip";
-    "i686-cygwin"   = "http://kindlegen.s3.amazonaws.com/kindlegen_win32_v${fileVersion}.zip";
-  }."${stdenv.system}" or (throw "system #{stdenv.system.} is not supported");
+  baseURL = "http://kindlegen.s3.amazonaws.com";
+  src = fetchOneOf stdenv.system {
+    "x86_64-linux"  = {
+      url = "${baseURL}/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
+      sha256 = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
+    };
+    "i686-linux"    = {
+      url = "${baseURL}/kindlegen_linux_2.6_i386_v${fileVersion}.tar.gz";
+      sha256 = "15i20kzhdcmi94w7wfhqbl6j20v47cdakjm2mn3x8w495iddna4q";
+    };
+    "x86_64-darwin" = {
+      url = "${baseURL}/KindleGen_Mac_i386_v${fileVersion}.zip";
+      sha256 = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
+    };
+    "i686-darwin"   = {
+      url = "${baseURL}/KindleGen_Mac_i386_v${fileVersion}.zip";
+      sha256 = "0zniyn0s41fxqrajbgwxbcsj5vzf9m7a6yvdz2b11mphr00kpbbs";
+    };
+    "x86_64-cygwin" = {
+      url = "${baseURL}/kindlegen_win32_v${fileVersion}.zip";
+      sha256 = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
+    };
+    "i686-cygwin"   = {
+      url = "${baseURL}/kindlegen_win32_v${fileVersion}.zip";
+      sha256 = "02slfh1bbpijay4skj85cjiv7z43ha8vm5aa1lwiqjk86qbl1f3h";
+    };
+  };
 
 in stdenv.mkDerivation rec {
   name = "kindlegen-${version}";
 
-  src = fetchurl {
-    inherit url;
-    inherit sha256;
-  };
+  inherit src;
 
   sourceRoot = ".";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -262,6 +262,11 @@ in
   } // removeAttrs args [ "repo" "rev" ]) // { inherit rev; };
 
   fetchNuGet = callPackage ../build-support/fetchnuget { };
+
+  fetchOneOf = callPackage ../build-support/fetch-one-of {
+    fetchers = pkgs;
+  };
+
   buildDotnetPackage = callPackage ../build-support/build-dotnet-package { };
 
   resolveMirrorURLs = {url}: fetchurl {


### PR DESCRIPTION
###### Motivation for this change

it's currently painful to update sha256s with multi-arch sources (binary packages). With fetchmulti it's possible to do `nix-prefetch-url . -A mypackage.src.all` and get all the hashes out.

This is a continuation of #19540 with more packages converted.

@garbas firefox-bin is the biggest-one left that I could find. It has some heuristic to select the locale which we might consider removing?

@edolstra this PR only introduces the `fetchOneOf` since the previous PR had a bit of a mix of concerns.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
