### PR TITLE
mc: Fix darwin build

### DIFF
--- a/pkgs/development/libraries/slang/default.nix
+++ b/pkgs/development/libraries/slang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, pcre, libpng, zlib, readline }:
+{ stdenv, fetchurl, ncurses, pcre, libpng, zlib, readline, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "slang-2.3.0";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sed -i -e "s|-ltermcap|-lncurses|" ./configure
   '';
   configureFlags = "--with-png=${libpng.dev} --with-z=${zlib.dev} --with-pcre=${pcre.dev} --with-readline=${readline.dev}";
-  buildInputs = [ pcre libpng zlib readline ];
+  buildInputs = [ pcre libpng zlib readline ] ++ stdenv.lib.optionals (stdenv.isDarwin) [ libiconv ];
   propagatedBuildInputs = [ ncurses ];
 
   postInstall = ''

--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1kmysm1x7smxs9k483nin6bx1rx0av8xrqjx9yf73hc7r4anhqzp";
   };
   
-  buildInputs = [ pkgconfig perl glib gpm slang zip unzip file gettext libX11 libICE e2fsprogs
-    libssh2 openssl ];
+  buildInputs = [ pkgconfig perl glib slang zip unzip file gettext libX11 libICE
+    libssh2 openssl ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [ e2fsprogs gpm ];
 
   configureFlags = [ "--enable-vfs-smb" ];
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     repositories.git = git://github.com/MidnightCommander/mc.git;
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.sander ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     updateWalker = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Midnight commander did not build on darwin before. Now it compiles fine.

###### Things done

We remove linux specific packages from the darwin build of midnight
commander. Also slang wouldn't build on darwin without libiconv.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

