### PR TITLE
rxvt_unicode: create .desktop file

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode/default.nix
@@ -1,10 +1,29 @@
-{ stdenv, fetchurl, perlSupport, libX11, libXt, libXft, ncurses, perl,
-  fontconfig, freetype, pkgconfig, libXrender, gdkPixbufSupport, gdk_pixbuf,
-  unicode3Support }:
+{ stdenv, fetchurl, makeDesktopItem, perlSupport, libX11, libXt, libXft,
+  ncurses, perl, fontconfig, freetype, pkgconfig, libXrender,
+  gdkPixbufSupport, gdk_pixbuf, unicode3Support }:
 
 let
   pname = "rxvt-unicode";
   version = "9.22";
+
+  desktopItem = makeDesktopItem {
+    name = "${pname}";
+    exec = "urxvt";
+    icon = "utilities-terminal";
+    comment = meta.description;
+    desktopName = "URxvt";
+    genericName = "${pname}";
+    categories = "System;TerminalEmulator;";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A clone of the well-known terminal emulator rxvt";
+    homepage = "http://software.schmorp.de/pkg/rxvt-unicode.html";
+    downloadPage = "http://dist.schmorp.de/rxvt-unicode/Attic/";
+    maintainers = [ maintainers.mornfall ];
+    platforms = platforms.unix;
+  };
+
 in
 
 stdenv.mkDerivation (rec {
@@ -47,13 +66,6 @@ stdenv.mkDerivation (rec {
   postInstall = ''
     mkdir -p $out/nix-support
     echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
+    cp -r ${desktopItem}/share/applications/ $out/share/
   '';
-
-  meta = {
-    description = "A clone of the well-known terminal emulator rxvt";
-    homepage = "http://software.schmorp.de/pkg/rxvt-unicode.html";
-    downloadPage = "http://dist.schmorp.de/rxvt-unicode/Attic/";
-    maintainers = [ stdenv.lib.maintainers.mornfall ];
-    platforms = stdenv.lib.platforms.unix;
-  };
 })


### PR DESCRIPTION
###### Motivation for this change
URxvt doesn't show up in the start menu.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


