### PR TITLE
WIP gtk3: 3.22.1 -> 3.22.2

### DIFF
--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -13,7 +13,7 @@ with stdenv.lib;
 
 let
   ver_maj = "3.22";
-  ver_min = "1";
+  ver_min = "2";
   version = "${ver_maj}.${ver_min}";
 in
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk+/${ver_maj}/gtk+-${version}.tar.xz";
-    sha256 = "127c8c5cfc32681f9ab3cb542eb0d5c16c1c02faba68bf8fcac9a3cf278ef471";
+    sha256 = "0ik9rd7df7529839p2hpzvmv2zpg1w8z8vqk33vpw8zwsapdqhr3";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change (:warning: WIP)
- Several improvements to the win32 theme
- Deprecations have been added for APIs that will be removed
  in GTK+ 4
- Bug fixes:
  - 767713 Fullscreen in wayland is buggy
  - 771320 Maps widget is displayed at wrong position inside gnome-contacts
  - 772345 placesviewrow: busy_spinner when visible offsets the rest of the...
  - 772389 Appending a character to a GtkEntry control in overwrite mode ri...
  - 772415 Avoid calling eglGetDisplay
  - 772552 Deprecate gtk_menu_popup
  - 772683 Usage of FALSE instead of gint in glarea demo
  - 772695 Show the keyboard shortcuts from left to right even in RTL
  - 772775 menu bindings needs attribute to force LTR for horizontal-button...
  - 772859 Fix memory leaks in implementations of common widgets
  - 772922 GtkMenu: Try using gdk_window_move_to_rect() more often
  - 772926 shortcutswindow: working version of set_section_name()
  - 773029 style-set signal problem
  - 773082 overlay: Document availability of properties
  - 773113 tests: fix clipboard test by loading correct icon
  - 773180 Don't second-guess whether our GDK GL context is GLES
  - 773246 Typo in css color definitions documentation 
###### Things done
- [ ] Tested using sandboxing
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

:warning: neither built nor tested

/cc @groxxda @lethalman 
