### PR TITLE
BItcoin and Electrum servers

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -282,6 +282,7 @@
       stanchion = 262;
       riak-cs = 263;
       bitcoind = 264;
+      electrum-server = 265;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -534,6 +535,7 @@
       stanchion = 262;
       riak-cs = 263;
       #bitcoind = 264; # unused
+      #electrum-server = 265; # unused
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -281,6 +281,7 @@
       ipfs  = 261;
       stanchion = 262;
       riak-cs = 263;
+      bitcoind = 264;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -532,6 +533,7 @@
       ipfs = 261;
       stanchion = 262;
       riak-cs = 263;
+      #bitcoind = 264; # unused
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -231,6 +231,7 @@
   ./services/misc/apache-kafka.nix
   ./services/misc/autofs.nix
   ./services/misc/bepasty.nix
+  ./services/misc/bitcoind.nix
   ./services/misc/canto-daemon.nix
   ./services/misc/calibre-server.nix
   ./services/misc/cfdyndns.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -246,6 +246,7 @@
   ./services/misc/emby.nix
   ./services/misc/errbot.nix
   ./services/misc/etcd.nix
+  ./services/misc/electrum-server.nix
   ./services/misc/felix.nix
   ./services/misc/folding-at-home.nix
   ./services/misc/gammu-smsd.nix

--- a/nixos/modules/services/misc/bitcoind.nix
+++ b/nixos/modules/services/misc/bitcoind.nix
@@ -1,0 +1,113 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.bitcoind;
+
+  args = [
+    "-disablewallet"
+    "-server"
+    "-txindex"
+    "-datadir=${cfg.dataDir}"
+    "-port=${toString cfg.port}"
+    "-rpcbind=${cfg.rpcAddress}"
+    "-rpcport=${toString cfg.rpcPort}"
+    "-rpcuser=${cfg.rpcUser}"
+    "-rpcpassword=${cfg.rpcPassword}"
+  ] ++ map (x: "-rpcallowip=${x}") cfg.rpcAllowIp
+    ++ cfg.extraOptions;
+
+in {
+  options = {
+    services.bitcoind = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable Bitcoin daemon";
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/bitcoind";
+        description = "Directory to contain blockchain";
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 8333;
+        description = "Port for incoming connections";
+      };
+
+      rpcAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        example = "0.0.0.0";
+        description = "Address to which Bitcoin RPC listener is bound";
+      };
+
+      rpcPort = mkOption {
+        type = types.int;
+        default = 8332;
+        description = "Port to which Bitcoin RPC listener is bound";
+      };
+
+      rpcAllowIp = mkOption {
+        type = types.listOf types.str;
+        default = [ "127.0.0.1" ];
+        description = "Allowed source IP addresses to connect to the daemon";
+      };
+
+      rpcUser = mkOption {
+        type = types.str;
+        default = "guest";
+        description = "RPC user for logging in into bitcoind";
+      };
+
+      rpcPassword = mkOption {
+        type = types.str;
+        default = "guest";
+        description = "RPC password for logging in into bitcoind. WARNING: It will be globally accessible in the Nix store!";
+      };
+
+      extraOptions = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Extra command line options for the Bitcoin daemon";
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    users.extraUsers.bitcoind = {
+      uid = config.ids.uids.bitcoind;
+      group = "nogroup";
+      home = cfg.dataDir;
+      createHome = true;
+    };
+
+    systemd.services.bitcoind = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        User = "bitcoind";
+        Group = "nogroup";
+        ExecStart = "${pkgs.altcoins.bitcoind}/bin/bitcoind ${escapeShellArgs args}";
+        PermissionsStartOnly = true;
+      };
+
+      preStart = ''
+        if [ ! -d "${cfg.dataDir}" ]; then
+          mkdir -p "${cfg.dataDir}"
+          chown bitcoind:nogroup "${cfg.dataDir}"
+        fi
+      '';
+    };
+
+  };
+}

