### PR TITLE
mplus-outline-fonts: 061 -> 062

### DIFF
--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mplus-${version}";
-  version = "061";
+  version = "062";
 
   src = fetchurl {
     url = "mirror://sourceforgejp/mplus-fonts/62344/mplus-TESTFLIGHT-${version}.tar.xz";
-    sha256 = "1yrv65l2y8f9jmpalqb5iiay7z1x3754mnqpgp2bax72g8k8728g";
+    sha256 = "1f44vmnma5njhfiz351gwblxmdh9njv486864zrxqaa1h5pvdhha";
   };
 
   phases = [ "unpackPhase" "installPhase" ];


### PR DESCRIPTION
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
