### PR TITLE
netdata service: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -300,6 +300,7 @@
   ./services/monitoring/monit.nix
   ./services/monitoring/munin.nix
   ./services/monitoring/nagios.nix
+  ./services/monitoring/netdata.nix
   ./services/monitoring/prometheus/default.nix
   ./services/monitoring/prometheus/node-exporter.nix
   ./services/monitoring/prometheus/alertmanager.nix

--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -1,0 +1,78 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.netdata;
+
+  configFile = pkgs.writeText "netdata.conf" cfg.configText;
+
+  defaultUser = "netdata";
+
+in {
+  options = {
+    services.netdata = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Whether to enable netdata monitoring.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "netdata";
+        description = "User account under which netdata runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "netdata";
+        description = "Group under which netdata runs.";
+      };
+
+      configText = mkOption {
+        type = types.lines;
+        default = "";
+        description = "netdata.conf configuration.";
+        example = ''
+          [global]
+          debug log = syslog
+          access log = syslog
+          error log = syslog
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.netdata = {
+      description = "Real time performance monitoring";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      preStart = concatStringsSep "\n" (map (dir: ''
+        mkdir -vp ${dir}
+        chmod 750 ${dir}
+        chown -R ${cfg.user}:${cfg.group} ${dir}
+        '') [ "/var/cache/netdata"
+              "/var/log/netdata"
+              "/var/lib/netdata" ]);
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = true;
+        ExecStart = "${pkgs.netdata}/bin/netdata -D -c ${configFile}";
+        TimeoutStopSec = 60;
+      };
+    };
+
+    users.extraUsers = optional (cfg.user == defaultUser) {
+      name = defaultUser;
+    };
+
+    users.extraGroups = optional (cfg.group == defaultUser) {
+      name = defaultUser;
+    };
+
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

make netdata easier to enable

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


