### PR TITLE
smokeping service: Use setuid-wrapped fping binary

### DIFF
--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -221,7 +221,7 @@ in
         type = types.string;
         default = ''
           + FPing
-          binary = ${pkgs.fping}/bin/fping
+          binary = ${config.security.wrapperDir}/fping
         '';
         description = "Probe configuration";
       };


### PR DESCRIPTION
The current default probe config uses the unwrapped fping binary, which
leads to an error because fping must be executed with elevated permissions.

I fixed this by changing the path to the default binary to the
setuid-wrapped version.

cc @cransom