### PR TITLE
peervpn: init at 0.044

### DIFF
--- a/pkgs/tools/networking/peervpn/default.nix
+++ b/pkgs/tools/networking/peervpn/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, openssl
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  major = "0";
+  minor = "044";
+  name = "peervpn-${major}.${minor}";
+
+  src = fetchurl {
+    url = "https://peervpn.net/files/peervpn-${major}-${minor}.tar.gz";
+    sha256 = "14l3xlps23g9r202b385d8p9rsxrhkcmbd5fp22zz5bdjp7da0j4";
+  };
+
+
+  buildInputs = [ zlib openssl ];
+
+  installPhase = "install -D peervpn $out/bin/peervpn";
+
+  meta = with stdenv; {
+    description = "An open source peer-to-peer VPN";
+    homepage = https://peervpn.net;
+    maintainers = with lib.maintainers; [ hce ];
+    platforms = lib.platforms.unix;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17469,4 +17469,6 @@ in
   nitrokey-app = callPackage ../tools/security/nitrokey-app { };
 
   fpm2 = callPackage ../tools/security/fpm2 { };
+
+  peervpn = callPackage ../tools/networking/peervpn { };
 }


### PR DESCRIPTION
###### Motivation for this change

PeerVPN is a software that builds virtual ethernet networks between multiple computers.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
