### PR TITLE
ocaml-cstruct: 1.6.0 -> 2.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,20 +1,40 @@
-{stdenv, writeText, fetchurl, ocaml, ocplib-endian, sexplib_p4, findlib,
- async_p4 ? null, lwt ? null, camlp4}:
+{stdenv, buildOcaml, fetchFromGitHub, writeText,
+ ocaml, ocplib-endian, sexplib, findlib, ounit,
+ async ? null,      lwt     ? null, ppx_tools ? null,
+ withAsync ? true, withLwt ? true, withPpx   ? true}:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
+with stdenv.lib;
+assert withAsync -> async != null;
+assert withLwt -> lwt != null;
+assert withPpx -> ppx_tools != null;
 
-stdenv.mkDerivation {
-  name = "ocaml-cstruct-1.6.0";
+buildOcaml rec {
+  name = "cstruct";
+  version = "2.3.0";
 
-  src = fetchurl {
-    url = https://github.com/mirage/ocaml-cstruct/archive/v1.6.0.tar.gz;
-    sha256 = "0f90a1b7a03091cf22a3ccb11a0cce03b6500f064ad3766b5ed81418ac008ece";
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-cstruct";
+    rev = "v${version}";
+    sha256 = "19spsgkry41dhsbm6ij71kws90bqp7wiggc6lsqdl43xxvbgdmys";
   };
 
-  configureFlags = stdenv.lib.strings.concatStringsSep " " ((if lwt != null then ["--enable-lwt"] else []) ++
-                                          (if async_p4 != null then ["--enable-async"] else []));
-  buildInputs = [ocaml findlib camlp4];
-  propagatedBuildInputs = [ocplib-endian sexplib_p4 lwt async_p4];
+  configureFlags = [ "--enable-tests" ] ++
+                   optional withLwt [ "--enable-lwt" ] ++
+                   optional withAsync [ "--enable-async" ] ++
+                   optional withPpx ["--enable-ppx"];
+  configurePhase = "./configure --prefix $out $configureFlags";
+
+  buildInputs = [ ocaml findlib ounit sexplib ];
+  propagatedBuildInputs = [ocplib-endian ] ++
+                          optional withPpx ppx_tools ++
+                          optional withAsync async ++
+                          optional withLwt lwt;
+
+  doCheck = true;
+  checkTarget = "test";
 
   createFindlibDestdir = true;
   dontStrip = true;


### PR DESCRIPTION
cc @vbgl 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


This commit also refactors the expression.