### PR TITLE
nodejs: 4.6.0 -> 4.6.2; 6.8.0 -> 6.9.1

### DIFF
--- a/pkgs/development/web/nodejs/v4.nix
+++ b/pkgs/development/web/nodejs/v4.nix
@@ -10,11 +10,11 @@ let
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 in
   stdenv.mkDerivation (nodejs // rec {
-    version = "4.6.0";
+    version = "4.6.2";
     name = "${baseName}-${version}";
     src = fetchurl {
       url = "http://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
-      sha256 = "1566q1kkv8j30fgqx8sm2h8323f38wwpa1hfb10gr6z46jyhv4a2";
+      sha256 = "17ick2r2biyxs5zf83i8q8844fbcphm0d5g1z70mcrb86yrmi545";
     };
 
   })

--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -10,19 +10,12 @@ let
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 in
   stdenv.mkDerivation (nodejs // rec {
-    version = "6.8.0";
+    version = "6.9.1";
     name = "${baseName}-${version}";
     src = fetchurl {
       url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-      sha256 = "13arzwki13688hr1lh871y06lrk019g4hkasmg11arm8j1dcwcpq";
+      sha256 = "0a87vzb33xdg8w0xi3c605hfav3c9m4ylab1436whz3p0l9qvp8b";
     };
-
-    patches = nodejs.patches ++ [
-      (fetchpatch {
-        url = "https://github.com/nodejs/node/commit/fc164acbbb700fd50ab9c04b47fc1b2687e9c0f4.patch";
-        sha256 = "1rms3n09622xmddn013yvf5c6p3s8w8s0d2h813zs8c1l15k4k1i";
-      })
-    ];
 
   })
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Please backport to 16.09
