### PR TITLE
jsduck: init version

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -334,6 +334,7 @@
   palo = "Ingolf Wanger <palipalo9@googlemail.com>";
   pashev = "Igor Pashev <pashev.igor@gmail.com>";
   pawelpacana = "Paweł Pacana <pawel.pacana@gmail.com>";
+  periklis = "theopompos@gmail.com";
   pesterhazy = "Paulus Esterhazy <pesterhazy@gmail.com>";
   peterhoeg = "Peter Hoeg <peter@hoeg.com>";
   peti = "Peter Simons <simons@cryp.to>";

--- a/pkgs/development/tools/jsduck/Gemfile
+++ b/pkgs/development/tools/jsduck/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "jsduck"

--- a/pkgs/development/tools/jsduck/Gemfile.lock
+++ b/pkgs/development/tools/jsduck/Gemfile.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    dimensions (1.2.0)
+    jsduck (5.3.4)
+      dimensions (~> 1.2.0)
+      json (~> 1.8.0)
+      parallel (~> 0.7.1)
+      rdiscount (~> 2.1.6)
+      rkelly-remix (~> 0.0.4)
+    json (1.8.3)
+    parallel (0.7.1)
+    rdiscount (2.1.8)
+    rkelly-remix (0.0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jsduck
+
+BUNDLED WITH
+   1.13.6

--- a/pkgs/development/tools/jsduck/default.nix
+++ b/pkgs/development/tools/jsduck/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, bundlerEnv, makeWrapper, }:
+
+stdenv.mkDerivation rec {
+  pname = "jsduck";
+  name = "${pname}-${version}";
+  version = "5.3.4";
+
+  env = bundlerEnv {
+    name = "${pname}";
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+
+  phases = [ "installPhase" ];
+
+  buildInputs = [ env makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${env}/bin/jsduck $out/bin/jsduck
+  '';
+
+  meta = with lib; {
+    description = "Simple JavaScript Duckumentation generator.";
+    homepage    = https://github.com/senchalabs/jsduck;
+    license     = with licenses; gpl3;
+    maintainers = with stdenv.lib.maintainers; [ periklis ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/jsduck/gemset.nix
+++ b/pkgs/development/tools/jsduck/gemset.nix
@@ -1,0 +1,51 @@
+{
+  dimensions = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pqb7yzjcpbgbyi196ifqbd1wy570cn12bkzcvpcha4xilhajja0";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  jsduck = {
+    dependencies = ["dimensions" "json" "parallel" "rdiscount" "rkelly-remix"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hac7g9g6gg10bigbm8dskwwbv1dfch8ca353gh2bkwf244qq2xr";
+      type = "gem";
+    };
+    version = "5.3.4";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nsby6ry8l9xg3yw4adlhk2pnc7i0h0rznvcss4vk3v74qg0k8lc";
+      type = "gem";
+    };
+    version = "1.8.3";
+  };
+  parallel = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1kzz6ydg7r23ks2b7zbpx4vz3h186n19vhgnjcwi7xwd6h2f1fsq";
+      type = "gem";
+    };
+    version = "0.7.1";
+  };
+  rdiscount = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vcyy90r6wfg0b0y5wqp3d25bdyqjbwjhkm1xy9jkz9a7j72n70v";
+      type = "gem";
+    };
+    version = "2.1.8";
+  };
+  rkelly-remix = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g7hjl9nx7f953y7lncmfgp0xgxfxvgfm367q6da9niik6rp1y3j";
+      type = "gem";
+    };
+    version = "0.0.7";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2285,6 +2285,8 @@ in
 
   jscoverage = callPackage ../development/tools/misc/jscoverage { };
 
+  jsduck = callPackage ../development/tools/jsduck { };
+
   jwhois = callPackage ../tools/networking/jwhois { };
 
   k2pdfopt = callPackage ../applications/misc/k2pdfopt { };
@@ -16391,7 +16393,7 @@ in
   paml = callPackage ../applications/science/biology/paml { };
 
   plink = callPackage ../applications/science/biology/plink/default.nix { };
-  
+
   plink-ng = callPackage ../applications/science/biology/plink-ng/default.nix { };
 
   samtools = callPackage ../applications/science/biology/samtools/default.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


