### PR TITLE
hashcat3: init at 3.10

### DIFF
--- a/pkgs/tools/security/hashcat/hashcat3/default.nix
+++ b/pkgs/tools/security/hashcat/hashcat3/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, makeWrapper, opencl-headers, opencl-icd }:
+
+assert stdenv.isLinux;
+
+stdenv.mkDerivation rec {
+  name    = "hashcat-${version}";
+  version = "3.10";
+
+  src = fetchurl {
+    name = "${name}.tar.gz";
+    url = "https://hashcat.net/files_legacy/hashcat-${version}.tar.gz";
+    sha256 = "1sg30d9as6xsl7b0i7mz26igachbv0l0yimwb12nmarmgdgmwm9v";
+  };
+
+  buildInputs = [ opencl-headers makeWrapper ];
+
+  makeFlags = [ "OPENCL_HEADERS_KHRONOS=${opencl-headers}/include" ];
+
+  # $out is not known until the build has started.
+  configurePhase = ''
+    makeFlags="$makeFlags PREFIX=$out"
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/hashcat --prefix LD_LIBRARY_PATH : ${opencl-icd}/lib
+  '';
+
+  meta = {
+    description = "Fast password cracker";
+    homepage    = http://hashcat.net/hashcat/;
+    license     = stdenv.lib.licenses.mit;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.kierdavis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2101,6 +2101,7 @@ in
   hardlink = callPackage ../tools/system/hardlink { };
 
   hashcat = callPackage ../tools/security/hashcat { };
+  hashcat3 = callPackage ../tools/security/hashcat/hashcat3 { };
 
   hash-slinger = callPackage ../tools/security/hash-slinger { };
 


### PR DESCRIPTION
###### Motivation for this change

We already have a 'hashcat', but it's at version 2.x, which is incompatible with hashcat 3.x.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This builds and runs on my machines, but I'm not yet convinced that it's portable. I'd be grateful if a couple other people could test that this package builds and that running `result/bin/hashcat -b` starts the benchmark running on at least one device (CPU, GPU, APU etc).
