### PR TITLE
qemu: add curl to buildInputs

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch, python, zlib, pkgconfig, glib
 , ncurses, perl, pixman, vde2, alsaLib, texinfo, libuuid, flex
-, bison, lzo, snappy, libaio, gnutls, nettle
+, bison, lzo, snappy, libaio, gnutls, nettle, curl
 , makeWrapper
 , attr, libcap, libcap_ng
 , CoreServices, Cocoa, rez, setfile
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ python zlib pkgconfig glib ncurses perl pixman
       vde2 texinfo libuuid flex bison makeWrapper lzo snappy
-      gnutls nettle
+      gnutls nettle curl
     ]
     ++ optionals stdenv.isDarwin [ CoreServices Cocoa rez setfile ]
     ++ optionals seccompSupport [ libseccomp ]


### PR DESCRIPTION
###### Motivation for this change

Enables support for accessing files over HTTP:

```
qemu-system-x86_64 -drive media=cdrom,file=http://host/path.iso,readonly
```

Increases the closures size from 445 to 447 MiB.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

