### PR TITLE
marathon: 1.1.2 -> 1.3.6

### DIFF
--- a/pkgs/applications/networking/cluster/marathon/default.nix
+++ b/pkgs/applications/networking/cluster/marathon/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "marathon-${version}";
-  version = "1.1.2";
+  version = "1.3.6";
 
   src = fetchurl {
     url = "https://downloads.mesosphere.com/marathon/v${version}/marathon-${version}.tgz";
-    sha256 = "1c1ml3blhhc10mky5pqxhpndbz6nk7qgcfbzwdqj9kqfzmwlsfbb";
+    sha256 = "12a6ah6qsx1ap6y7sps4vwkq8lyc08k1qnak2mnsa04ifrx9z0dy";
   };
 
   buildInputs = [ makeWrapper jdk mesos ];


### PR DESCRIPTION
###### Motivation for this change

Marathon update to match Mesos 1.0

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


