### PR TITLE
Backport Plasma 5.8

### DIFF
--- a/pkgs/desktops/kde-5/plasma/default.nix
+++ b/pkgs/desktops/kde-5/plasma/default.nix
@@ -78,7 +78,9 @@ let
     plasma-desktop = callPackage ./plasma-desktop {};
     plasma-integration = callPackage ./plasma-integration.nix {};
     plasma-nm = callPackage ./plasma-nm {};
-    plasma-pa = callPackage ./plasma-pa.nix {};
+    plasma-pa = callPackage ./plasma-pa.nix {
+      inherit (pkgs.gnome3) gconf;
+    };
     plasma-workspace = callPackage ./plasma-workspace {};
     plasma-workspace-wallpapers = callPackage ./plasma-workspace-wallpapers.nix {};
     polkit-kde-agent = callPackage ./polkit-kde-agent.nix {};

--- a/pkgs/desktops/kde-5/plasma/fetch.sh
+++ b/pkgs/desktops/kde-5/plasma/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/plasma/5.7.4/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/plasma/5.7.5/ -A '*.tar.xz' )

--- a/pkgs/desktops/kde-5/plasma/fetch.sh
+++ b/pkgs/desktops/kde-5/plasma/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/plasma/5.8.0/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/plasma/5.8.1/ -A '*.tar.xz' )

--- a/pkgs/desktops/kde-5/plasma/fetch.sh
+++ b/pkgs/desktops/kde-5/plasma/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/plasma/5.7.5/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/plasma/5.8.0/ -A '*.tar.xz' )

--- a/pkgs/desktops/kde-5/plasma/fetch.sh
+++ b/pkgs/desktops/kde-5/plasma/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/plasma/5.8.1/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/plasma/5.8.2/ -A '*.tar.xz' )

--- a/pkgs/desktops/kde-5/plasma/fetch.sh
+++ b/pkgs/desktops/kde-5/plasma/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/plasma/5.8.2/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/plasma/5.8.3/ -A '*.tar.xz' )

--- a/pkgs/desktops/kde-5/plasma/kmenuedit.nix
+++ b/pkgs/desktops/kde-5/plasma/kmenuedit.nix
@@ -1,11 +1,14 @@
-{ plasmaPackage, ecm, kdoctools, ki18n, kxmlgui
-, kdbusaddons, kiconthemes, kio, sonnet, kdelibs4support
+{
+  plasmaPackage,
+  ecm, kdoctools,
+  kdbusaddons, kdelibs4support, khotkeys, ki18n, kiconthemes, kio, kxmlgui,
+  sonnet
 }:
 
 plasmaPackage {
   name = "kmenuedit";
   nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
-    kdelibs4support ki18n kio sonnet kxmlgui kdbusaddons kiconthemes
+    kdbusaddons kdelibs4support khotkeys ki18n kiconthemes kio kxmlgui sonnet
   ];
 }

--- a/pkgs/desktops/kde-5/plasma/ksysguard.nix
+++ b/pkgs/desktops/kde-5/plasma/ksysguard.nix
@@ -3,7 +3,7 @@
   ecm, kdoctools,
   lm_sensors,
   kconfig, kcoreaddons, kdelibs4support, ki18n, kiconthemes, kitemviews,
-  knewstuff, libksysguard, lm_sensors, qtwebkit
+  knewstuff, libksysguard, qtwebkit
 }:
 
 plasmaPackage {

--- a/pkgs/desktops/kde-5/plasma/ksysguard.nix
+++ b/pkgs/desktops/kde-5/plasma/ksysguard.nix
@@ -1,6 +1,6 @@
 { plasmaPackage, ecm, kdoctools, kconfig
 , kcoreaddons, kdelibs4support, ki18n, kitemviews, knewstuff
-, kiconthemes, libksysguard
+, kiconthemes, libksysguard, qtwebkit
 }:
 
 plasmaPackage {
@@ -8,6 +8,6 @@ plasmaPackage {
   nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kconfig kcoreaddons kitemviews knewstuff kiconthemes libksysguard
-    kdelibs4support ki18n
+    kdelibs4support ki18n qtwebkit
   ];
 }

--- a/pkgs/desktops/kde-5/plasma/ksysguard.nix
+++ b/pkgs/desktops/kde-5/plasma/ksysguard.nix
@@ -1,11 +1,15 @@
-{ plasmaPackage, ecm, kdoctools, kconfig
-, kcoreaddons, kdelibs4support, ki18n, kitemviews, knewstuff
-, kiconthemes, libksysguard, qtwebkit
+{
+  plasmaPackage,
+  ecm, kdoctools,
+  lm_sensors,
+  kconfig, kcoreaddons, kdelibs4support, ki18n, kiconthemes, kitemviews,
+  knewstuff, libksysguard, lm_sensors, qtwebkit
 }:
 
 plasmaPackage {
   name = "ksysguard";
   nativeBuildInputs = [ ecm kdoctools ];
+  buildInputs = [ lm_sensors ];
   propagatedBuildInputs = [
     kconfig kcoreaddons kitemviews knewstuff kiconthemes libksysguard
     kdelibs4support ki18n qtwebkit

--- a/pkgs/desktops/kde-5/plasma/kwin/default.nix
+++ b/pkgs/desktops/kde-5/plasma/kwin/default.nix
@@ -21,7 +21,7 @@ plasmaPackage {
     kidletime kinit kio knewstuff knotifications kpackage kscreenlocker kservice
     kwayland kwidgetsaddons kwindowsystem kxmlgui libinput libICE libSM
     plasma-framework qtdeclarative qtmultimedia qtscript qtx11extras udev
-    wayland xcb-util-cursor
+    wayland xcb-util-cursor xwayland
   ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
   postPatch = ''

--- a/pkgs/desktops/kde-5/plasma/libksysguard/default.nix
+++ b/pkgs/desktops/kde-5/plasma/libksysguard/default.nix
@@ -1,7 +1,9 @@
-{ fetchpatch, plasmaPackage, ecm, kauth, kcompletion
-, kconfigwidgets, kcoreaddons, kservice, kwidgetsaddons
-, kwindowsystem, plasma-framework, qtscript, qtx11extras
-, kconfig, ki18n, kiconthemes
+{
+  plasmaPackage,
+  ecm,
+  kauth, kcompletion, kconfig, kconfigwidgets, kcoreaddons, ki18n, kiconthemes,
+  kservice, kwidgetsaddons, kwindowsystem, plasma-framework, qtscript, qtwebkit,
+  qtx11extras
 }:
 
 plasmaPackage {
@@ -9,11 +11,10 @@ plasmaPackage {
   patches = [
     ./0001-qdiriterator-follow-symlinks.patch
   ];
-  nativeBuildInputs = [
-    ecm
-  ];
+  nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
-    kauth kconfig ki18n kiconthemes kwindowsystem plasma-framework qtx11extras
-    kcompletion kconfigwidgets kcoreaddons kservice kwidgetsaddons qtscript
+    kauth kconfig ki18n kiconthemes kwindowsystem kcompletion kconfigwidgets
+    kcoreaddons kservice kwidgetsaddons plasma-framework qtscript qtx11extras
+    qtwebkit
   ];
 }

--- a/pkgs/desktops/kde-5/plasma/oxygen.nix
+++ b/pkgs/desktops/kde-5/plasma/oxygen.nix
@@ -1,16 +1,16 @@
-{ plasmaPackage, ecm, ki18n, kcmutils, kconfig
-, kdecoration, kguiaddons, kwidgetsaddons, kservice, kcompletion
-, frameworkintegration, kwindowsystem, makeQtWrapper, qtx11extras
+{
+  plasmaPackage,
+  ecm, makeQtWrapper,
+  frameworkintegration, kcmutils, kcompletion, kconfig, kdecoration, kguiaddons,
+  ki18n, kwidgetsaddons, kservice, kwayland, kwindowsystem, qtx11extras
 }:
 
 plasmaPackage {
   name = "oxygen";
-  nativeBuildInputs = [
-    ecm makeQtWrapper
-  ];
+  nativeBuildInputs = [ ecm makeQtWrapper ];
   propagatedBuildInputs = [
-    kcmutils kconfig kdecoration kguiaddons kwidgetsaddons kservice kcompletion
-    frameworkintegration ki18n kwindowsystem qtx11extras
+    frameworkintegration kcmutils kcompletion kconfig kdecoration kguiaddons
+    ki18n kservice kwayland kwidgetsaddons kwindowsystem qtx11extras
   ];
   postInstall = ''
     wrapQtProgram "$out/bin/oxygen-demo5"

--- a/pkgs/desktops/kde-5/plasma/plasma-desktop/default.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-desktop/default.nix
@@ -1,20 +1,20 @@
-{ plasmaPackage, substituteAll, ecm, kdoctools
-, attica, baloo, boost, fontconfig, kactivities, kactivities-stats
-, kauth, kcmutils, kdbusaddons, kdeclarative, kded, kdelibs4support, kemoticons
-, kglobalaccel, ki18n, kitemmodels, knewstuff, knotifications
-, knotifyconfig, kpeople, krunner, kwallet, kwin, phonon
-, plasma-framework, plasma-workspace, qtdeclarative, qtx11extras
-, qtsvg, libXcursor, libXft, libxkbfile, xf86inputevdev
-, xf86inputsynaptics, xinput, xkeyboard_config, xorgserver
-, libcanberra_kde, libpulseaudio, utillinux
-, qtquickcontrols, ksysguard
+{
+  plasmaPackage, substituteAll,
+  ecm, kdoctools,
+  attica, baloo, boost, fontconfig, ibus, kactivities, kactivities-stats, kauth,
+  kcmutils, kdbusaddons, kdeclarative, kded, kdelibs4support, kemoticons,
+  kglobalaccel, ki18n, kitemmodels, knewstuff, knotifications, knotifyconfig,
+  kpeople, krunner, ksysguard, kwallet, kwin, libXcursor, libXft,
+  libcanberra_kde, libpulseaudio, libxkbfile, phonon, plasma-framework,
+  plasma-workspace, qtdeclarative, qtquickcontrols, qtsvg, qtx11extras, xf86inputevdev,
+  xf86inputsynaptics, xinput, xkeyboard_config, xorgserver, utillinux
 }:
 
 plasmaPackage rec {
   name = "plasma-desktop";
   nativeBuildInputs = [ ecm kdoctools ];
   buildInputs = [
-    attica boost fontconfig kcmutils kdbusaddons kded kitemmodels knewstuff
+    attica boost fontconfig ibus kcmutils kdbusaddons kded kitemmodels knewstuff
     knotifications knotifyconfig kwallet libcanberra_kde libXcursor
     libpulseaudio libXft libxkbfile phonon qtsvg xf86inputevdev
     xf86inputsynaptics xkeyboard_config xinput baloo kactivities

--- a/pkgs/desktops/kde-5/plasma/plasma-pa.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-pa.nix
@@ -1,16 +1,17 @@
-{ plasmaPackage, ecm, glib, kdoctools, kconfigwidgets
-, kcoreaddons, kdeclarative, kglobalaccel, ki18n, libpulseaudio
-, plasma-framework
+{
+  plasmaPackage,
+  ecm,
+  gconf, glib, kdoctools, kconfigwidgets, kcoreaddons, kdeclarative, kglobalaccel,
+  ki18n, libcanberra_gtk3, libpulseaudio, plasma-framework
 }:
 
 plasmaPackage {
   name = "plasma-pa";
   nativeBuildInputs = [
-    ecm
-    kdoctools
+    ecm kdoctools
   ];
   propagatedBuildInputs = [
-    glib kconfigwidgets kcoreaddons libpulseaudio kdeclarative kglobalaccel
-    ki18n plasma-framework
+    gconf glib kconfigwidgets kcoreaddons kdeclarative
+    kglobalaccel ki18n libcanberra_gtk3 libpulseaudio plasma-framework
   ];
 }

--- a/pkgs/desktops/kde-5/plasma/plasma-workspace/default.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-workspace/default.nix
@@ -5,10 +5,10 @@
 
   baloo, kactivities, kcmutils, kconfig, kcrash, kdbusaddons, kdeclarative,
   kdelibs4support, kdesu, kglobalaccel, kidletime, kjsembed, knewstuff,
-  knotifyconfig, kpackage, krunner, ktexteditor, ktextwidgets, kwallet, kwayland,
-  kwin, kxmlrpcclient, libkscreen, libksysguard, networkmanager-qt, phonon,
-  plasma-framework, qtquickcontrols, qtscript, qtx11extras, solid, isocodes,
-  libdbusmenu, libSM, libXcursor, pam, wayland
+  knotifyconfig, kpackage, krunner, ktexteditor, ktextwidgets, kwallet,
+  kwayland, kwin, kxmlrpcclient, libkscreen, libksysguard, networkmanager-qt,
+  phonon, plasma-framework, qtgraphicaleffects, qtquickcontrols, qtscript,
+  qtx11extras, solid, isocodes, libdbusmenu, libSM, libXcursor, pam, wayland
 }:
 
 plasmaPackage {
@@ -20,8 +20,8 @@ plasmaPackage {
     kdelibs4support kdesu kglobalaccel kidletime kjsembed knewstuff
     knotifyconfig kpackage krunner ktexteditor ktextwidgets kwallet kwayland
     kwin kxmlrpcclient libkscreen libksysguard networkmanager-qt phonon
-    plasma-framework qtquickcontrols qtscript qtx11extras solid
-    isocodes libdbusmenu libSM libXcursor pam wayland
+    plasma-framework qtgraphicaleffects qtquickcontrols qtscript qtx11extras
+    solid isocodes libdbusmenu libSM libXcursor pam wayland
   ];
 
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/desktops/kde-5/plasma/srcs.nix
+++ b/pkgs/desktops/kde-5/plasma/srcs.nix
@@ -3,315 +3,323 @@
 
 {
   bluedevil = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/bluedevil-5.7.4.tar.xz";
-      sha256 = "0f6hdl5z9nfakhgsh9lgf1j63wnrw28wdqibahra6n97z5q6ymn9";
-      name = "bluedevil-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/bluedevil-5.7.5.tar.xz";
+      sha256 = "1kvdaf1dkzafc3kkgwj0jzdkd897jfdqpp9spk9ywg7pd3ds072x";
+      name = "bluedevil-5.7.5.tar.xz";
     };
   };
   breeze = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/breeze-5.7.4.tar.xz";
-      sha256 = "0sjcbn87zk1xnkw19byhqwkldz9j1j10421akc77cwla0qmz1586";
-      name = "breeze-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/breeze-5.7.5.tar.xz";
+      sha256 = "0amxc3g4bb3mg5fai8ssjfvpxd86kx9zz45qpxpgp4jb5g6n03w2";
+      name = "breeze-5.7.5.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/breeze-grub-5.7.4.tar.xz";
-      sha256 = "0gixa1myhim3g06jpvbp5ygkmg1pq8bncigc9njc2fxxy8naj8jf";
-      name = "breeze-grub-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/breeze-grub-5.7.5.tar.xz";
+      sha256 = "03wgxxgpgkcx5jrm13h3sc1f5b8zwa2jqzvmc1fpb3y0m4qaajvy";
+      name = "breeze-grub-5.7.5.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/breeze-gtk-5.7.4.tar.xz";
-      sha256 = "0igrr82cprk69g19h2lgv265780jbjlgbj1rh1j6hpfccwrwhg0x";
-      name = "breeze-gtk-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/breeze-gtk-5.7.5.tar.xz";
+      sha256 = "0vg60b999z9pli5ng8jnb6svy80jv9c2sn63b7a6xj59xajclzxc";
+      name = "breeze-gtk-5.7.5.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/breeze-plymouth-5.7.4.tar.xz";
-      sha256 = "02qn0fvkcq4gd170pakm0ypfmwj51wjascdhylvn9aclmac3j7zk";
-      name = "breeze-plymouth-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/breeze-plymouth-5.7.5.tar.xz";
+      sha256 = "08bxsfljpaz3qpy7p6zxs1bfnssjs951kh3v0qb5wwa4zpm04zpd";
+      name = "breeze-plymouth-5.7.5.tar.xz";
     };
   };
   discover = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/discover-5.7.4.tar.xz";
-      sha256 = "00w4n7c7k0lmjkqa6554sg0fh91n8aj01srcq6dz5h5fx1n858wz";
-      name = "discover-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/discover-5.7.5.tar.xz";
+      sha256 = "1i3qmyxl4rs3849hsgda85x6lckbl4ycal3dl3s6k1mx9fk6hm6c";
+      name = "discover-5.7.5.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kactivitymanagerd-5.7.4.tar.xz";
-      sha256 = "10v4w8cadrhnc7xpy8j0s1fi10gmcv1vvisi6lc8vqzdil2hk89b";
-      name = "kactivitymanagerd-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kactivitymanagerd-5.7.5.tar.xz";
+      sha256 = "1ly57792c27vvia62gmnc3xrpav9ysfzql8xrapw09vdvyp0yc6r";
+      name = "kactivitymanagerd-5.7.5.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kde-cli-tools-5.7.4.tar.xz";
-      sha256 = "0q2dz8qx2zqsc7d185zvmv1x5wz1mvkb8zs6i2454l2l1jy6934p";
-      name = "kde-cli-tools-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kde-cli-tools-5.7.5.tar.xz";
+      sha256 = "0jmav5mkn3qvv8a52kpfyn0065g4wnqiw2r7gw9fh0qh4wckd85s";
+      name = "kde-cli-tools-5.7.5.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kdecoration-5.7.4.tar.xz";
-      sha256 = "160cb3ra9vgxydrgskvsacm50jhwnb0caqmfaj387gcpykxxayl1";
-      name = "kdecoration-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kdecoration-5.7.5.tar.xz";
+      sha256 = "091h6aivk58k66cpry6h3i4w3vsmpl0d3i9r9zz679j0mz5vghxf";
+      name = "kdecoration-5.7.5.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kde-gtk-config-5.7.4.tar.xz";
-      sha256 = "0l69d6rj0r9mga2p6rf9vwsalcir140xb3szy2nhdrgqmrka3mbl";
-      name = "kde-gtk-config-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kde-gtk-config-5.7.5.tar.xz";
+      sha256 = "1r82js7b2js97v803qky6cybb1239c0628m4a11am81191d0a0rn";
+      name = "kde-gtk-config-5.7.5.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kdeplasma-addons-5.7.4.tar.xz";
-      sha256 = "0vc865f3903g93r5w8phi9l0rnlblq68nirwblic2j2a2gyjsn4r";
-      name = "kdeplasma-addons-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kdeplasma-addons-5.7.5.tar.xz";
+      sha256 = "04qnbharl3z74d8jwrvky02mrzcy9h92827a8qcx6xis9kfvlrh0";
+      name = "kdeplasma-addons-5.7.5.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kgamma5-5.7.4.tar.xz";
-      sha256 = "15y86qhgrfs7p8imabsf45l7rpfis1mcjg4g22phizk17w4rzk92";
-      name = "kgamma5-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kgamma5-5.7.5.tar.xz";
+      sha256 = "1x2vn26f6krb9zxkyj7kxj4wlmjqjslvqncvmwbsi4lxpnsrsxsk";
+      name = "kgamma5-5.7.5.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/khotkeys-5.7.4.tar.xz";
-      sha256 = "1lggfcgpq4x1hdvlcjmi3k63rffprhrpjkfvjhryhx62648xb24a";
-      name = "khotkeys-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/khotkeys-5.7.5.tar.xz";
+      sha256 = "0c54zkib69dg31llipbkabd40hs16p0ff4h6mpw3x3iqj2nmxjpg";
+      name = "khotkeys-5.7.5.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kinfocenter-5.7.4.tar.xz";
-      sha256 = "0j4l5yw0h0iwqqcfyah1wh5mnrg47nhqmqza7dz13b48n0bpg31l";
-      name = "kinfocenter-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kinfocenter-5.7.5.tar.xz";
+      sha256 = "0f2j25jvqjw4qy7xaqz1l0sba9vsjp6x6f32ykblnb1kbmbzbkgr";
+      name = "kinfocenter-5.7.5.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kmenuedit-5.7.4.tar.xz";
-      sha256 = "1g8a092kx68spvrys0b8xjyrnx1y94i5lsi51j1cw0ylgjmqsp3p";
-      name = "kmenuedit-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kmenuedit-5.7.5.tar.xz";
+      sha256 = "1midyip0vb9zs4xcyzih5vlj49klkmby3w9ylb2mq4bvp9h62bx1";
+      name = "kmenuedit-5.7.5.tar.xz";
     };
   };
   kscreen = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kscreen-5.7.4.tar.xz";
-      sha256 = "1i0c0znfr2y7b5aczmkym5aflh08sv1f7nfi3j6xmbzcxpfdvidy";
-      name = "kscreen-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kscreen-5.7.5.tar.xz";
+      sha256 = "1hjnbqgng19k5bxfx9m5kbm6hx6rn0hr7ya00i8nj8qvb4l8q7cd";
+      name = "kscreen-5.7.5.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kscreenlocker-5.7.4.tar.xz";
-      sha256 = "03giy5fxy11bdz6ww5hmgwhnlngcrzk7ahp4l1sd9yf3fd4rav6q";
-      name = "kscreenlocker-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kscreenlocker-5.7.5.tar.xz";
+      sha256 = "1q8dpfsprrd8ryindi8xpssc8sn2j7fiwzx6awmgxa3ibz0y7zv5";
+      name = "kscreenlocker-5.7.5.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/ksshaskpass-5.7.4.tar.xz";
-      sha256 = "15b0jhpkg086rspjmcpqi0ylnvxvl9wylz13vkaqdm6408d558gg";
-      name = "ksshaskpass-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/ksshaskpass-5.7.5.tar.xz";
+      sha256 = "0f89s06phnzwn4k4y51haqcw8i5bp6rh1ns0qpyps03vpalqhwln";
+      name = "ksshaskpass-5.7.5.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/ksysguard-5.7.4.tar.xz";
-      sha256 = "1r96zrplcbfb37r8vxvm2hzq638g979xx9y0jrsyhpzxhxgv4w1w";
-      name = "ksysguard-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/ksysguard-5.7.5.tar.xz";
+      sha256 = "0b9y98043craw4afzs63lw7xgi0fbylyr6iv24zxxyig50n8frs7";
+      name = "ksysguard-5.7.5.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kwallet-pam-5.7.4.tar.xz";
-      sha256 = "1p3py66qw09s9pcrbn0x356c13w24nrhkgypz0v3kyr51ia1r1jr";
-      name = "kwallet-pam-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kwallet-pam-5.7.5.tar.xz";
+      sha256 = "1ljxfp8w20329c67y0hkk9ar4mff0x3329lq2rlj9sdsxrhbn6sa";
+      name = "kwallet-pam-5.7.5.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kwayland-integration-5.7.4.tar.xz";
-      sha256 = "05n0m38rmil1zg5clilsic2pq7973nymcr54w6kh93dzrr4r9ls3";
-      name = "kwayland-integration-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kwayland-integration-5.7.5.tar.xz";
+      sha256 = "1da8qq67nn2bilarxn9g76hys723jrv8p0vazq7dnis786adk1yl";
+      name = "kwayland-integration-5.7.5.tar.xz";
     };
   };
   kwin = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kwin-5.7.4.tar.xz";
-      sha256 = "06fmk3jpk3zbig46rzsi5wmxa17z0lnh3r0fk9hxdalxdz4c9ws8";
-      name = "kwin-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kwin-5.7.5.tar.xz";
+      sha256 = "1mi6j7lqdarzih8ib4lxxc9wk4yx0898cl9s6j4rqs8rzz9rh7mb";
+      name = "kwin-5.7.5.tar.xz";
     };
   };
   kwrited = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/kwrited-5.7.4.tar.xz";
-      sha256 = "14c1rw8vmvi4iffqinkz7pgk49g80hw3mhh2mqk5lqj21rnrliqz";
-      name = "kwrited-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/kwrited-5.7.5.tar.xz";
+      sha256 = "0kqjgqq92sd92897sk7a28mzvyjzbismx816llyld6f1lm7saqrs";
+      name = "kwrited-5.7.5.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/libkscreen-5.7.4.tar.xz";
-      sha256 = "1jifb6xi3d541y2c3ipx666dr4wa0i9sc59a4s75cdp82322qvsj";
-      name = "libkscreen-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/libkscreen-5.7.5.tar.xz";
+      sha256 = "0z4wk0g7qwr9jq8larpv2y7j7cfklarimjnwdi7hjvgvkjb98671";
+      name = "libkscreen-5.7.5.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/libksysguard-5.7.4.tar.xz";
-      sha256 = "1kkfsjzpraj0hc02mrz93jdp3ha2dv0m28jmwrxd7z059slfyfj0";
-      name = "libksysguard-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/libksysguard-5.7.5.tar.xz";
+      sha256 = "0iys51c72lg5v503cpns3vqw915mh43p21185v461qmp63pf9145";
+      name = "libksysguard-5.7.5.tar.xz";
     };
   };
   milou = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/milou-5.7.4.tar.xz";
-      sha256 = "1v117cdsiwg4l6g7x2k0mpgp57a9gc6k95jxxms9d41hqwq8qg6q";
-      name = "milou-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/milou-5.7.5.tar.xz";
+      sha256 = "0wnz2rj27rk272zk12gj3231lljqiq9z9ymkvfza14pqikx2vyq5";
+      name = "milou-5.7.5.tar.xz";
     };
   };
   oxygen = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/oxygen-5.7.4.tar.xz";
