### PR TITLE
scala: Fix hash

### DIFF
--- a/pkgs/development/compilers/scala/default.nix
+++ b/pkgs/development/compilers/scala/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.scala-lang.org/files/archive/${name}.tgz";
-    sha256 = "148wmk7gjiyfms9lrwgiky7vw78pwnvpnx71rg4l30zd6jfiknp9";
+    sha256 = "1g34fw2nib9bzk1qw68a4wvh4zy09y5yqvnlq4yw250f6lqfi17r";
   };
 
   propagatedBuildInputs = [ jre ] ;


### PR DESCRIPTION
###### Motivation for this change
Apparently, the Scala folks re-cut the 2.12.0 release, so the hash has changed.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


