### PR TITLE
font-awesome: use fetchFromGitHub instead of url

### DIFF
--- a/pkgs/data/fonts/font-awesome-ttf/default.nix
+++ b/pkgs/data/fonts/font-awesome-ttf/default.nix
@@ -1,28 +1,30 @@
-{stdenv, fetchurl, unzip}:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "font-awesome-4.6.3";
+  name = "font-awesome-${version}";
+  version = "4.6.3";
 
-  src = fetchurl {
-    url = "http://fortawesome.github.io/Font-Awesome/assets/${name}.zip";
-    sha256 = "06d6p3rydy86hg82igra4vqglyx7bii19jj5kdyhva0d2gqv7zfn";
+  src = fetchFromGitHub {
+    owner  = "FortAwesome";
+    repo   = "Font-Awesome";
+    rev    = "v${version}";
+    sha256 = "135k1xskksqzriad9zzcxa79iprldyp2bnmc22wslak0dvjz74w0";
   };
 
   buildCommand = ''
-    ${unzip}/bin/unzip $src
     mkdir -p $out/share/fonts/truetype
-    cp */fonts/*.ttf $out/share/fonts/truetype
+    cp $src/fonts/*.ttf $out/share/fonts/truetype
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Font Awesome - TTF font";
     longDescription = ''
       Font Awesome gives you scalable vector icons that can instantly be customized.
       This package includes only the TTF font. For full CSS etc. see the project website.
     '';
     homepage = "http://fortawesome.github.io/Font-Awesome/";
-    license = stdenv.lib.licenses.ofl;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.abaldeau ];
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ abaldeau ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

minor cleanup
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
