### PR TITLE
quassel: Add a package option

### DIFF
--- a/nixos/modules/services/networking/quassel.nix
+++ b/nixos/modules/services/networking/quassel.nix
@@ -3,8 +3,8 @@
 with lib;
 
 let
-  quassel = pkgs.kde4.quasselDaemon;
   cfg = config.services.quassel;
+  quassel = cfg.package;
   user = if cfg.user != null then cfg.user else "quassel";
 in
 
@@ -21,6 +21,15 @@ in
         description = ''
           Whether to run the Quassel IRC client daemon.
         '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.kde4.quasselDaemon;
+        description = ''
+          The package of the quassel daemon.
+        '';
+        example = pkgs.quasselDaemon;
       };
 
       interfaces = mkOption {


### PR DESCRIPTION
###### Motivation for this change
There are packages for quassel with qt4 and qt5 because quassel and KDE don't work together with qt5. For a server application this is irrelevant if you have a server that deploys a quassel daemon. A qt5 version can has advantages so it should be up to the user what package should be used.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


