### PR TITLE
ocaml-erm_xmpp_0_3: init at 0.3

### DIFF
--- a/pkgs/development/ocaml-modules/erm_xmpp/0.3.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/0.3.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildOcaml, fetchFromGitHub, fetchurl, ocaml, findlib, erm_xml, nocrypto }:
+
+buildOcaml rec {
+  version = "0.3";
+  name = "erm_xmpp";
+
+  src = fetchFromGitHub {
+    owner  = "hannesm";
+    repo   = "xmpp";
+    rev    = "eee18bd3dd343550169969c0b45548eafd51cfe1";
+    sha256 = "0hzs528lrx1ayalv6fh555pjn0b4l8xch1f72hd3b07g1xahdas5";
+  };
+
+  buildInputs = [ ocaml findlib ];
+  propagatedBuildInputs = [ erm_xml nocrypto ];
+
+  configurePhase = "ocaml setup.ml -configure --prefix $out";
+  buildPhase = "ocaml setup.ml -build";
+  installPhase = "ocaml setup.ml -install";
+
+  createFindlibDestdir = true;
+
+  meta = {
+    homepage = https://github.com/hannesm/xmpp;
+    description = "OCaml based XMPP implementation (fork)";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -158,6 +158,8 @@ let
 
     erm_xmpp = callPackage ../development/ocaml-modules/erm_xmpp { };
 
+    erm_xmpp_0_3 = callPackage ../development/ocaml-modules/erm_xmpp/0.3.nix { };
+
     estring = callPackage ../development/ocaml-modules/estring { };
 
     ezjsonm = callPackage ../development/ocaml-modules/ezjsonm {


### PR DESCRIPTION
###### Motivation for this change

re-introduce erm_xmpp_0_3, an updated version of erm_xmpp.
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


