### PR TITLE
replaceDependency: fix syntax error

### DIFF
--- a/pkgs/build-support/replace-dependency.nix
+++ b/pkgs/build-support/replace-dependency.nix
@@ -22,7 +22,7 @@
 with lib;
 
 let
-  warn = if verbose then builtins.trace else (x:y:y);
+  warn = if verbose then builtins.trace else (x: y: y);
   references = import (runCommand "references.nix" { exportReferencesGraph = [ "graph" drv ]; } ''
     (echo {
     while read path


### PR DESCRIPTION
###### Motivation for this change

This is parsed as an uri instead of a lambda like it's intended.

Since the error was there from the beginning (given that uri parsing existed one year ago), that code path was almost certainly never used and could as well be removed.

cc @shlevy  @oconnorr 
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
