### PR TITLE
nixos/tests: Use a patched QEMU for testing

### DIFF
--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -110,6 +110,9 @@ let kernel = config.boot.kernelPackages.kernel; in
 
     networking.usePredictableInterfaceNames = false;
 
+    # Make sure we use a patched QEMU that ignores file ownership.
+    virtualisation.qemu.program = "${pkgs.qemu_test}/bin/qemu-kvm";
+
     # Make it easy to log in as root when running the test interactively.
     users.extraUsers.root.initialHashedPassword = mkOverride 150 "";
 

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -70,7 +70,7 @@ let
       '')}
 
       # Start QEMU.
-      exec ${pkgs.qemu_kvm}/bin/qemu-kvm \
+      exec ${cfg.qemu.program} \
           -name ${vmName} \
           -m ${toString config.virtualisation.memorySize} \
           ${optionalString (pkgs.stdenv.system == "x86_64-linux") "-cpu kvm64"} \
@@ -299,6 +299,14 @@ in
       };
 
     virtualisation.qemu = {
+      program = mkOption {
+        type = types.path;
+        default = "${pkgs.qemu_kvm}/bin/qemu-kvm";
+        defaultText = "\${pkgs.qemu_kvm}/bin/qemu-kvm";
+        example = literalExample "\${pkgs.qemu_test}/bin/qemu-kvm";
+        description = "The QEMU variant used to start the VM.";
+      };
+
       options =
         mkOption {
           type = types.listOf types.unspecified;

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -11,6 +11,7 @@
 , vncSupport ? true, libjpeg, libpng
 , spiceSupport ? !stdenv.isDarwin, spice, spice_protocol, usbredir
 , x86Only ? false
+, nixosTestRunner ? false
 }:
 
 with stdenv.lib;
@@ -118,7 +119,7 @@ stdenv.mkDerivation rec {
 
     # from http://git.qemu.org/?p=qemu.git;a=patch;h=ff55e94d23ae94c8628b0115320157c763eb3e06
     ./CVE-2016-9102.patch
-  ];
+  ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch;
   hardeningDisable = [ "stackprotector" ];
 
   configureFlags =

--- a/pkgs/applications/virtualization/qemu/force-uid0-on-9p.patch
+++ b/pkgs/applications/virtualization/qemu/force-uid0-on-9p.patch
@@ -1,0 +1,48 @@
+diff --git a/hw/9pfs/9p-local.c b/hw/9pfs/9p-local.c
+index 845675e..43fa036 100644
+--- a/hw/9pfs/9p-local.c
++++ b/hw/9pfs/9p-local.c
+@@ -128,6 +128,8 @@ static int local_lstat(FsContext *fs_ctx, V9fsPath *fs_path, struct stat *stbuf)
+     if (err) {
+         goto err_out;
+     }
++    stbuf->st_uid = 0;
++    stbuf->st_gid = 0;
+     if (fs_ctx->export_flags & V9FS_SM_MAPPED) {
+         /* Actual credentials are part of extended attrs */
+         uid_t tmp_uid;
+@@ -462,6 +464,16 @@ static ssize_t local_pwritev(FsContext *ctx, V9fsFidOpenState *fs,
+     return ret;
+ }
+ 
++static int maybe_chmod(const char *path, mode_t mode)
++{
++    static char *store_path = NULL;
++    if (store_path == NULL)
++        store_path = getenv("NIX_STORE");
++    if (strncmp(path, store_path, strlen(store_path)) != 0)
++        return chmod(path, mode);
++    return 0;
++}
++
+ static int local_chmod(FsContext *fs_ctx, V9fsPath *fs_path, FsCred *credp)
+ {
+     char *buffer;
+@@ -477,7 +489,7 @@ static int local_chmod(FsContext *fs_ctx, V9fsPath *fs_path, FsCred *credp)
+     } else if ((fs_ctx->export_flags & V9FS_SM_PASSTHROUGH) ||
+                (fs_ctx->export_flags & V9FS_SM_NONE)) {
+         buffer = rpath(fs_ctx, path);
+-        ret = chmod(buffer, credp->fc_mode);
++        ret = maybe_chmod(buffer, credp->fc_mode);
+         g_free(buffer);
+     }
+     return ret;
+@@ -621,6 +633,8 @@ static int local_fstat(FsContext *fs_ctx, int fid_type,
+     if (err) {
+         return err;
+     }
++    stbuf->st_uid = 0;
++    stbuf->st_gid = 0;
+     if (fs_ctx->export_flags & V9FS_SM_MAPPED) {
+         /* Actual credentials are part of extended attrs */
+         uid_t tmp_uid;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11358,6 +11358,7 @@ in
   watch = callPackage ../os-specific/linux/procps/watch.nix { };
 
   qemu_kvm = lowPrio (qemu.override { x86Only = true; });
+  qemu_test = lowPrio (qemu.override { x86Only = true; nixosTestRunner = true; });
 
   firmwareLinuxNonfree = callPackage ../os-specific/linux/firmware/firmware-linux-nonfree { };
 


### PR DESCRIPTION
Our NixOS test runner is using `virtio` to make the store available to the VMs within the test. Since NixOS/nix@5e51ffb1c265e16486fcdd888ce4a04db9e5552b we now build with user namespaces and we have a mapping from the uid/gid of the current build user to a uid/gid within the newly created user namespace. In NixOS/nix#1131 this is going to be 0/0 again but even using 1000/100 before (in NixOS/nix@ff0c0b645cc1448959126185bb2fafe41cf0bddf) doesn't avoid the following problem.

So the problem here is that the bind-mounted file systems within the build process will have a different uid/gid mapping and this in turn leads to test failures like these:

 * https://headcounter.org/hydra/build/1436479/nixlog/3/raw
 * https://headcounter.org/hydra/build/1454600/nixlog/1/raw

What happens here is that the programs tested here (`sudo` and `cups`) are doing strict permission checks and bail out because the paths that are mounted within the builder sandbox now have uid/gid 65534 and thus don't match with the user that the process is running (uid/gid 0) as.

From the perspective of namespacing this makes sense, because the uid 0 within the user namespace isn't the same as uid 0 from the upper namespace.

Right now it seems that the official Hydra doesn't yet run with a recent enough Nix version to be hitting this problem, but it will eventually get there as well.

So the following options come in mind to address this:

  * Patch programs like `sudo` and `cups` to not do restrictive checks on paths within the Nix store.
  * Use something like `bindfs` to override the uid/gid (very slow, because it's implemented as FUSE).
  * Prevent the Nix builder from creating user namespaces on a selective basis (this however also prevents relocated stores).
  * Patch qemu to always report uid 0 and gid 0 to the VM on `stat()`.

With this PR I've chosen the latter, because it's the most generic and least invasive approach. However we still need to fix build failures of some programs (for example go's tests fail because of this https://headcounter.org/hydra/build/1455527/nixlog/1/raw, but I haven't looked into it in detail yet).

Cc: @edolstra