### PR TITLE
autojump: 22.2.4 -> 22.5.0

### DIFF
--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, python, bash }:
 
 let
-  version = "22.2.4";
+  version = "22.5.0";
 in
   stdenv.mkDerivation rec {
     name = "autojump-${version}";
@@ -9,7 +9,7 @@ in
     src = fetchurl {
       url = "http://github.com/joelthelion/autojump/archive/release-v${version}.tar.gz";
       name = "autojump-${version}.tar.gz";
-      sha256 = "816badb0721f735e2b86bdfa8b333112f3867343c7c2263c569f75b4ec91f475";
+      sha256 = "00ai0j37ka3557a8m7ig44dby7v01pckwi8gl479vz5b5pw1z8cd";
     };
 
     buildInputs = [ python bash ];


### PR DESCRIPTION
###### Motivation for this change

I was affected by https://github.com/wting/autojump/issues/411 and a version upgrade fixes the issue. Works fine for me now.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).