### PR TITLE
frotz: init at 2.44

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -302,6 +302,7 @@
   nfjinjing = "Jinjing Wang <nfjinjing@gmail.com>";
   nhooyr = "Anmol Sethi <anmol@aubble.com>";
   nico202 = "Nicolò Balzarotti <anothersms@gmail.com>";
+  nick = "Nick Novitski <nixpkgs@nicknovitski.com>";
   notthemessiah = "Brian Cohen <brian.cohen.88@gmail.com>";
   NikolaMandic = "Ratko Mladic <nikola@mandic.email>";
   np = "Nicolas Pouillard <np.nix@nicolaspouillard.fr>";

--- a/pkgs/games/frotz/default.nix
+++ b/pkgs/games/frotz/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+  version = "2.44";
+  name = "frotz-${version}";
+
+  src = fetchFromGitHub {
+    owner = "DavidGriffith";
+    repo = "frotz";
+    rev = version;
+    sha256 = "0gjkk4gxzqmxfdirrz2lr0bms6l9fc31vkmlywigkbdlh8wxgypp";
+  };
+
+  makeFlags = ''CC=cc PREFIX=$(out) CURSES=-lncurses'';
+
+  buildInputs = [ ncurses ];
+
+  meta = with stdenv.lib; {
+    homepage = http://frotz.sourceforge.net/;
+    description = "A z-machine interpreter for Infocom games and other interactive fiction.";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.nick ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15461,6 +15461,8 @@ in
 
   freeorion = callPackage ../games/freeorion { };
 
+  frotz = callPackage ../games/frotz { };
+
   fsg = callPackage ../games/fsg {
     wxGTK = wxGTK28.override { unicode = false; };
   };


### PR DESCRIPTION
###### Motivation for this change

I'm a fan of IF. 😊 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- ~~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
## \- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
