### PR TITLE
saxonb: Use sha256

### DIFF
--- a/pkgs/development/libraries/java/saxon/default8.nix
+++ b/pkgs/development/libraries/java/saxon/default8.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "saxonb-8.8";
   src = fetchurl {
     url = mirror://sourceforge/saxon/saxonb8-8j.zip;
-    md5 = "35c4c376174cfe340f179d2e44dd84f0";
+    sha256 = "15bzrfyd2f1045rsp9dp4znyhmizh1pm97q8ji2bc0b43q23xsb8";
   };
 
   buildInputs = [unzip];


### PR DESCRIPTION
###### Motivation for this change
#4491
Replace MD5 with SHA256

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


