### PR TITLE
fix proxychains ld flags

### DIFF
--- a/pkgs/tools/networking/proxychains/default.nix
+++ b/pkgs/tools/networking/proxychains/default.nix
@@ -16,4 +16,10 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
   };
+
+  preConfigure = ''
+  # patch, add -ldl flag
+  sed -i Makefile -e '/-lpthread/a LDFLAGS+=-ldl'
+  '';
+
 }


### PR DESCRIPTION
Withou the patch, I got an error with `proxychains4 git submodule add ...`

```
[roxma@nixos:~/test]$ nix-env -i proxychains
replacing old ‘proxychains-4.2.0’
installing ‘proxychains-4.2.0’

[roxma@nixos:~/test]$ proxychains4 git submodule add git@github.com:haad/proxychains.git
[proxychains] config file found: /home/roxma/test/proxychains.conf
[proxychains] preloading /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so
[proxychains] DLL init
[proxychains] DLL init
sedbasename: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
sed: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
basename: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
/nix/store/dilcmbv8rlvv5l9vkig7y6rx0jbs0f0z-gettext-0.19.8/bin/gettext: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
/nix/store/dilcmbv8rlvv5l9vkig7y6rx0jbs0f0z-gettext-0.19.8/bin/envsubst: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
/nix/store/dilcmbv8rlvv5l9vkig7y6rx0jbs0f0z-gettext-0.19.8/bin/envsubst: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
uname: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
sed: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
/nix/store/dilcmbv8rlvv5l9vkig7y6rx0jbs0f0z-gettext-0.19.8/bin/gettext: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
/nix/store/dilcmbv8rlvv5l9vkig7y6rx0jbs0f0z-gettext-0.19.8/bin/envsubst: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
/nix/store/dilcmbv8rlvv5l9vkig7y6rx0jbs0f0z-gettext-0.19.8/bin/envsubst: symbol lookup error: /nix/store/vq6lvswd1qq6119c96b767axilil88i7-proxychains-4.2.0/lib/libproxychains4.so: undefined symbol: dlerror
```

Using the patch:

```

[roxma@nixos:~/test]$ nix-env -f ~/nixpkgs -i proxychains
replacing old ‘proxychains-4.2.0’
installing ‘proxychains-4.2.0’

[roxma@nixos:~/test]$ proxychains4 git submodule add git@github.com:haad/proxychains.git
[proxychains] config file found: /home/roxma/test/proxychains.conf
[proxychains] preloading /nix/store/sna49dpbb34gp7hgdkj5y1d4clrzffys-proxychains-4.2.0/lib/libproxychains4.so
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
Cloning into '/home/roxma/test/proxychains'...
[proxychains] DLL init
[proxychains] Strict chain  ...  10.0.2.2:1080  ...  192.30.253.112:22  ...  OK
remote: Counting objects: 794, done.
[proxychains] DLL init
remote: Total 794 (delta 0), reused 0 (delta 0), pack-reused 794
Receiving objects: 100% (794/794), 457.87 KiB | 130.00 KiB/s, done.
Resolving deltas: 100% (471/471), done.
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
[proxychains] DLL init
```
