### PR TITLE
Flatbuffers

### DIFF
--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "flatbuffers-${version}";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "flatbuffers";
+    rev = "v${version}";
+    sha256 = "0jsqk49h521d5h4c9gk39a8968g6rcd6520a8knbfc7ssc4028y0";
+  };
+
+  buildInputs = [ cmake ];
+  enableParallelBuilding = true;
+
+  # Not sure how tests are supposed to be run.
+  # "make: *** No rule to make target 'check'.  Stop."
+  doCheck = false;
+
+  meta = {
+    description = "Memory Efficient Serialization Library.";
+    longDescription = ''
+      FlatBuffers is an efficient cross platform serialization library for
+      games and other memory constrained apps. It allows you to directly
+      access serialized data without unpacking/parsing it first, while still
+      having great forwards/backwards compatibility.
+    '';
+    maintainers = [ stdenv.lib.maintainers.teh ];
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.unix;
+    homepage = http://google.github.io/flatbuffers;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8754,6 +8754,8 @@ in
   protobufc1_1 = callPackage ../development/libraries/protobufc/1.1.nix { };
   protobufc1_0 = callPackage ../development/libraries/protobufc/1.0.nix { };
 
+  flatbuffers = callPackage ../development/libraries/flatbuffers { };
+
   pth = callPackage ../development/libraries/pth { };
 
   ptlib = callPackage ../development/libraries/ptlib {};


### PR DESCRIPTION
###### Motivation for this change

This seems like an omission - self contained so should be low maintenance.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
