### PR TITLE
motion: init at 4.0.1

### DIFF
--- a/pkgs/applications/video/motion/default.nix
+++ b/pkgs/applications/video/motion/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libjpeg, ffmpeg }:
+
+stdenv.mkDerivation rec {
+  name = "motion-${version}";
+  version = "4.0.1";
+  src = fetchFromGitHub {
+    owner = "Motion-Project";
+    repo = "motion";
+    rev = "release-${version}";
+    sha256 = "172bn2ny5r9fcb4kn9bjq3znpgl8ai84w4b99vhk5jggp2haa3bb";
+  };
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libjpeg ffmpeg ];
+  meta = with stdenv.lib; {
+    homepage = http://www.lavrsen.dk/foswiki/bin/view/Motion/WebHome;
+    description = "Monitors the video signal from cameras";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.puffnfresh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2378,6 +2378,8 @@ in
 
   most = callPackage ../tools/misc/most { };
 
+  motion = callPackage ../applications/video/motion { };
+
   mkcast = callPackage ../applications/video/mkcast { };
 
   multitail = callPackage ../tools/misc/multitail { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


