### PR TITLE
network-manager: give path to pppd executable

### DIFF
--- a/pkgs/tools/networking/network-manager/PppdPath.patch
+++ b/pkgs/tools/networking/network-manager/PppdPath.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ppp-manager/nm-ppp-manager.c b/src/ppp-manager/nm-ppp-manager.c
+index 89a7add..ae99eb4 100644
+--- a/src/ppp-manager/nm-ppp-manager.c
++++ b/src/ppp-manager/nm-ppp-manager.c
+@@ -843,7 +843,7 @@ create_pppd_cmd_line (NMPPPManager *self,
+ 
+ 	g_return_val_if_fail (setting != NULL, NULL);
+ 
+-	pppd_binary = nm_utils_find_helper ("pppd", NULL, err);
++	pppd_binary = nm_utils_find_helper ("pppd", PPPD_PATH, err);
+ 	if (!pppd_binary)
+ 		return NULL;
+ 

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation rec {
     "--with-libsoup=yes"
   ];
 
+  patches = [ ./PppdPath.patch ];
+
   buildInputs = [ systemd libgudev libnl libuuid polkit ppp libndp
                   bluez5 dnsmasq gobjectIntrospection modemmanager readline newt libsoup ];
 


### PR DESCRIPTION
###### Motivation for this change

This fixes an issue I have faced when trying to connect to the internet via wwan gsm modem.
###### Things done

I have tested this on 16.09 (see #19733) but not on master, because my NixOS machine has very limited resources.
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This fixes an issue I have faced when trying to connect to the internet
via wwan gsm modem.
