### PR TITLE
postgresql: fix build on darwin

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -58,7 +58,7 @@ let
         substituteInPlace "$out/lib/pgxs/src/Makefile.global" --replace ${stdenv.cc}/bin/ld ld
       '';
 
-    postFixup =
+    postFixup = lib.optionalString (!stdenv.isDarwin)
       ''
         # initdb needs access to "locale" command from glibc.
         wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin


### PR DESCRIPTION
This fixes the build of postgresql on OS X as [reported](https://github.com/NixOS/nixpkgs/commit/589cc65306229223176010d0b512fd676c491df6#commitcomment-19941795) by @jwiegley.

Tested on both NixOS en OS X.

@edolstra this also needs to be cherry picked on `release-16.09`.