### PR TITLE
aptly: use wrapProgram instead of propagatedUserEnvPkgs

### DIFF
--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, gnupg1compat, bzip2, xz, graphviz }:
+{ stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, gnupg1compat, bzip2, xz, graphviz }:
 
 buildGoPackage rec {
   name = "aptly-${version}";
@@ -15,11 +15,16 @@ buildGoPackage rec {
   goPackagePath = "github.com/smira/aptly";
   goDeps = ./deps.nix;
 
+  buildInputs = [ makeWrapper ];
+
   postInstall = ''
     rm $bin/bin/man
+    wrapProgram "$bin/bin/aptly" \
+      --prefix PATH ":" "${gnupg1compat}/bin" \
+      --prefix PATH ":" "${bzip2.bin}/bin" \
+      --prefix PATH ":" "${xz.bin}/bin" \
+      --prefix PATH ":" "${graphviz}/bin"
   '';
-
-  propagatedUserEnvPkgs = [ gnupg1compat bzip2.bin xz.bin graphviz ];
 
   meta = with stdenv.lib; {
     homepage = https://www.aptly.info;

--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -20,10 +20,7 @@ buildGoPackage rec {
   postInstall = ''
     rm $bin/bin/man
     wrapProgram "$bin/bin/aptly" \
-      --prefix PATH ":" "${gnupg1compat}/bin" \
-      --prefix PATH ":" "${bzip2.bin}/bin" \
-      --prefix PATH ":" "${xz.bin}/bin" \
-      --prefix PATH ":" "${graphviz}/bin"
+      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg1compat bzip2 xz graphviz ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -15,7 +15,7 @@ buildGoPackage rec {
   goPackagePath = "github.com/smira/aptly";
   goDeps = ./deps.nix;
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
     rm $bin/bin/man


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


