### PR TITLE
flashplayer: 11.2.202.637 -> 11.2.202.643 [Critical security fix]

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer-11/default.nix
@@ -70,11 +70,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "11.2.202.637";
+  version = "11.2.202.643";
 
   src = fetchurl {
     url = "https://fpdownload.macromedia.com/pub/flashplayer/installers/archive/fp_${version}_archive.zip";
-    sha256 = "0xp1pxhrnam4yi8wfwaifqx7m2im0zx2xv8xgbdm0llrzbkc57mh";
+    sha256 = "02imhdzhali42m8d1rw3bqscvi70707mssss7c43dm2kf67z6y8s";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

Critical security fix. Needs backporting.

https://helpx.adobe.com/security/products/flash-player/apsb16-36.html
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
