### PR TITLE
Fix asterisk & asterisk: 13.6.0 -> 14.1.2

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -469,7 +469,7 @@
       ihaskell = 189;
       i2p = 190;
       lambdabot = 191;
-      #asterisk = 192; # unused
+      asterisk = 192;
       plex = 193;
       sabnzbd = 194;
       bird = 195;

--- a/nixos/modules/services/networking/asterisk.nix
+++ b/nixos/modules/services/networking/asterisk.nix
@@ -31,13 +31,13 @@ let
       attrNames allConfFiles
     );
 
-    name = "asterisk.etc";
+    name = "asterisk-etc";
 
     # Default asterisk.conf file
     # (Notice that astetcdir will be set to the path of this derivation)
     asteriskConf = ''
       [directories]
-      astetcdir => @out@
+      astetcdir => /etc/asterisk
       astmoddir => ${pkgs.asterisk}/lib/asterisk/modules
       astvarlibdir => /var/lib/asterisk
       astdbdir => /var/lib/asterisk
@@ -203,6 +203,8 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.asterisk ];
 
+    environment.etc.asterisk.source = asteriskEtc;
+
     users.extraUsers.asterisk =
       { name = asteriskUser;
         group = asteriskGroup;
@@ -242,7 +244,7 @@ in
             # FIXME: This doesn't account for arguments with spaces
             argString = concatStringsSep " " cfg.extraArguments;
           in
-          "${pkgs.asterisk}/bin/asterisk -U ${asteriskUser} -C ${asteriskEtc}/asterisk.conf ${argString} -F";
+          "${pkgs.asterisk}/bin/asterisk -U ${asteriskUser} -C /etc/asterisk/asterisk.conf ${argString} -F";
         Type = "forking";
         PIDFile = "/var/run/asterisk/asterisk.pid";
       };

--- a/nixos/modules/services/networking/asterisk.nix
+++ b/nixos/modules/services/networking/asterisk.nix
@@ -225,6 +225,9 @@ in
 
       wantedBy = [ "multi-user.target" ];
 
+      # Do not restart, to avoid disruption of running calls. Restart unit by yourself!
+      restartIfChanged = false;
+
       preStart = ''
         # Copy skeleton directory tree to /var
         for d in '${varlibdir}' '${spooldir}' '${logdir}'; do
@@ -245,6 +248,8 @@ in
             argString = concatStringsSep " " cfg.extraArguments;
           in
           "${pkgs.asterisk}/bin/asterisk -U ${asteriskUser} -C /etc/asterisk/asterisk.conf ${argString} -F";
+        ExecReload = ''${pkgs.asterisk}/bin/asterisk -x "core reload"
+          '';
         Type = "forking";
         PIDFile = "/var/run/asterisk/asterisk.pid";
       };

--- a/nixos/modules/services/networking/asterisk.nix
+++ b/nixos/modules/services/networking/asterisk.nix
@@ -6,6 +6,7 @@ let
   cfg = config.services.asterisk;
 
   asteriskUser = "asterisk";
+  asteriskGroup = "asterisk";
 
   varlibdir = "/var/lib/asterisk";
   spooldir = "/var/spool/asterisk";
@@ -182,12 +183,18 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers = singleton
-    { name = asteriskUser;
-      uid = config.ids.uids.asterisk;
-      description = "Asterisk daemon user";
-      home = varlibdir;
-    };
+    users.extraUsers.asterisk =
+      { name = asteriskUser;
+        group = asteriskGroup;
+        uid = config.ids.uids.asterisk;
+        description = "Asterisk daemon user";
+        home = varlibdir;
+      };
+
+    users.extraGroups.asterisk =
+      { name = asteriskGroup;
+        gid = config.ids.gids.asterisk;
+      };
 
     systemd.services.asterisk = {
       description = ''
@@ -203,7 +210,7 @@ in
           if [ ! -e "$d" ]; then
             mkdir -p "$d"
             cp --recursive ${pkgs.asterisk}/"$d" "$d"
-            chown --recursive ${asteriskUser} "$d"
+            chown --recursive ${asteriskUser}:${asteriskGroup} "$d"
             find "$d" -type d | xargs chmod 0755
           fi
         done

--- a/nixos/modules/services/networking/asterisk.nix
+++ b/nixos/modules/services/networking/asterisk.nix
@@ -201,6 +201,8 @@ in
   };
 
   config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.asterisk ];
