### PR TITLE
gnupg: take libusb include path from pkg-config

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     readline libusb gnutls adns openldap zlib bzip2
   ];
 
+  patches = [ ./fix-libusb-include-path.patch ];
   postPatch = stdenv.lib.optionalString stdenv.isLinux ''
     sed -i 's,"libpcsclite\.so[^"]*","${pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
   ''; #" fix Emacs syntax highlighting :-(

--- a/pkgs/tools/security/gnupg/fix-libusb-include-path.patch
+++ b/pkgs/tools/security/gnupg/fix-libusb-include-path.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -8872,7 +8872,7 @@
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking libusb include dir" >&5
+ $as_echo_n "checking libusb include dir... " >&6; }
+    usb_incdir_found="no"
+-   for _incdir in "" "/usr/include/libusb-1.0" "/usr/local/include/libusb-1.0"; do
++   for _incdir in "" "/usr/include/libusb-1.0" "/usr/local/include/libusb-1.0" "$($PKG_CONFIG --variable=includedir libusb-1.0)/libusb-1.0"; do
+      _libusb_save_cppflags=$CPPFLAGS
+      if test -n "${_incdir}"; then
+        CPPFLAGS="-I${_incdir} ${CPPFLAGS}"

--- a/pkgs/tools/security/gnupg/fix-libusb-include-path.patch
+++ b/pkgs/tools/security/gnupg/fix-libusb-include-path.patch
@@ -5,7 +5,7 @@
  $as_echo_n "checking libusb include dir... " >&6; }
     usb_incdir_found="no"
 -   for _incdir in "" "/usr/include/libusb-1.0" "/usr/local/include/libusb-1.0"; do
-+   for _incdir in "" "/usr/include/libusb-1.0" "/usr/local/include/libusb-1.0" "$($PKG_CONFIG --variable=includedir libusb-1.0)/libusb-1.0"; do
++   for _incdir in "$($PKG_CONFIG --variable=includedir libusb-1.0)/libusb-1.0"; do
       _libusb_save_cppflags=$CPPFLAGS
       if test -n "${_incdir}"; then
         CPPFLAGS="-I${_incdir} ${CPPFLAGS}"


### PR DESCRIPTION
###### Motivation for this change

This makes smartcards (like the Nitrokey)  usable again.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This makes smartcards (like the Nitrokey)  usable again.
