### PR TITLE
vmware-guest: fix vmmouse driver

### DIFF
--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -5,6 +5,7 @@ with lib;
 let
   cfg = config.services.vmwareGuest;
   open-vm-tools = pkgs.open-vm-tools;
+  xf86inputvmmouse = pkgs.xorg.xf86inputvmmouse;
 in
 {
   options = {
@@ -29,16 +30,15 @@ in
 
     services.xserver = {
       videoDrivers = mkOverride 50 [ "vmware" ];
+      modules = [ xf86inputvmmouse ];
 
       config = ''
-          Section "InputDevice"
+          Section "InputClass"
             Identifier "VMMouse"
+            MatchDevicePath "/dev/input/event*"
+            MatchProduct "ImPS/2 Generic Wheel Mouse"
             Driver "vmmouse"
           EndSection
-        '';
-
-      serverLayoutSection = ''
-          InputDevice "VMMouse"
         '';
 
       displayManager.sessionCommands = ''


### PR DESCRIPTION
###### Motivation for this change
Automatic mouse release did not work because xorg vmmouse driver was not loaded.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Fix automatic mouse grabbing/releasing when running as a vmware guest.

1. The xf86inputvmmouse is not loaded by default. Add it.
2. InptutDevice sections for which specify a driver are ignored if
AutoAddDevices is enabled (which it is by default). See [1]. Instead use
an InputClass to load the vmmouse driver.

[1] https://www.x.org/archive/X11R7.7/doc/man/man5/xorg.conf.5.xhtml#heading8