### PR TITLE
python33Packages.mezzanine Fix

### DIFF
--- a/pkgs/development/python-modules/mezzanine/writable_settings.patch
+++ b/pkgs/development/python-modules/mezzanine/writable_settings.patch
@@ -1,0 +1,21 @@
+diff -Nur mezzanine-3.1.10/mezzanine/bin/mezzanine_project.py mezzanine-3.1.10-patched/mezzanine/bin/mezzanine_project.py
+--- mezzanine-3.1.10/mezzanine/bin/mezzanine_project.py	2014-08-30 07:12:19.000000000 +0200
++++ mezzanine-3.1.10-patched/mezzanine/bin/mezzanine_project.py	2016-10-31 14:47:30.982401818 +0100
+@@ -5,6 +5,7 @@
+ from distutils.dir_util import copy_tree
+ from optparse import OptionParser
+ import os
++import stat
+ from shutil import move
+ from uuid import uuid4
+ 
+@@ -61,6 +62,9 @@
+         copy_tree(os.path.join(package_path, "project_template"), project_path)
+         move(local_settings_path + ".template", local_settings_path)
+ 
++    os.chmod(local_settings_path,
++             os.stat(local_settings_path).st_mode | stat.S_IWRITE)
++
+     # Generate a unique SECRET_KEY for the project's setttings module.
+     with open(local_settings_path, "r") as f:
+         data = f.read()

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9719,6 +9719,9 @@ in {
     name = "Django-${version}";
     version = "1.6.11";
 
+    # Support to python-3.4 and higher was introduced in django_1_7
+    disabled = !(isPy26 || isPy27 || isPy33);
+
     src = pkgs.fetchurl {
       url = "http://www.djangoproject.com/m/releases/1.6/${name}.tar.gz";
       sha256 = "0misvia78c14y07zs5xsb9lv54q0v217jpaindrmhhw4wiryal3y";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13967,6 +13967,7 @@ in {
       url = "https://github.com/stephenmcd/mezzanine/archive/${version}.tar.gz";
       sha256 = "1cd7d3dji8q4mvcnf9asxn8j109pd5g5d5shr6xvn0iwr35qprgi";
     };
+    patches = [ ../development/python-modules/mezzanine/writable_settings.patch ];
 
     disabled = isPyPy;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10706,6 +10706,9 @@ in {
 
     buildInputs = [ self.django ];
 
+    # There is no test embedded
+    doCheck = false;
+
     meta = {
       description = "A snapshot of django-filebrowser for the Mezzanine CMS";
       longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

This is related to #19989 .

This PR makes sure that mezzanine can be used with python-3.3.

The following have been tested to check that a small instance can run:
```
$ mezzanine-project myproject
$ cd myproject
$ python3 manage.py createdb
$ python manage.py runserver
```

cc @FRidh 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] OS X
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

