### PR TITLE
w_scan: init at 20161022

### DIFF
--- a/pkgs/applications/video/w_scan/default.nix
+++ b/pkgs/applications/video/w_scan/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "w_scan-${version}";
+  version = "20161022";
+
+  src = fetchurl {
+    url = "http://wirbel.htpc-forum.de/w_scan/${name}.tar.bz2";
+    sha256 = "0y8dq2sm13xn2r2lrqf5pdhr9xcnbxbg1aw3iq1szds2idzsyxr0";
+  };
+
+  meta = {
+    description = "Small CLI utility to scan DVB and ATSC transmissions";
+    homepage = http://wirbel.htpc-forum.de/w_scan/index_en.html;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.nico202 ] ;
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12877,6 +12877,8 @@ in
 
   puddletag = callPackage ../applications/audio/puddletag { };
 
+  w_scan = callPackage ../applications/video/w_scan { };
+
   wavesurfer = callPackage ../applications/misc/audio/wavesurfer { };
 
   wavrsocvt = callPackage ../applications/misc/audio/wavrsocvt { };


### PR DESCRIPTION
###### Motivation for this change
Sometimes scan (dvb-apps) does not work [(example)](https://angrytechnician.wordpress.com/2013/05/08/another-way-to-scan-dvb-channels-w_scan/) while w_scan does the job.
