### PR TITLE
Revert "matrix-synapse: Pass required --report-stats opt"

### DIFF
--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -561,11 +561,7 @@ in {
           mkdir -p /var/lib/matrix-synapse
           chmod 700 /var/lib/matrix-synapse
           chown -R matrix-synapse:matrix-synapse /var/lib/matrix-synapse
-          ${cfg.package}/bin/homeserver \
-            --config-path ${configFile} \
-            --keys-directory /var/lib/matrix-synapse/ \
-            --generate-keys \
-            --report-stats ${if cfg.report_stats then "yes" else "no"}
+          ${cfg.package}/bin/homeserver --config-path ${configFile} --keys-directory /var/lib/matrix-synapse/ --generate-keys
         fi
       '';
       serviceConfig = {


### PR DESCRIPTION
Reverts NixOS/nixpkgs#19591

My bad.
