### PR TITLE
ignition: init messages, tools, and transport2

### DIFF
--- a/pkgs/development/libraries/ignition-messages/default.nix
+++ b/pkgs/development/libraries/ignition-messages/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, cmake, pkgconfig, protobuf, math2 } :
+
+stdenv.mkDerivation rec {
+  name = "ign-msgs-${version}";
+  version = "0.6.0";
+  src = fetchurl {
+    url = "https://bitbucket.org/ignitionrobotics/ign-msgs/get/ignition-msgs_0.6.0.tar.gz";
+    sha256 = "0akm7a0n5qfz24n3xsh68dm2m7lc5sj6cpg5j95sg10ixc77f232";
+  };
+  buildInputs = [ cmake pkgconfig protobuf math2 ];
+  postPatch = ''
+    substituteInPlace cmake/ignition-config.cmake.in --replace "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_" "@CMAKE_INSTALL_"
+  '';
+  meta = with stdenv.lib; {
+    homepage = http://ignitionrobotics.org/libraries/messages;
+    description = "Standard set of message definitions, used by Ignition Transport, and other applications";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ acowley ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/ignition-tools/default.nix
+++ b/pkgs/development/libraries/ignition-tools/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl, cmake, pkgconfig, ruby } :
+
+stdenv.mkDerivation {
+  name = "ign-tools-20160808";
+  src = fetchurl {
+    url = "https://bitbucket.org/ignitionrobotics/ign-tools/get/75a248c4c899.tar.gz";
+    sha256 = "1njwi1j9h2qqm949ix2pm3mgm6a9isd3r5xpv9yv9v3z6kp43c31";
+  };
+  buildInputs = [ cmake pkgconfig ruby ];
+  postPatch = ''
+    substituteInPlace cmake/ignition-config.cmake.in --replace "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_" "@CMAKE_INSTALL_"
+  '';
+  meta = with stdenv.lib; {
+    homepage = http://ignitionrobotics.org/libraries/tools;
+    description = "Umbrella CLI tool for individual Ingition Robotics projects";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ acowley ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/ignition-transport/2.1.0.nix
+++ b/pkgs/development/libraries/ignition-transport/2.1.0.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, cmake, pkgconfig, protobuf, zeromq, cppzmq, utillinux
+, tools, messages, math2 } :
+
+stdenv.mkDerivation rec {
+  version = "2.1.0";
+  name = "ign-transport2-${version}";
+  src = fetchurl {
+    url = "http://gazebosim.org/distributions/ign-transport/releases/ignition-transport2-${version}.tar.bz2";
+    sha256 = "0bi1pknj1676rlr49nh40pqfkr4g9jpzr3ijhf82p5l0m3k0w6gi";
+  };
+  buildInputs = [ cmake protobuf zeromq pkgconfig tools messages math2 ]
+    ++ stdenv.lib.optional stdenv.isLinux utillinux;
+  propagatedBuildInputs = [ cppzmq ];
+  postPatch = ''
+    substituteInPlace cmake/ignition-config.cmake.in --replace "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_" "@CMAKE_INSTALL_"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace cmake/ignition-config.cmake.in --replace "if (NOT uuid_FOUND)" "if (FALSE)"
+    substituteInPlace cmake/SearchForStuff.cmake \
+      --replace "pkg_check_modules(uuid uuid)" "" \
+      --replace "if (NOT uuid_FOUND)" "if (FALSE)"
+  '';
+  meta = with stdenv.lib; {
+    homepage = http://ignitionrobotics.org/libraries/transport;
+    description = "Combines ZeroMQ with Protobufs to create a fast and efficient message passing system";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ acowley ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2205,7 +2205,17 @@ in
 
     transport1 = callPackage ../development/libraries/ignition-transport/1.0.1.nix { };
 
+    transport2 = callPackage ../development/libraries/ignition-transport/2.1.0.nix { 
+      inherit (ignition) tools messages math2;
+    };
+
     transport = ignition.transport0;
+
+    messages = callPackage ../development/libraries/ignition-messages/default.nix { 
+      inherit (ignition) math2;
+    };
+
+    tools = callPackage ../development/libraries/ignition-tools/default.nix { };
   };
 
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


These are interlinked packages used by the Gazebo robot simulator.

nixpkgs already contains earlier versions of transport, but transport2
reflects an apparent refactoring in the ignition libraries to depend
on the tools and messages libraries.