### PR TITLE
fetchapt: fetching Debian-compatible packages

### DIFF
--- a/pkgs/build-support/fetchapt/default.nix
+++ b/pkgs/build-support/fetchapt/default.nix
@@ -1,0 +1,114 @@
+{ stdenv, coreutils, fetchurl, gzip, nix }:
+
+# Fetch the current version of a Debian-compatible binary package from an APT
+# repository. This function performs minimal parsing of APT repository metadata
+# to identify the current version of the named package, and returns a
+# derivation that fetches the package file.
+#
+# This function contains multiple chained derivations to support interleaved
+# downloading and parsing. Evaluating this function builds internal derivations
+# that fetch repository metadata files over network.
+#
+# This function is non-deterministic but cache-friendly. Evaluating always
+# downloads the base repository Release file so that the function can tell
+# whether the repository has been updated. If the Release file has not been
+# changed since last evaluation, all subsequent derivations will do nothing and
+# return cached results. Using this function to fetch different packages from
+# the same repository automatically reuses cached repository metadata files
+# where appropriate.
+
+let
+
+  # Fetch a file from a URL and produce a content-addressable result. This
+  # function is non-deterministic, but its result changes only if the fetched
+  # file changes.  Returns Nix store path to the fetched file.
+  prefetch = url:
+    builtins.readFile (stdenv.mkDerivation {
+      inherit nix url;
+      buildInputs = [ nix ];
+      name = "prefetch";
+      builder = ./prefetch.sh;
+      # TODO: support cusom cache TTL through parameterized trigger.
+      dummy = builtins.currentTime;
+    });
+
+  # Extract SHA256 hash of target path from the given Release file.
+  process_release = release: target:
+    builtins.readFile (stdenv.mkDerivation {
+      inherit release target;
+      name = "process-release";
+      builder = ./process-release.sh;
+    });
+
+  # Extract repository relative path and SHA256 hash of a package from
+  # the given Packages file.
+  process_packages = packages: target:
+    let
+      info = stdenv.mkDerivation {
+        inherit coreutils gzip packages target;
+        buildInputs = [ coreutils gzip ];
+        name = "process-packages-${target}";
+        builder = ./process-packages.sh;
+      };
+    in {
+      filename = builtins.readFile "${info}/filename";
+      sha256 = builtins.readFile "${info}/sha256";
+    };
+
+in
+
+{ # Base URL for the APT repository, as listed in the sources.list file on
+  # Debian-based systems. The URL cannot be a mirror reference because some
+  # files are not fetched through fetchurl. Example:
+  # http://http.debian.net/debian
+  repository
+
+, # Debian distribution, which can be a release codename (e.g., sid) or a suite
+  # (e.g., stable).
+  distribution ? "stable"
+
+, # Debian package component, which is typically one of main, contrib, and
+  # non-free.
+  component ? "main"
+
+, # Debian package architecture, as listed in www.debian.org/ports.
+  arch ? "amd64"
+
+, # Name of the Debian package to fetch, without version number (e.g., bash).
+  package
+}:
+
+rec {
+
+  dist_base = "${repository}/dists/${distribution}";
+
+  # Fetch the repository top-level Release file, which lists the SHA256 hash of
+  # the Packages file (to be obtained next). This step does not check hash
+  # value because its purpose is to fetch the current version of the file.
+  # TODO: support secure APT (wiki.debian.org/SecureApt).
+  release_file = prefetch "${dist_base}/Release";
+
+  # Fetch the relevant Packages.gz file and verify its integrity using the hash
+  # value obtained from the Release file. This step chooses to fetch the gzip
+  # compressed version of the Packages file, which seems to be most commonly
+  # available in APT repositories.
+  # TODO: support uncompressed and other compression formats.
+  # TODO: support downloading source packages (cf. binary packages).
+  packages_ref = "${component}/binary-${arch}/Packages.gz";
+  packages_file = fetchurl {
+    url = "${dist_base}/${packages_ref}";
+    sha256 = process_release release_file packages_ref;
+  };
+
+  # Search the Packages file for the named package, and extract the relative
+  # file path and the hash value of the package.
+  package_info = process_packages packages_file package;
+
+  # Download the package file and verify its integrity.
+  package_file = fetchurl {
+    url = "${repository}/${package_info.filename}";
+    sha256 = package_info.sha256;
+  };
+
+}.package_file
+

