### PR TITLE
nagios: 4.0.8 -> 4.2.3 (for CVE)

### DIFF
--- a/pkgs/servers/monitoring/nagios/default.nix
+++ b/pkgs/servers/monitoring/nagios/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchurl, perl, php, gd, libpng, zlib }:
+{ stdenv, fetchurl, perl, php, gd, libpng, zlib, unzip }:
 
 stdenv.mkDerivation rec {
   name = "nagios-${version}";
-  version = "4.0.8";
+  version = "4.2.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/nagios/nagios-4.x/${name}/${name}.tar.gz";
-    sha256 = "0jyad39wa318613awlnpczrrakvjcipz8qp1mdsig1cp1hjqs9lb";
+    sha256 = "0p16sm5pkbzf4py30hwzm38194cl23wfzsvkhk4jkf3p1fq7xvl3";
   };
 
   patches = [ ./nagios.patch ];
-  buildInputs = [ php perl gd libpng zlib ];
+  buildInputs = [ php perl gd libpng zlib unzip ];
 
   configureFlags = [ "--localstatedir=/var/lib/nagios" ];
   buildFlags = "all";

--- a/pkgs/servers/monitoring/nagios/plugins/official-2.x.nix
+++ b/pkgs/servers/monitoring/nagios/plugins/official-2.x.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "nagios-plugins-${version}";
-  version = "2.0.3";
+  version = "2.1.4";
 
   src = fetchurl {
     url = "http://nagios-plugins.org/download/${name}.tar.gz";
-    sha256 = "0jm0mn55hqwl8ffx8ww9mql2wrkhp1h2k8jw53q3h0ff5m22204g";
+    sha256 = "146hrpcwciz0niqsv4k5yvkhaggs9mr5v02xnnxp5yp0xpdbama3";
   };
 
   # !!! Awful hack. Grrr... this of course only works on NixOS.


### PR DESCRIPTION
###### Motivation for this change

Nagios update contains many security related fixes (see https://www.nagios.org/projects/nagios-core/history/4x/) . 5b6d52b should probably be backported to stable.

Nagios version 4.2.0 fixes:
- CVE-2008-4796
- CVE-2013-4214

Nagios version 4.2.2 fixes:
- CVE-2016-9565

Nagios version 4.2.3 fixes:
- CVE-2016-8641

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

