### PR TITLE
remind: fix tkremind

### DIFF
--- a/pkgs/tools/misc/remind/default.nix
+++ b/pkgs/tools/misc/remind/default.nix
@@ -1,11 +1,32 @@
-{stdenv, fetchurl} :
+{stdenv, fetchurl, tk, tcllib, makeWrapper
+, tkremind ? true
+} :
 
-stdenv.mkDerivation {
+assert tkremind -> tk != null;
+assert tkremind -> tcllib != null;
+assert tkremind -> makeWrapper != null;
+
+stdenv.mkDerivation rec {
   name = "remind-3.1.15";
   src = fetchurl {
     url = http://www.roaringpenguin.com/files/download/remind-03.01.15.tar.gz;
     sha256 = "1hcfcxz5fjzl7606prlb7dgls5kr8z3wb51h48s6qm8ang0b9nla";
   };
+
+  tclLibraries = if tkremind then [ tcllib tk ] else [];
+  tclLibPaths = stdenv.lib.concatStringsSep " "
+    (map (p: "${p}/lib/${p.libPrefix}") tclLibraries);
+
+  buildInputs = if tkremind then [ makeWrapper ] else [];
+  propagatedBuildInputs = tclLibraries;
+
+  postPatch = if tkremind then ''
+    substituteInPlace scripts/tkremind --replace "exec wish" "exec ${tk}/bin/wish"
+  '' else "";
+
+  postInstall = if tkremind then ''
+    wrapProgram $out/bin/tkremind --set TCLLIBPATH "${tclLibPaths}"
+  '' else "";
 
   meta = {
     homepage = http://www.roaringpenguin.com/products/remind;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
