### PR TITLE
Dictd touchup

### DIFF
--- a/nixos/modules/services/misc/dictd.nix
+++ b/nixos/modules/services/misc/dictd.nix
@@ -24,7 +24,7 @@ in
 
       DBs = mkOption {
         type = types.listOf types.package;
-        default = [];
+        default = with pkgs.dictdDBs; [ wiktionary wordnet ];
         example = [ pkgs.dictdDBs.nld2eng ];
         description = ''List of databases to make available.'';
       };

--- a/nixos/modules/services/misc/dictd.nix
+++ b/nixos/modules/services/misc/dictd.nix
@@ -2,6 +2,10 @@
 
 with lib;
 
+let
+  cfg = config.services.dictd;
+in
+
 {
 
   ###### interface
@@ -34,8 +38,8 @@ with lib;
 
   config = let dictdb = pkgs.dictDBCollector { dictlist = map (x: {
                name = x.name;
-               filename = x; } ) config.services.dictd.DBs; };
-  in mkIf config.services.dictd.enable {
+               filename = x; } ) cfg.DBs; };
+  in mkIf cfg.enable {
 
     # get the command line client on system path to make some use of the service
     environment.systemPackages = [ pkgs.dict ];

--- a/pkgs/servers/dict/dictd-db.nix
+++ b/pkgs/servers/dict/dictd-db.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, callPackage }:
 
 let
  # Probably a bug in some FreeDict release files, but easier to trivially
@@ -82,4 +82,6 @@ in rec {
     dbName = "mueller-names";
     locale = "en_UK";
   };
+  wordnet = callPackage ./dictd-wordnet.nix {};
+  wiktionary = callPackage ./dictd-wiktionary.nix {};
 }

--- a/pkgs/servers/dict/dictd-wiktionary.nix
+++ b/pkgs/servers/dict/dictd-wiktionary.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, python, dict, glibcLocales, writeScript}:
 
 stdenv.mkDerivation rec {
-  version = "20140118";
+  version = "20161001";
   name = "dict-db-wiktionary-${version}";
   data = fetchurl {
     url = "http://dumps.wikimedia.org/enwiktionary/${version}/enwiktionary-${version}-pages-articles.xml.bz2";
-    sha256 = "892c9fc16b248a31e2d3e42590267161c1b899b31fe923eb1ede1deb6d24cfa8";
+    sha256 = "0g3k7kxp2nzg0v56i4cz253af3aqvhn1lwkys2fnam51cn3yqm7m";
   };
 
   convert = ./wiktionary2dict.py;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9817,10 +9817,6 @@ in
 
   dictDBCollector = callPackage ../servers/dict/dictd-db-collector.nix {};
 
-  dictdWiktionary = callPackage ../servers/dict/dictd-wiktionary.nix {};
-
-  dictdWordnet = callPackage ../servers/dict/dictd-wordnet.nix {};
-
   diod = callPackage ../servers/diod { lua = lua5_1; };
 
   #dnschain = callPackage ../servers/dnschain { };


### PR DESCRIPTION
###### Motivation for this change

Update wiktionary, collect dictd dicts, make wiktionary and wordnet default dicts since the service will fail loading its config with no dicts.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
