### PR TITLE
physlock: git-20150126 -> 0.5

### DIFF
--- a/pkgs/misc/screensavers/physlock/default.nix
+++ b/pkgs/misc/screensavers/physlock/default.nix
@@ -1,13 +1,11 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchurl  }:
 
 stdenv.mkDerivation rec {
-  version = "git-20150126";
-  name = "physlock-${version}";
-  src = fetchFromGitHub {
-    owner  = "muennich";
-    repo   = "physlock";
-    rev    = "b64dccc8c22710f8bf01eb5419590cdb0e65cabb";
-    sha256 = "1dapkwj3y6bb4j8q4glms7zsqm7drr37nrnr30sbahwq67rnvzcc";
+  version = "0.5";
+  name = "physlock-v${version}";
+  src = fetchurl {
+    url = "http://github.com/muennich/physlock/archive/v${version}.tar.gz";
+    sha256 = "10l7amxn8lrjzlyfidn5075c8970gf2rvgcnyyfqgcxzx6mp6n1r";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


