### PR TITLE
git-annex-remote-rclone: init at 0.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -45,6 +45,8 @@ rec {
 
   git-annex-remote-b2 = callPackage ./git-annex-remote-b2 { };
 
+  git-annex-remote-rclone = callPackage ./git-annex-remote-rclone { };
+
   # support for bugzilla
   git-bz = callPackage ./git-bz { };
 

--- a/pkgs/applications/version-management/git-and-tools/git-annex-remote-rclone/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-remote-rclone/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, rclone, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "git-annex-remote-rclone-${version}";
+  version = "0.4";
+  rev = "v${version}";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "DanielDent";
+    repo = "git-annex-remote-rclone";
+    sha256 = "1myk307hqm8dlxhkmwr347rdd28niv5h0gyrxm30y77zlly30ddk";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp git-annex-remote-rclone $out/bin
+    wrapProgram "$out/bin/git-annex-remote-rclone" \
+      --prefix PATH ":" "${stdenv.lib.makeBinPath [ rclone ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/DanielDent/git-annex-remote-rclone;
+    description = "Use rclone supported cloud storage providers with git-annex";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.montag451 ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


