### PR TITLE
libgeotiff: 1.2.5 -> 1.4.2

### DIFF
--- a/pkgs/development/libraries/libgeotiff/default.nix
+++ b/pkgs/development/libraries/libgeotiff/default.nix
@@ -1,14 +1,19 @@
-{ stdenv, fetchurl, libtiff }:
+{ stdenv, fetchurl, libtiff, libjpeg, proj, zlib}:
 
-stdenv.mkDerivation {
-  name = "libgeotiff-1.2.5";
+stdenv.mkDerivation rec {
+  version = "1.4.2";
+  name = "libgeotiff-${version}";
 
   src = fetchurl {
-    url = http://download.osgeo.org/geotiff/libgeotiff/libgeotiff-1.2.5.tar.gz;
-    sha256 = "0z2yx77pm0zs81hc0b4lwzdd5s0rxcbylnscgq80b649src1fyzj";
+    url = "http://download.osgeo.org/geotiff/libgeotiff/${name}.tar.gz";
+    sha256 = "0vjy3bwfhljjx66p9w999i4mdhsf7vjshx29yc3pn5livf5091xd";
   };
 
-  buildInputs = [ libtiff ];
+  configureFlags = [
+    "--with-jpeg=${libjpeg.dev}"
+    "--with-zlib=${zlib.dev}"
+  ];
+  buildInputs = [ libtiff proj ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change
The version bump should fix the failing gdal build on darwin.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


