### PR TITLE
nodePackages: default to 4.x packages

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2456,7 +2456,7 @@ in
     nodejs = pkgs.nodejs-4_x;
   };
 
-  nodePackages = nodePackages_6_x;
+  nodePackages = nodePackages_4_x;
 
   # Can be used as a user shell
   nologin = shadow;


### PR DESCRIPTION
###### Motivation for this change

In #19973 I changed `nodePackages` to export the v6.x node packages but these don't include `npm2nix` yet. I am not entirely sure why that is but the fact that it is missing does break things so lets set it back to v4 packages for now.

@svanderburg is there a specific reason that the v6 node packages don't include npm2nix ?