### PR TITLE
fldigi: 3.23.07 -> 3.23.15

### DIFF
--- a/pkgs/applications/audio/fldigi/default.nix
+++ b/pkgs/applications/audio/fldigi/default.nix
@@ -2,13 +2,13 @@
   libsamplerate, libpulseaudio, libXinerama, gettext, pkgconfig, alsaLib }:
 
 stdenv.mkDerivation rec {
-  version = "3.23.07";
+  version = "3.23.15";
   pname = "fldigi";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/${name}.tar.gz";
-    sha256 = "0v78sk9bllxw640wxd4q2qy0h8z2j1d077nxhmpkjpf6mn6vwcda";
+    sha256 = "1nxafk99fr6yb09cq3vdpzjcd85mnjwwl8rzccx21kla1ysihl5m";
   };
 
   buildInputs = [ libXinerama gettext hamlib fltk13 libjpeg libpng portaudio


### PR DESCRIPTION
###### Motivation for this change

* I don't really do ham radio but this fixes the hydra build

cc maintainers @relrod @ftrvxmtrx 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---