### PR TITLE
kafka: 0.10.0.1 -> 0.10.1.0

### DIFF
--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -11,9 +11,9 @@ let
               scalaVersion = "2.11";
               sha256 = "0ykcjv5dz9i5bws9my2d60pww1g9v2p2nqr67h0i2xrjm7az8a6v";
             };
-    "0.10" = { kafkaVersion = "0.10.0.1";
+    "0.10" = { kafkaVersion = "0.10.1.0";
                scalaVersion = "2.11";
-               sha256 = "0bdhzbhmm87a47162hyazcjmfibqg9r3ryzfjag7r0nxxmd64wrd";
+               sha256 = "144k6bqg8q8f3x3nk05hvaaad8xa32qjifg785i15j69cnp355bd";
              };
   };
 in


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
