### PR TITLE
[Do not merge*] Restore stdenv debugging at the cost of more complexity

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1,5 +1,11 @@
-{ lib, allPackages
-, system, platform, crossSystem, config
+{ _defaults    ? import ../debug.nix
+, argsResolved ? _defaults.extend (_: _: args)
+, lib          ? argsResolved.lib
+, allPackages  ? argsResolved.allPackages
+, system       ? argsResolved.system
+, platform     ? argsResolved.platform
+, crossSystem  ? argsResolved.crossSystem
+, config       ? argsResolved.config
 
 # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
 , bootstrapFiles ? let
@@ -13,7 +19,7 @@
     cpio    = fetch { file = "cpio";  sha256 = "0lw057bmcqls96j0gv1n3mgl66q31mba7i413cbkkaf0rfzz3dxj"; };
     tarball = fetch { file = "bootstrap-tools.cpio.bz2"; sha256 = "13ihbj002pis3fgy1d9c4fi7flca21z9brjsjkklm82h5b4nlwxl"; executable = false; };
   }
-}:
+} @ args:
 
 assert crossSystem == null;
 

--- a/pkgs/stdenv/debug.nix
+++ b/pkgs/stdenv/debug.nix
@@ -1,0 +1,25 @@
+# This file mimicks top-level/default.nix, and is used to provide default
+# arguments for testing stdenvs.
+
+let lib = import ../../lib; in
+
+builtins.trace
+
+"Information from pkgs/stdenv/debug.nix is strictly for debugging. You should not see this message durring normal use of nixpkgs."
+
+(lib.makeExtensible (self: {
+  test-pkgspath = ../..;
+
+  lib = import (self.test-pkgspath + "/lib");
+  platforms = import (self.test-pkgspath + "/pkgs/top-level/platforms.nix");
+  allPackages = args: import (self.test-pkgspath + "/pkgs/top-level/stage.nix") ({
+    inherit (self) lib;
+    nixpkgsFun = args: builtins.abort
+      "`nixpkgsFun` is too difficult to support for this mockup, and shouldn't be used by packages anyways.";
+  } // args);
+
+  system = builtins.currentSystem;
+  platform = self.platforms.selectPlatformBySystem self.system;
+  crossSystem = null;
+  config = {};
+}))

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -1,6 +1,12 @@
-{ lib, allPackages
-, system, platform, crossSystem, config
-}:
+{ _defaults    ? import ../debug.nix
+, argsResolved ? _defaults.extend (_: _: args)
+, lib          ? argsResolved.lib
+, allPackages  ? argsResolved.allPackages
+, system       ? argsResolved.system
+, platform     ? argsResolved.platform
+, crossSystem  ? argsResolved.crossSystem
+, config       ? argsResolved.config
+} @ args:
 
 assert crossSystem == null;
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -3,8 +3,16 @@
 # external (non-Nix) tools, such as /usr/bin/gcc, and it contains a C
 # compiler and linker that do not search in default locations,
 # ensuring purity of components produced by it.
-{ lib, allPackages
-, system, platform, crossSystem, config
+
+# The function defaults are for easy testing.
+{ _defaults    ? import ../debug.nix
+, argsResolved ? _defaults.extend (_: _: args)
+, lib          ? argsResolved.lib
+, allPackages  ? argsResolved.allPackages
+, system       ? argsResolved.system
+, platform     ? argsResolved.platform
+, crossSystem  ? argsResolved.crossSystem
+, config       ? argsResolved.config
 
 , bootstrapFiles ?
     if system == "i686-linux" then import ./bootstrap/i686.nix
@@ -14,7 +22,7 @@
     else if system == "armv7l-linux" then import ./bootstrap/armv7l.nix
     else if system == "mips64el-linux" then import ./bootstrap/loongson2f.nix
     else abort "unsupported platform for the pure Linux stdenv"
-}:
+} @ args:
 
 assert crossSystem == null;
 

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -175,13 +175,6 @@ rec {
 
   bootstrapTools = (import ./default.nix {
     inherit system bootstrapFiles;
-
-    lib = assert false; null;
-    allPackages = assert false; null;
-
-    platform = assert false; null;
-    crossSystem = assert false; null;
-    config = assert false; null;
   }).bootstrapTools;
 
   test = derivation {

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -1,6 +1,12 @@
-{ lib, allPackages
-, system, platform, crossSystem, config
-}:
+{ _defaults    ? import ../debug.nix
+, argsResolved ? _defaults.extend (_: _: args)
+, lib          ? argsResolved.lib
+, allPackages  ? argsResolved.allPackages
+, system       ? argsResolved.system
+, platform     ? argsResolved.platform
+, crossSystem  ? argsResolved.crossSystem
+, config       ? argsResolved.config
+} @ args:
 
 assert crossSystem == null;
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/15043 simplifies and cleans up the way stdenvs are bootstrapped, at the cost of removing potentially useful debugging aids. This adds back debugging aids at least as useful as the old ones, but at the cost of some complexity (though the extra stuff should all be dead code when not debugging.)

I'm, not sure whether this is a good idea or not--my hope is that by opening this anyone who's workflows are gummed up by #15043 has somewhere to turn. If that's you, feel free to merge.