### PR TITLE
minio: build on all 64bit platforms

### DIFF
--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     homepage = https://www.minio.io/;
     description = "An S3-compatible object storage server";
     maintainers = [ lib.maintainers.eelco ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.x86_64;
     license = lib.licenses.asl20;
   };
 }


### PR DESCRIPTION

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


