### PR TITLE
network interfaces: Reduce the start rate limit interval from 10 to 3 seconds

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -84,6 +84,7 @@ in
             serviceConfig = {
               Type = "oneshot";
               RemainAfterExit = true;
+              StartLimitIntervalSec = 3;
             };
 
             unitConfig.DefaultDependencies = false;


### PR DESCRIPTION
###### Motivation for this change
Sometimes, network connections fail a few times before they're stable. During boot, I don't want to have to wait 10 seconds in between attempting each phase of establishing a stable ethernet connection. So this lowers that.
