### PR TITLE
Add dante package & accompanying service module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -346,6 +346,7 @@
   ./services/networking/connman.nix
   ./services/networking/consul.nix
   ./services/networking/coturn.nix
+  ./services/networking/dante.nix
   ./services/networking/ddclient.nix
   ./services/networking/dhcpcd.nix
   ./services/networking/dhcpd.nix

--- a/nixos/modules/services/networking/dante.nix
+++ b/nixos/modules/services/networking/dante.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+with lib;
+
+let
+  cfg = config.services.dante;
+  confFile = pkgs.writeText "dante-sockd.conf" ''
+    user.privileged: root
+    user.unprivileged: dante
+
+    ${cfg.config}
+  '';
+in
+
+{
+  meta = {
+    maintainers = with maintainers; [ arobyn ];
+  };
+
+  options = {
+    services.dante = {
+      enable = mkEnableOption "Dante SOCKS proxy";
+
+      config = mkOption {
+        default     = null;
+        type        = types.str;
+        description = ''
+          Contents of Dante's configuration file
+          NOTE: user.privileged/user.unprivileged are set by the service
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      { assertion   = cfg.config != null;
+        message     = "please provide Dante configuration file contents";
+      }
+    ];
+
+    users.users.dante = {
+      description   = "Dante SOCKS proxy daemon user";
+      isSystemUser  = true;
+      group         = "dante";
+    };
+    users.groups.dante = {};
+
+    systemd.services.dante = {
+      description   = "Dante SOCKS v4 and v5 compatible proxy server";
+      after         = [ "network.target" ];
+      wantedBy      = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type        = "simple";
+        ExecStart   = "${pkgs.dante}/bin/sockd -f ${confFile}";
+        ExecReload  = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        Restart     = "always";
+      };
+    };
+  };
+}

--- a/pkgs/servers/dante/default.nix
+++ b/pkgs/servers/dante/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation (rec {
+  name = "dante-${version}";
+  version = "1.4.1";
+
+  src = fetchurl {
+    url = "https://www.inet.no/dante/files/${name}.tar.gz";
+    sha256 = "0lsg3hk8zd2h9f08s13bn4l4pvyyzkj4gr4ppwa7vj7gdyyk5lmn";
+  };
+
+  configureFlags = [
+    "--with-libc=libc.so.6"
+  ];
+
+  meta = {
+    description = "A circuit-level SOCKS client/server that can be used to provide convenient and secure network connectivity.";
+    homepage    = "https://www.inet.no/dante/";
+    maintainers = [ stdenv.lib.maintainers.arobyn ];
+    license     = stdenv.lib.licenses.bsdOriginal;
+    platforms   = stdenv.lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -787,6 +787,8 @@ in
 
   daemontools = callPackage ../tools/admin/daemontools { };
 
+  dante = callPackage ../servers/dante { };
+
   datamash = callPackage ../tools/misc/datamash { };
 
   datefudge = callPackage ../tools/system/datefudge { };


### PR DESCRIPTION
###### Motivation for this change

Adds package and service module for the Dante SOCKS v4 & v5 proxy server.

Service module is pretty minimal as Dante/sockd's configuration is both pretty flexible and a stable format, not sure how much benefit there is in tightly wrapping it.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
