### PR TITLE
haskellPackages.HDBC-odbc: remove haddock fix again

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1068,15 +1068,6 @@ self: super: {
   # https://github.com/roelvandijk/terminal-progress-bar/issues/13
   terminal-progress-bar = doJailbreak super.terminal-progress-bar;
 
-  # https://github.com/hdbc/hdbc-odbc/pull/29
-  HDBC-odbc = overrideCabal super.HDBC-odbc (old: {
-    postPatch = old.postPatch or "" + ''
-      sed -e '/data BoundValue =/ { s/$/{/ ; n; n ; s/{ bvVal/  bvVal/ }' \
-          -e 's/-- | This is rather/-- This is rather/' \
-          -i Database/HDBC/ODBC/Statement.hsc
-    '';
-  });
-
   # https://github.com/vshabanov/HsOpenSSL/issues/11
   HsOpenSSL = doJailbreak super.HsOpenSSL;
 


### PR DESCRIPTION
Was fixed upstream /nix/store/3pc0b9hbnkzvyfxwyk88yaashzlp06w8-HDBC-odbc-2.5.0.1