### PR TITLE
tpacpi-bat: init at 3.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -316,6 +316,7 @@
   offline = "Jaka Hudoklin <jakahudoklin@gmail.com>";
   olcai = "Erik Timan <dev@timan.info>";
   olejorgenb = "Ole Jørgen Brønner <olejorgenb@yahoo.no>";
+  orbekk = "KJ Ørbekk <kjetil.orbekk@gmail.com>";
   orbitz = "Malcolm Matalka <mmatalka@gmail.com>";
   osener = "Ozan Sener <ozan@ozansener.com>";
   otwieracz = "Slawomir Gonet <slawek@otwiera.cz>";

--- a/pkgs/os-specific/linux/tpacpi-bat/default.nix
+++ b/pkgs/os-specific/linux/tpacpi-bat/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchgit, perl, kmod }:
+{ stdenv, fetchFromGitHub, perl, kmod }:
 
 # Requires the acpi_call kernel module in order to run.
 stdenv.mkDerivation rec {
-  name = "tpacpi-bat";
+  name = "tpacpi-bat-${version}";
+  version = "3.0";
 
-  src = fetchgit {
-    url = "https://github.com/teleshoes/tpacpi-bat.git";
-    rev = "06ec1d5c7e0766b43b5acb98dd61aa96360da6be";
+  src = fetchFromGitHub {
+    owner = "teleshoes";
+    repo = "tpacpi-bat";
+    rev = "v${version}";
     sha256 = "0l72qvjk5j7sg9x4by7an0xwx65x10dx82fky8lnwlwfv54vgg8l";
   };
 

--- a/pkgs/os-specific/linux/tpacpi-bat/default.nix
+++ b/pkgs/os-specific/linux/tpacpi-bat/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit, perl, kmod }:
+
+# Requires the acpi_call kernel module in order to run.
+stdenv.mkDerivation rec {
+  name = "tpacpi-bat";
+
+  src = fetchgit {
+    url = "https://github.com/teleshoes/tpacpi-bat.git";
+    rev = "06ec1d5c7e0766b43b5acb98dd61aa96360da6be";
+    sha256 = "0l72qvjk5j7sg9x4by7an0xwx65x10dx82fky8lnwlwfv54vgg8l";
+  };
+
+  buildInputs = [ perl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp tpacpi-bat $out/bin
+  '';
+
+  postPatch = ''
+    substituteInPlace tpacpi-bat --replace modprobe ${kmod}/bin/modprobe
+  '';
+
+  meta = {
+    maintainers = [stdenv.lib.maintainers.orbekk];
+    platforms = stdenv.lib.platforms.linux;
+    description = "Tool to set battery charging thesholds on Lenovo Thinkpad";
+    license = stdenv.lib.licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11390,6 +11390,8 @@ in
 
   tiptop = callPackage ../os-specific/linux/tiptop { };
 
+  tpacpi-bat = callPackage ../os-specific/linux/tpacpi-bat { };
+
   trinity = callPackage ../os-specific/linux/trinity { };
 
   tunctl = callPackage ../os-specific/linux/tunctl { };


### PR DESCRIPTION
###### Motivation for this change

Allow setting battery thresholds on newer Thinkpad models that don't support the tp_smapi kernel module.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


