### PR TITLE
virtualbox-{systemd-detect-virt,net-hostonlyif} test: fix dbus socket dir

### DIFF
--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -11,10 +11,10 @@ let
       #!${pkgs.stdenv.shell} -xe
       export PATH="${lib.makeBinPath [ pkgs.coreutils pkgs.utillinux ]}"
 
-      mkdir -p /var/run/dbus
+      mkdir -p /run/dbus
       cat > /etc/passwd <<EOF
       root:x:0:0::/root:/bin/false
-      messagebus:x:1:1::/var/run/dbus:/bin/false
+      messagebus:x:1:1::/run/dbus:/bin/false
       EOF
       cat > /etc/group <<EOF
       root:x:0:


### PR DESCRIPTION
The test complains that

> Failed to start message bus: Failed to bind socket "/run/dbus/system_bus_socket": No such file or directory

In 639e5401ff51d4c0075b5ceffcbdbfec64c67db3, the dbus socket dir is set
to `/run/dbus`; in the test vm `/var/run/dbus` is used, but the standard
`/run -> /var/run` link is typically not created until stage 2 init, not
in the minimal init used here.  Thus, dbus fails to run within the test
environment .  Fix by changing `/var/run/dbus` to simply `/run/dbus`.
