### PR TITLE
f3: newer git rev, build extra binaries

### DIFF
--- a/pkgs/tools/filesystems/f3/default.nix
+++ b/pkgs/tools/filesystems/f3/default.nix
@@ -1,20 +1,34 @@
-{ stdenv, fetchFromGitHub }:
-
+{ stdenv, fetchFromGitHub
+, parted, udev
+}:
+let
+  version = "unstable-2016-11-26";
+in
 stdenv.mkDerivation rec {
   name = "f3-${version}";
-  version = "6.0";
 
   enableParallelBuilding = true;
 
   src = fetchFromGitHub {
     owner = "AltraMayor";
     repo = "f3";
-    rev = "v${version}";
-    sha256 = "1azi10ba0h9z7m0gmfnyymmfqb8380k9za8hn1rrw1s442hzgnz2";
+    rev = "eabf001f69a788e64912bc9e812c118a324077d5";
+    sha256 = "0ypqyqwqiy3ynssdd9gamk1jxywg6avb45ndlzhv3wxh2qcframm";
   };
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  buildInputs = [ parted udev ];
+
   patchPhase = "sed -i 's/-oroot -groot//' Makefile";
+
+  buildFlags   = [ "CFLAGS=-fgnu89-inline"  # HACK for weird gcc incompatibility with -O2
+                   "all"                    # f3read, f3write
+                   "extra"                  # f3brew, f3fix, f3probe
+                 ];
+
+  installFlags = [ "PREFIX=$(out)"
+                   "install"
+                   "install-extra"
+                 ];
 
   meta = {
     description = "Fight Flash Fraud";


### PR DESCRIPTION
###### Motivation for this change

The `v6.0` tag is almost a year old, so I've just switched to the newest revision on github. Also, 3 binaries (f3brew, f3fix, f3probe) weren't being built by this derivation. I had to add a HACK for building with the current gcc+glibc, as described here: https://github.com/AltraMayor/f3/issues/34

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md] (https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


