### PR TITLE
erlang_basho_R16: B03-1 -> B02-8

### DIFF
--- a/pkgs/development/interpreters/erlang/R16B02-8-basho.nix
+++ b/pkgs/development/interpreters/erlang/R16B02-8-basho.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchgit, perl, gnum4, ncurses, openssl, autoconf264, gcc, erlang
+{ stdenv, fetchurl, fetchFromGitHub, perl, gnum4, ncurses, openssl, autoconf264, gcc, erlang
 , gnused, gawk, makeWrapper
 , odbcSupport ? false, unixODBC ? null
 , wxSupport ? false, mesa ? null, wxGTK ? null, xorg ? null
@@ -12,12 +12,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "erlang-basho-" + version + "${optionalString odbcSupport "-odbc"}";
-  version = "16B03-1";
+  version = "16B02";
 
-  src = fetchgit {
-    url = "https://github.com/basho/otp";
-    rev = "cb3a485894e493ad172db2749129e613fe52713a";
-    sha256 = "0xn28cxlq0ya1aww9q14rg8jf3x2flwxrz6wdnpb0l2h2dasr655";
+  src = fetchFromGitHub {
+    owner = "basho";
+    repo = "otp";
+    rev = "OTP_R16B02_basho8";
+    sha256 = "1w0hbm0axxxa45v3kl6bywc9ayir5vwqxjpnjlzc616ldszb2m0x";
   };
 
   debugInfo = enableDebugInfo;
@@ -56,7 +57,7 @@ stdenv.mkDerivation rec {
   postInstall = let
     manpages = fetchurl {
       url = "http://www.erlang.org/download/otp_doc_man_R${version}.tar.gz";
-      sha256 = "17f3k5j17rdsah18gywjngip6cbfgp6nb9di6il4pahmf9yvqc8g";
+      sha256 = "12apxjmmd591y9g9bhr97z5jbd1jarqg7wj0y2sqhl21hc1yp75p";
     };
   in ''
     ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5400,10 +5400,10 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
     odbcSupport = true;
   };
-  erlang_basho_R16B03 = callPackage ../development/interpreters/erlang/R16B03-1-basho.nix {
+  erlang_basho_R16B02 = callPackage ../development/interpreters/erlang/R16B02-8-basho.nix {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };
-  erlang_basho_R16B03_odbc = callPackage ../development/interpreters/erlang/R16B03-1-basho.nix {
+  erlang_basho_R16B02_odbc = callPackage ../development/interpreters/erlang/R16B02-8-basho.nix {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
     odbcSupport = true;
   };
@@ -10277,11 +10277,11 @@ in
   riak = callPackage ../servers/nosql/riak/2.1.1.nix { };
 
   riak-cs = callPackage ../servers/nosql/riak-cs/2.1.1.nix {
-    erlang = erlang_basho_R16B03;
+    erlang = erlang_basho_R16B02;
   };
 
   stanchion = callPackage ../servers/nosql/riak-cs/stanchion.nix {
-    erlang = erlang_basho_R16B03;
+    erlang = erlang_basho_R16B02;
   };
 
   influxdb = callPackage ../servers/nosql/influxdb { };


### PR DESCRIPTION
###### Motivation for this change
Changing the version of Basho's Erlang interpreter from R16B03-1 to R16B02-8. This is the recommended change as listed on the [Riak/Riak-CS/Stanchion pages](http://docs.basho.com/riak/kv/2.2.0/setup/installing/source/erlang/#installing-with-kerl).
On top of this, I have removed the git dependency, as `fetchgit` was changed to `fetchFromGitHub`.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

