### PR TITLE
Hyperterm: 0.7.6 -> (Hyper) 0.8.3

### DIFF
--- a/pkgs/applications/misc/hyper/default.nix
+++ b/pkgs/applications/misc/hyper/default.nix
@@ -11,11 +11,11 @@ let
   ];
 in
 stdenv.mkDerivation rec {
-  version = "0.7.6";
-  name = "hyperterm-${version}";
+  version = "0.8.3";
+  name = "hyper-${version}";
   src = fetchurl {
-    url = https://github.com/zeit/hyperterm/releases/download/v0.7.1/hyperterm-0.7.1.deb;
-    sha256 = "1xdwhmzlkg1ly1xgsbv99xk4x1g1x270vx1b12dvf10ck5x9v63a";
+    url = "https://github.com/zeit/hyper/releases/download/${version}/hyper-${version}-amd64.deb";
+    sha256 = "1683gc0fhifn89l9h67yz02pk1xz7p5l3qpiyddr9w21qr9h3lhq";
   };
   buildInputs = [ dpkg ];
   unpackPhase = ''
@@ -25,16 +25,16 @@ stdenv.mkDerivation rec {
   '';
   installPhase = ''
     mkdir -p "$out/bin"
-    ln -s "$out/opt/HyperTerm/HyperTerm" "$out/bin/HyperTerm"
     mv opt "$out/"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:\$ORIGIN" "$out/opt/HyperTerm/HyperTerm"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}" "$out/opt/HyperTerm/resources/app/node_modules/child_pty/build/Release/exechelper"
+    ln -s "$out/opt/Hyper/Hyper" "$out/bin/Hyper"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}:\$ORIGIN" "$out/opt/Hyper/Hyper"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}" "$out/opt/Hyper/resources/app/node_modules/child_pty/build/Release/exechelper"
     mv usr/* "$out/"
   '';
   dontPatchELF = true;
   meta = with lib; {
     description = "A terminal built on web technologies";
-    homepage    = https://hyperterm.org/;
+    homepage    = https://hyper.is/;
     maintainers = with maintainers; [ puffnfresh ];
     license     = licenses.mit;
     platforms   = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7788,7 +7788,7 @@ in
   };
 
   libgumbo = callPackage ../development/libraries/libgumbo { };
-  
+
   libhangul = callPackage ../development/libraries/libhangul { };
 
   libharu = callPackage ../development/libraries/libharu { };
@@ -13207,7 +13207,8 @@ in
 
   hydrogen = callPackage ../applications/audio/hydrogen { };
 
-  hyperterm = callPackage ../applications/misc/hyperterm { inherit (gnome2) GConf; };
+  hyper = callPackage ../applications/misc/hyper { inherit (gnome2) GConf; };
+  hyperterm = self.hyper;
 
   slack = callPackage ../applications/networking/instant-messengers/slack { };
 


### PR DESCRIPTION
###### Motivation for this change

`Hyperterm` rebranded to `Hyper` and has had several updates that make it more stable usable in Linux environments.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
