### PR TITLE
cmst: 2016.04.03 -> 2016.10.03

### DIFF
--- a/pkgs/tools/networking/cmst/default.nix
+++ b/pkgs/tools/networking/cmst/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "cmst-${version}";
-  version = "2016.04.03";
+  version = "2016.10.03";
 
   src = fetchFromGitHub {
     repo = "cmst";
     owner = "andrew-bibb";
     rev = name;
-    sha256 = "1334ynhq1lxcfqln3bq17hy1awyfnn3zhzpsnymlyp0z3h4ydpp9";
+    sha256 = "1pvk1jg0fiw0j4f1wrnhgirgziliwa44sxfdmcq9ans4zbig4izh";
   };
 
   nativeBuildInputs = [ makeWrapper qmakeHook ];
@@ -19,16 +19,14 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace ./cmst.pro \
-      --replace "/usr/bin" "$out/bin" \
-      --replace "/usr/share" "$out/usr/share"
+      --replace "/usr/share" "$out/share"
 
     substituteInPlace ./cmst.pri \
       --replace "/usr/lib" "$out/lib" \
       --replace "/usr/share" "$out/share"
 
     substituteInPlace ./apps/cmstapp/cmstapp.pro \
-      --replace "/usr/bin" "$out/bin" \
-      --replace "/usr/share" "$out/share"
+      --replace "/usr/bin" "$out/bin"
 
     substituteInPlace ./apps/rootapp/rootapp.pro \
       --replace "/etc" "$out/etc" \


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
