### PR TITLE
pari/gp: 2.7.6 -> 2.9.0

### DIFF
--- a/pkgs/applications/science/math/pari/default.nix
+++ b/pkgs/applications/science/math/pari/default.nix
@@ -1,30 +1,56 @@
-{ stdenv, fetchurl, gmp, readline }:
+{ stdenv, fetchurl
+, gmp, readline, libX11, libpthreadstubs, tex, perl }:
 
 stdenv.mkDerivation rec {
-  version = "2.7.6";
+
   name = "pari-${version}";
+  version = "2.9.0";
 
   src = fetchurl {
     url = "http://pari.math.u-bordeaux.fr/pub/pari/unix/${name}.tar.gz";
-    sha256 = "04dqi697czd8mmw8aiwzrkgbvkjassqagg6lfy3lkf1k5qi9g9rr";
+    sha256 = "0rljznrvjgy71n4hlpgx1l1yy1qx52mly68k3c05ds21mlvzg92a";
   };
 
-  buildInputs = [gmp readline];
+  buildInputs = [ gmp readline libX11 libpthreadstubs tex perl ];
 
   configureScript = "./Configure";
   configureFlags =
+    "--mt=pthread" +
     "--with-gmp=${gmp.dev} " +
     "--with-readline=${readline.dev}";
 
+  makeFlags = "all";
+
   meta = with stdenv.lib; {
     description = "Computer algebra system for high-performance number theory computations";
-    homepage    = "http://pari.math.u-bordeaux.fr/";
-    license     = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ertes raskin ];
-    platforms   = platforms.linux;
+    longDescription = ''
+       PARI/GP is a widely used computer algebra system designed for fast
+       computations in number theory (factorizations, algebraic number theory,
+       elliptic curves...), but also contains a large number of other useful
+       functions to compute with mathematical entities such as matrices,
+       polynomials, power series, algebraic numbers etc., and a lot of
+       transcendental functions. PARI is also available as a C library to allow
+       for faster computations.
 
-    inherit version;
+       Originally developed by Henri Cohen and his co-workers (Université
+       Bordeaux I, France), PARI is now under the GPL and maintained by Karim
+       Belabas with the help of many volunteer contributors.
+
+       - PARI is a C library, allowing fast computations.  
+       - gp is an easy-to-use interactive shell giving access to the
+          PARI functions.
+       - GP is the name of gp's scripting language.
+       - gp2c, the GP-to-C compiler, combines the best of both worlds 
+          by compiling GP scripts to the C language and transparently loading 
+          the resulting functions into gp. (gp2c-compiled scripts will typically
+          run 3 or 4 times faster.) gp2c currently only understands a subset
+           of the GP language.
+    '';
+    homepage    = "http://pari.math.u-bordeaux.fr/";
     downloadPage = "http://pari.math.u-bordeaux.fr/download.html";
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ertes raskin AndersonTorres ];
+    platforms   = platforms.linux;
     updateWalker = true;
   };
 }

--- a/pkgs/applications/science/math/pari/gp2c.nix
+++ b/pkgs/applications/science/math/pari/gp2c.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl
+, pari, perl }:
+
+stdenv.mkDerivation rec {
+
+  name = "gp2c-${version}";
+  version = "0.0.10";
+
+  src = fetchurl {
+    url = "http://pari.math.u-bordeaux.fr/pub/pari/GP2C/${name}.tar.gz";
+    sha256 = "1xhpz5p81iw261ay1kip283ggr0ir8ydz8qx3v24z8jfms1r3y70";
+  };
+
+  buildInputs = [ pari perl ];
+
+  configureFlags = [
+    "--with-paricfg=${pari}/lib/pari/pari.cfg"
+    "--with-perl=${perl}/bin/perl" ];
+
+  meta = with stdenv.lib; {
+    description =  "A compiler to translate GP scripts to PARI programs";
+    homepage    = "http://pari.math.u-bordeaux.fr/";
+    downloadPage = "http://pari.math.u-bordeaux.fr/download.html";
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}
+# TODO: add it as "source file" for default package

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16833,7 +16833,8 @@ in
 
   wxmaxima = callPackage ../applications/science/math/wxmaxima { wxGTK = wxGTK30; };
 
-  pari = callPackage ../applications/science/math/pari {};
+  pari = callPackage ../applications/science/math/pari { tex = texlive.combined.scheme-basic; };
+  gp2c = callPackage ../applications/science/math/pari/gp2c.nix { };
   pari-unstable = callPackage ../applications/science/math/pari/unstable.nix {};
 
   ratpoints = callPackage ../applications/science/math/ratpoints {};


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