-      sha256 = "1g18h5a3vxa7pxp07wg9g0yzddvjcqs7cnrlrb2mj8r4zdxg4nx3";
-      name = "oxygen-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/oxygen-5.7.5.tar.xz";
+      sha256 = "0y6s50w27q94zk9kdf6jy4zicr593ks63dygpjhj0iwll3wqnw39";
+      name = "oxygen-5.7.5.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/plasma-desktop-5.7.4.tar.xz";
-      sha256 = "0xm8666acp3149gd9simmbkjpi36fbibpy86ppj0hg26pknc66mr";
-      name = "plasma-desktop-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/plasma-desktop-5.7.5.tar.xz";
+      sha256 = "04x6sr6mh0bkzwbq9kvvr94ffijnzymbdsxzm8r3739grk5hbg3y";
+      name = "plasma-desktop-5.7.5.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/plasma-integration-5.7.4.tar.xz";
-      sha256 = "0h0pmwhkz052dzv7gk9j2a699912agzx39z9iirhigkwniij8q1x";
-      name = "plasma-integration-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/plasma-integration-5.7.5.tar.xz";
+      sha256 = "05nfycbzj27q4jcc9qw2d42nxdib73fr7v5ai4agmlrj733bs6nl";
+      name = "plasma-integration-5.7.5.tar.xz";
+    };
+  };
+  plasma-mediacenter = {
+    version = "5.7.5";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma/5.7.5/plasma-mediacenter-5.7.5.tar.xz";
+      sha256 = "1gv3m1cragvgj6mf1n3zvpjddqxjn8jmqdm657iw87p5qgdzf3fx";
+      name = "plasma-mediacenter-5.7.5.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/plasma-nm-5.7.4.tar.xz";
-      sha256 = "0p5c4n6xc4dw9393l2an320z85mgg8f9wsa04dxdami2638drq9i";
-      name = "plasma-nm-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/plasma-nm-5.7.5.tar.xz";
+      sha256 = "1vpd3bvlvzw1xjs2sxsn4bllc5igxz4102zjnrxhj0r7jrn2ax7b";
+      name = "plasma-nm-5.7.5.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/plasma-pa-5.7.4.tar.xz";
-      sha256 = "1zk6kry02vfmm4mwznq5gy7xzjlbpvbb4a749z0zq0nkmlpx78d4";
-      name = "plasma-pa-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/plasma-pa-5.7.5.tar.xz";
+      sha256 = "09wagng7v33kxlyq8vd498fahcixs00dq22g46243xrf363rsa6i";
+      name = "plasma-pa-5.7.5.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/plasma-sdk-5.7.4.tar.xz";
-      sha256 = "11zq31ja965p9xi4k5siki25blmy5lqsmhscq6pysqs7yzijjban";
-      name = "plasma-sdk-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/plasma-sdk-5.7.5.tar.xz";
+      sha256 = "07x1dywdm5x93bm7c6ipm0jqrwlphq45vgp878sd67mwj6gdc2s2";
+      name = "plasma-sdk-5.7.5.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/plasma-workspace-5.7.4.tar.xz";
-      sha256 = "0g8f1wn3cjgxiyvsbgaac91digglrka9lqsf1xr4fj6l7kfvb1ap";
-      name = "plasma-workspace-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/plasma-workspace-5.7.5.tar.xz";
+      sha256 = "1xdr7skwb8jbkc6nzyb7r4ima23qaiyin3qkcf0xa4n20krrlv8i";
+      name = "plasma-workspace-5.7.5.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/plasma-workspace-wallpapers-5.7.4.tar.xz";
-      sha256 = "1px6sp59wld8j6b7a22dc61b4x4rk4jv4bdfispkxv9b6nb29pdp";
-      name = "plasma-workspace-wallpapers-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/plasma-workspace-wallpapers-5.7.5.tar.xz";
+      sha256 = "1z64vnm05n8wh17g509ndhmvi1ivbjmdnlxy5jn69ayfipz49bpi";
+      name = "plasma-workspace-wallpapers-5.7.5.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.7.4";
+    version = "1-5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/polkit-kde-agent-1-5.7.4.tar.xz";
-      sha256 = "19xw0y1d5cbxs5x79gg8x5nhpsc3lzrk3cq913symg1lz4y8py8l";
-      name = "polkit-kde-agent-1-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/polkit-kde-agent-1-5.7.5.tar.xz";
+      sha256 = "1mham7i0wwskjdaybn5rqsib4k77gjwb61yzf7vibbfv6njra8af";
+      name = "polkit-kde-agent-1-5.7.5.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/powerdevil-5.7.4.tar.xz";
-      sha256 = "19vjhs7cccfgvln4zn8wdnawk5xq6l12qi9jkzzxbhds456xqr84";
-      name = "powerdevil-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/powerdevil-5.7.5.tar.xz";
+      sha256 = "1j9fiyqxgccpxxssgj9mjr8wr9sklqq0k1nijzimbc1vg7ghxyak";
+      name = "powerdevil-5.7.5.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/sddm-kcm-5.7.4.tar.xz";
-      sha256 = "0aljr8pmc65dd6xq4c1i17wasn50nk3p3qwm54rfm9z063qm865h";
-      name = "sddm-kcm-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/sddm-kcm-5.7.5.tar.xz";
+      sha256 = "1s8jkip5fn2ljll0xsj4sy46bz9ggp1qx4q0fwriqagfr0pvphs1";
+      name = "sddm-kcm-5.7.5.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/systemsettings-5.7.4.tar.xz";
-      sha256 = "024rqmnw5bdph15ck8zmzxjars77jzh0hfh3yys1c3ydbhnvrc3w";
-      name = "systemsettings-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/systemsettings-5.7.5.tar.xz";
+      sha256 = "16r0ajzj9g1k1g7ypmxzknwqw38xki98jq9yvycawkf0jpg3h2cn";
+      name = "systemsettings-5.7.5.tar.xz";
     };
   };
   user-manager = {
-    version = "5.7.4";
+    version = "5.7.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.4/user-manager-5.7.4.tar.xz";
-      sha256 = "002qzlvh911ybffp7d0ln4qn6z87lnikagmcagy5bb3ypg217ijf";
-      name = "user-manager-5.7.4.tar.xz";
+      url = "${mirror}/stable/plasma/5.7.5/user-manager-5.7.5.tar.xz";
+      sha256 = "1zrcy8vj59xa0b57liqm48lvkmw9g9w0l4kzkg9li37hf6z3hk6s";
+      name = "user-manager-5.7.5.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/kde-5/plasma/srcs.nix
+++ b/pkgs/desktops/kde-5/plasma/srcs.nix
@@ -3,323 +3,323 @@
 
 {
   bluedevil = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/bluedevil-5.7.5.tar.xz";
-      sha256 = "1kvdaf1dkzafc3kkgwj0jzdkd897jfdqpp9spk9ywg7pd3ds072x";
-      name = "bluedevil-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/bluedevil-5.8.0.tar.xz";
+      sha256 = "1rpabb4ccjrzql3r3w88jx847cqqg31nppzvaacdvz9g4c648652";
+      name = "bluedevil-5.8.0.tar.xz";
     };
   };
   breeze = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/breeze-5.7.5.tar.xz";
-      sha256 = "0amxc3g4bb3mg5fai8ssjfvpxd86kx9zz45qpxpgp4jb5g6n03w2";
-      name = "breeze-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/breeze-5.8.0.tar.xz";
+      sha256 = "0g45vq6pczy0dmim0h8nzi3amhyps03a8y5ajyv4i77drk5ccc0n";
+      name = "breeze-5.8.0.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/breeze-grub-5.7.5.tar.xz";
-      sha256 = "03wgxxgpgkcx5jrm13h3sc1f5b8zwa2jqzvmc1fpb3y0m4qaajvy";
-      name = "breeze-grub-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/breeze-grub-5.8.0.tar.xz";
+      sha256 = "1zja3m6hnmmax8p1lh0ygapp3inbydxr98rabcrb8yzkasz95xsf";
+      name = "breeze-grub-5.8.0.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/breeze-gtk-5.7.5.tar.xz";
-      sha256 = "0vg60b999z9pli5ng8jnb6svy80jv9c2sn63b7a6xj59xajclzxc";
-      name = "breeze-gtk-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/breeze-gtk-5.8.0.tar.xz";
+      sha256 = "1lzhaw8rml5cpd965zdj9n1xw9w965rl0yq1xwbsyad7qln864n3";
+      name = "breeze-gtk-5.8.0.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/breeze-plymouth-5.7.5.tar.xz";
-      sha256 = "08bxsfljpaz3qpy7p6zxs1bfnssjs951kh3v0qb5wwa4zpm04zpd";
-      name = "breeze-plymouth-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/breeze-plymouth-5.8.0.tar.xz";
+      sha256 = "0p0dg97f94n59918jg4hr8z0hfsv46s1iz0gcgwy6v3s7jhl0cy8";
+      name = "breeze-plymouth-5.8.0.tar.xz";
     };
   };
   discover = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/discover-5.7.5.tar.xz";
