### PR TITLE
sks: init at 1.1.6

### DIFF
--- a/pkgs/servers/sks/default.nix
+++ b/pkgs/servers/sks/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromBitbucket, ocaml, zlib, db48, perl }:
+
+stdenv.mkDerivation rec {
+  name = "sks-${version}";
+  version = "1.1.6";
+
+  src = fetchFromBitbucket {
+    owner = "skskeyserver";
+    repo = "sks-keyserver";
+    rev = "${version}";
+    sha256 = "00q5ma5rvl10rkc6cdw8d69bddgrmvy0ckqj3hbisy65l4idj2zm";
+  };
+
+  buildInputs = [ ocaml zlib db48 perl ];
+
+  makeFlags = [ "PREFIX=$(out)" "MANDIR=$(out)/share/man" ];
+  preConfigure = ''
+    cp Makefile.local.unused Makefile.local
+    sed -i \
+      -e "s:^LIBDB=.*$:LIBDB=-ldb-4.8:g" \
+      Makefile.local
+  '';
+
+  preBuild = "make dep";
+
+  doCheck = true;
+  checkPhase = "./sks unit_test";
+
+  meta = with stdenv.lib; {
+    description = "An OpenPGP keyserver whose goal is to provide easy to
+      deploy, decentralized, and highly reliable synchronization";
+    longDescription = ''
+      SKS is an OpenPGP keyserver whose goal is to provide easy to deploy,
+      decentralized, and highly reliable synchronization. That means that a key
+      submitted to one SKS server will quickly be distributed to all key
+      servers, and even wildly out-of-date servers, or servers that experience
+      spotty connectivity, can fully synchronize with rest of the system.
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3678,6 +3678,8 @@ in
 
   skippy-xd = callPackage ../tools/X11/skippy-xd {};
 
+  sks = callPackage ../servers/sks { };
+
   skydns = callPackage ../servers/skydns { };
 
   sipcalc = callPackage ../tools/networking/sipcalc { };


### PR DESCRIPTION
###### Motivation for this change

Add SKS:
"SKS is an OpenPGP keyserver whose goal is to provide easy to deploy,
decentralized, and highly reliable synchronization. That means that a key
submitted to one SKS server will quickly be distributed to all key
servers, and even wildly out-of-date servers, or servers that experience
spotty connectivity, can fully synchronize with rest of the system."

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (I couldn't test all binaries yet but the unit tests and "sks version" succeed. I.e. everything should be fine.)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've copied the sample configuration files to `$out/var/lib/sks` as I thought about writing a module that just copies some of these config files (especially the web files) to `/var/lib/sks` - might be a bad idea tho... They might also be useful as a reference but I guess one normally wouldn't look for them under the store path.