### PR TITLE
blueman: use "with" expression for  variable

### DIFF
--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
     sed -i 's,CDLL(",CDLL("${libpulseaudio.out}/lib/,g' blueman/main/PulseAudioUtils.py
   '';
 
-  pythonPath = with pythonPackages; [ dbus-python pygobject3 pythonPackages.pycairo ];
+  pythonPath = with pythonPackages; [ dbus-python pygobject3 pycairo ];
 
   propagatedUserEnvPkgs = [ obex_data_server dconf ];
 


### PR DESCRIPTION
###### Motivation for this change

We don't need to prepend the variable with `pythonPackages`, since we have a with expression right there.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


