### PR TITLE
ocaml-x509: set mininimum supported ocaml version

### DIFF
--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -4,6 +4,8 @@ buildOcaml rec {
   name = "x509";
   version = "0.5.3";
 
+  mininimumSupportedOcamlVersion = "4.02";
+
   src = fetchFromGitHub {
     owner  = "mirleft";
     repo   = "ocaml-x509";


### PR DESCRIPTION
###### Motivation for this change

Make the mininimum needed ocaml version explicit (currently it does not evaluate because of `nocrypto`).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
