### PR TITLE
qt5: more reproducible builds

### DIFF
--- a/pkgs/development/libraries/qt-5/5.5/qtbase/setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/setup-hook.sh
@@ -91,7 +91,7 @@ _qtSetQmakePath() {
 
 if [ -z "$NIX_QT5_TMP" ]; then
     if [ -z "$NIX_QT_SUBMODULE" ]; then
-        NIX_QT5_TMP=$(mktemp -d)
+        NIX_QT5_TMP=$(pwd)/__nix_qt5__
     else
         NIX_QT5_TMP=$out
     fi

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/setup-hook.sh
@@ -91,7 +91,7 @@ _qtSetQmakePath() {
 
 if [ -z "$NIX_QT5_TMP" ]; then
     if [ -z "$NIX_QT_SUBMODULE" ]; then
-        NIX_QT5_TMP=$(mktemp -d)
+        NIX_QT5_TMP=$(pwd)/__nix_qt5__
     else
         NIX_QT5_TMP=$out
     fi

--- a/pkgs/development/libraries/qt-5/5.7/qtbase/setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/5.7/qtbase/setup-hook.sh
@@ -91,7 +91,7 @@ _qtSetQmakePath() {
 
 if [ -z "$NIX_QT5_TMP" ]; then
     if [ -z "$NIX_QT_SUBMODULE" ]; then
-        NIX_QT5_TMP=$(mktemp -d)
+        NIX_QT5_TMP=$(pwd)/__nix_qt5__
     else
         NIX_QT5_TMP=$out
     fi


### PR DESCRIPTION
###### Motivation for this change

Eliminate ``$(mktemp -d)`` in source directory of each qt5 dependant package, which affect include paths, and at least debug information in resulting binaries.
Instead of ``tmpXXXXXX`` custom fixed directory used -- ``__nix_qt5__``.

I tested at least on virtualbox, qastools, and couple more applications depends on qt5.5 and 5.6. Change similiar for all qt5.x

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Avoid mktemp -d in sources, where pathnames can affect result.