### PR TITLE
GIMP on Darwin (use Quartz)

### DIFF
--- a/pkgs/applications/graphics/gimp/2.8.nix
+++ b/pkgs/applications/graphics/gimp/2.8.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, pkgconfig, intltool, babl, gegl, gtk2, glib, gdk_pixbuf
 , pango, cairo, freetype, fontconfig, lcms, libpng, libjpeg, poppler, libtiff
 , webkit, libmng, librsvg, libwmf, zlib, libzip, ghostscript, aalib, jasper
-, python2Packages, libart_lgpl, libexif, gettext, xorg }:
+, python2Packages, libart_lgpl, libexif, gettext, xorg
+, AppKit, Cocoa, gtk-mac-integration }:
 
 let
   inherit (python2Packages) pygtk wrapPython python;
@@ -26,7 +27,8 @@ in stdenv.mkDerivation rec {
       libmng librsvg libwmf zlib libzip ghostscript aalib jasper
       python pygtk libart_lgpl libexif gettext xorg.libXpm
       wrapPython
-    ];
+    ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ AppKit Cocoa gtk-mac-integration ];
 
   pythonPath = [ pygtk ];
 
@@ -51,6 +53,6 @@ in stdenv.mkDerivation rec {
     description = "The GNU Image Manipulation Program";
     homepage = http://www.gimp.org/;
     license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/gtk-mac-bundler/default.nix
+++ b/pkgs/development/tools/gtk-mac-bundler/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gtk-mac-bundler-${version}";
+  version = "0.7.4";
+
+  src = fetchFromGitHub {
+    owner = "GNOME";
+    repo = "gtk-mac-bundler";
+    rev = "bundler-${version}";
+    sha256 = "1kyyq2hc217i5vhbfff0ldgv0r3aziwryd1xlck5cw3s6hgskbza";
+  };
+
+  installPhase = ''
+  	mkdir -p $out/bin
+    substitute gtk-mac-bundler.in $out/bin/gtk-mac-bundler \
+      --subst-var-by PATH $out/share
+    chmod a+x $out/bin/gtk-mac-bundler
+
+    mkdir -p $out/share
+    cp -r bundler $out/share
+  '';
+
+  meta = with lib; {
+    description = "a helper script that creates application bundles form GTK+ executables for Mac OS X";
+    maintainers = [ maintainers.matthewbauer ];
+    platforms = platforms.darwin;
+    homepage = https://wiki.gnome.org/Projects/GTK+/OSX/Bundling;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7539,6 +7539,8 @@ in
     gtk = gtk2;
   };
 
+  gtk-mac-bundler = callPackage ../development/tools/gtk-mac-bundler {};
+
   gtkspell2 = callPackage ../development/libraries/gtkspell { };
 
   gtkspell3 = callPackage ../development/libraries/gtkspell/3.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13352,6 +13352,7 @@ in
     inherit (gnome2) libart_lgpl;
     webkit = null;
     lcms = lcms2;
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
   };
 
   gimp = gimp_2_8;


### PR DESCRIPTION
###### Motivation for this change

This adds some tricks to get GIMP to build on my Darwin machine.

GTK2 has a quartz backend that we haven't been using. I'm not sure why it's not being used but it should probably be enabled by default. While GIMP may work without GTK +quartz, I XQuartz is really annoying to use and not my preference.

For some reason PyGTK and GTK2 +quartz don't seem to work well. It's really confusing because it looks like at some point the MacPorts project had everything working well but the compiler seems to treat objc headers like they are c header. See https://trac.macports.org/ticket/37713.

Note: This does not produce an "Application" yet on Darwin. It should be possible but our GIMP release does not seem to produce the correct "gtk-mac-bundler" .bundle file (see the gimp/build/osx/gimp-2.8.bundle file).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
