### PR TITLE
su-exec: init at 0.2

### DIFF
--- a/pkgs/tools/security/su-exec/default.nix
+++ b/pkgs/tools/security/su-exec/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "su-exec-${version}";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner  = "ncopa";
+    repo   = "su-exec";
+    rev    = "v${version}";
+    sha256 = "12vqlnpv48cjfh25sn98k1myc7h2wiv5qw2y2awgp6sipzv88abv";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a su-exec $out/bin/su-exec
+  '';
+
+  meta = with stdenv.lib; {
+    description = "switch user and group id and exec";
+    homepage    = "https://github.com/ncopa/su-exec";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ zimbatm ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3756,6 +3756,8 @@ in
 
   sstp = callPackage ../tools/networking/sstp {};
 
+  su-exec = callPackage ../tools/security/su-exec {};
+
   subsurface =
     qt55.callPackage ../applications/misc/subsurface {
         libgit2 = pkgs.libgit2_0_23;


### PR DESCRIPTION
###### Motivation for this change

Package is missing

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


