### PR TITLE
saxon: use sha256

### DIFF
--- a/pkgs/development/libraries/java/saxon/default.nix
+++ b/pkgs/development/libraries/java/saxon/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   builder = ./unzip-builder.sh;
   src = fetchurl {
     url = mirror://sourceforge/saxon/saxon6_5_3.zip;
-    md5 = "7b8c7c187473c04d2abdb40d8ddab5c6";
+    sha256 = "0l5y3y2z4wqgh80f26dwwxwncs8v3nkz3nidv14z024lmk730vs3";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change
#4491
Replace MD5 with SHA256

###### Things done

-  [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


