### PR TITLE
groovy: no easily conflicting files in top-level (#19872)

### DIFF
--- a/pkgs/development/interpreters/groovy/default.nix
+++ b/pkgs/development/interpreters/groovy/default.nix
@@ -15,8 +15,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out
+    mkdir -p $out/share/doc/groovy
     rm bin/*.bat
-    mv * $out
+    mv {bin,conf,embeddable,grooid,indy,lib} $out
+    mv {licenses,LICENSE,NOTICE} $out/share/doc/groovy
 
     sed -i 's#which#${which}/bin/which#g' $out/bin/startGroovy
 
@@ -26,8 +28,6 @@ stdenv.mkDerivation rec {
             --prefix PATH ":" "${jdk}/bin"
     done
   '';
-
-  phases = "unpackPhase installPhase";
 
   meta = with stdenv.lib; {
     description = "An agile dynamic language for the Java Platform";


### PR DESCRIPTION
###### Motivation for this change

Related to #19872.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
