### PR TITLE
eclipse-modeling: Helios(3.6) -> Neon.1(4.6.1)

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -80,6 +80,22 @@ rec {
   };
   eclipse_cpp_36 = eclipse-cpp-36; # backward compatibility, added 2016-01-30
 
+  eclipse-modeling-46 = buildEclipse {
+    name = "eclipse-modeling-4.6";
+    description = "Eclipse Modeling Tools";
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/1a/eclipse-modeling-neon-1a-linux-gtk-x86_64.tar.gz;
+          sha1 = "3695fd049c4cca2d235f424557e19877795a8183";
+        }
+      else
+        fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/1a/eclipse-modeling-neon-1a-linux-gtk.tar.gz;
+          sha1 = "fa0694a0b44e8e9c2301417f84dba45cf9ac6e61";
+        };
+  };
+
   eclipse-modeling-36 = buildEclipse {
     name = "eclipse-modeling-3.6.2";
     description = "Eclipse Modeling Tools (includes Incubating components)";


### PR DESCRIPTION
###### Motivation for this change

eclipse modeling tools are out of date (2011)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS (only x86_64)
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
