### PR TITLE
cudnn51_cudatoolkit80: Init at 5.1-8.0

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/8.0-5.1/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/8.0-5.1/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, requireFile
+, cudatoolkit
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  version = "5.1";
+  cudatoolkit_version = "8.0";
+
+  name = "cudatoolkit-${cudatoolkit_version}-cudnn-${version}";
+
+  src = fetchurl {
+    url = "http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz";
+    sha256 = "a87cb2df2e5e7cc0a05e266734e679ee1a2fadad6f06af82a76ed81a23b102c8";
+  };
+
+  installPhase = ''
+    function fixRunPath {
+      p=$(patchelf --print-rpath $1)
+      patchelf --set-rpath "$p:${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}" $1
+    }
+    fixRunPath lib64/libcudnn.so
+
+    mkdir -p $out
+    cp -a include $out/include
+    cp -a lib64 $out/lib64
+  '';
+
+  propagatedBuildInputs = [
+    cudatoolkit
+  ];
+
+  meta = with stdenv.lib; {
+    description = "NVIDIA CUDA Deep Neural Network library (cuDNN)";
+    homepage = "https://developer.nvidia.com/cudnn";
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with maintainers; [ mdaiter ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1312,6 +1312,10 @@ in
     cudatoolkit = cudatoolkit8;
   };
 
+  cudnn51_cudatoolkit80 = callPackage ../development/libraries/science/math/cudnn/8.0-5.1 {
+    cudatoolkit = cudatoolkit8;
+  };
+
   curlFull = curl.override {
     idnSupport = true;
     ldapSupport = true;


### PR DESCRIPTION
###### Motivation for this change
Add CuDNN 5.1 with CUDA toolkit 8.0 support into the main repository.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


