### PR TITLE
dockerTools: Fix loop typo.

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -438,7 +438,7 @@ rec {
                      < image/repositories)
 
           for l in image/*/layer.tar; do
-            ls_tar image/*/layer.tar >> baseFiles
+            ls_tar $l >> baseFiles
           done
         fi
 


### PR DESCRIPTION
###### Motivation for this change

Typo in the layer extraction logic causes only a single layer to be de-duplicated, rather than all layers.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
