### PR TITLE
sonarr: 2.0.0.4389 -> 2.0.0.4409

### DIFF
--- a/pkgs/servers/sonarr/default.nix
+++ b/pkgs/servers/sonarr/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "sonarr-${version}";
-  version = "2.0.0.4389";
+  version = "2.0.0.4409";
 
   src = fetchurl {
     url = "http://download.sonarr.tv/v2/master/mono/NzbDrone.master.${version}.mono.tar.gz";
-    sha256 = "17vvfld6m1wr8yxvm9i7gaxny04ymvq86pizad816a73jk4h16my";
+    sha256 = "1kaj1m4ifby8liks8i7fsbgwbajaqwd96yindqp5maf2n6px2nw2";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://github.com/Sonarr/Sonarr/releases/tag/v2.0.0.4409

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


