### PR TITLE
qutebrowser: fix wrapper

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -72,7 +72,6 @@ in buildPythonApplication rec {
   '';
 
   postFixup = ''
-    wrapPythonPrograms
     mv $out/bin/qutebrowser $out/bin/.qutebrowser-noqtpath
     makeQtWrapper $out/bin/.qutebrowser-noqtpath $out/bin/qutebrowser
 


### PR DESCRIPTION
###### Motivation for this change

Address #20000.

cc @abbradar The reason was that mk-python-derivation.nix is also calling the derivation `postFixup` resulting in `wrapPythonPrograms` called 2 times. That change was added in 85a87f5155f66dbdfcdb9869f4bd4f2a10fe8e2c.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


