### PR TITLE
Remove obsolete versions of db

### DIFF
--- a/pkgs/development/libraries/db/db-4.4.nix
+++ b/pkgs/development/libraries/db/db-4.4.nix
@@ -1,9 +1,0 @@
-{ stdenv, fetchurl, ... } @ args:
-
-import ./generic.nix (args // rec {
-  version = "4.4.20";
-  extraPatches = [ ./cygwin-4.4.patch ];
-  sha256 = "0y9vsq8dkarx1mhhip1vaciz6imbbyv37c1dm8b20l7p064bg2i9";
-  branch = "4.4";
-  drvArgs = { hardeningDisable = [ "format" ]; };
-})

--- a/pkgs/development/libraries/db/db-4.5.nix
+++ b/pkgs/development/libraries/db/db-4.5.nix
@@ -1,9 +1,0 @@
-{ stdenv, fetchurl, ... } @ args:
-
-import ./generic.nix (args // rec {
-  version = "4.5.20";
-  extraPatches = [ ./cygwin-4.5.patch ./register-race-fix.patch ];
-  sha256 = "0bd81k0qv5i8w5gbddrvld45xi9k1gvmcrfm0393v0lrm37dab7m";
-  branch = "4.5";
-  drvArgs = { hardeningDisable = [ "format" ]; };
-})

--- a/pkgs/development/libraries/db/db-4.7.nix
+++ b/pkgs/development/libraries/db/db-4.7.nix
@@ -1,8 +1,0 @@
-{ stdenv, fetchurl, ... } @ args:
-
-import ./generic.nix (args // rec {
-  version = "4.7.25";
-  sha256 = "0gi667v9cw22c03hddd6xd6374l0pczsd56b7pba25c9sdnxjkzi";
-  branch = "4.7";
-  drvArgs = { hardeningDisable = [ "format" ]; };
-})

--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -41,7 +41,7 @@
       # this is the example we will be using
       nixEnv = complicatedMyEnv {
         name = "nix";
-        buildInputs = [ libtool stdenv perl curl bzip2 openssl db45 autoconf automake zlib ];
+        buildInputs = [ libtool stdenv perl curl bzip2 openssl db5 autoconf automake zlib ];
       };
     };
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5517,7 +5517,7 @@ in
   python3Packages = python35Packages;
 
   python26 = callPackage ../development/interpreters/python/cpython/2.6 {
-    db = db47;
+    db = db4;
     self = python26;
   };
   python27 = callPackage ../development/interpreters/python/cpython/2.7 {
@@ -6498,7 +6498,7 @@ in
 
   aprutil = callPackage ../development/libraries/apr-util {
     bdbSupport = true;
-    db = if stdenv.isFreeBSD then db47 else db;
+    db = if stdenv.isFreeBSD then db4 else db;
     # XXX: only the db_185 interface was available through
     #      apr with db58 on freebsd (nov 2015), for unknown reasons
   };
@@ -6712,7 +6712,6 @@ in
   # bsd-like license
   db = db5;
   db4 = db48;
-  db47 = callPackage ../development/libraries/db/db-4.7.nix { };
   db48 = callPackage ../development/libraries/db/db-4.8.nix { };
   db5 = db53;
   db53 = callPackage ../development/libraries/db/db-5.3.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6712,7 +6712,6 @@ in
   # bsd-like license
   db = db5;
   db4 = db48;
-  db45 = callPackage ../development/libraries/db/db-4.5.nix { };
   db47 = callPackage ../development/libraries/db/db-4.7.nix { };
   db48 = callPackage ../development/libraries/db/db-4.8.nix { };
   db5 = db53;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6712,7 +6712,6 @@ in
   # bsd-like license
   db = db5;
   db4 = db48;
-  db44 = callPackage ../development/libraries/db/db-4.4.nix { };
   db45 = callPackage ../development/libraries/db/db-4.5.nix { };
   db47 = callPackage ../development/libraries/db/db-4.7.nix { };
   db48 = callPackage ../development/libraries/db/db-4.8.nix { };


### PR DESCRIPTION
Fixes #19897 

None of these seem essential, and we generally try to avoid accumulating old versions of things in nixpkgs unless one of our packages can't avoid using them.

I care in particular because we need to patch db to be compatible with LLVM 3.8. The patches are different for each version, upstream is never going to bother patching these old versions, and I don't feel like figuring out the correct patch for each of them.

cc @LnL7 