### PR TITLE
libtiff: patch for some more CVEs, fix patch urls

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -2,6 +2,7 @@
 
 let
   version = "4.0.6";
+  debversion = "3";
 in
 stdenv.mkDerivation rec {
   name = "libtiff-${version}";
@@ -19,35 +20,48 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/01-CVE-2015-8665_and_CVE-2015-8683.patch";
-      sha256 = "1c4zmvxj124873al8fvkiv8zq7wx5mv2vd4f1y9w8liv92cm7hkc";
+  patches = let p = "https://sources.debian.net/data/main/t/tiff/${version}-${debversion}/debian/patches"; in [
+    (fetchurl {
+      url = "${p}/01-CVE-2015-8665_and_CVE-2015-8683.patch";
+      sha256 = "0qiiqpbbsf01b59x01z38cg14pmg1ggcsqm9n1gsld6rr5wm3ryz";
     })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/02-fix_potential_out-of-bound_writes_in_decode_functions.patch";
-      sha256 = "0rsc7zh7cdhgcmx2vbjfaqrb0g93a3924ngqkrzb14w5j2fqfbxv";
+    (fetchurl {
+      url = "${p}/02-fix_potential_out-of-bound_writes_in_decode_functions.patch";
+      sha256 = "1ph057w302i2s94rhdw6ksyvpsmg1nlanvc0251x01s23gkdbakv";
     })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/03-fix_potential_out-of-bound_write_in_NeXTDecode.patch";
-      sha256 = "1s01xhp4sl04yhqhqwp50gh43ykcqk230mmbv62vhy2jh7v0ky3a";
+    (fetchurl {
+      url = "${p}/03-fix_potential_out-of-bound_write_in_NeXTDecode.patch";
+      sha256 = "1nhjg2gdvyzi4wa2g7nwmzm7nssz9dpdfkwms1rp8i1034qdlgc6";
     })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/04-CVE-2016-5314_CVE-2016-5316_CVE-2016-5320_CVE-2016-5875.patch";
-      sha256 = "0by35qxpzv9ib3mnh980gd30jf3qmsfp2kl730rq4pq66wpzg9m8";
+    (fetchurl {
+      url = "${p}/04-CVE-2016-5314_CVE-2016-5316_CVE-2016-5320_CVE-2016-5875.patch";
+      sha256 = "0n47yk9wcvc9j72yvm5bhpaqq0yfz8jnq9zxbnzx5id9gdxmrkn3";
     })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/05-CVE-2016-6223.patch";
-      sha256 = "0rh8ia0wsf5yskzwdjrlbiilc9m0lq0igs42k6922pl3sa1lxzv1";
+    (fetchurl {
+      url = "${p}/05-CVE-2016-6223.patch";
+      sha256 = "0r80hil9k6scdjppgyljhm0s2z6c8cm259f0ic0xvxidfaim6g2r";
     })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/06-CVE-2016-5321.patch";
-      sha256 = "0n0igfxbd3kqvvj2k2xgysrp63l4v2gd110fwkk4apfpm0hvzwh0";
+    (fetchurl {
+      url = "${p}/06-CVE-2016-5321.patch";
+      sha256 = "4n0igfxbd3kqvvj2k2xgysrp63l4v2gd110fwkk4apfpm0hvzwh0";
     })
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/t/tiff/4.0.6-2/debian/patches/07-CVE-2016-5323.patch";
-      sha256 = "1j6w8g6qizkx5h4aq95kxzx6bgkn4jhc8l22swwhvlkichsh4910";
+    (fetchurl {
+      url = "${p}/07-CVE-2016-5323.patch";
+      sha256 = "1xr5hy2fxa71j3fcc1l998pxyblv207ygzyhibwb1lia5zjgblch";
     })
+    (fetchurl {
+      url = "${p}/08-CVE-2016-3623_CVE-2016-3624.patch";
+      sha256 = "1xnvwjvgyxi387h1sdiyp4360a3176jmipb7ghm8vwiz7cisdn9z";
+    })
+    (fetchurl {
+      url = "${p}/09-CVE-2016-5652.patch";
+      sha256 = "1yqfq32gzh21ab2jfqkq13gaz0nin0492l06adzsyhr5brvdhnx8";
+    })
+    (fetchurl {
+      url = "${p}/10-CVE-2016-3658.patch";
+      sha256 = "01kb8rfk30fgjf1hy0m088yhjfld1yyh4bk3gkg8jx3dl9bd076d";
+    })
+
 
   ];
 


### PR DESCRIPTION
It is a bit of a mass-rebuild, bit it's also a security update, so

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


