### PR TITLE
graphviz: Make derivations pure on non-NixOS systems.

### DIFF
--- a/pkgs/tools/graphics/graphviz/2.0.nix
+++ b/pkgs/tools/graphics/graphviz/2.0.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
       "--with-jpeglibdir=${libjpeg.out}/lib"
       "--with-expatincludedir=${expat.dev}/include"
       "--with-expatlibdir=${expat.out}/lib"
+      "--with-ltdl-include=${libtool}/include"
+      "--with-ltdl-lib=${libtool.lib}/lib"
     ]
     ++ stdenv.lib.optional (xlibsWrapper == null) "--without-x";
 

--- a/pkgs/tools/graphics/graphviz/2.32.nix
+++ b/pkgs/tools/graphics/graphviz/2.32.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
       "--with-jpeglibdir=${libjpeg.out}/lib"
       "--with-expatincludedir=${expat.dev}/include"
       "--with-expatlibdir=${expat.out}/lib"
+      "--with-ltdl-include=${libtool}/include"
+      "--with-ltdl-lib=${libtool.lib}/lib"
       "--with-cgraph=no"
       "--with-sparse=no"
     ]


### PR DESCRIPTION
###### Motivation for this change
Without these flags the graphviz configure script will look for `libltdl` in `/usr/lib` (and will likely find it on non-NixOS systems). Making these paths explicit makes the graphviz derivations pure on non-NixOS systems.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


