### PR TITLE
[WIP] mlocate: init at version 0.26

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -15,6 +15,15 @@ in {
       '';
     };
 
+    locate = mkOption {
+      type = types.package;
+      default = pkgs.findutils;
+      example = "pkgs.mlocate";
+      description = ''
+        The locate implementation to use
+      '';
+    };
+
     interval = mkOption {
       type = types.str;
       default = "02:15";
@@ -77,7 +86,7 @@ in {
         script =
           ''
             mkdir -m 0755 -p $(dirname ${toString cfg.output})
-            exec updatedb \
+            exec ${cfg.locate}/bin/updatedb \
               --localuser=${cfg.localuser} \
               ${optionalString (!cfg.includeStore) "--prunepaths='/nix/store'"} \
               --output=${toString cfg.output} ${concatStringsSep " " cfg.extraFlags}

--- a/pkgs/tools/misc/mlocate/default.nix
+++ b/pkgs/tools/misc/mlocate/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "mlocate-${version}";
+  version = "0.26";
+
+  src = fetchurl {
+    url = "http://fedorahosted.org/releases/m/l/mlocate/${name}.tar.xz";
+    sha256 = "0gi6y52gkakhhlnzy0p6izc36nqhyfx5830qirhvk3qrzrwxyqrh";
+  };
+
+  buildInputs = [ ];
+
+  meta = with stdenv.lib; {
+    description = "Merging locate is an utility to index and quickly search for files";
+    homepage = https://fedorahosted.org/mlocate/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13881,6 +13881,8 @@ in
 
   diffpdf = callPackage ../applications/misc/diffpdf { };
 
+  mlocate = callPackage ../tools/misc/mlocate { };
+
   mypaint = callPackage ../applications/graphics/mypaint { };
 
   mythtv = callPackage ../applications/video/mythtv { };


### PR DESCRIPTION
###### Motivation for this change

Add the option to use the mlocate implementation of locate.

`mlocate` binary has been tested but module has not. 
Is `${cfg.locate}/bin/updatedb` the correct way to choose between packages?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
