### PR TITLE
nodejs: call paxctl on nodejs binary if grsec is enabled

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
-, pkgconfig, runCommand, which, libtool, fetchpatch
+, pkgconfig, runCommand, which, libtool, fetchpatch, paxctl, config
 , callPackage
 , darwin ? null
 , enableNpm ? true
@@ -30,6 +30,7 @@ in
     buildInputs = optionals stdenv.isDarwin [ CoreServices ApplicationServices ]
     ++ [ python2 which zlib libuv openssl ]
     ++ optionals stdenv.isLinux [ utillinux http-parser ]
+    ++ optionals config.security.grsecurity.enable [paxctl]
     ++ optionals stdenv.isDarwin [ pkgconfig libtool ];
 
     configureFlags = sharedConfigureFlags ++ [ "--without-dtrace" ] ++ extraConfigFlags;
@@ -57,6 +58,7 @@ in
 
     postInstall = ''
       PATH=$out/bin:$PATH patchShebangs $out
+      ${optionalString config.security.grsecurity.enable "paxctl -Cm $out/bin/node"}
     '';
 
     meta = {

--- a/pkgs/development/web/nodejs/v4.nix
+++ b/pkgs/development/web/nodejs/v4.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
-, pkgconfig, runCommand, which, libtool, fetchpatch
+{ stdenv, config, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
+, pkgconfig, runCommand, which, libtool, fetchpatch, paxctl
 , callPackage
 , darwin ? null
 , enableNpm ? true

--- a/pkgs/development/web/nodejs/v5.nix
+++ b/pkgs/development/web/nodejs/v5.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
-, pkgconfig, runCommand, which, libtool
+{ stdenv, config, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
+, pkgconfig, runCommand, which, libtool, paxctl
 , callPackage
 }@args:
 

--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
-, pkgconfig, runCommand, which, libtool, fetchpatch
+{ stdenv, config, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
+, pkgconfig, runCommand, which, libtool, fetchpatch, paxctl
 , callPackage
 , darwin ? null
 , enableNpm ? true

--- a/pkgs/development/web/nodejs/v7.nix
+++ b/pkgs/development/web/nodejs/v7.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
-, pkgconfig, runCommand, which, libtool, fetchpatch
+{ stdenv, config, fetchurl, openssl, python2, zlib, libuv, v8, utillinux, http-parser
+, pkgconfig, runCommand, which, libtool, fetchpatch, paxctl
 , callPackage
 , darwin ? null
 , enableNpm ? true


### PR DESCRIPTION
###### Motivation for this change
grsec throws a fit otherwise.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


