### PR TITLE
qastools: 0.18.1 -> 0.21.0

### DIFF
--- a/pkgs/tools/audio/qastools/default.nix
+++ b/pkgs/tools/audio/qastools/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, cmake, alsaLib, udev, qt4 }:
+{ stdenv, fetchurl, cmake, alsaLib, udev, qtbase,
+  qtsvg, qttools, makeQtWrapper }:
 
 let
-  version = "0.18.1";
+  version = "0.21.0";
 in
 
 stdenv.mkDerivation {
   name = "qastools-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/qastools/qastools_${version}.tar.bz2";
-    sha256 = "1sac6a0j1881wgpv4491b2f4jnhqkab6xyldmcg1wfqb5qkdgzvg";
+    url = "mirror://sourceforge/project/qastools/${version}/qastools_${version}.tar.bz2";
+    sha256 = "1zl9cn5h43n63yp3z1an87xvw554k9hlcz75ddb30lvpcczkmwrh";
   };
 
   buildInputs = [
-    cmake alsaLib udev qt4
+    cmake alsaLib udev qtbase qtsvg qttools makeQtWrapper
   ];
 
   cmakeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3346,7 +3346,7 @@ in
 
   qalculate-gtk = callPackage ../applications/science/math/qalculate-gtk { };
 
-  qastools = callPackage ../tools/audio/qastools { };
+  qastools = qt5.callPackage ../tools/audio/qastools { };
 
   qesteidutil = qt5.callPackage ../tools/security/qesteidutil { } ;
   qdigidoc = qt5.callPackage ../tools/security/qdigidoc { } ;


### PR DESCRIPTION
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
