### PR TITLE
numpy: enable numpy.distutils patch only if it's also in distutils

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -39,6 +39,7 @@ let
     sha256 = "0y7rl603vmwlxm6ilkhc51rx2mfj14ckcz40xxgs0ljnvlhp30yp";
   };
 
+  hasDistutilsCxxPatch = !(stdenv.cc.isGNU or false);
   patches =
     [ # Look in C_INCLUDE_PATH and LIBRARY_PATH for stuff.
       ./search-path.patch
@@ -82,7 +83,7 @@ let
       ./2.7.3-dylib.patch
       ./2.7.3-getpath-exe-extension.patch
       ./2.7.3-no-libm.patch
-    ] ++ optionals (!(stdenv.cc.isGNU or false)) [
+    ] ++ optionals hasDistutilsCxxPatch [
 
       # Patch from http://bugs.python.org/issue1222585 adapted to work with
       # `patch -p1' and with a last hunk removed
@@ -180,7 +181,7 @@ in stdenv.mkDerivation {
       '';
 
     passthru = rec {
-      inherit libPrefix sitePackages x11Support;
+      inherit libPrefix sitePackages x11Support hasDistutilsCxxPatch;
       executable = libPrefix;
       buildEnv = callPackage ../../wrapper.nix { python = self; };
       withPackages = import ../../with-packages.nix { inherit buildEnv; pythonPackages = python27Packages; };

--- a/pkgs/development/python-modules/numpy.nix
+++ b/pkgs/development/python-modules/numpy.nix
@@ -12,7 +12,7 @@ in buildPythonPackage (args // rec {
   buildInputs = args.buildInputs or [ gfortran nose ];
   propagatedBuildInputs = args.propagatedBuildInputs or [ passthru.blas ];
 
-  patches = lib.optionals isPy27 [
+  patches = lib.optionals (python.hasDistutilsCxxPatch or false) [
     # See cpython 2.7 patches.
     # numpy.distutils is used by cython during it's check phase
     ./numpy-distutils-C++.patch


### PR DESCRIPTION
###### Motivation for this change

Fix a bug in #19585
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes: 095095c ('python: add C++ compiler support for distutils')
Cc: @FRidh 
