### PR TITLE
haskell/ghcjs: fix ghcjs-ffiqq, add ghcjs-vdom

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -76,6 +76,7 @@ self: super:
     '';
   });
 
+  # experimental
   ghcjs-ffiqq = self.callPackage
     ({ mkDerivation, base, template-haskell, ghcjs-base, split, containers, text, ghc-prim
      }:
@@ -85,15 +86,37 @@ self: super:
        src = pkgs.fetchFromGitHub {
          owner = "ghcjs";
          repo = "ghcjs-ffiqq";
-         rev = "da31b18582542fcfceade5ef6b2aca66662b9e20";
-         sha256 = "1mkp8p9hispyzvkb5v607ihjp912jfip61id8d42i19k554ssp8y";
+         rev = "b52338c2dcd3b0707bc8aff2e171411614d4aedb";
+         sha256 = "08zxfm1i6zb7n8vbz3dywdy67vkixfyw48580rwfp48rl1s2z1c7";
        };
        libraryHaskellDepends = [
          base template-haskell ghcjs-base split containers text ghc-prim
        ];
        description = "FFI QuasiQuoter for GHCJS";
-       license = stdenv.lib.licenses.mit;
+       license = pkgs.stdenv.lib.licenses.mit;
      }) {};
+  # experimental
+  ghcjs-vdom = self.callPackage
+    ({ mkDerivation, base, ghc-prim, ghcjs-ffiqq, ghcjs-base, ghcjs-prim
+      , containers, split, template-haskell
+    }:
+    mkDerivation rec {
+      pname = "ghcjs-vdom";
+      version = "0.2.0.0";
+      src = pkgs.fetchFromGitHub {
+        owner = "ghcjs";
+        repo = pname;
+        rev = "1c1175ba22eca6d7efa96f42a72290ade193c148";
+        sha256 = "0c6l1dk2anvz94yy5qblrfh2iv495rjq4qmhlycc24dvd02f7n9m";
+      };
+      libraryHaskellDepends = [
+        base ghc-prim ghcjs-ffiqq ghcjs-base ghcjs-prim containers split
+        template-haskell
+      ];
+      license = pkgs.stdenv.lib.licenses.mit;
+      description = "bindings for https://github.com/Matt-Esch/virtual-dom";
+      inherit (src) homepage;
+    }) {};
 
   ghcjs-dom = overrideCabal super.ghcjs-dom (drv: {
     libraryHaskellDepends = [ self.ghcjs-base ] ++


### PR DESCRIPTION
Both experimental libraries that are in the ghcjs GitHub organization, but are
not yet officially released on hackage.