### PR TITLE
kdevelop: 5.0.2 -> 5.0.3

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -4,13 +4,13 @@
 , kjobwidgets, kcmutils, kio, knewstuff, knotifyconfig, kparts, ktexteditor
 , threadweaver, kxmlgui, kwindowsystem, grantlee
 , plasma-framework, krunner, kdevplatform, kdevelop-pg-qt, shared_mime_info
-, libksysguard, llvmPackages, makeWrapper
+, libksysguard, konsole, llvmPackages, makeWrapper
 }:
 
 let
   pname = "kdevelop";
-  version = "5.0.2";
-  dirVersion = "5.0.2";
+  version = "5.0.3";
+  dirVersion = "5.0.3";
 
 in
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${dirVersion}/src/${name}.tar.xz";
-    sha256 = "9b017901167723230dee8b565cdc7b0e61762415ffcc0a32708f04f7ab668666";
+    sha256 = "17a58dfc38b853c6c5987084e8973b4f7f5015a6c2c20f94c2a9f96b0c13f601";
   };
 
   nativeBuildInputs = [
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     kconfig kdeclarative kdoctools kiconthemes ki18n kitemmodels kitemviews
     kjobwidgets kcmutils kio knewstuff knotifyconfig kparts ktexteditor
     threadweaver kxmlgui kwindowsystem grantlee plasma-framework krunner
-    kdevplatform kdevelop-pg-qt shared_mime_info libksysguard
+    kdevplatform kdevelop-pg-qt shared_mime_info libksysguard konsole.unwrapped
     llvmPackages.llvm llvmPackages.clang-unwrapped
   ];
 

--- a/pkgs/applications/editors/kdevelop5/kdevplatform.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevplatform.nix
@@ -6,8 +6,8 @@
 
 let
   pname = "kdevplatform";
-  version = "5.0.2";
-  dirVersion = "5.0.2";
+  version = "5.0.3";
+  dirVersion = "5.0.3";
 
 in
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   
   src = fetchurl {
     url = "mirror://kde/stable/kdevelop/${dirVersion}/src/${name}.tar.xz";
-    sha256 = "a7f311198bb72f5fee064d99055e8df39ecf4e9066fe5c0ff901ee8c24d960ec";
+    sha256 = "643d1145e1948af221f9ae148d0a10809f3d89af4b97ff0d6c4d571004f46bd4";
   };
 
   nativeBuildInputs = [ cmake gettext pkgconfig extra-cmake-modules makeQtWrapper ];


### PR DESCRIPTION
###### Motivation for this change

New minor version.
Added konsole dependency to make the integrated terminal work.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


