### PR TITLE
yadm: 1.04 -> 1.05

### DIFF
--- a/pkgs/applications/version-management/yadm/default.nix
+++ b/pkgs/applications/version-management/yadm/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub }:
 
-let version = "1.04"; in
+let version = "1.05"; in
 stdenv.mkDerivation {
   name = "yadm-${version}";
 
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     owner  = "TheLocehiliosan";
     repo   = "yadm";
     rev    = "${version}";
-    sha256 = "1g5nz4y63ccxlbz67klm78525ps41ynis8683iayakg4907vd898";
+    sha256 = "11bqgz28qzgb3iz8xvda9z0mh5r1a9m032pqm772ypiixsfz8hdd";
   };
 
   buildCommand = ''


### PR DESCRIPTION
###### Motivation for this change

Updated `yadm` from 1.04 to 1.05.
###### Things done

I'm new to NixOS, so I'm not entirely sure about anything. Anyway, I followed these instructions:

https://nixos.org/nixpkgs/manual/#chap-submitting-changes

I ran `nix-env -i pkg-name -f <path to your local nixpkgs folder>` and then used the binary `yadm` successfully.
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
