### PR TITLE
delve: init at 0.11.0-alpha

### DIFF
--- a/pkgs/development/tools/delve/default.nix
+++ b/pkgs/development/tools/delve/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "delve-${version}";
+  version = "0.11.0-alpha";
+
+  goPackagePath = "github.com/derekparker/delve";
+  excludedPackages = "_fixtures";
+
+  src = fetchFromGitHub {
+    owner = "derekparker";
+    repo = "delve";
+    rev = "v${version}";
+    sha256 = "10axxlvqpa6gx6pz2djp8bb08b83rdj1pavay0nqdd2crsb6rvgd";
+  };
+
+  meta = {
+    description = "debugger for the Go programming language";
+    homepage = "https://github.com/derekparker/delve";
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11304,6 +11304,8 @@ in
     inherit (gnome2) gtk gtkmm;
   };
 
+  delve = callPackage ../development/tools/delve { };
+
   go-bindata = callPackage ../development/tools/go-bindata { };
 
   go-bindata-assetfs = callPackage ../development/tools/go-bindata-assetfs { };


### PR DESCRIPTION
###### Motivation for this change

[delve](https://github.com/derekparker/delve) is a debugger for the Go programming language — that can be used from various editor/ide.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Init delve at 0.11.0-alpha

Signed-off-by: Vincent Demeester <vincent@sbr.pm>