### PR TITLE
matplotlib: Fix "attribute ‘tkinter’ missing"

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     ]
     ++ stdenv.lib.optional enableGtk2 pygtk
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ]
-    ++ stdenv.lib.optionals enableTk [ python.tkinter tcl tk tkinter libX11 ];
+    ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ];
 
   patches =
     [ ./basedirlist.patch ] ++


### PR DESCRIPTION
###### Motivation for this change

Matplotlib with TkAgg was broken due to a reference to the nonexistent attribute `python.tkinter`.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @FRidh @lovek323 