### PR TITLE
Rust updates

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -14,16 +14,16 @@ let
     then "x86_64-apple-darwin"
     else abort "missing boostrap url for platform ${stdenv.system}";
 
-  # fetch hashes by running `print-hashes.sh 1.9.0`
+  # fetch hashes by running `print-hashes.sh 1.12.1`
   bootstrapHash =
     if stdenv.system == "i686-linux"
-    then "f5a3f5d53defe827a71447b1a0e7a656394b87ee23e009d7bf73a0277c1b5ac2"
+    then "ede9b9d14d1ddbc29975d1ead73fcf2758719b4b371363afe1c32eb8d6e96bb3"
     else if stdenv.system == "x86_64-linux"
-    then "f4ebbd6d9494cb8fa6c410cb58954e1913546c2bca8963faebc424591547d83f"
+    then "9e546aec13e389429ba2d86c8f4e67eba5af146c979e4faa16ffb40ddaf9984c"
     else if stdenv.system == "i686-darwin"
-    then "bf07182bc362985fcdd48af905cdb559e20c68518cd71dabec3c30b78ca8a94a"
+    then "2648645c4fe1ecf36beb7de63501dd99e9547a7a6d5683acf2693b919a550b69"
     else if stdenv.system == "x86_64-darwin"
-    then "2cdbc47438dc86ecaf35298317b77d735956eb160862e3f6d0fda0da656ecc35"
+    then "0ac5e58dba3d24bf09dcc90eaac02d2df053122b0def945ec4cfe36ac6d4d011"
     else throw "missing boostrap hash for platform ${stdenv.system}";
 
   needsPatchelf = stdenv.isLinux;
@@ -33,7 +33,7 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "1.11.0";
+  version = "1.12.1";
 in
 
 rec {

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -7,12 +7,12 @@ in
 
 rec {
   rustc = callPackage ./rustc.nix {
-    shortVersion = "1.12.1";
+    shortVersion = "1.13";
     isRelease = true;
     forceBundledLLVM = false;
     configureFlags = [ "--release-channel=stable" ];
-    srcRev = "d4f39402a0c2c2b94ec0375cd7f7f6d7918113cd";
-    srcSha = "1lpykjy96rwz4jy28rf7ijca0q9lvckgnbzvcdsrspd5rs2ywfwr";
+    srcRev = "2c6933acc05c61e041be764cb1331f6281993f3f";
+    srcSha = "1w0alyyc29cy2lczrqvg1kfycjxy0xg8fpzdac80m88fxpv23glp";
 
     patches = [
       ./patches/disable-lockfile-check.patch
@@ -25,10 +25,10 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.13.0";
-    srcRev = "109cb7c33d426044d141457049bd0fffaca1327c";
-    srcSha = "0p79m7hpzjh36l4fc6a59h6r8yz6qafjcdg5v1yb7bac9m2wi7vs";
-    depsSha256 = "1cwp4p8b985fj8j2qmgsi2mpp51rdpwzm9qa60760nrry1fy624z";
+    version = "0.14.0";
+    srcRev = "eca9e159b6b0d484788ac757cf23052eba75af55";
+    srcSha = "1zm5rzw1mvixnkzr4775pcxx6k235qqxbysyp179cbxsw3dm045s";
+    depsSha256 = "0gpn0cpwgpzwhc359qn6qplx371ag9pqbwayhqrsydk1zm5bm3zr";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo

--- a/pkgs/development/tools/misc/tokei/default.nix
+++ b/pkgs/development/tools/misc/tokei/default.nix
@@ -23,5 +23,6 @@ buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ gebner ];
     platforms = platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/development/tools/rust/rustfmt/default.nix
+++ b/pkgs/development/tools/rust/rustfmt/default.nix
@@ -4,20 +4,20 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "rustfmt-${version}";
-  version = "0.6";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "rust-lang-nursery";
     repo = "rustfmt";
-    rev = "d022f05f340b9aa4956ca315f5e424a6d3ab3248";
-    sha256 = "1w6ll3802061wbggqhk31pmzws423qm7jc4hyxk8a6pf9ksp0nk5";
+    rev = "4418fab4f24e6497aa2a1f71bb4cf963c2971a28";
+    sha256 = "0x2kg2sqpj4lsqqskcy5p0w3264f0by1irkjj369ch89xax7l52l";
   };
 
-  depsSha256 = "13rrhgzxxx5gwpwvyxw03m5xng9c1xyaycmqpi123ma3ps5822jf";
+  depsSha256 = "022mwggmy6p9n8dh22y6m3sadrwvwlbpj9w9ki9avmgsm3cj2mhs";
 
   meta = with stdenv.lib; {
     description = "A tool for formatting Rust code according to style guidelines";
-    homepage = https://github.com/nrc/rustfmt;
+    homepage = https://github.com/rust-lang-nursery/rustfmt;
     license = with licenses; [ mit asl20 ];
     maintainers = [ maintainers.globin ];
     platforms = platforms.all;

--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -36,5 +36,6 @@ buildRustPackage rec {
     homepage = http://bsago.me/exa;
     license = licenses.mit;
     maintainer = [ maintainers.ehegnes ];
+    broken = true;
   };
 }

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2016-10-29";
-  rev = "623cc0d9328bfb949b54209443f2b4f06c41961e";
-  sha256 = "1jyb0ixnrxb7m0c18p6yfi6x8rsy3yz5yc3nyz9f462fr4g6azcs";
+  version = "2016-11-15";
+  rev = "4ed749b5a45d596e59c454e6ffc27177bd93a221";
+  sha256 = "09vw8lbwm34qp9amxzb4a2nvxzz0aaw4sas0qkay7gh4ryy5wflk";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change
Updated rust, cargo and rustfmt to their latest versions. Marked exa and tokei as broken as updating isn't enough for them to compile. Pinging maintainers: @ehegnes for exa and @gebner for tokei.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

