### PR TITLE
avro-cpp: 1.7.5 -> 1.8.1 + using boost 1.55 -> 1.60

### DIFF
--- a/pkgs/development/libraries/avro-c++/default.nix
+++ b/pkgs/development/libraries/avro-c++/default.nix
@@ -1,21 +1,26 @@
-{ stdenv, fetchurl, cmake, boost155, pythonPackages
+{ stdenv, fetchurl, cmake, boost, pythonPackages
 }:
 
-let version = "1.7.5"; in
+let version = "1.8.1"; in
 
 stdenv.mkDerivation {
   name = "avro-c++-${version}";
 
   src = fetchurl {
     url = "mirror://apache/avro/avro-${version}/cpp/avro-cpp-${version}.tar.gz";
-    sha256 = "064ssbbgrc3hyalzj8rn119bsrnyk1vlpkhl8gghv96jgqbpdyb3";
+    sha256 = "6559755ac525e908e42a2aa43444576cba91e522fe989088ee7f70c169bcc403";
   };
 
   buildInputs = [
     cmake
-    boost155
+    boost
     pythonPackages.python
   ];
+
+  preConfigure = ''
+    substituteInPlace test/SchemaTests.cc --replace "BOOST_CHECKPOINT" "BOOST_TEST_CHECKPOINT"
+    substituteInPlace test/buffertest.cc --replace "BOOST_MESSAGE" "BOOST_TEST_MESSAGE"
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -564,7 +564,7 @@ in
     qt4Support = config.avahi.qt4Support or false;
   };
 
-  avro-cpp = callPackage ../development/libraries/avro-c++ { };
+  avro-cpp = callPackage ../development/libraries/avro-c++ { boost = boost160; };
 
   aws = callPackage ../tools/virtualization/aws { };
 


### PR DESCRIPTION
###### Motivation for this change

I'm currently trying to package iRods. I need avro-cpp to be linked with boost 1.60 instead of boost 1.55. So I upgraded it and made the changes for boost 1.60 support.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
