### PR TITLE
nodejs: refactor build

### DIFF
--- a/pkgs/development/web/nodejs/v4.nix
+++ b/pkgs/development/web/nodejs/v4.nix
@@ -1,17 +1,20 @@
 { stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
-, pkgconfig, runCommand, which, libtool
+, pkgconfig, runCommand, which, libtool, fetchpatch
 , callPackage
+, darwin ? null
+, enableNpm ? true
 }@args:
 
-import ./nodejs.nix (args // rec {
-  version = "4.6.0";
-  src = fetchurl {
-    url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
-    sha256 = "1566q1kkv8j30fgqx8sm2h8323f38wwpa1hfb10gr6z46jyhv4a2";
-  };
+let
+  nodejs = import ./nodejs.nix args;
+  baseName = if enableNpm then "nodejs" else "nodejs-slim";
+in
+  stdenv.mkDerivation (nodejs // rec {
+    version = "4.6.0";
+    name = "${baseName}-${version}";
+    src = fetchurl {
+      url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
+      sha256 = "1566q1kkv8j30fgqx8sm2h8323f38wwpa1hfb10gr6z46jyhv4a2";
+    };
 
-  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace src/util.h \
-      --replace "tr1/type_traits" "type_traits"
-  '';
-})
+  })

--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -2,24 +2,27 @@
 , pkgconfig, runCommand, which, libtool, fetchpatch
 , callPackage
 , darwin ? null
+, enableNpm ? true
 }@args:
 
 let
-  inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
+  nodejs = import ./nodejs.nix args;
+  baseName = if enableNpm then "nodejs" else "nodejs-slim";
+in
+  stdenv.mkDerivation (nodejs // rec {
+    version = "6.8.0";
+    name = "${baseName}-${version}";
+    src = fetchurl {
+      url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
+      sha256 = "13arzwki13688hr1lh871y06lrk019g4hkasmg11arm8j1dcwcpq";
+    };
 
-in import ./nodejs.nix (args // rec {
-  version = "6.8.0";
-  sha256 = "13arzwki13688hr1lh871y06lrk019g4hkasmg11arm8j1dcwcpq";
-  extraBuildInputs = stdenv.lib.optionals stdenv.isDarwin
-    [ CoreServices ApplicationServices ];
-  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
-    sed -i -e "s|tr1/type_traits|type_traits|g" \
-      -e "s|std::tr1|std|" src/util.h
-  '';
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/nodejs/node/commit/fc164acbbb700fd50ab9c04b47fc1b2687e9c0f4.patch";
-      sha256 = "1rms3n09622xmddn013yvf5c6p3s8w8s0d2h813zs8c1l15k4k1i";
-    })
-  ];
-})
+    patches = nodejs.patches ++ [
+      (fetchpatch {
+        url = "https://github.com/nodejs/node/commit/fc164acbbb700fd50ab9c04b47fc1b2687e9c0f4.patch";
+        sha256 = "1rms3n09622xmddn013yvf5c6p3s8w8s0d2h813zs8c1l15k4k1i";
+      })
+    ];
+
+  })
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2426,15 +2426,27 @@ in
 
   ninka = callPackage ../development/tools/misc/ninka { };
 
+  nodejs = nodejs-6_x;
+
+  nodejs-slim = nodejs-slim-6_x;
+
   nodejs-4_x = callPackage ../development/web/nodejs/v4.nix {
     libtool = darwin.cctools;
+  };
+
+  nodejs-slim-4_x = callPackage ../development/web/nodejs/v4.nix {
+    libtool = darwin.cctools;
+    enableNpm = false;
   };
 
   nodejs-6_x = callPackage ../development/web/nodejs/v6.nix {
     libtool = darwin.cctools;
   };
 
-  nodejs = nodejs-6_x;
+  nodejs-slim-6_x = callPackage ../development/web/nodejs/v6.nix {
+    libtool = darwin.cctools;
+    enableNpm = false;
+  };
 
   nodePackages_6_x = callPackage ../development/node-packages/default-v6.nix {
     nodejs = pkgs.nodejs-6_x;
@@ -2444,7 +2456,7 @@ in
     nodejs = pkgs.nodejs-4_x;
   };
 
-  nodePackages = nodePackages_4_x;
+  nodePackages = nodePackages_6_x;
 
   # Can be used as a user shell
   nologin = shadow;


### PR DESCRIPTION
#### nodejs refactoring

The build for nodejs was getting messy. Now that only v4 and v6 is left most could be moved to a generic `nodejs.nix` and `v4.nix` and `v6.nix` apply only minor overwrites respectively.

Furthermore:
- Adds `slim` variations which exclude `npm`. This rids nodejs of a python runtime dependency reducing the closure size considerably 
- Removes shared library includes (as suggested by @vcunat in #19965 
