### PR TITLE
add defaultConfig for mysql ruby gem

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -89,6 +89,10 @@ in
   msgpack = attrs: {
     buildInputs = [ libmsgpack ];
   };
+  
+  mysql = attrs: {
+    buildInputs = [ mysql.lib zlib openssl ];
+  };
 
   mysql2 = attrs: {
     buildInputs = [ mysql.lib zlib openssl ];


### PR DESCRIPTION
###### Motivation for this change

The mysql gem doesn't build by default because it has dependencies on system libraries. This lets it build. The mysql gem needs the same libraries as the mysql2 gem.