### PR TITLE
lxqt: better organize system packages

### DIFF
--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -63,6 +63,68 @@ let
     screengrab = callPackage ./optional/screengrab { };
     qlipper = callPackage ./optional/qlipper { };
 
+    preRequisitePackages = [
+      pkgs.gvfs # virtual file systems support for PCManFM-QT
+      pkgs.kde5.kwindowsystem # provides some QT5 plugins needed by lxqt-panel
+      pkgs.kde5.libkscreen # provides plugins for screen management software
+      pkgs.libfm
+      pkgs.libfm-extra
+      pkgs.lxmenu-data
+      pkgs.menu-cache
+      pkgs.openbox # default window manager
+      pkgs.qt5.qtsvg # provides QT5 plugins for svg icons
+    ];
+
+    corePackages = [
+      ### BASE
+      libqtxdg
+      libsysstat
+      liblxqt
+
+      ### CORE 1
+      libfm-qt
+      lxqt-about
+      lxqt-admin
+      lxqt-common
+      lxqt-config
+      lxqt-globalkeys
+      lxqt-l10n
+      lxqt-notificationd
+      lxqt-openssh-askpass
+      lxqt-policykit
+      lxqt-powermanagement
+      lxqt-qtplugin
+      lxqt-session
+      lxqt-sudo
+      pavucontrol-qt
+
+      ### CORE 2
+      lxqt-panel
+      lxqt-runner
+      pcmanfm-qt
+    ];
+
+    optionalPackages = [
+      ### LXQt project
+      qterminal
+      compton-conf
+      obconf-qt
+      lximage-qt
+
+      ### QtDesktop project
+      qps
+      screengrab
+
+      ### Qlipper
+      qlipper
+
+      ### Default icon theme
+      pkgs.kde5.oxygen-icons5
+
+      ### Screen saver
+      pkgs.xscreensaver
+    ];
+
   };
 
 in self


### PR DESCRIPTION
###### Motivation for this change

Better organization of system packages used by LXQt inspired by the GNOME module.

- Split packages in three categories, all of them going into the system package list:
  - prerequisite packages
  - core packages
  - optional packages

- Add a new configuration option 'environment.lxqt.excludePackages' to specify optional LXQt packages that should be excluded from system packages.

- Add 'gvfs' as a pre-requisite package, needed by 'pcmanfm-qt' to handle virtual places, like "Computer" and "Network".

Obsoletes https://github.com/NixOS/nixpkgs/pull/20426.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).