### PR TITLE
fpm2: init at 0.79

### DIFF
--- a/pkgs/tools/security/fpm2/default.nix
+++ b/pkgs/tools/security/fpm2/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     description = "FPM2 is GTK2 port from Figaro's Password Manager originally developed by John Conneely, with some new enhancements.";
     homepage    = http://als.regnet.cz/fpm2/;
     license     = licenses.gpl2;
-    platforms   = platforms.all;
+    platforms   = platforms.linux;
     maintainers = with maintainers; [ hce ];
   };
 }

--- a/pkgs/tools/security/fpm2/default.nix
+++ b/pkgs/tools/security/fpm2/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, pkgconfig, gnupg, gtk2
+, libxml2, intltool
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "fpm2-${version}";
+  version = "0.79";
+
+  src = fetchurl {
+    url = "http://als.regnet.cz/fpm2/download/fpm2-${version}.tar.bz2";
+    sha256 = "d55e9ce6be38a44fc1053d82db2d117cf3991a51898bd86d7913bae769f04da7";
+  };
+
+  buildInputs = [ pkgconfig gnupg gtk2 libxml2 intltool ];
+
+  meta = {
+    description = "FPM2 is GTK2 port from Figaro's Password Manager originally developed by John Conneely, with some new enhancements.";
+    homepage    = http://als.regnet.cz/fpm2/;
+    license     = licenses.gpl2;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ hce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17376,4 +17376,6 @@ in
   xulrunner = firefox-unwrapped;
 
   nitrokey-app = callPackage ../tools/security/nitrokey-app { };
+
+  fpm2 = callPackage ../tools/security/fpm2 { };
 }


### PR DESCRIPTION
###### Motivation for this change

fpm2 is a nice and slim password manager which I am using productively on NixOS, and thought it might be useful for others, too.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
