### PR TITLE
bluejeans: 2.160.66.8 -> 2.180.71.8

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/bluejeans/default.nix
@@ -17,11 +17,11 @@ in
 stdenv.mkDerivation rec {
   name = "bluejeans-${version}";
 
-  version = "2.160.66.8";
+  version = "2.180.71.8";
 
   src = fetchurl {
     url = "https://swdl.bluejeans.com/skinny/bjnplugin_${version}-1_amd64.deb";
-    sha256 = "1wf9jgd2717gfzm2wb0hxj4i76kczhgnwfhhpiy15zkqdcsmczsr";
+    sha256 = "1fgjgzss0ghk734xpfidazyknfdn11pmyw77pc3wigl83dvx4nb2";
   };
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];


### PR DESCRIPTION
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
