### PR TITLE
libtiff: `fetchpatch` -> `fetchurl` (followup to #20206)

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -21,33 +21,33 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   patches = let p = "https://sources.debian.net/data/main/t/tiff/${version}-${debversion}/debian/patches"; in [
-    (fetchpatch {
+    (fetchurl {
       url = "${p}/01-CVE-2015-8665_and_CVE-2015-8683.patch";
-      sha256 = "1c4zmvxj124873al8fvkiv8zq7wx5mv2vd4f1y9w8liv92cm7hkc";
+      sha256 = "0qiiqpbbsf01b59x01z38cg14pmg1ggcsqm9n1gsld6rr5wm3ryz";
     })
-    (fetchpatch {
+    (fetchurl {
       url = "${p}/02-fix_potential_out-of-bound_writes_in_decode_functions.patch";
-      sha256 = "0rsc7zh7cdhgcmx2vbjfaqrb0g93a3924ngqkrzb14w5j2fqfbxv";
+      sha256 = "1ph057w302i2s94rhdw6ksyvpsmg1nlanvc0251x01s23gkdbakv";
     })
-    (fetchpatch {
+    (fetchurl {
       url = "${p}/03-fix_potential_out-of-bound_write_in_NeXTDecode.patch";
-      sha256 = "1s01xhp4sl04yhqhqwp50gh43ykcqk230mmbv62vhy2jh7v0ky3a";
+      sha256 = "1nhjg2gdvyzi4wa2g7nwmzm7nssz9dpdfkwms1rp8i1034qdlgc6";
     })
-    (fetchpatch {
+    (fetchurl {
       url = "${p}/04-CVE-2016-5314_CVE-2016-5316_CVE-2016-5320_CVE-2016-5875.patch";
-      sha256 = "0by35qxpzv9ib3mnh980gd30jf3qmsfp2kl730rq4pq66wpzg9m8";
+      sha256 = "0n47yk9wcvc9j72yvm5bhpaqq0yfz8jnq9zxbnzx5id9gdxmrkn3";
     })
-    (fetchpatch {
+    (fetchurl {
       url = "${p}/05-CVE-2016-6223.patch";
-      sha256 = "0rh8ia0wsf5yskzwdjrlbiilc9m0lq0igs42k6922pl3sa1lxzv1";
+      sha256 = "0r80hil9k6scdjppgyljhm0s2z6c8cm259f0ic0xvxidfaim6g2r";
     })
-    (fetchpatch {
+    (fetchurl {
       url = "${p}/06-CVE-2016-5321.patch";
-      sha256 = "0n0igfxbd3kqvvj2k2xgysrp63l4v2gd110fwkk4apfpm0hvzwh0";
+      sha256 = "4n0igfxbd3kqvvj2k2xgysrp63l4v2gd110fwkk4apfpm0hvzwh0";
     })
-    (fetchpatch {
+    (fetchurl {
       url = "${p}/07-CVE-2016-5323.patch";
-      sha256 = "1j6w8g6qizkx5h4aq95kxzx6bgkn4jhc8l22swwhvlkichsh4910";
+      sha256 = "1xr5hy2fxa71j3fcc1l998pxyblv207ygzyhibwb1lia5zjgblch";
     })
     (fetchurl {
       url = "${p}/08-CVE-2016-3623_CVE-2016-3624.patch";
@@ -61,8 +61,6 @@ stdenv.mkDerivation rec {
       url = "${p}/10-CVE-2016-3658.patch";
       sha256 = "01kb8rfk30fgjf1hy0m088yhjfld1yyh4bk3gkg8jx3dl9bd076d";
     })
-
-
   ];
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change
OCD

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


