### PR TITLE
Fix texlive on darwin

### DIFF
--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -5,18 +5,18 @@
 # - full: contains base plus modules in withModules
 { stdenv, fetchurl, libsigsegv, gettext, ncurses, readline, libX11
 , libXau, libXt, pcre, zlib, libXpm, xproto, libXext, xextproto
-, libffi, libffcall, coreutils
+, libffi
+, libffcall
+, coreutils
 # build options
 , threadSupport ? (stdenv.isi686 || stdenv.isx86_64)
 , x11Support ? (stdenv.isi686 || stdenv.isx86_64)
 , dllSupport ? true
 , withModules ? [
-    "bindings/glibc"
     "pcre"
     "rawsock"
-    "wildcard"
-    "zlib"
   ]
+  ++ stdenv.lib.optionals stdenv.isLinux [ "bindings/glibc" "zlib" "wildcard" ]
   ++ stdenv.lib.optional x11Support "clx/new-clx"
 }:
 
@@ -33,15 +33,17 @@ stdenv.mkDerivation rec {
   };
 
   inherit libsigsegv gettext coreutils;
-  
+
+  ffcallAvailable = stdenv.isLinux && (libffcall != null);
+
   buildInputs = [libsigsegv]
   ++ stdenv.lib.optional (gettext != null) gettext
   ++ stdenv.lib.optional (ncurses != null) ncurses
   ++ stdenv.lib.optional (pcre != null) pcre
   ++ stdenv.lib.optional (zlib != null) zlib
   ++ stdenv.lib.optional (readline != null) readline
-  ++ stdenv.lib.optional (libffi != null) libffi
-  ++ stdenv.lib.optional (libffcall != null) libffcall
+  ++ stdenv.lib.optional (ffcallAvailable && (libffi != null)) libffi
+  ++ stdenv.lib.optional ffcallAvailable libffcall
   ++ stdenv.lib.optionals x11Support [
     libX11 libXau libXt libXpm xproto libXext xextproto
   ];
@@ -64,8 +66,10 @@ stdenv.mkDerivation rec {
   configureFlags = "builddir"
   + stdenv.lib.optionalString (!dllSupport) " --without-dynamic-modules"
   + stdenv.lib.optionalString (readline != null) " --with-readline"
-  + stdenv.lib.optionalString (libffi != null) " --with-dynamic-ffi"
-  + stdenv.lib.optionalString (libffcall != null) " --with-ffcall"
+  # --with-dynamic-ffi can only exist with --with-ffcall - foreign.d does not compile otherwise
+  + stdenv.lib.optionalString (ffcallAvailable && (libffi != null)) " --with-dynamic-ffi"
+  + stdenv.lib.optionalString ffcallAvailable " --with-ffcall"
+  + stdenv.lib.optionalString (!ffcallAvailable) " --without-ffcall"
   + stdenv.lib.concatMapStrings (x: " --with-module=" + x) withModules
   + stdenv.lib.optionalString threadSupport " --with-threads=POSIX_THREADS";
 
@@ -88,6 +92,6 @@ stdenv.mkDerivation rec {
     description = "ANSI Common Lisp Implementation";
     homepage = http://clisp.cons.org;
     maintainers = with stdenv.lib.maintainers; [raskin tohl];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl
 , texlive
-, zlib, bzip2, ncurses, libpng, flex, bison, libX11, libICE, xproto
+, zlib, bzip2, ncurses, libiconv, libpng, flex, bison, libX11, libICE, xproto
 , freetype, t1lib, gd, libXaw, icu, ghostscript, ed, libXt, libXpm, libXmu, libXext
 , xextproto, perl, libSM, ruby, expat, curl, libjpeg, python, fontconfig, pkgconfig
 , poppler, libpaper, graphite2, zziplib, harfbuzz, texinfo, potrace, gmp, mpfr
@@ -296,7 +296,7 @@ xindy = stdenv.mkDerivation {
     pkgconfig perl
     (texlive.combine { inherit (texlive) scheme-basic cyrillic ec; })
   ];
-  buildInputs = [ clisp ];
+  buildInputs = [ clisp libiconv ];
 
   configureFlags = [ "--with-clisp-runtime=system" "--disable-xindy-docs" ];
 


### PR DESCRIPTION
###### Motivation for this change

texlive-2016 would not build on Darwin.
###### Things done
- Unbreak build of clisp on Darwin (on which xindy depends on which texlive depends), which previously was Linux only.
- Add a dependency to xindy to libiconv.
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
