### PR TITLE
wp-cli: 0.24.1 -> 1.0.0

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, writeText, writeScript, fetchurl, php }:
 
 let
-  version = "0.24.1";
+  version = "1.0.0";
   name = "wp-cli-${version}";
 
   phpIni = writeText "wp-cli-php.ini" ''
@@ -18,12 +18,12 @@ let
 
   src = fetchurl {
     url = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${name}.phar";
-    sha256 = "027nclp8qbfr624ja6aixzcwnvb55d7dskk9l1i042bc86hmphfd";
+    sha256 = "06a80fz9na9arjdpmnislwr0121kkg11kxfqmac0axa9vkv9fjcp";
   };
 
 in stdenv.mkDerivation rec {
 
-  inherit name;
+  inherit name src;
 
   buildCommand = ''
     mkdir -p $out/bin


### PR DESCRIPTION
###### Motivation for this change

First "proper" release. I'll do a backport for 16.09 as well.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


