### PR TITLE
nodejs: fix darwin build

### DIFF
--- a/pkgs/development/web/nodejs/v4.nix
+++ b/pkgs/development/web/nodejs/v4.nix
@@ -9,4 +9,9 @@ import ./nodejs.nix (args // rec {
     url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
     sha256 = "1566q1kkv8j30fgqx8sm2h8323f38wwpa1hfb10gr6z46jyhv4a2";
   };
+
+  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace src/util.h \
+      --replace "tr1/type_traits" "type_traits"
+  '';
 })


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] OS X
  - [x] ~~Other Platforms~~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
