### PR TITLE
xmonad: Allow alternative path

### DIFF
--- a/pkgs/development/haskell-modules/patches/xmonad-nix.patch
+++ b/pkgs/development/haskell-modules/patches/xmonad-nix.patch
@@ -8,6 +8,19 @@
  import Graphics.X11.Xlib
  import Graphics.X11.Xlib.Extras (Event)
  import Data.Typeable
+@@ -433,7 +433,11 @@
+
+ -- | Return the path to @~\/.xmonad@.
+ getXMonadDir :: MonadIO m => m String
+-getXMonadDir = io $ getAppUserDataDirectory "xmonad"
++getXMonadDir = io $ do e <- userExists; if e then user else (return "/etc/xmonad")
++  where
++  user = getAppUserDataDirectory "xmonad"
++  userExists = user >>= doesDirectoryExist
++
+
+ -- | 'recompile force', recompile @~\/.xmonad\/xmonad.hs@ when any of the
+ -- following apply:
 @@ -463,6 +464,7 @@ recompile force = io $ do
          err  = base ++ ".errors"
          src  = base ++ ".hs"
@@ -23,7 +36,7 @@
 -            waitForProcess =<< runProcess "ghc" ["--make", "xmonad.hs", "-i", "-ilib", "-fforce-recomp", "-main-is", "main", "-v0", "-o",binn] (Just dir)
 +            waitForProcess =<< runProcess ghc ["--make", "xmonad.hs", "-i", "-ilib", "-fforce-recomp", "-main-is", "main", "-v0", "-o",binn] (Just dir)
                                      Nothing Nothing Nothing (Just h)
- 
+
          -- re-enable SIGCHLD:
 @@ -480,6 +482,7 @@ recompile force = io $ do
          -- now, if it fails, run xmessage to let the user know:


### PR DESCRIPTION
###### Motivation for this change
This is something I had to do for #20258

Essentially, I want to be able to decoratively define my XMonad configuration and not have to move files around in my home folder.

This patch will cause XMonad to continue exhibiting its default behaviour of loading `~/.xmonad/xmonad.hs` but fall back onto `/etc/xmonad/xmonad.hs`, should the former not exist.
This change will have no impact on existing XMonad users.

**Could somebody with Haskell experience check out my patch and see how it could be refactored? I am sure it is not very elegant right now but it works :smile:**

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


