### PR TITLE
qtwebengine: hardcode paths

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -106,7 +106,7 @@ let
         qtconnectivity qtdeclarative qtdoc qtenginio qtgraphicaleffects
         qtimageformats qtlocation qtmultimedia qtquickcontrols qtscript
         qtsensors qtserialport qtsvg qttools qttranslations qtwayland
-        qtwebsockets qtx11extras qtxmlpatterns
+        qtwebchannel qtwebengine qtwebsockets qtx11extras qtxmlpatterns
       ];
 
       makeQtWrapper = makeSetupHook { deps = [ makeWrapper ]; } ./make-qt-wrapper.sh;

--- a/pkgs/development/libraries/qt-5/5.6/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebengine/default.nix
@@ -30,7 +30,12 @@ qtSubmodule {
       --replace /bin/echo ${coreutils}/bin/echo
     substituteInPlace ./src/3rdparty/chromium/v8/build/standalone.gypi \
       --replace /bin/echo ${coreutils}/bin/echo
-      
+
+    # hardcode paths for which default path resolution does not work in nix
+    sed -i -e 's,\(static QString potentialResourcesPath =\).*,\1 QLatin1String("'$out'/resources");,' src/core/web_engine_library_info.cpp
+    sed -i -e 's,\(static QString processPath\),\1 = QLatin1String("'$out'/libexec/QtWebEngineProcess"),' src/core/web_engine_library_info.cpp
+    sed -i -e 's,\(static QString potentialLocalesPath =\).*,\1 QLatin1String("'$out'/translations/qtwebengine_locales");,' src/core/web_engine_library_info.cpp
+
     configureFlags+="\
         -plugindir $out/lib/qt5/plugins \
         -importdir $out/lib/qt5/imports \


### PR DESCRIPTION
###### Motivation for this change

qtwebengine library starts a process with the executable QtWebEngineProcess. This executable cannot be found on nix, so the path is hardcoded. The paths for the resources required by the process are also hardcoded.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Hardcode the paths for which the default path resolution does not work in nix.