### PR TITLE
liquibase: improve external jar integration

### DIFF
--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -1,4 +1,13 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ stdenv, fetchurl, writeText, jre, makeWrapper, fetchMavenArtifact
+, mysqlSupport ? true, mysql_jdbc ? null }:
+
+assert mysqlSupport -> mysql_jdbc != null;
+
+with stdenv.lib;
+let
+  extraJars = optional mysqlSupport mysql_jdbc;
+
+in
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -16,18 +25,38 @@ stdenv.mkDerivation rec {
     tar xfz ${src}
   '';
 
-  installPhase = ''
-    mkdir -p $out/{bin,lib,sdk}
-    mv ./* $out/
-    wrapProgram $out/liquibase --prefix PATH ":" ${jre}/bin --set LIQUIBASE_HOME $out;
-    ln -s $out/liquibase $out/bin/liquibase
+  installPhase =
+    let addJars = dir: ''
+      for jar in ${dir}/*.jar; do
+        CP="\$CP":"\$jar"
+      done
+    '';
+    in ''
+      mkdir -p $out/{bin,lib,sdk}
+      mv ./* $out/
+
+      # we provide our own script
+      rm $out/liquibase
+
+      # there’s a lot of escaping, but I’m not sure how to improve that
+      cat > $out/bin/liquibase <<EOF
+      #!/usr/bin/env bash
+      # taken from the executable script in the source
+      CP="$out/liquibase.jar"
+      ${addJars "$out/lib"}
+      ${concatStringsSep "\n" (map (p: addJars "${p}/share/java") extraJars)}
+
+      ${getBin jre}/bin/java -cp "\$CP" \$JAVA_OPTS \
+        liquibase.integration.commandline.Main \''${1+"\$@"}
+      EOF
+      chmod +x $out/bin/liquibase
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "Version Control for your database";
     homepage = "http://www.liquibase.org/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nequissimus ];
+    maintainers = with maintainers; [ nequissimus profpatsch ];
     platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)

This replaces the upstream wrapper script with one tailored for nixpkgs.
We gain the ability to selectively enable/disable jdbc backends.