### PR TITLE
SoundScape Renderer and ecasound

### DIFF
--- a/pkgs/applications/audio/ecasound/default.nix
+++ b/pkgs/applications/audio/ecasound/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchurl
+, alsaLib
+, audiofile
+, libjack2
+, liblo
+, liboil
+, libsamplerate
+, libsndfile
+, lilv
+, lv2
+}:
+
+# TODO: fix readline, ncurses, lilv, liblo, liboil and python. See configure log.
+
+stdenv.mkDerivation rec {
+  name = "ecasound-${version}";
+  version = "2.9.1";
+
+  src = fetchurl {
+    url = "http://ecasound.seul.org/download/ecasound-${version}.tar.gz";
+    sha256 = "1wyws3xc4f9pglrrqv6k9137sarv4asizqrxz8h0dn44rnzfiz1r";
+  };
+
+  buildInputs = [ alsaLib audiofile libjack2 liblo liboil libsamplerate libsndfile lilv lv2 ];
+
+  meta = {
+    description = "Ecasound is a software package designed for multitrack audio processing";
+    license = with stdenv.lib.licenses;  [ gpl2 lgpl21 ];
+    homepage = http://nosignal.fi/ecasound/;
+  };
+}

--- a/pkgs/applications/audio/soundscape-renderer/default.nix
+++ b/pkgs/applications/audio/soundscape-renderer/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchgit
+, autoreconfHook
+, help2man
+, pkgconfig
+, libsndfile
+, fftwFloat
+, libjack2
+, libxml2
+, qt4
+, boost
+, ecasound
+, glibcLocales
+, mesa # Needed because help2man basically does a ./ssr-binaural  --help and ssr-binaural needs libGL
+}:
+
+stdenv.mkDerivation rec {
+  name = "soundscape-renderer-unstable-${version}";
+
+  version = "2016-11-03";
+
+  src = fetchgit {
+    url = https://github.com/SoundScapeRenderer/ssr;
+    rev = "0dd0136dd24e47b63d8a4e05de467f5c7b047ec9";
+    sha256 = "095x2spv9bmg6pi71mpajnghbqj58ziflg16f9854awx0qp9d8x7";
+  };
+
+  # Without it doesn't find all of the boost libraries.
+  BOOST_LIB_DIR="${boost}/lib";
+
+  LC_ALL = "en_US.UTF-8";
+
+  buildInputs = [ autoreconfHook boost boost.dev ecasound mesa help2man pkgconfig libsndfile fftwFloat libjack2 libxml2 qt4 glibcLocales ];
+
+  # 1) Fix detecting version. https://github.com/SoundScapeRenderer/ssr/pull/53
+  # 2) Make it find ecasound headers
+  # 3) Fix locale for help2man
+  prePatch = ''
+    substituteInPlace configure.ac --replace 'git describe ||' 'git describe 2> /dev/null ||';
+    substituteInPlace configure.ac --replace '/{usr,opt}/{,local/}' '${ecasound}/'
+    substituteInPlace man/Makefile.am --replace '--locale=en' '--locale=en_US.UTF-8'
+  '';
+
+  meta = {
+    homepage = http://spatialaudio.net/ssr/;
+    description = "The SoundScape Renderer (SSR) is a tool for real-time spatial audio reproduction";
+    license = stdenv.lib.licenses.gpl3;
+    maintainer = stdenv.lib.maintainers.fridh;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -824,6 +824,8 @@ in
 
   dynamic-colors = callPackage ../tools/misc/dynamic-colors { };
 
+  ecasound = callPackage ../applications/audio/ecasound { };
+
   edac-utils = callPackage ../os-specific/linux/edac-utils { };
 
   eggdrop = callPackage ../tools/networking/eggdrop { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14601,6 +14601,8 @@ in
     git = gitMinimal;
   };
 
+  ssr = callPackage ../applications/audio/soundscape-renderer {};
+
   stalonetray = callPackage ../applications/window-managers/stalonetray {};
 
   stp = callPackage ../applications/science/logic/stp {};


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

