### PR TITLE
quiterss: init at 0.18.4

### DIFF
--- a/pkgs/applications/networking/newsreaders/quiterss/default.nix
+++ b/pkgs/applications/networking/newsreaders/quiterss/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, qt5, qmakeHook, makeQtWrapper, pkgconfig, sqlite }:
+
+stdenv.mkDerivation rec {
+  name = "quiterss-${version}";
+  version = "0.18.4";
+
+  src = fetchFromGitHub {
+    owner = "QuiteRSS";
+    repo = "quiterss";
+    rev = "${version}";
+    sha256 = "0gk4s41npg8is0jf4yyqpn8ksqrhwxq97z40iqcbd7dzsiv7bkvj";
+  };
+
+  buildInputs = [ qt5.qtbase qt5.qttools qt5.qtwebkit qmakeHook makeQtWrapper pkgconfig sqlite.dev ];
+
+  postInstall = ''
+    wrapQtProgram "$out/bin/quiterss"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Qt-based RSS/Atom news feed reader";
+    longDescription = ''
+      QuiteRSS is a open-source cross-platform RSS/Atom news feeds reader
+      written on Qt/C++
+    '';
+    homepage = "https://quiterss.org";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14260,6 +14260,8 @@ in
 
   quirc = callPackage ../tools/graphics/quirc {};
 
+  quiterss = qt5.callPackage ../applications/networking/newsreaders/quiterss {};
+
   quodlibet = callPackage ../applications/audio/quodlibet { };
 
   quodlibet-with-gst-plugins = callPackage ../applications/audio/quodlibet {


### PR DESCRIPTION
###### Motivation for this change

Add QuiteRSS: "QuiteRSS is a open-source cross-platform RSS/Atom news feeds reader written on Qt/C++"

cc @qknight 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux (Gentoo+Nix)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

