### PR TITLE
haskell: Remove lib directory if no active libraries

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -259,7 +259,10 @@ stdenv.mkDerivation ({
   installPhase = ''
     runHook preInstall
 
-    ${if !hasActiveLibrary then "${setupCommand} install" else ''
+    ${if !hasActiveLibrary then ''
+      ${setupCommand} install
+      rm -rf $out/lib
+    '' else ''
       ${setupCommand} copy
       local packageConfDir="$out/lib/${ghc.name}/package.conf.d"
       local packageConfFile="$packageConfDir/${pname}-${version}.conf"


### PR DESCRIPTION
###### Motivation for this change

I want to compile statically linked Haskell binaries with small closures so that I can put them into Docker images.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Currently we can't compile static executables if the .cabal file
contains a section for both executables and libraries.

This is because we do a "./Setup install" which copies the libraries,
even when "isLibrary = false' is specified. It doesn't seem like Cabal
provides a way to specify installing only libraries - so this just
removes the default directory which Cabal installs into.

This expression shows the problem:

  haskell.lib.overrideCabal haskellPackages.palindromes (p: {
    isLibrary = false;
    enableSharedExecutables = false;
  })

The above will have references to GHC in its closure because the lib
directory had references to GHC.

After this change, the closure should only contain base things like GMP
and glibc.

---

@peti @shajra