+
     users.extraUsers.asterisk =
       { name = asteriskUser;
         group = asteriskGroup;
@@ -227,7 +229,7 @@ in
           # TODO: Make exceptions for /var directories that likely should be updated
           if [ ! -e "$d" ]; then
             mkdir -p "$d"
-            cp --recursive ${pkgs.asterisk}/"$d" "$d"
+            cp --recursive ${pkgs.asterisk}/"$d"/* "$d"/
             chown --recursive ${asteriskUser}:${asteriskGroup} "$d"
             find "$d" -type d | xargs chmod 0755
           fi

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -43,10 +43,10 @@ stdenv.mkDerivation rec {
 
   # Use the following preConfigure section when building Asterisk from sources
   # other than the release tarball.
-#   preConfigure = ''
-#     ln -s ${coreSounds} sounds/asterisk-core-sounds-en-gsm-1.4.26.tar.gz
-#     ln -s ${mohSounds} sounds/asterisk-moh-opsound-wav-2.03.tar.gz
-#   '';
+  # preConfigure = ''
+  #   ln -s ${coreSounds} sounds/asterisk-core-sounds-en-gsm-1.5.tar.gz
+  #   ln -s ${mohSounds} sounds/asterisk-moh-opsound-wav-2.03.tar.gz
+  #'';
 
   # The default libdir is $PREFIX/usr/lib, which causes problems when paths
   # compiled into Asterisk expect ${out}/usr/lib rather than ${out}/lib.

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -71,9 +71,6 @@ stdenv.mkDerivation rec {
     description = "Software implementation of a telephone private branch exchange (PBX)";
     homepage = http://www.asterisk.org/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ auntie ];
-    # Marked as broken due to needing an update for security issues.
-    # See: https://github.com/NixOS/nixpkgs/issues/18856
-    broken = true;
+    maintainers = with maintainers; [ auntie DerTim1 ];
   };
 }

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -2,19 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "asterisk-${version}";
-  version = "13.6.0";
+  version = "14.1.2";
 
   src = fetchurl {
     url = "http://downloads.asterisk.org/pub/telephony/asterisk/old-releases/asterisk-${version}.tar.gz";
-    sha256 = "0nh0fnqx84as92kk9d73s0386cndd17l06y1c72jl2bdjhyba0ca";
+    sha256 = "0w9s4334rwvpyxm169grmnb4k9yq0l2al73dyh4cb8769qcs0ij8";
   };
 
   # Note that these sounds are included with the release tarball. They are
   # provided here verbatim for the convenience of anyone wanting to build
   # Asterisk from other sources.
   coreSounds = fetchurl {
-    url = http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-core-sounds-en-gsm-1.4.26.tar.gz;
-    sha256 = "2300e3ed1d2ded6808a30a6ba71191e7784710613a5431afebbd0162eb4d5d73";
+    url = http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-core-sounds-en-gsm-1.5.tar.gz;
+    sha256 = "01xzbg7xy0c5zg7sixjw5025pvr4z64kfzi9zvx19im0w331h4cd";
   };
   mohSounds = fetchurl {
     url = http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-moh-opsound-wav-2.03.tar.gz;

--- a/pkgs/servers/asterisk/disable-download.patch
+++ b/pkgs/servers/asterisk/disable-download.patch
@@ -1,7 +1,7 @@
-diff -ruN asterisk-13.2.0/sounds/Makefile asterisk-13.2.0-patched/sounds/Makefile
---- asterisk-13.2.0/sounds/Makefile	2014-09-09 14:01:11.000000000 -0600
-+++ asterisk-13.2.0-patched/sounds/Makefile	2015-03-31 16:12:00.549133670 -0600
-@@ -89,7 +89,7 @@
+diff -ruN asterisk-14.1.2/sounds/Makefile asterisk-14.1.2-patched/sounds/Makefile 
+--- asterisk-14.1.2/sounds/Makefile	2016-11-10 20:43:02.000000000 +0100
++++ asterisk-14.1.2-patched/sounds/Makefile	2016-11-16 10:08:46.591615147 +0100
+@@ -90,7 +90,7 @@
  	  ) && touch "$(1)$(if $(3),/$(3),)/$$@"; \
  	fi
  

--- a/pkgs/servers/asterisk/runtime-vardirs.patch
+++ b/pkgs/servers/asterisk/runtime-vardirs.patch
@@ -1,6 +1,6 @@
-diff -rupN asterisk-13.3.2/build_tools/make_defaults_h asterisk-13.3.2-patched/build_tools/make_defaults_h
---- asterisk-13.3.2/build_tools/make_defaults_h	2012-01-30 14:21:16.000000000 -0700
-+++ asterisk-13.3.2-patched/build_tools/make_defaults_h	2015-04-15 19:07:46.760351155 -0600
+diff -rupN asterisk-14.1.2/build_tools/make_defaults_h asterisk-14.1.2-patched/build_tools/make_defaults_h
+--- asterisk-14.1.2/build_tools/make_defaults_h	2016-11-10 20:43:02.000000000 +0100
++++ asterisk-14.1.2-patched/build_tools/make_defaults_h	2016-11-16 10:09:04.189625495 +0100
 @@ -1,4 +1,13 @@
  #!/bin/sh
 +


### PR DESCRIPTION
###### Motivation for this change
Bring back Asterisk Telephony Server to NixOS. #18856 

- Fix bug in skel creation
- Update to newest version
- Compile with modules lua, pjsip and format_mp3 (e.g. for musiconhold)
- Use /etc/asterisk instead of direct linkt to etc in nixstore (otherwise you have to restart asterisk to reload config changes)
- Add NixOS-Option to use some of the default config files.

Example Configuration to use Asterisk on NixOS could be something like this:
```
{ config, pkgs, lib, ... }:

{
  services.asterisk = {
    enable = true;
    # asterisk.conf here:
    extraConfig = ''
      [options]
      documentation_language = en_US

      [compat]
      pbx_realtime=1.6
      res_agi=1.6
      app_set=1.6

    '';
    confFiles = { # Put not asterisk.conf here
      "agents.conf" = builtins.readFile asterisk/conf/agents.conf;
      "dundi.conf" = builtins.readFile asterisk/conf/dundi.conf;
      "extensions.lua" = builtins.readFile asterisk/conf/extensions.lua;
      "manager.conf" = builtins.readFile asterisk/conf/manager.conf;
      "musiconhold.conf" = builtins.readFile asterisk/conf/musiconhold.conf;
      "sip.conf" = builtins.readFile asterisk/conf/sip.conf + builtins.readFile asterisk/conf/my-sip.conf;
      "voicemail.conf" = builtins.readFile asterisk/conf/voicemail.conf;
      "myconfig.conf" = ''
          ;;Some Asterisk options
      '';
    };
    # useTheseDefaultConfFiles = [
    #   "phone.conf"
    #   "unistim.conf"
    # ];
  };

  networking.firewall.allowedTCPPorts = [ 5060 5600 ];
  networking.firewall.allowedUDPPorts = [ 5060 5600 2048 2051 2727 4569 5036 53357 ];
  networking.firewall.allowedUDPPortRanges = [ { from = 10000; to = 20000; } ];
}
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

