### PR TITLE
pssh: init at 2.3.1

### DIFF
--- a/pkgs/tools/networking/pssh/default.nix
+++ b/pkgs/tools/networking/pssh/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "pssh-${version}";
+  version = "2.3.1";
+
+  src = fetchFromGitHub {
+    owner = "lilydjwg";
+    repo = "pssh";
+    rev = "v${version}";
+    sha256 = "0nawarxczfwajclnlsimhqkpzyqb1byvz9nsl54mi1bp80z5i4jq";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Parallel SSH Tools";
+    longDescription = ''
+      PSSH provides parallel versions of OpenSSH and related tools,
+      including pssh, pscp, prsync, pnuke and pslurp.
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ chris-martin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3382,6 +3382,8 @@ in
 
   psmisc = callPackage ../os-specific/linux/psmisc { };
 
+  pssh = callPackage ../tools/networking/pssh { };
+
   pstoedit = callPackage ../tools/graphics/pstoedit { };
 
   psutils = callPackage ../tools/typesetting/psutils { };


### PR DESCRIPTION
###### Motivation for this change

Adds [pssh](https://github.com/lilydjwg/pssh), which provides commands like pssh and pscp for executing commands and copying files over ssh to multiple machines at once.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


