### PR TITLE
Vulnerability Roundup #9 Mass Rebuild Rollup (WIP)

### DIFF
--- a/pkgs/applications/graphics/shutter/default.nix
+++ b/pkgs/applications/graphics/shutter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, perlPackages, makeWrapper, imagemagick, gdk_pixbuf, librsvg }:
+{ stdenv, fetchurl, fetchpatch, perl, perlPackages, makeWrapper, imagemagick, gdk_pixbuf, librsvg }:
 
 let
   perlModules = with perlPackages;
@@ -17,6 +17,14 @@ stdenv.mkDerivation rec {
     url = "http://shutter-project.org/wp-content/uploads/releases/tars/${name}.tar.gz";
     sha256 = "09cn3scwy98wqxkrjhnmxhpfnnynlbb41856yn5m3zwzqrxiyvak";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "http://svnweb.mageia.org/packages/cauldron/shutter/current/SOURCES/CVE-2015-0854.patch?revision=880308&view=co";
+      name = "CVE-2015-0854.patch";
+      sha256 = "14r18sxz3ylf39cn9b85snjhjxdk6ngq4vnpljwghw2q5430nb12";
+    })
+  ];
 
   buildInputs = [ perl makeWrapper gdk_pixbuf librsvg ] ++ perlModules;
 

--- a/pkgs/development/libraries/jasper/default.nix
+++ b/pkgs/development/libraries/jasper/default.nix
@@ -1,11 +1,14 @@
 { stdenv, fetchurl, fetchpatch, libjpeg, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "jasper-1.900.21";
+  name = "jasper-1.900.28";
 
   src = fetchurl {
+    # You can find this code on Github at https://github.com/mdadams/jasper
+    # however note at https://www.ece.uvic.ca/~frodo/jasper/#download
+    # not all tagged releases are for distribution.
     url = "http://www.ece.uvic.ca/~mdadams/jasper/software/${name}.tar.gz";
-    sha256 = "1cypmlzq5vmbacsn8n3ls9p7g64scv3fzx88qf8c270dz10s5j79";
+    sha256 = "0nsiblsfpfa0dahsk6hw9cd18fp9c8sk1z5hdp19m33c0bf92ip9";
   };
 
   # newer reconf to recognize a multiout flag

--- a/pkgs/servers/xinetd/default.nix
+++ b/pkgs/servers/xinetd/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv }:
+{ fetchurl, fetchpatch, stdenv }:
 
 stdenv.mkDerivation rec {
   name = "xinetd-2.3.15";
@@ -7,6 +7,14 @@ stdenv.mkDerivation rec {
     url = "http://www.xinetd.org/${name}.tar.gz";
     sha256 = "1qsv1al506x33gh92bqa8w21k7mxqrbsrwmxvkj0amn72420ckmz";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-apps/xinetd/files/xinetd-2.3.15-creds.patch?id=426002bfe2789fb6213fba832c8bfee634d68d02";
+      name = "CVE-2013-4342.patch";
+      sha256 = "1iqcrqzgisz4b6vamprzg2y6chai7qpifqcihisrwbjwbc4wzj8v";
+    })
+  ];
 
   meta = {
     description = "Secure replacement for inetd";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/20462

 - jasper: 1.900.21 -> 1.900.28 https://lwn.net/Vulnerabilities/705673/, https://lwn.net/Vulnerabilities/705824/

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


