### PR TITLE
nixos/pulseaudio: make daemon.conf configurable

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -160,6 +160,13 @@ in {
             if activated.
           '';
         };
+
+        config = mkOption {
+          type = types.attrsOf types.unspecified;
+          default = {};
+          description = ''Config of the pulse daemon. See <literal>man pulse-daemon.conf</literal>.'';
+          example = literalExample ''{ flat-volumes = "no"; }'';
+        };
       };
 
       zeroconf = {
@@ -204,10 +211,13 @@ in {
     (mkIf cfg.enable {
       environment.systemPackages = [ overriddenPackage ];
 
-      environment.etc = singleton {
-        target = "asound.conf";
-        source = alsaConf;
-      };
+      environment.etc = [
+        { target = "asound.conf";
+          source = alsaConf; }
+
+        { target = "pulse/daemon.conf";
+          source = writeText "daemon.conf" (lib.generators.toKeyValue {} cfg.daemon.config); }
+      ];
 
       # Allow PulseAudio to get realtime priority using rtkit.
       security.rtkit.enable = true;


### PR DESCRIPTION
###### Motivation for this change

There is no possibilty to adjust the behavior of the pulseadio daemon via the daemon.conf file at the moment.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This adds the following options:

* `pulseaudio.daemon.flat-volumes`: wether to allow pulseaudio to adjust
  the sink volume based on playback volumes
* `pulseaudio.daemon.resample-method`: set pulseaudios resampling method
* `pulseaudio.daemon.extraConfig`: extra config for daemon.conf

Open question: Should we change the default value of flat-volumes?
The behavior has caused some controversy and Ubuntu as well as ArchLinux
chose to disable the feature.

---

Note: This is my first change involving `nixos/modules` and I am happy to receive suggestions to improve the code.