### PR TITLE
lumina: init at 1.1.0-p1

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -19,7 +19,8 @@ in
   # E.g., if KDE is enabled, it supersedes xterm.
   imports = [
     ./none.nix ./xterm.nix ./xfce.nix ./kde4.nix ./kde5.nix
-    ./lxqt.nix ./enlightenment.nix ./gnome3.nix ./kodi.nix
+    ./lumina.nix ./lxqt.nix ./enlightenment.nix ./gnome3.nix
+    ./kodi.nix
   ];
 
   options = {

--- a/nixos/modules/services/x11/desktop-managers/lumina.nix
+++ b/nixos/modules/services/x11/desktop-managers/lumina.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  xcfg = config.services.xserver;
+  cfg = xcfg.desktopManager.lumina;
+
+in
+
+{
+  options = {
+
+    services.xserver.desktopManager.lumina.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable the Lumina desktop manager";
+    };
+
+  };
+
+
+  config = mkIf (xcfg.enable && cfg.enable) {
+
+    services.xserver.desktopManager.session = singleton {
+      name = "lumina";
+      start = ''
+        exec ${pkgs.lumina}/bin/start-lumina-desktop
+      '';
+    };
+
+    environment.systemPackages = [
+      pkgs.fluxbox
+      pkgs.kde5.kwindowsystem
+      pkgs.kde5.oxygen-icons5
+      pkgs.lumina
+      pkgs.numlockx
+      pkgs.qt5.qtsvg
+      pkgs.xscreensaver
+    ];
+
+    # Link some extra directories in /run/current-system/software/share
+    environment.pathsToLink = [
+      "/share/desktop-directories"
+      "/share/icons"
+      "/share/lumina"
+      "/share"
+    ];
+
+  };
+}

--- a/pkgs/desktops/lumina/LuminaOS-NixOS.cpp.patch
+++ b/pkgs/desktops/lumina/LuminaOS-NixOS.cpp.patch
@@ -1,0 +1,26 @@
+diff --git a/src-qt5/core/libLumina/LuminaOS-NixOS.cpp b/src-qt5/core/libLumina/LuminaOS-NixOS.cpp
+index b92d1b0..441b1bf 100644
+--- a/src-qt5/core/libLumina/LuminaOS-NixOS.cpp
++++ b/src-qt5/core/libLumina/LuminaOS-NixOS.cpp
+@@ -13,17 +13,17 @@
+ //can't read xbrightness settings - assume invalid until set
+ static int screenbrightness = -1;
+ 
+-QString LOS::OSName(){ return "Gentoo Linux"; }
++QString LOS::OSName(){ return "NixOS"; }
+ 
+ //OS-specific prefix(s)
+ // NOTE: PREFIX, L_ETCDIR, L_SHAREDIR are defined in the OS-detect.pri project file and passed in
+ QString LOS::LuminaShare(){ return (L_SHAREDIR+"/lumina-desktop/"); } //Install dir for Lumina share files
+-QString LOS::AppPrefix(){ return "/usr/"; } //Prefix for applications
+-QString LOS::SysPrefix(){ return "/"; } //Prefix for system
++QString LOS::AppPrefix(){ return PREFIX+"/usr"; } //Prefix for applications
++QString LOS::SysPrefix(){ return PREFIX; } //Prefix for system
+ 
+ //OS-specific application shortcuts (*.desktop files)
+ QString LOS::ControlPanelShortcut(){ return ""; } //system control panel
+-QString LOS::AppStoreShortcut(){ return LOS::AppPrefix() + "/share/applications/porthole.desktop"; } //graphical app/pkg manager
++QString LOS::AppStoreShortcut(){ return ""; } //graphical app/pkg manager
+ //OS-specific RSS feeds (Format: QStringList[ <name>::::<url> ]; )
+ QStringList LOS::RSSFeeds(){ return QStringList(); } 
+ 

