### PR TITLE
sisco.lv2: init at 0.7.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -132,6 +132,7 @@
   drets = "Dmytro Rets <dmitryrets@gmail.com>";
   drewkett = "Andrew Burkett <burkett.andrew@gmail.com>";
   dtzWill = "Will Dietz <nix@wdtz.org>";
+  e-user = "Alexander Kahl <nixos@sodosopa.io>";
   ebzzry = "Rommel Martinez <ebzzry@gmail.com>";
   ederoyd46 = "Matthew Brown <matt@ederoyd.co.uk>";
   eduarrrd = "Eduard Bachmakov <e.bachmakov@gmail.com>";

--- a/pkgs/applications/audio/sisco.lv2/default.nix
+++ b/pkgs/applications/audio/sisco.lv2/default.nix
@@ -1,33 +1,35 @@
-{ stdenv, fetchurl, lv2, pkgconfig, mesa, cairo, pango, libjack2 }:
+{ stdenv, fetchFromGitHub, lv2, pkgconfig, mesa, cairo, pango, libjack2 }:
 
 let
-  name = "sisco.lv2-${version}";
+  name = "sisco.lv2-${src.rev}";
   version = "0.7.0";
 
   robtkVersion = "80a2585253a861c81f0bfb7e4579c75f5c73af89";
   robtkName = "robtk-${robtkVersion}";
 
-  src = fetchurl {
-    name = "${name}.tar.gz";
-    url = "https://github.com/x42/sisco.lv2/archive/v${version}.tar.gz";
-    sha256 = "af7caccf2660138ab4da9b33b2f0e545516e6e49369682e9c7a7b791e1fda0b2";
+  src = fetchFromGitHub {
+    owner = "x42";
+    repo = "sisco.lv2";
+    rev = "v${version}";
+    sha256 = "1r6g29yqbdqgkh01x6d3nvmvc58rk2dp94fd0qyyizq37a1qplj1";
   };
 
-  robtkSrc = fetchurl {
-    name = "${robtkName}.tar.gz";
-    url = "https://github.com/x42/robtk/archive/${robtkVersion}.tar.gz";
-    sha256 = "81fc907b97705c218670e1fc2642daca6513d11f3d7554a22f8e144877e5c350";
+  robtkSrc = fetchFromGitHub {
+    owner = "x42";
+    repo = "robtk";
+    rev = robtkVersion;
+    sha256 = "0gk16nrvnrffqqw0yd015kja9wkgbzvb648bl1pagriabhznhfxl";
   };
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   inherit name;
 
   srcs = [ src robtkSrc ];
-  sourceRoot = name;
+  sourceRoot = "${name}-src";
 
   buildInputs = [ pkgconfig lv2 pango cairo libjack2 mesa ];
 
-  postUnpack = "mv ${robtkName}/* ${name}/robtk";
+  postUnpack = "chmod u+w -R ${robtkName}-src; mv ${robtkName}-src/* ${sourceRoot}/robtk";
   sisco_VERSION = version;
   preConfigure = "makeFlagsArray=(PREFIX=$out)";
 

--- a/pkgs/applications/audio/sisco.lv2/default.nix
+++ b/pkgs/applications/audio/sisco.lv2/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, lv2, pkgconfig, mesa, cairo, pango, libjack2 }:
 
 let
-  name = "sisco.lv2-${src.rev}";
+  name = "sisco.lv2-${version}";
   version = "0.7.0";
 
   robtkVersion = "80a2585253a861c81f0bfb7e4579c75f5c73af89";
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   inherit name;
 
   srcs = [ src robtkSrc ];
-  sourceRoot = "${name}-src";
+  sourceRoot = "sisco.lv2-${src.rev}-src";
 
   buildInputs = [ pkgconfig lv2 pango cairo libjack2 mesa ];
 

--- a/pkgs/applications/audio/sisco.lv2/default.nix
+++ b/pkgs/applications/audio/sisco.lv2/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, lv2, pkgconfig, mesa, cairo, pango, libjack2 }:
+
+let
+  name = "sisco.lv2-${version}";
+  version = "0.7.0";
+
+  robtkVersion = "80a2585253a861c81f0bfb7e4579c75f5c73af89";
+  robtkName = "robtk-${robtkVersion}";
+
+  src = fetchurl {
+    name = "${name}.tar.gz";
+    url = "https://github.com/x42/sisco.lv2/archive/v${version}.tar.gz";
+    sha256 = "af7caccf2660138ab4da9b33b2f0e545516e6e49369682e9c7a7b791e1fda0b2";
+  };
+
+  robtkSrc = fetchurl {
+    name = "${robtkName}.tar.gz";
+    url = "https://github.com/x42/robtk/archive/${robtkVersion}.tar.gz";
+    sha256 = "81fc907b97705c218670e1fc2642daca6513d11f3d7554a22f8e144877e5c350";
+  };
+in
+stdenv.mkDerivation {
+  inherit name;
+
+  srcs = [ src robtkSrc ];
+  sourceRoot = name;
+
+  buildInputs = [ pkgconfig lv2 pango cairo libjack2 mesa ];
+
+  postUnpack = "mv ${robtkName}/* ${name}/robtk";
+  sisco_VERSION = version;
+  preConfigure = "makeFlagsArray=(PREFIX=$out)";
+
+  meta = with stdenv.lib; {
+    description = "Simple audio oscilloscope with variable time scale, triggering, cursors and numeric readout in LV2 plugin format";
+    homepage = http://x42.github.io/sisco.lv2/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.e-user ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3683,6 +3683,8 @@ in
 
   sipsak = callPackage ../tools/networking/sipsak { };
 
+  sisco.lv2 = callPackage ../applications/audio/sisco.lv2 { };
+
   skippy-xd = callPackage ../tools/X11/skippy-xd {};
 
   sks = callPackage ../servers/sks { };


### PR DESCRIPTION
###### Motivation for this change

I needed sisco.lv2 myself for analyzing waveforms.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Also added maintainer `e-user`