### PR TITLE
firefox: fix geolocation feature

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -70,6 +70,7 @@ common = { pname, version, sha512 }: stdenv.mkDerivation rec {
       "--enable-jemalloc"
       "--disable-gconf"
       "--enable-default-toolkit=cairo-gtk2"
+      "--with-google-api-keyfile=ga"
     ]
     ++ lib.optional enableGTK3 "--enable-default-toolkit=cairo-gtk3"
     ++ (if debugBuild then [ "--enable-debug" "--enable-profiling" ]
@@ -85,6 +86,9 @@ common = { pname, version, sha512 }: stdenv.mkDerivation rec {
       configureScript="$(realpath ./configure)"
       mkdir ../objdir
       cd ../objdir
+
+      # Google API key used for geolocation
+      cat >ga <<<"AIzaSyAeBuGRUrxHr4_eHhrCwdkl0G-O4qR5UXs"
     '';
 
   preInstall =


### PR DESCRIPTION
###### Motivation for this change
Some websites ask the user if they wish to be geolocated. This feature isn't currently working in firefox because of the way it is packaged in NixOS.

Firefox performs geolocation with the value from geo.wifi.uri (see in about:config), which is set by default to `https://www.googleapis.com/geolocation/v1/geolocate?key=%GOOGLE_API_KEY%`. The google api key must be set at compile time in order for geolocation to work (it defaults to no-google-api-key).

This commit adds the key from Ubuntu sources (apt-get source firefox), after that it works. I don't know if we can simply copy the key from another distro, and if it's supposed to be updated. Poking around reveals that there are other keys which aren't set : 

```
#define MOZ_MOZILLA_API_KEY no-mozilla-api-key
#define MOZ_GOOGLE_API_KEY no-google-api-key
#define MOZ_GOOGLE_OAUTH_API_KEY no-google-oauth-api-key
#define MOZ_GOOGLE_OAUTH_API_CLIENTID no-google-oauth-api-clientid
#define MOZ_BING_API_KEY no-bing-api-key
#define MOZ_BING_API_CLIENTID no-bing-api-clientid
```

I don't know what the other keys are used for.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Firefox uses a google API to perform geolocation. This API requires a
key which must be given at build time. This commit adds the key from
Ubuntu's firefox sources.