### PR TITLE
ponyc: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation ( rec {
   name = "ponyc-${version}";
-  version = "0.5.1";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
     rev = version;
-    sha256 = "14c6qs3cqn9hk2hrq2d5rd4cmwzzz2fcb02dg5q1blq17pj7mcxa";
+    sha256 = "10miwsyxl589b0n1h3dbbc2qckq8z8a58s0d53asq88w2gpc339q";
   };
 
   buildInputs = [ llvm makeWrapper which ];

--- a/pkgs/development/compilers/ponyc/disable-tests.patch
+++ b/pkgs/development/compilers/ponyc/disable-tests.patch
@@ -2,15 +2,13 @@ diff --git a/packages/net/_test.pony b/packages/net/_test.pony
 index ce26bd7..9a98cc7 100644
 --- a/packages/net/_test.pony
 +++ b/packages/net/_test.pony
-@@ -5,11 +5,7 @@ actor Main is TestList
+@@ -5,9 +5,7 @@ actor Main is TestList
    new make() => None
 
    fun tag tests(test: PonyTest) =>
 -    test(_TestBroadcast)
 -    test(_TestTCPWritev)
--    ifdef not windows then
--      test(_TestTCPExpect)
--    end
+-    test(_TestTCPExpect)
 +    None
 
  class _TestPing is UDPNotify

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5110,7 +5110,7 @@ in
   };
 
   ponyc = callPackage ../development/compilers/ponyc {
-    llvm = llvm_38;
+    llvm = llvm_39;
   };
 
   pony-stable = callPackage ../development/compilers/ponyc/pony-stable.nix { };


### PR DESCRIPTION
###### Motivation for this change

Update to latest ponyc release
- Update to using llvm 3.9 for ponyc builds as it should resolve a Skylake cpu issue. See #19457 and ponylang/ponyc#1176. cc @NeQuissimus 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
