### PR TITLE
rtags: fix darwin build

### DIFF
--- a/pkgs/development/tools/rtags/default.nix
+++ b/pkgs/development/tools/rtags/default.nix
@@ -9,7 +9,6 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     export LIBCLANG_CXXFLAGS="-isystem ${llvmPackages.clang.cc}/include $(llvm-config --cxxflags) " \
-
            LIBCLANG_LIBDIR="${llvmPackages.clang.cc}/lib" \
 
   '' + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/tools/rtags/default.nix
+++ b/pkgs/development/tools/rtags/default.nix
@@ -1,14 +1,20 @@
-{ stdenv, fetchgit, cmake, llvmPackages, openssl, writeScript, bash, emacs }:
+{ stdenv, lib, fetchgit, cmake, llvmPackages, openssl, writeScript, apple_sdk, bash, emacs }:
 
 stdenv.mkDerivation rec {
   name = "rtags-${version}";
   version = "2.3";
 
-  buildInputs = [ cmake llvmPackages.llvm openssl llvmPackages.clang emacs ];
+  buildInputs = [ cmake llvmPackages.llvm openssl llvmPackages.clang emacs ]
+    ++ lib.optional stdenv.isDarwin apple_sdk.sdk;
 
   preConfigure = ''
-    export LIBCLANG_CXXFLAGS="-isystem ${llvmPackages.clang.cc}/include $(llvm-config --cxxflags)" \
-           LIBCLANG_LIBDIR="${llvmPackages.clang.cc}/lib"
+    export LIBCLANG_CXXFLAGS="-isystem ${llvmPackages.clang.cc}/include $(llvm-config --cxxflags) " \
+
+           LIBCLANG_LIBDIR="${llvmPackages.clang.cc}/lib" \
+
+  '' + lib.optionalString stdenv.isDarwin ''
+    export CXXFLAGS="-isysroot ${apple_sdk.sdk}/" \
+           MACOSX_DEPLOYMENT_TARGET="10.9"
   '';
 
   src = fetchgit {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5130,7 +5130,9 @@ in
 
   rgbds = callPackage ../development/compilers/rgbds { };
 
-  rtags = callPackage ../development/tools/rtags/default.nix {};
+  rtags = callPackage ../development/tools/rtags/default.nix {
+    inherit (darwin) apple_sdk;
+  };
 
   rust = rustStable;
   rustStable = callPackage ../development/compilers/rust {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Adds dependency to MacOS_SDK 10.9 and accordingly to the macosx
deployment target to configure SDK-based deployment in rtags. In detail,
rtags makes use of launch_activate_socket() which is available in
launchd.h >10.9. Latter is still not available through
apple-opensource-releases, if ever. Thus, the deployment target and
build input have to be added to let rtags build scripts make use of MAC_OS_X_VERSION_MAX_ALLOWED correctly.