### PR TITLE
types: loeOf -> listOf

### DIFF
--- a/nixos/doc/manual/development/option-types.xml
+++ b/nixos/doc/manual/development/option-types.xml
@@ -100,12 +100,6 @@
         value.</para></listitem>
   </varlistentry>
   <varlistentry>
-    <term><varname>types.loeOf</varname> <replaceable>t</replaceable></term>
-    <listitem><para>A list or an element of <replaceable>t</replaceable> type. 
-        Multiple definitions are merged according to the 
-        values.</para></listitem>
-  </varlistentry>
-  <varlistentry>
     <term><varname>types.nullOr</varname> <replaceable>t</replaceable></term>
     <listitem><para><literal>null</literal> or type 
         <replaceable>t</replaceable>. Multiple definitions are merged according 

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -41,7 +41,7 @@ in
         strings.  The latter is concatenated, interspersed with colon
         characters.
       '';
-      type = types.attrsOf (types.loeOf types.str);
+      type = with types; attrsOf (either str (listOf str));
       apply = mapAttrs (n: v: if isList v then concatStringsSep ":" v else v);
     };
 

--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -23,7 +23,7 @@ in
         strings.  The latter is concatenated, interspersed with colon
         characters.
       '';
-      type = types.attrsOf (types.loeOf types.str);
+      type = with types; attrsOf (either str (listOf str));
       apply = mapAttrs (n: v: if isList v then concatStringsSep ":" v else v);
     };
 

--- a/nixos/modules/services/misc/taskserver/default.nix
+++ b/nixos/modules/services/misc/taskserver/default.nix
@@ -292,7 +292,7 @@ in {
       };
 
       allowedClientIDs = mkOption {
-        type = with types; loeOf (either (enum ["all" "none"]) str);
+        type = with types; either str (listOf str);
         default = [];
         example = [ "[Tt]ask [2-9]+" ];
         description = ''
@@ -306,7 +306,7 @@ in {
       };
 
       disallowedClientIDs = mkOption {
-        type = with types; loeOf (either (enum ["all" "none"]) str);
+        type = with types; either str (listOf str);
         default = [];
         example = [ "[Tt]ask [2-9]+" ];
         description = ''


### PR DESCRIPTION
###### Motivation for this change

First step to deprecate `loeOf`.

https://github.com/NixOS/nixpkgs/pull/19670#issuecomment-257372127

@aszlig 
The taskserver module was using `with types; loeOf (either (enum ["all" "none"]) str);` but as `enum ["all" "none"]` is included in `str`, it is equivalent to `loeOf str`.  
So this was changed into `either str (listOf str)`.

cc @nbp @groxxda 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

