### PR TITLE
MAR1D: init at 0.2.0

### DIFF
--- a/pkgs/games/mar1d/default.nix
+++ b/pkgs/games/mar1d/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, mesa_glu
+, x11
+, xorg
+, xinput_calibrator
+, doxygen
+, libpthreadstubs
+, alsaLib
+, alsaOss
+, libao
+, width ? 30
+, mute ? false
+, effects ? false
+, sensitivity ? 5
+, reverseY ? false
+}:
+
+stdenv.mkDerivation rec {
+  name = "MAR1D-${version}";
+  version = "0.2.0";
+  options = "-w${toString width}"
+          + " -s${toString sensitivity}"
+          + (if mute then " -m" else "")
+          + (if effects then " -f" else "")
+          + (if reverseY then " -r" else "");
+
+  src = fetchFromGitHub {
+    sha256 = "152w5dnlxzv60cl24r5cmrj2q5ar0jiimrmxnp87kf4d2dpbnaq7";
+    rev = "v${version}";
+    repo = "fp_mario";
+    owner = "olynch";
+  };
+
+  buildInputs =
+    [
+      alsaLib
+      alsaOss
+      cmake
+      doxygen
+      libao
+      libpthreadstubs
+      mesa_glu
+      x11
+      xinput_calibrator
+      xorg.libXrandr
+      xorg.libXi
+      xorg.xinput
+    ];
+
+  preConfigure = ''
+    cd src
+  '';
+
+  meta = with stdenv.lib; {
+    description = "First person Super Mario Bros";
+    longDescription = ''
+      The original Super Mario Bros as you've never seen it. Step into Mario's
+      shoes in this first person clone of the classic Mario game. True to the
+      original, however, the game still takes place in a two dimensional world.
+      You must view the world as mario does, as a one dimensional line.
+    '';
+    homepage = https://github.com/olynch/fp_mario;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ taeer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -941,6 +941,8 @@ in
     hiredis = null;
   };
 
+  mar1d = callPackage ../games/mar1d { } ;
+
   mcrypt = callPackage ../tools/misc/mcrypt { };
 
   mongodb-tools = callPackage ../tools/misc/mongodb-tools { };


### PR DESCRIPTION
###### Motivation for this change
I would like my game to be accessible via nixpkgs

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
     I have not actually tested it on a mac because I don't have easy access to one, but it should work with small modifications
   - [ ] Linux
     As far as I can tell it should just work on other linux's, but I've only tested it on NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


