### PR TITLE
irods: init at 4.2.0

### DIFF
--- a/pkgs/tools/filesystems/irods/common.nix
+++ b/pkgs/tools/filesystems/irods/common.nix
@@ -1,0 +1,57 @@
+{ stdenv, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp, boost, jansson, zeromq, openssl, pam, libiodbc, kerberos, gcc, libcxx, which }:
+
+# Common attributes of irods packages
+
+with stdenv;
+
+{
+  enableParallelBuilding = true;
+
+  buildInputs = [ bzip2 zlib autoconf automake cmake gnumake help2man texinfo libtool cppzmq libarchive avro-cpp jansson zeromq openssl pam libiodbc kerberos gcc boost libcxx which ];
+
+  propagateBuildInputs = [ boost ];
+
+  cmakeFlags = [
+    "-DIRODS_EXTERNALS_FULLPATH_CLANG=${stdenv.cc}"
+    "-DIRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME=${stdenv.cc}"
+    "-DIRODS_EXTERNALS_FULLPATH_ARCHIVE=${libarchive.lib}"
+    "-DIRODS_EXTERNALS_FULLPATH_AVRO=${avro-cpp}"
+    "-DIRODS_EXTERNALS_FULLPATH_BOOST=${boost}"
+    "-DIRODS_EXTERNALS_FULLPATH_JANSSON=${jansson}"
+    "-DIRODS_EXTERNALS_FULLPATH_ZMQ=${zeromq}"
+    "-DIRODS_EXTERNALS_FULLPATH_CPPZMQ=${cppzmq}"
+    "-DIRODS_LINUX_DISTRIBUTION_NAME=nix"
+    "-DIRODS_LINUX_DISTRIBUTION_VERSION_MAJOR=${builtins.nixVersion}"
+    "-DCPACK_GENERATOR=TGZ"
+    "-DCMAKE_CXX_FLAGS=-I${libcxx}/include/c++/v1"
+  ];
+
+  preConfigure = ''
+    patchShebangs ./packaging
+    patchShebangs ./scripts
+    substituteInPlace CMakeLists.txt --replace "DESTINATION usr/bin" "DESTINATION bin"
+    substituteInPlace CMakeLists.txt --replace "INCLUDE_DIRS usr/include/" "INCLUDE_DIRS include/"
+    substituteInPlace CMakeLists.txt --replace "DESTINATION usr/lib/" "DESTINATION lib/"
+    export cmakeFlags="$cmakeFlags
+      -DCMAKE_INSTALL_PREFIX=$out
+    "
+  '';
+
+  meta = {
+    description = "Integrated Rule-Oriented Data System (iRODS)";
+    longDescription = ''
+      The Integrated Rule-Oriented Data System (iRODS) is open source data management
+      software used by research organizations and government agencies worldwide.
+      iRODS is released as a production-level distribution aimed at deployment in mission
+      critical environments.  It virtualizes data storage resources, so users can take
+      control of their data, regardless of where and on what device the data is stored.
+      As data volumes grow and data services become more complex, iRODS is increasingly
+      important in data management. The development infrastructure supports exhaustive
+      testing on supported platforms; plug-in support for microservices, storage resources,
+      drivers, and databases; and extensive documentation, training and support services.'';
+    homepage = http://irods.org;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.bzizou ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -1,0 +1,84 @@
+{ stdenv, fetchurl, python, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp, boost, jansson, zeromq, openssl , pam, libiodbc, kerberos, gcc, libcxx, which }:
+
+with stdenv;
+
+let
+  common = import ./common.nix {
+    inherit stdenv bzip2 zlib autoconf automake cmake gnumake
+            help2man texinfo libtool cppzmq libarchive jansson
+            zeromq openssl pam libiodbc kerberos gcc libcxx
+            boost avro-cpp which;
+  };
+in rec {
+
+  # irods: libs and server package
+  irods = stdenv.mkDerivation (common // rec {
+    version = "4.2.0";
+    prefix = "irods";
+    name = "${prefix}-${version}";
+
+    src = fetchurl {
+      url = "https://github.com/irods/irods/releases/download/${version}/irods-${version}.tar.gz";
+      sha256 = "b5c0d7209219629da139058ce462a237ecc22ad4dae613413a428961e4ff9d3e";
+    };
+
+    # Patches:
+    # irods_root_path.patch : the root path is obtained by stripping 3 items of the path,
+    #                         but we don't use /usr with nix, so remove only 2 items.
+    patches = [ ./irods_root_path.patch ];
+
+    preConfigure = common.preConfigure + ''
+      patchShebangs ./test
+      substituteInPlace plugins/database/CMakeLists.txt --replace "COMMAND cpp" "COMMAND ${gcc.cc}/bin/cpp"
+      substituteInPlace cmake/server.cmake --replace "DESTINATION usr/sbin" "DESTINATION sbin"
+      substituteInPlace cmake/server.cmake --replace "IRODS_DOC_DIR usr/share" "IRODS_DOC_DIR share"
+      substituteInPlace cmake/runtime_library.cmake --replace "DESTINATION usr/lib" "DESTINATION lib"
+      substituteInPlace cmake/development_library.cmake --replace "DESTINATION usr/lib" "DESTINATION lib"
+      substituteInPlace cmake/development_library.cmake --replace "DESTINATION usr/include" "DESTINATION include"
+      export cmakeFlags="$cmakeFlags
+        -DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,$out/lib
+        -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath,$out/lib
+        -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-rpath,$out/lib
+        "
+    '';
+
+    meta = common.meta // {
+      longDescription = common.meta.longDescription + ''
+        This package provides the servers and libraries.'';
+    };
+  });
+
+
+  # icommands (CLI) package, depends on the irods package
+  irods-icommands = stdenv.mkDerivation (common // rec {
+     version = "4.2.0";
+     name = "irods-icommands-${version}";
+     src = fetchurl {
+       url = "http://github.com/irods/irods_client_icommands/archive/${version}.tar.gz";
+       sha256 = "b581067c8139b5ef7897f15fc1fc79f69d2e784a0f36d96e8fa3cb260b6378ce";
+     };
+
+     buildInputs = common.buildInputs ++ [ irods ];
+
+     propagateBuildInputs = [ boost ];
+
+     preConfigure = common.preConfigure + ''
+       patchShebangs ./bin
+     '';
+
+     cmakeFlags = common.cmakeFlags ++ [
+       "-DCMAKE_INSTALL_PREFIX=${out}"
+       "-DIRODS_DIR=${irods}/lib/irods/cmake"
+       "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
+       "-DCMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
+       "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
+    ];
+
+     meta = common.meta // {
+       description = common.meta.description + " CLI clients";
+       longDescription = common.meta.longDescription + ''
+         This package provides the CLI clients, called 'icommands'.'';
+     };
+  });
+}
+

