### PR TITLE
openshift: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, go, which }:
 
 let
-  version = "1.3.0";
+  version = "1.3.1";
   versionMajor = "1";
   versionMinor = "3";
 in
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "openshift";
     repo = "origin";
     rev = "v${version}";
-    sha256 = "07s7xv8x8pch68j7lsw29im0axi07x32ag9wh9aqa0y570q9xgxy";
+    sha256 = "1kxa1k38hvi1vg52p82mmkmp9k4bbbm2pryzapsxwga7d8x4bnbh";
   };
 
   buildInputs = [ go which ];
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     homepage = http://www.openshift.org;
     maintainers = with maintainers; [offline];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to latest patch version.
Also declare that it works on all linux platforms not only x86_64.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


