### PR TITLE
less: 483 -> 481: Use recommended upstream version since less-483.tar.gz has disappeared

### DIFF
--- a/pkgs/tools/misc/less/default.nix
+++ b/pkgs/tools/misc/less/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, ncurses, lessSecure ? false }:
 
 stdenv.mkDerivation rec {
-  name = "less-483";
+  name = "less-481";
 
   src = fetchurl {
     url = "http://www.greenwoodsoftware.com/less/${name}.tar.gz";
-    sha256 = "07z43kwbmba2wh3q1gps09l72p8izfagygmqq1izi50s2h51mfvy";
+    sha256 = "19fxj0h10y5bhr3a1xa7kqvnwl44db3sdypz8jxl1q79yln8z8rz";
   };
 
   configureFlags = [ "--sysconfdir=/etc" ] # Look for ‘sysless’ in /etc.


### PR DESCRIPTION
###### Motivation for this change
Change less version to 481 since the current source http://www.greenwoodsoftware.com/less/less-483.tar.gz has become unavailable, making it impossible to build this.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is a fix for the current package source file
  http://www.greenwoodsoftware.com/less/less-483.tar.gz
not being available anymore.

We bump the less version back to 481, and adjust the source package hash
accordingly. This is a (slight) downgrade from 483 as opposed to an
upgrade since
  a) 481 is the current Recommended version by http://www.greenwoodsoftware.com/less/download.html
  b) Upstream is unreliable about keeping experimental versions around.