### PR TITLE
hplip: use mkPythonDerivation

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -3,7 +3,7 @@
 , cups, zlib, libjpeg, libusb1, pythonPackages, sane-backends, dbus, usbutils
 , net_snmp, openssl, polkit
 , bash, coreutils, utillinux
-, qtSupport ? true, qt4
+, qtSupport ? true
 , withPlugin ? false
 }:
 
@@ -47,32 +47,27 @@ in
 assert withPlugin -> builtins.elem hplipArch pluginArches
   || throw "HPLIP plugin not supported on ${stdenv.system}";
 
-stdenv.mkDerivation {
+pythonPackages.mkPythonDerivation {
   inherit name src;
 
   buildInputs = [
     libjpeg
     cups
     libusb1
-    pythonPackages.python
-    pythonPackages.wrapPython
     sane-backends
     dbus
     net_snmp
     openssl
-  ] ++ stdenv.lib.optionals qtSupport [
-    qt4
   ];
 
   nativeBuildInputs = [
     pkgconfig
   ];
 
-  pythonPath = with pythonPackages; [
+  propagatedBuildInputs = with pythonPackages; [
     dbus
     pillow
     pygobject2
-    recursivePthLoader
     reportlab
     usbutils
   ] ++ stdenv.lib.optionals qtSupport [
@@ -149,32 +144,7 @@ stdenv.mkDerivation {
     rm $out/etc/udev/rules.d/56-hpmud.rules
   '';
 
-  fixupPhase = ''
-    # Wrap the user-facing Python scripts in $out/bin without turning the
-    # ones in $out /share into shell scripts (they need to be importable).
-    # Note that $out/bin contains only symlinks to $out/share.
-    for bin in $out/bin/*; do
-      py=`readlink -m $bin`
-      rm $bin
-      cp $py $bin
-      wrapPythonProgramsIn $bin "$out $pythonPath"
-      sed -i "s@$(dirname $bin)/[^ ]*@$py@g" $bin
-    done
-
-    # Remove originals. Knows a little too much about wrapPythonProgramsIn.
-    rm -f $out/bin/.*-wrapped
-
-    # Merely patching shebangs in $out/share does not cause trouble.
-    for i in $out/share/hplip{,/*}/*.py; do
-      substituteInPlace $i \
-        --replace /usr/bin/python \
-        ${pythonPackages.python}/bin/${pythonPackages.python.executable} \
-        --replace "/usr/bin/env python" \
-        ${pythonPackages.python}/bin/${pythonPackages.python.executable}
-    done
-
-    wrapPythonProgramsIn $out/lib "$out $pythonPath"
-
+  postFixup = ''
     substituteInPlace $out/etc/hp/hplip.conf --replace /usr $out
   '' + stdenv.lib.optionalString (!withPlugin) ''
     # A udev rule to notify users that they need the binary plugin.


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/19469 and https://github.com/NixOS/nixpkgs/issues/19878.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Use `mkPythonDerivation` since `hplip` is a Python package that doesn't use `setuptools`. Note that a
`setup.py` is provided, however, using `buildPythonPackage` fails.
