### PR TITLE
nitrokey-app: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/tools/security/nitrokey-app/FixInstallDestination.patch
+++ b/pkgs/tools/security/nitrokey-app/FixInstallDestination.patch
@@ -1,35 +1,57 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 16393a8..3991d2a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -219,18 +219,18 @@ IF(NOT WIN32)
+@@ -251,23 +251,23 @@
+       #      ${CMAKE_SOURCE_DIR}/data/icons/48x48
+       #      ${CMAKE_SOURCE_DIR}/data/icons/128x128
+     ${CMAKE_SOURCE_DIR}/data/icons/
+-    DESTINATION usr/share/icons/
++    DESTINATION share/icons/
+   )
+ 
+   install(FILES
+     ${CMAKE_SOURCE_DIR}/data/nitrokey-app.desktop
+-    DESTINATION usr/share/applications
++    DESTINATION share/applications
+   )
+ 
+   install(FILES
+     ${CMAKE_SOURCE_DIR}/data/icons/hicolor/128x128/apps/nitrokey-app.png
+-    DESTINATION usr/share/pixmaps
++    DESTINATION share/pixmaps
+   )
+ 
    # Install Nitrokey udev rules
    install(FILES
-     ${CMAKE_SOURCE_DIR}/data/40-nitrokey.rules
--    DESTINATION /etc/udev/rules.d
-+    DESTINATION etc/udev/rules.d
+    ${CMAKE_SOURCE_DIR}/data/40-nitrokey.rules
+-   DESTINATION usr/lib/udev/rules.d
++   DESTINATION lib/udev/rules.d
    )
  
    # Install autocompletion scripts
+@@ -278,7 +278,7 @@
+ 
    install(FILES
-     ${CMAKE_SOURCE_DIR}/data//bash-autocomplete/nitrokey-app
--    DESTINATION /etc/bash_completion.d
-+    DESTINATION etc/bash_completion.d
+    ${CMAKE_SOURCE_DIR}/po/de_DE/nitrokey-app.mo
+-   DESTINATION usr/share/locale/de_DE/LC_MESSAGES
++   DESTINATION share/locale/de_DE/LC_MESSAGES
    )
  
    install(FILES
-     ${CMAKE_SOURCE_DIR}/po/de_DE/nitrokey-app.mo
--    DESTINATION /usr/share/locale/de_DE/LC_MESSAGES
-+    DESTINATION share/locale/de_DE/LC_MESSAGES
-   )
- 
-   install(FILES
-@@ -238,7 +238,7 @@ IF(NOT WIN32)
+@@ -286,7 +286,7 @@
      ${CMAKE_SOURCE_DIR}/images/quit.png
      ${CMAKE_SOURCE_DIR}/images/safe_zahlenkreis.png
      ${CMAKE_SOURCE_DIR}/images/settings.png
--    DESTINATION /usr/share/nitrokey
+-    DESTINATION usr/share/nitrokey
 +    DESTINATION share/nitrokey
    )
  
  ENDIF () # NOT WIN32
+@@ -299,7 +299,7 @@
+   ${resources_ouput}
+ )
+ 
+-INSTALL(TARGETS nitrokey-app DESTINATION usr/bin)
++INSTALL(TARGETS nitrokey-app DESTINATION bin)
+ 
+ TARGET_LINK_LIBRARIES(nitrokey-app
+   ${QT_LIBRARIES}

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -1,21 +1,18 @@
-{ stdenv, cmake, fetchFromGitHub, libappindicator-gtk2, libnotify, libusb1, pkgconfig
-, qt5 }:
+{ stdenv, cmake, fetchFromGitHub, libusb1, pkgconfig, qt5 }:
 
 stdenv.mkDerivation rec {
   name = "nitrokey-app";
-  version = "0.4";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nitrokey-app";
     rev = "v${version}";
-    sha256 = "0h131847pllsr7rk7nn8vlj74byb5f14cl9h3g3pmlq5zj8ylfkx";
+    sha256 = "0acb2502r3wa0mry6h8sz1k16zaa4bgnhxwxqd1vd1y42xc6g9bw";
   };
 
   buildInputs = [
     cmake
-    libappindicator-gtk2
-    libnotify
     libusb1
     pkgconfig
     qt5.qtbase
@@ -24,6 +21,7 @@ stdenv.mkDerivation rec {
      ./FixInstallDestination.patch
      ./HeaderPath.patch
   ];
+  cmakeFlags = "-DHAVE_LIBAPPINDICATOR=NO";
   meta = {
     description      = "Provides extra functionality for the Nitrokey Pro and Storage";
     longDescription  = ''


### PR DESCRIPTION
###### Motivation for this change

Update nitrokey to latest version
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
