### PR TITLE
Fix lnav-0.8.0 compilation.

### DIFF
--- a/pkgs/tools/misc/lnav/default.nix
+++ b/pkgs/tools/misc/lnav/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pcre, sqlite, ncurses,
+{ stdenv, fetchFromGitHub, pcre-cpp, sqlite, ncurses,
   readline, zlib, bzip2, autoconf, automake }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     zlib
     bzip2
     ncurses
-    pcre
+    pcre-cpp
     readline
     sqlite
   ];


### PR DESCRIPTION
###### Motivation for this change

Doing a `nix-env -i lnav` on current master fails:

    command_executor.cc:34:21: fatal error: pcrecpp.h: No such file or directory

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This fixes by using pcre-cpp instead of pcre.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>