### PR TITLE
subsurface init at 4.5.6 and dependencies (libdivecomputer, libmarble-ssrf, libgit2 @ 0.23.2)

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -273,6 +273,7 @@
   mdaiter = "Matthew S. Daiter <mdaiter8121@gmail.com>";
   meditans = "Carlo Nucera <meditans@gmail.com>";
   meisternu = "Matt Miemiec <meister@krutt.org>";
+  mguentner = "Maximilian Güntner <code@klandest.in>";
   mic92 = "Jörg Thalheim <joerg@higgsboson.tk>";
   michaelpj = "Michael Peyton Jones <michaelpj@gmail.com>";
   michalrus = "Michal Rus <m@michalrus.com>";

--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -1,0 +1,64 @@
+{
+  stdenv,
+  cmake,
+  curl,
+  fetchgit,
+  grantlee,
+  libdivecomputer,
+  libgit2,
+  libmarble-ssrf,
+  libssh2,
+  libxml2,
+  libxslt,
+  libzip,
+  pkgconfig,
+  qtbase,
+  qtconnectivity,
+  qttools,
+  qtwebkit,
+  sqlite
+}:
+
+stdenv.mkDerivation rec {
+  version = "4.5.6";
+  name = "subsurface-${version}";
+
+  # use fetchgit instead of the official tgz is not complete
+  src = fetchgit {
+    sha256 = "156rqcszy0c4plk2mv7wdd4h7s7mygpq5sdc64pjfs4qvvsdj10f";
+    url = "git://git.subsurface-divelog.org/subsurface";
+    rev = "4d8d7c2a0fa1b4b0e6953d92287c75b6f97472d0";
+    branchName = "v4.5-branch";
+  };
+
+  buildInputs = [ qtbase libdivecomputer libmarble-ssrf libxslt
+                  libzip libxml2 grantlee qtwebkit qttools
+                  qtconnectivity libgit2 libssh2 curl ];
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  enableParallelBuilding = true;
+
+  # hack incoming...
+  preConfigure = ''
+    marble_libs=$(echo $(echo $CMAKE_LIBRARY_PATH | grep -o "/nix/store/[[:alnum:]]*-libmarble-ssrf-[a-zA-Z0-9\-]*/lib")/libssrfmarblewidget.so)
+    cmakeFlags="$cmakeFlags -DCMAKE_BUILD_TYPE=Debug \
+                            -DMARBLE_LIBRARIES=$marble_libs \
+                            -DNO_PRINTING=OFF \
+                            -DUSE_LIBGIT23_API=1"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Subsurface is an open source divelog program that runs on Windows, Mac and Linux";
+    longDescription = ''
+      Subsurface can track single- and multi-tank dives using air, Nitrox or TriMix.
+      It allows tracking of dive locations including GPS coordinates (which can also
+      conveniently be entered using a map interface), logging of equipment used and
+      names of other divers, and lets users rate dives and provide additional notes.
+    '';
+    homepage = https://subsurface-divelog.org;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.mguentner ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/development/libraries/git2/0.23.nix
+++ b/pkgs/development/libraries/git2/0.23.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pkgconfig, cmake, zlib, python, libssh2, openssl, http-parser, libiconv }:
+
+stdenv.mkDerivation (rec {
+  version = "0.23.2";
+  name = "libgit2-${version}";
+
+  src = fetchurl {
+    name = "${name}.tar.gz";
+    url = "https://github.com/libgit2/libgit2/tarball/v${version}";
+    sha256 = "1d3901bmgvdnmzrx21afi1d0llsqmca3ckj942p0i2wpdpr1kbcp";
+  };
+
+  cmakeFlags = "-DTHREADSAFE=ON";
+
+  nativeBuildInputs = [ cmake python pkgconfig ];
+  buildInputs = [ zlib libssh2 openssl http-parser ];
+
+  meta = {
+    description = "the Git linkable library";
+    homepage = http://libgit2.github.com/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = with stdenv.lib.platforms; all;
+  };
+} // stdenv.lib.optionalAttrs (!stdenv.isLinux) {
+  NIX_LDFLAGS = "-liconv";
+  propagatedBuildInputs = [ libiconv ];
+})

--- a/pkgs/development/libraries/libdivecomputer/default.nix
+++ b/pkgs/development/libraries/libdivecomputer/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libdivecomputer-${version}";
+  version = "0.5.0";
+
+  src = fetchurl {
+    url = "http://www.libdivecomputer.org/releases/${name}.tar.gz";
+    sha256 = "11n2qpqg4b2h7mqifp9qm5gm1aqwy7wj1j4j5ha0wdjf55zzy30y";
+  };
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.libdivecomputer.org;
+    description = "A cross-platform and open source library for communication with dive computers from various manufacturers";
+    maintainers = [ maintainers.mguentner ];
+    license = licenses.lgpl21;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libmarble-ssrf/default.nix
+++ b/pkgs/development/libraries/libmarble-ssrf/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, doxygen, pkgconfig, cmake, qtbase, qtscript, qtquick1 }:
+
+stdenv.mkDerivation rec {
+  name = "libmarble-ssrf-${version}";
+  version = "2016-11-09";
+
+  src = fetchgit {
+    sha256 = "1dm2hdk6y36ls7pxbzkqmyc46hdy2cd5f6pkxa6nfrbhvk5f31zd";
+    url = "git://git.subsurface-divelog.org/marble";
+    rev = "4325da93b7516abb6f93a1417adc10593dacd794";
+  };
+
+  buildInputs = [ qtbase qtscript qtquick1 ];
+  nativeBuildInputs = [ doxygen pkgconfig cmake ];
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    cmakeFlags="$cmakeFlags -DCMAKE_BUILD_TYPE=Release \
+                            -DQTONLY=TRUE -DQT5BUILD=ON \
+                            -DBUILD_MARBLE_TESTS=NO \
+                            -DWITH_DESIGNER_PLUGIN=NO \
+                            -DBUILD_MARBLE_APPS=NO"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Qt library for a slippy map with patches from the Subsurface project";
+    homepage = "http://subsurface-divelog.org";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.mguentner ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7665,6 +7665,8 @@ in
 
   libdiscid = callPackage ../development/libraries/libdiscid { };
 
+  libdivecomputer = callPackage ../development/libraries/libdivecomputer { };
+
   libdivsufsort = callPackage ../development/libraries/libdivsufsort { };
 
   libdmtx = callPackage ../development/libraries/libdmtx { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2368,6 +2368,8 @@ in
 
   makebootfat = callPackage ../tools/misc/makebootfat { };
 
+  libmarble-ssrf = qt55.callPackage ../development/libraries/libmarble-ssrf { };
+
   matrix-synapse = callPackage ../servers/matrix-synapse { };
 
   memtester = callPackage ../tools/system/memtester { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3718,6 +3718,11 @@ in
 
   sstp = callPackage ../tools/networking/sstp {};
 
+  subsurface =
+    qt55.callPackage ../applications/misc/subsurface {
+        libgit2 = pkgs.libgit2_0_23;
+    };
+
   sudo = callPackage ../tools/security/sudo { };
 
   suidChroot = callPackage ../tools/system/suid-chroot { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7031,6 +7031,7 @@ in
   );
 
   libgit2_0_21 = callPackage ../development/libraries/git2/0.21.nix { };
+  libgit2_0_23 = callPackage ../development/libraries/git2/0.23.nix { };
 
   gle = callPackage ../development/libraries/gle { };
 


### PR DESCRIPTION
###### Motivation for this change
 
(Free)divers should also use NixOS :ocean: 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).