### PR TITLE
Add jackline and (updated) ocaml-dependencies

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -1,0 +1,37 @@
+{stdenv, fetchFromGitHub, ocamlPackages}:
+
+assert stdenv.lib.versionAtLeast ocamlPackages.ocaml.version "4.02.2";
+
+stdenv.mkDerivation rec {
+  version = "2016-10-30";
+  name = "jackline-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "hannesm";
+    repo   = "jackline";
+    rev    = "8d829b03f2cdad6b13260ad293aeaa44075bd894";
+    sha256 = "1xsngldyracfb15jxa9h5qnpaywv6bn8gkg0hzccycjz1nfskl17";
+  };
+
+  buildInputs = with ocamlPackages; [
+                  ocaml ocamlbuild findlib topkg ppx_sexp_conv
+                  erm_xmpp_0_3 tls nocrypto x509 ocaml_lwt otr astring
+                  ptime notty sexplib_p4 hex uutf opam
+                ];
+
+  buildPhase = with ocamlPackages; ''
+    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib pkg/pkg.ml build \
+      --pinned true
+  '';
+
+  installPhase = ''
+    opam-installer --prefix=$out --script | sh
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/hannesm/jackline;
+    description = "Terminal-based XMPP client in pure OCaml.";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/astring/default.nix
+++ b/pkgs/development/ocaml-modules/astring/default.nix
@@ -1,0 +1,43 @@
+{stdenv, fetchurl, buildOcaml, ocaml, findlib, ocamlbuild, topkg, opam}:
+
+buildOcaml rec {
+  version = "0.8.3";
+  name = "astring";
+
+  src = fetchurl {
+    url = "http://erratique.ch/software/astring/releases/astring-${version}.tbz";
+    sha256 = "0ixjwc3plrljvj24za3l9gy0w30lsbggp8yh02lwrzw61ls4cri0";
+  };
+
+  unpackCmd = "tar -xf $curSrc";
+
+  buildInputs = [ ocaml findlib ocamlbuild topkg opam ];
+
+  buildPhase = ''
+    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ pkg/pkg.ml build
+  '';
+
+  installPhase = ''
+    opam-installer --script --prefix=$out astring.install | sh
+    ln -s $out/lib/astring $out/lib/ocaml/${ocaml.version}/site-lib/
+  '';
+
+  meta = {
+    homepage = http://erratique.ch/software/ptime;
+    description = "Alternative String module for OCaml.";
+    longDescription = ''
+      Astring exposes an alternative String module for OCaml. This module tries
+      to balance minimality and expressiveness for basic, index-free, string
+      processing and provides types and functions for substrings, string sets
+      and string maps.
+
+      Remaining compatible with the OCaml String module is a non-goal.
+      The String module exposed by Astring has exception safe functions, removes
+      deprecated and rarely used functions, alters some signatures and names,
+      adds a few missing functions and fully exploits OCaml's newfound string
+      immutability.
+    '';
+    license = stdenv.lib.licenses.isc;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,20 +1,40 @@
-{stdenv, writeText, fetchurl, ocaml, ocplib-endian, sexplib_p4, findlib,
- async_p4 ? null, lwt ? null, camlp4}:
+{stdenv, buildOcaml, fetchFromGitHub, writeText,
+ ocaml, ocplib-endian, sexplib_p4, findlib, ounit, camlp4,
+ async_p4  ? null, lwt     ? null, ppx_tools ? null,
+ withAsync ? true, withLwt ? true, withPpx   ? true}:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
+with stdenv.lib;
+assert withAsync -> async_p4 != null;
+assert withLwt -> lwt != null;
+assert withPpx -> ppx_tools != null;
 
-stdenv.mkDerivation {
-  name = "ocaml-cstruct-1.6.0";
+buildOcaml rec {
+  name = "cstruct";
+  version = "2.3.0";
 
-  src = fetchurl {
-    url = https://github.com/mirage/ocaml-cstruct/archive/v1.6.0.tar.gz;
-    sha256 = "0f90a1b7a03091cf22a3ccb11a0cce03b6500f064ad3766b5ed81418ac008ece";
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-cstruct";
+    rev = "v${version}";
+    sha256 = "19spsgkry41dhsbm6ij71kws90bqp7wiggc6lsqdl43xxvbgdmys";
   };
 
-  configureFlags = stdenv.lib.strings.concatStringsSep " " ((if lwt != null then ["--enable-lwt"] else []) ++
-                                          (if async_p4 != null then ["--enable-async"] else []));
-  buildInputs = [ocaml findlib camlp4];
-  propagatedBuildInputs = [ocplib-endian sexplib_p4 lwt async_p4];
+  configureFlags = [ "--enable-tests" ] ++
+                   optional withLwt [ "--enable-lwt" ] ++
+                   optional withAsync [ "--enable-async" ] ++
+                   optional withPpx ["--enable-ppx"];
+  configurePhase = "./configure --prefix $out $configureFlags";
+
+  buildInputs = [ ocaml findlib camlp4 ounit ];
+  propagatedBuildInputs = [ocplib-endian sexplib_p4 ] ++
+                          optional withPpx ppx_tools ++
+                          optional withAsync async_p4 ++
+                          optional withLwt lwt;
+
+  doCheck = true;
+  checkTarget = "test";
 
   createFindlibDestdir = true;
   dontStrip = true;

--- a/pkgs/development/ocaml-modules/erm_xmpp/0.3.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/0.3.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildOcaml, fetchFromGitHub, fetchurl, ocaml, findlib, erm_xml, nocrypto, camlp4 }:
+
+buildOcaml rec {
+  version = "0.3";
+  name = "erm_xmpp";
+
+  src = fetchFromGitHub {
+    owner  = "hannesm";
+    repo   = "xmpp";
+    rev    = "eee18bd3dd343550169969c0b45548eafd51cfe1";
+    sha256 = "0hzs528lrx1ayalv6fh555pjn0b4l8xch1f72hd3b07g1xahdas5";
+  };
+
+  buildInputs = [ ocaml findlib camlp4 ];
+  propagatedBuildInputs = [ erm_xml nocrypto ];
+
+  configurePhase = "ocaml setup.ml -configure --prefix $out";
+  buildPhase = "ocaml setup.ml -build";
+  installPhase = "ocaml setup.ml -install";
+
+  createFindlibDestdir = true;
+
+  meta = {
+    homepage = https://github.com/hannesm/xmpp;
+    description = "OCaml based XMPP implementation (fork).";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
@@ -1,10 +1,10 @@
 {stdenv, buildOcamlJane,
- ppx_core, ppx_tools, ppx_type_conv, sexplib}:
+ ppx_core, ppx_tools, ppx_type_conv, sexplib_p4}:
 
 buildOcamlJane rec {
   name = "ppx_sexp_conv";
   hash = "1kgbmlc11w5jhbhmy5n0f734l44zwyry48342dm5qydi9sfzcgq2";
-  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib];
+  propagatedBuildInputs = [ ppx_core ppx_tools ppx_type_conv sexplib_p4 ];
 
   meta = with stdenv.lib; {
     description = "PPX syntax extension that generates code for converting OCaml types to and from s-expressions, as defined in the sexplib library";

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -1,20 +1,30 @@
-{ stdenv, fetchzip, ocaml, findlib, cstruct, type_conv, zarith, ounit }:
+{ stdenv, buildOcaml, fetchFromGitHub, ocaml, findlib, cstruct, type_conv, zarith, ounit, ocaml_oasis, ppx_sexp_conv
+, lwt     ? null
+, withLwt ? true}:
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.01";
+with stdenv.lib;
+assert withLwt -> lwt != null;
 
-stdenv.mkDerivation rec {
-  name = "ocaml-nocrypto-${version}";
-  version = "0.5.1";
+buildOcaml rec {
+  name = "nocrypto";
+  version = "0.5.3";
 
-  src = fetchzip {
-    url = "https://github.com/mirleft/ocaml-nocrypto/archive/${version}.tar.gz";
-    sha256 = "15gffvixk12ghsfra9amfszd473c8h188zfj03ngvblbdm0d80m0";
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner  = "mirleft";
+    repo   = "ocaml-nocrypto";
+    rev    = "v${version}";
+    sha256 = "0m3yvqpgfffqp15mcl08b78cv8zw25rnp6z1pkj5aimz6xg3gqbl";
   };
 
-  buildInputs = [ ocaml findlib type_conv ounit ];
-  propagatedBuildInputs = [ cstruct zarith ];
+  buildInputs = [ ocaml ocaml_oasis findlib type_conv ounit ppx_sexp_conv ];
+  propagatedBuildInputs = [ cstruct zarith ] ++ optional withLwt lwt;
 
-  configureFlags = "--enable-tests";
+  configureFlags = [ "--enable-tests" ] ++ optional withLwt ["--enable-lwt"];
+
+  configurePhase = "./configure --prefix $out $configureFlags";
+
   doCheck = true;
   checkTarget = "test";
   createFindlibDestdir = true;
@@ -22,7 +32,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = https://github.com/mirleft/ocaml-nocrypto;
     description = "Simplest possible crypto to support TLS";
-    platforms = ocaml.meta.platforms or [];
     license = stdenv.lib.licenses.bsd2;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, buildOcaml, fetchFromGitHub, findlib
+, result, uucp, uuseg, uutf
+, withLwt ? true
+, lwt     ? null }:
+
+with stdenv.lib;
+assert withLwt -> lwt != null;
+
+buildOcaml rec {
+  version = "0.1.1";
+  name = "notty";
+
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner  = "pqwy";
+    repo   = "notty";
+    rev    = "v${version}";
+    sha256 = "0bw3bq8z2y1rhc20zn13s78sazywyzpg8nmyjch33p7ypxfglf01";
+  };
+
+  buildInputs = [ findlib ];
+  propagatedBuildInputs = [ result uucp uuseg uutf ] ++
+                          optional withLwt lwt;
+
+  configureFlags = [ "--enable-unix" ] ++
+                   optional withLwt ["--enable-lwt"];
+  configurePhase = "./configure --prefix $out $configureFlags";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pqwy/notty/tree/master;
+    description = "Declarative terminal graphics for OCaml.";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/otr/default.nix
+++ b/pkgs/development/ocaml-modules/otr/default.nix
@@ -1,0 +1,43 @@
+{stdenv, buildOcaml, fetchFromGitHub, ocamlbuild, findlib, topkg, ocaml, opam,
+ ppx_tools, ppx_sexp_conv, cstruct, sexplib_p4, result, nocrypto, astring}:
+
+let ocamlFlags = "-I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/"; in
+
+buildOcaml rec {
+  name = "otr";
+  version = "0.3.3";
+
+  minimumSupportedOcamlVersion = "4.02.2";
+
+  src = fetchFromGitHub {
+    owner  = "hannesm";
+    repo   = "ocaml-otr";
+    rev    = "${version}";
+    sha256 = "07zzix5mfsasqpqdx811m0x04gp8mq1ayf4b64998k98027v01rr";
+  };
+
+  buildInputs = [ ocamlbuild findlib topkg ppx_tools ppx_sexp_conv opam ];
+  propagatedBuildInputs = [ cstruct sexplib_p4 result nocrypto astring ];
+
+  buildPhase = ''
+    ocaml ${ocamlFlags}  pkg/pkg.ml build \
+      --tests true
+  '';
+
+  installPhase = ''
+    opam-installer --prefix=$out --script | sh
+    ln -s $out/lib/otr $out/lib/ocaml/${ocaml.version}/site-lib
+  '';
+
+  doCheck = true;
+  checkPhase = "ocaml ${ocamlFlags} pkg/pkg.ml test";
+
+  createFindlibDestdir = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/hannesm/ocaml-otr;
+    description = "Off-the-record (OTR) messaging protocol, purely in OCaml.";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ptime/default.nix
+++ b/pkgs/development/ocaml-modules/ptime/default.nix
@@ -1,0 +1,47 @@
+{stdenv, fetchurl, buildOcaml, ocaml, findlib, ocamlbuild, topkg, result, opam}:
+
+let ocaml-version = stdenv.lib.getVersion ocaml; in
+
+buildOcaml rec {
+  version = "0.8.2";
+  name = "ptime";
+
+  src = fetchurl {
+    url = "http://erratique.ch/software/ptime/releases/ptime-${version}.tbz";
+    sha256 = "1lihkhzskzwxskiarh4mvf7gbz5nfv25vmazbfz81m344i32a5pj";
+  };
+
+  unpackCmd = "tar -xf $curSrc";
+
+  buildInputs = [ ocaml findlib ocamlbuild topkg opam ];
+
+  propagatedBuildInputs = [ result ];
+
+  buildPhase = ''
+    ocaml -I ${findlib}/lib/ocaml/${ocaml-version}/site-lib/ pkg/pkg.ml build --with-js_of_ocaml false
+  '';
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ptime.install | sh
+    ln -s $out/lib/ptime $out/lib/ocaml/${ocaml.version}/site-lib
+  '';
+
+  meta = {
+    homepage = http://erratique.ch/software/ptime;
+    description = "POSIX time for OCaml.";
+    longDescription = ''
+      Ptime has platform independent POSIX time support in pure OCaml.
+      It provides a type to represent a well-defined range of POSIX timestamps
+      with picosecond precision, conversion with date-time values, conversion
+      with RFC 3339 timestamps and pretty printing to a human-readable,
+      locale-independent representation.
+
+      The additional Ptime_clock library provides access to a system POSIX clock
+      and to the system's current time zone offset.
+
+      Ptime is not a calendar library.
+    '';
+    license = stdenv.lib.licenses.isc;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, buildOcaml, fetchFromGitHub, findlib, ocamlbuild, ocaml_oasis
+, ppx_tools, ppx_sexp_conv, result, x509, nocrypto, cstruct
+, withLwt ? true
+, lwt     ? null}:
+
+with stdenv.lib;
+assert withLwt -> lwt != null;
+
+buildOcaml rec {
+  version = "0.7.1";
+  name = "tls";
+
+  minimunSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner  = "mirleft";
+    repo   = "ocaml-tls";
+    rev    = "${version}";
+    sha256 = "19q2hzxiasz9pzczgb63kikg0mc9mw98dfvch5falf2rincycj24";
+  };
+
+  buildInputs = [ ocamlbuild findlib ocaml_oasis ppx_sexp_conv ];
+  propagatedBuildInputs = [ cstruct nocrypto result x509 ] ++
+                          optional withLwt lwt;
+
+  configureFlags = [ "--disable-mirage" "--enable-tests" ] ++
+                   optional withLwt ["--enable-lwt"];
+
+  configurePhase = "./configure --prefix $out $configureFlags";
+
+  doCheck = true;
+  checkTarget = "test";
+  createFindlibDestdir = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mirleft/ocaml-tls;
+    description = "TLS in pure OCaml.";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/uuseg/default.nix
+++ b/pkgs/development/ocaml-modules/uuseg/default.nix
@@ -1,40 +1,39 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, uucp, uutf, cmdliner }:
+{ stdenv, buildOcaml, fetchurl, ocaml, findlib, ocamlbuild, opam, uucp, uutf, cmdliner }:
 
 let
-  inherit (stdenv.lib) getVersion versionAtLeast;
-
   pname = "uuseg";
-  version = "0.8.0";
   webpage = "http://erratique.ch/software/${pname}";
 in
 
-assert versionAtLeast (getVersion ocaml) "4.01";
+buildOcaml rec {
 
-stdenv.mkDerivation {
+  minimumSupportedOcamlVersion = "4.01";
 
-  name = "ocaml-${pname}-${version}";
+  name = pname;
+  version = "0.9.0";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
     sha256 = "00n4zi8dyw2yzi4nr2agcrr33b0q4dr9mgnkczipf4c0gm5cm50h";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opam cmdliner ];
-  propagatedBuildInputs = [ uucp uutf ];
+  buildInputs = [ ocaml findlib ocamlbuild opam ];
+  propagatedBuildInputs = [ uucp uutf cmdliner ];
 
   createFindlibDestdir = true;
 
   unpackCmd = "tar xjf $src";
 
   buildPhase = ''
+    ocaml pkg/git.ml
     ocaml pkg/build.ml \
       native=true native-dynlink=true \
       uutf=true cmdliner=true
   '';
 
   installPhase = ''
-    opam-installer --script --prefix=$out ${pname}.install | sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${getVersion ocaml}/site-lib/${pname}
+    opam-installer --prefix $out --script | sh
+    ln -s $out/lib/uuseg $out/lib/ocaml/${ocaml.version}/site-lib/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/uutf/default.nix
+++ b/pkgs/development/ocaml-modules/uutf/default.nix
@@ -1,32 +1,38 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam }:
+{ stdenv, buildOcaml, fetchurl, ocaml, findlib, ocamlbuild, opam, cmdliner}:
 let
   pname = "uutf";
   webpage = "http://erratique.ch/software/${pname}";
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "3.12";
+buildOcaml rec {
+  name = pname;
+  version = "0.9.4";
 
-stdenv.mkDerivation rec {
-  name = "ocaml-${pname}-${version}";
-  version = "0.9.3";
+  minimumSupportedOcamlVersion = "3.12";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "0xvq20knmq25902ijpbk91ax92bkymsqkbfklj1537hpn64lydhz";
+    sha256 = "1f71fyawxal42x6g82539bv0ava2smlar6rmxxz1cyq3l0i6fw0k";
   };
 
   buildInputs = [ ocaml findlib ocamlbuild opam ];
+  propagatedBuildInputs = [ cmdliner ];
 
   createFindlibDestdir = true;
 
   unpackCmd = "tar xjf $src";
 
-  buildPhase = "./pkg/build true";
+  buildPhase = ''
+    ocaml pkg/git.ml
+    ocaml pkg/build.ml \
+      native=true \
+      native-dynlink=true \
+      cmdliner=true
+  '';
 
   installPhase = ''
-    opam-installer --script --prefix=$out ${pname}.install > install.sh
-    sh install.sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
+    opam-installer --prefix=$out --script | sh
+    ln -s $out/lib/uutf $out/lib/ocaml/${ocaml.version}/site-lib/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -1,28 +1,30 @@
-{ stdenv, fetchzip, ocaml, findlib, asn1-combinators, nocrypto, ounit }:
+{stdenv, buildOcaml, fetchFromGitHub, ocaml, findlib, asn1-combinators, nocrypto, ounit, ocaml_oasis, ppx_sexp_conv}:
 
-let version = "0.5.0"; in
+buildOcaml rec {
+  name = "x509";
+  version = "0.5.3";
 
-stdenv.mkDerivation {
-  name = "ocaml-x509-${version}";
-
-  src = fetchzip {
-    url = "https://github.com/mirleft/ocaml-x509/archive/${version}.tar.gz";
-    sha256 = "0i9618ph4i2yk5dvvhiqhm7wf3qmd6b795mxwff8jf856gb2gdyn";
+  src = fetchFromGitHub {
+    owner  = "mirleft";
+    repo   = "ocaml-x509";
+    rev    = "${version}";
+    sha256 = "07cc3z6h87460z3f4vz8nlczw5jkc4vjhix413z9x6nral876rn7";
   };
 
-  buildInputs = [ ocaml findlib ounit ];
+  buildInputs = [ ocaml ocaml_oasis findlib ounit ppx_sexp_conv ];
   propagatedBuildInputs = [ asn1-combinators nocrypto ];
 
   configureFlags = "--enable-tests";
+  configurePhase = "./configure --prefix $out $configureFlags";
+
   doCheck = true;
   checkTarget = "test";
   createFindlibDestdir = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/mirleft/ocaml-x509;
     description = "X509 (RFC5280) handling in OCaml";
-    platforms = ocaml.meta.platforms or [];
-    license = stdenv.lib.licenses.bsd2;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13251,6 +13251,10 @@ in
   hyper = callPackage ../applications/misc/hyper { inherit (gnome2) GConf; };
   hyperterm = self.hyper;
 
+  jackline = callPackage ../applications/networking/instant-messengers/jackline {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_02;
+  };
+
   slack = callPackage ../applications/networking/instant-messengers/slack { };
 
   spectrwm = callPackage ../applications/window-managers/spectrwm { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -22,6 +22,8 @@ let
 
     asn1-combinators = callPackage ../development/ocaml-modules/asn1-combinators { };
 
+    astring = callPackage ../development/ocaml-modules/astring { };
+
     async_extra_p4 = callPackage ../development/ocaml-modules/async_extra { };
 
     async_find = callPackage ../development/ocaml-modules/async_find { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -263,6 +263,10 @@ let
       lwt = ocaml_lwt;
     };
 
+    notty = callPackage ../development/ocaml-modules/notty {
+      lwt = ocaml_lwt;
+    };
+
     ocaml_batteries = callPackage ../development/ocaml-modules/batteries { };
 
     comparelib = callPackage ../development/ocaml-modules/comparelib { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -343,6 +343,8 @@ let
 
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
+    otr = callPackage ../development/ocaml-modules/otr { };
+
     ounit = callPackage ../development/ocaml-modules/ounit { };
 
     piqi = callPackage ../development/ocaml-modules/piqi { };
@@ -649,7 +651,7 @@ let
       then { tools = pkgs.pkgsi686Linux.stdenv.cc; }
       else {}
     );
-    
+
     glsurf = callPackage ../applications/science/math/glsurf {
       libpng = pkgs.libpng12;
       giflib = pkgs.giflib_4_1;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -257,7 +257,9 @@ let
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
-    nocrypto =  callPackage ../development/ocaml-modules/nocrypto { };
+    nocrypto =  callPackage ../development/ocaml-modules/nocrypto {
+      lwt = ocaml_lwt;
+    };
 
     ocaml_batteries = callPackage ../development/ocaml-modules/batteries { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -364,6 +364,10 @@ let
 
     textutils_p4 = callPackage ../development/ocaml-modules/textutils { };
 
+    tls = callPackage ../development/ocaml-modules/tls {
+      lwt = ocaml_lwt;
+    };
+
     type_conv_108_08_00 = callPackage ../development/ocaml-modules/type_conv/108.08.00.nix { };
     type_conv_109_60_01 = callPackage ../development/ocaml-modules/type_conv/109.60.01.nix { };
     type_conv_112_01_01 = callPackage ../development/ocaml-modules/type_conv/112.01.01.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -158,6 +158,8 @@ let
 
     erm_xmpp = callPackage ../development/ocaml-modules/erm_xmpp { };
 
+    erm_xmpp_0_3 = callPackage ../development/ocaml-modules/erm_xmpp/0.3.nix { };
+
     estring = callPackage ../development/ocaml-modules/estring { };
 
     ezjsonm = callPackage ../development/ocaml-modules/ezjsonm {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -340,6 +340,8 @@ let
     piqi = callPackage ../development/ocaml-modules/piqi { };
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 
+    ptime = callPackage ../development/ocaml-modules/ptime { };
+
     re2_p4 = callPackage ../development/ocaml-modules/re2 { };
 
     result = callPackage ../development/ocaml-modules/ocaml-result { };


### PR DESCRIPTION
###### Motivation for this change

Addition of `jackline`, a terminal-based XMPP client purely in OCaml.

For `jackline` added missing dependencies:

* `ptime`
* `tls`
* `notty`
* `otr`
* `erm_xmpp_0_3`

and updated the following packages:

* `x509`
* `cstruct`
* `nocrypto`
* `uutf`
* `uuseg`

This PR also incudes minor fixes for:

* ~~~`zarith`~~~ (@vbgl has fixed it on master)
* `ppx_conv_sexp`

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
