### PR TITLE
coWPAtty: init at 4.6

### DIFF
--- a/pkgs/tools/security/cowpatty/default.nix
+++ b/pkgs/tools/security/cowpatty/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, openssl, libpcap
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "cowpatty-${version}";
+  version = "4.6";
+
+  buildInputs = [ openssl libpcap ];
+
+  src = fetchurl {
+    url = "http://www.willhackforsushi.com/code/cowpatty/${version}/${name}.tgz";
+    sha256 = "1hivh3bq2maxvqzwfw06fr7h8bbpvxzah6mpibh3wb85wl9w2gyd";
+  };
+
+  installPhase = "make DESTDIR=$out BINDIR=/bin install";
+
+  meta = {
+    description = "Offline dictionary attack against WPA/WPA2 networks";
+    license = licenses.gpl2;
+    homepage = http://www.willhackforsushi.com/?page_id=50;
+    maintainers = with maintainers; [ nico202 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1284,6 +1284,8 @@ in
 
   corkscrew = callPackage ../tools/networking/corkscrew { };
 
+  cowpatty = callPackage ../tools/security/cowpatty { };
+
   cpio = callPackage ../tools/archivers/cpio { };
 
   crackxls = callPackage ../tools/security/crackxls { };


### PR DESCRIPTION
###### Motivation for this change
Missing PenTesting package

###### Things done

- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
