### PR TITLE
idea-ultimate: 2016.2.2 -> 2016.2.5

### DIFF
--- a/pkgs/applications/editors/idea/default.nix
+++ b/pkgs/applications/editors/idea/default.nix
@@ -180,12 +180,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2016.2.2";
+    version = "2016.2.5";
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}.tar.gz";
-      sha256 = "1z5kr47n3hhx0ck163193lwlh76sykgchnq9hw1ihi25n6655j1z";
+      sha256 = "0g8v3fw3610gyi25x489vlb72200rgb3b4rwh0igr4w35gwdv91h";
     };
     wmClass = "jetbrains-idea";
   };


### PR DESCRIPTION
###### Motivation for this change

- Let's have an updated, bug-fixed version of `idea-ultimate`
- Jetbrains seems to remove any old version from download, so 2016.2.2 is no longer available to downlad, neither 2016.2.3, … Only 2016.2.5 is available for 2016.2.x versions. So `idea-ultimate` is currently no more installable on a 16.09 machine.

`master` is already using a new version `2016.3` that's why I'm opening it against 16.09 :angel: 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Update minor version of idea-ultimate in order to be able to build it.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>