### PR TITLE
gnome3: default to 3.22

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -82,7 +82,7 @@ in {
 
     environment.gnome3.packageSet = mkOption {
       default = null;
-      example = literalExample "pkgs.gnome3_20";
+      example = literalExample "pkgs.gnome3_22";
       description = "Which GNOME 3 package set to use.";
       apply = p: if p == null then pkgs.gnome3 else p;
     };

--- a/pkgs/desktops/gnome-3/3.22/core/vte/2.90.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/vte/2.90.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, intltool, pkgconfig, gnome3, ncurses, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  versionMajor = "0.36";
+  versionMinor = "3";
+  moduleName   = "vte";
+
+  name = "${moduleName}-${versionMajor}.${versionMinor}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${moduleName}/${versionMajor}/${name}.tar.xz";
+    sha256 = "54e5b07be3c0f7b158302f54ee79d4de1cb002f4259b6642b79b1e0e314a959c";
+  };
+
+  buildInputs = [ gobjectIntrospection intltool pkgconfig gnome3.glib gnome3.gtk3 ncurses ];
+
+  configureFlags = [ "--enable-introspection" ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    substituteInPlace $out/lib/libvte2_90.la --replace "-lncurses" "-L${ncurses.out}/lib -lncurses"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.gnome.org/;
+    description = "A library implementing a terminal emulator widget for GTK+";
+    longDescription = ''
+      VTE is a library (libvte) implementing a terminal emulator widget for
+      GTK+, and a minimal sample application (vte) using that.  Vte is
+      mainly used in gnome-terminal, but can also be used to embed a
+      console/terminal in games, editors, IDEs, etc. VTE supports Unicode and
+      character set conversion, as well as emulating any terminal known to
+      the system's terminfo database.
+    '';
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ astsmtl antono lethalman ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/3.22/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/default.nix
@@ -232,6 +232,8 @@ let
 
   vte = callPackage ./core/vte { };
 
+  vte_290 = callPackage ./core/vte/2.90.nix { };
+
   vino = callPackage ./core/vino { };
 
   yelp = callPackage ./core/yelp { };

--- a/pkgs/misc/themes/zuki/default.nix
+++ b/pkgs/misc/themes/zuki/default.nix
@@ -4,20 +4,20 @@ stdenv.mkDerivation rec {
   name = "zuki-themes-${version}";
   version = "${gnome3.version}.${date}";
   date = {
-    "3.18" = "2016-06-21";
     "3.20" = "2016-07-01";
+    "3.22" = "2016-10-20";
   }."${gnome3.version}";
 
   src = fetchFromGitHub {
     owner = "lassekongo83";
     repo = "zuki-themes";
     rev = {
-      "3.18" = "5c83a847ad8fab0fe0b82ed2a7db429655ac9c10";
       "3.20" = "dda1726ac7b556df2ef9696e530f8c2eaa0aed37";
+      "3.22" = "a48f0f12f81c49b480f82369ae45cfa49d78b143";
     }."${gnome3.version}";
     sha256 = {
-      "3.18" = "1x9zrx5dqq8kivhqj5kjwhy4vwr899pri6jvwxbff5hibvyc7ipy";
       "3.20" = "0p7db8a2ni494vwp3b7av7d214fnynf6gr976qma6h9x4ck3phiz";
+      "3.22" = "05sa5ighq01krbgfd4lddxvbhfqk5x5kgw6jnxwvx9rmmff713s1";
     }."${gnome3.version}";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14616,7 +14616,7 @@ in
   };
 
   termite = callPackage ../applications/misc/termite {
-    vte = gnome3.vte-select-text;
+    vte = gnome3_20.vte-select-text;
   };
 
   tesseract = callPackage ../applications/graphics/tesseract { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15906,7 +15906,7 @@ in
 
   gnome3_22 = recurseIntoAttrs (callPackage ../desktops/gnome-3/3.22 { });
 
-  gnome3 = gnome3_20;
+  gnome3 = gnome3_22;
 
   hsetroot = callPackage ../tools/X11/hsetroot { };
 


### PR DESCRIPTION
###### Motivation for this change

The modules got updated and are now incompatible with gnome3.20
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
