### PR TITLE
linuxPackages.dpdk: 16.07 -> 16.11

### DIFF
--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -4,11 +4,11 @@ assert lib.versionAtLeast kernel.version "3.18";
 
 stdenv.mkDerivation rec {
   name = "dpdk-${version}-${kernel.version}";
-  version = "16.07";
+  version = "16.11";
 
   src = fetchurl {
     url = "http://dpdk.org/browse/dpdk/snapshot/dpdk-${version}.tar.gz";
-    sha256 = "1sgh55w3xpc0lb70s74cbyryxdjijk1fbv9b25jy8ms3lxaj966c";
+    sha256 = "002wnkhfm0dqsapvfhd9mbzrz4pfsibvlkjzvs5x4y2c5dab7640";
   };
 
   buildInputs = [ pkgconfig libvirt ];


### PR DESCRIPTION
Tested with

> nix-build -A linuxPackages.dpdk -A linuxPackages_latest.dpdk

Fixes build against recent kernels

Probably good to pick to release but I've yet to verify the build.