### PR TITLE
corosync: 2.3.4 -> 2.4.1

### DIFF
--- a/pkgs/servers/corosync/default.nix
+++ b/pkgs/servers/corosync/default.nix
@@ -7,11 +7,11 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "corosync-2.3.4";
+  name = "corosync-2.4.1";
 
   src = fetchurl {
     url = "http://build.clusterlabs.org/corosync/releases/${name}.tar.gz";
-    sha256 = "1m276b060fjghr93hdzfag81whi5ph65dc2ka8ln1igm3kxr7bix";
+    sha256 = "0w8m97ih7a2g99pmjsckw4xwbgzv96xdgg62s2a4qbgnw4yl637y";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
