### PR TITLE
hexRegistrySnapshot: d58a937 -> e88db1f

### DIFF
--- a/pkgs/development/beam-modules/hex-registry-snapshot.nix
+++ b/pkgs/development/beam-modules/hex-registry-snapshot.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
     name = "hex-registry";
-    rev = "d58a937";
+    rev = "e88db1f";
     version = "0.0.0+build.${rev}";
 
     src = fetchFromGitHub {
         owner = "erlang-nix";
         repo = "hex-pm-registry-snapshots";
         inherit rev;
-        sha256 = "11ymmn75qjlhzf7aaza708gq0hqg55dzd3q13npgq43wg90rgpxy";
+        sha256 = "0877dragfxs22a05d8mv42z5535kfx9rs4y7fwwbd1ybphczf8za";
     };
 
     installPhase = ''


### PR DESCRIPTION
*Depends on erlang-nix/hex-pm-registry-snapshots#2.*

**Update**: https://github.com/erlang-nix/hex-pm-registry-snapshots/pull/2 has been merged.

- [x] Update to depend on https://github.com/erlang-nix/hex-pm-registry-snapshots/commit/e5e494acc046877c1b4dc96f3fcbcf74ca1740cc instead

###### Motivation for this change

The previous version is several months old.

/cc @ericbmerritt @gleber

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
