### PR TITLE
streamlink: 1.14.0-rc1 -> 0.0.2

### DIFF
--- a/pkgs/applications/video/streamlink/default.nix
+++ b/pkgs/applications/video/streamlink/default.nix
@@ -1,14 +1,14 @@
 { stdenv, pythonPackages, fetchFromGitHub, rtmpdump }:
 
 pythonPackages.buildPythonApplication rec {
-  version = "1.14.0-rc1";
+  version = "0.0.2";
   name = "streamlink-${version}";
 
   src = fetchFromGitHub {
     owner = "streamlink";
     repo = "streamlink";
-    rev = "ffc099b16b9a9d2c0c44081d687c50ee2e935f29";
-    sha256 = "0ix2k2yd2jzcazkjjb0iczr4bv7pgx873k7bhxgb9zwplklxpw1k";
+    rev = "${version}";
+    sha256 = "156b3smivs8lja7a98g3qa74bawqhc4mi8w8f3dscampbxx4dr9y";
   };
 
   propagatedBuildInputs = (with pythonPackages; [ pycrypto requests2 ]) ++ [ rtmpdump ];


### PR DESCRIPTION
###### Motivation for this change

Update streamlink to 0.0.2
1.14.0-rc1 was not an official release and they have restarted version numbering.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
