### PR TITLE
ocaml-tls: init at 0.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, buildOcaml, fetchFromGitHub, findlib, ocamlbuild, ocaml_oasis
+, ppx_tools, ppx_sexp_conv, result, x509, nocrypto, cstruct, ounit
+, lwt     ? null}:
+
+with stdenv.lib;
+
+let withLwt = lwt != null; in
+
+buildOcaml rec {
+  version = "0.7.1";
+  name = "tls";
+
+  minimunSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner  = "mirleft";
+    repo   = "ocaml-tls";
+    rev    = "${version}";
+    sha256 = "19q2hzxiasz9pzczgb63kikg0mc9mw98dfvch5falf2rincycj24";
+  };
+
+  buildInputs = [ ocamlbuild findlib ocaml_oasis ppx_sexp_conv ounit ];
+  propagatedBuildInputs = [ cstruct nocrypto result x509 ] ++
+                          optional withLwt lwt;
+
+  configureFlags = [ "--disable-mirage" "--enable-tests" ] ++
+                   optional withLwt ["--enable-lwt"];
+
+  configurePhase = "./configure --prefix $out $configureFlags";
+
+  doCheck = true;
+  checkTarget = "test";
+  createFindlibDestdir = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mirleft/ocaml-tls;
+    description = "TLS in pure OCaml";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -366,6 +366,10 @@ let
 
     textutils_p4 = callPackage ../development/ocaml-modules/textutils { };
 
+    tls = callPackage ../development/ocaml-modules/tls {
+      lwt = ocaml_lwt;
+    };
+
     type_conv_108_08_00 = callPackage ../development/ocaml-modules/type_conv/108.08.00.nix { };
     type_conv_109_60_01 = callPackage ../development/ocaml-modules/type_conv/109.60.01.nix { };
     type_conv_112_01_01 = callPackage ../development/ocaml-modules/type_conv/112.01.01.nix { };


### PR DESCRIPTION
###### Motivation for this change

re-introduce tls.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).