### PR TITLE
Update to docker 1.13.x

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, pkgconfig, go-md2man
-, go, containerd, runc
+, go, containerd, runc, docker-proxy, tini
 , sqlite, iproute, bridge-utils, devicemapper, systemd
 , btrfs-progs, iptables, e2fsprogs, xz, utillinux, xfsprogs
 , procps
@@ -11,14 +11,52 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "docker-${version}";
-  version = "1.12.6";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "docker";
     repo = "docker";
     rev = "v${version}";
-    sha256 = "10jhjas07xxlxjsxby8865rr0d0zsc5azy16rsz1idmy7f7lk6jh";
+    sha256 = "03b181xiqgnwanc567w9p6rbdgdvrfv0lk4r7b604ksm0fr4cz23";
   };
+
+  docker-runc = runc.overrideAttrs (oldAttrs: rec {
+    name = "docker-runc";
+    src = fetchFromGitHub {
+      owner = "docker";
+      repo = "runc";
+      rev = "2f7393a47307a16f8cee44a37b262e8b81021e3e";
+      sha256 = "1s5nfnbinzmcnm8avhvsniz0ihxyva4w5qz1hzzyqdyr0w2scnbj";
+    };
+    # docker/runc already include these patches / are not applicable
+    patches = [];
+  });
+  docker-containerd = containerd.overrideAttrs (oldAttrs: rec {
+    name = "docker-containerd";
+    src = fetchFromGitHub {
+      owner = "docker";
+      repo = "containerd";
+      rev = "03e5862ec0d8d3b3f750e19fca3ee367e13c090e";
+      sha256 = "184sd9dwkcba3zhxnz9grw8p81x05977p36cif2dgkhjdhv12map";
+    };
+  });
+  docker-tini = tini.overrideAttrs  (oldAttrs: rec {
+    name = "docker-init";
+    src = fetchFromGitHub {
+      owner = "krallin";
+      repo = "tini";
+      rev = "949e6facb77383876aeff8a6944dde66b3089574";
+      sha256 = "0zj4kdis1vvc6dwn4gplqna0bs7v6d1y2zc8v80s3zi018inhznw";
+    };
+
+    # Do not remove static from make files as we want a static binary
+    patchPhase = ''
+    '';
+
+    NIX_CFLAGS_COMPILE = [
+      "-DMINIMAL=ON"
+    ];
+  });
 
   buildInputs = [
     makeWrapper pkgconfig go-md2man go
@@ -52,16 +90,17 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -Dm755 ./bundles/${version}/dynbinary-client/docker-${version} $out/libexec/docker/docker
     install -Dm755 ./bundles/${version}/dynbinary-daemon/dockerd-${version} $out/libexec/docker/dockerd
-    install -Dm755 ./bundles/${version}/dynbinary-daemon/docker-proxy-${version} $out/libexec/docker/docker-proxy
     makeWrapper $out/libexec/docker/docker $out/bin/docker \
       --prefix PATH : "$out/libexec/docker:$extraPath"
     makeWrapper $out/libexec/docker/dockerd $out/bin/dockerd \
       --prefix PATH : "$out/libexec/docker:$extraPath"
 
     # docker uses containerd now
-    ln -s ${containerd}/bin/containerd $out/libexec/docker/docker-containerd
-    ln -s ${containerd}/bin/containerd-shim $out/libexec/docker/docker-containerd-shim
-    ln -s ${runc}/bin/runc $out/libexec/docker/docker-runc
+    ln -s ${docker-containerd}/bin/containerd $out/libexec/docker/docker-containerd
+    ln -s ${docker-containerd}/bin/containerd-shim $out/libexec/docker/docker-containerd-shim
+    ln -s ${docker-runc}/bin/runc $out/libexec/docker/docker-runc
+    ln -s ${docker-proxy}/bin/docker-proxy $out/libexec/docker/docker-proxy
+    ln -s ${docker-tini}/bin/tini-static $out/libexec/docker/docker-init
 
     # systemd
     install -Dm644 ./contrib/init/systemd/docker.service $out/etc/systemd/system/docker.service

--- a/pkgs/applications/virtualization/docker/proxy.nix
+++ b/pkgs/applications/virtualization/docker/proxy.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, go, docker }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "docker-proxy-${rev}";
+  rev = "0f534354b813003a754606689722fe253101bc4e";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "docker";
+    repo = "libnetwork";
+    sha256 = "1ah7h417llcq0xzdbp497pchb9m9qvjhrwajcjb0ybrs8v889m31";
+  };
+
+  buildInputs = [ go ];
+
+  buildPhase = ''
+    mkdir -p .gopath/src/github.com/docker
+    ln -sf $(pwd) .gopath/src/github.com/docker/libnetwork
+    GOPATH="$(pwd)/.gopath:$(pwd)/Godeps/_workspace" go build -ldflags="$PROXY_LDFLAGS" -o docker-proxy ./cmd/proxy
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp docker-proxy $out/bin
+  '';
+
+  meta = {
+    description = "Docker proxy binary to forward traffic between host and containers";
+    license = licenses.asl20;
+    homepage = https://github.com/docker/libnetwork;
+    maintainers = with maintainers; [vdemeester];
+    platforms = docker.meta.platforms;
+  };
+}

