### PR TITLE
erlang_basho_R16B03: Changed platforms to explicitly x86_64

### DIFF
--- a/pkgs/development/interpreters/erlang/R16B03-1-basho.nix
+++ b/pkgs/development/interpreters/erlang/R16B03-1-basho.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
       repository.
     '';
 
-    platforms = platforms.unix;
+    platforms = ["x86_64-linux" "x86_64-darwin"];
     license = stdenv.lib.licenses.asl20;
     maintainers = with maintainers; [ mdaiter ];
   };


### PR DESCRIPTION
###### Motivation for this change
Realised that the erlang_basho_R16B03 package is [only officially supported for x86_64 platforms](https://github.com/basho/otp/tree/OTP_R16B03).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

