### PR TITLE
blivet: Remove unneccesary patching

### DIFF
--- a/pkgs/development/python-modules/blivet/default.nix
+++ b/pkgs/development/python-modules/blivet/default.nix
@@ -28,7 +28,6 @@ in buildPythonPackage rec {
     }' blivet/formats/__init__.py
     sed -i -e 's|"lsof"|"${lsof}/bin/lsof"|' blivet/formats/fs.py
     sed -i -r -e 's|"(u?mount)"|"${utillinux}/bin/\1"|' blivet/util.py
-    sed -i -e '/pvscan/s/, *"--cache"//' blivet/devicelibs/lvm.py
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/tools/filesystems/nixpart/0.4/blivet.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/blivet.nix
@@ -28,7 +28,6 @@ buildPythonApplication rec {
     }' blivet/formats/__init__.py
     sed -i -e 's|"lsof"|"${lsof}/bin/lsof"|' blivet/formats/fs.py
     sed -i -r -e 's|"(u?mount)"|"${utillinux.bin}/bin/\1"|' blivet/util.py
-    sed -i '/pvscan/s/, *"--cache"//' blivet/devicelibs/lvm.py
   '' + stdenv.lib.optionalString useNixUdev ''
     sed -i -e '/find_library/,/find_library/ {
       c libudev = "${systemd.lib}/lib/libudev.so.1"


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixops/issues/552

`--cache` argument is now mandatory for `pvscan` both from hetzner rescue
system and from nixpkgs.

With this patch I was able to do successful deploy to hetzner host.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
