### PR TITLE
oblogout: init at 0.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -77,6 +77,7 @@
   ./programs/man.nix
   ./programs/mosh.nix
   ./programs/nano.nix
+  ./programs/oblogout.nix
   ./programs/screen.nix
   ./programs/shadow.nix
   ./programs/shell.nix

--- a/nixos/modules/programs/oblogout.nix
+++ b/nixos/modules/programs/oblogout.nix
@@ -1,0 +1,160 @@
+# Global configuration for oblogout.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.oblogout;
+
+in
+{
+  ###### interface
+
+  options = {
+
+    programs.oblogout = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to install OBLogout and create <filename>/etc/oblogout.conf</filename>.
+          See <filename>${pkgs.oblogout}/share/doc/README</filename>.
+        '';
+      };
+
+      opacity = mkOption {
+        type = types.int;
+        default = 70;
+        description = ''
+        '';
+      };
+
+      bgcolor = mkOption {
+        type = types.str;
+        default = "black";
+        description = ''
+        '';
+      };
+
+      buttontheme = mkOption {
+        type = types.str;
+        default = "simplistic";
+        description = ''
+        '';
+      };
+
+      buttons = mkOption {
+        type = types.str;
+        default =  "cancel, logout, restart, shutdown, suspend, hibernate";
+        description = ''
+        '';
+      };
+
+      cancel = mkOption {
+        type = types.str;
+        default =  "Escape";
+        description = ''
+        '';
+      };
+
+      shutdown = mkOption {
+        type = types.str;
+        default = "S";
+        description = ''
+        '';
+      };
+
+      restart = mkOption {
+        type = types.str;
+        default = "R";
+        description = ''
+        '';
+      };
+
+      suspend = mkOption {
+        type = types.str;
+        default = "U";
+        description = ''
+        '';
+      };
+
+      logout = mkOption {
+        type = types.str;
+        default = "L";
+        description = ''
+        '';
+      };
+
+      lock = mkOption {
+        type = types.str;
+        default = "K";
+        description = ''
+        '';
+      };
+
+      hibernate = mkOption {
+        type = types.str;
+        default =  "H";
+        description = ''
+        '';
+      };
+
+      clogout = mkOption {
+        type = types.str;
+        default = "openbox --exit";
+        description = ''
+        '';
+      };
+
+      clock = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+        '';
+      };
+
+      cswitchuser = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.oblogout ];
+
+    environment.etc."oblogout.conf".text = ''
+      [settings]
+      usehal = false
+
+      [looks]
+      opacity = ${toString cfg.opacity}
+      bgcolor = ${cfg.bgcolor}
+      buttontheme = ${cfg.buttontheme}
+      buttons = ${cfg.buttons}
+
+      [shortcuts]
+      cancel = ${cfg.cancel}
+      shutdown = ${cfg.shutdown}
+      restart = ${cfg.restart}
+      suspend = ${cfg.suspend}
+      logout = ${cfg.logout}
+      lock = ${cfg.lock}
+      hibernate = ${cfg.hibernate}
+
+      [commands]
+      shutdown = systemctl poweroff
+      restart = systemctl reboot
+      suspend = systemctl suspend
+      hibernate = systemctl hibernate
+      logout = ${cfg.clogout}
+      lock = ${cfg.clock}
+      switchuser = ${cfg.cswitchuser}
+    '';
+  };
+}

--- a/pkgs/tools/X11/oblogout/default.nix
+++ b/pkgs/tools/X11/oblogout/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, intltool, file, pythonPackages, cairo }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "oblogout-${version}";
+  version = "2009-11-18";
+
+  src = fetchFromGitHub {
+    owner = "nikdoof";
+    repo = "oblogout";
+    rev = "ee023158c03dee720a1af9b1307b14ed5a95f5a0";
+    sha256 = "0nj87q94idb5ki4wnb2xipfgc6k6clr3rmm4xxh46b58z4zhhbmj";
+  };
+
+  nativeBuildInputs = [ intltool file pythonPackages.distutils_extra ];
+
+  buildInputs = [ cairo ];
+
+  propagatedBuildInputs = [ pythonPackages.pygtk pythonPackages.pillow pythonPackages.dbus-python ];
+
+  patches = [ ./oblogout-0.3-fixes.patch ];
+
+  postPatch = ''
+    substituteInPlace data/oblogout --replace sys.prefix \"$out/${pythonPackages.python.sitePackages}\"
+    substituteInPlace oblogout/__init__.py --replace sys.prefix \"$out\"
+    mkdir -p $out/share/doc
+    cp -a README $out/share/doc
+  '';
+
+  meta = {
+    description = "Openbox logout script";
+    homepage = "https://launchpad.net/oblogout";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/tools/X11/oblogout/default.nix
+++ b/pkgs/tools/X11/oblogout/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, intltool, file, pythonPackages, cairo }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "oblogout-${version}";
+  name = "oblogout-unstable-${version}";
   version = "2009-11-18";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/X11/oblogout/oblogout-0.3-fixes.patch
