### PR TITLE
nixops: explicitly specify python2

### DIFF
--- a/pkgs/tools/package-management/nixops/generic.nix
+++ b/pkgs/tools/package-management/nixops/generic.nix
@@ -1,9 +1,9 @@
-{ lib, pythonPackages, fetchurl, libxslt, docbook5_xsl, openssh
+{ lib, python2Packages, fetchurl, libxslt, docbook5_xsl, openssh
 # version args
 , src, version
 }:
 
-pythonPackages.buildPythonApplication {
+python2Packages.buildPythonApplication {
   name = "nixops-${version}";
   namePrefix = "";
 
@@ -11,18 +11,18 @@ pythonPackages.buildPythonApplication {
 
   buildInputs = [ libxslt ];
 
-  pythonPath =
-    [ pythonPackages.prettytable
-      pythonPackages.boto
-      pythonPackages.sqlite3
-      pythonPackages.hetzner
-      pythonPackages.libcloud
-      pythonPackages.azure-storage
-      pythonPackages.azure-mgmt-compute
-      pythonPackages.azure-mgmt-network
-      pythonPackages.azure-mgmt-resource
-      pythonPackages.azure-mgmt-storage
-      pythonPackages.adal
+  pythonPath = with python2Packages;
+    [ prettytable
+      boto
+      sqlite3
+      hetzner
+      libcloud
+      azure-storage
+      azure-mgmt-compute
+      azure-mgmt-network
+      azure-mgmt-resource
+      azure-mgmt-storage
+      adal
     ];
 
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Help with #18185.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
