### PR TITLE
wineUnstable: 1.9.20 -> 1.9.22

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -30,9 +30,9 @@ in rec {
   };
 
   unstable = fetchurl rec {
-    version = "1.9.20";
+    version = "1.9.22";
     url = "https://dl.winehq.org/wine/source/1.9/wine-${version}.tar.bz2";
-    sha256 = "1pvrlawp079qg74q348v9p2qzlj4aqibxxwn4vqid69j883g6s97";
+    sha256 = "0hgc85d695mi1z4hyk561q2s9pblhdy6h5a23rh459y7qwd8xgx3";
     inherit (stable) mono;
     gecko32 = fetchurl rec {
       version = "2.47";
@@ -48,7 +48,7 @@ in rec {
 
   staging = fetchFromGitHub rec {
     inherit (unstable) version;
-    sha256 = "1hk20axv0hppi5rqgslibwfjmcpjks3xa2dxi5v1y27qqhphvxpl";
+    sha256 = "1yqrxx4zaxc8khnnqfgz53apfa9mc315114psq3kvai01lz4a7p8";
     owner = "wine-compholio";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
###### Motivation for this change

Update wine.
Only 32bit build tested

###### Things done

- [*] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [*] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [*] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Also update staging as well