### PR TITLE
lib/generators: add toKeyValue & mkKeyValueLine

### DIFF
--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -135,6 +135,22 @@ runTests {
   # these tests assume attributes are converted to lists
   # in alphabetical order
 
+  testMkKeyValueLine = {
+    expr = generators.mkKeyValueLine ":" "f:oo" "bar";
+    expected = ''f\:oo:bar'';
+  };
+
+  testToKeyValue = {
+    expr = generators.toKeyValue {} {
+      key = "value";
+      "other=key" = "baz";
+    };
+    expected = ''
+      key=value
+      other\=key=baz
+    '';
+  };
+
   testToINIEmpty = {
     expr = generators.toINI {} {};
     expected = "";


### PR DESCRIPTION
generators for the common use case of simple config files which hold keys and
values. Used in the implementation for toINI.

- [x] three new unit tests that pass, old tests pass as well

Can be used in https://github.com/NixOS/nixpkgs/pull/20888 directly.