### PR TITLE
gnome-calculator: update license to gpl3

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/core/gnome-calculator/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/gnome-calculator/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     homepage = https://wiki.gnome.org/action/show/Apps/Calculator;
     description = "Application that solves mathematical equations and is suitable as a default application in a Desktop environment";
     maintainers = gnome3.maintainers;
-    license = licenses.gpl2;
+    license = licenses.gpl3;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-calculator/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-calculator/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     homepage = https://wiki.gnome.org/action/show/Apps/Calculator;
     description = "Application that solves mathematical equations and is suitable as a default application in a Desktop environment";
     maintainers = gnome3.maintainers;
-    license = licenses.gpl2;
+    license = licenses.gpl3;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Updated the license based on the upstream license information. Fixes #20679.

###### Things done
Updated both 3.22 and 3.20 calculator license information from default.nix to GPLv3 as gnome-calculator uses GPLv3 since 3.16. 

