### PR TITLE
kdevelop: 5.0.0 -> 5.0.2

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, cmake, gettext, pkgconfig, extra-cmake-modules, makeQtWrapper
-, qtquickcontrols, qtwebkit
+, qtquickcontrols, qtwebkit, qttools
 , kconfig, kdeclarative, kdoctools, kiconthemes, ki18n, kitemmodels, kitemviews
 , kjobwidgets, kcmutils, kio, knewstuff, knotifyconfig, kparts, ktexteditor
-, threadweaver, kxmlgui, kwindowsystem
+, threadweaver, kxmlgui, kwindowsystem, grantlee
 , plasma-framework, krunner, kdevplatform, kdevelop-pg-qt, shared_mime_info
-, libksysguard, llvmPackages
+, libksysguard, llvmPackages, makeWrapper
 }:
 
 let
   pname = "kdevelop";
-  version = "5.0";
-  dirVersion = "5.0.0";
+  version = "5.0.2";
+  dirVersion = "5.0.2";
 
 in
 stdenv.mkDerivation rec {
@@ -18,22 +18,25 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${dirVersion}/src/${name}.tar.xz";
-    sha256 = "5e034b8670f4ba13ccb2948c28efa0b54df346e85b648078698cca8974ea811c";
+    sha256 = "9b017901167723230dee8b565cdc7b0e61762415ffcc0a32708f04f7ab668666";
   };
 
-  nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules makeQtWrapper ];
+  nativeBuildInputs = [
+    cmake gettext pkgconfig extra-cmake-modules makeWrapper makeQtWrapper
+  ];
 
   buildInputs = [
     qtquickcontrols qtwebkit
     kconfig kdeclarative kdoctools kiconthemes ki18n kitemmodels kitemviews
     kjobwidgets kcmutils kio knewstuff knotifyconfig kparts ktexteditor
-    threadweaver kxmlgui kwindowsystem plasma-framework krunner
+    threadweaver kxmlgui kwindowsystem grantlee plasma-framework krunner
     kdevplatform kdevelop-pg-qt shared_mime_info libksysguard
     llvmPackages.llvm llvmPackages.clang-unwrapped
   ];
 
   postInstall = ''
     wrapQtProgram "$out/bin/kdevelop"
+    wrapProgram "$out/bin/kdevelop!" --prefix PATH ":" "${qttools}/bin"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/editors/kdevelop5/kdevplatform.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevplatform.nix
@@ -6,8 +6,8 @@
 
 let
   pname = "kdevplatform";
-  version = "5.0";
-  dirVersion = "5.0.0";
+  version = "5.0.2";
+  dirVersion = "5.0.2";
 
 in
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   
   src = fetchurl {
     url = "mirror://kde/stable/kdevelop/${dirVersion}/src/${name}.tar.xz";
-    sha256 = "4085b355ab8d599d902afbc11027e1aefb22afe30d63ed54ea5fe02f24edfd10";
+    sha256 = "a7f311198bb72f5fee064d99055e8df39ecf4e9066fe5c0ff901ee8c24d960ec";
   };
 
   nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules makeQtWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Minor version bump.
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
