### PR TITLE
ocaml-x509: 0.5.0 -> 0.5.3

### DIFF
--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -1,28 +1,30 @@
-{ stdenv, fetchzip, ocaml, findlib, asn1-combinators, nocrypto, ounit }:
+{stdenv, buildOcaml, fetchFromGitHub, ocaml, findlib, asn1-combinators, nocrypto, ounit, ocaml_oasis, ppx_sexp_conv}:
 
-let version = "0.5.0"; in
+buildOcaml rec {
+  name = "x509";
+  version = "0.5.3";
 
-stdenv.mkDerivation {
-  name = "ocaml-x509-${version}";
-
-  src = fetchzip {
-    url = "https://github.com/mirleft/ocaml-x509/archive/${version}.tar.gz";
-    sha256 = "0i9618ph4i2yk5dvvhiqhm7wf3qmd6b795mxwff8jf856gb2gdyn";
+  src = fetchFromGitHub {
+    owner  = "mirleft";
+    repo   = "ocaml-x509";
+    rev    = "${version}";
+    sha256 = "07cc3z6h87460z3f4vz8nlczw5jkc4vjhix413z9x6nral876rn7";
   };
 
-  buildInputs = [ ocaml findlib ounit ];
+  buildInputs = [ ocaml ocaml_oasis findlib ounit ppx_sexp_conv ];
   propagatedBuildInputs = [ asn1-combinators nocrypto ];
 
   configureFlags = "--enable-tests";
+  configurePhase = "./configure --prefix $out $configureFlags";
+
   doCheck = true;
   checkTarget = "test";
   createFindlibDestdir = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/mirleft/ocaml-x509;
     description = "X509 (RFC5280) handling in OCaml";
-    platforms = ocaml.meta.platforms or [];
-    license = stdenv.lib.licenses.bsd2;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ vbgl ];
   };
 }


### PR DESCRIPTION
cc @vbgl 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
