### PR TITLE
ansible: add dnspython dependency

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -877,7 +877,7 @@ in modules // {
 
     propagatedBuildInputs = with self; [
       pycrypto paramiko jinja2 pyyaml httplib2 boto six
-      netaddr
+      netaddr dns
     ] ++ optional windowsSupport pywinrm;
 
     meta = {
@@ -914,7 +914,7 @@ in modules // {
 
     propagatedBuildInputs = with self; [
       pycrypto paramiko jinja2 pyyaml httplib2 boto six readline
-      netaddr
+      netaddr dns
     ] ++ optional windowsSupport pywinrm;
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Add the dnspython dependency to ansible. This is required to use the lookup plugging for performing dns lookups. Tested to be working with ansible2 on the following template to generate conf :

```
...
{{ lookup('dig', 'qa-env.fqdn.') }}
...
```

Relevant piece of ansible documentation: http://docs.ansible.com/ansible/playbooks_lookups.html#the-dns-lookup-dig
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This dependency is required to use the lookup plugging for performing
dns lookups.

http://docs.ansible.com/ansible/playbooks_lookups.html#the-dns-lookup-dig
