### PR TITLE
mumudvb: init at 2.0.0

### DIFF
--- a/pkgs/applications/video/mumudvb/default.nix
+++ b/pkgs/applications/video/mumudvb/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "mumudvb-${version}";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    repo = "MuMuDVB";
+    owner = "braice";
+    rev = "${version}";
+    sha256 = "0ym7xlpng0k2048wk77gcm0xbbjz6a766dl0qpdicmzc2bcj1l4m";
+  };
+
+  buildInputs = [ autoreconfHook ];
+
+  meta = {
+    description = "Redistributes streams from DVB or ATSC on a network";
+    homepage = http://mumudvb.net/;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.nico202 ] ;
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13947,6 +13947,8 @@ in
       else null;
   };
 
+  mumudvb = callPackage ../applications/video/mumudvb { };
+
   musescore = qt55.callPackage ../applications/audio/musescore { };
 
   mutt = callPackage ../applications/networking/mailreaders/mutt { };


### PR DESCRIPTION
###### Motivation for this change
[MuMuDVB](https://github.com/braice/MuMuDVB) streams digital tv via IPTV/http 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux


