### PR TITLE
mlterm: fix mouse keybinding with numlock

### DIFF
--- a/pkgs/applications/misc/mlterm/default.nix
+++ b/pkgs/applications/misc/mlterm/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     harfbuzz fribidi m17n_lib openssl libssh2
   ];
 
+  patches = [ ./x_shortcut.c.patch ]; #fixes numlock in 3.7.2. should be safe to remove by 3.7.3 since it's already in the trunk: https://bitbucket.org/arakiken/mlterm/commits/4820d42c7abfe1760a5ea35492c83be469c642b3
+
   #bad configure.ac and Makefile.in everywhere
   preConfigure = ''
     sed -ie 's;-L/usr/local/lib -R/usr/local/lib;;g' \
@@ -91,7 +93,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = https://sourceforge.net/projects/mlterm/;
+    homepage = http://mlterm.sourceforge.net/;
     license = licenses.bsd2;
     maintainers = with maintainers; [ vrthra ramkromberg ];
     platforms = with platforms; linux;

--- a/pkgs/applications/misc/mlterm/x_shortcut.c.patch
+++ b/pkgs/applications/misc/mlterm/x_shortcut.c.patch
@@ -1,0 +1,26 @@
+--- mlterm-3.7.2/xwindow/x_shortcut.c
++++ mlterm-3.7.2/xwindow/x_shortcut.c
+@@ -292,6 +292,11 @@
+ 	/* ingoring except these masks */
+ 	state &= (ModMask|ControlMask|ShiftMask|CommandMask|button_mask) ;
+ 
++	if( state & button_mask)
++	{
++		state &= ~Mod2Mask ;	/* XXX NumLock */
++	}
++
+ 	if( shortcut->map[func].ksym == ksym &&
+ 	    shortcut->map[func].state ==
+ 	      ( state |
+@@ -318,6 +323,11 @@
+ 	/* ingoring except these masks */
+ 	state &= (ModMask|ControlMask|ShiftMask|CommandMask|button_mask) ;
+ 
++	if( state & button_mask)
++	{
++		state &= ~Mod2Mask ;	/* XXX NumLock */
++	}
++
+ 	for( count = 0 ; count < shortcut->str_map_size ; count ++)
+ 	{
+                 if( shortcut->str_map[count].ksym == ksym &&


### PR DESCRIPTION
###### Motivation for this change

a patch for a very annoying bug upstream fixed ( https://bitbucket.org/arakiken/mlterm/commits/4820d42c7abfe1760a5ea35492c83be469c642b3 ) but has yet point release.

tested in stable pulling from both master or stable rebase.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
