### PR TITLE
wireshark: add darwin support

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -3,6 +3,7 @@
 , zlib
 , withGtk ? false, gtk2 ? null, pango ? null, cairo ? null, gdk_pixbuf ? null
 , withQt ? false, qt4 ? null
+, ApplicationServices, SystemConfiguration, gmp
 }:
 
 assert withGtk -> !withQt && gtk2 != null;
@@ -25,9 +26,11 @@ stdenv.mkDerivation {
 
   buildInputs = [
     bison flex perl pkgconfig libpcap lua5 openssl libgcrypt gnutls
-    geoip libnl c-ares python libcap glib zlib
+    geoip c-ares python glib zlib
   ] ++ optional withQt qt4
-    ++ (optionals withGtk [gtk2 pango cairo gdk_pixbuf]);
+    ++ (optionals withGtk [gtk2 pango cairo gdk_pixbuf])
+    ++ optionals stdenv.isLinux [ libcap libnl ]
+    ++ optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ];
 
   patches = [ ./wireshark-lookup-dumpcap-in-path.patch ];
 
@@ -68,7 +71,7 @@ stdenv.mkDerivation {
       experts. It runs on UNIX, OS X and Windows.
     '';
 
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ bjornfor fpletz ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12887,6 +12887,7 @@ in
   wireshark-cli = callPackage ../applications/networking/sniffers/wireshark {
     withQt = false;
     withGtk = false;
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices SystemConfiguration;
   };
   wireshark-gtk = wireshark-cli.override { withGtk = true; };
   wireshark-qt = wireshark-cli.override { withQt = true; };


### PR DESCRIPTION
###### Motivation for this change

This should enable both wireshark-cli and wireshark-gtk to build on macOS.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


