### PR TITLE
lfe: 1.1.1 -> 1.2.1

### DIFF
--- a/pkgs/development/interpreters/lfe/no-test-deps.patch
+++ b/pkgs/development/interpreters/lfe/no-test-deps.patch
@@ -1,0 +1,13 @@
+diff --git a/rebar.config b/rebar.config
+index 1d5a68e..ca33be7 100644
+--- a/rebar.config
++++ b/rebar.config
+@@ -2,7 +2,7 @@
+ 
+ {erl_opts, [debug_info]}.
+ 
+-{profiles, [{test, [{deps, [proper]}]}]}.
++%% {profiles, [{test, [{deps, [proper]}]}]}.
+ 
+ {pre_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)", ct,
+               "bin/lfe bin/lfec"

--- a/pkgs/development/interpreters/lfe/setup-hook.sh
+++ b/pkgs/development/interpreters/lfe/setup-hook.sh
@@ -1,5 +1,0 @@
-addLfeLibPath() {
-    addToSearchPath ERL_LIBS $1/lib/lfe/lib
-}
-
-envHooks+=(addLfeLibPath)


### PR DESCRIPTION
*Depends on #20664.*

###### Motivation for this change

~~Update to 1.2.0, not 1.2.1, since it has issues wrt `clj-tests`. I'll need to chat with @rvirding and get that sorted.~~

Use `buildRebar3` instead of `mkDerivation`, obviating the need for `setup-hook.sh`.

Manually build [`proper`](https://hex.pm/packages/proper/1.1.1-beta) and patch `rebar.config` s.t. it doesn't try to fetch it manually.
N.B. I can't seem to figure out how to get the hermetic `rebar3` to play nice with `proper`, so this is a hack, but it suits our needs for running LFE tests.

Set `checkTarget = "travis"` so we can actually run the tests.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---