### PR TITLE
busybox: 1.24.2 -> 1.25.1

### DIFF
--- a/pkgs/os-specific/linux/busybox/busybox-in-store.patch
+++ b/pkgs/os-specific/linux/busybox/busybox-in-store.patch
@@ -1,15 +1,14 @@
 Allow BusyBox to be invoked as "<something>-busybox". This is
 necessary when it's run from the Nix store as <hash>-busybox during
 stdenv bootstrap.
-
---- busybox-1.24.2-orig/libbb/appletlib.c	2016-03-17 21:35:49.000000000 +0100
-+++ busybox-1.24.2/libbb/appletlib.c	2016-09-25 08:48:18.293104041 +0200
-@@ -779,7 +779,7 @@
- 	int applet = find_applet_by_name(name);
- 	if (applet >= 0)
- 		run_applet_no_and_exit(applet, argv);
+--- busybox-1.25.1-orig/libbb/appletlib.orig	2016-10-26 19:54:20.510957575 -0400
++++ busybox-1.25.1/libbb/appletlib.c	2016-10-26 19:48:31.590862853 -0400
+@@ -884,7 +884,7 @@
+ 	int applet;
+ 
+ # if ENABLE_BUSYBOX
 -	if (is_prefixed_with(name, "busybox"))
 +	if (strstr(name, "busybox") != 0)
  		exit(busybox_main(argv));
- }
- 
+ # endif
+ 	/* find_applet_by_name() search is more expensive, so goes second */

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -26,11 +26,11 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "busybox-1.24.2";
+  name = "busybox-1.25.1";
 
   src = fetchurl {
     url = "http://busybox.net/downloads/${name}.tar.bz2";
-    sha256 = "0mf8f6ly8yi1fbr15jkyv6hxwh2x800x661rcd11rwsnqqzga7p7";
+    sha256 = "0bm0l8xdjdz3kdyajp8wg27yamsw7r2y88nnrxwvvz984c7pwri7";
   };
 
   hardeningDisable = [ "format" ] ++ lib.optional enableStatic [ "fortify" ];


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of **SOME** binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Pinging @Mic92 @joachifm @zimbatm @edolstra because they were part of the last busybox PR #18943
