### PR TITLE
grsecurity_testing: 4.7.10 -> 4.8.7

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -86,9 +86,9 @@ rec {
   };
 
   grsecurity_testing = grsecPatch
-    { kver   = "4.8.6";
-      grrev  = "201611091800";
-      sha256 = "09kz4mjsrjixwvr8hf4q1lwk1miqb3mq6i6adzrha7c5s6c940x0";
+    { kver   = "4.8.7";
+      grrev  = "201611102210";
+      sha256 = "1n7avhvzy4njf9wky38l99i18v1rr05bgspivnp440j8d6nh60nh";
     };
 
   # This patch relaxes grsec constraints on the location of usermode helpers,

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -86,9 +86,9 @@ rec {
   };
 
   grsecurity_testing = grsecPatch
-    { kver   = "4.7.10";
-      grrev  = "201611011946";
-      sha256 = "0nva1007r4shlcxzflbxvd88yzvb98si2kjlgnhdqphyz1c0qhql";
+    { kver   = "4.8.6";
+      grrev  = "201611091800";
+      sha256 = "09kz4mjsrjixwvr8hf4q1lwk1miqb3mq6i6adzrha7c5s6c940x0";
     };
 
   # This patch relaxes grsec constraints on the location of usermode helpers,


### PR DESCRIPTION
Works for me, assuming I manually set boot.kernelPackages = pkgs.linuxPackages_latest;
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


