### PR TITLE
opencv3: Move IPP to use sha256

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -45,14 +45,14 @@ stdenv.mkDerivation rec {
     let ippicvVersion = "20151201";
         ippicvPlatform = if stdenv.system == "x86_64-linux" || stdenv.system == "i686-linux" then "linux"
                          else throw "ICV is not available for this platform (or not yet supported by this package)";
-        ippicvHash = if ippicvPlatform == "linux" then "808b791a6eac9ed78d32a7666804320e"
+        ippicvHash = if ippicvPlatform == "linux" then "1nph0w0pdcxwhdb5lxkb8whpwd9ylvwl97hn0k425amg80z86cs3"
                      else throw "ippicvHash: impossible";
 
         ippicvName = "ippicv_${ippicvPlatform}_${ippicvVersion}.tgz";
         ippicvArchive = "3rdparty/ippicv/downloads/linux-${ippicvHash}/${ippicvName}";
         ippicv = fetchurl {
           url = "https://github.com/Itseez/opencv_3rdparty/raw/ippicv/master_${ippicvVersion}/ippicv/${ippicvName}";
-          md5 = ippicvHash;
+          sha256 = ippicvHash;
         };
     in lib.optionalString enableIpp
       ''


### PR DESCRIPTION
###### Motivation for this change
#4491

Replace md5 with sha256

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


