### PR TITLE
haskellPackages.dataenc: jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1041,4 +1041,8 @@ self: super: {
     http-conduit = self.http-conduit_2_2_3;
   });
 
+  # https://hydra.nixos.org/build/42769611/nixlog/1/raw
+  # note: the library is unmaintained, no upstream issue
+  dataenc = doJailbreak super.dataenc;
+
 }


### PR DESCRIPTION
Relaxes overly strict bounds on base (3 > && < 4.8).  The dataenc package is unmaintained so there is no corresponding upstream issue.