### PR TITLE
docker.buildUtils: use baseNameOf to allow for slashes in name

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -395,10 +395,14 @@ rec {
 
       layer =
         if runAsRoot == null
-        then mkPureLayer { inherit name baseJson contents extraCommands; }
-        else mkRootLayer { inherit name baseJson fromImage fromImageName
-                                   fromImageTag contents runAsRoot diskSize
-                                   extraCommands; };
+        then mkPureLayer {
+          name = baseName;
+          inherit baseJson contents extraCommands;
+        } else mkRootLayer {
+          name = baseName;
+          inherit baseJson fromImage fromImageName fromImageTag
+                  contents runAsRoot diskSize extraCommands;
+        };
       result = runCommand "docker-image-${baseName}.tar.gz" {
         buildInputs = [ jshon pigz coreutils findutils ];
         imageName = name;


### PR DESCRIPTION
###### Motivation for this change

Fixes #20016

###### Things done

Use `baseNameOf` on layer names, to allow for things like `name = "foo/bar:baz"`.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


