### PR TITLE
menu-cache: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/libraries/menu-cache/default.nix
+++ b/pkgs/development/libraries/menu-cache/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, glib, pkgconfig, libfm-extra }:
 
-let name = "menu-cache-1.0.1";
+let name = "menu-cache-1.0.2";
 in
 stdenv.mkDerivation {
   inherit name;
   src = fetchurl {
     url = "mirror://sourceforge/lxde/${name}.tar.xz";
-    sha256 = "0ngxvwfj9drabqi3lyzgpi0d0za6431sy2ijb010filrj54jdiqa";
+    sha256 = "1m8j40npykfcfqs43kc0fmksal2jfmfi8lnb3mq3xy1lvvrfv0vg";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).