### PR TITLE
neomutt: 20160910 -> 20161104

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -2,14 +2,14 @@
 , cyrus_sasl, gdbm, gpgme, kerberos, libidn, notmuch, openssl }:
 
 stdenv.mkDerivation rec {
-  version = "20160910";
+  version = "20161104";
   name = "neomutt-${version}";
 
   src = fetchFromGitHub {
     owner = "neomutt";
     repo = "neomutt";
     rev = "neomutt-${version}";
-    sha256 = "1i1idqk9l3njqsiw8n8jgjawcz9n9h5180qvpxfwg7sg9zx2sjhj";
+    sha256 = "070p18khvxsrcn30jhyrnagka5mgza9mi5vmrrr6xl8mpgkyrlaw";
   };
 
   buildInputs =
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.neomutt.org;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ cstrahan vrthra ];
+    maintainers = with maintainers; [ cstrahan vrthra erikryb ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New NeoMutt release: [https://www.neomutt.org/2016/11/04/release](https://www.neomutt.org/2016/11/04/release)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


