### PR TITLE
Unbreak finding gstreamer plugins in $NIX_PROFILES

### DIFF
--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     for prog in "$dev/bin/"*; do
-        wrapProgram "$prog" --prefix GST_PLUGIN_SYSTEM_PATH : "\$(unset _tmp; for profile in \$NIX_PROFILES; do _tmp="\$profile/lib/gstreamer-1.0''$\{_tmp:+:\}\$_tmp"; done; printf "\$_tmp")"
+        wrapProgram "$prog" --suffix GST_PLUGIN_SYSTEM_PATH : "\$(unset _tmp; for profile in \$NIX_PROFILES; do _tmp="\$profile/lib/gstreamer-1.0''$\{_tmp:+:\}\$_tmp"; done; printf "\$_tmp")"
     done
   '';
 

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    for prog in "$out/bin/"*; do
+    for prog in "$dev/bin/"*; do
         wrapProgram "$prog" --prefix GST_PLUGIN_SYSTEM_PATH : "\$(unset _tmp; for profile in \$NIX_PROFILES; do _tmp="\$profile/lib/gstreamer-1.0''$\{_tmp:+:\}\$_tmp"; done; printf "\$_tmp")"
     done
   '';


### PR DESCRIPTION
###### Motivation for this change
Making gst-launch and friends find plugins is a generally useful thing. It used to work but got broken with the multiple-outputs change. This PR fixes it.

Also lower the priority on plugins found in $NIX_PROFILES by using --suffix instead of --prefix. This is the saner priority setting IMHO.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

