### PR TITLE
singularity: init 2.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -198,6 +198,7 @@
   jagajaga = "Arseniy Seroka <ars.seroka@gmail.com>";
   javaguirre = "Javier Aguirre <contacto@javaguirre.net>";
   jb55 = "William Casarin <bill@casarin.me>";
+  jbedo = "Justin Bedő <cu@cua0.org>";
   jcumming = "Jack Cummings <jack@mudshark.org>";
   jefdaj = "Jeffrey David Johnson <jefdaj@gmail.com>";
   jfb = "James Felix Black <james@yamtime.com>";

--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "singularity-${version}";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "singularityware";
+    repo = "singularity";
+    rev = version;
+    sha256 = "19g43gfdy5s8y4252474cp39d6ypn5dd37wp0s21fgd13vqy26px";
+  };
+
+  buildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    homepage = http://singularity.lbl.gov/;
+    description = "Designed around the notion of extreme mobility of compute and reproducible science, Singularity enables users to have full control of their operating system environment";
+    license = "BSD license with 2 modifications";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.jbedo ];
+  };
+}

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -1,0 +1,100 @@
+{ runCommand
+, stdenv
+, storeDir ? builtins.storeDir
+, writeScript
+, singularity
+, writeReferencesToFile
+, bash
+, vmTools
+, gawk
+, utillinux
+, e2fsprogs
+, squashfsTools }:
+
+rec {
+  shellScript = name: text:
+    writeScript name ''
+      #!${stdenv.shell}
+      set -e
+      ${text}
+    '';
+
+  mkLayer = {
+    name,
+    contents ? [],
+  }:
+    runCommand "singularity-layer-${name}" {
+      inherit contents;
+    } ''
+      mkdir $out
+      for f in $contents ; do
+        cp -ra $f $out/
+      done
+    '';
+
+  buildImage = {
+    name,
+    contents ? [],
+    diskSize ? 1024,
+    runScript ? "#!${stdenv.shell}\nexec /bin/sh",
+    runAsRoot ? null,
+    extraSpace ? 0
+  }:
+    let layer = mkLayer {
+          inherit name;
+          contents = contents ++ [ bash runScriptFile ];
+          };
+        runAsRootFile = shellScript "run-as-root.sh" runAsRoot;
+        runScriptFile = shellScript "run-script.sh" runScript;
+        result = vmTools.runInLinuxVM (
+          runCommand "singularity-image-${name}.img" {
+            buildInputs = [ singularity e2fsprogs utillinux gawk ];
+            layerClosure = writeReferencesToFile layer;
+            preVM = vmTools.createEmptyImage {
+              size = diskSize;
+              fullName = "singularity-run-disk";
+            };
+          }
+          ''
+            rm -rf $out
+            mkdir disk
+            mkfs -t ext3 -b 4096 /dev/${vmTools.hd}
+            mount /dev/${vmTools.hd} disk
+            cd disk
+
+            # Run root script
+            ${stdenv.lib.optionalString (runAsRoot != null) ''
+              mkdir -p ./${storeDir}
+              mount --rbind ${storeDir} ./${storeDir}
+              unshare -imnpuf --mount-proc chroot ./ ${runAsRootFile}
+              umount -R ./${storeDir}
+            ''}
+
+            # Build /bin and copy across closure
+            mkdir -p bin nix/store
+            for f in $(cat $layerClosure) ; do
+              cp -ar $f ./$f
+              for f in $f/bin/* ; do
+                if [ ! -e bin/$(basename $f) ] ; then
+                  ln -s $f bin/
+                fi
+              done
+            done
+
+            # Create runScript
+            ln -s ${runScriptFile} singularity
+
+            # Size calculation
+            cd ..
+            umount disk
+            size=$(resize2fs -P /dev/${vmTools.hd} | awk '{print $NF}')
+            mount /dev/${vmTools.hd} disk
+            cd disk
+
+            export PATH=$PATH:${e2fsprogs}/bin/
+            singularity create -s $((1 + size * 4 / 1024 + ${toString extraSpace})) $out
+            tar -c . | singularity import $out
+          '');
+
+    in result;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -282,6 +282,8 @@ in
 
   pathsFromGraph = ../build-support/kernel/paths-from-graph.pl;
 
+  singularity-tools = callPackage ../build-support/singularity-tools { };
+
   srcOnly = args: callPackage ../build-support/src-only args;
 
   substituteAll = callPackage ../build-support/substitute/substitute-all.nix { };
@@ -13252,6 +13254,8 @@ in
   hyperterm = self.hyper;
 
   slack = callPackage ../applications/networking/instant-messengers/slack { };
+
+  singularity = callPackage ../applications/virtualization/singularity { };
 
   spectrwm = callPackage ../applications/window-managers/spectrwm { };
 


### PR DESCRIPTION
###### Motivation for this change

Singularity is a container system similar to docker for mobile compute. It has a strong focus on HPC use. I have added a build expression for Singularity and also some support for building Singularity images. The image building interface is inspired by dockerTools.buildImage.

I have tested images produced by my buildImage function both on my NixOS install using the Singularity expression in this pull request. I have also tested the images running on my HPC cluster on a standard Linux setup.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


