### PR TITLE
weechat: Fixed Darwin build issues

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, ncurses, openssl, aspell, gnutls
 , zlib, curl , pkgconfig, libgcrypt
-, cmake, makeWrapper, libobjc, libiconv
+, cmake, makeWrapper, libobjc, libresolv, libiconv
 , asciidoctor # manpages
 , guileSupport ? true, guile
 , luaSupport ? true, lua5
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
       cmake
       asciidoctor
       ]
-    ++ optionals stdenv.isDarwin [ pync libobjc ]
+    ++ optionals stdenv.isDarwin [ pync libobjc libresolv ]
     ++ optional  guileSupport    guile
     ++ optional  luaSupport      lua5
     ++ optional  perlSupport     perl
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${python}/include/${python.libPrefix}"
     # Fix '_res_9_init: undefined symbol' error
-    + (stdenv.lib.optionalString stdenv.isDarwin "-DBIND_8_COMPAT=1");
+    + (stdenv.lib.optionalString stdenv.isDarwin "-DBIND_8_COMPAT=1 -lresolv");
 
   postInstall = with stdenv.lib; ''
     NIX_PYTHONPATH="$out/lib/${python.libPrefix}/site-packages"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14971,6 +14971,7 @@ in
 
   weechat = callPackage ../applications/networking/irc/weechat {
     inherit (darwin) libobjc;
+    inherit (darwin) libresolv;
   };
 
   westonLite = callPackage ../applications/window-managers/weston {


### PR DESCRIPTION
###### Motivation for this change

Fixes #19684. WeeChat fails to build on Darwin due to res_9_init missing symbol.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS). 
- Built on platform(s)
  - [ ] NixOS
  - [X] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Build was failing with res_9_init missing on OS X. Resolved with a little help from
https://github.com/Homebrew/homebrew-core/pull/4427.
