### PR TITLE
urxvt: add vtwheel extension

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-vtwheel.nix
+++ b/pkgs/applications/misc/rxvt_unicode-plugins/urxvt-vtwheel.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchgit, perl }:
+
+stdenv.mkDerivation {
+
+  name = "rxvt_unicode-vtwheel-0.3.2";
+
+  src = fetchgit {
+   url = "https://aur.archlinux.org/urxvt-vtwheel.git";
+   rev = "36d3e861664aeae36a45f96100f10f8fe2218035";
+   sha256 = "1h3vrsbli5q9kr84j5ijbivlhpwlh3l8cv233pg362v2zz4ja8i7";
+  };
+  
+  installPhase = ''
+    sed -i 's|#! perl|#! ${perl}/bin/perl|g' vtwheel
+    mkdir -p $out/lib/urxvt/perl
+    cp vtwheel $out/lib/urxvt/perl
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pass mouse wheel commands to secondary screens (screen, less, nano, etc)";
+    homepage = "https://aur.archlinux.org/packages/urxvt-vtwheel";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danbst ];
+    platforms = with platforms; unix;
+  };
+  
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14475,6 +14475,7 @@ in
       urxvt_tabbedex
       urxvt_font_size
       urxvt_theme_switch
+      urxvt_vtwheel
     ];
   };
 
@@ -14484,6 +14485,7 @@ in
   urxvt_tabbedex = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-tabbedex { };
   urxvt_font_size = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-font-size { };
   urxvt_theme_switch = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-theme-switch { };
+  urxvt_vtwheel = callPackage ../applications/misc/rxvt_unicode-plugins/urxvt-vtwheel.nix { };
 
   uade123 = callPackage ../applications/audio/uade123 {};
 


### PR DESCRIPTION
This allows to scroll content in less, screen, nano, tmux and others
(the ones, who create so called "secondary screens"), similar to VTE-based
terminals.

Note, however, that mouse wheel won't work in `less -X`, which is used
by basic `journalctl`. Fix it with `export SYSTEMD_LESS=FRSMK`