### PR TITLE
e17gtk: init at 3.22.0

### DIFF
--- a/pkgs/misc/themes/e17gtk/default.nix
+++ b/pkgs/misc/themes/e17gtk/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, gnome3 }:
+
+stdenv.mkDerivation rec {
+  name = "e17gtk-${version}";
+  version = "${gnome3.version}.0";
+
+  src = fetchFromGitHub {
+    owner = "tsujan";
+    repo = "E17gtk";
+    rev = "V${version}";
+    sha256 = {
+      "3.20" = "1dbhwsqqk12rff1971q2snvg38dx2y33dxr2l9yvwrhrhsgmc2v7";
+      "3.22" = "17ir1f7ka765m57bdx3knq4k1837p118a384qnmsj83bz15k39i3";
+    }."${gnome3.version}";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/{doc,themes}/E17gtk
+    cp -a index.theme gtk-2.0 gtk-3.0 metacity-1 $out/share/themes/E17gtk/
+    cp -a README.md WORKAROUNDS screenshot.jpg $out/share/doc/E17gtk/
+  '';
+
+  meta = {
+    description = "An Enlightenment-like GTK+ theme with sharp corners";
+    homepage = https://github.com/tsujan/E17gtk;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17034,6 +17034,8 @@ in
 
   crashplan = callPackage ../applications/backup/crashplan { };
 
+  e17gtk = callPackage ../misc/themes/e17gtk { };
+
   epson-escpr = callPackage ../misc/drivers/epson-escpr { };
 
   epson_201207w = callPackage ../misc/drivers/epson_201207w { };


### PR DESCRIPTION
###### Motivation for this change

Add [E17gtk](https://github.com/tsujan/E17gtk), an Enlightenment-like GTK+ theme with sharp corners.

> E17gtk is a dark GTK2/GTK3 theme with sharp corners, which is designed for use in Enlightenment and gives the elegant look of Enlightenment to GTK widgets. Of course, it can be used in other environments too but it is not tuned to Gnome or any of its apps.

> ![screenshot](https://cloud.githubusercontent.com/assets/1217934/20858697/79cfc77a-b932-11e6-8f10-fc46de66d03f.jpg)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).