### PR TITLE
fix autobuild compilation

### DIFF
--- a/pkgs/development/tools/misc/autobuild/default.nix
+++ b/pkgs/development/tools/misc/autobuild/default.nix
@@ -12,11 +12,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postInstall = ''
-    wrapProgram $out/bin/ab{put,build}-sourceforge \
-      --prefix PATH ":" "${stdenv.lib.makeBinPath [ openssh rsync ]}"
-  '';
-
   meta = {
     description = "Continuous integration tool";
 


### PR DESCRIPTION
Currently autobuild failed to build in both master and release-16.03. The
error message is
```
   mv: cannot stat '/nix/store/a4jzlkrhd4b4nr5760caj3rrjxhyg4z3-autobuild-5.3/bin/abput-sourceforge': No such file or directory
   builder for ‘/nix/store/l19vywq8zvbarswby5h7vl4iq1c1pvq7-autobuild-5.3.drv’ failed with exit code 1
```
It happens in post install script

```
   postInstall = ''
     wrapProgram $out/bin/ab{put,build}-sourceforge \
       --prefix PATH ":" "${stdenv.lib.makeBinPath [ openssh rsync ]}"
   '';
```

The problem is that in autobuild 5.0 the ab{put,build}-sourceforge were removed

```
   * Version 5.0 (released 2008-11-25)
   ...
   ** abput, abput-sourceforge, abput-testdrive: Remove.
   ** abbuild, abbuild-sourceforge: Remove.
   Both the SourceForge and TestDrive systems have been shutdown.  The
   scripts were of questionable value anyway.
```

Possibly the bug was introduced in commit
8c4fcc87f8320004e924f53bbaee29ae3b7b4692: autobuild: 3.5 -> 5.3.

As the package doesn't contain these programs there is no need in wrapping
them. This commit just remove the postInstall section of corresponding
package.