### PR TITLE
hackage2nix: add hruby x86_64-linux to hydra

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -4518,7 +4518,7 @@ dont-distribute-packages:
   HROOT-io:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
   HROOT-math:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   HROOT:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  hruby:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
+  hruby:                                        [ i686-linux, x86_64-darwin ]
   hs-blake2:                                    [ i686-linux, x86_64-linux, x86_64-darwin ]
   hs-carbon-examples:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   hs-cdb:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
###### Motivation for this change

`hruby` has successfully built on Hydra before and it is a dependency required by language-puppet 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
