### PR TITLE
minikube: init at 0.12.2

### DIFF
--- a/pkgs/development/tools/minikube/default.nix
+++ b/pkgs/development/tools/minikube/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, go-bindata }:
+
+let
+  version = "0.12.2";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "kubernetes";
+    repo = "minikube";
+    sha256 = "18zif97qd10w4ps55pwfpc5fkgrprs5j01b0rv5yjwjkzakdcrdy";
+  };
+
+  localkube = buildGoPackage {
+    inherit src;
+
+    name = "localkube-${version}";
+    goPackagePath = "k8s.io/minikube";
+    subPackages = ["cmd/localkube"];
+
+    buildInputs = [stdenv.glibc.static];
+
+    buildFlagsArray = ''
+      -ldflags=
+        -extldflags "-static"
+    '';
+  };
+
+in buildGoPackage {
+  name = "minikube-${version}";
+
+  inherit src;
+
+  goPackagePath = "k8s.io/minikube";
+  subPackages = ["cmd/minikube"];
+
+  buildInputs = [go-bindata];
+
+  preBuild = ''
+    (cd go/src/k8s.io/minikube && mkdir out && cp ${localkube.bin}/bin/localkube ./out/localkube &&
+     go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets ./out/localkube deploy/addons)
+  '';
+
+  postInstall = ''
+    cp ${localkube.bin}/bin/localkube $bin/bin/localkube
+  '';
+
+  meta = with lib; {
+    description = "Run Kubernetes locally";
+    license = licenses.asl20;
+    homepage = https://github.com/kubernetes/minikube;
+    maintainers = with maintainers; [offline];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -928,6 +928,8 @@ in
 
   meson = callPackage ../development/tools/build-managers/meson { };
 
+  minikube = callPackage ../development/tools/minikube { };
+
   mp3fs = callPackage ../tools/filesystems/mp3fs { };
 
   mpdcron = callPackage ../tools/audio/mpdcron { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


