### PR TITLE
haskellPackages.ghcjs-dom: Add overrides

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -96,10 +96,15 @@ self: super:
      }) {};
 
   ghcjs-dom = overrideCabal super.ghcjs-dom (drv: {
-    libraryHaskellDepends = [ self.ghcjs-base ] ++
-      removeLibraryHaskellDepends [
-        "glib" "gtk" "gtk3" "webkitgtk" "webkitgtk3"
-      ] drv.libraryHaskellDepends;
+    libraryHaskellDepends = with self; [
+      ghcjs-base ghcjs-dom-jsffi text transformers
+    ];
+    configureFlags = [ "-fjsffi" "-f-webkit" ];
+  });
+
+  ghcjs-dom-jsffi = overrideCabal super.ghcjs-dom-jsffi (drv: {
+    libraryHaskellDepends = [ self.ghcjs-base self.text ];
+    isLibrary = true;
   });
 
   ghc-paths = overrideCabal super.ghc-paths (drv: {
@@ -153,13 +158,12 @@ self: super:
   });
 
   semigroups = addBuildDepends super.semigroups [ self.hashable self.unordered-containers self.text self.tagged ];
-  # triggers an internal pattern match failure in haddock
-  # https://github.com/haskell/haddock/issues/553
-  wai = dontHaddock super.wai;
 
   transformers-compat = overrideCabal super.transformers-compat (drv: {
     configureFlags = [];
   });
 
-
+  # triggers an internal pattern match failure in haddock
+  # https://github.com/haskell/haddock/issues/553
+  wai = dontHaddock super.wai;
 }


### PR DESCRIPTION
###### Motivation for this change

These overrides allow `haskell.packages.ghcjsHEAD.ghcjs-dom` to build.

It will not work with `haskell.compiler.ghcjs`, only `ghcjsHEAD`, because the latest version of `ghcjs-dom` requires Cabal 1.24.

Thanks @TravisWhitaker for setting up `ghcjsHEAD`.

/cc @Profpatsch @ryantrinkle 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
