### PR TITLE
tahoe service: use ExecStart instead of script

### DIFF
--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -233,6 +233,12 @@ in
             serviceConfig = {
               Type = "simple";
               PIDFile = pidfile;
+              # Believe it or not, Tahoe is very brittle about the order of
+              # arguments to $(tahoe start). The node directory must come first,
+              # and arguments which alter Twisted's behavior come afterwards.
+              ExecStart = ''
+                ${settings.package}/bin/tahoe start ${nodedir} -n -l- --pidfile=${pidfile}
+              '';
             };
             preStart = ''
               if [ \! -d ${nodedir} ]; then
@@ -247,12 +253,6 @@ in
               # rm ${nodedir}/tahoe.cfg
               # ln -s /etc/tahoe-lafs/introducer-${node}.cfg ${nodedir}/tahoe.cfg
               cp /etc/tahoe-lafs/introducer-${node}.cfg ${nodedir}/tahoe.cfg
-            '';
-            # Believe it or not, Tahoe is very brittle about the order of
-            # arguments to $(tahoe start). The node directory must come first,
-            # and arguments which alter Twisted's behavior come afterwards.
-            script = ''
-              tahoe start ${nodedir} -n -l- --pidfile=${pidfile}
             '';
           });
         users.extraUsers = flip mapAttrs' cfg.introducers (node: _:
@@ -333,6 +333,12 @@ in
             serviceConfig = {
               Type = "simple";
               PIDFile = pidfile;
+              # Believe it or not, Tahoe is very brittle about the order of
+              # arguments to $(tahoe start). The node directory must come first,
+              # and arguments which alter Twisted's behavior come afterwards.
+              ExecStart = ''
+                ${settings.package}/bin/tahoe start ${nodedir} -n -l- --pidfile=${pidfile}
+              '';
             };
             preStart = ''
               if [ \! -d ${nodedir} ]; then
@@ -347,12 +353,6 @@ in
               # rm ${nodedir}/tahoe.cfg
               # ln -s /etc/tahoe-lafs/${node}.cfg ${nodedir}/tahoe.cfg
               cp /etc/tahoe-lafs/${node}.cfg ${nodedir}/tahoe.cfg
-            '';
-            # Believe it or not, Tahoe is very brittle about the order of
-            # arguments to $(tahoe start). The node directory must come first,
-            # and arguments which alter Twisted's behavior come afterwards.
-            script = ''
-              tahoe start ${nodedir} -n -l- --pidfile=${pidfile}
             '';
           });
         users.extraUsers = flip mapAttrs' cfg.nodes (node: _:


### PR DESCRIPTION
###### Motivation for this change

To avoid having an unnecessary Bash instance running for each Tahoe node. An alternative way to solve this would be to change the `script` variable to read `exec tahoe start …` but since it is only a single command I figured `ExecStart` is more straightforward.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).