### PR TITLE
pangoxsl: Use sha256

### DIFF
--- a/pkgs/development/libraries/pangoxsl/default.nix
+++ b/pkgs/development/libraries/pangoxsl/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "pangoxsl-1.6.0.3";
   src = fetchurl {
     url = mirror://sourceforge/pangopdf/pangoxsl-1.6.0.3.tar.gz;
-    md5 = "c98bad47ffa7de2e946a8e35d45e071c";
+    sha256 = "1wcd553nf4nwkrfrh765cyzwj9bsg7zpkndg2hjs8mhwgx04lm8n";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
#4491

Replace md5 hash

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


