### PR TITLE
libdwarf: 20161001 -> 20161021 for CVE-2016-8679

### DIFF
--- a/pkgs/development/libraries/libdwarf/default.nix
+++ b/pkgs/development/libraries/libdwarf/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libelf }:
 
 stdenv.mkDerivation rec {
-  name = "libdwarf-20161001";
+  name = "libdwarf-20161021";
 
   src = fetchurl {
     url = "http://www.prevanders.net/${name}.tar.gz";
-    sha512 = "2c522ae0b6e2afffd09e2e79562987fd819b197c9bce4900b6a4fd176b5ff229e88c6b755cfbae7831e7160ddeb3bfe2afbf39d756d7e75ec31ace0668554048";
+    sha512 = "733523fd5c58f878d65949c1812b2f46b40c4cc3177bc780c703ec71f83675d4b84e81bc1bcca42adf69b5e122562e4ce8e9a8743af29cc6fafe78ed9f8213fd";
   };
 
   configureFlags = " --enable-shared --disable-nonshared";


### PR DESCRIPTION
###### Motivation for this change

http://www.securityfocus.com/bid/93601/info
https://lwn.net/Alerts/703955/
https://github.com/NixOS/nixpkgs/issues/19884
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
