### PR TITLE
opencv3: added release option

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -2,6 +2,7 @@
 , zlib
 , enableIpp ? false
 , enableContrib ? false
+, enableRelease ? true
 , enablePython ? false, pythonPackages
 , enableGtk2 ? false, gtk2
 , enableGtk3 ? false, gtk3
@@ -86,6 +87,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DWITH_IPP=${if enableIpp then "ON" else "OFF"}"
+    "-DCMAKE_BUILD_TYPE=${if enableRelease then "RELEASE" else "DEBUG"}"
     (opencvFlag "TIFF" enableTIFF)
     (opencvFlag "JASPER" enableJPEG2K)
     (opencvFlag "WEBP" enableWebP)


### PR DESCRIPTION
###### Motivation for this change
OpenCV has a 'release' option that compiles the OpenCV package with less debugging info and compile flags oriented at performance gains (e.g. -O3). We should allow users to enable this.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

