### PR TITLE
Rename keepassx2-http to keepassx-reboot

### DIFF
--- a/pkgs/applications/misc/keepassx/reboot.nix
+++ b/pkgs/applications/misc/keepassx/reboot.nix
@@ -1,23 +1,23 @@
 { stdenv, fetchFromGitHub, cmake, libgcrypt, qt5, zlib, libmicrohttpd, libXtst }:
 
 stdenv.mkDerivation rec {
-  name = "keepassx2-http-unstable-${version}";
-  version = "2016-05-27";
+  name = "keepassx-reboot-${version}";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
-    owner = "droidmonkey";
-    repo = "keepassx_http";
-    rev = "bb2e1ee8da3a3245c3ca58978a979dd6b5c2472a";
-    sha256 = "1rlbjs0i1kbrkksliisnykhki8f15g09xm3fwqlgcfc2czwbv5sv";
+    owner = "keepassxreboot";
+    repo = "keepassx";
+    rev = "${version}-http";
+    sha256 = "0pj3mirhw87hk9nlls9hgfx08xrr8ln7d1fqi3fcm519qjr72lmv";
   };
 
   buildInputs = [ cmake libgcrypt zlib qt5.full libXtst libmicrohttpd ];
 
   meta = {
     description = "Fork of the keepassX password-manager with additional http-interface to allow browser-integration an use with plugins such as PasslFox (https://github.com/pfn/passifox). See also keepassX2.";
-    homepage = http://www.keepassx.org/;
+    homepage = https://github.com/keepassxreboot/keepassx;
     license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ s1lvester ];
+    maintainers = with stdenv.lib.maintainers; [ s1lvester jonafato ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -60,6 +60,7 @@ doNotDisplayTwice rec {
   inotifyTools = inotify-tools;
   joseki = apache-jena-fuseki; # added 2016-02-28
   jquery_ui = jquery-ui;  # added 2014-09-07
+  keepassx2-http = keepassx-reboot; # added 2016-10-17
   keybase-go = keybase;  # added 2016-08-24
   letsencrypt = certbot; # added 2016-05-16
   libdbusmenu_qt5 = qt5.libdbusmenu;  # added 2015-12-19

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12696,7 +12696,7 @@ in
 
   keepassx = callPackage ../applications/misc/keepassx { };
   keepassx2 = callPackage ../applications/misc/keepassx/2.0.nix { };
-  keepassx2-http = callPackage ../applications/misc/keepassx/2.0-http.nix { };
+  keepassx-reboot = callPackage ../applications/misc/keepassx/reboot.nix { };
 
   inherit (gnome3) evince;
   evolution_data_server = gnome3.evolution_data_server;


### PR DESCRIPTION
###### Motivation for this change

The `keepassx2-http` fork has been moved to a new organization and
renamed to `keepassx-reboot`. For more details on the change, see the
discussions in GitHub issues [1][2].
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Included changes:
- Rename the `keepassx2-http` package to `keepassx-reboot`
- Fetch source from correct (moved) GitHub repository
- Update the version to the latest release
- Change the `homepage`, as these projects are likely to diverge over
  time
- Add `keepassx2-http` to `aliases.nix

[1] https://github.com/keepassx/keepassx/pull/111#issuecomment-250639109
[2] https://github.com/keepassxreboot/keepassx/issues/40
