### PR TITLE
openconnect: use openconnect linked against gnutls by default

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4016,7 +4016,7 @@ in
     SDL = SDL_sixel;
   };
 
-  openconnect = openconnect_openssl;
+  openconnect = openconnect_gnutls;
 
   openconnect_openssl = callPackage ../tools/networking/openconnect.nix {
     gnutls = null;


### PR DESCRIPTION
###### Motivation for this change

OpenSSL Openconnect cannot connect to Juniper VPNs and fails with a nondescriptive message (`cannot establish SSL connection`). Gnutls-linked Openconnect doesn't have this bug and it's already used by Arch (https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/openconnect) and possibly other distros.
###### Things done

This is just a change of a default openconnect alias, so I haven't ran the tests. Should I?
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
