### PR TITLE
cudnn5_cudatoolkit80: adding to main repo

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -269,6 +269,7 @@
   mbe = "Brandon Edens <brandonedens@gmail.com>";
   mboes = "Mathieu Boespflug <mboes@tweag.net>";
   mcmtroffaes = "Matthias C. M. Troffaes <matthias.troffaes@gmail.com>";
+  mdaiter = "Matthew S. Daiter <mdaiter8121@gmail.com>";
   meditans = "Carlo Nucera <meditans@gmail.com>";
   meisternu = "Matt Miemiec <meister@krutt.org>";
   mic92 = "Jörg Thalheim <joerg@higgsboson.tk>";

--- a/pkgs/development/libraries/science/math/cudnn/8.0-5.0/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/8.0-5.0/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, requireFile
+, cudatoolkit
+}:
+
+stdenv.mkDerivation rec {
+  version = "5.0";
+  cudatoolkit_version = "8.0";
+
+  name = "cudatoolkit-${cudatoolkit_version}-cudnn-${version}";
+
+  src = requireFile rec {
+    name = "cudnn-${cudatoolkit_version}-linux-x64-v${version}-ga.tgz";
+    message = ''
+      This nix expression requires that ${name} is already part of the store.
+      Register yourself to NVIDIA Accelerated Computing Developer Program, retrieve the cuDNN library
+      at https://developer.nvidia.com/cudnn, and run the following command in the download directory:
+      nix-prefetch-url file://${name}
+    '';
+    sha256 = "af80eb1ce0cb51e6a734b2bdc599e6d50b676eab3921e5bddfe5443485df86b6";
+  };
+
+  installPhase = ''
+    function fixRunPath {
+      p=$(patchelf --print-rpath $1)
+      patchelf --set-rpath "$p:${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}" $1
+    }
+    fixRunPath lib64/libcudnn.so
+
+    mkdir -p $out
+    cp -a include $out/include
+    cp -a lib64 $out/lib64
+  '';
+
+  propagatedBuildInputs = [
+    cudatoolkit
+  ];
+
+  meta = with stdenv.lib; {
+    description = "NVIDIA CUDA Deep Neural Network library (cuDNN)";
+    homepage = "https://developer.nvidia.com/cudnn";
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with maintainers; [ mdaiter ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1278,6 +1278,10 @@ in
     cudatoolkit = cudatoolkit75;
   };
 
+  cudnn5_cudatoolkit80 = callPackage ../development/libraries/science/math/cudnn/8.0-5.0 {
+    cudatoolkit = cudatoolkit8;
+  };
+
   curlFull = curl.override {
     idnSupport = true;
     ldapSupport = true;


### PR DESCRIPTION
###### Motivation for this change
For specific NVIDIA GPUs (Pascal architecture) the only form of cuDNN that can be used is cuDNN 5.0 or later. Allowing the selection between cuDNN 4.0 and cuDNN 5.0 in the main repo alleviates the barrier to using cuDNN on systems with a Pascal architecture GPU.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
