### PR TITLE
file_cmds: init at 264.1.1

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -39,6 +39,7 @@ let
       network_cmds  = "481.20.1";
       basic_cmds    = "55";
       adv_cmds      = "163";
+      file_cmds     = "264.1.1";
     };
     "osx-10.11.5" = {
       Libc          = "1082.50.1"; # 10.11.6 still unreleased :/
@@ -231,6 +232,7 @@ let
     basic_cmds      = applePackage "basic_cmds"        "osx-10.11.6"     "0hvab4b1v5q2x134hdkal0rmz5gsdqyki1vb0dbw4py1bqf0yaw9" {};
     developer_cmds  = applePackage "developer_cmds"    "osx-10.11.6"     "1r9c2b6dcl22diqf90x58psvz797d3lxh4r2wppr7lldgbgn24di" {};
     network_cmds    = applePackage "network_cmds"      "osx-10.11.6"     "0lhi9wz84qr1r2ab3fb4nvmdg9gxn817n5ldg7zw9gnf3wwn42kw" {};
+    file_cmds       = applePackage "file_cmds"         "osx-10.11.6"     "1zfxbmasps529pnfdjvc13p7ws2cfx8pidkplypkswyff0nff4wp" {};
 
     libsecurity_apple_csp      = libsecPackage "libsecurity_apple_csp"      "osx-10.7.5" "1ngyn1ik27n4x981px3kfd1z1n8zx7r5w812b6qfjpy5nw4h746w" {};
     libsecurity_apple_cspdl    = libsecPackage "libsecurity_apple_cspdl"    "osx-10.7.5" "1svqa5fhw7p7njzf8bzg7zgc5776aqjhdbnlhpwmr5hmz5i0x8r7" {};

--- a/pkgs/os-specific/darwin/apple-source-releases/file_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/file_cmds/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, appleDerivation, xcbuild, zlib, bzip2, lzma }:
+
+appleDerivation rec {
+  buildInputs = [ xcbuild zlib bzip2 lzma ];
+
+  # some commands not working:
+  # mtree: _simple.h not found
+  # ipcs: sys/ipcs.h not found
+  # so remove their targets from the project
+  patchPhase = ''
+    substituteInPlace file_cmds.xcodeproj/project.pbxproj \
+      --replace "FC8A8CAA14B655FD001B97AD /* PBXTargetDependency */," "" \
+      --replace "FC8A8C9C14B655FD001B97AD /* PBXTargetDependency */," "" \
+      --replace "productName = file_cmds;" ""
+    sed -i -re "s/name = ([a-zA-Z]+);/name = \1; productName = \1;/" file_cmds.xcodeproj/project.pbxproj
+  '';
+
+  # temporary install phase until xcodebuild has "install" support
+  installPhase = ''
+    mkdir -p $out/bin/
+    install file_cmds-*/Build/Products/Release/* $out/bin/
+
+    for n in 1; do
+      mkdir -p $out/share/man/man$n
+      install */*.$n $out/share/man/man$n
+    done
+  '';
+
+  meta = {
+    platforms = stdenv.lib.platforms.darwin;
+    maintainers = with stdenv.lib.maintainers; [ matthewbauer ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This will add the "file_cmds" derivation to apple-source-releases.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


