### PR TITLE
rssh: Make rssh a valid shell

### DIFF
--- a/pkgs/shells/rssh/default.nix
+++ b/pkgs/shells/rssh/default.nix
@@ -79,4 +79,8 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [ arobyn ];
   };
+
+  passthru = {
+    shellPath = "/bin/rssh";
+  };
 }


### PR DESCRIPTION
The rssh package did not have the 'shellPath' attribute, so it could not
be used as the default shell for a nixos user. I fixed this by adding
the attribute.