### PR TITLE
riak: added extraAdvancedConfig option to service module

### DIFF
--- a/nixos/modules/services/databases/riak.nix
+++ b/nixos/modules/services/databases/riak.nix
@@ -70,6 +70,14 @@ in
         '';
       };
 
+      extraAdvancedConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Additional text to be appended to <filename>advanced.config</filename>.
+        '';
+      };
+
     };
 
   };
@@ -88,6 +96,10 @@ in
       platform_data_dir = ${cfg.dataDir}
 
       ${cfg.extraConfig}
+    '';
+
+    environment.etc."riak/advanced.config".text = ''
+      ${cfg.extraAdvancedConfig}
     '';
 
     users.extraUsers.riak = {


### PR DESCRIPTION
##### Motivation for this change
Added the option to modify the advanced.config file in the /etc folder for Riak. Need this for specific Riak CS configurations. 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

