### PR TITLE
supertux: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/games/supertux/default.nix
+++ b/pkgs/games/supertux/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "supertux-${version}";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchurl {
     url = "https://github.com/SuperTux/supertux/releases/download/v${version}/SuperTux-v${version}-Source.tar.gz";
-    sha256 = "0fx7c7m6mfanqy7kln7yf6abb5l3r68picf32js2yls11jj0vbng";
+    sha256 = "1i8avad7w7ikj870z519j383ldy29r6f956bs38cbr8wk513pp69";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];


### PR DESCRIPTION
###### Motivation for this change

[Release notes](https://github.com/SuperTux/supertux/releases/tag/v0.5.1):

> This is a bugfix release fixing some smaller problems that were reported after the release of 0.5.0. It mostly features changes to the behavior of the level editor, and adds some options that were missing but should have been included in the stable release 0.5.0.
> 
> If you'd like to help with SuperTux development, you can find more resources in our wiki at https://github.com/SuperTux/supertux/wiki. Please get in touch with us. The fastest way is usually IRC, but please wait if you don't get an answer immediately. We urgently need more graphic designers and developers for future releases, help in these areas would be really appreciated.
> 
> Changes:
> 
> - Editor: Tilemap: Add an option to change the draw target
> - Editor: Add an option to snap objects to the grid (this will make it easier to add objects to a nice location in levels)
> - Editor: Camera: Remove autoscroll option, as it is deprecated and should not be used anymore
> - Editor: Fix an issue where some areas in the editor would be excessively large relative to the window/screen size

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).