### PR TITLE
keras: 1.0.3 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/Theano/theano-with-cuda/default.nix
+++ b/pkgs/development/python-modules/Theano/theano-with-cuda/default.nix
@@ -17,30 +17,17 @@
 }:
 
 buildPythonPackage rec {
-  name = "Theano-cuda-${version}";
+  name = "Theano-CUDA-${version}";
   version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "Theano";
     repo = "Theano";
-    rev = "46fbfeb628220b5e42bf8277a5955c52d153e874";
-    sha256 = "1sl91gli3jaw5gpjqqab4fiq4x6282spqciaid1s65pjsf3k55sc";
+    rev = "cdac0c69c24cf730eb6689037f9c41bdf1c43686";
+    sha256 = "1wi2sx8kr1jqj15k7w1bmb3hrjkkfgyp2iwqy5q3mqz15k5k377f";
   };
 
   doCheck = false;
-
-  patchPhase = ''
-    pushd theano/sandbox/gpuarray
-    sed -i -re '2s/^/from builtins import bytes\n/g' subtensor.py
-    sed -i -re "s/(b'2')/int(bytes(\1))/g" subtensor.py
-    sed -i -re "s/(ctx.bin_id\[\-2\])/int(\1)/g" subtensor.py
-
-    sed -i -re '2s/^/from builtins import bytes\n/g' dnn.py
-    sed -i -re "s/(b'30')/int(bytes(\1))/g" dnn.py
-    sed -i -re "s/(ctx.bin_id\[\-2:\])/int(\1)/g" dnn.py
-    popd
-  '';
-
   dontStrip = true;
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/libgpuarray/cuda/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/cuda/default.nix
@@ -26,8 +26,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Theano"; 
     repo = "libgpuarray";
-    rev = "fc36a40526c0a8303ace6c574ffdefba7feafe17"; 
-    sha256 = "1kb0k42addqjxiahlcbv6v6271yhsmz71j12186fpy60870i7zm7"; 
+    rev = "6779942f29ff56adff0ed7fbcdc5a41aeeeeda1c";
+    sha256 = "093m0g87myp8jajshp66swhjgxg485cpa857ydyyjmcbaknmry0w";
   }; 
 
   doCheck = true;
@@ -120,7 +120,7 @@ EOF
 
   meta = with stdenv.lib; {
     homepage = https://github.com/Theano/libgpuarray;
-    description = "Library to manipulate tensors on GPU.";
+    description = "Library to manipulate tensors on the GPU";
     license = licenses.free;
     maintainers = with maintainers; [ artuuge ];
     platforms = platforms.linux;

--- a/pkgs/development/python-modules/pycuda/default.nix
+++ b/pkgs/development/python-modules/pycuda/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     homepage = https://github.com/inducer/pycuda/;
-    description = "CUDA integration for Python.";
+    description = "CUDA integration for Python";
     license = licenses.mit;
     maintainers = with maintainers; [ artuuge ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16495,7 +16495,7 @@ in
   blas = callPackage ../development/libraries/science/math/blas { };
 
   clblas-cuda = callPackage ../development/libraries/science/math/clblas/cuda {
-    cudatoolkit = pkgs.cudatoolkit75;
+    cudatoolkit = pkgs.cudatoolkit8;
     inherit (linuxPackages) nvidia_x11;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8646,7 +8646,7 @@ in {
   };
 
   pycuda = callPackage ../development/python-modules/pycuda rec {
-    cudatoolkit = pkgs.cudatoolkit75;
+    cudatoolkit = pkgs.cudatoolkit8;
     inherit (pkgs.stdenv) mkDerivation;
     inherit pythonOlder;
   };
@@ -13511,7 +13511,7 @@ in {
   libgpuarray-cuda = callPackage ../development/python-modules/libgpuarray/cuda/default.nix rec {
     inherit (self) numpy scipy;
     inherit (pkgs.linuxPackages) nvidia_x11;
-    cudatoolkit = pkgs.cudatoolkit75;
+    cudatoolkit = pkgs.cudatoolkit8;
     clblas = pkgs.clblas-cuda;
   };
 
@@ -23357,12 +23357,12 @@ in {
 
   TheanoWithCuda = callPackage ../development/python-modules/Theano/theano-with-cuda (
   let
-    boost = pkgs.boost159.override {
+    boost = pkgs.boost160.override {
       inherit (self) python numpy scipy;
     };
   in rec {
-    cudatoolkit = pkgs.cudatoolkit75;
-    cudnn = pkgs.cudnn5_cudatoolkit75;
+    cudatoolkit = pkgs.cudatoolkit8;
+    cudnn = pkgs.cudnn51_cudatoolkit80;
     inherit (self) numpy scipy;
     pycuda = self.pycuda.override { inherit boost; };
     libgpuarray = self.libgpuarray-cuda.override {
@@ -30303,20 +30303,22 @@ in {
 
   Keras = buildPythonPackage rec {
     name = "Keras-${version}";
-    version = "1.0.3";
-    disabled = isPy3k;
+    version = "1.1.1";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/k/keras/${name}.tar.gz";
-      sha256 = "0wi826bvifvy12w490ghj1g45z5xb83q2cadqh425sg56p98khaq";
+      sha256 = "1di3phykbdya6jx0ddcp7flrlvbyqifqd6i39brgc6ai5vv6f6xy";
     };
+
+    # Tests fail without TensorFlow
+    doCheck = false;
 
     propagatedBuildInputs = with self; [
       six Theano pyyaml
     ];
 
     meta = {
-      description = "Deep Learning library for Theano and TensorFlow";
+      description = "High-level neural networks library for Theano and TensorFlow";
       homepage = "https://keras.io";
       license = licenses.mit;
       maintainers = with maintainers; [ NikolaMandic ];


### PR DESCRIPTION
###### Motivation for this change
This updates Keras and its dependencies to support the latest Python and CUDA versions.

As of now, only the TensorFlow backend can be used (requires #20794). When using the Theano backend, it crashes with the following message:

```bash
Using Theano backend.
ERROR (theano.sandbox.cuda): Failed to compile cuda_ndarray.cu: libcublas.so.8.0: cannot open shared object file: No such file or directory
WARNING (theano.sandbox.cuda): CUDA is installed, but device gpu0 is not available  (error: cuda unavailable)
```

Trying to set the missing paths, leads to a segmentation fault:

```bash
$ result/bin/bash
$ export CUDA_HOME=/nix/store/f4lxdw6pjbj40dic2p546nc05afqvgjx-cudatoolkit-8.0.44/
$ export LD_LIBRARY_PATH=/nix/store/f4lxdw6pjbj40dic2p546nc05afqvgjx-cudatoolkit-8.0.44/lib64/
$ python -m theano
*** Error in `python': free(): invalid pointer: 0x00007f42dd4fa380 ***
======= Backtrace: =========
/usr/lib/libc.so.6(+0x70c4b)[0x7f42fefb3c4b]
/usr/lib/libc.so.6(+0x76fe6)[0x7f42fefb9fe6]
/usr/lib/libc.so.6(+0x777de)[0x7f42fefba7de]
/Users/tim/.theano/compiledir_Linux-4.8--ARCH-x86_64-with-arch--3.5.2-64/cuda_ndarray/cuda_ndarray.so(_ZNSt6locale5_Impl16_M_install_facetEPKNS_2idEPKNS_5facetE+0x142)[0x7f42dd296ff2]
[...]
```

Would it be possible to create a "virtual" package `theano` with a boolean property `gpuSupport`? Right now, Keras pulls in the Keras package without GPU support.

I couldn't check whether the changes from `patchPhase` are still needed to support Python 3.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


