### PR TITLE
haskellPackages: fix libsystemd-journal

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1045,4 +1045,10 @@ self: super: {
   # note: the library is unmaintained, no upstream issue
   dataenc = doJailbreak super.dataenc;
 
+  libsystemd-journal = overrideCabal super.libsystemd-journal (old: {
+    # https://github.com/ocharles/libsystemd-journal/pull/17
+    jailbreak = true;
+    librarySystemDepends = old.librarySystemDepends or [] ++ [ pkgs.systemd ];
+  });
+
 }


### PR DESCRIPTION
not sure why it broke in the first place, in an earlier version it had `jailbreak = true;` and sytstemd was set to the correct version in `hackage-packages.nix`. Did something with `hackage2nix` change @peti?