### PR TITLE
pyload: add send2trash as dep

### DIFF
--- a/pkgs/applications/networking/pyload/default.nix
+++ b/pkgs/applications/networking/pyload/default.nix
@@ -6,8 +6,8 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "pyload";
     repo = "pyload";
-    rev = "03f3ad9e39da2b9a378987693c4a69720e4084c7";
-    sha256 = "0fgsz6yzxrlq3qvsyxsyzgmy4za35v1xh3i4drhispk9zb5jm1xx";
+    rev = "721ea9f089217b9cb0f2799c051116421faac081";
+    sha256 = "1ad4r9slx1wgvd2fs4plfbpzi4i2l2bk0lybzsb2ncgh59m87h54";
   };
 
   patches =
@@ -29,7 +29,7 @@ pythonPackages.buildPythonApplication rec {
 
   propagatedBuildInputs = with pythonPackages; [
     pycurl jinja2 beaker thrift simplejson pycrypto feedparser tkinter
-    beautifulsoup
+    beautifulsoup send2trash
   ];
 
   #remove this once the PR patches above are merged. Needed because githubs diff endpoint


### PR DESCRIPTION
###### Motivation for this change
Support more functionality of pyload

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


With this pyload is able to move compressed files into trash after unpacking them