### PR TITLE
puddletag: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -2,19 +2,20 @@
 
 let
   pypkgs = python2Packages;
+  pname = "puddletag";
 
 in pypkgs.buildPythonApplication rec {
-  name = "puddletag-${version}";
-  version = "1.1.1";
+  name = "${pname}-${version}";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "keithgg";
-    repo = "puddletag";
-    rev = version;
-    sha256 = "0zmhc01qg64fb825b3kj0mb0r0d9hms30nqvhdks0qnv7ahahqrx";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1g6wa91awy17z5b704yi9kfynnvfm9lkrvpfvwccscr1h8s3qmiz";
   };
 
-  sourceRoot = "${name}-src/source";
+  sourceRoot = "${pname}-v${version}-src/source";
 
   disabled = pypkgs.isPy3k; # work to support python 3 has not begun
 


### PR DESCRIPTION
###### Motivation for this change

Bug fixes from upstream.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
