### PR TITLE
mkdocs: init at 0.16.0.

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16579,6 +16579,38 @@ in {
     };
   };
 
+  livereload = buildPythonPackage rec {
+    name = "livereload-2.5.0";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/l/livereload/${name}.tar.gz";
+      sha256 = "bc708b46e22dff243c02e709c636ffeb8a64cdd019c95a215304e6ce183c4859";
+    };
+    propagatedBuildInputs = with self; [ six tornado ];
+    buildInputs = [ ];
+    meta = with pkgs.stdenv.lib; {
+      description = "LiveReload";
+      homepage = "https://github.com/lepture/python-livereload";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ aloiscochard ];
+    };
+  };
+
+  mkdocs = buildPythonPackage rec {
+    name = "mkdocs-0.16.0";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/m/mkdocs/${name}.tar.gz";
+      sha256 = "ab674a1545713af8e2542f3732aa1cc84a233ac008aa1cab81ebab7b7a56bdf7";
+    };
+    propagatedBuildInputs = with self; [ pyyaml markdown click livereload pyramid_jinja2 ];
+    buildInputs = [ ];
+    meta = with pkgs.stdenv.lib; {
+      description = "Project documentation with Markdown.";
+      homepage = "http://www.mkdocs.org/";
+      license = licenses.bsd3;
+      maintainers = with maintainers; [ aloiscochard ];
+    };
+  };
+
   pycadf = buildPythonPackage rec {
     name = "pycadf-${version}";
     version = "1.1.0";


### PR DESCRIPTION
###### Motivation for this change

Make `mkdocs` available in NiXOS.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


I'm running `17.03pre95306.a24728f (Gorilla)`