### PR TITLE
lxqt: add gvfs to system packages

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -32,6 +32,7 @@ in
     };
 
     environment.systemPackages = [
+      pkgs.gvfs
       pkgs.kde5.kwindowsystem # provides some QT5 plugins needed by lxqt-panel
       pkgs.kde5.libkscreen # provides plugins for screen management software
       pkgs.kde5.oxygen-icons5 # default icon theme
@@ -79,6 +80,8 @@ in
       "/share/icons"
       "/share/lxqt"
     ];
+
+    environment.variables.GIO_EXTRA_MODULES = [ "${pkgs.gvfs}/lib/gio/modules" ];
 
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Access to virtual file systems in PCManFM-QT depends on gvfs.

Fixes https://github.com/NixOS/nixpkgs/issues/20363.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).