### PR TITLE
asn1c: init at 0.9.27

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -289,6 +289,7 @@
   mlieberman85 = "Michael Lieberman <mlieberman85@gmail.com>";
   modulistic = "Pablo Costa <modulistic@gmail.com>";
   mog = "Matthew O'Gorman <mog-lists@rldn.net>";
+  montag451 = "montag451 <montag451@laposte.net>";
   moosingin3space = "Nathan Moos <moosingin3space@gmail.com>";
   moretea = "Maarten Hoogendoorn <maarten@moretea.nl>";
   mornfall = "Petr Ročkai <me@mornfall.net>";

--- a/pkgs/development/compilers/asn1c/default.nix
+++ b/pkgs/development/compilers/asn1c/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, perl }:
+
+stdenv.mkDerivation rec {
+  name = "asn1c-${version}";
+  version = "0.9.27";
+
+  src = fetchurl {
+    url = "http://lionet.info/soft/asn1c-${version}.tar.gz";
+    sha256 = "17nvn2kzvlryasr9dzqg6gs27b9lvqpval0k31pb64bjqbhn8pq2";
+  };
+
+  outputs = [ "out" "doc" "man" ];
+
+  buildInputs = [ perl ];
+
+  preConfigure = ''
+    patchShebangs examples/crfc2asn1.pl
+  '';
+
+  postInstall = ''
+    cp -r skeletons/standard-modules $out/share/asn1c
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://lionet.info/asn1c/compiler.html;
+    description = "Open Source ASN.1 Compiler";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.montag451 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4499,6 +4499,8 @@ in
 
   arachne-pnr = callPackage ../development/compilers/arachne-pnr { };
 
+  asn1c = callPackage ../development/compilers/asn1c { };
+
   aspectj = callPackage ../development/compilers/aspectj { };
 
   ats = callPackage ../development/compilers/ats { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


