### PR TITLE
remmina: fix GSettings schemas not found error

### DIFF
--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, makeWrapper
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, wrapGAppsHook
 , glib, gtk3, gettext, libxkbfile, libgnome_keyring, libX11
 , freerdp, libssh, libgcrypt, gnutls, makeDesktopItem
 , pcre, webkitgtk, libdbusmenu-gtk3, libappindicator-gtk3
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     sha256 = "07lj6a7x9cqcff18pwfkx8c8iml015zp6sq29dfcxpfg4ai578h0";
   };
 
-  buildInputs = [ cmake pkgconfig makeWrapper
+  buildInputs = [ cmake pkgconfig wrapGAppsHook
                   glib gtk3 gettext libxkbfile libgnome_keyring libX11
                   freerdp_git libssh libgcrypt gnutls
                   pcre webkitgtk libdbusmenu-gtk3 libappindicator-gtk3
@@ -55,10 +55,15 @@ stdenv.mkDerivation {
 
   cmakeFlags = "-DWITH_VTE=OFF -DWITH_TELEPATHY=OFF -DWITH_AVAHI=OFF -DWINPR_INCLUDE_DIR=${freerdp_git}/include/winpr2";
 
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "${libX11.out}/lib"
+    )
+  '';
+
   postInstall = ''
     mkdir -pv $out/share/applications
     cp ${desktopItem}/share/applications/* $out/share/applications
-    wrapProgram $out/bin/remmina --prefix LD_LIBRARY_PATH : "${libX11.out}/lib"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

To fix #19600 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Use gappWrapper to wrap the program so that remmina can find GSettings schemas.
