### PR TITLE
unifont_upper: 9.0.01 -> 9.0.03

### DIFF
--- a/pkgs/data/fonts/unifont_upper/default.nix
+++ b/pkgs/data/fonts/unifont_upper/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "unifont_upper-${version}";
-  version = "9.0.01";
+  version = "9.0.03";
 
   ttf = fetchurl {
-    url = "http://unifoundry.com/pub/unifont-9.0.01/font-builds/${name}.ttf";
-    sha256 = "06b7na4vb2fjn0zn14bmarzn6vb3ndkysixc89kmb2cc24kfpix1";
+    url = "http://unifoundry.com/pub/unifont-${version}/font-builds/${name}.ttf";
+    sha256 = "015v39y6nnyz4ld006349jzk9isyaqp4cnvmz005ylfnicl4zwhi";
   };
 
   phases = "installPhase";


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
