### PR TITLE
agrep: init at 3.41.5

### DIFF
--- a/pkgs/tools/text/agrep/default.nix
+++ b/pkgs/tools/text/agrep/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "agrep-${version}";
+  version = "3.41.5";
+
+  src = fetchFromGitHub {
+    owner = "Wikinaut";
+    repo = "agrep";
+    # This repository has numbered versions, but not Git tags.
+    rev = "eef20411d605d9d17ead07a0ade75046f2728e21";
+    sha256 = "14addnwspdf2mxpqyrw8b84bb2257y43g5ccy4ipgrr91fmxq2sk";
+  };
+
+  installPhase = ''
+    install -Dm 555 agrep -t "$out/bin"
+    install -Dm 444 docs/* -t "$out/doc"
+  '';
+
+  meta = {
+    description = "Approximate grep for fast fuzzy string searching";
+    homepage = "https://www.tgries.de/agrep/";
+    license = stdenv.lib.licenses.isc;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -367,6 +367,8 @@ in
 
   afpfs-ng = callPackage ../tools/filesystems/afpfs-ng/default.nix { };
 
+  agrep = callPackage ../tools/text/agrep { };
+
   aha = callPackage ../tools/text/aha { };
 
   ahcpd = callPackage ../tools/networking/ahcpd { };


### PR DESCRIPTION
In category `tools`, subcategory `text`, add a package definition for
the program [`agrep`][1] — "Approximate `grep` for fast fuzzy string
searching".

I have tested this patch per nixpkgs manual section 11.1 ("Making
patches").

[1]: <https://www.tgries.de/agrep/>

