### PR TITLE
pythonPackages.passlib: 1.6.2 -> 1.6.5

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8144,12 +8144,12 @@ in modules // {
   };
 
   passlib = buildPythonPackage rec {
-    version = "1.6.2";
+    version = "1.6.5";
     name    = "passlib-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/passlib/passlib-${version}.tar.gz";
-      sha256 = "e987f6000d16272f75314c7147eb015727e8532a3b747b1a8fb58e154c68392d";
+      sha256 = "1z27wdxs5rj5xhhqfzvzn3yg682irkxw6dcs5jj7mcf97psk8gd8";
     };
 
     buildInputs = with self; [ nose pybcrypt];


### PR DESCRIPTION
###### Motivation for this change

A new python package `conan` needs this update.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Only `keystone` need this package. It starts successfully:

```
[20:08] igor@nixos-pc nixpkgs (passlib *) $ /run/user/1000/nox-review-98f6fs_p/result-3/bin/keystone-all --config-dir /run/user/1000/nox-review-98f6fs_p/result-3/etc/
2016-10-27 20:08:36.795 7240 WARNING root [-] Running keystone via eventlet is deprecated as of Kilo in favor of running in a WSGI server (e.g. mod_wsgi). Support for keystone under eventlet will be removed in the "M"-Release.
2016-10-27 20:08:36.796 7240 INFO keystone.common.environment.eventlet_server [-] Starting keystone-all on 0.0.0.0:35357
2016-10-27 20:08:36.796 7240 INFO oslo_service.service [-] Starting 8 workers
2016-10-27 20:08:36.798 7240 INFO oslo_service.service [-] Started child 7245
2016-10-27 20:08:36.800 7245 INFO eventlet.wsgi.server [-] (7245) wsgi starting up on http://0.0.0.0:35357/
2016-10-27 20:08:36.801 7240 INFO oslo_service.service [-] Started child 7246
2016-10-27 20:08:36.803 7246 INFO eventlet.wsgi.server [-] (7246) wsgi starting up on http://0.0.0.0:35357/
2016-10-27 20:08:36.803 7240 INFO oslo_service.service [-] Started child 7247
2016-10-27 20:08:36.805 7247 INFO eventlet.wsgi.server [-] (7247) wsgi starting up on http://0.0.0.0:35357/
2016-10-27 20:08:36.806 7240 INFO oslo_service.service [-] Started child 7248
2016-10-27 20:08:36.807 7248 INFO eventlet.wsgi.server [-] (7248) wsgi starting up on http://0.0.0.0:35357/
2016-10-27 20:08:36.808 7240 INFO oslo_service.service [-] Started child 7249
2016-10-27 20:08:36.810 7249 INFO eventlet.wsgi.server [-] (7249) wsgi starting up on http://0.0.0.0:35357/
2016-10-27 20:08:36.810 7240 INFO oslo_service.service [-] Started child 7250
...
```
