### PR TITLE
stdenv.hasLicense: ? supports nested lookup

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -44,7 +44,7 @@ let
       throw "whitelistedLicenses and blacklistedLicenses are not mutually exclusive.";
 
   hasLicense = attrs:
-    builtins.hasAttr "meta" attrs && builtins.hasAttr "license" attrs.meta;
+    attrs ? meta.license;
 
   hasWhitelistedLicense = assert areLicenseListsValid; attrs:
     hasLicense attrs && builtins.elem attrs.meta.license whitelist;


### PR DESCRIPTION
###### Motivation for this change

minor performance gain
this avoids one copy of the attrset

supported since [nix 1.0](https://nixos.org/nix/manual/#ssec-relnotes-1.0)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

outtake from evaluation statistics:

| value | pre | post |
| --- | --- | --- |
| time elapsed: | 2.618 | 2.425 |
| values allocated | 1685932 (40462368 bytes) | 1646089 (39506136 bytes) |
| number of thunks: | 1391156 | 1378151 |
| number of thunks avoided: | 944109 | 903438 |
| number of attr lookups: | 423421 | 383578 |
| number of primop calls: | 220634 | 193796 |
| total allocations: | 203529544 bytes | 202573312 bytes |
| total Boehm heap allocations: | 245309136 bytes | 244035280 bytes |
