### PR TITLE
gnutls: 3.5.4 -> 3.5.5

### DIFF
--- a/pkgs/development/libraries/gnutls/3.5.nix
+++ b/pkgs/development/libraries/gnutls/3.5.nix
@@ -1,10 +1,10 @@
 { callPackage, fetchurl, autoreconfHook, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "3.5.4";
+  version = "3.5.5";
 
   src = fetchurl {
     url = "ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5/gnutls-${version}.tar.xz";
-    sha256 = "1sx8p7v452s9m854r2c5pvcd1k15a3caiv5h35fhrxz0691h2f2f";
+    sha256 = "0ag5q3dfxzv0dmqy7q0a8y74yc3m5yzvjrp324l6vqafh3klz6c6";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
