### PR TITLE
xournal: add desktop file and mime info

### DIFF
--- a/pkgs/applications/graphics/xournal/default.nix
+++ b/pkgs/applications/graphics/xournal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, makeDesktopItem
 , ghostscript, atk, gtk2, glib, fontconfig, freetype
 , libgnomecanvas, libgnomeprint, libgnomeprintui
 , pango, libX11, xproto, zlib, poppler
@@ -20,6 +20,32 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
 
   NIX_LDFLAGS = [ "-lX11" "-lz" ];
+
+  desktopItem = makeDesktopItem {
+    name = name;
+    exec = "xournal";
+    icon = "xournal";
+    desktopName = "Xournal";
+    comment = meta.description;
+    categories = "Office;Graphics;";
+    mimeType = "application/pdf;application/x-xoj";
+    genericName = "PDF Editor";
+  };
+
+  postInstall=''
+      mkdir --parents $out/share/mime/packages
+      cat << EOF > $out/share/mime/packages/xournal.xml
+      <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+         <mime-type type="application/x-xoj">
+          <comment>Xournal Document</comment>
+          <glob pattern="*.xoj"/>
+         </mime-type>
+      </mime-info>
+      EOF
+      cp --recursive ${desktopItem}/share/applications $out/share
+      mkdir --parents $out/share/icons
+      cp $out/share/xournal/pixmaps/xournal.png $out/share/icons
+  '';
 
   meta = {
     homepage = http://xournal.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change

It was a pain launching Xournal in a graphical environment.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

(Pinging listed maintainers: @dguibert) This is a squashed history. A full version of the history is [here](https://github.com/lverns/nixpkgs/tree/xournal-desktop-fix).

---

Fixes #20510.

The application now appears in system menus, and Konqueror now suggests
opening .xoj files with Xournal. Other file browsers should as well.