### PR TITLE
ksysguard: Add required qtwebkit dependency.

### DIFF
--- a/pkgs/desktops/kde-5/plasma/ksysguard.nix
+++ b/pkgs/desktops/kde-5/plasma/ksysguard.nix
@@ -1,6 +1,6 @@
 { plasmaPackage, ecm, kdoctools, kconfig
 , kcoreaddons, kdelibs4support, ki18n, kitemviews, knewstuff
-, kiconthemes, libksysguard
+, kiconthemes, libksysguard, qtwebkit
 }:
 
 plasmaPackage {
@@ -8,6 +8,6 @@ plasmaPackage {
   nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kconfig kcoreaddons kitemviews knewstuff kiconthemes libksysguard
-    kdelibs4support ki18n
+    kdelibs4support ki18n qtwebkit
   ];
 }


### PR DESCRIPTION
###### Motivation for this change
KSysGuard GUI is missing.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Without this the only the daemon would be built without a GUI.