### PR TITLE
stdenv: throwEvalHelp performance

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -128,8 +128,7 @@ let
       throwEvalHelp = { reason, errormsg }:
         # uppercase the first character of string s
         let up = s: with lib;
-          let cs = lib.stringToCharacters s;
-          in concatStrings (singleton (toUpper (head cs)) ++ tail cs);
+          (toUpper (substring 0 1 s)) + (substring 1 (stringLength s) s);
         in
         assert builtins.elem reason ["unfree" "broken" "blacklisted"];
 


### PR DESCRIPTION
###### Motivation for this change

Converting to a list of characters only to uppercase the first letter is not ideal.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

outtake from evaluation statistics (`nix-env -qa`):

| value | pre | post |
| --- | --- | --- |
| time elapsed: | 2.407 | 2.308 |
| environments allocated: | 476392 (17245712 bytes) | 465818 (16991936 bytes) |
| list elements: | 279456 (2235648 bytes) | 264528 (2116224 bytes) |
| list concatenations: | 24008 | 23386 |
| values allocated: | 1688496 (40523904 bytes) | 1664237 (39941688 bytes) |
| number of thunks: | 1393297 | 1388320 |
| number of thunks avoided: | 945625 | 931320 |
| number of attr lookups: | 424122 | 422878 |
| number of primop calls: | 221019 | 213555 |
| number of function calls: | 347026 | 337074 |
| total allocations: | 203850048 bytes | 202894632 bytes |
| total Boehm heap allocations: | 245686752 bytes | 244413360 bytes |
