### PR TITLE
reaver-wps-t6x

### DIFF
--- a/pkgs/tools/networking/pixiewps/default.nix
+++ b/pkgs/tools/networking/pixiewps/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "pixiewps-${version}";
+  version = "1.2.2";
+  src = fetchFromGitHub {
+    owner = "wiire";
+    repo = "pixiewps";
+    rev = "v${version}";
+    sha256 = "09znnj7p8cks7zxzklkdm4zy2qnp92vhngm9r0zfgawnl2b4r2aw";
+  };
+
+  preBuild = ''
+    cd src
+    substituteInPlace Makefile --replace "\$(DESTDIR)/usr" "$out"
+    substituteInPlace Makefile --replace "/local" ""
+  '';
+  
+  meta = {
+    description = "An offline WPS bruteforce utility";
+    homepage = https://github.com/wiire/pixiewps;
+    license = stdenv.lib.licenses.gpl3;
+    maintainer = stdenv.lib.maintainers.nico202;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/reaver-wps-t6x/default.nix
+++ b/pkgs/tools/networking/reaver-wps-t6x/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, libpcap, sqlite, pixiewps }:
+
+stdenv.mkDerivation rec {
+  version = "1.5.2";
+  name = "reaver-wps-t6x-${version}";
+
+  src = fetchFromGitHub {
+    owner = "t6x";
+    repo = "reaver-wps-fork-t6x";
+    rev = "v${version}";
+    sha256 = "0zhlms89ncqz1f1hc22yw9x1s837yv76f1zcjizhgn5h7vp17j4b";
+  };
+
+  buildInputs = [ libpcap sqlite pixiewps ];
+
+  prePatch = "cd src";
+
+  preInstall = "mkdir -p $out/bin";
+
+  meta = {
+    description = "Online and offline brute force attack against WPS";
+    homepage = https://github.com/t6x/reaver-wps-fork-t6x;
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.linux;
+    maintainer = stdenv.lib.maintainers.nico202;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3417,6 +3417,8 @@ in
   rtmpdump_gnutls = rtmpdump.override { gnutlsSupport = true; opensslSupport = false; };
 
   reaverwps = callPackage ../tools/networking/reaver-wps {};
+  
+  reaverwps-t6x = callPackage ../tools/networking/reaver-wps-t6x {};
 
   recordmydesktop = callPackage ../applications/video/recordmydesktop { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3222,6 +3222,8 @@ in
 
   pius = callPackage ../tools/security/pius { };
 
+  pixiewps = callPackage ../tools/networking/pixiewps {};
+
   pk2cmd = callPackage ../tools/misc/pk2cmd { };
 
   plantuml = callPackage ../tools/misc/plantuml { };


### PR DESCRIPTION
###### Motivation for this change

reaver-wps has been forked with some bugfix, and the fork supports pixiewps (faster and offline wps cracking).
I added both the packages, but the original version of reaver-wps is still present.
@viric Let me know what do you think
