### PR TITLE
[wip] nodejs: building and paxmarking mksnapshot in preBuild

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -48,10 +48,8 @@ in
     preBuild = optionalString stdenv.isDarwin ''
       sed -i -e "s|tr1/type_traits|type_traits|g" \
       -e "s|std::tr1|std|" src/util.h
-    '' + ''
-      make -j${nix.buildCores} -l${nix.buildCores} -C $out mksnapshot
-      paxmark m $out/bin/mksnapshot
-    '';
+    '' + " make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES SHELL=$SHELL $makeFlags $buildFlags -C $out mksnapshot
+      paxmark m $out/bin/mksnapshot";
 
     prePatch = ''
       patchShebangs .

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -49,7 +49,7 @@ in
       sed -i -e "s|tr1/type_traits|type_traits|g" \
       -e "s|std::tr1|std|" src/util.h
     '' + ''
-      make -j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES} -C $out mksnapshot
+      make -j${nix.buildCores} -l${nix.buildCores} -C $out mksnapshot
       paxmark m $out/bin/mksnapshot
     '';
 

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -45,9 +45,12 @@ in
 
     patches = optionals stdenv.isDarwin [ ./no-xcode.patch ];
 
-    preBuild = optionalString stdenv.isDarwin ''
+preBuild = optionalString stdenv.isDarwin ''
       sed -i -e "s|tr1/type_traits|type_traits|g" \
       -e "s|std::tr1|std|" src/util.h
+    '' + ''
+      make -j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES} -C $out mksnapshot
+      paxmark m $out/bin/mksnapshot
     '';
 
     prePatch = ''

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -45,7 +45,7 @@ in
 
     patches = optionals stdenv.isDarwin [ ./no-xcode.patch ];
 
-preBuild = optionalString stdenv.isDarwin ''
+    preBuild = optionalString stdenv.isDarwin ''
       sed -i -e "s|tr1/type_traits|type_traits|g" \
       -e "s|std::tr1|std|" src/util.h
     '' + ''


### PR DESCRIPTION
###### Motivation for this change
Can't build on grsec kernels 'cus MPROTECT violation for mksnapshot.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


