### PR TITLE
plover: move out of python-packages.nix

### DIFF
--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, python27Packages, wmctrl }:
+
+python27Packages.buildPythonPackage rec {
+  name = "plover-${version}";
+  version = "3.1.0";
+
+  meta = with stdenv.lib; {
+    description = "OpenSteno Plover stenography software";
+    maintainers = with maintainers; [ twey kovirobi ];
+    license = licenses.gpl2;
+  };
+
+  src = fetchurl {
+    url = "https://github.com/openstenoproject/plover/archive/v${version}.tar.gz";
+    sha256 = "1zdlgyjp93sfvk6by7rsh9hj4ijzplglrxpcpkcir6c3nq2bixl4";
+  };
+
+  # This is a fix for https://github.com/pypa/pip/issues/3624 causing regression https://github.com/pypa/pip/issues/3781
+  postPatch = ''
+    substituteInPlace setup.py --replace " in sys_platform" " == sys_platform"
+    '';
+
+  buildInputs = with python27Packages; [ pytest mock ];
+  propagatedBuildInputs = with python27Packages; [ six setuptools pyserial appdirs hidapi
+    wxPython xlib wmctrl ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14158,6 +14158,8 @@ in
     gtksharp = gtk-sharp-2_0;
   };
 
+  plover = callPackage ../applications/misc/plover { };
+
   plugin-torture = callPackage ../applications/audio/plugin-torture { };
 
   pmenu = callPackage ../applications/misc/pmenu { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14878,33 +14878,6 @@ in {
     };
   };
 
-
-  plover = buildPythonPackage rec {
-    name = "plover-${version}";
-    version = "3.1.0";
-    disabled = !isPy27;
-
-    meta = {
-      description = "OpenSteno Plover stenography software";
-      maintainers = with maintainers; [ twey kovirobi ];
-      license = licenses.gpl2;
-    };
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/openstenoproject/plover/archive/v${version}.tar.gz";
-      sha256 = "1zdlgyjp93sfvk6by7rsh9hj4ijzplglrxpcpkcir6c3nq2bixl4";
-    };
-
-    # This is a fix for https://github.com/pypa/pip/issues/3624 causing regression https://github.com/pypa/pip/issues/3781
-    postPatch = ''
-     substituteInPlace setup.py --replace " in sys_platform" " == sys_platform"
-    '';
-
-    buildInputs = with self; [ pytest mock ];
-    propagatedBuildInputs = with self; [ six setuptools pyserial appdirs hidapi
-                                         wxPython xlib pkgs.wmctrl ];
-  };
-
   pygal = buildPythonPackage rec {
     version = "2.0.10";
     name = "pygal-${version}";


### PR DESCRIPTION
###### Motivation for this change

Plover is a standalone application, not a library. Thought this change, as it is, may break people's existing installation as it moves plover from pkgs.python27Packages.plover to pkgs.plover.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


