### PR TITLE
gnome-mines:update license to GPLv3

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/games/gnome-mines/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/games/gnome-mines/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     homepage = https://wiki.gnome.org/Apps/Mines;
     description = "Clear hidden mines from a minefield";
     maintainers = gnome3.maintainers;
-    license = licenses.gpl2;
+    license = licenses.gpl3;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
GNOME mines has recently (in February 2016) been relicensed to GPLv3 (3.22.0 is already GPLv3, 3.20.0 is still GPLv2, thus only mines 3.22 default.nix is updated in this request)
