### PR TITLE
ffmpeg: 3.1.3 -> 3.1.4

### DIFF
--- a/pkgs/development/libraries/ffmpeg/3.1.nix
+++ b/pkgs/development/libraries/ffmpeg/3.1.nix
@@ -5,9 +5,9 @@
 }@args:
 
 callPackage ./generic.nix (args // rec {
-  version = "${branch}.3";
+  version = "${branch}.4";
   branch = "3.1";
-  sha256 = "0f4ajs0c4088nkal4gqagx05wfyhd1izfxmzxxsdh56ibp38kg2q";
+  sha256 = "1ynb1f0py5jb6hs78ypynpwc3jlqrw51vl8y1wnd44nwlisxz6bw";
   darwinFrameworks = [ Cocoa CoreMedia ];
   patches = stdenv.lib.optional stdenv.isDarwin ./sdk_detection.patch;
 })


### PR DESCRIPTION
###### Motivation for this change

Changelog indicates security fixes: https://git.ffmpeg.org/gitweb/ffmpeg.git/shortlog/n3.1.4
https://github.com/NixOS/nixpkgs/issues/19678
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
