### PR TITLE
Add protobuf 3.1.0

### DIFF
--- a/pkgs/development/libraries/protobuf/3.0.0-beta-2.nix
+++ b/pkgs/development/libraries/protobuf/3.0.0-beta-2.nix
@@ -1,43 +1,6 @@
-{ stdenv, fetchFromGitHub , autoreconfHook, zlib, gmock }:
+{ callPackage, ... }:
 
-stdenv.mkDerivation rec {
-  name = "protobuf-${version}";
-
+callPackage ./generic-v3.nix {
   version = "3.0.0-beta-2";
-  # make sure you test also -A pythonPackages.protobuf
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "protobuf";
-    rev = "v${version}";
-    sha256 = "0cbr1glgma5vakabsjwcs41pcnn8yphhn037l0zd121zb9gdaqc1";
-  };
-
-  postPatch = ''
-    rm -rf gmock
-    cp -r ${gmock.source} gmock
-    chmod -R a+w gmock
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace src/google/protobuf/testing/googletest.cc \
-      --replace 'tmpnam(b)' '"'$TMPDIR'/foo"'
-  '';
-
-  buildInputs = [ autoreconfHook zlib ];
-
-  enableParallelBuilding = true;
-
-  doCheck = true;
-
-  meta = {
-    description = "Google's data interchange format";
-    longDescription =
-      ''Protocol Buffers are a way of encoding structured data in an efficient
-        yet extensible format. Google uses Protocol Buffers for almost all of
-        its internal RPC protocols and file formats.
-      '';
-    license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.unix;
-    homepage = https://developers.google.com/protocol-buffers/;
-  };
-
-  passthru.version = version;
+  sha256 = "0cbr1glgma5vakabsjwcs41pcnn8yphhn037l0zd121zb9gdaqc1";
 }

--- a/pkgs/development/libraries/protobuf/3.0.nix
+++ b/pkgs/development/libraries/protobuf/3.0.nix
@@ -1,43 +1,6 @@
-{ stdenv, fetchFromGitHub , autoreconfHook, zlib, gmock }:
+{ callPackage, ... }:
 
-stdenv.mkDerivation rec {
-  name = "protobuf-${version}";
-
+callPackage ./generic-v3.nix {
   version = "3.0.0";
-  # make sure you test also -A pythonPackages.protobuf
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "protobuf";
-    rev = "v${version}";
-    sha256 = "05qkcl96lkdama848m7q3nzzzdckjc158iiyvgmln0zi232xx7g7";
-  };
-
-  postPatch = ''
-    rm -rf gmock
-    cp -r ${gmock.source} gmock
-    chmod -R a+w gmock
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace src/google/protobuf/testing/googletest.cc \
-      --replace 'tmpnam(b)' '"'$TMPDIR'/foo"'
-  '';
-
-  buildInputs = [ autoreconfHook zlib ];
-
-  enableParallelBuilding = true;
-
-  doCheck = true;
-
-  meta = {
-    description = "Google's data interchange format";
-    longDescription =
-      ''Protocol Buffers are a way of encoding structured data in an efficient
-        yet extensible format. Google uses Protocol Buffers for almost all of
-        its internal RPC protocols and file formats.
-      '';
-    license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.unix;
-    homepage = https://developers.google.com/protocol-buffers/;
-  };
-
-  passthru.version = version;
+  sha256 = "05qkcl96lkdama848m7q3nzzzdckjc158iiyvgmln0zi232xx7g7";
 }

--- a/pkgs/development/libraries/protobuf/3.1.nix
+++ b/pkgs/development/libraries/protobuf/3.1.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... }:
+
+callPackage ./generic-v3.nix {
+  version = "3.1.0";
+  sha256 = "0qlvpsmqgh9nw0k4zrxlxf75pafi3p0ahz99v6761b903y8qyv4i";
+}

--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook, zlib, gmock
+, version, sha256
+, ...
+}:
+
+stdenv.mkDerivation rec {
+  name = "protobuf-${version}";
+
+  # make sure you test also -A pythonPackages.protobuf
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "protobuf";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  postPatch = ''
+    rm -rf gmock
+    cp -r ${gmock.source} gmock
+    chmod -R a+w gmock
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace src/google/protobuf/testing/googletest.cc \
+      --replace 'tmpnam(b)' '"'$TMPDIR'/foo"'
+  '';
+
+  buildInputs = [ autoreconfHook zlib ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  meta = {
+    description = "Google's data interchange format";
+    longDescription =
+      ''Protocol Buffers are a way of encoding structured data in an efficient
+        yet extensible format. Google uses Protocol Buffers for almost all of
+        its internal RPC protocols and file formats.
+      '';
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.unix;
+    homepage = https://developers.google.com/protocol-buffers/;
+  };
+
+  passthru.version = version;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8821,6 +8821,7 @@ in
   protobuf3_0 = lowPrio (callPackage ../development/libraries/protobuf/3.0.nix { });
   # 3.0.0-beta-2 is only introduced for tensorflow. remove this version when tensorflow is moved to 3.0.
   protobuf3_0_0b2 = lowPrio (callPackage ../development/libraries/protobuf/3.0.0-beta-2.nix { });
+  protobuf3_1 = callPackage ../development/libraries/protobuf/3.1.nix { };
   protobuf2_6 = callPackage ../development/libraries/protobuf/2.6.nix { };
   protobuf2_5 = callPackage ../development/libraries/protobuf/2.5.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
Add the latest version of protobuf and keep older ones since some projects require some a specific protobuf version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

