### PR TITLE
torbrowser: 6.0.6 -> 6.0.7

### DIFF
--- a/pkgs/tools/security/tor/torbrowser.nix
+++ b/pkgs/tools/security/tor/torbrowser.nix
@@ -12,13 +12,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "tor-browser-${version}";
-  version = "6.0.6";
+  version = "6.0.7";
 
   src = fetchurl {
     url = "https://archive.torproject.org/tor-package-archive/torbrowser/${version}/tor-browser-linux${if stdenv.is64bit then "64" else "32"}-${version}_en-US.tar.xz";
     sha256 = if stdenv.is64bit then
-      "0ydcbkpyrdwsqn841cxzpbr05nzly720xhsin89gjc1sirvmlxmx" else
-      "0q8ygkgs47wjq12l37kwm93v1420gzrlacwqc0yz4b3b58aa1d4z";
+      "1llgqvxmn572wyxk7r1hf3j6ldi9hkgahm7918rsmsvk66i187h4" else
+      "16z8qfmcgxbvmv5hriv1gq4lpz54fy04mhhwdd6s72y52dfcvfy3";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Motivation for this change

Security update to Tor Browser released last night, addressing vulnerability that is known to affect Windows. While no known Linux exploits are known it is prudent to keep up to date.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


