### PR TITLE
ssldump: init at 09b3

### DIFF
--- a/pkgs/tools/networking/ssldump/default.nix
+++ b/pkgs/tools/networking/ssldump/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, openssl, libpcap }:
+
+stdenv.mkDerivation rec {
+  name = "ssldump";
+  version = "0.9b3";
+
+  src = fetchFromGitHub {
+    owner = "adulau";
+    repo = "ssldump";
+    rev = "4529d03a50d39d3697c3e39a3d6f6c9b29448aa0";
+    sha256 = "0wwsamzxabfxcil5y2g4v2261vdspxlp12wz4xhji8607jbyjwr1";
+  };
+
+  buildInputs = [ libpcap openssl ];
+  prePatch = ''
+    sed -i -e 's|#include.*net/bpf.h|#include <pcap/bpf.h>|' \
+      base/pcap-snoop.c
+  '';
+  configureFlags = [ "--with-pcap-lib=${libpcap}/lib"
+                     "--with-pcap-inc=${libpcap}/include"
+                     "--with-openssl-lib=${openssl}/lib"
+                     "--with-openssl-inc=${openssl}/include" ];
+  meta = {
+    description = "ssldump is an SSLv3/TLS network protocol analyzer";
+    homepage = http://ssldump.sourceforge.net;
+    license = "BSD-style";
+    maintainers = with stdenv.lib.maintainers; [ aycanirican ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3682,6 +3682,8 @@ in
 
   sshuttle = callPackage ../tools/security/sshuttle { };
 
+  ssldump = callPackage ../tools/networking/ssldump { };
+  
   sstp = callPackage ../tools/networking/sstp {};
 
   sudo = callPackage ../tools/security/sudo { };


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
