### PR TITLE
dnscrypt: Auto-restart

### DIFF
--- a/nixos/modules/services/networking/dnscrypt-proxy.nix
+++ b/nixos/modules/services/networking/dnscrypt-proxy.nix
@@ -277,7 +277,8 @@ in
         ExecStart = "${dnscrypt-proxy}/bin/dnscrypt-proxy ${toString daemonArgs}";
         Restart = "always";
         User = "dnscrypt-proxy";
-
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
         PrivateTmp = true;
         PrivateDevices = true;
         ProtectHome = true;

--- a/nixos/modules/services/networking/dnscrypt-proxy.nix
+++ b/nixos/modules/services/networking/dnscrypt-proxy.nix
@@ -263,7 +263,7 @@ in
     systemd.services.dnscrypt-proxy = {
       description = "dnscrypt-proxy daemon";
 
-      after = [ "network-online.target" ]
+      after = [ "network.target" ]
         ++ optional apparmorEnabled "apparmor.service"
         ++ optional useUpstreamResolverList "init-dnscrypt-proxy-statedir.service";
 

--- a/nixos/modules/services/networking/dnscrypt-proxy.nix
+++ b/nixos/modules/services/networking/dnscrypt-proxy.nix
@@ -263,7 +263,7 @@ in
     systemd.services.dnscrypt-proxy = {
       description = "dnscrypt-proxy daemon";
 
-      after = [ "network.target" ]
+      after = [ "network-online.target" ]
         ++ optional apparmorEnabled "apparmor.service"
         ++ optional useUpstreamResolverList "init-dnscrypt-proxy-statedir.service";
 
@@ -275,7 +275,7 @@ in
         Type = "simple";
         NonBlocking = "true";
         ExecStart = "${dnscrypt-proxy}/bin/dnscrypt-proxy ${toString daemonArgs}";
-
+        Restart = "always";
         User = "dnscrypt-proxy";
 
         PrivateTmp = true;

--- a/nixos/modules/services/networking/dnscrypt-proxy.nix
+++ b/nixos/modules/services/networking/dnscrypt-proxy.nix
@@ -277,8 +277,6 @@ in
         ExecStart = "${dnscrypt-proxy}/bin/dnscrypt-proxy ${toString daemonArgs}";
         Restart = "always";
         User = "dnscrypt-proxy";
-        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
-        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
         PrivateTmp = true;
         PrivateDevices = true;
         ProtectHome = true;


### PR DESCRIPTION
###### Motivation for this change
Without this, it gives up trying to start on my system upon boot. dnscrypt requires network-online because it has to handshake with the upstream DNS server.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


