### PR TITLE
gti: 2015-05-21 -> 2016-12-07

### DIFF
--- a/pkgs/tools/misc/gti/default.nix
+++ b/pkgs/tools/misc/gti/default.nix
@@ -2,18 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "gti-${version}";
-  version = "2015-05-21";
+  version = "2016-12-07";
 
   src = fetchFromGitHub {
     owner = "rwos";
     repo = "gti";
-    rev = "edaac795b0b0ff01f2347789f96c740c764bf376";
-    sha256 = "1wki7d61kcmv9s3xayky9cz84qa773x3y1z88y768hq8ifwadcbn";
+    rev = "d78001bd5b4b6f6ad853b4ec810e9a1ecde1ee32";
+    sha256 = "0449h9m16x542fy6gmhqqkvkg7z7brxw5vmb85nkk1gdlr9pl1mr";
   };
-
-  prePatch = ''
-    substituteInPlace Makefile --replace gcc cc
-  '';
 
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man6


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


No need to replace gcc with cc thanks to
https://github.com/rwos/gti/pull/26

This needs to be tested on OS X. Can someone with access to a Mac do this please?