### PR TITLE
bibtex2html: init at 1.98

### DIFF
--- a/pkgs/tools/misc/bibtex2html/default.nix
+++ b/pkgs/tools/misc/bibtex2html/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, ocaml }:
+
+stdenv.mkDerivation rec {
+  name = "bibtex2html-${version}";
+  version = "1.98";
+
+  src = fetchurl {
+    url = http://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.98.tar.gz;
+    sha256 = "1mh6hxmc9qv05hgjc11m2zh5mk9mk0kaqp59pny18ypqgfws09g9";
+  };
+
+  buildInputs = [ ocaml ];
+
+  meta = with stdenv.lib; {
+    description = "A collection of tools for translating from BibTeX to HTML";
+    homepage = https://www.lri.fr/~filliatr/bibtex2html/;
+    licence = licenses.gpl2;
+    platforms = ocaml.meta.platforms or [];
+    maintainers = [ maintainers.scolobb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -608,6 +608,8 @@ in
 
   bibutils = callPackage ../tools/misc/bibutils { };
 
+  bibtex2html = callPackage ../tools/misc/bibtex2html { };
+
   bindfs = callPackage ../tools/filesystems/bindfs { };
 
   bins = callPackage ../tools/graphics/bins { };


### PR DESCRIPTION
###### Motivation for this change

Add `bibtex2html`—a convenient tool for converting BibTeX bibliographies to HTML.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
