### PR TITLE
pythonPackages.mezzanine: fixes #19989

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14070,6 +14070,7 @@ in {
       license = licenses.free;
       maintainers = with maintainers; [ prikhi ];
       platforms = platforms.linux;
+      broken = true; # broken dependency of django within filebrowser_safe
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
`mezzanine` depends on `Django-1.6` that does not support `python>3.3`. But it also depends on `filebrowser_safe` that depens on `self.django` that is actually a `Django-1.10`. I've explicitly overrided `django` for dependent `filebrowser_safe` to get a correct installation error.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] OS X
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Tests:
```sh
[15:01] igor@nixos-pc nixpkgs (master *) $ nix-shell -I nixpkgs=~/nixpkgs -p python33Packages.mezzanine
[15:01] igor@nixos-pc nixpkgs (master *) [nix-shell] % python3
Python 3.3.6 (default, Oct 12 2014, 07:03:57) 
[GCC 5.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mezzanine
>>> from mezzanine import utils
>>> 
[15:02] igor@nixos-pc nixpkgs (master *) [nix-shell] % exit
[15:02] igor@nixos-pc nixpkgs (master *) $ nix-shell -I nixpkgs=~/nixpkgs -p python34Packages.mezzanine
error: Django-1.6.11 not supported for interpreter python3.4m
(use ‘--show-trace’ to show detailed location information)
[15:02] igor@nixos-pc nixpkgs (master *) ✗ (1) $ nix-shell -I nixpkgs=~/nixpkgs -p python35Packages.mezzanine
error: Django-1.6.11 not supported for interpreter python3.5m
(use ‘--show-trace’ to show detailed location information)
[15:02] igor@nixos-pc nixpkgs (master *) ✗ (1) $ 
```
