### PR TITLE
wp-cli: 0.23.1 -> 1.0.0

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -1,38 +1,40 @@
-{ stdenv, lib, writeText, bash, fetchurl, php }:
+{ stdenv, lib, writeText, writeScript, fetchurl, php }:
 
 let
+  version = "1.0.0";
+  name = "wp-cli-${version}";
+
   phpIni = writeText "wp-cli-php.ini" ''
     [Phar]
     phar.readonly = Off
   '';
 
-in stdenv.mkDerivation rec {
-  version = "0.23.1";
-  name = "wp-cli-${version}";
+  wpBin = writeScript "wp" ''
+    #! ${stdenv.shell} -e
+    exec ${php}/bin/php \
+      -c ${phpIni} \
+      -f ${src} "$@"
+  '';
 
   src = fetchurl {
     url = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${name}.phar";
-    sha256 = "1sjai8gjsx6j82lsxq9m827bczp4ajnldk6ibj4krcisn9pjva5f";
+    sha256 = "06a80fz9na9arjdpmnislwr0121kkg11kxfqmac0axa9vkv9fjcp";
   };
 
-  propagatedBuildInputs = [ php ];
+in stdenv.mkDerivation rec {
+
+  inherit name src;
 
   buildCommand = ''
     mkdir -p $out/bin
-
-    cat >$out/bin/wp <<EOF
-    #! ${bash}/bin/bash -e
-    exec ${php}/bin/php -c ${phpIni} -f ${src} "\$@"
-    EOF
-
-    chmod +x $out/bin/wp
+    ln -s ${wpBin} $out/bin/wp
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A command line interface for WordPress";
-    maintainers = [ stdenv.lib.maintainers.peterhoeg ];
-    platforms = stdenv.lib.platforms.all;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.all;
     homepage = https://wp-cli.org;
-    license = stdenv.lib.licenses.mit;
+    license = licenses.mit;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Newer version of WP require a later version to work, so upgrade to the latest.

I've only tested this on ```nixos-unstable``` where it works.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


0.23.1 doesn't work with newer WP versions, so we need to upgrade anyway.