### PR TITLE
memcached: 1.4.20 -> 1.4.32 for CVE-2016-8704, CVE-2016-8705, CVE-201…

### DIFF
--- a/pkgs/servers/memcached/default.nix
+++ b/pkgs/servers/memcached/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, cyrus_sasl, libevent}:
 
 stdenv.mkDerivation rec {
-  name = "memcached-1.4.20";
+  name = "memcached-1.4.32";
 
   src = fetchurl {
     url = "http://memcached.org/files/${name}.tar.gz";
-    sha256 = "0620llasj8xgffk6hk2ml15z0c5i34455wwg60i1a2zdir023l95";
+    sha256 = "0pc77l64lqxs7m68lv526ll9l001ng3cnrzszg8krdxvbz6rmfsl";
   };
 
   buildInputs = [cyrus_sasl libevent];


### PR DESCRIPTION
###### Motivation for this change

https://lwn.net/Vulnerabilities/705214/
https://github.com/NixOS/nixpkgs/issues/20078

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


…6-8706

https://lwn.net/Vulnerabilities/705214/