### PR TITLE
numix-icon-theme-square: init at 2016-11-23

### DIFF
--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, numix-icon-theme }:
+
+stdenv.mkDerivation rec {
+  version = "2016-11-23";
+
+  package-name = "numix-icon-theme-square";
+
+  name = "${package-name}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "numixproject";
+    repo = package-name;
+    rev = "1c30eb02aea3d95c49f95c212702b56e93ac9043";
+    sha256 = "1d2car4dsh1dnim9jlakm035ydqd1f115cagm6zm8gwa5w9annag";
+  };
+
+  buildInputs = [ numix-icon-theme ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/icons
+    cp -a Numix-Square{,-Light} $out/share/icons/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Numix icon theme (square version)";
+    homepage = https://numixproject.org;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Numix icon theme (square version)";
     homepage = https://numixproject.org;
     license = licenses.gpl3;
-    platforms = platforms.all;
+    platforms = with platforms; allBut darwin;
     maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11908,6 +11908,8 @@ in
 
   numix-icon-theme-circle = callPackage ../data/icons/numix-icon-theme-circle { };
 
+  numix-icon-theme-square = callPackage ../data/icons/numix-icon-theme-square { };
+
   oldstandard = callPackage ../data/fonts/oldstandard { };
 
   oldsindhi = callPackage ../data/fonts/oldsindhi { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).