### PR TITLE
inform7: init at 6M62

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -272,6 +272,7 @@
   matthiasbeyer = "Matthias Beyer <mail@beyermatthias.de>";
   maurer = "Matthew Maurer <matthew.r.maurer+nix@gmail.com>";
   mbakke = "Marius Bakke <mbakke@fastmail.com>";
+  mbbx6spp = "Susan Potter <me@susanpotter.net>";
   mbe = "Brandon Edens <brandonedens@gmail.com>";
   mboes = "Mathieu Boespflug <mboes@tweag.net>";
   mcmtroffaes = "Matthias C. M. Troffaes <matthias.troffaes@gmail.com>";

--- a/pkgs/development/compilers/inform7/default.nix
+++ b/pkgs/development/compilers/inform7/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, writeText, fetchzip, coreutils, perl, gnutar, gzip }:
+let
+  version = "6M62";
+in stdenv.mkDerivation {
+  name = "inform7-${version}";
+  buildInputs = [ perl coreutils gnutar gzip ];
+  src = fetchzip {
+    url = "http://inform7.com/download/content/6M62/I7_6M62_Linux_all.tar.gz";
+    sha256 = "0bk0pfymvsn1g8ci0pfdw7dgrlzb232a8pc67y2xk6zgpf3m41vj";
+  };
+  preConfigure = "touch Makefile.PL";
+  buildPhase = "";
+  installPhase = ''
+    mkdir -p $out
+    pushd $src
+    ./install-inform7.sh --prefix $out
+    popd
+
+    substituteInPlace "$out/bin/i7" \
+      --replace "/usr/bin/perl" "${perl}/bin/perl"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A design system for interactive fiction.";
+    homepage = http://inform7.com/;
+    license = licenses.artistic2;
+    maintainers = with maintainers; [ mbbx6spp ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2230,6 +2230,8 @@ in
 
   inetutils = callPackage ../tools/networking/inetutils { };
 
+  inform7 = callPackage ../development/compilers/inform7 { };
+
   innoextract = callPackage ../tools/archivers/innoextract { };
 
   ioping = callPackage ../tools/system/ioping { };


### PR DESCRIPTION
###### Motivation for this change

No package appeared to exist in `nixpkgs` for inform7.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


