### PR TITLE
Build all derivations on Linux, unless specified otherwise

### DIFF
--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -85,7 +85,7 @@ rec {
   packagePlatforms = mapAttrs (name: value:
     let res = builtins.tryEval (
       if isDerivation value then
-        value.meta.hydraPlatforms or (value.meta.platforms or [])
+        value.meta.hydraPlatforms or (value.meta.platforms or [ "x86_64-linux" ])
       else if value.recurseForDerivations or false || value.recurseForRelease or false then
         packagePlatforms value
       else


### PR DESCRIPTION
We have packages dating back to 2010 that never get built or tested. In order to prevent that in the future, I propose we always build packages at least on Linux platform.

This will increase failed builds, but we should go through them and see what's feasible to keep.

If there won't be strong reasons not to do this, I'll make a separate hydra jobset to get the first impression.

PS: Haskell, Python and other will still not get build due to overrides in `pkgs/top-level/release.nix`
PS2: Broken derivation will still not build
