### PR TITLE
cpp-ipfs-api: init at 2016-11-09

### DIFF
--- a/pkgs/development/libraries/cpp-ipfs-api/default.nix
+++ b/pkgs/development/libraries/cpp-ipfs-api/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, curl, cmake, nlohmann_json }:
+
+stdenv.mkDerivation rec {
+  name = "cpp-ipfs-api-${version}";
+  version = "2016-11-09";
+
+  src = fetchFromGitHub {
+    owner = "vasild";
+    repo = "cpp-ipfs-api";
+    rev = "46e473e49ede4fd829235f1d4930754d5356a747";
+    sha256 = "10c5hmg9857zb0fp262ca4a42gq9iqdyqz7f975cp3qs70x12q08";
+  };
+
+  buildInputs = [ cmake curl ];
+  propagatedBuildInputs = [ nlohmann_json ];
+
+  meta = with stdenv.lib; {
+    description = "IPFS C++ API client library";
+    homepage = https://github.com/vasild/cpp-ipfs-api;
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6805,6 +6805,8 @@ in
 
   cpp-hocon = callPackage ../development/libraries/cpp-hocon { };
 
+  cpp-ipfs-api = callPackage ../development/libraries/cpp-ipfs-api { };
+
   cpp-netlib = callPackage ../development/libraries/cpp-netlib { };
   uri = callPackage ../development/libraries/uri { };
 


### PR DESCRIPTION
###### Motivation for this change

preparation for something bigger...

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @fpletz 
