### PR TITLE
mutt: fix smime_keys hard-coded openssl path

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
     sha256 = "0idkamdiwj9fgqaz1vzkfg78cnmkzp74skv0ibw2xjfq6ds9hghx";
   };
 
+  patchPhase = optionalString (openssl != null ) ''
+    sed -i 's#/usr/bin/openssl#${openssl}/bin/openssl#' smime_keys.pl
+  '';
+
   buildInputs =
     [ ncurses which perl ]
     ++ optional headerCache  gdbm

--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     sha256 = "0idkamdiwj9fgqaz1vzkfg78cnmkzp74skv0ibw2xjfq6ds9hghx";
   };
 
-  patchPhase = optionalString (openssl != null ) ''
+  patchPhase = optionalString (openssl != null) ''
     sed -i 's#/usr/bin/openssl#${openssl}/bin/openssl#' smime_keys.pl
   '';
 


### PR DESCRIPTION
###### Motivation for this change

smime_keys does not work with the current mutt package because it contains a hard-coded path to openssl (/usr/bin/openssl).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


smime_keys uses hard-coded path to openssl, use path in /nix/store for openssl