### PR TITLE
haskell/hoogle.nix: make an empty packages list possible

### DIFF
--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -23,8 +23,8 @@
 # This will build mmorph and monadControl, and have the hoogle installation
 # refer to their documentation via symlink so they are not garbage collected.
 
-{ lib, stdenv, hoogle, writeText
-, ghc, packages ? [ ghc.ghc ]
+{ lib, stdenv, hoogle, writeText, ghc
+, packages
 }:
 
 let
@@ -51,6 +51,9 @@ let
     else writeText "ghcjs-prologue.txt" ''
       This index includes documentation for many Haskell modules.
     '';
+
+  docPackages = lib.closePropagation packages;
+
 in
 stdenv.mkDerivation {
   name = "hoogle-local-0.1";
@@ -58,14 +61,9 @@ stdenv.mkDerivation {
 
   phases = [ "buildPhase" ];
 
-  docPackages = (lib.closePropagation packages);
+  inherit docPackages;
 
   buildPhase = ''
-    if [ -z "$docPackages" ]; then
-        echo "ERROR: The packages attribute has not been set"
-        exit 1
-    fi
-
     mkdir -p $out/share/doc/hoogle
 
     echo importing builtin packages


### PR DESCRIPTION
Building hoogle environments with an empty list of packages threw a built-time
error. This was particularly confusing when giving e.g. `(hps: [hps.Cabal])`
which, since `Cabal` is set to `null` (because it’s a distribution package),
would have lead to the same error as an empty list.

It was not useful to throw an error at all, because sometimes one only wants to
build an environment for the distribution packages. We switch to displaying a
warning (because it might be that the user made a mistake).

- [x] tested with an empty list
- [x] tested with a non-empty list

cc @peti @cstrahan 