### PR TITLE
wallabag: 2.1.2 -> 2.1.3

### DIFF
--- a/pkgs/servers/web-apps/wallabag/default.nix
+++ b/pkgs/servers/web-apps/wallabag/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "wallabag-${version}";
-  version = "2.1.2";
+  version = "2.1.3";
 
   # remember to rm -r var/cache/* after a rebuild or unexpected errors will occur
 
   src = fetchurl {
     url = "https://framabag.org/wallabag-release-${version}.tar.gz";
-    sha256 = "01i4xdzw126wwwkxy0d97dizrikvawpzqj95bykd1g25m7jzvb7k";
+    sha256 = "0pl1sqigrp08r657jmfpf8m3wnw65g2k3mg50zsc8xbrzn6nwbgp";
   };
 
   outputs = [ "out" "doc" ];


### PR DESCRIPTION
###### Motivation for this change
Updated wallabag to the latest release.
During testing I discovered that the internal settings page is broken (#20214), I will fix that later. The issue does not impact the main functionility.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

