### PR TITLE
pythonPackages: pint: init at 0.7.2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14909,6 +14909,20 @@ in {
     };
   };
 
+  pint = buildPythonPackage rec {
+    name = "pint-${version}";
+    version = "0.7.2";
+
+    meta = {
+      description = "Physical quantities module";
+      license = licenses.bsd3;
+    };
+
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/c5/e5/1c317a30e51810d6ac1d744a6c232569c5a06d4478bdd20c2f0614d117e7/Pint-0.7.2.tar.gz";
+      sha256 = "1bbp5s34gcb9il2wyz4spznshahwbjvwi5bhjm7bnxk358spvf9q";
+    };
+  };
 
   plover = buildPythonPackage rec {
     name = "plover-${version}";


### PR DESCRIPTION
###### Motivation for this change

Add python pint package for working with physical quantities.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


