### PR TITLE
steam: fix crash at startup with open source radeon drivers

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -9,7 +9,7 @@ let
   opensslCrossSystem = stdenv.cross.openssl.system or
     (throw "openssl needs its platform name cross building");
 
-  common = args@{ version, sha256, patches ? [] }: stdenv.mkDerivation rec {
+  common = args@{ version, sha256, patches ? [], configureFlags ? [], makeDepend ? false }: stdenv.mkDerivation rec {
     name = "openssl-${version}";
 
     src = fetchurl {
@@ -45,7 +45,10 @@ let
     ] ++ stdenv.lib.optionals withCryptodev [
       "-DHAVE_CRYPTODEV"
       "-DUSE_CRYPTODEV_DIGESTS"
-    ] ++ stdenv.lib.optional enableSSL2 "enable-ssl2";
+    ] ++ stdenv.lib.optional enableSSL2 "enable-ssl2"
+    ++ args.configureFlags or [];
+
+    postConfigure = if makeDepend then "make depend" else null;
 
   makeFlags = [ "MANDIR=$(man)/share/man" ];
 
@@ -119,6 +122,14 @@ in {
   openssl_1_1_0 = common {
     version = "1.1.0b";
     sha256 = "1xznrqvb1dbngv2k2nb6da6fdw00c01sy2i36yjdxr4vpxrf0pd4";
+  };
+
+  openssl_1_0_2-steam = common {
+    version = "1.0.2j";
+    sha256 = "0cf4ar97ijfc7mg35zdgpad6x8ivkdx9qii6mz35khi1ps9g5bz7";
+    configureFlags = [ "no-engine" ];
+    makeDepend = true;
+    patches = [ ./openssl-fix-cpuid_setup.patch ];
   };
 
 }

--- a/pkgs/development/libraries/openssl/openssl-fix-cpuid_setup.patch
+++ b/pkgs/development/libraries/openssl/openssl-fix-cpuid_setup.patch
@@ -1,0 +1,105 @@
+diff --git a/crypto/cryptlib.c b/crypto/cryptlib.c
+index 1925428..d2e42d2 100644
+--- a/crypto/cryptlib.c
++++ b/crypto/cryptlib.c
+@@ -676,10 +676,15 @@ typedef unsigned __int64 IA32CAP;
+ #  else
+ typedef unsigned long long IA32CAP;
+ #  endif
++
++/* Compat function for STEAM */
++extern IA32CAP OPENSSL_ia32_cpuid_new(unsigned int*);
++IA32CAP OPENSSL_ia32_cpuid(void) { return OPENSSL_ia32_cpuid_new(OPENSSL_ia32cap_P); }
++
+ void OPENSSL_cpuid_setup(void)
+ {
+     static int trigger = 0;
+-    IA32CAP OPENSSL_ia32_cpuid(unsigned int *);
++    IA32CAP OPENSSL_ia32_cpuid_new(unsigned int *);
+     IA32CAP vec;
+     char *env;
+ 
+@@ -697,9 +702,9 @@ void OPENSSL_cpuid_setup(void)
+             vec = strtoul(env + off, NULL, 0);
+ #  endif
+         if (off)
+-            vec = OPENSSL_ia32_cpuid(OPENSSL_ia32cap_P) & ~vec;
++            vec = OPENSSL_ia32_cpuid_new(OPENSSL_ia32cap_P) & ~vec;
+         else if (env[0] == ':')
+-            vec = OPENSSL_ia32_cpuid(OPENSSL_ia32cap_P);
++            vec = OPENSSL_ia32_cpuid_new(OPENSSL_ia32cap_P);
+ 
+         OPENSSL_ia32cap_P[2] = 0;
+         if ((env = strchr(env, ':'))) {
+@@ -713,7 +718,7 @@ void OPENSSL_cpuid_setup(void)
+                 OPENSSL_ia32cap_P[2] = vecx;
+         }
+     } else
+-        vec = OPENSSL_ia32_cpuid(OPENSSL_ia32cap_P);
++        vec = OPENSSL_ia32_cpuid_new(OPENSSL_ia32cap_P);
+ 
+     /*
+      * |(1<<10) sets a reserved bit to signal that variable
+diff --git a/crypto/cryptlib.h b/crypto/cryptlib.h
+index fba180a..b927c79 100644
+--- a/crypto/cryptlib.h
++++ b/crypto/cryptlib.h
+@@ -99,6 +99,9 @@ extern "C" {
+ # define HEX_SIZE(type)          (sizeof(type)*2)
+ 
+ void OPENSSL_cpuid_setup(void);
++#pragma GCC visibility push(hidden)
++unsigned long long OPENSSL_ia32_cpuid(void);
++#pragma GCC visibility pop
+ extern unsigned int OPENSSL_ia32cap_P[];
+ void OPENSSL_showfatal(const char *fmta, ...);
+ void *OPENSSL_stderr(void);
+diff --git a/crypto/x86_64cpuid.pl b/crypto/x86_64cpuid.pl
+index d208d02..d4c0b24 100644
+--- a/crypto/x86_64cpuid.pl
++++ b/crypto/x86_64cpuid.pl
+@@ -52,10 +52,10 @@ OPENSSL_rdtsc:
+ 	ret
+ .size	OPENSSL_rdtsc,.-OPENSSL_rdtsc
+ 
+-.globl	OPENSSL_ia32_cpuid
+-.type	OPENSSL_ia32_cpuid,\@function,1
++.globl	OPENSSL_ia32_cpuid_new
++.type	OPENSSL_ia32_cpuid_new,\@function,1
+ .align	16
+-OPENSSL_ia32_cpuid:
++OPENSSL_ia32_cpuid_new:
+ 	mov	%rbx,%r8		# save %rbx
+ 
+ 	xor	%eax,%eax
+@@ -181,7 +181,7 @@ OPENSSL_ia32_cpuid:
+ 	mov	%r8,%rbx		# restore %rbx
+ 	or	%r9,%rax
+ 	ret
+-.size	OPENSSL_ia32_cpuid,.-OPENSSL_ia32_cpuid
++.size	OPENSSL_ia32_cpuid_new,.-OPENSSL_ia32_cpuid_new
+ 
+ .globl  OPENSSL_cleanse
+ .type   OPENSSL_cleanse,\@abi-omnipotent
+diff --git a/crypto/x86cpuid.pl b/crypto/x86cpuid.pl
+index e95f627..0781010 100644
+--- a/crypto/x86cpuid.pl
++++ b/crypto/x86cpuid.pl
+@@ -8,7 +8,7 @@ require "x86asm.pl";
+ 
+ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
+ 
+-&function_begin("OPENSSL_ia32_cpuid");
++&function_begin("OPENSSL_ia32_cpuid_new");
+ 	&xor	("edx","edx");
+ 	&pushf	();
+ 	&pop	("eax");
+@@ -153,7 +153,7 @@ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
+ 	&mov	("eax","esi");
+ 	&mov	("edx","ebp");
+ &set_label("nocpuid");
+-&function_end("OPENSSL_ia32_cpuid");
++&function_end("OPENSSL_ia32_cpuid_new");
+ 
+ &external_label("OPENSSL_ia32cap_P");
+ 

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -58,7 +58,6 @@ let
     SDL
     SDL2_image
     glew110
-    openssl
     libidn
 
     # Other things from runtime
@@ -88,6 +87,7 @@ let
     alsaLib
     openalSoft
     libva
+    openssl-steam
   ] ++ lib.optional newStdcpp gcc.cc;
 
   ourRuntime = if runtimeOnly then []

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8692,6 +8692,7 @@ in
   wolfssl = callPackage ../development/libraries/wolfssl { };
 
   openssl = openssl_1_0_2;
+  openssl-steam = openssl_1_0_2-steam;
 
   inherit (callPackages ../development/libraries/openssl {
       fetchurl = fetchurlBoot;
@@ -8702,7 +8703,8 @@ in
     })
     openssl_1_0_1
     openssl_1_0_2
-    openssl_1_1_0;
+    openssl_1_1_0
+    openssl_1_0_2-steam;
 
   openssl-chacha = callPackage ../development/libraries/openssl/chacha.nix {
     cryptodevHeaders = linuxPackages.cryptodev.override {


### PR DESCRIPTION
###### Motivation for this change

This is basically a port of [this fix from OpenSUSE](https://bugzilla.opensuse.org/show_bug.cgi?id=988273).

Steam ships statically linked with a version of libcrypto that conflics with the one dynamically loaded by radeonsi_dri.so.

This provides a compatible one (w/ engine disabled, cpuid fix) and links it into the steam runtime.

The error looks like:

```
steam.sh: line 713: 7842 Segmentation fault (core dumped) 
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

