### PR TITLE
godef: init at 20160620-ee532b9

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -455,6 +455,7 @@
   vbgl = "Vincent Laporte <Vincent.Laporte@gmail.com>";
   vbmithr = "Vincent Bernardoff <vb@luminar.eu.org>";
   vcunat = "Vladimír Čunát <vcunat@gmail.com>";
+  vdemeester = "Vincent Demeester <vincent@sbr.pm>";
   veprbl = "Dmitry Kalinkin <veprbl@gmail.com>";
   viric = "Lluís Batlle i Rossell <viric@viric.name>";
   vizanto = "Danny Wilson <danny@prime.vc>";

--- a/pkgs/development/tools/godef/default.nix
+++ b/pkgs/development/tools/godef/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, buildGoPackage, fetchgit }:
+
+buildGoPackage rec {
+  name = "godef-${version}";
+  version = "20160620-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "ee532b944160bb27b6f23e4f5ef38b8fdaa2a6bd";
+
+  goPackagePath = "github.com/rogpeppe/godef";
+  excludedPackages = "go/printer/testdata";
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://github.com/rogpeppe/godef";
+    sha256 = "1r8c4ijjnwvb9pci4wasmq88yj0ginwly2542kw4hyg2c87j613l";
+  };
+
+  meta = {
+    description = "Print where symbols are defined in Go source code";
+    homepage = "https://github.com/rogpeppe/godef/";
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    licence = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7077,7 +7077,7 @@ in
 
   #GMP ex-satellite, so better keep it near gmp
   mpfr = callPackage ../development/libraries/mpfr/default.nix { };
-  
+
   mpfi = callPackage ../development/libraries/mpfi { };
 
   # A GMP fork
@@ -11227,6 +11227,8 @@ in
   golint = callPackage ../development/tools/golint { };
 
   godep = callPackage ../development/tools/godep { };
+
+  godef = callPackage ../development/tools/godef { };
 
   goimports = callPackage ../development/tools/goimports { };
 


### PR DESCRIPTION
###### Motivation for this change

`godef` is pretty useful and used by several editors (like emacs) to be able to jump to declaration. It looks like it was there at some point and has been removed. This re-adds it 👼

🐸

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] <del>Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`</del>
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Signed-off-by: Vincent Demeester <vincent@sbr.pm>