### PR TITLE
gnome-control-center: provides access to the tracker gsettings schemas

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/gnome-control-center/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       shared_mime_info icu libtool docbook_xsl docbook_xsl_ns gnome3.grilo
       gdk_pixbuf gnome3.defaultIconTheme librsvg clutter clutter_gtk
       gnome3.vino udev libcanberra_gtk3 libgudev
-      networkmanager modemmanager makeWrapper gnome3.gnome-bluetooth grilo ];
+      networkmanager modemmanager makeWrapper gnome3.gnome-bluetooth grilo tracker ];
 
   preBuild = ''
     substituteInPlace panels/datetime/tz.h --replace "/usr/share/zoneinfo/zone.tab" "${tzdata}/share/zoneinfo/zone.tab"


### PR DESCRIPTION
###### Motivation for this change

gnome-control-center needs access to the tracker gsettings schemas to
enable the settings button in the search panel.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).