### PR TITLE
nixos: docs: note that channels are per user

### DIFF
--- a/nixos/doc/manual/installation/upgrading.xml
+++ b/nixos/doc/manual/installation/upgrading.xml
@@ -104,7 +104,7 @@ nixos; nixos-rebuild switch</literal>.</para>
 <note><para>Channels are set per user. This means that running <literal>
 nix-channel --add</literal> as a non root user (or without sudo) will not
 affect configuration in <literal>/etc/nixos/configuration.nix</literal>
-</para><note>
+</para></note>
 
 <warning><para>It is generally safe to switch back and forth between
 channels.  The only exception is that a newer NixOS may also have a

--- a/nixos/doc/manual/installation/upgrading.xml
+++ b/nixos/doc/manual/installation/upgrading.xml
@@ -101,6 +101,11 @@ channel by running
 which is equivalent to the more verbose <literal>nix-channel --update
 nixos; nixos-rebuild switch</literal>.</para>
 
+<note><para>Channels are set per user. This means that running <literal>
+nix-channel --add</literal> as a non root user (or without sudo) will not
+affect configuration in <literal>/etc/nixos/configuration.nix</literal>
+</para><note>
+
 <warning><para>It is generally safe to switch back and forth between
 channels.  The only exception is that a newer NixOS may also have a
 newer Nix version, which may involve an upgrade of Nix’s database


### PR DESCRIPTION
###### Motivation for this change

I'm new to nix and this tripped me up, thought it was worth adding to the docs.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


