### PR TITLE
ardour5: add dummy backend, so Ardour Session Utilities get built

### DIFF
--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     patchShebangs ./tools/
   '';
 
-  configurePhase = "${python2.interpreter} waf configure --optimize --docs --with-backends=jack,alsa --prefix=$out";
+  configurePhase = "${python2.interpreter} waf configure --optimize --docs --with-backends=jack,alsa,dummy --prefix=$out";
 
   buildPhase = "${python2.interpreter} waf";
 


### PR DESCRIPTION
###### Motivation for this change
Ardour 5 has a few usefull utility scripts that only get built when the dummy backend is included.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] OS X
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


