### PR TITLE
nixos-container: support bridge and port forwarding for imperative nixos-container

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -347,7 +347,10 @@ let
       default = [];
       example = [ { protocol = "tcp"; hostPort = 8080; containerPort = 80; } ];
       description = ''
-        List of forwarded ports from host to container. Each forwarded port is specified by protocol, hostPort and containerPort. By default, protocol is tcp and hostPort and containerPort are assumed to be the same if containerPort is not explicitly given. 
+        List of forwarded ports from host to container. Each forwarded port
+        is specified by protocol, hostPort and containerPort. By default,
+        protocol is tcp and hostPort and containerPort are assumed to be
+        the same if containerPort is not explicitly given. 
       '';
     };
 

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -89,6 +89,9 @@ let
         if [ -n "$HOST_BRIDGE" ]; then
           extraFlags+=" --network-bridge=$HOST_BRIDGE"
         fi
+        if [ -n "$HOST_PORT" ]; then
+          extraFlags+=" --port=$HOST_PORT"
+        fi
       fi
 
       extraFlags+=" ${concatStringsSep " " (mapAttrsToList nspawnExtraVethArgs cfg.extraVeths)}"

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -90,13 +90,13 @@ let
           extraFlags+=" --network-bridge=$HOST_BRIDGE"
         fi
         if [ -n "$HOST_PORT" ]; then
-	  OIFS=$IFS
-	  IFS=","
+          OIFS=$IFS
+          IFS=","
           for i in $HOST_PORT
-	  do
+          do
               extraFlags+=" --port=$i"
-	  done
-	  IFS=$OIFS
+          done
+          IFS=$OIFS
         fi
       fi
 
@@ -325,12 +325,29 @@ let
       '';
     };
 
-    hostPort = mkOption {
-      type = types.listOf types.str;
-      default = null;
-      example = [ "8080" ];
+    forwardPorts = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          protocol = mkOption {
+            type = types.str;
+            default = "tcp";
+            description = "The protocol specifier for port forwarding between host and container";
+          };
+          hostPort = mkOption {
+            type = types.int;
+            description = "Source port of the external interface on host";
+          };
+          containerPort = mkOption {
+            type = types.nullOr types.int;
+            default = null;
+            description = "Target port of container";
+          };
+        };
+      });
+      default = [];
+      example = [ { protocol = "tcp"; hostPort = 8080; containerPort = 80; } ];
       description = ''
-        List of forwarded ports from the host to the container. 
+        List of forwarded ports from host to container. Each forwarded port is specified by protocol, hostPort and containerPort. By default, protocol is tcp and hostPort and containerPort are assumed to be the same if containerPort is not explicitly given. 
       '';
     };
 
@@ -651,7 +668,9 @@ in
     # Generate a configuration file in /etc/containers for each
     # container so that container@.target can get the container
     # configuration.
