### PR TITLE
gopenvpn: init at 0.8

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -141,6 +141,7 @@
   ehmry = "Emery Hemingway <emery@vfemail.net>";
   eikek = "Eike Kettner <eike.kettner@posteo.de>";
   elasticdog = "Aaron Bull Schaefer <aaron@elasticdog.com>";
+  eleanor = "Dejan Lukan <dejan@proteansec.com>";
   elitak = "Eric Litak <elitak@gmail.com>";
   ellis = "Ellis Whitehead <nixos@ellisw.net>";
   epitrochoid = "Mabry Cervin <mpcervin@uncg.edu>";

--- a/pkgs/desktops/gnome-2/desktop/gopenvpn/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gopenvpn/default.nix
@@ -1,6 +1,5 @@
-{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, glib, gtk2, gnome2, dbus_glib, gmime, libnotify, libgnome_keyring,
-  openssl, cyrus_sasl, gnonlin, sylpheed, gob2, gettext, intltool, libglade, polkit, autoconf, automake, expect,
-  openvpn, makeWrapper, pkexecPath ? "/var/setuid-wrappers/pkexec" }:
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, automake111x, glib, gtk2, gnome2, dbus_glib, gmime,
+  libnotify, libgnome_keyring, libglade, polkit, openvpn, pkexecPath ? "/var/setuid-wrappers/pkexec" }:
 
 stdenv.mkDerivation rec {
   rev = "2b9285f1ea2d11434b8ee8e10d937b2ea5285b63";
@@ -14,9 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0pkdravr5wm7phdr2rd1rx1ry4dpwkrf0hv7wi99n4ywsl5jqwq8";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib gtk2 dbus_glib gmime libnotify libgnome_keyring openssl cyrus_sasl gnonlin sylpheed gob2
-                  gettext intltool libglade polkit pkgconfig autoconf automake expect openvpn makeWrapper ];
+  buildInputs = [ glib gtk2 dbus_glib gmime libnotify libgnome_keyring pkgconfig automake111x autoreconfHook
+                  libglade polkit openvpn ];
 
   # disable the format hardening flags in order for the program to compile even though a potential vulnerability
   # might be present in the form of a format string vulnerability. By failing to add this the program compilation
@@ -33,16 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   # configure with pkexec to be able to run openvpn as privileged user
-  configureFlags = ["--with-pkexec=${pkexecPath}/bin/pkexec"];
-
-  preConfigure = ''
-    # copy standard gettext infrastructure files into a source package
-    autopoint -f
-    expect -c "spawn gettextize -f; expect -re \"Press Return to acknowledge the previous\""
-
-    # updating configuration files not required anymore due to autoreconfHook
-    autoreconf -vif
-  '';
+  configureFlags = ["--with-pkexec=${pkexecPath}"];
 
   meta = with stdenv.lib; {
     description = "Graphical front-end for OpenVPN";

--- a/pkgs/desktops/gnome-2/desktop/gopenvpn/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gopenvpn/default.nix
@@ -2,9 +2,7 @@
   openssl, cyrus_sasl, gnonlin, sylpheed, gob2, gettext, intltool, libglade, polkit, autoconf, automake, expect,
   openvpn, makeWrapper, pkexecPath ? "/var/setuid-wrappers/pkexec" }:
 
-let
-  redirects = [ "/usr/bin/pkexec=${pkexecPath}" ];
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   rev = "2b9285f1ea2d11434b8ee8e10d937b2ea5285b63";
   version = "0.8";
   name = "gopenvpn-${version}";
