### PR TITLE
aptly: init at 0.9.7

### DIFF
--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, gnupg1compat, bzip2, xz, graphviz }:
+
+buildGoPackage rec {
+  name = "aptly-${version}";
+  version = "0.9.7";
+  rev = "v${version}";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "smira";
+    repo = "aptly";
+    sha256 = "0j1bmqdah4i83r2cf8zcq87aif1qg90yasgf82yygk3hj0gw1h00";
+  };
+
+  goPackagePath = "github.com/smira/aptly";
+  goDeps = ./deps.nix;
+
+  postInstall = ''
+    rm $bin/bin/man
+  '';
+
+  propagatedUserEnvPkgs = [ gnupg1compat bzip2.bin xz.bin graphviz ];
+
+  meta = with stdenv.lib; {
+    homepage = https://www.aptly.info;
+    description = "Debian repository management tool";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.montag451 ];
+  };
+}

--- a/pkgs/tools/misc/aptly/deps.nix
+++ b/pkgs/tools/misc/aptly/deps.nix
@@ -1,0 +1,245 @@
+[
+    {
+      goPackagePath = "github.com/AlekSi/pointer";
+      fetch = {
+        type = "git";
+        url = https://github.com/AlekSi/pointer.git;
+        rev = "5f6d527dae3d678b46fbb20331ddf44e2b841943";
+        sha256 = "127n71d8y1d8hxv9fq9z1midw3vk5xa6aq45gffjvwabx4cgha1l";
+      };
+    }
+    {
+      goPackagePath = "github.com/awalterschulze/gographviz";
+      fetch = {
+        type = "git";
+        url = https://github.com/awalterschulze/gographviz.git;
+        rev = "20d1f693416d9be045340150094aa42035a41c9e";
+        sha256 = "1q4796nzanikqmz77jdc2xrq30n93w6ljcfsbhij3yj3s698bcaf";
+      };
+    }
+    {
+      goPackagePath = "github.com/aws/aws-sdk-go";
+      fetch = {
+        type = "git";
+        url = https://github.com/aws/aws-sdk-go.git;
+        rev = "a170e9cb76475a0da7c0326a13cc2b39e9244b3b";
+        sha256 = "0z7pgb9q0msvdkrvjwi95cbl9k9w8f3n2liwkl6fli0nx9jyamqw";
+      };
+    }
+    {
+      goPackagePath = "github.com/cheggaaa/pb";
+      fetch = {
+        type = "git";
+        url = https://github.com/cheggaaa/pb.git;
+        rev = "2c1b74620cc58a81ac152ee2d322e28c806d81ed";
+        sha256 = "148fv6a0ranzcc1lv4v5lmvgbfx05dhzpwsg8vxi9ggn51n496ny";
+      };
+    }
+    {
+      goPackagePath = "github.com/DisposaBoy/JsonConfigReader";
+      fetch = {
+        type = "git";
+        url = https://github.com/DisposaBoy/JsonConfigReader.git;
+        rev = "33a99fdf1d5ee1f79b5077e9c06f955ad356d5f4";
+        sha256 = "1rq7hp1xk8lzvn9bv9jfkszw8p2qia8prvrx540gb2y93jw9i847";
+      };
+    }
+    {
+      goPackagePath = "github.com/gin-gonic/gin";
+      fetch = {
+        type = "git";
+        url = https://github.com/gin-gonic/gin.git;
+        rev = "b1758d3bfa09e61ddbc1c9a627e936eec6a170de";
+        sha256 = "0y3v5vi68xafcvz9yz6ffww96xs2qalklnaab7vrwpax3brlkipk";
+      };
+    }
+    {
+      goPackagePath = "github.com/go-ini/ini";
+      fetch = {
+        type = "git";
+        url = https://github.com/go-ini/ini.git;
+        rev = "afbd495e5aaea13597b5e14fe514ddeaa4d76fc3";
+        sha256 = "0xi8zr9qw38sdbv95c2ip31yczbm4axdvmj3ljyivn9xh2nbxfia";
+      };
+    }
+    {
+      goPackagePath = "github.com/jlaffaye/ftp";
+      fetch = {
+        type = "git";
+        url = https://github.com/jlaffaye/ftp.git;
+        rev = "fec71e62e457557fbe85cefc847a048d57815d76";
+        sha256 = "08ivzsfswgl4xlr6wmqpbf77jclh8ivhwxlhj59allp27lic1kgm";
+      };
+    }
+    {
+      goPackagePath = "github.com/jmespath/go-jmespath";
+      fetch = {
+        type = "git";
+        url = https://github.com/jmespath/go-jmespath.git;
+        rev = "0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74";
+        sha256 = "1vv6hph8j6xgv7gwl9vvhlsaaqsm22sxxqmgmldi4v11783pc1ld";
+      };
+    }
+    {
+      goPackagePath = "github.com/julienschmidt/httprouter";
+      fetch = {
+        type = "git";
+        url = https://github.com/julienschmidt/httprouter.git;
+        rev = "46807412fe50aaceb73bb57061c2230fd26a1640";
+        sha256 = "0mvzjpzlb1gkb6lp0nwni3vid6fw33dkzl6s9gj7gp2wsbwzcdhd";
+      };
+    }
+    {
+      goPackagePath = "github.com/mattn/go-shellwords";
+      fetch = {
+        type = "git";
+        url = https://github.com/mattn/go-shellwords.git;
+        rev = "c7ca6f94add751566a61cf2199e1de78d4c3eee4";
+        sha256 = "1714ca0p0mwijck0vxdssizxyjjjki1dpc5bl51ayw5sa7s6d4n2";
+      };
+    }
+    {
+      goPackagePath = "github.com/mkrautz/goar";
+      fetch = {
+        type = "git";
+        url = https://github.com/mkrautz/goar.git;
+        rev = "282caa8bd9daba480b51f1d5a988714913b97aad";
+        sha256 = "0b6nmgyh5lmm8d1psm5yqqmshkqi87di1191c9q95z1gkkfi16b2";
+      };
+    }
+    {
+      goPackagePath = "github.com/mxk/go-flowrate";
+      fetch = {
+        type = "git";
+        url = https://github.com/mxk/go-flowrate.git;
+        rev = "cca7078d478f8520f85629ad7c68962d31ed7682";
+        sha256 = "0zqs39923ja0yypdmiqk6x8pgmfs3ms5x5sl1dqv9z6zyx2xy541";
+      };
+    }
+    {
+      goPackagePath = "github.com/ncw/swift";
+      fetch = {
+        type = "git";
+        url = https://github.com/ncw/swift.git;
+        rev = "384ef27c70645e285f8bb9d02276bf654d06027e";
+        sha256 = "1is9z6pbn55yr5b7iizfyi8y19nc9xprd87cwab4i54bxkqqp5hg";
+      };
+    }
+    {
+      goPackagePath = "github.com/smira/go-aws-auth";
+      fetch = {
+        type = "git";
+        url = https://github.com/smira/go-aws-auth.git;
+        rev = "0070896e9d7f4f9f2d558532b2d896ce2239992a";
+        sha256 = "0ic7fgpgr8n1gvhwab1isbm82azy8kb9bzjxsch5i2dpvnz03rvh";
+      };
+    }
+    {
+      goPackagePath = "github.com/smira/go-xz";
+      fetch = {
+        type = "git";
+        url = https://github.com/smira/go-xz.git;
+        rev = "0c531f070014e218b21f3cfca801cc992d52726d";
+        sha256 = "1wpgw8y6xjyf75dfcirx58cr1c277avdb6hr7xvcddhcfn01qzma";
+      };
+    }
+    {
+      goPackagePath = "github.com/smira/commander";
+      fetch = {
+        type = "git";
+        url = https://github.com/smira/commander.git;
+        rev = "f408b00e68d5d6e21b9f18bd310978dafc604e47";
+        sha256 = "0gzhxjni17qq0z4zhakjrp98qd0qmf6wlyrx5xwwsqgh07nyzssa";
+      };
+    }
+    {
+      goPackagePath = "github.com/smira/flag";
+      fetch = {
+        type = "git";
+        url = https://github.com/smira/flag.git;
+        rev = "357ed3e599ffcbd4aeaa828e1d10da2df3ea5107";
+        sha256 = "0wh77lz7z23rs9mbyi89l28i16gp1zx2312zxs4ngqdvjvinsiri";
+      };
+    }
+    {
+      goPackagePath = "github.com/smira/go-ftp-protocol";
+      fetch = {
+        type = "git";
+        url = https://github.com/smira/go-ftp-protocol.git;
+        rev = "066b75c2b70dca7ae10b1b88b47534a3c31ccfaa";
+        sha256 = "1az9p44fa7bcw92ywcyrqch2j1781b96rpid2qggyp3nhjivx8rx";
+      };
+    }
+    {
+      goPackagePath = "github.com/smira/go-uuid";
+      fetch = {
+        type = "git";
+        url = https://github.com/smira/go-uuid.git;
+        rev = "ed3ca8a15a931b141440a7e98e4f716eec255f7d";
+        sha256 = "1vasidfa2pqrawk4zm5bqsi5q7f3qx3xm159hs36r0h0kj0c7sz4";
+      };
+    }
+    {
+      goPackagePath = "github.com/smira/lzma";
+      fetch = {
+        type = "git";
+        url = https://github.com/smira/lzma.git;
+        rev = "7f0af6269940baa2c938fabe73e0d7ba41205683";
+        sha256 = "0ka8mbyg2dj076aslbi1hiahw5n5gjyn7s4w3x4ws9ak5chw5zif";
+      };
+    }
+    {
+      goPackagePath = "github.com/golang/snappy";
+      fetch = {
+        type = "git";
+        url = https://github.com/golang/snappy.git;
+        rev = "723cc1e459b8eea2dea4583200fd60757d40097a";
+        sha256 = "0bprq0qb46f5511b5scrdqqzskqqi2z8b4yh3216rv0n1crx536h";
+      };
+    }
+    {
+      goPackagePath = "github.com/syndtr/goleveldb";
+      fetch = {
+        type = "git";
+        url = https://github.com/syndtr/goleveldb.git;
+        rev = "917f41c560270110ceb73c5b38be2a9127387071";
+        sha256 = "0ybpcizg2gn3ln9rycqbaqlclci3k2q8mipcwq7927ym113d7q32";
+      };
+    }
+    {
+      goPackagePath = "github.com/ugorji/go";
+      fetch = {
+        type = "git";
+        url = https://github.com/ugorji/go.git;
+        rev = "71c2886f5a673a35f909803f38ece5810165097b";
+        sha256 = "157f24xnkhclrjwwa1b7lmpj112ynlbf7g1cfw0c657iqny5720j";
+      };
+    }
+    {
+      goPackagePath = "github.com/vaughan0/go-ini";
+      fetch = {
+        type = "git";
+        url = https://github.com/vaughan0/go-ini.git;
+        rev = "a98ad7ee00ec53921f08832bc06ecf7fd600e6a1";
+        sha256 = "1l1isi3czis009d9k5awsj4xdxgbxn4n9yqjc1ac7f724x6jacfa";
+      };
+    }
+    {
+      goPackagePath = "github.com/wsxiaoys/terminal";
+      fetch = {
+        type = "git";
+        url = https://github.com/wsxiaoys/terminal.git;
+        rev = "5668e431776a7957528361f90ce828266c69ed08";
+        sha256 = "0dirblp3lwijsrx590qfp8zn5xspkjzq7ihkv05806mpncg5ivxd";
+      };
+    }
+    {
+      goPackagePath = "golang.org/x/crypto";
+      fetch = {
+        type = "git";
+        url = https://go.googlesource.com/crypto.git;
+        rev = "a7ead6ddf06233883deca151dffaef2effbf498f";
+        sha256 = "0gyvja1kh6xkxy7mg5y72zpvmi6hfix34kmzg4sry1x7bycw3dfc";
+      };
+    }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -421,6 +421,8 @@ in
 
   apt-offline = callPackage ../tools/misc/apt-offline { };
 
+  aptly = callPackage ../tools/misc/aptly { };
+
   apulse = callPackage ../misc/apulse { };
 
   archivemount = callPackage ../tools/filesystems/archivemount { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


