### PR TITLE
Fix riemann-health service (backport to release-16.09)

### DIFF
--- a/nixos/modules/services/monitoring/riemann-tools.nix
+++ b/nixos/modules/services/monitoring/riemann-tools.nix
@@ -50,6 +50,7 @@ in {
 
     systemd.services.riemann-health = {
       wantedBy = [ "multi-user.target" ];
+      path = [ procps ];
       serviceConfig = {
         User = "riemanntools";
         ExecStart = "${healthLauncher}/bin/riemann-health";


### PR DESCRIPTION
Cherry-picking #19262 into 16.09.

Fixes one of the health metrics that doesn't work due to not having `ps` available.
