### PR TITLE
nettle: 3.2 -> 3.3

### DIFF
--- a/pkgs/development/libraries/nettle/default.nix
+++ b/pkgs/development/libraries/nettle/default.nix
@@ -1,10 +1,10 @@
 { callPackage, fetchurl, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "3.2";
+  version = "3.3";
 
   src = fetchurl {
     url = "mirror://gnu/nettle/nettle-${version}.tar.gz";
-    sha256 = "15wxhk52yc62rx0pddmry66hqm6z5brrrkx4npd3wh9nybg86hpa";
+    sha256 = "07mif3af077763vc35s1x8vzhzlgqcgxh67c1xr13jnhslkjd526";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

This is mainly a bugfix release.

See http://lists.gnu.org/archive/html/info-gnu/2016-10/msg00003.html
for release announcement.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


This is a bugfix release.

See http://lists.gnu.org/archive/html/info-gnu/2016-10/msg00003.html
for release announcement.