### PR TITLE
networkd: allow to supply own unit files

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -165,6 +165,11 @@ let
       '';
     };
 
+    extraConfig = mkOption {
+      default = "";
+      type = types.lines;
+      description = "Extra configuration append to unit";
+    };
   };
 
   linkOptions = commonNetworkOptions // {
@@ -515,6 +520,8 @@ let
         ''
           [Link]
           ${attrsToSection def.linkConfig}
+
+          ${def.extraConfig}
         '';
     };
 
@@ -565,6 +572,7 @@ let
             ${attrsToSection def.bondConfig}
 
           ''}
+          ${def.extraConfig}
         '';
     };
 
@@ -603,6 +611,7 @@ let
             ${attrsToSection x.routeConfig}
 
           '')}
+          ${def.extraConfig}
         '';
     };
 


### PR DESCRIPTION
###### Motivation for this change

A lot of effort was put into this module, but it only support half the options
supported by latest systemd-networkd. 
The patch allows to generate/write own files to this directory. Instead of providing /etc/systemd/network only single files are symlinked to this directory.

The following example:

```
systemd.network= {
  enable = true;
  networks.eth0 = {
    enable = true;
    name = "eth0";
    address = [ "2a03:4000:13:31e::/64" ];
    gateway = [ "fe80::1" ];
    DHCP = "v4";
    networkConfig.IPv6AcceptRA = "no";
  };
};
```

can be then also written as:

```
systemd.network.enable = true;
environment.etc."systemd/network/eth0.network".text = ''
  [Match]
  Name = eth0

  [Network]
  DHCP = v4
  Address = 2a03:4000:13:31e::/64
  Gateway = fe80::1
  IPv6AcceptRA = no
'';
```

The latter one is much easier to interfere by looking at the manpage or
copy'n'paste from other examples. Also systemd-networkd provides better
error messages compared to the module. 

In future wireguard vpn will be supported by networkd.
To avoid leakage of private keys, those could be then also put
outside of the /nix/store

Currently files changed outside of this module will not trigger update
of networkd. My suggestion therefor is to refactor the module to
just take strings instead of attributes.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

