### PR TITLE
elm: 0.17.1 -> 0.18

### DIFF
--- a/pkgs/development/compilers/elm/packages/elm-compiler.nix
+++ b/pkgs/development/compilers/elm/packages/elm-compiler.nix
@@ -7,11 +7,11 @@
 }:
 mkDerivation {
   pname = "elm-compiler";
-  version = "0.17.1";
+  version = "0.18";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-compiler";
-    sha256 = "17y0jlii81mnjywknblcv1nfja51slmwrhz9x8w144b0sblcj0if";
-    rev = "e44deafaf9cbf3749484070f267f03a368711adb";
+    sha256 = "09fmrbfpc1kzc3p9h79w57b9qjhajdswc4jfm9gyjw95vsiwasgh";
+    rev = "eb97f2a5dd5421c708a91b71442e69d02453cc80";
   };
   isLibrary = true;
   isExecutable = true;
@@ -35,4 +35,7 @@ mkDerivation {
   homepage = "http://elm-lang.org";
   description = "Values to help with elm-package, elm-make, and elm-lang.org.";
   license = stdenv.lib.licenses.bsd3;
+  # added manually since tests are not passing
+  # https://travis-ci.org/elm-lang/elm-compiler/builds/176845852
+  doCheck = false;
 }

--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -7,11 +7,11 @@
 }:
 mkDerivation {
   pname = "elm-format";
-  version = "0.4.0";
+  version = "0.5.2";
   src = fetchgit {
     url = "http://github.com/avh4/elm-format";
-    sha256 = "199xh2w5cwcf79a8fv6j8dpk9h8a4cygrf8cfr9p7bvp2wvczibm";
-    rev = "d9cbe65c5f01d21b5a02c2f963aa4c9d3f0539d0";
+    sha256 = "0lman7h6wr75y90javcc4y1scvwgv125gqqaqvfrd5xrfmm43gg8";
+    rev = "e452ed9342620e7bb0bc822983b96411d57143ef";
   };
   isLibrary = false;
   isExecutable = true;
@@ -32,14 +32,4 @@ mkDerivation {
   homepage = "http://elm-lang.org";
   description = "A source code formatter for Elm";
   license = stdenv.lib.licenses.bsd3;
-
-  # XXX: I've manually disabled tests, only the following test is failing
-  # ...
-  # ElmFormat.Cli
-  #   format a single file in place:                    OK
-  #   usage instructions:                               FAIL
-  # ...
-  # 1 out of 266 tests failed (0.50s)
-  # Test suite elm-format-tests: FAIL
-  doCheck = false;
 }

--- a/pkgs/development/compilers/elm/packages/elm-make.nix
+++ b/pkgs/development/compilers/elm/packages/elm-make.nix
@@ -5,11 +5,11 @@
 }:
 mkDerivation {
   pname = "elm-make";
-  version = "0.17.1";
+  version = "0.18";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-make";
-    sha256 = "0k9w5gl48lhhr3n2iflf0vkb3w6al0xcbglgiw4fq1ssz3aa7ijw";
-    rev = "0a0a1f52ab04e2d68d60a5798722e1de30b47335";
+    sha256 = "1yq4w4yqignlc2si5ns53pmz0a99gix5d2qgi6x7finf7i6sxyw2";
+    rev = "1a554833a70694ab142b9179bfac996143f68d9e";
   };
   isLibrary = false;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/packages/elm-package.nix
