### PR TITLE
eclipse: cleanup (#19723)

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -108,22 +108,21 @@ rec {
 
   ################### Eclipse Scala SDK ################################################################################
 
-  eclipse-scala-sdk-40 = buildEclipse {
-    name = "eclipse-scala-sdk-4.0.0";
+  eclipse-scala-sdk-441 = buildEclipse {
+    name = "eclipse-scala-sdk-4.4.1";
     description = "Eclipse IDE for Scala Developers";
     src =
       if stdenv.system == "x86_64-linux" then
         fetchurl { # tested
-          url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86_64.tar.gz;
-          sha256  = "b65c5e8160e72c8389537e9e427138e6daa2065f9df3a943a86e40dd1543dd83";
+          url = http://downloads.typesafe.com/scalaide-pack/4.4.1-vfinal-luna-211-20160504/scala-SDK-4.4.1-vfinal-2.11-linux.gtk.x86_64.tar.gz;
+          sha256  = "4c2d1ac68384e12a11a851cf0fc7757aea087eba69329b21d539382a65340d27";
         }
       else
         fetchurl { # untested
-          url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86.tar.gz;
-          sha256 = "f422aea5903c97d212264a5a43c6ebc638aecbd4ce5e6078d92618725bc5d31e";
+          url = http://downloads.typesafe.com/scalaide-pack/4.4.1-vfinal-luna-211-20160504/scala-SDK-4.4.1-vfinal-2.11-linux.gtk.x86.tar.gz;
+          sha256 = "35383cb09567187e14a30c15de9fd9aa0eef99e4bbb342396ce3acd11fb5cbac";
         };
   };
-  eclipse_scala_sdk_40 = eclipse-scala-sdk-40; # backward compatibility, added 2016-01-30
 
 
   ################### Eclipse SDK ######################################################################################

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -12,73 +12,45 @@ rec {
 
   buildEclipse = callPackage ./build-eclipse.nix { };
 
-  eclipse-sdk-35 = buildEclipse {
-    name = "eclipse-sdk-3.5.2";
-    description = "Eclipse Classic";
+
+  ################### Eclipse CPP ######################################################################################
+
+  eclipse-cpp-46 = buildEclipse {
+    name = "eclipse-cpp-4.6.0";
+    description = "Eclipse IDE for C/C++ Developers, Neon release";
     src =
       if stdenv.system == "x86_64-linux" then
         fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.5.2-201002111343/eclipse-SDK-3.5.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "1ndvanxw62b5ywi6ww0dyimabfmjdsw9q3xpy95zd8d5ygj2qsgq";
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk-x86_64.tar.gz;
+          sha256 = "09fqsgvbjfdqvn7z03crkii34z4bsb34y272q68ib8741bxk0i6m";
         }
-      else
+      else if stdenv.system == "i686-linux" then
         fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.5.2-201002111343/eclipse-SDK-3.5.2-linux-gtk.tar.gz;
-          sha256 = "0y5n0cyr9lgjmmzkfmav7j5w66rc1jq3300hcw3vrfjiv1k6ng3w";
-        };
-  };
-  eclipse_sdk_35 = eclipse-sdk-35; # backward compatibility, added 2016-01-30
-
-  eclipse-sdk-36 = buildEclipse {
-    name = "eclipse-sdk-3.6.2";
-    description = "Eclipse Classic";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "0dfcfadcd6337c897fbfd5b292de481931dfce12d43289ecb93691fd27dd47f4";
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk.tar.gz;
+          sha256 = "0a12qmqq22v7sbmwn1hjv1zcrkmp64bf0ajmdjljhs9ac79mxn5h";
         }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk.tar.gz;
-          sha256 = "1bh8ykliqr8wbciv13vpiy50rvm7yszk7y8dslr796dbwhi5b1cj";
-        };
+      else throw "Unsupported system: ${stdenv.system}";
   };
-  eclipse_sdk_36 = eclipse-sdk-36; # backward compatibility, added 2016-01-30
 
-  eclipse-scala-sdk-40 = buildEclipse {
-    name = "eclipse-scala-sdk-4.0.0";
-    description = "Eclipse IDE for Scala Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl { # tested
-          url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86_64.tar.gz;
-          sha256  = "b65c5e8160e72c8389537e9e427138e6daa2065f9df3a943a86e40dd1543dd83";
-        }
-      else
-        fetchurl { # untested
-          url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86.tar.gz;
-          sha256 = "f422aea5903c97d212264a5a43c6ebc638aecbd4ce5e6078d92618725bc5d31e";
-        };
-  };
-  eclipse_scala_sdk_40 = eclipse-scala-sdk-40; # backward compatibility, added 2016-01-30
-
-  eclipse-cpp-36 = buildEclipse {
-    name = "eclipse-cpp-3.6.2";
+  eclipse-cpp-37 = buildEclipse {
+    name = "eclipse-cpp-3.7";
     description = "Eclipse IDE for C/C++ Developers";
     src =
       if stdenv.system == "x86_64-linux" then
         fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-cpp-helios-SR2-linux-gtk-x86_64.tar.gz;
-          sha1 = "6f914e11fa15a900c46825e4aa8299afd76e7e65";
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/indigo/R/eclipse-cpp-indigo-incubation-linux-gtk-x86_64.tar.gz;
+          sha256 = "14ppc9g9igzvj1pq7jl01vwhzb66nmzbl9wsdl1sf3xnwa9wnqk3";
         }
       else
         fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/helios/SR2/eclipse-cpp-helios-SR2-linux-gtk.tar.gz;
-          sha1 = "1156e4bc0253ae3a3a4e54839e4944dc64d3108f";
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/indigo/R/eclipse-cpp-indigo-incubation-linux-gtk.tar.gz;
+          sha256 = "1cvg1vgyazrkinwzlvlf0dpl197p4784752srqybqylyj5psdi3b";
         };
   };
