### PR TITLE
[17.03] Revert "gnome-session: enable debug"

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-session/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     for desktopFile in $(grep -rl "Exec=gnome-session" $out/share)
     do
       echo "Patching gnome-session path in: $desktopFile"
-      sed -i "s,^Exec=gnome-session,Exec=$out/bin/gnome-session --debug," $desktopFile
+      sed -i "s,^Exec=gnome-session,Exec=$out/bin/gnome-session," $desktopFile
     done
     wrapProgram "$out/bin/gnome-session" \
       --prefix PATH : "${glib.dev}/bin" \


### PR DESCRIPTION
### Dont merge
### This PR is only a reminder for 17.03.
###### Motivation for this change

Debugging should not make it into the next release.
###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
