### PR TITLE
mkvtoolnix: fix GUI not being built

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -19,12 +19,17 @@ stdenv.mkDerivation rec {
     sha256 = "1dyhlpik8d9z78dg47cha313r0dm9fcjg6hzkmzd2ng9yrq5pmdy";
   };
 
-  nativeBuildInputs = [ pkgconfig autoconf automake gettext ruby ];
+  nativeBuildInputs = [
+    autoconf automake
+    pkgconfig gettext ruby
+  ];
 
   buildInputs = [
-    expat file xdg_utils boost libebml zlib libmatroska libogg
-    libvorbis flac
-  ] ++ optional withGUI qt5.qtbase;
+    expat file xdg_utils
+    boost libebml zlib
+    libmatroska libogg libvorbis flac
+    (optional withGUI qt5.full)
+  ];
 
   preConfigure = "./autogen.sh; patchShebangs .";
   buildPhase   = "./drake -j $NIX_BUILD_CORES";


### PR DESCRIPTION
###### Motivation for this change

With `qt5.qtbase` the configure script will skip building the GUI because some dependency is missing
###### Things done
- [x] Tested using sandboxing
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
