### PR TITLE
franz: Allow to run with grsecurity kernel

### DIFF
--- a/pkgs/applications/networking/instant-messengers/franz/default.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
       "16l9jma2hiwzl9l41yhrwribcgmxca271rq0cfbbm9701mmmciyy";
   };
 
-  phases = [ "unpackPhase" "installPhase" ];
+  phases = [ "unpackPhase" "installPhase" "postFixup" ];
 
   deps = with xorg; [
    gtk2 atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
@@ -51,6 +51,10 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/share/applications $out/share/pixmaps
     ln -s ${desktopItem}/share/applications/* $out/share/applications
     ln -s $out/share/franz/resources/app.asar.unpacked/assets/franz.png $out/share/pixmaps
+  '';
+
+  postFixup = ''
+    paxmark m $out/share/franz/Franz
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Fix #20539

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


