### PR TITLE
Darwin closed-source apps: init Steam, Spotify

### DIFF
--- a/pkgs/applications/audio/spotify/darwin.nix
+++ b/pkgs/applications/audio/spotify/darwin.nix
@@ -1,0 +1,28 @@
+{ fetchurl, stdenv, lib, undmg }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.42.151.g19de0aa6";
+  name = "spotify-mac";
+
+  src = fetchurl {
+    url = "http://download.spotify.com/Spotify.dmg";
+    sha256 = "0fxfibw465mm7p90da53n1ss7hxjk9vp2dfg56wamzyag77xxpqx";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -r . $out/Applications/Spotify.app
+  '';
+
+  meta = with lib; {
+    homepage = https://www.spotify.com/;
+    description = "Play music from the Spotify music service";
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with stdenv.lib.maintainers; [ matthewbauer ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/applications/networking/browsers/google-chrome/darwin.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/darwin.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchurl, undmg, chromium }:
+
+with lib;
+
+with chromium.upstream-info;
+
+stdenv.mkDerivation rec {
+  inherit version;
+
+  name = "google-chrome-${version}";
+
+  src = fetchurl {
+    url = "https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg";
+    sha256 = "15yzac36av54hs8jfp1wbqgv8c7sxwf1cj0vbk8sdx8xf8mpax4x";
+  };
+
+  buildInputs = [ undmg ];
+
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -r . $out/Applications/"Google Chrome.app"
+  '';
+
+  meta = {
+    description = "A freeware web browser developed by Google";
+    homepage = https://www.google.com/chrome/browser/;
+    license = licenses.unfree;
+    maintainers = [ maintainers.matthewbauer ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/games/steam/darwin.nix
+++ b/pkgs/games/steam/darwin.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, lib, undmg }:
+
+stdenv.mkDerivation rec {
+  version = "1476379980";
+  name = "steam-${version}";
+
+  src = fetchurl {
+    url = "https://steamcdn-a.akamaihd.net/client/installer/steam.dmg";
+    sha256 = "1xmc4qiqgdm8vslm8p890mh1b0dbdkc8cbjwf6bl9i0bcf3g8v6a";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -r . $out/Applications/Steam.app
+  '';
+
+  meta = with lib; {
+    description = "A digital distribution platform";
+    homepage = http://store.steampowered.com/;
+    license = licenses.unfreeRedistributable;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ jagajaga ];
+  };
+}

--- a/pkgs/tools/archivers/undmg/default.nix
+++ b/pkgs/tools/archivers/undmg/default.nix
@@ -1,15 +1,14 @@
 { stdenv, fetchFromGitHub, zlib, bzip2 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.2";
+  version = "1.0.3";
   name = "undmg-${version}";
 
   src = fetchFromGitHub {
     owner = "matthewbauer";
     repo = "undmg";
-    rev = "refs/tags/v${version}";
-    sha256 = "0w9vwvj9zbpsjkg251bwv9y10wjyjmh54q2piklz74w64rlbqblr";
-    name = "undmg-${version}";
+    rev = "v${version}";
+    sha256 = "1pxqw92h2w75d4jwiihwnkhnsfk09cddh3flgrqwh9r3ry14fgbb";
   };
 
   buildInputs = [ zlib bzip2 ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14627,11 +14627,12 @@ in
     ffmpeg = ffmpeg_2;
   };
 
-  spotify = callPackage ../applications/audio/spotify {
-    inherit (gnome2) GConf;
-    libgcrypt = libgcrypt_1_5;
-    libpng = libpng12;
-  };
+  spotify = if stdenv.isDarwin then callPackage ../applications/audio/spotify/darwin.nix {}
+    else callPackage ../applications/audio/spotify {
+      inherit (gnome2) GConf;
+      libgcrypt = libgcrypt_1_5;
+      libpng = libpng12;
+    };
 
   libspotify = callPackage ../development/libraries/libspotify {
     apiKey = config.libspotify.apiKey or null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15860,11 +15860,12 @@ in
 
   steamPackages = callPackage ../games/steam { };
 
-  steam = steamPackages.steam-chrootenv.override {
+  steam = if stdenv.isDarwin then callPackage ../games/steam/darwin.nix {}
+  else if stdenv.isLinux then steamPackages.steam-chrootenv.override {
     # DEPRECATED
     withJava = config.steam.java or false;
     withPrimus = config.steam.primus or false;
-  };
+  } else null;
 
   steam-run = steam.run;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13195,7 +13195,9 @@ in
 
   gollum = callPackage ../applications/misc/gollum { };
 
-  google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
+  google-chrome = if stdenv.isDarwin
+  then callPackage ../applications/networking/browsers/google-chrome/darwin.nix {}
+  else callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
 
   google-chrome-beta = google-chrome.override { chromium = chromiumBeta; channel = "beta"; };
 


### PR DESCRIPTION
###### Motivation for this change

This inits derivations for spotify and steam on Darwin. undmg needs to be updated to set the executable bits correctly.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
