### PR TITLE
root: fix environment setup

### DIFF
--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -21,6 +21,9 @@ stdenv.mkDerivation rec {
       sha256 = "186i7ni75yvjydy6lpmaplqxfb5z2019bgpbhff1n6zn2qlrff2r";
     })
     ./sw_vers.patch
+
+    # this prevents thisroot.sh from setting $p, which interferes with stdenv setup
+    ./thisroot.patch
   ];
 
   preConfigure = ''

--- a/pkgs/applications/science/misc/root/setup-hook.sh
+++ b/pkgs/applications/science/misc/root/setup-hook.sh
@@ -6,4 +6,4 @@ thisroot () {
     source @out@/bin/thisroot.sh
 }
 
-envHooks+=(thisroot)
+postHooks+=(thisroot)

--- a/pkgs/applications/science/misc/root/thisroot.patch
+++ b/pkgs/applications/science/misc/root/thisroot.patch
@@ -1,0 +1,15 @@
+diff --git a/config/thisroot.sh b/config/thisroot.sh
+index 85dee20..532cb28 100644
+--- a/config/thisroot.sh
++++ b/config/thisroot.sh
+@@ -15,8 +15,8 @@ drop_from_path()
+       return 1
+    fi
+ 
+-   p=$1
+-   drop=$2
++   local p=$1
++   local drop=$2
+ 
+    newpath=`echo $p | sed -e "s;:${drop}:;:;g" \
+                           -e "s;:${drop};;g"   \


### PR DESCRIPTION
###### Motivation for this change

root environment had some issues with nix-shell, where system $PATH would get unset. Also using envHook is called for all nativeBuildInputs, which is undefined number of times, whereas we want it to execute it just once.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


1) s/envHook/postHook/
2) patch to not set $p that fixes nested ```nix-shell -p root``` calls