### PR TITLE
either type: improve merge function

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -333,7 +333,15 @@ rec {
       name = "either";
       description = "${t1.description} or ${t2.description}";
       check = x: t1.check x || t2.check x;
-      merge = mergeOneOption;
+      merge = loc: defs:
+        let
+          defList = map (d: d.value) defs;
+        in
+          if   all (x: t1.check x) defList
+               then t1.merge loc defs
+          else if all (x: t2.check x) defList
+               then t2.merge loc defs
+          else mergeOneOption loc defs;
       typeMerge = f':
         let mt1 = t1.typeMerge (elemAt f'.wrapped 0).functor;
             mt2 = t2.typeMerge (elemAt f'.wrapped 1).functor;


### PR DESCRIPTION
###### Motivation for this change

#20225

Either type definitions are currently not mergeable.
This PR change the merge function so it can merge if all the definitions are of the same wrapped type and that wrapped type have merging capabilities.

cc @nbp @bjornfor 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