--- a/pkgs/build-support/fetchapt/prefetch.sh
+++ b/pkgs/build-support/fetchapt/prefetch.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+NIX_REMOTE=daemon "${nix}/bin/nix-prefetch-url" \
+  --type sha256 --print-path "${url}" \
+  | { read hash ; read store ; echo -n "${store}" > "${out}" ; }

--- a/pkgs/build-support/fetchapt/process-packages.sh
+++ b/pkgs/build-support/fetchapt/process-packages.sh
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+PATH="${coreutils}/bin:${gzip}/bin"
+
+name_pattern="^Package:[[:space:]]+${target}$"
+filename_pattern="^Filename:[[:space:]]+([^[:space:]]+)$"
+sha256_pattern="^SHA256:[[:space:]]+([[:xdigit:]]{64})$"
+
+mkdir "${out}"
+unset in_package has_filename has_sha256
+while read line; do
+  if [[ -z "${in_package}" ]]; then
+    if [[ $line =~ $name_pattern ]]; then
+      in_package=yes
+    fi
+  else
+    if [[ $line =~ $filename_pattern ]]; then
+      echo -n "${BASH_REMATCH[1]}" > "${out}/filename"
+      has_filename=yes
+    elif [[ $line =~ $sha256_pattern ]]; then
+      echo -n "${BASH_REMATCH[1]}" > "${out}/sha256"
+      has_sha256=yes
+    fi
+    [[ "${has_filename}" && "${has_sha256}" ]] && break
+  fi
+done < <( zcat "${packages}" )

--- a/pkgs/build-support/fetchapt/process-release.sh
+++ b/pkgs/build-support/fetchapt/process-release.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+pattern="^([[:xdigit:]]{64})[[:space:]]+[[:digit:]]+[[:space:]]+${target}$"
+while read line; do
+  if [[ $line =~ $pattern ]]; then
+    echo -n "${BASH_REMATCH[1]}" >> ${out}
+    break
+  fi
+done < ${release}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -132,6 +132,8 @@ in
       else throw "You need an adc_pass attribute in your config to download files from Apple Developer Connection";
   };
 
+  fetchapt = callPackage ../build-support/fetchapt { };
+
   fetchbower = callPackage ../build-support/fetchbower {
     inherit (nodePackages) bower2nix;
   };
@@ -13140,9 +13142,9 @@ in
 
   google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
 
-  google-chrome-beta = google-chrome.override { chromium = chromiumBeta; channel = "beta"; };
+  google-chrome-beta = google-chrome.override { channel = "beta"; };
 
-  google-chrome-dev = google-chrome.override { chromium = chromiumDev; channel = "dev"; };
+  google-chrome-dev = google-chrome.override { channel = "unstable"; };
 
   googleearth = callPackage_i686 ../applications/misc/googleearth { };
 


### PR DESCRIPTION
###### Motivation for this change

Enable timely, hassle-free updates for packages based on Debian-compatible binary packages.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


This patch implements fetchapt, a function that fetches
Debian-compatible binary packages from an APT repository. It also
updates the google-chrome package to use fetchapt.

fetchapt is designed to replace fetchurl when interacting with an APT
repository. Using fetchurl for this purpose requires specifying package
versions and hash values, which inconveniences maintainers (who need to
update the package file periodically) and users (who need wait longer to
see new versions in nixpkgs). The problem is particularly serious for
packages like google-chrome, which regularly releases new versions with
security fixes.

fetchapt does not require maintainers to specify package versions and
hash values; instead it extracts both from APT repository metadata. It
allows nixpkgs users to receive timely updates (i.e., as soon as they
become available on the APT repository) without constant churn on the
nixpkgs package definition.