### PR TITLE
Use KDE 5 for the graphical installation DVD

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
@@ -18,7 +18,10 @@ with lib;
       autoLogin = true;
     };
 
-    desktopManager.kde5.enable = true;
+    desktopManager.kde5 = {
+      enable = true;
+      enableQt4Support = false;
+    };
 
     # Enable touchpad support for many laptops.
     synaptics.enable = true;

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
@@ -1,19 +1,37 @@
 # This module defines a NixOS installation CD that contains X11 and
-# KDE 4.
+# KDE 5.
 
 { config, lib, pkgs, ... }:
 
 with lib;
 
 {
-  imports = [ ./installation-cd-base.nix ../../profiles/graphical.nix ];
+  imports = [ ./installation-cd-base.nix ];
 
-  # Provide wicd for easy wireless configuration.
-  #networking.wicd.enable = true;
+  services.xserver = {
+    enable = true;
+
+    # Automatically login as root.
+    displayManager.slim = {
+      enable = true;
+      defaultUser = "root";
+      autoLogin = true;
+    };
+
+    desktopManager.kde5.enable = true;
+
+    # Enable touchpad support for many laptops.
+    synaptics.enable = true;
+  };
 
   environment.systemPackages =
-    [ # Include gparted for partitioning disks.
+    [ pkgs.glxinfo
+
+      # Include gparted for partitioning disks.
       pkgs.gparted
+
+      # Firefox for reading the manual.
+      pkgs.firefox
 
       # Include some editors.
       pkgs.vim
@@ -32,23 +50,12 @@ with lib;
   # Don't start the X server by default.
   services.xserver.autorun = mkForce false;
 
-  # Auto-login as root.
-  services.xserver.displayManager.kdm.extraConfig =
-    ''
-      [X-*-Core]
-      AllowRootLogin=true
-      AutoLoginEnable=true
-      AutoLoginUser=root
-      AutoLoginPass=""
-    '';
-
   # Custom kde-workspace adding some icons on the desktop
-
   system.activationScripts.installerDesktop = let
     openManual = pkgs.writeScript "nixos-manual.sh" ''
       #!${pkgs.stdenv.shell}
       cd ${config.system.build.manual.manual}/share/doc/nixos/
-      konqueror ./index.html
+      firefox ./index.html
     '';
 
     desktopFile = pkgs.writeText "nixos-manual.desktop" ''
@@ -57,55 +64,14 @@ with lib;
       Type=Application
       Name=NixOS Manual
       Exec=${openManual}
-      Icon=konqueror
+      Icon=firefox
     '';
 
   in ''
     mkdir -p /root/Desktop
     ln -sfT ${desktopFile} /root/Desktop/nixos-manual.desktop
-    ln -sfT ${pkgs.kde4.konsole}/share/applications/kde4/konsole.desktop /root/Desktop/konsole.desktop
+    ln -sfT ${pkgs.kde5.konsole}/share/applications/org.kde.konsole.desktop /root/Desktop/org.kde.konsole.desktop
     ln -sfT ${pkgs.gparted}/share/applications/gparted.desktop /root/Desktop/gparted.desktop
   '';
-
-  services.xserver.desktopManager.kde4.kdeWorkspacePackage = let
-    pkg = pkgs.kde4.kde_workspace;
-
-    plasmaInit = pkgs.writeText "00-defaultLayout.js" ''
-      loadTemplate("org.kde.plasma-desktop.defaultPanel")
-
-      for (var i = 0; i < screenCount; ++i) {
-        var desktop = new Activity
-        desktop.name = i18n("Desktop")
-        desktop.screen = i
-        desktop.wallpaperPlugin = 'image'
-        desktop.wallpaperMode = 'SingleImage'
-
-        var folderview = desktop.addWidget("folderview");
-        folderview.writeConfig("url", "desktop:/");
-
-        //Create more panels for other screens
-        if (i > 0){
-          var panel = new Panel
-          panel.screen = i
-          panel.location = 'bottom'
-          panel.height = screenGeometry(i).height > 1024 ? 35 : 27
-          var tasks = panel.addWidget("tasks")
-          tasks.writeConfig("showOnlyCurrentScreen", true);
-        }
-      }
-    '';
-
-  in
-    pkgs.runCommand pkg.name
-      { inherit (pkg) meta; }
-      ''
-        mkdir -p $out
-        cp -prf ${pkg}/* $out/
-        chmod a+w $out/share/apps/plasma-desktop/init
-        cp -f ${plasmaInit} $out/share/apps/plasma-desktop/init/00-defaultLayout.js
-      '';
-
-  # Disable large stuff that's not very useful on the installation CD.
-  services.xserver.desktopManager.kde4.enablePIM = false;
 
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
@@ -53,21 +53,14 @@ with lib;
   # Don't start the X server by default.
   services.xserver.autorun = mkForce false;
 
-  # Custom kde-workspace adding some icons on the desktop
   system.activationScripts.installerDesktop = let
-    openManual = pkgs.writeScript "nixos-manual.sh" ''
-      #!${pkgs.stdenv.shell}
-      cd ${config.system.build.manual.manual}/share/doc/nixos/
-      firefox ./index.html
-    '';
-
     desktopFile = pkgs.writeText "nixos-manual.desktop" ''
       [Desktop Entry]
       Version=1.0
       Type=Application
       Name=NixOS Manual
-      Exec=${openManual}
-      Icon=firefox
+      Exec=firefox ${config.system.build.manual.manual}/share/doc/nixos/index.html
+      Icon=text-html
     '';
 
   in ''

--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -141,22 +141,18 @@ in
         kde5.konsole
         kde5.print-manager
 
-        # Oxygen icons moved to KDE Frameworks 5.16 and later.
-        (kde5.oxygen-icons or kde5.oxygen-icons5)
+        # Install Breeze icons if available
+        (kde5.breeze-icons or kde5.oxygen-icons5 or kde5.oxygen-icons)
         pkgs.hicolor_icon_theme
 
-        kde5.kde-gtk-config
+        kde5.kde-gtk-config kde5.breeze-gtk
 
-        pkgs.phonon-backend-gstreamer
         pkgs.qt5.phonon-backend-gstreamer
       ]
 
       # Plasma 5.5 and later has a Breeze GTK theme.
       # If it is not available, Orion is very similar to Breeze.
       ++ lib.optional (!(lib.hasAttr "breeze-gtk" kde5)) pkgs.orion
-
-      # Install Breeze icons if available
-      ++ lib.optional (lib.hasAttr "breeze-icons" kde5) kde5.breeze-icons
 
       # Install activity manager if available
       ++ lib.optional (lib.hasAttr "kactivitymanagerd" kde5) kde5.kactivitymanagerd
@@ -217,7 +213,6 @@ in
         kde5.ecm # for the setup-hook
         kde5.plasma-workspace
         kde5.breeze-icons
-        (kde5.oxygen-icons or kde5.oxygen-icons5)
       ];
     };
 

--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -22,6 +22,15 @@ in
         description = "Enable the Plasma 5 (KDE 5) desktop environment.";
       };
 
+      enableQt4Support = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Enable support for Qt 4-based applications. Particularly, install the
+          Qt 4 version of the Breeze theme and a default backend for Phonon.
+        '';
+      };
+
     };
 
   };
@@ -105,7 +114,7 @@ in
         kde5.sonnet
         kde5.threadweaver
 
-        kde5.breeze
+        kde5.breeze-qt5
         kde5.kactivitymanagerd
         kde5.kde-cli-tools
         kde5.kdecoration
@@ -159,6 +168,8 @@ in
 
       # frameworkintegration was split with plasma-integration in Plasma 5.6
       ++ lib.optional (lib.hasAttr "plasma-integration" kde5) kde5.plasma-integration
+
+      ++ lib.optionals cfg.enableQt4Support [ kde5.breeze-qt4 pkgs.phonon-backend-gstreamer ]
 
       # Optional hardware support features
       ++ lib.optional config.hardware.bluetooth.enable kde5.bluedevil

--- a/pkgs/desktops/kde-5/plasma/default.nix
+++ b/pkgs/desktops/kde-5/plasma/default.nix
@@ -44,14 +44,6 @@ let
       inherit (srcs.breeze) src version;
     };
     breeze-qt5 = callPackage ./breeze-qt5.nix {};
-    breeze =
-      let
-        version = (builtins.parseDrvName breeze-qt5.name).version;
-      in
-        symlinkJoin {
-          name = "breeze-${version}";
-          paths = map (pkg: pkg.out or pkg) [ breeze-gtk breeze-qt4 breeze-qt5 ];
-        };
     breeze-grub = callPackage ./breeze-grub.nix {};
     breeze-plymouth = callPackage ./breeze-plymouth {};
     kactivitymanagerd = callPackage ./kactivitymanagerd.nix {};

--- a/pkgs/desktops/kde-5/plasma/oxygen.nix
+++ b/pkgs/desktops/kde-5/plasma/oxygen.nix
@@ -1,19 +1,20 @@
 {
-  plasmaPackage,
-  ecm, makeQtWrapper,
+  plasmaPackage, kdeWrapper,
+  ecm,
   frameworkintegration, kcmutils, kcompletion, kconfig, kdecoration, kguiaddons,
   ki18n, kwidgetsaddons, kservice, kwayland, kwindowsystem, qtx11extras
 }:
 
-plasmaPackage {
-  name = "oxygen";
-  nativeBuildInputs = [ ecm makeQtWrapper ];
-  propagatedBuildInputs = [
-    frameworkintegration kcmutils kcompletion kconfig kdecoration kguiaddons
-    ki18n kservice kwayland kwidgetsaddons kwindowsystem qtx11extras
-  ];
-  postInstall = ''
-    wrapQtProgram "$out/bin/oxygen-demo5"
-    wrapQtProgram "$out/bin/oxygen-settings5"
-  '';
+let
+  unwrapped = plasmaPackage {
+    name = "oxygen";
+    nativeBuildInputs = [ ecm ];
+    propagatedBuildInputs = [
+      frameworkintegration kcmutils kcompletion kconfig kdecoration kguiaddons
+      ki18n kservice kwayland kwidgetsaddons kwindowsystem qtx11extras
+    ];
+  };
+in
+kdeWrapper unwrapped {
+  targets = [ "bin/oxygen-demo5" "bin/oxygen-settings5" ];
 }

--- a/pkgs/desktops/kde-5/plasma/plasma-desktop/default.nix
+++ b/pkgs/desktops/kde-5/plasma/plasma-desktop/default.nix
@@ -38,4 +38,9 @@ plasmaPackage rec {
     "-DEvdev_INCLUDE_DIRS=${xf86inputevdev.dev}/include/xorg"
     "-DSynaptics_INCLUDE_DIRS=${xf86inputsynaptics.dev}/include/xorg"
   ];
+  postInstall = ''
+    # Display ~/Desktop contents on the desktop by default.
+    sed -i "$out/share/plasma/shells/org.kde.plasma.desktop/contents/defaults" \
+        -e 's/Containment=org.kde.desktopcontainment/Containment=org.kde.plasma.folder/'
+  '';
 }

--- a/pkgs/desktops/kde-5/plasma/startkde/startkde.sh
+++ b/pkgs/desktops/kde-5/plasma/startkde/startkde.sh
@@ -7,7 +7,8 @@ export QML_IMPORT_PATH="$QML_IMPORT_PATH${QML_IMPORT_PATH:+:}@QML_IMPORT_PATH@"
 export QML2_IMPORT_PATH="$QML2_IMPORT_PATH${QML2_IMPORT_PATH:+:}@QML2_IMPORT_PATH@"
 
 # Set the default GTK 2 theme
-if [ ! -e $HOME/.gtkrc-2.0 -a -e /run/current-system/sw/share/themes/Breeze/gtk-2.0/gtkrc ]; then
+if ! [ -e $HOME/.gtkrc-2.0 ] \
+     && [ -e /run/current-system/sw/share/themes/Breeze/gtk-2.0/gtkrc ]; then
     cat >$HOME/.gtkrc-2.0 <<EOF
 # Default GTK+ 2 config for NixOS KDE 5
 include "/run/current-system/sw/share/themes/Breeze/gtk-2.0/gtkrc"
@@ -21,7 +22,8 @@ gtk-button-images=1
 EOF
 fi
 
-if [ ! -e $HOME/.config/gtk-3.0/settings.ini -a -e /run/current-system/sw/share/themes/Breeze/gtk-3.0 ]; then
+if ! [ -e $HOME/.config/gtk-3.0/settings.ini ] \
+       && [ -e /run/current-system/sw/share/themes/Breeze/gtk-3.0 ]; then
     cat >$HOME/.config/gtk-3.0/settings.ini <<EOF
 [Settings]
 gtk-theme-name=Breeze
@@ -98,6 +100,14 @@ fi
 # We need to create config folder so we can write startupconfigkeys
 configDir=$(qtpaths --writable-path GenericConfigLocation)
 mkdir -p "$configDir"
+
+if ! [ -e $configDir/kcminputrc ]; then
+    cat >$configDir/kcminputrc <<EOF
+[Mouse]
+cursorTheme=breeze_cursors
+cursorSize=0
+EOF
+fi
 
 THEME=org.kde.breeze
 #This is basically setting defaults so we can use them with kstartupconfig5

--- a/pkgs/desktops/kde-5/plasma/startkde/startkde.sh
+++ b/pkgs/desktops/kde-5/plasma/startkde/startkde.sh
@@ -6,6 +6,34 @@ export QT_PLUGIN_PATH="$QT_PLUGIN_PATH${QT_PLUGIN_PATH:+:}@QT_PLUGIN_PATH@"
 export QML_IMPORT_PATH="$QML_IMPORT_PATH${QML_IMPORT_PATH:+:}@QML_IMPORT_PATH@"
 export QML2_IMPORT_PATH="$QML2_IMPORT_PATH${QML2_IMPORT_PATH:+:}@QML2_IMPORT_PATH@"
 
+# Set the default GTK 2 theme
+if [ ! -e $HOME/.gtkrc-2.0 -a -e /run/current-system/sw/share/themes/Breeze/gtk-2.0/gtkrc ]; then
+    cat >$HOME/.gtkrc-2.0 <<EOF
+# Default GTK+ 2 config for NixOS KDE 5
+include "/run/current-system/sw/share/themes/Breeze/gtk-2.0/gtkrc"
+gtk-theme-name="Breeze"
+gtk-icon-theme-name="breeze"
+gtk-fallback-icon-theme="hicolor"
+gtk-cursor-theme-name="breeze_cursors"
+gtk-toolbar-style=GTK_TOOLBAR_ICONS
+gtk-menu-images=1
+gtk-button-images=1
+EOF
+fi
+
+if [ ! -e $HOME/.config/gtk-3.0/settings.ini -a -e /run/current-system/sw/share/themes/Breeze/gtk-3.0 ]; then
+    cat >$HOME/.config/gtk-3.0/settings.ini <<EOF
+[Settings]
+gtk-theme-name=Breeze
+gtk-icon-theme-name=breeze
+gtk-fallback-icon-theme=hicolor
+gtk-cursor-theme-name=breeze_cursors
+gtk-toolbar-style=GTK_TOOLBAR_ICONS
+gtk-menu-images=1
+gtk-button-images=1
+EOF
+fi
+
 # The KDE icon cache is supposed to update itself
 # automatically, but it uses the timestamp on the icon
 # theme directory as a trigger.  Since in Nix the


### PR DESCRIPTION
###### Motivation for this change

Using KDE 4 for our graphical installation DVD does not present our best face to the world! The installation DVD is updated to use KDE 5. Combined with several of my multiple-outputs-related pull requests, there is no significant change in image size; it remains at 1.9 GB. I have also made several changes that make KDE 5 work more perfectly out of the box.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

