### PR TITLE
lxcfs: init at 2.0.4

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -483,6 +483,7 @@
   ./services/security/torify.nix
   ./services/security/tor.nix
   ./services/security/torsocks.nix
+  ./services/system/cgmanager.nix
   ./services/system/cloud-init.nix
   ./services/system/dbus.nix
   ./services/system/kerberos.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -618,6 +618,7 @@
   ./virtualisation/docker.nix
   ./virtualisation/libvirtd.nix
   ./virtualisation/lxc.nix
+  ./virtualisation/lxcfs.nix
   ./virtualisation/lxd.nix
   ./virtualisation/amazon-options.nix
   ./virtualisation/openvswitch.nix

--- a/nixos/modules/services/system/cgmanager.nix
+++ b/nixos/modules/services/system/cgmanager.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.cgmanager;
+in {
+  meta.maintainers = [ maintainers.mic92 ];
+
+  ###### interface
+  options.services.cgmanager.enable = mkEnableOption "cgmanager";
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    systemd.services.cgmanager = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "local-fs.target" ];
+      description = "Cgroup management daemon";
+      restartIfChanged = false;
+      serviceConfig = {
+        ExecStart = "${pkgs.cgmanager}/bin/cgmanager -m name=systemd";
+        KillMode = "process";
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/nixos/modules/virtualisation/lxcfs.nix
+++ b/nixos/modules/virtualisation/lxcfs.nix
@@ -1,0 +1,49 @@
+# LXC Configuration
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.virtualisation.lxc.lxcfs;
+in {
+  meta.maintainers = [ maintainers.mic92 ];
+
+  ###### interface
+  options.virtualisation.lxc.lxcfs = {
+    enable =
+      mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          This enables LXCFS, a FUSE filesystem for LXC.
+          To use lxcfs in include the following configuration in your
+          container configuration:
+          <code>
+            virtualisation.lxc.defaultConfig = "lxc.include = ''${pkgs.lxcfs}/share/lxc/config/common.conf.d/00-lxcfs.conf";
+          </code>
+        '';
+      };
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    services.cgmanager.enable = true;
+
+    systemd.services.lxcfs = {
+      description = "FUSE filesystem for LXC";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "cgmanager.service" ];
+      after = [ "cgmanager.service" ];
+      before = [ "lxc.service" ];
+      restartIfChanged = false;
+      serviceConfig = {
+        ExecStartPre="${pkgs.coreutils}/bin/mkdir -p /var/lib/lxcfs";
+        ExecStart="${pkgs.lxcfs}/bin/lxcfs /var/lib/lxcfs";
+        ExecStopPost="-${pkgs.fuse}/bin/fusermount -u /var/lib/lxcfs";
+        KillMode="process";
+        Restart="on-failure";
+      };
+    };
+  };
+}

--- a/pkgs/os-specific/linux/lxcfs/default.nix
+++ b/pkgs/os-specific/linux/lxcfs/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, pkgconfig, help2man, fuse, pam }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "lxcfs-${version}";
+  version = "2.0.4";
+
+  src = fetchurl {
+    url = "https://linuxcontainers.org/downloads/lxcfs/lxcfs-${version}.tar.gz";
+    sha256 = "0pfrsn7hqccpcnwg4xk8ds0avb2yc9gyvj7bk2bl90vpwsm35j7y";
+  };
+
+  nativeBuildInputs = [ pkgconfig help2man ];
+  buildInputs = [ fuse pam ];
+
+  configureFlags = [
+    "--with-init-script=systemd"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+  ];
+
+  installFlags = [ "SYSTEMD_UNIT_DIR=\${out}/lib/systemd" ];
+
+  postFixup = ''
+    # liblxcfs.so is reloaded with dlopen()
+    patchelf --set-rpath "$(patchelf --print-rpath "$out/bin/lxcfs"):$out/lib" "$out/bin/lxcfs"
+  '';
+
+  meta = {
+    homepage = https://linuxcontainers.org/lxcfs;
+    description = "FUSE filesystem for LXC";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mic92 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2637,6 +2637,7 @@ in
   lshw = callPackage ../tools/system/lshw { };
 
   lxc = callPackage ../os-specific/linux/lxc { };
+  lxcfs = callPackage ../os-specific/linux/lxcfs { };
   lxd = callPackage ../tools/admin/lxd { };
 
   lzfse = callPackage ../tools/compression/lzfse { };


### PR DESCRIPTION
###### Motivation for this change

Tested on a production machine with 30+ containers.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

