### PR TITLE
hecate: init at 0.0.1

### DIFF
--- a/pkgs/applications/editors/hecate/default.nix
+++ b/pkgs/applications/editors/hecate/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  version = "0.0.1";
+  name = "hecate-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "evanmiller";
+    repo   = "hecate";
+    rev    = "v${version}";
+    sha256 = "0ymirsd06z3qa9wi59k696mg8f4mhscw8gc5c5zkd0n3n8s0k0z8";
+  };
+
+  goPackagePath = "hecate";
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "terminal hex editor";
+    longDescription = "The Hex Editor From Hell!";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ramkromberg ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/applications/editors/hecate/deps.nix
+++ b/pkgs/applications/editors/hecate/deps.nix
@@ -1,0 +1,29 @@
+[
+  {
+    goPackagePath = "github.com/nsf/termbox-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nsf/termbox-go";
+      rev = "b6acae516ace002cb8105a89024544a1480655a5";
+      sha256 = "0zf95qdd5bif9rw03hqk87x7d905p373bvsj0bl4gi16spqjbdil";
+    };
+  }
+  {
+    goPackagePath = "github.com/edsrzf/mmap-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/edsrzf/mmap-go";
+      rev = "935e0e8a636ca4ba70b713f3e38a19e1b77739e8";
+      sha256 = "11a63wrjwfnchjhwqjp6yd5j0370ysppjgv31l5bmvvwps7whq9d";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "737072b4e32b7a5018b4a7125da8d12de90e8045";
+      sha256 = "09ni8bmj6p2b774bdh6mfcxl03bh5sqk860z03xpb6hv6yfxqkjm";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2073,6 +2073,8 @@ in
     inherit gfortran;
   });
 
+  hecate = callPackage ../applications/editors/hecate { };
+
   heimdall = callPackage ../tools/misc/heimdall { };
 
   hevea = callPackage ../tools/typesetting/hevea { };


### PR DESCRIPTION
###### Motivation for this change

some pros and cons over dhex.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
