### PR TITLE
libhttpseverywhere: update git remote

### DIFF
--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -1,14 +1,15 @@
-{stdenv, fetchFromGitHub, gnome3, glib, json_glib, libxml2, libarchive, libsoup, gobjectIntrospection, meson, ninja, pkgconfig,  valadoc}:
+{stdenv, fetchurl, gnome3, glib, json_glib, libxml2, libarchive, libsoup, gobjectIntrospection, meson, ninja, pkgconfig,  valadoc}:
 
 stdenv.mkDerivation rec {
-  name = "libhttpseverywhere-${version}";
-  version = "0.2.3";
+  major = "0.2";
+  minor = "3";
+  version = "${major}.${minor}";
 
-  src = fetchFromGitHub {
-    owner = "grindhold";
-    repo  = "libhttpseverywhere";
-    rev = "${version}";
-    sha256 = "0ggg1kw5yjakqqpnmjcbcpnq5m4lhc76javh8waqv2klr5mxd2a7";
+  name = "libhttpseverywhere-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/libhttpseverywhere/${major}/libhttpseverywhere-${version}.tar.xz";
+    sha256 = "0ndk6yyfcd7iwwkv4rkivhd08k0x8v03gnp9dk1ms4bxb1l2i8l1";
   };
 
   nativeBuildInputs = [ gnome3.vala valadoc  gobjectIntrospection meson ninja pkgconfig ];
@@ -33,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "library to use HTTPSEverywhere in desktop applications";
-    homepage    = https://github.com/grindhold/libhttpseverywhere;
+    homepage    = https://git.gnome.org/browse/libhttpseverywhere;
     license     = stdenv.lib.licenses.lgpl3;
     platforms   = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ sternenseemann ];


### PR DESCRIPTION
###### Motivation for this change

libhttpseverywhere is a semi-official GNOME project now, so the repository moved to git.gnome.org
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
