### PR TITLE
XTerm: fix app-defaults, fixes menu options

### DIFF
--- a/pkgs/applications/misc/xterm/default.nix
+++ b/pkgs/applications/misc/xterm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, xorg, ncurses, freetype, fontconfig, pkgconfig
+{ stdenv, fetchurl, xorg, ncurses, freetype, fontconfig, pkgconfig, makeWrapper
 , enableDecLocator ? true
 }:
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ xorg.libXaw xorg.xproto xorg.libXt xorg.libXext xorg.libX11 xorg.libSM xorg.libICE
-      ncurses freetype fontconfig pkgconfig xorg.libXft xorg.luit
+      ncurses freetype fontconfig pkgconfig xorg.libXft xorg.luit makeWrapper
     ];
 
   patches = [
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     "--enable-luit"
     "--enable-mini-luit"
     "--with-tty-group=tty"
+    "--with-app-defaults=$(out)/lib/X11/app-defaults"
   ] ++ stdenv.lib.optional enableDecLocator "--enable-dec-locator";
 
   # Work around broken "plink.sh".
@@ -42,6 +43,12 @@ stdenv.mkDerivation rec {
   # groups, and the builder will end up removing any setgid.
   postConfigure = ''
     echo '#define USE_UTMP_SETGID 1'
+  '';
+
+  postInstall = ''
+    for bin in $out/bin/*; do
+      wrapProgram $bin --set XAPPLRESDIR $out/lib/X11/app-defaults/
+    done
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

XTerm menu labels were missing, and menu items did nothing.
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
