### PR TITLE
brltty: 5.2 -> 5.4

### DIFF
--- a/nixos/modules/services/hardware/brltty.nix
+++ b/nixos/modules/services/hardware/brltty.nix
@@ -28,7 +28,7 @@ in {
       };
       serviceConfig = {
         ExecStart = "${pkgs.brltty}/bin/brltty --no-daemon";
-        Type = "simple";        # Change to notidy after next releae
+        Type = "notify";
         TimeoutStartSec = 5;
         TimeoutStopSec = 10;
         Restart = "always";

--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -1,17 +1,21 @@
-{ stdenv, fetchurl, pkgconfig, alsaSupport, alsaLib ? null, bluez }:
+{ stdenv, fetchurl, pkgconfig, alsaSupport, alsaLib ? null, bluez, systemdSupport, systemd ? null }:
 
 assert alsaSupport -> alsaLib != null;
+assert systemdSupport -> systemd != null;
 
 stdenv.mkDerivation rec {
-  name = "brltty-5.2";
+  name = "brltty-5.4";
   
   src = fetchurl {
     url = "http://brltty.com/archive/${name}.tar.gz";
-    sha256 = "1zaab5pxkqrv081n23p3am445d30gk0km4azqdirvcpw9z15q0cz";
+    sha256 = "1993brxa76yf7z3ckax0bbmqv6jp8vjwxp19h425v4gpm0m17k7l";
   };
+
+  patches = [ ./systemd.patch ];
   
-  buildInputs = [ pkgconfig alsaLib bluez ]
-    ++ stdenv.lib.optional alsaSupport alsaLib;
+  buildInputs = [ pkgconfig bluez ]
+    ++ stdenv.lib.optional alsaSupport alsaLib
+    ++ stdenv.lib.optional systemdSupport systemd;
   
   meta = {
     description = "Access software for a blind person using a braille display";
@@ -27,7 +31,9 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.all;
   };
   
-  patchPhase = ''
+  preConfigurePhases = [ "preConfigure" ];
+
+  preConfigure = ''
     substituteInPlace configure --replace /sbin/ldconfig ldconfig
   '';
 }

--- a/pkgs/tools/misc/brltty/systemd.patch
+++ b/pkgs/tools/misc/brltty/systemd.patch
@@ -1,0 +1,22 @@
+diff --git a/config.mk.in b/config.mk.in
+index 5093b9c..b707bd4 100644
+--- a/config.mk.in
++++ b/config.mk.in
+@@ -235,7 +235,7 @@ TUNE_OBJECTS = tune.$O notes.$O $(BEEP_OBJECTS) $(PCM_OBJECTS) $(MIDI_OBJECTS) $
+ ASYNC_OBJECTS = async_handle.$O async_data.$O async_wait.$O async_alarm.$O async_task.$O async_io.$O async_event.$O async_signal.$O thread.$O
+ BASE_OBJECTS = log.$O addresses.$O file.$O device.$O parse.$O variables.$O datafile.$O unicode.$O $(CHARSET_OBJECTS) timing.$O $(ASYNC_OBJECTS) queue.$O lock.$O $(DYNLD_OBJECTS) $(PORTS_OBJECTS) $(SYSTEM_OBJECTS)
+ OPTIONS_OBJECTS = options.$O $(PARAMS_OBJECTS)
+-PROGRAM_OBJECTS = program.$O $(PGMPATH_OBJECTS) $(SERVICE_OBJECTS) $(SERVICE_LIBS) pid.$O $(OPTIONS_OBJECTS) $(BASE_OBJECTS)
++PROGRAM_OBJECTS = program.$O $(PGMPATH_OBJECTS) $(SERVICE_OBJECTS) pid.$O $(OPTIONS_OBJECTS) $(BASE_OBJECTS)
+ 
+ CC = @CC@
+ CPPFLAGS = -I$(BLD_DIR) -I$(SRC_DIR) -I$(BLD_TOP:/=)/$(PGM_DIR) -I$(SRC_TOP:/=)/$(PGM_DIR) -I$(SRC_TOP:/=)/$(HDR_DIR) -I$(BLD_TOP:/=) -I$(SRC_TOP:/=) @CPPFLAGS@ @DEFS@
+@@ -248,7 +248,7 @@ LIBCXXFLAGS = $(CXXFLAGS) @LIBCXXFLAGS@
+ 
+ LD = @LD@
+ LDFLAGS = @LDFLAGS@
+-LDLIBS = $(ICU_LIBS) $(POLKIT_LIBS) $(SYSTEM_LIBS) @LIBS@
++LDLIBS = $(ICU_LIBS) $(POLKIT_LIBS) $(SYSTEM_LIBS) $(SERVICE_LIBS) @LIBS@
+ 
+ MKOBJ = @MKOBJ@
+ MKMOD = @MKMOD@

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -652,6 +652,7 @@ in
 
   brltty = callPackage ../tools/misc/brltty {
     alsaSupport = (!stdenv.isDarwin);
+    systemdSupport = stdenv.isLinux;
   };
   bro = callPackage ../applications/networking/ids/bro { };
 


### PR DESCRIPTION
###### Motivation for this change

Update the BRLTTY package to latest release (5.4) from upstream.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
