### PR TITLE
qsyncthingtray: init at 0.5.5rc2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -483,4 +483,5 @@
   zimbatm = "zimbatm <zimbatm@zimbatm.com>";
   zohl = "Al Zohali <zohl@fmap.me>";
   zoomulator = "Kim Simmons <zoomulator@gmail.com>";
+  zraexy = "David Mell <zraexy@gmail.com>";
 }

--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub
+, qtbase, qtwebengine
+, qmakeHook }:
+
+stdenv.mkDerivation rec {
+  version = "0.5.5rc2";
+  name = "qsyncthingtray-${version}";
+
+  src = fetchFromGitHub {
+    owner = "sieren";
+    repo = "QSyncthingTray";
+    rev = "${version}";
+    sha256 = "1x7j7ylgm4ih06m7gb5ls3c9bdjwbra675489caq2f04kgw4yxq2";
+  };
+
+  buildInputs = [ qtbase qtwebengine ];
+  nativeBuildInputs = [ qmakeHook ];
+  enableParallelBuilding = true;
+  
+  postInstall = ''
+    mkdir -p $out/bin
+    cp binary/QSyncthingTray $out/bin
+    cat > $out/bin/qt.conf <<EOF
+    [Paths]
+    Prefix = ${qtwebengine.out}
+    EOF
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/sieren/QSyncthingTray/;
+    description = "A Traybar Application for Syncthing written in C++";
+    longDescription = ''
+        A cross-platform status bar for Syncthing.
+        Currently supports OS X, Windows and Linux.
+        Written in C++ with Qt.
+    '';
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ zraexy ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14201,6 +14201,8 @@ in
   qscreenshot = callPackage ../applications/graphics/qscreenshot {
     qt = qt4;
   };
+  
+  qsyncthingtray = qt5.callPackage ../applications/misc/qsyncthingtray { };
 
   qsynth = callPackage ../applications/audio/qsynth { };
 


### PR DESCRIPTION
###### Motivation for this change

Add QSyncthingTray

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

