### PR TITLE
tigervnc: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -7,13 +7,13 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.6.0";
+  version = "1.7.0";
   name = "tigervnc-${version}";
 
   src = fetchgit {
     url = "https://github.com/TigerVNC/tigervnc/";
-    sha256 = "1plljv1cxsax88kv52g02n8c1hzwgp6j1p8z1aqhskw36shg4pij";
-    rev = "5a727f25990d05c9a1f85457b45d6aed66409cb3";
+    sha256 = "1b6n2gq6078x8dwz471a68jrkgpcxmbiivmlsakr42vrndm7niz3";
+    rev = "e25272fc74ef09987ccaa33b9bf1736397c76fdf";
   };
 
   inherit fontDirectories;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


