### PR TITLE
grabserial: 1.7.0 -> 1.9.3

### DIFF
--- a/pkgs/development/tools/grabserial/default.nix
+++ b/pkgs/development/tools/grabserial/default.nix
@@ -2,13 +2,13 @@
 
 pythonPackages.buildPythonApplication rec {
 
-  name = "grabserial-20141120";
+  name = "grabserial-1.9.3";
   namePrefix = "";
 
   src = fetchgit {
     url = https://github.com/tbird20d/grabserial.git;
-    rev  = "8b9c98ea35d382bac2aafc7a8a9c02440369a792";
-    sha256 = "ff27f5e5ab38c8450a4a0291e943e6c5a265e56d29d6a1caa849ae3238d71679";
+    rev  = "7cbf104b61ffdf68e6782a8e885050565399a014";
+    sha256 = "043r2p5jw0ymx8ka1d39q1ap39i7sliq5f4w3yr1n53lzshjmc5g";
   };
 
   propagatedBuildInputs = [ pythonPackages.pyserial ];


### PR DESCRIPTION
###### Motivation for this change

Upgrade to the latest release available on github
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
