### PR TITLE
curl: disable HTTP/2 support

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, perl
-, http2Support ? true, nghttp2
+, http2Support ? false, nghttp2
 , idnSupport ? false, libidn ? null
 , ldapSupport ? false, openldap ? null
 , zlibSupport ? false, zlib ? null

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1327,7 +1327,6 @@ in
 
   curl = callPackage ../tools/networking/curl rec {
     fetchurl = fetchurlBoot;
-    http2Support = !stdenv.isDarwin;
     zlibSupport = true;
     sslSupport = zlibSupport;
     scpSupport = zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin;


### PR DESCRIPTION
###### Motivation for this change

Most services like cache.nixos.org and nginx httpd servers are much slower serving files using HTTP/2 with curl/nghttp2. The reason is unknown but it's just annoying.

If you use `curl --http1.1` the downloads are fast but with `curl --http2` they are slow. nghttp2 ships with a download tool which yields the same performance as `curl --http2`. Using a HTTP/2 capable browser like Chromium you can observe fast download speeds.

###### Benchmarks

```
$ nix-shell -p nghttp2 curl
$ time curl --http2 https://hydra.mayflower.de/nar/rhxyhz1pj949njsdyqfbh5hnbynns9z3-openttd-1.6.1 > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 18.7M    0 18.7M    0     0  1440k      0 --:--:--  0:00:13 --:--:-- 1309k

real    0m13.324s
user    0m0.258s
sys     0m0.145s

$ time curl --http1.1 https://hydra.mayflower.de/nar/rhxyhz1pj949njsdyqfbh5hnbynns9z3-openttd-1.6.1 > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 18.7M    0 18.7M    0     0  4687k      0 --:--:--  0:00:04 --:--:-- 4693k

real    0m4.098s
user    0m0.215s
sys     0m0.109s

$ time nghttp https://hydra.mayflower.de/nar/rhxyhz1pj949njsdyqfbh5hnbynns9z3-openttd-1.6.1 > /dev/null

real    0m12.874s
user    0m0.134s
sys     0m0.100s
```