### PR TITLE
teensyduino: init at 1.31

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -1,10 +1,21 @@
 { stdenv, lib, fetchFromGitHub, fetchurl, jdk, ant
 , libusb, libusb1, unzip, zlib, ncurses, readline
-, withGui ? false, gtk2 ? null
+, withGui ? false, gtk2 ? null, withTeensyduino ? false
+  /* Packages needed for Teensyduino */
+, upx, fontconfig, xorg, gcc, xdotool, xvfb_run
+, atk, glib, pango, gdk_pixbuf, libpng12, expat, freetype
 }:
 
 assert withGui -> gtk2 != null;
+assert withTeensyduino -> withGui;
 
+# TODO: Teensyduino is disabled for i686-linux due to an indefinite hang in the
+# xdotool script; the cause of this hang is not yet known.
+# TODO: There is a fair chance that Teensyduino works with arm-linux, but it
+# has not yet been tested.
+if withTeensyduino && (stdenv.system != "x86_64-linux") then throw
+  "Teensyduino is only supported on x86_64-linux at this time (patches welcome)."
+else
 let
   externalDownloads = import ./downloads.nix {inherit fetchurl; inherit (lib) optionalAttrs; inherit (stdenv) system;};
   # Some .so-files are later copied from .jar-s to $HOME, so patch them beforehand
@@ -14,10 +25,37 @@ let
   ;
   # abiVersion 6 is default, but we need 5 for `avrdude_bin` executable
   ncurses5 = ncurses.override { abiVersion = "5"; };
