### PR TITLE
oraclejdk: 8u101/102 -> 8u111/112

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "101";
+  patchVersion = "111";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "0p9nvaifb1mn7scmprbcyv9a4lyqy8i0mf7rsb59cli30vpi44mi";
-  sha256_x86_64 = "0a0kb3c7xfh81vx5sicw2frgxq0gyv5qp0d725rviwldlcxk4zs6";
+  sha256_i686 = "07wyyds52c3fp4ha1fnzp6mbxwq0rs3vx59167b57gkggg7qz3ls";
+  sha256_x86_64 = "0x4937c3307v78wx1jf227b89cf5lsd5yarmbjrxs4pq6lidlzhq";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "102";
+  patchVersion = "112";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "1bsypgf9va8jds0rlpnwp9n9p11hz77gqlmb0b0w2qwfmlmi227d";
-  sha256_x86_64 = "1dq4kqi8k2k11sc28fnbp6cmncfj86jv57iy1gkap94i0fyf1yvw";
+  sha256_i686 = "19b9vwb7bd17s9p04y47zzjkccazzmpy4dqx4rgxd79k1fw2yz0y";
+  sha256_x86_64 = "19blsx81x5p2f6d9vig89z7cc8778cp6qdjy9ylsa2444vaxfyvp";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Motivation for this change

Security update, as mentioned in #19678 

More information at http://www.oracle.com/technetwork/security-advisory/cpuoct2016-2881722.html#AppendixJAVA

_Fixed CVEs_
- CVE-2016-5556
- CVE-2016-5568
- CVE-2016-5582
- CVE-2016-5573
- CVE-2016-5597
- CVE-2016-5554
- CVE-2016-5542
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
