### PR TITLE
Emacs macport version fix

### DIFF
--- a/pkgs/applications/editors/emacs/macport-24.5.nix
+++ b/pkgs/applications/editors/emacs/macport-24.5.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     "--enable-mac-app=$$out/Applications"
   ];
 
-  CFLAGS = "-O3 -DMAC_OS_X_VERSION_MAX_ALLOWED=1090";
+  CFLAGS = "-O3 -DMAC_OS_X_VERSION_MAX_ALLOWED=1090 -DMAC_OS_X_VERSION_MIN_REQUIRED=1090";
   LDFLAGS = "-O3 -L${ncurses.out}/lib";
 
   postInstall = ''

--- a/pkgs/applications/editors/emacs/macport-25.1.nix
+++ b/pkgs/applications/editors/emacs/macport-25.1.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation rec {
   emacsName = "emacs-25.1";
-  name = "${emacsName}-mac-6.0";
+  name = "${emacsName}-mac-6.1";
 
   builder = ./builder.sh;
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   macportSrc = fetchurl {
     url = "ftp://ftp.math.s.chiba-u.ac.jp/emacs/${name}.tar.gz";
-    sha256 = "2f7a3fd826e6dea541ada04f4a1ff2903a87a1f736b89c5b90bf7bb820568e34";
+    sha256 = "1zwxh7zsvwcg221mpjh0dhpdas3j9mc5q92pprf8yljl7clqvg62";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/editors/emacs/macport-25.1.nix
+++ b/pkgs/applications/editors/emacs/macport-25.1.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     "--enable-mac-app=$$out/Applications"
   ];
 
-  CFLAGS = "-O3 -DMAC_OS_X_VERSION_MAX_ALLOWED=1090";
+  CFLAGS = "-O3 -DMAC_OS_X_VERSION_MAX_ALLOWED=1090 -DMAC_OS_X_VERSION_MIN_REQUIRED=1090";
   LDFLAGS = "-O3 -L${ncurses.out}/lib";
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

This sets MAC_OS_X_VERSION_MIN_REQUIRED=1090 to get the emacs25macport working again. This should also be needed for emacs24macport.

Also: update to emacs-mac 6.1.


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Previously emacs-macport was giving the error:

- AppKit/AppKit.h: present but cannot be compiled
- Carbon/Carbon.h: present but cannot be compiled

This adds "MAC_OS_X_VERSION_MIN_REQUIRED=1090" to CFLAGS to allow them
to compile with the new 10.10 headers.

Fixes #20682.