### PR TITLE
stanchion: changed default option to defaultText

### DIFF
--- a/nixos/modules/services/databases/stanchion.nix
+++ b/nixos/modules/services/databases/stanchion.nix
@@ -20,7 +20,7 @@ in
 
       package = mkOption {
         type = types.package;
-        default = pkgs.stanchion;
+        defaultText = "pkgs.stanchion";
         example = literalExample "pkgs.stanchion";
         description = ''
           Stanchion package to use.


### PR DESCRIPTION
###### Motivation for this change
Allow the manual to build on an i686 system. For this, the `stanchion` package (uniquely built for x86_64) must not reference the actual package for a default, but rather a string for a defaultText.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