-      sha256 = "1i3qmyxl4rs3849hsgda85x6lckbl4ycal3dl3s6k1mx9fk6hm6c";
-      name = "discover-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/discover-5.8.0.tar.xz";
+      sha256 = "0wxa5w9rys5w4mr81cr7z0n721lp1hyl9ab006drszbdsqb512kb";
+      name = "discover-5.8.0.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kactivitymanagerd-5.7.5.tar.xz";
-      sha256 = "1ly57792c27vvia62gmnc3xrpav9ysfzql8xrapw09vdvyp0yc6r";
-      name = "kactivitymanagerd-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kactivitymanagerd-5.8.0.tar.xz";
+      sha256 = "1hjfyw5r6fzl8q07rlnzca59lh9229w30hb7v3m3nz9fi0jksxwy";
+      name = "kactivitymanagerd-5.8.0.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kde-cli-tools-5.7.5.tar.xz";
-      sha256 = "0jmav5mkn3qvv8a52kpfyn0065g4wnqiw2r7gw9fh0qh4wckd85s";
-      name = "kde-cli-tools-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kde-cli-tools-5.8.0.tar.xz";
+      sha256 = "19i8wycgsk7yqv7scmwnnd0cridnvg6v8p5jj5x98bc9z1g2jqc5";
+      name = "kde-cli-tools-5.8.0.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kdecoration-5.7.5.tar.xz";
-      sha256 = "091h6aivk58k66cpry6h3i4w3vsmpl0d3i9r9zz679j0mz5vghxf";
-      name = "kdecoration-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kdecoration-5.8.0.tar.xz";
+      sha256 = "0gab3lpg5p156628wy04svbyj81jwpq133bbycrc97k281m2nppr";
+      name = "kdecoration-5.8.0.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kde-gtk-config-5.7.5.tar.xz";
-      sha256 = "1r82js7b2js97v803qky6cybb1239c0628m4a11am81191d0a0rn";
-      name = "kde-gtk-config-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kde-gtk-config-5.8.0.tar.xz";
+      sha256 = "1b3ncnil4yhwnms53gl7nds3ggjhq6zi0j5hdik829wmplxrh8ac";
+      name = "kde-gtk-config-5.8.0.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kdeplasma-addons-5.7.5.tar.xz";
-      sha256 = "04qnbharl3z74d8jwrvky02mrzcy9h92827a8qcx6xis9kfvlrh0";
-      name = "kdeplasma-addons-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kdeplasma-addons-5.8.0.tar.xz";
+      sha256 = "0sf7f3by07g3w7jf13z7yspqjf14dj7z5p0g8lvks3xsikf74vkc";
+      name = "kdeplasma-addons-5.8.0.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kgamma5-5.7.5.tar.xz";
-      sha256 = "1x2vn26f6krb9zxkyj7kxj4wlmjqjslvqncvmwbsi4lxpnsrsxsk";
-      name = "kgamma5-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kgamma5-5.8.0.tar.xz";
+      sha256 = "146jd594byzi2gxvr1iy85p34y8yw04qi5ja9bcpcfzz7m7jwa41";
+      name = "kgamma5-5.8.0.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/khotkeys-5.7.5.tar.xz";
-      sha256 = "0c54zkib69dg31llipbkabd40hs16p0ff4h6mpw3x3iqj2nmxjpg";
-      name = "khotkeys-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/khotkeys-5.8.0.tar.xz";
+      sha256 = "06sc7s8dim4c55l5m8algxpw3g75lx3mdx9p46pxv5gppg3zlgg1";
+      name = "khotkeys-5.8.0.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kinfocenter-5.7.5.tar.xz";
-      sha256 = "0f2j25jvqjw4qy7xaqz1l0sba9vsjp6x6f32ykblnb1kbmbzbkgr";
-      name = "kinfocenter-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kinfocenter-5.8.0.tar.xz";
+      sha256 = "02jrs9c7k8fsz0mvmsj5ammvwm4rxj8835zi0sh427h8l8vs5n6z";
+      name = "kinfocenter-5.8.0.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kmenuedit-5.7.5.tar.xz";
-      sha256 = "1midyip0vb9zs4xcyzih5vlj49klkmby3w9ylb2mq4bvp9h62bx1";
-      name = "kmenuedit-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kmenuedit-5.8.0.tar.xz";
+      sha256 = "0ih4qmijnfvs5dp9m8pbr93d3mxvw9bhninfv7m3h0ngkxqwxwfn";
+      name = "kmenuedit-5.8.0.tar.xz";
     };
   };
   kscreen = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kscreen-5.7.5.tar.xz";
-      sha256 = "1hjnbqgng19k5bxfx9m5kbm6hx6rn0hr7ya00i8nj8qvb4l8q7cd";
-      name = "kscreen-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kscreen-5.8.0.tar.xz";
+      sha256 = "19p1rfqir59hd8ww8x78m6kgky7n82w0s0gw15404p6wk25nvyzx";
+      name = "kscreen-5.8.0.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kscreenlocker-5.7.5.tar.xz";
-      sha256 = "1q8dpfsprrd8ryindi8xpssc8sn2j7fiwzx6awmgxa3ibz0y7zv5";
-      name = "kscreenlocker-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kscreenlocker-5.8.0.tar.xz";
+      sha256 = "1hr0cqi2zhrq3crs4j9zh10nr7xmnw1bp9nvm1v1psrrg5wilxzw";
+      name = "kscreenlocker-5.8.0.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/ksshaskpass-5.7.5.tar.xz";
-      sha256 = "0f89s06phnzwn4k4y51haqcw8i5bp6rh1ns0qpyps03vpalqhwln";
-      name = "ksshaskpass-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/ksshaskpass-5.8.0.tar.xz";
+      sha256 = "1lklixan8c80yj02rgazr70x20zfh8lrjmimwismdrmvxpadn7sb";
+      name = "ksshaskpass-5.8.0.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/ksysguard-5.7.5.tar.xz";
-      sha256 = "0b9y98043craw4afzs63lw7xgi0fbylyr6iv24zxxyig50n8frs7";
-      name = "ksysguard-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/ksysguard-5.8.0.tar.xz";
+      sha256 = "1cq6gxwpihfip7wxjlja7ha0pknsn8x8rkpcq3lb28pap88g54fz";
+      name = "ksysguard-5.8.0.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kwallet-pam-5.7.5.tar.xz";
-      sha256 = "1ljxfp8w20329c67y0hkk9ar4mff0x3329lq2rlj9sdsxrhbn6sa";
-      name = "kwallet-pam-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kwallet-pam-5.8.0.tar.xz";
+      sha256 = "10rqfqavawnp6hdqfpv3zwnaw1g8f5zakfirm3aym5w2lllrdydh";
+      name = "kwallet-pam-5.8.0.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kwayland-integration-5.7.5.tar.xz";
-      sha256 = "1da8qq67nn2bilarxn9g76hys723jrv8p0vazq7dnis786adk1yl";
-      name = "kwayland-integration-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kwayland-integration-5.8.0.tar.xz";
+      sha256 = "0pypjbvg2v4f4gsr9pq3w6y5mnlrcd3sjh1wwnad6shcrwkpy8vq";
+      name = "kwayland-integration-5.8.0.tar.xz";
     };
   };
   kwin = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kwin-5.7.5.tar.xz";
-      sha256 = "1mi6j7lqdarzih8ib4lxxc9wk4yx0898cl9s6j4rqs8rzz9rh7mb";
-      name = "kwin-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kwin-5.8.0.tar.xz";
+      sha256 = "17lr1ffwmyndqglhk9c3hi2r4kyr86696p15ir33rplzjnki15qc";
+      name = "kwin-5.8.0.tar.xz";
     };
   };
   kwrited = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/kwrited-5.7.5.tar.xz";
-      sha256 = "0kqjgqq92sd92897sk7a28mzvyjzbismx816llyld6f1lm7saqrs";
-      name = "kwrited-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/kwrited-5.8.0.tar.xz";
+      sha256 = "10iffb1agqrsy214zpf2ax6ak5ahb6c5p8ik0ar52iwmgxrxkicf";
+      name = "kwrited-5.8.0.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/libkscreen-5.7.5.tar.xz";
-      sha256 = "0z4wk0g7qwr9jq8larpv2y7j7cfklarimjnwdi7hjvgvkjb98671";
-      name = "libkscreen-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/libkscreen-5.8.0.tar.xz";
+      sha256 = "0bzqdcfibw1zw7nmgsqg9sn9pgcsp5yx53dd4phin741iqafwqm9";
+      name = "libkscreen-5.8.0.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/libksysguard-5.7.5.tar.xz";
-      sha256 = "0iys51c72lg5v503cpns3vqw915mh43p21185v461qmp63pf9145";
-      name = "libksysguard-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/libksysguard-5.8.0.tar.xz";
+      sha256 = "0h6m2dj8dml98rgq1va8xpyndwq7bj0q0z97644cpiw0sv00cg66";
+      name = "libksysguard-5.8.0.tar.xz";
     };
   };
   milou = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/milou-5.7.5.tar.xz";
-      sha256 = "0wnz2rj27rk272zk12gj3231lljqiq9z9ymkvfza14pqikx2vyq5";
-      name = "milou-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/milou-5.8.0.tar.xz";
+      sha256 = "0ahjc28zmdnp4h86929m2719fwbldcj772axbkbz6riljdbhaw4v";
+      name = "milou-5.8.0.tar.xz";
     };
   };
   oxygen = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/oxygen-5.7.5.tar.xz";
-      sha256 = "0y6s50w27q94zk9kdf6jy4zicr593ks63dygpjhj0iwll3wqnw39";
-      name = "oxygen-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/oxygen-5.8.0.tar.xz";
+      sha256 = "1snvc7j8bz1f12yx21s2i6lcspwv7apwrrjm90pxyk4mk7lhgmm0";
+      name = "oxygen-5.8.0.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/plasma-desktop-5.7.5.tar.xz";
-      sha256 = "04x6sr6mh0bkzwbq9kvvr94ffijnzymbdsxzm8r3739grk5hbg3y";
-      name = "plasma-desktop-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/plasma-desktop-5.8.0.tar.xz";
+      sha256 = "1isbgbm12prffkb0bhx1mkr45dng3il0x5mhhm54cnkgn4g6nclb";
+      name = "plasma-desktop-5.8.0.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/plasma-integration-5.7.5.tar.xz";
-      sha256 = "05nfycbzj27q4jcc9qw2d42nxdib73fr7v5ai4agmlrj733bs6nl";
-      name = "plasma-integration-5.7.5.tar.xz";
-    };
-  };
-  plasma-mediacenter = {
-    version = "5.7.5";
-    src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/plasma-mediacenter-5.7.5.tar.xz";
-      sha256 = "1gv3m1cragvgj6mf1n3zvpjddqxjn8jmqdm657iw87p5qgdzf3fx";
-      name = "plasma-mediacenter-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/plasma-integration-5.8.0.tar.xz";
+      sha256 = "1k776ybz8wd37c283fgnnrvpl573bgwicvgjbfns1127bzybqgy7";
+      name = "plasma-integration-5.8.0.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/plasma-nm-5.7.5.tar.xz";
-      sha256 = "1vpd3bvlvzw1xjs2sxsn4bllc5igxz4102zjnrxhj0r7jrn2ax7b";
-      name = "plasma-nm-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/plasma-nm-5.8.0.tar.xz";
+      sha256 = "1hvzq96xw6f6j637fhaml4n8xv7gp3cif86h9gmxnbqczdfx617r";
+      name = "plasma-nm-5.8.0.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/plasma-pa-5.7.5.tar.xz";
-      sha256 = "09wagng7v33kxlyq8vd498fahcixs00dq22g46243xrf363rsa6i";
-      name = "plasma-pa-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/plasma-pa-5.8.0.tar.xz";
+      sha256 = "0jgsadzdrlyrq8hagqi5m1mr7hmsmjz33vg508a3b7390mwfw8ah";
+      name = "plasma-pa-5.8.0.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/plasma-sdk-5.7.5.tar.xz";
-      sha256 = "07x1dywdm5x93bm7c6ipm0jqrwlphq45vgp878sd67mwj6gdc2s2";
-      name = "plasma-sdk-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/plasma-sdk-5.8.0.tar.xz";
+      sha256 = "1ncp858cq5nad5n16r1wfk2fg2m30mlaw3hs343rbw81139386m5";
+      name = "plasma-sdk-5.8.0.tar.xz";
+    };
+  };
+  plasma-tests = {
+    version = "5.8.0";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma/5.8.0/plasma-tests-5.8.0.tar.xz";
+      sha256 = "1xacmw8mv3yymz8xj1r37sphrds8y2hsjixali28i7n0njqbx400";
+      name = "plasma-tests-5.8.0.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/plasma-workspace-5.7.5.tar.xz";
-      sha256 = "1xdr7skwb8jbkc6nzyb7r4ima23qaiyin3qkcf0xa4n20krrlv8i";
-      name = "plasma-workspace-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/plasma-workspace-5.8.0.tar.xz";
+      sha256 = "06dklafkszn0rfm980mixr5kh4p40ybk63my3ayn6y7fd4n1anrn";
+      name = "plasma-workspace-5.8.0.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/plasma-workspace-wallpapers-5.7.5.tar.xz";
-      sha256 = "1z64vnm05n8wh17g509ndhmvi1ivbjmdnlxy5jn69ayfipz49bpi";
-      name = "plasma-workspace-wallpapers-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/plasma-workspace-wallpapers-5.8.0.tar.xz";
+      sha256 = "1nf7ggwpakn14ash0ymmi05ld2wns6bk189845f89cy763ssx52g";
+      name = "plasma-workspace-wallpapers-5.8.0.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.7.5";
+    version = "1-5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/polkit-kde-agent-1-5.7.5.tar.xz";
-      sha256 = "1mham7i0wwskjdaybn5rqsib4k77gjwb61yzf7vibbfv6njra8af";
-      name = "polkit-kde-agent-1-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/polkit-kde-agent-1-5.8.0.tar.xz";
+      sha256 = "0x5sdgbq9jj2z4wdgx6v47d9004srqfvnl0bvmzml53mzyrh07kx";
+      name = "polkit-kde-agent-1-5.8.0.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/powerdevil-5.7.5.tar.xz";
-      sha256 = "1j9fiyqxgccpxxssgj9mjr8wr9sklqq0k1nijzimbc1vg7ghxyak";
-      name = "powerdevil-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/powerdevil-5.8.0.tar.xz";
+      sha256 = "03l1c1x6a0xhvh4xswv2lwpk7kjl86i5mc3afsx8zp8h59wfg1w1";
+      name = "powerdevil-5.8.0.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/sddm-kcm-5.7.5.tar.xz";
-      sha256 = "1s8jkip5fn2ljll0xsj4sy46bz9ggp1qx4q0fwriqagfr0pvphs1";
-      name = "sddm-kcm-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/sddm-kcm-5.8.0.tar.xz";
+      sha256 = "0in5s7h860vn12w8i55bzxw5hv6bnhp3zapbbf1jpgvwixhx8bkf";
+      name = "sddm-kcm-5.8.0.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/systemsettings-5.7.5.tar.xz";
-      sha256 = "16r0ajzj9g1k1g7ypmxzknwqw38xki98jq9yvycawkf0jpg3h2cn";
-      name = "systemsettings-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/systemsettings-5.8.0.tar.xz";
+      sha256 = "0kf671hpj42ps27clsc90fj2ndiv3q45y76fc09wv4say351kz1c";
+      name = "systemsettings-5.8.0.tar.xz";
     };
   };
   user-manager = {
-    version = "5.7.5";
+    version = "5.8.0";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.7.5/user-manager-5.7.5.tar.xz";
-      sha256 = "1zrcy8vj59xa0b57liqm48lvkmw9g9w0l4kzkg9li37hf6z3hk6s";
-      name = "user-manager-5.7.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.0/user-manager-5.8.0.tar.xz";
+      sha256 = "0zyg8i9igya3j80pz6lj3wav894z0f1j34aysixm5lc7pakghkg6";
+      name = "user-manager-5.8.0.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/kde-5/plasma/srcs.nix
+++ b/pkgs/desktops/kde-5/plasma/srcs.nix
@@ -3,323 +3,323 @@
 
 {
   bluedevil = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/bluedevil-5.8.0.tar.xz";
-      sha256 = "1rpabb4ccjrzql3r3w88jx847cqqg31nppzvaacdvz9g4c648652";
-      name = "bluedevil-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/bluedevil-5.8.1.tar.xz";
+      sha256 = "0j2mrx2qchcl1s13j3bhqrbgx7myq901clb20x4v9bfdcv1j9cp1";
+      name = "bluedevil-5.8.1.tar.xz";
     };
   };
   breeze = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/breeze-5.8.0.tar.xz";
-      sha256 = "0g45vq6pczy0dmim0h8nzi3amhyps03a8y5ajyv4i77drk5ccc0n";
-      name = "breeze-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/breeze-5.8.1.tar.xz";
+      sha256 = "1s9z8j4jzs951yv1742lq5yh4pz82rkc1d80d7q2yh6964ck733p";
+      name = "breeze-5.8.1.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/breeze-grub-5.8.0.tar.xz";
-      sha256 = "1zja3m6hnmmax8p1lh0ygapp3inbydxr98rabcrb8yzkasz95xsf";
-      name = "breeze-grub-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/breeze-grub-5.8.1.tar.xz";
+      sha256 = "1d3skcj2yg82f5nqghpz9nbz1yb0b5kps3lf28hsq2k2vpqrp4mc";
+      name = "breeze-grub-5.8.1.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/breeze-gtk-5.8.0.tar.xz";
-      sha256 = "1lzhaw8rml5cpd965zdj9n1xw9w965rl0yq1xwbsyad7qln864n3";
-      name = "breeze-gtk-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/breeze-gtk-5.8.1.tar.xz";
+      sha256 = "0nmf6h9kvq5l73yqri3xvldyw669a3rgbjmjizzq1qisri3y0qsz";
+      name = "breeze-gtk-5.8.1.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/breeze-plymouth-5.8.0.tar.xz";
-      sha256 = "0p0dg97f94n59918jg4hr8z0hfsv46s1iz0gcgwy6v3s7jhl0cy8";
-      name = "breeze-plymouth-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/breeze-plymouth-5.8.1.tar.xz";
+      sha256 = "149af4ja38h9sln7sfi05zxwnd8whhmp849zyxgbvdrjc3xxsvcz";
+      name = "breeze-plymouth-5.8.1.tar.xz";
     };
   };
   discover = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/discover-5.8.0.tar.xz";
