### PR TITLE
kernel: 4.1.33 -> 4.1.35

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.1.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.1.33";
+  version = "4.1.35";
   extraMeta.branch = "4.1";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "15ms5mvvf0wpmscv8l5irp4j7j3l6k61hcjx9ln41pz6si00zj3l";
+    sha256 = "0jn09hs91d5fi6615v9fnbpggyh1x192q6faggpbb90q110g0jjl";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Motivation for this change
#19884
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
