### PR TITLE
ghostscript: 9.18 -> 9.20 for multiple CVEs

### DIFF
--- a/pkgs/development/libraries/ijs/default.nix
+++ b/pkgs/development/libraries/ijs/default.nix
@@ -5,15 +5,6 @@ stdenv.mkDerivation {
 
   inherit (ghostscript) src;
 
-  patches = [
-    # http://bugs.ghostscript.com/show_bug.cgi?id=696246
-    (fetchpatch {
-      name = "devijs-account-for-device-subclassing.patch";
-      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=b68e05c3";
-      sha256 = "1c3fzfjzvf15z533vpw3l3da8wcxw98qi3p1lc6lf13940a57c7n";
-    })
-  ];
-
   postPatch = "cd ijs";
 
   enableParallelBuilding = true;

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -8,8 +8,8 @@
 assert x11Support -> xlibsWrapper != null;
 assert cupsSupport -> cups != null;
 let
-  version = "9.18";
-  sha256 = "18ad90za28dxybajqwf3y3dld87cgkx1ljllmcnc7ysspfxzbnl3";
+  version = "9.20";
+  sha256 = "1az0dnvgingqv78yvfhzmx1zavn5sv1xrrscz984hy3gvz2ks3rw";
 
   fonts = stdenv.mkDerivation {
     name = "ghostscript-fonts";
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   name = "ghostscript-${version}";
 
   src = fetchurl {
-    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs918/${name}.tar.bz2";
+    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs920/${name}.tar.xz";
     inherit sha256;
   };
 
@@ -57,34 +57,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./urw-font-files.patch
-    # http://bugs.ghostscript.com/show_bug.cgi?id=696281
-    (fetchpatch {
-      name = "fix-check-for-using-shared-freetype-lib.patch";
-      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=8f5d285";
-      sha256 = "1f0k043rng7f0rfl9hhb89qzvvksqmkrikmm38p61yfx51l325xr";
-    })
-    # http://bugs.ghostscript.com/show_bug.cgi?id=696301
-    (fetchpatch {
-      name = "add-gserrors.h-to-the-installed-files.patch";
-      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=feafe5e5";
-      sha256 = "0s4ayzakjv809dkn7vilxwvs4dw35p3pw942ml91bk9z4kkaxyz7";
-    })
-    # http://bugs.ghostscript.com/show_bug.cgi?id=696246
-    (fetchpatch {
-      name = "guard-against-NULL-base-for-non-clist-devices.patch";
-      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=007bd77d08d800e6b07274d62e3c91be7c4a3f47";
-      sha256 = "1la53273agl92lpy7qd0qhgzynx8b90hrk8g9jsj3055ssn6rqwh";
-    })
-    (fetchpatch {
-      name = "ensure-plib-devices-always-use-the-clist.patch";
-      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=1bdbe4f87dc57648821e613ebcc591b84e8b35b3";
-      sha256 = "1cq83fgyvrycapxm69v4r9f9qhzsr40ygrc3bkp8pk15wsmvq0k7";
-    })
-    (fetchpatch {
-      name = "prevent-rinkj-device-crash-when-misconfigured.patch";
-      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=5571ddfa377c5d7d98f55af40e693814ac287ae4";
-      sha256 = "08iqdlrngi6k0ml2b71dj5q136fyp1s9g0rr87ayyshn0k0lxwkv";
-    })
   ];
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/19678
https://lwn.net/Vulnerabilities/703324/
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
