### PR TITLE
emacs: Use wrapGAppsHook always when on GTK

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -45,10 +45,10 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withX
       [ xlibsWrapper libXaw Xaw3d libXpm libpng libjpeg libungif libtiff librsvg libXft
         imagemagick gconf ]
-    ++ lib.optional (withX && withGTK2) gtk2
-    ++ lib.optional (withX && withGTK3) gtk3
+    ++ lib.optionals (withX && withGTK2) [ gtk2 wrapGAppsHook ]
+    ++ lib.optionals (withX && withGTK3) [ gtk3 wrapGAppsHook ]
     ++ lib.optional (stdenv.isDarwin && withX) cairo
-    ++ lib.optionals withXwidgets [ webkitgtk24x wrapGAppsHook glib_networking ];
+    ++ lib.optionals withXwidgets [ webkitgtk24x glib_networking ];
 
   propagatedBuildInputs = lib.optionals stdenv.isDarwin [ AppKit GSS ImageIO ];
 


### PR DESCRIPTION
###### Motivation for this change

The GTK theme is not recognized (e.g., the mouse pointer is different when inside an Emacs window).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
