### PR TITLE
python-plover: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14839,7 +14839,7 @@ in {
 
   plover = buildPythonPackage rec {
     name = "plover-${version}";
-    version = "3.0.0";
+    version = "3.1.0";
     disabled = !isPy27;
 
     meta = {
@@ -14850,7 +14850,7 @@ in {
 
     src = pkgs.fetchurl {
       url = "https://github.com/openstenoproject/plover/archive/v${version}.tar.gz";
-      sha256 = "1jja37nhiypdx1z6cazp8ffsf0z3yqmpdbprpdzf668lcb422rl0";
+      sha256 = "1zdlgyjp93sfvk6by7rsh9hj4ijzplglrxpcpkcir6c3nq2bixl4";
     };
 
     # This is a fix for https://github.com/pypa/pip/issues/3624 causing regression https://github.com/pypa/pip/issues/3781


### PR DESCRIPTION
###### Motivation for this change

New plover release, see the [Plover Google Group](https://groups.google.com/forum/#!topic/ploversteno/gOiuDbQHR_I) for more details.

Also, I was wondering since this is an application, rather than a library (is package pythonspeak for library?), should it be in its own place rather than python-packages.nix? I was looking at [Nixpkgs manual 8.10.2.2.](https://nixos.org/nixpkgs/manual/#building-packages-and-applications).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


