### PR TITLE
systemd: Added an option to set default systemd.exec config

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -325,6 +325,7 @@ let
             X-RestartIfChanged=false
           '' else ""}
           ${optionalString (!def.stopIfChanged) "X-StopIfChanged=false"}
+          ${attrsToSection cfg.defaultExecConfig}
           ${attrsToSection def.serviceConfig}
         '';
     };
@@ -334,6 +335,7 @@ let
       text = commonUnitText def +
         ''
           [Socket]
+          ${attrsToSection cfg.defaultExecConfig}
           ${attrsToSection def.socketConfig}
           ${concatStringsSep "\n" (map (s: "ListenStream=${s}") def.listenStreams)}
         '';
@@ -362,6 +364,7 @@ let
       text = commonUnitText def +
         ''
           [Mount]
+          ${attrsToSection cfg.defaultExecConfig}
           ${attrsToSection def.mountConfig}
         '';
     };
@@ -507,6 +510,15 @@ in
       description = ''
         Extra config options for systemd. See man systemd-system.conf for
         available options.
+      '';
+    };
+    
+    systemd.defaultExecConfig = mkOption {
+      default = {};
+      type = types.attrs;
+      example = {NoNewPrivileges = true;};
+      description = ''Default configuration options for services, sockets, 
+        mount points, and swap devices.
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change
Allows you to add default options for [system.exec](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) units. 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


