### PR TITLE
wireshark: 2.2.0 -> 2.2.2

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -11,7 +11,7 @@ assert withQt -> !withGtk && qt4 != null;
 with stdenv.lib;
 
 let
-  version = "2.2.0";
+  version = "2.2.2";
   variant = if withGtk then "gtk" else if withQt then "qt" else "cli";
 in
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.bz2";
-    sha256 = "010i7wpsv2231pwb1xdqs0xfwywi3514siidv6wnrfpw3rs7x156";
+    sha256 = "1csm035ayfzn1xzzsmzcjk2ixx39d70aykr4nh0a88chk9gfzb7r";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


See releases announcements:

- https://www.wireshark.org/docs/relnotes/wireshark-2.2.1.html
- https://www.wireshark.org/docs/relnotes/wireshark-2.2.2.html

wireshark-2.2.1 fixes the following vulnerabilities:

- CVE-2016-7957
- CVE-2016-7958

wireshard-2.2.2 fixes the following vulnerabilities:

- CVE-2016-9372
- CVE-2016-9374
- CVE-2016-9376
- CVE-2016-9373
- CVE-2016-9375