### PR TITLE
WIP: mesa bleeding edge

### DIFF
--- a/pkgs/development/compilers/llvm/svn/clang/default.nix
+++ b/pkgs/development/compilers/llvm/svn/clang/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src, python }:
+
+let
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  self = stdenv.mkDerivation {
+    name = "clang-${version}";
+
+    unpackPhase = ''
+      unpackFile ${fetch "cfe" "19k4dk7dfd0yql5ryjlvypw1ix5ny19fs174v0zysfnxcm0zcf0c"}
+      chmod -R u+w cfe-*
+      mv cfe-* clang
+      sourceRoot=$PWD/clang
+      unpackFile ${clang-tools-extra_src}
+      chmod -R u+w clang-tools-extra-*
+      mv clang-tools-extra-* $sourceRoot/tools/extra
+    '';
+
+    buildInputs = [ cmake libedit libxml2 llvm python ];
+
+    cmakeFlags = [
+      "-DCMAKE_CXX_FLAGS=-std=c++11"
+    ] ++
+    # Maybe with compiler-rt this won't be needed?
+    (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
+    (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
+
+    patches = [ ./purity.patch ];
+
+    postPatch = ''
+      sed -i -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/Tools.cpp
+      sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' lib/Driver/ToolChains.cpp
+    '';
+
+    # Clang expects to find LLVMgold in its own prefix
+    # Clang expects to find sanitizer libraries in its own prefix
+    postInstall = ''
+      ln -sv ${llvm}/lib/LLVMgold.so $out/lib
+      ln -sv ${llvm}/lib/clang/${version}/lib $out/lib/clang/${version}/
+      ln -sv $out/bin/clang $out/bin/cpp
+    '';
+
+    enableParallelBuilding = true;
+
+    passthru = {
+      lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
+      isClang = true;
+    } // stdenv.lib.optionalAttrs stdenv.isLinux {
+      inherit gcc;
+    };
+
+    meta = {
+      description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";
+      homepage    = http://llvm.org/;
+      license     = stdenv.lib.licenses.bsd3;
+      platforms   = stdenv.lib.platforms.all;
+    };
+  };
+in self

--- a/pkgs/development/compilers/llvm/svn/clang/purity.patch
+++ b/pkgs/development/compilers/llvm/svn/clang/purity.patch
@@ -1,0 +1,16 @@
+--- a/lib/Driver/Tools.cpp	2016-08-25 15:48:05.187553443 +0200
++++ b/lib/Driver/Tools.cpp	2016-08-25 15:48:47.534468882 +0200
+@@ -9420,13 +9420,6 @@
+   if (!Args.hasArg(options::OPT_static)) {
+     if (Args.hasArg(options::OPT_rdynamic))
+       CmdArgs.push_back("-export-dynamic");
+-
+-    if (!Args.hasArg(options::OPT_shared)) {
+-      const std::string Loader =
+-          D.DyldPrefix + ToolChain.getDynamicLinker(Args);
+-      CmdArgs.push_back("-dynamic-linker");
+-      CmdArgs.push_back(Args.MakeArgString(Loader));
+-    }
+   }
+ 
+   CmdArgs.push_back("-o");

--- a/pkgs/development/compilers/llvm/svn/default.nix
+++ b/pkgs/development/compilers/llvm/svn/default.nix
@@ -1,0 +1,46 @@
+{ newScope, stdenv, isl, fetchsvn, overrideCC, wrapCC, darwin, ccWrapperFun }:
+let
+  callPackage = newScope (self // { inherit stdenv isl version fetch; });
+
+  rev = "289607";
+  version = "4.0.0";
+
+  fetch = name: sha256: fetchsvn {
+    url = "http://llvm.org/svn/llvm-project/${name}/trunk/";
+    inherit rev sha256;
+  };
+
+  compiler-rt_src = fetch "compiler-rt" "0ddjslcmkr64z8k1r7qz1hgrghgnipcsp5rbj30znpb1hqhyyq2k";
+  clang-tools-extra_src = fetch "clang-tools-extra" "1y3qva7x4qbywzpi7bjaiq9bbwr2kdxkmn2xpzknkcqzi522vz0z";
+
+  self = {
+    llvm = callPackage ./llvm.nix {
+      inherit compiler-rt_src stdenv;
+    };
+
+    clang-unwrapped = callPackage ./clang {
+      inherit clang-tools-extra_src stdenv;
+    };
+
+    clang = wrapCC self.clang-unwrapped;
+
+    libcxxClang = ccWrapperFun {
+      cc = self.clang-unwrapped;
+      isClang = true;
+      inherit (self) stdenv;
+      /* FIXME is this right? */
+      inherit (stdenv.cc) libc nativeTools nativeLibc;
+      extraPackages = [ self.libcxx self.libcxxabi ];
+    };
+
+    stdenv = overrideCC stdenv self.clang;
+
+    libcxxStdenv = overrideCC stdenv self.libcxxClang;
+
+    lldb = callPackage ./lldb.nix {};
+
+    libcxx = callPackage ./libc++ {};
+
+    libcxxabi = callPackage ./libc++abi.nix {};
+  };
+in self

--- a/pkgs/development/compilers/llvm/svn/libc++/darwin.patch
+++ b/pkgs/development/compilers/llvm/svn/libc++/darwin.patch
@@ -1,0 +1,39 @@
+--- libcxx-3.8.0.src.org/lib/CMakeLists.txt	2015-12-16 15:41:05.000000000 -0800
++++ libcxx-3.8.0.src/lib/CMakeLists.txt	2016-06-17 19:40:00.293394500 -0700
+@@ -94,30 +94,30 @@
+     add_definitions(-D__STRICT_ANSI__)
+     add_link_flags(
+       "-compatibility_version 1"
+       "-current_version 1"
+-      "-install_name /usr/lib/libc++.1.dylib"
+-      "-Wl,-reexport_library,/usr/lib/libc++abi.dylib"
++      "-install_name ${LIBCXX_LIBCXXABI_LIB_PATH}/libc++.1.dylib"
++      "-Wl,-reexport_library,${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib"
+       "-Wl,-unexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++unexp.exp"
+       "/usr/lib/libSystem.B.dylib")
+   else()
+     if ( ${CMAKE_OSX_SYSROOT} )
+       list(FIND ${CMAKE_OSX_ARCHITECTURES} "armv7" OSX_HAS_ARMV7)
+       if (OSX_HAS_ARMV7)
+         set(OSX_RE_EXPORT_LINE
+-          "${CMAKE_OSX_SYSROOT}/usr/lib/libc++abi.dylib"
++          "${CMAKE_OSX_SYSROOT}${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib"
+           "-Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++sjlj-abi.exp")
+       else()
+         set(OSX_RE_EXPORT_LINE
+-          "-Wl,-reexport_library,${CMAKE_OSX_SYSROOT}/usr/lib/libc++abi.dylib")
++          "-Wl,-reexport_library,${CMAKE_OSX_SYSROOT}${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib")
+       endif()
+     else()
+-      set(OSX_RE_EXPORT_LINE "/usr/lib/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
++      set(OSX_RE_EXPORT_LINE "${LIBCXX_LIBCXXABI_LIB_PATH}/libc++abi.dylib -Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++abi${LIBCXX_LIBCPPABI_VERSION}.exp")
+     endif()
+ 
+     add_link_flags(
+       "-compatibility_version 1"
+-      "-install_name /usr/lib/libc++.1.dylib"
++      "-install_name ${LIBCXX_LIBCXXABI_LIB_PATH}/libc++.1.dylib"
+       "-Wl,-unexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libc++unexp.exp"
+       "${OSX_RE_EXPORT_LINE}"
+       "-Wl,-force_symbols_not_weak_list,${CMAKE_CURRENT_SOURCE_DIR}/notweak.exp"
+       "-Wl,-force_symbols_weak_list,${CMAKE_CURRENT_SOURCE_DIR}/weak.exp")

--- a/pkgs/development/compilers/llvm/svn/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/svn/libc++/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetch, cmake, libcxxabi, fixDarwinDylibNames, version }:
+
+stdenv.mkDerivation rec {
+  name = "libc++-${version}";
+
+  src = fetch "libcxx" "1kmyvzq06fd7zcxqvmsvym4cq6q7yl0dsbkfav8cg9v9rpvqfx0x";
+
+  postUnpack = ''
+    unpackFile ${libcxxabi.src}
+    chmod -R u+w libcxxabi-*
+    mv libcxxabi-* libcxxabi
+    libcxxabiPath=$PWD/libcxxabi
+  '';
+
+  preConfigure = ''
+    # Get headers from the cxxabi source so we can see private headers not installed by the cxxabi package
+    cmakeFlagsArray=($cmakeFlagsArray -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$libcxxabiPath/include")
+  '';
+
+  patches = lib.optional stdenv.isDarwin ./darwin.patch;
+
+  buildInputs = [ cmake libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+  cmakeFlags = [
+      "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
+      "-DLIBCXX_LIBCPPABI_VERSION=2"
+      "-DLIBCXX_CXX_ABI=libcxxabi"
+    ];
+
+  enableParallelBuilding = true;
+
+  linkCxxAbi = stdenv.isLinux;
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    homepage = http://libcxx.llvm.org/;
+    description = "A new implementation of the C++ standard library, targeting C++11";
+    license = "BSD";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/svn/libc++/setup-hook.sh
+++ b/pkgs/development/compilers/llvm/svn/libc++/setup-hook.sh
@@ -1,0 +1,3 @@
+linkCxxAbi="@linkCxxAbi@"
+export NIX_CXXSTDLIB_COMPILE+=" -isystem @out@/include/c++/v1"
+export NIX_CXXSTDLIB_LINK=" -stdlib=libc++${linkCxxAbi:+" -lc++abi"}"

--- a/pkgs/development/compilers/llvm/svn/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/svn/libc++abi.nix
@@ -1,0 +1,47 @@
+{ stdenv, cmake, fetch, libcxx, libunwind, llvm, version }:
+
+stdenv.mkDerivation {
+  name = "libc++abi-${version}";
+
+  src = fetch "libcxxabi" "06ayr0hhlvg2rhm7r4x3vli8mxyg5kyx0q0bjlqj15xkclwrxlb3";
+
+  buildInputs = [ cmake ] ++ stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;
+
+  postUnpack = ''
+    unpackFile ${libcxx.src}
+    unpackFile ${llvm.src}
+    export NIX_CFLAGS_COMPILE+=" -I$PWD/include"
+    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_INCLUDES=$PWD/$(ls -d libcxx-*)/include"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export TRIPLE=x86_64-apple-darwin
+  '';
+
+  installPhase = if stdenv.isDarwin
+    then ''
+      for file in lib/*.dylib; do
+        # this should be done in CMake, but having trouble figuring out
+        # the magic combination of necessary CMake variables
+        # if you fancy a try, take a look at
+        # http://www.cmake.org/Wiki/CMake_RPATH_handling
+        install_name_tool -id $out/$file $file
+      done
+      make install
+      install -d 755 $out/include
+      install -m 644 ../include/*.h $out/include
+    ''
+    else ''
+      install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.so.1.0 $out/lib
+      install -m 644 ../include/cxxabi.h $out/include
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
+      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
+    '';
+
+  meta = {
+    homepage = http://libcxxabi.llvm.org/;
+    description = "A new implementation of low level support for a standard C++ library";
+    license = "BSD";
+    maintainers = with stdenv.lib.maintainers; [ vlstill ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/llvm/svn/lldb.nix
+++ b/pkgs/development/compilers/llvm/svn/lldb.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetch
+, cmake
+, zlib
+, ncurses
+, swig
+, which
+, libedit
+, llvm
+, clang-unwrapped
+, python
+, version
+}:
+
+stdenv.mkDerivation {
+  name = "lldb-${version}";
+
+  src = fetch "lldb" "0wh6bynr8vmzq5rc029saca4pfbzp1i8rxfr7qnmq9lsd7fdkmyr";
+
+  postUnpack = ''
+    # Hack around broken standalone build as of 3.8
+    unpackFile ${llvm.src}
+    chmod -R u+w llvm-*
+    srcDir="$(ls -d lldb-*)"
+    mkdir -p "$srcDir/tools/lib/Support"
+    cp "$(ls -d llvm-*)/lib/Support/regex_impl.h" "$srcDir/tools/lib/Support/"
+
+    # Fix up various paths that assume llvm and clang are installed in the same place
+    substituteInPlace $srcDir/cmake/modules/LLDBStandalone.cmake \
+      --replace CheckAtomic $(readlink -f llvm-*)/cmake/modules/CheckAtomic.cmake
+    sed -i 's,".*ClangConfig.cmake","${clang-unwrapped}/lib/cmake/clang/ClangConfig.cmake",' \
+      $srcDir/cmake/modules/LLDBStandalone.cmake
+    sed -i 's,".*tools/clang/include","${clang-unwrapped}/include",' \
+      $srcDir/cmake/modules/LLDBStandalone.cmake
+    sed -i 's,"$.LLVM_LIBRARY_DIR.",${llvm}/lib ${clang-unwrapped}/lib,' \
+      $srcDir/cmake/modules/LLDBStandalone.cmake
+  '';
+
+  buildInputs = [ cmake python which swig ncurses zlib libedit llvm ];
+
+  CXXFLAGS = "-fno-rtti";
+  hardeningDisable = [ "format" ];
+
+  cmakeFlags = [
+    "-DLLVM_MAIN_INCLUDE_DIR=${llvm}/include"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A next-generation high-performance debugger";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.bsd3;
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/compilers/llvm/svn/llvm-outputs.patch
+++ b/pkgs/development/compilers/llvm/svn/llvm-outputs.patch
@@ -1,0 +1,26 @@
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 94d426b..37f7794 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -333,6 +333,21 @@ int main(int argc, char **argv) {
+     ActiveIncludeOption = "-I" + ActiveIncludeDir;
+   }
+ 
++  /// Nix-specific multiple-output handling: override ActiveLibDir if --link-shared
++  if (!IsInDevelopmentTree) {
++    bool WantShared = true;
++    for (int i = 1; i < argc; ++i) {
++      StringRef Arg = argv[i];
++      if (Arg == "--link-shared")
++        WantShared = true;
++      else if (Arg == "--link-static")
++        WantShared = false; // the last one wins
++    }
++
++    if (WantShared)
++      ActiveLibDir = std::string("@lib@") + "/lib" + LLVM_LIBDIR_SUFFIX;
++  }
++
+   /// We only use `shared library` mode in cases where the static library form
+   /// of the components provided are not available; note however that this is
+   /// skipped if we're run from within the build dir. However, once installed,

--- a/pkgs/development/compilers/llvm/svn/llvm.nix
+++ b/pkgs/development/compilers/llvm/svn/llvm.nix
@@ -1,0 +1,118 @@
+{ stdenv
+, fetch
+, perl
+, groff
+, cmake
+, python
+, libffi
+, binutils
+, libxml2
+, valgrind
+, ncurses
+, version
+, zlib
+, compiler-rt_src
+, libcxxabi
+, debugVersion ? false
+, enableSharedLibraries ? true
+, darwin
+}:
+
+let
+  src = fetch "llvm" "1v6k1rg9bdk18iaaqkrzpp1y5wrp4v9cxdv579c83gzpbdaplm2s";
+  shlib = if stdenv.isDarwin then "dylib" else "so";
+
+  # Used when creating a version-suffixed symlink of libLLVM.dylib
+  shortVersion = with stdenv.lib;
+    concatStringsSep "." (take 2 (splitString "." version));
+in stdenv.mkDerivation rec {
+  name = "llvm-${version}";
+
+  unpackPhase = ''
+    unpackFile ${src}
+    chmod -R u+w llvm-*
+    mv llvm-* llvm
+    sourceRoot=$PWD/llvm
+    unpackFile ${compiler-rt_src}
+    chmod -R u+w compiler-rt-*
+    mv compiler-rt-* $sourceRoot/projects/compiler-rt
+  '';
+
+  outputs = [ "out" ] ++ stdenv.lib.optional enableSharedLibraries "lib";
+
+  buildInputs = [ perl groff cmake libxml2 python libffi ]
+    ++ stdenv.lib.optionals stdenv.isDarwin
+         [ libcxxabi darwin.cctools darwin.apple_sdk.libs.xpc ];
+
+  propagatedBuildInputs = [ ncurses zlib ];
+
+  postPatch = ""
+  # hacky fix: New LLVM releases require a newer OS X SDK than
+  # 10.9. This is a temporary measure until nixpkgs darwin support is
+  # updated.
+  + stdenv.lib.optionalString stdenv.isDarwin ''
+        sed -i 's/os_trace(\(.*\)");$/printf(\1\\n");/g' ./projects/compiler-rt/lib/sanitizer_common/sanitizer_mac.cc
+  ''
+  # Patch llvm-config to return correct library path based on --link-{shared,static}.
+  + stdenv.lib.optionalString (enableSharedLibraries) ''
+    substitute '${./llvm-outputs.patch}' ./llvm-outputs.patch --subst-var lib
+    patch -p1 < ./llvm-outputs.patch
+  '';
+
+  # hacky fix: created binaries need to be run before installation
+  preBuild = ''
+    mkdir -p $out/
+    ln -sv $PWD/lib $out
+  '';
+
+  cmakeFlags = with stdenv; [
+    "-DCMAKE_BUILD_TYPE=${if debugVersion then "Debug" else "Release"}"
+    "-DLLVM_INSTALL_UTILS=ON"  # Needed by rustc
+    "-DLLVM_BUILD_TESTS=ON"
+    "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_ENABLE_RTTI=ON"
+    "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
+  ] ++ stdenv.lib.optional enableSharedLibraries [
+    "-DLLVM_LINK_LLVM_DYLIB=ON"
+  ] ++ stdenv.lib.optional (!isDarwin)
+    "-DLLVM_BINUTILS_INCDIR=${binutils.dev}/include"
+    ++ stdenv.lib.optionals (isDarwin) [
+    "-DLLVM_ENABLE_LIBCXX=ON"
+    "-DCAN_TARGET_i386=false"
+    "-DCMAKE_LIBTOOL=${darwin.cctools}/bin/libtool"
+  ];
+
+  postBuild = ''
+    rm -fR $out
+
+    paxmark m bin/{lli,llvm-rtdyld}
+  '';
+
+  postInstall = ""
+  + stdenv.lib.optionalString (enableSharedLibraries) ''
+    moveToOutput "lib/libLLVM-*" "$lib"
+    moveToOutput "lib/libLLVM.${shlib}" "$lib"
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-release.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
+  ''
+  + stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
+    substituteInPlace "$out/lib/cmake/llvm/LLVMExports-release.cmake" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM.dylib" "$lib/lib/libLLVM.dylib"
+    install_name_tool -id $lib/lib/libLLVM.dylib $lib/lib/libLLVM.dylib
+    install_name_tool -change @rpath/libLLVM.dylib $lib/lib/libLLVM.dylib $out/bin/llvm-config
+    ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${shortVersion}.dylib
+    ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${version}.dylib
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.src = src;
+
+  meta = {
+    description = "Collection of modular and reusable compiler and toolchain technologies";
+    homepage    = http://llvm.org/;
+    license     = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ lovek323 raskin viric ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/libraries/glew/default.nix
+++ b/pkgs/development/libraries/glew/default.nix
@@ -3,11 +3,11 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "glew-1.13.0";
+  name = "glew-2.0.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/glew/${name}.tgz";
-    sha256 = "1iwb2a6wfhkzv6fa7zx2gz1lkwa0iwnd9ka1im5vdc44xm4dq9da";
+    sha256 = "0r37fg2s1f0jrvwh6c8cz5x6v4wqmhq42qm15cs9qs349q5c6wn5";
   };
 
   outputs = [ "bin" "out" "dev" "doc" ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     mkdir -pv $out/share/doc/glew
     mkdir -p $out/lib/pkgconfig
     cp glew*.pc $out/lib/pkgconfig
-    cp -r README.txt LICENSE.txt doc $out/share/doc/glew
+    cp -r README.md LICENSE.txt doc $out/share/doc/glew
     rm $out/lib/*.a
   '';
 

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -1,7 +1,11 @@
 { stdenv
 , callPackage
 , substituteAll
+, fetchgit
 , systemd
+, bison
+, flex
+, llvmPackages-svn
 , grsecEnabled ? false
 , enableTextureFloats ? false # Texture floats are patented, see docs/patents.txt
 , ...
@@ -15,12 +19,22 @@ let
 in {
 
   mesa_13_0_2 = common {
-    version = "13.0.0";
+    version = "13.0.2";
     sha256 = "a6ed622645f4ed61da418bf65adde5bcc4bb79023c36ba7d6b45b389da4416d5";
-    enableRadv = true;
+  };
+
+  mesa_13_1_0-git = common {
+    version = "13.1.0-dev";
+    src = fetchgit {
+      url = "git://anongit.freedesktop.org/mesa/mesa";
+      rev = "9fe3f2649ea20d3ab736475faec6209fc3ff7c66";
+      sha256 = "0i9nlpv694rs7cw1k6qg1plvangjbhqnmbysy7ba8pm5a9x65c4g";
+    };
     extraPatches = [
       ./vulkan-icd-paths.patch
     ];
+    llvmPackages = llvmPackages-svn;
+    buildInputs = [ bison flex ];
   };
 
 }

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -1,182 +1,26 @@
-{ stdenv, fetchurl, fetchpatch
-, pkgconfig, intltool, autoreconfHook, substituteAll
-, file, expat, libdrm, xorg, wayland, openssl
-, llvmPackages, libffi, libomxil-bellagio, libva
-, libelf, libvdpau, python2
+{ stdenv
+, callPackage
+, substituteAll
+, systemd
 , grsecEnabled ? false
 , enableTextureFloats ? false # Texture floats are patented, see docs/patents.txt
-}:
-
-
-/** Packaging design:
-  - The basic mesa ($out) contains headers and libraries (GLU is in mesa_glu now).
-    This or the mesa attribute (which also contains GLU) are small (~ 2 MB, mostly headers)
-    and are designed to be the buildInput of other packages.
-  - DRI drivers are compiled into $drivers output, which is much bigger and
-    depends on LLVM. These should be searched at runtime in
-    "/run/opengl-driver{,-32}/lib/*" and so are kind-of impure (given by NixOS).
-    (I suppose on non-NixOS one would create the appropriate symlinks from there.)
-  - libOSMesa is in $osmesa (~4 MB)
-*/
+, ...
+} @ args :
 
 with stdenv.lib;
 
-if ! lists.elem stdenv.system platforms.mesaPlatforms then
-  throw "unsupported platform for Mesa"
-else
-
 let
-  version = "13.0.2";
-  branch  = head (splitString "." version);
-  driverLink = "/run/opengl-driver" + optionalString stdenv.isi686 "-32";
-in
+  common = attr: callPackage ./generic.nix (args // attr);
 
-stdenv.mkDerivation {
-  name = "mesa-noglu-${version}";
+in {
 
-  src =  fetchurl {
-    urls = [
-      "ftp://ftp.freedesktop.org/pub/mesa/${version}/mesa-${version}.tar.xz"
-      "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
-      "https://launchpad.net/mesa/trunk/${version}/+download/mesa-${version}.tar.xz"
-    ];
+  mesa_13_0_2 = common {
+    version = "13.0.0";
     sha256 = "a6ed622645f4ed61da418bf65adde5bcc4bb79023c36ba7d6b45b389da4416d5";
+    enableRadv = true;
+    extraPatches = [
+      ./vulkan-icd-paths.patch
+    ];
   };
 
-  prePatch = "patchShebangs .";
-
-  # TODO:
-  #  revive ./dricore-gallium.patch when it gets ported (from Ubuntu), as it saved
-  #  ~35 MB in $drivers; watch https://launchpad.net/ubuntu/+source/mesa/+changelog
-  patches = [
-    ./glx_ro_text_segm.patch # fix for grsecurity/PaX
-    ./symlink-drivers.patch
-  ];
-
-  postPatch = ''
-    substituteInPlace src/egl/main/egldriver.c \
-      --replace _EGL_DRIVER_SEARCH_DIR '"${driverLink}"'
-  '';
-
-  outputs = [ "out" "dev" "drivers" "osmesa" ];
-
-  # TODO: Figure out how to enable opencl without having a runtime dependency on clang
-  configureFlags = [
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
-    "--with-dri-driverdir=$(drivers)/lib/dri"
-    "--with-dri-searchpath=${driverLink}/lib/dri"
-    "--with-egl-platforms=x11,wayland,drm"
-  ]
-    ++ optionals (stdenv.system != "armv7l-linux") [
-      "--with-gallium-drivers=svga,i915,ilo,r300,r600,radeonsi,nouveau,freedreno,swrast"
-      "--with-dri-drivers=i915,i965,nouveau,radeon,r200,swrast"
-      "--with-vulkan-drivers=intel"
-  ]
-    ++ [
-    (enableFeature enableTextureFloats "texture-float")
-    (enableFeature grsecEnabled "glx-rts")
-    (enableFeature stdenv.isLinux "dri3")
-    (enableFeature stdenv.isLinux "nine") # Direct3D in Wine
-    "--enable-dri"
-    "--enable-driglx-direct"
-    "--enable-gles1"
-    "--enable-gles2"
-    "--enable-glx"
-    "--enable-glx-tls"
-    "--enable-gallium-osmesa" # used by wine
-    "--enable-gallium-llvm"
-    "--enable-egl"
-    "--enable-xa" # used in vmware driver
-    "--enable-gbm"
-    "--enable-xvmc"
-    "--enable-vdpau"
-    "--enable-shared-glapi"
-    "--enable-sysfs"
-    "--enable-llvm-shared-libs"
-    "--enable-omx"
-    "--enable-va"
-    "--disable-opencl"
-  ];
-
-  nativeBuildInputs = [ pkgconfig file ];
-
-  propagatedBuildInputs = with xorg;
-    [ libXdamage libXxf86vm ]
-    ++ optional stdenv.isLinux libdrm;
-
-  buildInputs = with xorg; [
-    autoreconfHook intltool expat llvmPackages.llvm
-    glproto dri2proto dri3proto presentproto
-    libX11 libXext libxcb libXt libXfixes libxshmfence
-    libffi wayland libvdpau libelf libXvMC
-    libomxil-bellagio libva libpthreadstubs openssl/*or another sha1 provider*/
-    (python2.withPackages (ps: [ ps.Mako ]))
-  ];
-
-
-  enableParallelBuilding = true;
-  doCheck = false;
-
-  installFlags = [
-    "sysconfdir=\${out}/etc"
-    "localstatedir=\${TMPDIR}"
-  ];
-
-  # TODO: probably not all .la files are completely fixed, but it shouldn't matter;
-  postInstall = ''
-    # move gallium-related stuff to $drivers, so $out doesn't depend on LLVM
-    mv -t "$drivers/lib/"    \
-      $out/lib/libXvMC*      \
-      $out/lib/d3d           \
-      $out/lib/vdpau         \
-      $out/lib/bellagio      \
-      $out/lib/libxatracker* \
-      $out/lib/libvulkan_*
-
-    # move share/vulkan/icd.d/
-    mv $out/share/ $drivers/
-    # Update search path used by Vulkan (it's pointing to $out but
-    # drivers are in $drivers)
-    for js in $drivers/share/vulkan/icd.d/*.json; do
-      substituteInPlace "$js" --replace "$out" "$drivers"
-    done
-
-    mv $out/lib/dri/* $drivers/lib/dri # */
-    rmdir "$out/lib/dri"
-
-    # move libOSMesa to $osmesa, as it's relatively big
-    mkdir -p {$osmesa,$drivers}/lib/
-    mv -t $osmesa/lib/ $out/lib/libOSMesa*
-
-    # now fix references in .la files
-    sed "/^libdir=/s,$out,$osmesa," -i $osmesa/lib/libOSMesa*.la
-
-    # set the default search path for DRI drivers; used e.g. by X server
-    substituteInPlace "$dev/lib/pkgconfig/dri.pc" --replace '$(drivers)' "${driverLink}"
-  '';
-
-  # TODO:
-  #  @vcunat isn't sure if drirc will be found when in $out/etc/;
-  #  check $out doesn't depend on llvm: builder failures are ignored
-  #  for some reason grep -qv '${llvmPackages.llvm}' -R "$out";
-  postFixup = ''
-    # add RPATH so the drivers can find the moved libgallium and libdricore9
-    # moved here to avoid problems with stripping patchelfed files
-    for lib in $drivers/lib/*.so* $drivers/lib/*/*.so*; do
-      if [[ ! -L "$lib" ]]; then
-        patchelf --set-rpath "$(patchelf --print-rpath $lib):$drivers/lib" "$lib"
-      fi
-    done
-  '';
-
-  passthru = { inherit libdrm version driverLink; };
-
-  meta = with stdenv.lib; {
-    description = "An open source implementation of OpenGL";
-    homepage = http://www.mesa3d.org/;
-    license = licenses.mit; # X11 variant, in most files
-    platforms = platforms.mesaPlatforms;
-    maintainers = with maintainers; [ eduarrrd vcunat ];
-  };
 }

--- a/pkgs/development/libraries/mesa/generic.nix
+++ b/pkgs/development/libraries/mesa/generic.nix
@@ -1,0 +1,178 @@
+{ stdenv, fetchurl, fetchpatch
+, pkgconfig, intltool, autoreconfHook
+, file, expat, libdrm, xorg, wayland, openssl
+, llvmPackages, libffi, libomxil-bellagio, libva
+, libelf, libvdpau, python2
+, grsecEnabled ? false
+, enableTextureFloats ? false # Texture floats are patented, see docs/patents.txt
+, version
+, sha256
+, extraPatches ? []
+, ...
+}:
+
+
+/** Packaging design:
+  - The basic mesa ($out) contains headers and libraries (GLU is in mesa_glu now).
+    This or the mesa attribute (which also contains GLU) are small (~ 2 MB, mostly headers)
+    and are designed to be the buildInput of other packages.
+  - DRI drivers are compiled into $drivers output, which is much bigger and
+    depends on LLVM. These should be searched at runtime in
+    "/run/opengl-driver{,-32}/lib/*" and so are kind-of impure (given by NixOS).
+    (I suppose on non-NixOS one would create the appropriate symlinks from there.)
+  - libOSMesa is in $osmesa (~4 MB)
+*/
+
+with stdenv.lib;
+
+if ! lists.elem stdenv.system platforms.mesaPlatforms then
+  throw "unsupported platform for Mesa"
+else
+
+let
+  branch = head (splitString "." version);
+  driverLink = "/run/opengl-driver" + optionalString stdenv.isi686 "-32";
+
+in stdenv.mkDerivation {
+  name = "mesa-noglu-${version}";
+
+  src = fetchurl {
+    urls = [
+      "ftp://ftp.freedesktop.org/pub/mesa/${version}/mesa-${version}.tar.xz"
+      "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
+      "https://launchpad.net/mesa/trunk/${version}/+download/mesa-${version}.tar.xz"
+    ];
+    inherit sha256;
+  };
+
+  prePatch = "patchShebangs .";
+
+  # TODO:
+  #  revive ./dricore-gallium.patch when it gets ported (from Ubuntu), as it saved
+  #  ~35 MB in $drivers; watch https://launchpad.net/ubuntu/+source/mesa/+changelog
+  patches = [
+    ./glx_ro_text_segm.patch # fix for grsecurity/PaX
+    ./symlink-drivers.patch
+  ] ++ extraPatches;
+
+  postPatch = ''
+    substituteInPlace src/egl/main/egldriver.c \
+      --replace _EGL_DRIVER_SEARCH_DIR '"${driverLink}"'
+  '';
+
+  outputs = [ "out" "dev" "drivers" "osmesa" ];
+
+  # TODO: Figure out how to enable opencl without having a runtime dependency on clang
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--with-dri-driverdir=$(drivers)/lib/dri"
+    "--with-dri-searchpath=${driverLink}/lib/dri"
+    "--with-egl-platforms=x11,wayland,drm"
+  ]
+    ++ optionals (stdenv.system != "armv7l-linux") [
+      "--with-gallium-drivers=svga,i915,ilo,r300,r600,radeonsi,nouveau,freedreno,swrast"
+      "--with-dri-drivers=i915,i965,nouveau,radeon,r200,swrast"
+      ("--with-vulkan-drivers=intel,radeon")
+  ]
+    ++ [
+    (enableFeature enableTextureFloats "texture-float")
+    (enableFeature grsecEnabled "glx-rts")
+    (enableFeature stdenv.isLinux "dri3")
+    (enableFeature stdenv.isLinux "nine") # Direct3D in Wine
+    "--enable-dri"
+    "--enable-driglx-direct"
+    "--enable-gles1"
+    "--enable-gles2"
+    "--enable-glx"
+    "--enable-glx-tls"
+    "--enable-gallium-osmesa" # used by wine
+    "--enable-gallium-llvm"
+    "--enable-egl"
+    "--enable-xa" # used in vmware driver
+    "--enable-gbm"
+    "--enable-xvmc"
+    "--enable-vdpau"
+    "--enable-shared-glapi"
+    "--enable-sysfs"
+    "--enable-llvm-shared-libs"
+    "--enable-omx"
+    "--enable-va"
+    "--disable-opencl"
+  ];
+
+  nativeBuildInputs = [ pkgconfig file ];
+
+  propagatedBuildInputs = with xorg;
+    [ libXdamage libXxf86vm ]
+    ++ optional stdenv.isLinux libdrm;
+
+  buildInputs = with xorg; [
+    autoreconfHook intltool expat llvmPackages.llvm
+    glproto dri2proto dri3proto presentproto
+    libX11 libXext libxcb libXt libXfixes libxshmfence
+    libffi wayland libvdpau libelf libXvMC
+    libomxil-bellagio libva libpthreadstubs openssl/*or another sha1 provider*/
+    (python2.withPackages (ps: [ ps.Mako ]))
+  ] ++ (args.buildInputs or []);
+
+  enableParallelBuilding = true;
+  doCheck = false;
+
+  installFlags = [
+    "sysconfdir=\${out}/etc"
+    "localstatedir=\${TMPDIR}"
+  ];
+
+  # TODO: probably not all .la files are completely fixed, but it shouldn't matter;
+  postInstall = ''
+    # move gallium-related stuff to $drivers, so $out doesn't depend on LLVM
+    mv -t "$drivers/lib/"    \
+      $out/lib/libXvMC*      \
+      $out/lib/d3d           \
+      $out/lib/vdpau         \
+      $out/lib/bellagio      \
+      $out/lib/libxatracker* \
+      $out/lib/libvulkan_*
+
+    # move share/vulkan/icd.d/
+    mv $out/share/ $drivers/
+
+    mv $out/lib/dri/* $drivers/lib/dri
+    rmdir "$out/lib/dri"
+
+    # move libOSMesa to $osmesa, as it's relatively big
+    mkdir -p {$osmesa,$drivers}/lib/
+    mv -t $osmesa/lib/ $out/lib/libOSMesa*
+
+    # now fix references in .la files
+    sed "/^libdir=/s,$out,$osmesa," -i $osmesa/lib/libOSMesa*.la
+
+    # set the default search path for DRI drivers; used e.g. by X server
+    substituteInPlace "$dev/lib/pkgconfig/dri.pc" --replace '$(drivers)' "${driverLink}"
+  '';
+
+  # TODO:
+  #  @vcunat isn't sure if drirc will be found when in $out/etc/;
+  #  check $out doesn't depend on llvm: builder failures are ignored
+  #  for some reason grep -qv '${llvmPackages.llvm}' -R "$out";
+  postFixup = ''
+    # add RPATH so the drivers can find the moved libgallium and libdricore9
+    # moved here to avoid problems with stripping patchelfed files
+    for lib in $drivers/lib/*.so* $drivers/lib/*/*.so*; do
+      if [[ ! -L "$lib" ]]; then
+        patchelf --set-rpath "$(patchelf --print-rpath $lib):$drivers/lib" "$lib"
+      fi
+    done
+  '';
+
+  passthru = { inherit libdrm version driverLink; };
+
+  meta = with stdenv.lib; {
+    description = "An open source implementation of OpenGL";
+    homepage = http://www.mesa3d.org/;
+    license = licenses.mit; # X11 variant, in most files
+    platforms = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ eduarrrd vcunat ];
+  };
+}

--- a/pkgs/development/libraries/mesa/generic.nix
+++ b/pkgs/development/libraries/mesa/generic.nix
@@ -64,7 +64,7 @@ in stdenv.mkDerivation {
 
   # TODO: Figure out how to enable opencl without having a runtime dependency on clang
   configureFlags = [
-    "--sysconfdir=/etc"
+    "--sysconfdir=$(out)/etc"
     "--localstatedir=/var"
     "--with-dri-driverdir=$(drivers)/lib/dri"
     "--with-dri-searchpath=${driverLink}/lib/dri"
@@ -120,7 +120,6 @@ in stdenv.mkDerivation {
   doCheck = false;
 
   installFlags = [
-    "sysconfdir=\${out}/etc"
     "localstatedir=\${TMPDIR}"
   ];
 
@@ -153,7 +152,6 @@ in stdenv.mkDerivation {
   '';
 
   # TODO:
-  #  @vcunat isn't sure if drirc will be found when in $out/etc/;
   #  check $out doesn't depend on llvm: builder failures are ignored
   #  for some reason grep -qv '${llvmPackages.llvm}' -R "$out";
   postFixup = ''

--- a/pkgs/development/libraries/mesa/generic.nix
+++ b/pkgs/development/libraries/mesa/generic.nix
@@ -6,10 +6,10 @@
 , grsecEnabled ? false
 , enableTextureFloats ? false # Texture floats are patented, see docs/patents.txt
 , version
-, sha256
+, sha256 ? null
 , extraPatches ? []
 , ...
-}:
+} @args :
 
 
 /** Packaging design:
@@ -36,14 +36,14 @@ let
 in stdenv.mkDerivation {
   name = "mesa-noglu-${version}";
 
-  src = fetchurl {
+  src = args.src or (fetchurl {
     urls = [
       "ftp://ftp.freedesktop.org/pub/mesa/${version}/mesa-${version}.tar.xz"
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://launchpad.net/mesa/trunk/${version}/+download/mesa-${version}.tar.xz"
     ];
     inherit sha256;
-  };
+  });
 
   prePatch = "patchShebangs .";
 

--- a/pkgs/development/libraries/mesa/vulkan-icd-paths.patch
+++ b/pkgs/development/libraries/mesa/vulkan-icd-paths.patch
@@ -1,0 +1,26 @@
+diff --git a/src/amd/vulkan/Makefile.am b/src/amd/vulkan/Makefile.am
+index c559a95..733fbaa 100644
+--- a/src/amd/vulkan/Makefile.am
++++ b/src/amd/vulkan/Makefile.am
+@@ -166,7 +166,7 @@ dev_icd.json : dev_icd.json.in
+ 
+ radeon_icd.@host_cpu@.json : radeon_icd.json.in
+ 	$(AM_V_GEN) $(SED) \
+-		-e "s#@install_libdir@#${libdir}#" \
++		-e "s#@install_libdir@#${drivers}/lib#" \
+ 		< $(srcdir)/radeon_icd.json.in > $@
+ 
+ include $(top_srcdir)/install-lib-links.mk
+diff --git a/src/intel/vulkan/Makefile.am b/src/intel/vulkan/Makefile.am
+index 4a7bb18..2dee07d 100644
+--- a/src/intel/vulkan/Makefile.am
++++ b/src/intel/vulkan/Makefile.am
+@@ -178,7 +178,7 @@ dev_icd.json : dev_icd.json.in
+ 
+ intel_icd.@host_cpu@.json : intel_icd.json.in
+ 	$(AM_V_GEN) $(SED) \
+-		-e "s#@install_libdir@#${libdir}#" \
++		-e "s#@install_libdir@#${drivers}/lib#" \
+ 		< $(srcdir)/intel_icd.json.in > $@
+ 
+ # Libvulkan with dummy gem. Used for unit tests.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4592,6 +4592,7 @@ in
 
   clang = llvmPackages.clang;
 
+  clang-svn = llvmPackages-svn.clang;
   clang_39 = llvmPackages_39.clang;
   clang_38 = llvmPackages_38.clang;
   clang_37 = llvmPackages_37.clang;
@@ -5119,6 +5120,7 @@ in
 
   llvm = llvmPackages.llvm;
 
+  llvm-svn = llvmPackages-svn.llvm;
   llvm_39 = llvmPackages_39.llvm;
   llvm_38 = llvmPackages_38.llvm;
   llvm_37 = llvmPackages_37.llvm;
@@ -5154,6 +5156,10 @@ in
   };
 
   llvmPackages_39 = callPackage ../development/compilers/llvm/3.9 {
+    inherit (stdenvAdapters) overrideCC;
+  };
+
+  llvmPackages-svn = callPackage ../development/compilers/llvm/svn {
     inherit (stdenvAdapters) overrideCC;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8592,6 +8592,16 @@ in
 
   mesaSupported = lib.elem system lib.platforms.mesaPlatforms;
 
+  inherit (callPackage ../development/libraries/mesa {
+    # makes it slower, but during runtime we link against just mesa_drivers
+    # through /run/opengl-driver*, which is overriden according to config.grsecurity
+    grsecEnabled = true;
+    llvmPackages = llvmPackages_39;
+  })
+    mesa_13_0_2;
+
+  mesa_current = mesa_13_0_2;
+
   mesaDarwinOr = alternative: if stdenv.isDarwin
     then callPackage ../development/libraries/mesa-darwin {
       inherit (darwin.apple_sdk.frameworks) OpenGL;
@@ -8599,12 +8609,7 @@ in
       inherit (darwin) apple_sdk;
     }
     else alternative;
-  mesa_noglu = mesaDarwinOr (callPackage ../development/libraries/mesa {
-    # makes it slower, but during runtime we link against just mesa_drivers
-    # through /run/opengl-driver*, which is overriden according to config.grsecurity
-    grsecEnabled = true;
-    llvmPackages = llvmPackages_39;
-  });
+  mesa_noglu = mesaDarwinOr mesa_current;
   mesa_glu =  mesaDarwinOr (callPackage ../development/libraries/mesa-glu { });
   mesa_drivers = mesaDarwinOr (
     let mo = mesa_noglu.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8598,7 +8598,8 @@ in
     grsecEnabled = true;
     llvmPackages = llvmPackages_39;
   })
-    mesa_13_0_2;
+    mesa_13_0_2
+    mesa_13_1_0-git;
 
   mesa_current = mesa_13_0_2;
 


### PR DESCRIPTION
###### Motivation for this change

@Ralith @vcunat 

This brings in development versions of llvm and mesa, which provides the open source amdgpu vulkan driver, OpenGL 4.5 core context, etc.

* The amount of duplicate code in /llvm/*/ seems excessive.  if I was going to package a new release (e.g. 4.0) I think I'd start by abstracting what I have in svn/).

* I'm not quite sure about the way I exposed multiple versions of mesa.  It's more like openssl than llvm.

My packageOverrides currently looks like this:

```
    packageOverrides = pkgs:
      with pkgs.stdenv.lib; {
      stdenv = pkgs.stdenv // {
        platform = pkgs.stdenv.platform // optionalAttrs (!amdgpu-pro) {
          kernelExtraConfig = "DRM_AMDGPU_CIK y";
        };
      };
      steam = pkgs.steam.override {
        newStdcpp = true;
      };
      mesa_drivers = (pkgs.mesa_13_1_0-git.override {
        enableTextureFloats = true;
      }).drivers;
    };
```

* enable experimental support for certain GPUs (could this be a nixos option?)
* enable the new libc in steam for compatibility with mesa drivers (should this be the default, or enabled when the driver is enabled?)
* select mesa 13.1 driver only, to avoid rebuilding mesa dependencies, which is almost everything.
* enable patent protected floating point textures
  * this probably deserves it's own nixos option and a mention in the manual.  without it, you can only get an opengl 2.1 context.

Interesting glxinfo to prove it's working: 

```
OpenGL renderer string: Gallium 0.4 on AMD HAWAII (DRM 3.3.0 / 4.8.7, LLVM 4.0.0)
OpenGL core profile version string: 4.5 (Core Profile) Mesa 13.1.0-devel
```

Any thoughts?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

