### PR TITLE
gmad: init at HEAD

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -10,6 +10,7 @@
   aaronschif = "Aaron Schif <aaronschif@gmail.com>";
   abaldeau = "Andreas Baldeau <andreas@baldeau.net>";
   abbradar = "Nikolay Amiantov <ab@fmap.me>";
+  abigailbuccaneer = "Abigail Bunyan <abigailbuccaneer@gmail.com>";
   aboseley = "Adam Boseley <adam.boseley@gmail.com>";
   abuibrahim = "Ruslan Babayev <ruslan@babayev.com>";
   acowley = "Anthony Cowley <acowley@gmail.com>";

--- a/pkgs/development/libraries/bootil/default.nix
+++ b/pkgs/development/libraries/bootil/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, fetchpatch, premake4 }:
+
+stdenv.mkDerivation rec {
+  name = "bootil-unstable-2015-12-17";
+
+  meta = {
+    description = "Garry Newman's personal utility library";
+    homepage = https://github.com/garrynewman/bootil;
+    # License unsure - see https://github.com/garrynewman/bootil/issues/21
+    license = stdenv.lib.licenses.free;
+    maintainers = [ stdenv.lib.maintainers.abigailbuccaneer ];
+    platforms = stdenv.lib.platforms.all;
+  };
+
+  src = fetchFromGitHub {
+    owner = "garrynewman";
+    repo = "bootil";
+    rev = "1d3e321fc2be359e2350205b8c7f1cad2164ee0b";
+    sha256 = "03wq526r80l2px797hd0n5m224a6jibwipcbsvps6l9h740xabzg";
+  };
+
+  patches = [ (fetchpatch {
+    url = https://github.com/garrynewman/bootil/pull/22.patch;
+    name = "github-pull-request-22.patch";
+    sha256 = "1qf8wkv00pb9w1aa0dl89c8gm4rmzkxfl7hidj4gz0wpy7a24qa2";
+  })];
+
+  platform =
+    if stdenv.isLinux then "linux"
+    else if stdenv.isDarwin then "macosx"
+    else abort "unrecognized platform";
+
+  buildInputs = [ premake4 ];
+
+  configurePhase = "premake4 --file=projects/premake4.lua gmake";
+  makeFlags = "-C projects/${platform}/gmake";
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp lib/${platform}/gmake/libbootil_static.a $out/lib/
+    cp -r include $out/
+  '';
+}

--- a/pkgs/games/gmad/default.nix
+++ b/pkgs/games/gmad/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, premake4, bootil }:
+
+stdenv.mkDerivation rec {
+  name = "gmad-unstable-2015-04-16";
+
+  meta = {
+    description = "Garry's Mod Addon Creator and Extractor";
+    homepage = https://github.com/garrynewman/gmad;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.abigailbuccaneer ];
+    platforms = stdenv.lib.platforms.all;
+  };
+
+  src = fetchFromGitHub {
+    owner = "garrynewman";
+    repo = "gmad";
+    rev = "377f3458bf1ecb8a1a2217c2194773e3c2a2dea0";
+    sha256="0myi9njr100gxhxk1vrzr2sbij5kxl959sq0riiqgg01div338g0";
+  };
+
+  buildInputs = [ premake4 bootil ];
+
+  targetName =
+    if stdenv.isLinux then "gmad_linux"
+    else if stdenv.isDarwin then "gmad_osx"
+    else "gmad";
+
+  configurePhase = "premake4 --bootil_lib=${bootil}/lib --bootil_inc=${bootil}/include gmake";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${targetName} $out/bin/gmad
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16804,6 +16804,8 @@ in
 
   blackbird = callPackage ../misc/themes/blackbird { };
 
+  bootil = callPackage ../development/libraries/bootil { };
+
   brgenml1lpr = callPackage_i686 ../misc/cups/drivers/brgenml1lpr {};
 
   brgenml1cupswrapper = callPackage ../misc/cups/drivers/brgenml1cupswrapper {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15542,6 +15542,8 @@ in
 
   gltron = callPackage ../games/gltron { };
 
+  gmad = callPackage ../games/gmad { };
+
   gnubg = callPackage ../games/gnubg { };
 
   gnuchess = callPackage ../games/gnuchess { };


### PR DESCRIPTION
###### Motivation for this change

[gmad](https://github.com/garrynewman/gmad) is a utility that packages addons for the game Garry's Mod to be published to the Steam Workshop. It's available inside binary distributions of Garry's Mod, but it's not suitable to install Garry's Mod (which costs money and takes multiple gigabytes of space on disk) on a small build server. My intent is to use gmad and Nix to automate creating and publishing Garry's Mod addons.

This pull request also adds [bootil](https://github.com/garrynewman/bootil), a utility library that's a requirement of gmad.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
