### PR TITLE
nodejs: 7.1.0 -> 7.2.0

### DIFF
--- a/pkgs/development/web/nodejs/v7.nix
+++ b/pkgs/development/web/nodejs/v7.nix
@@ -10,11 +10,11 @@ let
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 in
   stdenv.mkDerivation (nodejs // rec {
-    version = "7.1.0";
+    version = "7.2.0";
     name = "${baseName}-${version}";
     src = fetchurl {
       url = "https://nodejs.org/download/release/v${version}/node-v${version}.tar.xz";
-      sha256 = "10a9rwi9v8ylpxydfh1f59smqbljk5axqwghp1qszqwh40d87bjm";
+      sha256 = "1ywlj8a55zq7084ywahyysz0gniqfs3wmvxg5ynj35b5xyvlsva8";
     };
 
   })


### PR DESCRIPTION
###### Things done

- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

nodejs 7.2.0 depends on libuv 1.10.1

[nodejs release notes](https://nodejs.org/en/blog/release/v7.2.0/)
[libuv changelog](https://github.com/libuv/libuv/blob/c1c55ee1aa071ff566dc486ba274969ada2c7e18/ChangeLog#L1)