-  eclipse_cpp_36 = eclipse-cpp-36; # backward compatibility, added 2016-01-30
+  eclipse_cpp_37 = eclipse-cpp-37; # backward compatibility, added 2016-01-30
+
+
+  ################### Eclipse Modeling  ################################################################################
 
   eclipse-modeling-46 = buildEclipse {
     name = "eclipse-modeling-4.6";
@@ -113,6 +85,64 @@ rec {
   };
   eclipse_modeling_36 = eclipse-modeling-36; # backward compatibility, added 2016-01-30
 
+
+  ################### Eclipse Platform #################################################################################
+
+  eclipse-platform = eclipse-platform-46;
+
+  eclipse-platform-46 = buildEclipse {
+    name = "eclipse-platform-4.6";
+    description = "Eclipse platform";
+    sources = {
+      "x86_64-linux" = fetchurl {
+          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk-x86_64.tar.gz;
+          sha256 = "02lfa0f4j53q4ks3nal4jxnm1vc6xck2k9zng58izfh49v73jyjd";
+        };
+      "i686-linux" = fetchurl {
+          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk.tar.gz;
+          sha256 = "053hsy87jmr9phn934a4qny959d6inxjx8nlcmxa2165ra8d7qfr";
+        };
+    };
+  };
+
+
+  ################### Eclipse Scala SDK ################################################################################
+
+  eclipse-scala-sdk-40 = buildEclipse {
+    name = "eclipse-scala-sdk-4.0.0";
+    description = "Eclipse IDE for Scala Developers";
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl { # tested
+          url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86_64.tar.gz;
+          sha256  = "b65c5e8160e72c8389537e9e427138e6daa2065f9df3a943a86e40dd1543dd83";
+        }
+      else
+        fetchurl { # untested
+          url = http://downloads.typesafe.com/scalaide-pack/4.0.0.vfinal-luna-211-20150305/scala-SDK-4.0.0-vfinal-2.11-linux.gtk.x86.tar.gz;
+          sha256 = "f422aea5903c97d212264a5a43c6ebc638aecbd4ce5e6078d92618725bc5d31e";
+        };
+  };
+  eclipse_scala_sdk_40 = eclipse-scala-sdk-40; # backward compatibility, added 2016-01-30
+
+
+  ################### Eclipse SDK ######################################################################################
+
+  eclipse-sdk-46 = buildEclipse {
+    name = "eclipse-sdk-4.6";
+    description = "Eclipse Neon Classic";
+    sources = {
+      "x86_64-linux" = fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk-x86_64.tar.gz;
+          sha256 = "4d7a39ce4e04ba1f5179f6a72926eb86ed506d97842a3bf4247814491c508e0a";
+        };
+      "i686-linux" = fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk.tar.gz;
+          sha256 = "d9e1d390cac504a17a65d4a22ebb8da6a592bcc54491912cbc29577990d77014";
+        };
+    };
+  };
+
   eclipse-sdk-37 = buildEclipse {
     name = "eclipse-sdk-3.7";
     description = "Eclipse Classic";
@@ -129,313 +159,8 @@ rec {
   };
   eclipse_sdk_37 = eclipse-sdk-37; # backward compatibility, added 2016-01-30
 
-  eclipse-cpp-37 = buildEclipse {
-    name = "eclipse-cpp-3.7";
-    description = "Eclipse IDE for C/C++ Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/indigo/R/eclipse-cpp-indigo-incubation-linux-gtk-x86_64.tar.gz;
-          sha256 = "14ppc9g9igzvj1pq7jl01vwhzb66nmzbl9wsdl1sf3xnwa9wnqk3";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/indigo/R/eclipse-cpp-indigo-incubation-linux-gtk.tar.gz;
-          sha256 = "1cvg1vgyazrkinwzlvlf0dpl197p4784752srqybqylyj5psdi3b";
-        };
-  };
-  eclipse_cpp_37 = eclipse-cpp-37; # backward compatibility, added 2016-01-30
 
