### PR TITLE
ocaml-uuseg: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/uuseg/default.nix
+++ b/pkgs/development/ocaml-modules/uuseg/default.nix
@@ -1,18 +1,16 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, uucp, uutf, cmdliner }:
+{ stdenv, buildOcaml, fetchurl, ocaml, findlib, ocamlbuild, opam, uucp, uutf, cmdliner }:
 
 let
-  inherit (stdenv.lib) getVersion versionAtLeast;
-
   pname = "uuseg";
-  version = "0.8.0";
   webpage = "http://erratique.ch/software/${pname}";
 in
 
-assert versionAtLeast (getVersion ocaml) "4.01";
+buildOcaml rec {
 
-stdenv.mkDerivation {
+  minimumSupportedOcamlVersion = "4.01";
 
-  name = "ocaml-${pname}-${version}";
+  name = pname;
+  version = "0.9.0";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
@@ -34,7 +32,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     opam-installer --script --prefix=$out ${pname}.install | sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${getVersion ocaml}/site-lib/${pname}
+    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/${pname}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nox-review -k wip --against HEAD~1`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
