### PR TITLE
login test: Create and use direct reads of the TTY contents.

### DIFF
--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -504,6 +504,31 @@ sub screenshot {
     }, { image => $name } );
 }
 
+# Get the text of TTY<n>
+sub getTTYText {
+    my ($self, $tty) = @_;
+
+    my ($status, $out) = $self->execute("fold -w 80 /dev/vcs${tty}");
+    return $out;
+}
+
+# Wait until TTY<n>'s text matches a particular regular expression
+sub waitUntilTTYMatches {
+    my ($self, $tty, $regexp) = @_;
+
+    $self->nest("waiting for $regexp to appear on tty $tty", sub {
+        retry sub {
+            return 1 if $self->getTTYText($tty) =~ /$regexp/;
+        }
+    });
+}
+
+# Debugging: Dump the contents of the TTY<n>
+sub dumpTTYContents {
+    my ($self, $tty) = @_;
+
+    $self->execute("fold -w 80 /dev/vcs${tty} | systemd-cat");
+}
 
 # Take a screenshot and return the result as text using optical character
 # recognition.

--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -33,10 +33,11 @@ import ./make-test.nix ({ pkgs, latestKernel ? false, ... }:
 
       # Log in as alice on a virtual console.
       subtest "virtual console login", sub {
-          $machine->sleep(2); # urgh: wait for username prompt
+          $machine->waitUntilTTYMatches(2, "login: ");
           $machine->sendChars("alice\n");
+          $machine->waitUntilTTYMatches(2, "login: alice");
           $machine->waitUntilSucceeds("pgrep login");
-          $machine->sleep(2); # urgh: wait for `Password:'
+          $machine->waitUntilTTYMatches(2, "Password: ");
           $machine->sendChars("foobar\n");
           $machine->waitUntilSucceeds("pgrep -u alice bash");
           $machine->sendChars("touch done\n");


### PR DESCRIPTION
###### Motivation for this change

The `login` test for 16.09 has been failing lately, for no good reason. It appears that the typing for the username `alice` is too soon, causing this failure. This is hard to test, since it depends on the system being under load.

I added test primitives to access the raw TTY memory and see what is on the TTY. This could possibly be used to stabilize other tests, too.

Here is an example of where the retry helped prevent a race condition:

```
machine: sending keys ‘alice
’
machine: sending monitor command: sendkey a
machine: sending monitor command: sendkey l
machine: sending monitor command: sendkey i
machine: sending monitor command: sendkey c
machine: sending monitor command: sendkey e
machine: sending monitor command: sendkey ret
machine: waiting for login: alice to appear on tty 2
machine: running command: fold -w 80 /dev/vcs2
machine: exit status 0
machine: running command: fold -w 80 /dev/vcs2
machine: exit status 0
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


