### PR TITLE
findlib: 1.6.1 → 1.7.1; ocamlbuild: 0.9.2 → 0.9.3

### DIFF
--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ocaml-findlib-${version}";
-  version = "1.6.1";
+  version = "1.7.1";
 
   src = fetchurl {
     url = "http://download.camlcity.org/download/findlib-${version}.tar.gz";
-    sha256 = "02abg1lsnwvjg3igdyb8qjgr5kv1nbwl4gaf8mdinzfii5p82721";
+    sha256 = "1vsys5gpahi36nxv5yx29zhwn8b2d7sqqswza05vxy5bx5wrljsx";
   };
 
   buildInputs = [m4 ncurses ocaml];

--- a/pkgs/development/tools/ocaml/findlib/install_topfind.patch
+++ b/pkgs/development/tools/ocaml/findlib/install_topfind.patch
@@ -6,7 +6,7 @@
  	mkdir -p "$(prefix)$(OCAMLFIND_BIN)"
 -	test $(INSTALL_TOPFIND) -eq 0 || cp topfind "$(prefix)$(OCAML_CORE_STDLIB)"
 +	test $(INSTALL_TOPFIND) -eq 0 || cp topfind "$(prefix)$(OCAML_SITELIB)"
- 	files=`$(TOP)/tools/collect_files $(TOP)/Makefile.config findlib.cmi findlib.mli findlib.cma topfind.cmi topfind.mli fl_package_base.mli fl_package_base.cmi fl_metascanner.mli fl_metascanner.cmi fl_metatoken.cmi findlib_top.cma findlib.cmxa findlib.a findlib.cmxs findlib_dynload.cma findlib_dynload.cmxa findlib_dynload.a findlib_dynload.cmxs fl_dynload.mli fl_dynload.cmi META` && \
- 	cp $$files "$(prefix)$(OCAML_SITELIB)/$(NAME)"
- 	f="ocamlfind$(EXEC_SUFFIX)"; { test -f ocamlfind_opt$(EXEC_SUFFIX) && f="ocamlfind_opt$(EXEC_SUFFIX)"; }; \
+	files=`$(TOP)/tools/collect_files $(TOP)/Makefile.config findlib.cmi findlib.mli findlib.cma findlib.cmxa findlib.a findlib.cmxs topfind.cmi topfind.mli fl_package_base.mli fl_package_base.cmi fl_metascanner.mli fl_metascanner.cmi fl_metatoken.cmi findlib_top.cma findlib_top.cmxa findlib_top.a findlib_top.cmxs findlib_dynload.cma findlib_dynload.cmxa findlib_dynload.a findlib_dynload.cmxs fl_dynload.mli fl_dynload.cmi META` && \
+	cp $$files "$(prefix)$(OCAML_SITELIB)/$(NAME)"
+	f="ocamlfind$(EXEC_SUFFIX)"; { test -f ocamlfind_opt$(EXEC_SUFFIX) && f="ocamlfind_opt$(EXEC_SUFFIX)"; }; \
 

--- a/pkgs/development/tools/ocaml/ocamlbuild/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlbuild/default.nix
@@ -1,17 +1,17 @@
 {stdenv, fetchFromGitHub, ocaml, findlib, buildOcaml, type_conv, camlp4,
  ocamlmod, ocamlify, ounit, expect}:
 let
-  version = "0.9.2";
+  version = "0.9.3";
 in
 stdenv.mkDerivation {
-  name = "ocamlbuild";
+  name = "ocamlbuild-${version}";
   inherit version;
 
   src = fetchFromGitHub {
     owner = "ocaml";
     repo = "ocamlbuild";
     rev = version;
-    sha256 = "0q4bvik08v444g1pill9zgwal48xs50jf424lbryfvqghhw5xjjc";
+    sha256 = "1ikm51lx4jz5vmbvrdwsm5p59bwbz3pi22vqkyz5lmqcciyn69i3";
   };
 
   createFindlibDestdir = true;
@@ -25,18 +25,12 @@ stdenv.mkDerivation {
     "OCAMLBUILD_LIBDIR=$OCAMLFIND_DESTDIR"
   '';
 
-  # configurePhase = "ocaml setup.ml -configure --prefix $out";
-  # buildPhase     = "ocaml setup.ml -build";
-  # installPhase   = "ocaml setup.ml -install";
-
-  # meta = with stdenv.lib; {
-  #   homepage = http://oasis.forge.ocamlcore.org/;
-  #   description = "Configure, build and install system for OCaml projects";
-  #   license = licenses.lgpl21;
-  #   platforms = ocaml.meta.platforms or [];
-  #   maintainers = with maintainers; [
-  #     vbgl z77z
-  #   ];
-  # };
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ocaml/ocamlbuild/;
+    description = "A build system with builtin rules to easily build most OCaml projects";
+    license = licenses.lgpl2;
+    inherit (ocaml.meta) platforms;
+    maintainers = with maintainers; [ vbgl ];
+  };
 }
 


### PR DESCRIPTION
This updates two basic OCaml packages, hence affects virtually all OCaml programs and libraries. I did not try to rebuild them all, only a few.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