--- a/pkgs/desktops/lumina/avoid-absolute-path-on-sessdir.patch
+++ b/pkgs/desktops/lumina/avoid-absolute-path-on-sessdir.patch
@@ -1,0 +1,11 @@
+diff -Naur lumina-1.0.0-Release-p1-OLD/src-qt5/OS-detect.pri lumina-1.0.0-Release-p1-PATCH/src-qt5/OS-detect.pri
+--- lumina-1.0.0-Release-p1-OLD/src-qt5/OS-detect.pri	2016-08-09 12:04:30.000000000 -0300
++++ lumina-1.0.0-Release-p1-PATCH/src-qt5/OS-detect.pri	2016-08-13 17:32:18.272137900 -0300
+@@ -55,7 +55,6 @@
+     #Use the defaults for everything else
+ 
+   }else : linux-*{
+-    L_SESSDIR=/usr/share/xsessions
+     OS=Linux
+     LIBS += -L/usr/local/lib -L/usr/lib -L/lib
+ 

--- a/pkgs/desktops/lumina/default.nix
+++ b/pkgs/desktops/lumina/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, fetchFromGitHub, fluxbox, xscreensaver, desktop_file_utils,
+  numlockx, xorg, qt5, kde5
+}:
+
+stdenv.mkDerivation rec {
+  name = "lumina-${version}";
+  version = "1.1.0-p1";
+
+  src = fetchFromGitHub {
+    owner = "trueos";
+    repo = "lumina";
+    rev = "v${version}";
+    sha256 = "1kkb6v6p6w5mx1qdmcrq3r674k9ahpc6wlsb9pi2lq8qk9yaid0m";
+  };
+
+  nativeBuildInputs = [
+    qt5.qmakeHook
+    qt5.qttools
+  ];
+
+  buildInputs = [
+    xorg.libxcb
+    xorg.xcbutilwm
+    xorg.xcbutilimage
+    qt5.qtbase
+    qt5.qtsvg
+    qt5.qtmultimedia
+    qt5.qtx11extras
+    kde5.oxygen-icons5
+    fluxbox
+    xscreensaver
+    desktop_file_utils
+    numlockx
+  ];
+
+  patches = [
+    ./avoid-absolute-path-on-sessdir.patch
+    ./LuminaOS-NixOS.cpp.patch
+  ];
+
+  prePatch = ''
+    # Copy Gentoo setup as NixOS setup and then patch it
+    # TODO: write a complete NixOS setup?
+    cp -a src-qt5/core/libLumina/LuminaOS-Gentoo.cpp src-qt5/core/libLumina/LuminaOS-NixOS.cpp
+  '';
+
+  postPatch = ''
+    # Fix location of fluxbox styles
+    substituteInPlace src-qt5/core-utils/lumina-config/pages/page_fluxbox_settings.cpp \
+      --replace 'LOS::AppPrefix()+"share/fluxbox' "\"${fluxbox}/share/fluxbox"
+  '';
+
+  qmakeFlags = [ "LINUX_DISTRO=NixOS" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A lightweight, portable desktop environment";
+    longDescription = ''
+      The Lumina Desktop Environment is a lightweight system interface
+      that is designed for use on any Unix-like operating system. It
+      is based on QT5.
+    '';
+    homepage = https://lumina-desktop.org;
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16206,6 +16206,8 @@ in
 
     in makeOverridable makePackages extra;
 
+  lumina = callPackage ../desktops/lumina { };
+
   lxqt = recurseIntoAttrs (callPackage ../desktops/lxqt { });
 
   mate = recurseIntoAttrs (callPackage ../desktops/mate {


### PR DESCRIPTION
###### Motivation for this change

Add the [Lumina Desktop Environment](https://lumina-desktop.org/) to NixOS.

> The Lumina® Desktop Environment is a lightweight system interface designed for use on any Unix-like operating system. Lumina® is based on using plugins, which allows the entire interface to be arranged by each individual user as desired. A system wide default layout is also included, and is configurable by the system administrator. This allows every system (or user session) to be designed to maximize the individual user's productivity. (View some examples)
> 
> The Lumina® desktop developers understand that the point of a computer system is to run applications, so Lumina® was designed to require as few system dependencies/requirements as possible. This allows it to be used to revitalize older systems or to allow the user to run applications that may need a higher percentage of the system resources than were previously available with other desktop environments.
> 
> All of this results in a very lightweight, customizable, and smooth desktop experience with minimal system overhead.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested on a virtual machine with a minimal configuration file.