### PR TITLE
WIP: pythonPackages.pyjwt: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15800,7 +15800,7 @@ in modules // {
 
     buildInputs = with self; [ mock nose unittest2 ];
 
-    propagatedBuildInputs = with self; [ pycrypto blinker pyjwt ];
+    propagatedBuildInputs = with self; [ pycrypto blinker pyjwt_1_4 ];
 
     meta = {
       homepage = https://github.com/idan/oauthlib;
@@ -19958,12 +19958,12 @@ in modules // {
   };
 
   pyjwt = buildPythonPackage rec {
-    version = "1.4.0";
+    version = "1.4.2";
     name = "pyjwt-${version}";
 
     src = pkgs.fetchurl {
       url = "http://github.com/progrium/pyjwt/archive/${version}.tar.gz";
-      sha256 = "118rzhpyvx1h4hslms4fdizyv6mnyd4g34fv089lvs116pj08k9c";
+      sha256 = "06vg84aicwkv0kli8i4jhg0kc6298cmh38ib058q01yxzk6q17gn";
     };
 
     propagatedBuildInputs = with self; [ pycrypto ecdsa ];
@@ -19977,6 +19977,21 @@ in modules // {
       maintainers = with maintainers; [ prikhi ];
       platforms = platforms.unix;
     };
+  };
+
+  # oauthlib 0.7.2 works with PyJWT==1.4.0
+  pyjwt_1_4 = buildPythonPackage rec {
+    version = "1.4.0";
+    name = "pyjwt-${version}";
+
+    src = pkgs.fetchurl {
+      url = "http://github.com/progrium/pyjwt/archive/${version}.tar.gz";
+      sha256 = "118rzhpyvx1h4hslms4fdizyv6mnyd4g34fv089lvs116pj08k9c";
+    };
+
+    propagatedBuildInputs = with self; [ pycrypto ecdsa ];
+
+    inherit (self.pyjwt) meta;
   };
 
   pykickstart = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

1.4.0 version has wrong version of installed package:

``` bash
[22:22] igor@nixos-pc nixpkgs (pyjwt *) $ ls /nix/store/iic4b8zv78rplx4gs5vmadsadxaf1j9n-python3.5-pyjwt-1.4.0/lib/python3.5/site-packages/
jwt  PyJWT-0.3.2.dist-info
```

1.4.2 version fixes this:

```
[22:20] igor@nixos-pc nixpkgs (pyjwt *) $ ls /nix/store/p5qs5qy1n6vsr953svzzbakw3z8w30dp-python3.5-pyjwt-1.4.2/lib/python3.5/site-packages/
jwt  PyJWT-1.4.2.dist-info
```
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Full list of dependent:

``` sh
lrwxrwxrwx 1 igor users 54 Oct 27 22:16 result -> /nix/store/1299ncg4sbhjknip34bqyr4w1vx5dnw2-nixops-1.4
lrwxrwxrwx 1 igor users 64 Oct 27 22:16 result-2 -> /nix/store/fq2569s0i3zgqq1ba8p9bnlsb6nd9jx7-python2.7-adal-0.1.0
lrwxrwxrwx 1 igor users 65 Oct 27 22:16 result-3 -> /nix/store/iic4b8zv78rplx4gs5vmadsadxaf1j9n-python3.5-pyjwt-1.4.0
lrwxrwxrwx 1 igor users 65 Oct 27 22:16 result-4 -> /nix/store/va98gqj0sdlp2qw2q37qijigrms95gjc-python2.7-pyjwt-1.4.0
lrwxrwxrwx 1 igor users 64 Oct 27 22:16 result-5 -> /nix/store/3rrrxxf893fj4lxiw9h5fgwf833kh6df-python3.5-adal-0.1.0
lrwxrwxrwx 1 igor users 65 Oct 27 22:16 result-6 -> /nix/store/4bdp2lk5fss6q3h8wg9gs7y86g7p4qfc-python2.7-pyjwt-1.4.2
lrwxrwxrwx 1 igor users 65 Oct 27 22:16 result-7 -> /nix/store/p5qs5qy1n6vsr953svzzbakw3z8w30dp-python3.5-pyjwt-1.4.2
```