@@ -20,11 +18,22 @@ in stdenv.mkDerivation rec {
   buildInputs = [ glib gtk2 dbus_glib gmime libnotify libgnome_keyring openssl cyrus_sasl gnonlin sylpheed gob2
                   gettext intltool libglade polkit pkgconfig autoconf automake expect openvpn makeWrapper ];
 
+  # disable the format hardening flags in order for the program to compile even though a potential vulnerability
+  # might be present in the form of a format string vulnerability. By failing to add this the program compilation
+  # will end with the following line:
+  #
+  #  > gopenvpn.c:978:10: error: format not a string literal and no format arguments [-Werror=format-security]
+  #
+  hardeningDisable = [ "format" ];
+
   patchPhase = ''
     # configure and remote extra "po/Makefile.in" in AC_CONFIG_FILES
     sed -i -e 's:AC_CONFIG_FILES(\[pixmaps/Makefile po/Makefile.in:AC_CONFIG_FILES(\[pixmaps/Makefile:g' configure.ac
     cat configure.ac | grep CONFIG_FILES
   '';
+
+  # configure with pkexec to be able to run openvpn as privileged user
+  configureFlags = ["--with-pkexec=${pkexecPath}/bin/pkexec"];
 
   preConfigure = ''
     # copy standard gettext infrastructure files into a source package
@@ -33,23 +42,6 @@ in stdenv.mkDerivation rec {
 
     # updating configuration files not required anymore due to autoreconfHook
     autoreconf -vif
-  '';
-
-  preBuild = ''
-    # add no warnings flag to the Makefile, otherwise the following error will occur during built time:
-    #
-    #  > gopenvpn.c:978:10: error: format not a string literal and no format arguments [-Werror=format-security]
-    #
-    # Note that this wasn't solved by adding the "-Wformat-nonliteral -Wno-format-security -Wno-error=format-security"
-    # flags
-    sed -i -e '/^CFLAGS =/ s/$/ -w/' src/Makefile
-  '';
-
-  installPhase = ''
-    make install
-    echo $out
-    find $out
-    wrapProgram $out/bin/gopenvpn --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-2/desktop/gopenvpn/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gopenvpn/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, glib, gtk2, gnome2, dbus_glib, gmime, libnotify, libgnome_keyring,
+  openssl, cyrus_sasl, gnonlin, sylpheed, gob2, gettext, intltool, libglade, polkit, autoconf, automake, expect,
+  openvpn, makeWrapper, pkexecPath ? "/var/setuid-wrappers/pkexec" }:
+
+let
+  redirects = [ "/usr/bin/pkexec=${pkexecPath}" ];
+in stdenv.mkDerivation rec {
+  rev = "2b9285f1ea2d11434b8ee8e10d937b2ea5285b63";
+  version = "0.8";
+  name = "gopenvpn-${version}";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "proteansec";
+    repo = "gopenvpn";
+    sha256 = "0pkdravr5wm7phdr2rd1rx1ry4dpwkrf0hv7wi99n4ywsl5jqwq8";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ glib gtk2 dbus_glib gmime libnotify libgnome_keyring openssl cyrus_sasl gnonlin sylpheed gob2
+                  gettext intltool libglade polkit pkgconfig autoconf automake expect openvpn makeWrapper ];
+
+  patchPhase = ''
+    # configure and remote extra "po/Makefile.in" in AC_CONFIG_FILES
+    sed -i -e 's:AC_CONFIG_FILES(\[pixmaps/Makefile po/Makefile.in:AC_CONFIG_FILES(\[pixmaps/Makefile:g' configure.ac
+    cat configure.ac | grep CONFIG_FILES
+  '';
+
+  preConfigure = ''
+    # copy standard gettext infrastructure files into a source package
+    autopoint -f
+    expect -c "spawn gettextize -f; expect -re \"Press Return to acknowledge the previous\""
+
+    # updating configuration files not required anymore due to autoreconfHook
+    autoreconf -vif
+  '';
+
+  preBuild = ''
+    # add no warnings flag to the Makefile, otherwise the following error will occur during built time:
+    #
+    #  > gopenvpn.c:978:10: error: format not a string literal and no format arguments [-Werror=format-security]
+    #
+    # Note that this wasn't solved by adding the "-Wformat-nonliteral -Wno-format-security -Wno-error=format-security"
+    # flags
+    sed -i -e '/^CFLAGS =/ s/$/ -w/' src/Makefile
+  '';
+
+  installPhase = ''
+    make install
+    echo $out
+    find $out
+    wrapProgram $out/bin/gopenvpn --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Graphical front-end for OpenVPN";
+    homepage = "http://gopenvpn.sourceforge.net/";
+    license = "GPL";
+    platforms = platforms.unix;
+    maintainers = [ maintainers.eleanor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12950,6 +12950,10 @@ in
 
   goldendict = qt55.callPackage ../applications/misc/goldendict { };
 
+  gopenvpn = callPackage ../desktops/gnome-2/desktop/gopenvpn {
+    inherit (gnome2) libglade;
+  };
+
   inherit (ocamlPackages) google-drive-ocamlfuse;
 
   google-musicmanager = callPackage ../applications/audio/google-musicmanager { };


### PR DESCRIPTION
###### Motivation for this change

Adding gopenvpn package.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


