### PR TITLE
mopidy-gmusic: 1.0.0 -> 2.0.0

### DIFF
--- a/pkgs/applications/audio/mopidy-gmusic/default.nix
+++ b/pkgs/applications/audio/mopidy-gmusic/default.nix
@@ -2,14 +2,19 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "mopidy-gmusic-${version}";
-  version = "1.0.0";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "https://github.com/mopidy/mopidy-gmusic/archive/v${version}.tar.gz";
-    sha256 = "0yfilzfamy1bxnmgb1xk56jrk4sz0i7vcnc0a8klrm9sc7agnm9i";
+    sha256 = "1xryw2aixfza3brxlgjdlg0lghlb17g7kay9zy56mlzp0jr7m87j";
   };
 
-  propagatedBuildInputs = [ mopidy pythonPackages.requests2 pythonPackages.gmusicapi ];
+  propagatedBuildInputs = [
+    mopidy
+    pythonPackages.requests2
+    pythonPackages.gmusicapi
+    pythonPackages.cachetools
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/pycryptodome/default.nix
+++ b/pkgs/development/python-modules/pycryptodome/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl, python, buildPythonPackage, gmp }:
+
+buildPythonPackage rec {
+  version = "3.4.3";
+  name = "pycryptodome-${version}";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pycryptodome/${name}.tar.gz";
+    sha256 = "1x2kk2va77lqys2dd7gwh35m4vrp052zz5hvv1zqxzksg2srf5jb";
+  };
+
+  meta = {
+    homepage = "https://www.pycryptodome.org/";
+    description = "Python Cryptography Toolkit";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7271,12 +7271,12 @@ in {
   };
 
   gpsoauth = buildPythonPackage rec {
-    version = "0.0.4";
+    version = "0.2.0";
     name = "gpsoauth-${version}";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/g/gpsoauth/${name}.tar.gz";
-      sha256 = "1mhd2lkl1f4fmia1cwxwik8gvqr5q16scjip7kfwzadh9a11n9kw";
+      sha256 = "01zxw8rhml8xfwda7ba8983890bzwkfa55ijd6qf8qrdy6ja1ncn";
     };
 
     propagatedBuildInputs = with self; [
@@ -7289,7 +7289,7 @@ in {
       pyopenssl
       pyasn1
       pycparser
-      pycrypto
+      pycryptodome
       requests2
       six
     ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7078,18 +7078,18 @@ in {
   };
 
   gmusicapi = with pkgs; buildPythonPackage rec {
-    name = "gmusicapi-7.0.0";
+    name = "gmusicapi-10.1.0";
 
     src = pkgs.fetchurl {
-      url = "mirror://pypi/g/gmusicapi/gmusicapi-7.0.0.tar.gz";
-      sha256 = "1zji4cgylyzz97cz69lywkbsn5nvvzrhk7iaqnpqpfvj9gwdchwn";
+      url = "mirror://pypi/g/gmusicapi/gmusicapi-10.1.0.tar.gz";
+      sha256 = "0smlrafh1bjzrcjzl7im8pf8f04gcnx92lf3g5qr7yzgq8k20xa2";
     };
 
     propagatedBuildInputs = with self; [
       validictory
       decorator
       mutagen
-      protobuf
+      protobuf3_0
       setuptools
       requests2
       dateutil
@@ -7100,6 +7100,7 @@ in {
       pyopenssl
       gpsoauth
       MechanicalSoup
+      future
     ];
 
     meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -218,6 +218,8 @@ in {
 
   pycrypto = callPackage ../development/python-modules/pycrypto { };
 
+  pycryptodome = callPackage ../development/python-modules/pycryptodome { };
+
   pyexiv2 = if (!isPy3k) then callPackage ../development/python-modules/pyexiv2 {} else throw "pyexiv2 not supported for interpreter ${python.executable}";
 
   pygame = callPackage ../development/python-modules/pygame { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14761,11 +14761,11 @@ in {
   };
 
   mutagen = buildPythonPackage (rec {
-    name = "mutagen-1.32";
+    name = "mutagen-1.34";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/m/mutagen/${name}.tar.gz";
-      sha256 = "1d9sxl442xjj7pdyjj5h0dsjyd7d3wqswr8icqqgqdmg9k8dw8bp";
+      sha256 = "06anfzpjajwwh25n3afavwafrix3abahgwfr2zinrhqh2w98kw5s";
     };
 
     # Needed for tests only


### PR DESCRIPTION
###### Motivation for this change
Gmusic api changed - 2.x version is required to connect to google music.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


