### PR TITLE
virtualbox-demo: Add modesetting to drivers

### DIFF
--- a/nixos/modules/installer/virtualbox-demo.nix
+++ b/nixos/modules/installer/virtualbox-demo.nix
@@ -18,5 +18,5 @@ with lib;
 
   # Add some more video drivers to give X11 a shot at working in
   # VMware and QEMU.
-  services.xserver.videoDrivers = mkOverride 40 [ "virtualbox" "vmware" "cirrus" "vesa" ];
+  services.xserver.videoDrivers = mkOverride 40 [ "virtualbox" "vmware" "cirrus" "vesa" "modesetting" ];
 }


### PR DESCRIPTION
###### Motivation for this change

This needs to be included for VirtualBox to detect that it needs to start the video driver. "modesetting" is also set in virtualbox-image.nix but this line seems to take precedence over that one (even though the virtualbox-image.nix has a higher override?) This should fix the problems that I and a few others have been having with the .ova files built for nixos.org.

I haven't been able to build this yet but manual editing of the xorg.conf file in a NixOS virtualbox image fixes the problem, and allowing X11 to start.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


This needs to be included for VirtualBox to detect that it needs to start the video driver. "modesetting" is also set in virtualbox-image.nix but this line seems to take precedence over that one (even though the virtualbox-image.nix has a higher override?) This should fix the problems that I and a few others have been having with the .ova files built for nixos.org.

Fixes #20007.