### PR TITLE
nixos/atftpd: various improvements

### DIFF
--- a/nixos/modules/services/networking/atftpd.nix
+++ b/nixos/modules/services/networking/atftpd.nix
@@ -20,13 +20,27 @@ in
         default = false;
         type = types.bool;
         description = ''
-          Whenever to enable the atftpd TFTP server.
+          Whether to enable the atftpd TFTP server. By default, the server
+          binds to address 0.0.0.0.
+        '';
+      };
+
+      extraOptions = mkOption {
+        default = [];
+        type = types.listOf types.str;
+        example = literalExample ''
+          [ "--bind-address 192.168.9.1"
+            "--verbose=7"
+          ]
+        '';
+        description = ''
+          Extra command line arguments to pass to atftp.
         '';
       };
 
       root = mkOption {
-        default = "/var/empty";
-        type = types.str;
+        default = "/srv/tftp";
+        type = types.path;
         description = ''
           Document root directory for the atftpd.
         '';
@@ -39,11 +53,11 @@ in
   config = mkIf cfg.enable {
 
     systemd.services.atftpd = {
-      description = "atftpd TFTP server";
+      description = "TFTP Server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       # runs as nobody
-      serviceConfig.ExecStart = "${pkgs.atftp}/sbin/atftpd --daemon --no-fork --bind-address 0.0.0.0 ${cfg.root}";
+      serviceConfig.ExecStart = "${pkgs.atftp}/sbin/atftpd --daemon --no-fork ${lib.concatStringsSep " " cfg.extraOptions} ${cfg.root}";
     };
 
   };


### PR DESCRIPTION
###### Motivation for this change

[From commit message]
- Add extraOptions option, to pass arbitrary command line options to
  atftp. Especially useful to specify which address to bind to
  (--bind-addres ...).
- Improve descriptions (fix a typo, document default bind address,
  don't repeat service name in systemd description + capitalize)
- Change default server directory from /var/empty to /srv/tftp, and
  change types.str to types.path.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
