### PR TITLE
apple-sdk: Include system cups libraries

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -31,6 +31,10 @@ let
       mv System/* .
       rmdir System
 
+      pushd lib
+      ln -s -L /usr/lib/libcups*.dylib .
+      popd
+
       cd Library/Frameworks/QuartzCore.framework/Versions/A/Headers
       for file in CI*.h; do
         rm $file


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


The SDK includes cups header files, but not the libraries. The
`nixpkgs.cups` definition doesn't build on darwin due to the SDK being
too old. This change symlinks the system cups libraries into the old
SDK.