### PR TITLE
containers module: Add readOnly and tmpfs options

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -129,8 +129,12 @@ let
         --setenv HOST_ADDRESS6="$HOST_ADDRESS6" \
         --setenv LOCAL_ADDRESS6="$LOCAL_ADDRESS6" \
         --setenv PATH="$PATH" \
+        ${optionalString (cfg.readOnly) ''--read-only''} \
         ${if cfg.additionalCapabilities != null then
           ''--capability="${concatStringsSep " " cfg.additionalCapabilities}"'' else ""
+        } \
+        ${if cfg.tmpfs != null && cfg.tmpfs != [] then
+          ''--tmpfs="${concatStringsSep ":" cfg.tmpfs}"'' else ""
         } \
         ${containerInit cfg} "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/init"
     '';
@@ -367,6 +371,8 @@ let
       hostAddress6 = null;
       localAddress = null;
       localAddress6 = null;
+      readOnly = false;
+      tmpfs = null;
     };
 
 in
@@ -507,6 +513,23 @@ in
               example = [ { node = "/dev/net/tun"; modifier = "rw"; } ];
               description = ''
                 A list of device nodes to which the containers has access to.
+              '';
+            };
+
+            readOnly = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Mount the root file system read-only for the container.
+              '';
+            };
+
+            tmpfs = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              example = [ "/var" ];
+              description = ''
+                Mount a tmpfs file system into the container.
               '';
             };
 


### PR DESCRIPTION
###### Motivation for this change

Enables the easy creation of stateless containers by turning the root file system read-only and file systems such as /var as a tmpfs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


The added options to containers allow nixos-containers be described
with:

 - readOnly: Mounts the root file system of the container as read-only.
 - tmpfs: allows one or more directories to be mounted as a read-only
          file system.

This makes it convenient to run volatile containers that do not retain
state.