### PR TITLE
nixos.libvirtd: fix broken VMs due to emulator path changes

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -123,7 +123,7 @@ in {
         # config file. But this path can unfortunately be garbage collected
         # while still being used by the virtual machine. So update the
         # emulator path on each startup to something valid (re-scan $PATH).
-        for file in /etc/libvirt/qemu/*.xml /etc/libvirt/lxc/*.xml; do
+        for file in /var/lib/libvirt/qemu/*.xml /var/lib/libvirt/lxc/*.xml; do
             test -f "$file" || continue
             # get (old) emulator path from config file
             emulator=$(grep "^[[:space:]]*<emulator>" "$file" | sed 's,^[[:space:]]*<emulator>\(.*\)</emulator>.*,\1,')


### PR DESCRIPTION
###### Motivation for this change

Sometime after updating to release 16.09, libvirtd stopped showing VMs, and instead showed these kind of errors in the journal: 
`.libvirtd-wrapp[3540]: Cannot check QEMU binary /nix/store/bil674npq8c1l0air...`

These errors had already been fixed in f52f9bf7cd922b54c874e5500a2c64277e57d417, but the problem was reintroduced in bce59a1a8bb0430533178df080937ce24efe926a because the path to the XML files changed.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


