### PR TITLE
Use multiple outputs for gtkmm and friends

### DIFF
--- a/pkgs/development/libraries/atkmm/default.nix
+++ b/pkgs/development/libraries/atkmm/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "ff95385759e2af23828d4056356f25376cfabc41e690ac1df055371537e458bd";
   };
 
+  outputs = [ "out" "dev" ];
+
   propagatedBuildInputs = [ atk glibmm ];
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/cairomm/default.nix
+++ b/pkgs/development/libraries/cairomm/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ cairo libsigcxx ];
   buildInputs = [ fontconfig freetype ]

--- a/pkgs/development/libraries/gtkmm/2.x.nix
+++ b/pkgs/development/libraries/gtkmm/2.x.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0680a53b7bf90b4e4bf444d1d89e6df41c777e0bacc96e9c09fc4dd2f5fe6b72";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [pkgconfig];
 
   propagatedBuildInputs = [ glibmm gtk2 atkmm cairomm pangomm ];

--- a/pkgs/development/libraries/gtkmm/3.x.nix
+++ b/pkgs/development/libraries/gtkmm/3.x.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "05da4d4b628fb20c8384630ddf478a3b5562952b2d6181fe28d58f6cbc0514f5";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ epoxy ];
 

--- a/pkgs/development/libraries/pangomm/default.nix
+++ b/pkgs/development/libraries/pangomm/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "9762ee2a2d5781be6797448d4dd2383ce14907159b30bc12bf6b08e7227be3af";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pango glibmm cairomm ];
 

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -10,6 +10,8 @@ mkPythonDerivation rec {
     sha256 = "08b29cfb08efc80f7a8630a2734dec65a99c1b59f1e5771c671d2e4ed8a5cbe7";
   };
 
+  outputs = [ "out" "dev" ];
+
   buildInputs = [ pkgconfig glib gobjectIntrospection ]
                  ++ stdenv.lib.optionals stdenv.isDarwin [ which ncurses ];
   propagatedBuildInputs = [ pycairo cairo ];


### PR DESCRIPTION
###### Motivation for this change

Using multiple outputs for gtkmm and related packages reduces the closure on the installation CD.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

