### PR TITLE
ocamlPackage.ppx_import: init at 1.1

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -1,0 +1,32 @@
+{stdenv, fetchFromGitHub, buildOcaml, ocaml, opam,
+ cppo, ppx_tools, ounit, ppx_deriving}:
+
+buildOcaml rec {
+  name = "ppx_import";
+
+  version = "1.1";
+
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner = "whitequark";
+    repo = "ppx_import";
+    rev = "v${version}";
+    sha256 = "1hfvbc81dg58q7kkpn808b3j0xazrqfrr4v71sd1yvmnk71wak6k";
+  };
+
+  buildInputs = [ cppo ounit ppx_deriving opam ];
+
+  doCheck = true;
+  checkTarget = "test";
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ppx_import.install | sh
+    ln -s $out/lib/ppx_import $out/lib/ocaml/${ocaml.version}/site-lib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A syntax extension that allows to pull in types or signatures from other compiled interface files";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -416,6 +416,8 @@ let
       then callPackage ../development/ocaml-modules/ppx_deriving {}
       else null;
 
+    ppx_import = callPackage ../development/ocaml-modules/ppx_import {};
+
     ppx_tools =
       if lib.versionAtLeast ocaml.version "4.02"
       then callPackage ../development/ocaml-modules/ppx_tools {}


### PR DESCRIPTION
###### Motivation for this change

I am introducing this new OCaml package because I wanted to compile https://github.com/ejgallego/coq-serapi with Nix (without Opam).
I am not sure if coq-serapi should be introduced as well in nixpkgs. I feel that it might be still a bit early in development and additionally it depends on Coq 8.6 (which has not yet been added to nixpkgs, which is normal since the beta hasn't yet been published).

###### Difficulties encountered

That's the first time I'm adding an OCaml package to nixpkgs. I have followed the example of ppx_deriving which is another package by the same author (@whitequark) which is already in nixpkgs. However the installation procedure needs to be different because the Makefile has no install target. I have the following install phase which seem to do the right thing but might not follow standard guidelines (I have no experience with `ocamlfind install`):
```
    mv _build/src/ppx_import.native _build/src/ppx_import
    ocamlfind install ppx_import _build/doc/* _build/pkg/META _build/src/ppx_import
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` N/A
- Tested execution of all binary files (usually in `./result/bin/`) N/A
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I have compiled successfully coq-serapi with this but I don't know how to test it further.

