### PR TITLE
google-fonts: Fix typos in homepage, description

### DIFF
--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -38,8 +38,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://www.google.com/fontsl;
-    description = "Font files available from Google Font";
+    homepage = https://fonts.google.com;
+    description = "Font files available from Google Fonts";
     license = with licenses; [ asl20 ofl ufl ];
     platforms = platforms.all;
     hydraPlatforms = [];


### PR DESCRIPTION
In the `meta`data for the `google-fonts` package --
- the `homepage` field was set to the URL
  https://www.google.com/fontsl, which would appear to be a
  misspelt version of https://www.google.com/fonts, which now
  redirects to https://fonts.google.com.
- the `description` field referred to Google Fonts as "Google Font".

This patch corrects these errors, and updates the `homepage` URL.
