### PR TITLE
guile: 2.0.12 -> 2.0.13 (for CVE)

### DIFF
--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -7,11 +7,11 @@
  else stdenv.mkDerivation)
 
 (rec {
-  name = "guile-2.0.12";
+  name = "guile-2.0.13";
 
   src = fetchurl {
     url = "mirror://gnu/guile/${name}.tar.xz";
-    sha256 = "1sdpjq0jf1h65w29q0zprj4x6kdp5jskkvbnlwphy9lvdxrqg0fy";
+    sha256 = "12yqkr974y91ylgw6jnmci2v90i90s7h9vxa4zk0sai8vjnz4i1p";
   };
 
   nativeBuildInputs = [ makeWrapper gawk pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

This is a maintenance release on the stable series, containing
security fixes.

Once merges into `master`, I’ll cherry-pick it into `release-16.09`
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a maintenance release on the stable series, containing
security fixes.

It addresses CVE-2016-8606

See http://lists.gnu.org/archive/html/info-gnu/2016-10/msg00009.html
for upstream announcement
