### PR TITLE
Update Darktable, dependencies

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -11,12 +11,12 @@
 assert stdenv ? glibc;
 
 stdenv.mkDerivation rec {
-  version = "2.0.6";
+  version = "2.0.7";
   name = "darktable-${version}";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    sha256 = "1h9qwxyvcv0fc6y5b6l2x4jd5mmw026blhjkcihj00r1aa3c2s13";
+    sha256 = "1aqxiaw89xdx0s0h3gb9nvdzw4690y3kp7h794sihf2581bn28m9";
   };
 
   buildInputs =

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -1,16 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, python, glib, zlib, libpng, gnumake3 }:
+{ stdenv, fetchurl, pkgconfig, python, glib, zlib, libpng, gnumake3, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "lensfun-0.2.8";
+  version = "0.3.2";
+  name = "lensfun-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/lensfun/${name}.tar.bz2";
-    sha256 = "0j0smagnksdm9gjnk13w200hjxshmxf2kvyxxnra4nc2qzxrg3zq";
+    url = "mirror://sourceforge/lensfun/${version}/${name}.tar.gz";
+    sha256 = "0cfk8jjhs9nbfjfdy98plrj9ayi59aph0nx6ppslgjhlcvacm2xf";
   };
 
-  patchPhase = "sed -e 's@/usr/bin/python@${python}/bin/python@' -i configure";
-
-  buildInputs = [ pkgconfig glib zlib libpng gnumake3 ];
+  buildInputs = [ pkgconfig glib zlib libpng cmake gnumake3 ];
 
   configureFlags = "-v";
 

--- a/pkgs/development/libraries/libgphoto2/default.nix
+++ b/pkgs/development/libraries/libgphoto2/default.nix
@@ -1,21 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, libusb1, libtool, libexif, libjpeg, gettext }:
+{ stdenv, fetchpatch, fetchFromGitHub, pkgconfig, libusb1, libtool, libexif, libjpeg, gettext, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "libgphoto2-${meta.version}";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/gphoto/${name}.tar.bz2";
-    sha256 = "1wjf79ipqwb5phfjjwf15rwgigakylnfqaj4crs5qnds6ba6i1ld";
+  src = fetchFromGitHub {
+    owner = "gphoto";
+    repo = "libgphoto2";
+    rev = "${meta.tag}";
+    sha256 = "17k3jxib2jcr2wk83p34h3lvvjbs2gqhqfcngm8zmlrwb385yalh";
   };
 
-  patches = [(fetchurl {
+  patches = [(fetchpatch {
+    name = "libjpeg_turbo_1.5.0_fix.patch";
     url = "https://anonscm.debian.org/cgit/pkg-phototools/libgphoto2.git/plain"
       + "/debian/patches/libjpeg_turbo_1.5.0_fix.patch?id=8ce79a2a02d";
-    sha256 = "114iyhk6idxz2jhnzpf1glqm6d0x0y8cqfpqxz9i96q9j7x3wwin";
+    sha256 = "1zclgg20nv4krj8gigq3ylirxqiv1v8p59cfji041m156hy80gy2";
   })];
 
-  nativeBuildInputs = [ pkgconfig gettext ];
-  buildInputs = [ libtool libjpeg libusb1 ];
+  nativeBuildInputs = [ pkgconfig gettext autoreconfHook ];
+  buildInputs = [ libtool libjpeg libusb1  ];
 
   # These are mentioned in the Requires line of libgphoto's pkg-config file.
   propagatedBuildInputs = [ libexif ];
@@ -31,6 +34,7 @@ stdenv.mkDerivation rec {
       from digital cameras.
     '';
     version = "2.5.10";
+    tag = "libgphoto2-2_5_10-release";
     # XXX: the homepage claims LGPL, but several src files are lgpl21Plus
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = with stdenv.lib.platforms; unix;


### PR DESCRIPTION
###### Motivation for this change
Updates, refactor

Fixes #20209 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

