### PR TITLE
exercism: init at 2.3.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -360,6 +360,7 @@
   rardiol = "Ricardo Ardissone <ricardo.ardissone@gmail.com>";
   rasendubi = "Alexey Shmalko <rasen.dubi@gmail.com>";
   raskin = "Michael Raskin <7c6f434c@mail.ru>";
+  rbasso = "Rafael Basso <rbasso@sharpgeeks.net>";
   redbaron = "Maxim Ivanov <ivanov.maxim@gmail.com>";
   redvers = "Redvers Davies <red@infect.me>";
   refnil = "Martin Lavoie <broemartino@gmail.com>";

--- a/pkgs/applications/misc/exercism/default.nix
+++ b/pkgs/applications/misc/exercism/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name    = "exercism-${version}";
+  version = "2.3.0";
+
+  goPackagePath = "github.com/exercism/cli";
+
+  src = fetchFromGitHub {
+    owner  = "exercism";
+    repo   = "cli";
+    rev    = "v${version}";
+    sha256 = "1zhvvmsh5kw739kylk0bqj1wa6vjyahz43dlxdpv42h8gfiiksf5";
+  };
+
+  meta = with stdenv.lib; {
+   description = "A Go based command line tool for exercism.io";
+   homepage    = http://exercism.io/cli;
+   license     = licenses.mit;
+   maintainers = [ maintainers.rbasso ];
+   platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12749,6 +12749,8 @@ in
 
   evopedia = callPackage ../applications/misc/evopedia { };
 
+  exercism = callPackage ../applications/misc/exercism { };
+
   gpg-mdp = callPackage ../applications/misc/gpg-mdp { };
 
   keepassx = callPackage ../applications/misc/keepassx { };


### PR DESCRIPTION
Hi!

I'm new to *Nix* and this is my first PR here, so please be extra-cautious.

###### Motivation for this change

This package was accidentally removed from *nixpkgs* by #16017, as mentioned in https://github.com/NixOS/nixpkgs/issues/19597#issuecomment-254052165.

Considering that the removed version was more than a year old, I decided to rewrite it from scratch using the latest release.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] OS X
   - [ ] Linux
- [X] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~ n/a
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Fixes #19597.
