### PR TITLE
minted: 2.2.1 -> 2.4.1 (WIP)

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/pkgs.nix
+++ b/pkgs/tools/typesetting/tex/texlive/pkgs.nix
@@ -16209,7 +16209,7 @@ tl: { # no indentation
   sha512.doc = "";
   sha512.source = "";
   hasRunfiles = true;
-  version = "2.2.1";
+  version = "2.4.1";
 };
 "mintspirit" = {
   stripPrefix = 0;


### PR DESCRIPTION
I want to update the version of the `texlive` package `minted` from `2.2.1` to `2.4.1`.  Unfortunately I could not find any documentation on how to add a package for `texlive`.

I saw that there are some hashes in `pkgs/tools/typesetting/tex/texlive/fixedHashes.nix` but I don't know if this is somehow autogenerated or if I have to somehow run a script for that.

Would be great if someone could help me with this.