### PR TITLE
NixOS Manual: Container Networking with NM

### DIFF
--- a/nixos/doc/manual/administration/container-networking.xml
+++ b/nixos/doc/manual/administration/container-networking.xml
@@ -47,4 +47,12 @@ where <literal>eth0</literal> should be replaced with the desired
 external interface. Note that <literal>ve-+</literal> is a wildcard
 that matches all container interfaces.</para>
 
+<para>If you are using Network Manager, you need to explicitly prevent
+it from managing container interfaces:
+
+<programlisting>
+networking.networkmanager.unmanaged = [ "interface-name:ve-*" ];
+</programlisting>
+</para>
+
 </section>


### PR DESCRIPTION
###### Motivation for this change

I recently had the problem that I get locked out of containers (can't ssh) a few seconds after starting them. Adding the virtual container interface to networking.networkmanager.unmanaged seems to have resolved that issue for me so I'm mentioning this in the manual.
If there's a way to set a wildcard which sets all ve-* interfaces to not be managed by Network Manager, that would be even better.

Note: changing the configuration and running `nixos-rebuild switch` was not enough to activate the new configuration. I needed to manually restart Network Manager too.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Network Manager calls dhclient on container interfaces and fails
which locks you out of the container after a few seconds, unless
you tell it not to manage these interfaces.