### PR TITLE
openslp: patch for CVE-2016-7567

### DIFF
--- a/pkgs/development/libraries/openslp/default.nix
+++ b/pkgs/development/libraries/openslp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation {
   name = "openslp-2.0.0";
@@ -7,6 +7,19 @@ stdenv.mkDerivation {
     url = "mirror://sourceforge/openslp/2.0.0/2.0.0/openslp-2.0.0.tar.gz";
     sha256 = "16splwmqp0400w56297fkipaq9vlbhv7hapap8z09gp5m2i3fhwj";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "openslp-2.0.0-null-pointer-deref.patch";
+      url = "https://svnweb.mageia.org/packages/cauldron/openslp/current/SOURCES/openslp-2.0.0-null-pointer-deref.patch?revision=1019712&view=co";
+      sha256 = "186f3rj3z2lf5h1lpbhqk0szj2a9far1p3mjqg6422f29yjfnz6a";
+    })
+    (fetchpatch {
+      name = "openslp-2.0.0-CVE-2016-7567.patch";
+      url = "https://svnweb.mageia.org/packages/cauldron/openslp/current/SOURCES/openslp-2.0.0-CVE-2016-7567.patch?revision=1057233&view=co";
+      sha256 = "1zrgql91vjjl2v7brlibc8jqndnjz9fclqbdn0b6fklkpwznprny";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = "http://openslp.org/";


### PR DESCRIPTION
###### Motivation for this change

https://svnweb.mageia.org/packages/cauldron/openslp/current/
https://github.com/NixOS/nixpkgs/issues/19884
https://lwn.net/Vulnerabilities/704249/
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
