### PR TITLE
pythonPackages.buildnotify: init at 0.3.5

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -454,6 +454,7 @@
   vbmithr = "Vincent Bernardoff <vb@luminar.eu.org>";
   vcunat = "Vladimír Čunát <vcunat@gmail.com>";
   veprbl = "Dmitry Kalinkin <veprbl@gmail.com>";
+  vikstrous = "Viktor Stanchev <me@viktorstanchev.com>";
   viric = "Lluís Batlle i Rossell <viric@viric.name>";
   vizanto = "Danny Wilson <danny@prime.vc>";
   vklquevs = "vklquevs <vklquevs@gmail.com>";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2158,6 +2158,29 @@ in {
     };
   };
 
+  buildnotify = buildPythonPackage rec {
+    name = "BuildNotify-${version}";
+    version = "0.3.5";
+
+    disabled = !isPy27;
+    doCheck = false;
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/b/buildnotify/${name}.tar.gz";
+      sha256 = "0659i9k579b456f3mnnfq6mxp0zg90jwmsimks2wd4n0mknq1fny";
+    };
+
+    propagatedBuildInputs = with self; [ dateutil setuptools pytz pyqt4 ];
+
+    meta = {
+      description = "Cruise Control build monitor";
+      homepage = https://bitbucket.org/Anay/buildnotify/wiki/Home;
+      license = licenses.gpl3;
+      maintainers = with maintainers; [ vikstrous ];
+      platforms = platforms.unix;
+    };
+  };
+
   buttersink = buildPythonPackage rec {
     name = "buttersink-0.6.8";
 


### PR DESCRIPTION
###### Motivation for this change
I wanted to try out buildnotify.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


The executable is called `buildnotifyapplet.py` and I think that's fine. If you guys want me to change it, I might need help. This is my first nix package.