### PR TITLE
mesos module: add running tasks in service tests

### DIFF
--- a/nixos/tests/mesos.nix
+++ b/nixos/tests/mesos.nix
@@ -1,32 +1,78 @@
-import ./make-test.nix ({ pkgs, ...} : {
-  name = "simple";
+import ./make-test.nix ({ pkgs, ...} : rec {
+  name = "mesos";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ offline ];
+    maintainers = [ offline kamilchm ];
   };
 
-  machine = { config, pkgs, ... }: {
-    services.zookeeper.enable = true;
-    virtualisation.docker.enable = true;
-    services.mesos = {
-      slave = {
-        enable = true;
-        master = "zk://localhost:2181/mesos";
-        attributes = {
-          tag1 = "foo";
-          tag2 = "bar";
-        };
-      };
-      master = {
-        enable = true;
-        zk = "zk://localhost:2181/mesos";
+  nodes = {
+    master = { config, pkgs, ... }: {
+      networking.firewall.enable = false;
+      services.zookeeper.enable = true;
+      services.mesos.master = {
+          enable = true;
+          zk = "zk://master:2181/mesos";
       };
     };
+
+    slave = { config, pkgs, ... }: {
+      networking.firewall.enable = false;
+      networking.nat.enable = true;
+      virtualisation.docker.enable = true;
+      services.mesos = {
+        slave = {
+          enable = true;
+          master = "master:5050";
+        };
+      };
+    };
+  };
+
+  simpleDocker = pkgs.dockerTools.buildImage {
+    name = "echo";
+    contents = pkgs.coreutils;
+    config = {
+      Entrypoint = [ "${pkgs.coreutils}/bin/echo" ];
+    };
+  };
+
+  testFramework = pkgs.pythonPackages.buildPythonPackage {
+    name = "mesos-tests";
+    propagatedBuildInputs = [ pkgs.mesos ];
+    catchConflicts = false;
+    src = ./mesos_test.py;
+    phases = [ "installPhase" "fixupPhase" ];
+    installPhase = ''
+      mkdir $out
+      cp $src $out/mesos_test.py
+      chmod +x $out/mesos_test.py
+
+      echo "done" > test.result
+      tar czf $out/test.tar.gz test.result
+    '';
   };
 
   testScript =
     ''
       startAll;
-      $machine->waitForUnit("mesos-master.service");
-      $machine->waitForUnit("mesos-slave.service");
+      $master->waitForUnit("mesos-master.service");
+      $slave->waitForUnit("mesos-slave.service");
+
+      $master->waitForOpenPort(5050);
+      $slave->waitForOpenPort(5051);
+
+      # is slave registred? 
+      $master->waitUntilSucceeds("curl -s --fail http://master:5050/master/slaves".
+                                 " | grep -q \"\\\"hostname\\\":\\\"slave\\\"\"");
+
+      # try to run docker image 
+      $slave->succeed("docker load < ${simpleDocker}");
+      $master->succeed("${pkgs.mesos}/bin/mesos-execute --master=master:5050".
+                       " --resources=\"cpus:0.1;mem:32\" --name=simple-docker".
+                       " --containerizer=docker --docker_image=echo".
+                       " --shell=false --command=\"done\" | grep -q TASK_FINISHED");
+
+      # simple command with .tar.gz uri
+      $master->succeed("${testFramework}/mesos_test.py master ".
+                       "${testFramework}/test.tar.gz");
     '';
 })

--- a/nixos/tests/mesos_test.py
+++ b/nixos/tests/mesos_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+import uuid
+import time
+
+import sys
+
+from mesos.interface import Scheduler
+from mesos.native import MesosSchedulerDriver
+from mesos.interface import mesos_pb2
+
+
+class NixosTestScheduler(Scheduler):
+    def __init__(self):
+        self.master_ip = sys.argv[1]
+        self.download_uri = sys.argv[2]
+
+    def resourceOffers(self, driver, offers):
+        offer = offers[0]
+        task = self.new_task(offer)
+        uri = task.command.uris.add()
+        uri.value = self.download_uri
+        task.command.value = "cat test.result"
+        driver.launchTasks(offer.id, [task])
+
+    def statusUpdate(self, driver, update):
+        if update.state == mesos_pb2.TASK_FAILED:
+            print "Test task failed with message: " + update.message
+            driver.stop()
+            sys.exit(1)
+        elif update.state == mesos_pb2.TASK_FINISHED:
+            driver.stop()
+            sys.exit(0)
+
+    def new_task(self, offer):
+        task = mesos_pb2.TaskInfo()
+        id = uuid.uuid4()
+        task.task_id.value = str(id)
+        task.slave_id.value = offer.slave_id.value
+        task.name = "task {}".format(str(id))
+
+        cpus = task.resources.add()
+        cpus.name = "cpus"
+        cpus.type = mesos_pb2.Value.SCALAR
+        cpus.scalar.value = 0.1
+
+        mem = task.resources.add()
+        mem.name = "mem"
+        mem.type = mesos_pb2.Value.SCALAR
+        mem.scalar.value = 32
+
+        return task
+
+
+if __name__ == '__main__':
+    framework = mesos_pb2.FrameworkInfo()
+    framework.user = "root"
+    framework.name = "nixos-test-framework"
+    driver = MesosSchedulerDriver(
+        NixosTestScheduler(),
+        framework,
+        sys.argv[1] + ":5050"
+    )
+    driver.run()

--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -46,6 +46,13 @@ in stdenv.mkDerivation rec {
     pythonProtobuf
   ];
 
+  tarWithGzip = lib.overrideDerivation gnutar (oldAttrs: {
+    buildInputs = [ makeWrapper ];
+    postInstall = ''
+      wrapProgram $out/bin/tar --prefix PATH ":" "${gzip}/bin"
+    '';
+  });
+
   preConfigure = ''
     substituteInPlace 3rdparty/stout/include/stout/os/posix/fork.hpp \
       --subst-var-by sh ${bash}/bin/bash


### PR DESCRIPTION
###### Motivation for this change

Mesos needs better automatic checks when upgrading. Each update can brake some kind of tasks (#19064).
I want to have tests for my use cases, where I need to spawn docker or task provided as `.tar.gz`.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @cstrahan, @kevincox, @benley, @philip-wernersbach
