### PR TITLE
libtiff: patch for many CVEs

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, zlib, libjpeg, xz }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, zlib, libjpeg, xz }:
 
 let
   version = "4.0.6";
@@ -18,6 +18,38 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ zlib libjpeg xz ]; #TODO: opengl support (bogus configure detection)
 
   enableParallelBuilding = true;
+
+  patches = [
+    (fetchpatch {
+      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/01-CVE-2015-8665_and_CVE-2015-8683.patch";
+      sha256 = "1c4zmvxj124873al8fvkiv8zq7wx5mv2vd4f1y9w8liv92cm7hkc";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/02-fix_potential_out-of-bound_writes_in_decode_functions.patch";
+      sha256 = "0rsc7zh7cdhgcmx2vbjfaqrb0g93a3924ngqkrzb14w5j2fqfbxv";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/03-fix_potential_out-of-bound_write_in_NeXTDecode.patch";
+      sha256 = "1s01xhp4sl04yhqhqwp50gh43ykcqk230mmbv62vhy2jh7v0ky3a";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/04-CVE-2016-5314_CVE-2016-5316_CVE-2016-5320_CVE-2016-5875.patch";
+      sha256 = "0by35qxpzv9ib3mnh980gd30jf3qmsfp2kl730rq4pq66wpzg9m8";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/05-CVE-2016-6223.patch";
+      sha256 = "0rh8ia0wsf5yskzwdjrlbiilc9m0lq0igs42k6922pl3sa1lxzv1";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/06-CVE-2016-5321.patch";
+      sha256 = "0n0igfxbd3kqvvj2k2xgysrp63l4v2gd110fwkk4apfpm0hvzwh0";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/07-CVE-2016-5323.patch";
+      sha256 = "1j6w8g6qizkx5h4aq95kxzx6bgkn4jhc8l22swwhvlkichsh4910";
+    })
+
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/703467/
https://github.com/NixOS/nixpkgs/issues/19678
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
