### PR TITLE
dobi: init at 0.8

### DIFF
--- a/pkgs/development/tools/dobi/default.nix
+++ b/pkgs/development/tools/dobi/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "dobi-${version}";
+  version = "v0.8";
+  rev = "1b5f0c4c7304b4b279581eac6d7f017a9a7d4f4e";
+
+  buildFlagsArray = let t = "${goPackagePath}/cmd"; in ''
+    -ldflags=
+       -X ${t}.gitsha=${rev}
+       -X ${t}.buildDate=unknown
+  '';
+  goPackagePath = "github.com/dnephin/dobi";
+  excludedPackages = "docs";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "dnephin";
+    repo = "dobi";
+    sha256 = "0qhmbb172mkj4sifiapgscqq71fw3ccbh9ybyf7ihkysf94smkgk";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = {
+    description = "A build automation tool for Docker applications";
+    homepage = https://dnephin.github.io/dobi/;
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    license = stdenv.lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/tools/dobi/deps.nix
+++ b/pkgs/development/tools/dobi/deps.nix
@@ -1,0 +1,220 @@
+[
+  {
+    goPackagePath = "github.com/Azure/go-ansiterm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/go-ansiterm";
+      rev = "fa152c58bc15761d0200cb75fe958b89a9d4888e";
+      sha256 = "09qlywlnp8gwjn4n5ri376bnvmkid823la8xsp0v0si8a98z8bv4";
+    };
+  }
+  {
+    goPackagePath = "github.com/dnephin/configtf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dnephin/configtf";
+      rev = "6b0d1fdf5e68504061777fe78693fba1b40aef85";
+      sha256 = "0qbcpq2vqm8wws3ixb25z9dz5v4n62w8m10vhy68vvblsp46x2jp";
+    };
+  }
+  {
+    goPackagePath = "github.com/dnephin/go-os-user";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dnephin/go-os-user";
+      rev = "44e2994deb1ed3c8bf21e28cbd5d2e3107b35e0b";
+      sha256 = "0dk122hicmqvkdl7lm099mwsbhb0zrndafm7r9qxvlbffigipx1f";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/docker";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/docker";
+      rev = "515e5dade7a006dbd2c42880f1af695da22ece60";
+      sha256 = "1m4cll2v0j0l00mp117x7gbs5r5shxgf7ydbp21pgjxb9v8f969y";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/go-connections";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/go-connections";
+      rev = "1494b6df4050e60923d68cd8cc6a19e7af9f1c01";
+      sha256 = "1r1r2a3giir1ixdqwqvg82mjvnah19xjry2i1nv30ri3xfxcz33n";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/go-units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/go-units";
+      rev = "8a7beacffa3009a9ac66bad506b18ffdd110cf97";
+      sha256 = "0cljjl9j2bi10fy16y7icb3iz95x1zhjfswhc2yj0w2l8wvgzfjp";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsouza/go-dockerclient";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsouza/go-dockerclient";
+      rev = "348eb84e7de87ad89fd9a2656f56081b2a4d837b";
+      sha256 = "0gm4cn2wcbnwb4zc5qwj4nry4hg9k922kk6b23zvhl63hy35mizv";
+    };
+  }
+  {
+    goPackagePath = "github.com/gogits/git-module";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogits/git-module";
+      rev = "b3009dc4f5842cf9e2e80fef1e125e79c38e4949";
+      sha256 = "1f5mms15hknnj17nvb5dwwk8fcm8a9msy9qdjvkplihxgaqm0amz";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-cleanhttp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-cleanhttp";
+      rev = "ad28ea4487f05916463e2423a55166280e8254b5";
+      sha256 = "0xw0qas3ixg8p2xh09hhc81km0mfn9lbnfgrdb309hzcwhmiyqjm";
+    };
+  }
+  /*
+  {
+    goPackagePath = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1j51aaskfqc953p5s9naqimr04hzfijm4yczdsiway1xnnvvpfr1";
+    };
+  }
+  */
+  {
+    goPackagePath = "github.com/kballard/go-shellquote";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kballard/go-shellquote";
+      rev = "d8ec1a69a250a17bb0e419c386eac1f3711dc142";
+      sha256 = "1a57hm0zwyi70am670s0pkglnkk1ilddnmfxz1ba7innpkf5z6s7";
+    };
+  }
+  {
+    goPackagePath = "github.com/mcuadros/go-version";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mcuadros/go-version";
+      rev = "d52711f8d6bea8dc01efafdb68ad95a4e2606630";
+      sha256 = "08ps27vvn77jhrnks8p8mx5cwgb1ikhaddcnrpgpz7aq905a5kzn";
+    };
+  }
+  {
+    goPackagePath = "github.com/metakeule/fmtdate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/metakeule/fmtdate";
+      rev = "427373e7d2f8fcaa70a83e289c15fb3618a945bc";
+      sha256 = "1xfcg8vd1z12kvp03arp5rbvrf5717blwippia9c1yxn050a4qwy";
+    };
+  }
+  {
+    goPackagePath = "github.com/Microsoft/go-winio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Microsoft/go-winio";
+      rev = "ce2922f643c8fd76b46cadc7f404a06282678b34";
+      sha256 = "162533q8jhbpl48hcpxyzbldrkmm9v803s8r6ssds5xbqx7gv2s1";
+    };
+  }
+  {
+    goPackagePath = "github.com/opencontainers/runc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/runc";
+      rev = "4c8007f34a0077a1040923ee4c7cec64b6e070d4";
+      sha256 = "0dlrlflam74035gz6c351ay32yb7vysv5wf0a971hy01lvm68d7c";
+    };
+  }
+  {
+    goPackagePath = "github.com/renstorm/dedent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/renstrom/dedent";
+      rev = "020d11c3b9c0c7a3c2efcc8e5cf5b9ef7bcea21f";
+      sha256 = "0awsnc3hf4n46p388zg0cijh2sk813cyqpqk6f95kbzx9h9gv7lk";
+    };
+  }
+  {
+    goPackagePath = "github.com/Sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Sirupsen/logrus";
+      rev = "26709e2714106fb8ad40b773b711ebce25b78914";
+      sha256 = "11sd2dc5w3ny84zk1pcvvirkmq84ac0bnf1vq4p9j5qj05zjz3rb";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dnephin/cobra";
+      rev = "8e4c18bd418c1b9060ddf7760316aa7c2a468127";
+      sha256 = "0an8mv9xn3zlzvy0whq8k9wi9jwqk2mwb2rv7fks6yknyfpvdh98";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "5ccb023bc27df288a957c5e994cd44fd19619465";
+      sha256 = "1r65j8sw15pz0iacwnf303p6s51vkv0k6qc5cyb2kybfraqd7f7z";
+    };
+  }
+  {
+    goPackagePath = "github.com/Unknwon/com";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Unknwon/com";
+      rev = "28b053d5a2923b87ce8c5a08f3af779894a72758";
+      sha256 = "09i9slj4zbsqmwkkx9bqi7cgpv6hqby6r98l6qx1wag89qijybz2";
+    };
+  }
+  {
+    goPackagePath = "github.com/valyala/fasttemplate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/valyala/fasttemplate";
+      rev = "3b874956e03f1636d171bda64b130f9135f42cff";
+      sha256 = "0h17a316a148g3diylpasa9hwx0rp8l619kqdz6spmf9l5iml4hh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "3fe3024eef808ba2798cc1855690f49e2b860573";
+      sha256 = "0r6i9b3r33lzpcww0sijzw16dw4klz97m4dynja1ids7g6yddq4a";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "c200b10b5d5e122be351b67af224adc6128af5bf";
+      sha256 = "1f764m3q05q2dq1pdms07jcixw4xakqw46w1djrmbhjmd9q8b0av";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "a5b47d31c556af34a302ce5d659e6fea44d90de0";
+      sha256 = "0v6l48fshdjrqzyq1kwn22gy7vy434xdr1i0lm3prsf6jbln9fam";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -810,6 +810,8 @@ in
 
   dlx = callPackage ../misc/emulators/dlx { };
 
+  dobi = callPackage ../development/tools/dobi { };
+
   dosage = pythonPackages.dosage;
 
   dpic = callPackage ../tools/graphics/dpic { };


### PR DESCRIPTION
###### Motivation for this change

[dobi](https://github.com/dnephin/dobi) is a build automation tool for Docker applications that I tend to use on several projects.

I have a question though : Is there a way to specify `-ldflags` with `buildGoPackage` ? (didn't find it but I might have miss something).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] <del>Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`</del>
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>