### PR TITLE
ocaml-cstruct & ocaml-nocrypto update

### DIFF
--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,20 +1,40 @@
-{stdenv, writeText, fetchurl, ocaml, ocplib-endian, sexplib_p4, findlib,
- async_p4 ? null, lwt ? null, camlp4}:
+{stdenv, buildOcaml, fetchFromGitHub, writeText,
+ ocaml, ocplib-endian, sexplib, findlib, ounit,
+ async ? null,      lwt     ? null, ppx_tools ? null,
+ withAsync ? true, withLwt ? true, withPpx   ? true}:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
+with stdenv.lib;
+assert withAsync -> async != null;
+assert withLwt -> lwt != null;
+assert withPpx -> ppx_tools != null;
 
-stdenv.mkDerivation {
-  name = "ocaml-cstruct-1.6.0";
+buildOcaml rec {
+  name = "cstruct";
+  version = "2.3.0";
 
-  src = fetchurl {
-    url = https://github.com/mirage/ocaml-cstruct/archive/v1.6.0.tar.gz;
-    sha256 = "0f90a1b7a03091cf22a3ccb11a0cce03b6500f064ad3766b5ed81418ac008ece";
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-cstruct";
+    rev = "v${version}";
+    sha256 = "19spsgkry41dhsbm6ij71kws90bqp7wiggc6lsqdl43xxvbgdmys";
   };
 
-  configureFlags = stdenv.lib.strings.concatStringsSep " " ((if lwt != null then ["--enable-lwt"] else []) ++
-                                          (if async_p4 != null then ["--enable-async"] else []));
-  buildInputs = [ocaml findlib camlp4];
-  propagatedBuildInputs = [ocplib-endian sexplib_p4 lwt async_p4];
+  configureFlags = [ "--enable-tests" ] ++
+                   optional withLwt [ "--enable-lwt" ] ++
+                   optional withAsync [ "--enable-async" ] ++
+                   optional withPpx ["--enable-ppx"];
+  configurePhase = "./configure --prefix $out $configureFlags";
+
+  buildInputs = [ ocaml findlib ounit sexplib ];
+  propagatedBuildInputs = [ocplib-endian ] ++
+                          optional withPpx ppx_tools ++
+                          optional withAsync async ++
+                          optional withLwt lwt;
+
+  doCheck = true;
+  checkTarget = "test";
 
   createFindlibDestdir = true;
   dontStrip = true;

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -1,20 +1,30 @@
-{ stdenv, fetchzip, ocaml, findlib, cstruct, type_conv, zarith, ounit }:
+{ stdenv, buildOcaml, fetchFromGitHub, ocaml, findlib, cstruct, type_conv, zarith, ounit, ocaml_oasis, ppx_sexp_conv
+, lwt     ? null
+, withLwt ? true}:
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.01";
+with stdenv.lib;
+assert withLwt -> lwt != null;
 
-stdenv.mkDerivation rec {
-  name = "ocaml-nocrypto-${version}";
-  version = "0.5.1";
+buildOcaml rec {
+  name = "nocrypto";
+  version = "0.5.3";
 
-  src = fetchzip {
-    url = "https://github.com/mirleft/ocaml-nocrypto/archive/${version}.tar.gz";
-    sha256 = "15gffvixk12ghsfra9amfszd473c8h188zfj03ngvblbdm0d80m0";
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner  = "mirleft";
+    repo   = "ocaml-nocrypto";
+    rev    = "v${version}";
+    sha256 = "0m3yvqpgfffqp15mcl08b78cv8zw25rnp6z1pkj5aimz6xg3gqbl";
   };
 
-  buildInputs = [ ocaml findlib type_conv ounit ];
-  propagatedBuildInputs = [ cstruct zarith ];
+  buildInputs = [ ocaml ocaml_oasis findlib type_conv ounit ppx_sexp_conv ];
+  propagatedBuildInputs = [ cstruct zarith ] ++ optional withLwt lwt;
 
-  configureFlags = "--enable-tests";
+  configureFlags = [ "--enable-tests" ] ++ optional withLwt ["--enable-lwt"];
+
+  configurePhase = "./configure --prefix $out $configureFlags";
+
   doCheck = true;
   checkTarget = "test";
   createFindlibDestdir = true;
@@ -22,7 +32,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = https://github.com/mirleft/ocaml-nocrypto;
     description = "Simplest possible crypto to support TLS";
-    platforms = ocaml.meta.platforms or [];
     license = stdenv.lib.licenses.bsd2;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -259,7 +259,9 @@ let
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
-    nocrypto =  callPackage ../development/ocaml-modules/nocrypto { };
+    nocrypto =  callPackage ../development/ocaml-modules/nocrypto {
+      lwt = ocaml_lwt;
+    };
 
     ocaml_batteries = callPackage ../development/ocaml-modules/batteries { };
 


### PR DESCRIPTION
The trick fixing the build issue was removing `async` support. I am not sure, if this breaks any other packages, but it fixes all the build errors we discovered previously.

cc @vbgl @Zimmi48 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


