### PR TITLE
llvmPackages: change default to 3.9

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5036,9 +5036,11 @@ in
   llvm_35 = llvmPackages_35.llvm;
   llvm_34 = llvmPackages_34.llvm;
 
-  llvmPackages = recurseIntoAttrs llvmPackages_37;
+  _llvmPackages = if stdenv.isDarwin then llvmPackages_37 else llvmPackages_39;
 
-  llvmPackagesSelf = llvmPackages_34.override {
+  llvmPackages = recurseIntoAttrs _llvmPackages;
+
+  llvmPackagesSelf = _llvmPackages.override {
     stdenv = libcxxStdenv;
   };
 


### PR DESCRIPTION
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/issues/19195.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Note that `llvmPackages` and `llvmPackagesSelf` were out of sync—I'm not sure if that was intended. (If that was, we should add a comment explaining this.)

That's probably a mass rebuild (at least for darwin), so opening against staging.