-      sha256 = "0wxa5w9rys5w4mr81cr7z0n721lp1hyl9ab006drszbdsqb512kb";
-      name = "discover-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/discover-5.8.1.tar.xz";
+      sha256 = "01njqp15qlqvkppn83m2y0yf64v53378f7l2zkzcyxx00pvq2ivk";
+      name = "discover-5.8.1.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kactivitymanagerd-5.8.0.tar.xz";
-      sha256 = "1hjfyw5r6fzl8q07rlnzca59lh9229w30hb7v3m3nz9fi0jksxwy";
-      name = "kactivitymanagerd-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kactivitymanagerd-5.8.1.tar.xz";
+      sha256 = "0pdr4m9qm62v7qansax1jl8va9j4iarmw0iw4cm60m7g6z1aaf4m";
+      name = "kactivitymanagerd-5.8.1.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kde-cli-tools-5.8.0.tar.xz";
-      sha256 = "19i8wycgsk7yqv7scmwnnd0cridnvg6v8p5jj5x98bc9z1g2jqc5";
-      name = "kde-cli-tools-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kde-cli-tools-5.8.1.tar.xz";
+      sha256 = "1bvirh2cbp8cmqrm9h1kdpjdrzbbl9nxsgwh3fw7374k3lsiry01";
+      name = "kde-cli-tools-5.8.1.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kdecoration-5.8.0.tar.xz";
-      sha256 = "0gab3lpg5p156628wy04svbyj81jwpq133bbycrc97k281m2nppr";
-      name = "kdecoration-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kdecoration-5.8.1.tar.xz";
+      sha256 = "09d59f10jsvhsh8dwnz9vd4ngiy22si5wcpj0idml4xvkq1sn1gj";
+      name = "kdecoration-5.8.1.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kde-gtk-config-5.8.0.tar.xz";
-      sha256 = "1b3ncnil4yhwnms53gl7nds3ggjhq6zi0j5hdik829wmplxrh8ac";
-      name = "kde-gtk-config-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kde-gtk-config-5.8.1.tar.xz";
+      sha256 = "1yz9abniqjsp8xc4dndcsbvjigff10787fflwczz4f48is611s3f";
+      name = "kde-gtk-config-5.8.1.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kdeplasma-addons-5.8.0.tar.xz";
-      sha256 = "0sf7f3by07g3w7jf13z7yspqjf14dj7z5p0g8lvks3xsikf74vkc";
-      name = "kdeplasma-addons-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kdeplasma-addons-5.8.1.tar.xz";
+      sha256 = "1148kxdkrdyspy5y3wbs4l7asig4imjjlmssn5g0p8h3q8ag8lbx";
+      name = "kdeplasma-addons-5.8.1.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kgamma5-5.8.0.tar.xz";
-      sha256 = "146jd594byzi2gxvr1iy85p34y8yw04qi5ja9bcpcfzz7m7jwa41";
-      name = "kgamma5-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kgamma5-5.8.1.tar.xz";
+      sha256 = "1v390jlfd56v2pins903yx3z4i32dkjf4cg48ah66shxqp2lr55g";
+      name = "kgamma5-5.8.1.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/khotkeys-5.8.0.tar.xz";
-      sha256 = "06sc7s8dim4c55l5m8algxpw3g75lx3mdx9p46pxv5gppg3zlgg1";
-      name = "khotkeys-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/khotkeys-5.8.1.tar.xz";
+      sha256 = "1g3qd9v2mxi8a9556x8hrj30d0wcv0bqr414zxl631c8sm0rwami";
+      name = "khotkeys-5.8.1.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kinfocenter-5.8.0.tar.xz";
-      sha256 = "02jrs9c7k8fsz0mvmsj5ammvwm4rxj8835zi0sh427h8l8vs5n6z";
-      name = "kinfocenter-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kinfocenter-5.8.1.tar.xz";
+      sha256 = "0iarh97wpq0l5llasb2ikd2f53v41rilj4f6qj1flmxligs4pwdd";
+      name = "kinfocenter-5.8.1.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kmenuedit-5.8.0.tar.xz";
-      sha256 = "0ih4qmijnfvs5dp9m8pbr93d3mxvw9bhninfv7m3h0ngkxqwxwfn";
-      name = "kmenuedit-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kmenuedit-5.8.1.tar.xz";
+      sha256 = "128cqnxw6rkb378p05s33i7yyz6yydnfdbf462ngiq628n6aqvrp";
+      name = "kmenuedit-5.8.1.tar.xz";
     };
   };
   kscreen = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kscreen-5.8.0.tar.xz";
-      sha256 = "19p1rfqir59hd8ww8x78m6kgky7n82w0s0gw15404p6wk25nvyzx";
-      name = "kscreen-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kscreen-5.8.1.tar.xz";
+      sha256 = "0m9ddmp4vi38vkzik8bi5mir1mw66il2dfrf77h7amwfsnkicvfi";
+      name = "kscreen-5.8.1.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kscreenlocker-5.8.0.tar.xz";
-      sha256 = "1hr0cqi2zhrq3crs4j9zh10nr7xmnw1bp9nvm1v1psrrg5wilxzw";
-      name = "kscreenlocker-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kscreenlocker-5.8.1.tar.xz";
+      sha256 = "08ibp746w1xp6p5ccyl0p16giwcfrvq3nakwhwvhlwh0lirgvlrh";
+      name = "kscreenlocker-5.8.1.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/ksshaskpass-5.8.0.tar.xz";
-      sha256 = "1lklixan8c80yj02rgazr70x20zfh8lrjmimwismdrmvxpadn7sb";
-      name = "ksshaskpass-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/ksshaskpass-5.8.1.tar.xz";
+      sha256 = "0yma28axv91zl0zjanrnwjjws9l187l6m4cjshy4ai77prcyzlqn";
+      name = "ksshaskpass-5.8.1.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/ksysguard-5.8.0.tar.xz";
-      sha256 = "1cq6gxwpihfip7wxjlja7ha0pknsn8x8rkpcq3lb28pap88g54fz";
-      name = "ksysguard-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/ksysguard-5.8.1.tar.xz";
+      sha256 = "1msrxhlln561y78gi6rdqzkv9sc0pk3w0znca9fjlsnacl7dbcn9";
+      name = "ksysguard-5.8.1.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kwallet-pam-5.8.0.tar.xz";
-      sha256 = "10rqfqavawnp6hdqfpv3zwnaw1g8f5zakfirm3aym5w2lllrdydh";
-      name = "kwallet-pam-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kwallet-pam-5.8.1.tar.xz";
+      sha256 = "1nl0lb71s2sqhdplyfn5xl01q8zrqj544vlmjd2vc1a18p6qlkcy";
+      name = "kwallet-pam-5.8.1.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kwayland-integration-5.8.0.tar.xz";
-      sha256 = "0pypjbvg2v4f4gsr9pq3w6y5mnlrcd3sjh1wwnad6shcrwkpy8vq";
-      name = "kwayland-integration-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kwayland-integration-5.8.1.tar.xz";
+      sha256 = "1qwdlv7k6r7rzzihvmfhp4bsnz0nlfbi70fxxkdxdr49k1wqhxih";
+      name = "kwayland-integration-5.8.1.tar.xz";
     };
   };
   kwin = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kwin-5.8.0.tar.xz";
-      sha256 = "17lr1ffwmyndqglhk9c3hi2r4kyr86696p15ir33rplzjnki15qc";
-      name = "kwin-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kwin-5.8.1.tar.xz";
+      sha256 = "0b1p6vz87ffy30ja5nz9n1q0i1nhjllcr0rfqnwa1b6wkiv7dabl";
+      name = "kwin-5.8.1.tar.xz";
     };
   };
   kwrited = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/kwrited-5.8.0.tar.xz";
-      sha256 = "10iffb1agqrsy214zpf2ax6ak5ahb6c5p8ik0ar52iwmgxrxkicf";
-      name = "kwrited-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/kwrited-5.8.1.tar.xz";
+      sha256 = "0sk7lwrwl7h174x7bips9a4nzb4wrfqyby0whp8qjpxq891cxbgy";
+      name = "kwrited-5.8.1.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/libkscreen-5.8.0.tar.xz";
-      sha256 = "0bzqdcfibw1zw7nmgsqg9sn9pgcsp5yx53dd4phin741iqafwqm9";
-      name = "libkscreen-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/libkscreen-5.8.1.tar.xz";
+      sha256 = "1pgpn49vgjx9ydqvnvvrs87sjc7zkfcyddw00270m6pk76zcxvc4";
+      name = "libkscreen-5.8.1.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/libksysguard-5.8.0.tar.xz";
-      sha256 = "0h6m2dj8dml98rgq1va8xpyndwq7bj0q0z97644cpiw0sv00cg66";
-      name = "libksysguard-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/libksysguard-5.8.1.tar.xz";
+      sha256 = "1l9gwirs6b3iingq6fcv3yfhkqifjwwg0vwpz9041rj4rry4h73p";
+      name = "libksysguard-5.8.1.tar.xz";
     };
   };
   milou = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/milou-5.8.0.tar.xz";
-      sha256 = "0ahjc28zmdnp4h86929m2719fwbldcj772axbkbz6riljdbhaw4v";
-      name = "milou-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/milou-5.8.1.tar.xz";
+      sha256 = "0znxcmm0h3ghzy22bpcca3jkxypq9zhlwbka4a7skw7ckl55xszm";
+      name = "milou-5.8.1.tar.xz";
     };
   };
   oxygen = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/oxygen-5.8.0.tar.xz";
-      sha256 = "1snvc7j8bz1f12yx21s2i6lcspwv7apwrrjm90pxyk4mk7lhgmm0";
-      name = "oxygen-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/oxygen-5.8.1.tar.xz";
+      sha256 = "0fbj96614f59xkl7ia3k810in793jkmqmzb5csmng19qw1qjg5wk";
+      name = "oxygen-5.8.1.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/plasma-desktop-5.8.0.tar.xz";
-      sha256 = "1isbgbm12prffkb0bhx1mkr45dng3il0x5mhhm54cnkgn4g6nclb";
-      name = "plasma-desktop-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/plasma-desktop-5.8.1.tar.xz";
+      sha256 = "1da96cy3pkryhff6f5cnyvvicz8brjjjh17k0rg5vbrd53zgsz4r";
+      name = "plasma-desktop-5.8.1.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/plasma-integration-5.8.0.tar.xz";
-      sha256 = "1k776ybz8wd37c283fgnnrvpl573bgwicvgjbfns1127bzybqgy7";
-      name = "plasma-integration-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/plasma-integration-5.8.1.tar.xz";
+      sha256 = "1xfc7nn5gcfccmby7ivwh7clrk1z4k8m1qag14r1rxfv8gnswm67";
+      name = "plasma-integration-5.8.1.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/plasma-nm-5.8.0.tar.xz";
-      sha256 = "1hvzq96xw6f6j637fhaml4n8xv7gp3cif86h9gmxnbqczdfx617r";
-      name = "plasma-nm-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/plasma-nm-5.8.1.tar.xz";
+      sha256 = "0v34nvc004zini3i3ya9xw6cvyyh3r7i7z2kijjaqi70vnhx1dp6";
+      name = "plasma-nm-5.8.1.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/plasma-pa-5.8.0.tar.xz";
-      sha256 = "0jgsadzdrlyrq8hagqi5m1mr7hmsmjz33vg508a3b7390mwfw8ah";
-      name = "plasma-pa-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/plasma-pa-5.8.1.tar.xz";
+      sha256 = "1dhqljwn1ihr4wj4785ggja6gvjm5cwfyc5gvmkvb2ls226k2ihb";
+      name = "plasma-pa-5.8.1.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/plasma-sdk-5.8.0.tar.xz";
-      sha256 = "1ncp858cq5nad5n16r1wfk2fg2m30mlaw3hs343rbw81139386m5";
-      name = "plasma-sdk-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/plasma-sdk-5.8.1.tar.xz";
+      sha256 = "0gav6b7bnxl9myf440lygiaymj8jmj6b5mf2nr4vnibymiiq6asm";
+      name = "plasma-sdk-5.8.1.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/plasma-tests-5.8.0.tar.xz";
-      sha256 = "1xacmw8mv3yymz8xj1r37sphrds8y2hsjixali28i7n0njqbx400";
-      name = "plasma-tests-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/plasma-tests-5.8.1.tar.xz";
+      sha256 = "1g5cx7vbghw2av7c943whgmsasgw612ccb9nl5kdfb0g0icpxalk";
+      name = "plasma-tests-5.8.1.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/plasma-workspace-5.8.0.tar.xz";
-      sha256 = "06dklafkszn0rfm980mixr5kh4p40ybk63my3ayn6y7fd4n1anrn";
-      name = "plasma-workspace-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/plasma-workspace-5.8.1.tar.xz";
+      sha256 = "0p7d9a612qqhfm296gg2qda4cqnqy51znbapddyra5dq9ywkhnn0";
+      name = "plasma-workspace-5.8.1.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/plasma-workspace-wallpapers-5.8.0.tar.xz";
-      sha256 = "1nf7ggwpakn14ash0ymmi05ld2wns6bk189845f89cy763ssx52g";
-      name = "plasma-workspace-wallpapers-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/plasma-workspace-wallpapers-5.8.1.tar.xz";
+      sha256 = "17xz75pfpgyzynjy7n1bdm2cnbqyrqhi0d7b4ghpvygg0m1iba9s";
+      name = "plasma-workspace-wallpapers-5.8.1.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.8.0";
+    version = "1-5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/polkit-kde-agent-1-5.8.0.tar.xz";
-      sha256 = "0x5sdgbq9jj2z4wdgx6v47d9004srqfvnl0bvmzml53mzyrh07kx";
-      name = "polkit-kde-agent-1-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/polkit-kde-agent-1-5.8.1.tar.xz";
+      sha256 = "1q5wfr308ayqarvq0fr049aqfwz36hyx8wl7pirllralnz2wmvgv";
+      name = "polkit-kde-agent-1-5.8.1.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/powerdevil-5.8.0.tar.xz";
-      sha256 = "03l1c1x6a0xhvh4xswv2lwpk7kjl86i5mc3afsx8zp8h59wfg1w1";
-      name = "powerdevil-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/powerdevil-5.8.1.tar.xz";
+      sha256 = "0qkmdnck3im0wd1v9a24p8pxwxi38x7kx1a4z8zddsd8pd8d8sjv";
+      name = "powerdevil-5.8.1.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/sddm-kcm-5.8.0.tar.xz";
-      sha256 = "0in5s7h860vn12w8i55bzxw5hv6bnhp3zapbbf1jpgvwixhx8bkf";
-      name = "sddm-kcm-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/sddm-kcm-5.8.1.tar.xz";
+      sha256 = "0kflarcq3q1gbd1blxpspq918cyxxwyigwv8jsmr29yfx947ik17";
+      name = "sddm-kcm-5.8.1.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/systemsettings-5.8.0.tar.xz";
-      sha256 = "0kf671hpj42ps27clsc90fj2ndiv3q45y76fc09wv4say351kz1c";
-      name = "systemsettings-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/systemsettings-5.8.1.tar.xz";
+      sha256 = "04f0z4gq7zyyljb84na184q1wn6mkr9mg06mfv9zkbamsfaiazd8";
+      name = "systemsettings-5.8.1.tar.xz";
     };
   };
   user-manager = {
-    version = "5.8.0";
+    version = "5.8.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.0/user-manager-5.8.0.tar.xz";
-      sha256 = "0zyg8i9igya3j80pz6lj3wav894z0f1j34aysixm5lc7pakghkg6";
-      name = "user-manager-5.8.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.1/user-manager-5.8.1.tar.xz";
+      sha256 = "1bccibypnv58gkmh895w1b9lnmhwda1kypxbd34b9hcldq1dgag7";
+      name = "user-manager-5.8.1.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/kde-5/plasma/srcs.nix
+++ b/pkgs/desktops/kde-5/plasma/srcs.nix
@@ -3,323 +3,323 @@
 
 {
   bluedevil = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/bluedevil-5.8.1.tar.xz";
-      sha256 = "0j2mrx2qchcl1s13j3bhqrbgx7myq901clb20x4v9bfdcv1j9cp1";
-      name = "bluedevil-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/bluedevil-5.8.2.tar.xz";
+      sha256 = "1m8bhvh27af8hwqyicsrqbxsfl6mmwlyc9y9cv5fh4rkf0lkcsnd";
+      name = "bluedevil-5.8.2.tar.xz";
     };
   };
   breeze = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/breeze-5.8.1.tar.xz";
-      sha256 = "1s9z8j4jzs951yv1742lq5yh4pz82rkc1d80d7q2yh6964ck733p";
-      name = "breeze-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/breeze-5.8.2.tar.xz";
+      sha256 = "1n87n2vaxgb7wpg5jmb6x6l1z6gwl8jh9kjrgaq0blm1qkhac3k8";
+      name = "breeze-5.8.2.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/breeze-grub-5.8.1.tar.xz";
-      sha256 = "1d3skcj2yg82f5nqghpz9nbz1yb0b5kps3lf28hsq2k2vpqrp4mc";
-      name = "breeze-grub-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/breeze-grub-5.8.2.tar.xz";
+      sha256 = "1q4i87xvxajz67lkdf9k9z6vy6l0wlirz31n043fyy32gw0mrmf1";
+      name = "breeze-grub-5.8.2.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/breeze-gtk-5.8.1.tar.xz";
-      sha256 = "0nmf6h9kvq5l73yqri3xvldyw669a3rgbjmjizzq1qisri3y0qsz";
-      name = "breeze-gtk-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/breeze-gtk-5.8.2.tar.xz";
+      sha256 = "1vdn7nh1vn8cjxd6cvaj12imd523g7qjc7rlhih6q76ly6h9hv7k";
+      name = "breeze-gtk-5.8.2.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/breeze-plymouth-5.8.1.tar.xz";
-      sha256 = "149af4ja38h9sln7sfi05zxwnd8whhmp849zyxgbvdrjc3xxsvcz";
-      name = "breeze-plymouth-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/breeze-plymouth-5.8.2.tar.xz";
+      sha256 = "1dkp0h3idzpfbvwrmjzn5sbq0077ndr36qh087yyhdjwj1mlk98r";
+      name = "breeze-plymouth-5.8.2.tar.xz";
     };
   };
   discover = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/discover-5.8.1.tar.xz";
