### PR TITLE
spark: 1.6.0 -> 1.6.2

### DIFF
--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -6,15 +6,17 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name    = "spark-${version}";
-  version = "1.6.0";
+  version = "1.6.2";
 
   src = fetchzip {
     url    = "mirror://apache/spark/${name}/${name}-bin-cdh4.tgz";
-    sha256 = "19ycx1r8g82vkvzmn9wxkssmv2damrg72yfmrgzpc6xyh071g91c";
+    sha256 = "1wiwfz68npsznq63xyxghhn161ynhvyjwnspbr8cl7n101vm7ic7";
   };
 
   buildInputs = [ makeWrapper jre pythonPackages.python pythonPackages.numpy ]
-    ++ optional mesosSupport mesos;
+  # remove mesos dependency temporarily as it is broken atm
+  # ++ optional mesosSupport mesos
+  ;
 
   untarDir = "${name}-bin-cdh4";
   installPhase = ''
@@ -41,7 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description      = "Lightning-fast cluster computing";
+    description      = "A fast and general engine for large-scale data processing. ";
     homepage         = "http://spark.apache.org";
     license          = stdenv.lib.licenses.asl20;
     platforms        = stdenv.lib.platforms.all;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

spark-shell still has some problems due to a hard coded path to /bin/ls in org.apache.hadoop.util.Shell.class - it was also there in the previous version.
