### PR TITLE
monit: 5.19.0 -> 5.20.0 for CVE-2016-7067

### DIFF
--- a/pkgs/tools/system/monit/default.nix
+++ b/pkgs/tools/system/monit/default.nix
@@ -1,15 +1,15 @@
-{stdenv, fetchurl, openssl, bison, flex, pam, usePAM ? stdenv.isLinux }:
+{stdenv, fetchurl, openssl, bison, flex, pam, zlib, usePAM ? stdenv.isLinux }:
 
 stdenv.mkDerivation rec {
-  name = "monit-5.19.0";
+  name = "monit-5.20.0";
 
   src = fetchurl {
     url = "${meta.homepage}dist/${name}.tar.gz";
-    sha256 = "1f32dz7zzp575d35m8xkgjgrqs2vbls0q6vdzm7wwashcm1xbz5y";
+    sha256 = "13drg4k9r9drn7bpj3n04kkf1l29q05jdccdar6yc6hcqmg3kb7b";
   };
 
   nativeBuildInputs = [ bison flex ];
-  buildInputs = [ openssl ] ++ stdenv.lib.optionals usePAM [ pam ];
+  buildInputs = [ openssl zlib.dev ] ++ stdenv.lib.optionals usePAM [ pam ];
 
   configureFlags = [
     "--with-ssl-incl-dir=${openssl.dev}/include"


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/20462
https://cve.space/CVE-2016-7067


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


