### PR TITLE
sysdig: 0.10.0 -> 0.12.0

### DIFF
--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -1,26 +1,19 @@
-{stdenv, fetchurl, fetchFromGitHub, cmake, luajit, kernel, zlib, ncurses, perl, jsoncpp, libb64, openssl, curl}:
+{stdenv, fetchurl, fetchFromGitHub, cmake, luajit, kernel, zlib, ncurses, perl, jsoncpp, libb64, openssl, curl, jq, gcc}:
 let
   inherit (stdenv.lib) optional optionalString;
   baseName = "sysdig";
-  version = "0.10.0";
-  # sysdig-0.11.0 depends on some headers from jq which are not
-  # installed by default.
-  # Relevant sysdig issue: https://github.com/draios/sysdig/issues/626
-  jq-prefix = fetchurl {
-    url="https://github.com/stedolan/jq/releases/download/jq-1.5/jq-1.5.tar.gz";
-    sha256="0g29kyz4ykasdcrb0zmbrp2jqs9kv1wz9swx849i2d1ncknbzln4";
-  };
+  version = "0.12.0";
 in
 stdenv.mkDerivation {
   name = "${baseName}-${version}";
 
   src = fetchurl {
     url = "https://github.com/draios/sysdig/archive/${version}.tar.gz";
-    sha256 = "0hs0r9z9j7padqdcj69bwx52iw6gvdl0w322qwivpv12j3prcpsj";
+    sha256 = "17nf2h5ajy333rwh91hzaw8zq2mnkb3lxy8fmbbs8qazgsvwz6c3";
   };
 
   buildInputs = [
-    cmake zlib luajit ncurses perl jsoncpp libb64 openssl curl
+    cmake zlib luajit ncurses perl jsoncpp libb64 openssl curl jq gcc
   ];
 
   hardeningDisable = [ "pic" ];
@@ -31,7 +24,6 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     "-DUSE_BUNDLED_DEPS=OFF"
-    "-DUSE_BUNDLED_JQ=ON"
     "-DSYSDIG_VERSION=${version}"
   ] ++ optional (kernel == null) "-DBUILD_DRIVER=OFF";
 
@@ -41,12 +33,23 @@ stdenv.mkDerivation {
     export KERNELDIR="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   '';
 
-  preBuild = ''
-    mkdir -p jq-prefix/src
-    cp ${jq-prefix} jq-prefix/src/jq-1.5.tar.gz
-  '';
+  libPath = stdenv.lib.makeLibraryPath [
+    zlib
+    luajit
+    ncurses
+    jsoncpp
+    curl
+    jq
+    openssl
+    libb64
+    gcc
+    stdenv.cc.cc
+  ];
 
-  postInstall = optionalString (kernel != null) ''
+  postInstall = ''
+    patchelf --set-rpath "$libPath" "$out/bin/sysdig"
+    patchelf --set-rpath "$libPath" "$out/bin/csysdig"
+  '' + optionalString (kernel != null) ''
     make install_driver
     kernel_dev=${kernel.dev}
     kernel_dev=''${kernel_dev#/nix/store/}


### PR DESCRIPTION
###### Motivation for this change

Sysdig v12 has lots of awesome new features.  :)
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