--- a/pkgs/tools/filesystems/irods/irods_root_path.patch
+++ b/pkgs/tools/filesystems/irods/irods_root_path.patch
@@ -1,0 +1,11 @@
+--- a/lib/core/src/irods_default_paths.cpp	2016-10-24 17:09:02.955889536 +0200
++++ b/lib/core/src/irods_default_paths.cpp	2016-10-24 17:09:43.178722157 +0200
+@@ -18,7 +18,7 @@
+         try {
+             boost::filesystem::path path{dl_info.dli_fname};
+             path = boost::filesystem::canonical(path);
+-            path.remove_filename().remove_filename().remove_filename(); // Removes filename and the two directories (usr and lib) between libirods_common.so and base of irods install
++            path.remove_filename().remove_filename(); // Removes filename and the two directories (usr and lib) between libirods_common.so and base of irods install
+             return path;
+         } catch(const boost::filesystem::filesystem_error& e) {
+             THROW(-1, e.what());

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2203,6 +2203,14 @@ in
 
   ifuse = callPackage ../tools/filesystems/ifuse/default.nix { };
 
+  inherit (callPackages ../tools/filesystems/irods rec {
+            stdenv = llvmPackages_38.libcxxStdenv;
+            libcxx = llvmPackages_38.libcxx;
+            boost = boost160.override { inherit stdenv; };
+          })
+      irods
+      irods-icommands;
+
   ignition = recurseIntoAttrs {
 
     math = callPackage ../development/libraries/ignition-math { };


### PR DESCRIPTION
###### Motivation for this change

New packages for the iRods filesystem http://irods.org/

###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
