### PR TITLE
pythonPackages.bitbucket_api: fixes #19988

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21702,13 +21702,17 @@ in {
 
   requests_oauth2 = buildPythonPackage rec {
     name = "requests-oauth2-0.1.1";
+    # python3 does not support relative imports
+    disabled = isPy3k;
 
     src = pkgs.fetchurl {
       url = https://github.com/maraujop/requests-oauth2/archive/0.1.1.tar.gz;
       sha256 = "1aij66qg9j5j4vzyh64nbg72y7pcafgjddxsi865racsay43xfqg";
     };
 
-    propagatedBuildInputs = with self; [ requests_oauthlib ];
+    propagatedBuildInputs = with self; [ requests2 ];
+    # no tests in tarball
+    doCheck = false;
 
     meta = {
       description = "Python's Requests OAuth2 (Open Authentication) plugin";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2630,13 +2630,15 @@ in {
 
   bitbucket_api = buildPythonPackage rec {
     name = "bitbucket-api-0.4.4";
+    # python3 does not support relative imports
+    disabled = isPy3k;
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/b/bitbucket-api/${name}.tar.gz";
       sha256 = "e890bc3893d59a6f203c1eb2bae60e78ac4d3869da7ea4fb104dca588aea85b2";
     };
 
-    propagatedBuildInputs = with self; [ requests_oauth2 nose sh ];
+    propagatedBuildInputs = with self; [ requests_oauthlib nose sh ];
 
     doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change
`bitbucket_api` and `requests_oauth2` do not support `python3`. Also, `bitbucket_api` uses `requests_oauthlib` not `requests_oauth2`, and `requests_oauth2` does not depend on `requests_oauthlib`. Discovered this from `requirements.txt` of the packages.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Testing `bitbucket_api`:
```sh
[10:49] igor@nixos-pc nixpkgs (bitbucket_api) $ nix-shell -I nixpkgs=~/nixpkgs -p pythonPackages.bitbucket_api
[10:52] igor@nixos-pc nixpkgs (bitbucket_api) [nix-shell] % python -m bitbucket.tests.public
.................
----------------------------------------------------------------------
Ran 17 tests in 5.614s

OK
```
And `requests_oauth2`:
```sh
[11:01] igor@nixos-pc nixpkgs (bitbucket_api) $ nix-shell -I nixpkgs=~/nixpkgs -p pythonPackages.requests_oauth2
[11:01] igor@nixos-pc nixpkgs (bitbucket_api) [nix-shell] % python
Python 2.7.12 (default, Jun 25 2016, 21:49:32) 
[GCC 5.4.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import oauth2
>>> from oauth2 import OAuth2
>>> OAuth2.token_url
'/oauth/token'
>>> 
```
After `nox-review`:
```sh
Result in /run/user/1000/nox-review-e094idbo
total 0
lrwxrwxrwx 1 igor users 75 Nov  4 10:46 result -> /nix/store/gkm6dvbdks87yzv99fkq0gbbwzlnzhr0-python2.7-requests-oauth2-0.1.1
lrwxrwxrwx 1 igor users 73 Nov  4 10:46 result-2 -> /nix/store/143byqpyknrhfaqfxvi0apz705w45iz2-python2.7-bitbucket-api-0.4.4
```