### PR TITLE
gdal: Activate darwin build - Fixes #18194

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -20,14 +20,13 @@ composableDerivation.composableDerivation {} (fixed: rec {
 
   hardeningDisable = [ "format" ];
 
-  # Don't use optimization for gcc >= 4.3. That's said to be causing segfaults.
   # Unset CC and CXX as they confuse libtool.
-  preConfigure = "export CFLAGS=-O0 CXXFLAGS=-O0; unset CC CXX";
+  preConfigure = "unset CC CXX";
 
   configureFlags = [
     "--with-jpeg=${libjpeg.dev}"
     "--with-libtiff=${libtiff.dev}" # optional (without largetiff support)
-    "--with-libpng=${libpng.dev}"   # optional
+    "--with-png=${libpng.dev}"      # optional
     "--with-libz=${zlib.dev}"       # optional
 
     "--with-pg=${postgresql}/bin/pg_config"
@@ -53,6 +52,6 @@ composableDerivation.composableDerivation {} (fixed: rec {
     homepage = http://www.gdal.org/;
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 })

--- a/pkgs/development/libraries/libgeotiff/default.nix
+++ b/pkgs/development/libraries/libgeotiff/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.remotesensing.org/geotiff/geotiff.html;
     license = stdenv.lib.licenses.mit;
     maintainers = [stdenv.lib.maintainers.marcweber];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Due to [veprbl's contribution](https://github.com/NixOS/nixpkgs/commit/468a5bc22458f7aeb3ee7b887f29a8e8799c6337) gdal should compile fine again on both linux and darwin.
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

