### PR TITLE
libxslt: fixed crossDrv, where no python is available

### DIFF
--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, libxml2, findXMLCatalogs
-, pythonSupport ? true, python2
+, python2, pythonSupport ? (! stdenv ? cross)
 }:
 
 assert pythonSupport -> python2 != null;


### PR DESCRIPTION
###### Motivation for this change
crossDrv was broken because python is unavailable when crossSystem is set in pkgs. `pythonSupport` now defaults to false when cross building.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


