### PR TITLE
groonga: 6.0.9 -> 6.1.0

### DIFF
--- a/pkgs/servers/search/groonga/default.nix
+++ b/pkgs/servers/search/groonga/default.nix
@@ -7,11 +7,11 @@
 stdenv.mkDerivation rec {
 
   name    = "groonga-${version}";
-  version = "6.0.9";
+  version = "6.1.0";
 
   src = fetchurl {
     url    = "http://packages.groonga.org/source/groonga/${name}.tar.gz";
-    sha256 = "1n7kf25yimgy9wy04hv5qvp4rzdzdr0ar92lhwms812qkhp3i4mq";
+    sha256 = "03wz6zjql211dd8kvzcqyzkc8czd8gayr7rw5v274lajcs8f6rkb";
   };
 
   buildInputs = with stdenv.lib; [ pkgconfig mecab kytea libedit ] ++


### PR DESCRIPTION
###### Motivation for this change

Update groonga to the latest version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


release notes: http://groonga.org/en/blog/2016/10/29/groonga-6.1.0.html