### PR TITLE
texlive manual: adds import of nixpkgs in nix-repl

### DIFF
--- a/doc/languages-frameworks/texlive.xml
+++ b/doc/languages-frameworks/texlive.xml
@@ -35,6 +35,7 @@ texlive.combine {
       You can list packages e.g. by <command>nix-repl</command>.
       <programlisting>
 $ nix-repl
+nix-repl> :l &lt;nixpkgs>
 nix-repl> texlive.collection-&lt;TAB>
       </programlisting>
     </para></listitem>


### PR DESCRIPTION
###### Motivation for this change

I wanted to list the different texlive collections using the nix-repl, as per the [manual](https://nixos.org/nixpkgs/manual/#idm140737316065984). 

It didn't work, since the nixpkgs were not loaded. Doing `:l <nixpkgs>` first resolved the problem.

This change adds the nixpkgs loading step to the manual so that the next inexperienced person don't have to figure out why it didn't work.

I tested this on NixOS unstable (16.09pre90254.6b20d5b) with nix-repl 1.11.3.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
