### PR TITLE
Sawfish: 1.11.90 -> 1.12.0

### DIFF
--- a/pkgs/applications/window-managers/sawfish/default.nix
+++ b/pkgs/applications/window-managers/sawfish/default.nix
@@ -1,5 +1,8 @@
-{ stdenv, fetchgit, pkgconfig, which, autoreconfHook, rep-gtk, pango
-, gdk_pixbuf, libXinerama, libXrandr, libXtst, imlib, gettext, texinfo
+{ stdenv, fetchurl
+, pkgconfig, which, autoreconfHook
+, rep-gtk, pango, gdk_pixbuf
+, imlib, gettext, texinfo
+, libXinerama, libXrandr, libXtst, libICE, libSM
 , makeWrapper
 }:
 
@@ -8,18 +11,18 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "sawfish-${version}";
-  version = "1.11.90";
+  version = "1.12.0";
+  sourceName = "sawfish_${version}";
 
-  src = fetchgit {
-    url = "https://github.com/SawfishWM/sawfish.git";
-    rev = "b121f832571c9aebd228691c32604146e49f5e55";
-    sha256 = "0y7rmjzp7ha5qj9q1dasw50gd6jiaxc0qsjbvyfzxvwssl3i9hsc";
+  src = fetchurl {
+    url = "http://download.tuxfamily.org/sawfish/${sourceName}.tar.xz";
+    sha256 = "1z7awzgw8d15aw17kpbj460pcxq8l2rhkaxk47w7yg9qrmg0xja4";
   };
 
-  buildInputs =
-    [ pkgconfig which autoreconfHook rep-gtk pango gdk_pixbuf libXinerama
-      libXrandr libXtst imlib gettext texinfo makeWrapper
-    ];
+  buildInputs = [  pkgconfig which autoreconfHook
+    rep-gtk pango gdk_pixbuf imlib gettext texinfo
+    libXinerama libXrandr libXtst libICE libSM
+    makeWrapper ];
 
   patchPhase = ''
     sed -e 's|REP_DL_LOAD_PATH=|REP_DL_LOAD_PATH=$(REP_DL_LOAD_PATH):|g' -i Makedefs.in

--- a/pkgs/development/libraries/librep/default.nix
+++ b/pkgs/development/libraries/librep/default.nix
@@ -7,11 +7,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "librep-${version}";
-  version = "0.92.5";
+  version = "0.92.6";
+  sourceName = "librep_${version}";
 
   src = fetchurl {
-    url = "https://github.com/SawfishWM/librep/archive/${name}.tar.gz";
-    sha256 = "1ly425cgs0yi3lb5l84v3bacljw7m2nmzgky3acy1anp709iwi76";
+    url = "http://download.tuxfamily.org/librep/${sourceName}.tar.xz";
+    sha256 = "1k6c0hmyzxh8459r790slh9vv9vwy9d7w3nlmrqypbx9mk855hgy";
   };
 
   buildInputs = [ pkgconfig autoreconfHook readline texinfo ];
@@ -30,9 +31,10 @@ stdenv.mkDerivation rec {
       interpreter, a byte-code compiler, and a virtual
       machine. It can serve as an application extension language
       but is also suitable for standalone scripts.
-    '';
+     '';
     homepage = http://sawfish.wikia.com;
     license = licenses.gpl2;
     maintainers = [ maintainers.AndersonTorres ];
   };
 }
+# TODO: investigate fetchFromGithub

--- a/pkgs/development/libraries/rep-gtk/default.nix
+++ b/pkgs/development/libraries/rep-gtk/default.nix
@@ -4,11 +4,12 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "rep-gtk-${version}";
-  version = "0.90.8.2";
+  version = "0.90.8.3";
+  sourceName = "rep-gtk_${version}";
 
   src = fetchurl {
-    url = "https://github.com/SawfishWM/rep-gtk/archive/${name}.tar.gz";
-    sha256 = "0pkpp7pj22c8hkyyivr9qw6q08ad42alynsf54ixdy6p9wn4qs1r";
+    url = "http://download.tuxfamily.org/librep/rep-gtk/${sourceName}.tar.xz";
+    sha256 = "0hgkkywm8zczir3lqr727bn7ybgg71x9cwj1av8fykkr8pdpard9";
   };
 
   buildInputs = [ pkgconfig autoreconfHook ];
@@ -25,3 +26,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.AndersonTorres ];
   };
 }
+# TODO: investigate fetchFromGithub


### PR DESCRIPTION
###### Motivation for this change

Sawfish Upates:
[X] librep: 0.92.5 -> 0.92.6
[X] rep-gtk: 0.90.8.2 -> 0.90.8.2
[X] Sawfish: 1.11.90 -> 1.12.0
###### Things done
- [X ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [X ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
