### PR TITLE
atom: 1.12.0 -> 1.12.1

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "atom-${version}";
-  version = "1.12.0";
+  version = "1.12.1";
 
   src = fetchurl {
     url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
-    sha256 = "0grl5lw05gjw9381pr8asgqp9f912li28v0bvl8j6i0ynfy67jmk";
+    sha256 = "0v7qlqkpq5zymn0ww35ywkh0vzm2mfpah18nqrc0rx0kvxr0xzqj";
     name = "${name}.deb";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


