### PR TITLE
plink-ng: init at 1.90b3

### DIFF
--- a/pkgs/applications/science/biology/plink-ng/default.nix
+++ b/pkgs/applications/science/biology/plink-ng/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, zlib, openblas, darwin}:
+
+stdenv.mkDerivation rec {
+  name = "plink-ng-${version}";
+  version = "1.90b3";
+
+  src = fetchFromGitHub {
+    owner = "chrchang";
+    repo = "plink-ng";
+    rev = "v${version}";
+    sha256 = "1zhffjbwpd50dxywccbnv1rxy9njwz73l4awc5j7i28rgj3davcq";
+  };
+
+  buildInputs = [ zlib ] ++ (if stdenv.isDarwin then [ darwin.apple_sdk.frameworks.Accelerate ] else [ openblas ]) ;
+
+  buildPhase = ''
+    sed -i 's|zlib-1.2.8/zlib.h|zlib.h|g' *.c *.h
+    ${if stdenv.cc.isClang then "sed -i 's|g++|clang++|g' Makefile.std" else ""}
+    make ZLIB=-lz ${if stdenv.isDarwin then "" else "BLASFLAGS=-lopenblas"} -f Makefile.std
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp plink $out/bin
+  '';
+
+  meta = {
+    description = "A comprehensive update to the PLINK association analysis toolset";
+    homepage = "https://www.cog-genomics.org/plink2";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16350,6 +16350,8 @@ in
   paml = callPackage ../applications/science/biology/paml { };
 
   plink = callPackage ../applications/science/biology/plink/default.nix { };
+  
+  plink-ng = callPackage ../applications/science/biology/plink-ng/default.nix { };
 
   samtools = callPackage ../applications/science/biology/samtools/default.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Add plink-ng derivation.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


