### PR TITLE
chromium: Fix for yellow icons.

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -106,6 +106,7 @@ let
     patches = [
       ./patches/glibc-2.24.patch
       ./patches/nix_plugin_paths_52.patch
+      ./patches/ui_resources_200_percent.patch
     ] ++ optional enableWideVine ./patches/widevine.patch;
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/patches/ui_resources_200_percent.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/ui_resources_200_percent.patch
@@ -1,0 +1,29 @@
+--- a/ui/resources/BUILD.gn	2016-11-09 22:48:28.509443093 +0100
++++ b/ui/resources/BUILD.gn	2016-11-09 22:52:26.110380470 +0100
+@@ -62,6 +62,17 @@
+       "//ui/resources",
+     ]
+   }
++  copy("copy_ui_resources_200_percent") {
++    sources = [
++      "$root_gen_dir/ui/resources/ui_resources_200_percent.pak",
++    ]
++    outputs = [
++      "$root_out_dir/ui_resources_200_percent.pak",
++    ]
++    deps = [
++      "//ui/resources",
++    ]
++  }
+ }
+ 
+ # On iOS and Mac the string resources need to go into a locale subfolder, which
+@@ -186,7 +197,7 @@
+   }
+ 
+   if (!is_mac) {
+-    deps += [ ":copy_ui_resources_100_percent" ]
++    deps += [ ":copy_ui_resources_100_percent", ":copy_ui_resources_200_percent" ]
+   }
+ 
+   if (is_chromeos) {


### PR DESCRIPTION
###### Motivation for this change
Possible fix for bug #17958. Maybe someone else manages to test is before me :)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


