### PR TITLE
services: Add Interplanetary File System service

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -277,6 +277,7 @@
       gitlab-runner = 257;
       postgrey = 258;
       hound = 259;
+      ipfs  = 260;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -524,6 +525,7 @@
       gitlab-runner = 257;
       postgrey = 258;
       hound = 259;
+      ipfs = 260;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -316,6 +316,7 @@
   ./services/monitoring/zabbix-server.nix
   ./services/network-filesystems/cachefilesd.nix
   ./services/network-filesystems/drbd.nix
+  ./services/network-filesystems/ipfs.nix
   ./services/network-filesystems/netatalk.nix
   ./services/network-filesystems/nfsd.nix
   ./services/network-filesystems/openafs-client/default.nix

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -92,14 +92,14 @@ in
 
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" "local-fs.target" ];
-      path  = [ pkgs.ipfs pkgs.runit ];
+      path  = [ pkgs.ipfs pkgs.su pkgs.bash ];
 
       preStart =
         ''
           install -m 0755 -o ${cfg.user} -g ${cfg.group} -d ${cfg.dataDir}
           if [[ ! -d ${cfg.dataDir}/.ipfs ]]; then
             cd ${cfg.dataDir}
-            ${pkgs.runit}/bin/chpst -u "${cfg.user}:${cfg.group}" ipfs init
+            ${pkgs.su}/bin/su -s ${pkgs.bash}/bin/sh ${cfg.user} -c "${ipfs}/bin/ipfs init"
           fi
         '';
 

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -1,0 +1,118 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  inherit (pkgs) ipfs;
+
+  cfg = config.services.ipfs;
+
+
+  ipfsFlags = ''${if cfg.autoMigrate then "--migrate" else ""}
+                ${if cfg.enableGC    then "--enable-gc" else ""}
+                ${toString cfg.extraFlags}'';
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.ipfs = {
+
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to start a daemon for the Interplanetary
+          file system (IPFS).
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "ipfs";
+        description = "User under which the IPFS daemon runs";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "ipfs";
+        description = "Group under which the IPFS daemon runs";
+      };
+
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/ipfs";
+        description = "The data dir for IPFS";
+      };
+
+      autoMigrate = mkOption {
+        default = false;
+        description = ''
+          Whether IPFS should try to migrate the file system automatically.
+        '';
+      };
+
+      enableGC = mkOption {
+        default = false;
+        description = ''
+          Whether to enable automatic garbadge collection.
+        '';
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        description = "Extra flags passed to the IPFS daemon";
+        default = [];
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.ipfs ];
+
+    users.extraUsers = optionalAttrs (cfg.user == "ipfs") singleton {
+      name = "ipfs";
+      group = cfg.group;
+      home = cfg.dataDir;
+      createHome = false;
+      uid = config.ids.uids.ipfs;
+      description = "IPFS daemon user";
+    };
+
+    users.extraGroups = optionalAttrs (cfg.group == "ipfs") singleton {
+      name = "ipfs";
+      gid = config.ids.gids.ipfs;
+    };
+
+    systemd.services.ipfs = {
+      description = "IPFS Daemon";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "local-fs.target" ];
+      path  = [ pkgs.ipfs pkgs.runit ];
+
+      preStart =
+        ''
+          mkdir -m 0755 -p ${cfg.dataDir}
+          chown ${cfg.user}:${cfg.group} ${cfg.dataDir}
+          if [[ ! -d ${cfg.dataDir}/.ipfs ]]; then
+            cd ${cfg.dataDir}
+            ${pkgs.runit}/bin/chpst -u "${cfg.user}:${cfg.group}" ipfs init
+          fi
+        '';
+
+      serviceConfig = {
+        ExecStart = "${ipfs}/bin/ipfs daemon ${ipfsFlags}";
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = true;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -8,9 +8,7 @@ let
   cfg = config.services.ipfs;
 
 
-  ipfsFlags = ''${if cfg.autoMigrate then "--migrate" else ""}
-                ${if cfg.enableGC    then "--enable-gc" else ""}
-                ${toString cfg.extraFlags}'';
+  ipfsFlags = ''${if cfg.autoMigrate then "--migrate" else ""} ${if cfg.enableGC then "--enable-gc" else ""} ${toString cfg.extraFlags}'';
 
 in
 
@@ -98,8 +96,7 @@ in
 
       preStart =
         ''
-          mkdir -m 0755 -p ${cfg.dataDir}
-          chown ${cfg.user}:${cfg.group} ${cfg.dataDir}
+          install -m 0755 -o ${cfg.user} -g ${cfg.group} -d ${cfg.dataDir}
           if [[ ! -d ${cfg.dataDir}/.ipfs ]]; then
             cd ${cfg.dataDir}
             ${pkgs.runit}/bin/chpst -u "${cfg.user}:${cfg.group}" ipfs init
@@ -108,7 +105,6 @@ in
 
       serviceConfig = {
         ExecStart = "${ipfs}/bin/ipfs daemon ${ipfsFlags}";
-        Type = "simple";
         User = cfg.user;
         Group = cfg.group;
         PermissionsStartOnly = true;

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, gx, gx-go }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchgx }:
 
 buildGoPackage rec {
   name = "ipfs-${version}";
@@ -7,6 +7,13 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/ipfs/go-ipfs";
 
+  extraSrcPaths = [
+    (fetchgx {
+      inherit name src;
+      sha256 = "0mm1rs2mbs3rmxfcji5yal9ai3v1w75kk05bfyhgzmcjvi6lwpyb";
+    })
+  ];
+
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "go-ipfs";
@@ -14,15 +21,11 @@ buildGoPackage rec {
     sha256 = "06iq7fmq7p0854aqrnmd0f0jvnxy9958wvw7ibn754fdfii9l84l";
   };
 
-  buildInputs = [ gx gx-go ];
-
-  # Extra build step for gx dependecies
-  preBuild = ''
-    (cd "go/src/${goPackagePath}"; gx install)
-  '';
-
   meta = with stdenv.lib; {
     description = "A global, versioned, peer-to-peer filesystem";
+    homepage = https://ipfs.io/;
     license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, gx, gx-go }:
 
 buildGoPackage rec {
   name = "ipfs-${version}";
-  version = "i20160112--${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "7070b4d878baad57dcc8da80080dd293aa46cabd";
+  version = "0.4.4";
+  rev = "d905d485192616abaea25f7e721062a9e1093ab9";
 
   goPackagePath = "github.com/ipfs/go-ipfs";
 
@@ -11,12 +11,18 @@ buildGoPackage rec {
     owner = "ipfs";
     repo = "go-ipfs";
     inherit rev;
-    sha256 = "1b7aimnbz287fy7p27v3qdxnz514r5142v3jihqxanbk9g384gcd";
+    sha256 = "06iq7fmq7p0854aqrnmd0f0jvnxy9958wvw7ibn754fdfii9l84l";
   };
+
+  buildInputs = [ gx gx-go ];
+
+  # Extra build step for gx dependecies
+  preBuild = ''
+    (cd "go/src/${goPackagePath}"; gx install)
+  '';
 
   meta = with stdenv.lib; {
     description = "A global, versioned, peer-to-peer filesystem";
     license = licenses.mit;
-    broken = true;
   };
 }

--- a/pkgs/build-support/fetchgx/default.nix
+++ b/pkgs/build-support/fetchgx/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, gx, gx-go, go, cacert }:
+
+{ name, src, sha256 }:
+
+stdenv.mkDerivation {
+  name = "${name}-gxdeps";
+  inherit src;
+
+  buildInputs = [ go gx gx-go ];
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = sha256;
+
+  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  buildPhase = ''
+    export GOPATH=$(pwd)/vendor
+    mkdir vendor
+    gx install
+  '';
+
+  installPhase = ''
+    mv vendor $out
+  '';
+
+  preferLocalBuild = true;
+}

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -1,4 +1,4 @@
-{ go, govers, parallel, lib, fetchgit, fetchhg }:
+{ go, govers, parallel, lib, fetchgit, fetchhg, rsync }:
 
 { name, buildInputs ? [], nativeBuildInputs ? [], passthru ? {}, preFixup ? ""
 
@@ -16,6 +16,10 @@
 
 # Extra sources to include in the gopath
 , extraSrcs ? [ ]
+
+# Extra gopaths containing src subfolder
+# with sources to include in the gopath
+, extraSrcPaths ? [ ]
 
 # go2nix dependency file
 , goDeps ? null
@@ -85,6 +89,9 @@ go.stdenv.mkDerivation (
     chmod -R u+w goPath/*
     mv goPath/* "go/src/${goPackagePath}"
     rmdir goPath
+
+  '') + (lib.optionalString (extraSrcPaths != []) ''
+    ${rsync}/bin/rsync -a ${lib.concatMapStrings (p: "${p}/src") extraSrcPaths} go
 
   '') + ''
     export GOPATH=$NIX_BUILD_TOP/go:$GOPATH

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -250,6 +250,8 @@ in
   fetchNuGet = callPackage ../build-support/fetchnuget { };
   buildDotnetPackage = callPackage ../build-support/build-dotnet-package { };
 
+  fetchgx = callPackage ../build-support/fetchgx { };
+
   resolveMirrorURLs = {url}: fetchurl {
     showURLs = true;
     inherit url;


### PR DESCRIPTION
###### Motivation for this change

Adds a systemd unit for IPFS. :rocket:
~~Don't pull before #19931~~ *has been merged!*

###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
