### PR TITLE
kid3: 3.3.0 -> 3.4.2

### DIFF
--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -1,23 +1,24 @@
 { stdenv, fetchurl
-, pkgconfig, cmake, perl, ffmpeg
+, pkgconfig, cmake
 , docbook_xml_dtd_45, docbook_xsl, libxslt
-, phonon, automoc4, chromaprint, id3lib
-, taglib, mp4v2, flac, libogg, libvorbis
+, python, ffmpeg, mp4v2, flac, libogg, libvorbis
+, phonon, automoc4, chromaprint, id3lib, taglib
 , qt, zlib, readline
 , makeWrapper
 }:
 
 stdenv.mkDerivation rec {
 
-  name = "kid3-${meta.version}";
+  name = "kid3-${version}";
+  version = "3.4.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/kid3/kid3/${meta.version}/${name}.tar.gz";
-    sha256 = "12sa54mg1b3wkagmh5yi20ski8km9d199lk0a1yfxy0ffjfld7js";
+    url = "mirror://sourceforge/project/kid3/kid3/${version}/${name}.tar.gz";
+    sha256 = "0gka4na583015jyqva18g85q7vnkjdk0iji2jp88di3kpvqhf1sw";
   };
 
   buildInputs = with stdenv.lib;
-  [ pkgconfig cmake perl ffmpeg docbook_xml_dtd_45 docbook_xsl libxslt
+  [ pkgconfig cmake python ffmpeg docbook_xml_dtd_45 docbook_xsl libxslt
     phonon automoc4 chromaprint id3lib taglib mp4v2 flac libogg libvorbis
     qt zlib readline makeWrapper ];
 
@@ -33,7 +34,6 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    version = "3.3.0";
     description = "A simple and powerful audio tag editor";
     longDescription = ''
       If you want to easily tag multiple MP3, Ogg/Vorbis, FLAC, MPC,
@@ -71,4 +71,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-# TODO: Qt5 support
+# TODO: Qt5 support - not so urgent!


### PR DESCRIPTION
###### Motivation for this change

Kid3 update
Also it changed from perl to python!
###### Things done
-  [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
