### PR TITLE
screenfetch: add bc dependency

### DIFF
--- a/pkgs/tools/misc/screenfetch/default.nix
+++ b/pkgs/tools/misc/screenfetch/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper, coreutils, gawk, procps, gnused
-, findutils, xdpyinfo, xprop, gnugrep, ncurses
+, bc, findutils, xdpyinfo, xprop, gnugrep, ncurses
 }:
 
 stdenv.mkDerivation {
@@ -30,7 +30,8 @@ stdenv.mkDerivation {
       --prefix PATH : "${xdpyinfo}/bin" \
       --prefix PATH : "${xprop}/bin" \
       --prefix PATH : "${gnugrep}/bin" \
-      --prefix PATH : "${ncurses}/bin"
+      --prefix PATH : "${ncurses}/bin" \
+      --prefix PATH : "${bc}/bin"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

`screenfetch` needs `bc`:

```
[[ ! ]] /nix/store/j026vgnq3fb697c1g7mrfxssh9xgrxhi-screenFetch-2016-10-11/bin/.screenfetch-wrapped: line 1217: bc: command not found
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


