### PR TITLE
netdata: allow execution without a config file

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -16,11 +16,19 @@ stdenv.mkDerivation rec{
   # Allow UI to load when running as non-root
   patches = [ ./web_access.patch ];
 
-  preConfigure = ''
-    export ZLIB_CFLAGS=" "
-    export ZLIB_LIBS="-lz"
-    export UUID_CFLAGS=" "
-    export UUID_LIBS="-luuid"
+  # Build will fail trying to create /var/{cache,lib,log}/netdata without this
+  postPatch = ''
+   sed -i '/dist_.*_DATA = \.keep/d' src/Makefile.am
+  '';
+
+  configureFlags = [
+    "--localstatedir=/var"
+  ];
+
+  # App fails on runtime if the default config file is not detected
+  # The upstream installer does prepare an empty file too
+  postInstall = ''
+    touch $out/etc/netdata/netdata.conf
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec{
 
   buildInputs = [ autoreconfHook zlib pkgconfig libuuid ];
 
+  # Allow UI to load when running as non-root
+  patches = [ ./web_access.patch ];
+
   preConfigure = ''
     export ZLIB_CFLAGS=" "
     export ZLIB_LIBS="-lz"

--- a/pkgs/tools/system/netdata/web_access.patch
+++ b/pkgs/tools/system/netdata/web_access.patch
@@ -1,0 +1,20 @@
+--- a/src/web_client.c.orig
++++ b/src/web_client.c
+@@ -331,7 +331,7 @@
+         buffer_sprintf(w->response.data, "File '%s' does not exist, or is not accessible.", webfilename);
+         return 404;
+     }
+-
++#if 0
+     // check if the file is owned by expected user
+     if(stat.st_uid != web_files_uid()) {
+         error("%llu: File '%s' is owned by user %u (expected user %u). Access Denied.", w->id, webfilename, stat.st_uid, web_files_uid());
+@@ -345,7 +345,7 @@
+         buffer_sprintf(w->response.data, "Access to file '%s' is not permitted.", webfilename);
+         return 403;
+     }
+-
++#endif
+     if((stat.st_mode & S_IFMT) == S_IFDIR) {
+         snprintfz(webfilename, FILENAME_MAX, "%s/index.html", filename);
+         return mysendfile(w, webfilename);


### PR DESCRIPTION
###### Motivation for this change

netdata does not work when not passed a configuration file. I've also updated the `web_access.patch` for version 1.4 which was removed in the latest commit.

```
# netdata
16-10-25 15:13:28: ERROR: netdata: Cannot open file '/nix/store/8cgjg5isb8dp72ww9mbgkgifq9d33j8v-netdata-1.4.0/etc/netdata/netdata.conf' (errno 2, No such file or directory)
16-10-25 15:13:28: INFO: netdata: System has 8 processors.
16-10-25 15:13:28: INFO: netdata: System supports 32768 pids.
16-10-25 15:13:28: ERROR: netdata: Group 'nobody' is not present. Ignoring option.
16-10-25 15:13:28: ERROR: netdata: Cannot open file '/nix/store/8cgjg5isb8dp72ww9mbgkgifq9d33j8v-netdata-1.4.0/var/log/netdata/debug.log'. Leaving 1 to its default. (errno 30, Read-only file system)
16-10-25 15:13:28: ERROR: netdata: Cannot open file '/nix/store/8cgjg5isb8dp72ww9mbgkgifq9d33j8v-netdata-1.4.0/var/log/netdata/error.log'. Leaving 2 to its default. (errno 30, Read-only file system)
16-10-25 15:13:28: ERROR: netdata: Cannot open file '/nix/store/8cgjg5isb8dp72ww9mbgkgifq9d33j8v-netdata-1.4.0/var/log/netdata/access.log'. Leaving -1 to its default. (errno 30, Read-only file system)
16-10-25 15:13:28: INFO: netdata: Adjusted my Out-Of-Memory score to 1000.
16-10-25 15:13:28: INFO: netdata: Adjusted my scheduling priority to IDLE.
16-10-25 15:13:28: INFO: netdata: 
Successfully became user 'nobody'.
16-10-25 15:13:28: INFO: netdata: NetData started on pid 31914
16-10-25 15:13:28: FATAL: netdata: Cannot create unique machine id file '/nix/store/8cgjg5isb8dp72ww9mbgkgifq9d33j8v-netdata-1.4.0/var/lib/netdata/registry/netdata.public.unique.id'. Please fix this. # : Read-only file system

16-10-25 15:13:28: INFO: netdata: Called: netdata_cleanup_and_exit()
16-10-25 15:13:28: INFO: netdata: Saving database...
16-10-25 15:13:28: INFO: netdata: NetData exiting. Bye bye...
```

Also cleaned up the preConfigure section as the libraries appear to be linked OK.

```
$ ldd result/bin/netdata 
    linux-vdso.so.1 (0x00007ffdb91f1000)
    libm.so.6 => /nix/store/23vndix3mzcyw84kag06h8fh464g32nq-glibc-2.24/lib/libm.so.6 (0x00007efdf5d8d000)
    libz.so.1 => /nix/store/caz03y58cyrqn4i5ckdw4i21g9sdjb18-zlib-1.2.8/lib/libz.so.1 (0x00007efdf5b77000)
    libuuid.so.1 => /nix/store/1dyxjvsdnq15sc2ikfibfffvf4l6lq3c-util-linux-2.28.1/lib/libuuid.so.1 (0x00007efdf5972000)
    libpthread.so.0 => /nix/store/23vndix3mzcyw84kag06h8fh464g32nq-glibc-2.24/lib/libpthread.so.0 (0x00007efdf5755000)
    libc.so.6 => /nix/store/23vndix3mzcyw84kag06h8fh464g32nq-glibc-2.24/lib/libc.so.6 (0x00007efdf53b7000)
    /nix/store/23vndix3mzcyw84kag06h8fh464g32nq-glibc-2.24/lib/ld-linux-x86-64.so.2 (0x00007efdf6092000)
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
