### PR TITLE
doctl: 1.3.1 -> 1.5.0

### DIFF
--- a/pkgs/development/tools/doctl/default.nix
+++ b/pkgs/development/tools/doctl/default.nix
@@ -2,15 +2,26 @@
 
 buildGoPackage rec {
   name = "doctl-${version}";
-  version = "1.3.1";
-  rev = "a57555c195d06bc7aa5037af77fde0665ad1231f";
+  version = "${major}.${minor}.${patch}";
+  major = "1";
+  minor = "5";
+  patch = "0";
   goPackagePath = "github.com/digitalocean/doctl";
+
+  excludedPackages = ''\(doctl-gen-doc\|install-doctl\|release-doctl\)'';
+  buildFlagsArray = let t = "${goPackagePath}"; in ''
+     -ldflags=
+        -X ${t}.Major=${major}
+        -X ${t}.Minor=${minor}
+        -X ${t}.Patch=${patch}
+        -X ${t}.Label=release
+   '';
 
   src = fetchFromGitHub {
     owner = "digitalocean";
     repo = "doctl";
-    rev = "${rev}";
-    sha256 = "03z652fw0a628gv666w8vpi05a4sdilvs1j5scjhcbi82zsbkvma";
+    rev = "v${version}";
+    sha256 = "0dk7l4b0ngqkwdlx8qgr99jzipyzazvkv7dybi75dnp725lwxkl2";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

`doctl auth login` on 1.3.1 doesn't work as it looks for `/usr/bin/xdg-open` which is not available on NixOS. `doct` 1.5.0 doesn't use `xdg-open` anymore and `doctl auth init` works just fine. And as a bonus we get an update :angel:.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


