### PR TITLE
vim-plugins/deoplete-go: init at 2016-11-12

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -2,6 +2,7 @@
 { fetchurl, stdenv, python, go, cmake, vim, vimUtils, perl, ruby, unzip
 , which, fetchgit, llvmPackages
 , xkb_switch, rustracerd, fzf
+, python3
 , Cocoa ? null
 }:
 
@@ -1491,6 +1492,23 @@ rec {
     };
     dependencies = ["vim-misc"];
 
+  };
+
+  deoplete-go = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "deoplete-go-2016-11-12";
+    src = fetchgit {
+      url = "git://github.com/zchee/deoplete-go";
+      rev = "807b5536e7cebd06d0ce7b7d54c021a82774aee2";
+      sha256 = "1ragxnlzpf17f1wdy512hkz6bd673gzl16f14v78873rcyxpiw53";
+    };
+    dependencies = [];
+    buildInputs = [ python3 ]; 
+    buildPhase = ''
+      pushd ./rplugin/python3/deoplete/ujson
+      python3 setup.py build --build-base=$PWD/build --build-lib=$PWD/build
+      popd
+      find ./rplugin/ -name "ujson*.so" -exec mv -v {} ./rplugin/python3/ \;
+    '';
   };
 
   deoplete-jedi = buildVimPluginFrom2Nix { # created by nix#NixDerivation

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -117,6 +117,7 @@
 "github:wincent/command-t"
 "github:xolox/vim-easytags"
 "github:zchee/deoplete-jedi"
+"github:zchee/deoplete-go"
 "goyo"
 "matchit.zip"
 "pathogen"

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/deoplete-go
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/deoplete-go
@@ -1,0 +1,7 @@
+    buildInputs = [ python3 ]; 
+    buildPhase = ''
+      pushd ./rplugin/python3/deoplete/ujson
+      python3 setup.py build --build-base=$PWD/build --build-lib=$PWD/build
+      popd
+      find ./rplugin/ -name "ujson*.so" -exec mv -v {} ./rplugin/python3/ \;
+    '';


### PR DESCRIPTION
###### Motivation for this change
deoplete is recommended over neocomplete, and deoplete-go will give Go completion

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

###### Status
- [x] get autocompletion working with neovim