### PR TITLE
Fix bcftools installation prefix

### DIFF
--- a/pkgs/applications/science/biology/bcftools/default.nix
+++ b/pkgs/applications/science/biology/bcftools/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "HSTDIR=${htslib}"
-    "prefix=$out"
+    "prefix=$(out)"
     "CC=cc"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

bcftools was not installing properly, the final result in the nix store was empty.

###### Things done

- [ X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [X ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