-      sha256 = "01njqp15qlqvkppn83m2y0yf64v53378f7l2zkzcyxx00pvq2ivk";
-      name = "discover-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/discover-5.8.2.tar.xz";
+      sha256 = "00zmdr6di37rcqncss4z51557a8zzli7n01imjjv8h784vkn0p04";
+      name = "discover-5.8.2.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kactivitymanagerd-5.8.1.tar.xz";
-      sha256 = "0pdr4m9qm62v7qansax1jl8va9j4iarmw0iw4cm60m7g6z1aaf4m";
-      name = "kactivitymanagerd-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kactivitymanagerd-5.8.2.tar.xz";
+      sha256 = "1dgdxpdxkdz0l498sadgfbp21by8d73r11ibb6mvxwmrba6q4lsc";
+      name = "kactivitymanagerd-5.8.2.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kde-cli-tools-5.8.1.tar.xz";
-      sha256 = "1bvirh2cbp8cmqrm9h1kdpjdrzbbl9nxsgwh3fw7374k3lsiry01";
-      name = "kde-cli-tools-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kde-cli-tools-5.8.2.tar.xz";
+      sha256 = "1gwp6hkpfaijxxc1v4km6kcwrzvwagkn5dgl181xghra26ar0bca";
+      name = "kde-cli-tools-5.8.2.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kdecoration-5.8.1.tar.xz";
-      sha256 = "09d59f10jsvhsh8dwnz9vd4ngiy22si5wcpj0idml4xvkq1sn1gj";
-      name = "kdecoration-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kdecoration-5.8.2.tar.xz";
+      sha256 = "0wbi6z3k9s18fi1vc7larnhwcdzrxrc13plpcnl365la8zrnp766";
+      name = "kdecoration-5.8.2.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kde-gtk-config-5.8.1.tar.xz";
-      sha256 = "1yz9abniqjsp8xc4dndcsbvjigff10787fflwczz4f48is611s3f";
-      name = "kde-gtk-config-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kde-gtk-config-5.8.2.tar.xz";
+      sha256 = "16kn6wy71x1zjpfppiwpmj6skw97ni5pyg2b2af733spfbkx0ca7";
+      name = "kde-gtk-config-5.8.2.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kdeplasma-addons-5.8.1.tar.xz";
-      sha256 = "1148kxdkrdyspy5y3wbs4l7asig4imjjlmssn5g0p8h3q8ag8lbx";
-      name = "kdeplasma-addons-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kdeplasma-addons-5.8.2.tar.xz";
+      sha256 = "18d9a2iwvr4klgm10yvsjjhszkc6zk26kmsay4c2q4pqbsvq7nqq";
+      name = "kdeplasma-addons-5.8.2.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kgamma5-5.8.1.tar.xz";
-      sha256 = "1v390jlfd56v2pins903yx3z4i32dkjf4cg48ah66shxqp2lr55g";
-      name = "kgamma5-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kgamma5-5.8.2.tar.xz";
+      sha256 = "0l73w2arpvv7x4yawp044j781pwmwpijr23mwhfcmnw7bmc7g5vn";
+      name = "kgamma5-5.8.2.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/khotkeys-5.8.1.tar.xz";
-      sha256 = "1g3qd9v2mxi8a9556x8hrj30d0wcv0bqr414zxl631c8sm0rwami";
-      name = "khotkeys-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/khotkeys-5.8.2.tar.xz";
+      sha256 = "17cmlny98ip0ckdafhlqm97p0rkrr9w2d18xf0hdxcypj13q4ba5";
+      name = "khotkeys-5.8.2.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kinfocenter-5.8.1.tar.xz";
-      sha256 = "0iarh97wpq0l5llasb2ikd2f53v41rilj4f6qj1flmxligs4pwdd";
-      name = "kinfocenter-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kinfocenter-5.8.2.tar.xz";
+      sha256 = "1j1l3fczw7sy43dff0mcwpvyvfz4r7ja7zg7x8vq5v2hi3c3f865";
+      name = "kinfocenter-5.8.2.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kmenuedit-5.8.1.tar.xz";
-      sha256 = "128cqnxw6rkb378p05s33i7yyz6yydnfdbf462ngiq628n6aqvrp";
-      name = "kmenuedit-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kmenuedit-5.8.2.tar.xz";
+      sha256 = "0r214s2pqm925l1mpzj4cwk73xvsf00wbm4g495dc63kwxpamx21";
+      name = "kmenuedit-5.8.2.tar.xz";
     };
   };
   kscreen = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kscreen-5.8.1.tar.xz";
-      sha256 = "0m9ddmp4vi38vkzik8bi5mir1mw66il2dfrf77h7amwfsnkicvfi";
-      name = "kscreen-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kscreen-5.8.2.tar.xz";
+      sha256 = "03i2zwpalq4d1y38bkwacvkqfanzdsdpafpqw17qjcan3jgxkkwr";
+      name = "kscreen-5.8.2.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kscreenlocker-5.8.1.tar.xz";
-      sha256 = "08ibp746w1xp6p5ccyl0p16giwcfrvq3nakwhwvhlwh0lirgvlrh";
-      name = "kscreenlocker-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kscreenlocker-5.8.2.tar.xz";
+      sha256 = "0may2h54yamzzd3jfv50skcxsws2liw36vb4smvyv9j8nvqvwyp1";
+      name = "kscreenlocker-5.8.2.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/ksshaskpass-5.8.1.tar.xz";
-      sha256 = "0yma28axv91zl0zjanrnwjjws9l187l6m4cjshy4ai77prcyzlqn";
-      name = "ksshaskpass-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/ksshaskpass-5.8.2.tar.xz";
+      sha256 = "1wk8jrwlr7lndsbhngkffvpjrqwi88x19vrxivb18gcr28m6403s";
+      name = "ksshaskpass-5.8.2.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/ksysguard-5.8.1.tar.xz";
-      sha256 = "1msrxhlln561y78gi6rdqzkv9sc0pk3w0znca9fjlsnacl7dbcn9";
-      name = "ksysguard-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/ksysguard-5.8.2.tar.xz";
+      sha256 = "1myg260bn7bjv18wadwzfwns9jc63r5plk3psdf6w727hcmizvnn";
+      name = "ksysguard-5.8.2.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kwallet-pam-5.8.1.tar.xz";
-      sha256 = "1nl0lb71s2sqhdplyfn5xl01q8zrqj544vlmjd2vc1a18p6qlkcy";
-      name = "kwallet-pam-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kwallet-pam-5.8.2.tar.xz";
+      sha256 = "1iw8cyr44kwjfqhf1ybnjy0pjv4yk87w3vir8j91an4mxhdcc2sb";
+      name = "kwallet-pam-5.8.2.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kwayland-integration-5.8.1.tar.xz";
-      sha256 = "1qwdlv7k6r7rzzihvmfhp4bsnz0nlfbi70fxxkdxdr49k1wqhxih";
-      name = "kwayland-integration-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kwayland-integration-5.8.2.tar.xz";
+      sha256 = "12zmf11117y5zp307ymfy5gsjpcf97sqw1n3nzk55p9kzlfln1pa";
+      name = "kwayland-integration-5.8.2.tar.xz";
     };
   };
   kwin = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kwin-5.8.1.tar.xz";
-      sha256 = "0b1p6vz87ffy30ja5nz9n1q0i1nhjllcr0rfqnwa1b6wkiv7dabl";
-      name = "kwin-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kwin-5.8.2.tar.xz";
+      sha256 = "04c9bvbd487pgf4l7a7vxaydjr9hwdjg149mzcxzm5y1nx7ll08y";
+      name = "kwin-5.8.2.tar.xz";
     };
   };
   kwrited = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/kwrited-5.8.1.tar.xz";
-      sha256 = "0sk7lwrwl7h174x7bips9a4nzb4wrfqyby0whp8qjpxq891cxbgy";
-      name = "kwrited-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/kwrited-5.8.2.tar.xz";
+      sha256 = "1659783rca0hcisrhxz1bnimn0q17825sbs6zlwxlwsh2qq8fq23";
+      name = "kwrited-5.8.2.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/libkscreen-5.8.1.tar.xz";
-      sha256 = "1pgpn49vgjx9ydqvnvvrs87sjc7zkfcyddw00270m6pk76zcxvc4";
-      name = "libkscreen-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/libkscreen-5.8.2.tar.xz";
+      sha256 = "0p2nhgvr3cxq0js6zkcnhglwqffnrnws8vdi7lyl069y9r8lvp7c";
+      name = "libkscreen-5.8.2.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/libksysguard-5.8.1.tar.xz";
-      sha256 = "1l9gwirs6b3iingq6fcv3yfhkqifjwwg0vwpz9041rj4rry4h73p";
-      name = "libksysguard-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/libksysguard-5.8.2.tar.xz";
+      sha256 = "158n30wbpsgbw3axhhsc58hnwhwdd02j3zc9hhcybmnbkfl5c96l";
+      name = "libksysguard-5.8.2.tar.xz";
     };
   };
   milou = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/milou-5.8.1.tar.xz";
-      sha256 = "0znxcmm0h3ghzy22bpcca3jkxypq9zhlwbka4a7skw7ckl55xszm";
-      name = "milou-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/milou-5.8.2.tar.xz";
+      sha256 = "0ikba2xk2d4v66rhdln97d89avrkbhpjh1zir5ds3s103yyrj4q9";
+      name = "milou-5.8.2.tar.xz";
     };
   };
   oxygen = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/oxygen-5.8.1.tar.xz";
-      sha256 = "0fbj96614f59xkl7ia3k810in793jkmqmzb5csmng19qw1qjg5wk";
-      name = "oxygen-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/oxygen-5.8.2.tar.xz";
+      sha256 = "1n0gfgn7m0953dd69nvl0ikp97zmcn3hjm01s43nxjma3gp8pqar";
+      name = "oxygen-5.8.2.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/plasma-desktop-5.8.1.tar.xz";
-      sha256 = "1da96cy3pkryhff6f5cnyvvicz8brjjjh17k0rg5vbrd53zgsz4r";
-      name = "plasma-desktop-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/plasma-desktop-5.8.2.tar.xz";
+      sha256 = "0023wb3fnk0cap7v2zwig6h3vqvykrwwq9vyl0xbsj5vzx3f8yqj";
+      name = "plasma-desktop-5.8.2.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/plasma-integration-5.8.1.tar.xz";
-      sha256 = "1xfc7nn5gcfccmby7ivwh7clrk1z4k8m1qag14r1rxfv8gnswm67";
-      name = "plasma-integration-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/plasma-integration-5.8.2.tar.xz";
+      sha256 = "1z7pd5j7llac1iv4w4q4r9wysqi4shc65fcg6bh637gxqjgyq4rf";
+      name = "plasma-integration-5.8.2.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/plasma-nm-5.8.1.tar.xz";
-      sha256 = "0v34nvc004zini3i3ya9xw6cvyyh3r7i7z2kijjaqi70vnhx1dp6";
-      name = "plasma-nm-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/plasma-nm-5.8.2.tar.xz";
+      sha256 = "035nhs8z977gp3d041ywnam1y4vk7458mx81f2qrx2bv8g6znq22";
+      name = "plasma-nm-5.8.2.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/plasma-pa-5.8.1.tar.xz";
-      sha256 = "1dhqljwn1ihr4wj4785ggja6gvjm5cwfyc5gvmkvb2ls226k2ihb";
-      name = "plasma-pa-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/plasma-pa-5.8.2.tar.xz";
+      sha256 = "1j55q4brjh77i1imr7pb9gp9a8vaynnr2ljdsm4jqsijwcjj1yhi";
+      name = "plasma-pa-5.8.2.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/plasma-sdk-5.8.1.tar.xz";
-      sha256 = "0gav6b7bnxl9myf440lygiaymj8jmj6b5mf2nr4vnibymiiq6asm";
-      name = "plasma-sdk-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/plasma-sdk-5.8.2.tar.xz";
+      sha256 = "0h6393qxwms0xdq69nyzs18kbyl6amzff26l20fqpp49xrqpq95y";
+      name = "plasma-sdk-5.8.2.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/plasma-tests-5.8.1.tar.xz";
-      sha256 = "1g5cx7vbghw2av7c943whgmsasgw612ccb9nl5kdfb0g0icpxalk";
-      name = "plasma-tests-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/plasma-tests-5.8.2.tar.xz";
+      sha256 = "0ls8mxabvw39xb8nrl89n1jn0bkgykzx7hcv45q17aw5jm8s0wy5";
+      name = "plasma-tests-5.8.2.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/plasma-workspace-5.8.1.tar.xz";
-      sha256 = "0p7d9a612qqhfm296gg2qda4cqnqy51znbapddyra5dq9ywkhnn0";
-      name = "plasma-workspace-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/plasma-workspace-5.8.2.tar.xz";
+      sha256 = "1dxvxz9qvkg1h79j997qgs573l730w1g0n1dy78n344bnvn8zx44";
+      name = "plasma-workspace-5.8.2.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/plasma-workspace-wallpapers-5.8.1.tar.xz";
-      sha256 = "17xz75pfpgyzynjy7n1bdm2cnbqyrqhi0d7b4ghpvygg0m1iba9s";
-      name = "plasma-workspace-wallpapers-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/plasma-workspace-wallpapers-5.8.2.tar.xz";
+      sha256 = "0wkkpl1n6ggicgj6lszmb661wrmddhq9wx3djr3hyvvi5r586rxi";
+      name = "plasma-workspace-wallpapers-5.8.2.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.8.1";
+    version = "1-5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/polkit-kde-agent-1-5.8.1.tar.xz";
-      sha256 = "1q5wfr308ayqarvq0fr049aqfwz36hyx8wl7pirllralnz2wmvgv";
-      name = "polkit-kde-agent-1-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/polkit-kde-agent-1-5.8.2.tar.xz";
+      sha256 = "1ipli3xq4dc8lnyamqfzsjcfh3808gbw3qaaqksng2ki0i84aw8f";
+      name = "polkit-kde-agent-1-5.8.2.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/powerdevil-5.8.1.tar.xz";
-      sha256 = "0qkmdnck3im0wd1v9a24p8pxwxi38x7kx1a4z8zddsd8pd8d8sjv";
-      name = "powerdevil-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/powerdevil-5.8.2.tar.xz";
+      sha256 = "0bjk08f3bliy4cz3pcs77qhsc3l82fqk3q0djiwgmsr77ksabj7x";
+      name = "powerdevil-5.8.2.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/sddm-kcm-5.8.1.tar.xz";
-      sha256 = "0kflarcq3q1gbd1blxpspq918cyxxwyigwv8jsmr29yfx947ik17";
-      name = "sddm-kcm-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/sddm-kcm-5.8.2.tar.xz";
+      sha256 = "1n3r2hjwrsxiwzzgkpf4xgp2645kzzdl49i91qcsqznhiqp7kjx3";
+      name = "sddm-kcm-5.8.2.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/systemsettings-5.8.1.tar.xz";
-      sha256 = "04f0z4gq7zyyljb84na184q1wn6mkr9mg06mfv9zkbamsfaiazd8";
-      name = "systemsettings-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/systemsettings-5.8.2.tar.xz";
+      sha256 = "157knafprh4b689jjr8w4bqrh9kp92ggvf40s4ny8cfyjr2bzcvi";
+      name = "systemsettings-5.8.2.tar.xz";
     };
   };
   user-manager = {
-    version = "5.8.1";
+    version = "5.8.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.1/user-manager-5.8.1.tar.xz";
-      sha256 = "1bccibypnv58gkmh895w1b9lnmhwda1kypxbd34b9hcldq1dgag7";
-      name = "user-manager-5.8.1.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.2/user-manager-5.8.2.tar.xz";
+      sha256 = "1344qvzrlswc69wvnaqic300wxra6ix6w6iczj29sprxsa5ycf91";
+      name = "user-manager-5.8.2.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/kde-5/plasma/srcs.nix
+++ b/pkgs/desktops/kde-5/plasma/srcs.nix
@@ -3,323 +3,323 @@
 
 {
   bluedevil = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/bluedevil-5.8.2.tar.xz";
-      sha256 = "1m8bhvh27af8hwqyicsrqbxsfl6mmwlyc9y9cv5fh4rkf0lkcsnd";
-      name = "bluedevil-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/bluedevil-5.8.3.tar.xz";
+      sha256 = "1d05bzy1za7s9mlsh1drhlgjbb7z78jayhqml3zym05igs517la6";
+      name = "bluedevil-5.8.3.tar.xz";
     };
   };
   breeze = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/breeze-5.8.2.tar.xz";
-      sha256 = "1n87n2vaxgb7wpg5jmb6x6l1z6gwl8jh9kjrgaq0blm1qkhac3k8";
-      name = "breeze-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/breeze-5.8.3.tar.xz";
+      sha256 = "0apim1byibkbqkxb1f5ra53wfr4cwmrkdsx4ls7mph4iknr5wdwp";
+      name = "breeze-5.8.3.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/breeze-grub-5.8.2.tar.xz";
-      sha256 = "1q4i87xvxajz67lkdf9k9z6vy6l0wlirz31n043fyy32gw0mrmf1";
-      name = "breeze-grub-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/breeze-grub-5.8.3.tar.xz";
+      sha256 = "01yyhwccxrkmxi95rsg9645fd0i2ca97j425q0pxci9fg93bwl8k";
+      name = "breeze-grub-5.8.3.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/breeze-gtk-5.8.2.tar.xz";
-      sha256 = "1vdn7nh1vn8cjxd6cvaj12imd523g7qjc7rlhih6q76ly6h9hv7k";
-      name = "breeze-gtk-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/breeze-gtk-5.8.3.tar.xz";
+      sha256 = "1wm8v4fav9crk3wn3azsylymvcg67cgncv4zx1fy8rmblikp080g";
+      name = "breeze-gtk-5.8.3.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/breeze-plymouth-5.8.2.tar.xz";
-      sha256 = "1dkp0h3idzpfbvwrmjzn5sbq0077ndr36qh087yyhdjwj1mlk98r";
-      name = "breeze-plymouth-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/breeze-plymouth-5.8.3.tar.xz";
+      sha256 = "0gdl603kjxfrvcardinfq710j5gzzc6ky8ypzmr7myk5kl4i9gf3";
+      name = "breeze-plymouth-5.8.3.tar.xz";
     };
   };
   discover = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/discover-5.8.2.tar.xz";
