### PR TITLE
[WIP] Adopt google authenticator

### DIFF
--- a/pkgs/os-specific/linux/google-authenticator/default.nix
+++ b/pkgs/os-specific/linux/google-authenticator/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pam, qrencode }:
+{ stdenv, lib, fetchurl, pam, qrencode }:
 
 stdenv.mkDerivation rec {
   name = "google-authenticator-1.0";
@@ -20,10 +20,11 @@ stdenv.mkDerivation rec {
     cp google-authenticator $out/bin
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = https://code.google.com/p/google-authenticator/;
     description = "Two-step verification, with pam module";
-    license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ aneeshusa ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -51,6 +51,7 @@ doNotDisplayTwice rec {
   fuse_zip = fuse-zip; # added 2016-04-27
   gettextWithExpat = gettext; # 2016-02-19
   git-hub = gitAndTools.git-hub; # added 2016-04-29
+  googleAuthenticator = google-authenticator # added 2016-10-16
   grantlee5 = qt5.grantlee;  # added 2015-12-19
   gupnptools = gupnp-tools;  # added 2015-12-19
   gnustep-make = gnustep.make; # added 2016-7-6

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1876,7 +1876,7 @@ in
   # rename to upower-notify?
   go-upower-notify = callPackage ../tools/misc/upower-notify { };
 
-  googleAuthenticator = callPackage ../os-specific/linux/google-authenticator { };
+  google-authenticator = callPackage ../os-specific/linux/google-authenticator { };
 
   google-cloud-sdk = callPackage ../tools/admin/google-cloud-sdk { };
 


### PR DESCRIPTION
###### Motivation for this change

The existing URL for the Google Authenticator source has been taken down. I have asked the maintainers to make a new release, and will update this PR with the new version once it is out.

I am planning to send a separate PR for a google-authenticator PAM module that I have been using in the near future.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
