### PR TITLE
adapta-backgrounds: init at 0.4.0.6

### DIFF
--- a/pkgs/data/misc/adapta-backgrounds/default.nix
+++ b/pkgs/data/misc/adapta-backgrounds/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "adapta-backgrounds-${version}";
+  version = "0.4.0.6";
+
+  src = fetchFromGitHub {
+    owner = "adapta-project";
+    repo = "adapta-backgrounds";
+    rev = version;
+    sha256 = "1yqxrwhjl6g92wm52kalbns41i2l5g45qbd4185b22crhbrn5x79";
+  };
+
+  nativeBuildInputs = [ autoreconfHook  ];
+
+  meta = with stdenv.lib; {
+    description = "A wallpaper collection for adapta-project";
+    homepage = https://github.com/adapta-project/adapta-backgrounds;
+    license = with licenses; [ gpl2 cc-by-sa-30 ];
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11690,6 +11690,8 @@ in
 
   ### DATA
 
+  adapta-backgrounds = callPackage ../data/misc/adapta-backgrounds { };
+
   andagii = callPackage ../data/fonts/andagii { };
 
   android-udev-rules = callPackage ../os-specific/linux/android-udev-rules { };


### PR DESCRIPTION
###### Motivation for this change

[Adapta Backgrounds](https://github.com/adapta-project/adapta-backgrounds) is a wallpaper collection for adapta-project.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).