### PR TITLE
zcash: init at 1.0.0

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -1,6 +1,11 @@
-{ callPackage, pkgs }:
+{ callPackage, boost162, openssl_1_1_0, pkgs }:
 
 rec {
+  zcash = callPackage ./zcash {
+    withGui = false;
+    boost = boost162;
+    openssl = openssl_1_1_0;
+  };
 
   bitcoin  = callPackage ./bitcoin.nix { withGui = true; };
   bitcoind = callPackage ./bitcoin.nix { withGui = false; };

--- a/pkgs/applications/altcoins/zcash/default.nix
+++ b/pkgs/applications/altcoins/zcash/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, libsodium, fetchFromGitHub, pkgconfig, autoreconfHook, openssl, db62, boost
+, zlib, gtest, gmock, miniupnpc, callPackage, gmp, qt4, utillinux, protobuf, qrencode, libevent
+, withGui }:
+
+let snark = callPackage ./snark { };
+in
+with stdenv.lib;
+stdenv.mkDerivation rec{
+
+  name = "zcash" + (toString (optional (!withGui) "d")) + "-" + version;
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "str4d";
+    repo  = "zcash";
+    rev = "ed03ab9bb1d2a70e0ceb8e66ede86cda0e714b9b";
+    sha256 = "072nlqf3gkfnx22kba37las2np45nqk1223gg9y0b7hizy3xwy5l";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ pkgconfig gtest gmock gmp snark autoreconfHook openssl db62 boost zlib
+                  miniupnpc protobuf libevent snark libsodium]
+                  ++ optionals stdenv.isLinux [ utillinux ]
+                  ++ optionals withGui [ qt4 qrencode ];
+
+  configureFlags = [ "LIBSNARK_INCDIR=${snark}/include/libsnark"
+                     "--with-boost-libdir=${boost.out}/lib"
+                   ] ++ optionals withGui [ "--with-gui=qt4" ];
+
+  patchPhase = ''
+    sed -i"" '/^\[LIBSNARK_INCDIR/d'               configure.ac
+    sed -i"" 's,-lboost_system-mt,-lboost_system,' configure.ac
+    sed -i"" 's,-fvisibility=hidden,,g'            src/Makefile.am
+  '';
+
+  postInstall = ''
+    cp zcutil/fetch-params.sh $out/bin/zcash-fetch-params
+  '';
+
+  meta = {
+    description = "Peer-to-peer, anonymous electronic cash system";
+    homepage = "https://z.cash/";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/zcash/default.nix
+++ b/pkgs/applications/altcoins/zcash/default.nix
@@ -2,7 +2,7 @@
 , zlib, gtest, gmock, miniupnpc, callPackage, gmp, qt4, utillinux, protobuf, qrencode, libevent
 , withGui }:
 
