### PR TITLE
NixOS manual: Update link to list of AMIs

### DIFF
--- a/nixos/doc/manual/installation/obtaining.xml
+++ b/nixos/doc/manual/installation/obtaining.xml
@@ -32,7 +32,7 @@ running NixOS system through several other means:
   <listitem>
     <para>Using AMIs for Amazon’s EC2.  To find one for your region
     and instance type, please refer to the <link
-    xlink:href="https://github.com/NixOS/nixops/blob/master/nix/ec2-amis.nix">list
+    xlink:href="https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualisation/ec2-amis.nix">list
     of most recent AMIs</link>.</para>
   </listitem>
   <listitem>


### PR DESCRIPTION
###### Motivation for this change

Link in NixOS manual was incorrect after commit https://github.com/NixOS/nixops/commit/48fc0ffb53c97eb7ea895b0470816b83d0d34647.
