### PR TITLE
corosync: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/development/libraries/libibverbs/default.nix
+++ b/pkgs/development/libraries/libibverbs/default.nix
@@ -46,6 +46,20 @@ in stdenv.mkDerivation rec {
       make -j$NIX_BUILD_CORES
       make install
     done
+
+    mkdir -p $out/lib/pkgconfig
+    cat >$out/lib/pkgconfig/ibverbs.pc <<EOF
+    prefix=$out
+    exec_prefix=\''${prefix}
+    libdir=\''${exec_prefix}/lib
+    includedir=\''${prefix}/include
+
+    Name: IB verbs
+    Version: ${version}
+    Description: Library for direct userspace use of RDMA (InfiniBand/iWARP)
+    Libs: -L\''${libdir} -libverbs
+    Cflags: -I\''${includedir}
+    EOF
   '';
 
   # Re-add the libibverbs path into runpath of the library

--- a/pkgs/development/libraries/librdmacm/default.nix
+++ b/pkgs/development/libraries/librdmacm/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, libibverbs }:
 
 stdenv.mkDerivation rec {
-  name = "librdmacm-1.0.21";
+  name = "librdmacm-${version}";
+  version = "1.0.21";
 
   src = fetchurl {
     url = "https://www.openfabrics.org/downloads/rdmacm/${name}.tar.gz";
@@ -9,6 +10,22 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libibverbs ];
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+    cat >$out/lib/pkgconfig/rdmacm.pc <<EOF
+    prefix=$out
+    exec_prefix=\''${prefix}
+    libdir=\''${exec_prefix}/lib
+    includedir=\''${prefix}/include
+
+    Name: RDMA library
+    Version: ${version}
+    Description: Library for managing RDMA connections
+    Libs: -L\''${libdir} -lrdmacm
+    Cflags: -I\''${includedir}
+    EOF
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://www.openfabrics.org/;

--- a/pkgs/servers/corosync/default.nix
+++ b/pkgs/servers/corosync/default.nix
@@ -1,50 +1,61 @@
 { stdenv, fetchurl, makeWrapper, pkgconfig, nss, nspr, libqb
-, dbus ? null
-, librdmacm ? null, libibverbs ? null
-, libstatgrab ? null
-, net_snmp ? null
+, dbus, librdmacm, libibverbs, libstatgrab, net_snmp
+, enableDbus ? false
+, enableInfiniBandRdma ? false
+, enableMonitoring ? false
+, enableSnmp ? false
 }:
 
 with stdenv.lib;
+
 stdenv.mkDerivation rec {
-  name = "corosync-2.4.1";
+  name = "corosync-2.4.2";
 
   src = fetchurl {
     url = "http://build.clusterlabs.org/corosync/releases/${name}.tar.gz";
-    sha256 = "0w8m97ih7a2g99pmjsckw4xwbgzv96xdgg62s2a4qbgnw4yl637y";
+    sha256 = "1aab380mv4ivy5icmwvk7941jbs6ikm21p5ijk7brr4z608k0vpj";
   };
 
-  buildInputs = [
-    makeWrapper pkgconfig nss nspr libqb
-    dbus librdmacm libibverbs libstatgrab net_snmp
-  ];
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
 
-  # Remove when rdma libraries gain pkgconfig support
-  ibverbs_CFLAGS = optionalString (libibverbs != null)
-    "-I${libibverbs}/include/infiniband";
-  ibverbs_LIBS = optionalString (libibverbs != null) "-libverbs";
-  rdmacm_CFLAGS = optionalString (librdmacm != null)
-    "-I${librdmacm}/include/rdma";
-  rdmacm_LIBS = optionalString (librdmacm != null) "-lrdmacm";
+  buildInputs = [
+    nss nspr libqb
+  ] ++ optional enableDbus dbus
+    ++ optional enableInfiniBandRdma [ librdmacm libibverbs ]
+    ++ optional enableMonitoring libstatgrab
+    ++ optional enableSnmp net_snmp;
 
   configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--with-logdir=/var/log/corosync"
     "--enable-watchdog"
     "--enable-qdevices"
-  ] ++ optional (dbus != null) "--enable-dbus"
-    ++ optional (librdmacm != null && libibverbs != null) "--enable-rdma"
-    ++ optional (libstatgrab != null) "--enable-monitoring"
-    ++ optional (net_snmp != null) "--enable-snmp";
+  ] ++ optional enableDbus "--enable-dbus"
+    ++ optional enableInfiniBandRdma "--enable-rdma"
+    ++ optional enableMonitoring "--enable-monitoring"
+    ++ optional enableSnmp "--enable-snmp";
+
+  installFlags = [
+    "sysconfdir=$(out)/etc"
+    "localstatedir=$(out)/var"
+    "COROSYSCONFDIR=$(out)/etc/corosync"
+    "INITDDIR=$(out)/etc/init.d"
+    "LOGROTATEDIR=$(out)/etc/logrotate.d"
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/corosync-blackbox \
       --prefix PATH ":" "$out/sbin:${libqb}/sbin"
   '';
 
+  enableParallelBuilding = true;
+
   meta = {
     homepage = http://corosync.org/;
     description = "A Group Communication System with features for implementing high availability within applications";
     license = licenses.bsd3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
+    maintainers = with maintainers; [ wkennington montag451 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Preliminary works on a future pull request to provide a NixOS module for corosync

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

