### PR TITLE
xen service: fix wrong netmask handed out by xen-bridge.service

### DIFF
--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -324,7 +324,7 @@ in
         domain-needed
         dhcp-hostsfile=/var/run/xen/dnsmasq.etherfile
         dhcp-authoritative
-        dhcp-range=$XEN_BRIDGE_IP_RANGE_START,$XEN_BRIDGE_IP_RANGE_END,$XEN_BRIDGE_NETWORK_ADDRESS
+        dhcp-range=$XEN_BRIDGE_IP_RANGE_START,$XEN_BRIDGE_IP_RANGE_END
         dhcp-no-override
         no-ping
         dhcp-leasefile=/var/run/xen/dnsmasq.leasefile


### PR DESCRIPTION
###### Motivation for this change

The xen-bridge.service serves an invalid netmask over DHCP to VMs, as described in #19883. Fix it by omitting the option specifying the netmask from dnsmasq.conf used by the dnsmasq of xen-bridge.service.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The dnsmasq instance run by the xen-bridge.service errorenously
hands out 172.16.0.0 as the netmask over DHCP to the VMs. This
commit removes the option responsible for that from dnsmasq.conf,
so that the proper netmask is inferred by dnsmasq instead.

Addresses https://github.com/NixOS/nixpkgs/issues/19883
