### PR TITLE
Reduce closure size of installer images

### DIFF
--- a/nixos/lib/make-squashfs.nix
+++ b/nixos/lib/make-squashfs.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation {
 
       # Generate the squashfs image.
       mksquashfs nix-path-registration $storePaths $out \
-        -keep-as-directory -all-root
+        -keep-as-directory -all-root -comp xz
     '';
 }

--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -42,8 +42,6 @@
     # Some compression/archiver tools.
     pkgs.unzip
     pkgs.zip
-    pkgs.dar # disk archiver
-    pkgs.cabextract
   ];
 
   # Include support for various filesystems.

--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -7,7 +7,7 @@
   # Include some utilities that are useful for installing or repairing
   # the system.
   environment.systemPackages = [
-    pkgs.w3m # needed for the manual anyway
+    pkgs.w3m-nox # needed for the manual anyway
     pkgs.testdisk # useful for repairing boot problems
     pkgs.mssys # for writing Microsoft boot sectors / MBRs
     pkgs.efibootmgr

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -14,4 +14,6 @@ with lib;
 
   programs.man.enable = mkDefault false;
   programs.info.enable = mkDefault false;
+
+  sound.enable = mkDefault false;
 }

--- a/pkgs/development/libraries/giblib/default.nix
+++ b/pkgs/development/libraries/giblib/default.nix
@@ -2,16 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "giblib-1.2.4";
-  
+
   src = fetchurl {
     url = "http://linuxbrit.co.uk/downloads/${name}.tar.gz";
     sha256 = "1b4bmbmj52glq0s898lppkpzxlprq9aav49r06j2wx4dv3212rhp";
   };
-  
-  buildInputs = [xlibsWrapper imlib2];
+
+  buildInputs = [ xlibsWrapper ];
+  propagatedBuildInputs = [ imlib2 ];
 
   meta = {
     homepage = http://linuxbrit.co.uk/giblib/;
+    description = "wrapper library for imlib2, and other stuff";
     platforms = stdenv.lib.platforms.unix;
+    license = stdenv.lib.licenses.mit;
   };
 }

--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, xlibsWrapper, libjpeg, libtiff, giflib, libpng, bzip2, pkgconfig }:
+{ stdenv, fetchurl, libjpeg, libtiff, giflib, libpng, bzip2, pkgconfig
+, freetype
+, x11Support ? true, xlibsWrapper ? null }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "imlib2-1.4.9";
@@ -8,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "08809xxk2555yj6glixzw9a0x3x8cx55imd89kj3r0h152bn8a3x";
   };
 
-  buildInputs = [ xlibsWrapper libjpeg libtiff giflib libpng bzip2 ];
+  buildInputs = [ libjpeg libtiff giflib libpng bzip2 freetype ]
+    ++ optional x11Support xlibsWrapper;
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -21,7 +26,8 @@ stdenv.mkDerivation rec {
 
   # Do not build amd64 assembly code on Darwin, because it fails to compile
   # with unknow directive errors
-  configureFlags = if stdenv.isDarwin then [ "--enable-amd64=no" ] else null;
+  configureFlags = optional stdenv.isDarwin "--enable-amd64=no"
+    ++ optional (!x11Support) "--without-x";
 
   meta = {
     description = "Image manipulation library";
@@ -34,8 +40,8 @@ stdenv.mkDerivation rec {
       easily, without sacrificing speed.
     '';
 
-    license = stdenv.lib.licenses.free;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ spwhitt ];
+    license = licenses.free;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ spwhitt ];
   };
 }

--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -29,6 +29,12 @@ stdenv.mkDerivation rec {
   configureFlags = optional stdenv.isDarwin "--enable-amd64=no"
     ++ optional (!x11Support) "--without-x";
 
+  outputs = [ "out" "bin" "dev" ];
+
+  postInstall = ''
+    moveToOutput bin/imlib2-config "$dev"
+  '';
+
   meta = {
     description = "Image manipulation library";
 

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -27,6 +27,8 @@ with stdenv.lib;
     MODULE_COMPRESS_XZ y
   ''}
 
+  KERNEL_XZ y
+
   # Debugging.
   DEBUG_KERNEL y
   TIMER_STATS y

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15105,13 +15105,15 @@ in
   # Version without X11
   w3m-nox = w3m.override {
     x11Support = false;
+    imlib2 = imlib2-nox;
   };
 
   # Version for batch text processing, not a good browser
   w3m-batch = w3m.override {
     graphicsSupport = false;
-    x11Support = false;
     mouseSupport = false;
+    x11Support = false;
+    imlib2 = imlib2-nox;
   };
 
   weechat = callPackage ../applications/networking/irc/weechat {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7452,6 +7452,9 @@ in
   iml = callPackage ../development/libraries/iml { };
 
   imlib2 = callPackage ../development/libraries/imlib2 { };
+  imlib2-nox = imlib2.override {
+    x11Support = false;
+  };
 
   imlibsetroot = callPackage ../applications/graphics/imlibsetroot { libXinerama = xorg.libXinerama; } ;
 


### PR DESCRIPTION
###### Motivation for this change

In a minimal NixOS ISO installer environment I noticed some packages like X11 libraries which I felt were not needed and digged deeper.

The base installer profile includes `dar` in the system path which depends on gnupg which depends on `pinentry`, `gtk2`, `openldap`… I don't think this is a generally used tool and therefore propose to remove it.

But these were not all X11 dependencies. `w3m` was included twice, with X11 (from the base installer profile) and without (from `services.nixosManual`). But `w3m-nox` depended on `imlib2` which again depended on X11 libraries. Therefore a new `imlib2-nox` was introduced. The minimal installer is now free of X11 libs!

Both the sizes of the kernel and the squashfs for the ISO and netboot images were reduced by about 20-25% by using XZ instead of gzip for compression. Disabling sound support also saved a few megabytes.

###### Stats for `iso_minimal.x86_64-linux`

 * master: 390MB
 * this PR: 309MB

###### Discussion & future work

 * Split linux-firmware-nonfree into categories and only include essential ones (~ 157M total)
 * Maybe put some non-essential kernel modules into own store paths or outputs? (~ 69M total)