### PR TITLE
riak-cs: init at 2.1.1

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -280,6 +280,7 @@
       leaps = 260;
       ipfs  = 261;
       stanchion = 262;
+      riak-cs = 263;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -530,6 +531,7 @@
       leaps = 260;
       ipfs = 261;
       stanchion = 262;
+      riak-cs = 263;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -159,6 +159,7 @@
   ./services/databases/postgresql.nix
   ./services/databases/redis.nix
   ./services/databases/riak.nix
+  ./services/databases/riak-cs.nix
   ./services/databases/stanchion.nix
   ./services/databases/virtuoso.nix
   ./services/desktops/accountsservice.nix

--- a/pkgs/servers/nosql/riak-cs/2.1.1.nix
+++ b/pkgs/servers/nosql/riak-cs/2.1.1.nix
@@ -1,0 +1,67 @@
+{ stdenv, lib, fetchurl, unzip, erlang, git, wget, which, pam, coreutils, riak }:
+
+stdenv.mkDerivation rec {
+  name = "riak_cs-2.1.1";
+
+  buildInputs = [
+    which unzip erlang pam git wget
+  ];
+
+  src = fetchurl {
+    url = "http://s3.amazonaws.com/downloads.basho.com/riak-cs/2.1/2.1.1/riak-cs-2.1.1.tar.gz";
+    sha256 = "115cac127aac6d759c1b429a52e0d18e491c0719a6530b1b88aa52c4efdbedd5";
+  };
+
+
+  postPatch = ''
+    sed -i deps/node_package/priv/base/env.sh \
+      -e 's@{{platform_data_dir}}@''${RIAK_DATA_DIR:-/var/db/riak-cs}@' \
+      -e 's@^RUNNER_SCRIPT_DIR=.*@RUNNER_SCRIPT_DIR='$out'/bin@' \
+      -e 's@^RUNNER_BASE_DIR=.*@RUNNER_BASE_DIR='$out'@' \
+      -e 's@^RUNNER_ETC_DIR=.*@RUNNER_ETC_DIR=''${RIAK_ETC_DIR:-/etc/riak-cs}@' \
+      -e 's@^RUNNER_LOG_DIR=.*@RUNNER_LOG_DIR=''${RIAK_LOG_DIR:-/var/log}@'
+
+    sed -i ./Makefile \
+      -e 's@rel: deps compile@rel: deps compile-src@'
+  '';
+
+  preBuild = ''
+    patchShebangs .
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    make locked-deps
+    make rel
+
+    runHook postBuild
+  '';
+
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    mv rel/riak-cs/etc rel/riak-cs/riak-etc
+    mkdir -p rel/riak-cs/etc
+    mv rel/riak-cs/riak-etc rel/riak-cs/etc/riak-cs
+    mv rel/riak-cs/* $out
+
+    for prog in $out/bin/*; do
+      substituteInPlace $prog \
+        --replace '. "`cd \`dirname $0\` && /bin/pwd`/../lib/env.sh"' \
+                  ". $out/lib/env.sh"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Dynamo inspired NoSQL DB by Basho with S3 compatibility";
+    platforms   = [ "x86_64-linux" ];
+    license     = licenses.asl20;
+    maintainer  = with maintainers; [ mdaiter ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10245,6 +10245,10 @@ in
 
   riak = callPackage ../servers/nosql/riak/2.1.1.nix { };
 
+  riak-cs = callPackage ../servers/nosql/riak-cs/2.1.1.nix {
+    erlang = erlang_basho_R16B03;  
+  };
+
   stanchion = callPackage ../servers/nosql/riak-cs/stanchion.nix {
     erlang = erlang_basho_R16B03;
   };


### PR DESCRIPTION
###### Motivation for this change
Adding riak-cs to package/services. See https://github.com/NixOS/nixpkgs/pull/20129 for historical info.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---