### PR TITLE
zita-resampler: 1.3.0 -> 1.6.0

### DIFF
--- a/pkgs/development/libraries/audio/zita-resampler/default.nix
+++ b/pkgs/development/libraries/audio/zita-resampler/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "zita-resampler-${version}";
-  version = "1.3.0";
+  version = "1.6.0";
   src = fetchurl {
     url = "http://kokkinizita.linuxaudio.org/linuxaudio/downloads/${name}.tar.bz2";
-    sha256 = "0r9ary5sc3y8vba5pad581ha7mgsrlyai83w7w4x2fmhfy64q0wq";
+    sha256 = "1w48lp99jn4wh687cvbnbnjgaraqzkb4bgir16cp504x55v8v20h";
   };
 
   makeFlags = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


