### PR TITLE
Fix/ctrlp cmatcher

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -304,16 +304,14 @@ rec {
   };
 
   ctrlp-cmatcher = buildVimPluginFrom2Nix { # created by nix#NixDerivation
-    name = "ctrlp-cmatcher-2016-09-22";
+    name = "ctrlp-cmatcher-2015-10-15";
     src = fetchgit {
       url = "git://github.com/JazzCore/ctrlp-cmatcher";
       rev = "6c36334f106b6fd981d23e724e9a618734cab43a";
       sha256 = "1573kd6xf3n8sxlz2j4zadai4rnc7k3s9c54648yfzickwn57d8q";
     };
     dependencies = [];
-
     buildInputs = [ python ];
-
     buildPhase = ''
       patchShebangs .
       ./install.sh

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/ctrlp-cmatcher
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/ctrlp-cmatcher
@@ -1,0 +1,5 @@
+    buildInputs = [ python ];
+    buildPhase = ''
+      patchShebangs .
+      ./install.sh
+    '';


### PR DESCRIPTION
###### Motivation for this change
Requested by @vcunat in #20237 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

