### PR TITLE
git: link git-credential-netrc into $out/bin

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -93,6 +93,7 @@ stdenv.mkDerivation {
       # Install contrib stuff.
       mkdir -p $out/share/git
       mv contrib $out/share/git/
+      ln -s "$out/share/git/contrib/credential/netrc/git-credential-netrc" $out/bin/
       mkdir -p $out/share/emacs/site-lisp
       ln -s "$out/share/git/contrib/emacs/"*.el $out/share/emacs/site-lisp/
       mkdir -p $out/etc/bash_completion.d


### PR DESCRIPTION
###### Motivation for this change

`git-credential-netrc` is a simple cross-platform credential helper that doesn't need to be compiled.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
     git-annex failed with an error that looks unrelated:
    ```
    {standard input}: Assembler messages:
    {standard input}: Warning: end of file not at end of a line; newline inserted
    {standard input}:354: Error: unknown pseudo-op: `.lcold'
    g++: internal compiler error: Killed (program cc1plus)
    ```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


