### PR TITLE
libjack2Unstable: 2015-09-03 -> 2016-08-18

### DIFF
--- a/pkgs/development/libraries/libsoundio/default.nix
+++ b/pkgs/development/libraries/libsoundio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, alsaLib, libjack2-git, libpulseaudio }:
+{ stdenv, fetchFromGitHub, cmake, alsaLib, libjack2Unstable, libpulseaudio }:
 
 stdenv.mkDerivation rec {
   version = "1.1.0";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mw197l4bci1cjc2z877gxwsvk8r43dr7qiwci2hwl2cjlcnqr2p";
   };
 
-  buildInputs = [ cmake alsaLib libjack2-git libpulseaudio ];
+  buildInputs = [ cmake alsaLib libjack2Unstable libpulseaudio ];
 
   meta = with stdenv.lib; {
     description = "Cross platform audio input and output";

--- a/pkgs/misc/jackaudio/unstable.git
+++ b/pkgs/misc/jackaudio/unstable.git
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, python2Packages, makeWrapper
-, bash, libsamplerate, libsndfile, readline
+, bash, libsamplerate, libsndfile, readline, eigen, celt
 
 # Optional Dependencies
 , dbus ? null, libffado ? null, alsaLib ? null
@@ -23,21 +23,21 @@ let
   optLibopus = shouldUsePkg libopus;
 in
 stdenv.mkDerivation rec {
-  name = "${prefix}jack2-${version}";
-  version = "2015-09-03";
+  name = "${prefix}jack2-unstable-${version}";
+  version = "2016-08-18";
 
   src = fetchFromGitHub {
     owner = "jackaudio";
     repo = "jack2";
-    rev = "2e8c5502c692a25f1c0213f3f7eeba1f4434da3c";
-    sha256 = "0r1xdshm251yqb748r5l5f6xpznhwlqyyxkky7vgx5m2q51qb0a1";
+    rev = "f2ece2418c875eb7e7ac3d25fbb484ddda47ab46";
+    sha256 = "0cvb0m6qz3k8a5njwyw65l4y3izi2rsh512hv5va97kjc6wzzx4j";
   };
 
   nativeBuildInputs = [ pkgconfig python makeWrapper ];
   buildInputs = [
     python
 
-    libsamplerate libsndfile readline
+    libsamplerate libsndfile readline eigen celt
 
     optDbus optPythonDBus optLibffado optAlsaLib optLibopus
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7077,7 +7077,7 @@ in
 
   #GMP ex-satellite, so better keep it near gmp
   mpfr = callPackage ../development/libraries/mpfr/default.nix { };
-  
+
   mpfi = callPackage ../development/libraries/mpfi { };
 
   # A GMP fork
@@ -16994,7 +16994,7 @@ in
     libopus = libopus.override { withCustomModes = true; };
   };
   libjack2 = jack2Full.override { prefix = "lib"; };
-  libjack2-git = callPackage ../misc/jackaudio/git.nix { };
+  libjack2Unstable = callPackage ../misc/jackaudio/unstable.nix { };
 
   keynav = callPackage ../tools/X11/keynav { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


