### PR TITLE
jdom: use sha256

### DIFF
--- a/pkgs/development/libraries/java/jdom/builder.sh
+++ b/pkgs/development/libraries/java/jdom/builder.sh
@@ -3,4 +3,4 @@ source $stdenv/setup
 
 tar zxvf $src
 mkdir -p $out
-mv $name/* $out
+mv * $out

--- a/pkgs/development/libraries/java/jdom/default.nix
+++ b/pkgs/development/libraries/java/jdom/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = http://www.jdom.org/dist/binary/jdom-1.0.tar.gz;
-    md5 = "ce29ecc05d63fdb419737fd00c04c281";
+    sha256 = "1igmxzcy0s25zcy9vmcw0kd13lh60r0b4qg8lnp1jic33f427pxf";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
#4491

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


