### PR TITLE
Nixos Vulnerability Patch Rollup: #10

### DIFF
--- a/pkgs/applications/graphics/graphicsmagick/default.nix
+++ b/pkgs/applications/graphics/graphicsmagick/default.nix
@@ -15,15 +15,15 @@ stdenv.mkDerivation {
   patches = [
     ./disable-popen.patch
     (fetchpatch {
-      url = "https://sources.debian.net/data/main/g/graphicsmagick/1.3.25-4/debian/patches/CVE-2016-7996_CVE-2016-7997.patch";
+      url = "https://sources.debian.net/data/main/g/graphicsmagick/1.3.25-5/debian/patches/CVE-2016-7996_CVE-2016-7997.patch";
       sha256 = "0xsby2z8n7cnnln7szjznq7iaabq323wymvdjra59yb41aix74r2";
     })
     (fetchpatch {
-      url = "https://sources.debian.net/data/main/g/graphicsmagick/1.3.25-4/debian/patches/CVE-2016-7800_part1.patch";
+      url = "https://sources.debian.net/data/main/g/graphicsmagick/1.3.25-5/debian/patches/CVE-2016-7800_part1.patch";
       sha256 = "02s0x9bkbnm5wrd0d2x9ld4d9z5xqpfk310lyylyr5zlnhqxmwgn";
     })
     (fetchpatch {
-      url = "https://sources.debian.net/data/main/g/graphicsmagick/1.3.25-4/debian/patches/CVE-2016-7800_part2.patch";
+      url = "https://sources.debian.net/data/main/g/graphicsmagick/1.3.25-5/debian/patches/CVE-2016-7800_part2.patch";
       sha256 = "1h4xv3i1aq5avsd584rwa5sa7ca8f7w9ggmh7j2llqq5kymwsv5f";
     })
     (fetchpatch {

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, fetchpatch
+{ stdenv, fetchFromGitHub, fetchpatch
 , ncurses, boehmgc, gettext, zlib
 , sslSupport ? true, openssl ? null
 , graphicsSupport ? true, imlib2 ? null
@@ -15,12 +15,13 @@ assert mouseSupport -> gpm-ncurses != null;
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "w3m-0.5.3-2015-12-20";
+  name = "w3m-v0.5.3+git20161120";
 
-  src = fetchgit {
-    url = "git://anonscm.debian.org/collab-maint/w3m.git";
-    rev = "e0b6e022810271bd0efcd655006389ee3879e94d";
-    sha256 = "1vahm3719hb0m20nc8k88165z35f8b15qasa0whhk78r12bls1q6";
+  src = fetchFromGitHub {
+    owner = "tats";
+    repo = "w3m";
+    rev = "v0.5.3+git20161120";
+    sha256 = "06n5a9jdyihkd4xdjmyci32dpqp1k2l5awia5g9ng0bn256bacdc";
   };
 
   NIX_LDFLAGS = optionalString stdenv.isSunOS "-lsocket -lnsl";

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -123,6 +123,11 @@ stdenv.mkDerivation rec {
       url = "http://git.qemu.org/?p=qemu.git;a=patch;h=8caed3d564672e8bc6d2e4c6a35228afd01f4723";
       sha256 = "19sq6fh7nh8wrk52skky4vwm80029lhm093g11f539krmzjgipik";
     })
+    (fetchpatch {
+      name = "qemu-CVE-2016-7907.patch";
+      url = "http://git.qemu.org/?p=qemu.git;a=patch;h=070c4b92b8cd5390889716677a0b92444d6e087a";
+      sha256 = "0in89697r6kwkf302v3cg16390q7qs33n2b4kba26m4x65632dxm";
+    })
 
     # FIXME: Fix for CVE-2016-9101 not yet ready: https://lists.gnu.org/archive/html/qemu-devel/2016-10/msg03024.html
 

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -10,11 +10,11 @@ assert xarSupport -> libxml2 != null;
 
 stdenv.mkDerivation rec {
   name = "libarchive-${version}";
-  version = "3.2.1";
+  version = "3.2.2";
 
   src = fetchurl {
     url = "${meta.homepage}/downloads/${name}.tar.gz";
-    sha256 = "1lngng84k1kkljl74q0cdqc3s82vn2kimfm02dgm4d6m7x71mvkj";
+    sha256 = "03q6y428rg723c9fj1vidzjw46w1vf8z0h95lkvz1l9jw571j739";
   };
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -1,15 +1,14 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, zlib, libjpeg, xz }:
 
 let
-  version = "4.0.6";
-  debversion = "3";
+  version = "4.0.7";
 in
 stdenv.mkDerivation rec {
   name = "libtiff-${version}";
 
   src = fetchurl {
     url = "http://download.osgeo.org/libtiff/tiff-${version}.tar.gz";
-    sha256 = "136nf1rj9dp5jgv1p7z4dk0xy3wki1w0vfjbk82f645m0w4samsd";
+    sha256 = "06ghqhr4db1ssq0acyyz49gr8k41gzw6pqb6mbn5r7jqp77s4hwz";
   };
 
   outputs = [ "bin" "dev" "out" "doc" ];
@@ -20,54 +19,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patches = let p = "https://sources.debian.net/data/main/t/tiff/${version}-${debversion}/debian/patches"; in [
-    (fetchurl {
-      url = "${p}/01-CVE-2015-8665_and_CVE-2015-8683.patch";
-      sha256 = "0qiiqpbbsf01b59x01z38cg14pmg1ggcsqm9n1gsld6rr5wm3ryz";
-    })
-    (fetchurl {
-      url = "${p}/02-fix_potential_out-of-bound_writes_in_decode_functions.patch";
-      sha256 = "1ph057w302i2s94rhdw6ksyvpsmg1nlanvc0251x01s23gkdbakv";
-    })
-    (fetchurl {
-      url = "${p}/03-fix_potential_out-of-bound_write_in_NeXTDecode.patch";
-      sha256 = "1nhjg2gdvyzi4wa2g7nwmzm7nssz9dpdfkwms1rp8i1034qdlgc6";
-    })
-    (fetchurl {
-      url = "${p}/04-CVE-2016-5314_CVE-2016-5316_CVE-2016-5320_CVE-2016-5875.patch";
-      sha256 = "0n47yk9wcvc9j72yvm5bhpaqq0yfz8jnq9zxbnzx5id9gdxmrkn3";
-    })
-    (fetchurl {
-      url = "${p}/05-CVE-2016-6223.patch";
-      sha256 = "0r80hil9k6scdjppgyljhm0s2z6c8cm259f0ic0xvxidfaim6g2r";
-    })
-    (fetchurl {
-      url = "${p}/06-CVE-2016-5321.patch";
-      sha256 = "1aacymlqv6cam8i4nbma9v05r3v3xjpagns7q0ii268h0mhzq6qg";
-    })
-    (fetchurl {
-      url = "${p}/07-CVE-2016-5323.patch";
-      sha256 = "1xr5hy2fxa71j3fcc1l998pxyblv207ygzyhibwb1lia5zjgblch";
-    })
-    (fetchurl {
-      url = "${p}/08-CVE-2016-3623_CVE-2016-3624.patch";
-      sha256 = "1xnvwjvgyxi387h1sdiyp4360a3176jmipb7ghm8vwiz7cisdn9z";
-    })
-    (fetchurl {
-      url = "${p}/09-CVE-2016-5652.patch";
-      sha256 = "1yqfq32gzh21ab2jfqkq13gaz0nin0492l06adzsyhr5brvdhnx8";
-    })
-    (fetchurl {
-      url = "${p}/10-CVE-2016-3658.patch";
-      sha256 = "01kb8rfk30fgjf1hy0m088yhjfld1yyh4bk3gkg8jx3dl9bd076d";
-    })
-  ];
-
   doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Library and utilities for working with the TIFF image file format";
-    homepage = http://www.remotesensing.org/libtiff/;
+    homepage = http://download.osgeo.org/libtiff;
     license = licenses.libtiff;
     platforms = platforms.unix;
   };

--- a/pkgs/games/gnuchess/default.nix
+++ b/pkgs/games/gnuchess/default.nix
@@ -3,10 +3,10 @@ let
   s = # Generated upstream information
   rec {
     baseName="gnuchess";
-    version="6.2.3";
+    version="6.2.4";
     name="${baseName}-${version}";
     url="mirror://gnu/chess/${name}.tar.gz";
-    sha256="10hvnfhj9bkpz80x20jgxyqvgvrcgfdp8sfcbcrf1dgjn9v936bq";
+    sha256="1vw2w3jwnmn44d5vsw47f8y70xvxcsz9m5msq9fgqlzjch15qhiw";
   };
   buildInputs = [
     flex


### PR DESCRIPTION
###### Motivation for this change

Roll-up all changes in to one merge to prevent multiple mass rebuilds.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

re: https://github.com/NixOS/nixpkgs/issues/20647