### PR TITLE
pyload: init at stable

### DIFF
--- a/pkgs/applications/networking/pyload/default.nix
+++ b/pkgs/applications/networking/pyload/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub, fetchpatch, pythonPackages, gocr, unrar, rhino, spidermonkey }:
+pythonPackages.buildPythonApplication rec {
+  version = "0.4.9-next";
+  name = "pyLoad-" + version;
+
+  src = fetchFromGitHub {
+    owner = "pyload";
+    repo = "pyload";
+    rev = "03f3ad9e39da2b9a378987693c4a69720e4084c7";
+    sha256 = "0fgsz6yzxrlq3qvsyxsyzgmy4za35v1xh3i4drhispk9zb5jm1xx";
+  };
+
+  patches =
+    let
+      # gets merged in next release version of pyload
+      configParserPatch = fetchpatch {
+        url = "https://patch-diff.githubusercontent.com/raw/pyload/pyload/pull/2625.diff";
+        sha256 = "1bisgx78kcr5c0x0i3h0ch5mykns5wx5wx7gvjj0pc71lfzlxzb9";
+      };
+      setupPyPatch = fetchpatch {
+        url = "https://patch-diff.githubusercontent.com/raw/pyload/pyload/pull/2638.diff";
+        sha256 = "1gmvsmlcvb96g48kibv47cbmb5slivy3c5qflb5n0qc8k7axg3i9";
+      };
+    in [ configParserPatch setupPyPatch ];
+
+  buildInputs = [
+    unrar rhino spidermonkey gocr pythonPackages.paver
+  ];
+
+  propagatedBuildInputs = with pythonPackages; [
+    pycurl jinja2 beaker thrift simplejson pycrypto feedparser pyqt4 gdbm
+    tkinter beautifulsoup
+  ];
+
+  #remove this once the PR patches above are merged. Needed because githubs diff endpoint
+  #does not support diff -N
+  prePatch = ''
+    touch module/config/__init__.py
+  '';
+
+  preBuild = ''
+    paver generate_setup
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Free and open source downloader for 1-click-hosting sites";
+    homepage = https://github.com/pyload/pyload;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.mahe ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17001,6 +17001,8 @@ in
 
   pt = callPackage ../applications/misc/pt { };
 
+  pyload = callPackage ../applications/networking/pyload {};
+
   uae = callPackage ../misc/emulators/uae { };
 
   fsuae = callPackage ../misc/emulators/fs-uae { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19277,7 +19277,6 @@ in modules // {
     };
   });
 
-
   pycurl2 = buildPythonPackage (rec {
     name = "pycurl2-7.20.0";
     disabled = isPy3k;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19260,7 +19260,7 @@ in modules // {
       sha256 = "0hqsap82zklhi5fxhc69kxrwzb0g9566f7sdpz7f9gyxkmyam839";
     };
 
-    propagatedBuildInputs = with self; [ pkgs.curl pkgs.openssl ];
+    propagatedBuildInputs = with self; [ pkgs.curl pkgs.openssl.out ];
 
     # error: invalid command 'test'
     doCheck = false;
@@ -19268,6 +19268,11 @@ in modules // {
     preConfigure = ''
       substituteInPlace setup.py --replace '--static-libs' '--libs'
       export PYCURL_SSL_LIBRARY=openssl
+    '';
+
+    #TODO no idea why this is needed
+    postInstall = ''
+      ln -s ${pkgs.openssl.out}/lib/libcrypto* $out/lib/
     '';
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

Provide a nice download tool on nix
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
