### PR TITLE
qutebrowser: 0.8.2 -> 0.8.4

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -24,12 +24,12 @@ let
 
 in buildPythonApplication rec {
   name = "qutebrowser-${version}";
-  version = "0.8.2";
+  version = "0.8.4";
   namePrefix = "";
 
   src = fetchurl {
     url = "https://github.com/The-Compiler/qutebrowser/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "1kfxjdn1dqla8d8gcggp55zcgf4zb77knkfshd213my0iw2yzgcf";
+    sha256 = "0wc6iq7rw89625v595bs4y8spzhid6nnz2gq67f2kbjppk2rikpm";
   };
 
   # Needs tox


### PR DESCRIPTION
###### Motivation for this change
qutebrowser update
changes:
* Fixed crash when doing :<space><enter>, another corner-case introduced in v0.8.0
* Fixed :open-editor (<Ctrl-e>) on Windows
* Fixed crash when setting general -> auto-save-interval to a too big value.
* Fixed crash when using hints on Void Linux.
* Fixed compatibility with Python 3.5.2+ on Debian unstable
Compatibility with pdfjs v1.6.210
* :bind can now be used to bind to an alias (binding by editing keys.conf already worked before)
* The command completion now updates correctly when changing aliases
* The tabbar now displays correctly with the Adwaita Qt theme
* The default sk keybinding now sets the commandline to :bind correctly
* Fixed crash when closing a window without focusing it
* v0.8.3 accidentally broke compatibility with Python 3.4, which is restored with this release.

I'm not quite sure about the hash as I couln't reproduce it for 0.8.2 but this one for 0.8.4 seems to work for me

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

