### PR TITLE
Move stdenvCross and customStdenv to pkgs/stdenv

### DIFF
--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -1,9 +1,13 @@
 { system, allPackages, platform, crossSystem, config, ... } @ args:
 
 rec {
-  vanillaStdenv = (import ../. (args // {
+  argClobber = {
     crossSystem = null;
-    allPackages = args: allPackages ({ crossSystem = null; } // args);
+    # Ignore custom stdenvs when cross compiling for compatability
+    config = builtins.removeAttrs config [ "replaceStdenv" ];
+  };
+  vanillaStdenv = (import ../. (args // argClobber // {
+    allPackages = args: allPackages (argClobber // args);
   })).stdenv;
 
   # Yeah this isn't so cleanly just build-time packages yet. Notice the

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -1,0 +1,27 @@
+{ system, allPackages, platform, crossSystem, config, ... } @ args:
+
+rec {
+  vanillaStdenv = (import ../. (args // {
+    crossSystem = null;
+    allPackages = args: allPackages ({ crossSystem = null; } // args);
+  })).stdenv;
+
+  # Yeah this isn't so cleanly just build-time packages yet. Notice the
+  # buildPackages <-> stdenvCross cycle. Yup, it's very weird.
+  #
+  # This works because the derivation used to build `stdenvCross` are in
+  # fact using `forceNativeDrv` to use the `nativeDrv` attribute of the resulting
+  # derivation built with `vanillaStdenv` (second argument of `makeStdenvCross`).
+  #
+  # Eventually, `forceNativeDrv` should be removed and the cycle broken.
+  buildPackages = allPackages {
+    # It's OK to change the built-time dependencies
+    allowCustomOverrides = true;
+    bootStdenv = stdenvCross;
+    inherit system platform crossSystem config;
+  };
+
+  stdenvCross = buildPackages.makeStdenvCross
+    vanillaStdenv crossSystem
+    buildPackages.binutilsCross buildPackages.gccCrossStageFinal;
+}

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -1,0 +1,17 @@
+{ system, allPackages, platform, crossSystem, config, ... } @ args:
+
+rec {
+  vanillaStdenv = (import ../. (args // {
+    # Remove config.replaceStdenv to ensure termination.
+    config = builtins.removeAttrs config [ "replaceStdenv" ];
+  })).stdenv;
+
+  buildPackages = allPackages {
+    # It's OK to change the built-time dependencies
+    allowCustomOverrides = true;
+    bootStdenv = vanillaStdenv;
+    inherit system platform crossSystem config;
+  };
+
+  stdenvCustom = config.replaceStdenv { pkgs = buildPackages; };
+}

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -5,7 +5,7 @@
 # Posix utilities, the GNU C compiler, and so on.  On other systems,
 # we use the native C library.
 
-{ system, allPackages ? import ../.., platform, config, lib }:
+{ system, allPackages ? import ../.., platform, config, crossSystem, lib }:
 
 
 rec {
@@ -36,10 +36,13 @@ rec {
   # Linux standard environment.
   inherit (import ./linux { inherit system allPackages platform config lib; }) stdenvLinux;
 
-  inherit (import ./darwin { inherit system allPackages platform config;}) stdenvDarwin;
+  inherit (import ./darwin { inherit system allPackages platform config; }) stdenvDarwin;
+
+  inherit (import ./cross { inherit system allPackages platform crossSystem config lib; }) stdenvCross;
 
   # Select the appropriate stdenv for the platform `system'.
   stdenv =
+    if crossSystem != null then stdenvCross else
     if system == "i686-linux" then stdenvLinux else
     if system == "x86_64-linux" then stdenvLinux else
     if system == "armv5tel-linux" then stdenvLinux else

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -40,9 +40,12 @@ rec {
 
   inherit (import ./cross { inherit system allPackages platform crossSystem config lib; }) stdenvCross;
 
+  inherit (import ./custom { inherit system allPackages platform crossSystem config lib; }) stdenvCustom;
+
   # Select the appropriate stdenv for the platform `system'.
   stdenv =
     if crossSystem != null then stdenvCross else
+    if config ? replaceStdenv then stdenvCustom else
     if system == "i686-linux" then stdenvLinux else
     if system == "x86_64-linux" then stdenvLinux else
     if system == "armv5tel-linux" then stdenvLinux else

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5,9 +5,9 @@
  * to merges. Please use the full-text search of your editor. ;)
  * Hint: ### starts category names.
  */
-{ system, bootStdenv, noSysDirs, config, crossSystem, platform, lib
+{ system, noSysDirs, config, crossSystem, platform, lib
 , nixpkgsFun
-, ... }:
+}:
 self: pkgs:
 
 with pkgs;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -12,6 +12,11 @@
   # null, the default standard environment is used.
   bootStdenv ? null
 
+, # This is used because stdenv replacement and the stdenvCross do benefit from
+  # the overridden configuration provided by the user, as opposed to the normal
+  # bootstrapping stdenvs.
+  allowCustomOverrides ? (bootStdenv == null)
+
 , # Non-GNU/Linux OSes are currently "impure" platforms, with their libc
   # outside of the store.  Thus, GCC, GFortran, & co. must always look for
   # files in standard system directories (/usr/include, etc.)
@@ -109,7 +114,7 @@ let
   # attributes to refer to the original attributes (e.g. "foo =
   # ... pkgs.foo ...").
   configOverrides = self: super:
-    lib.optionalAttrs (bootStdenv == null)
+    lib.optionalAttrs allowCustomOverrides
       ((config.packageOverrides or (super: {})) super);
 
   # The complete chain of package set builders, applied from top to bottom

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -79,12 +79,12 @@ let
 
   stdenvDefault = self: super:
     import ./stdenv.nix {
-      inherit system bootStdenv noSysDirs config crossSystem platform lib nixpkgsFun pkgs;
+      inherit system bootStdenv crossSystem config platform lib nixpkgsFun pkgs;
     };
 
   allPackages = self: super:
     let res = import ./all-packages.nix
-      { inherit system bootStdenv noSysDirs config crossSystem platform lib nixpkgsFun; }
+      { inherit system noSysDirs config crossSystem platform lib nixpkgsFun; }
       res self;
     in res;
 

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -56,10 +56,6 @@ let
   platform = if platform_ != null then platform_
     else config.platform or platformAuto;
 
-  topLevelArguments = {
-    inherit system bootStdenv noSysDirs config crossSystem platform lib nixpkgsFun;
-  };
-
   # A few packages make a new package set to draw their dependencies from.
   # (Currently to get a cross tool chain, or forced-i686 package.) Rather than
   # give `all-packages.nix` all the arguments to this function, even ones that
@@ -81,10 +77,15 @@ let
       inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.xorg) lndir;
     };
 
-  stdenvDefault = self: super: (import ./stdenv.nix topLevelArguments) pkgs;
+  stdenvDefault = self: super:
+    import ./stdenv.nix {
+      inherit system bootStdenv noSysDirs config crossSystem platform lib nixpkgsFun pkgs;
+    };
 
   allPackages = self: super:
-    let res = import ./all-packages.nix topLevelArguments res self;
+    let res = import ./all-packages.nix
+      { inherit system bootStdenv noSysDirs config crossSystem platform lib nixpkgsFun; }
+      res self;
     in res;
 
   aliases = self: super: import ./aliases.nix super;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -77,9 +77,9 @@ let
     };
 
   trivialBuilders = self: super:
-    (import ../build-support/trivial-builders.nix {
+    import ../build-support/trivial-builders.nix {
       inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.xorg) lndir;
-    });
+    };
 
   stdenvDefault = self: super: (import ./stdenv.nix topLevelArguments) pkgs;
 

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -84,7 +84,7 @@ let
 
   stdenvDefault = self: super:
     import ./stdenv.nix {
-      inherit system bootStdenv crossSystem config platform lib nixpkgsFun pkgs;
+      inherit system bootStdenv crossSystem config platform lib nixpkgsFun;
     };
 
   allPackages = self: super:

--- a/pkgs/top-level/stdenv.nix
+++ b/pkgs/top-level/stdenv.nix
@@ -1,5 +1,4 @@
-{ system, bootStdenv, crossSystem, config, platform, lib, nixpkgsFun, ... }:
-pkgs:
+{ system, bootStdenv, crossSystem, config, platform, lib, nixpkgsFun, pkgs, ... }:
 
 rec {
   allStdenvs = import ../stdenv {

--- a/pkgs/top-level/stdenv.nix
+++ b/pkgs/top-level/stdenv.nix
@@ -2,28 +2,23 @@
 
 rec {
   allStdenvs = import ../stdenv {
-    inherit system platform config lib;
-    # TODO(@Ericson2314): hack for cross-compiling until I clean that in follow-up PR
-    allPackages = args: nixpkgsFun (args // { crossSystem = null; });
+    inherit system platform config crossSystem lib;
+    allPackages = nixpkgsFun;
   };
 
   defaultStdenv = allStdenvs.stdenv // { inherit platform; };
 
   stdenv =
-    if bootStdenv != null then (bootStdenv // {inherit platform;}) else
-      if crossSystem != null then
-        pkgs.stdenvCross
-      else
-        let
-            changer = config.replaceStdenv or null;
-        in if changer != null then
-          changer {
-            # We import again all-packages to avoid recursivities.
-            pkgs = nixpkgsFun {
-              # We remove packageOverrides to avoid recursivities
-              config = removeAttrs config [ "replaceStdenv" ];
-            };
-          }
-      else
-        defaultStdenv;
+    if bootStdenv != null then
+      (bootStdenv // { inherit platform; })
+    else if crossSystem == null && config ? replaceStdenv then
+      config.replaceStdenv {
+        # We import again all-packages to avoid recursivities.
+        pkgs = nixpkgsFun {
+          # We remove packageOverrides to avoid recursivities
+          config = removeAttrs config [ "replaceStdenv" ];
+        };
+      }
+    else
+      defaultStdenv;
 }

--- a/pkgs/top-level/stdenv.nix
+++ b/pkgs/top-level/stdenv.nix
@@ -1,4 +1,4 @@
-{ system, bootStdenv, crossSystem, config, platform, lib, nixpkgsFun, pkgs }:
+{ system, bootStdenv, crossSystem, config, platform, lib, nixpkgsFun }:
 
 rec {
   allStdenvs = import ../stdenv {

--- a/pkgs/top-level/stdenv.nix
+++ b/pkgs/top-level/stdenv.nix
@@ -9,16 +9,7 @@ rec {
   defaultStdenv = allStdenvs.stdenv // { inherit platform; };
 
   stdenv =
-    if bootStdenv != null then
-      (bootStdenv // { inherit platform; })
-    else if crossSystem == null && config ? replaceStdenv then
-      config.replaceStdenv {
-        # We import again all-packages to avoid recursivities.
-        pkgs = nixpkgsFun {
-          # We remove packageOverrides to avoid recursivities
-          config = removeAttrs config [ "replaceStdenv" ];
-        };
-      }
-    else
-      defaultStdenv;
+    if bootStdenv != null
+    then (bootStdenv // { inherit platform; })
+    else defaultStdenv;
 }

--- a/pkgs/top-level/stdenv.nix
+++ b/pkgs/top-level/stdenv.nix
@@ -1,4 +1,4 @@
-{ system, bootStdenv, crossSystem, config, platform, lib, nixpkgsFun, pkgs, ... }:
+{ system, bootStdenv, crossSystem, config, platform, lib, nixpkgsFun, pkgs }:
 
 rec {
   allStdenvs = import ../stdenv {


### PR DESCRIPTION
###### Motivation for this change

Cleanup enabled by https://github.com/NixOS/nixpkgs/pull/19940. This too leads up to https://github.com/NixOS/nixpkgs/pull/15043. I pulled some more commits from #15043 so that now `top-level/stdenv.nix` hardly needs to exist.

Cross compiling still behaviors weird (I don't want to change semantics with this patch), but the weirdness is syntactically isolated from normal behavior: `pkgs/stdenv/cross/default.nix` won't be imported unless one is cross compiling and the weirdness is confined to there.

~~@zimbatm this should basically be what you reviewed originally, modulo identifier renaming.~~

###### Things done

I modified @DavidEGrayson's excellent test script at https://gist.github.com/Ericson2314/fc745290db68b20235bdc457961b3658 . It now just checks for all combinations with *all* combinations: native target, cross compiling, custom stdenvs, and custom stdenvs + cross compiling. You can replicate my results by running
```shell
nix-instantiate --eval -E 'import (builtins.fetchTarball https://gist.github.com/Ericson2314/fc745290db68b20235bdc457961b3658/archive/master.tar.gz) {}' -A testsPass
```

CC @nbp @DavidEGrayson 

