### PR TITLE
Added package for dehydrated.

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -344,6 +344,7 @@
   proglodyte = "Proglodyte <proglodyte23@gmail.com>";
   pshendry = "Paul Hendry <paul@pshendry.com>";
   psibi = "Sibi <sibi@psibi.in>";
+  pstn = "Philipp Steinpaß <philipp@xndr.de>";
   pSub = "Pascal Wittmann <mail@pascal-wittmann.de>";
   puffnfresh = "Brian McKenna <brian@brianmckenna.org>";
   pxc = "Patrick Callahan <patrick.callahan@latitudeengineering.com>";

--- a/pkgs/tools/admin/dehydrated/default.nix
+++ b/pkgs/tools/admin/dehydrated/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     description = "Letsencrypt/acme client implemented as a shell-script";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = maintainers.pstn;
+    maintainers = [ maintainers.pstn ];
   };
 }

--- a/pkgs/tools/admin/dehydrated/default.nix
+++ b/pkgs/tools/admin/dehydrated/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, bash, curl, openssl, makeWrapper, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "dehydrated-0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "lukas2511";
+    repo = "dehydrated";
+    rev = "ec49a4433b48a7bc8f178d06dad3f55cff24bdf3";
+    sha256 = "0prg940ykbsfb4w48bc03j5abycg8v7f9rg9x3kcva37y8ml0jsp";
+  };
+
+  buildInputs = [ makeWrapper ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a dehydrated $out/bin
+    cp -a docs $out/
+    cp -a CHANGELOG $out/
+    wrapProgram "$out/bin/dehydrated" --prefix PATH : "${stdenv.lib.makeBinPath [ curl openssl ]}"
+    '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "This is a client for signing certificates with an ACME-server (currently only provided by letsencrypt) implemented as a relatively simple bash-script.";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/admin/dehydrated/default.nix
+++ b/pkgs/tools/admin/dehydrated/default.nix
@@ -1,26 +1,29 @@
-{ stdenv, bash, curl, openssl, makeWrapper, fetchFromGitHub }:
+{ stdenv, bash, coreutils, curl, diffutils, gawk, gnugrep, gnused, openssl, makeWrapper, fetchFromGitHub }:
+let
+  pkgName = "dehydrated";
+  version = "0.3.1";
+in
 stdenv.mkDerivation rec {
-  name = "dehydrated-0.3.1";
+  name = pkgName + "-" + version;
 
   src = fetchFromGitHub {
     owner = "lukas2511";
     repo = "dehydrated";
-    rev = "ec49a4433b48a7bc8f178d06dad3f55cff24bdf3";
+    rev = "v${version}";
     sha256 = "0prg940ykbsfb4w48bc03j5abycg8v7f9rg9x3kcva37y8ml0jsp";
   };
 
   buildInputs = [ makeWrapper ];
+
   installPhase = ''
     mkdir -p $out/bin
     cp -a dehydrated $out/bin
-    cp -a docs $out/
-    cp -a CHANGELOG $out/
-    wrapProgram "$out/bin/dehydrated" --prefix PATH : "${stdenv.lib.makeBinPath [ curl openssl ]}"
+    wrapProgram "$out/bin/dehydrated" --prefix PATH : "${stdenv.lib.makeBinPath [ openssl coreutils gnused gnugrep diffutils curl gawk ]}"
     '';
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
-    description = "This is a client for signing certificates with an ACME-server (currently only provided by letsencrypt) implemented as a relatively simple bash-script.";
+    description = "Letsencrypt/acme client implemented as a shell-script";
     license = licenses.mit;
     platforms = platforms.all;
   };

--- a/pkgs/tools/admin/dehydrated/default.nix
+++ b/pkgs/tools/admin/dehydrated/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation rec {
     description = "Letsencrypt/acme client implemented as a shell-script";
     license = licenses.mit;
     platforms = platforms.all;
+    maintainers = maintainers.pstn;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -772,6 +772,8 @@ in
 
   ddate = callPackage ../tools/misc/ddate { };
 
+  dehydrated = callPackage ../tools/admin/dehydrated { };
+
   deis = callPackage ../development/tools/deis {};
 
   diagrams-builder = callPackage ../tools/graphics/diagrams-builder {


### PR DESCRIPTION
###### Motivation for this change

I want to create native nixos options for let's encrypt including automated cert renewal. This is the simplest tool for the job.
###### Things done
- [x ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x ] NixOS
  - [ ] OS X
  - [ ] Linux
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
