### PR TITLE
postgresql: bug fix updates for all versions

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -75,33 +75,33 @@ let
 in {
 
   postgresql91 = common {
-    version = "9.1.23";
+    version = "9.1.24";
     psqlSchema = "9.1";
-    sha256 = "1mgnfm65fspkq62skfy48rjkprnxcfhydw0x3ipp4sdkngl72x3z";
+    sha256 = "1lz5ibvgz6cxprxlnd7a8iwv387idr7k53bdsvy4bw9ayglq83fy";
   };
 
   postgresql92 = common {
-    version = "9.2.18";
+    version = "9.2.19";
     psqlSchema = "9.2";
-    sha256 = "1x1mxbwqvgj9s4y8pb4vv6fmmr36z5zl3b2ggb84ckdfhvakganp";
+    sha256 = "1bfvx1h1baxp40y4xi88974p43vazz13mwc0h8scq3sr9wxdfa8x";
   };
 
   postgresql93 = common {
-    version = "9.3.14";
+    version = "9.3.15";
     psqlSchema = "9.3";
-    sha256 = "1783kl0abf9az90mvs08pdh63d33cv2njc1q515zz89bqkqj4hsw";
+    sha256 = "0kswvs4rzcmjz12hhyi61w5x2wh4dxskar8v7rgajfm98qabmz59";
   };
 
   postgresql94 = common {
-    version = "9.4.9";
+    version = "9.4.10";
     psqlSchema = "9.4";
-    sha256 = "1jg1l6vrfwhfyqrx07bgcpqxb5zcp8zwm8qd2vcj0k11j0pac861";
+    sha256 = "1kvfhalf3rs59887b5qa14zp85zcnsc6pislrs0wd08rxn5nfqbh";
   };
 
   postgresql95 = common {
-    version = "9.5.4";
+    version = "9.5.5";
     psqlSchema = "9.5";
-    sha256 = "1l3fqxlpxgl6nrcd4h6lpi2hsiv56yg83n3xrn704rmdch8mfpng";
+    sha256 = "157kf6mdazmxfmd11f0akya2xcz6sfgprn7yqc26dpklps855ih2";
   };
 
 


### PR DESCRIPTION
These postgresql minor updates fix issues that can cause data corruption, which are described in the release notes. It also patches a number of other bugs reported over the last few months.

See: https://www.postgresql.org/about/news/1712/

It would be great if this can be cherry picked on `release-16.09` as well.