### PR TITLE
openblas: disable some hardening flags

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -34,6 +34,21 @@ stdenv.mkDerivation {
 
   inherit blas64;
 
+  # Some hardening features are disabled due to sporadic failures in
+  # OpenBLAS-based programs. The problem may not be with OpenBLAS itself, but
+  # with how these flags interact with hardening measures used downstream.
+  # In either case, OpenBLAS must only be used by trusted code--it is
+  # inherently unsuitable for security-conscious applications--so there should
+  # be no objection to disabling these hardening measures.
+  hardeningDisable = [
+    # don't modify or move the stack
+    "stackprotector" "pic"
+    # don't alter index arithmetic
+    "strictoverflow"
+    # don't interfere with dynamic target detection.
+    "relro" "bindnow"
+  ];
+
   nativeBuildInputs = optionals stdenv.isDarwin [coreutils] ++ [gfortran perl which];
 
   makeFlags =


### PR DESCRIPTION
###### Motivation for this change

I am experiencing random failures in OpenBLAS-based libraries (numerical results which I know to be incorrect). I have ruled out hardware failure as a cause by reproducing on multiple machines with different architectures. I have confirmed that these issues do not occur with OpenBLAS before hardening-by-default features were added to Nixpkgs. I have disabled the hardening features I think are likely to cause problems and that appears to fix the problem. The random nature of the failures makes it difficult to determine a minimal set of flags to disable. OpenBLAS (and indeed, any BLAS) should only be used with trusted code and data, so there should not be any security implications.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
