### PR TITLE
light: 0.9 -> 1.0

### DIFF
--- a/pkgs/os-specific/linux/light/default.nix
+++ b/pkgs/os-specific/linux/light/default.nix
@@ -1,14 +1,17 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, help2man }:
 
 stdenv.mkDerivation rec {
-  version = "0.9";
+  version = "1.0";
   name = "light-${version}";
   src = fetchurl {
     url = "https://github.com/haikarainen/light/archive/v${version}.tar.gz";
-    sha256 = "1dnzkkg307izvw76gvzsl2vpxd2a1grxg5h82ix505rb9nnmn0d6";
+    sha256 = "974608ee42ffe85cfd23184306d56d86ec4e6f4b0518bafcb7b3330998b1af64";
   };
+  buildInputs = [ help2man ];
 
   installPhase = "mkdir -p $out/bin; cp light $out/bin/";
+
+  preFixup = "make man; mkdir -p $out/man/man1; mv light.1.gz $out/man/man1";
 
   meta = {
     description = "GNU/Linux application to control backlights";


### PR DESCRIPTION
###### Motivation for this change

Update light from 0.9 to 1.0. The [new Makefile](https://github.com/haikarainen/light/blob/v1.0/Makefile) uses `help2man` to build a man page, hence the added dependency.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Update to version 1.0