Test binaries:

``` bash
[22:16] igor@nixos-pc nixpkgs (pyjwt *) $ /run/user/1000/nox-review-byezun16/result/bin/nixops list-generations
error: could not find specified deployment in state file ‘/home/igor/.nixops/deployments.nixops’
[22:17] igor@nixos-pc nixpkgs (pyjwt *) ✗ (1) $ /run/user/1000/nox-review-byezun16/result-3/bin/jwt --key=secret foo=bar message=hello exp=+1000
b'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXNzYWdlIjoiaGVsbG8iLCJleHAiOjE0Nzc1OTY5MDMsImZvbyI6ImJhciJ9.Zz3Z2HSDzH5dWt52HGfJF5pGlWiuzBmdQGF-DRe89l4'
[22:18] igor@nixos-pc nixpkgs (pyjwt *) $ /run/user/1000/nox-review-byezun16/result-3/bin/jwt --key=secret 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXNzYWdlIjoiaGVsbG8iLCJleHAiOjE0Nzc1OTY5MDMsImZvbyI6ImJhciJ9.Zz3Z2HSDzH5dWt52HGfJF5pGlWiuzBmdQGF-DRe89l4'
{"exp": 1477596903, "foo": "bar", "message": "hello"}
[22:18] igor@nixos-pc nixpkgs (pyjwt *) $ /run/user/1000/nox-review-byezun16/result-6/bin/jwt --key=secret foo=bar message=hello oa=me exp=+1000
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8iLCJmb28iOiJiYXIiLCJleHAiOjE0Nzc1OTY5NDIsIm9hIjoibWUifQ.74KH2oIXov_jv-UdjbNDkb9yFVx9YArH0YE9y3Nb_c4
[22:19] igor@nixos-pc nixpkgs (pyjwt *) $ /run/user/1000/nox-review-byezun16/result-6/bin/jwt --key=secret eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXNzYWdlIjoiaGVsbG8iLCJmb28iOiJiYXIiLCJleHAiOjE0Nzc1OTY5NDIsIm9hIjoibWUifQ.74KH2oIXov_jv-UdjbNDkb9yFVx9YArH0YE9y3Nb_c4
{"message": "hello", "foo": "bar", "oa": "me", "exp": 1477596942}
[22:19] igor@nixos-pc nixpkgs (pyjwt *) $ /run/user/1000/nox-review-byezun16/result-7/bin/jwt --key=secret message=hello oa=me exp=+1000
b'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0Nzc1OTcwMDEsIm1lc3NhZ2UiOiJoZWxsbyIsIm9hIjoibWUifQ.dMVJJlf16fnvMTBq4mUyBDYcnx8C_l2xnyXBLXBobcs'
[22:20] igor@nixos-pc nixpkgs (pyjwt *) $ /run/user/1000/nox-review-byezun16/result-7/bin/jwt --key=secret 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0Nzc1OTcwMDEsIm1lc3NhZ2UiOiJoZWxsbyIsIm9hIjoibWUifQ.dMVJJlf16fnvMTBq4mUyBDYcnx8C_l2xnyXBLXBobcs'
{"message": "hello", "oa": "me", "exp": 1477597001}
```

Old 1.4.0 package is preserved for `oathlib` package because it can be compiled only with 1.4.0.

``` sh
[22:29] igor@nixos-pc nixpkgs (pyjwt *) $ nix-shell -I nixpkgs=~/nixpkgs -p pythonPackages.oauthlib
[22:30] igor@nixos-pc nixpkgs (pyjwt *) [nix-shell] % python
Python 2.7.12 (default, Jun 25 2016, 21:49:32) 
[GCC 5.4.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import oauthlib
>>> help(oauthlib)
```
