### PR TITLE
youtube-dl: 2016-11-08.1 -> 2016-11-14.1

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -15,11 +15,11 @@ with stdenv.lib;
 buildPythonApplication rec {
 
   name = "youtube-dl-${version}";
-  version = "2016.11.08.1";
+  version = "2016.11.14.1";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${name}.tar.gz";
-    sha256 = "95d45438254c949952127b269451da861682fb06a7ef62b5f5dc75bc40bfaeeb";
+    sha256 = "d96b5e5fe7de67ea01c2be746c00dc78ffbf3f74654aa989db8baaf153243537";
   };
 
   buildInputs = [ makeWrapper zip ] ++ optional generateManPage pandoc;


### PR DESCRIPTION
###### Motivation for this change
youtube-dl update
most notable changes:
+ Respect HTTP headers from info dict
* Fix media templates with Bandwidth substitution pattern in
  MPD manifests
* Improve thumbnail extraction from JSON-LD

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