--- a/nixos/modules/services/misc/electrum-server.nix
+++ b/nixos/modules/services/misc/electrum-server.nix
@@ -1,0 +1,172 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.electrum-server;
+
+  configFile = pkgs.writeText "electrum.conf" ''
+    [server]
+    # hostname. set it to a FQDN in order to be reached from outside
+    host = ${cfg.hostname}
+    # paths
+    # logfile = /var/log/electrum.log
+    # ports
+    electrum_rpc_port = ${toString cfg.rpcPort}
+    stratum_tcp_port = ${toString cfg.stratumPort}
+    # SSL
+    ${optionalString (cfg.sslCert != null) "ssl_certfile = ${cfg.sslCert}"}
+    ${optionalString (cfg.sslKey != null) "ssl_keyfile = ${cfg.sslKey}"}
+    ${optionalString (cfg.stratumSSLPort != null) "stratum_tcp_ssl_port = ${toString cfg.stratumSSLPort}"}
+
+    [leveldb]
+    # path to your database
+    path = ${cfg.dataDir}
+    pruning_limit = ${toString cfg.pruningLimit}
+
+    [bitcoind]
+    bitcoind_host = ${cfg.bitcoindHost}
+    bitcoind_port = ${toString cfg.bitcoindPort}
+    bitcoind_user = ${cfg.bitcoindUser}
+    bitcoind_password = ${cfg.bitcoindPassword}
+  '';
+
+in {
+  options = {
+    services.electrum-server = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable Electrum server daemon";
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/electrum-server";
+        description = "Data directory for Electrum server database";
+      };
+
+      hostname = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "Hostname to bind Electrum server to";
+      };
+
+      rpcPort = mkOption {
+        type = types.int;
+        default = 8000;
+        description = "RPC port for Electrum server";
+      };
+
+      stratumPort = mkOption {
+        type = types.int;
+        default = 50001;
+        description = "Stratum port for Electrum server";
+      };
+
+      stratumSSLPort = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 50002;
+        description = "SSL Stratum port for Electrum server";
+      };
+
+      sslCert = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "SSL certificate to use.";
+      };
+
+      sslKey = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "SSL key to use.";
+      };
+
+      bitcoindHost = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "Bitcoin server host to use with Electrum";
+      };
+
+      bitcoindPort = mkOption {
+        type = types.int;
+        default = 8332;
+        description = "Bitcoin server port to use with Electrum";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "electrum-server";
+        description = "User to run Electrum server";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nogroup";
+        description = "Group to run Electrum server";
+      };
+
+      bitcoindUser = mkOption {
+        type = types.str;
+        default = "guest";
+        description = "Bitcoin server user";
+      };
+
+      bitcoindPassword = mkOption {
+        type = types.str;
+        default = "guest";
+        description = "Bitcoin server password. WARNING: it will be globally accessible in the Nix store!";
+      };
+
+      pruningLimit = mkOption {
+        type = types.int;
+        default = 100;
+        description = "For each address, history will be pruned if it is longer than this limit";
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf (cfg.sslCert != null || cfg.sslKey != null) {
+      services.electrum-server.stratumSSLPort = mkDefault 50002;
+    })
+
+    { assertions = singleton {
+        assertion = all (x: x == (cfg.stratumSSLPort != null)) [(cfg.sslCert != null) (cfg.sslKey != null)];
+        message = "You should specify both SSL certificate and key for Electrum server";
+      };
+
+      users.extraUsers = mkIf (cfg.user == "electrum-server") {
+        electrum-server = {
+          uid = config.ids.uids.electrum-server;
+          group = cfg.group;
+          home = cfg.dataDir;
+          createHome = true;
+        };
+      };
+
+      systemd.services.electrum-server = {
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          User = cfg.user;
+          Group = cfg.group;
+          ExecStart = "${pkgs.electrum-server}/bin/run_electrum_server.py --conf ${configFile}";
+          PermissionsStartOnly = true;
+        };
+
+        preStart = ''
+          if [ ! -d "${cfg.dataDir}" ]; then
+            mkdir -p "${cfg.dataDir}"
+            chown "${cfg.user}:${cfg.group}" "${cfg.dataDir}"
+          fi
+        '';
+      };
+    }
+  ]);
+}

--- a/pkgs/applications/misc/electrum/server.nix
+++ b/pkgs/applications/misc/electrum/server.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "electrum-server-${version}";
+  version = "2016-10-10";
+
+  src = fetchFromGitHub {
+    owner = "spesmilo";
+    repo = "electrum-server";
+    rev = "c46e6daae4f257b2b28a362933c091d0b3ef9f43";
+    sha256 = "0n89m6brzpx0ys2cc5w0igpw1d6548f27qzgn70paijvcc37gfg7";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    irc jsonrpclib plyvel
+  ];
+
+  postPatch = ''
+    sed -i 's/, *<=14.0//g' setup.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Electrum server";
+    homepage = https://electrum.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12572,6 +12572,8 @@ in
 
   electrum = callPackage ../applications/misc/electrum { };
 
+  electrum-server = callPackage ../applications/misc/electrum/server.nix { };
+
   electrum-dash = callPackage ../applications/misc/electrum-dash { };
 
   elinks = callPackage ../applications/networking/browsers/elinks { };


### PR DESCRIPTION
###### Motivation for this change

Add services to keep your own Electrum server node.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Notice that while that seems to work, I haven't been able to use it because Electrum server is _very_ inefficient, to the point that my server is not fast enough to be synced with the network.