### PR TITLE
screenFetch: 2016-01-13 -> 2016-10-11

### DIFF
--- a/pkgs/tools/misc/screenfetch/default.nix
+++ b/pkgs/tools/misc/screenfetch/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchgit, makeWrapper
-, coreutils, gawk, procps, gnused, findutils, xdpyinfo, xprop, gnugrep
+{ stdenv, fetchFromGitHub, makeWrapper, coreutils, gawk, procps, gnused
+, findutils, xdpyinfo, xprop, gnugrep, ncurses
 }:
 
 stdenv.mkDerivation {
-  name = "screenFetch-2016-01-13";
+  name = "screenFetch-2016-10-11";
 
-  src = fetchgit {
-    url = git://github.com/KittyKatt/screenFetch.git;
-    rev = "22e5bee7647453d45ec82f543f37b8a6a062835d";
-    sha256 = "0xdiz02bqg7ajj547j496qq9adysm1f6zymcy3yyfgw3prnzvdir";
+  src = fetchFromGitHub {
+    owner = "KittyKatt";
+    repo = "screenFetch";
+    rev = "89e51f24018c89b3647deb24406a9af3a78bbe99";
+    sha256 = "0i2k261jj2s4sfhav7vbsd362pa0gghw6qhwafhmicmf8hq2a18v";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -28,7 +29,8 @@ stdenv.mkDerivation {
       --prefix PATH : "${findutils}/bin" \
       --prefix PATH : "${xdpyinfo}/bin" \
       --prefix PATH : "${xprop}/bin" \
-      --prefix PATH : "${gnugrep}/bin"
+      --prefix PATH : "${gnugrep}/bin" \
+      --prefix PATH : "${ncurses}/bin"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Keeping packages up-to-date, and with correct dependencies.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] macOS
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Added `ncurses` as it is needed when using the `-t` switch. Also switched to `fetchFromGitHub` as it seems like the preferred way of doing things.

The only thing I'm unsure about, is whether the package should be renamed `screenfetch-unstable` as per the naming convention. Please advise!