-  eclipse-cpp-42 = buildEclipse {
-    name = "eclipse-cpp-4.2";
-    description = "Eclipse IDE for C/C++ Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/juno/SR2/eclipse-cpp-juno-SR2-linux-gtk-x86_64.tar.gz;
-          sha256 = "1qq04926pf7v9sf3s0z53zvlbl1j0rmmjmbmhqi49473fnjikh7y";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/juno/SR2/eclipse-cpp-juno-SR2-linux-gtk.tar.gz;
-          sha256 = "1a4s9qlhfpfpdhvffyglnfdr3dq5r2ywcxqywhqi95yhq5nmsgyk";
-        };
-  };
-  eclipse_cpp_42 = eclipse-cpp-42; # backward compatibility, added 2016-01-30
-
-  eclipse-cpp-43 = buildEclipse {
-    name = "eclipse-cpp-4.3.2";
-    description = "Eclipse IDE for C/C++ Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/kepler/SR2/eclipse-cpp-kepler-SR2-linux-gtk-x86_64.tar.gz;
-          sha256 = "16zhjm6bx78263b1clg75kfiliahkhwg0k116vp9fj039nlpc30l";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/kepler/SR2/eclipse-cpp-kepler-SR2-linux-gtk.tar.gz;
-          sha256 = "0d6jlj7hwz8blx6csrlyi2h2prql0wckbh7ihwjmgclwpcpj84g6";
-        };
-  };
-  eclipse_cpp_43 = eclipse-cpp-43; # backward compatibility, added 2016-01-30
-  
-  eclipse-cpp-44 = buildEclipse {
-    name = "eclipse-cpp-4.4.2";
-    description = "Eclipse IDE for C/C++ Developers";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/luna/SR2/eclipse-cpp-luna-SR2-linux-gtk-x86_64.tar.gz;
-          sha256 = "1vxwj7yihgipvrb3gksmddqkarzazpwk3mh1mjnw0i5xz2y32ba4";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/luna/SR2/eclipse-cpp-luna-SR2-linux-gtk.tar.gz;
-          sha256 = "1yn7yzzx8izc199c8w4f7vrc0b08idyq0dn113i8123b0mxw5lkp";
-        };
-  };
-  eclipse_cpp_44 = eclipse-cpp-44; # backward compatibility, added 2016-01-30
-
-  eclipse-cpp-45 = buildEclipse {
-    name = "eclipse-cpp-4.5.1";
-    description = "Eclipse IDE for C/C++ Developers, Mars release";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/mars/1/eclipse-cpp-mars-1-linux-gtk-x86_64.tar.gz;
-          sha256 = "1j6rsgr44kya2v7y34ifscajqk7lnq1w9m9fx4i0qgby84sy4xj7";
-        }
-      else if stdenv.system == "i686-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/mars/1/eclipse-cpp-mars-1-linux-gtk.tar.gz;
-          sha256 = "0qsbvjkq0ssxbnafh4gs8pfclynqis3nf7xlxx4w3k20jcjx7sr2";
-        }
-      else throw "Unsupported system: ${stdenv.system}";
-  };
-  eclipse_cpp_45 = eclipse-cpp-45; # backward compatibility, added 2016-01-30
-
-  eclipse-cpp-46 = buildEclipse {
-    name = "eclipse-cpp-4.6.0";
-    description = "Eclipse IDE for C/C++ Developers, Neon release";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk-x86_64.tar.gz;
-          sha256 = "09fqsgvbjfdqvn7z03crkii34z4bsb34y272q68ib8741bxk0i6m";
-        }
-      else if stdenv.system == "i686-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/neon/R/eclipse-cpp-neon-R-linux-gtk.tar.gz;
-          sha256 = "0a12qmqq22v7sbmwn1hjv1zcrkmp64bf0ajmdjljhs9ac79mxn5h";
-        }
-      else throw "Unsupported system: ${stdenv.system}";
-  };
-
-  eclipse-sdk-421 = buildEclipse {
-    name = "eclipse-sdk-4.2.1";
-    description = "Eclipse Classic";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.1-201209141800/eclipse-SDK-4.2.1-linux-gtk-x86_64.tar.gz;
-          sha256 = "1mlyy90lk08lb2971ynglgi3nqvqfq1k70md2kb39jk160wd1xrk";
-        }
-      else
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.1-201209141800/eclipse-SDK-4.2.1-linux-gtk.tar.gz;
-          sha256 = "1av6qm9wkbyk123qqf38f0jq4jv2bj9wp6fmpnl55zg6qr463c1w";
-        };
-    };
-  eclipse_sdk_421 = eclipse-sdk-421; # backward compatibility, added 2016-01-30
-
-  eclipse-sdk-422 = buildEclipse {
-    name = "eclipse-sdk-4.2.2";
-    description = "Eclipse Classic";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.2-201302041200/eclipse-SDK-4.2.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "0ysa6ymk4h3k1vn59dc909iy197kmx132671kbzfwbim87jmgnqb";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.2.2-201302041200/eclipse-SDK-4.2.2-linux-gtk.tar.gz;
-          sha256 = "038yibbrcia38wi72qrdl03g7l35mpvl5nxdfdnvpqxrkfffb826";
-        };
-    };
-  };
-  eclipse_sdk_422 = eclipse-sdk-422; # backward compatibility, added 2016-01-30
-
-  eclipse-sdk-431 = buildEclipse {
-    name = "eclipse-sdk-4.3.1";
-    description = "Eclipse Classic";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.3.1-201309111000/eclipse-SDK-4.3.1-linux-gtk-x86_64.tar.gz;
-          sha256 = "0ncm56ylwxw9z8rk8ccgva68c2yr9yrf1kcr1zkgw6p87xh1yczd";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.3.1-201309111000/eclipse-SDK-4.3.1-linux-gtk.tar.gz;
-          sha256 = "1zxsh838khny7mvl01h28xna6xdh01yi4mvls28zj22v0340lgsg";
-        };
-    };
-  };
-  eclipse_sdk_431 = eclipse-sdk-431; # backward compatibility, added 2016-01-30
-
-  eclipse-sdk-44 = buildEclipse {
-    name = "eclipse-sdk-4.4";
-    description = "Eclipse Classic";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-linux-gtk-x86_64.tar.gz;
-          sha256 = "14hdkijsjq0hhzi9ijpwjjkhz7wm0pry86l3dniy5snlh3l5bsb2";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4-201406061215/eclipse-SDK-4.4-linux-gtk.tar.gz;
-          sha256 = "0hjc4zrsmik6vff851p0a4ydnx99840j2xrx8348kk6h0af8vx6z";
-        };
-    };
-  };
-  eclipse_sdk_44 = eclipse-sdk-44; # backward compatibility, added 2016-01-30
-
-  eclipse-sdk-442 = buildEclipse {
-    name = "eclipse-sdk-4.4.2";
-    description = "Eclipse Classic";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "0g00alsixfaakmn4khr0m9fxvkrbhbg6qqfa27xr6a9np6gzg98l";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-linux-gtk.tar.gz;
-          sha256 = "1hacyjjwhhxi7r3xyhpqgjqpd5r0irw9bfkalz5s5l6shb0lq4i7";
-        };
-    };
-  };
-  eclipse_sdk_442 = eclipse-sdk-442; # backward compatibility, added 2016-01-30
-
-  eclipse-sdk-45 = buildEclipse {
-    name = "eclipse-sdk-4.5";
-    description = "Eclipse Mars Classic";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-SDK-4.5-linux-gtk-x86_64.tar.gz;
-          sha256 = "0vfql4gh263ms8bg7sgn05gnjajplx304cn3nr03jlacgr3pkarf";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-SDK-4.5-linux-gtk.tar.gz;
-          sha256 = "0xv66l6hdlvxpswcqrsh398wg6xhy30f833dr7jvvz45s5437hm3";
-        };
-    };
-  };
-  eclipse_sdk_45 = eclipse-sdk-45; # backward compatibility, added 2016-01-30
-
-  eclipse-sdk-451 = buildEclipse {
-    name = "eclipse-sdk-4.5.1";
-    description = "Eclipse Mars Classic";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-SDK-4.5.1-linux-gtk-x86_64.tar.gz;
-          sha256 = "b56503ab4b86f54e1cdc93084ef8c32fb1eaabc6f6dad9ef636153b14c928e02";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-SDK-4.5.1-linux-gtk.tar.gz;
-          sha256 = "f2e41da52e138276f8f121fd4d57c3f98839817836b56f8424e99b63c9b1b025";
-        };
-    };
-  };
-  eclipse_sdk_451 = eclipse-sdk-451; # backward compatibility, added 2016-01-30
-  
-  eclipse-sdk-452 = buildEclipse {
-    name = "eclipse-sdk-4.5.2";
-    description = "Eclipse Mars Classic";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "87f82b0c13c245ee20928557dbc4435657d1e029f72d9135683c8d585c69ba8d";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk.tar.gz;
-          sha256 = "78f7e537b34333401fc782fbd1260087c586ff93b17b88da5b177642f3aa5a02";
-        };
-    };
-  };
-  
-  eclipse-sdk-46 = buildEclipse {
-    name = "eclipse-sdk-4.6";
-    description = "Eclipse Neon Classic";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk-x86_64.tar.gz;
-          sha256 = "4d7a39ce4e04ba1f5179f6a72926eb86ed506d97842a3bf4247814491c508e0a";
-        };
-      "i686-linux" = fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk.tar.gz;
-          sha256 = "d9e1d390cac504a17a65d4a22ebb8da6a592bcc54491912cbc29577990d77014";
-        };
-    };
-  };
-
-  eclipse-platform = eclipse-platform-46;
-
-  eclipse-platform-45 = buildEclipse {
-    name = "eclipse-platform-4.5";
-    description = "Eclipse platform";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk-x86_64.tar.gz;
-          sha256 = "1510j41yr86pbzwf48kjjdd46nkpkh8zwn0hna0cqvsw1gk2vqcg";
-        };
-      "i686-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5-201506032000/eclipse-platform-4.5-linux-gtk.tar.gz;
-          sha256 = "1f97jd3qbi3830y3djk8bhwzd9whsq8gzfdk996chxc55prn0qbd";
-        };
-    };
-  };
-
-  eclipse-platform-451 = buildEclipse {
-    name = "eclipse-platform-4.5.1";
-    description = "Eclipse platform";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-platform-4.5.1-linux-gtk-x86_64.tar.gz;
-          sha256 = "1m7bzyi20yss6cz74d7hvhxj1cddcpgzxjia5wcjycsvq33kkny0";
-        };
-      "i686-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.1-201509040015/eclipse-platform-4.5.1-linux-gtk.tar.gz;
-          sha256 = "17x8w4k0rba0c0v9ghxdl0zqfadla5c1aakfd5k0q9q3x3qi6rxp";
-        };
-    };
-  };
-
-  eclipse-platform-452 = buildEclipse {
-    name = "eclipse-platform-4.5.2";
-    description = "Eclipse platform";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk-x86_64.tar.gz;
-          sha256 = "13dsd5f5i39wd0sr2bgp57hd2msn8g2dnmw5j8hfwif22c62py47";
-        };
-      "i686-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.5.2-201602121500/eclipse-SDK-4.5.2-linux-gtk.tar.gz;
-          sha256 = "00jsmbrl4xhpbgd8hyxijgzqdic700kd3yw2qwgl0cs3ncvybxvq";
-        };
-    };
-  };
-
-  eclipse-platform-46 = buildEclipse {
-    name = "eclipse-platform-4.6";
-    description = "Eclipse platform";
-    sources = {
-      "x86_64-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk-x86_64.tar.gz;
-          sha256 = "02lfa0f4j53q4ks3nal4jxnm1vc6xck2k9zng58izfh49v73jyjd";
-        };
-      "i686-linux" = fetchurl {
-          url = https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops4/R-4.6-201606061100/eclipse-SDK-4.6-linux-gtk.tar.gz;
-          sha256 = "053hsy87jmr9phn934a4qny959d6inxjx8nlcmxa2165ra8d7qfr";
-        };
-    };
-  };
+  ################### Eclipse with Plugins #############################################################################
 
   eclipseWithPlugins = { eclipse, plugins ? [], jvmArgs ? [] }:
     let


### PR DESCRIPTION
###### Motivation for this change

attempt to clean up the mess that is the eclipse management file
Idea:
- sorted packages alpahbetically
- sorted package version (newest first) (makes it easier to add new version)
- added an overview over available eclipse packages
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
