### PR TITLE
opencv3: added CUDA 8.0 specific patches

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig, unzip
+{ lib, stdenv, fetchurl, fetchpatch, fetchFromGitHub, cmake, pkgconfig, unzip
 , zlib
 , enableIpp ? false
 , enableContrib ? false
@@ -14,7 +14,7 @@
 , enableFfmpeg ? false, ffmpeg
 , enableGStreamer ? false, gst_all_1
 , enableEigen ? false, eigen
-, enableCuda ? false, cudatoolkit, gcc49
+, enableCuda ? false, cudatoolkit, gcc5
 }:
 
 let
@@ -41,6 +41,17 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1l0w12czavgs0wzw1c594g358ilvfg2fn32cn8z7pv84zxj4g429";
   };
+
+  patches = [
+    (fetchpatch { # Patch for CUDA 8 compatibility
+      url = "https://github.com/opencv/opencv/commit/10896129b39655e19e4e7c529153cb5c2191a1db.patch";
+      sha256 = "0jka3kxxywgs3prqqgym5kav6p73rrblwj50k1nf3fvfpk194ah1";
+    })
+    (fetchpatch { # Patch to add CUDA Compute Capability compilation targets up to 6.0
+      url = "https://github.com/opencv/opencv/commit/d76f258aebdf63f979a205cabe6d3e81700a7cd8.patch";
+      sha256 = "00b3msfgrcw7laij6qafn4b18c1dl96xxpzwx05wxzrjldqb6kqg";
+    })
+  ];
 
   preConfigure =
     let ippicvVersion = "20151201";
@@ -75,7 +86,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableFfmpeg ffmpeg
     ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base ])
     ++ lib.optional enableEigen eigen
-    ++ lib.optional enableCuda [ cudatoolkit gcc49 ]
+    ++ lib.optional enableCuda [ cudatoolkit gcc5 ]
     ;
 
   propagatedBuildInputs = lib.optional enablePython pythonPackages.numpy;


### PR DESCRIPTION
###### Motivation for this change
Need this in order to add CUDA support for graphics cards beyond CC 3.5. This new version of OpenCV is compiled with a newer version of OpenCV 3, on order to allow this compilation to occur. This will bring us up to date with the repository around August. The CC support will now be up to 6.0.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


opencv3: reverted defaults