### PR TITLE
gajim: add enableOmemoPluginDependencies option

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -7,6 +7,7 @@
 , enableRST ? true
 , enableSpelling ? true, gtkspell2 ? null
 , enableNotifications ? false
+, enableOmemoPluginDependencies ? false
 , extraPythonPackages ? pkgs: []
 }:
 
@@ -68,7 +69,9 @@ stdenv.mkDerivation rec {
   ] ++ optional enableE2E pythonPackages.pycrypto
     ++ optional enableRST pythonPackages.docutils
     ++ optional enableNotifications pythonPackages.notify
-    ++ extraPythonPackages pythonPackages;
+    ++ optionals enableOmemoPluginDependencies (with pythonPackages; [
+      cryptography python-axolotl python-axolotl-curve25519 qrcode
+    ]) ++ extraPythonPackages pythonPackages;
 
   postFixup = ''
     install -m 644 -t "$out/share/gajim/icons/hicolor" \


### PR DESCRIPTION
###### Motivation for this change

make omemo plugin easier to install.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


