### PR TITLE
d binding for gtk

### DIFF
--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -1,0 +1,39 @@
+{stdenv, fetchurl, fetchFromGitHub, dmd, pango, atk,  gdk_pixbuf, gnome3, gstreamer, gtk3, glibc , pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "gtkd";
+  version = "3.3.1";
+  buildInputs = [ dmd pango atk  gdk_pixbuf gstreamer gtk3 gnome3.gtksourceview glibc pkgconfig ];
+
+   src = fetchFromGitHub {
+     owner = "gtkd-developers";
+     repo = "GtkD";
+     rev = "v${version}";
+     md5 = "1a6bb6fa3763d67e200dd269eb264f3b";
+   };
+
+  preConfigure = ''cd ${src}'';
+
+  makeFlags = ''
+    "PREFIX=$out/usr"
+
+    "DESTDIR="${src}/"
+  '';
+
+  buildPhase = ''
+    mkdir -p $out/usr
+    mkdir -p $out/lib
+    make DC='ldconfig' all
+  '';
+
+  installPhase = ''
+    make ${makeFlags} install \
+    install-vte install-shared install-shared-vte
+  '';
+
+  meta = {
+    description = ''D bindings for GTK+ and related libraries'';
+    license = stdenv.lib.licenses.lgpl2 ;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
D bindings for gtk. I couldnt build it yet because of above errors.

building path(s) ‘/nix/store/1f0345wiy7f0cgz3yrjsgy9f136iag6f-gtkd’
unpacking sources
unpacking source archive /nix/store/qgj3a219dijmgjc6jd74780xxhj57l57-GtkD-v3.3.1-src
source root is GtkD-v3.3.1-src
patching sources
configuring
no configure script, doing nothing
building
ldconfig -O -m64 -Isrc -c src/atk/HyperlinkImplIF.d -ofsrc/atk/HyperlinkImplIF.o
ldconfig: invalid option -- 'O'
Try `ldconfig --help' or `ldconfig --usage' for more information.
make: *** [GNUmakefile:210: src/atk/HyperlinkImplIF.o] Error 64


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


