### PR TITLE
league-of-moveable-type: fix raleway integration

### DIFF
--- a/pkgs/data/fonts/league-of-moveable-type/default.nix
+++ b/pkgs/data/fonts/league-of-moveable-type/default.nix
@@ -21,8 +21,10 @@ stdenv.mkDerivation rec {
   sourceRoot = ".";
 
   installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp */*.otf $out/share/fonts/truetype
+    mkdir -p $out/share/fonts/opentype
+    cp */*.otf $out/share/fonts/opentype
+    # for Raleway, where the fonts are already in /share/…
+    cp */share/fonts/opentype/*.otf $out/share/fonts/opentype
   '';
 
   meta = {

--- a/pkgs/data/fonts/raleway/default.nix
+++ b/pkgs/data/fonts/raleway/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp "$src/fonts/OTF v3.000 Fontlab"/*.otf $out/share/fonts/truetype
+    mkdir -p $out/share/fonts/opentype
+    cp "$src/fonts/OTF v3.000 Fontlab"/*.otf $out/share/fonts/opentype
     find -type f -maxdepth 1 -exec cp "{}" $out/ \;
   '';
 


### PR DESCRIPTION
The raleway fonts need to be copied from their /share folder to be
included properly.

Found out that I could test it via `fc-list | grep -i rale`, and everything seems to work now.
cc @Mic92 since you merged the first PR.
