### PR TITLE
skopeo: init at 0.1.16

### DIFF
--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, gpgme }:
+
+buildGoPackage rec {
+  name = "skopeo-${version}";
+  version = "0.1.16";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/projectatomic/skopeo";
+  excludedPackages = "integration";
+
+  buildInputs = [ gpgme ];
+  
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "projectatomic";
+    repo = "skopeo";
+    sha256 = "11na7imx6yc1zijb010hx6fjh6v0m3wm5r4sa2nkclm5lkjq259b";
+  };
+
+  meta = {
+    description = "A command line utility for various operations on container images and image repositories.";
+    homepage = "https://github.com/projectatomic/skopeo";
+    maintainers = with stdenv.lib.maintainers; [ vdemeester ];
+    license = stdenv.lib.licenses.asl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11440,6 +11440,8 @@ in
     rcshutdown = "/etc/rc.d/rc.shutdown";
   };
 
+  skopeo = callPackage ../development/tools/skopeo { };
+
   smem = callPackage ../os-specific/linux/smem { };
 
   statifier = callPackage ../os-specific/linux/statifier { };


### PR DESCRIPTION
###### Motivation for this change

[skopeo](https://github.com/projectatomic/skopeo) is a command line utility for various operations on container images and image repositories. It is able to inspect a repository on a Docker registry and fetch images layers, copy and delete images on the registries, …

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Init skopeo at v0.1.16
Signed-off-by: Vincent Demeester <vincent@sbr.pm>