### PR TITLE
add config.services.xserver.windowManager.sway

### DIFF
--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -26,6 +26,7 @@ in
     ./sawfish.nix
     ./stumpwm.nix
     ./spectrwm.nix
+    ./sway.nix
     ./twm.nix
     ./windowmaker.nix
     ./wmii.nix

--- a/nixos/modules/services/x11/window-managers/sway.nix
+++ b/nixos/modules/services/x11/window-managers/sway.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  wmCfg = config.services.xserver.windowManager;
+
+  swayOption = name: {
+    enable = mkEnableOption name;
+    configFile = mkOption {
+      default = null;
+      type = types.nullOr types.path;
+      description = ''
+        Path to the sway configuration file.
+        If left at the default value, $HOME/.config/sway/config will be used.
+      '';
+    };
+    enableDebug = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Enable full logging, including debug information.
+      '';
+    };
+    extraSessionCommands = mkOption {
+      default = "";
+      type = types.lines;
+      description = ''
+        Shell commands executed just before sway is started.
+      '';
+    };
+  };
+
+  swayConfig = name: pkg: cfg: {
+    services.xserver.windowManager.session = [{
+      inherit name;
+      start = ''
+        ${cfg.extraSessionCommands}
+
+        ${pkg}/bin/sway \
+          ${optionalString (cfg.configFile != null)
+            "-c \"${cfg.configFile}\""
+          } \
+          ${optionalString (cfg.enableDebug)
+            "-d"
+          } &
+        waitPID=$!
+      '';
+    }];
+    environment.systemPackages = [ pkg ];
+  };
+
+in
+
+{
+  options.services.xserver.windowManager = {
+    sway = swayOption "sway";
+  };
+
+  config = mkMerge [
+    (mkIf wmCfg.sway.enable (swayConfig "sway" pkgs.sway wmCfg.sway))
+  ];
+}

--- a/nixos/modules/services/x11/window-managers/sway.nix
+++ b/nixos/modules/services/x11/window-managers/sway.nix
@@ -15,11 +15,11 @@ let
         If left at the default value, $HOME/.config/sway/config will be used.
       '';
     };
-    enableDebug = mkOption {
+    debug = mkOption {
       default = false;
       type = types.bool;
       description = ''
-        Enable full logging, including debug information.
+        Whether to enable full logging, including debug information.
       '';
     };
     extraSessionCommands = mkOption {
@@ -41,7 +41,7 @@ let
           ${optionalString (cfg.configFile != null)
             "-c \"${cfg.configFile}\""
           } \
-          ${optionalString (cfg.enableDebug)
+          ${optionalString (cfg.debug)
             "-d"
           } &
         waitPID=$!


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
