### PR TITLE
octave: darwin fix

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
     sha256 = "11y2w6jgngj4rxiy136mkcs02l52rxk60kapyfc4rgrxz5hli3ym";
   };
 
-  buildInputs = [ gfortran readline ncurses perl flex texinfo qhull libX11
-    graphicsmagick pcre pkgconfig mesa fltk zlib curl openblas libsndfile
-    fftw fftwSinglePrec qrupdate arpack libwebp ]
+  buildInputs = [ gfortran readline ncurses perl flex texinfo qhull
+    graphicsmagick pcre pkgconfig fltk zlib curl openblas libsndfile fftw
+    fftwSinglePrec qrupdate arpack libwebp ]
     ++ (stdenv.lib.optional (qt != null) qt)
     ++ (stdenv.lib.optional (qscintilla != null) qscintilla)
     ++ (stdenv.lib.optional (ghostscript != null) ghostscript)
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     ++ (stdenv.lib.optional (jdk != null) jdk)
     ++ (stdenv.lib.optional (gnuplot != null) gnuplot)
     ++ (stdenv.lib.optional (python != null) python)
-    ++ (stdenv.lib.optionals (!stdenv.isDarwin) [mesa libX11])
+    ++ (stdenv.lib.optionals (!stdenv.isDarwin) [ mesa libX11 ])
     ;
 
   doCheck = !stdenv.isDarwin;

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -21,6 +21,8 @@ composableDerivation.composableDerivation {} {
       --replace 'class Fl_XFont_On_Demand' 'class FL_EXPORT Fl_XFont_On_Demand'
   '';
 
+  patches = stdenv.lib.optionals stdenv.isDarwin [ ./nsosv.patch ];
+
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ inputproto ]
     ++ (if stdenv.isDarwin

--- a/pkgs/development/libraries/fltk/nsosv.patch
+++ b/pkgs/development/libraries/fltk/nsosv.patch
@@ -1,0 +1,20 @@
+diff --git a/src/Fl_cocoa.mm b/src/Fl_cocoa.mm
+index 6f5b8b1..2c7763d 100644
+--- a/src/Fl_cocoa.mm
++++ b/src/Fl_cocoa.mm
+@@ -4074,15 +4074,6 @@ Window fl_xid(const Fl_Window* w)
+ static int calc_mac_os_version() {
+   int M, m, b = 0;
+   NSAutoreleasePool *localPool = [[NSAutoreleasePool alloc] init];
+-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
+-  if ([NSProcessInfo instancesRespondToSelector:@selector(operatingSystemVersion)]) {
+-    NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+-    M = version.majorVersion;
+-    m = version.minorVersion;
+-    b = version.patchVersion;
+-  }
+-  else
+-#endif
+   {
+     NSDictionary * sv = [NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"];
+     const char *s = [[sv objectForKey:@"ProductVersion"] UTF8String];

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
   makeFlags =
     (if local then localFlags else genericFlags)
     ++
-    optionals stdenv.isDarwin ["MACOSX_DEPLOYMENT_TARGET=10.9"]
+    optionals stdenv.isDarwin ["MACOSX_DEPLOYMENT_TARGET=10.7"]
     ++
     [
       "FC=gfortran"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5477,7 +5477,7 @@ in
     glpk = null;
     suitesparse = null;
     jdk = null;
-    openblas = openblas;
+    openblas = if stdenv.isDarwin then openblasCompat else openblas;
   };
   octaveFull = (lowPrio (callPackage ../development/interpreters/octave {
     qt = qt4;


### PR DESCRIPTION
###### Motivation for this change

Fix octave on darwin.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

octave build would fail on mac during a test of openblas ABI. I've tried recompiling openblas with different C compilers. It's build system was not willing to appreciate GCC on darwin system. Using different versions of clang (3.6, 3.9) didn't give any positive results. 32bit ABI seems to be a good and quick workaround.
