### PR TITLE
activator: 1.3.10 -> 1.3.11

### DIFF
--- a/pkgs/development/tools/activator/default.nix
+++ b/pkgs/development/tools/activator/default.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
 
   name = "${pname}-${version}";
   pname = "activator";
-  version = "1.3.10";
+  version = "1.3.11";
 
   src = fetchurl {
     url = "http://downloads.typesafe.com/typesafe-${pname}/${version}/typesafe-${name}.zip";
-    sha256 = "43693f041c8422ee06a2a90a805fd7b0e258dc85da31f0a4dca340dfd119b4ce";
+    sha256 = "1xpdh0mh97jiyh835524whq8n6rkvi1bl9fj9mc9fv73x4y2fg9k";
   };
 
   buildInputs = [ unzip jre ];


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
