### PR TITLE
firefox: 49.0.2 -> 50.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -141,8 +141,8 @@ in {
 
   firefox-unwrapped = common {
     pname = "firefox";
-    version = "49.0.2";
-    sha512 = "e9daa62c8e645ec034f1435afb579ddb5c503db313ea0cc3e48b7508f8368028979de07ca1426cc4c0f3ae82756f39dcb3b349712d520b8503a34afbd443fb1e";
+    version = "50.0";
+    sha512 = "1v0lc2pn6varpy93vbjs2pl1c5d0vcnvq356zal1mh4wdyp6zvr8rzc5amwpp7h000w2l7pmp037wn9h0nwrzrcrdw3pk1qw8amacnc";
   };
 
   firefox-esr-unwrapped = common {

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -9,11 +9,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "nss-${version}";
-  version = "3.26";
+  version = "3.26.2";
 
   src = fetchurl {
-    url = "mirror://mozilla/security/nss/releases/NSS_3_26_RTM/src/${name}.tar.gz";
-    sha256 = "0r65s5q8kk0vr48s0zr8xi610k7h072lgkkpp4z6jlxr19bkly4i";
+    url = "mirror://mozilla/security/nss/releases/NSS_3_26_2_RTM/src/${name}.tar.gz";
+    sha256 = "0nhs2cxbk6npnnv590yd772nvwvxwwldkzf7sjrzmxgdjwphm90k";
   };
 
   buildInputs = [ nspr perl zlib sqlite ];


### PR DESCRIPTION
###### Motivation for this change
Update, see #20434 for the `firefox-bin` updates

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


