### PR TITLE
libreoffice-fresh: 5.2.2.2 -> 5.2.3.3

### DIFF
--- a/pkgs/applications/office/libreoffice/default-primary-src.nix
+++ b/pkgs/applications/office/libreoffice/default-primary-src.nix
@@ -3,8 +3,8 @@
 rec {
   major = "5";
   minor = "2";
-  patch = "2";
-  tweak = "2";
+  patch = "3";
+  tweak = "3";
 
   subdir = "${major}.${minor}.${patch}";
 
@@ -12,6 +12,6 @@ rec {
 
   src = fetchurl {
     url = "http://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "1q6rv935g633ngg10hzi23sg0wqfq2apyffagk7mj1kan2hflljr";
+    sha256 = "1h9j3j7drhr49nw2p6by5vvrr8nc8rpldn3yp724mwkb2rfkdwd8";
   };
 }

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -42,14 +42,14 @@ let
 
     translations = fetchSrc {
       name = "translations";
-      sha256 = "0nxwf3b63gzb04svb6z1hi3qf95i90pwda5gpmlrfrq6250n3bpi";
+      sha256 = "0j0ajli1cbfwbgzrcqkx3db174jv1fgm22ds0gqlgkci9cffa0c4";
     };
 
     # TODO: dictionaries
 
     help = fetchSrc {
       name = "help";
-      sha256 = "1gm23i0snhcm4svciypm0qiviiqv9zpiyplkh22baccs7li3kih1";
+      sha256 = "0fndi6cv8rw426c3l071z130ks9sqf6ca5yas7am9d666mmy4fs4";
     };
 
   };


### PR DESCRIPTION
###### Motivation for this change
New fresh version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


