### PR TITLE
bro: 2.4.1 -> 2.5

### DIFF
--- a/pkgs/applications/networking/ids/bro/default.nix
+++ b/pkgs/applications/networking/ids/bro/default.nix
@@ -1,15 +1,15 @@
 {stdenv, fetchurl, cmake, flex, bison, openssl, libpcap, perl, zlib, file, curl
-, geoip, gperftools }:
+, geoip, gperftools, python }:
 
 stdenv.mkDerivation rec {
-  name = "bro-2.4.1";
+  name = "bro-2.5";
 
   src = fetchurl {
-    url = "http://www.bro.org/downloads/release/${name}.tar.gz";
-    sha256 = "1xn8qwgnxihlr4lmg7kz2vqjk46aqgwc8878pbv30ih2lmrrdffq";
+    url = "http://www.bro.org/downloads/${name}.tar.gz";
+    sha256 = "10603lwhwsmh08m5rgknbspbhd4lis71qv7z8ixacgv6sf8a40hm";
   };
 
-  buildInputs = [ cmake flex bison openssl libpcap perl zlib file curl geoip gperftools ];
+  buildInputs = [ cmake flex bison openssl libpcap perl zlib file curl geoip gperftools python ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


