### PR TITLE
buildEnv: allow custom environment variables to be set

### DIFF
--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -38,12 +38,15 @@
 , # Additional inputs. Handy e.g. if using makeWrapper in `postBuild`.
   buildInputs ? []
 
+# Other environment variables to set at build time.
+, environment ? {}
+
 , passthru ? {}
 , meta ? {}
 }:
 
 runCommand name
-  rec {
+  (environment // rec {
     inherit manifest ignoreCollisions checkCollisionContents passthru
             meta pathsToLink extraPrefix postBuild buildInputs;
     pkgs = builtins.toJSON (map (drv: {
@@ -54,17 +57,17 @@ runCommand name
         # aren't expected to have multiple outputs.
         (if drv.outputUnspecified or false
             && drv.meta.outputsToInstall or null != null
-          then map (outName: drv.${outName}) drv.meta.outputsToInstall
+          then map (outName: drv."${outName}") drv.meta.outputsToInstall
           else [ drv ])
         # Add any extra outputs specified by the caller of `buildEnv`.
         ++ lib.filter (p: p!=null)
-          (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
+          (builtins.map (outName: drv."${outName}" or null) extraOutputsToInstall);
       priority = drv.meta.priority or 5;
     }) paths);
     preferLocalBuild = true;
     # XXX: The size is somewhat arbitrary
     passAsFile = if builtins.stringLength pkgs >= 128*1024 then [ "pkgs" ] else null;
-  }
+  })
   ''
     ${perl}/bin/perl -w ${./builder.pl}
     eval "$postBuild"


### PR DESCRIPTION
###### Motivation for this change

`buildEnv` allows for a `postBuild` step, but doesn't provide a mechanism for setting environment variables during that step besides inlining them into the bash string (which could have problems e.g. with special characters). This adds an `environment` parameter which allows environment variables to be set.

###### Things done

Not really anything to test here; none of the existing libraries use this. I've build `env`s of my own using this parameter, and it works.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


