### PR TITLE
build jack unstable without profiling

### DIFF
--- a/pkgs/misc/jackaudio/unstable.nix
+++ b/pkgs/misc/jackaudio/unstable.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation rec {
     python waf configure --prefix=$out \
       ${optionalString (optDbus != null) "--dbus"} \
       --classic \
-      --profile \
       ${optionalString (optLibffado != null) "--firewire"} \
       ${optionalString (optAlsaLib != null) "--alsa"} \
       --autostart=${if (optDbus != null) then "dbus" else "classic"} \


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


