### PR TITLE
ocaml-otr: init at 0.3.3

### DIFF
--- a/pkgs/development/ocaml-modules/otr/default.nix
+++ b/pkgs/development/ocaml-modules/otr/default.nix
@@ -1,0 +1,43 @@
+{stdenv, buildOcaml, fetchFromGitHub, ocamlbuild, findlib, topkg, ocaml, opam,
+ ppx_tools, ppx_sexp_conv, cstruct, sexplib, result, nocrypto, astring}:
+
+let ocamlFlags = "-I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/"; in
+
+buildOcaml rec {
+  name = "otr";
+  version = "0.3.3";
+
+  minimumSupportedOcamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner  = "hannesm";
+    repo   = "ocaml-otr";
+    rev    = "${version}";
+    sha256 = "07zzix5mfsasqpqdx811m0x04gp8mq1ayf4b64998k98027v01rr";
+  };
+
+  buildInputs = [ ocamlbuild findlib topkg ppx_tools ppx_sexp_conv opam ];
+  propagatedBuildInputs = [ cstruct sexplib result nocrypto astring ];
+
+  buildPhase = ''
+    ocaml ${ocamlFlags} pkg/pkg.ml build \
+      --tests true
+  '';
+
+  installPhase = ''
+    opam-installer --prefix=$out --script | sh
+    ln -s $out/lib/otr $out/lib/ocaml/${ocaml.version}/site-lib
+  '';
+
+  doCheck = true;
+  checkPhase = "ocaml ${ocamlFlags} pkg/pkg.ml test";
+
+  createFindlibDestdir = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/hannesm/ocaml-otr;
+    description = "Off-the-record messaging protocol, purely in OCaml";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -339,6 +339,8 @@ let
 
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
+    otr = callPackage ../development/ocaml-modules/otr { };
+
     ounit = callPackage ../development/ocaml-modules/ounit { };
 
     piqi = callPackage ../development/ocaml-modules/piqi { };
@@ -641,7 +643,7 @@ let
       then { tools = pkgs.pkgsi686Linux.stdenv.cc; }
       else {}
     );
-    
+
     glsurf = callPackage ../applications/science/math/glsurf {
       libpng = pkgs.libpng12;
       giflib = pkgs.giflib_4_1;


### PR DESCRIPTION
###### Motivation for this change

re-introduce ocaml-otr

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


