### PR TITLE
mpg123: 1.22.2 -> 1.23.8 for CVE-2016-1000247

### DIFF
--- a/pkgs/applications/audio/mpg123/default.nix
+++ b/pkgs/applications/audio/mpg123/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, alsaLib }:
 
 stdenv.mkDerivation rec {
-  name = "mpg123-1.22.2";
+  name = "mpg123-1.23.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/mpg123/${name}.tar.bz2";
-    sha256 = "0i1phi6fdjas37y00h3j8rb0b8ngr9az6hy5ff5bl53ify3j87kd";
+    sha256 = "13ngfzk84k4ks7ymanmq8f6707yrybra5h0mk3ir6mdnxk4068yy";
   };
 
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin) alsaLib;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/19678
https://osdir.com/ml/general/2016-10/msg15629.html
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
