### PR TITLE
kdeconnect: [WIP/RFC] let dbus activate via systemd

### DIFF
--- a/pkgs/applications/misc/kdeconnect/default.nix
+++ b/pkgs/applications/misc/kdeconnect/default.nix
@@ -12,15 +12,41 @@
 , qca-qt5
 , libfakekey
 , libXtst
+, writeText
 }:
 
-stdenv.mkDerivation rec {
+let
+  busName = "org.kde.kdeconnect";
+  serviceName = "kdeconnectd.service";
+
+  dbus = writeText "dbus-${serviceName}" ''
+    [D-BUS Service]
+    Name=${busName}
+    Exec=@out@/lib/libexec/kdeconnectd
+    SystemdService=dbus-${busName}.service
+  '';
+
+  service = writeText serviceName ''
+    [Unit]
+    Description=KDE Connect daemon
+
+    [Service]
+    Type=dbus
+    BusName=${busName}
+    ExecStart=@out@/lib/libexec/kdeconnectd
+    ExecStop=${kdbusaddons}/bin/kquitapp5 kdeconnectd
+    Restart=on-failure
+    PrivateTmp=true
+    Slice=kde.slice
+  '';
+
+in stdenv.mkDerivation rec {
   name = "kdeconnect-${version}";
-  version = "1.0";
+  version = "1.0.1";
 
   src = fetchurl {
-    url = http://download.kde.org/stable/kdeconnect/1.0/src/kdeconnect-kde-1.0.tar.xz;
-    sha256 = "0pd8qw0w6akc7yzmsr0sjkfj3nw6rgm5xvq41g61ak8pp05syzr0";
+    url = "http://download.kde.org/stable/kdeconnect/${version}/src/kdeconnect-kde-${version}.tar.xz";
+    sha256 = "00p1njkp80lhnpjs82b1xgkzb58xwbgycll1z74hzq32icrwqfsm";
   };
 
   buildInputs = [
@@ -42,6 +68,14 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapQtProgram "$out/bin/kdeconnect-cli"
+
+    mkdir -p $out/lib/systemd/user $out/share/dbus-1/services
+    sed "s|@out@|$out|g" ${service} > $out/lib/systemd/user/${serviceName}
+    ln -sr $out/lib/systemd/user/${serviceName} $out/lib/systemd/user/dbus-${busName}.service
+
+    rm -f $out/etc/xdg/autostart/${serviceName}
+
+    sed "s|@out@|$out|g" ${dbus} > $out/share/dbus-1/services/${busName}.service
   '';
 
   meta = {
@@ -50,5 +84,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ fridh ];
     homepage = https://community.kde.org/KDEConnect;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

This is proof of concept and VERY much open to comments.

The next version of systemd will give us the standard targets for launching the entire graphical session using systemd, but we can (and I have here) been taking advantage of having dbus launch dbus activated services via systemd instead of doing it directly.

It will give us 3 immediate benefits:
1. A dead dbus daemon no longer means a messed up desktop. Since it triggers systemd to spawn the service, they are not direct children of dbus and thus survive the dbus process dying.
2. Auto-spawn if they get killed - I used this a lot when xembedsniproxy was in early stages and quite crashy.
3. Resource management for something like "baloo" where it is very nice to be able to down prioritize both CPU and IO.

In order to have dbus spawn the processes via systemd, we need to make the following changes:
1. the dbus service file for each service needs to be augmented with "systemdservice=name-of-service.service"
2. create a service file each service
3. create an alias for the dbus activatable service

Item 3 is technically not necessary, but simply to play nice with how other distributions are doing it.

This PR implements items 1 to 3 for kdeconnect in a very non-reusable and naive way, but as mentioned this is simply proof of concept.

I have used kdeconnect for this experiment as there is nothing else that depends on this, but I have tried with both kwallet and baloo here using the same approach and they work fine. They just require a rebuild of the entire KDE environment.

cc: @ttuegel @fridh @groxxda
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
