### PR TITLE
ocamlPackages.menhir: 20160526 -> 20161115

### DIFF
--- a/pkgs/development/ocaml-modules/menhir/default.nix
+++ b/pkgs/development/ocaml-modules/menhir/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, ocaml, findlib, ocamlbuild
-, version ? if stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.02" then "20160526" else "20140422"
+, version ? if stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.02" then "20161115" else "20140422"
 }@args:
 
 let
   sha256 =
   if version == "20140422" then "1ki1f2id6a14h9xpv2k8yb6px7dyw8cvwh39csyzj4qpzx7wia0d"
-  else if version == "20160526" then "1i6yqxhs29n6qcvi6c5qbg5mh8752ywsyv1dr6x1qcv0ncqpxhns"
+  else if version == "20161115" then "1j8nmcj2gq6hyyi16z27amiahplgrnk4ppchpm0v4qy80kwkf47k"
   else throw ("menhir: unknown version " ++ version);
 in
 


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

