### PR TITLE
libgit2: 0.24.2 -> 0.24.3

### DIFF
--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pkgconfig, cmake, zlib, python, libssh2, openssl, curl, http-parser, libiconv }:
 
 stdenv.mkDerivation (rec {
-  version = "0.24.2";
+  version = "0.24.3";
   name = "libgit2-${version}";
 
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "https://github.com/libgit2/libgit2/tarball/v${version}";
-    sha256 = "0avijw83vfx64cn23vx2j1h14zmkx8silgjnq6q2qw2z3sh73hs1";
+    sha256 = "01jdp0i0nxhx8w2gjd75mwfy1d4z2c5xzz7q5jfypa6pkdi86dmh";
   };
 
   # TODO: `cargo` (rust's package manager) surfaced a serious bug in


### PR DESCRIPTION
###### Motivation for this change
#20462 
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


