### PR TITLE
ipfs: i20160112 -> 0.4.4, fetchgx

### DIFF
--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, gx, gx-go }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchgx }:
 
 buildGoPackage rec {
   name = "ipfs-${version}";
@@ -7,6 +7,13 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/ipfs/go-ipfs";
 
+  extraSrcPaths = [
+    (fetchgx {
+      inherit name src;
+      sha256 = "0mm1rs2mbs3rmxfcji5yal9ai3v1w75kk05bfyhgzmcjvi6lwpyb";
+    })
+  ];
+
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "go-ipfs";
@@ -14,15 +21,11 @@ buildGoPackage rec {
     sha256 = "06iq7fmq7p0854aqrnmd0f0jvnxy9958wvw7ibn754fdfii9l84l";
   };
 
-  buildInputs = [ gx gx-go ];
-
-  # Extra build step for gx dependecies
-  preBuild = ''
-    (cd "go/src/${goPackagePath}"; gx install)
-  '';
-
   meta = with stdenv.lib; {
     description = "A global, versioned, peer-to-peer filesystem";
+    homepage = https://ipfs.io/;
     license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, gx, gx-go }:
 
 buildGoPackage rec {
   name = "ipfs-${version}";
-  version = "i20160112--${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "7070b4d878baad57dcc8da80080dd293aa46cabd";
+  version = "0.4.4";
+  rev = "d905d485192616abaea25f7e721062a9e1093ab9";
 
   goPackagePath = "github.com/ipfs/go-ipfs";
 
@@ -11,12 +11,18 @@ buildGoPackage rec {
     owner = "ipfs";
     repo = "go-ipfs";
     inherit rev;
-    sha256 = "1b7aimnbz287fy7p27v3qdxnz514r5142v3jihqxanbk9g384gcd";
+    sha256 = "06iq7fmq7p0854aqrnmd0f0jvnxy9958wvw7ibn754fdfii9l84l";
   };
+
+  buildInputs = [ gx gx-go ];
+
+  # Extra build step for gx dependecies
+  preBuild = ''
+    (cd "go/src/${goPackagePath}"; gx install)
+  '';
 
   meta = with stdenv.lib; {
     description = "A global, versioned, peer-to-peer filesystem";
     license = licenses.mit;
-    broken = true;
   };
 }

--- a/pkgs/build-support/fetchgx/default.nix
+++ b/pkgs/build-support/fetchgx/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, gx, gx-go, go, cacert }:
+
+{ name, src, sha256 }:
+
+stdenv.mkDerivation {
+  name = "${name}-gxdeps";
+  inherit src;
+
+  buildInputs = [ go gx gx-go ];
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = sha256;
+
+  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  buildPhase = ''
+    export GOPATH=$(pwd)/vendor
+    mkdir vendor
+    gx install
+  '';
+
+  installPhase = ''
+    mv vendor $out
+  '';
+
+  preferLocalBuild = true;
+}

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -1,4 +1,4 @@
-{ go, govers, parallel, lib, fetchgit, fetchhg }:
+{ go, govers, parallel, lib, fetchgit, fetchhg, rsync }:
 
 { name, buildInputs ? [], nativeBuildInputs ? [], passthru ? {}, preFixup ? ""
 
@@ -16,6 +16,10 @@
 
 # Extra sources to include in the gopath
 , extraSrcs ? [ ]
+
+# Extra gopaths containing src subfolder
+# with sources to include in the gopath
+, extraSrcPaths ? [ ]
 
 # go2nix dependency file
 , goDeps ? null
@@ -85,6 +89,9 @@ go.stdenv.mkDerivation (
     chmod -R u+w goPath/*
     mv goPath/* "go/src/${goPackagePath}"
     rmdir goPath
+
+  '') + (lib.optionalString (extraSrcPaths != []) ''
+    ${rsync}/bin/rsync -a ${lib.concatMapStrings (p: "${p}/src") extraSrcPaths} go
 
   '') + ''
     export GOPATH=$NIX_BUILD_TOP/go:$GOPATH

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -250,6 +250,8 @@ in
   fetchNuGet = callPackage ../build-support/fetchnuget { };
   buildDotnetPackage = callPackage ../build-support/build-dotnet-package { };
 
+  fetchgx = callPackage ../build-support/fetchgx { };
+
   resolveMirrorURLs = {url}: fetchurl {
     showURLs = true;
     inherit url;


### PR DESCRIPTION
###### Motivation for this change
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)

_BUT_
-> the build process fails with

```
ERROR: [33 / 33 ] parallel fetch: failed to fetch package: [..] dial tcp: lookup ipfs.io on [::1]:53: read udp [::1]:33704->[::1]:53: read: connection refused
```

So it seems that DNS requests by `gx` do not work inside the sandbox. Does somebody have an idea why and how to fix that?
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

- switched from rev to official release
- added preBuild to install gx dependencies
- removed broken flag

Signed-off-by: Maximilian Güntner code@klandest.in
