### PR TITLE
nocrypto: 0.5.1 -> 0.5.3

### DIFF
--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, writeText, fetchFromGitHub, ocaml, ocplib-endian, sexplib_p4, findlib, ppx_tools
-, async_p4 ? null, lwt ? null, camlp4
+{ stdenv, writeText, fetchFromGitHub, ocaml, ocplib-endian, sexplib, findlib, ppx_tools
+, async ? null, lwt ? null
 }:
 
 assert stdenv.lib.versionAtLeast ocaml.version "4.01";
@@ -22,10 +22,10 @@ stdenv.mkDerivation {
     inherit (param) sha256;
   };
 
-  configureFlags = [ "${opt lwt}-lwt" "${opt async_p4}-async" "${opt ppx_tools}-ppx" ];
+  configureFlags = [ "${opt lwt}-lwt" "${opt async}-async" "${opt ppx_tools}-ppx" ];
 
-  buildInputs = [ ocaml findlib ppx_tools camlp4 lwt async_p4 ];
-  propagatedBuildInputs = [ ocplib-endian sexplib_p4 ];
+  buildInputs = [ ocaml findlib ppx_tools lwt async ];
+  propagatedBuildInputs = [ ocplib-endian sexplib ];
 
   createFindlibDestdir = true;
   dontStrip = true;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -259,7 +259,9 @@ let
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
-    nocrypto =  callPackage ../development/ocaml-modules/nocrypto { };
+    nocrypto =  callPackage ../development/ocaml-modules/nocrypto {
+      lwt = ocaml_lwt;
+    };
 
     ocaml_batteries = callPackage ../development/ocaml-modules/batteries { };
 


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @vbgl 

I suspected that the change of `cstruct` would break things (especially on 4.01), but a `nox-review wip` did not reveal anything.