### PR TITLE
xfce4-whiskermenu-plugin: 1.5.3 -> 1.6.1

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin.nix
@@ -4,7 +4,7 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   p_name  = "xfce4-whiskermenu-plugin";
-  version = "1.5.3";
+  version = "1.6.1";
 
   name = "${p_name}-${version}";
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "gottcode";
     repo = "xfce4-whiskermenu-plugin";
     rev = "v${version}";
-    sha256 = "07gmf9x3pw6xajklj0idahbnv0psnkhiqhb88bmkp344jirsx6ba";
+    sha256 = "19hldrrgy7qmrncv5rfsclybycjp9rjfnslhm996h62d2p675qpc";
   };
 
   nativeBuildInputs = [ cmake pkgconfig intltool ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).