### PR TITLE
[wip] nodejs: Flag to disable building with openSSL

### DIFF
--- a/pkgs/development/web/nodejs/v4.nix
+++ b/pkgs/development/web/nodejs/v4.nix
@@ -3,6 +3,7 @@
 , callPackage
 , darwin ? null
 , enableNpm ? true
+, enableSsl ? true
 }@args:
 
 let

--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -3,6 +3,7 @@
 , callPackage
 , darwin ? null
 , enableNpm ? true
+, enableSsl ? true
 }@args:
 
 let

--- a/pkgs/development/web/nodejs/v7.nix
+++ b/pkgs/development/web/nodejs/v7.nix
@@ -3,6 +3,7 @@
 , callPackage
 , darwin ? null
 , enableNpm ? true
+, enableSsl ? true
 }@args:
 
 let


### PR DESCRIPTION
###### Motivation for this change
Some uses for nodejs are not web servers, such as being a build system (looking at you, cjdns). Thus it makes no sense to pull in OpenSSL in these cases. This creates a flag to build without SSL.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