-      sha256 = "00zmdr6di37rcqncss4z51557a8zzli7n01imjjv8h784vkn0p04";
-      name = "discover-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/discover-5.8.3.tar.xz";
+      sha256 = "18fqr15jw3hfbpq6ma3md89lqzmlilfbic6zd0pm9mvpmwawbjxh";
+      name = "discover-5.8.3.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kactivitymanagerd-5.8.2.tar.xz";
-      sha256 = "1dgdxpdxkdz0l498sadgfbp21by8d73r11ibb6mvxwmrba6q4lsc";
-      name = "kactivitymanagerd-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kactivitymanagerd-5.8.3.tar.xz";
+      sha256 = "18nkg64i7znyk29km8clcmpg5wrd60a0nbgdb6n0cnjjyra2ljfj";
+      name = "kactivitymanagerd-5.8.3.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kde-cli-tools-5.8.2.tar.xz";
-      sha256 = "1gwp6hkpfaijxxc1v4km6kcwrzvwagkn5dgl181xghra26ar0bca";
-      name = "kde-cli-tools-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kde-cli-tools-5.8.3.tar.xz";
+      sha256 = "02sa4l6mx6bfys44wcaf9mpfk3vrw65zzd1jx466xy0dda43kw9b";
+      name = "kde-cli-tools-5.8.3.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kdecoration-5.8.2.tar.xz";
-      sha256 = "0wbi6z3k9s18fi1vc7larnhwcdzrxrc13plpcnl365la8zrnp766";
-      name = "kdecoration-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kdecoration-5.8.3.tar.xz";
+      sha256 = "0d7q16ms3vrsrwc7fql3ly7hmbyx0v35llj9z8h1k642j3ci8jca";
+      name = "kdecoration-5.8.3.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kde-gtk-config-5.8.2.tar.xz";
-      sha256 = "16kn6wy71x1zjpfppiwpmj6skw97ni5pyg2b2af733spfbkx0ca7";
-      name = "kde-gtk-config-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kde-gtk-config-5.8.3.tar.xz";
+      sha256 = "0y3xykz8db3y92mnhbwld2wcsh4sqxacnmx899ig5xy08chqym3d";
+      name = "kde-gtk-config-5.8.3.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kdeplasma-addons-5.8.2.tar.xz";
-      sha256 = "18d9a2iwvr4klgm10yvsjjhszkc6zk26kmsay4c2q4pqbsvq7nqq";
-      name = "kdeplasma-addons-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kdeplasma-addons-5.8.3.tar.xz";
+      sha256 = "1ssk70rvfzi3a9mx514qsh5hld2v12kz3m4n7vpl9sq1fc5hq8k3";
+      name = "kdeplasma-addons-5.8.3.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kgamma5-5.8.2.tar.xz";
-      sha256 = "0l73w2arpvv7x4yawp044j781pwmwpijr23mwhfcmnw7bmc7g5vn";
-      name = "kgamma5-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kgamma5-5.8.3.tar.xz";
+      sha256 = "038i3dm6lxvlb5s6faxr5h6cw6xhymq71fnbphhbcbc1v08sa065";
+      name = "kgamma5-5.8.3.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/khotkeys-5.8.2.tar.xz";
-      sha256 = "17cmlny98ip0ckdafhlqm97p0rkrr9w2d18xf0hdxcypj13q4ba5";
-      name = "khotkeys-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/khotkeys-5.8.3.tar.xz";
+      sha256 = "0lqwsdbr38qhz79sgdg3m3wx70f6ys4bv8mhnczfs06mchzm6zy9";
+      name = "khotkeys-5.8.3.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kinfocenter-5.8.2.tar.xz";
-      sha256 = "1j1l3fczw7sy43dff0mcwpvyvfz4r7ja7zg7x8vq5v2hi3c3f865";
-      name = "kinfocenter-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kinfocenter-5.8.3.tar.xz";
+      sha256 = "1hs9yg15rhhm2lra472wq9f1ca7aj6wsd6drb538mdma53mz21pv";
+      name = "kinfocenter-5.8.3.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kmenuedit-5.8.2.tar.xz";
-      sha256 = "0r214s2pqm925l1mpzj4cwk73xvsf00wbm4g495dc63kwxpamx21";
-      name = "kmenuedit-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kmenuedit-5.8.3.tar.xz";
+      sha256 = "06zji52iw8d18nda87xh54d7q94aqddrfgp3i9lsir50bgabqnc7";
+      name = "kmenuedit-5.8.3.tar.xz";
     };
   };
   kscreen = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kscreen-5.8.2.tar.xz";
-      sha256 = "03i2zwpalq4d1y38bkwacvkqfanzdsdpafpqw17qjcan3jgxkkwr";
-      name = "kscreen-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kscreen-5.8.3.tar.xz";
+      sha256 = "07mldxxxna1y8ngam8l2h3bs1plvfgqhzj95ryprsfypls7pj1ny";
+      name = "kscreen-5.8.3.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kscreenlocker-5.8.2.tar.xz";
-      sha256 = "0may2h54yamzzd3jfv50skcxsws2liw36vb4smvyv9j8nvqvwyp1";
-      name = "kscreenlocker-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kscreenlocker-5.8.3.tar.xz";
+      sha256 = "039i01c48g3grfm6vn5zmgaazlv4lln8w3rx8d107rlfqslfq4gv";
+      name = "kscreenlocker-5.8.3.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/ksshaskpass-5.8.2.tar.xz";
-      sha256 = "1wk8jrwlr7lndsbhngkffvpjrqwi88x19vrxivb18gcr28m6403s";
-      name = "ksshaskpass-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/ksshaskpass-5.8.3.tar.xz";
+      sha256 = "0kvfnzbq6y9vs1a9yn3hf0cxbwdfs0mw440gsgjgbpmamnv4xpkj";
+      name = "ksshaskpass-5.8.3.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/ksysguard-5.8.2.tar.xz";
-      sha256 = "1myg260bn7bjv18wadwzfwns9jc63r5plk3psdf6w727hcmizvnn";
-      name = "ksysguard-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/ksysguard-5.8.3.tar.xz";
+      sha256 = "0a1mfm0gfsi1b79c7m62rk8pp6fsbvrqhv5b07rasapn53zwr6zd";
+      name = "ksysguard-5.8.3.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kwallet-pam-5.8.2.tar.xz";
-      sha256 = "1iw8cyr44kwjfqhf1ybnjy0pjv4yk87w3vir8j91an4mxhdcc2sb";
-      name = "kwallet-pam-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kwallet-pam-5.8.3.tar.xz";
+      sha256 = "1lbmzi0pimp2pw4g0dmrw0vpb2mmm64akzjzv0l72i6f4sylsqpd";
+      name = "kwallet-pam-5.8.3.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kwayland-integration-5.8.2.tar.xz";
-      sha256 = "12zmf11117y5zp307ymfy5gsjpcf97sqw1n3nzk55p9kzlfln1pa";
-      name = "kwayland-integration-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kwayland-integration-5.8.3.tar.xz";
+      sha256 = "1w717601ivpnfvjprlyh0qvcj61m8nh9qpsqmhsy7993jvm8wal4";
+      name = "kwayland-integration-5.8.3.tar.xz";
     };
   };
   kwin = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kwin-5.8.2.tar.xz";
-      sha256 = "04c9bvbd487pgf4l7a7vxaydjr9hwdjg149mzcxzm5y1nx7ll08y";
-      name = "kwin-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kwin-5.8.3.tar.xz";
+      sha256 = "0a3z17f1ma6yspbs4wyj1cp17hglf4xj1pmwya6nbf08d6gbxq1w";
+      name = "kwin-5.8.3.tar.xz";
     };
   };
   kwrited = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/kwrited-5.8.2.tar.xz";
-      sha256 = "1659783rca0hcisrhxz1bnimn0q17825sbs6zlwxlwsh2qq8fq23";
-      name = "kwrited-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/kwrited-5.8.3.tar.xz";
+      sha256 = "0s2fsxyw6x664pirbvkd5zf0zazhx9yxzv2xk8d8cb8gfbj32cc9";
+      name = "kwrited-5.8.3.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/libkscreen-5.8.2.tar.xz";
-      sha256 = "0p2nhgvr3cxq0js6zkcnhglwqffnrnws8vdi7lyl069y9r8lvp7c";
-      name = "libkscreen-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/libkscreen-5.8.3.tar.xz";
+      sha256 = "09jakk3yrnp0vf2dihalm08lndcvp18c6c4qjr1bg65cjij9fvx7";
+      name = "libkscreen-5.8.3.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/libksysguard-5.8.2.tar.xz";
-      sha256 = "158n30wbpsgbw3axhhsc58hnwhwdd02j3zc9hhcybmnbkfl5c96l";
-      name = "libksysguard-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/libksysguard-5.8.3.tar.xz";
+      sha256 = "11601hlrm6lm0vrw2icx2778g6yzd9fsgpa8s8rdwr0qw9i0wacy";
+      name = "libksysguard-5.8.3.tar.xz";
     };
   };
   milou = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/milou-5.8.2.tar.xz";
-      sha256 = "0ikba2xk2d4v66rhdln97d89avrkbhpjh1zir5ds3s103yyrj4q9";
-      name = "milou-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/milou-5.8.3.tar.xz";
+      sha256 = "03vr8ndr14ak111gq0hwlq4b5g1hwhbh3vk5b3xrk13bhxg6nfsl";
+      name = "milou-5.8.3.tar.xz";
     };
   };
   oxygen = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/oxygen-5.8.2.tar.xz";
-      sha256 = "1n0gfgn7m0953dd69nvl0ikp97zmcn3hjm01s43nxjma3gp8pqar";
-      name = "oxygen-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/oxygen-5.8.3.tar.xz";
+      sha256 = "0ircd8v5khgmpigazxy7pykiqk8maah28ypsh3z66aim0ni4h3jg";
+      name = "oxygen-5.8.3.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/plasma-desktop-5.8.2.tar.xz";
-      sha256 = "0023wb3fnk0cap7v2zwig6h3vqvykrwwq9vyl0xbsj5vzx3f8yqj";
-      name = "plasma-desktop-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/plasma-desktop-5.8.3.tar.xz";
+      sha256 = "0pkjkhwqgin203dkl5clnvc9l9jnk7dqaxh7h7rbc8d5bfjiwzg7";
+      name = "plasma-desktop-5.8.3.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/plasma-integration-5.8.2.tar.xz";
-      sha256 = "1z7pd5j7llac1iv4w4q4r9wysqi4shc65fcg6bh637gxqjgyq4rf";
-      name = "plasma-integration-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/plasma-integration-5.8.3.tar.xz";
+      sha256 = "196gxymfbrdjravgqk2ia2fpanim4l08a0vh5r13ppm7q7vzwz23";
+      name = "plasma-integration-5.8.3.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/plasma-nm-5.8.2.tar.xz";
-      sha256 = "035nhs8z977gp3d041ywnam1y4vk7458mx81f2qrx2bv8g6znq22";
-      name = "plasma-nm-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/plasma-nm-5.8.3.tar.xz";
+      sha256 = "1rsj0gl9plza7ykkp161ipvxlax67vdvns0fnq34sk9hg7s5ckb7";
+      name = "plasma-nm-5.8.3.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/plasma-pa-5.8.2.tar.xz";
-      sha256 = "1j55q4brjh77i1imr7pb9gp9a8vaynnr2ljdsm4jqsijwcjj1yhi";
-      name = "plasma-pa-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/plasma-pa-5.8.3.tar.xz";
+      sha256 = "1l3xdcrkvjpmmbzvyhqrs6y8xhkz5k1xkxlm3d3bx4x0mn24qmq4";
+      name = "plasma-pa-5.8.3.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/plasma-sdk-5.8.2.tar.xz";
-      sha256 = "0h6393qxwms0xdq69nyzs18kbyl6amzff26l20fqpp49xrqpq95y";
-      name = "plasma-sdk-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/plasma-sdk-5.8.3.tar.xz";
+      sha256 = "1jgv6yf7m9x2869cprbg2r9ka56ypmprvvznagb4zrjnjfdnqrm7";
+      name = "plasma-sdk-5.8.3.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/plasma-tests-5.8.2.tar.xz";
-      sha256 = "0ls8mxabvw39xb8nrl89n1jn0bkgykzx7hcv45q17aw5jm8s0wy5";
-      name = "plasma-tests-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/plasma-tests-5.8.3.tar.xz";
+      sha256 = "1aidrc3wi3z7lap5m193xqcahl0p2pdg9hddygzq6dr46r1ipbi4";
+      name = "plasma-tests-5.8.3.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/plasma-workspace-5.8.2.tar.xz";
-      sha256 = "1dxvxz9qvkg1h79j997qgs573l730w1g0n1dy78n344bnvn8zx44";
-      name = "plasma-workspace-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/plasma-workspace-5.8.3.tar.xz";
+      sha256 = "16h5flf346lwrdl35clkq0qv3i0fa4clxyyn3dvpsp9mvxdlabwb";
+      name = "plasma-workspace-5.8.3.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/plasma-workspace-wallpapers-5.8.2.tar.xz";
-      sha256 = "0wkkpl1n6ggicgj6lszmb661wrmddhq9wx3djr3hyvvi5r586rxi";
-      name = "plasma-workspace-wallpapers-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/plasma-workspace-wallpapers-5.8.3.tar.xz";
+      sha256 = "0dy3w60d4wbm571kbv6qshmrqf6r30j53hz92kkyiwgqja18ysg2";
+      name = "plasma-workspace-wallpapers-5.8.3.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.8.2";
+    version = "1-5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/polkit-kde-agent-1-5.8.2.tar.xz";
-      sha256 = "1ipli3xq4dc8lnyamqfzsjcfh3808gbw3qaaqksng2ki0i84aw8f";
-      name = "polkit-kde-agent-1-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/polkit-kde-agent-1-5.8.3.tar.xz";
+      sha256 = "04llryjkjzkzccfjwdhwcbkvp8wfgjfw4yabbq4kl1i2girimw0z";
+      name = "polkit-kde-agent-1-5.8.3.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/powerdevil-5.8.2.tar.xz";
-      sha256 = "0bjk08f3bliy4cz3pcs77qhsc3l82fqk3q0djiwgmsr77ksabj7x";
-      name = "powerdevil-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/powerdevil-5.8.3.tar.xz";
+      sha256 = "1im9sxzb4c3cplplzizfxdlyg1knm94y2hj9ssllxfggy5d38ps1";
+      name = "powerdevil-5.8.3.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/sddm-kcm-5.8.2.tar.xz";
-      sha256 = "1n3r2hjwrsxiwzzgkpf4xgp2645kzzdl49i91qcsqznhiqp7kjx3";
-      name = "sddm-kcm-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/sddm-kcm-5.8.3.tar.xz";
+      sha256 = "1cs29rb259zz06qwfhnjxzy2xzzqvfwpphz4whbyl5kn07bzah8d";
+      name = "sddm-kcm-5.8.3.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/systemsettings-5.8.2.tar.xz";
-      sha256 = "157knafprh4b689jjr8w4bqrh9kp92ggvf40s4ny8cfyjr2bzcvi";
-      name = "systemsettings-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/systemsettings-5.8.3.tar.xz";
+      sha256 = "0shac5659h928p2kq053kllw66j3sw6a06kczgck5lq28kxwh3mm";
+      name = "systemsettings-5.8.3.tar.xz";
     };
   };
   user-manager = {
-    version = "5.8.2";
+    version = "5.8.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.8.2/user-manager-5.8.2.tar.xz";
-      sha256 = "1344qvzrlswc69wvnaqic300wxra6ix6w6iczj29sprxsa5ycf91";
-      name = "user-manager-5.8.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.8.3/user-manager-5.8.3.tar.xz";
+      sha256 = "0kh9knr2rfrhakzdyf94cap19v21ciglammdp4svyql7drwfvq8v";
+      name = "user-manager-5.8.3.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -40,7 +40,6 @@ let
       let
         inherit (args) name;
         inherit (srcs."${name}") src version;
-        qtVersion = (builtins.parseDrvName self.qtbase.name).version;
       in kdeDerivation (args // {
         name = "${name}-${version}";
         inherit src;
@@ -51,7 +50,7 @@ let
           ];
           platforms = lib.platforms.linux;
           homepage = "http://www.kde.org";
-          broken = builtins.compareVersions qtVersion "5.6.0" < 0;
+          broken = builtins.compareVersions self.qtbase.version "5.6.0" < 0;
         } // (args.meta or {});
       });
 

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -40,6 +40,7 @@ let
       let
         inherit (args) name;
         inherit (srcs."${name}") src version;
+        qtVersion = (builtins.parseDrvName self.qtbase.name).version;
       in kdeDerivation (args // {
         name = "${name}-${version}";
         inherit src;
@@ -50,6 +51,7 @@ let
           ];
           platforms = lib.platforms.linux;
           homepage = "http://www.kde.org";
+          broken = builtins.compareVersions qtVersion "5.6.0" < 0;
         } // (args.meta or {});
       });
 

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -36,7 +36,9 @@ let
 
       });
 
-    kdeFramework = args:
+    kdeFramework = let
+      broken = builtins.compareVersions self.qtbase.version "5.6.0" < 0;
+    in args:
       let
         inherit (args) name;
         inherit (srcs."${name}") src version;
@@ -50,7 +52,7 @@ let
           ];
           platforms = lib.platforms.linux;
           homepage = "http://www.kde.org";
-          broken = builtins.compareVersions self.qtbase.version "5.6.0" < 0;
+          inherit broken;
         } // (args.meta or {});
       });
 

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/frameworks/5.24/ -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/frameworks/5.26/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/kde-env.nix
+++ b/pkgs/development/libraries/kde-frameworks/kde-env.nix
@@ -26,15 +26,6 @@ stdenv.mkDerivation {
         done
     done
 
-    for p in $propagated; do
-        for s in applications dbus-1 desktop-directories icons mime polkit-1; do
-            if [ -d "$p/share/$s" ]; then
-                propagatedUserEnvPkgs+=" $p"
-                break
-            fi
-        done
-    done
-
     runHook postInstall
   '';
 }

--- a/pkgs/development/libraries/kde-frameworks/kde-wrapper.nix
+++ b/pkgs/development/libraries/kde-frameworks/kde-wrapper.nix
@@ -37,7 +37,13 @@ stdenv.mkDerivation {
         fi
     done
 
-    mkdir -p "$out/nix-support"
-    ln -s "$env/nix-support/propagated-user-env-packages" "$out/nix-support/"
+    if [ -a "$drv/share" ]; then
+        ln -s "$drv/share" "$out"
+    fi
+
+    if [ -a "$drv/nix-support/propagated-user-env-packages" ]; then
+        mkdir -p "$out/nix-support"
+        ln -s "$drv/nix-support/propagated-user-env-packages" "$out/nix-support/"
+    fi
   '';
 }

