### PR TITLE
peruse: init at 1.1

### DIFF
--- a/pkgs/development/libraries/kirigami/default.nix
+++ b/pkgs/development/libraries/kirigami/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake, ecm, pkgconfig, plasma-framework, qtbase, qtquickcontrols }:
+
+stdenv.mkDerivation rec {
+  pname = "kirigami";
+  version = "1.1.0";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/${name}.tar.xz";
+    sha256 = "1p9ydggwbyfdgwmvyc8004sk9mfshlg9b83lzvz9qk3a906ayxv6";
+  };
+
+  buildInputs = [ qtbase qtquickcontrols plasma-framework ];
+
+  nativeBuildInputs = [ cmake pkgconfig ecm ];
+
+  meta = with stdenv.lib; {
+    license = licenses.lgpl2;
+    homepage = http://www.kde.org;
+    maintainers = with maintainers; [ ttuegel peterhoeg ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/peruse/default.nix
+++ b/pkgs/tools/misc/peruse/default.nix
@@ -1,0 +1,42 @@
+{
+  kdeDerivation, kdeWrapper, fetchFromGitHub, fetchurl, lib,
+  ecm, kdoctools,
+  baloo, kconfig, kfilemetadata, kinit, kirigami, plasma-framework
+}:
+
+let
+  pname = "peruse";
+  version = "1.1";
+  unarr = fetchFromGitHub {
+    owner  = "zeniko";
+    repo   = "unarr";
+    rev    = "d1be8c43a82a4320306c8e835a86fdb7b2574ca7";
+    sha256 = "03ds5da69zipa25rsp76l6xqivrh3wcgygwyqa5x2rgcz3rjnlpr";
+  };
+  unwrapped = kdeDerivation rec {
+    name = "${pname}-${version}";
+
+    src = fetchurl {
+      url = "mirror://kde/stable/${pname}/${name}.tar.xz";
+      sha256 = "1akk9hg12y6iis0rb5kdkznm3xk7hk04r9ccqyz8lr6y073n5f9j";
+    };
+
+    nativeBuildInputs = [ ecm kdoctools ];
+
+    propagatedBuildInputs = [ baloo kconfig kfilemetadata kinit kirigami plasma-framework ];
+
+    preConfigure = ''
+      rmdir src/qtquick/karchive-rar/external/unarr
+      ln -s ${unarr} src/qtquick/karchive-rar/external/unarr
+    '';
+
+    meta = with lib; {
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ peterhoeg ];
+    };
+
+  };
+
+in kdeWrapper unwrapped {
+  targets = [ "bin/peruse" ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2298,6 +2298,8 @@ in
 
   kronometer = qt5.callPackage ../tools/misc/kronometer { };
 
+  peruse = qt5.callPackage ../tools/misc/peruse { };
+
   kst = qt5.callPackage ../tools/graphics/kst { gsl = gsl_1; };
 
   kytea = callPackage ../tools/text/kytea { };
@@ -8832,6 +8834,8 @@ in
     fcitx-qt5 = callPackage ../tools/inputmethods/fcitx/fcitx-qt5.nix { };
 
     grantlee = callPackage ../development/libraries/grantlee/5.x.nix { };
+
+    kirigami = callPackage ../development/libraries/kirigami { };
 
     libcommuni = callPackage ../development/libraries/libcommuni { };
 


### PR DESCRIPTION
###### Motivation for this change

The `peruse` part is straight forward, but I have no idea if `kirigami` is handled properly being an official KDE library. @ttuegel, any thoughts?
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
