### PR TITLE
mark roxterm as broken

### DIFF
--- a/pkgs/applications/misc/roxterm/default.nix
+++ b/pkgs/applications/misc/roxterm/default.nix
@@ -58,5 +58,6 @@ in stdenv.mkDerivation rec {
     '';
     maintainers = with maintainers; [ cdepillabout ];
     platforms = platforms.linux;
+    broken = true; # https://github.com/NixOS/nixpkgs/issues/19579
   };
 }


### PR DESCRIPTION
###### Motivation for this change

roxterm segfaults (#19579), and Debian just gave up on the package in the wake of the same problem. I want to avoid people booting into partially broken setups like I did due to it being unfixed but not marked as broken.
###### Things done

(Those are not really applicable, as it should NOT build anymore, but I did test that it does not build. ;-))

```
error: Package ‘roxterm-2.9.4’ in ‘/home/aristid/nixpkgs/pkgs/applications/misc/roxterm/default.nix:55’ is marked as broken, refusing to evaluate.
a) For `nixos-rebuild` you can set
  { nixpkgs.config.allowBroken = true; }
in configuration.nix to override this.

b) For `nix-env`, `nix-build` or any other Nix command you can add
  { allowBroken = true; }
to ~/.nixpkgs/config.nix.
```
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
