### PR TITLE
linux: 4.8.4 -> 4.8.5

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.8.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.8.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.8.4";
+  version = "4.8.5";
   extraMeta.branch = "4.8";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "1c122kcd98ljk2f7w4qkbx4cjv7a50w4gdc9qrxkpciaj4yqvjy1";
+    sha256 = "0264h3b8h4bqgcif2jzbz4yzv290nrn444bhcqzb0lizj8a1f5s8";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Motivation for this change

Update
###### Things done
- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
