### PR TITLE
octave: 4.0.1 → 4.0.3 (+ portaudio dep)

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gfortran, readline, ncurses, perl, flex, texinfo, qhull
-, libsndfile, libX11, graphicsmagick, pcre, pkgconfig, mesa, fltk
+, libsndfile, portaudio, libX11, graphicsmagick, pcre, pkgconfig, mesa, fltk
 , fftw, fftwSinglePrec, zlib, curl, qrupdate, openblas, arpack, libwebp
 , qt ? null, qscintilla ? null, ghostscript ? null, llvm ? null, hdf5 ? null,glpk ? null
 , suitesparse ? null, gnuplot ? null, jdk ? null, python ? null, overridePlatforms ? null
@@ -18,16 +18,16 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "4.0.1";
+  version = "4.0.3";
   name = "octave-${version}";
   src = fetchurl {
     url = "mirror://gnu/octave/${name}.tar.xz";
-    sha256 = "11y2w6jgngj4rxiy136mkcs02l52rxk60kapyfc4rgrxz5hli3ym";
+    sha256 = "11day29k4yfvxh4101x5yf26ld992x5n6qvmhjjk6mzsd26fqayw";
   };
 
   buildInputs = [ gfortran readline ncurses perl flex texinfo qhull
     graphicsmagick pcre pkgconfig fltk zlib curl openblas libsndfile fftw
-    fftwSinglePrec qrupdate arpack libwebp ]
+    fftwSinglePrec portaudio qrupdate arpack libwebp ]
     ++ (stdenv.lib.optional (qt != null) qt)
     ++ (stdenv.lib.optional (qscintilla != null) qscintilla)
     ++ (stdenv.lib.optional (ghostscript != null) ghostscript)


### PR DESCRIPTION
###### Motivation for this change

1. Version bump.

1. Previously, sound playback did not work:

```
% nix-shell -p octave
$ octave
GNU Octave, version 4.0.1
octave:1> audiodevinfo
error: portaudio not found on your system and thus audio functionality is not present
```

Now it does:

```
% nix-shell -p octave
$ octave
GNU Octave, version 4.0.3
octave:1> audiodevinfo
ans =
  scalar structure containing the fields:
[…]
```

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) — *they have automatic tests*
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
