### PR TITLE
hexRegistrySnapshot: updating to latest

### DIFF
--- a/pkgs/development/beam-modules/hex-registry-snapshot.nix
+++ b/pkgs/development/beam-modules/hex-registry-snapshot.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
     name = "hex-registry";
-    rev = "d58a937";
+    rev = "e5e494a";
     version = "0.0.0+build.${rev}";
 
     src = fetchFromGitHub {
         owner = "erlang-nix";
         repo = "hex-pm-registry-snapshots";
         inherit rev;
-        sha256 = "11ymmn75qjlhzf7aaza708gq0hqg55dzd3q13npgq43wg90rgpxy";
+        sha256 = "0877dragfxs22a05d8mv42z5535kfx9rs4y7fwwbd1ybphczf8za";
     };
 
     installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Updating the Hex registry for Erlang to the latest committed version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


