### PR TITLE
ocaml-astring: init at 0.8.3

### DIFF
--- a/pkgs/development/ocaml-modules/astring/default.nix
+++ b/pkgs/development/ocaml-modules/astring/default.nix
@@ -1,0 +1,43 @@
+{stdenv, fetchurl, buildOcaml, ocaml, findlib, ocamlbuild, topkg, opam}:
+
+buildOcaml rec {
+  version = "0.8.3";
+  name = "astring";
+
+  src = fetchurl {
+    url = "http://erratique.ch/software/astring/releases/astring-${version}.tbz";
+    sha256 = "0ixjwc3plrljvj24za3l9gy0w30lsbggp8yh02lwrzw61ls4cri0";
+  };
+
+  unpackCmd = "tar -xf $curSrc";
+
+  buildInputs = [ ocaml findlib ocamlbuild topkg opam ];
+
+  buildPhase = ''
+    ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ pkg/pkg.ml build
+  '';
+
+  installPhase = ''
+    opam-installer --script --prefix=$out astring.install | sh
+    ln -s $out/lib/astring $out/lib/ocaml/${ocaml.version}/site-lib/
+  '';
+
+  meta = {
+    homepage = http://erratique.ch/software/astring;
+    description = "Alternative String module for OCaml";
+    longDescription = ''
+      Astring exposes an alternative String module for OCaml. This module tries
+      to balance minimality and expressiveness for basic, index-free, string
+      processing and provides types and functions for substrings, string sets
+      and string maps.
+
+      Remaining compatible with the OCaml String module is a non-goal.
+      The String module exposed by Astring has exception safe functions, removes
+      deprecated and rarely used functions, alters some signatures and names,
+      adds a few missing functions and fully exploits OCaml's newfound string
+      immutability.
+    '';
+    license = stdenv.lib.licenses.isc;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -22,6 +22,8 @@ let
 
     asn1-combinators = callPackage ../development/ocaml-modules/asn1-combinators { };
 
+    astring = callPackage ../development/ocaml-modules/astring { };
+
     async_extra_p4 = callPackage ../development/ocaml-modules/async_extra { };
 
     async_find = callPackage ../development/ocaml-modules/async_find { };


### PR DESCRIPTION
cc @vbgl 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
