### PR TITLE
opensmtpd: missing pkgs in attribute

### DIFF
--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -115,7 +115,7 @@ in {
         chown smtpq.root /var/spool/smtpd/purge
         chmod 700 /var/spool/smtpd/purge
       '';
-      serviceConfig.ExecStart = "${opensmtpd}/sbin/smtpd -d -f ${conf} ${args}";
+      serviceConfig.ExecStart = "${pkgs.opensmtpd}/sbin/smtpd -d -f ${conf} ${args}";
       environment.OPENSMTPD_PROC_PATH = "${procEnv}/libexec/opensmtpd";
     };
 


### PR DESCRIPTION
###### Motivation for this change

After the recent [Opensmtpd module refactorings](https://github.com/NixOS/nixpkgs/pull/19874) which explicitly uses `pkgs`, there is an occurrence of `${opensmtpd}` without it. This PR fixes it.

Without this fix NixOS cannot be rebuilt:

```
# nixos-rebuild boot 2>&1 | tee /var/tmp/nixos-rebuild.log
building Nix...
building the system configuration...
trace: types.optionSet is deprecated; use types.submodule instead
error: undefined variable ‘opensmtpd’ at /nix/var/nix/profiles/per-user/root/channels/nixos/nixpkgs/nixos/modules/services/mail/opensmtpd.nix:118:36
(use ‘--show-trace’ to show detailed location information)
```
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
