### PR TITLE
xdgmenumaker: 0.9 -> 1.1

### DIFF
--- a/pkgs/applications/misc/xdgmenumaker/default.nix
+++ b/pkgs/applications/misc/xdgmenumaker/default.nix
@@ -32,7 +32,8 @@ stdenv.mkDerivation rec {
     description = "Command line tool that generates XDG menus for several window managers";
     homepage = https://github.com/gapan/xdgmenumaker;
     license = licenses.gpl2Plus;
-    platforms = platforms.unix;
+    # NOTE: exclude darwin from platforms because Travis reports hash mismatch
+    platforms = with platforms; filter (x: !(elem x darwin)) unix;
     maintainers = [ maintainers.romildo ];
   };
 }

--- a/pkgs/applications/misc/xdgmenumaker/default.nix
+++ b/pkgs/applications/misc/xdgmenumaker/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "xdgmenumaker-${version}";
-  version = "0.9";
+  version = "1.1";
 
   src = fetchFromGitHub {
-    rev = version;
     owner = "gapan";
     repo = "xdgmenumaker";
-    sha256 = "1n29syadsgj0vpnkc8nji4k1c8gminr1xdriz5ck2bcygsgxkdrd";
+    rev = version;
+    sha256 = "11mqafpgfnz0h0d6fxd1xsfsjxzg1abvwqgwy9jmm5xhcjx3c3l7";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).