### PR TITLE
pidgin-skypeweb: 1.2.1 -> 1.2.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-skypeweb/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-skypeweb/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pidgin-skypeweb-${version}";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "EionRobb";
     repo = "skype4pidgin";
     rev = "${version}";
-    sha256 = "0qmqf1r9kc7r6rgzz0byyq7yf5spsl2iima0cvxafs43gn4hnc2z";
+    sha256 = "1lxpz316jmns6i143v4j6sd6k0a4a54alw08rvwjckf2rig57lj2";
   };
 
   sourceRoot = "skype4pidgin-${version}-src/skypeweb";


### PR DESCRIPTION
###### Motivation for this change
Version 1.2.1 is defunct.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Update defunct version 1.2.1 to 1.2.2