### PR TITLE
wordgrinder: init at 0.6

### DIFF
--- a/pkgs/applications/office/wordgrinder/default.nix
+++ b/pkgs/applications/office/wordgrinder/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, pkgconfig, makeWrapper
+, lua52Packages, libXft, ncurses, readline, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "wordgrinder-${version}";
+  version = "0.6-db14181";
+
+  src = fetchFromGitHub {
+    repo = "wordgrinder";
+    owner = "davidgiven";
+    rev = "db141815e8bd1da6e684a1142a59492e516f3041";
+    sha256 = "1l1jqzcqiwnc8r1igfi7ay4pzzhdhss81znnmfr4rc1ia8bpdjc2";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "LUA_INCLUDE=${lua52Packages.lua}/include"
+    "LUA_LIB=${lua52Packages.lua}/lib/liblua.so"
+  ];
+
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
+
+  buildInputs = [
+    libXft
+    lua52Packages.lua
+    ncurses
+    readline
+    zlib
+  ];
+
+  # To be able to find <Xft.h>
+  NIX_CFLAGS_COMPILE = "-I${libXft.dev}/include/X11";
+
+  # Binaries look for LuaFileSystem library (lfs.so) at runtime
+  postInstall = ''
+    wrapProgram $out/bin/wordgrinder --set LUA_CPATH "${lua52Packages.luafilesystem}/lib/lua/5.2/lfs.so";
+    wrapProgram $out/bin/xwordgrinder --set LUA_CPATH "${lua52Packages.luafilesystem}/lib/lua/5.2/lfs.so";
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Text-based word processor";
+    homepage = https://cowlark.com/wordgrinder;
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17072,6 +17072,8 @@ with pkgs;
 
   wordnet = callPackage ../applications/misc/wordnet { };
 
+  wordgrinder = callPackage ../applications/office/wordgrinder { };
+
   worker = callPackage ../applications/misc/worker { };
 
   workrave = callPackage ../applications/misc/workrave {


### PR DESCRIPTION
Does not build yet, as `lua5.2` is not found. Can someone help me? I'm not sure why it isn't found here...

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


