### PR TITLE
quagga: 1.0.20160315 -> 1.0.20161017 for CVE-2016-1245

### DIFF
--- a/pkgs/servers/quagga/default.nix
+++ b/pkgs/servers/quagga/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "quagga-${version}";
-  version = "1.0.20160315";
+  version = "1.0.20161017";
 
   src = fetchurl {
     url = "mirror://savannah/quagga/${name}.tar.gz";
-    sha256 = "0qrjhp6l1hw35jrvcwyl0df4zjx1kqhrsafx307i6pzgs2xbgzr1";
+    sha256 = "0629f7bkyh0a3n90kkr202g2i44id09qzkl05y8z66blvd6p49lg";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/703868/
https://github.com/NixOS/nixpkgs/issues/19678
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