-    environment.etc = mapAttrs' (name: cfg: nameValuePair "containers/${name}.conf"
+    environment.etc =
+      let mkPortStr = p: p.protocol + ":" + (toString p.hostPort) + ":" + (if p.containerPort == null then toString p.hostPort else toString p.containerPort); 
+      in mapAttrs' (name: cfg: nameValuePair "containers/${name}.conf"
       { text =
           ''
             SYSTEM_PATH=${cfg.path}
@@ -660,8 +679,8 @@ in
               ${optionalString (cfg.hostBridge != null) ''
                 HOST_BRIDGE=${cfg.hostBridge}
               ''}
-              ${optionalString (length cfg.hostPort > 0) ''
-                HOST_PORT=${concatStringsSep "," cfg.hostPort}
+              ${optionalString (length cfg.forwardPorts > 0) ''
+                HOST_PORT=${concatStringsSep "," (map mkPortStr cfg.forwardPorts)}
               ''}
               ${optionalString (cfg.hostAddress != null) ''
                 HOST_ADDRESS=${cfg.hostAddress}

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -90,7 +90,13 @@ let
           extraFlags+=" --network-bridge=$HOST_BRIDGE"
         fi
         if [ -n "$HOST_PORT" ]; then
-          extraFlags+=" --port=$HOST_PORT"
+	  OIFS=$IFS
+	  IFS=","
+          for i in $HOST_PORT
+	  do
+              extraFlags+=" --port=$i"
+	  done
+	  IFS=$OIFS
         fi
       fi
 
@@ -320,11 +326,11 @@ let
     };
 
     hostPort = mkOption {
-      type = types.nullOr types.string;
+      type = types.listOf types.str;
       default = null;
-      example = "8080";
+      example = [ "8080" ];
       description = ''
-        Allow port forwarding from the host to the container. 
+        List of forwarded ports from the host to the container. 
       '';
     };
 
@@ -654,8 +660,8 @@ in
               ${optionalString (cfg.hostBridge != null) ''
                 HOST_BRIDGE=${cfg.hostBridge}
               ''}
-              ${optionalString (cfg.hostPort != null) ''
-                HOST_PORT=${cfg.hostPort}
+              ${optionalString (length cfg.hostPort > 0) ''
+                HOST_PORT=${concatStringsSep "," cfg.hostPort}
               ''}
               ${optionalString (cfg.hostAddress != null) ''
                 HOST_ADDRESS=${cfg.hostAddress}

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -131,6 +131,7 @@ let
         --setenv LOCAL_ADDRESS="$LOCAL_ADDRESS" \
         --setenv HOST_ADDRESS6="$HOST_ADDRESS6" \
         --setenv LOCAL_ADDRESS6="$LOCAL_ADDRESS6" \
+        --setenv HOST_PORT="$HOST_PORT" \
         --setenv PATH="$PATH" \
         ${if cfg.additionalCapabilities != null && cfg.additionalCapabilities != [] then
           ''--capability="${concatStringsSep " " cfg.additionalCapabilities}"'' else ""
@@ -317,6 +318,16 @@ let
         Only one of hostAddress* or hostBridge can be given.
       '';
     };
+
+    hostPort = mkOption {
+      type = types.nullOr types.string;
+      default = null;
+      example = "8080";
+      description = ''
+        Allow port forwarding from the host to the container. 
+      '';
+    };
+
 
     hostAddress = mkOption {
       type = types.nullOr types.str;
@@ -642,6 +653,9 @@ in
               PRIVATE_NETWORK=1
               ${optionalString (cfg.hostBridge != null) ''
                 HOST_BRIDGE=${cfg.hostBridge}
+              ''}
+              ${optionalString (cfg.hostPort != null) ''
+                HOST_PORT=${cfg.hostPort}
               ''}
               ${optionalString (cfg.hostAddress != null) ''
                 HOST_ADDRESS=${cfg.hostAddress}

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -1,0 +1,63 @@
+# Test for NixOS' container support.
+
+let
+  hostIp = "192.168.0.1";
+  hostPort = 10080;
+  containerIp = "192.168.0.100";
+  containerPort = 80;
+in 
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "containers-portforward";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ aristid aszlig eelco chaoflow kampfschlaefer ianwookim ];
+  };
+
+  machine =
+    { config, pkgs, ... }:
+    { imports = [ ../modules/installer/cd-dvd/channel.nix ];
+      virtualisation.writableStore = true;
+      virtualisation.memorySize = 768;
+
+      containers.webserver =
+        { privateNetwork = true;
+          hostAddress = hostIp;
+          localAddress = containerIp;
+          forwardPorts = [ { protocol = "tcp"; hostPort = hostPort; containerPort = containerPort; } ];
+          config =
+            { services.httpd.enable = true;
+              services.httpd.adminAddr = "foo@example.org";
+              networking.firewall.allowedTCPPorts = [ 80 ];
+              networking.firewall.allowPing = true;
+            };
+        };
+
+      virtualisation.pathsInNixDB = [ pkgs.stdenv ];
+    };
+
+  testScript =
+    ''
+      $machine->succeed("nixos-container list") =~ /webserver/ or die;
+
+      # Start the webserver container.
+      $machine->succeed("nixos-container start webserver");
+
+      # wait two seconds for the container to start and the network to be up
+      sleep 2;
+
+      # Since "start" returns after the container has reached
+      # multi-user.target, we should now be able to access it.
+      #my $ip = $machine->succeed("nixos-container show-ip webserver");
+      #chomp $ip;
+      $machine->succeed("ping -n -c1 ${hostIp}");
+      $machine->succeed("curl --fail http://${hostIp}:${toString hostPort}/ > /dev/null");
+
+      # Stop the container.
+      $machine->succeed("nixos-container stop webserver");
+      $machine->fail("curl --fail --connect-timeout 2 http://${hostIp}:${toString hostPort}/ > /dev/null");
+
+      # Destroying a declarative container should fail.
+      $machine->fail("nixos-container destroy webserver");
+    '';
+
+})

--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -16,7 +16,7 @@ umask 0022;
 sub showHelp {
     print <<EOF;
 Usage: nixos-container list
-       nixos-container create <container-name> [--nixos-path <path>] [--system-path <path>] [--config-file <path>] [--config <string>] [--ensure-unique-name] [--auto-start] [--bridge <iface>]
+       nixos-container create <container-name> [--nixos-path <path>] [--system-path <path>] [--config-file <path>] [--config <string>] [--ensure-unique-name] [--auto-start] [--bridge <iface>] [--port <port>]
        nixos-container destroy <container-name>
        nixos-container start <container-name>
        nixos-container stop <container-name>
@@ -37,6 +37,7 @@ my $nixosPath;
 my $ensureUniqueName = 0;
 my $autoStart = 0;
 my $bridge;
+my $port;
 my $extraConfig;
 my $signal;
 my $configFile;
@@ -46,6 +47,7 @@ GetOptions(
     "ensure-unique-name" => \$ensureUniqueName,
     "auto-start" => \$autoStart,
     "bridge=s" => \$bridge,
+    "port=s" => \$port,
     "system-path=s" => \$systemPath,
     "signal=s" => \$signal,
     "nixos-path=s" => \$nixosPath,
@@ -156,6 +158,7 @@ if ($action eq "create") {
     push @conf, "HOST_ADDRESS=$hostAddress\n";
     push @conf, "LOCAL_ADDRESS=$localAddress\n";
     push @conf, "HOST_BRIDGE=$bridge\n";
+    push @conf, "HOST_PORT=$port\n";
     push @conf, "AUTO_START=$autoStart\n";
     write_file($confFile, \@conf);
 

--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -16,7 +16,7 @@ umask 0022;
 sub showHelp {
     print <<EOF;
 Usage: nixos-container list
-       nixos-container create <container-name> [--nixos-path <path>] [--system-path <path>] [--config-file <path>] [--config <string>] [--ensure-unique-name] [--auto-start]
+       nixos-container create <container-name> [--nixos-path <path>] [--system-path <path>] [--config-file <path>] [--config <string>] [--ensure-unique-name] [--auto-start] [--bridge <iface>]
        nixos-container destroy <container-name>
        nixos-container start <container-name>
        nixos-container stop <container-name>
@@ -36,6 +36,7 @@ my $systemPath;
 my $nixosPath;
 my $ensureUniqueName = 0;
 my $autoStart = 0;
+my $bridge;
 my $extraConfig;
 my $signal;
 my $configFile;
@@ -44,6 +45,7 @@ GetOptions(
     "help" => sub { showHelp() },
     "ensure-unique-name" => \$ensureUniqueName,
     "auto-start" => \$autoStart,
+    "bridge=s" => \$bridge,
     "system-path=s" => \$systemPath,
     "signal=s" => \$signal,
     "nixos-path=s" => \$nixosPath,
@@ -153,6 +155,7 @@ if ($action eq "create") {
     push @conf, "PRIVATE_NETWORK=1\n";
     push @conf, "HOST_ADDRESS=$hostAddress\n";
     push @conf, "LOCAL_ADDRESS=$localAddress\n";
+    push @conf, "HOST_BRIDGE=$bridge\n";
     push @conf, "AUTO_START=$autoStart\n";
     write_file($confFile, \@conf);
 


### PR DESCRIPTION
###### Motivation for this change
systemd-nspawn supports network bridge and port forwarding via `--network-bridge` and `--port` option. Declarative container already supports network bridge but does not support port yet. Imperative container does not support both. 

This PR introduces two options `--bridge` and `--port` to nixos-container commands and implements corresponding `--port` option in nixos/modules/virtualisation/containers.nix.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

