### PR TITLE
encryptr: init at 2.0.0

### DIFF
--- a/pkgs/tools/security/encryptr/default.nix
+++ b/pkgs/tools/security/encryptr/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchurl, glib, nss, nspr, gconf, fontconfig, freetype
+, pango , cairo, libX11 , libXi, libXcursor, libXext, libXfixes
+, libXrender, libXcomposite , alsaLib, libXdamage, libXtst, libXrandr
+, expat, libcap, systemd , dbus, gtk2 , gdk_pixbuf, libnotify
+}:
+
+let
+  arch = if stdenv.system == "x86_64-linux" then "amd"
+    else if stdenv.system == "i686-linux" then "i386"
+    else throw "Encryptr for ${stdenv.system} not supported!";
+
+  sha256 = if stdenv.system == "x86_64-linux" then "1j3g467g7ar86hpnh6q9mf7mh2h4ia94mwhk1283zh739s2g53q2"
+    else if stdenv.system == "i686-linux" then "02j9hg9b1jlv25q1sjfhv8d46mii33f94dj0ccn83z9z18q4y2cm"
+    else throw "Encryptr for ${stdenv.system} not supported!";
+
+in stdenv.mkDerivation rec {
+  name = "encryptr-${version}";
+  version = "2.0.0";
+
+  src = fetchurl {
+    url = "https://spideroak.com/dist/encryptr/signed/linux/targz/encryptr-${version}_${arch}.tar.gz";
+    inherit sha256;
+  };
+
+  dontBuild = true;
+
+  rpath = stdenv.lib.makeLibraryPath [
+    glib nss nspr gconf fontconfig freetype pango cairo libX11 libXi
+    libXcursor libXext libXfixes libXrender libXcomposite alsaLib
+    libXdamage libXtst libXrandr expat libcap dbus gtk2 gdk_pixbuf
+    libnotify stdenv.cc.cc
+  ];
+
+  installPhase = ''
+    mkdir -pv $out/bin $out/lib
+    cp -v {encryptr-bin,icudtl.dat,nw.pak} $out/bin
+    mv -v $out/bin/encryptr{-bin,}
+    cp -v lib* $out/lib
+    ln -sv ${systemd.lib}/lib/libudev.so.1 $out/lib/libudev.so.0
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+             --set-rpath $out/lib:${rpath} \
+             $out/bin/encryptr
+  '';
+
+  # If stripping, node-webkit does not find
+  # its application and shows a generic page
+  dontStrip = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://spideroak.com/solutions/encryptr;
+    description = "Free, private and secure password management tool and e-wallet";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ guillaumekoenig ];
+    platform = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -495,6 +495,10 @@ in
 
   elvish = callPackage ../shells/elvish { };
 
+  encryptr = callPackage ../tools/security/encryptr {
+    gconf = gnome2.GConf;
+ };
+
   enpass = callPackage ../tools/security/enpass { };
 
   genymotion = callPackage ../development/mobile/genymotion { };


### PR DESCRIPTION
###### Motivation for this change
This adds Spideroak encryptr, a node-webkit app that does password management with syncing in the cloud. Note I only tested it working on x86_64 (don't know how to test i386). I left the license to unfree because we're reusing an executable binary from the web. However the code is up on github and really is GPLv3. Given the complex nature of dependencies it's probably going to take some effort to build from source.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


