### PR TITLE
postgresql: add 9.6.1

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -1,8 +1,9 @@
-{ lib, stdenv, fetchurl, zlib, readline, libossp_uuid, openssl }:
+{ lib, stdenv, glibc, fetchurl, zlib, readline, libossp_uuid, openssl, makeWrapper }:
 
 let
 
-  common = { version, sha256, psqlSchema } @ args: stdenv.mkDerivation (rec {
+  common = { version, sha256, psqlSchema } @ args:
+   let atLeast = lib.versionAtLeast version; in stdenv.mkDerivation (rec {
     name = "postgresql-${version}";
 
     src = fetchurl {
@@ -14,7 +15,7 @@ let
     setOutputFlags = false; # $out retains configureFlags :-/
 
     buildInputs =
-      [ zlib readline openssl ]
+      [ zlib readline openssl makeWrapper ]
       ++ lib.optionals (!stdenv.isDarwin) [ libossp_uuid ];
 
     enableParallelBuilding = true;
@@ -30,9 +31,9 @@ let
       ++ lib.optional (!stdenv.isDarwin) "--with-ossp-uuid";
 
     patches =
-      [ (if lib.versionAtLeast version "9.4" then ./disable-resolve_symlinks-94.patch else ./disable-resolve_symlinks.patch)
-        ./less-is-more.patch
-        ./hardcode-pgxs-path.patch
+      [ (if atLeast "9.4" then ./disable-resolve_symlinks-94.patch else ./disable-resolve_symlinks.patch)
+        (if atLeast "9.6" then ./less-is-more-96.patch             else ./less-is-more.patch)
+        (if atLeast "9.6" then ./hardcode-pgxs-path-96.patch       else ./hardcode-pgxs-path.patch)
         ./specify_pkglibdir_at_runtime.patch
       ];
 
@@ -41,10 +42,11 @@ let
     LC_ALL = "C";
 
     postConfigure =
-      ''
-        # Hardcode the path to pgxs so pg_config returns the path in $out
-        substituteInPlace "src/bin/pg_config/pg_config.c" --replace HARDCODED_PGXS_PATH $out/lib
-      '';
+      let path = if atLeast "9.6" then "src/common/config_info.c" else "src/bin/pg_config/pg_config.c"; in
+        ''
+          # Hardcode the path to pgxs so pg_config returns the path in $out
+          substituteInPlace "${path}" --replace HARDCODED_PGXS_PATH $out/lib
+        '';
 
     postInstall =
       ''
@@ -54,6 +56,12 @@ let
 
         # Prevent a retained dependency on gcc-wrapper.
         substituteInPlace "$out/lib/pgxs/src/Makefile.global" --replace ${stdenv.cc}/bin/ld ld
+      '';
+
+    postFixup =
+      ''
+        # initdb needs access to "locale" command from glibc.
+        wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
       '';
 
     disallowedReferences = [ stdenv.cc ];
@@ -104,5 +112,10 @@ in {
     sha256 = "1l3fqxlpxgl6nrcd4h6lpi2hsiv56yg83n3xrn704rmdch8mfpng";
   };
 
+  postgresql96 = common {
+    version = "9.6.1";
+    psqlSchema = "9.6";
+    sha256 = "1k8zwnabsl8f7vlp3azm4lrklkb9jkaxmihqf0mc27ql9451w475";
+  };
 
 }

--- a/pkgs/servers/sql/postgresql/hardcode-pgxs-path-96.patch
+++ b/pkgs/servers/sql/postgresql/hardcode-pgxs-path-96.patch
@@ -1,0 +1,14 @@
+diff -Naur postgresql-9.6.1-orig/src/common/config_info.c postgresql-9.6.1/src/common/config_info.c
+--- postgresql-9.6.1-orig/src/common/config_info.c	2016-11-22 21:39:29.231929261 +0100
++++ postgresql-9.6.1/src/common/config_info.c	2016-11-22 23:36:53.685163543 +0100
+@@ -118,7 +118,10 @@
+ 	i++;
+
+ 	configdata[i].name = pstrdup("PGXS");
++	strlcpy(path, "HARDCODED_PGXS_PATH", sizeof(path));
++/* commented out to be able to point to nix $out path
+ 	get_pkglib_path(my_exec_path, path);
++*/
+ 	strlcat(path, "/pgxs/src/makefiles/pgxs.mk", sizeof(path));
+ 	cleanup_path(path);
+ 	configdata[i].setting = pstrdup(path);

--- a/pkgs/servers/sql/postgresql/less-is-more-96.patch
+++ b/pkgs/servers/sql/postgresql/less-is-more-96.patch
@@ -1,0 +1,12 @@
+diff -Naur postgresql-9.6.1-orig/src/include/fe_utils/print.h postgresql-9.6.1/src/include/fe_utils/print.h
+--- postgresql-9.6.1-orig/src/include/fe_utils/print.h	2016-11-22 21:39:29.148932827 +0100
++++ postgresql-9.6.1/src/include/fe_utils/print.h	2016-11-22 21:39:36.283626258 +0100
+@@ -18,7 +18,7 @@
+ 
+ /* This is not a particularly great place for this ... */
+ #ifndef __CYGWIN__
+-#define DEFAULT_PAGER "more"
++#define DEFAULT_PAGER "less"
+ #else
+ #define DEFAULT_PAGER "less"
+ #endif

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10324,7 +10324,8 @@ in
     postgresql92
     postgresql93
     postgresql94
-    postgresql95;
+    postgresql95
+    postgresql96;
 
   postgresql_jdbc = callPackage ../servers/sql/postgresql/jdbc { };
 


### PR DESCRIPTION
postgresql-9.6.1 builds and runs fine on my NixOS-16.09 system. I tested a few SQL queries.

I also tested if the problem fixed in https://github.com/NixOS/nixpkgs/pull/15470 is still fixed and concluded that postgis builds successfully with this new version of postgresql. 

It would be great if this could be cherry picked on `release-16.09` as well.