### PR TITLE
go: 1.7.1 -> 1.7.3

### DIFF
--- a/pkgs/development/compilers/go/1.7.nix
+++ b/pkgs/development/compilers/go/1.7.nix
@@ -24,13 +24,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.7.1";
+  version = "1.7.3";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "121cvpjpbyl3lyd6j5lnnq6pr8vl7ar5zvap1132c522lxgxw356";
+    sha256 = "0dcappkx4ichl249swwdyk7l078ajng0gl6a885va85z8m1jnvbs";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
###### Motivation for this change

Update to latest patch version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


