### PR TITLE
sam: 2016-09-15 -> 2016-10-08

### DIFF
--- a/pkgs/applications/editors/deadpixi-sam/default.nix
+++ b/pkgs/applications/editors/deadpixi-sam/default.nix
@@ -1,14 +1,16 @@
 { stdenv, fetchFromGitHub, freetype, libX11, libXt, libXft
+, version ? "2016-10-08"
+, rev ? "a17c4a9c2a1af2de0a756fe16d482e0db88c0541"
+, sha256 ? "03xmfzlijz4gbmr7l0pb1gl9kmlz1ab3hr8d51innvlasy4g6xgj"
 }:
 
 stdenv.mkDerivation rec {
-  name = "deadpixi-sam-unstable";
-  version = "2016-09-15";
+  inherit version;
+  name = "deadpixi-sam-unstable-${version}";
     src = fetchFromGitHub {
+      inherit sha256 rev;
       owner = "deadpixi";
       repo = "sam";
-      rev = "a6a8872246e8634d884b0ce52bc3be9770ab1b0f";
-      sha256 = "1zr8dl0vp1xic3dq69h4bp2fcxsjhrzasfl6ayvkibjd6z5dn07p";
     };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

maintenance and restructuring to make overriding easier.

tested in stable pulling from both master or stable rebase.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
