### PR TITLE
bloaty: init at 2016.11.16

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -129,6 +129,7 @@
   doublec = "Chris Double <chris.double@double.co.nz>";
   drets = "Dmytro Rets <dmitryrets@gmail.com>";
   drewkett = "Andrew Burkett <burkett.andrew@gmail.com>";
+  dtzWill = "Will Dietz <nix@wdtz.org>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";
   eduarrrd = "Eduard Bachmakov <e.bachmakov@gmail.com>";

--- a/pkgs/development/tools/bloaty/default.nix
+++ b/pkgs/development/tools/bloaty/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, binutils, fetchgit }:
+
+stdenv.mkDerivation rec {
+  version = "2016.11.16";
+  name = "bloaty-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/google/bloaty.git";
+    rev = "d040e4821ace478f9b43360acd6801aefdd323f7";
+    sha256 = "1qk2wgd7vzr5zy0332y9h69cwkqmy8x7qz97xpgwwnk54amm8i3k";
+    fetchSubmodules = true;
+  };
+
+  enableParallelBuilding = true;
+
+  configurePhase = ''
+    sed -i 's,c++filt,${binutils}/bin/c++filt,' src/bloaty.cc
+  '';
+
+  installPhase = ''
+    install -Dm755 {.,$out/bin}/bloaty
+  '';
+
+  meta = with stdenv.lib; {
+    description = "a size profiler for binaries";
+    homepage = https://github.com/google/bloaty;
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5864,6 +5864,8 @@ in
   bison3 = callPackage ../development/tools/parsing/bison/3.x.nix { };
   bison = bison3;
 
+  bloaty = callPackage ../development/tools/bloaty { };
+
   bossa = callPackage ../development/tools/misc/bossa {
     wxGTK = wxGTK30;
   };


### PR DESCRIPTION
###### Motivation for this change

New tool for profiling size of binaries, from Google.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

