### PR TITLE
vmfs-tools: init at 2016-01-16

### DIFF
--- a/pkgs/tools/filesystems/vmfs-tools/default.nix
+++ b/pkgs/tools/filesystems/vmfs-tools/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, pkgconfig
+, asciidoc, docbook_xml_xslt, fuse, libuuid, libxslt }:
+
+stdenv.mkDerivation rec {
+  name = "vmfs-tools";
+
+  src = fetchFromGitHub {
+    owner  = "glandium";
+    repo   = "vmfs-tools";
+    rev    = "4ab76ef5b074bdf06e4b518ff6d50439de05ae7f";
+    sha256 = "14y412ww5hxk336ils62s3fwykfh6mx1j0iiaa5cwc615pi6qvi4";
+  };
+
+  nativeBuildInputs = [ asciidoc docbook_xml_xslt fuse libuuid libxslt pkgconfig ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/glandium/vmfs-tools;
+    description = "FUSE-based VMFS (vmware) mounting tools";
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10161,6 +10161,8 @@ in
 
   cbfstool = callPackage ../applications/virtualization/cbfstool { };
 
+  vmfs-tools = callPackage ../tools/filesystems/vmfs-tools { };
+
   pgpool92 = pgpool.override { postgresql = postgresql92; };
   pgpool93 = pgpool.override { postgresql = postgresql93; };
   pgpool94 = pgpool.override { postgresql = postgresql94; };


### PR DESCRIPTION
###### Motivation for this change

The binaries run, but I haven't tried it yet against VMFS volumes. I will later this week though.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
