### PR TITLE
[WIP] munin: add version 2.999.3 and reworked service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -297,6 +297,7 @@
   ./services/monitoring/longview.nix
   ./services/monitoring/monit.nix
   ./services/monitoring/munin.nix
+  ./services/monitoring/munin-ng.nix
   ./services/monitoring/nagios.nix
   ./services/monitoring/prometheus/default.nix
   ./services/monitoring/prometheus/node-exporter.nix

--- a/nixos/modules/services/monitoring/munin-ng.nix
+++ b/nixos/modules/services/monitoring/munin-ng.nix
@@ -1,0 +1,237 @@
+{ config, lib, pkgs, ... }:
+
+# TODO: support munin-async
+
+with lib;
+
+let
+  nodeCfg = config.services.munin-node-ng;
+  muninCfg = config.services.munin;
+  httpdCfg = config.services.munin.httpd;
+  cfgPackage = pkgs.muninUnstable.override { plugins = nodeCfg.plugins; };
+in
+
+{
+
+  options = {
+
+    services.munin-node-ng = {
+
+      enable = mkEnableOption "munin-node agent";
+      
+      config = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          <filename>munin-node.conf</filename> extra configuration. See
+          <link xlink:href='http://guide.munin-monitoring.org/en/latest/reference/munin-node.conf.html' />
+        '';
+      };
+
+      pluginConfig = mkOption {
+        default = "";
+        type = types.lines;
+        example = ''
+          [postgres_]
+          env.PGUSER root
+        '';
+        description = ''
+          <filename>plugin-conf.d</filename> extra configuration. See
+          <link xlink:href='https://munin.readthedocs.io/en/latest/plugin/use.html#configuring' />
+        '';
+      };
+      
+      plugins = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = ''
+          List of extra plugin providers. Plugins should be located in share/plugins subdirectory.
+        '';
+      };
+
+    };
+    
+    services.munin = {
+    
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable munin-cron resource stats collector. Enables also services.munin-node for self-monitoring
+          and starts web interface on 4948 port (which can be disabled with services.munin.httpd.enable = false).
+        '';
+      };
+      
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/munin";
+        description = ''
+          Data directory for Munin.
+        '';
+      };
+      
+      config = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          <filename>munin.conf</filename> extra configuration.
+          See <link xlink:href='http://guide.munin-monitoring.org/en/latest/reference/munin.conf.html' />.
+          Useful to setup notifications, see
+          <link xlink:href='http://guide.munin-monitoring.org/en/latest/tutorial/alert.html' />
+        '';
+      };
+      
+      configNodes = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          [local]
+          address localhost
+          port 4949
+       '';
+        description = ''
+          Definitions of nodes and node groups to collect data from. Needs at least one
+          host for munin-cron to succeed. See
+          <link xlink:href='http://guide.munin-monitoring.org/en/latest/reference/munin.conf.html#node-definitions' />
+        '';
+      };
+      
+      httpd = {
+        enable = mkOption {
+          default = false;
+          description = ''
+            Whether to enable munin-httpd web interface
+            You may want to set caching proxy in front of munin-httpd. You can do this with nginx:
+            
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkMerge [
+  
+     (mkIf (nodeCfg.enable || muninCfg.enable || httpdCfg.enable)  {
+
+    environment.systemPackages = [ cfgPackage ];
+
+  }) (mkIf (muninCfg.enable || httpdCfg.enable) {
+  
+    users.extraUsers = [{
+      name = "munin";
+      description = "Munin monitoring user";
+      group = "munin";
+      uid = config.ids.uids.munin;
+    }];
+
+    users.extraGroups = [{
+      name = "munin";
+      gid = config.ids.gids.munin;
+    }];
+
+  }) (mkIf nodeCfg.enable {
+  
+    services.munin-node-ng.plugins = mkBefore [ pkgs.muninUnstable ];
+    
+    services.munin-node-ng.pluginConfig = mkBefore ''
+      [postgres_]
+      env.PGUSER root
+    '';
+    
+    services.munin.configNodes = mkIf muninCfg.enable ''
+      [${config.networking.hostName}]
+      address munin://localhost
+    '';
+  
+    services.munin-node-ng.config = mkBefore ''
+      log_level 3
+      log_file Sys::Syslog
+      port 4949
+      background 0
+      host_name ${config.networking.hostName}
+      setsid 0
+      cidr_allow 127.0.0.1/32
+    '';
+
+    systemd.services.munin-node = 
+      let pluginsConf = pkgs.writeTextDir "plugin-conf.d" nodeCfg.pluginConfig;
+          nodeConf = pkgs.writeText "munin-node.conf" nodeCfg.config;
+    in {
+      description = "Munin Node";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [ munin gawk procps ntp nettools ];
+      preStart = ''
+        echo "updating munin plugins..."
+        mkdir -p /etc/munin/plugins
+        rm -rf /etc/munin/plugins/*
+        mkdir -p /var/lib/munin-node/plugin-state
+        
+        for pluginDir in ${concatMapStringsSep " "  builtins.toString nodeCfg.plugins}; do
+          PATH="/var/setuid-wrappers:/run/current-system/sw/bin:$PATH" \
+            munin-node-configure --shell --families=contrib,auto,manual \
+              --config=${nodeConf} \
+              --sconfdir=${pluginsConf} \
+              --libdir $pluginDir/share/plugins \
+              --servicedir=/etc/munin/plugins \
+              2>/dev/null | ${pkgs.bash}/bin/bash
+        done
+      '';
+      serviceConfig = {
+        ExecStart = ''${cfgPackage}/bin/munin-node \
+          --config ${nodeConf} \
+          --sconfdir=${pluginsConf} \
+          --servicedir /etc/munin/plugins'';
+      };
+    };
+
+  }) (mkIf muninCfg.enable {
+  
+    services.munin-node-ng.enable = mkDefault true;
+    services.munin.httpd.enable = mkDefault true;
+  
+    services.munin.config = mkBefore ''
+      dbdir     ${muninCfg.dataDir}
+      logdir    ${muninCfg.dataDir}/logs
+      rundir    /run/munin
+      tmpldir   ${cfgPackage}/share/templates
+    '';
+
+    systemd.services.munin-cron = {
+      path = [ cfgPackage ];
+      after = [ "network.target" ] ++ (optional nodeCfg.enable "munin-node.service");
+      wants = optional nodeCfg.enable "munin-node.service";
+      preStart = ''
+        mkdir -p ${muninCfg.dataDir} /run/munin
+        chown -R munin:munin ${muninCfg.dataDir} /run/munin
+      '';
+      script = ''
+        munin-cron --config ${pkgs.writeText "munin.conf" (muninCfg.config + muninCfg.configNodes)}
+      '';
+      serviceConfig.Type = "oneshot";
+      serviceConfig.User = "munin";
+      serviceConfig.Group = "munin";
+      serviceConfig.PermissionsStartOnly = true;
+    };
+    
+    systemd.timers.munin-cron = {
+      wantedBy = [ "multi-user.target" ];
+      timerConfig = {
+        Unit = "munin-cron.service";
+        OnCalendar = "*:0/5";
+        Persistent = "true";
+      };
+    };
+    
+  }) (mkIf httpdCfg.enable {
+  
+    systemd.services.munin-httpd = {
+      path = with pkgs; [ rrdtool ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig.User = "munin";
+      serviceConfig.Group = "munin";
+      script = "${cfgPackage}/bin/munin-httpd --config ${pkgs.writeText "munin.conf" (muninCfg.config + muninCfg.configNodes)}";
+    } // optionalAttrs muninCfg.enable { after = [ "munin-cron.service" ]; };
+
+  })];
+}

--- a/pkgs/servers/monitoring/munin/unstable.nix
+++ b/pkgs/servers/monitoring/munin/unstable.nix
@@ -1,0 +1,124 @@
+{ stdenv, fetchurl, makeWrapper, rrdtool, perl, perlPackages
+, plugins ? []
+}:
+
+let pluginDeps = with perlPackages;   [
+  Log4Perl IOSocketInet6 Socket6 URI DBFile DateManip
+  HTMLTemplate FileCopyRecursive FCGI NetCIDR NetSNMP NetServer
+  ListMoreUtils TimeHiRes DBDPg LWPUserAgent rrdtool
+  LogDispatch DBDSQLite
+  # for munin-httpd
+  HTTPServerSimpleCGI IOString HTMLTemplatePro XMLDumper XMLParser JSON
+] ++ (stdenv.lib.concatMap (x: x.propagatedBuildInputs) plugins);
+
+in stdenv.mkDerivation rec {
+  version = "2.999.3";
+  name = "munin-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/munin-monitoring/munin/archive/${version}.tar.gz";
+    sha256 = "18rnlcsim50mnfm25pdn8wz6mqkh90p7frfsgmbspph6najq3qqj";
+  };
+
+  buildInputs = [ perl makeWrapper rrdtool ]
+   ++ (with perlPackages; [
+    ModuleBuild
+    LogDispatch
+    ParamsValidate
+    LWPUserAgent
+    HTMLTemplate
+    
+    NetCIDR
+    NetSSLeay
+    NetServer
+    Log4Perl
+    IOSocketInet6
+    Socket6
+    URI
+    DBFile
+    DateManip
+    FileCopyRecursive
+    FCGI
+    NetSNMP
+    NetServer
+    ListMoreUtils
+    TimeHiRes
+    DBDPg
+   ]);
+
+  propagatedBuildInputs = pluginDeps;
+   
+  patchPhase = ''
+    # their Makefile isn't very flexible
+    rm -f Makefile
+    
+    # didn't find better way to set MUNIN_BINDIR
+    sed -i 's/$Config{installsitebin}/$build->install_path('"'"'script'"'"')/g' Build.PL
+    
+    # munin hardcodes PATH, we need it to obey $PATH
+    sed -i '/ENV{PATH}/d' lib/Munin/Node/Service.pm
+    
+    # couldn't figure out, why rrdtool isn't found in PATH while being run as systemd service
+    sed -i 's|"rrdtool"|"${rrdtool}/bin/rrdtool"|g' lib/Munin/Master/Graph.pm
+    
+    # this fixes rrdtool graph generation
+    sed -i 's|\\\\l||g' lib/Munin/Master/Graph.pm
+  '';
+  
+  buildPhase = ''
+    # fragile, but otherwise manual rearrangement of directories is required
+    perl Build.PL --destdir $out \
+       --install_path script=$out/bin \
+       --install_path lib=lib/perl5/site_perl \
+       --install_path bindoc=share/man/man1 \
+       --install_path libdoc=share/man/man3 \
+       --install_path share=$out/share \
+       --install_path etc=$out/share \
+       --install_path web=$out/share \
+       --install_path plugins=$out/share/plugins \
+       --install_path arch=/dev/null \
+       --install_path var=/var \
+       --install_path MUNIN_BINDIR=$out/bin
+  '';
+
+  installPhase = ''
+    ./Build install --destdir $out \
+       --install_path script=bin \
+       --install_path lib=lib/perl5/site_perl \
+       --install_path bindoc=share/man/man1 \
+       --install_path libdoc=share/man/man3 \
+       --install_path share=share \
+       --install_path etc=share \
+       --install_path web=share \
+       --install_path plugins=share/plugins \
+       --install_path arch=/dev/null \
+       --install_path var=/var \
+       --install_path MUNIN_BINDIR=$out/bin
+  '';
+  
+  postFixup = ''
+    echo "Removing references to /usr/{bin,sbin}/ from munin plugins..."
+    find "$out/share/plugins" -type f -print0 | xargs -0 -L1 sed -i -e "s|/usr/bin/||g" -e "s|/usr/sbin/||g"
+
+    for file in $out/bin/* ; do
+        wrapProgram "$file" \
+          --set PERL5LIB "$out/lib/perl5/site_perl:${perlPackages.makeFullPerlPath pluginDeps}" \
+          --set PERL6LIB "$out/lib/perl5/site_perl:${perlPackages.makeFullPerlPath pluginDeps}"
+
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Networked resource monitoring tool";
+    longDescription = ''
+      Munin is a monitoring tool that surveys all your computers and remembers
+      what it saw. It presents all the information in graphs through a web
+      interface. Munin can help analyze resource trends and 'what just happened
+      to kill our performance?' problems.
+    '';
+    homepage = https://munin-monitoring.org/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ danbst ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10188,6 +10188,7 @@ in
   nagios = callPackage ../servers/monitoring/nagios { };
 
   munin = callPackage ../servers/monitoring/munin { };
+  muninUnstable = callPackage ../servers/monitoring/munin/unstable.nix { };
 
   nagiosPluginsOfficial = callPackage ../servers/monitoring/nagios/plugins/official-2.x.nix { };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23,6 +23,13 @@ let self = _self // overrides; _self = with self; {
       checkPhase = "./Build test";
     });
 
+  # Create PERL5LIB path for a list of packages and their propagated dependencies
+  makeFullPerlPath = packages: stdenv.lib.fileContents ''${stdenv.mkDerivation {
+    name = "PERL5LIB";
+    buildInputs = [perl] ++ packages;
+    buildCommand = "echo $PERL5LIB > $out";
+  }}'';
+
 
   ack = buildPerlPackage rec {
     name = "ack-2.14";
@@ -6192,6 +6199,15 @@ let self = _self // overrides; _self = with self; {
     propagatedBuildInputs = [ CGI ];
   };
 
+  HTMLTemplatePro = pkgs.buildPerlPackage {
+      name = "HTML-Template-Pro-0.9510";
+      src = pkgs.fetchurl {
+        url = mirror://cpan/authors/id/V/VI/VIY/HTML-Template-Pro-0.9510.tar.gz;
+        sha256 = "11la3z0ajvm6mv1hjywwf7mj3ihdnx2xbkag2jfl7l80jvz7gjv7";
+      };
+      doCheck = false;
+  };
+
   HTMLTidy = buildPerlPackage rec {
     name = "HTML-Tidy-1.56";
     src = fetchurl {
@@ -6419,6 +6435,15 @@ let self = _self // overrides; _self = with self; {
     meta = {
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
+  };
+
+  HTTPServerSimpleCGI = pkgs.buildPerlPackage {
+      name = "HTTP-Server-Simple-0.51";
+      src = pkgs.fetchurl {
+        url = mirror://cpan/authors/id/B/BP/BPS/HTTP-Server-Simple-0.51.tar.gz;
+        sha256 = "1yvd2g57z2kq00q5i3zzfi15k98qgbif3vghjsda6v612agmrp5r";
+      };
+      doCheck = false;
   };
 
   HTTPServerSimpleMason = buildPerlPackage {
@@ -14428,6 +14453,15 @@ let self = _self // overrides; _self = with self; {
       sha256 = "1jvqfi0jm8wh80rd5h9c3k72car8l7x1jywj8rck8w6rm1mlxldy";
     };
     propagatedBuildInputs = [XMLRegExp XMLParser LWP libxml_perl];
+  };
+
+  XMLDumper = pkgs.buildPerlPackage {
+      name = "XML-Dumper-0.81";
+      src = pkgs.fetchurl {
+        url = mirror://cpan/authors/id/M/MI/MIKEWONG/XML-Dumper-0.81.tar.gz;
+        sha256 = "1q7q0fs4dvfx3pq89pb2ynx89nrvwx7xsiswxfx624kf4fshw5zl";
+      };
+      doCheck = false;
   };
 
   XMLFilterBufferText = buildPerlPackage {


### PR DESCRIPTION
###### Motivation for this change

Munin v3 has nice web interface, so let's package it ahead of it's official release.

I've developed and tested this against 16.03 and 16.09 branches.

I've chosen to create separate package and module, because:
- I didn't like the plugin patching mechanism (it's nice that plugins can be standalone, but not very useful in presence of `munin-run`)
- new munin supports more command-line options, which I'd like to use
- new `munin-httpd` service would be inapplicable to old munin (but old `munin-node` should be compatible with new munin)
- self-monitored munin can be started with only `services.munin.enable = true;`

TODOs:
- [ ] add doc about basic munin-ng setup
- [ ] add example of nginx caching dynamically generated graphs
- [ ] find out if there are better alternatives to managing `PERL5LIB` other than via hack-like `makeFullPerlPath`
- [ ] get rid of munin package double rebuild (once with plugins and once without)
- [ ] revert `nixos/modules/services/monitoring/munin.nix`, I don't want to change existing expression
- [ ] remove `HTTPServerSimpleCGI`, update `HTTPServerSimple` instead (this will require to check dependent packages)
- [ ] find out why line `sed -i 's|\\\\l||g' lib/Munin/Master/Graph.pm` is necessary for graph generation (maybe we should update rrdtool?)
- [ ] test against `unstable`
- [ ] add `contrib` plugin suite (as requested in https://github.com/NixOS/nixpkgs/issues/17895)
- [ ] add an option to runtime disable plugins
- [ ] make default plugins error-less (currently they spam into journald)
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

ping @domenkozar , feedback is welcome.
