### PR TITLE
vndr: init at 20161110-cf8678f

### DIFF
--- a/pkgs/development/tools/vndr/default.nix
+++ b/pkgs/development/tools/vndr/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "vndr-${version}";
+  version = "20161110-${lib.strings.substring 0 7 rev}";
+  rev = "cf8678fba5591fbacc4dafab1a22d64f6c603c20";
+
+  goPackagePath = "github.com/LK4D4/vndr";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "LK4D4";
+    repo = "vndr";
+    sha256 = "1fbrpdpfir05hqj1dr8rxw8hnjkhl0xbzncxkva56508vyyzbxcs";
+  };
+
+  meta = {
+    description = "Stupid golang vendoring tool, inspired by docker vendor script";
+    homepage = "https://github.com/LK4D4/vndr";
+    maintainers = with lib.maintainers; [ vdemeester ];
+    licence = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11498,6 +11498,8 @@ in
     qt5 = null;
   };
 
+  vndr = callPackage ../development/tools/vndr { };
+
   windows = rec {
     cygwinSetup = callPackage ../os-specific/windows/cygwin-setup { };
 


### PR DESCRIPTION
###### Motivation for this change

[vndr](https://github.com/LK4D4/vndr) is a simple *golang* vendoring tool, which is inspired by docker vendor script that I tend to use on several projects.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] <del>Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`</del>
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Signed-off-by: Vincent Demeester <vincent@sbr.pm>