### PR TITLE
pyload change: another patch for missing templates

### DIFF
--- a/pkgs/applications/networking/pyload/default.nix
+++ b/pkgs/applications/networking/pyload/default.nix
@@ -19,7 +19,7 @@ pythonPackages.buildPythonApplication rec {
       };
       setupPyPatch = fetchpatch {
         url = "https://patch-diff.githubusercontent.com/raw/pyload/pyload/pull/2638.diff";
-        sha256 = "1gmvsmlcvb96g48kibv47cbmb5slivy3c5qflb5n0qc8k7axg3i9";
+        sha256 = "006g4qbl582262ariflbyfrszcx8ck2ac1cpry1f82f76p4cgf6z";
       };
     in [ configParserPatch setupPyPatch ];
 
@@ -28,8 +28,8 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with pythonPackages; [
-    pycurl jinja2 beaker thrift simplejson pycrypto feedparser pyqt4 gdbm
-    tkinter beautifulsoup
+    pycurl jinja2 beaker thrift simplejson pycrypto feedparser tkinter
+    beautifulsoup
   ];
 
   #remove this once the PR patches above are merged. Needed because githubs diff endpoint


### PR DESCRIPTION
###### Motivation for this change

Some files within the python wheel were still missing. Updated the upstream patch to fix this. In addition, unneeded python deps are removed
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
