### PR TITLE
Terminix: init at 1.3.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -129,7 +129,7 @@
   doublec = "Chris Double <chris.double@double.co.nz>";
   drets = "Dmytro Rets <dmitryrets@gmail.com>";
   drewkett = "Andrew Burkett <burkett.andrew@gmail.com>";
-  dyrnade - "Cem Guresci <gurescicem@gmail.com>";
+  dyrnade = "Cem Guresci <gurescicem@gmail.com>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";
   eduarrrd = "Eduard Bachmakov <e.bachmakov@gmail.com>";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -129,6 +129,7 @@
   doublec = "Chris Double <chris.double@double.co.nz>";
   drets = "Dmytro Rets <dmitryrets@gmail.com>";
   drewkett = "Andrew Burkett <burkett.andrew@gmail.com>";
+  dyrnade - "Cem Guresci <gurescicem@gmail.com>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";
   eduarrrd = "Eduard Bachmakov <e.bachmakov@gmail.com>";

--- a/pkgs/applications/misc/terminix/default.nix
+++ b/pkgs/applications/misc/terminix/default.nix
@@ -1,0 +1,65 @@
+{ stdenv, fetchurl, lib, zlib, atk, glib, dbus, gtk3, gnome3
+, hicolor_icon_theme, libX11, unzip, gdk_pixbuf, cairo
+, libXext, libsecret, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "terminix-${version}";
+  version = "1.3.5";
+
+  src = fetchurl {
+    url = "https://github.com/gnunn1/terminix/releases/download/${version}/terminix.zip";
+    sha512 = "c312bfd99ceda3796d03b3fa5c0d1c27992a1c60a40bbe3f06fd004c5f69b1959bc3156b905ed835c0757512bf75feb680bfdd07ab64b6861fc56d5f25eacfa8";
+  };
+
+  buildInputs = [ unzip makeWrapper ];
+
+
+  inherit libX11 libXext;
+  buildCommand =
+
+  let
+
+    packages = [
+      stdenv.cc.cc zlib glib dbus gtk3 atk
+      gdk_pixbuf cairo gnome3.vte libsecret
+    ];
+
+    libPathNative = lib.makeLibraryPath packages;
+    libPath64 = lib.makeSearchPathOutput "lib" "lib64" packages;
+    libPath = "${libPathNative}:${libPath64}";
+
+  in ''
+      mkdir -p $out
+      cd $out
+      unzip $src
+      mkdir $out/lib
+
+      #mv $out/usr/* .
+      #rm -rf $out/usr
+
+      sed -i "s|Exec=terminix|Exec=$out/usr/bin/terminix|g" $out/usr/share/applications/com.gexperts.Terminix.desktop
+
+      fixupPhase
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+            --set-rpath "$libX11/lib:$libXext/lib:${libPath}" \
+            $out/usr/bin/terminix
+
+      mkdir -p $out/usr/bin/wrapped
+      mv "$out/usr/bin/terminix" "$out/usr/bin/wrapped/terminix"
+      makeWrapper "$out/usr/bin/wrapped/terminix" "$out/usr/bin/terminix" \
+        --prefix XDG_DATA_DIRS : "$out/usr/share:$GSETTINGS_SCHEMAS_PATH" \
+        --prefix GIO_EXTRA_MODULES : "${gnome3.dconf}/lib/gio/modules"
+
+      ${glib.dev}/bin/glib-compile-schemas $out/usr/share/glib-2.0/schemas
+
+  '';
+
+
+meta = with stdenv.lib; {
+    description = " A tiling terminal emulator for Linux using GTK+ 3 ";
+    homepage = https://github.com/gnunn1/terminix;
+    license = licenses.mpl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.gnunn1 ];
+  };
+}

--- a/pkgs/applications/misc/terminix/default.nix
+++ b/pkgs/applications/misc/terminix/default.nix
@@ -60,6 +60,6 @@ meta = with stdenv.lib; {
     homepage = https://github.com/gnunn1/terminix;
     license = licenses.mpl20;
     platforms = platforms.linux;
-    maintainers = [ maintainers.gnunn1 ];
+    maintainers = [ maintainers.dyrnade ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17506,4 +17506,6 @@ in
   nitrokey-app = callPackage ../tools/security/nitrokey-app { };
 
   fpm2 = callPackage ../tools/security/fpm2 { };
+
+  terminix = callPackage ../applications/misc/terminix { };
 }


### PR DESCRIPTION
###### Motivation for this change
Terminix package

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

