### PR TITLE
haskellPackages.tinc: 20160924 -> 20161102

### DIFF
--- a/pkgs/development/tools/haskell/tinc/default.nix
+++ b/pkgs/development/tools/haskell/tinc/default.nix
@@ -7,12 +7,12 @@
 }:
 mkDerivation {
   pname = "tinc";
-  version = "20160924";
+  version = "20161102";
   src = fetchFromGitHub {
     owner = "sol";
     repo = "tinc";
-    rev = "f5ba99264930a2af2f24770a23af2613acdac631";
-    sha256 = "19mvswpjak9dxpd4w86fz1wv0zkn6ippc37gdkhyg4xcj9jn21a9";
+    rev = "411d0f319717d01dc71bd5c1faef8035656eaf3d";
+    sha256 = "040vyg9n7ihnqs6fyhhr5p4xscfxhji02wsfw4nncpxflzaciji5";
   };
   isLibrary = false;
   isExecutable = true;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


