### PR TITLE
rox-filer: init at 2.11

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -141,6 +141,7 @@
   ehmry = "Emery Hemingway <emery@vfemail.net>";
   eikek = "Eike Kettner <eike.kettner@posteo.de>";
   elasticdog = "Aaron Bull Schaefer <aaron@elasticdog.com>";
+  eleanor = "Dejan Lukan <dejan@proteansec.com>";
   elitak = "Eric Litak <elitak@gmail.com>";
   ellis = "Ellis Whitehead <nixos@ellisw.net>";
   epitrochoid = "Mabry Cervin <mpcervin@uncg.edu>";

--- a/pkgs/desktops/rox/rox-filer/default.nix
+++ b/pkgs/desktops/rox/rox-filer/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, perl, libxml2, libglade, gtk, libSM,
-  shared_mime_info, intltool, gettext, gcc, vim, hicolor_icon_theme }:
+{ stdenv, fetchurl, pkgconfig, libxml2, gtk, libSM, shared_mime_info, hicolor_icon_theme }:
 
 let
   version = "2.11";
@@ -8,11 +7,11 @@ in stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
-    url = http://downloads.sourceforge.net/rox/rox-filer-2.11.tar.bz2;
+    url = "mirror://sourceforge/rox/rox-filer-${version}.tar.bz2";
     sha256 = "a929bd32ee18ef7a2ed48b971574574592c42e34ae09f36604bf663d7c101ba8";
   };
 
-  buildInputs = [ pkgconfig perl libxml2 libglade gtk shared_mime_info intltool gettext gcc vim hicolor_icon_theme libSM ];
+  buildInputs = [ pkgconfig libxml2 gtk shared_mime_info hicolor_icon_theme libSM ];
 
   patches = [
     ./rox-filer-2.11-in-source-build.patch
@@ -71,7 +70,7 @@ in stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "Fast, lightweight, gtk2 file manager";
     homepage = "http://rox.sourceforge.net/desktop";
-    license = "GPL-2 LGPL-2";
+    license = with licenses; [ gpl2 lgpl2 ];
     platforms = platforms.linux;
     maintainers = [ maintainers.eleanor ];
   };

--- a/pkgs/desktops/rox/rox-filer/default.nix
+++ b/pkgs/desktops/rox/rox-filer/default.nix
@@ -1,0 +1,78 @@
+{ stdenv, fetchurl, pkgconfig, perl, libxml2, libglade, gtk, libSM,
+  shared_mime_info, intltool, gettext, gcc, vim, hicolor_icon_theme }:
+
+let
+  version = "2.11";
+  name = "rox-filer-${version}";
+in stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchurl {
+    url = http://downloads.sourceforge.net/rox/rox-filer-2.11.tar.bz2;
+    sha256 = "a929bd32ee18ef7a2ed48b971574574592c42e34ae09f36604bf663d7c101ba8";
+  };
+
+  buildInputs = [ pkgconfig perl libxml2 libglade gtk shared_mime_info intltool gettext gcc vim hicolor_icon_theme libSM ];
+
+  patches = [
+    ./rox-filer-2.11-in-source-build.patch
+  ];
+
+  # go to the source directory after unpacking the sources
+  setSourceRoot = "export sourceRoot=rox-filer-${version}/ROX-Filer/";
+
+  # patch source with defined patches
+  patchFlags = "-p0";
+
+  # patch the main.c to disable the lookup of the APP_DIR environment variable,
+  # which is used to lookup the location for certain images when rox-filer
+  # starts; rather override the location with an absolute path to the directory
+  # where images are stored to prevent having to use a wrapper, which sets the
+  # APP_DIR environment variable prior to starting rox-filer
+  preConfigure = ''
+    sed -i -e "s:g_strdup(getenv(\"APP_DIR\")):\"$out\":" src/main.c
+    mkdir build
+    cd build
+  '';
+
+  configureScript = "../src/configure";
+
+  installPhase = ''
+    mkdir -p "$out"
+    cd ..
+    cp -av Help Messages Options.xml ROX images style.css .DirIcon "$out"
+
+    # create the man/ directory, which will be moved from $out to share/ in the fixup phase
+    mkdir "$out/man/"
+    cp -av ../rox.1 "$out/man/"
+
+    # the main executable
+    mkdir "$out/bin/"
+    cp -v ROX-Filer "$out/bin/rox"
+
+    # mime types
+    mkdir -p "$out/ROX/MIME"
+    cd "$out/ROX/MIME"
+    ln -sv text-x-{diff,patch}.png
+    ln -sv application-x-font-{afm,type1}.png
+    ln -sv application-xml{,-dtd}.png
+    ln -sv application-xml{,-external-parsed-entity}.png
+    ln -sv application-{,rdf+}xml.png
+    ln -sv application-x{ml,-xbel}.png
+    ln -sv application-{x-shell,java}script.png
+    ln -sv application-x-{bzip,xz}-compressed-tar.png
+    ln -sv application-x-{bzip,lzma}-compressed-tar.png
+    ln -sv application-x-{bzip-compressed-tar,lzo}.png
+    ln -sv application-x-{bzip,xz}.png
+    ln -sv application-x-{gzip,lzma}.png
+    ln -sv application-{msword,rtf}.png
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fast, lightweight, gtk2 file manager";
+    homepage = "http://rox.sourceforge.net/desktop";
+    license = "GPL-2 LGPL-2";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.eleanor ];
+  };
+}

--- a/pkgs/desktops/rox/rox-filer/rox-filer-2.11-in-source-build.patch
+++ b/pkgs/desktops/rox/rox-filer/rox-filer-2.11-in-source-build.patch
@@ -1,0 +1,16 @@
+--- src/configure	2011-10-09 16:32:14.000000000 +0200
++++ src/configure2	2016-03-20 09:26:31.640891863 +0100
+@@ -2132,13 +2132,6 @@
+ 
+ 
+ ac_config_headers="$ac_config_headers config.h"
+-
+-
+- if [ -f configure ]; then
+-	as_fn_error $? "Please run configure from the build directory (try ../AppRun --compile)" "$LINENO" 5
+-	exit 1
+-fi
+-
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16421,6 +16421,11 @@ in
 
   theme-vertex = callPackage ../misc/themes/vertex { };
 
+  rox-filer = callPackage ../desktops/rox/rox-filer {
+    gtk = gtk2;
+    inherit (gnome2) libglade;
+  };
+
   xfce = xfce4-12;
   xfce4-12 = recurseIntoAttrs (callPackage ../desktops/xfce { });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16423,7 +16423,6 @@ in
 
   rox-filer = callPackage ../desktops/rox/rox-filer {
     gtk = gtk2;
-    inherit (gnome2) libglade;
   };
 
   xfce = xfce4-12;


### PR DESCRIPTION
###### Motivation for this change

Addition of rox-filer package manager.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


