### PR TITLE
molly-guard: init at 0.6.3

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -116,6 +116,7 @@
   deepfire = "Kosyrev Serge <_deepfire@feelingofgreen.ru>";
   demin-dmitriy = "Dmitriy Demin <demindf@gmail.com>";
   DerGuteMoritz = "Moritz Heidkamp <moritz@twoticketsplease.de>";
+  DerTim1 = "Tim Digel <tim.digel@active-group.de>";
   desiderius = "Didier J. Devroye <didier@devroye.name>";
   devhell = "devhell <\"^\"@regexmail.net>";
   dezgeg = "Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>";

--- a/pkgs/os-specific/linux/molly-guard/default.nix
+++ b/pkgs/os-specific/linux/molly-guard/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, dpkg, busybox, systemd }:
+
+stdenv.mkDerivation rec {
+  name = "molly-guard-${version}";
+  version = "0.6.3";
+
+  src = fetchurl {
+    url = "https://launchpad.net/ubuntu/+source/molly-guard/${version}/+build/8892607/+files/molly-guard_${version}_all.deb";
+    sha256 = "1d1x60m6kh9wfh9lc22g5s0j40aivwgsczykk27ymwl1pvk58dxn";
+  };
+
+  buildInputs = [ dpkg ];
+
+  sourceRoot = ".";
+
+  unpackCmd = ''
+    dpkg-deb -x "$src" .
+  '';
+
+  installPhase = ''
+    sed -i "s|/lib/molly-guard|${systemd}/sbin|g" lib/molly-guard/molly-guard
+    sed -i "s|run-parts|${busybox}/bin/run-parts|g" lib/molly-guard/molly-guard
+    sed -i "s|/etc/molly-guard/|$out/etc/molly-guard/|g" lib/molly-guard/molly-guard
+    cp -r ./ $out/
+  '';
+
+  postFixup = ''
+    for modus in init halt poweroff reboot runlevel shutdown telinit; do
+       ln -sf $out/lib/molly-guard/molly-guard $out/bin/$modus;
+    done;
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Attempts to prevent you from accidentally shutting down or rebooting machines";
+    homepage    = https://anonscm.debian.org/git/collab-maint/molly-guard.git/;
+    license     = licenses.artistic2;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ DerTim1 ];
+    priority    = -10;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2738,6 +2738,8 @@ in
 
   modsecurity_standalone = callPackage ../tools/security/modsecurity { };
 
+  molly-guard = callPackage ../os-specific/linux/molly-guard { };
+
   monit = callPackage ../tools/system/monit { };
 
   moreutils = callPackage ../tools/misc/moreutils {


### PR DESCRIPTION
###### Motivation for this change

Init molly-guard: Protect machines of accidentally reboots/shutdowns if your in a remote session (e.g. ssh). molly-guard adds a demand ("Please enter hostname of the machine") before a reboot or shutdown. See also http://manpages.ubuntu.com/manpages/xenial/man8/molly-guard.8.html
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux (Nix on Ubuntu 16.04)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
