### PR TITLE
ruby-zoom: init at 4.1.0

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -141,6 +141,13 @@ in
     buildInputs = [ imagemagick pkgconfig which ];
   };
 
+  ruby-terminfo = attrs: {
+    buildInputs = [ ncurses ];
+    buildFlags = [
+      "--with-cflags=-I${ncurses.dev}/include"
+      "--with-ldflags=-L${ncurses.out}/lib"
+    ];
+  };
   rugged = attrs: {
     buildInputs = [ cmake pkgconfig openssl libssh2 zlib ];
   };

--- a/pkgs/tools/text/ruby-zoom/Gemfile
+++ b/pkgs/tools/text/ruby-zoom/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'ruby-zoom'

--- a/pkgs/tools/text/ruby-zoom/Gemfile.lock
+++ b/pkgs/tools/text/ruby-zoom/Gemfile.lock
@@ -1,0 +1,25 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    djinni (2.0.1)
+      fagin (~> 0.1, >= 0.1.2)
+      ruby-terminfo (~> 0.1, >= 0.1.1)
+    fagin (0.1.2)
+    hilighter (0.1.7)
+    json_config (0.1.2)
+    ruby-terminfo (0.1.1)
+    ruby-zoom (4.1.0)
+      djinni (~> 2.0, >= 2.0.1)
+      hilighter (~> 0.1, >= 0.1.3)
+      json_config (~> 0.1, >= 0.1.2)
+      scoobydoo (~> 0.1, >= 0.1.4)
+    scoobydoo (0.1.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ruby-zoom
+
+BUNDLED WITH
+   1.13.1

--- a/pkgs/tools/text/ruby-zoom/default.nix
+++ b/pkgs/tools/text/ruby-zoom/default.nix
@@ -1,0 +1,18 @@
+{ lib, bundlerEnv, ruby, stdenv }:
+
+bundlerEnv {
+  pname = "ruby-zoom";
+
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  meta = with lib; {
+    description = "Quickly open CLI search results in your favorite editor!";
+    homepage    = https://gitlab.com/mjwhitta/zoom;
+    license     = with licenses; gpl3;
+    maintainers = with stdenv.lib.maintainers; [ vmandela ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/text/ruby-zoom/gemset.nix
+++ b/pkgs/tools/text/ruby-zoom/gemset.nix
@@ -1,0 +1,58 @@
+{
+  djinni = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wl4q4qs1nyla5n2b2ys6n3i35gvli8xb8mxz2xv0ik306cikqm6";
+      type = "gem";
+    };
+    version = "2.0.1";
+  };
+  fagin = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17d419vkfr26gdbad97fg2ikskhn82vs3bnxlzd27w6lwyf13qxk";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  hilighter = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1a9a9clgd6kx63a82msjzi6abznfqivsgmds7qaqwb1dsl1nznbh";
+      type = "gem";
+    };
+    version = "0.1.7";
+  };
+  json_config = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16q3q0j9s8w93lzxa7rrvh5wqk11np7s2nmgmdlrh8gl3w76xcz6";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  ruby-terminfo = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rl4ic5pzvrpgd42z0c1s2n3j39c9znksblxxvmhkzrc0ckyg2cm";
+      type = "gem";
+    };
+    version = "0.1.1";
+  };
+  ruby-zoom = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "132pk0zp3rayvvbccfs5ksigg9zpflp9734b4r0jz5aimmv2qpvp";
+      type = "gem";
+    };
+    version = "4.1.0";
+  };
+  scoobydoo = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1w83zgip3qvh20pgqgcp9yp0k35ypn7ny0d61xcv1ik0r3ab8ga0";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10330,6 +10330,8 @@ in
 
   seyren = callPackage ../servers/monitoring/seyren { };
 
+  ruby-zoom = callPackage ../tools/text/ruby-zoom { };
+
   sensu = callPackage ../servers/monitoring/sensu {
     ruby = ruby_2_1;
   };


### PR DESCRIPTION
###### Motivation for this change

This tool is very useful in quickly searching in a git repository and opening the results in an editor. 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

From the website,

https://gitlab.com/mjwhitta/zoom

Zoom adds some convenience to ag/ack/grep by allowing you to quickly
open your search results in your editor of choice.

Also available as a ruby gem.

https://rubygems.org/gems/ruby-zoom
