### PR TITLE
tracker: 1.8.0 -> 1.10.1 (16.09)

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/core/tracker/src.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/tracker/src.nix
@@ -1,11 +1,11 @@
 fetchurl: rec {
-  major = "1.8";
-  minor = "0";
+  major = "1.10";
+  minor = "1";
   name = "tracker-${major}.${minor}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/tracker/${major}/${name}.tar.xz";
-    sha256 = "0zchaahk4w7dwanqk1vx0qgnyrlzlp81krwawfx3mv5zffik27x1";
+    sha256 = "14a13wbsx2ragscdwb47df4cr0sn42sl1pfwvlrndggbm367isk7";
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Contribute to #19678.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
