### PR TITLE
rust-bindgen: init at 0.19.1

### DIFF
--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, rustPlatform, llvmPackages }:
+
+with rustPlatform;
+
+# Future work: Automatically communicate NIX_CFLAGS_COMPILE to bindgen's tests and the bindgen executable itself.
+
+buildRustPackage rec {
+  name = "rust-bindgen-${version}";
+  version = "0.19.1";
+
+  src = fetchFromGitHub {
+    owner = "Yamakaky";
+    repo = "rust-bindgen";
+    rev = "${version}";
+    sha256 = "0pv1vcgp455hys8hb0yj4vrh2k01zysayswkasxq4hca8s2p7qj9";
+  };
+
+  buildInputs = [ llvmPackages.clang-unwrapped ];
+
+  configurePhase = ''
+    export LIBCLANG_PATH="${llvmPackages.clang-unwrapped}/lib"
+  '';
+
+  depsSha256 = "0rlmdiqjg9ha9yzhcy33abvhrck6sphczc2gbab9zhfa95gxprv8";
+
+  doCheck = false; # A test fails because it can't find standard headers in NixOS
+
+  meta = with stdenv.lib; {
+    description = "C binding generator";
+    homepage = https://github.com/Yamakaky/rust-bindgen;
+    license = with licenses; [ bsd3 ];
+    maintainers = [ maintainers.ralith ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5206,6 +5206,7 @@ in
   rustfmt = callPackage ../development/tools/rust/rustfmt { };
   rustracer = callPackage ../development/tools/rust/racer { };
   rustracerd = callPackage ../development/tools/rust/racerd { };
+  rust-bindgen = callPackage ../development/tools/rust/bindgen { };
 
   sbclBootstrap = callPackage ../development/compilers/sbcl/bootstrap.nix {};
   sbcl = callPackage ../development/compilers/sbcl {};


### PR DESCRIPTION
This package would benefit from a wrapper script to communicate `NIX_CFLAGS_COMPILE` to it, but such a script wouldn't be completely trivial, and it is still useful without one.

A git version is packaged because no stable release yet contains the `Cargo.lock` file required for packaging with nix.

`rustRegistry` was bumped for `clang-sys` 0.11
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
