### PR TITLE
rambox: Allow to run with grsecurity kernel

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
       "0gq0ywk1jr0apl39dnm0vwdwg1inr7fari3cmfz3fvaym7gc8fki";
   };
 
-  phases = [ "unpackPhase" "installPhase" ];
+  phases = [ "unpackPhase" "installPhase" "postFixup" ];
 
   deps = with xorg; [
    gtk2 atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
@@ -51,6 +51,10 @@ in stdenv.mkDerivation rec {
 
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  postFixup = ''
+    paxmark m $out/share/rambox/Rambox
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Paxmark, so it can run in a hardened environment

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


