### PR TITLE
btrbk: 0.22.2 -> 0.24.0

### DIFF
--- a/pkgs/tools/backup/btrbk/default.nix
+++ b/pkgs/tools/backup/btrbk/default.nix
@@ -1,19 +1,17 @@
-{ stdenv, fetchurl, coreutils, bash, btrfs-progs, perl, perlPackages, makeWrapper }:
+{ stdenv, fetchurl, coreutils, bash, btrfs-progs, openssh, perl, perlPackages, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "btrbk-${version}";
-  version = "0.22.2";
+  version = "0.24.0";
 
   src = fetchurl {
     url = "http://digint.ch/download/btrbk/releases/${name}.tar.xz";
-    sha256 = "1gbgi0dp62wlw7y72pgxjs6byxkrk73g35kqxzw0gjf32r5i4sb8";
+    sha256 = "01jrlswly28h4q4r3qfrzadz0pf0ms6wynmqhwddj1ahj31729h3";
   };
 
   patches = [
     # https://github.com/digint/btrbk/pull/74
     ./btrbk-Prefix-PATH-instead-of-resetting-it.patch
-    # https://github.com/digint/btrbk/pull/73
-    ./btrbk-mail-Use-btrbk-instead-of-unbound-variable-btr.patch
   ];
 
   buildInputs = with perlPackages; [ makeWrapper perl DateCalc ];
@@ -38,7 +36,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/sbin/btrbk \
       --set PERL5LIB $PERL5LIB \
-      --prefix PATH ':' "${stdenv.lib.makeBinPath [ btrfs-progs bash ]}"
+      --prefix PATH ':' "${stdenv.lib.makeBinPath [ btrfs-progs bash openssh ]}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Upgrades btrbk to the latest upstream version.
This new version requires config migrations due to [incompatible changes](https://github.com/digint/btrbk/blob/master/doc/upgrade_to_v0.23.0.md).
Does a package need to handle this somehow?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


