### PR TITLE
avro-c++: added support of libcxx with clang

### DIFF
--- a/pkgs/development/libraries/avro-c++/default.nix
+++ b/pkgs/development/libraries/avro-c++/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, cmake, boost, pythonPackages
+{ stdenv, fetchurl, cmake, boost, pythonPackages, llvmPackages
+, libcxxSupport ? false
 }:
 
 let version = "1.8.1"; in
@@ -15,11 +16,14 @@ stdenv.mkDerivation {
     cmake
     boost
     pythonPackages.python
-  ];
+  ] ++ stdenv.lib.optionals libcxxSupport [ llvmPackages.clang llvmPackages.libcxx llvmPackages.libcxxabi ];
 
   preConfigure = ''
     substituteInPlace test/SchemaTests.cc --replace "BOOST_CHECKPOINT" "BOOST_TEST_CHECKPOINT"
     substituteInPlace test/buffertest.cc --replace "BOOST_MESSAGE" "BOOST_TEST_MESSAGE"
+  '' + stdenv.lib.optionalString libcxxSupport ''
+    export CXX=clang++
+    export CXXFLAGS="-nostdinc++ -I${llvmPackages.libcxx}/include/c++/v1"
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Still in the process of creating iRods packages. I need to compile avro-c++ with clang and libcxx support.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
## This changes nothing to the default. The libcxxSupport=true will be called by the irods package.
