### PR TITLE
solc: 0.4.2 -> 0.4.4

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchFromGitHub, boost, cmake, jsoncpp }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.2";
+  version = "0.4.4";
   name = "solc-${version}";
 
   src = fetchFromGitHub {
     owner = "ethereum";
     repo = "solidity";
     rev = "v${version}";
-    sha256 = "1d5x3psz8a9z9jnm30aspfvrpd9kblr14cn5vyl21p27x2vdlzr4";
+    sha256 = "150prr7m0jnx3vhq0wy3avzsijxd3pn7c8jxdvf6jkcc408dgn6z";
   };
 
   patchPhase = ''
-    echo >commit_hash.txt af6afb0415761b53721f89c7f65064807f41cbd3
+    echo >commit_hash.txt 4633f3def897db0f91237f98cf46e5d84fb05e61
   '';
 
   buildInputs = [ boost cmake jsoncpp ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/ethereum/solidity/releases/tag/v0.4.4

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


