### PR TITLE
smokeping service: Fix permissions in $smokepingHome

### DIFF
--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -284,10 +284,10 @@ in
         mkdir -m 0755 -p ${smokepingHome}/cache ${smokepingHome}/data
         rm -f ${smokepingHome}/cropper
         ln -s ${cfg.package}/htdocs/cropper ${smokepingHome}/cropper
-        chown -R ${cfg.user} ${smokepingHome}
         cp ${cgiHome} ${smokepingHome}/smokeping.fcgi
         ${cfg.package}/bin/smokeping --check --config=${configPath}
         ${cfg.package}/bin/smokeping --static --config=${configPath}
+        chown -R ${cfg.user} ${smokepingHome}
       '';
       script = ''${cfg.package}/bin/smokeping --config=${configPath} --nodaemon'';
     };


### PR DESCRIPTION
In the prestart config of the smokeping service, smokeping is executed
initially. This happens as the user root and writes some files to
$smokepingHome, which can't be overwritten by the smokeping user. This
gives an error message.

I fixed this by moving the chown step after the initial smokeping runs,
so that it also affects the generated files.