### PR TITLE
displayManager, windowManager, desktopManager: use extensible option types

### DIFF
--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -36,7 +36,7 @@ latter might look like this:
 { config, pkgs, ... }:
 
 { services.xserver.enable = true;
-  services.xserver.displayManager.sddm.enable = true;
+  services.xserver.displayManager.select = "sddm";
   services.xserver.desktopManager.plasma5.enable = true;
 }
 </programlisting>

--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -37,7 +37,7 @@ latter might look like this:
 
 { services.xserver.enable = true;
   services.xserver.displayManager.select = "sddm";
-  services.xserver.desktopManager.plasma5.enable = true;
+  services.xserver.desktopManager.select = "plasma5";
 }
 </programlisting>
 

--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -35,9 +35,8 @@ latter might look like this:
 <programlisting>
 { config, pkgs, ... }:
 
-{ services.xserver.enable = true;
-  services.xserver.displayManager.select = "sddm";
-  services.xserver.desktopManager.select = "plasma5";
+{ 
+  services.xserver.desktopManager.select = [ "plasma5" ];
 }
 </programlisting>
 

--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -28,10 +28,10 @@ the following lines:
 services.xserver.desktopManager.select = [ "plasma5" ];
 services.xserver.desktopManager.select = [ "xfce" ];
 services.xserver.desktopManager.select = [ "gnome3" ];
-services.xserver.windowManager.xmonad.enable = true;
-services.xserver.windowManager.twm.enable = true;
-services.xserver.windowManager.icewm.enable = true;
-services.xserver.windowManager.i3.enable = true;
+services.xserver.windowManager.select = [ "xmonad" ];
+services.xserver.windowManager.select = [ "twm" ];
+services.xserver.windowManager.select = [ "icewm" ];
+services.xserver.windowManager.select = [ "i3" ];
 </programlisting>
 </para>
 

--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -40,8 +40,8 @@ program that provides a graphical login prompt and manages the X
 server) is SLiM. You can select an alternative one by picking one
 of the following lines:
 <programlisting>
-services.xserver.displayManager.sddm.enable = true;
-services.xserver.displayManager.lightdm.enable = true;
+services.xserver.displayManager.select = "sddm";
+services.xserver.displayManager.select = "lightdm";
 </programlisting>
 </para>
 

--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -25,9 +25,9 @@ Otherwise, you can only log into a plain undecorated
 <command>xterm</command> window.  Thus you should pick one or more of
 the following lines:
 <programlisting>
-services.xserver.desktopManager.plasma5.enable = true;
-services.xserver.desktopManager.xfce.enable = true;
-services.xserver.desktopManager.gnome3.enable = true;
+services.xserver.desktopManager.select = [ "plasma5" ];
+services.xserver.desktopManager.select = [ "xfce" ];
+services.xserver.desktopManager.select = [ "gnome3" ];
 services.xserver.windowManager.xmonad.enable = true;
 services.xserver.windowManager.twm.enable = true;
 services.xserver.windowManager.icewm.enable = true;

--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -35,10 +35,20 @@ services.xserver.windowManager.select = [ "i3" ];
 </programlisting>
 </para>
 
+<note><para>It is possible to use more than one window manager or desktop
+manager at the same time by adding items to the list. In this case, the
+first item of the list will become the default window manager or desktop
+manager.
+<programlisting>
+services.xserver.desktopManager.select = [ "plasma5" "xfce" ];
+services.xserver.windowManager.select = [ "xmonad" "i3" ];
+</programlisting>
+</para></note>
+
 <para>NixOS’s default <emphasis>display manager</emphasis> (the
 program that provides a graphical login prompt and manages the X
-server) is SLiM. You can select an alternative one by picking one
-of the following lines:
+server) depends on the selected desktop manager or window manager. 
+You can select an alternative one by picking one of the following lines:
 <programlisting>
 services.xserver.displayManager.select = "sddm";
 services.xserver.displayManager.select = "lightdm";

