### PR TITLE
opencc: init at 1.0.4

### DIFF
--- a/pkgs/tools/text/opencc/default.nix
+++ b/pkgs/tools/text/opencc/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, cmake, python }:
+
+stdenv.mkDerivation {
+  name = "opencc-1.0.4";
+  src = fetchurl {
+    url = "https://github.com/BYVoid/OpenCC/archive/ver.1.0.4.tar.gz";
+    sha256 = "0553b7461ebd379d118d45d7f40f8a6e272750115bdbc49267595a05ee3481ac";
+  };
+
+  buildInputs = [ cmake python ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=OFF"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/BYVoid/OpenCC";
+    license = licenses.asl20;
+    description = "A project for conversion between Traditional and Simplified Chinese";
+    longDescription = ''
+      Open Chinese Convert (OpenCC) is an opensource project for conversion between
+      Traditional Chinese and Simplified Chinese, supporting character-level conversion,
+      phrase-level conversion, variant conversion and regional idioms among Mainland China,
+      Taiwan and Hong kong.
+    '';
+    maintainers = [ maintainers.mingchuan ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2988,6 +2988,8 @@ in
 
   oh-my-zsh = callPackage ../shells/oh-my-zsh { };
 
+  opencc = callPackage ../tools/text/opencc { };
+
   opencryptoki = callPackage ../tools/security/opencryptoki { };
 
   opendbx = callPackage ../development/libraries/opendbx { };


### PR DESCRIPTION
###### Motivation for this change

opencc is a tool for converting texts in different dialects of chinese.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


