### PR TITLE
ocaml-ptime: init at 0.8.2

### DIFF
--- a/pkgs/development/ocaml-modules/ptime/default.nix
+++ b/pkgs/development/ocaml-modules/ptime/default.nix
@@ -1,0 +1,45 @@
+{stdenv, fetchurl, buildOcaml, ocaml, findlib, ocamlbuild, topkg, result, opam}:
+
+buildOcaml rec {
+  version = "0.8.2";
+  name = "ptime";
+
+  src = fetchurl {
+    url = "http://erratique.ch/software/ptime/releases/ptime-${version}.tbz";
+    sha256 = "1lihkhzskzwxskiarh4mvf7gbz5nfv25vmazbfz81m344i32a5pj";
+  };
+
+  unpackCmd = "tar -xf $curSrc";
+
+  buildInputs = [ ocaml findlib ocamlbuild topkg opam ];
+
+  propagatedBuildInputs = [ result ];
+
+  buildPhase = ''
+    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ pkg/pkg.ml build --with-js_of_ocaml false
+  '';
+
+  installPhase = ''
+    opam-installer --script --prefix=$out ptime.install | sh
+    ln -s $out/lib/ptime $out/lib/ocaml/${ocaml.version}/site-lib
+  '';
+
+  meta = {
+    homepage = http://erratique.ch/software/ptime;
+    description = "POSIX time for OCaml";
+    longDescription = ''
+      Ptime has platform independent POSIX time support in pure OCaml.
+      It provides a type to represent a well-defined range of POSIX timestamps
+      with picosecond precision, conversion with date-time values, conversion
+      with RFC 3339 timestamps and pretty printing to a human-readable,
+      locale-independent representation.
+
+      The additional Ptime_clock library provides access to a system POSIX clock
+      and to the system's current time zone offset.
+
+      Ptime is not a calendar library.
+    '';
+    license = stdenv.lib.licenses.isc;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -340,6 +340,8 @@ let
     piqi = callPackage ../development/ocaml-modules/piqi { };
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 
+    ptime = callPackage ../development/ocaml-modules/ptime { };
+
     re2_p4 = callPackage ../development/ocaml-modules/re2 { };
 
     result = callPackage ../development/ocaml-modules/ocaml-result { };


### PR DESCRIPTION
cc @vbgl 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

