### PR TITLE
zgrviewer: pass arguments and use full java path

### DIFF
--- a/pkgs/applications/graphics/zgrviewer/default.nix
+++ b/pkgs/applications/graphics/zgrviewer/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     cp -r target/* "$out/share/java/zvtm/"
 
     echo '#!/bin/sh' > "$out/bin/zgrviewer"
-    echo "java -jar '$out/share/java/zvtm/zgrviewer-${version}.jar'" >> "$out/bin/zgrviewer"
+    echo "${jre}/lib/openjdk/jre/bin/java -jar '$out/share/java/zvtm/zgrviewer-${version}.jar' \"\$@\"" >> "$out/bin/zgrviewer"
     chmod a+x "$out/bin/zgrviewer"
   '';
   meta = {


### PR DESCRIPTION
###### Motivation for this change

I don't have java in my user environment and want to use zgrviewer, and to be able to pass files on the command line.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

So the user doesn't need java in their environment and can pass
filenames on the command line.
