### PR TITLE
quassel-webserver: init at 2.1.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -492,6 +492,7 @@
   ./services/web-apps/pump.io.nix
   ./services/web-apps/tt-rss.nix
   ./services/web-apps/selfoss.nix
+  ./services/web-apps/quassel-webserver.nix
   ./services/web-servers/apache-httpd/default.nix
   ./services/web-servers/caddy.nix
   ./services/web-servers/fcgiwrap.nix

--- a/nixos/modules/services/web-apps/quassel-webserver.nix
+++ b/nixos/modules/services/web-apps/quassel-webserver.nix
@@ -89,11 +89,10 @@ in {
 
   config = mkIf cfg.enable {
     systemd.services.quassel-webserver = {
-      enable = true;
       description = "A web server/client for Quassel";
+      wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         ExecStart = "${quassel-webserver}/lib/node_modules/quassel-webserver/bin/www -p ${toString cfg.port} -m ${if cfg.useHttps == true then "https" else "http"} -c ${settingsFile}";
-        WantedBy = [ "multi-user.target" ];
       };
     };
   };

--- a/nixos/modules/services/web-apps/quassel-webserver.nix
+++ b/nixos/modules/services/web-apps/quassel-webserver.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.quassel-webserver;
+  quassel-webserver = cfg.pkg;
+  settings = ''
+    module.exports = {
+      default: {
+        host: '${cfg.quasselCoreHost}',  // quasselcore host
+        port: ${toString cfg.quasselCorePort},  // quasselcore port
+        initialBacklogLimit: ${toString cfg.initialBacklogLimit},  // Amount of backlogs to fetch per buffer on connection
+        backlogLimit: ${toString cfg.backlogLimit},  // Amount of backlogs to fetch per buffer after first retrieval
+        securecore: ${if cfg.secureCore then "true" else "false"},  // Connect to the core using SSL
+        theme: '${cfg.theme}'  // Default UI theme
+      },
+      themes: ['default', 'darksolarized'],  //  Available themes
+      forcedefault: ${if cfg.forceHostAndPort then "true" else "false"},  // Will force default host and port to be used, and will hide the corresponding fields in the UI
+      prefixpath: '${cfg.prefixPath}'  // Configure this if you use a reverse proxy
+    };
+  '';
+  settingsFile = pkgs.writeText "settings-user.js" settings;
+in {
+  options = {
+    services.quassel-webserver = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Whether to enable the quassel webclient service";
+      };
+      pkg = mkOption {
+        default = pkgs.quassel-webserver;
+	description = "The quassel-webserver package";
+      };
+      quasselCoreHost = mkOption {
+        default = "";
+        type = types.str;
+        description = "The default host of the quassel core";
+      };
+      quasselCorePort = mkOption {
+        default = 4242;
+        description = "The default quassel core port";
+      };
+      initialBacklogLimit = mkOption {
+        default = 20;
+        description = "Amount of backlogs to fetch per buffer on connection";
+      };
+      backlogLimit = mkOption {
+        default = 100;
+        description = "Amount of backlogs to fetch per buffer after first retrieval";
+      };
+      secureCore = mkOption {
+        default = true;
+        type = types.bool;
+        description = "Connect to the core using SSL";
+      };
+      theme = mkOption {
+        default = "default";
+        description = "default or darksolarized";
+      };
+      prefixPath = mkOption {
+        default = "";
+        description = "Configure this if you use a reverse proxy. Must start with a '/'";
+        example = "/quassel";
+      };
+      port = mkOption {
+        default = "60443";
+        description = "The port the quassel webserver should listen on";
+      };
+      useHttps = mkOption {
+        default = true;
+        description = "Whether the quassel webserver connection should be a https connection";
+      };
+      forceHostAndPort = mkOption {
+        default = false;
+        description = "Force the users to use the quasselCoreHost and quasselCorePort defaults";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.quassel-webserver = {
+      description = "A web server/client for Quassel";
+      serviceConfig = {
+        ExecStart = "${quassel-webserver}/lib/node_modules/quassel-webserver/bin/www -p ${cfg.port} -m ${if cfg.useHttps == true then "https" else "http"} -c ${settingsFile}";
+        WantedBy = [ "multi-user.target" ];
+      };
+    };
+  };
+}

--- a/nixos/modules/services/web-apps/quassel-webserver.nix
+++ b/nixos/modules/services/web-apps/quassel-webserver.nix
@@ -70,7 +70,7 @@ in {
         example = "/quassel";
       };
       port = mkOption {
-        default = "60443";
+        default = 60443;
         type = types.int;
         description = "The port the quassel webserver should listen on";
       };
@@ -92,7 +92,7 @@ in {
       enable = true;
       description = "A web server/client for Quassel";
       serviceConfig = {
-        ExecStart = "${quassel-webserver}/lib/node_modules/quassel-webserver/bin/www -p ${cfg.port} -m ${if cfg.useHttps == true then "https" else "http"} -c ${settingsFile}";
+        ExecStart = "${quassel-webserver}/lib/node_modules/quassel-webserver/bin/www -p ${toString cfg.port} -m ${if cfg.useHttps == true then "https" else "http"} -c ${settingsFile}";
         WantedBy = [ "multi-user.target" ];
       };
     };

