### PR TITLE
tilda: 1.2.4 -> 1.3.3

### DIFF
--- a/pkgs/applications/misc/tilda/default.nix
+++ b/pkgs/applications/misc/tilda/default.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
 
   name = "tilda-${version}";
-  version = "1.2.4";
+  version = "1.3.3";
 
   src = fetchurl {
     url = "https://github.com/lanoxx/tilda/archive/${name}.tar.gz";
-    sha256 = "1f7b52c5d8cfd9038ad2e41fc633fce935f420fa657ed15e3942722c8570751e";
+    sha256 = "1cc4qbg1m3i04lj5p6i6xbd0zvy1320pxdgmjhz5p3j95ibsbfki";
   };
 
   buildInputs = [ pkgconfig autoreconfHook gettext confuse vte gtk makeWrapper ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14815,7 +14815,7 @@ in
   tig = gitAndTools.tig;
 
   tilda = callPackage ../applications/misc/tilda {
-    vte = gnome3.vte_290;
+    vte = gnome3.vte;
     gtk = gtk3;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Update

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


