### PR TITLE
kdeFramework: performance optimization

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -40,7 +40,6 @@ let
       let
         inherit (args) name;
         inherit (srcs."${name}") src version;
-        qtVersion = (builtins.parseDrvName self.qtbase.name).version;
       in kdeDerivation (args // {
         name = "${name}-${version}";
         inherit src;
@@ -51,7 +50,7 @@ let
           ];
           platforms = lib.platforms.linux;
           homepage = "http://www.kde.org";
-          broken = builtins.compareVersions qtVersion "5.6.0" < 0;
+          broken = builtins.compareVersions self.qtbase.version "5.6.0" < 0;
         } // (args.meta or {});
       });
 

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -36,7 +36,9 @@ let
 
       });
 
-    kdeFramework = args:
+    kdeFramework = let
+      broken = builtins.compareVersions self.qtbase.version "5.6.0" < 0;
+    in args:
       let
         inherit (args) name;
         inherit (srcs."${name}") src version;
@@ -50,7 +52,7 @@ let
           ];
           platforms = lib.platforms.linux;
           homepage = "http://www.kde.org";
-          broken = builtins.compareVersions self.qtbase.version "5.6.0" < 0;
+          inherit broken;
         } // (args.meta or {});
       });
 


### PR DESCRIPTION
###### Motivation for this change

Another micro optimization to improve evaluation speed / memory consumption.

These are two independent changes:

The first uses `qtbase.version` instead of parsing the version from the name. In my tests this worked, but I might have missed a qt version where this is not supported?  
CC @ttuegel 

The second change moves the compare out of the function since it does not depend on the function arguments. The effect is that the compare is only done once when the `kdeFramework` is evaluated and not every time `kdeFramework` is called.
Since this reduces readability a bit, I'm open for discussion.
### evaluation statistics:

| value | pre | post |
| --- | --- | --- |
| time elapsed: | 1.87 | 1.856 |
| environments allocated: | 538568 (18730072 bytes) | 538185 (18722288 bytes) |
| values allocated: | 1804472 (43307328 bytes) | 1802807 (43267368 bytes) |
| sets allocated: | 441918 (142269864 bytes) | 441708 (142258104 bytes) |
| number of thunks: | 1441150 | 1440319 |
| number of thunks avoided: | 1047037 | 1046623 |
| number of attr lookups: | 552736 | 551695 |
| number of primop calls: | 280003 | 279379 |
| total allocations: | 206764136 bytes | 206704632 bytes |
| total Boehm heap allocations: | 250171760 bytes | 250089840 bytes |
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
