### PR TITLE
gitlab service: fix syntax highlighting

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -499,7 +499,7 @@ in {
         chown -R ${cfg.user}:${cfg.group} ${gitlabEnv.HOME}/
         chmod -R u+rwX,go-rwx+X ${gitlabEnv.HOME}/
 
-        cp -rf ${cfg.packages.gitlab}/share/gitlab/config.dist/* ${cfg.statePath}/config
+        cp -rf ${cfg.packages.gitlab}/share/gitlab/config.dist\/* ${cfg.statePath}/config
         ${optionalString cfg.smtp.enable ''
           ln -sf ${smtpSettings} ${cfg.statePath}/config/initializers/smtp_settings.rb
         ''}


### PR DESCRIPTION
###### Motivation for this change

The syntax highlighting of the Gitlab service file has the usual issue with `/*` in the shell code. My solution is to escape the slash.

This commit merges cleanly with both `master` and `release-16.09`, the merge request for the later is #20651.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