+++ b/pkgs/development/compilers/elm/packages/elm-package.nix
@@ -7,11 +7,11 @@
 }:
 mkDerivation {
   pname = "elm-package";
-  version = "0.17.1";
+  version = "0.18";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-package";
-    sha256 = "0dnn871py0pvzxsjjggy5ww2zj9g71c2dcnp38rcr4nbj8yxik85";
-    rev = "9011ccdbced1d06aa60de0e3096e609ef44d26dd";
+    sha256 = "19krnkjvfk02gmmic5h5i1i0lw7s30927bnd5g57cj8nqbigysv7";
+    rev = "8bd150314bacab5b6fc451927aa01deec2276fbf";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/packages/elm-reactor-elm.nix
+++ b/pkgs/development/compilers/elm/packages/elm-reactor-elm.nix
@@ -1,22 +1,22 @@
 {
   "elm-lang/virtual-dom" = {
-    version = "1.1.0";
-    sha256 = "16g66cvvh85ddciq0ymaqfyq2bcz11pxn0g0dc1wx7bmlqx7q1jz";
+    version = "2.0.1";
+    sha256 = "19nfjx072m7a7bx8flc50vbmiww172jmscyq9x91cr2kby5hvbw3";
   };
   "evancz/elm-markdown" = {
-    version = "3.0.0";
-    sha256 = "0r3hcim4mpn46ahv1q6sjp6i2viyp7jik6i71xgwmvfb9drns2p6";
+    version = "3.0.1";
+    sha256 = "144lzpcapf2mhqiz90mkllmm4skrcs0iha1daps42qn3xps7hvmj";
   };
   "elm-lang/html" = {
-    version = "1.1.0";
-    sha256 = "1v7pwxxd81qrfywb4rr199p2i9z77vjkbwjwm5gy1nxdpi8mb50y";
+    version = "2.0.0";
+    sha256 = "05sqjd5n8jnq4lv5v0ipcg98b8im1isnnl4wns1zzn4w5nbrjjzi";
   };
   "elm-lang/svg" = {
-    version = "1.1.1";
-    sha256 = "0xzc0fq2kg797km0nq2f52w6xdffrl9l0y5zbkpa72w163zpxkkn";
+    version = "2.0.0";
+    sha256 = "1c7p967n1yhynravqwgh80vprwz7r2r1n0x3icn5wzk9iaqs069l";
   };
   "elm-lang/core" = {
-    version = "4.0.2";
-    sha256 = "1qjhfr3gd1qmfvna7iddspmk26v2nmgmgw9m6yyz10ygy3i9mla6";
+    version = "5.0.0";
+    sha256 = "0gqyc09bh43pi7r2cizyjm5y0zpgarv3is17dl325qvxb9s1y2gn";
   };
 }

--- a/pkgs/development/compilers/elm/packages/elm-reactor.nix
+++ b/pkgs/development/compilers/elm/packages/elm-reactor.nix
@@ -6,11 +6,11 @@
 }:
 mkDerivation {
   pname = "elm-reactor";
-  version = "0.17.1";
+  version = "0.18";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-reactor";
-    sha256 = "14kkqskvhkfznpl8cmjlvv3rp6ciqmdbxrmq6f20p3aznvkrdvf8";
-    rev = "7522d7ef379c5a4ffbba11b1be09ed04add08a63";
+    sha256 = "0lpidsckyfcr8d6bln735d98dx7ga7j1vyssw0qsv8ijj18gxx65";
+    rev = "c519d4ec0aaf2f043a416fe858346b0181eca516";
   };
   isLibrary = false;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/packages/elm-repl.nix
+++ b/pkgs/development/compilers/elm/packages/elm-repl.nix
@@ -6,11 +6,11 @@
 }:
 mkDerivation {
   pname = "elm-repl";
-  version = "0.17.1";
+  version = "0.18";
   src = fetchgit {
     url = "https://github.com/elm-lang/elm-repl";
-    sha256 = "0nh2yfr0bi4rg1kak1gjaczpq56y1nii05b5y7hn6n4w651jkm28";
-    rev = "413ac0d4ee43c8542afd3041bbb7b8c903cd3d30";
+    sha256 = "112fzykils4lqz4pc44q4mwvxg0px0zfwx511bfvblrxkwwqlfb5";
+    rev = "85f0bcfc28ea6c8a99a360d55c21ff25a556f9fe";
   };
   isLibrary = false;
   isExecutable = true;

--- a/pkgs/development/compilers/elm/packages/release.nix
+++ b/pkgs/development/compilers/elm/packages/release.nix
@@ -2,7 +2,7 @@
 # Please, do not modify it by hand!
 { callPackage }:
 {
-  version = "0.17.1";
+  version = "0.18.0";
   packages = {
     elm-compiler = callPackage ./elm-compiler.nix { };
     elm-package = callPackage ./elm-package.nix { };

--- a/pkgs/development/compilers/elm/update-elm.rb
+++ b/pkgs/development/compilers/elm/update-elm.rb
@@ -1,12 +1,12 @@
 #!/usr/bin/env ruby
 
 # Take those from https://github.com/elm-lang/elm-platform/blob/master/installers/BuildFromSource.hs
-$elm_version = "0.17.1"
-$elm_packages = { "elm-compiler" => "0.17.1",
-                  "elm-package" => "0.17.1",
-                  "elm-make" => "0.17.1",
-                  "elm-reactor" => "0.17.1",
-                  "elm-repl" => "0.17.1"
+$elm_version = "0.18.0"
+$elm_packages = { "elm-compiler" => "0.18.0",
+                  "elm-package" => "0.18.0",
+                  "elm-make" => "0.18.0",
+                  "elm-reactor" => "0.18.0",
+                  "elm-repl" => "0.18.0"
                 }
 
 for pkg, ver in $elm_packages


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