--- a/pkgs/applications/virtualization/tini/default.nix
+++ b/pkgs/applications/virtualization/tini/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchurl, cmake }:
+{ stdenv, fetchFromGitHub, cmake, glibc }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.3";
+  version = "0.13.1";
   name = "tini-${version}";
-  src = fetchurl {
-    url = "https://github.com/krallin/tini/archive/v0.8.3.tar.gz";
-    sha256 ="1w7rj4crrcyv25idmh4asbp2sxzwyihy5mbpw384bzxjzaxn9xpa";
+  src = fetchFromGitHub {
+    owner = "krallin";
+    repo = "tini";
+    rev = "v${version}";
+    sha256 ="1g4n8v5d197zcb41fcpbhip2x342383zw1d2zkv57w73vkqgv6z6";
   };
   patchPhase = "sed -i /tini-static/d CMakeLists.txt";
   NIX_CFLAGS_COMPILE = [
     "-DPR_SET_CHILD_SUBREAPER=36"
     "-DPR_GET_CHILD_SUBREAPER=37"
   ];
-  buildInputs = [ cmake ];
+  buildInputs = [ cmake glibc glibc.static ];
   meta = with stdenv.lib; {
     description = "A tiny but valid init for containers";
     homepage = https://github.com/krallin/tini;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12802,6 +12802,7 @@ in
   };
 
   docker = callPackage ../applications/virtualization/docker { };
+  docker-proxy = callPackage ../applications/virtualization/docker/proxy.nix { };
 
   docker-gc = callPackage ../applications/virtualization/docker/gc.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

`docker` 1.13.0 is going to be released next month (more or less). This shouldn't be merged before official release but gives time to review. This change the package quite a bit, so let me describe the changes :

- There is more binaries now : `docker`, `dockerd`, `docker-proxy`, `docker-runc`, `docker-containerd`, `docker-containerd-shim` and `docker-init` — from 5 projects : `docker/docker`, `docker/runc` (to follow docker release), `docker/containerd`, `docker-libnetwork` and `krallin/tini`.
- The package builds all the pieces itself instead of depending to other packages like `runc` and `containerd`. This makes sure we have the same binary (from the same git commit) than the official release and thus have no weird bugs because of version mismatch.
- The man pages of `docker` are in the process of beeing automatically generate so there is some missing man page in the current package. This aims to fix that as well (*still working on it*).
- This adds a `experimental` options to the `docker` service too – to start `docker` with experimental features (using `--experimental`).

There is still a few things to do :
- <del>[ ] Fix missing man pages</del> Currently, part of the manpages are generated in a docker container. I have no clean way to build manpage otherwise for now.. 😓 
- [ ] Handle version and build time better (`docker version` and `docker info`) 
  ```
   containerd version:  (expected: 03e5862ec0d8d3b3f750e19fca3ee367e13c090e)
   runc version: N/A (expected: 51371867a01c467f08af739783b8beafc154c4d7)
   init version: N/A (expected: 949e6facb77383876aeff8a6944dde66b3089574)
  ```
- [x] Update the package to `1.13.0` when released (and on each rc too)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


- Update docker version to 1.13
- Build containerd, runc, tini, docker-proxy from the right
  version (little duplicated from conf in docker scripts)