### PR TITLE
audacity: add jack and lv2 capabilities

### DIFF
--- a/pkgs/applications/audio/audacity/default.nix
+++ b/pkgs/applications/audio/audacity/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, wxGTK30, pkgconfig, gettext, gtk2, glib, zlib, perl, intltool,
-  libogg, libvorbis, libmad, alsaLib, libsndfile, soxr, flac, lame, fetchpatch,
+  libogg, libvorbis, libmad, libjack2, lv2, lilv, serd, sord, sratom, suil, alsaLib, libsndfile, soxr, flac, lame, fetchpatch,
   expat, libid3tag, ffmpeg, soundtouch /*, portaudio - given up fighting their portaudio.patch */
   }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig gettext wxGTK30 expat alsaLib
-    libsndfile soxr libid3tag gtk2
+    libsndfile soxr libid3tag libjack2 lv2 lilv serd sord sratom suil gtk2
     ffmpeg libmad lame libvorbis flac soundtouch
   ]; #ToDo: detach sbsms
 


### PR DESCRIPTION
###### Motivation for this change
Now you can use lv2 plugins, and run the audio trough jack.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] OS X
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


