### PR TITLE
matrix-synapse: Pass required --report-stats opt

### DIFF
--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -561,7 +561,11 @@ in {
           mkdir -p /var/lib/matrix-synapse
           chmod 700 /var/lib/matrix-synapse
           chown -R matrix-synapse:matrix-synapse /var/lib/matrix-synapse
-          ${cfg.package}/bin/homeserver --config-path ${configFile} --keys-directory /var/lib/matrix-synapse/ --generate-keys
+          ${cfg.package}/bin/homeserver \
+            --config-path ${configFile} \
+            --keys-directory /var/lib/matrix-synapse/ \
+            --generate-keys \
+            --report-stats ${if cfg.report_stats then "yes" else "no"}
         fi
       '';
       serviceConfig = {


### PR DESCRIPTION
###### Motivation for this change

The script `matrix-synapse-pre-start` was failing because `synapse` [expects](https://github.com/matrix-org/synapse/blob/9bba6ebaa903a81cd94fada114aa71e20b685adb/synapse/config/_base.py#L238-L242) the `--report-stats` option to be passed on the command line (even if it exists in the configuration file).

Hope this is OK.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
