### PR TITLE
linuxPackages.ati_drivers_x11: patch for kernel 4.7+

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -197,6 +197,7 @@
   jb55 = "William Casarin <bill@casarin.me>";
   jcumming = "Jack Cummings <jack@mudshark.org>";
   jefdaj = "Jeffrey David Johnson <jefdaj@gmail.com>";
+  jerith666 = "Matt McHenry <github@matt.mchenryfamily.org>";
   jfb = "James Felix Black <james@yamtime.com>";
   jgeerds = "Jascha Geerds <jascha@jgeerds.name>";
   jgillich = "Jakob Gillich <jakob@gillich.me>";

--- a/pkgs/os-specific/linux/ati-drivers/default.nix
+++ b/pkgs/os-specific/linux/ati-drivers/default.nix
@@ -127,7 +127,7 @@ stdenv.mkDerivation rec {
     description = "ATI Catalyst display drivers";
     homepage = http://support.amd.com/us/gpudownload/Pages/index.aspx;
     license = licenses.unfree;
-    maintainers = with maintainers; [ marcweber offline jgeerds ];
+    maintainers = with maintainers; [ marcweber offline jgeerds jerith666 ];
     platforms = platforms.linux;
     hydraPlatforms = [];
     # Copied from the nvidia default.nix to prevent a store collision.

--- a/pkgs/os-specific/linux/ati-drivers/default.nix
+++ b/pkgs/os-specific/linux/ati-drivers/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, kernel ? null, which
+{ stdenv, lib, fetchurl, kernel ? null, which
 , xorg, makeWrapper, glibc, patchelf, unzip
 , fontconfig, freetype, mesa # for fgl_glxgears
 , # Whether to build the libraries only (i.e. not the kernel module or
@@ -75,9 +75,12 @@ stdenv.mkDerivation rec {
     ./patches/15.9-preempt.patch
     ./patches/15.9-sep_printf.patch ]
   ++ optionals ( kernel != null &&
-                 (builtins.compareVersions kernel.version "4.6") >= 0 )
+                 (lib.versionAtLeast kernel.version "4.6") )
                [ ./patches/kernel-4.6-get_user_pages.patch
-                 ./patches/kernel-4.6-page_cache_release-put_page.patch ];
+                 ./patches/kernel-4.6-page_cache_release-put_page.patch ]
+  ++ optionals ( kernel != null &&
+                 (lib.versionAtLeast kernel.version "4.7") )
+               [ ./patches/4.7-arch-cpu_has_pge-v2.patch ];
 
   buildInputs =
     [ xorg.libXrender xorg.libXext xorg.libX11 xorg.libXinerama xorg.libSM

--- a/pkgs/os-specific/linux/ati-drivers/patches/4.7-arch-cpu_has_pge-v2.patch
+++ b/pkgs/os-specific/linux/ati-drivers/patches/4.7-arch-cpu_has_pge-v2.patch
@@ -1,0 +1,70 @@
+diff -uNr 16.8/common/lib/modules/fglrx/build_mod/firegl_public.c 16.8b/common/lib/modules/fglrx/build_mod/firegl_public.c
+--- 16.8/common/lib/modules/fglrx/build_mod/firegl_public.c	2015-12-18 19:47:41.000000000 +0100
++++ 16.8b/common/lib/modules/fglrx/build_mod/firegl_public.c	2016-08-15 15:09:37.228538907 +0200
+@@ -4518,7 +4518,11 @@
+     write_cr0(cr0);
+     wbinvd();
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0)
++    if (boot_cpu_has(X86_FEATURE_PGE))
++#else
+     if (cpu_has_pge)
++#endif
+     {
+         cr4 = READ_CR4();
+         WRITE_CR4(cr4 & ~X86_CR4_PGE);
+@@ -4532,7 +4536,11 @@
+     wbinvd();
+     __flush_tlb();
+     write_cr0(cr0 & 0xbfffffff);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0)
++    if (boot_cpu_has(X86_FEATURE_PGE))
++#else
+     if (cpu_has_pge)
++#endif
+     {
+         WRITE_CR4(cr4);
+     }
+@@ -4559,7 +4567,11 @@
+     write_cr0(cr0);
+     wbinvd();
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0)
++    if (boot_cpu_has(X86_FEATURE_PGE))
++#else
+     if (cpu_has_pge)
++#endif
+     {
+         cr4 = READ_CR4();
+         WRITE_CR4(cr4 & ~X86_CR4_PGE);
+@@ -4572,7 +4584,11 @@
+     wbinvd();
+     __flush_tlb();
+     write_cr0(cr0 & 0xbfffffff);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0)
++    if (boot_cpu_has(X86_FEATURE_PGE))
++#else
+     if (cpu_has_pge)
++#endif
+     {
+         WRITE_CR4(cr4);
+     }
+diff -uNr 16.8/common/lib/modules/fglrx/build_mod/firegl_public.h 16.8b/common/lib/modules/fglrx/build_mod/firegl_public.h
+--- 16.8/common/lib/modules/fglrx/build_mod/firegl_public.h	2015-12-18 19:47:41.000000000 +0100
++++ 16.8b/common/lib/modules/fglrx/build_mod/firegl_public.h	2016-08-15 15:09:05.815141238 +0200
+@@ -650,9 +650,15 @@
+ #define cpu_has_pat  test_bit(X86_FEATURE_PAT, (void *) &boot_cpu_data.x86_capability)
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0)
++#ifndef boot_cpu_has(X86_FEATURE_PGE)
++#define boot_cpu_has(X86_FEATURE_PGE) test_bit(X86_FEATURE_PGE, &boot_cpu_data.x86_capability)
++#endif
++#else
+ #ifndef cpu_has_pge
+ #define cpu_has_pge test_bit(X86_FEATURE_PGE, &boot_cpu_data.x86_capability)
+ #endif
++#endif
+ 
+ /* 2.6.29 defines pgprot_writecombine as a macro which resolves to a
+  * GPL-only function with the same name. So we always use our own


### PR DESCRIPTION
###### Motivation for this change

Yet another case of binary ATI drivers lagging behind kernel API changes.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

uses patch from commit 392aac08 in https://aur.archlinux.org/packages/catalyst/

Confirmed working with minecraft and starcraft 2 locally.
