### PR TITLE
services: Add Interplanetary File System service - rebased

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -277,6 +277,7 @@
       gitlab-runner = 257;
       postgrey = 258;
       hound = 259;
+      ipfs  = 260;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -524,6 +525,7 @@
       gitlab-runner = 257;
       postgrey = 258;
       hound = 259;
+      ipfs = 260;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -316,6 +316,7 @@
   ./services/monitoring/zabbix-server.nix
   ./services/network-filesystems/cachefilesd.nix
   ./services/network-filesystems/drbd.nix
+  ./services/network-filesystems/ipfs.nix
   ./services/network-filesystems/netatalk.nix
   ./services/network-filesystems/nfsd.nix
   ./services/network-filesystems/openafs-client/default.nix

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -7,7 +7,6 @@ let
 
   cfg = config.services.ipfs;
 
-
   ipfsFlags = ''${if cfg.autoMigrate then "--migrate" else ""} ${if cfg.enableGC then "--enable-gc" else ""} ${toString cfg.extraFlags}'';
 
 in
@@ -20,13 +19,7 @@ in
 
     services.ipfs = {
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to start a daemon for the Interplanetary
-          file system (IPFS).
-        '';
-      };
+      enable = mkEnableOption "Interplanetary File System";
 
       user = mkOption {
         type = types.str;
@@ -47,6 +40,7 @@ in
       };
 
       autoMigrate = mkOption {
+        type = types.bool;
         default = false;
         description = ''
           Whether IPFS should try to migrate the file system automatically.
@@ -54,9 +48,10 @@ in
       };
 
       enableGC = mkOption {
+        type = types.bool;
         default = false;
         description = ''
-          Whether to enable automatic garbadge collection.
+          Whether to enable automatic garbage collection.
         '';
       };
 
@@ -73,18 +68,20 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.ipfs ];
 
-    users.extraUsers = optionalAttrs (cfg.user == "ipfs") singleton {
-      name = "ipfs";
-      group = cfg.group;
-      home = cfg.dataDir;
-      createHome = false;
-      uid = config.ids.uids.ipfs;
-      description = "IPFS daemon user";
+    users.extraUsers = mkIf (cfg.user == "ipfs") {
+      ipfs = {
+        group = cfg.group;
+        home = cfg.dataDir;
+        createHome = false;
+        uid = config.ids.uids.ipfs;
+        description = "IPFS daemon user";
+      };
     };
 
-    users.extraGroups = optionalAttrs (cfg.group == "ipfs") singleton {
-      name = "ipfs";
-      gid = config.ids.gids.ipfs;
+    users.extraGroups = mkIf (cfg.group == "ipfs") {
+      ipfs = {
+        gid = config.ids.gids.ipfs;
+      };
     };
 
     systemd.services.ipfs = {

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -1,0 +1,114 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  inherit (pkgs) ipfs;
+
+  cfg = config.services.ipfs;
+
+
+  ipfsFlags = ''${if cfg.autoMigrate then "--migrate" else ""} ${if cfg.enableGC then "--enable-gc" else ""} ${toString cfg.extraFlags}'';
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.ipfs = {
+
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to start a daemon for the Interplanetary
+          file system (IPFS).
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "ipfs";
+        description = "User under which the IPFS daemon runs";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "ipfs";
+        description = "Group under which the IPFS daemon runs";
+      };
+
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/ipfs";
+        description = "The data dir for IPFS";
+      };
+
+      autoMigrate = mkOption {
+        default = false;
+        description = ''
+          Whether IPFS should try to migrate the file system automatically.
+        '';
+      };
+
+      enableGC = mkOption {
+        default = false;
+        description = ''
+          Whether to enable automatic garbadge collection.
+        '';
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        description = "Extra flags passed to the IPFS daemon";
+        default = [];
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.ipfs ];
+
+    users.extraUsers = optionalAttrs (cfg.user == "ipfs") singleton {
+      name = "ipfs";
+      group = cfg.group;
+      home = cfg.dataDir;
+      createHome = false;
+      uid = config.ids.uids.ipfs;
+      description = "IPFS daemon user";
+    };
+
+    users.extraGroups = optionalAttrs (cfg.group == "ipfs") singleton {
+      name = "ipfs";
+      gid = config.ids.gids.ipfs;
+    };
+
+    systemd.services.ipfs = {
+      description = "IPFS Daemon";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "local-fs.target" ];
+      path  = [ pkgs.ipfs pkgs.su pkgs.bash ];
+
+      preStart =
+        ''
+          install -m 0755 -o ${cfg.user} -g ${cfg.group} -d ${cfg.dataDir}
+          if [[ ! -d ${cfg.dataDir}/.ipfs ]]; then
+            cd ${cfg.dataDir}
+            ${pkgs.su}/bin/su -s ${pkgs.bash}/bin/sh ${cfg.user} -c "${ipfs}/bin/ipfs init"
+          fi
+        '';
+
+      serviceConfig = {
+        ExecStart = "${ipfs}/bin/ipfs daemon ${ipfsFlags}";
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

NixOS needs IPFS

###### Things done

rebased and squashed version of #20004 

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Signed-off-by: Maximilian Güntner <code@klandest.in>