### PR TITLE
haskellPackages.servant_0_9: fix compilation issue #19819

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1041,4 +1041,15 @@ self: super: {
     http-conduit = self.http-conduit_2_2_3;
   });
 
+  # http-api-data_0.3.x requires QuickCheck > 2.9
+  http-api-data_0_3_2 = dontCheck super.http-api-data_0_3_2;
+  servant_0_9_1_1 = super.servant_0_9_1_1.overrideScope (self: super: {
+    http-api-data = self.http-api-data_0_3_2;
+  });
+  servant-client_0_9_1_1 = super.servant-client_0_9_1_1.overrideScope (self: super: {
+    http-api-data = self.http-api-data_0_3_2;
+    servant-server = self.servant-server_0_9_1_1;
+    servant = self.servant_0_9_1_1;
+  });
+
 }


### PR DESCRIPTION
###### Motivation for this change
Fixing issue #19819

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] Tested using `nix-shell -p '(import <nixpkgs> {}).haskellPackages.ghcWithPackages (p: with p; [servant_0_9_1_1])` for all modified packages.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


