### PR TITLE
lxqt: it is capable of setting a background

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -25,6 +25,7 @@ in
 
     services.xserver.desktopManager.session = singleton {
       name = "lxqt";
+      bgSupport = true;
       start = ''
         exec ${pkgs.lxqt.lxqt-common}/bin/startlxqt
       '';


### PR DESCRIPTION
###### Motivation for this change

Currently `feh` gets installed although LxQt doesn't use it for setting wallpapers. The fix consists can be fixed by setting bgSupport accordingly: https://github.com/NixOS/nixos/blob/5f444a4d8d49a497bcfabe2544bda264c845653e/modules/services/x11/desktop-managers/default.nix#L12

Thanks to Tim Nieradzik for pointing that out.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).