### PR TITLE
libgit2: 0.24.1 -> 0.24.2 for CVE-2016-8568, CVE-2016-8569

### DIFF
--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pkgconfig, cmake, zlib, python, libssh2, openssl, curl, http-parser, libiconv }:
 
 stdenv.mkDerivation (rec {
-  version = "0.24.1";
+  version = "0.24.2";
   name = "libgit2-${version}";
 
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "https://github.com/libgit2/libgit2/tarball/v${version}";
-    sha256 = "0rw80480dx2f6a2wbb1bwixygg1iwq3r7vwhxdmkkf4lpxd35jhd";
+    sha256 = "0avijw83vfx64cn23vx2j1h14zmkx8silgjnq6q2qw2z3sh73hs1";
   };
 
   # TODO: `cargo` (rust's package manager) surfaced a serious bug in


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/19884
https://lwn.net/Vulnerabilities/703984/
https://github.com/libgit2/libgit2/releases
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
