### PR TITLE
top-level: Preserve config and other arguments when recurring, while preventing information leak

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6,6 +6,7 @@
  * Hint: ### starts category names.
  */
 { system, bootStdenv, noSysDirs, config, crossSystem, platform, lib
+, nixpkgsFun
 , ... }:
 self: pkgs:
 
@@ -35,10 +36,9 @@ in
   newScope = extra: lib.callPackageWith (defaultScope // extra);
 
   # Override system. This is useful to build i686 packages on x86_64-linux.
-  forceSystem = system: kernel: (import ../..) {
+  forceSystem = system: kernel: nixpkgsFun {
     inherit system;
     platform = platform // { kernelArch = kernel; };
-    inherit bootStdenv noSysDirs config crossSystem;
   };
 
   # Used by wine, firefox with debugging version of Flash, ...
@@ -4233,9 +4233,7 @@ in
     # load into the Ben Nanonote
     gccCross =
       let
-        pkgsCross = (import ../..) {
-          inherit system;
-          inherit bootStdenv noSysDirs config;
+        pkgsCross = nixpkgsFun {
           # Ben Nanonote system
           crossSystem = {
             config = "mipsel-unknown-linux";


### PR DESCRIPTION
Current there is a few times that nixpkgs recurs, and when it does config/etc is discarded which seems...wrong. Additionally, we take advantage of the separation of the pure and impure generation of default nixpkgs arguments: only the pure generation is repeated on recur.

At the same time, this means that `all-packages.nix` and `stdenv.nix` need not more but *less* arguments, because some were just used when recurring and `mkPackages` will close over those instead. This prevents people from accidentally inspecting those arguments complicating the fixpoint. [`mkPackages` should have a bad smell, we don't the same things to happen without the odor.]

This is part of my https://github.com/NixOS/nixpkgs/pull/15043, and also part of #18386 

This entire patch is fairly small, but is again broken up into _puny_ commits for easy reviewing.

CC @DavidEGrayson because the patch overlaps with your first commit
CC @zimbatm because you've helped me merge that PR piece-by-piece before :D
