### PR TITLE
airwave: 1.3.2 → 1.3.3

### DIFF
--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -4,13 +4,13 @@
 
 let
 
-  version = "1.3.2";
+  version = "1.3.3";
 
   airwave-src = fetchFromGitHub {
     owner = "phantom-code";
     repo = "airwave";
     rev = version;
-    sha256 = "053kkx5yq1vas0qisidkgq0h6hzfwy3677jprjkcrwc4hp2i2v12";
+    sha256 = "1ban59skw422mak3cp57lj27hgq5d3a4f6y79ysjnamf8rpz9x4s";
   };
 
   stdenv_multi = overrideCC stdenv gcc_multi;
@@ -59,6 +59,9 @@ stdenv_multi.mkDerivation {
   # libstdc++.so link gets lost in 64-bit executables during
   # shrinking.
   dontPatchELF = true;
+
+  # Cf. https://github.com/phantom-code/airwave/issues/57
+  hardeningDisable = [ "format" ];
 
   cmakeFlags = "-DVSTSDK_PATH=${vst-sdk}";
 


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).