### PR TITLE
In `lib/trivial/makeExtensible*` allow extenders to refer to refixer …

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -74,9 +74,9 @@ rec {
   # Same as `makeExtensible` but the name of the extending attribute is
   # customized.
   makeExtensibleWithCustomName = extenderName: rattrs:
-    fix' rattrs // {
+    fix' (extends (_: _: {
       ${extenderName} = f: makeExtensibleWithCustomName extenderName (extends f rattrs);
-   };
+    }) rattrs);
 
   # Flip the order of the arguments of a binary function.
   flip = f: a: b: f b a;


### PR DESCRIPTION
###### Motivation for this change

As [reported][1] by @FRidh, `pkgs.overridePackages` no longer works because
that function is added to the attribute set *after* fixing. Precisely, that
means the `include pkgs` in `allpackages.nix` doesn't pick it up with the
rest of the final fixed package set.

This changes changes `makeExtensibleWithCustomName`, and by extension plain
`makeExtensible` so that the refixer function is added as a final extension
before fixing.

[1]: https://github.com/NixOS/nixpkgs/pull/19496#issuecomment-264695646

###### Things done

Tested manually using `nix-repl`. Should we create an automatic test for this?


CC @nbp for posterity---I don't expect you to have any time for this.