### PR TITLE
stanchion: added default to service

### DIFF
--- a/nixos/modules/services/databases/stanchion.nix
+++ b/nixos/modules/services/databases/stanchion.nix
@@ -20,6 +20,7 @@ in
 
       package = mkOption {
         type = types.package;
+        default = pkgs.stanchion;
         defaultText = "pkgs.stanchion";
         example = literalExample "pkgs.stanchion";
         description = ''


### PR DESCRIPTION
###### Motivation for this change
In the `stanchion` package, we need to add a default.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

