### PR TITLE
librecad: 2.0.10 -> 2.1.3

### DIFF
--- a/pkgs/applications/misc/librecad/default.nix
+++ b/pkgs/applications/misc/librecad/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, qt4, qmake4Hook, muparser, which, boost, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  version = "2.0.10";
+  version = "2.1.3";
   name = "librecad-${version}";
 
   src = fetchurl {
     url = "https://github.com/LibreCAD/LibreCAD/tarball/${version}";
     name = name + ".tar.gz";
-    sha256 = "13jr0zkirnnpkbx8ysh7j6sh2psxi1dg7ncfjqzyxrcr2b270rcj";
+    sha256 = "1czp8bja61hfav2m7184cq1np1n76w3w6vn0hlkp81hhz9zc62sx";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Upgrade librecad to 2.1.3

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


