### PR TITLE
dbus: 1.10.10 -> 1.10.12 for CVE-2015-0245

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -6,8 +6,8 @@ assert x11Support -> libX11 != null
                   && libSM != null;
 
 let
-  version = "1.10.10";
-  sha256 = "0hwsfczhx2djmc9116vj5v230i7gpjihwh3vbljs1ldlk831v3wx";
+  version = "1.10.12";
+  sha256 = "0pa71vf5c0d7k3gni06iascmplj0j5g70wbc833ayvi71d1pj2i1";
 
 self =  stdenv.mkDerivation {
     name = "dbus-${version}";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/19678
https://lwn.net/Vulnerabilities/703606/
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
