### PR TITLE
ocaml-notty: init at 0.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, buildOcaml, fetchFromGitHub, findlib
+, result, uucp, uuseg, uutf
+, lwt     ? null }:
+
+with stdenv.lib;
+
+let withLwt = lwt != null; in
+
+buildOcaml rec {
+  version = "0.1.1";
+  name = "notty";
+
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner  = "pqwy";
+    repo   = "notty";
+    rev    = "v${version}";
+    sha256 = "0bw3bq8z2y1rhc20zn13s78sazywyzpg8nmyjch33p7ypxfglf01";
+  };
+
+  buildInputs = [ findlib ];
+  propagatedBuildInputs = [ result uucp uuseg uutf ] ++
+                          optional withLwt [ lwt ];
+
+  configureFlags = [ "--enable-unix" ] ++
+                   (if withLwt then ["--enable-lwt"] else ["--disable-lwt"]);
+
+  configurePhase = "./configure --prefix $out $configureFlags";
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "Declarative terminal graphics for OCaml";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -263,6 +263,10 @@ let
       lwt = ocaml_lwt;
     };
 
+    notty = callPackage ../development/ocaml-modules/notty {
+      lwt = ocaml_lwt;
+    };
+
     ocaml_batteries = callPackage ../development/ocaml-modules/batteries { };
 
     comparelib = callPackage ../development/ocaml-modules/comparelib { };


### PR DESCRIPTION
###### Motivation for this change

re-introduce notty

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).