### PR TITLE
nitrogen: 1.5.2 -> 1.6.0

### DIFF
--- a/pkgs/tools/X11/nitrogen/default.nix
+++ b/pkgs/tools/X11/nitrogen/default.nix
@@ -1,20 +1,25 @@
 { stdenv, fetchurl, pkgconfig, glib, gtkmm2 }:
 
-let version = "1.5.2";
+let version = "1.6.0";
 in
 stdenv.mkDerivation rec {
   name = "nitrogen-${version}";
 
   src = fetchurl {
-    url = "http://projects.l3ib.org/nitrogen/files/nitrogen-${version}.tar.gz";
-    sha256 = "60a2437ce6a6c0ba44505fc8066c1973140d4bb48e1e5649f525c7b0b8bf9fd2";
+    url = "http://projects.l3ib.org/nitrogen/files/${name}.tar.gz";
+    sha256 = "1pil2qa3v7x56zh9xvba8v96abnf9qgglbsdlrlv0kfjlhzl4jhr";
   };
 
-  buildInputs = [ glib gtkmm2 pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ];
 
-  NIX_LDFLAGS = "-lX11";
+  buildInputs = [ glib gtkmm2 ];
 
-  patchPhase = "patchShebangs data/icon-theme-installer";
+  NIX_CXXFLAGS_COMPILE = "-std=c++11";
+
+  patchPhase = ''
+    substituteInPlace data/Makefile.in --replace /usr/share $out/share
+    patchShebangs data/icon-theme-installer
+  '';
 
   meta = {
     description = "A wallpaper browser and setter for X11";


### PR DESCRIPTION
###### Motivation for this change

Update to new released version.

[Nitrogen 1.6.0: Finally](https://github.com/l3ib/nitrogen/releases/tag/1.6.0)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).