### PR TITLE
pythonPackages.fasteners: 0.13.0 -> 0.14.1

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17109,11 +17109,11 @@ in modules // {
 
   fasteners = buildPythonPackage rec {
     name = "fasteners-${version}";
-    version = "0.13.0";
+    version = "0.14.1";
 
     src = pkgs.fetchurl {
-      url = "mirror://pypi/f/fasteners/fasteners-0.13.0.tar.gz";
-      sha256 = "0nghdq3zihiqg10dp76ls7yn44m5wjncyz7fk8isagkrspkh9a3n";
+      url = "mirror://pypi/f/fasteners/${name}.tar.gz";
+      sha256 = "063y20kx01ihbz2mziapmjxi2cd0dq48jzg587xdsdp07xvpcz22";
     };
 
     propagatedBuildInputs = with self; [ six monotonic testtools ];


### PR DESCRIPTION
###### Motivation for this change

Need this package version greater or equal to 0.14.1 to submit a new python package `conan`
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Did't perform a complete test of binaries. It seems that they work but all of them are services and require additional configurations. List of them:

```
lrwxrwxrwx 1 igor users 55 Oct 27 19:26 result -> /nix/store/8rl4y5w7m5r2c9zp7vldsn7b980yramq-nova-12.0.0
lrwxrwxrwx 1 igor users 68 Oct 27 19:26 result-10 -> /nix/store/rif3phda9zicz8bfvl9xabh4f0whmncq-python2.7-os-brick-0.5.0
lrwxrwxrwx 1 igor users 82 Oct 27 19:26 result-11 -> /nix/store/sdhi2ib2c1c795ixdxxzx5arfv3hjzff-python2.7-oslo.versionedobjects-0.11.0
lrwxrwxrwx 1 igor users 78 Oct 27 19:26 result-12 -> /nix/store/fz1nb6rcn9il9b0qz1ppimgqczxkhlqg-python2.7-keystonemiddleware-2.4.1
lrwxrwxrwx 1 igor users 72 Oct 27 19:26 result-13 -> /nix/store/3fh8zv6kq2l6xwzw47k0y110rwflp9m9-python2.7-oslo.vmware-1.22.0
lrwxrwxrwx 1 igor users 57 Oct 27 19:26 result-2 -> /nix/store/zmh6fglzxsxfkq5zl3y74phr0b2nxzxk-glance-11.0.0
lrwxrwxrwx 1 igor users 69 Oct 27 19:26 result-3 -> /nix/store/g6335s33dbfim8l24nf1dghssjcyg8ny-python2.7-taskflow-1.23.0
lrwxrwxrwx 1 igor users 76 Oct 27 19:26 result-4 -> /nix/store/dzpshwlwa6jr0j8sh34f7dazzfdkvglm-python2.7-oslo-concurrency-2.7.0
lrwxrwxrwx 1 igor users 74 Oct 27 19:26 result-5 -> /nix/store/p7xh6h6bq1y9zkrd9fj1q1w792w2kmdm-python2.7-oslo.messaging-2.7.0
lrwxrwxrwx 1 igor users 58 Oct 27 19:26 result-6 -> /nix/store/sv596d0392877jaw7sikdnfs8cwxbs42-keystone-8.0.0
lrwxrwxrwx 1 igor users 72 Oct 27 19:26 result-7 -> /nix/store/icnb1b150jqlhx3q4yjp4pv3m9qfw7rg-python2.7-glance_store-0.9.1
lrwxrwxrwx 1 igor users 70 Oct 27 19:26 result-8 -> /nix/store/h35s4rw7gq4nlzh8xsr5kia3ag48silb-python2.7-fasteners-0.14.1
lrwxrwxrwx 1 igor users 73 Oct 27 19:26 result-9 -> /nix/store/fjjy9w5jl7bq77knjdc2dxm4vhy6xakn-python2.7-oslo.service-0.10.0
```
