### PR TITLE
libmusicbrainz5: 5.0.1 -> 5.1.0

### DIFF
--- a/pkgs/development/libraries/libmusicbrainz/5.x.nix
+++ b/pkgs/development/libraries/libmusicbrainz/5.x.nix
@@ -1,13 +1,16 @@
-{ stdenv, fetchurl, cmake, neon, libdiscid }:
+{ stdenv, fetchFromGitHub, cmake, neon, libdiscid, libxml2, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "libmusicbrainz-5.0.1";
+  version = "5.1.0";
+  name = "libmusicbrainz-${version}";
 
-  buildInputs = [ cmake neon libdiscid ];
+  buildInputs = [ cmake neon libdiscid libxml2 pkgconfig ];
 
-  src = fetchurl {
-    url = "https://github.com/downloads/metabrainz/libmusicbrainz/${name}.tar.gz";
-    md5 = "a0406b94c341c2b52ec0fe98f57cadf3";
+  src = fetchFromGitHub {
+    owner  = "metabrainz";
+    repo   = "libmusicbrainz";
+    sha256 = "0ah9kaf3g3iv1cps2vs1hs33nfbjfx1xscpjgxr1cg28p4ri6jhq";
+    rev    = "release-${version}";
   };
 
   dontUseCmakeBuildDir=true;


### PR DESCRIPTION
###### Motivation for this change

Include new release and use a sha256 hash.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
