### PR TITLE
nodejs: disable PaX mprotect() hardening

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -42,6 +42,7 @@ in stdenv.mkDerivation {
   '';
 
   postInstall = ''
+    paxmark m $out/bin/node
     PATH=$out/bin:$PATH patchShebangs $out
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Needed for nodejs to run with PaX.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note that nodejs still doesn't _build_ with PaX; it can be made to build by adding `"--without-snapshot"` to `configureFlags`.