--- a/nixos/doc/manual/configuration/xfce.xml
+++ b/nixos/doc/manual/configuration/xfce.xml
@@ -43,7 +43,7 @@ services.compton = {
         You can, for example, select KDE’s
         <command>sddm</command> instead:
         <programlisting>
-services.xserver.displayManager.sddm.enable = true;
+services.xserver.displayManager.select = "sddm";
         </programlisting>
     </para>
 

--- a/nixos/doc/manual/configuration/xfce.xml
+++ b/nixos/doc/manual/configuration/xfce.xml
@@ -9,10 +9,7 @@
     <para>
         To enable the Xfce Desktop Environment, set
         <programlisting>
-services.xserver.desktopManager = {
-    xfce.enable = true;
-    default = "xfce";
-};
+services.xserver.desktopManager.select = [ "xfce" ];
         </programlisting>
     </para>
 
@@ -55,7 +52,7 @@ services.xserver.displayManager.select = "sddm";
             <emphasis>Thunar</emphasis>
             volume support, put
             <programlisting>
-services.xserver.desktopManager.xfce.enable = true;
+services.xserver.desktopManager.select = [ "xfce" ];
             </programlisting>
             into your <emphasis>configuration.nix</emphasis>.
         </para>

--- a/nixos/doc/manual/release-notes/rl-1709.xml
+++ b/nixos/doc/manual/release-notes/rl-1709.xml
@@ -89,6 +89,56 @@ rmdir /var/lib/ipfs/.ipfs
       The <literal>postgres</literal> default <literal>dataDir</literal> has changed from <literal>/var/db/postgres</literal> to <literal>/var/lib/postgresql/$psqlSchema</literal> where $psqlSchema is 9.6 for example.
     </para>
   </listitem>
+  <listitem>
+    <para>
+      The X server configuration interface changed, especially <literal>services.xserver.displayManager.*.enable</literal>,
+      <literal>services.xserver.windowManager.*.enable</literal> and <literal>services.xserver.desktopManager.*.enable</literal> options.
+      The <literal>services.xserver.desktopManager.default</literal> and <literal>services.xserver.windowManager.default</literal> have also
+      been removed.
+    </para>
+    <para>
+      <literal>services.xserver.displayManager.*.enable</literal> option was moved to <literal>services.xserver.displayManager.select</literal>
+      that has the <literal>nullOr enum</literal> type. The value of <literal>services.xserver.displayManager.select</literal> should be the name
+      of the used display manager. For example a configuration that was using:
+<programlisting>
+services.xserver.displayManager.lightdm.enable = true;
+</programlisting>
+      Should be changed to:
+<programlisting>
+services.xserver.displayManager.select = "lightdm";
+</programlisting>
+      Note: In case a desktop manager or a window manager is enabled, setting <literal>services.xserver.displayManager.select</literal> 
+      is optional. If it is not explicitely set, its value will be set accordingly to the default window or desktop manager.
+    </para>
+    <para>
+      <literal>services.xserver.windowManager.*.enable</literal> option was moved to <literal>services.xserver.windowManager.select</literal>
+      that has the <literal>listOf enum</literal> type. The value of <literal>services.xserver.displayManager.select</literal> should be set to a
+      list of the used window managers names. For example a configuration that was using:
+<programlisting>
+services.xserver.windowManager.i3.enable = true;
+</programlisting>
+      Should be changed to:
+<programlisting>
+services.xserver.windowManager.select = [ "i3" ];
+</programlisting>
+      Note: This option is a list because it is possible to enable multiple window managers at the same time.
+      If multiple window managers are set, the first in the list will become the default one.
+    </para>
+    <para>
+      <literal>services.xserver.desktopManager.*.enable</literal> option was moved to <literal>services.xserver.desktopManager.select</literal>
+      that has the <literal>listOf enum</literal> type. The value of <literal>services.xserver.desktopManager.select</literal> should be set to a
+      list of the used desktop managers names. For example a configuration that was using:
+<programlisting>
+services.xserver.desktopManager.plasma5.enable = true;
+</programlisting>
+      Should be changed to:
+<programlisting>
+services.xserver.desktopManager.select = [ "plasma5" ];
+</programlisting>
+      Note: This option is a list because it is possible to enable multiple desktop managers at the same time.
+      If multiple desktop managers are set, the first in the list will become the default one.
+    </para>
+  </listitem>
 </itemizedlist>
 
 

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -210,8 +210,7 @@ rec {
           virtualisation.memorySize = 1024;
           services.xserver.enable = true;
           services.xserver.displayManager.select = "auto";
-          services.xserver.windowManager.default = "icewm";
-          services.xserver.windowManager.icewm.enable = true;
+          services.xserver.windowManager.select = [ "icewm" ];
         };
     in
       runInMachine ({

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -212,7 +212,6 @@ rec {
           services.xserver.displayManager.select = "auto";
           services.xserver.windowManager.default = "icewm";
           services.xserver.windowManager.icewm.enable = true;
-          services.xserver.desktopManager.default = "none";
         };
     in
       runInMachine ({

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -209,8 +209,7 @@ rec {
           inherit require;
           virtualisation.memorySize = 1024;
           services.xserver.enable = true;
-          services.xserver.displayManager.slim.enable = false;
-          services.xserver.displayManager.auto.enable = true;
+          services.xserver.displayManager.select = "auto";
           services.xserver.windowManager.default = "icewm";
           services.xserver.windowManager.icewm.enable = true;
           services.xserver.desktopManager.default = "none";

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -16,8 +16,8 @@ with lib;
       defaultUser = "root";
       autoLogin = true;
     };
+    desktopManager.select = [ "gnome3" ];
     desktopManager.gnome3 = {
-      enable = true;
       extraGSettingsOverrides = ''
         [org.gnome.desktop.background]
         show-desktop-icons=true

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -11,8 +11,8 @@ with lib;
   services.xserver = {
     enable = true;
     # GDM doesn't start in virtual machines with ISO
+    displayManager.select = "slim";
     displayManager.slim = {
-      enable = true;
       defaultUser = "root";
       autoLogin = true;
     };

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
@@ -18,8 +18,8 @@ with lib;
       autoLogin = true;
     };
 
+    desktopManager.select = [ "plasma5" ];
     desktopManager.plasma5 = {
-      enable = true;
       enableQt4Support = false;
     };
 

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -607,7 +607,7 @@ $bootLoaderConfig
 
   # Enable the KDE Desktop Environment.
   # services.xserver.displayManager.select = "sddm";
-  # services.xserver.desktopManager.plasma5.enable = true;
+  # services.xserver.desktopManager.select = [ "plasma5" ];
 
   # Define a user account. Don't forget to set a password with ‘passwd’.
   # users.extraUsers.guest = {

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -606,7 +606,6 @@ $bootLoaderConfig
   # services.xserver.xkbOptions = "eurosign:e";
 
   # Enable the KDE Desktop Environment.
-  # services.xserver.displayManager.select = "sddm";
   # services.xserver.desktopManager.select = [ "plasma5" ];
 
   # Define a user account. Don't forget to set a password with ‘passwd’.

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -606,7 +606,7 @@ $bootLoaderConfig
   # services.xserver.xkbOptions = "eurosign:e";
 
   # Enable the KDE Desktop Environment.
-  # services.xserver.displayManager.sddm.enable = true;
+  # services.xserver.displayManager.select = "sddm";
   # services.xserver.desktopManager.plasma5.enable = true;
 
   # Define a user account. Don't forget to set a password with ‘passwd’.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -598,6 +598,15 @@
   ./services/x11/unclutter.nix
   ./services/x11/unclutter-xfixes.nix
   ./services/x11/desktop-managers/default.nix
+  ./services/x11/desktop-managers/enlightenment.nix
+  ./services/x11/desktop-managers/gnome3.nix
+  ./services/x11/desktop-managers/kodi.nix
+  ./services/x11/desktop-managers/lumina.nix
+  ./services/x11/desktop-managers/lxqt.nix
+  ./services/x11/desktop-managers/none.nix
+  ./services/x11/desktop-managers/plasma5.nix
+  ./services/x11/desktop-managers/xfce.nix
+  ./services/x11/desktop-managers/xterm.nix
   ./services/x11/display-managers/auto.nix
   ./services/x11/display-managers/default.nix
   ./services/x11/display-managers/gdm.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -620,16 +620,36 @@
   ./services/x11/hardware/wacom.nix
   ./services/x11/redshift.nix
   ./services/x11/urxvtd.nix
+  ./services/x11/window-managers/2bwm.nix
+  ./services/x11/window-managers/afterstep.nix
   ./services/x11/window-managers/awesome.nix
-  #./services/x11/window-managers/compiz.nix
-  ./services/x11/window-managers/default.nix
-  ./services/x11/window-managers/fluxbox.nix
-  ./services/x11/window-managers/icewm.nix
   ./services/x11/window-managers/bspwm.nix
+  ./services/x11/window-managers/clfswm.nix
+  ./services/x11/window-managers/compiz.nix
+  ./services/x11/window-managers/default.nix
+  ./services/x11/window-managers/dwm.nix
+  ./services/x11/window-managers/exwm.nix
+  ./services/x11/window-managers/fluxbox.nix
+  ./services/x11/window-managers/fvwm.nix
+  ./services/x11/window-managers/herbstluftwm.nix
+  ./services/x11/window-managers/i3.nix
+  ./services/x11/window-managers/icewm.nix
+  ./services/x11/window-managers/jwm.nix
   ./services/x11/window-managers/metacity.nix
+  ./services/x11/window-managers/mwm.nix
   ./services/x11/window-managers/none.nix
+  ./services/x11/window-managers/notion.nix
+  ./services/x11/window-managers/openbox.nix
+  ./services/x11/window-managers/oroborus.nix
+  ./services/x11/window-managers/pekwm.nix
+  ./services/x11/window-managers/qtile.nix
+  ./services/x11/window-managers/ratpoison.nix
+  ./services/x11/window-managers/sawfish.nix
+  ./services/x11/window-managers/spectrwm.nix
+  ./services/x11/window-managers/stumpwm.nix
   ./services/x11/window-managers/twm.nix
   ./services/x11/window-managers/windowlab.nix
+  ./services/x11/window-managers/windowmaker.nix
   ./services/x11/window-managers/wmii.nix
   ./services/x11/window-managers/xmonad.nix
   ./services/x11/xautolock.nix

--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -7,7 +7,7 @@
   services.xserver = {
     enable = true;
     displayManager.select = "sddm";
-    desktopManager.plasma5.enable = true;
+    desktopManager.select = [ "plasma5" ];
     synaptics.enable = true; # for touchpad support on many laptops
   };
 

--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -6,7 +6,7 @@
 {
   services.xserver = {
     enable = true;
-    displayManager.sddm.enable = true;
+    displayManager.select = "sddm";
     desktopManager.plasma5.enable = true;
     synaptics.enable = true; # for touchpad support on many laptops
   };

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -108,9 +108,6 @@ with lib;
 
     (mkRenamedOptionModule [ "services" "hostapd" "extraCfg" ] [ "services" "hostapd" "extraConfig" ])
 
-    # Enlightenment
-    (mkRenamedOptionModule [ "services" "xserver" "desktopManager" "e19" "enable" ] [ "services" "xserver" "desktopManager" "enlightenment" "enable" ])
-
     # Iodine
     (mkRenamedOptionModule [ "services" "iodined" "enable" ] [ "services" "iodine" "server" "enable" ])
     (mkRenamedOptionModule [ "services" "iodined" "domain" ] [ "services" "iodine" "server" "domain" ])

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -24,6 +24,8 @@ in
         default = [];
         description = ''
           Select which desktop manager to use.
+          Selecting a desktop manager will automatically enable the X server and a default display manager.
+          The First item in the list will be made the default window manager.
         '';
       };
 

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -14,17 +14,18 @@ let
 in
 
 {
-  # Note: the order in which desktop manager modules are imported here
-  # determines the default: later modules (if enabled) are preferred.
-  # E.g., if Plasma 5 is enabled, it supersedes xterm.
-  imports = [
-    ./none.nix ./xterm.nix ./xfce.nix ./plasma5.nix ./lumina.nix
-    ./lxqt.nix ./enlightenment.nix ./gnome3.nix ./kodi.nix
-  ];
 
   options = {
 
     services.xserver.desktopManager = {
+
+      select = mkOption {
+        type = with types; listOf (enum [ ]);
+        default = [];
+        description = ''
+          Select which desktop manager to use.
+        '';
+      };
 
       wallpaper = {
         mode = mkOption {
@@ -84,26 +85,6 @@ in
         };
       };
 
-      default = mkOption {
-        type = types.str;
-        default = "";
-        example = "none";
-        description = "Default desktop manager loaded if none have been chosen.";
-        apply = defaultDM:
-          if defaultDM == "" && cfg.session.list != [] then
-            (head cfg.session.list).name
-          else if any (w: w.name == defaultDM) cfg.session.list then
-            defaultDM
-          else
-            throw ''
-              Default desktop manager (${defaultDM}) not found.
-              Probably you want to change
-                services.xserver.desktopManager.default = "${defaultDM}";
-              to one of
-                ${concatMapStringsSep "\n  " (w: "services.xserver.desktopManager.default = \"${w.name}\";") cfg.session.list}
-            '';
-      };
-
     };
 
   };
@@ -113,4 +94,20 @@ in
     environment.systemPackages =
       mkIf cfg.session.needBGPackages [ pkgs.feh ]; # xsetroot via xserver.enable
   };
+
+  imports = [
+   # backward compatibility for pre extensible option types
+   (mkMergedOptionModule
+     (map
+       (dm: [ "services" "xserver" "desktopManager" dm "enable" ])
+       [ "elightenment" "gnome3" "kodi" "lumina" "lxqt" "plasma5" "xfce" "xterm" ])
+     [ "services" "xserver" "desktopManager" "select" ]
+     (config:
+       filter (dm:
+         (getAttrFromPath [ "services" "xserver" "desktopManager" dm "enable" ] config) == true
+       ) [ "elightenment" "gnome3" "kodi" "lumina" "lxqt" "plasma5" "xfce" "xterm" ]))
+
+    (mkRemovedOptionModule [ "services" "xserver" "desktopManager" "default" ]
+      "The default desktop manager is the first item of the services.xserver.desktopManager.select list.")
+  ];
 }

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -6,7 +6,7 @@ let
 
   e = pkgs.enlightenment;
   xcfg = config.services.xserver;
-  cfg = xcfg.desktopManager.enlightenment;
+  dmcfg = config.services.xserver.desktopManager;
   GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
     pkgs.gst_all_1.gst-plugins-base
     pkgs.gst_all_1.gst-plugins-good
@@ -18,14 +18,13 @@ in
 {
   options = {
 
-    services.xserver.desktopManager.enlightenment.enable = mkOption {
-      default = false;
-      description = "Enable the Enlightenment desktop environment.";
+    services.xserver.desktopManager.select = mkOption {
+      type = with types; listOf (enum [ "enlightenment" ]);
     };
 
   };
 
-  config = mkIf (xcfg.enable && cfg.enable) {
+  config = mkIf (elem "enlightenment" dmcfg.select) {
 
     environment.systemPackages = [
       e.efl e.enlightenment

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -3,6 +3,7 @@
 with lib;
 
 let
+  dmcfg = config.services.xserver.desktopManager;
   cfg = config.services.xserver.desktopManager.gnome3;
   gnome3 = config.environment.gnome3.packageSet;
 
@@ -50,11 +51,11 @@ in {
 
   options = {
 
+    services.xserver.desktopManager.select = mkOption {
+      type = with types; listOf (enum [ "gnome3" ]);
+    };
+
     services.xserver.desktopManager.gnome3 = {
-      enable = mkOption {
-        default = false;
-        description = "Enable Gnome 3 desktop manager.";
-      };
 
       sessionPath = mkOption {
         default = [];
@@ -95,7 +96,7 @@ in {
 
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "gnome3" dmcfg.select) {
 
     # Enable helpful DBus services.
     security.polkit.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -57,6 +57,12 @@ in {
 
     services.xserver.desktopManager.gnome3 = {
 
+      preferredDisplayManager = mkOption {
+        internal = true;
+        default = "gdm";
+        description = "Sets the preferred display manager for this desktop manager.";
+      };
+
       sessionPath = mkOption {
         default = [];
         example = literalExample "[ pkgs.gnome3.gpaste ]";

--- a/nixos/modules/services/x11/desktop-managers/kodi.nix
+++ b/nixos/modules/services/x11/desktop-managers/kodi.nix
@@ -3,20 +3,17 @@
 with lib;
 
 let
-  cfg = config.services.xserver.desktopManager.kodi;
+  dmcfg = config.services.xserver.desktopManager;
 in
 
 {
   options = {
-    services.xserver.desktopManager.kodi = {
-      enable = mkOption {
-        default = false;
-        description = "Enable the kodi multimedia center.";
-      };
+    services.xserver.desktopManager.select = mkOption {
+      type = with types; listOf (enum [ "kodi" ]);
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "kodi" dmcfg.select) {
     services.xserver.desktopManager.session = [{
       name = "kodi";
       start = ''

--- a/nixos/modules/services/x11/desktop-managers/lumina.nix
+++ b/nixos/modules/services/x11/desktop-managers/lumina.nix
@@ -4,24 +4,20 @@ with lib;
 
 let
 
-  xcfg = config.services.xserver;
-  cfg = xcfg.desktopManager.lumina;
+  dmcfg = config.services.xserver.desktopManager;
 
 in
 
 {
   options = {
 
-    services.xserver.desktopManager.lumina.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable the Lumina desktop manager";
+    services.xserver.desktopManager.select = mkOption {
+      type = with types; listOf (enum [ "lumina" ]);
     };
 
   };
 
-
-  config = mkIf (xcfg.enable && cfg.enable) {
+  config = mkIf (elem "lumina" dmcfg.select) {
 
     services.xserver.desktopManager.session = singleton {
       name = "lumina";

--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -13,6 +13,7 @@ let
       filter (x: !(builtins.elem (pkgName x) ysNames)) xs;
 
   xcfg = config.services.xserver;
+  dmcfg = xcfg.desktopManager;
   cfg = xcfg.desktopManager.lxqt;
 
 in
@@ -20,10 +21,8 @@ in
 {
   options = {
 
-    services.xserver.desktopManager.lxqt.enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Enable the LXQt desktop manager";
+    services.xserver.desktopManager.select = mkOption {
+      type = with types; listOf (enum [ "lxqt" ]);
     };
 
     environment.lxqt.excludePackages = mkOption {
@@ -35,7 +34,7 @@ in
 
   };
 
-  config = mkIf (xcfg.enable && cfg.enable) {
+  config = mkIf (elem "lxqt" dmcfg.select) {
 
     services.xserver.desktopManager.session = singleton {
       name = "lxqt";

--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -25,6 +25,12 @@ in
       type = with types; listOf (enum [ "lxqt" ]);
     };
 
+    services.xserver.desktopManager.lxqt.preferredDisplayManager = mkOption {
+      internal = true;
+      default = "sddm";
+      description = "Sets the preferred display manager for this desktop manager.";
+    };
+
     environment.lxqt.excludePackages = mkOption {
       default = [];
       example = literalExample "[ pkgs.lxqt.qterminal ]";

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -30,6 +30,12 @@ in
         '';
       };
 
+      preferredDisplayManager = mkOption {
+        internal = true;
+        default = "sddm";
+        description = "Sets the preferred display manager for this desktop manager.";
+      };
+
       extraPackages = mkOption {
         type = types.listOf types.package;
         default = [];

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
 
+  dmcfg = config.services.xserver.desktopManager;
   xcfg = config.services.xserver;
   cfg = xcfg.desktopManager.plasma5;
 
@@ -14,12 +15,11 @@ in
 {
   options = {
 
+    services.xserver.desktopManager.select = mkOption {
+      type = with types; listOf (enum [ "plasma5" ]);
+    };
+
     services.xserver.desktopManager.plasma5 = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable the Plasma 5 (KDE 5) desktop environment.";
-      };
 
       enableQt4Support = mkOption {
         type = types.bool;
@@ -48,7 +48,7 @@ in
       environment.systemPackages = [ (kdeWrapper cfg.extraPackages) ];
     })
 
-    (mkIf (xcfg.enable && cfg.enable) {
+    (mkIf (elem "plasma5" dmcfg.select) {
       services.xserver.desktopManager.session = singleton {
         name = "plasma5";
         bgSupport = true;

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -6,18 +6,18 @@ let
 
   xcfg = config.services.xserver;
   cfg = xcfg.desktopManager.xfce;
+  dmcfg = config.services.xserver.desktopManager;
 
 in
 
 {
   options = {
 
+    services.xserver.desktopManager.select = mkOption {
+      type = with types; listOf (enum [ "xfce" ]);
+    };
+
     services.xserver.desktopManager.xfce = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable the Xfce desktop environment.";
-      };
 
       thunarPlugins = mkOption {
         default = [];
@@ -58,7 +58,7 @@ in
   };
 
 
-  config = mkIf (xcfg.enable && cfg.enable) {
+  config = mkIf (elem "xfce" dmcfg.select) {
 
     services.xserver.desktopManager.session = singleton
       { name = "xfce";

--- a/nixos/modules/services/x11/desktop-managers/xterm.nix
+++ b/nixos/modules/services/x11/desktop-managers/xterm.nix
@@ -4,21 +4,20 @@ with lib;
 
 let
 
-  cfg = config.services.xserver.desktopManager.xterm;
+  dmcfg = config.services.xserver.desktopManager;
 
 in
 
 {
   options = {
 
-    services.xserver.desktopManager.xterm.enable = mkOption {
-      default = true;
-      description = "Enable a xterm terminal as a desktop manager.";
+    services.xserver.desktopManager.select = mkOption {
+      type = with types; listOf (enum [ "xterm" ]);
     };
 
   };
 
-  config = mkIf (config.services.xserver.enable && cfg.enable) {
+  config = mkIf (elem "xterm" dmcfg.select) {
 
     services.xserver.desktopManager.session = singleton
       { name = "xterm";

--- a/nixos/modules/services/x11/display-managers/auto.nix
+++ b/nixos/modules/services/x11/display-managers/auto.nix
@@ -15,17 +15,11 @@ in
 
   options = {
 
-    services.xserver.displayManager.auto = {
+    services.xserver.displayManager.select = mkOption {
+      type = with types; nullOr (enum [ "auto" ]);
+    };
 
-      enable = mkOption {
-        default = false;
-        description = ''
-          Whether to enable the fake "auto" display manager, which
-          automatically logs in the user specified in the
-          <option>user</option> option.  This is mostly useful for
-          automated tests.
-        '';
-      };
+    services.xserver.displayManager.auto = {
 
       user = mkOption {
         default = "root";
@@ -36,17 +30,12 @@ in
 
   };
 
-
-  ###### implementation
-
-  config = mkIf cfg.enable {
-
+  config = mkIf (dmcfg.select == "auto") {
     services.xserver.displayManager.slim = {
-      enable = true;
-      autoLogin = true;
+      enabled     = true;
+      autoLogin   = true;
       defaultUser = cfg.user;
     };
-
   };
 
 }

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -205,6 +205,14 @@ in
 
     services.xserver.displayManager = {
 
+      select = mkOption {
+        type = with types; nullOr (enum [ ]);
+        default = null;
+        description = ''
+          Select which display manager to use.
+        '';
+      };
+
       xauthBin = mkOption {
         internal = true;
         default = "${xorg.xauth}/bin/xauth";
@@ -343,6 +351,17 @@ in
   imports = [
    (mkRemovedOptionModule [ "services" "xserver" "displayManager" "desktopManagerHandlesLidAndPower" ]
      "The option is no longer necessary because all display managers have already delegated lid management to systemd.")
+
+   # backward compatibility for pre extensible option types
+   (mkMergedOptionModule
+     (map
+       (dm: [ "services" "xserver" "displayManager" dm "enable" ])
+       [ "auto" "gdm" "kdm" "lightdm" "sddm" "slim" ])
+     [ "services" "xserver" "displayManager" "select" ]
+     (config:
+       findFirst (dm:
+         (getAttrFromPath [ "services" "xserver" "displayManager" dm "enable" ] config) == true
+       ) null [ "auto" "gdm" "kdm" "lightdm" "sddm" "slim" ]))
   ];
 
 }

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -27,6 +27,10 @@ let
     Xft.hintstyle: hintslight
   '';
 
+  defaultDM =
+    if cfg.desktopManager.select == [] then "none"
+    else head cfg.desktopManager.select;
+
   # file provided by services.xserver.displayManager.session.script
   xsession = wm: dm: pkgs.writeScript "xsession"
     ''
@@ -140,7 +144,7 @@ let
       windowManager="''${sessionType##*+}"
       : ''${windowManager:=${cfg.windowManager.default}}
       desktopManager="''${sessionType%%+*}"
-      : ''${desktopManager:=${cfg.desktopManager.default}}
+      : ''${desktopManager:=${defaultDM}}
 
       # Start the window manager.
       case "$windowManager" in

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -205,6 +205,22 @@ let
       '') names}
     '';
 
+    /* Select a default display manager according to desktop manager or window
+       manager settings.
+       If the selected Dm or WM have an internal `preferredDisplayManager` option,
+       its value will be used.
+    */
+    defaultDisplayManager =
+      let
+        dmcfg = cfg.desktopManager;
+        wmcfg = cfg.windowManager;
+      in
+      if dmcfg.select != []
+         then attrByPath [ (head dmcfg.select) "preferredDisplayManager" ] "slim" dmcfg
+      else if wmcfg.select != []
+           then attrByPath [ (head wmcfg.select) "preferredDisplayManager" ] "slim" wmcfg
+      else null;
+
 in
 
 {
@@ -215,7 +231,7 @@ in
 
       select = mkOption {
         type = with types; nullOr (enum [ ]);
-        default = null;
+        default = defaultDisplayManager;
         description = ''
           Select which display manager to use.
         '';

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -221,6 +221,13 @@ in
         '';
       };
 
+      defaultSessionName = mkOption {
+        type = types.str;
+        default = "${defaultDM}+${defaultWM}";
+        internal = true;
+        description = "Name of the default session.";
+      };
+
       xauthBin = mkOption {
         internal = true;
         default = "${xorg.xauth}/bin/xauth";

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -31,6 +31,10 @@ let
     if cfg.desktopManager.select == [] then "none"
     else head cfg.desktopManager.select;
 
+  defaultWM =
+    if cfg.windowManager.select == [] then "none"
+    else head cfg.windowManager.select;
+
   # file provided by services.xserver.displayManager.session.script
   xsession = wm: dm: pkgs.writeScript "xsession"
     ''
@@ -142,7 +146,7 @@ let
       # extract those (see:
       # http://wiki.bash-hackers.org/syntax/pe#substring_removal).
       windowManager="''${sessionType##*+}"
-      : ''${windowManager:=${cfg.windowManager.default}}
+      : ''${windowManager:=${defaultWM}}
       desktopManager="''${sessionType%%+*}"
       : ''${desktopManager:=${defaultDM}}
 

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -16,14 +16,11 @@ in
 
   options = {
 
-    services.xserver.displayManager.gdm = {
+    services.xserver.displayManager.select = mkOption {
+      type = with types; nullOr (enum [ "gdm" ]);
+    };
 
-      enable = mkEnableOption ''
-        GDM as the display manager.
-        <emphasis>GDM in NixOS is not well-tested with desktops other
-        than GNOME, so use with caution, as it could render the
-        system unusable.</emphasis>
-      '';
+    services.xserver.displayManager.gdm = {
 
       debug = mkEnableOption ''
         debugging messages in GDM
@@ -72,15 +69,13 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.gdm.enable {
+  config = mkIf (cfg.select == "gdm") {
 
     assertions = [
       { assertion = cfg.gdm.autoLogin.enable -> cfg.gdm.autoLogin.user != null;
         message = "GDM auto-login requires services.xserver.displayManager.gdm.autoLogin.user to be set";
       }
     ];
-
-    services.xserver.displayManager.slim.enable = false;
 
     users.extraUsers.gdm =
       { name = "gdm";

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -117,7 +117,7 @@ in
 
   };
 
-  config = mkIf (ldmcfg.enable && cfg.enable) {
+  config = mkIf ((dmcfg.select == "lightdm") && cfg.enable) {
 
     services.xserver.displayManager.lightdm.greeter = mkDefault {
       package = wrappedGtkGreeter;

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -73,15 +73,11 @@ in
 
   options = {
 
-    services.xserver.displayManager.lightdm = {
+    services.xserver.displayManager.select = mkOption {
+      type = with types; nullOr (enum [ "lightdm" ]);
+    };
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable lightdm as the display manager.
-        '';
-      };
+    services.xserver.displayManager.lightdm = {
 
       greeter =  {
         enable = mkOption {
@@ -164,7 +160,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (dmcfg.select == "lightdm") {
 
     assertions = [
       { assertion = cfg.autoLogin.enable -> cfg.autoLogin.user != null;
@@ -186,8 +182,6 @@ in
         '';
       }
     ];
-
-    services.xserver.displayManager.slim.enable = false;
 
     services.xserver.displayManager.job = {
       logsXsession = true;

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -52,16 +52,11 @@ let
       ${optionalString cfg.autoLogin.enable ''
         autologin-user = ${cfg.autoLogin.user}
         autologin-user-timeout = ${toString cfg.autoLogin.timeout}
-        autologin-session = ${defaultSessionName}
+        autologin-session = ${dmcfg.defaultSessionName}
       ''}
       ${cfg.extraSeatDefaults}
     '';
 
-  defaultSessionName =
-    let
-      dm = xcfg.desktopManager.default;
-      wm = xcfg.windowManager.default;
-    in dm + optionalString (wm != "none") ("+" + wm);
 in
 {
   # Note: the order in which lightdm greeter modules are imported
@@ -166,13 +161,6 @@ in
       { assertion = cfg.autoLogin.enable -> cfg.autoLogin.user != null;
         message = ''
           LightDM auto-login requires services.xserver.displayManager.lightdm.autoLogin.user to be set
-        '';
-      }
-      { assertion = cfg.autoLogin.enable -> elem defaultSessionName dmcfg.session.names;
-        message = ''
-          LightDM auto-login requires that services.xserver.desktopManager.default and
-          services.xserver.windowMananger.default are set to valid values. The current
-          default session: ${defaultSessionName} is not valid.
         '';
       }
       { assertion = !cfg.greeter.enable -> (cfg.autoLogin.enable && cfg.autoLogin.timeout == 0);

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -58,18 +58,12 @@ let
     ${optionalString cfg.autoLogin.enable ''
     [Autologin]
     User=${cfg.autoLogin.user}
-    Session=${defaultSessionName}.desktop
+    Session=${dmcfg.defaultSessionName}.desktop
     Relogin=${boolToString cfg.autoLogin.relogin}
     ''}
 
     ${cfg.extraConfig}
   '';
-
-  defaultSessionName =
-    let
-      dm = xcfg.desktopManager.default;
-      wm = xcfg.windowManager.default;
-    in dm + optionalString (wm != "none") ("+" + wm);
 
 in
 {
@@ -185,13 +179,6 @@ in
       { assertion = cfg.autoLogin.enable -> cfg.autoLogin.user != null;
         message = ''
           SDDM auto-login requires services.xserver.displayManager.sddm.autoLogin.user to be set
-        '';
-      }
-      { assertion = cfg.autoLogin.enable -> elem defaultSessionName dmcfg.session.names;
-        message = ''
-          SDDM auto-login requires that services.xserver.desktopManager.default and
-          services.xserver.windowMananger.default are set to valid values. The current
-          default session: ${defaultSessionName} is not valid.
         '';
       }
     ];

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -75,15 +75,11 @@ in
 {
   options = {
 
-    services.xserver.displayManager.sddm = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable sddm as the display manager.
-        '';
-      };
+    services.xserver.displayManager.select = mkOption {
+      type = with types; nullOr (enum [ "sddm" ]);
+    };
 
+    services.xserver.displayManager.sddm = {
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -183,7 +179,7 @@ in
 
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (dmcfg.select == "sddm") {
 
     assertions = [
       { assertion = cfg.autoLogin.enable -> cfg.autoLogin.user != null;
@@ -199,8 +195,6 @@ in
         '';
       }
     ];
-
-    services.xserver.displayManager.slim.enable = false;
 
     services.xserver.displayManager.job = {
       logsXsession = true;

--- a/nixos/modules/services/x11/display-managers/slim.nix
+++ b/nixos/modules/services/x11/display-managers/slim.nix
@@ -45,13 +45,19 @@ in
 
   options = {
 
+    services.xserver.displayManager.select = mkOption {
+      type = with types; nullOr (enum [ "slim" ]);
+      example = "slim";
+    };
+
     services.xserver.displayManager.slim = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = config.services.xserver.enable;
+      enabled = mkOption {
+        type     = types.bool;
+        internal = true;
+        default  = dmcfg.select == "slim";
         description = ''
-          Whether to enable SLiM as the display manager.
+          Option to abstract slim usage.
         '';
       };
 
@@ -126,7 +132,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = mkIf dmcfg.slim.enabled {
 
     services.xserver.displayManager.job =
       { environment =

--- a/nixos/modules/services/x11/terminal-server.nix
+++ b/nixos/modules/services/x11/terminal-server.nix
@@ -17,7 +17,7 @@ with lib;
     services.xserver.videoDrivers = [];
 
     # Enable GDM.  Any display manager will do as long as it supports XDMCP.
-    services.xserver.displayManager.gdm.enable = true;
+    services.xserver.displayManager.select = "gdm";
 
     systemd.sockets.terminal-server =
       { description = "Terminal Server Socket";

--- a/nixos/modules/services/x11/window-managers/2bwm.nix
+++ b/nixos/modules/services/x11/window-managers/2bwm.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
 
-  cfg = config.services.xserver.windowManager."2bwm";
+  wmcfg = config.services.xserver.windowManager;
 
 in
 
@@ -13,13 +13,15 @@ in
   ###### interface
 
   options = {
-    services.xserver.windowManager."2bwm".enable = mkEnableOption "2bwm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "2bwm" ]);
+    };
   };
 
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "2bwm" wmcfg.select) {
 
     services.xserver.windowManager.session = singleton
       { name = "2bwm";

--- a/nixos/modules/services/x11/window-managers/afterstep.nix
+++ b/nixos/modules/services/x11/window-managers/afterstep.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.afterstep;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.afterstep.enable = mkEnableOption "afterstep";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "afterstep" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "afterstep" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "afterstep";
       start = ''

--- a/nixos/modules/services/x11/window-managers/awesome.nix
+++ b/nixos/modules/services/x11/window-managers/awesome.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-
+  wmcfg = config.services.xserver.windowManager;
   cfg = config.services.xserver.windowManager.awesome;
   awesome = cfg.package;
   inherit (pkgs.luaPackages) getLuaPath getLuaCPath;
@@ -15,9 +15,11 @@ in
 
   options = {
 
-    services.xserver.windowManager.awesome = {
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "awesome" ]);
+    };
 
-      enable = mkEnableOption "Awesome window manager";
+    services.xserver.windowManager.awesome = {
 
       luaModules = mkOption {
         default = [];
@@ -40,7 +42,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "awesome" wmcfg.select) {
 
     services.xserver.windowManager.session = singleton
       { name = "awesome";

--- a/nixos/modules/services/x11/window-managers/bspwm.nix
+++ b/nixos/modules/services/x11/window-managers/bspwm.nix
@@ -3,14 +3,17 @@
 with lib;
 
 let
+  wmcfg = config.services.xserver.windowManager;
   cfg = config.services.xserver.windowManager.bspwm;
 in
 
 {
   options = {
-    services.xserver.windowManager.bspwm = {
-      enable = mkEnableOption "bspwm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "bspwm" ]);
+    };
 
+    services.xserver.windowManager.bspwm = {
       package = mkOption {
         type        = types.package;
         default     = pkgs.bspwm;
@@ -53,7 +56,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "bspwm" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name  = "bspwm";
       start = ''

--- a/nixos/modules/services/x11/window-managers/clfswm.nix
+++ b/nixos/modules/services/x11/window-managers/clfswm.nix
@@ -3,15 +3,17 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.clfswm;
+  wmcfg = config.services.xserver.windowManager;
 in
 
 {
   options = {
-    services.xserver.windowManager.clfswm.enable = mkEnableOption "clfswm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "clfswm" ]);
+    };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "clfswm" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "clfswm";
       start = ''

--- a/nixos/modules/services/x11/window-managers/compiz.nix
+++ b/nixos/modules/services/x11/window-managers/compiz.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
 
+  wmcfg = config.services.xserver.windowManager;
   cfg = config.services.xserver.windowManager.compiz;
   xorg = config.services.xserver.package;
 
@@ -13,9 +14,11 @@ in
 
   options = {
 
-    services.xserver.windowManager.compiz = {
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "compiz" ]);
+    };
 
-      enable = mkEnableOption "compiz";
+    services.xserver.windowManager.compiz = {
 
       renderingFlag = mkOption {
         default = "";
@@ -28,7 +31,7 @@ in
   };
 
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "compiz" wmcfg.select) {
 
     services.xserver.windowManager.session = singleton
       { name = "compiz";

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -17,7 +17,7 @@ in
         default = [];
         description = ''
           Select which window manager to use.
-          Selecting a window manager will automatically enable the X server.
+          Selecting a window manager will automatically enable the X server and a default display manager.
           The First item in the list will be made the default window manager.
         '';
       };

--- a/nixos/modules/services/x11/window-managers/dwm.nix
+++ b/nixos/modules/services/x11/window-managers/dwm.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
 
-  cfg = config.services.xserver.windowManager.dwm;
+  wmcfg = config.services.xserver.windowManager;
 
 in
 
@@ -13,13 +13,15 @@ in
   ###### interface
 
   options = {
-    services.xserver.windowManager.dwm.enable = mkEnableOption "dwm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "dwm" ]);
+    };
   };
 
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "bspwm" wmcfg.select) {
 
     services.xserver.windowManager.session = singleton
       { name = "dwm";

--- a/nixos/modules/services/x11/window-managers/exwm.nix
+++ b/nixos/modules/services/x11/window-managers/exwm.nix
@@ -3,6 +3,7 @@
 with lib;
 
 let
+  wmcfg = config.services.xserver.windowManager;
   cfg = config.services.xserver.windowManager.exwm;
   loadScript = pkgs.writeText "emacs-exwm-load" ''
     (require 'exwm)
@@ -17,8 +18,11 @@ in
 
 {
   options = {
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "exwm" ]);
+    };
+
     services.xserver.windowManager.exwm = {
-      enable = mkEnableOption "exwm";
       enableDefaultConfig = mkOption {
         default = true;
         type = lib.types.bool;
@@ -42,7 +46,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "exwm" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "exwm";
       start = ''

--- a/nixos/modules/services/x11/window-managers/fluxbox.nix
+++ b/nixos/modules/services/x11/window-managers/fluxbox.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.fluxbox;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.fluxbox.enable = mkEnableOption "fluxbox";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "fluxbox" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "fluxbox" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "fluxbox";
       start = ''

--- a/nixos/modules/services/x11/window-managers/fvwm.nix
+++ b/nixos/modules/services/x11/window-managers/fvwm.nix
@@ -3,6 +3,7 @@
 with lib;
 
 let
+  wmcfg = config.services.xserver.windowManager;
   cfg = config.services.xserver.windowManager.fvwm;
   fvwm = pkgs.fvwm.override { gestures = cfg.gestures; };
 in
@@ -12,9 +13,11 @@ in
   ###### interface
 
   options = {
-    services.xserver.windowManager.fvwm = {
-      enable = mkEnableOption "Fvwm window manager";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "fvwm" ]);
+    };
 
+    services.xserver.windowManager.fvwm = {
       gestures = mkOption {
         default = false;
         type = types.bool;
@@ -26,7 +29,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "fvwm" wmcfg.select) {
     services.xserver.windowManager.session = singleton
       { name = "fvwm";
         start =

--- a/nixos/modules/services/x11/window-managers/herbstluftwm.nix
+++ b/nixos/modules/services/x11/window-managers/herbstluftwm.nix
@@ -3,14 +3,17 @@
 with lib;
 
 let
+  wmcfg = config.services.xserver.windowManager;
   cfg = config.services.xserver.windowManager.herbstluftwm;
 in
 
 {
   options = {
-    services.xserver.windowManager.herbstluftwm = {
-      enable = mkEnableOption "herbstluftwm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "herbstluftwm" ]);
+    };
 
+    services.xserver.windowManager.herbstluftwm = {
       configFile = mkOption {
         default     = null;
         type        = with types; nullOr path;
@@ -23,7 +26,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "herbstluftwm" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "herbstluftwm";
       start =

--- a/nixos/modules/services/x11/window-managers/i3.nix
+++ b/nixos/modules/services/x11/window-managers/i3.nix
@@ -3,13 +3,16 @@
 with lib;
 
 let
+  wmcfg = config.services.xserver.windowManager;
   cfg = config.services.xserver.windowManager.i3;
 in
 
 {
-  options.services.xserver.windowManager.i3 = {
-    enable = mkEnableOption "i3 window manager";
+  options.services.xserver.windowManager.select = mkOption {
+    type = with types; listOf (enum [ "i3" ]);
+  };
 
+  options.services.xserver.windowManager.i3 = {
     configFile = mkOption {
       default     = null;
       type        = with types; nullOr path;
@@ -53,7 +56,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "i3" wmcfg.select) {
     services.xserver.windowManager.session = [{
       name  = "i3";
       start = ''

--- a/nixos/modules/services/x11/window-managers/icewm.nix
+++ b/nixos/modules/services/x11/window-managers/icewm.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.icewm;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.icewm.enable = mkEnableOption "icewm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "icewm" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "icewm" wmcfg.select) {
     services.xserver.windowManager.session = singleton
       { name = "icewm";
         start =

--- a/nixos/modules/services/x11/window-managers/jwm.nix
+++ b/nixos/modules/services/x11/window-managers/jwm.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.jwm;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.jwm.enable = mkEnableOption "jwm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "jwm" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "jwm" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "jwm";
       start = ''

--- a/nixos/modules/services/x11/window-managers/metacity.nix
+++ b/nixos/modules/services/x11/window-managers/metacity.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
 
+  wmcfg = config.services.xserver.windowManager;
   cfg = config.services.xserver.windowManager.metacity;
   xorg = config.services.xserver.package;
   gnome = pkgs.gnome;
@@ -12,10 +13,12 @@ in
 
 {
   options = {
-    services.xserver.windowManager.metacity.enable = mkEnableOption "metacity";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "metacity" ]);
+    };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "metacity" wmcfg.select) {
 
     services.xserver.windowManager.session = singleton
       { name = "metacity";

--- a/nixos/modules/services/x11/window-managers/mwm.nix
+++ b/nixos/modules/services/x11/window-managers/mwm.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.mwm;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.mwm.enable = mkEnableOption "mwm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "mwm" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "mwm" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "mwm";
       start = ''

--- a/nixos/modules/services/x11/window-managers/notion.nix
+++ b/nixos/modules/services/x11/window-managers/notion.nix
@@ -3,15 +3,17 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.notion;
+  wmcfg = config.services.xserver.windowManager;
 in
 
 {
   options = {
-    services.xserver.windowManager.notion.enable = mkEnableOption "notion";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "notion" ]);
+    };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "notion" wmcfg.select) {
     services.xserver.windowManager = {
       session = [{
         name = "notion";

--- a/nixos/modules/services/x11/window-managers/openbox.nix
+++ b/nixos/modules/services/x11/window-managers/openbox.nix
@@ -3,15 +3,17 @@
 with lib;
 let
   inherit (lib) mkOption mkIf;
-  cfg = config.services.xserver.windowManager.openbox;
+  wmcfg = config.services.xserver.windowManager;
 in
 
 {
   options = {
-    services.xserver.windowManager.openbox.enable = mkEnableOption "openbox";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "openbox" ]);
+    };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "openbox" wmcfg.select) {
     services.xserver.windowManager = {
       session = [{
         name = "openbox";

--- a/nixos/modules/services/x11/window-managers/oroborus.nix
+++ b/nixos/modules/services/x11/window-managers/oroborus.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.oroborus;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.oroborus.enable = mkEnableOption "oroborus";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "oroborus" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "oroborus" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "oroborus";
       start = ''

--- a/nixos/modules/services/x11/window-managers/pekwm.nix
+++ b/nixos/modules/services/x11/window-managers/pekwm.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.pekwm;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.pekwm.enable = mkEnableOption "pekwm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "pekwm" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "pekwm" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "pekwm";
       start = ''

--- a/nixos/modules/services/x11/window-managers/qtile.nix
+++ b/nixos/modules/services/x11/window-managers/qtile.nix
@@ -3,15 +3,17 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.qtile;
+  wmcfg = config.services.xserver.windowManager;
 in
 
 {
   options = {
-    services.xserver.windowManager.qtile.enable = mkEnableOption "qtile";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "qtile" ]);
+    };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "qtile" wmcfg.select) {
     services.xserver.windowManager.session = [{
       name = "qtile";
       start = ''

--- a/nixos/modules/services/x11/window-managers/ratpoison.nix
+++ b/nixos/modules/services/x11/window-managers/ratpoison.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.ratpoison;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.ratpoison.enable = mkEnableOption "ratpoison";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "ratpoison" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "ratpoison" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "ratpoison";
       start = ''

--- a/nixos/modules/services/x11/window-managers/sawfish.nix
+++ b/nixos/modules/services/x11/window-managers/sawfish.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.sawfish;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.sawfish.enable = mkEnableOption "sawfish";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "sawfish" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "sawfish" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "sawfish";
       start = ''

--- a/nixos/modules/services/x11/window-managers/spectrwm.nix
+++ b/nixos/modules/services/x11/window-managers/spectrwm.nix
@@ -4,15 +4,17 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.spectrwm;
+  wmcfg = config.services.xserver.windowManager;
 in
 
 {
   options = {
-    services.xserver.windowManager.spectrwm.enable = mkEnableOption "spectrwm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "spectrwm" ]);
+    };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "spectrwm" wmcfg.select) {
     services.xserver.windowManager = {
       session = [{
         name = "spectrwm";

--- a/nixos/modules/services/x11/window-managers/stumpwm.nix
+++ b/nixos/modules/services/x11/window-managers/stumpwm.nix
@@ -3,15 +3,17 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.stumpwm;
+  wmcfg = config.services.xserver.windowManager;
 in
 
 {
   options = {
-    services.xserver.windowManager.stumpwm.enable = mkEnableOption "stumpwm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "stumpwm" ]);
+    };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "stumpwm" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "stumpwm";
       start = ''

--- a/nixos/modules/services/x11/window-managers/twm.nix
+++ b/nixos/modules/services/x11/window-managers/twm.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
 
-  cfg = config.services.xserver.windowManager.twm;
+  wmcfg = config.services.xserver.windowManager;
 
 in
 
@@ -13,13 +13,15 @@ in
   ###### interface
 
   options = {
-    services.xserver.windowManager.twm.enable = mkEnableOption "twm";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "twm" ]);
+    };
   };
 
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "twm" wmcfg.select) {
 
     services.xserver.windowManager.session = singleton
       { name = "twm";

--- a/nixos/modules/services/x11/window-managers/windowlab.nix
+++ b/nixos/modules/services/x11/window-managers/windowlab.nix
@@ -1,16 +1,18 @@
 {lib, pkgs, config, ...}:
 
+with lib;
 let
-  cfg = config.services.xserver.windowManager.windowlab;
+  wmcfg = config.services.xserver.windowManager;
 in
 
 {
   options = {
-    services.xserver.windowManager.windowlab.enable =
-      lib.mkEnableOption "windowlab";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "windowlab" ]);
+    };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = mkIf (elem "windowlab" wmcfg.select) {
     services.xserver.windowManager = {
       session =
         [{ name  = "windowlab";

--- a/nixos/modules/services/x11/window-managers/windowmaker.nix
+++ b/nixos/modules/services/x11/window-managers/windowmaker.nix
@@ -3,16 +3,18 @@
 with lib;
 
 let
-  cfg = config.services.xserver.windowManager.windowmaker;
+  wmcfg = config.services.xserver.windowManager;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.windowmaker.enable = mkEnableOption "windowmaker";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "windowmaker" ]);
+    };
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = mkIf (elem "windowmaker" wmcfg.select) {
     services.xserver.windowManager.session = singleton {
       name = "windowmaker";
       start = ''

--- a/nixos/modules/services/x11/window-managers/wmii.nix
+++ b/nixos/modules/services/x11/window-managers/wmii.nix
@@ -3,15 +3,17 @@
 with lib;
 let
   inherit (lib) mkOption mkIf singleton;
-  cfg = config.services.xserver.windowManager.wmii;
+  wmcfg = config.services.xserver.windowManager;
   wmii = pkgs.wmii_hg;
 in
 {
   options = {
-    services.xserver.windowManager.wmii.enable = mkEnableOption "wmii";
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "wmii" ]);
+    };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (elem "wmii" wmcfg.select) {
     services.xserver.windowManager.session = singleton
       # stop wmii by
       #   $wmiir xwrite /ctl quit

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -3,6 +3,7 @@
 with lib;
 let
   inherit (lib) mkOption mkIf optionals literalExample;
+  wmcfg = config.services.xserver.windowManager;
   cfg = config.services.xserver.windowManager.xmonad;
   xmonad = pkgs.xmonad-with-packages.override {
     ghcWithPackages = cfg.haskellPackages.ghcWithPackages;
@@ -13,8 +14,11 @@ let
 in
 {
   options = {
+    services.xserver.windowManager.select = mkOption {
+      type = with types; listOf (enum [ "xmonad" ]);
+    };
+
     services.xserver.windowManager.xmonad = {
-      enable = mkEnableOption "xmonad";
       haskellPackages = mkOption {
         default = pkgs.haskellPackages;
         defaultText = "pkgs.haskellPackages";
@@ -49,7 +53,8 @@ in
       };
     };
   };
-  config = mkIf cfg.enable {
+
+  config = mkIf (elem "xmonad" wmcfg.select) {
     services.xserver.windowManager = {
       session = [{
         name = "xmonad";

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -516,6 +516,8 @@ in
 
   config = mkIf cfg.enable {
 
+    services.xserver.displayManager.select = mkDefault "slim";
+
     hardware.opengl.enable = mkDefault true;
 
     services.xserver.videoDrivers = mkIf (cfg.videoDriver != null) [ cfg.videoDriver ];

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -155,7 +155,7 @@ in
 
       enable = mkOption {
         type = types.bool;
-        default = false;
+        default = cfg.displayManager != null;
         description = ''
           Whether to enable the X server.
         '';
@@ -515,8 +515,6 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-
-    services.xserver.displayManager.select = mkDefault "slim";
 
     hardware.opengl.enable = mkDefault true;
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -332,12 +332,12 @@ in rec {
     kde = makeClosure ({ pkgs, ... }:
       { services.xserver.enable = true;
         services.xserver.displayManager.select = "sddm";
-        services.xserver.desktopManager.plasma5.enable = true;
+        services.xserver.desktopManager.select = [ "plasma5" ];
       });
 
     xfce = makeClosure ({ pkgs, ... }:
       { services.xserver.enable = true;
-        services.xserver.desktopManager.xfce.enable = true;
+        services.xserver.desktopManager.select = [ "xfce" ];
       });
 
     # Linux/Apache/PostgreSQL/PHP stack.

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -331,7 +331,7 @@ in rec {
 
     kde = makeClosure ({ pkgs, ... }:
       { services.xserver.enable = true;
-        services.xserver.displayManager.sddm.enable = true;
+        services.xserver.displayManager.select = "sddm";
         services.xserver.desktopManager.plasma5.enable = true;
       });
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -330,13 +330,13 @@ in rec {
       });
 
     kde = makeClosure ({ pkgs, ... }:
-      { services.xserver.enable = true;
+      { 
         services.xserver.displayManager.select = "sddm";
         services.xserver.desktopManager.select = [ "plasma5" ];
       });
 
     xfce = makeClosure ({ pkgs, ... }:
-      { services.xserver.enable = true;
+      {
         services.xserver.desktopManager.select = [ "xfce" ];
       });
 

--- a/nixos/tests/common/x11.nix
+++ b/nixos/tests/common/x11.nix
@@ -7,6 +7,4 @@
   services.xserver.windowManager.default = "icewm";
   services.xserver.windowManager.icewm.enable = true;
 
-  # Don't use a desktop manager.
-  services.xserver.desktopManager.default = "none";
 }

--- a/nixos/tests/common/x11.nix
+++ b/nixos/tests/common/x11.nix
@@ -1,7 +1,7 @@
 { services.xserver.enable = true;
 
   # Automatically log in.
-  services.xserver.displayManager.auto.enable = true;
+  services.xserver.displayManager.select = "auto";
 
   # Use IceWM as the window manager.
   services.xserver.windowManager.default = "icewm";

--- a/nixos/tests/common/x11.nix
+++ b/nixos/tests/common/x11.nix
@@ -4,7 +4,6 @@
   services.xserver.displayManager.select = "auto";
 
   # Use IceWM as the window manager.
-  services.xserver.windowManager.default = "icewm";
-  services.xserver.windowManager.icewm.enable = true;
+  services.xserver.windowManager.select = [ "icewm" ];
 
 }

--- a/nixos/tests/common/x11.nix
+++ b/nixos/tests/common/x11.nix
@@ -1,9 +1,7 @@
-{ services.xserver.enable = true;
-
+{ 
   # Automatically log in.
   services.xserver.displayManager.select = "auto";
 
   # Use IceWM as the window manager.
   services.xserver.windowManager.select = [ "icewm" ];
-
 }

--- a/nixos/tests/gnome3-gdm.nix
+++ b/nixos/tests/gnome3-gdm.nix
@@ -9,8 +9,6 @@ import ./make-test.nix ({ pkgs, ...} : {
 
     { imports = [ ./common/user-account.nix ];
 
-      services.xserver.enable = true;
-
       services.xserver.displayManager.select = "gdm";
       services.xserver.displayManager.gdm = {
         autoLogin = {

--- a/nixos/tests/gnome3-gdm.nix
+++ b/nixos/tests/gnome3-gdm.nix
@@ -18,7 +18,7 @@ import ./make-test.nix ({ pkgs, ...} : {
           user = "alice";
         };
       };
-      services.xserver.desktopManager.gnome3.enable = true;
+      services.xserver.desktopManager.select = [ "gnome3" ];
 
       virtualisation.memorySize = 512;
     };

--- a/nixos/tests/gnome3-gdm.nix
+++ b/nixos/tests/gnome3-gdm.nix
@@ -11,9 +11,8 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       services.xserver.enable = true;
 
-      services.xserver.displayManager.slim.enable = false;
+      services.xserver.displayManager.select = "gdm";
       services.xserver.displayManager.gdm = {
-        enable = true;
         autoLogin = {
           enable = true;
           user = "alice";

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -11,7 +11,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       services.xserver.enable = true;
 
-      services.xserver.displayManager.auto.enable = true;
+      services.xserver.displayManager.select = "auto";
       services.xserver.displayManager.auto.user = "alice";
       services.xserver.desktopManager.gnome3.enable = true;
 

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -9,8 +9,6 @@ import ./make-test.nix ({ pkgs, ...} : {
 
     { imports = [ ./common/user-account.nix ];
 
-      services.xserver.enable = true;
-
       services.xserver.displayManager.select = "auto";
       services.xserver.displayManager.auto.user = "alice";
       services.xserver.desktopManager.select = [ "gnome3" ];

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -13,7 +13,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       services.xserver.displayManager.select = "auto";
       services.xserver.displayManager.auto.user = "alice";
-      services.xserver.desktopManager.gnome3.enable = true;
+      services.xserver.desktopManager.select = [ "gnome3" ];
 
       virtualisation.memorySize = 512;
     };

--- a/nixos/tests/i3wm.nix
+++ b/nixos/tests/i3wm.nix
@@ -5,7 +5,8 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   machine = { lib, pkgs, ... }: {
-    imports = [ ./common/x11.nix ./common/user-account.nix ];
+    imports = [ ./common/user-account.nix ];
+    services.xserver.displayManager.select = "auto";
     services.xserver.displayManager.auto.user = "alice";
     services.xserver.windowManager.select = [ "i3" ];
   };

--- a/nixos/tests/i3wm.nix
+++ b/nixos/tests/i3wm.nix
@@ -7,8 +7,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   machine = { lib, pkgs, ... }: {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
     services.xserver.displayManager.auto.user = "alice";
-    services.xserver.windowManager.default = lib.mkForce "i3";
-    services.xserver.windowManager.i3.enable = true;
+    services.xserver.windowManager.select = [ "i3" ];
   };
 
   testScript = { nodes, ... }: ''

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -8,8 +8,7 @@ import ./make-test.nix ({ pkgs, ...} : {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
     services.xserver.displayManager.select = "lightdm";
-    services.xserver.windowManager.default = "icewm";
-    services.xserver.windowManager.icewm.enable = true;
+    services.xserver.windowManager.select = [ "icewm " ];
   };
 
   enableOCR = true;

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -10,7 +10,6 @@ import ./make-test.nix ({ pkgs, ...} : {
     services.xserver.displayManager.select = "lightdm";
     services.xserver.windowManager.default = "icewm";
     services.xserver.windowManager.icewm.enable = true;
-    services.xserver.desktopManager.default = "none";
   };
 
   enableOCR = true;

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -6,9 +6,8 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   machine = { lib, ... }: {
     imports = [ ./common/user-account.nix ];
-    services.xserver.enable = true;
     services.xserver.displayManager.select = "lightdm";
-    services.xserver.windowManager.select = [ "icewm " ];
+    services.xserver.windowManager.select = [ "icewm" ];
   };
 
   enableOCR = true;

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -7,7 +7,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   machine = { lib, ... }: {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
-    services.xserver.displayManager.lightdm.enable = true;
+    services.xserver.displayManager.select = "lightdm";
     services.xserver.windowManager.default = "icewm";
     services.xserver.windowManager.icewm.enable = true;
     services.xserver.desktopManager.default = "none";

--- a/nixos/tests/phabricator.nix
+++ b/nixos/tests/phabricator.nix
@@ -54,7 +54,7 @@ import ./make-test.nix ({ pkgs, ... }: {
     client =
       { config, pkgs, ... }:
       { imports = [ ./common/x11.nix ];
-        services.xserver.desktopManager.plasma5.enable = true;
+        services.xserver.desktopManager.select = [ "plasma5" ];
       };
   };
 

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -8,7 +8,6 @@ import ./make-test.nix ({ pkgs, ...} :
 
   machine = { lib, ... }: {
     imports = [ ./common/user-account.nix ];
-    services.xserver.enable = true;
     services.xserver.displayManager.select = "sddm";
     services.xserver.desktopManager.select = [ "plasma5" ];
     virtualisation.memorySize = 1024;

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -9,7 +9,7 @@ import ./make-test.nix ({ pkgs, ...} :
   machine = { lib, ... }: {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
-    services.xserver.displayManager.sddm.enable = true;
+    services.xserver.displayManager.select = "sddm";
     services.xserver.desktopManager.plasma5.enable = true;
     services.xserver.desktopManager.default = "plasma5";
     virtualisation.memorySize = 1024;

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -10,8 +10,7 @@ import ./make-test.nix ({ pkgs, ...} :
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
     services.xserver.displayManager.select = "sddm";
-    services.xserver.desktopManager.plasma5.enable = true;
-    services.xserver.desktopManager.default = "plasma5";
+    services.xserver.desktopManager.select = [ "plasma5" ];
     virtualisation.memorySize = 1024;
 
     # fontconfig-penultimate-0.3.3 -> 0.3.4 broke OCR apparently, but no idea why.

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -15,7 +15,6 @@ let
         services.xserver.displayManager.select = "sddm";
         services.xserver.windowManager.default = "icewm";
         services.xserver.windowManager.icewm.enable = true;
-        services.xserver.desktopManager.default = "none";
       };
 
       enableOCR = true;

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -12,7 +12,7 @@ let
       machine = { lib, ... }: {
         imports = [ ./common/user-account.nix ];
         services.xserver.enable = true;
-        services.xserver.displayManager.sddm.enable = true;
+        services.xserver.displayManager.select = "sddm";
         services.xserver.windowManager.default = "icewm";
         services.xserver.windowManager.icewm.enable = true;
         services.xserver.desktopManager.default = "none";
@@ -42,8 +42,8 @@ let
       machine = { lib, ... }: {
         imports = [ ./common/user-account.nix ];
         services.xserver.enable = true;
+        services.xserver.displayManager.select = "sddm";
         services.xserver.displayManager.sddm = {
-          enable = true;
           autoLogin = {
             enable = true;
             user = "alice";

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -11,9 +11,8 @@ let
 
       machine = { lib, ... }: {
         imports = [ ./common/user-account.nix ];
-        services.xserver.enable = true;
         services.xserver.displayManager.select = "sddm";
-        services.xserver.windowManager.select = [ "icewm " ];
+        services.xserver.windowManager.select = [ "icewm" ];
       };
 
       enableOCR = true;
@@ -39,17 +38,14 @@ let
 
       machine = { lib, ... }: {
         imports = [ ./common/user-account.nix ];
-        services.xserver.enable = true;
         services.xserver.displayManager.select = "sddm";
+        services.xserver.windowManager.select = [ "icewm" ];
         services.xserver.displayManager.sddm = {
           autoLogin = {
             enable = true;
             user = "alice";
           };
         };
-        services.xserver.windowManager.default = "icewm";
-        services.xserver.windowManager.icewm.enable = true;
-        services.xserver.desktopManager.default = "none";
       };
 
       testScript = { nodes, ... }: ''

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -13,8 +13,7 @@ let
         imports = [ ./common/user-account.nix ];
         services.xserver.enable = true;
         services.xserver.displayManager.select = "sddm";
-        services.xserver.windowManager.default = "icewm";
-        services.xserver.windowManager.icewm.enable = true;
+        services.xserver.windowManager.select = [ "icewm " ];
       };
 
       enableOCR = true;

--- a/nixos/tests/slim.nix
+++ b/nixos/tests/slim.nix
@@ -11,9 +11,8 @@ import ./make-test.nix ({ pkgs, ...} : {
     services.xserver.windowManager.default = "icewm";
     services.xserver.windowManager.icewm.enable = true;
     services.xserver.desktopManager.default = "none";
+    services.xserver.displayManager.select = "slim";
     services.xserver.displayManager.slim = {
-      enable = true;
-
       # Use a custom theme in order to get best OCR results
       theme = pkgs.runCommand "slim-theme-ocr" {
         nativeBuildInputs = [ pkgs.imagemagick ];

--- a/nixos/tests/slim.nix
+++ b/nixos/tests/slim.nix
@@ -7,7 +7,6 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   machine = { pkgs, lib, ... }: {
     imports = [ ./common/user-account.nix ];
-    services.xserver.enable = true;
     services.xserver.windowManager.select = [ "icewm" ];
     services.xserver.displayManager.select = "slim";
     services.xserver.displayManager.slim = {

--- a/nixos/tests/slim.nix
+++ b/nixos/tests/slim.nix
@@ -8,8 +8,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   machine = { pkgs, lib, ... }: {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
-    services.xserver.windowManager.default = "icewm";
-    services.xserver.windowManager.icewm.enable = true;
+    services.xserver.windowManager.select = [ "icewm" ];
     services.xserver.displayManager.select = "slim";
     services.xserver.displayManager.slim = {
       # Use a custom theme in order to get best OCR results

--- a/nixos/tests/slim.nix
+++ b/nixos/tests/slim.nix
@@ -10,7 +10,6 @@ import ./make-test.nix ({ pkgs, ...} : {
     services.xserver.enable = true;
     services.xserver.windowManager.default = "icewm";
     services.xserver.windowManager.icewm.enable = true;
-    services.xserver.desktopManager.default = "none";
     services.xserver.displayManager.select = "slim";
     services.xserver.displayManager.slim = {
       # Use a custom theme in order to get best OCR results

--- a/nixos/tests/trac.nix
+++ b/nixos/tests/trac.nix
@@ -45,7 +45,7 @@ import ./make-test.nix ({ pkgs, ... }: {
     client =
       { config, pkgs, ... }:
       { imports = [ ./common/x11.nix ];
-        services.xserver.desktopManager.plasma5.enable = true;
+        services.xserver.desktopManager.select = [ "plasma5" ];
       };
   };
 

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -9,11 +9,8 @@ import ./make-test.nix ({ pkgs, ...} : {
 
     { imports = [ ./common/user-account.nix ];
 
-      services.xserver.enable = true;
-
       services.xserver.displayManager.select = "auto";
       services.xserver.displayManager.auto.user = "alice";
-
       services.xserver.desktopManager.select = [ "xfce" ];
 
       environment.systemPackages = [ pkgs.xorg.xmessage ];

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -14,7 +14,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       services.xserver.displayManager.select = "auto";
       services.xserver.displayManager.auto.user = "alice";
 
-      services.xserver.desktopManager.xfce.enable = true;
+      services.xserver.desktopManager.select = [ "xfce" ];
 
       environment.systemPackages = [ pkgs.xorg.xmessage ];
     };

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -11,7 +11,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       services.xserver.enable = true;
 
-      services.xserver.displayManager.auto.enable = true;
+      services.xserver.displayManager.select = "auto";
       services.xserver.displayManager.auto.user = "alice";
 
       services.xserver.desktopManager.xfce.enable = true;


### PR DESCRIPTION
###### Motivation for this change

Use extensible option types for xserver displayManager, windowManager and desktopManager options.
This should allow easier xserver configuration and modules.

- [x] displayManager
- [x] windowManager
- [x] desktopManager
- [ ] All test passing
- [x] Documentation
- [x] Backward compatibility

---

Note: This PR content allow to setup Xserver by only setting required options, related options will automatically get adapted defaults. For example, to set `plasma5` it was required to set the following:

```nix
{
  services.xserver.enable = true;
  services.xserver.displayManager.sddm.enable = true;
  services.xserver.desktopManager.plasma5.enable = true;
}
```

Now the following will have the same result:

```nix
{
  services.xserver.desktopManager.select = [ "plasma5" ];
}
```

Setting plasma5 as the desktop manager will automatically select `sddm` as display manager and enable the X server.

Note: The desktop managers and window managers are a list because it is possible to enable multiple at the same time. In that case the first entry in the list is considered as the default.

cc: @edolstra @nbp

