### PR TITLE
buku: 2.4 -> 2.5

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -1,21 +1,22 @@
 { stdenv, pythonPackages, fetchFromGitHub,
 }:
 
-pythonPackages.buildPythonApplication rec {
-  version = "2.4";
+with pythonPackages; buildPythonApplication rec {
+  version = "2.5";
   name = "buku-${version}";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "buku";
     rev = "v${version}";
-    sha256 = "0rmvlpp1pzzgn1hf87ksigj9kp60gfwkvxymb4wiz7dqa57b1q0n";
+    sha256 = "0m6km37zylinsblwm2p8pm760xlsf9m82xyws3762xs8zxbnfmsd";
   };
 
   buildInputs = [
-    pythonPackages.cryptography
-    pythonPackages.beautifulsoup4
+    cryptography
+    beautifulsoup4
   ];
+  propagatedBuildInputs = [ beautifulsoup4 ];
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
 


### PR DESCRIPTION
###### Motivation for this change

Updates buku, adds beatifulsoup as a program runtime dep.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@matthiasbeyer 
