### PR TITLE
lmdb: 0.9.16 -> 0.9.18

### DIFF
--- a/pkgs/development/libraries/lmdb/default.nix
+++ b/pkgs/development/libraries/lmdb/default.nix
@@ -3,11 +3,11 @@
 let optional = stdenv.lib.optional;
 in stdenv.mkDerivation rec {
   name = "lmdb-${version}";
-  version = "0.9.16";
+  version = "0.9.18";
 
   src = fetchzip {
     url = "https://github.com/LMDB/lmdb/archive/LMDB_${version}.tar.gz";
-    sha256 = "1lkmngscijwiz09gdkqygdp87x55vp8gb4fh4vq7s34k4jv0327l";
+    sha256 = "01j384kxg36kym060pybr5p6mjw0xv33bqbb8arncdkdq57xk8wg";
   };
 
   postUnpack = "sourceRoot=\${sourceRoot}/libraries/liblmdb";


### PR DESCRIPTION
###### Motivation for this change

Update.

Only broken reverse dep is 'caffe', which seems to be broken anyway.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
