### PR TITLE
top-level: Make cross compiling slightly saner

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -46,10 +46,13 @@ in
 
   callPackage_i686 = lib.callPackageWith (pkgsi686Linux // pkgsi686Linux.xorg);
 
-  forceNativeDrv = drv : if crossSystem == null then drv else
-    (drv // { crossDrv = drv.nativeDrv; });
-
-  stdenvCross = lowPrio (makeStdenvCross defaultStdenv crossSystem binutilsCross gccCrossStageFinal);
+  forceNativeDrv = drv:
+    # Even when cross compiling, some packages come from the stdenv's
+    # bootstrapping package set. Those packages are only built for the native
+    # platform.
+    if crossSystem != null && drv ? crossDrv
+    then drv // { crossDrv = drv.nativeDrv; }
+    else drv;
 
   # A stdenv capable of building 32-bit binaries.  On x86_64-linux,
   # it uses GCC compiled with multilib support; on i686-linux, it's


### PR DESCRIPTION
###### Motivation for this change

Removes the weird stdenv cycle used to match the old infrastructure.
It turns out that matching it so precisely is not needed.

CC @nbp 

###### Things done

Tested with https://gist.github.com/Ericson2314/fc745290db68b20235bdc457961b3658, try:
```
nix-instantiate --eval -E 'import (builtins.fetchTarball https://gist.github.com/Ericson2314/fc745290db68b20235bdc457961b3658/archive/master.tar.gz) { me = "184adcc98c27bb75ad7f59c09dd93bfd978c24e6"; base = "a24728fe295f28648f1812b3565541f7ef6269f1"; }' -A testsPass
```
