### PR TITLE
terminus-font-ttf: init at 4.40.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -323,6 +323,7 @@
   ocharles = "Oliver Charles <ollie@ocharles.org.uk>";
   odi = "Oliver Dunkl <oliver.dunkl@gmail.com>";
   offline = "Jaka Hudoklin <jakahudoklin@gmail.com>";
+  okasu = "Okasu <oka.sux@gmail.com>";
   olcai = "Erik Timan <dev@timan.info>";
   olejorgenb = "Ole Jørgen Brønner <olejorgenb@yahoo.no>";
   orbekk = "KJ Ørbekk <kjetil.orbekk@gmail.com>";

--- a/pkgs/data/fonts/terminus-font-ttf/default.nix
+++ b/pkgs/data/fonts/terminus-font-ttf/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "terminus-font-ttf-${version}";
+  version = "4.40.1";
+
+  src = fetchurl {
+    url = "http://files.ax86.net/terminus-ttf/files/${version}/terminus-ttf-${version}.zip";
+    sha256 = "c3cb690c2935123035a0b1f3bfdd9511c282dab489cd423e161a47c592edf188";
+  };
+
+  buildInputs = [unzip];
+
+  installPhase = ''
+    for i in *.ttf; do
+      local destname="$(echo "$i" | sed -E 's|-[[:digit:].]+\.ttf$|.ttf|')"
+      install -Dm 644 "$i" "$out/share/fonts/truetype/$destname"
+    done
+
+    install -Dm 644 COPYING "$out/share/doc/COPYING"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A clean fixed width TTF font";
+    longDescription = ''
+      Monospaced bitmap font designed for long work with computers
+      (TTF version, mainly for Java applications)
+    '';
+    homepage = http://files.ax86.net/terminus-ttf;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ okasu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17602,4 +17602,6 @@ in
   fpm2 = callPackage ../tools/security/fpm2 { };
 
   simplenote = callPackage ../applications/misc/simplenote { };
+
+  terminus_font_ttf = callPackage ../data/fonts/terminus-font-ttf { };
 }


### PR DESCRIPTION
###### Motivation for this change
Would be good to have TTF version of terminus font which is already included in nixpkgs,
because non TTF version isn't usable within Java/Browser/etc applications.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


