### PR TITLE
Update Solidity compiler to latest version

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -1,15 +1,19 @@
 { stdenv, fetchFromGitHub, boost, cmake, jsoncpp }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.6";
+  version = "0.4.1";
   name = "solc-${version}";
 
   src = fetchFromGitHub {
     owner = "ethereum";
     repo = "solidity";
     rev = "v${version}";
-    sha256 = "1cynqwy8wr63l3l4wv9z6shhcy6lq0q8pbsh3nav0dg9qgj9sg57";
+    sha256 = "0ww8s0dngx6sbjyz7pr14xl3bbmfzx3nwc8xd9fx8ddg9682cwry";
   };
+
+  patchPhase = ''
+    echo >commit_hash.txt 4fc6fc2ca59579fae2472df319c2d8d31fe5bde5
+  '';
 
   buildInputs = [ boost cmake jsoncpp ];
 

--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchFromGitHub, boost, cmake, jsoncpp }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.1";
+  version = "0.4.2";
   name = "solc-${version}";
 
   src = fetchFromGitHub {
     owner = "ethereum";
     repo = "solidity";
     rev = "v${version}";
-    sha256 = "0ww8s0dngx6sbjyz7pr14xl3bbmfzx3nwc8xd9fx8ddg9682cwry";
+    sha256 = "1d5x3psz8a9z9jnm30aspfvrpd9kblr14cn5vyl21p27x2vdlzr4";
   };
 
   patchPhase = ''
-    echo >commit_hash.txt 4fc6fc2ca59579fae2472df319c2d8d31fe5bde5
+    echo >commit_hash.txt af6afb0415761b53721f89c7f65064807f41cbd3
   '';
 
   buildInputs = [ boost cmake jsoncpp ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
