### PR TITLE
Adjust ruby gem defaults for scrypt on darwin

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -152,6 +152,14 @@ in
     buildInputs = [ cmake pkgconfig openssl libssh2 zlib ];
   };
 
+  scrypt = attrs:
+    if stdenv.isDarwin then {
+      dontBuild = false;
+      postPatch = ''
+        sed -i -e "s/-arch i386//" Rakefile ext/scrypt/Rakefile
+      '';
+    } else {};
+
   snappy = attrs: {
     buildInputs = [ args.snappy ];
   };
@@ -212,4 +220,3 @@ in
   };
 
 }
-


### PR DESCRIPTION
###### Motivation for this change

Ran into build trouble when trying to package a Gemset which included scrypt. I'll add the full error output into the comments.

Was building against channels/nixpkgs-unstable

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Without the adjustment I was not able to build scrypt. It was failing
because of missing symbols due to the parameter '-arch i386' being
appended to the clang calls.