### PR TITLE
pugixml: fix darwin build

### DIFF
--- a/pkgs/development/libraries/pugixml/default.nix
+++ b/pkgs/development/libraries/pugixml/default.nix
@@ -20,11 +20,14 @@ stdenv.mkDerivation rec {
     sed -ire '/PUGIXML_HAS_LONG_LONG/ s/^\/\///' ../src/pugiconfig.hpp
   '';
 
+  patches = []
+    ++ stdenv.lib.optionals stdenv.isDarwin [ ./no-long-long.patch ];
+
   meta = with stdenv.lib; {
     description = "Light-weight, simple and fast XML parser for C++ with XPath support";
     homepage = http://pugixml.org/;
     license = licenses.mit;
     maintainers = with maintainers; [ pSub ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/pugixml/no-long-long.patch
+++ b/pkgs/development/libraries/pugixml/no-long-long.patch
@@ -1,0 +1,19 @@
+Get rid of long-long feature. This breaks on AppleClang compilers.
+---
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 40a7ab0..c84f0f7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -26,9 +26,9 @@ else()
+ endif()
+ 
+ # Enable C++11 long long for compilers that are capable of it
+-if(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} STRLESS 3.1)
+-	target_compile_features(pugixml PUBLIC cxx_long_long_type)
+-endif()
++# if(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} STRLESS 3.1)
++# 	target_compile_features(pugixml PUBLIC cxx_long_long_type)
++# endif()
+ 
+ set_target_properties(pugixml PROPERTIES VERSION 1.7 SOVERSION 1)
+ 


### PR DESCRIPTION
###### Motivation for this change

This should fix things on darwin by disabling the long long option.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

