### PR TITLE
libxml2 and libxslt python bindings

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, zlib, xz, python2, findXMLCatalogs, libiconv, fetchpatch
-, supportPython ? (! stdenv ? cross) }:
+, pythonSupport ? (! stdenv ? cross) }:
 
 let
   python = python2;
@@ -28,10 +28,10 @@ in stdenv.mkDerivation rec {
   };
 
   outputs = [ "bin" "dev" "out" "doc" ]
-    ++ lib.optional supportPython "py";
-  propagatedBuildOutputs = "out bin" + lib.optionalString supportPython " py";
+    ++ lib.optional pythonSupport "py";
+  propagatedBuildOutputs = "out bin" + lib.optionalString pythonSupport " py";
 
-  buildInputs = lib.optional supportPython python
+  buildInputs = lib.optional pythonSupport python
     # Libxml2 has an optional dependency on liblzma.  However, on impure
     # platforms, it may end up using that from /usr/lib, and thus lack a
     # RUNPATH for that, leading to undefined references for its users.
@@ -39,7 +39,7 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ zlib findXMLCatalogs ];
 
-  configureFlags = lib.optional supportPython "--with-python=${python}"
+  configureFlags = lib.optional pythonSupport "--with-python=${python}"
     ++ [ "--exec_prefix=$dev" ];
 
   enableParallelBuilding = true;
@@ -55,9 +55,9 @@ in stdenv.mkDerivation rec {
     propagatedBuildInputs =  [ findXMLCatalogs libiconv ];
   };
 
-  preInstall = lib.optionalString supportPython
+  preInstall = lib.optionalString pythonSupport
     ''substituteInPlace python/libxml2mod.la --replace "${python}" "$py"'';
-  installFlags = lib.optionalString supportPython
+  installFlags = lib.optionalString pythonSupport
     ''pythondir="$(py)/lib/${python.libPrefix}/site-packages"'';
 
   postFixup = ''
@@ -66,7 +66,7 @@ in stdenv.mkDerivation rec {
     moveToOutput share/man/man1 "$bin"
   '';
 
-  passthru = { inherit version; pythonSupport = supportPython; };
+  passthru = { inherit version; pythonSupport = pythonSupport; };
 
   meta = {
     homepage = http://xmlsoft.org/;

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -10,7 +10,7 @@ with pkgs; rec {
   
   libxml2 = (pkgs.libxml2.override {
     stdenv = emscriptenStdenv;
-    supportPython = false;
+    pythonSupport = false;
   }).overrideDerivation
     (old: { 
       buildInputs = old.buildInputs ++ [ autoreconfHook pkgconfig zlib nodejs ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13448,7 +13448,7 @@ in {
   };
 
   libxml2 = if isPy3k then throw "libxml2 not supported for interpreter ${python.executable}" else
-    (pkgs.libxml2.override{supportPython=true; python2=python;}).py;
+    (pkgs.libxml2.override{pythonSupport=true; python2=python;}).py;
 
   libxslt = if isPy3k then throw "libxslt not supported for interpreter ${python.executable}" else
     (pkgs.libxslt.override{pythonSupport=true; python2=python; inherit (self) libxml2;}).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13447,6 +13447,9 @@ in {
     clblas = pkgs.clblas-cuda;
   };
 
+  libxslt = if isPy3k then throw "libxslt not supported for interpreter ${python.executable}" else
+    (pkgs.libxslt.override{pythonSupport=true; python2=python; inherit (self) libxml2;}).py;
+
   limnoria = buildPythonPackage rec {
     name = "limnoria-${version}";
     version = "2016.05.06";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13447,6 +13447,9 @@ in {
     clblas = pkgs.clblas-cuda;
   };
 
+  libxml2 = if isPy3k then throw "libxml2 not supported for interpreter ${python.executable}" else
+    (pkgs.libxml2.override{supportPython=true; python2=python;}).py;
+
   libxslt = if isPy3k then throw "libxslt not supported for interpreter ${python.executable}" else
     (pkgs.libxslt.override{pythonSupport=true; python2=python; inherit (self) libxml2;}).py;
 


### PR DESCRIPTION
###### Motivation for this change

Build libxslt python bindings and have aliases for the bindings of libxslt and libxml2 in python-packages.nix.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

