### PR TITLE
Python: no separate output for tkinter but build interpreter twice

### DIFF
--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -422,7 +422,7 @@ exists.
 
 #### Missing `tkinter` module standard library
 
-To reduce closure size the `Tkinter`/`tkinter` is put in a separate output. The `tkinter` is available as `python35Packages.tkinter`.
+To reduce closure size the `Tkinter`/`tkinter` is available as a separate package, `pythonPackages.tkinter`.
 
 #### Attributes on interpreters packages
 

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -6,7 +6,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, xlibsWrapper ? null, libX11 ? null, x11Support ? !stdenv.isCygwin
+, tcl ? null, tk ? null, xlibsWrapper ? null, libX11 ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -169,14 +169,6 @@ in stdenv.mkDerivation {
 
         rm "$out"/lib/python*/plat-*/regen # refers to glibc.dev
       '';
-
-    postFixup = optionalString x11Support ''
-      # tkinter goes in a separate output
-      mkdir -p $tkinter/${sitePackages}
-      mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/
-    '';
-
-    outputs = ["out"] ++ optional x11Support "tkinter";
 
     passthru = rec {
       inherit libPrefix sitePackages x11Support;

--- a/pkgs/development/interpreters/python/cpython/3.3/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.3/default.nix
@@ -6,7 +6,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? !stdenv.isCygwin
+, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -92,13 +92,7 @@ in stdenv.mkDerivation {
     # FIXME: should regenerate this.
     rm $out/lib/python${majorVersion}/__pycache__/_sysconfigdata.cpython*
 
-  '' + optionalString x11Support ''
-    # tkinter goes in a separate output
-    mkdir -p $tkinter/${sitePackages}
-    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/
   '';
-
-  outputs = ["out"] ++ optional x11Support "tkinter";
 
   passthru = rec {
     inherit libPrefix sitePackages x11Support;

--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -6,7 +6,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? !stdenv.isCygwin
+, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -101,13 +101,7 @@ in stdenv.mkDerivation {
     # FIXME: should regenerate this.
     rm $out/lib/python${majorVersion}/__pycache__/_sysconfigdata.cpython*
 
-  '' + optionalString x11Support ''
-    # tkinter goes in a separate output
-    mkdir -p $tkinter/${sitePackages}
-    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/
   '';
-
-  outputs = ["out"] ++ optional x11Support "tkinter";
 
   passthru = rec {
     inherit libPrefix sitePackages x11Support;

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -6,7 +6,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? !stdenv.isCygwin
+, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -100,14 +100,7 @@ in stdenv.mkDerivation {
 
     # FIXME: should regenerate this.
     rm $out/lib/python${majorVersion}/__pycache__/_sysconfigdata.cpython*
-
-  '' + optionalString x11Support ''
-    # tkinter goes in a separate output
-    mkdir -p $tkinter/${sitePackages}
-    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/
   '';
-
-  outputs = ["out"] ++ optional x11Support "tkinter";
 
   passthru = rec {
     inherit libPrefix sitePackages x11Support;

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -7,7 +7,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? !stdenv.isCygwin
+, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -90,14 +90,6 @@ in stdenv.mkDerivation {
     # Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
     echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
   '';
-
-  postFixup = optionalString x11Support ''
-    # tkinter goes in a separate output
-    mkdir -p $tkinter/${sitePackages}
-    mv $out/lib/${libPrefix}/lib-dynload/_tkinter* $tkinter/${sitePackages}/
-  '';
-
-  outputs = ["out"] ++ optional x11Support "tkinter";
 
   passthru = rec {
     inherit libPrefix sitePackages x11Support;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1663,7 +1663,6 @@ in
 
   fontforge = lowPrio (callPackage ../tools/misc/fontforge {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-    python = pythonSmall;
   });
   fontforge-gtk = callPackage ../tools/misc/fontforge {
     withGTK = true;
@@ -5494,11 +5493,6 @@ in
   python2 = python27;
   python3 = python35;
 
-  # Python uses multiple outputs, and by default `python` is without X11/tkinter.
-  # This package only exists to prevent an infinite recursion and should only be used
-  # for packages Python itself depends on.
-  pythonSmall = python.override {x11Support = false;};
-
   # pythonPackages further below, but assigned here because they need to be in sync
   pythonPackages = python2Packages;
   python2Packages = python27Packages;
@@ -7144,7 +7138,6 @@ in
   gtkmathview = callPackage ../development/libraries/gtkmathview { };
 
   glib = callPackage ../development/libraries/glib {
-    python = pythonSmall;
   };
   glib-tested = glib.override { # checked version separate to break cycles
     doCheck = true;
@@ -8269,7 +8262,6 @@ in
   libxmi = callPackage ../development/libraries/libxmi { };
 
   libxml2 = callPackage ../development/libraries/libxml2 {
-    python = pythonSmall;
   };
   libxml2Python = pkgs.buildEnv { # slightly hacky
     name = "libxml2+py-${self.libxml2.version}";
@@ -10364,7 +10356,6 @@ in
     inherit (darwin) apple_sdk cf-private libobjc;
     bootstrap_cmds = if stdenv.isDarwin then darwin.bootstrap_cmds else null;
     mesa = mesa_noglu;
-    python = pythonSmall;
     udev = if stdenv.isLinux then udev else null;
     libdrm = if stdenv.isLinux then libdrm else null;
     fglrxCompat = config.xorg.fglrxCompat or false; # `config` because we have no `xorg.override`
@@ -11516,9 +11507,7 @@ in
 
   bgnet = callPackage ../data/documentation/bgnet { };
 
-  cacert = callPackage ../data/misc/cacert {
-    python = pythonSmall;
-  };
+  cacert = callPackage ../data/misc/cacert { };
 
   caladea = callPackage ../data/fonts/caladea {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24675,20 +24675,24 @@ in {
   };
 
   # Tkinter/tkinter is part of the Python standard library.
-  # To reduce closure size its put in a separate output, `python.tkinter`.
-  # This alias was added to make this output work like any other Python package.
-  tkinter = mkPythonDerivation rec {
+  # The Python interpreters in Nixpkgs come without tkinter by default.
+  # To make the module available, we make it available as any other
+  # Python package.
+  tkinter = let
+    py = python.override{x11Support=true;};
+  in mkPythonDerivation rec {
     name = "tkinter-${python.version}";
-    src = python.tkinter;
+    src = py;
 
     disabled = isPy26 || isPyPy;
 
     installPhase = ''
-      mkdir -p $out
-      cp -R ${python.tkinter}/* $out
+      mkdir -p $out/${py.sitePackages}
+      ls -Al lib/${py.libPrefix}/lib-dynload/ | grep tkinter
+      mv lib/${py.libPrefix}/lib-dynload/_tkinter* $out/${py.sitePackages}/
     '';
 
-    inherit (python) meta;
+    inherit (py) meta;
   };
 
   tlslite = buildPythonPackage rec {


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

In #19309 a separate output for tkinter was added.

Several dependencies of Python depend indirectly on Python. We have the
following two paths:

```
‘python-2.7.12’ - ‘tk-8.6.6’ - ‘libXft-2.3.2’ - ‘libXrender-0.9.10’ -
‘libX11-1.6.4’ - ‘libxcb-1.12’ - ‘libxslt-1.1.29’- ‘libxml2-2.9.4’ -
‘python-2.7.12’

‘python-2.7.12’ - ‘tk-8.6.6’ - ‘libXft-2.3.2’ - ‘fontconfig-2.12.1’ -
‘dejavu-fonts-2.37’ - ‘fontforge-20160404’ - ‘python-2.7.12’
```

Because only `tkinter` needs this, I added

```
pythonSmall = python.override {x11Support = false;};
```

to break the infinite recursion. We also still have the output
`tkinter`.

However, we might as well build without x11Support by default. Then we build with x11Support as well so we get the tkinter module and put that in a separate package.
