### PR TITLE
containers module: Add tmpfs options

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -88,6 +88,7 @@
   chris-martin = "Chris Martin <ch.martin@gmail.com>";
   chrisjefferson = "Christopher Jefferson <chris@bubblescope.net>";
   christopherpoole = "Christopher Mark Poole <mail@christopherpoole.net>";
+  ckampka = "Christian Kampka <christian@kampka.net>";
   cko = "Christine Koppelt <christine.koppelt@gmail.com>";
   cleverca22 = "Michael Bishop <cleverca22@gmail.com>";
   cmcdragonkai = "Roger Qiu <roger.qiu@matrix.ai>";

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -129,8 +129,11 @@ let
         --setenv HOST_ADDRESS6="$HOST_ADDRESS6" \
         --setenv LOCAL_ADDRESS6="$LOCAL_ADDRESS6" \
         --setenv PATH="$PATH" \
-        ${if cfg.additionalCapabilities != null then
+        ${if cfg.additionalCapabilities != null && cfg.additionalCapabilities != [] then
           ''--capability="${concatStringsSep " " cfg.additionalCapabilities}"'' else ""
+        } \
+        ${if cfg.tmpfs != null && cfg.tmpfs != [] then
+          ''--tmpfs=${concatStringsSep " --tmpfs=" cfg.tmpfs}'' else ""
         } \
         ${containerInit cfg} "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/init"
     '';
@@ -367,6 +370,7 @@ let
       hostAddress6 = null;
       localAddress = null;
       localAddress6 = null;
+      tmpfs = null;
     };
 
 in
@@ -507,6 +511,18 @@ in
               example = [ { node = "/dev/net/tun"; modifier = "rw"; } ];
               description = ''
                 A list of device nodes to which the containers has access to.
+              '';
+            };
+
+            tmpfs = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              example = [ "/var" ];
+              description = ''
+                Mounts a set of tmpfs file systems into the container.
+                Multiple paths can be specified.
+                Valid items must conform to the --tmpfs argument
+                of systemd-nspawn. See systemd-nspawn(1) for details.
               '';
             };
 

--- a/nixos/tests/containers-tmpfs.nix
+++ b/nixos/tests/containers-tmpfs.nix
@@ -1,0 +1,79 @@
+# Test for NixOS' container support.
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "containers-bridge";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ ckampka ];
+  };
+
+  machine =
+    { config, pkgs, ... }:
+    { imports = [ ../modules/installer/cd-dvd/channel.nix ];
+      virtualisation.writableStore = true;
+      virtualisation.memorySize = 768;
+
+      containers.tmpfs =
+        {
+          autoStart = true;
+          tmpfs = [
+            # Mount var as a tmpfs
+            "/var"
+
+            # Add a nested mount inside a tmpfs
+            "/var/log"
+
+            # Add a tmpfs on a path that does not exist
+            "/some/random/path"
+          ];
+          config = { };
+        };
+
+      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+    };
+
+  testScript =
+    ''
+      $machine->waitForUnit("default.target");
+      $machine->succeed("nixos-container list") =~ /tmpfs/ or die;
+
+      # Start the tmpfs container.
+      #$machine->succeed("nixos-container status tmpfs") =~ /up/ or die;
+
+      # Verify that /var is mounted as a tmpfs
+      #$machine->succeed("nixos-container run tmpfs -- systemctl status var.mount --no-pager 2>/dev/null") =~ /What: tmpfs/ or die;
+      $machine->succeed("nixos-container run tmpfs -- mountpoint -q /var 2>/dev/null");
+
+      # Verify that /var/log is mounted as a tmpfs
+      $machine->succeed("nixos-container run tmpfs -- systemctl status var-log.mount --no-pager 2>/dev/null") =~ /What: tmpfs/ or die;
+      $machine->succeed("nixos-container run tmpfs -- mountpoint -q /var/log 2>/dev/null");
+
+      # Verify that /some/random/path is mounted as a tmpfs
+      $machine->succeed("nixos-container run tmpfs -- systemctl status some-random-path.mount --no-pager 2>/dev/null") =~ /What: tmpfs/ or die;
+      $machine->succeed("nixos-container run tmpfs -- mountpoint -q /some/random/path 2>/dev/null");
+
+      # Verify that files created in the container in a non-tmpfs directory are visible on the host.
+      # This establishes legitimacy for the following tests
+      $machine->succeed("nixos-container run tmpfs -- touch /root/test.file 2>/dev/null");
+      $machine->succeed("nixos-container run tmpfs -- ls -l  /root | grep -q test.file 2>/dev/null");
+      $machine->succeed("test -e /var/lib/containers/tmpfs/root/test.file");
+
+
+      # Verify that /some/random/path is writable and that files created there
+      # are not in the hosts container dir but in the tmpfs
+      $machine->succeed("nixos-container run tmpfs -- touch /some/random/path/test.file 2>/dev/null");
+      $machine->succeed("nixos-container run tmpfs -- test -e /some/random/path/test.file 2>/dev/null");
+
+      $machine->fail("test -e /var/lib/containers/tmpfs/some/random/path/test.file");
+
+      # Verify that files created in the hosts container dir in a path where a tmpfs file system has been mounted
+      # are not visible to the container as the do not exist in the tmpfs
+      $machine->succeed("touch /var/lib/containers/tmpfs/var/test.file");
+
+      $machine->succeed("test -e /var/lib/containers/tmpfs/var/test.file");
+      $machine->succeed("ls -l /var/lib/containers/tmpfs/var/ | grep -q test.file 2>/dev/null");
+
+      $machine->fail("nixos-container run tmpfs -- ls -l /var | grep -q test.file 2>/dev/null");
+
+    '';
+
+})


### PR DESCRIPTION
###### Motivation for this change

Enables the easy creation of stateless containers by turning data filesystems such as /var into a tmpfs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Allows one or more directories to be mounted as a read-only file system.

This makes it convenient to run volatile containers that do not retain
application state.