### PR TITLE
pamix: 1.4.1 -> 1.5

### DIFF
--- a/pkgs/applications/audio/pamix/default.nix
+++ b/pkgs/applications/audio/pamix/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "pamix-${version}";
-  version = "1.4.1";
+  version = "1.5";
 
   src = fetchFromGitHub {
     owner  = "patroclos";
     repo   = "pamix";
-    rev    = "v${version}";
-    sha256 = "06pxpalzynb8z7qwhkfs7sj823k9chdmpyj40rp27f2znf2qga19";
+    rev    = version;
+    sha256 = "1d6b0iv8p73bwq88kdaanm4igvmp9rkq082vyaxpc67mz398yjbp";
   };
 
   nativeBuildInputs = [ autoreconfHook autoconf-archive pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


