### PR TITLE
shadow: fix collision with coreutils (man groups.1.gz)

### DIFF
--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -43,7 +43,8 @@ stdenv.mkDerivation rec {
   postInstall =
     ''
       # Don't install ‘groups’, since coreutils already provides it.
-      rm $out/bin/groups $out/share/man/man1/groups.*
+      rm $out/bin/groups
+      rm $man/share/man/man1/groups.*
 
       # Move the su binary into the su package
       mkdir -p $su/bin


### PR DESCRIPTION
The `groups.1.gz` collides with one from coreutils. The code to fix this
was already present in expression, but wrongly assumes that share/man/man1
directory will be copied to `man` output *after* `installPhase`.

It turned out, that man directory is set to `man` output at configure step, so we should
remove file from `man` output.