### PR TITLE
mkvtoolnix: 9.5.0 -> 9.6.0

### DIFF
--- a/pkgs/applications/video/mkvtoolnix/default.nix
+++ b/pkgs/applications/video/mkvtoolnix/default.nix
@@ -10,13 +10,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "mkvtoolnix-${version}";
-  version = "9.5.0";
+  version = "9.6.0";
 
   src = fetchFromGitHub {
     owner = "mbunkus";
     repo = "mkvtoolnix";
     rev = "release-${version}";
-    sha256 = "1v6rqlb5srhwzad45b50pvfbi1c9n719ihi54hzbkzklj7h4s70h";
+    sha256 = "14v6iclzkqxibzcdxr65bb5frmnsjyyly0d3lwv1gg7g1mkcw3jd";
   };
 
   nativeBuildInputs = [ pkgconfig autoconf automake gettext ruby ];


### PR DESCRIPTION
###### Motivation for this change

Update to the latest release of the package.

[**Release notes**](https://www.bunkus.org/blog/2016/11/mkvtoolnix-v9-6-0-released/)

> This release fixes one major bug in mkvmerge (an endless loop) when appending files. It mostly occurred when muxing MPLS playlists. Several other minor bug fixes and usability enhancements were implemented.
> 
> Nothing’s been changed regarding the packaging since v9.5.0.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).