### PR TITLE
rogue: Add alternative source archive URLs.

### DIFF
--- a/pkgs/games/rogue/default.nix
+++ b/pkgs/games/rogue/default.nix
@@ -4,7 +4,11 @@ stdenv.mkDerivation {
   name = "rogue-5.4.4";
 
   src = fetchurl {
-    url = http://rogue.rogueforge.net/files/rogue5.4/rogue5.4.4-src.tar.gz;
+    urls = [
+      "http://pkgs.fedoraproject.org/repo/pkgs/rogue/rogue5.4.4-src.tar.gz/033288f46444b06814c81ea69d96e075/rogue5.4.4-src.tar.gz"
+      "http://ftp.vim.org/ftp/pub/ftp/os/Linux/distr/slitaz/sources/packages-cooking/r/rogue5.4.4-src.tar.gz"
+      "http://rogue.rogueforge.net/files/rogue5.4/rogue5.4.4-src.tar.gz"
+    ];
     sha256 = "18g81274d0f7sr04p7h7irz0d53j6kd9j1y3zbka1gcqq0gscdvx";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Add working source archive URLs for rogue.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


As of right now, rogue.rogueforge.net has been down for at least several hours
(likely more).
We add two mirrors here which are likely to be more reliable. We keep the
original download location as a fallback, in case that estimate turns out to be
incorrect.