### PR TITLE
snapraid: 10.0 -> 11.0

### DIFF
--- a/pkgs/tools/filesystems/snapraid/default.nix
+++ b/pkgs/tools/filesystems/snapraid/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "snapraid-${version}";
-  version = "10.0";
+  version = "11.0";
 
   src = fetchurl {
     url = "https://github.com/amadvance/snapraid/releases/download/v${version}/snapraid-${version}.tar.gz";
-    sha256 = "1mhs0gl285a5y2bw6k04lrnyg1pp2am7dfcsvg0w4vr5h2ag3p7p";
+    sha256 = "0wapbi8ph7qcyh1jwyrn2r5slzsznlxvg137r4l02xgaaf42p9rh";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change

bump to latest release. I've tested the new version beforehand on my own servers without any issues.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).