### PR TITLE
v8-3_16_14 tweaks for the build on darwin

### DIFF
--- a/pkgs/development/libraries/v8/3.16.14.nix
+++ b/pkgs/development/libraries/v8/3.16.14.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
 
   configurePhase = stdenv.lib.optionalString stdenv.isDarwin ''
     ln -s /usr/bin/xcodebuild $TMPDIR
+    ln -s /usr/bin/libtool $TMPDIR
     export PATH=$TMPDIR:$PATH
   '' + ''
     PYTHONPATH="tools/generate_shim_headers:$PYTHONPATH" \
@@ -57,8 +58,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -vD out/Release/d8 "$out/bin/d8"
-    ${if stdenv.system == "x86_64-darwin" then ''
-    install -vD out/Release/lib.target/libv8.dylib "$out/lib/libv8.dylib"
+    ${if stdenv.isDarwin then ''
+    install -vD out/Release/libv8.dylib "$out/lib/libv8.dylib"
     '' else ''
     install -vD out/Release/lib.target/libv8.so "$out/lib/libv8.so"
     ''}


### PR DESCRIPTION
###### Motivation for this change

Wanted to install a ruby package called libv8 which depends on v8 on darwin, got stuck due to a failing build of v8. Tracked it down to these two bits based on building first in `nix-shell --pure` and at the end verified with a run of `nix-build` on darwin.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


The build was originally failing due to a missing libtool. Trying to add
the buildInput "libtool" did not work out, since a few command line
arguments are not supported. I've applied the same workaround as for
"xcodebuild".

The second change is about the install step, where the path of
"libv8.dylib" was just slightly different.