### PR TITLE
minikube: init at 0.13.1

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, kubernetes }:
+let
+  arch = if stdenv.isLinux
+         then "linux-amd64"
+         else "darwin-amd64";
+  checksum = if stdenv.isLinux
+             then "17r8w4lvj7fhh7qppi9z5i2fpqqry4s61zjr9zmsbybc5flnsw2j"
+             else "0jf0kd1mm35qcf0ydr5yyzfq6qi8ifxchvpjsydb1gm1kikp5g3p";
+in
+stdenv.mkDerivation rec {
+  pname = "minikube";
+  version = "0.13.1";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/minikube/releases/v${version}/minikube-${arch}";
+    sha256 = "${checksum}";
+  };
+
+  buildInputs = [ ];
+
+  propagatedBuildInputs = [ kubernetes ];
+
+  phases = [ "buildPhase" "installPhase" ];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+  '';
+
+  installPhase = ''
+    cp $src $out/bin/${pname}
+    chmod +x $out/bin/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/kubernetes/minikube;
+    description = "A tool that makes it easy to run Kubernetes locally";
+    license = licenses.asl20;
+    maintainers = [ maintainers.ebzzry ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13479,6 +13479,8 @@ in
 
   minidjvu = callPackage ../applications/graphics/minidjvu { };
 
+  minikube = callPackage ../applications/networking/cluster/minikube { };
+
   minitube = callPackage ../applications/video/minitube { };
 
   mimms = callPackage ../applications/audio/mimms {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