+
+  teensy_libpath = stdenv.lib.makeLibraryPath [
+    atk
+    expat
+    fontconfig
+    freetype
+    gcc.cc.lib
+    gdk_pixbuf
+    glib
+    gtk2
+    libpng12
+    libusb
+    pango
+    xorg.libSM
+    xorg.libX11
+    xorg.libXext
+    xorg.libXft
+    xorg.libXinerama
+    zlib
+  ];
+  teensy_architecture =
+      lib.optionalString (stdenv.system == "x86_64-linux") "linux64"
+      + lib.optionalString (stdenv.system == "i686-linux") "linux32"
+      + lib.optionalString (stdenv.system == "arm-linux") "linuxarm";
+
+  flavor = (if withTeensyduino then "teensyduino" else "arduino")
+             + stdenv.lib.optionalString (!withGui) "-core";
 in
 stdenv.mkDerivation rec {
   version = "1.6.12";
-  name = "arduino${stdenv.lib.optionalString (withGui == false) "-core"}-${version}";
+  name = "${flavor}-${version}";
 
   src = fetchFromGitHub {
     owner = "arduino";
@@ -26,7 +64,19 @@ stdenv.mkDerivation rec {
     sha256 = "0rz8dv1mncwx2wkafakxqdi2y0rq3f72fr57cg0z5hgdgdm89lkh";
   };
 
-  buildInputs = [ jdk ant libusb libusb1 unzip zlib ncurses5 readline ];
+  teensyduino_src = fetchurl {
+    url = "http://www.pjrc.com/teensy/td_131/TeensyduinoInstall.${teensy_architecture}";
+    sha256 =
+      lib.optionalString ("${teensy_architecture}" == "linux64")
+        "1q4wv6s0900hyv9z1mjq33fr2isscps4q3bsy0h12wi3l7ir94g9"
+      + lib.optionalString ("${teensy_architecture}" == "linux32")
+        "06fl951f44avqyqim5qmy73siylbqcnsmz55zmj2dzhgf4sflkvc"
+      + lib.optionalString ("${teensy_architecture}" == "linuxarm")
+        "0ldf33w8wkqwklcj8fn4p22f23ibpwpf7873dc6i2jfmmbx0yvxn";
+  };
+
+  buildInputs = [ jdk ant libusb libusb1 unzip zlib ncurses5 readline
+  ] ++ stdenv.lib.optionals withTeensyduino [ upx xvfb_run xdotool ];
   downloadSrcList = builtins.attrValues externalDownloads;
   downloadDstList = builtins.attrNames externalDownloads;
 
@@ -75,6 +125,50 @@ stdenv.mkDerivation rec {
         --replace '<BINARY_LOCATION>' "$out/bin/arduino" \
         --replace '<ICON_NAME>' "$out/share/arduino/icons/128x128/apps/arduino.png"
     ''}
+
+    ${stdenv.lib.optionalString withTeensyduino ''
+      # Extract and patch the Teensyduino installer
+      cp ${teensyduino_src} ./TeensyduinoInstall.${teensy_architecture}
+      chmod +w ./TeensyduinoInstall.${teensy_architecture}
+      upx -d ./TeensyduinoInstall.${teensy_architecture}
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          --set-rpath "${teensy_libpath}" \
+          ./TeensyduinoInstall.${teensy_architecture}
+      chmod +x ./TeensyduinoInstall.${teensy_architecture}
+
+      # Run the GUI-only installer in a virtual X server
+      # Script thanks to AUR package. See:
+      #   <https://aur.archlinux.org/packages/teensyduino/>
+      echo "Running Teensyduino installer..."
+      # Trick the GUI into using HOME as the install directory.
+      export HOME=$out/share/arduino
+      # Run the installer in a virtual X server in memory.
+      xvfb-run -n 99 ./TeensyduinoInstall.${teensy_architecture} &
+      sleep 4
+      echo "Waiting for Teensyduino to install (about 1 minute)..."
+      # Control the installer GUI with xdotool.
+      DISPLAY=:99 xdotool search --class "teensyduino" \
+        windowfocus \
+        key space sleep 1 \
+        key Tab sleep 0.4 \
+        key Tab sleep 0.4 \
+        key Tab sleep 0.4 \
+        key Tab sleep 0.4 \
+        key space sleep 1 \
+        key Tab sleep 0.4 \
+        key Tab sleep 0.4 \
+        key Tab sleep 0.4 \
+        key Tab sleep 0.4 \
+        key space sleep 1 \
+        key Tab sleep 0.4 \
+        key space sleep 35 \
+        key space sleep 2 &
+      # Wait for xdotool to terminate and swallow the inevitable XIO error
+      wait $! || true
+
+      # Check for successful installation
+      [ -d $out/share/arduino/hardware/teensy ] || exit 1
+    ''}
   '';
 
   # So we don't accidentally mess with firmware files
@@ -101,6 +195,14 @@ stdenv.mkDerivation rec {
     # avrdude_bin is linked against libtinfo.so.5
     mkdir $out/lib/
     ln -s ${lib.makeLibraryPath [ncurses5]}/libncursesw.so.5 $out/lib/libtinfo.so.5
+
+    ${stdenv.lib.optionalString withTeensyduino ''
+      # Patch the Teensy loader binary
+      patchelf --debug \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          --set-rpath "${teensy_libpath}" \
+          $out/share/arduino/hardware/tools/teensy
+    ''}
   '';
 
   meta = with stdenv.lib; {
@@ -108,6 +210,6 @@ stdenv.mkDerivation rec {
     homepage = http://arduino.cc/;
     license = stdenv.lib.licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ antono robberer bjornfor ];
+    maintainers = with maintainers; [ antono auntie robberer bjornfor ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6501,6 +6501,8 @@ in
 
   tcptrack = callPackage ../development/tools/misc/tcptrack { };
 
+  teensyduino = arduino-core.override { withGui = true; withTeensyduino = true; };
+
   teensy-loader-cli = callPackage ../development/tools/misc/teensy-loader-cli { };
 
   texinfo413 = callPackage ../development/tools/misc/texinfo/4.13a.nix { };


### PR DESCRIPTION
###### Motivation for this change
Teensyduino is the only way to program Teensy 3.x boards. It is also the most convenient way to program for older Teensy boards.

###### Things done
Teensyduino is an add-on package that is heavily integrated with the Arduino IDE. I modified the nix expression for arduino-core to support installing Teensyduino as an option.

Teensyduino is installed exclusively through a GUI installer. The script I use was adapted from the AUR and uses xvfb to provide the GUI environment. The installer is time sensitive, but the script waits sufficiently long that it should not be a problem.

If anyone has any suggestions for a cleaner way to package this please let me know.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


