### PR TITLE
mapnik: Fix darwin build

### DIFF
--- a/pkgs/development/libraries/icu/default.nix
+++ b/pkgs/development/libraries/icu/default.nix
@@ -16,9 +16,6 @@ stdenv.mkDerivation ({
   outputs = [ "out" "dev" ];
   outputBin = "dev";
 
-  makeFlags = stdenv.lib.optionalString stdenv.isDarwin
-    "CXXFLAGS=-headerpad_max_install_names";
-
   # FIXME: This fixes dylib references in the dylibs themselves, but
   # not in the programs in $out/bin.
   buildInputs = stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;

--- a/pkgs/development/libraries/mapnik/default.nix
+++ b/pkgs/development/libraries/mapnik/default.nix
@@ -24,7 +24,31 @@ stdenv.mkDerivation rec {
     ];
 
   configurePhase = ''
-    scons configure PREFIX="$out"
+    scons configure PREFIX="$out" BOOST_INCLUDES="${boost.dev}/include" \
+                                  BOOST_LIBS="${boost.out}/lib" \
+                                  CAIRO_INCLUDES="${cairo.dev}/include" \
+                                  CAIRO_LIBS="${cairo.out}/lib" \
+                                  FREETYPE_INCLUDES="${freetype.dev}/include" \
+                                  FREETYPE_LIBS="${freetype.out}/lib" \
+                                  GDAL_CONFIG="${gdal}/bin/gdal-config" \
+                                  HB_INCLUDES="${harfbuzz.dev}/include" \
+                                  HB_LIBS="${harfbuzz.out}/lib" \
+                                  ICU_INCLUDES="${icu.dev}/include" \
+                                  ICU_LIBS="${icu.out}/lib" \
+                                  JPEG_INCLUDES="${libjpeg.dev}/include" \
+                                  JPEG_LIBS="${libjpeg.out}/lib" \
+                                  PNG_INCLUDES="${libpng.dev}/include" \
+                                  PNG_LIBS="${libpng.out}/lib" \
+                                  PROJ_INCLUDES="${proj}/include" \
+                                  PROJ_LIBS="${proj}/lib" \
+                                  SQLITE_INCLUDES="${sqlite.dev}/include" \
+                                  SQLITE_LIBS="${sqlite.out}/lib" \
+                                  TIFF_INCLUDES="${libtiff.dev}/include" \
+                                  TIFF_LIBS="${libtiff.out}/lib" \
+                                  WEBP_INCLUDES="${libwebp}/include" \
+                                  WEBP_LIBS="${libwebp}/lib" \
+                                  XML2_INCLUDES="${libxml2.dev}/include" \
+                                  XML2_LIBS="${libxml2.out}/lib"
   '';
 
   buildPhase = false;


### PR DESCRIPTION
###### Motivation for this change
mapnik did not build on darwin. This was due to `libicu` not being compiled with C++11 support. (Because CXXFLAGS was accidentally overriden). Now it builds again.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

