### PR TITLE
ponyc: 0.6.0 -> 0.9.0

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation ( rec {
   name = "ponyc-${version}";
-  version = "0.6.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
     rev = version;
-    sha256 = "10miwsyxl589b0n1h3dbbc2qckq8z8a58s0d53asq88w2gpc339q";
+    sha256 = "1g2i3x9k36h5rx7ifx0i6hn78xlj42i86x8apwzvkh0y84y88adi";
   };
 
   buildInputs = [ llvm makeWrapper which ];
@@ -83,7 +83,7 @@ stdenv.mkDerivation ( rec {
     description = "Pony is an Object-oriented, actor-model, capabilities-secure, high performance programming language";
     homepage = http://www.ponylang.org;
     license = stdenv.lib.licenses.bsd2;
-    maintainers = [ stdenv.lib.maintainers.doublec ];
+    maintainers = with stdenv.lib.maintainers; [ doublec kamilchm ];
     platforms = stdenv.lib.platforms.unix;
   };
 })

--- a/pkgs/development/compilers/ponyc/disable-tests.patch
+++ b/pkgs/development/compilers/ponyc/disable-tests.patch
@@ -1,15 +1,19 @@
-diff --git a/packages/net/_test.pony b/packages/net/_test.pony
-index ce26bd7..9a98cc7 100644
---- a/packages/net/_test.pony
-+++ b/packages/net/_test.pony
-@@ -5,9 +5,7 @@ actor Main is TestList
+diff -Naur a/packages/net/_test.pony b/packages/net/_test.pony
+--- a/packages/net/_test.pony	1970-01-01 01:00:01.000000000 +0100
++++ b/packages/net/_test.pony	2016-12-01 22:25:59.102433053 +0100
+@@ -5,14 +5,7 @@
    new make() => None
-
+ 
    fun tag tests(test: PonyTest) =>
 -    test(_TestBroadcast)
 -    test(_TestTCPWritev)
 -    test(_TestTCPExpect)
+-    test(_TestTCPMute)
+-    test(_TestTCPUnmute)
+-    ifdef not windows then
+-      test(_TestTCPThrottle)
+-    end
 +    None
-
+ 
  class _TestPing is UDPNotify
    let _h: TestHelper


### PR DESCRIPTION
###### Motivation for this change
Pony update

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


