### PR TITLE
gogui: init at 1.4.9

### DIFF
--- a/pkgs/games/gogui/default.nix
+++ b/pkgs/games/gogui/default.nix
@@ -1,0 +1,28 @@
+{ fetchurl, stdenv, openjdk, unzip, makeWrapper }:
+
+let
+  version = "1.4.9";
+in stdenv.mkDerivation {
+  name = "gogui-${version}";
+  buildInputs = [ unzip makeWrapper ];
+  src = fetchurl {
+    url = "mirror://sourceforge/project/gogui/gogui/${version}/gogui-${version}.zip";
+    sha256 = "0qk6p1bhi1816n638bg11ljyj6zxvm75jdf02aabzdmmd9slns1j";
+  };
+  dontConfigure = true;
+  installPhase = ''
+    mkdir -p $out/share/doc
+    mv -vi {bin,lib} $out/
+    mv -vi doc $out/share/doc/gogui
+    for x in $out/bin/*; do
+      wrapProgram $x --prefix PATH ":" ${openjdk}/bin
+    done
+  '';
+  meta = {
+    maintainers = [ stdenv.lib.maintainers.cleverca22 ];
+    description = "A graphical user interface to programs that play the board game Go and support the Go Text Protocol such as GNU Go";
+    homepage = http://gogui.sourceforge.net/;
+    platforms = stdenv.lib.platforms.unix;
+    license = stdenv.lib.licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15649,6 +15649,8 @@ in
 
   gnugo = callPackage ../games/gnugo { };
 
+  gogui = callPackage ../games/gogui {};
+
   gtypist = callPackage ../games/gtypist { };
 
   gzdoom = callPackage ../games/gzdoom { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


