### PR TITLE
obnam: 1.19.1 -> 1.20.2

### DIFF
--- a/pkgs/tools/backup/obnam/default.nix
+++ b/pkgs/tools/backup/obnam/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "obnam-${version}";
-  version = "1.19.1";
+  version = "1.20.2";
 
   src = fetchurl rec {
     url = "http://code.liw.fi/debian/pool/main/o/obnam/obnam_${version}.orig.tar.xz";
-    sha256 = "096abbvz2c9vm8r7zm82yqrd7zj04pb1xzlv6z0dspkngd0cfdqc";
+    sha256 = "0r8gngjir9pinj5vp2aq326g74wnhv075n8y9i0hgc5cfvckjjmq";
   };
 
   buildInputs = [ pythonPackages.sphinx attr ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


