### PR TITLE
duplicity: updated dependencies

### DIFF
--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -3,7 +3,7 @@
 
 let
   version = "0.7.07.1";
-  inherit (python2Packages) boto ecdsa lockfile paramiko pycrypto python setuptools;
+  inherit (python2Packages) boto cffi cryptography ecdsa enum idna ipaddress lockfile paramiko pyasn1 pycrypto python setuptools six;
 in stdenv.mkDerivation {
   name = "duplicity-${version}";
 
@@ -15,10 +15,10 @@ in stdenv.mkDerivation {
   installPhase = ''
     python setup.py install --prefix=$out
     wrapProgram $out/bin/duplicity \
-      --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${pycrypto}):$(toPythonPath ${ecdsa}):$(toPythonPath ${paramiko}):$(toPythonPath ${boto}):$(toPythonPath ${lockfile})" \
+      --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${idna}):$(toPythonPath ${cffi}):$(toPythonPath ${ipaddress}):$(toPythonPath ${pyasn1}):$(toPythonPath ${six}):$(toPythonPath ${enum}):$(toPythonPath ${setuptools}):$(toPythonPath ${cryptography}):$(toPythonPath ${pycrypto}):$(toPythonPath ${ecdsa}):$(toPythonPath ${paramiko}):$(toPythonPath ${boto}):$(toPythonPath ${lockfile})" \
       --prefix PATH : "${stdenv.lib.makeBinPath [ gnupg ncftp rsync ]}"
     wrapProgram $out/bin/rdiffdir \
-      --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${pycrypto}):$(toPythonPath ${ecdsa}):$(toPythonPath ${paramiko}):$(toPythonPath ${boto}):$(toPythonPath ${lockfile})"
+      --prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${idna}):$(toPythonPath ${cffi}):$(toPythonPath ${ipaddress}):$(toPythonPath ${pyasn1}):$(toPythonPath ${six}):$(toPythonPath ${enum}):$(toPythonPath ${setuptools}):$(toPythonPath ${cryptography}):$(toPythonPath ${pycrypto}):$(toPythonPath ${ecdsa}):$(toPythonPath ${paramiko}):$(toPythonPath ${boto}):$(toPythonPath ${lockfile})"
   '';
 
   buildInputs = [ python librsync makeWrapper setuptools ];


### PR DESCRIPTION
###### Motivation for this change

See #18112
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

fixes #18112
https://github.com/NixOS/nixpkgs/issues/18112
