### PR TITLE
Fix purescript_0_10_1 package, fixes #20240

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -589,6 +589,7 @@ self: super: {
   # Tests attempt to use NPM to install from the network into
   # /homeless-shelter. Disabled.
   purescript = dontCheck super.purescript;
+  purescript_0_10_1 = dontCheck super.purescript_0_10_1;
 
   # https://github.com/tych0/xcffib/issues/37
   xcffib = dontCheck super.xcffib;


### PR DESCRIPTION
###### Motivation for this change
purescript_0_10_1 package was broken because of failing tests as per #20240 

###### Things done
Tested using nixos-rebuild switch -I


