### PR TITLE
multi-ghc-travis: git-2015-11-04 -> git-2016-10-23

### DIFF
--- a/pkgs/development/tools/haskell/multi-ghc-travis/default.nix
+++ b/pkgs/development/tools/haskell/multi-ghc-travis/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "multi-ghc-travis-${version}";
-  version = "git-2015-11-04";
+  version = "git-2016-10-23";
 
   buildInputs = [ ghc ];
 
   src = fetchFromGitHub {
     owner = "hvr";
     repo = "multi-ghc-travis";
-    rev = "4c288937ff8b80f6f1532609f9920912856dc3ee";
-    sha256 = "0978k81by403in7iq7ia4hsfwlvaalnjqyh3ihwyw8822a5gm8y9";
+    rev = "03dd35f3801d6af4224906d45e982a748de9960e";
+    sha256 = "1s08n8diis22cafych66zihdnd5q3dkv8m6i3a2s5g5f1phsk3mi";
   };
 
   patchPhase = ''
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    ghc -O --make make_travis_yml.hs -o $out/bin/multi-ghc-travis
+    ghc -O --make make_travis_yml_2.hs -o $out/bin/multi-ghc-travis
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Adds support for GHC8

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


adds support for ghc8