### PR TITLE
znc module: optionSet -> submodule

### DIFF
--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -208,11 +208,10 @@ in
 
         networks = mkOption {
           default = { };
-          type = types.loaOf types.optionSet;
+          type = with types; loaOf (submodule networkOpts);
           description = ''
             IRC networks to connect the user to.
           '';
-          options = [ networkOpts ];
           example = {
             "freenode" = {
               server = "chat.freenode.net";


### PR DESCRIPTION
###### Motivation for this change

`optionSet` is deprecated in favor of `submodule`.

related to #19636.

cc @schneefux This shouldn't, but please check that this does not break anything.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


