### PR TITLE
Ensure dbus detects new services

### DIFF
--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -31,9 +31,6 @@ let
 
       cp ${pkgs.dbus.out}/share/dbus-1/{system,session}.conf $out
 
-      # avoid circular includes
-      sed -ri 's@(<include ignore_missing="yes">/etc/dbus-1/(system|session)\.conf</include>)@<!-- \1 -->@g' $out/{system,session}.conf
-
       # include by full path
       sed -ri "s@/etc/dbus-1/(system|session)-@$out/\1-@" $out/{system,session}.conf
 
@@ -98,11 +95,6 @@ in
 
     environment.systemPackages = [ pkgs.dbus.daemon pkgs.dbus ];
 
-    environment.etc = singleton
-      { source = configDir;
-        target = "dbus-1";
-      };
-
     users.extraUsers.messagebus = {
       uid = config.ids.uids.messagebus;
       description = "D-Bus system message bus daemon user";
@@ -134,8 +126,8 @@ in
       reloadIfChanged = true;
       restartTriggers = [ configDir ];
       serviceConfig.ExecStart = [
-        ""
-        "${lib.getBin pkgs.dbus}/bin/dbus-daemon --config-file=${configDir}/system.conf ${daemonArgs}"
+        "" # Default dbus.service has two entries, we need to override both.
+        "${lib.getBin pkgs.dbus}/bin/dbus-daemon --config-file=/run/current-system/dbus/system.conf ${daemonArgs}"
       ];
     };
 
@@ -145,13 +137,17 @@ in
         reloadIfChanged = true;
         restartTriggers = [ configDir ];
         serviceConfig.ExecStart = [
-          ""
-          "${lib.getBin pkgs.dbus}/bin/dbus-daemon --config-file=${configDir}/session.conf ${daemonArgs}"
+          "" # Default dbus.service has two entries, we need to override both.
+          "${lib.getBin pkgs.dbus}/bin/dbus-daemon --config-file=/run/current-system/dbus/session.conf ${daemonArgs}"
         ];
       };
       sockets.dbus.wantedBy = mkIf cfg.socketActivated [ "sockets.target" ];
     };
 
     environment.pathsToLink = [ "/etc/dbus-1" "/share/dbus-1" ];
+
+    system.extraSystemBuilderCmds = ''
+      ln -s ${configDir} $out/dbus
+    '';
   };
 }


### PR DESCRIPTION
From the dbus introduction:

> The service files go into a directory indicated in a <servicedir>
> block in the bus' configuration file; the default location is
> /usr/share/dbus-1/services/. If you add service files while the bus is
> running, the bus daemon will notice and read them without any further
> prodding.

This patch sets <servicedir>'s to /run/current-system/sw/... and bundles
all the provided dbus schemas in that location. System updates are
automatically catched by dbus.

Fixes #19034.