### PR TITLE
gnutls: Build in parallel, cited problems were fixed upstream.

### DIFF
--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -34,11 +34,7 @@ stdenv.mkDerivation {
   ] ++ lib.optional guileBindings
     [ "--enable-guile" "--with-guile-site-dir=\${out}/share/guile/site" ];
 
-  # Build of the Guile bindings is not parallel-safe.  See
-  # <http://git.savannah.gnu.org/cgit/gnutls.git/commit/?id=330995a920037b6030ec0282b51dde3f8b493cad>
-  # for the actual fix.  Also an apparent race in the generation of
-  # systemkey-args.h.
-  enableParallelBuilding = false;
+  enableParallelBuilding = true;
 
   buildInputs = [ lzo lzip nettle libtasn1 libidn p11_kit zlib gmp autogen ]
     ++ lib.optional doCheck nettools


### PR DESCRIPTION
###### Motivation for this change

gnutls builds significantly faster when done in parallel, especially tests!

This was previously disabled for various reasons which have since
been resolved upstream.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The systemkey problem was fixed in 3.4.15 [1].

The guileBindings issue was fixed 3 years ago, and is included
in all versions of gnutls we use today [2].

[1] https://gitlab.com/gnutls/gnutls/commit/25d2f643c04bb3315fc045d14204f51f4fc97d01
[2] https://gitlab.com/gnutls/gnutls/commit/0d34b03f0e5e5eac5e04c795cce2655b52b7cfc9
