### PR TITLE
gnutls: 3.3.24 -> 3.3.25

### DIFF
--- a/pkgs/development/libraries/gnutls/3.3.nix
+++ b/pkgs/development/libraries/gnutls/3.3.nix
@@ -1,10 +1,10 @@
 { callPackage, fetchurl, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "3.3.24";
+  version = "3.3.25";
 
   src = fetchurl {
     url = "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.3/gnutls-${version}.tar.xz";
-    sha256 = "5b65fe2a91c8dfa32bedc78acffcb152e5426cd3349e2afc43cccc9bdaf18aa5";
+    sha256 = "0bhzkzpzwg3lhbhpas7m4rcj4mrnyq76zmic9z42wpa68d76r78q";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
