### PR TITLE
tor: 0.2.8.8 -> 0.2.8.9

### DIFF
--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "tor-0.2.8.8";
+  name = "tor-0.2.8.9";
 
   src = fetchurl {
     url = "https://archive.torproject.org/tor-package-archive/${name}.tar.gz";
-    sha256 = "1pp3h0a1cl25fv04b3j6wp8aw1sfpbd2lmag397dpp2k2b305bxi";
+    sha256 = "3f5c273bb887be4aff11f4d99b9e2e52d293b81ff4f6302b730161ff16dc5316";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Fixes a security hole that could be exploited for a denial of service attack against a tor client, relay, hidden service, or authority

Details at https://trac.torproject.org/projects/tor/ticket/20384
