### PR TITLE
cc-wrapper: expand response files

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -23,7 +23,7 @@ getVersion=0
 nonFlagArgs=0
 [[ "@prog@" = *++ ]] && isCpp=1 || isCpp=0
 
-params=("$@")
+expandResponseParams "$@"
 n=0
 while [ $n -lt ${#params[*]} ]; do
     p=${params[n]}

--- a/pkgs/build-support/cc-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/ld-wrapper.sh
@@ -16,7 +16,7 @@ source @out@/nix-support/utils.sh
 
 
 # Optionally filter out paths not refering to the store.
-params=("$@")
+expandResponseParams "$@"
 if [ "$NIX_ENFORCE_PURITY" = 1 -a -n "$NIX_STORE" \
         -a \( -z "$NIX_IGNORE_LD_THROUGH_GCC" -o -z "$NIX_LDFLAGS_SET" \) ]; then
     rest=()

--- a/pkgs/build-support/cc-wrapper/utils.sh
+++ b/pkgs/build-support/cc-wrapper/utils.sh
@@ -22,3 +22,27 @@ badPath() {
         "${p:0:4}" != "/tmp" -a \
         "${p:0:${#NIX_BUILD_TOP}}" != "$NIX_BUILD_TOP"
 }
+
+expandResponseParams() {
+    local inparams=("$@")
+    local n=0
+    local p
+    params=()
+    while [ $n -lt ${#inparams[*]} ]; do
+        p=${inparams[n]}
+        case $p in
+            @*)
+                if [ -e "${p:1}" ]; then
+                    args=$(<"${p:1}")
+                    eval 'for arg in '$args'; do params+=("$arg"); done'
+                else
+                    params+=("$p")
+                fi
+                ;;
+            *)
+                params+=("$p")
+                ;;
+        esac
+        n=$((n + 1))
+    done
+}


### PR DESCRIPTION
###### Motivation for this change

Some arguments were not handled by the gcc wrapper when passed in a response file.  When given a response file, gcc will in turn pass a response file to ld containing all arguments, not just the ones from the original reponse file.

I've tested it with quoted strings, escaped quotes, escaped spaces, newlines, etc.  It should interpret things the same as on the command line, but let me know if you can think of anything else I should test.

TODO:
- pack large argument lists in a temporary reponse file?
  - platform specific (e.g. cygwin)?
  - only when a response file is encountered?
- tests
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #11762
