### PR TITLE
k3d: 0.8.0.5 -> 0.8.0.6

### DIFF
--- a/pkgs/applications/graphics/k3d/default.nix
+++ b/pkgs/applications/graphics/k3d/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A 3D editor with support for procedural editing";
-    homepage = "http://k-3d.org/";
+    homepage = http://www.k-3d.org/;
     platforms = with stdenv.lib.platforms;
       linux;
     maintainers = with stdenv.lib.maintainers;

--- a/pkgs/applications/graphics/k3d/default.nix
+++ b/pkgs/applications/graphics/k3d/default.nix
@@ -1,18 +1,25 @@
-{ stdenv, fetchFromGitHub, unzip, ftgl, glew, asciidoc
+{ stdenv, fetchFromGitHub, fetchpatch, unzip, ftgl, glew, asciidoc
 , cmake, mesa, zlib, python, expat, libxml2, libsigcxx, libuuid, freetype
 , libpng, boost, doxygen, cairomm, pkgconfig, imagemagick, libjpeg, libtiff
 , gettext, intltool, perl, gtkmm2, glibmm, gtkglext, pangox_compat, libXmu }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.0.5";
+  version = "0.8.0.6";
   name = "k3d-${version}";
   src = fetchFromGitHub {
     owner = "K-3D";
     repo = "k3d";
     rev = name;
-    sha256 = "0q05d51vhnmrq887n15frpwkhx8w7n20h2sc1lpr338jzpryihb3";
+    sha256 = "0vdjjg6h8mxm2n8mvkkg2mvd27jn2xx90hnmx23cbd35mpz9p4aa";
   };
-  
+
+  patches = [
+    (fetchpatch { /* glibmm 2.50 fix */
+      url = https://github.com/K-3D/k3d/commit/c65889d0652490d88a573e47de7a9324bf27bff2.patch;
+      sha256 = "162icv1hicr2dirkb9ijacvg9bhz5j30yfwg7b45ijavk8rns62j";
+    })
+  ];
+
   cmakeFlags = "-DK3D_BUILD_DOCS=false -DK3D_BUILD_GUIDE=false";
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

* bump to latest upstream
* add glibmm 2.50 fix from K-3D/k3d#26

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---