--- a/nixos/modules/services/web-apps/quassel-webserver.nix
+++ b/nixos/modules/services/web-apps/quassel-webserver.nix
@@ -31,7 +31,7 @@ in {
       };
       pkg = mkOption {
         default = pkgs.quassel-webserver;
-	description = "The quassel-webserver package";
+        description = "The quassel-webserver package";
       };
       quasselCoreHost = mkOption {
         default = "";
@@ -40,14 +40,17 @@ in {
       };
       quasselCorePort = mkOption {
         default = 4242;
+        type = types.int;
         description = "The default quassel core port";
       };
       initialBacklogLimit = mkOption {
         default = 20;
+        type = types.int;
         description = "Amount of backlogs to fetch per buffer on connection";
       };
       backlogLimit = mkOption {
         default = 100;
+        type = types.int;
         description = "Amount of backlogs to fetch per buffer after first retrieval";
       };
       secureCore = mkOption {
@@ -57,23 +60,28 @@ in {
       };
       theme = mkOption {
         default = "default";
+        type = types.str;
         description = "default or darksolarized";
       };
       prefixPath = mkOption {
         default = "";
+        type = types.str;
         description = "Configure this if you use a reverse proxy. Must start with a '/'";
         example = "/quassel";
       };
       port = mkOption {
         default = "60443";
+        type = types.int;
         description = "The port the quassel webserver should listen on";
       };
       useHttps = mkOption {
         default = true;
+        type = types.bool;
         description = "Whether the quassel webserver connection should be a https connection";
       };
       forceHostAndPort = mkOption {
         default = false;
+        type = types.bool;
         description = "Force the users to use the quasselCoreHost and quasselCorePort defaults";
       };
     };

--- a/nixos/modules/services/web-apps/quassel-webserver.nix
+++ b/nixos/modules/services/web-apps/quassel-webserver.nix
@@ -89,6 +89,7 @@ in {
 
   config = mkIf cfg.enable {
     systemd.services.quassel-webserver = {
+      enable = true;
       description = "A web server/client for Quassel";
       serviceConfig = {
         ExecStart = "${quassel-webserver}/lib/node_modules/quassel-webserver/bin/www -p ${cfg.port} -m ${if cfg.useHttps == true then "https" else "http"} -c ${settingsFile}";

--- a/pkgs/applications/networking/irc/quassel-webserver/default.nix
+++ b/pkgs/applications/networking/irc/quassel-webserver/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, fetchFromGitHub, callPackage, python, utillinux}:
+
+with lib;
+
+let
+  nodePackages = callPackage <nixpkgs/pkgs/top-level/node-packages.nix> {
+    neededNatives = [ python ];
+    self = nodePackages;
+    generated = ./quassel-webserver.nix;
+  };
+
+in nodePackages.buildNodePackage rec {
+  name = "quassel-webserver-${version}";
+  version = "2.1.1";
+  src = fetchFromGitHub {
+    owner  = "magne4000";
+    repo   = "quassel-webserver";
+    rev    = "dda457f38795d15565557a8629085063fa6a7378";
+    sha256 = "0syglfdmjnssxdiak1dw8cns5f736v58zmlsh81dvxww90gx3k7h";
+  };
+  buildInputs = nodePackages.nativeDeps."quassel-webserver" or [];
+  deps = [ nodePackages.by-spec."body-parser"."^1.15.2"
+           nodePackages.by-spec."commander"."^2.9.0"
+           nodePackages.by-spec."cookie-parser"."~1.4.3"
+           nodePackages.by-spec."express"."^4.14.0"
+           nodePackages.by-spec."jade"."~1.11.0"
+           nodePackages.by-spec."less"."^2.7.1"
+           nodePackages.by-spec."less-middleware"."^2.2.0"
+           nodePackages.by-spec."libquassel"."~2.0.5"
+           nodePackages.by-spec."morgan"."^1.7.0"
+           nodePackages.by-spec."net-browserify-alt"."^1.0.0"
+           nodePackages.by-spec."serve-favicon"."~2.3.0"
+         ];
+  peerDependencies = [];
+
+  meta = {
+    description = "A web server/client for Quassel";
+    license = licenses.mit;
+    homepage = "https://github.com/magne4000/quassel-webserver";
+    maintainers = with maintainers; [ uwap ];
+    platforms = platforms.unix;
+  }; 
+}

--- a/pkgs/applications/networking/irc/quassel-webserver/quassel-webserver.nix
+++ b/pkgs/applications/networking/irc/quassel-webserver/quassel-webserver.nix
@@ -1,0 +1,2436 @@
+{ self, fetchurl, fetchgit ? null, lib }:
+
+{
+  by-spec."accepts"."~1.3.3" =
+    self.by-version."accepts"."1.3.3";
+  by-version."accepts"."1.3.3" = self.buildNodePackage {
+    name = "accepts-1.3.3";
+    version = "1.3.3";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz";
+      name = "accepts-1.3.3.tgz";
+      sha1 = "c3ca7434938648c3e0d9c1e328dd68b622c284ca";
+    };
+    deps = {
+      "mime-types-2.1.12" = self.by-version."mime-types"."2.1.12";
+      "negotiator-0.6.1" = self.by-version."negotiator"."0.6.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."acorn"."^1.0.1" =
+    self.by-version."acorn"."1.2.2";
+  by-version."acorn"."1.2.2" = self.buildNodePackage {
+    name = "acorn-1.2.2";
+    version = "1.2.2";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz";
+      name = "acorn-1.2.2.tgz";
+      sha1 = "c8ce27de0acc76d896d2b1fad3df588d9e82f014";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."acorn"."^2.1.0" =
+    self.by-version."acorn"."2.7.0";
+  by-version."acorn"."2.7.0" = self.buildNodePackage {
+    name = "acorn-2.7.0";
+    version = "2.7.0";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz";
+      name = "acorn-2.7.0.tgz";
+      sha1 = "ab6e7d9d886aaca8b085bc3312b79a198433f0e7";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."acorn-globals"."^1.0.3" =
+    self.by-version."acorn-globals"."1.0.9";
+  by-version."acorn-globals"."1.0.9" = self.buildNodePackage {
+    name = "acorn-globals-1.0.9";
+    version = "1.0.9";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz";
+      name = "acorn-globals-1.0.9.tgz";
+      sha1 = "55bb5e98691507b74579d0513413217c380c54cf";
+    };
+    deps = {
+      "acorn-2.7.0" = self.by-version."acorn"."2.7.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."align-text"."^0.1.1" =
+    self.by-version."align-text"."0.1.4";
+  by-version."align-text"."0.1.4" = self.buildNodePackage {
+    name = "align-text-0.1.4";
+    version = "0.1.4";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz";
+      name = "align-text-0.1.4.tgz";
+      sha1 = "0cd90a561093f35d0a99256c22b7069433fad117";
+    };
+    deps = {
+      "kind-of-3.0.4" = self.by-version."kind-of"."3.0.4";
+      "longest-1.0.1" = self.by-version."longest"."1.0.1";
+      "repeat-string-1.5.4" = self.by-version."repeat-string"."1.5.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."align-text"."^0.1.3" =
+    self.by-version."align-text"."0.1.4";
+  by-spec."amdefine".">=0.0.4" =
+    self.by-version."amdefine"."1.0.0";
+  by-version."amdefine"."1.0.0" = self.buildNodePackage {
+    name = "amdefine-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz";
+      name = "amdefine-1.0.0.tgz";
+      sha1 = "fd17474700cb5cc9c2b709f0be9d23ce3c198c33";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."array-flatten"."1.1.1" =
+    self.by-version."array-flatten"."1.1.1";
+  by-version."array-flatten"."1.1.1" = self.buildNodePackage {
+    name = "array-flatten-1.1.1";
+    version = "1.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz";
+      name = "array-flatten-1.1.1.tgz";
+      sha1 = "9a5f699051b1e7073328f2a008968b64ea2955d2";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."asap"."~1.0.0" =
+    self.by-version."asap"."1.0.0";
+  by-version."asap"."1.0.0" = self.buildNodePackage {
+    name = "asap-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz";
+      name = "asap-1.0.0.tgz";
+      sha1 = "b2a45da5fdfa20b0496fc3768cc27c12fa916a7d";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."asap"."~2.0.3" =
+    self.by-version."asap"."2.0.5";
+  by-version."asap"."2.0.5" = self.buildNodePackage {
+    name = "asap-2.0.5";
+    version = "2.0.5";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz";
+      name = "asap-2.0.5.tgz";
+      sha1 = "522765b50c3510490e52d7dcfe085ef9ba96958f";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."async"."~0.2.6" =
+    self.by-version."async"."0.2.10";
+  by-version."async"."0.2.10" = self.buildNodePackage {
+    name = "async-0.2.10";
+    version = "0.2.10";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/async/-/async-0.2.10.tgz";
+      name = "async-0.2.10.tgz";
+      sha1 = "b6bbe0b0674b9d719708ca38de8c237cb526c3d1";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."basic-auth"."~1.0.3" =
+    self.by-version."basic-auth"."1.0.4";
+  by-version."basic-auth"."1.0.4" = self.buildNodePackage {
+    name = "basic-auth-1.0.4";
+    version = "1.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz";
+      name = "basic-auth-1.0.4.tgz";
+      sha1 = "030935b01de7c9b94a824b29f3fccb750d3a5290";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."body-parser"."^1.15.2" =
+    self.by-version."body-parser"."1.15.2";
+  by-version."body-parser"."1.15.2" = self.buildNodePackage {
+    name = "body-parser-1.15.2";
+    version = "1.15.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz";
+      name = "body-parser-1.15.2.tgz";
+      sha1 = "d7578cf4f1d11d5f6ea804cef35dc7a7ff6dae67";
+    };
+    deps = {
+      "bytes-2.4.0" = self.by-version."bytes"."2.4.0";
+      "content-type-1.0.2" = self.by-version."content-type"."1.0.2";
+      "debug-2.2.0" = self.by-version."debug"."2.2.0";
+      "depd-1.1.0" = self.by-version."depd"."1.1.0";
+      "http-errors-1.5.0" = self.by-version."http-errors"."1.5.0";
+      "iconv-lite-0.4.13" = self.by-version."iconv-lite"."0.4.13";
+      "on-finished-2.3.0" = self.by-version."on-finished"."2.3.0";
+      "qs-6.2.0" = self.by-version."qs"."6.2.0";
+      "raw-body-2.1.7" = self.by-version."raw-body"."2.1.7";
+      "type-is-1.6.13" = self.by-version."type-is"."1.6.13";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "body-parser" = self.by-version."body-parser"."1.15.2";
+  by-spec."bytes"."2.4.0" =
+    self.by-version."bytes"."2.4.0";
+  by-version."bytes"."2.4.0" = self.buildNodePackage {
+    name = "bytes-2.4.0";
+    version = "2.4.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz";
+      name = "bytes-2.4.0.tgz";
+      sha1 = "7d97196f9d5baf7f6935e25985549edd2a6c2339";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."camelcase"."^1.0.2" =
+    self.by-version."camelcase"."1.2.1";
+  by-version."camelcase"."1.2.1" = self.buildNodePackage {
+    name = "camelcase-1.2.1";
+    version = "1.2.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz";
+      name = "camelcase-1.2.1.tgz";
+      sha1 = "9bb5304d2e0b56698b2c758b08a3eaa9daa58a39";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."center-align"."^0.1.1" =
+    self.by-version."center-align"."0.1.3";
+  by-version."center-align"."0.1.3" = self.buildNodePackage {
+    name = "center-align-0.1.3";
+    version = "0.1.3";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz";
+      name = "center-align-0.1.3.tgz";
+      sha1 = "aa0d32629b6ee972200411cbd4461c907bc2b7ad";
+    };
+    deps = {
+      "align-text-0.1.4" = self.by-version."align-text"."0.1.4";
+      "lazy-cache-1.0.4" = self.by-version."lazy-cache"."1.0.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."character-parser"."1.2.1" =
+    self.by-version."character-parser"."1.2.1";
+  by-version."character-parser"."1.2.1" = self.buildNodePackage {
+    name = "character-parser-1.2.1";
+    version = "1.2.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz";
+      name = "character-parser-1.2.1.tgz";
+      sha1 = "c0dde4ab182713b919b970959a123ecc1a30fcd6";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."clean-css"."^3.1.9" =
+    self.by-version."clean-css"."3.4.20";
+  by-version."clean-css"."3.4.20" = self.buildNodePackage {
+    name = "clean-css-3.4.20";
+    version = "3.4.20";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz";
+      name = "clean-css-3.4.20.tgz";
+      sha1 = "c0d8963b5448e030f0bcd3ddd0dac4dfe3dea501";
+    };
+    deps = {
+      "commander-2.8.1" = self.by-version."commander"."2.8.1";
+      "source-map-0.4.4" = self.by-version."source-map"."0.4.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."cliui"."^2.1.0" =
+    self.by-version."cliui"."2.1.0";
+  by-version."cliui"."2.1.0" = self.buildNodePackage {
+    name = "cliui-2.1.0";
+    version = "2.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz";
+      name = "cliui-2.1.0.tgz";
+      sha1 = "4b475760ff80264c762c3a1719032e91c7fea0d1";
+    };
+    deps = {
+      "center-align-0.1.3" = self.by-version."center-align"."0.1.3";
+      "right-align-0.1.3" = self.by-version."right-align"."0.1.3";
+      "wordwrap-0.0.2" = self.by-version."wordwrap"."0.0.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."commander"."2.8.x" =
+    self.by-version."commander"."2.8.1";
+  by-version."commander"."2.8.1" = self.buildNodePackage {
+    name = "commander-2.8.1";
+    version = "2.8.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz";
+      name = "commander-2.8.1.tgz";
+      sha1 = "06be367febfda0c330aa1e2a072d3dc9762425d4";
+    };
+    deps = {
+      "graceful-readlink-1.0.1" = self.by-version."graceful-readlink"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."commander"."^2.9.0" =
+    self.by-version."commander"."2.9.0";
+  by-version."commander"."2.9.0" = self.buildNodePackage {
+    name = "commander-2.9.0";
+    version = "2.9.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz";
+      name = "commander-2.9.0.tgz";
+      sha1 = "9c99094176e12240cb22d6c5146098400fe0f7d4";
+    };
+    deps = {
+      "graceful-readlink-1.0.1" = self.by-version."graceful-readlink"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "commander" = self.by-version."commander"."2.9.0";
+  by-spec."commander"."~2.6.0" =
+    self.by-version."commander"."2.6.0";
+  by-version."commander"."2.6.0" = self.buildNodePackage {
+    name = "commander-2.6.0";
+    version = "2.6.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz";
+      name = "commander-2.6.0.tgz";
+      sha1 = "9df7e52fb2a0cb0fb89058ee80c3104225f37e1d";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."constantinople"."~3.0.1" =
+    self.by-version."constantinople"."3.0.2";
+  by-version."constantinople"."3.0.2" = self.buildNodePackage {
+    name = "constantinople-3.0.2";
+    version = "3.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz";
+      name = "constantinople-3.0.2.tgz";
+      sha1 = "4b945d9937907bcd98ee575122c3817516544141";
+    };
+    deps = {
+      "acorn-2.7.0" = self.by-version."acorn"."2.7.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."content-disposition"."0.5.1" =
+    self.by-version."content-disposition"."0.5.1";
+  by-version."content-disposition"."0.5.1" = self.buildNodePackage {
+    name = "content-disposition-0.5.1";
+    version = "0.5.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz";
+      name = "content-disposition-0.5.1.tgz";
+      sha1 = "87476c6a67c8daa87e32e87616df883ba7fb071b";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."content-type"."~1.0.2" =
+    self.by-version."content-type"."1.0.2";
+  by-version."content-type"."1.0.2" = self.buildNodePackage {
+    name = "content-type-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz";
+      name = "content-type-1.0.2.tgz";
+      sha1 = "b7d113aee7a8dd27bd21133c4dc2529df1721eed";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."cookie"."0.3.1" =
+    self.by-version."cookie"."0.3.1";
+  by-version."cookie"."0.3.1" = self.buildNodePackage {
+    name = "cookie-0.3.1";
+    version = "0.3.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz";
+      name = "cookie-0.3.1.tgz";
+      sha1 = "e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."cookie-parser"."~1.4.3" =
+    self.by-version."cookie-parser"."1.4.3";
+  by-version."cookie-parser"."1.4.3" = self.buildNodePackage {
+    name = "cookie-parser-1.4.3";
+    version = "1.4.3";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz";
+      name = "cookie-parser-1.4.3.tgz";
+      sha1 = "0fe31fa19d000b95f4aadf1f53fdc2b8a203baa5";
+    };
+    deps = {
+      "cookie-0.3.1" = self.by-version."cookie"."0.3.1";
+      "cookie-signature-1.0.6" = self.by-version."cookie-signature"."1.0.6";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "cookie-parser" = self.by-version."cookie-parser"."1.4.3";
+  by-spec."cookie-signature"."1.0.6" =
+    self.by-version."cookie-signature"."1.0.6";
+  by-version."cookie-signature"."1.0.6" = self.buildNodePackage {
+    name = "cookie-signature-1.0.6";
+    version = "1.0.6";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz";
+      name = "cookie-signature-1.0.6.tgz";
+      sha1 = "e303a882b342cc3ee8ca513a79999734dab3ae2c";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."css"."~1.0.8" =
+    self.by-version."css"."1.0.8";
+  by-version."css"."1.0.8" = self.buildNodePackage {
+    name = "css-1.0.8";
+    version = "1.0.8";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/css/-/css-1.0.8.tgz";
+      name = "css-1.0.8.tgz";
+      sha1 = "9386811ca82bccc9ee7fb5a732b1e2a317c8a3e7";
+    };
+    deps = {
+      "css-parse-1.0.4" = self.by-version."css-parse"."1.0.4";
+      "css-stringify-1.0.5" = self.by-version."css-stringify"."1.0.5";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."css-parse"."1.0.4" =
+    self.by-version."css-parse"."1.0.4";
+  by-version."css-parse"."1.0.4" = self.buildNodePackage {
+    name = "css-parse-1.0.4";
+    version = "1.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz";
+      name = "css-parse-1.0.4.tgz";
+      sha1 = "38b0503fbf9da9f54e9c1dbda60e145c77117bdd";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."css-stringify"."1.0.5" =
+    self.by-version."css-stringify"."1.0.5";
+  by-version."css-stringify"."1.0.5" = self.buildNodePackage {
+    name = "css-stringify-1.0.5";
+    version = "1.0.5";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz";
+      name = "css-stringify-1.0.5.tgz";
+      sha1 = "b0d042946db2953bb9d292900a6cb5f6d0122031";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."debug"."^2.2.0" =
+    self.by-version."debug"."2.2.0";
+  by-version."debug"."2.2.0" = self.buildNodePackage {
+    name = "debug-2.2.0";
+    version = "2.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz";
+      name = "debug-2.2.0.tgz";
+      sha1 = "f87057e995b1a1f6ae6a4960664137bc56f039da";
+    };
+    deps = {
+      "ms-0.7.1" = self.by-version."ms"."0.7.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."debug"."~2.2.0" =
+    self.by-version."debug"."2.2.0";
+  by-spec."decamelize"."^1.0.0" =
+    self.by-version."decamelize"."1.2.0";
+  by-version."decamelize"."1.2.0" = self.buildNodePackage {
+    name = "decamelize-1.2.0";
+    version = "1.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz";
+      name = "decamelize-1.2.0.tgz";
+      sha1 = "f6534d15148269b20352e7bee26f501f9a191290";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."depd"."~1.1.0" =
+    self.by-version."depd"."1.1.0";
+  by-version."depd"."1.1.0" = self.buildNodePackage {
+    name = "depd-1.1.0";
+    version = "1.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz";
+      name = "depd-1.1.0.tgz";
+      sha1 = "e1bd82c6aab6ced965b97b88b17ed3e528ca18c3";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."destroy"."~1.0.4" =
+    self.by-version."destroy"."1.0.4";
+  by-version."destroy"."1.0.4" = self.buildNodePackage {
+    name = "destroy-1.0.4";
+    version = "1.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz";
+      name = "destroy-1.0.4.tgz";
+      sha1 = "978857442c44749e4206613e37946205826abd80";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ee-first"."1.1.1" =
+    self.by-version."ee-first"."1.1.1";
+  by-version."ee-first"."1.1.1" = self.buildNodePackage {
+    name = "ee-first-1.1.1";
+    version = "1.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz";
+      name = "ee-first-1.1.1.tgz";
+      sha1 = "590c61156b0ae2f4f0255732a158b266bc56b21d";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."encodeurl"."~1.0.1" =
+    self.by-version."encodeurl"."1.0.1";
+  by-version."encodeurl"."1.0.1" = self.buildNodePackage {
+    name = "encodeurl-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz";
+      name = "encodeurl-1.0.1.tgz";
+      sha1 = "79e3d58655346909fe6f0f45a5de68103b294d20";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."errno"."^0.1.1" =
+    self.by-version."errno"."0.1.4";
+  by-version."errno"."0.1.4" = self.buildNodePackage {
+    name = "errno-0.1.4";
+    version = "0.1.4";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz";
+      name = "errno-0.1.4.tgz";
+      sha1 = "b896e23a9e5e8ba33871fc996abd3635fc9a1c7d";
+    };
+    deps = {
+      "prr-0.0.0" = self.by-version."prr"."0.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."escape-html"."~1.0.3" =
+    self.by-version."escape-html"."1.0.3";
+  by-version."escape-html"."1.0.3" = self.buildNodePackage {
+    name = "escape-html-1.0.3";
+    version = "1.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz";
+      name = "escape-html-1.0.3.tgz";
+      sha1 = "0258eae4d3d0c0974de1c169188ef0051d1d1988";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."etag"."~1.7.0" =
+    self.by-version."etag"."1.7.0";
+  by-version."etag"."1.7.0" = self.buildNodePackage {
+    name = "etag-1.7.0";
+    version = "1.7.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz";
+      name = "etag-1.7.0.tgz";
+      sha1 = "03d30b5f67dd6e632d2945d30d6652731a34d5d8";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."eventemitter2"."^2.1.3" =
+    self.by-version."eventemitter2"."2.1.3";
+  by-version."eventemitter2"."2.1.3" = self.buildNodePackage {
+    name = "eventemitter2-2.1.3";
+    version = "2.1.3";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/eventemitter2/-/eventemitter2-2.1.3.tgz";
+      name = "eventemitter2-2.1.3.tgz";
+      sha1 = "bd7201f85c59548380e1e43b3f6a7286d4da7349";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."express"."^4.14.0" =
+    self.by-version."express"."4.14.0";
+  by-version."express"."4.14.0" = self.buildNodePackage {
+    name = "express-4.14.0";
+    version = "4.14.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/express/-/express-4.14.0.tgz";
+      name = "express-4.14.0.tgz";
+      sha1 = "c1ee3f42cdc891fb3dc650a8922d51ec847d0d66";
+    };
+    deps = {
+      "accepts-1.3.3" = self.by-version."accepts"."1.3.3";
+      "array-flatten-1.1.1" = self.by-version."array-flatten"."1.1.1";
+      "content-disposition-0.5.1" = self.by-version."content-disposition"."0.5.1";
+      "content-type-1.0.2" = self.by-version."content-type"."1.0.2";
+      "cookie-0.3.1" = self.by-version."cookie"."0.3.1";
+      "cookie-signature-1.0.6" = self.by-version."cookie-signature"."1.0.6";
+      "debug-2.2.0" = self.by-version."debug"."2.2.0";
+      "depd-1.1.0" = self.by-version."depd"."1.1.0";
+      "encodeurl-1.0.1" = self.by-version."encodeurl"."1.0.1";
+      "escape-html-1.0.3" = self.by-version."escape-html"."1.0.3";
+      "etag-1.7.0" = self.by-version."etag"."1.7.0";
+      "finalhandler-0.5.0" = self.by-version."finalhandler"."0.5.0";
+      "fresh-0.3.0" = self.by-version."fresh"."0.3.0";
+      "merge-descriptors-1.0.1" = self.by-version."merge-descriptors"."1.0.1";
+      "methods-1.1.2" = self.by-version."methods"."1.1.2";
+      "on-finished-2.3.0" = self.by-version."on-finished"."2.3.0";
+      "parseurl-1.3.1" = self.by-version."parseurl"."1.3.1";
+      "path-to-regexp-0.1.7" = self.by-version."path-to-regexp"."0.1.7";
+      "proxy-addr-1.1.2" = self.by-version."proxy-addr"."1.1.2";
+      "qs-6.2.0" = self.by-version."qs"."6.2.0";
+      "range-parser-1.2.0" = self.by-version."range-parser"."1.2.0";
+      "send-0.14.1" = self.by-version."send"."0.14.1";
+      "serve-static-1.11.1" = self.by-version."serve-static"."1.11.1";
+      "type-is-1.6.13" = self.by-version."type-is"."1.6.13";
+      "utils-merge-1.0.0" = self.by-version."utils-merge"."1.0.0";
+      "vary-1.1.0" = self.by-version."vary"."1.1.0";
+      "jade-1.11.0" = self.by-version."jade"."1.11.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "express" = self.by-version."express"."4.14.0";
+  by-spec."finalhandler"."0.5.0" =
+    self.by-version."finalhandler"."0.5.0";
+  by-version."finalhandler"."0.5.0" = self.buildNodePackage {
+    name = "finalhandler-0.5.0";
+    version = "0.5.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz";
+      name = "finalhandler-0.5.0.tgz";
+      sha1 = "e9508abece9b6dba871a6942a1d7911b91911ac7";
+    };
+    deps = {
+      "debug-2.2.0" = self.by-version."debug"."2.2.0";
+      "escape-html-1.0.3" = self.by-version."escape-html"."1.0.3";
+      "on-finished-2.3.0" = self.by-version."on-finished"."2.3.0";
+      "statuses-1.3.0" = self.by-version."statuses"."1.3.0";
+      "unpipe-1.0.0" = self.by-version."unpipe"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."forwarded"."~0.1.0" =
+    self.by-version."forwarded"."0.1.0";
+  by-version."forwarded"."0.1.0" = self.buildNodePackage {
+    name = "forwarded-0.1.0";
+    version = "0.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz";
+      name = "forwarded-0.1.0.tgz";
+      sha1 = "19ef9874c4ae1c297bcf078fde63a09b66a84363";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."fresh"."0.3.0" =
+    self.by-version."fresh"."0.3.0";
+  by-version."fresh"."0.3.0" = self.buildNodePackage {
+    name = "fresh-0.3.0";
+    version = "0.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz";
+      name = "fresh-0.3.0.tgz";
+      sha1 = "651f838e22424e7566de161d8358caa199f83d4f";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."graceful-fs"."^4.1.2" =
+    self.by-version."graceful-fs"."4.1.9";
+  by-version."graceful-fs"."4.1.9" = self.buildNodePackage {
+    name = "graceful-fs-4.1.9";
+    version = "4.1.9";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz";
+      name = "graceful-fs-4.1.9.tgz";
+      sha1 = "baacba37d19d11f9d146d3578bc99958c3787e29";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."graceful-readlink".">= 1.0.0" =
+    self.by-version."graceful-readlink"."1.0.1";
+  by-version."graceful-readlink"."1.0.1" = self.buildNodePackage {
+    name = "graceful-readlink-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz";
+      name = "graceful-readlink-1.0.1.tgz";
+      sha1 = "4cafad76bc62f02fa039b2f94e9a3dd3a391a725";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."http-errors"."~1.5.0" =
+    self.by-version."http-errors"."1.5.0";
+  by-version."http-errors"."1.5.0" = self.buildNodePackage {
+    name = "http-errors-1.5.0";
+    version = "1.5.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz";
+      name = "http-errors-1.5.0.tgz";
+      sha1 = "b1cb3d8260fd8e2386cad3189045943372d48211";
+    };
+    deps = {
+      "inherits-2.0.1" = self.by-version."inherits"."2.0.1";
+      "setprototypeof-1.0.1" = self.by-version."setprototypeof"."1.0.1";
+      "statuses-1.3.0" = self.by-version."statuses"."1.3.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."iconv-lite"."0.4.13" =
+    self.by-version."iconv-lite"."0.4.13";
+  by-version."iconv-lite"."0.4.13" = self.buildNodePackage {
+    name = "iconv-lite-0.4.13";
+    version = "0.4.13";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz";
+      name = "iconv-lite-0.4.13.tgz";
+      sha1 = "1f88aba4ab0b1508e8312acc39345f36e992e2f2";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."image-size"."~0.5.0" =
+    self.by-version."image-size"."0.5.0";
+  by-version."image-size"."0.5.0" = self.buildNodePackage {
+    name = "image-size-0.5.0";
+    version = "0.5.0";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/image-size/-/image-size-0.5.0.tgz";
+      name = "image-size-0.5.0.tgz";
+      sha1 = "be7aed1c37b5ac3d9ba1d66a24b4c47ff8397651";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."inherits"."2.0.1" =
+    self.by-version."inherits"."2.0.1";
+  by-version."inherits"."2.0.1" = self.buildNodePackage {
+    name = "inherits-2.0.1";
+    version = "2.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz";
+      name = "inherits-2.0.1.tgz";
+      sha1 = "b17d08d326b4423e568eff719f91b0b1cbdf69f1";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."int64-buffer"."^0.1.4" =
+    self.by-version."int64-buffer"."0.1.9";
+  by-version."int64-buffer"."0.1.9" = self.buildNodePackage {
+    name = "int64-buffer-0.1.9";
+    version = "0.1.9";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.9.tgz";
+      name = "int64-buffer-0.1.9.tgz";
+      sha1 = "9e039da043b24f78b196b283e04653ef5e990f61";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ipaddr.js"."1.1.1" =
+    self.by-version."ipaddr.js"."1.1.1";
+  by-version."ipaddr.js"."1.1.1" = self.buildNodePackage {
+    name = "ipaddr.js-1.1.1";
+    version = "1.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz";
+      name = "ipaddr.js-1.1.1.tgz";
+      sha1 = "c791d95f52b29c1247d5df80ada39b8a73647230";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is"."^3.1.0" =
+    self.by-version."is"."3.1.0";
+  by-version."is"."3.1.0" = self.buildNodePackage {
+    name = "is-3.1.0";
+    version = "3.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/is/-/is-3.1.0.tgz";
+      name = "is-3.1.0.tgz";
+      sha1 = "2945d205d691cbfe4833e3f8a11c8ae94673f2a7";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is-buffer"."^1.0.2" =
+    self.by-version."is-buffer"."1.1.4";
+  by-version."is-buffer"."1.1.4" = self.buildNodePackage {
+    name = "is-buffer-1.1.4";
+    version = "1.1.4";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz";
+      name = "is-buffer-1.1.4.tgz";
+      sha1 = "cfc86ccd5dc5a52fa80489111c6920c457e2d98b";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is-promise"."^2.0.0" =
+    self.by-version."is-promise"."2.1.0";
+  by-version."is-promise"."2.1.0" = self.buildNodePackage {
+    name = "is-promise-2.1.0";
+    version = "2.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz";
+      name = "is-promise-2.1.0.tgz";
+      sha1 = "79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."is-promise"."~1" =
+    self.by-version."is-promise"."1.0.1";
+  by-version."is-promise"."1.0.1" = self.buildNodePackage {
+    name = "is-promise-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz";
+      name = "is-promise-1.0.1.tgz";
+      sha1 = "31573761c057e33c2e91aab9e96da08cefbe76e5";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."jade"."~1.11.0" =
+    self.by-version."jade"."1.11.0";
+  by-version."jade"."1.11.0" = self.buildNodePackage {
+    name = "jade-1.11.0";
+    version = "1.11.0";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz";
+      name = "jade-1.11.0.tgz";
+      sha1 = "9c80e538c12d3fb95c8d9bb9559fa0cc040405fd";
+    };
+    deps = {
+      "character-parser-1.2.1" = self.by-version."character-parser"."1.2.1";
+      "clean-css-3.4.20" = self.by-version."clean-css"."3.4.20";
+      "commander-2.6.0" = self.by-version."commander"."2.6.0";
+      "constantinople-3.0.2" = self.by-version."constantinople"."3.0.2";
+      "jstransformer-0.0.2" = self.by-version."jstransformer"."0.0.2";
+      "mkdirp-0.5.1" = self.by-version."mkdirp"."0.5.1";
+      "transformers-2.1.0" = self.by-version."transformers"."2.1.0";
+      "uglify-js-2.7.3" = self.by-version."uglify-js"."2.7.3";
+      "void-elements-2.0.1" = self.by-version."void-elements"."2.0.1";
+      "with-4.0.3" = self.by-version."with"."4.0.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "jade" = self.by-version."jade"."1.11.0";
+  by-spec."jstransformer"."0.0.2" =
+    self.by-version."jstransformer"."0.0.2";
+  by-version."jstransformer"."0.0.2" = self.buildNodePackage {
+    name = "jstransformer-0.0.2";
+    version = "0.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz";
+      name = "jstransformer-0.0.2.tgz";
+      sha1 = "7aae29a903d196cfa0973d885d3e47947ecd76ab";
+    };
+    deps = {
+      "is-promise-2.1.0" = self.by-version."is-promise"."2.1.0";
+      "promise-6.1.0" = self.by-version."promise"."6.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."kind-of"."^3.0.2" =
+    self.by-version."kind-of"."3.0.4";
+  by-version."kind-of"."3.0.4" = self.buildNodePackage {
+    name = "kind-of-3.0.4";
+    version = "3.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz";
+      name = "kind-of-3.0.4.tgz";
+      sha1 = "7b8ecf18a4e17f8269d73b501c9f232c96887a74";
+    };
+    deps = {
+      "is-buffer-1.1.4" = self.by-version."is-buffer"."1.1.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."lazy-cache"."^1.0.3" =
+    self.by-version."lazy-cache"."1.0.4";
+  by-version."lazy-cache"."1.0.4" = self.buildNodePackage {
+    name = "lazy-cache-1.0.4";
+    version = "1.0.4";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz";
+      name = "lazy-cache-1.0.4.tgz";
+      sha1 = "a1d78fc3a50474cb80845d3b3b6e1da49a446e8e";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."less"."^2.7.1" =
+    self.by-version."less"."2.7.1";
+  by-version."less"."2.7.1" = self.buildNodePackage {
+    name = "less-2.7.1";
+    version = "2.7.1";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/less/-/less-2.7.1.tgz";
+      name = "less-2.7.1.tgz";
+      sha1 = "6cbfea22b3b830304e9a5fb371d54fa480c9d7cf";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+      "errno-0.1.4" = self.by-version."errno"."0.1.4";
+      "graceful-fs-4.1.9" = self.by-version."graceful-fs"."4.1.9";
+      "image-size-0.5.0" = self.by-version."image-size"."0.5.0";
+      "mime-1.3.4" = self.by-version."mime"."1.3.4";
+      "mkdirp-0.5.1" = self.by-version."mkdirp"."0.5.1";
+      "promise-7.1.1" = self.by-version."promise"."7.1.1";
+      "source-map-0.5.6" = self.by-version."source-map"."0.5.6";
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "less" = self.by-version."less"."2.7.1";
+  by-spec."less"."~2.7.1" =
+    self.by-version."less"."2.7.1";
+  by-spec."less-middleware"."^2.2.0" =
+    self.by-version."less-middleware"."2.2.0";
+  by-version."less-middleware"."2.2.0" = self.buildNodePackage {
+    name = "less-middleware-2.2.0";
+    version = "2.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/less-middleware/-/less-middleware-2.2.0.tgz";
+      name = "less-middleware-2.2.0.tgz";
+      sha1 = "c3e4d512c8403685204add7bdaad7398c535c674";
+    };
+    deps = {
+      "less-2.7.1" = self.by-version."less"."2.7.1";
+      "mkdirp-0.5.1" = self.by-version."mkdirp"."0.5.1";
+      "node.extend-1.1.6" = self.by-version."node.extend"."1.1.6";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "less-middleware" = self.by-version."less-middleware"."2.2.0";
+  by-spec."libquassel"."~2.0.5" =
+    self.by-version."libquassel"."2.0.5";
+  by-version."libquassel"."2.0.5" = self.buildNodePackage {
+    name = "libquassel-2.0.5";
+    version = "2.0.5";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/libquassel/-/libquassel-2.0.5.tgz";
+      name = "libquassel-2.0.5.tgz";
+      sha1 = "faeba62e381b37527b1d6dea2e2c2f4c7a0f220f";
+    };
+    deps = {
+      "debug-2.2.0" = self.by-version."debug"."2.2.0";
+      "eventemitter2-2.1.3" = self.by-version."eventemitter2"."2.1.3";
+      "net-browserify-alt-1.0.0" = self.by-version."net-browserify-alt"."1.0.0";
+      "qtdatastream-0.6.6" = self.by-version."qtdatastream"."0.6.6";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "libquassel" = self.by-version."libquassel"."2.0.5";
+  by-spec."longest"."^1.0.1" =
+    self.by-version."longest"."1.0.1";
+  by-version."longest"."1.0.1" = self.buildNodePackage {
+    name = "longest-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz";
+      name = "longest-1.0.1.tgz";
+      sha1 = "30a0b2da38f73770e8294a0d22e6625ed77d0097";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."media-typer"."0.3.0" =
+    self.by-version."media-typer"."0.3.0";
+  by-version."media-typer"."0.3.0" = self.buildNodePackage {
+    name = "media-typer-0.3.0";
+    version = "0.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz";
+      name = "media-typer-0.3.0.tgz";
+      sha1 = "8710d7af0aa626f8fffa1ce00168545263255748";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."merge-descriptors"."1.0.1" =
+    self.by-version."merge-descriptors"."1.0.1";
+  by-version."merge-descriptors"."1.0.1" = self.buildNodePackage {
+    name = "merge-descriptors-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz";
+      name = "merge-descriptors-1.0.1.tgz";
+      sha1 = "b00aaa556dd8b44568150ec9d1b953f3f90cbb61";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."methods"."~1.1.2" =
+    self.by-version."methods"."1.1.2";
+  by-version."methods"."1.1.2" = self.buildNodePackage {
+    name = "methods-1.1.2";
+    version = "1.1.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz";
+      name = "methods-1.1.2.tgz";
+      sha1 = "5529a4d67654134edcc5266656835b0f851afcee";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."mime"."1.3.4" =
+    self.by-version."mime"."1.3.4";
+  by-version."mime"."1.3.4" = self.buildNodePackage {
+    name = "mime-1.3.4";
+    version = "1.3.4";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz";
+      name = "mime-1.3.4.tgz";
+      sha1 = "115f9e3b6b3daf2959983cb38f149a2d40eb5d53";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."mime"."^1.2.11" =
+    self.by-version."mime"."1.3.4";
+  by-spec."mime-db"."~1.24.0" =
+    self.by-version."mime-db"."1.24.0";
+  by-version."mime-db"."1.24.0" = self.buildNodePackage {
+    name = "mime-db-1.24.0";
+    version = "1.24.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz";
+      name = "mime-db-1.24.0.tgz";
+      sha1 = "e2d13f939f0016c6e4e9ad25a8652f126c467f0c";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."mime-types"."~2.1.11" =
+    self.by-version."mime-types"."2.1.12";
+  by-version."mime-types"."2.1.12" = self.buildNodePackage {
+    name = "mime-types-2.1.12";
+    version = "2.1.12";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz";
+      name = "mime-types-2.1.12.tgz";
+      sha1 = "152ba256777020dd4663f54c2e7bc26381e71729";
+    };
+    deps = {
+      "mime-db-1.24.0" = self.by-version."mime-db"."1.24.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."minimist"."0.0.8" =
+    self.by-version."minimist"."0.0.8";
+  by-version."minimist"."0.0.8" = self.buildNodePackage {
+    name = "minimist-0.0.8";
+    version = "0.0.8";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz";
+      name = "minimist-0.0.8.tgz";
+      sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."mkdirp"."^0.5.0" =
+    self.by-version."mkdirp"."0.5.1";
+  by-version."mkdirp"."0.5.1" = self.buildNodePackage {
+    name = "mkdirp-0.5.1";
+    version = "0.5.1";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz";
+      name = "mkdirp-0.5.1.tgz";
+      sha1 = "30057438eac6cf7f8c4767f38648d6697d75c903";
+    };
+    deps = {
+      "minimist-0.0.8" = self.by-version."minimist"."0.0.8";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."mkdirp"."~0.5.0" =
+    self.by-version."mkdirp"."0.5.1";
+  by-spec."mkdirp"."~0.5.1" =
+    self.by-version."mkdirp"."0.5.1";
+  by-spec."morgan"."^1.7.0" =
+    self.by-version."morgan"."1.7.0";
+  by-version."morgan"."1.7.0" = self.buildNodePackage {
+    name = "morgan-1.7.0";
+    version = "1.7.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz";
+      name = "morgan-1.7.0.tgz";
+      sha1 = "eb10ca8e50d1abe0f8d3dad5c0201d052d981c62";
+    };
+    deps = {
+      "basic-auth-1.0.4" = self.by-version."basic-auth"."1.0.4";
+      "debug-2.2.0" = self.by-version."debug"."2.2.0";
+      "depd-1.1.0" = self.by-version."depd"."1.1.0";
+      "on-finished-2.3.0" = self.by-version."on-finished"."2.3.0";
+      "on-headers-1.0.1" = self.by-version."on-headers"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "morgan" = self.by-version."morgan"."1.7.0";
+  by-spec."ms"."0.7.1" =
+    self.by-version."ms"."0.7.1";
+  by-version."ms"."0.7.1" = self.buildNodePackage {
+    name = "ms-0.7.1";
+    version = "0.7.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz";
+      name = "ms-0.7.1.tgz";
+      sha1 = "9cd13c03adbff25b65effde7ce864ee952017098";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."negotiator"."0.6.1" =
+    self.by-version."negotiator"."0.6.1";
+  by-version."negotiator"."0.6.1" = self.buildNodePackage {
+    name = "negotiator-0.6.1";
+    version = "0.6.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz";
+      name = "negotiator-0.6.1.tgz";
+      sha1 = "2b327184e8992101177b28563fb5e7102acd0ca9";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."net-browserify-alt"."^1.0.0" =
+    self.by-version."net-browserify-alt"."1.0.0";
+  by-version."net-browserify-alt"."1.0.0" = self.buildNodePackage {
+    name = "net-browserify-alt-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/net-browserify-alt/-/net-browserify-alt-1.0.0.tgz";
+      name = "net-browserify-alt-1.0.0.tgz";
+      sha1 = "d85326b4940ba4630db5ea7644cc07c5551a0e7e";
+    };
+    deps = {
+      "body-parser-1.15.2" = self.by-version."body-parser"."1.15.2";
+      "ws-1.1.1" = self.by-version."ws"."1.1.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "net-browserify-alt" = self.by-version."net-browserify-alt"."1.0.0";
+  by-spec."node.extend"."~1.1.5" =
+    self.by-version."node.extend"."1.1.6";
+  by-version."node.extend"."1.1.6" = self.buildNodePackage {
+    name = "node.extend-1.1.6";
+    version = "1.1.6";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz";
+      name = "node.extend-1.1.6.tgz";
+      sha1 = "a7b882c82d6c93a4863a5504bd5de8ec86258b96";
+    };
+    deps = {
+      "is-3.1.0" = self.by-version."is"."3.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."on-finished"."~2.3.0" =
+    self.by-version."on-finished"."2.3.0";
+  by-version."on-finished"."2.3.0" = self.buildNodePackage {
+    name = "on-finished-2.3.0";
+    version = "2.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz";
+      name = "on-finished-2.3.0.tgz";
+      sha1 = "20f1336481b083cd75337992a16971aa2d906947";
+    };
+    deps = {
+      "ee-first-1.1.1" = self.by-version."ee-first"."1.1.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."on-headers"."~1.0.1" =
+    self.by-version."on-headers"."1.0.1";
+  by-version."on-headers"."1.0.1" = self.buildNodePackage {
+    name = "on-headers-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz";
+      name = "on-headers-1.0.1.tgz";
+      sha1 = "928f5d0f470d49342651ea6794b0857c100693f7";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."optimist"."~0.3.5" =
+    self.by-version."optimist"."0.3.7";
+  by-version."optimist"."0.3.7" = self.buildNodePackage {
+    name = "optimist-0.3.7";
+    version = "0.3.7";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz";
+      name = "optimist-0.3.7.tgz";
+      sha1 = "c90941ad59e4273328923074d2cf2e7cbc6ec0d9";
+    };
+    deps = {
+      "wordwrap-0.0.3" = self.by-version."wordwrap"."0.0.3";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."options".">=0.0.5" =
+    self.by-version."options"."0.0.6";
+  by-version."options"."0.0.6" = self.buildNodePackage {
+    name = "options-0.0.6";
+    version = "0.0.6";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/options/-/options-0.0.6.tgz";
+      name = "options-0.0.6.tgz";
+      sha1 = "ec22d312806bb53e731773e7cdaefcf1c643128f";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."parseurl"."~1.3.0" =
+    self.by-version."parseurl"."1.3.1";
+  by-version."parseurl"."1.3.1" = self.buildNodePackage {
+    name = "parseurl-1.3.1";
+    version = "1.3.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz";
+      name = "parseurl-1.3.1.tgz";
+      sha1 = "c8ab8c9223ba34888aa64a297b28853bec18da56";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."parseurl"."~1.3.1" =
+    self.by-version."parseurl"."1.3.1";
+  by-spec."path-to-regexp"."0.1.7" =
+    self.by-version."path-to-regexp"."0.1.7";
+  by-version."path-to-regexp"."0.1.7" = self.buildNodePackage {
+    name = "path-to-regexp-0.1.7";
+    version = "0.1.7";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz";
+      name = "path-to-regexp-0.1.7.tgz";
+      sha1 = "df604178005f522f15eb4490e7247a1bfaa67f8c";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."promise"."^6.0.1" =
+    self.by-version."promise"."6.1.0";
+  by-version."promise"."6.1.0" = self.buildNodePackage {
+    name = "promise-6.1.0";
+    version = "6.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz";
+      name = "promise-6.1.0.tgz";
+      sha1 = "2ce729f6b94b45c26891ad0602c5c90e04c6eef6";
+    };
+    deps = {
+      "asap-1.0.0" = self.by-version."asap"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."promise"."^7.1.1" =
+    self.by-version."promise"."7.1.1";
+  by-version."promise"."7.1.1" = self.buildNodePackage {
+    name = "promise-7.1.1";
+    version = "7.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz";
+      name = "promise-7.1.1.tgz";
+      sha1 = "489654c692616b8aa55b0724fa809bb7db49c5bf";
+    };
+    deps = {
+      "asap-2.0.5" = self.by-version."asap"."2.0.5";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."promise"."~2.0" =
+    self.by-version."promise"."2.0.0";
+  by-version."promise"."2.0.0" = self.buildNodePackage {
+    name = "promise-2.0.0";
+    version = "2.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz";
+      name = "promise-2.0.0.tgz";
+      sha1 = "46648aa9d605af5d2e70c3024bf59436da02b80e";
+    };
+    deps = {
+      "is-promise-1.0.1" = self.by-version."is-promise"."1.0.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."proxy-addr"."~1.1.2" =
+    self.by-version."proxy-addr"."1.1.2";
+  by-version."proxy-addr"."1.1.2" = self.buildNodePackage {
+    name = "proxy-addr-1.1.2";
+    version = "1.1.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz";
+      name = "proxy-addr-1.1.2.tgz";
+      sha1 = "b4cc5f22610d9535824c123aef9d3cf73c40ba37";
+    };
+    deps = {
+      "forwarded-0.1.0" = self.by-version."forwarded"."0.1.0";
+      "ipaddr.js-1.1.1" = self.by-version."ipaddr.js"."1.1.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."prr"."~0.0.0" =
+    self.by-version."prr"."0.0.0";
+  by-version."prr"."0.0.0" = self.buildNodePackage {
+    name = "prr-0.0.0";
+    version = "0.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz";
+      name = "prr-0.0.0.tgz";
+      sha1 = "1a84b85908325501411853d0081ee3fa86e2926a";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."qs"."6.2.0" =
+    self.by-version."qs"."6.2.0";
+  by-version."qs"."6.2.0" = self.buildNodePackage {
+    name = "qs-6.2.0";
+    version = "6.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz";
+      name = "qs-6.2.0.tgz";
+      sha1 = "3b7848c03c2dece69a9522b0fae8c4126d745f3b";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."qtdatastream"."^0.6.6" =
+    self.by-version."qtdatastream"."0.6.6";
+  by-version."qtdatastream"."0.6.6" = self.buildNodePackage {
+    name = "qtdatastream-0.6.6";
+    version = "0.6.6";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/qtdatastream/-/qtdatastream-0.6.6.tgz";
+      name = "qtdatastream-0.6.6.tgz";
+      sha1 = "c572113d4a2174acb4062e58c06644723b50e1c1";
+    };
+    deps = {
+      "debug-2.2.0" = self.by-version."debug"."2.2.0";
+      "int64-buffer-0.1.9" = self.by-version."int64-buffer"."0.1.9";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."range-parser"."~1.2.0" =
+    self.by-version."range-parser"."1.2.0";
+  by-version."range-parser"."1.2.0" = self.buildNodePackage {
+    name = "range-parser-1.2.0";
+    version = "1.2.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz";
+      name = "range-parser-1.2.0.tgz";
+      sha1 = "f49be6b487894ddc40dcc94a322f611092e00d5e";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."raw-body"."~2.1.7" =
+    self.by-version."raw-body"."2.1.7";
+  by-version."raw-body"."2.1.7" = self.buildNodePackage {
+    name = "raw-body-2.1.7";
+    version = "2.1.7";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz";
+      name = "raw-body-2.1.7.tgz";
+      sha1 = "adfeace2e4fb3098058014d08c072dcc59758774";
+    };
+    deps = {
+      "bytes-2.4.0" = self.by-version."bytes"."2.4.0";
+      "iconv-lite-0.4.13" = self.by-version."iconv-lite"."0.4.13";
+      "unpipe-1.0.0" = self.by-version."unpipe"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."repeat-string"."^1.5.2" =
+    self.by-version."repeat-string"."1.5.4";
+  by-version."repeat-string"."1.5.4" = self.buildNodePackage {
+    name = "repeat-string-1.5.4";
+    version = "1.5.4";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz";
+      name = "repeat-string-1.5.4.tgz";
+      sha1 = "64ec0c91e0f4b475f90d5b643651e3e6e5b6c2d5";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."right-align"."^0.1.1" =
+    self.by-version."right-align"."0.1.3";
+  by-version."right-align"."0.1.3" = self.buildNodePackage {
+    name = "right-align-0.1.3";
+    version = "0.1.3";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz";
+      name = "right-align-0.1.3.tgz";
+      sha1 = "61339b722fe6a3515689210d24e14c96148613ef";
+    };
+    deps = {
+      "align-text-0.1.4" = self.by-version."align-text"."0.1.4";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."send"."0.14.1" =
+    self.by-version."send"."0.14.1";
+  by-version."send"."0.14.1" = self.buildNodePackage {
+    name = "send-0.14.1";
+    version = "0.14.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/send/-/send-0.14.1.tgz";
+      name = "send-0.14.1.tgz";
+      sha1 = "a954984325392f51532a7760760e459598c89f7a";
+    };
+    deps = {
+      "debug-2.2.0" = self.by-version."debug"."2.2.0";
+      "depd-1.1.0" = self.by-version."depd"."1.1.0";
+      "destroy-1.0.4" = self.by-version."destroy"."1.0.4";
+      "encodeurl-1.0.1" = self.by-version."encodeurl"."1.0.1";
+      "escape-html-1.0.3" = self.by-version."escape-html"."1.0.3";
+      "etag-1.7.0" = self.by-version."etag"."1.7.0";
+      "fresh-0.3.0" = self.by-version."fresh"."0.3.0";
+      "http-errors-1.5.0" = self.by-version."http-errors"."1.5.0";
+      "mime-1.3.4" = self.by-version."mime"."1.3.4";
+      "ms-0.7.1" = self.by-version."ms"."0.7.1";
+      "on-finished-2.3.0" = self.by-version."on-finished"."2.3.0";
+      "range-parser-1.2.0" = self.by-version."range-parser"."1.2.0";
+      "statuses-1.3.0" = self.by-version."statuses"."1.3.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."serve-favicon"."~2.3.0" =
+    self.by-version."serve-favicon"."2.3.0";
+  by-version."serve-favicon"."2.3.0" = self.buildNodePackage {
+    name = "serve-favicon-2.3.0";
+    version = "2.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz";
+      name = "serve-favicon-2.3.0.tgz";
+      sha1 = "aed36cc6834069a6f189cc7222c6a1a811dc5b39";
+    };
+    deps = {
+      "etag-1.7.0" = self.by-version."etag"."1.7.0";
+      "fresh-0.3.0" = self.by-version."fresh"."0.3.0";
+      "ms-0.7.1" = self.by-version."ms"."0.7.1";
+      "parseurl-1.3.1" = self.by-version."parseurl"."1.3.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  "serve-favicon" = self.by-version."serve-favicon"."2.3.0";
+  by-spec."serve-static"."~1.11.1" =
+    self.by-version."serve-static"."1.11.1";
+  by-version."serve-static"."1.11.1" = self.buildNodePackage {
+    name = "serve-static-1.11.1";
+    version = "1.11.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz";
+      name = "serve-static-1.11.1.tgz";
+      sha1 = "d6cce7693505f733c759de57befc1af76c0f0805";
+    };
+    deps = {
+      "encodeurl-1.0.1" = self.by-version."encodeurl"."1.0.1";
+      "escape-html-1.0.3" = self.by-version."escape-html"."1.0.3";
+      "parseurl-1.3.1" = self.by-version."parseurl"."1.3.1";
+      "send-0.14.1" = self.by-version."send"."0.14.1";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."setprototypeof"."1.0.1" =
+    self.by-version."setprototypeof"."1.0.1";
+  by-version."setprototypeof"."1.0.1" = self.buildNodePackage {
+    name = "setprototypeof-1.0.1";
+    version = "1.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz";
+      name = "setprototypeof-1.0.1.tgz";
+      sha1 = "52009b27888c4dc48f591949c0a8275834c1ca7e";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."source-map"."0.4.x" =
+    self.by-version."source-map"."0.4.4";
+  by-version."source-map"."0.4.4" = self.buildNodePackage {
+    name = "source-map-0.4.4";
+    version = "0.4.4";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz";
+      name = "source-map-0.4.4.tgz";
+      sha1 = "eba4f5da9c0dc999de68032d8b4f76173652036b";
+    };
+    deps = {
+      "amdefine-1.0.0" = self.by-version."amdefine"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."source-map"."^0.5.3" =
+    self.by-version."source-map"."0.5.6";
+  by-version."source-map"."0.5.6" = self.buildNodePackage {
+    name = "source-map-0.5.6";
+    version = "0.5.6";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz";
+      name = "source-map-0.5.6.tgz";
+      sha1 = "75ce38f52bf0733c5a7f0c118d81334a2bb5f412";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."source-map"."~0.1.7" =
+    self.by-version."source-map"."0.1.43";
+  by-version."source-map"."0.1.43" = self.buildNodePackage {
+    name = "source-map-0.1.43";
+    version = "0.1.43";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz";
+      name = "source-map-0.1.43.tgz";
+      sha1 = "c24bc146ca517c1471f5dacbe2571b2b7f9e3346";
+    };
+    deps = {
+      "amdefine-1.0.0" = self.by-version."amdefine"."1.0.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."source-map"."~0.5.1" =
+    self.by-version."source-map"."0.5.6";
+  by-spec."statuses".">= 1.3.0 < 2" =
+    self.by-version."statuses"."1.3.0";
+  by-version."statuses"."1.3.0" = self.buildNodePackage {
+    name = "statuses-1.3.0";
+    version = "1.3.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz";
+      name = "statuses-1.3.0.tgz";
+      sha1 = "8e55758cb20e7682c1f4fce8dcab30bf01d1e07a";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."statuses"."~1.3.0" =
+    self.by-version."statuses"."1.3.0";
+  by-spec."transformers"."2.1.0" =
+    self.by-version."transformers"."2.1.0";
+  by-version."transformers"."2.1.0" = self.buildNodePackage {
+    name = "transformers-2.1.0";
+    version = "2.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz";
+      name = "transformers-2.1.0.tgz";
+      sha1 = "5d23cb35561dd85dc67fb8482309b47d53cce9a7";
+    };
+    deps = {
+      "promise-2.0.0" = self.by-version."promise"."2.0.0";
+      "css-1.0.8" = self.by-version."css"."1.0.8";
+      "uglify-js-2.2.5" = self.by-version."uglify-js"."2.2.5";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."type-is"."~1.6.13" =
+    self.by-version."type-is"."1.6.13";
+  by-version."type-is"."1.6.13" = self.buildNodePackage {
+    name = "type-is-1.6.13";
+    version = "1.6.13";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz";
+      name = "type-is-1.6.13.tgz";
+      sha1 = "6e83ba7bc30cd33a7bb0b7fb00737a2085bf9d08";
+    };
+    deps = {
+      "media-typer-0.3.0" = self.by-version."media-typer"."0.3.0";
+      "mime-types-2.1.12" = self.by-version."mime-types"."2.1.12";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."uglify-js"."^2.4.19" =
+    self.by-version."uglify-js"."2.7.3";
+  by-version."uglify-js"."2.7.3" = self.buildNodePackage {
+    name = "uglify-js-2.7.3";
+    version = "2.7.3";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz";
+      name = "uglify-js-2.7.3.tgz";
+      sha1 = "39b3a7329b89f5ec507e344c6e22568698ef4868";
+    };
+    deps = {
+      "async-0.2.10" = self.by-version."async"."0.2.10";
+      "source-map-0.5.6" = self.by-version."source-map"."0.5.6";
+      "uglify-to-browserify-1.0.2" = self.by-version."uglify-to-browserify"."1.0.2";
+      "yargs-3.10.0" = self.by-version."yargs"."3.10.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."uglify-js"."~2.2.5" =
+    self.by-version."uglify-js"."2.2.5";
+  by-version."uglify-js"."2.2.5" = self.buildNodePackage {
+    name = "uglify-js-2.2.5";
+    version = "2.2.5";
+    bin = true;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz";
+      name = "uglify-js-2.2.5.tgz";
+      sha1 = "a6e02a70d839792b9780488b7b8b184c095c99c7";
+    };
+    deps = {
+      "source-map-0.1.43" = self.by-version."source-map"."0.1.43";
+      "optimist-0.3.7" = self.by-version."optimist"."0.3.7";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."uglify-to-browserify"."~1.0.0" =
+    self.by-version."uglify-to-browserify"."1.0.2";
+  by-version."uglify-to-browserify"."1.0.2" = self.buildNodePackage {
+    name = "uglify-to-browserify-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz";
+      name = "uglify-to-browserify-1.0.2.tgz";
+      sha1 = "6e0924d6bda6b5afe349e39a6d632850a0f882b7";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ultron"."1.0.x" =
+    self.by-version."ultron"."1.0.2";
+  by-version."ultron"."1.0.2" = self.buildNodePackage {
+    name = "ultron-1.0.2";
+    version = "1.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz";
+      name = "ultron-1.0.2.tgz";
+      sha1 = "ace116ab557cd197386a4e88f4685378c8b2e4fa";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."unpipe"."1.0.0" =
+    self.by-version."unpipe"."1.0.0";
+  by-version."unpipe"."1.0.0" = self.buildNodePackage {
+    name = "unpipe-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz";
+      name = "unpipe-1.0.0.tgz";
+      sha1 = "b2bf4ee8514aae6165b4817829d21b2ef49904ec";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."unpipe"."~1.0.0" =
+    self.by-version."unpipe"."1.0.0";
+  by-spec."utils-merge"."1.0.0" =
+    self.by-version."utils-merge"."1.0.0";
+  by-version."utils-merge"."1.0.0" = self.buildNodePackage {
+    name = "utils-merge-1.0.0";
+    version = "1.0.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz";
+      name = "utils-merge-1.0.0.tgz";
+      sha1 = "0294fb922bb9375153541c4f7096231f287c8af8";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."vary"."~1.1.0" =
+    self.by-version."vary"."1.1.0";
+  by-version."vary"."1.1.0" = self.buildNodePackage {
+    name = "vary-1.1.0";
+    version = "1.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz";
+      name = "vary-1.1.0.tgz";
+      sha1 = "e1e5affbbd16ae768dd2674394b9ad3022653140";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."void-elements"."~2.0.1" =
+    self.by-version."void-elements"."2.0.1";
+  by-version."void-elements"."2.0.1" = self.buildNodePackage {
+    name = "void-elements-2.0.1";
+    version = "2.0.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz";
+      name = "void-elements-2.0.1.tgz";
+      sha1 = "c066afb582bb1cb4128d60ea92392e94d5e9dbec";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."window-size"."0.1.0" =
+    self.by-version."window-size"."0.1.0";
+  by-version."window-size"."0.1.0" = self.buildNodePackage {
+    name = "window-size-0.1.0";
+    version = "0.1.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz";
+      name = "window-size-0.1.0.tgz";
+      sha1 = "5438cd2ea93b202efa3a19fe8887aee7c94f9c9d";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."with"."~4.0.0" =
+    self.by-version."with"."4.0.3";
+  by-version."with"."4.0.3" = self.buildNodePackage {
+    name = "with-4.0.3";
+    version = "4.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/with/-/with-4.0.3.tgz";
+      name = "with-4.0.3.tgz";
+      sha1 = "eefd154e9e79d2c8d3417b647a8f14d9fecce14e";
+    };
+    deps = {
+      "acorn-1.2.2" = self.by-version."acorn"."1.2.2";
+      "acorn-globals-1.0.9" = self.by-version."acorn-globals"."1.0.9";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."wordwrap"."0.0.2" =
+    self.by-version."wordwrap"."0.0.2";
+  by-version."wordwrap"."0.0.2" = self.buildNodePackage {
+    name = "wordwrap-0.0.2";
+    version = "0.0.2";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz";
+      name = "wordwrap-0.0.2.tgz";
+      sha1 = "b79669bb42ecb409f83d583cad52ca17eaa1643f";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."wordwrap"."~0.0.2" =
+    self.by-version."wordwrap"."0.0.3";
+  by-version."wordwrap"."0.0.3" = self.buildNodePackage {
+    name = "wordwrap-0.0.3";
+    version = "0.0.3";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz";
+      name = "wordwrap-0.0.3.tgz";
+      sha1 = "a3d5da6cd5c0bc0008d37234bbaf1bed63059107";
+    };
+    deps = {
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."ws"."^1.1.1" =
+    self.by-version."ws"."1.1.1";
+  by-version."ws"."1.1.1" = self.buildNodePackage {
+    name = "ws-1.1.1";
+    version = "1.1.1";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz";
+      name = "ws-1.1.1.tgz";
+      sha1 = "082ddb6c641e85d4bb451f03d52f06eabdb1f018";
+    };
+    deps = {
+      "options-0.0.6" = self.by-version."options"."0.0.6";
+      "ultron-1.0.2" = self.by-version."ultron"."1.0.2";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+  by-spec."yargs"."~3.10.0" =
+    self.by-version."yargs"."3.10.0";
+  by-version."yargs"."3.10.0" = self.buildNodePackage {
+    name = "yargs-3.10.0";
+    version = "3.10.0";
+    bin = false;
+    src = fetchurl {
+      url = "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz";
+      name = "yargs-3.10.0.tgz";
+      sha1 = "f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1";
+    };
+    deps = {
+      "camelcase-1.2.1" = self.by-version."camelcase"."1.2.1";
+      "cliui-2.1.0" = self.by-version."cliui"."2.1.0";
+      "decamelize-1.2.0" = self.by-version."decamelize"."1.2.0";
+      "window-size-0.1.0" = self.by-version."window-size"."0.1.0";
+    };
+    optionalDependencies = {
+    };
+    peerDependencies = [];
+    os = [ ];
+    cpu = [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14170,6 +14170,8 @@ in
     withKDE = false;
   };
 
+  quassel-webserver = callPackage ../applications/networking/irc/quassel-webserver { };
+
   quirc = callPackage ../tools/graphics/quirc {};
 
   quodlibet = callPackage ../applications/audio/quodlibet { };


### PR DESCRIPTION
###### Motivation for this change

Bring the [qussel-webserver](https://github.com/magne4000/quassel-webserver) to NixOS!
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
