### PR TITLE
nspawn module: optionSet -> submodule

### DIFF
--- a/nixos/modules/system/boot/systemd-nspawn.nix
+++ b/nixos/modules/system/boot/systemd-nspawn.nix
@@ -41,41 +41,43 @@ let
   ];
 
   instanceOptions = {
+    options = {
 
-    execConfig = mkOption {
-      default = {};
-      example = { Parameters = "/bin/sh"; };
-      type = types.addCheck (types.attrsOf unitOption) checkExec;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Exec]</literal> section of this unit. See
-        <citerefentry><refentrytitle>systemd.nspawn</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
-    };
+      execConfig = mkOption {
+        default = {};
+        example = { Parameters = "/bin/sh"; };
+        type = types.addCheck (types.attrsOf unitOption) checkExec;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Exec]</literal> section of this unit. See
+          <citerefentry><refentrytitle>systemd.nspawn</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
 
-    filesConfig = mkOption {
-      default = {};
-      example = { Bind = [ "/home/alice" ]; };
-      type = types.addCheck (types.attrsOf unitOption) checkFiles;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Files]</literal> section of this unit. See
-        <citerefentry><refentrytitle>systemd.nspawn</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
-    };
+      filesConfig = mkOption {
+        default = {};
+        example = { Bind = [ "/home/alice" ]; };
+        type = types.addCheck (types.attrsOf unitOption) checkFiles;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Files]</literal> section of this unit. See
+          <citerefentry><refentrytitle>systemd.nspawn</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
 
-    networkConfig = mkOption {
-      default = {};
-      example = { Private = false; };
-      type = types.addCheck (types.attrsOf unitOption) checkNetwork;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Network]</literal> section of this unit. See
-        <citerefentry><refentrytitle>systemd.nspawn</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
+      networkConfig = mkOption {
+        default = {};
+        example = { Private = false; };
+        type = types.addCheck (types.attrsOf unitOption) checkNetwork;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Network]</literal> section of this unit. See
+          <citerefentry><refentrytitle>systemd.nspawn</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
     };
 
   };
@@ -99,8 +101,7 @@ in {
 
     systemd.nspawn = mkOption {
       default = {};
-      type = types.attrsOf types.optionSet;
-      options = [ instanceOptions ];
+      type = with types; attrsOf (submodule instanceOptions);
       description = "Definition of systemd-nspawn configurations.";
     };
 


### PR DESCRIPTION
###### Motivation for this change

Fix #19636 and `optionSet` is deprecated.

@groxxda I just tested building the manual, could you verify this does not break the module?
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
