### PR TITLE
urlscan: init at 0.8.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -123,6 +123,7 @@
   dmalikov = "Dmitry Malikov <malikov.d.y@gmail.com>";
   dochang = "Desmond O. Chang <dochang@gmail.com>";
   doublec = "Chris Double <chris.double@double.co.nz>";
+  dpaetzel = "David Pätzel <david.a.paetzel@gmail.com>";
   drets = "Dmytro Rets <dmitryrets@gmail.com>";
   drewkett = "Andrew Burkett <burkett.andrew@gmail.com>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";

--- a/pkgs/applications/misc/urlscan/default.nix
+++ b/pkgs/applications/misc/urlscan/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, isPy35, fetchFromGitHub, urwid }:
+
+buildPythonPackage rec {
+  name = "urlscan-${version}";
+  version = "0.8.3";
+
+  src = fetchFromGitHub {
+    owner = "firecat53";
+    repo = "urlscan";
+    rev = version;
+    # (equivalent but less nice(?): rev = "00333f6d03bf3151c9884ec778715fc605f58cc5")
+    sha256 = "0l40anfznam4d3q0q0jp2wwfrvfypz9ppbpjyzjdrhb3r2nizb0y";
+  };
+
+  propagatedBuildInputs = [ urwid ];
+
+  # FIXME doesn't work with 2.7; others than 2.7 and 3.5 were not tested (yet)
+  disabled = ! isPy35;
+
+  meta = with stdenv.lib; {
+    description = "Mutt and terminal url selector (similar to urlview)";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.dpaetzel ];
+  };
+}

--- a/pkgs/applications/misc/urlscan/default.nix
+++ b/pkgs/applications/misc/urlscan/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ urwid ];
 
   # FIXME doesn't work with 2.7; others than 2.7 and 3.5 were not tested (yet)
-  disabled = ! isPy35;
+  disabled = !pythonOlder "3.5";
 
   meta = with stdenv.lib; {
     description = "Mutt and terminal url selector (similar to urlview)";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -30753,4 +30753,5 @@ in modules // {
     };
   };
 
+  urlscan = callPackage ../applications/misc/urlscan { };
 }


### PR DESCRIPTION
###### Motivation for this change

urlscan improves upon urlview by a few features like showing context around each selectable url.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