--- a/pkgs/development/libraries/kde-frameworks/kglobalaccel.nix
+++ b/pkgs/development/libraries/kde-frameworks/kglobalaccel.nix
@@ -1,11 +1,7 @@
-{ kdeFramework, lib
-, ecm
-, kconfig
-, kcoreaddons
-, kcrash
-, kdbusaddons
-, kwindowsystem
-, qtx11extras
+{
+  kdeFramework, lib, ecm,
+  kconfig, kcoreaddons, kcrash, kdbusaddons, kservice, kwindowsystem,
+  qtx11extras
 }:
 
 kdeFramework {
@@ -13,6 +9,6 @@ kdeFramework {
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   nativeBuildInputs = [ ecm ];
   propagatedBuildInputs = [
-    kconfig kcoreaddons kcrash kdbusaddons kwindowsystem qtx11extras
+    kconfig kcoreaddons kcrash kdbusaddons kservice kwindowsystem qtx11extras
   ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kimageformats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kimageformats.nix
@@ -1,11 +1,14 @@
-{ kdeFramework, lib
-, ecm
-, ilmbase
+{
+  kdeFramework, lib,
+  ecm,
+  ilmbase, karchive
 }:
 
 kdeFramework {
   name = "kimageformats";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   nativeBuildInputs = [ ecm ];
+  buildInputs = [ ilmbase ];
+  propagatedBuildInputs = [ karchive ];
   NIX_CFLAGS_COMPILE = "-I${ilmbase.dev}/include/OpenEXR";
 }

--- a/pkgs/development/libraries/kde-frameworks/kservice/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kservice/default.nix
@@ -1,12 +1,13 @@
 {
-  kdeFramework, lib, copyPathsToStore, ecm,
+  kdeFramework, lib, copyPathsToStore,
+  bison, ecm, flex,
   kconfig, kcoreaddons, kcrash, kdbusaddons, kdoctools, ki18n, kwindowsystem
 }:
 
 kdeFramework {
   name = "kservice";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  propagatedNativeBuildInputs = [ ecm ];
+  propagatedNativeBuildInputs = [ bison ecm flex ];
   nativeBuildInputs = [ kdoctools ];
   propagatedBuildInputs = [ kconfig kcoreaddons kcrash kdbusaddons ki18n kwindowsystem ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
+++ b/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, copyPathsToStore
+{ kdeFramework, lib, copyPathsToStore, fetchurl
 , ecm, perl
 , karchive, kconfig, kguiaddons, kiconthemes, kparts
 , libgit2
@@ -9,6 +9,23 @@
 kdeFramework {
   name = "ktexteditor";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  patches = [
+    (fetchurl {
+      url = "https://cgit.kde.org/ktexteditor.git/patch/?id=2c4feeb0c9107732399f8ae3dacea3124572f345";
+      sha256 = "13pq9h9iry8c59cnv9gfwgvb7vaj3dz5hmc5wkjqf8iwc1fv4m1v";
+      name = "ktexteditor-searchbar-enter-methods.patch";
+    })
+    (fetchurl {
+      url = "https://cgit.kde.org/ktexteditor.git/patch/?id=09a1e864d54735ebcab6bf31198fdef969b92a67";
+      sha256 = "120743xbh5rx4zjd2p0bjki9kkv1qmxsrgd8qlis7x2szrlhrb46";
+      name = "ktexteditor-text-folding-cursor-valid.patch";
+    })
+    (fetchurl {
+      url = "https://cgit.kde.org/ktexteditor.git/patch/?id=86f1dde943389bbf211ec1cde3f27c9681351d3f";
+      sha256 = "0al3g1gg7rw7c71vgwpfdz7qpdyhyq11338f4ady6zssj6xx1i4k";
+      name = "ktexteditor-multiple-messages.patch";
+    })
+  ];
   nativeBuildInputs = [ ecm perl ];
   propagatedBuildInputs = [
     karchive kconfig kguiaddons ki18n kiconthemes kio kparts libgit2 qtscript

--- a/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
+++ b/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
@@ -1,4 +1,4 @@
-{ kdeFramework, lib, ecm, kactivities, karchive
+{ kdeFramework, lib, fetchurl, ecm, kactivities, karchive
 , kconfig, kconfigwidgets, kcoreaddons, kdbusaddons, kdeclarative
 , kdoctools, kglobalaccel, kguiaddons, ki18n, kiconthemes, kio
 , knotifications, kpackage, kservice, kwindowsystem, kxmlgui
@@ -8,6 +8,13 @@
 kdeFramework {
   name = "plasma-framework";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
+  patches = [
+    (fetchurl {
+      url = "https://cgit.kde.org/plasma-framework.git/patch/?id=62b0865492d863cd000814054681ba6a97972cd5";
+      sha256 = "1ipz79apa9lkvcyfm5pap6v67hzncfz60z7s00zi6rnlbz96cy5f";
+      name = "plasma-framework-osd-no-dialog.patch";
+    })
+  ];
   nativeBuildInputs = [ ecm kdoctools ];
   propagatedBuildInputs = [
     kactivities karchive kconfig kconfigwidgets kcoreaddons kdbusaddons

--- a/pkgs/development/libraries/kde-frameworks/solid.nix
+++ b/pkgs/development/libraries/kde-frameworks/solid.nix
@@ -1,11 +1,12 @@
-{ kdeFramework, lib
-, ecm
-, qtdeclarative
+{
+  kdeFramework, lib,
+  bison, ecm, flex,
+  qtdeclarative
 }:
 
 kdeFramework {
   name = "solid";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ ecm ];
+  nativeBuildInputs = [ bison ecm flex ];
   propagatedBuildInputs = [ qtdeclarative ];
 }

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -1,581 +1,581 @@
-# DO NOT EDIT! This file is generated automatically by fetchsrcs.sh
+# DO NOT EDIT! This file is generated automatically by fetch-kde-qt.sh
 { fetchurl, mirror }:
 
 {
   attica = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/attica-5.24.0.tar.xz";
-      sha256 = "0d368gmds7m7k5pnn625wqsij38cvxk1gkm4zv24phnk9f67v7cw";
-      name = "attica-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/attica-5.26.0.tar.xz";
+      sha256 = "1z7718vzknp25lzx4kh0k7xw7jgx5q8afwhfcdqhfrbydbch5ilc";
+      name = "attica-5.26.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/baloo-5.24.0.tar.xz";
-      sha256 = "1ayfdg6j9lvas17ryjdv4a0kaj6vw3bxfy2x9nadl0gkc9pak4nh";
-      name = "baloo-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/baloo-5.26.0.tar.xz";
+      sha256 = "0cgk2fmm1hivzjajih3f09x901cncl2rxxp4qq7wz6g7d2s59pfy";
+      name = "baloo-5.26.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/bluez-qt-5.24.0.tar.xz";
-      sha256 = "0gy0m7lcwwklf021l5i3v7j0cl7qz7cgvzrwpj87ix3kyw5xs80z";
-      name = "bluez-qt-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/bluez-qt-5.26.0.tar.xz";
+      sha256 = "0n235jsx6vw4v13y3hkbiz5fh4453avgvrwd1zzs4yc5mkz5w837";
+      name = "bluez-qt-5.26.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/breeze-icons-5.24.0.tar.xz";
-      sha256 = "1dh7bijx99sdb3vn6394wmm5cq0fvvmz8h17sx4hakmbga849cx2";
-      name = "breeze-icons-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/breeze-icons-5.26.0.tar.xz";
+      sha256 = "1kbbiid89inb7dpn0z612gb7v4p2msbvp9g5varb7wvyld1dgh59";
+      name = "breeze-icons-5.26.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/extra-cmake-modules-5.24.0.tar.xz";
-      sha256 = "01m12ml529pwr2sal951r5z6yb1rwbpid1y4k14nlk3xqgmdakwa";
-      name = "extra-cmake-modules-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/extra-cmake-modules-5.26.0.tar.xz";
+      sha256 = "1v3riz49r7pwvnj1ls6wnw0c4g69iky9yck2m4hgr9641k0rqlnd";
+      name = "extra-cmake-modules-5.26.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/frameworkintegration-5.24.0.tar.xz";
-      sha256 = "0brqgq05m06d98qqvyh30727f5z7hlzxgqysfhfvqzcf3x7f6yzj";
-      name = "frameworkintegration-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/frameworkintegration-5.26.0.tar.xz";
+      sha256 = "0lqnwgsd6ads17qzdbd75azpk1h5ky3924ygzhbam1llnvcvfk9p";
+      name = "frameworkintegration-5.26.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kactivities-5.24.0.tar.xz";
-      sha256 = "0s8g43zk6h35bq1am1nnhj0qvmhd6kz42gs8l7ybga0367jghzhf";
-      name = "kactivities-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kactivities-5.26.0.tar.xz";
+      sha256 = "0cnciipmflnn1dxz69iqc2xy6g27sw4yr17yq3hp0r6kkycmpf71";
+      name = "kactivities-5.26.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kactivities-stats-5.24.0.tar.xz";
-      sha256 = "1z3xvpifxbd05b2xaxxyiypcpid7jgjb1qpwiyjj1gnfp4rjmzpc";
-      name = "kactivities-stats-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kactivities-stats-5.26.0.tar.xz";
+      sha256 = "0vpbsg6jswaw3ax4ypp6ak823iymh9jqdf7ssn9kqljynnjhnfv8";
+      name = "kactivities-stats-5.26.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kapidox-5.24.0.tar.xz";
-      sha256 = "19a7alvn71nxflsyi7y3hghx1iw04qqc77qy54mcxcpkiyvpsggf";
-      name = "kapidox-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kapidox-5.26.0.tar.xz";
+      sha256 = "1snz4szrgbdzy03jc0sax9r7b1jynj2npil1ngpr40xchs70vnb8";
+      name = "kapidox-5.26.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/karchive-5.24.0.tar.xz";
-      sha256 = "1n5nfhrfvqnrdjgjjy7arqik4fya5bp3dvxa16mlhqr19azkavzq";
-      name = "karchive-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/karchive-5.26.0.tar.xz";
+      sha256 = "1sysk9zznnahrdjfxxp3aaw6qy9c5l7agh1nbhnk0j5xm31js25g";
+      name = "karchive-5.26.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kauth-5.24.0.tar.xz";
-      sha256 = "14sjjfgl3arqyqcr77w9qhpnd8mrnh53r5rfss6bvlk26bmihs49";
-      name = "kauth-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kauth-5.26.0.tar.xz";
+      sha256 = "08k1x943z7a044ihv79lm1c0vas5x9wc9wr4qirhllkrxd87nsc1";
+      name = "kauth-5.26.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kbookmarks-5.24.0.tar.xz";
-      sha256 = "10d8dnhvbrwp0dbmz93cqfdff6ir8iy3yiwaf9ihj6ma124qlyjn";
-      name = "kbookmarks-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kbookmarks-5.26.0.tar.xz";
+      sha256 = "0phhf5xv11iyf5vi8x6xwx7rqlxc27451bwmm2sr0c65bnnkj57j";
+      name = "kbookmarks-5.26.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kcmutils-5.24.0.tar.xz";
-      sha256 = "0aws1c76s6wbp0xpr6qv6cfwq8dw82v00pkf9gy84sbxknwjnizk";
-      name = "kcmutils-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kcmutils-5.26.0.tar.xz";
+      sha256 = "1pymbf50idnrz8vyy9lm9535h6s7ssd3p70fdg8dicx7lx6s5grd";
+      name = "kcmutils-5.26.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kcodecs-5.24.0.tar.xz";
-      sha256 = "1qpzjh3qc2zz80j2bmlinipbispms14k9bmqw8v61zhi6in9z14c";
-      name = "kcodecs-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kcodecs-5.26.0.tar.xz";
+      sha256 = "18xzxi5y47rn3wlxz3m98ix7sd20vmxnqsm3lksgakk08qcv47wk";
+      name = "kcodecs-5.26.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kcompletion-5.24.0.tar.xz";
-      sha256 = "1qln0v31gn86kzwhnkijr1ydf129n32jmiybbckrp4w6hyx6xfxv";
-      name = "kcompletion-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kcompletion-5.26.0.tar.xz";
+      sha256 = "1f3h6qrpqsdds5zf99qkzxan2lh1y83d67pdswqvbfvwhr3bnl7s";
+      name = "kcompletion-5.26.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kconfig-5.24.0.tar.xz";
-      sha256 = "1dc2i6icyigw1j6qxgdza6j2g8afh390qmxsa2a54mwl84fkfmxv";
-      name = "kconfig-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kconfig-5.26.0.tar.xz";
+      sha256 = "0rsym5196agxzxzfxzywvsqlgvarnvw91zx04xvlsy70fnj70c4d";
+      name = "kconfig-5.26.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kconfigwidgets-5.24.0.tar.xz";
-      sha256 = "0v25r50gh5i984lzlv0rradghglcfqf0gsfmnkn23h87b86fm9l2";
-      name = "kconfigwidgets-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kconfigwidgets-5.26.0.tar.xz";
+      sha256 = "08jr6rhh8fi85827bqxh8v4pavq63i2kzwbvqcfpvrrncj5aj4ci";
+      name = "kconfigwidgets-5.26.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kcoreaddons-5.24.0.tar.xz";
-      sha256 = "06sx7by3nvaridnavj5p0bxv4nh47n708jlacfw8ydaikmd9i03h";
-      name = "kcoreaddons-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kcoreaddons-5.26.0.tar.xz";
+      sha256 = "10krqzrmbzzkj0xg5rxgs6i4ngg57ydqn3fkmpyz0x6g4yl3raqz";
+      name = "kcoreaddons-5.26.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kcrash-5.24.0.tar.xz";
-      sha256 = "1lahgfwlp9b5rsl244kzp7rsl4ybv1q4qlvpv0xxz5ygssk48l0w";
-      name = "kcrash-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kcrash-5.26.0.tar.xz";
+      sha256 = "0x60rw2zy37s38fpa8agggl9mm4kgvdabbcgr673p7b6k6vj46j8";
+      name = "kcrash-5.26.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kdbusaddons-5.24.0.tar.xz";
-      sha256 = "183nxqrhz4qk4qfp1w4an0scp2dvfqcaqbpg4cgbgk0z590q0pkk";
-      name = "kdbusaddons-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kdbusaddons-5.26.0.tar.xz";
+      sha256 = "0wl5lpqqcckn003kqfz1wapi40wkn4xjk878zwykg3lplxfdlsqw";
+      name = "kdbusaddons-5.26.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kdeclarative-5.24.0.tar.xz";
-      sha256 = "00ik9q1r6y6g5rkdq96yczgrxmcg85x00lipyljvc3x6xw6bixbz";
-      name = "kdeclarative-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kdeclarative-5.26.0.tar.xz";
+      sha256 = "0hmj0aj559i9flsw72zzwb2s95ajnzqh11rrs6wmcraywd4xywk8";
+      name = "kdeclarative-5.26.0.tar.xz";
     };
   };
   kded = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kded-5.24.0.tar.xz";
-      sha256 = "0ngpxdxb596myn5r4kjxahx195bwklq33yvgjvcbxi2clg2wccaj";
-      name = "kded-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kded-5.26.0.tar.xz";
+      sha256 = "0rk8jh0bg6wqfpjcg0g1i2frmhprc8pmnj6bwdifx119kh894n0l";
+      name = "kded-5.26.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/portingAids/kdelibs4support-5.24.0.tar.xz";
-      sha256 = "12sis63mq6i372bhx64x8y0pw6czrv64hdhjscx27cx65a4ir451";
-      name = "kdelibs4support-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/portingAids/kdelibs4support-5.26.0.tar.xz";
+      sha256 = "0jc05qzpcn72rvfyink7x56hvc7g21dcmgkfdx9w84brvqjnscz8";
+      name = "kdelibs4support-5.26.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kdesignerplugin-5.24.0.tar.xz";
-      sha256 = "0i0s8pwwhwh5hyyvkv0cnj0yyv0g5bnm5xw18knv2yagiy4bvb2j";
-      name = "kdesignerplugin-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kdesignerplugin-5.26.0.tar.xz";
+      sha256 = "10c8d83zl8qlg785rxn4d5ps18p0zplf5l00jnq8ikpa4ijnyn2j";
+      name = "kdesignerplugin-5.26.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kdesu-5.24.0.tar.xz";
-      sha256 = "1ivcnhgvq75xvl0w9g7m45qzallz42ijaq0n1ap09lpdfmjbnrxk";
-      name = "kdesu-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kdesu-5.26.0.tar.xz";
+      sha256 = "0kxqrzbhjahp0cx3n828q2gh1bdxsp7gmhahbhfzasknkvp1nqqs";
+      name = "kdesu-5.26.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kdewebkit-5.24.0.tar.xz";
-      sha256 = "1xq36zv7vnllhqbisl6kcna8z6qzlvy29a47g0hbzgl8rc93qskf";
-      name = "kdewebkit-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kdewebkit-5.26.0.tar.xz";
+      sha256 = "1z66jm8zpmksbdk7yzvcps712wd8d85r0dxw8zj3vw0z5yd68cmm";
+      name = "kdewebkit-5.26.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kdnssd-5.24.0.tar.xz";
-      sha256 = "01b650g031apxc3vd2m91g2fxqk9l8ap67z6rafniphfwy8i0d5m";
-      name = "kdnssd-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kdnssd-5.26.0.tar.xz";
+      sha256 = "0jamzv7wxp50awjzk1vwhmj8pldnm6hjxx5zvsjfif26va30w0q3";
+      name = "kdnssd-5.26.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kdoctools-5.24.0.tar.xz";
-      sha256 = "1r129kpq0d11b9l87cqbal6fm5ycwhsps1g3r1a7jsxz70scz4ri";
-      name = "kdoctools-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kdoctools-5.26.0.tar.xz";
+      sha256 = "1306ag1waw0cxkvwbb0n9gb9yc9nw6zzjssjrn19z366yp1z9ja8";
+      name = "kdoctools-5.26.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kemoticons-5.24.0.tar.xz";
-      sha256 = "0gmc52k5jb553jvzxwsq79v5y87kgav8i5qqv4bqc9yl7p866zhn";
-      name = "kemoticons-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kemoticons-5.26.0.tar.xz";
+      sha256 = "09qpw3vr4l80hp4j6v73nsncmsrsxww2hab9c24i3167ygsvca5s";
+      name = "kemoticons-5.26.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kfilemetadata-5.24.0.tar.xz";
-      sha256 = "02n9qhpr0jlwdgdbid0k34abhs3bzhlsa56ybl5dq1aib6izk1sy";
-      name = "kfilemetadata-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kfilemetadata-5.26.0.tar.xz";
+      sha256 = "1y80llazn66f7vndyzspz7w0n1g2xhi8g13qwakws278wsi04p1l";
+      name = "kfilemetadata-5.26.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kglobalaccel-5.24.0.tar.xz";
-      sha256 = "123v0ld1q88hbm3d0mqgq6lcivfkqh7pbz4hb4n76ab5v43qc15c";
-      name = "kglobalaccel-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kglobalaccel-5.26.0.tar.xz";
+      sha256 = "0a1q9pif4n8fmp9kw8sbiaia2znc657fm1mi9gyvp5amphjjkzdd";
+      name = "kglobalaccel-5.26.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kguiaddons-5.24.0.tar.xz";
-      sha256 = "0ig96ah20ybg5rwpswj9va2klvkh2q4amwxmgy3z4niwfsm2g3ic";
-      name = "kguiaddons-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kguiaddons-5.26.0.tar.xz";
+      sha256 = "0gaaxkzjpdqk8534dpbn6dxb83nckh1g7w62nssv4a2jwfkyrmgp";
+      name = "kguiaddons-5.26.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/portingAids/khtml-5.24.0.tar.xz";
-      sha256 = "0f19m8ycaa41p61i0j43gafn364abral8dbiqhr0qcj33nsa4134";
-      name = "khtml-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/portingAids/khtml-5.26.0.tar.xz";
+      sha256 = "1h1dacbwix1j9r0hgnpxhgjfbffh545852n2yn8kl25bf2ppx3m8";
+      name = "khtml-5.26.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/ki18n-5.24.0.tar.xz";
-      sha256 = "0cw24spmwsqa3ppkw03cm6yjd3sfll0dbbk2ya76fd4nw9hb00dv";
-      name = "ki18n-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/ki18n-5.26.0.tar.xz";
+      sha256 = "1f5xr2zskmi9x0xp6drg4mx41hs3ssyskpkd5x01b6s51av0i247";
+      name = "ki18n-5.26.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kiconthemes-5.24.0.tar.xz";
-      sha256 = "1k5zig2n6wzfyv6pc8dpas2862mxjyxxza00m31myrfw5i1a1h6m";
-      name = "kiconthemes-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kiconthemes-5.26.0.tar.xz";
+      sha256 = "0zccfdwy12zssbca4szwypykzvz3yiqwi69sz1ndpiwsvvp575b7";
+      name = "kiconthemes-5.26.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kidletime-5.24.0.tar.xz";
-      sha256 = "09jsj0pj27h93nr8v46savs6b93h8frydinfr7wlijkvpsl02jb4";
-      name = "kidletime-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kidletime-5.26.0.tar.xz";
+      sha256 = "13wpfkr3jsj3p16c67jfiy60pi0j1b85wrkc9bqx91wl8a22xy02";
+      name = "kidletime-5.26.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kimageformats-5.24.0.tar.xz";
-      sha256 = "12mhgckmhnvcnm8k7mk15mipxrnm7i9ip7ykbjh8nxjiwyk1pmwc";
-      name = "kimageformats-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kimageformats-5.26.0.tar.xz";
+      sha256 = "13ibvrfjxm799sis1cilyaqc6cnb9wr464z605skn7qd2gqz7xfx";
+      name = "kimageformats-5.26.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kinit-5.24.0.tar.xz";
-      sha256 = "1i7l6gid5hrrfglw1c461gpjg51dwz7cl4lx7ll8vz2ha8mz4d3n";
-      name = "kinit-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kinit-5.26.0.tar.xz";
+      sha256 = "031wjnniqmvix70da4x019r21zcv99xa4njzk0nccfihpn6i2nx9";
+      name = "kinit-5.26.0.tar.xz";
     };
   };
   kio = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kio-5.24.0.tar.xz";
-      sha256 = "0zncj9yf8zaylazlwvirylpk9vki3j889b1x2s0aav54vvj7vdi5";
-      name = "kio-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kio-5.26.0.tar.xz";
+      sha256 = "1kvn570gcpzvm4fc8jygvf3w5jbgsjm4sr2bysbvw4zk983ldma0";
+      name = "kio-5.26.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kitemmodels-5.24.0.tar.xz";
-      sha256 = "1s1p4nw1pqdzbdwvjnka17p9avf00wadr437p4f96md1lvh3sh69";
-      name = "kitemmodels-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kitemmodels-5.26.0.tar.xz";
+      sha256 = "1qizknavlgnhc5dqrq5ins6k4s43s815v7inzwhs4qrgv175qcjv";
+      name = "kitemmodels-5.26.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kitemviews-5.24.0.tar.xz";
-      sha256 = "0y3fx9hk1x27arrmwfzq783a44cs7p8dpmhxrwzh0di4mwa8jafw";
-      name = "kitemviews-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kitemviews-5.26.0.tar.xz";
+      sha256 = "1z4j1h0bykb3544iy48halb9mrjmkrd40x2c09qsm2r1kc7n3312";
+      name = "kitemviews-5.26.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kjobwidgets-5.24.0.tar.xz";
-      sha256 = "1mcvrz66xcqjgbp08zpqsf943cm462wbqm5gh719p9s25hx8hwrc";
-      name = "kjobwidgets-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kjobwidgets-5.26.0.tar.xz";
+      sha256 = "0l2h7ghnrs3w8md5yajnbfl6na5ldg17sh9ifvhcwg6n9s57mibb";
+      name = "kjobwidgets-5.26.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/portingAids/kjs-5.24.0.tar.xz";
-      sha256 = "1qd5sdfrdg7id0g5mwf3ijwlfvh3g36kwnckw6kwns1nf4q6gwlz";
-      name = "kjs-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/portingAids/kjs-5.26.0.tar.xz";
+      sha256 = "1f8mhhzq5k3ifpa1b0yspy886j9b82isz0vw16zl611fr564jln2";
+      name = "kjs-5.26.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/portingAids/kjsembed-5.24.0.tar.xz";
-      sha256 = "1nx8ch8mzd1jyx8pd46364ij0bsbsclbipbgr6jm9aak3n13b0nw";
-      name = "kjsembed-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/portingAids/kjsembed-5.26.0.tar.xz";
+      sha256 = "030wrrxsdfkyalydi39s85hm0rgfx7647c4a4c1cck2v67k8iq3d";
+      name = "kjsembed-5.26.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/portingAids/kmediaplayer-5.24.0.tar.xz";
-      sha256 = "147xrffkvkyv3h8ighc1vlwksysfrqc0g55k8zrd72l6r0kjjh0p";
-      name = "kmediaplayer-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/portingAids/kmediaplayer-5.26.0.tar.xz";
+      sha256 = "0zq9xx6g0lfdyxrkrjqyrq6hnygpd7n0grrm6a75hdmyh3lklrvv";
+      name = "kmediaplayer-5.26.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/knewstuff-5.24.0.tar.xz";
-      sha256 = "0xdv3wh3100vzsx8p2zihy1dvh0wzfmrjkjq71v8igwz5d291zsj";
-      name = "knewstuff-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/knewstuff-5.26.0.tar.xz";
+      sha256 = "0jd80wmdz241ddk4wdqwrb655r5lzxbxbp0mjyljgi1mwlrhkry4";
+      name = "knewstuff-5.26.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/knotifications-5.24.0.tar.xz";
-      sha256 = "0qryp41phnpx4r9wa6rfhmnzy7nxl0ijnyrafadf2n2xb53ipkpa";
-      name = "knotifications-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/knotifications-5.26.0.tar.xz";
+      sha256 = "01fvbi4dlqhia5iqj0iddbvkzjafw698pmh2ii9ynb071sqyb2pq";
+      name = "knotifications-5.26.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/knotifyconfig-5.24.0.tar.xz";
-      sha256 = "1dij841fnqia4p44x2wnpdvl8cn3nkj833y0fah50fmipjc8r70b";
-      name = "knotifyconfig-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/knotifyconfig-5.26.0.tar.xz";
+      sha256 = "14ri2zkzc1b3wqvfb3v6rv0ri5srm7zjk06v9j5bwz778vdh436z";
+      name = "knotifyconfig-5.26.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kpackage-5.24.0.tar.xz";
-      sha256 = "03aqzkpqz3c1v4qgwfbs3ncdbapiyg7psrkhxqv3z48rklavk1ri";
-      name = "kpackage-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kpackage-5.26.0.tar.xz";
+      sha256 = "1laq92gi67gn6gjz9nw51idq0wwyfwy6syfch0mssw3nbv7araqg";
+      name = "kpackage-5.26.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kparts-5.24.0.tar.xz";
-      sha256 = "0z7qr93aq02i7g7cxgypx2rzlnsvbsx9cjblb0ijmad1nb8w3mix";
-      name = "kparts-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kparts-5.26.0.tar.xz";
+      sha256 = "1ni17k02152axvkx666lx77zwpbsfahknrhgy8y8sy2dbn47jvya";
+      name = "kparts-5.26.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kpeople-5.24.0.tar.xz";
-      sha256 = "0iknzkj23y927xh24kw5sjxyirhy6pkmfcmmgwzd78rba8a54qp2";
-      name = "kpeople-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kpeople-5.26.0.tar.xz";
+      sha256 = "1zx9mvy1j2ynbj7gg4hnvxrjr5akmrh0l82xh73l4b12l0b775ap";
+      name = "kpeople-5.26.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kplotting-5.24.0.tar.xz";
-      sha256 = "0gpypq9kh4b5s6dc7py3m117k3nbxczsfkxgxd9zxvr35kig7ya2";
-      name = "kplotting-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kplotting-5.26.0.tar.xz";
+      sha256 = "1f695bb5n46mn362wwvwf636xjy87s63w5ac97lm1c9ndiins394";
+      name = "kplotting-5.26.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kpty-5.24.0.tar.xz";
-      sha256 = "1ybvdzqpa53kkki9p5da0ff9x3c63rmksk7865wqwlgy8apzi2fs";
-      name = "kpty-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kpty-5.26.0.tar.xz";
+      sha256 = "1f1z4z73l4xb5vymg5hsqxcgv7jm81jnjgwn0v85alfcx94dax3m";
+      name = "kpty-5.26.0.tar.xz";
     };
   };
   kross = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/portingAids/kross-5.24.0.tar.xz";
-      sha256 = "0f29dpmfcj173vqnmrbpvdmfmzzbfsds1lbl546qfx9a5acdpf2p";
-      name = "kross-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/portingAids/kross-5.26.0.tar.xz";
+      sha256 = "05ilcgq74l5m3jjr047zwz7ij60yw5xxp5cpd12892mi054ijb31";
+      name = "kross-5.26.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/krunner-5.24.0.tar.xz";
-      sha256 = "0ff87ijjd47jxf6zw2ggqgngnbyx1rj59wdfgy5wbi3acws6bafl";
-      name = "krunner-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/krunner-5.26.0.tar.xz";
+      sha256 = "050qq146g9wj51615m22l9jjxmgh3gsah3v7iflbdda5nrnzhz3v";
+      name = "krunner-5.26.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kservice-5.24.0.tar.xz";
-      sha256 = "0w0nsg64d6xhgijr2vh0j5p544qi0q55jpqa9v9mv956zrrdssdk";
-      name = "kservice-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kservice-5.26.0.tar.xz";
+      sha256 = "103hjnwh4zwpf8vz3si27jb34j6dm0ff445nc9xafnl1nkwisvgr";
+      name = "kservice-5.26.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/ktexteditor-5.24.0.tar.xz";
-      sha256 = "1ykj1kvm7k1vxb1w235d5hp2swwdqjyp2y4c3pxbvkn999h9x5q5";
-      name = "ktexteditor-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/ktexteditor-5.26.0.tar.xz";
+      sha256 = "0q84vbdkhg1sjhyrcv9y8cdv5qx09f1pz5wiw7dzdw06q9xgi3v4";
+      name = "ktexteditor-5.26.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/ktextwidgets-5.24.0.tar.xz";
-      sha256 = "1q10xav2gkii6s3m31c9xvxf1988l7k2lpib6pyhgsidflmwjm02";
-      name = "ktextwidgets-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/ktextwidgets-5.26.0.tar.xz";
+      sha256 = "0qafnlzkdqbp1par1s6mish46arbqwbl4xclvql168dlwxgd6b42";
+      name = "ktextwidgets-5.26.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kunitconversion-5.24.0.tar.xz";
-      sha256 = "03dfjn4lm6sl2zcdrvw0b9irzvkyc2w2j5xixag5j8nw373742h8";
-      name = "kunitconversion-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kunitconversion-5.26.0.tar.xz";
+      sha256 = "08nd2i76l4mvgav69qcsq0rwc0r9rkmqy0d4d3b4bc9957yfhk4i";
+      name = "kunitconversion-5.26.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kwallet-5.24.0.tar.xz";
-      sha256 = "0zad5h4vsvcl2xv3vxsjwh42b71xbp6x6rj8cvmw8szr2rzz9gsx";
-      name = "kwallet-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kwallet-5.26.0.tar.xz";
+      sha256 = "0a3l079zry8bmwkd2lx0cvmkj8p3pvrvpffikca6z4qdw4mnnxjs";
+      name = "kwallet-5.26.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kwayland-5.24.0.tar.xz";
-      sha256 = "1h5anbqrxcl1s8kx1l53vcsfr8ifamcjqd47dk8a7lwr1ga6myq2";
-      name = "kwayland-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kwayland-5.26.0.tar.xz";
+      sha256 = "1ca2f0k1qsra3c014c3lrn2qxsdq1whk5lqrxqc9dqbpvpyjy939";
+      name = "kwayland-5.26.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kwidgetsaddons-5.24.0.tar.xz";
-      sha256 = "1kppx0ppfhnb6q6sijs2dffyar86wkkx8miqavsjsgw1l2wiymcx";
-      name = "kwidgetsaddons-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kwidgetsaddons-5.26.0.tar.xz";
+      sha256 = "1jam478939cibyhnwg6n3fwyqg8lx1njjbqmlqq4cmp9j62100cn";
+      name = "kwidgetsaddons-5.26.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kwindowsystem-5.24.0.tar.xz";
-      sha256 = "0w5ym8msl80v3q65253pdpj9f1fmb658rnndlbkrgpmm1rv1n6dz";
-      name = "kwindowsystem-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kwindowsystem-5.26.0.tar.xz";
+      sha256 = "1jmacixr2il5wpw7wzaqswslvmxam3qf7mih271qzbx6k6ngdyk3";
+      name = "kwindowsystem-5.26.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kxmlgui-5.24.0.tar.xz";
-      sha256 = "1qhixldhhcbklmrpjh67440h1rrzqy70h57hw6ialjdsr3pl6ihp";
-      name = "kxmlgui-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kxmlgui-5.26.0.tar.xz";
+      sha256 = "18w41iyfg2iphav2g7qikg4ccv2cr0wl5a6r9h460f45vq9aph4z";
+      name = "kxmlgui-5.26.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/kxmlrpcclient-5.24.0.tar.xz";
-      sha256 = "06ap6ipzqimz1rfrcr7z8zc7idy7sg4a97dws7h52i34ms7jqnc8";
-      name = "kxmlrpcclient-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/kxmlrpcclient-5.26.0.tar.xz";
+      sha256 = "001rvsmxi1mnbrs1kplsb8vx1wfpjp9g4kwm7714w3yh6vmr9j7p";
+      name = "kxmlrpcclient-5.26.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/modemmanager-qt-5.24.0.tar.xz";
-      sha256 = "0khz5bf84xxa8aqpzwb6x839xx6dbiadwqhyj7cvgha65fh2xinh";
-      name = "modemmanager-qt-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/modemmanager-qt-5.26.0.tar.xz";
+      sha256 = "1x4h334fcyqnclc9sxff73b79fsgg7a0r98c9palr787qvaafjv2";
+      name = "modemmanager-qt-5.26.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/networkmanager-qt-5.24.0.tar.xz";
-      sha256 = "11wy0ds0hqbba900ggkcxjfqc9n65xlzc3h1zv9433nn5d75v6fy";
-      name = "networkmanager-qt-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/networkmanager-qt-5.26.0.tar.xz";
+      sha256 = "0yqhchkava6jsyl0gpa62x4856qszdiglwjxsba9dgl5lasfyrg0";
+      name = "networkmanager-qt-5.26.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/oxygen-icons5-5.24.0.tar.xz";
-      sha256 = "1c7spjbzk04725vv0ly7vmyvwa96mfa5ki2pm146ld4888a896wm";
-      name = "oxygen-icons5-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/oxygen-icons5-5.26.0.tar.xz";
+      sha256 = "0lwwl26xiya7fr5ga5kf45zvj40lm10jpd7p523v2dm0xmqbkf8n";
+      name = "oxygen-icons5-5.26.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/plasma-framework-5.24.0.tar.xz";
-      sha256 = "0981vm00541dzihlr1fsax05biwp2ddpwjrmvnfysx5jagdc65cb";
-      name = "plasma-framework-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/plasma-framework-5.26.0.tar.xz";
+      sha256 = "0mjmzca0n51vwy9gxxanxfi2dvvzzdpwfjw0zdwmjm69znc870ja";
+      name = "plasma-framework-5.26.0.tar.xz";
     };
   };
   solid = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/solid-5.24.0.tar.xz";
-      sha256 = "00wvsxcnvhdx7ijzpcz5wny2ypkxr1drdpr4yvawgpwa678l1107";
-      name = "solid-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/solid-5.26.0.tar.xz";
+      sha256 = "1dlln9dqyf7md32s6a7pd23dbs6jrvv59ylldxcxgkyjyyb2g0j3";
+      name = "solid-5.26.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/sonnet-5.24.0.tar.xz";
-      sha256 = "152xz7fb1iwhb5w1n4xqvc648iaxi0inrl4kavxcsir61das1xyl";
-      name = "sonnet-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/sonnet-5.26.0.tar.xz";
+      sha256 = "0akvlrbbk0nbyh12rmcjch122xqa3926gz3l31bvhqgm50b683z2";
+      name = "sonnet-5.26.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.24.0";
+    version = "5.26.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.24/threadweaver-5.24.0.tar.xz";
-      sha256 = "02g60zr9cc4bg1p90giich4n0qvqaiakz0y94qrnyj9f7fg0yksl";
-      name = "threadweaver-5.24.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.26/threadweaver-5.26.0.tar.xz";
+      sha256 = "1bzlw3m1f207967pjmzlx1k0v38fwjvga9jg88iqh43zb60ks03a";
+      name = "threadweaver-5.26.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Plasma 5.8 is a LTS release from upstream which will continue to receive bug fixes for the lifetime of NixOS 16.09. This is strictly a backport of patches from master.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

