### PR TITLE
Add libsndfile and flac as dependencies

### DIFF
--- a/pkgs/applications/audio/openmpt123/default.nix
+++ b/pkgs/applications/audio/openmpt123/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL2, pkgconfig }:
+{ stdenv, fetchurl, SDL2, pkgconfig, flac, libsndfile }:
 
 let
   version = "0.2.7025-beta20.1";
@@ -8,7 +8,7 @@ in stdenv.mkDerivation rec {
     url = "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}.tar.gz";
     sha256 = "0qp2nnz6pnl1d7yv9hcjyim7q6yax5881k1jxm8jfgjqagmz5k6p";
   };
-  buildInputs = [ SDL2 pkgconfig ];
+  buildInputs = [ SDL2 pkgconfig flac libsndfile ];
   makeFlags = [ "NO_LTDL=1 TEST=0 EXAMPLES=0" ]
   ++ stdenv.lib.optional (stdenv.isDarwin) "SHARED_SONAME=0";
   installFlags = "PREFIX=\${out}";


### PR DESCRIPTION
###### Motivation for this change

Adding these libraries as dependencies allows openmpt123 to convert the modules to .wav files instead of playing them back in real time.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This allows openmpt123 to convert modules to .wav files