-let snark = callPackage ./snark { };
+let snark = callPackage ./snark { inherit boost openssl; };
 in
 with stdenv.lib;
 stdenv.mkDerivation rec{

--- a/pkgs/applications/altcoins/zcash/snark/ate-pairing.nix
+++ b/pkgs/applications/altcoins/zcash/snark/ate-pairing.nix
@@ -1,0 +1,29 @@
+{ stdenv, xbyak, gmp, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "ate-pairing";
+  version = "2016-05-03-git";
+
+  src = fetchFromGitHub {
+    owner = "herumi";
+    repo  = "ate-pairing";
+    rev = "dcb9da999b1113f90b115bccb6f4b57ddf3a8452";
+    sha256 = "0jr6r1cma414k8mhsyp7n8hqaqxi7zklsp6820a095sbb3zajckh";
+  };
+
+  buildInputs = [ gmp xbyak ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r lib $out
+    cp -r include $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Optimal Ate Pairing over Barreto-Naehrig Curves";
+    homepage = "https://github.com/herumi/ate-pairing";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/zcash/snark/default.nix
+++ b/pkgs/applications/altcoins/zcash/snark/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, libsodium, callPackage, boost, zlib, openssl, gmp, procps, fetchFromGitHub }:
+
+let atePairing = callPackage ./ate-pairing.nix { inherit xbyak; };
+    mie        = callPackage ./mie.nix { };
+    xbyak      = callPackage ./xbyak.nix {};
+in
+stdenv.mkDerivation rec{
+  name = "snark";
+  version = "2016-08-15-git";
+
+  src = fetchFromGitHub {
+    owner = "zcash";
+    repo  = "libsnark";
+    rev = "2e6314a9f7efcd9af1c77669d7d9a229df86a777";
+    sha256 = "0k4jhgc251d3ymga0sc1wiqhgklayr5d94n15jlb3n2lnqra07d5";
+  };
+
+  buildInputs = [ libsodium atePairing mie xbyak zlib openssl boost gmp ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "CURVE=ALT_BN128"
+    "NO_SUPERCOP=1"
+    "STATIC=1"
+  ];
+
+  buildPhase = ''
+    CXXFLAGS="-fPIC -DBINARY_OUTPUT -DNO_PT_COMPRESSION=1" \
+    make lib \
+      CURVE=ALT_BN128 \
+      MULTICORE=1 \
+      STATIC=1 \
+      NO_PROCPS=1 \
+      NO_GTEST=1 \
+      FEATUREFLAGS=-DMONTGOMERY_OUTPUT \
+  '';
+
+  meta = with stdenv.lib; {
+    description = "a C++ library for zkSNARK proofs";
+    homepage = "https://github.com/zcash/libsnark";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/zcash/snark/mie.nix
+++ b/pkgs/applications/altcoins/zcash/snark/mie.nix
@@ -1,0 +1,28 @@
+
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "mie";
+  version = "2016-05-10-git";
+
+  src = fetchFromGitHub {
+    owner = "herumi";
+    repo  = name;
+    rev = "704b625b7770a8e1eab26ac65d1fed14c2fcf090";
+    sha256 = "144bpmgfs2m4qqv7a2mccgi1aq5jmlr25gnk78ryq09z8cyv88y2";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r include $out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/herumi/mie";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/altcoins/zcash/snark/xbyak.nix
+++ b/pkgs/applications/altcoins/zcash/snark/xbyak.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "xbyak";
+  version = "2016-05-03-git";
+
+  src = fetchFromGitHub {
+    owner = "herumi";
+    repo  = name;
+    rev = "b6133a02dd6b7116bea31d0e6b7142bf97f071aa";
+    sha256 = "1rc2nx8kj2lj13whxb9chhh79f4hmjjj4j1hpqsd0lbdb60jikrn";
+  };
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/include
+    cp -r xbyak $out/include
+  '';
+
+  meta = with stdenv.lib; {
+    description = "JIT assembler for x86, x64";
+    homepage = "https://github.com/herumi/xbyak";
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/boost/1.62.nix
+++ b/pkgs/development/libraries/boost/1.62.nix
@@ -1,0 +1,11 @@
+{ stdenv, callPackage, fetchurl, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.62.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/boost/boost_1_62_0.tar.bz2";
+    sha256 = "07h9b5n03fc9gh4pdvgp0c511fwcsxiyicajjdqm3m7jvwmdq5d7";
+  };
+
+})

--- a/pkgs/development/libraries/db/db-6.2.nix
+++ b/pkgs/development/libraries/db/db-6.2.nix
@@ -1,0 +1,8 @@
+{ stdenv, fetchurl, ... } @ args:
+
+import ./generic.nix (args // rec {
+  version = "6.2.23";
+  sha256 = "1isxx4jfmnh913jzhp8hhfngbk6dsg46f4kjpvvc56maj64jqqa7";
+  license = stdenv.lib.licenses.agpl3;
+  branch = "6.0";
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6556,6 +6556,7 @@ in
   boost155 = callPackage ../development/libraries/boost/1.55.nix { };
   boost159 = callPackage ../development/libraries/boost/1.59.nix { };
   boost160 = callPackage ../development/libraries/boost/1.60.nix { };
+  boost162 = callPackage ../development/libraries/boost/1.62.nix { };
   boost = boost160;
 
   boost_process = callPackage ../development/libraries/boost-process { };
@@ -6715,6 +6716,7 @@ in
   db53 = callPackage ../development/libraries/db/db-5.3.nix { };
   db6 = db60;
   db60 = callPackage ../development/libraries/db/db-6.0.nix { };
+  db62 = callPackage ../development/libraries/db/db-6.2.nix { };
 
   dbus = callPackage ../development/libraries/dbus { };
   dbus_cplusplus  = callPackage ../development/libraries/dbus-cplusplus { };
@@ -12064,8 +12066,17 @@ in
 
   altcoins = recurseIntoAttrs ( callPackage ../applications/altcoins {
     callPackage = newScope { boost = boost155; };
-  } );
+  } ) // (
+    let callPackage = newScope { boost = boost162; openssl = openssl_1_1_0; };
+    in {
+      zcash = callPackage ../applications/altcoins/zcash {
+        withGui = false;
+        inherit callPackage;
+      };
+    });
+
   bitcoin = altcoins.bitcoin;
+  zcash = altcoins.zcash;
   bitcoin-xt = altcoins.bitcoin-xt;
 
   go-ethereum = self.altcoins.go-ethereum;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12066,14 +12066,7 @@ in
 
   altcoins = recurseIntoAttrs ( callPackage ../applications/altcoins {
     callPackage = newScope { boost = boost155; };
-  } ) // (
-    let callPackage = newScope { boost = boost162; openssl = openssl_1_1_0; };
-    in {
-      zcash = callPackage ../applications/altcoins/zcash {
-        withGui = false;
-        inherit callPackage;
-      };
-    });
+  });
 
   bitcoin = altcoins.bitcoin;
   zcash = altcoins.zcash;


### PR DESCRIPTION
###### Motivation for this change

zcash releases today, let's add it to nixos!
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
