### PR TITLE
qt56.qtwebengine, qt57.qtwebengine: make them build

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebengine.nix
@@ -1,6 +1,62 @@
-{ qtSubmodule, qtquickcontrols, qtlocation, qtwebchannel }:
+{ qtSubmodule, qtquickcontrols, qtlocation, qtwebchannel
+
+, xlibs, libXcursor, libXScrnSaver, libXrandr, libXtst
+, fontconfig, freetype, harfbuzz, icu, dbus
+, zlib, libjpeg, libpng, libtiff
+, alsaLib
+, libcap
+, pciutils
+
+, bison, flex, git, which, gperf
+, coreutils
+, pkgconfig, python
+
+}:
 
 qtSubmodule {
   name = "qtwebengine";
   qtInputs = [ qtquickcontrols qtlocation qtwebchannel ];
+  buildInputs = [ bison flex git which gperf ];
+  nativeBuildInputs = [ pkgconfig python coreutils ];
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    export MAKEFLAGS=-j$NIX_BUILD_CORES
+    substituteInPlace ./src/3rdparty/chromium/build/common.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/toolchain.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/standalone.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+      
+    configureFlags+="\
+        -plugindir $out/lib/qt5/plugins \
+        -importdir $out/lib/qt5/imports \
+        -qmldir $out/lib/qt5/qml \
+        -docdir $out/share/doc/qt5"
+  '';
+  propagatedBuildInputs = [
+    dbus zlib alsaLib
+
+    # Image formats
+    libjpeg libpng libtiff
+
+    # Text rendering
+    fontconfig freetype harfbuzz icu
+
+    # X11 libs
+    xlibs.xrandr libXScrnSaver libXcursor libXrandr xlibs.libpciaccess libXtst
+    xlibs.libXcomposite
+
+    libcap
+    pciutils
+  ];
+  postInstall = ''
+    cat > $out/libexec/qt.conf <<EOF
+    [Paths]
+    Prefix = ..
+    EOF
+  '';
 }

--- a/pkgs/development/libraries/qt-5/5.7/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtwebengine.nix
@@ -1,6 +1,62 @@
-{ qtSubmodule, qtquickcontrols, qtlocation, qtwebchannel }:
+{ qtSubmodule, qtquickcontrols, qtlocation, qtwebchannel
+
+, xlibs, libXcursor, libXScrnSaver, libXrandr, libXtst
+, fontconfig, freetype, harfbuzz, icu, dbus
+, zlib, libjpeg, libpng, libtiff
+, alsaLib
+, libcap
+, pciutils
+
+, bison, flex, git, which, gperf
+, coreutils
+, pkgconfig, python
+
+}:
 
 qtSubmodule {
   name = "qtwebengine";
   qtInputs = [ qtquickcontrols qtlocation qtwebchannel ];
+  buildInputs = [ bison flex git which gperf ];
+  nativeBuildInputs = [ pkgconfig python coreutils ];
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    export MAKEFLAGS=-j$NIX_BUILD_CORES
+    substituteInPlace ./src/3rdparty/chromium/build/common.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/toolchain.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace ./src/3rdparty/chromium/v8/build/standalone.gypi \
+      --replace /bin/echo ${coreutils}/bin/echo
+      
+    configureFlags+="\
+        -plugindir $out/lib/qt5/plugins \
+        -importdir $out/lib/qt5/imports \
+        -qmldir $out/lib/qt5/qml \
+        -docdir $out/share/doc/qt5"
+  '';
+  propagatedBuildInputs = [
+    dbus zlib alsaLib
+
+    # Image formats
+    libjpeg libpng libtiff
+
+    # Text rendering
+    fontconfig freetype harfbuzz icu
+
+    # X11 libs
+    xlibs.xrandr libXScrnSaver libXcursor libXrandr xlibs.libpciaccess libXtst
+    xlibs.libXcomposite
+
+    libcap
+    pciutils
+  ];
+  postInstall = ''
+    cat > $out/libexec/qt.conf <<EOF
+    [Paths]
+    Prefix = ..
+    EOF
+  '';
 }


### PR DESCRIPTION
###### Motivation for this change

Make qtwebengine build and work
#16561 was never committed and while testing it I discovered QtWebEngineProcess couldn't find it's locales.
This is the qtwebengine part of #16561 with added qt.conf generation.

###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
