### PR TITLE
libspatialite: link missing mod_spatialite.dylib

### DIFF
--- a/pkgs/development/libraries/libspatialite/default.nix
+++ b/pkgs/development/libraries/libspatialite/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, sqlite, zlib, proj, geos, libiconv }:
+{ stdenv, lib, fetchurl, pkgconfig, libxml2, sqlite, zlib, proj, geos, libiconv }:
+
+with lib;
 
 stdenv.mkDerivation rec {
   name = "libspatialite-4.2.0";
@@ -14,7 +16,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  postInstall = "" + optionalString stdenv.isDarwin ''
+    ln -s $out/lib/mod_spatialite.{so,dylib}
+  '';
+
+  meta = {
     description = "Extensible spatial index library in C++";
     homepage = https://www.gaia-gis.it/fossil/libspatialite;
     # They allow any of these


### PR DESCRIPTION
###### Motivation for this change

See #19856 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [x] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

fix #19856
