### PR TITLE
nimble: 0.7.8 -> 0.7.10

### DIFF
--- a/pkgs/development/tools/nimble/default.nix
+++ b/pkgs/development/tools/nimble/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "nimble-${version}";
 
-  version = "0.7.8";
+  version = "0.7.10";
 
   src = fetchFromGitHub {
     owner = "nim-lang";
     repo = "nimble";
     rev = "v${version}";
-    sha256 = "12znxzj1j5fflw2mkkrns9n7qg6sf207652zrdyf7h2jdyzzb73x";
+    sha256 = "1bcv8chir73nn6x7q8n3sw2scf3m0x2w9gkkzx162ryivza1nm1r";
   };
 
   buildInputs = [ nim openssl ];


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
