### PR TITLE
yices: 2.3.1 -> 2.5.1, run tests and build parallel

### DIFF
--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name    = "yices-${version}";
-  version = "2.3.1";
+  version = "2.5.1";
 
   src = fetchurl {
-    url = "http://yices.csl.sri.com/cgi-bin/yices2-newnewdownload.cgi?file=yices-2.3.1-src.tar.gz&accept=I+Agree";
+    url = "http://yices.csl.sri.com/cgi-bin/yices2-newnewdownload.cgi?file=yices-${version}-src.tar.gz&accept=I+Agree";
     name = "yices-${version}-src.tar.gz";
-    sha256 = "1da70n0cah0dh3pk7fcrvjkszx9qmhc0csgl15jqa7bdh707k2zs";
+    sha256 = "1wfq6hcm54h0mqmbs1ip63i0ywlwnciav86sbzk3gafxyzg1nd0c";
   };
 
   configureFlags = [ "--with-static-gmp=${gmp-static.out}/lib/libgmp.a"

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -10,10 +10,15 @@ stdenv.mkDerivation rec {
     sha256 = "1wfq6hcm54h0mqmbs1ip63i0ywlwnciav86sbzk3gafxyzg1nd0c";
   };
 
+  patchPhase = ''patchShebangs tests/regress/check.sh'';
+
   configureFlags = [ "--with-static-gmp=${gmp-static.out}/lib/libgmp.a"
                      "--with-static-gmp-include-dir=${gmp-static.dev}/include"
                    ];
   buildInputs = [ gmp-static gperf autoreconfHook ];
+
+  enableParallelBuilding = true;
+  doCheck = true;
 
   installPhase = ''make install LDCONFIG=true'';
 

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
                    ];
   buildInputs = [ gmp-static gperf autoreconfHook ];
 
+  installPhase = ''make install LDCONFIG=true'';
+
   meta = {
     description = "A high-performance theorem prover and SMT solver";
     homepage    = "http://yices.csl.sri.com";

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -22,11 +22,11 @@ stdenv.mkDerivation rec {
 
   installPhase = ''make install LDCONFIG=true'';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A high-performance theorem prover and SMT solver";
     homepage    = "http://yices.csl.sri.com";
-    license     = stdenv.lib.licenses.unfreeRedistributable;
-    platforms   = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    license     = licenses.unfreeRedistributable;
+    platforms   = platforms.linux ++ platforms.darwin;
+    maintainers = [ maintainers.thoughtpolice ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update and some minor improvements (parallel building, run tests).
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
