### PR TITLE
boost: support for libcxx and specific clang version

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6570,6 +6570,12 @@ in
   boost155 = callPackage ../development/libraries/boost/1.55.nix { };
   boost159 = callPackage ../development/libraries/boost/1.59.nix { };
   boost160 = callPackage ../development/libraries/boost/1.60.nix { };
+  boost160clang38 = callPackage ../development/libraries/boost/1.60.nix {
+    llvmPackages = llvmPackages_38;
+    toolset = "clang";
+    enableLibcxx = true;
+  };
+
   boost = boost160;
 
   boost_process = callPackage ../development/libraries/boost-process { };


### PR DESCRIPTION
###### Motivation for this change

Currently in the process of creating packages for iRods, I need a boost version compiled with a specific version of clang and libcxx. I added support for libcxx and possible override of the clang version.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
