### PR TITLE
ammonite-repl: init at 0.7.8

### DIFF
--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  name = "ammonite-repl-${version}";
+  version = "0.7.8";
+
+  src = fetchurl {
+    url = "https://github.com/lihaoyi/Ammonite/releases/download/${version}/${version}";
+    sha256 = "0s34p168h5c7ij61rbmaygb95r654yj4j0wh6qya53k4ywl32vkp";
+  };
+
+  propagatedBuildInputs = [ jre ] ;
+  buildInputs = [ makeWrapper ] ;
+
+  phases = "installPhase";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${src} $out/bin/amm
+    chmod +x $out/bin/amm
+    wrapProgram $out/bin/amm --prefix PATH ":" ${jre}/bin ;
+  '';
+
+  meta = {
+    description = "Improved Scala REPL";
+    longDescription = ''
+        The Ammonite-REPL is an improved Scala REPL, re-implemented from first principles.
+        It is much more featureful than the default REPL and comes
+        with a lot of ergonomic improvements and configurability
+        that may be familiar to people coming from IDEs or other REPLs such as IPython or Zsh.
+    '';
+    homepage = http://www.lihaoyi.com/Ammonite/;
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainer = [ lib.maintainers.nequissimus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -395,6 +395,8 @@ in
 
   albert = qt5.callPackage ../applications/misc/albert {};
 
+  ammonite-repl = callPackage ../development/tools/ammonite {};
+
   amtterm = callPackage ../tools/system/amtterm {};
 
   analog = callPackage ../tools/admin/analog {};


### PR DESCRIPTION
###### Motivation for this change

New package
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
