### PR TITLE
netdata: allow execution without a config file (16.09)

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -15,6 +15,21 @@ stdenv.mkDerivation rec{
 
   patches = [ ./web_access.patch ];
 
+  # Build will fail trying to create /var/{cache,lib,log}/netdata without this
+  postPatch = ''
+   sed -i '/dist_.*_DATA = \.keep/d' src/Makefile.am
+  '';
+
+  configureFlags = [
+    "--localstatedir=/var"
+  ];
+
+  # App fails on runtime if the default config file is not detected
+  # The upstream installer does prepare an empty file too
+  postInstall = ''
+    touch $out/etc/netdata/netdata.conf
+  '';
+
   meta = with stdenv.lib; {
     description = "Real-time performance monitoring tool";
     homepage = http://netdata.firehol.org;


### PR DESCRIPTION
###### Motivation for this change

backport #19861 to stable
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
