### PR TITLE
linux: 4.8.6 -> 4.8.7

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.8.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.8.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, perl, buildLinux, ... } @ args:
 
 import ./generic.nix (args // rec {
-  version = "4.8.6";
+  version = "4.8.7";
   extraMeta.branch = "4.8";
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0szk5m4wj6w0avpri9168acid8apbsjv78wz0k4cymh88804wx3l";
+    sha256 = "03qgqqy1kxdqpb844g2yfyq45xy77110hrz8ddqy0rlkia8kzx8m";
   };
 
   kernelPatches = args.kernelPatches;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


