### PR TITLE
reno: init at 1.8.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -179,6 +179,7 @@
   grahamc = "Graham Christensen <graham@grahamc.com>";
   gridaphobe = "Eric Seidel <eric@seidel.io>";
   guibert = "David Guibert <david.guibert@gmail.com>";
+  guillaumekoenig = "Guillaume Koenig <guillaume.edward.koenig@gmail.com>";
   hakuch = "Jesse Haber-Kucharsky <hakuch@gmail.com>";
   havvy = "Ryan Scheel <ryan.havvy@gmail.com>";
   hbunke = "Hendrik Bunke <bunke.hendrik@gmail.com>";

--- a/pkgs/development/tools/reno/default.nix
+++ b/pkgs/development/tools/reno/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "reno-${version}";
+  version = "1.8.0";
+
+  src = fetchurl {
+    url = "mirror://pypi/r/reno/${name}.tar.gz";
+    sha256 = "1pqg0xzcilmyrrnpa87m11xwlvfc94a98s28z9cgddkhw27lg3ps";
+  };
+
+  # Don't know how to make tests pass
+  doCheck = false;
+
+  # Nothing to strip (python files)
+  dontStrip = true;
+
+  propagatedBuildInputs = with pythonPackages; [ pbr six pyyaml ];
+  buildInputs = with pythonPackages; [ Babel ];
+
+  meta = with stdenv.lib; {
+    description = "Release Notes Manager";
+    homepage    = http://docs.openstack.org/developer/reno/;
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ guillaumekoenig ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6288,6 +6288,8 @@ in
 
   redo = callPackage ../development/tools/build-managers/redo { };
 
+  reno = callPackage ../development/tools/reno { };
+
   re2c = callPackage ../development/tools/parsing/re2c { };
 
   remake = callPackage ../development/tools/build-managers/remake { };


### PR DESCRIPTION
###### Motivation for this change

Add reno 1.8.0, a python tool for managing release notes.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
