### PR TITLE
jackline: init at 2016-11-18

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -1,0 +1,33 @@
+{stdenv, fetchFromGitHub, ocamlPackages, opam}:
+
+assert stdenv.lib.versionAtLeast ocamlPackages.ocaml.version "4.02.2";
+
+stdenv.mkDerivation rec {
+  version = "2016-11-18";
+  name = "jackline-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "hannesm";
+    repo   = "jackline";
+    rev    = "cab34acab004023911997ec9aee8b00a976af7e4";
+    sha256 = "0h7wdsic4v6ys130w61zvxm5s2vc7y574hn7zby12rq88lhhrjh7";
+  };
+
+  buildInputs = with ocamlPackages; [
+                  ocaml ocamlbuild findlib topkg ppx_sexp_conv
+                  erm_xmpp_0_3 tls nocrypto x509 ocaml_lwt otr astring
+                  ptime notty sexplib_p4 hex uutf opam
+                ];
+
+  buildPhase = with ocamlPackages;
+    "ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib pkg/pkg.ml build --pinned true";
+
+  installPhase = "opam-installer --prefix=$out --script | sh";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/hannesm/jackline;
+    description = "Terminal-based XMPP client in OCaml";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13328,6 +13328,10 @@ in
   hyper = callPackage ../applications/misc/hyper { inherit (gnome2) GConf; };
   hyperterm = self.hyper;
 
+  jackline = callPackage ../applications/networking/instant-messengers/jackline {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_02;
+  };
+
   slack = callPackage ../applications/networking/instant-messengers/slack { };
 
   singularity = callPackage ../applications/virtualization/singularity { };


### PR DESCRIPTION
###### Motivation for this change

Re-introduce jackline.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).