### PR TITLE
openra: 20160508 -> 20161019

### DIFF
--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, mono, makeWrapper, lua
 , SDL2, freetype, openal, systemd, pkgconfig,
-  dotnetPackages, gnome3
+  dotnetPackages, gnome3, curl, unzip
 }:
 
 let
-  version = "20160508";
+  version = "20161019";
 in stdenv.mkDerivation rec {
   name = "openra-${version}";
 
@@ -19,15 +19,15 @@ in stdenv.mkDerivation rec {
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "https://github.com/OpenRA/OpenRA/archive/release-${version}.tar.gz";
-    sha256 = "1vr5bvdkh0n5569ga2h7ggj43vnzr37hfqkfnsis1sg4vgwrnzr7";
+    sha256 = "1psmq3kb2whkavh5pm0xc4m5b4bihvrl8pfrk851iqg1cs22bg0w";
   };
 
   dontStrip = true;
 
   buildInputs = with dotnetPackages;
-     [ NUnit3 NewtonsoftJson MonoNat FuzzyLogicLibrary SmartIrc4net SharpZipLib MaxMindGeoIP2 MaxMindDb SharpFont StyleCopMSBuild StyleCopPlusMSBuild RestSharp NUnitConsole ]
-     ++ [ lua gnome3.zenity ];
-  nativeBuildInputs = [ mono makeWrapper lua pkgconfig ];
+     [ NUnit3 NewtonsoftJson MonoNat FuzzyLogicLibrary SmartIrc4net SharpZipLib MaxMindGeoIP2 MaxMindDb SharpFont StyleCopMSBuild StyleCopPlusMSBuild RestSharp NUnitConsole OpenNAT ]
+     ++ [ curl unzip lua gnome3.zenity ];
+  nativeBuildInputs = [ curl unzip mono makeWrapper lua pkgconfig ];
 
   patchPhase = ''
     mkdir Support
@@ -42,6 +42,7 @@ in stdenv.mkDerivation rec {
   '';
 
   preBuild = let dotnetPackagesDlls = with dotnetPackages; [
+    "${OpenNAT}/lib/dotnet/Open.NAT/net45/Open.Nat.dll"
     "${MonoNat}/lib/dotnet/Mono.Nat/net40/Mono.Nat.dll"
     "${FuzzyLogicLibrary}/lib/dotnet/FuzzyLogicLibrary/Release/FuzzyLogicLibrary.dll"
     "${SmartIrc4net}/lib/dotnet/SmartIrc4net/net40/SmarIrc4net*"

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -181,6 +181,13 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "bin/*" ];
   };
 
+  OpenNAT = fetchNuGet {
+    baseName = "Open.NAT";
+    version = "2.1.0";
+    sha256 = "1jyd30fwycdwx5ck96zhp2xf20yz0sp7g3pjbqhmay4kd322mfwk";
+    outputFiles = [ "lib/*" ];
+  };
+
   MonoNat = fetchNuGet {
     baseName = "Mono.Nat";
     version = "1.2.24";


### PR DESCRIPTION
###### Motivation for this change

Update to the latest and greatest version.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
