### PR TITLE
nodejs-7_x: init

### DIFF
--- a/pkgs/development/web/nodejs/v7.nix
+++ b/pkgs/development/web/nodejs/v7.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
+, pkgconfig, runCommand, which, libtool, fetchpatch
+, callPackage
+, darwin ? null
+, enableNpm ? true
+}@args:
+
+let
+  nodejs = import ./nodejs.nix args;
+  baseName = if enableNpm then "nodejs" else "nodejs-slim";
+in
+  stdenv.mkDerivation (nodejs // rec {
+    version = "7.0.0";
+    name = "${baseName}-${version}";
+    src = fetchurl {
+      url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
+      sha256 = "16l9r91z4dxmgc01fs1y8jdh8xjnmyyrq60isyznnxfnq9v3qv71";
+    };
+
+    patches = nodejs.patches ++ [
+      (fetchpatch {
+        url = "https://github.com/nodejs/node/commit/fc164acbbb700fd50ab9c04b47fc1b2687e9c0f4.patch";
+        sha256 = "1rms3n09622xmddn013yvf5c6p3s8w8s0d2h813zs8c1l15k4k1i";
+      })
+    ];
+
+  })
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2448,6 +2448,15 @@ in
     enableNpm = false;
   };
 
+  nodejs-7_x = callPackage ../development/web/nodejs/v7.nix {                                                                                                 
+    libtool = darwin.cctools;                                                                                                                                 
+  };                                                                                                                                                          
+                                                                                                                                                              
+  nodejs-slim-7_x = callPackage ../development/web/nodejs/v7.nix {                                                                                            
+    libtool = darwin.cctools;                                                                                                                                 
+    enableNpm = false;                                                                                                                                        
+  };
+
   nodePackages_6_x = callPackage ../development/node-packages/default-v6.nix {
     nodejs = pkgs.nodejs-6_x;
   };


### PR DESCRIPTION
###### Motivation for this change
node.js 7.0.0 has been released a few days ago

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


