### PR TITLE
Update various packages to use buildOcaml, with fixes

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,15 +1,10 @@
-{ stdenv, fetchurl, ocaml, findlib, which, ocsigen_server, ocsigen_deriving,
+{ buildOcaml, stdenv, fetchurl, which, ocsigen_server, ocsigen_deriving, ocaml,
   js_of_ocaml, ocaml_react, ocaml_lwt, calendar, cryptokit, tyxml,
   ipaddr, ocamlnet, ocaml_ssl, ocaml_pcre, ocaml_optcomp,
-  reactivedata, opam, ppx_tools, camlp4}:
+  reactivedata, opam, ppx_tools, ppx_deriving, camlp4}:
 
-let ocamlVersion = (stdenv.lib.getVersion ocaml);
-  in
-
-(
-assert stdenv.lib.versionAtLeast ocamlVersion "4";
-
-stdenv.mkDerivation rec
+let ocamlVersion = (stdenv.lib.getVersion ocaml); in
+buildOcaml rec
 {
   pname = "eliom";
   version = "5.0.0";
@@ -22,12 +17,11 @@ stdenv.mkDerivation rec
 
   patches = [ ./camlp4.patch ];
 
-  buildInputs = [ocaml which ocsigen_server findlib ocsigen_deriving
-                 js_of_ocaml ocaml_optcomp opam ppx_tools camlp4 ];
+  buildInputs = [ which ocaml_optcomp opam ppx_tools camlp4 ];
 
-  propagatedBuildInputs = [ ocaml_lwt reactivedata tyxml ipaddr
-                            calendar cryptokit ocamlnet ocaml_react ocaml_ssl
-                            ocaml_pcre ];
+  propagatedBuildInputs = [ ocaml_lwt reactivedata tyxml ipaddr ocsigen_server ppx_deriving
+                            ocsigen_deriving js_of_ocaml
+                            calendar cryptokit ocamlnet ocaml_react ocaml_ssl ocaml_pcre ];
 
   preConfigure = stdenv.lib.optionalString (!stdenv.lib.versionAtLeast ocamlVersion "4.02") ''
       export PPX=false
@@ -57,8 +51,6 @@ stdenv.mkDerivation rec
 
     license = stdenv.lib.licenses.lgpl21;
 
-    platforms = ocaml.meta.platforms or [];
-
     maintainers = [ stdenv.lib.maintainers.gal_bolle ];
   };
-})
+}

--- a/pkgs/development/ocaml-modules/pcre/default.nix
+++ b/pkgs/development/ocaml-modules/pcre/default.nix
@@ -1,7 +1,7 @@
 {stdenv, buildOcaml, fetchurl, pcre, ocaml, findlib}:
 
 buildOcaml {
-  name = "ocaml-pcre";
+  name = "pcre";
   version = "7.1.1";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/pgocaml/default.nix
+++ b/pkgs/development/ocaml-modules/pgocaml/default.nix
@@ -1,14 +1,17 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, camlp4, calendar, csv, ocaml_pcre }:
+{ stdenv, fetchurl, buildOcaml, calendar, csv, re }:
 
-stdenv.mkDerivation {
-  name = "ocaml-pgocaml-2.2";
+buildOcaml {
+  name = "pgocaml";
+  version = "2.3";
   src = fetchurl {
-    url = http://forge.ocamlcore.org/frs/download.php/1506/pgocaml-2.2.tgz;
-    sha256 = "0x0dhlz2rqxpwfdqi384f9fn0ng2irifadmxfm2b4gcz7y1cl9rh";
+    url = https://github.com/darioteixeira/pgocaml/archive/v2.3.tar.gz;
+    sha256 = "18lymxlvcf4nwxawkidq3pilsp5rhl0l8ifq6pjk3ssjlx9w53pg";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild camlp4 ];
-  propagatedBuildInputs = [ calendar csv ocaml_pcre ];
+  buildInputs = [ ];
+  propagatedBuildInputs = [ calendar csv re ];
+
+  configureFlags = [ "--enable-p4" ];
 
   createFindlibDestdir = true;
 
@@ -16,7 +19,6 @@ stdenv.mkDerivation {
     description = "An interface to PostgreSQL databases for OCaml applications";
     homepage = http://pgocaml.forge.ocamlcore.org/;
     license = licenses.lgpl2;
-    platforms = ocaml.meta.platforms or [];
     maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -8,9 +8,9 @@ stdenv.mkDerivation {
     sha256 = "1dali1akyd4zmkwav0d957ynxq2jj6cc94r4xiaql7ca89ajz4jj";
     };
 
-  buildInputs = [ ocaml findlib menhir ocsigen_deriving ppx_deriving
+  buildInputs = [ ocaml findlib menhir ocsigen_deriving
                  cmdliner tyxml reactivedata cppo which base64];
-  propagatedBuildInputs = [ ocaml_lwt camlp4 ];
+  propagatedBuildInputs = [ ocaml_lwt camlp4 ppx_deriving ];
 
   patches = [ ./Makefile.conf.diff ];
 


### PR DESCRIPTION
###### Motivation for this change

switch some ocaml packages to buildOcaml (and update pgocaml), and make various fixes to them.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [*] NixOS
  - [ ] OS X
  - [ ] Linux
- [*] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
