### PR TITLE
neovim-qt: 0.2.3 -> 0.2.4

### DIFF
--- a/pkgs/applications/editors/neovim/qt.nix
+++ b/pkgs/applications/editors/neovim/qt.nix
@@ -3,7 +3,7 @@
 }:
 
 let # not very usable ATM
-  version = "0.2.3";
+  version = "0.2.4";
 in
 stdenv.mkDerivation {
   name = "neovim-qt-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     owner = "equalsraf";
     repo = "neovim-qt";
     rev = "v${version}";
-    sha256 = "0ichqph7nfw3934jf0sp81bqd376xna3f899cc2xg88alb4f16dv";
+    sha256 = "0yf9wwkl0lbbj3vyf8hxnlsk7jhk5ggivszyqxply69dbar9ww59";
   };
 
   # It tries to download libmsgpack; let's use ours.


### PR DESCRIPTION
###### Motivation for this change
Fixes problem with `API methods mismatch: Cannot connect to this instance of Neovim, its version is likely too old, or the API has changed`

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


