### PR TITLE
font-awesome: 4.6.3 -> 4.7.0

### DIFF
--- a/pkgs/data/fonts/font-awesome-ttf/default.nix
+++ b/pkgs/data/fonts/font-awesome-ttf/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "font-awesome-${version}";
-  version = "4.6.3";
+  version = "4.7.0";
 
   src = fetchFromGitHub {
     owner  = "FortAwesome";
     repo   = "Font-Awesome";
     rev    = "v${version}";
-    sha256 = "135k1xskksqzriad9zzcxa79iprldyp2bnmc22wslak0dvjz74w0";
+    sha256 = "0w30y26jp8nvxa3iiw7ayl6rkza1rz62msl9xw3srvxya1c77grc";
   };
 
   buildCommand = ''


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
