### PR TITLE
Support for ARM in openblas

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -11,11 +11,12 @@ let blas64_ = blas64; in
 let local = config.openblas.preferLocalBuild or false;
     binary =
       { i686-linux = "32";
+        armv7l-linux = "32";
         x86_64-linux = "64";
         x86_64-darwin = "64";
       }."${stdenv.system}" or (throw "unsupported system: ${stdenv.system}");
     genericFlags =
-      [ "DYNAMIC_ARCH=1"
+      [ "DYNAMIC_ARCH=${if stdenv.system == "armv7l-linux" then "0" else "1"}"
         "NUM_THREADS=64"
       ];
     localFlags = config.openblas.flags or
@@ -65,7 +66,9 @@ stdenv.mkDerivation {
       "BINARY=${binary}"
       "USE_OPENMP=${if stdenv.isDarwin then "0" else "1"}"
       "INTERFACE64=${if blas64 then "1" else "0"}"
-    ];
+    ]
+    ++
+    optionals (stdenv.system == "armv7l-linux") ["TARGET=ARMV7"];
 
   doCheck = true;
   checkTarget = "tests";


### PR DESCRIPTION
###### Motivation for this change
Attempting to build openblas on ARM resulted in the error "unsupported system: armv7l_linux". This PR resolves that issue and some other issues that pop up when trying to build openblas for ARM.

This shouldn't change the package for other architectures.