### PR TITLE
syslog-ng: make sure the service activates

### DIFF
--- a/nixos/modules/services/logging/syslog-ng.nix
+++ b/nixos/modules/services/logging/syslog-ng.nix
@@ -82,9 +82,9 @@ in {
       description = "syslog-ng daemon";
       preStart = "mkdir -p /{var,run}/syslog-ng";
       wantedBy = [ "multi-user.target" ];
-      after = [ "multi-user.target" ]; # makes sure hostname etc is set
+      after = [ "network.target" ]; # makes sure hostname etc is set
       serviceConfig = {
-        Type = "notify";
+        Type = "simple";
         StandardOutput = "null";
         Restart = "on-failure";
         ExecStart = "${cfg.package}/sbin/syslog-ng ${concatStringsSep " " syslogngOptions}";


### PR DESCRIPTION
Fixes #20153.

This is based on `release-16.09` because that's where I noticed the problem and where I tested this patch. 