### PR TITLE
matplotlib: Fix TkAgg

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, buildPythonPackage, pycairo, isPy3k
+{ stdenv, fetchurl, writeText, python, buildPythonPackage, pycairo, isPy3k
 , which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado
 , freetype, libpng, pkgconfig, mock, pytz, pygobject3
 , enableGhostscript ? false, ghostscript ? null, gtk3
@@ -15,6 +15,58 @@ assert enableTk -> (tcl != null)
                 && ((!isPy3k) -> tkinter != null)
                 && (libX11 != null)
                 ;
+
+let
+  # Matplotlib tries to find Tcl/Tk by opening a Tk window and asking the
+  # corresponding interpreter object for its library paths. This fails if
+  # `$DISPLAY` is not set. The fallback option assumes that Tcl/Tk are both
+  # installed under the same path which is not true in Nix.
+  # With the following patch we just hard-code these paths into the install
+  # script.
+  tclTkPatch = writeText "tcl_tk.patch" ''
+    --- a/setupext.py
+    +++ b/setupext.py
+    @@ -1480,11 +1480,11 @@ class BackendTkAgg(OptionalBackendPackage):
+             return tcl_lib, tcl_inc, 'tcl' + tk_ver, tk_lib, tk_inc, 'tk' + tk_ver
+
+         def hardcoded_tcl_config(self):
+    -        tcl_inc = "/usr/local/include"
+    -        tk_inc = "/usr/local/include"
+    -        tcl_lib = "/usr/local/lib"
+    -        tk_lib = "/usr/local/lib"
+    -        return tcl_lib, tcl_inc, 'tcl', tk_lib, tk_inc, 'tk'
+    +        tcl_inc = "${tcl}/include"
+    +        tk_inc = "${tk.dev}/include"
+    +        tcl_lib = "${tcl}/lib"
+    +        tk_lib = "${tk}/lib"
+    +        return tcl_lib, tcl_inc, '${tcl.libPrefix}', tk_lib, tk_inc, '${tk.libPrefix}'
+
+         def add_flags(self, ext):
+             if sys.platform == 'win32':
+    @@ -1558,19 +1558,8 @@ class BackendTkAgg(OptionalBackendPackage):
+                 #   3. Use some hardcoded locations that seem to work on a lot
+                 #      of distros.
+
+    -            # Query Tcl/Tk system for library paths and version string
+    -            try:
+    -                tcl_lib_dir, tk_lib_dir, tk_ver = self.query_tcltk()
+    -            except:
+    -                tk_ver = '''
+    -                result = self.hardcoded_tcl_config()
+    -            else:
+    -                result = self.parse_tcl_config(tcl_lib_dir, tk_lib_dir)
+    -                if result is None:
+    -                    result = self.guess_tcl_config(
+    -                        tcl_lib_dir, tk_lib_dir, tk_ver)
+    -                    if result is None:
+    -                        result = self.hardcoded_tcl_config()
+    +            # Always use hardcoded locations in Nix
+    +            result = self.hardcoded_tcl_config()
+
+                 # Add final versions of directories and libraries to ext lists
+                 (tcl_lib_dir, tcl_inc_dir, tcl_lib,
+  '';
+in
 
 buildPythonPackage rec {
   name = "matplotlib-${version}";
@@ -44,21 +96,8 @@ buildPythonPackage rec {
 
   patches =
     [ ./basedirlist.patch ] ++
+    stdenv.lib.optionals enableTk [ tclTkPatch ] ++
     stdenv.lib.optionals stdenv.isDarwin [ ./darwin-stdenv.patch ];
-
-  # Matplotlib tries to find Tcl/Tk by opening a Tk window and asking the
-  # corresponding interpreter object for its library paths. This fails if
-  # `$DISPLAY` is not set. The fallback option assumes that Tcl/Tk are both
-  # installed under the same path which is not true in Nix.
-  # With the following patch we just hard-code these paths into the install
-  # script.
-  postPatch =
-    let
-      inherit (stdenv.lib.strings) substring;
-      tcl_tk_cache = ''"${tk}/lib", "${tcl}/lib", "${substring 0 3 tk.version}"'';
-    in
-    stdenv.lib.optionalString enableTk
-      "sed -i '/self.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py";
 
   checkPhase = ''
     ${python.interpreter} tests.py


### PR DESCRIPTION
###### Motivation for this change

Matplotlib with TkAgg was broken in 16.09 due to separate outputs in `tk`.
The matplotlib packages in `master` and `release-16.09` are so different that the changes in this PR and in #20774 are incompatible.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @FRidh @lovek323

Support for TkAgg was broken due to the package `tk` being split into
multiple outputs: The setup script was unable to locate the tk headers.

This patch fixes that by passing the include path from `tk.dev`
explicitly