+++ b/pkgs/tools/X11/oblogout/oblogout-0.3-fixes.patch
@@ -1,0 +1,66 @@
+diff --git a/data/oblogout b/data/oblogout
+index 8058c4a..dfe5285 100755
+--- a/data/oblogout
++++ b/data/oblogout
+@@ -77,8 +77,10 @@ def main(argv = None):
+             config = 'data/oblogout.conf'
+         elif os.path.isfile('%s/.config/oblogout.conf' % os.getenv("HOME")):
+             config = '%s/.config/oblogout.conf' % os.getenv("HOME")
+-        else:
++        elif os.path.isfile('/etc/oblogout.conf'):
+             config = '/etc/oblogout.conf'
++        else:
++            config = sys.prefix + '/etc/oblogout.conf'
+                 
+     # Check config in local path, if it exists pass it on     
+     if not os.path.isfile(config):
+diff --git a/data/oblogout.conf b/data/oblogout.conf
+index 810872c..b1c1009 100644
+--- a/data/oblogout.conf
++++ b/data/oblogout.conf
+@@ -1,11 +1,11 @@
+ [settings]
+-usehal = true
++usehal = false
+ 
+ [looks]
+ opacity = 70
+ bgcolor = black
+ buttontheme = simplistic
+-buttons = cancel, logout, restart, shutdown, suspend, lock
++buttons = cancel, logout, restart, shutdown, suspend
+ 
+ [shortcuts]
+ cancel = Escape
+@@ -17,11 +17,11 @@ lock = K
+ hibernate = H
+ 
+ [commands]
+-shutdown = shutdown -h now
+-restart = reboot
+-suspend = pmi action suspend
+-hibernate = pmi action hibernate
+-safesuspend = safesuspend
+-lock = gnome-screensaver-command -l
+-switchuser = gdm-control --switch-user
++shutdown = systemctl poweroff
++restart = systemctl reboot
++suspend = systemctl suspend
++hibernate = systemctl hibernate
++# safesuspend = safesuspend
++# lock = gnome-screensaver-command -l
++# switchuser = gdm-control --switch-user
+ logout = openbox --exit
+diff --git a/oblogout/__init__.py b/oblogout/__init__.py
+index b9e4e01..12f521f 100644
+--- a/oblogout/__init__.py
++++ b/oblogout/__init__.py
+@@ -138,7 +138,7 @@ class OpenboxLogout():
+             self.logger.debug("Rendering Fade")
+             # Convert Pixbuf to PIL Image
+             wh = (pb.get_width(),pb.get_height())
+-            pilimg = Image.fromstring("RGB", wh, pb.get_pixels())
++            pilimg = Image.frombytes("RGB", wh, pb.get_pixels())
+             
+             pilimg = pilimg.point(lambda p: (p * self.opacity) / 255 )
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13919,6 +13919,8 @@ in
     inherit (gnome2) libglade;
   };
 
+  oblogout = callPackage ../tools/X11/oblogout { };
+
   obs-studio = qt5.callPackage ../applications/video/obs-studio {
     alsaSupport = stdenv.isLinux;
     pulseaudioSupport = config.pulseaudio or true;


### PR DESCRIPTION
###### Motivation for this change

[OBLogout](https://launchpad.net/oblogout) 

> OBLogout is a expandable, configurable, and theme-able logout script designed to be used in a Openbox desktop environment.
> 
> OBLogout uses pyGTK/Cairo, PIL, and HAL/dbus. The code tries to remain simple and flexible for usage in any number of situations and is designed to run on desktops of any screen resolution and capabilities. If compositing isn't available a software rendering solution (PIL) is used instead.
> 
> Originally designed for CrunchBang Linux, it has now been expanded to be used in any distribution.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
