### PR TITLE
bugseverywhere: Fix to contain libbe

### DIFF
--- a/pkgs/applications/version-management/bugseverywhere/default.nix
+++ b/pkgs/applications/version-management/bugseverywhere/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, pythonPackages, fetchurl }:
+{ stdenv, python2Packages, fetchurl }:
 
 #
-# Upstream stopped development of this package. If this package does not build
-# anymore, feel free to remove it by reverting the appropriate patch
-# (git log --grep bugseverywhere)
+# Note that there is a github mirror at
+# https://github.com/aaiyer/bugseverywhere/
+# which is ahead of this very package, so upgrading to a newer version might be
+# possible even if bugseverywhere-1.1.1 is broken (on pypi or elsewhere).
 #
 pythonPackages.buildPythonApplication rec {
     version = "1.1.1";
@@ -18,7 +19,16 @@ pythonPackages.buildPythonApplication rec {
     # There are no tests in the repository.
     doCheck = false;
 
-    buildInputs = with pythonPackages; [
+    postInstall = ''
+      mkdir -p $out/{${pythonPackages.python.sitePackages},bin}/
+      cp libbe* -r $out/${pythonPackages.python.sitePackages}/
+
+      cp be $out/bin/
+      chmod +x $out/bin/be
+    '';
+
+
+    propagatedBuildInputs = with pythonPackages; [
         jinja2
         cherrypy
     ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -498,6 +498,8 @@ in
 
   bonnie = callPackage ../tools/filesystems/bonnie { };
 
+  bugseverywhere = callPackage ../applications/version-management/bugseverywhere { };
+
   djmount = callPackage ../tools/filesystems/djmount { };
 
   elvish = callPackage ../shells/elvish { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -138,8 +138,6 @@ in {
 
   breathe = callPackage ../development/python-modules/breathe { };
 
-  bugseverywhere = callPackage ../applications/version-management/bugseverywhere {};
-
   dbf = buildPythonPackage rec {
     name = "dbf-0.94.003";
     disabled = isPy3k;


### PR DESCRIPTION
**I need help here**

###### Motivation for this change

bugseverywhere is broken as `libbe` is not installed, which is a python package the bugseverywhere package provides itself, but our install setup did not yet cover.

Can someone with experience on python packaging help me here?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
