### PR TITLE
ldns: multiple outputs

### DIFF
--- a/pkgs/development/libraries/ldns/default.nix
+++ b/pkgs/development/libraries/ldns/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1kf8pkwhcssvgzhh6ha1pjjiziwvwmfaali7kaafh6118mcy124b";
   };
 
+  outputs = [ "out" "dev" ];
+
   patches = [ ./perl-5.22-compat.patch ];
 
   postPatch = ''
@@ -18,6 +20,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl ];
 
   configureFlags = [ "--with-ssl=${openssl.dev}" "--with-drill" ];
+
+  postInstall = ''
+    moveToOutput "bin/ldns-config" "$dev"
+  '';
 
   meta = with stdenv.lib; {
     description = "Library with the aim of simplifying DNS programming in C";


### PR DESCRIPTION
###### Motivation for this change

Using multiple outputs for ldns reduces the closure size for the installation CD.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


