### PR TITLE
pythonPackages.oauthlib: 0.7.2 -> 2.0.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7888,7 +7888,8 @@ in {
   };
 
   lti = let
-    self' = (self.override {self = self';}) // {pytest = self.pytest_27;};
+    # hypothesis (dependency of oauthlib) can't be built with pytest_27
+    self' = (self.override {self = self';}) // {pytest = self.pytest_27; hypothesis = self.hypothesis; };
     mock_1_0_1 = self'.mock.overrideDerivation (_: rec {
       name = "mock-1.0.1";
       propagatedBuildInputs = null;
@@ -12338,7 +12339,8 @@ in {
       sha256 = "030rf4gn4b0hylr90wazilwa3bc038fcqng0wibcx67mqaq035n4";
     };
 
-    buildInputs = with self; [ flake8 pytest flaky ];
+    # need pytest_29: https://github.com/HypothesisWorks/hypothesis-python/issues/380
+    buildInputs = with self; [ flake8 pytest_29 flaky ];
     propagatedBuildInputs = with self; ([ uncompyle6 ] ++ optionals isPy27 [ enum34  ]);
 
     # https://github.com/DRMacIver/hypothesis/issues/300

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16049,17 +16049,17 @@ in {
   };
 
   oauthlib = buildPythonPackage rec {
-    version = "0.7.2";
+    version = "2.0.0";
     name = "oauthlib-${version}";
 
     src = pkgs.fetchurl {
-      url = "https://github.com/idan/oauthlib/archive/${version}.tar.gz";
-      sha256 = "08b7swyswhxh90k9mp54rk1qks2l2s2pdcjap6x118y27p7dhp4h";
+      url = "https://github.com/idan/oauthlib/archive/v${version}.tar.gz";
+      sha256 = "02b645a8rqh4xfs1cmj8sss8wqppiadd1ndq3av1cdjz2frfqcjf";
     };
 
     buildInputs = with self; [ mock nose unittest2 ];
 
-    propagatedBuildInputs = with self; [ pycrypto blinker pyjwt ];
+    propagatedBuildInputs = with self; [ cryptography blinker pyjwt ];
 
     meta = {
       homepage = https://github.com/idan/oauthlib;


### PR DESCRIPTION
###### Motivation for this change
Related to #19935. Split up commits because `nox-review` shows building problem with `hypothesis` and `PyLTI`. So, I've had to update this as well. Also, I've changed `PyLTI` to avoid duplication problem:
```sh
Found duplicated packages in closure for dependency 'pytest': 
  pytest 2.9.2 (/nix/store/r2v8mbdn63q3jdh3339ghplza9fmi850-python2.7-pytest-2.9.2/lib/python2.7/site-packages)
  pytest 2.7.3 (/nix/store/pkaymk1w76xb6zf5l0cc8r3kbz24nrhw-python2.7-pytest-2.7.3/lib/python2.7/site-packages)
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
The changes require rebuilding of:
```sh
lrwxrwxrwx 1 igor users 68 Nov  6 16:17 result -> /nix/store/rn4sznvz095alfxy3gqp0dmwasfaapgn-python2.7-oauthlib-2.0.0
lrwxrwxrwx 1 igor users 77 Nov  6 16:17 result-10 -> /nix/store/8mkgbphq31pfipy48l486b2fjpprcyxj-python2.7-requests-oauthlib-0.4.1
lrwxrwxrwx 1 igor users 66 Nov  6 16:17 result-11 -> /nix/store/4kvcshfqb0r6i28ry25q8lghnz00k4v3-python2.7-turses-0.3.1
lrwxrwxrwx 1 igor users 73 Nov  6 16:17 result-12 -> /nix/store/cqaz9254h78cxm775vmsr0zky43ff9ij-python2.7-bitbucket-api-0.4.4
lrwxrwxrwx 1 igor users 66 Nov  6 16:17 result-2 -> /nix/store/8pj53xq59b48wv49sagbb9yl4fvajgzs-python3.5-tweepy-3.5.0
lrwxrwxrwx 1 igor users 68 Nov  6 16:17 result-3 -> /nix/store/2hbqdb6kd7ij470dikr1bl5fgb0z5zz3-python3.5-oauthlib-2.0.0
lrwxrwxrwx 1 igor users 66 Nov  6 16:17 result-4 -> /nix/store/9z0x9x6vn97w95213y95imh0dmxfan8z-python2.7-tweepy-3.5.0
lrwxrwxrwx 1 igor users 64 Nov  6 16:17 result-5 -> /nix/store/d5faxav5xqdm91wjn6g6a6fsbcjkqmf1-inginious-0.3a2.dev0
lrwxrwxrwx 1 igor users 65 Nov  6 16:17 result-6 -> /nix/store/j3bi2h2yjzbjrkxvy0cafg9y45mk5ssv-python2.7-PyLTI-0.4.1
lrwxrwxrwx 1 igor users 70 Nov  6 16:17 result-7 -> /nix/store/mz6qd30p725bbmb5001sgmll6nc350pz-python2.7-mezzanine-3.1.10
lrwxrwxrwx 1 igor users 77 Nov  6 16:17 result-8 -> /nix/store/z3dfnn78lm9dzzix8ir0h02bdn584if6-python3.5-requests-oauthlib-0.4.1
lrwxrwxrwx 1 igor users 58 Nov  6 16:17 result-9 -> /nix/store/z6rcmgpqh6vca3bpxsw19j8jhpdysyyl-keystone-8.0.0
```