### PR TITLE
httpstat: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/tools/networking/httpstat/default.nix
+++ b/pkgs/tools/networking/httpstat/default.nix
@@ -3,12 +3,12 @@
 pythonPackages.buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "httpstat";
-    version = "1.2.0";
+    version = "1.2.1";
     src = fetchFromGitHub {
       owner = "reorx";
       repo = pname;
       rev = "${version}";
-      sha256 = "1zfbv3fz3g3wwvsgrcyrk2cp7pjhkpf7lmx57ry9b43c62gcd7yh";
+      sha256 = "1vriibcsq4j1hvm5yigbbmmv21dc40y5c9gvd31dg9qkaz26hml6";
     };
     doCheck = false;
     propagatedBuildInputs = [ ];


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
