### PR TITLE
i3-gaps: 4.12 -> 4.13

### DIFF
--- a/pkgs/applications/window-managers/i3/gaps.nix
+++ b/pkgs/applications/window-managers/i3/gaps.nix
@@ -1,26 +1,20 @@
-{ fetchurl, stdenv, i3 }:
+{ fetchurl, stdenv, i3, autoreconfHook }:
 
 i3.overrideDerivation (super : rec {
 
   name = "i3-gaps-${version}";
-  version = "4.12";
-  releaseDate = "2016-03-06";
+  version = "4.13";
+  releaseDate = "2016-11-08";
 
   src = fetchurl {
     url = "https://github.com/Airblader/i3/archive/${version}.tar.gz";
-    sha256 = "1i9l993cak85fcw12zgrb5cpspmjixr3yf8naa4zb8589mg4rb8s";
+    sha256 = "0w959nx2crn00fckqwb5y78vcr1j9mvq5lh25wyjszx04pjhf378";
   };
 
-  postUnpack = ''
-      echo -n "${version} (${releaseDate}, branch \\\"gaps-next\\\")" > ./i3-${version}/I3_VERSION
-      echo -n "${version}" > ./i3-${version}/VERSION
-  '';
+  nativeBuildInputs = super.nativeBuildInputs ++ [ autoreconfHook ];
 
-  postInstall = ''
-    wrapProgram "$out/bin/i3-save-tree" --prefix PERL5LIB ":" "$PERL5LIB"
-    for program in $out/bin/i3-sensible-*; do
-      sed -i 's/which/command -v/' $program
-    done
+  postUnpack = ''
+      echo -n "${version} (${releaseDate})" > ./i3-${version}/I3_VERSION
   '';
 
 }) // {


### PR DESCRIPTION
###### Motivation for this change
Update the i3-gaps fork of the i3 window manager from 4.12 to 4.13 (i3 4.12 -> 4.13 is already merged to master, see #20296 and #20300).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Tested execution of `i3` and `i3bar` on NixOS.

