### PR TITLE
emacs-24.5-mac-5.15: fixed package by adding build tools

### DIFF
--- a/pkgs/applications/editors/emacs/macport-24.5.nix
+++ b/pkgs/applications/editors/emacs/macport-24.5.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, ncurses, pkgconfig, texinfo, libxml2, gnutls, gettext
 , AppKit, Carbon, Cocoa, IOKit, OSAKit, Quartz, QuartzCore, WebKit
+, autoconf, automake
 , ImageCaptureCore, GSS, ImageIO # These may be optional
 }:
 
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ ncurses libxml2 gnutls pkgconfig texinfo gettext ];
+  buildInputs = [ ncurses libxml2 gnutls pkgconfig texinfo gettext autoconf automake ];
 
   propagatedBuildInputs = [
     AppKit Carbon Cocoa IOKit OSAKit Quartz QuartzCore WebKit


### PR DESCRIPTION
###### Motivation for this change

Fixes the build which was missing automake and autoconf.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---