### PR TITLE
libgumbo: init at 0.10.1

### DIFF
--- a/pkgs/development/libraries/libgumbo/default.nix
+++ b/pkgs/development/libraries/libgumbo/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool }:
+
+stdenv.mkDerivation rec {
+  name = "libgumbo-${version}";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "gumbo-parser";
+    rev = "v${version}";
+    sha256 = "0xslckwdh2i0g2qjsb6rnm8mjmbagvziz0hjlf7d1lbljfms1iw1";
+  };
+
+  buildInputs = [ autoconf automake libtool ];
+
+  preConfigure = "./autogen.sh";
+
+  meta = with stdenv.lib; {
+    description = "C99 HTML parsing algorithm";
+    homepage = https://github.com/google/gumbo-parser;
+    maintainers = [ maintainers.nico202 ];
+    platforms = platforms.linux;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7776,6 +7776,8 @@ in
     inherit (perlPackages) libintlperl GetoptLong SysVirt;
   };
 
+  libgumbo = callPackage ../development/libraries/libgumbo { };
+  
   libhangul = callPackage ../development/libraries/libhangul { };
 
   libharu = callPackage ../development/libraries/libharu { };


### PR DESCRIPTION
###### Motivation for this change

I needed this library to use a julia package (Gumbo.jl).
https://github.com/google/gumbo-parser
###### Things done
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
