### PR TITLE
dunst: add svg-support patch

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, fetchpatch
 , pkgconfig, which, perl
 , cairo, dbus, freetype, gdk_pixbuf, glib, libX11, libXScrnSaver
 , libXext, libXinerama, libnotify, libxdg_basedir, pango, xproto
+, librsvg
 }:
 
 stdenv.mkDerivation rec {
@@ -15,11 +16,17 @@ stdenv.mkDerivation rec {
     sha256 = "102s0rkcdz22hnacsi3dhm7kj3lsw9gnikmh3a7wk862nkvvwjmk";
   };
 
+  patches = [(fetchpatch {
+    name = "add-svg-support.patch";
+    url = "https://github.com/knopwob/dunst/commit/63b11141185d1d07a6d12212257a543e182d250a.patch";
+    sha256 = "0giiaj5zjim7xqcav5ij5gn4x6nnchkllwcx0ln16j0p3vbi4y4x";
+  })];
+
   nativeBuildInputs = [ perl pkgconfig which ];
 
   buildInputs = [
     cairo dbus freetype gdk_pixbuf glib libX11 libXScrnSaver libXext
-    libXinerama libnotify libxdg_basedir pango xproto
+    libXinerama libnotify libxdg_basedir pango xproto librsvg
   ];
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
This adds svg icon support to dunst via https://github.com/knopwob/dunst/pull/223