### PR TITLE
go-font: init at 2016-11-17

### DIFF
--- a/pkgs/data/fonts/go-font/default.nix
+++ b/pkgs/data/fonts/go-font/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation rec {
+  name = "go-font-${version}";
+  version = "2016-11-17";
+
+  src = fetchgit {
+    url = "https://go.googlesource.com/image";
+    rev = "d2f07f8aaaa906f1a64eee0e327fc681cdb2944f";
+    sha256 = "1kmsipa4cyrwx86acc695c281hchrz9k9ni8r7giyggvdi577iga";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/doc/go-font
+    cp font/gofont/ttfs/* $out/share/fonts/truetype
+    mv $out/share/fonts/truetype/README $out/share/doc/go-font/LICENSE
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://blog.golang.org/go-fonts;
+    description = "The Go font family";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ sternenseemann ];
+    platforms = stdenv.lib.platforms.all;
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11774,6 +11774,8 @@ in
 
   inherit (gnome3) gsettings_desktop_schemas;
 
+  go-font = callPackage ../data/fonts/go-font { };
+
   gyre-fonts = callPackage ../data/fonts/gyre {};
 
   hack-font = callPackage ../data/fonts/hack { };


### PR DESCRIPTION
###### Motivation for this change

Add the recently released Go font.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
