### PR TITLE
ipxe: allow usage of preConfigure again

### DIFF
--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -27,8 +27,12 @@ stdenv.mkDerivation {
     ];
 
 
+  enabledOptions = [ "DOWNLOAD_PROTO_HTTPS" ];
+
   configurePhase = ''
-    echo "#define  DOWNLOAD_PROTO_HTTPS" >> src/config/general.h
+    runHook preConfigure
+    for opt in $enabledOptions; do echo "#define $opt" >> src/config/general.h; done
+    runHook postConfigure
   '';
 
   preBuild = "cd src";


### PR DESCRIPTION
###### Motivation for this change

PR #18938 broke my use of preConfigure in ipxe
this PR re-enables use of pre/post configure and also adds a simpler way to enable ipxe options
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
