### PR TITLE
gnome-shell-extensions: enable all extensions

### DIFF
--- a/pkgs/desktops/gnome-3/3.20/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome-3/3.20/core/gnome-shell-extensions/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig gtk3 glib libgtop intltool itstool
                   makeWrapper file ];
 
+  configureFlags = [ "--enable-extensions=all" ];
+
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/GnomeShell/Extensions;
     description = "Modify and extend GNOME Shell functionality and behavior";

--- a/pkgs/desktops/gnome-3/3.22/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/core/gnome-shell-extensions/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ pkgconfig gtk3 glib libgtop intltool itstool
                   makeWrapper file ];
 
+  configureFlags = [ "--enable-extensions=all" ];
+
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/GnomeShell/Extensions;
     description = "Modify and extend GNOME Shell functionality and behavior";


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).