### PR TITLE
libhttpseverywhere: 0.2.0 -> 0.2.3

### DIFF
--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libhttpseverywhere-${version}";
-  version = "0.2.0";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "grindhold";
     repo  = "libhttpseverywhere";
     rev = "${version}";
-    sha256 = "06yljz7xxh9v48awgmzma6avrnzs2kqh1ydd2hx4b1x2vgf8nfbb";
+    sha256 = "0ggg1kw5yjakqqpnmjcbcpnq5m4lhc76javh8waqv2klr5mxd2a7";
   };
 
   nativeBuildInputs = [ gnome3.vala valadoc  gobjectIntrospection meson ninja pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

This update contains a few bug fixes.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
