### PR TITLE
tre: add patch for CVE-2016-8859

### DIFF
--- a/pkgs/development/libraries/tre/default.nix
+++ b/pkgs/development/libraries/tre/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{stdenv, fetchurl, fetchpatch}:
 
 stdenv.mkDerivation rec {
   name = "tre-0.8.0";
@@ -6,6 +6,13 @@ stdenv.mkDerivation rec {
     url = "http://laurikari.net/tre/${name}.tar.gz";
     sha256 = "1pd7qsa7vc3ybdc6h2gr4pm9inypjysf92kab945gg4qa6jp11my";
   };
+
+  patches = [
+    (fetchpatch {
+      url = https://sources.debian.net/data/main/t/tre/0.8.0-6/debian/patches/03-cve-2016-8859;
+      sha256 = "0navhizym6qxd4gngrsslbij8x9r3s67p1jzzhvsnq6ky49j7w3p";
+    })
+  ];
 
   meta = {
     platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/20078
https://lwn.net/Vulnerabilities/704924/

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


