### PR TITLE
gem-config: add postgresql buildInput for sequel_pg

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -164,6 +164,10 @@ in
       '';
     } else {};
 
+  sequel_pg = attrs: {
+    buildInputs = [ postgresql ];
+  };
+
   snappy = attrs: {
     buildInputs = [ args.snappy ];
   };


### PR DESCRIPTION
###### Motivation for this change

sequel_pg does not build without postgresql

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Signed-off-by: Maximilian Güntner <code@klandest.in>