### PR TITLE
qt5.6/5.7: PaX compat qtwebengine

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebengine/default.nix
@@ -11,6 +11,7 @@
 , coreutils
 , pkgconfig, python2
 
+, stdenv # lib.optional, needsPax
 }:
 
 qtSubmodule {
@@ -60,11 +61,14 @@ qtSubmodule {
   ];
   patches = [
     ./chromium-clang-update-py.patch
-  ];
+  ] ++ stdenv.lib.optional stdenv.needsPax ./qtwebengine-paxmark-mksnapshot.patch;
+
   postInstall = ''
     cat > $out/libexec/qt.conf <<EOF
     [Paths]
     Prefix = ..
     EOF
+
+    paxmark m $out/libexec/QtWebEngineProcess
   '';
 }

--- a/pkgs/development/libraries/qt-5/5.6/qtwebengine/qtwebengine-paxmark-mksnapshot.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtwebengine/qtwebengine-paxmark-mksnapshot.patch
@@ -1,0 +1,46 @@
+--- qtwebengine-opensource-src-5.6.0-orig/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-03-04 01:48:36.000000000 +1100
++++ qtwebengine-opensource-src-5.6.0/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-05-01 19:15:44.052770543 +1000
+@@ -33,6 +33,7 @@
+     'embed_script%': "",
+     'v8_extra_library_files%': [],
+     'mksnapshot_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot<(EXECUTABLE_SUFFIX)',
++    'mksnapshot_u_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot_u<(EXECUTABLE_SUFFIX)',
+     'remove_v8base_debug_symbols%': 0,
+   },
+   'includes': ['../../build/toolchain.gypi', '../../build/features.gypi'],
+@@ -1913,7 +1914,7 @@
+         ]
+     },
+     {
+-      'target_name': 'mksnapshot',
++      'target_name': 'mksnapshot_u',
+       'type': 'executable',
+       'dependencies': ['v8_base', 'v8_nosnapshot', 'v8_libplatform'],
+       'include_dirs+': [
+@@ -1936,5 +1937,26 @@
+         }],
+       ],
+     },
++    {
++      'target_name': 'mksnapshot',
++      'type': 'executable',
++      'dependencies': ['mksnapshot_u'],
++      'actions': [
++        {
++          'action_name': 'paxmark_m_mksnapshot',
++          'inputs': [
++            '<(mksnapshot_u_exec)',
++          ],
++          'outputs': [
++            '<(mksnapshot_exec)',
++          ],
++          'action': [
++            'sh',
++            '-c',
++            'cp <(mksnapshot_u_exec) <(mksnapshot_exec) && paxctl -czexm <(mksnapshot_exec)',
++          ],
++        },
++      ],
++    },
+   ],
+ }

--- a/pkgs/development/libraries/qt-5/5.7/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/default.nix
@@ -90,7 +90,7 @@ let
       qttranslations = callPackage ./qttranslations.nix {};
       qtwayland = callPackage ./qtwayland.nix {};
       qtwebchannel = callPackage ./qtwebchannel.nix {};
-      qtwebengine = callPackage ./qtwebengine.nix {};
+      qtwebengine = callPackage ./qtwebengine {};
       qtwebkit = callPackage ./qtwebkit {};
       qtwebsockets = callPackage ./qtwebsockets.nix {};
       qtx11extras = callPackage ./qtx11extras.nix {};

--- a/pkgs/development/libraries/qt-5/5.7/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtwebengine/default.nix
@@ -11,6 +11,7 @@
 , coreutils
 , pkgconfig, python2
 
+, stdenv # lib.optional, needsPax
 }:
 
 qtSubmodule {
@@ -53,10 +54,13 @@ qtSubmodule {
     libcap
     pciutils
   ];
+  patches = stdenv.lib.optional stdenv.needsPax ./qtwebengine-paxmark-mksnapshot.patch;
   postInstall = ''
     cat > $out/libexec/qt.conf <<EOF
     [Paths]
     Prefix = ..
     EOF
+
+    paxmark m $out/libexec/QtWebEngineProcess
   '';
 }

--- a/pkgs/development/libraries/qt-5/5.7/qtwebengine/qtwebengine-paxmark-mksnapshot.patch
+++ b/pkgs/development/libraries/qt-5/5.7/qtwebengine/qtwebengine-paxmark-mksnapshot.patch
@@ -1,0 +1,46 @@
+--- qtwebengine-opensource-src-5.6.0-orig/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-03-04 01:48:36.000000000 +1100
++++ qtwebengine-opensource-src-5.6.0/src/3rdparty/chromium/v8/tools/gyp/v8.gyp	2016-05-01 19:15:44.052770543 +1000
+@@ -33,6 +33,7 @@
+     'embed_script%': "",
+     'v8_extra_library_files%': [],
+     'mksnapshot_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot<(EXECUTABLE_SUFFIX)',
++    'mksnapshot_u_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mksnapshot_u<(EXECUTABLE_SUFFIX)',
+     'remove_v8base_debug_symbols%': 0,
+   },
+   'includes': ['../../build/toolchain.gypi', '../../build/features.gypi'],
+@@ -1913,7 +1914,7 @@
+         ]
+     },
+     {
+-      'target_name': 'mksnapshot',
++      'target_name': 'mksnapshot_u',
+       'type': 'executable',
+       'dependencies': ['v8_base', 'v8_nosnapshot', 'v8_libplatform'],
+       'include_dirs+': [
+@@ -1936,5 +1937,26 @@
+         }],
+       ],
+     },
++    {
++      'target_name': 'mksnapshot',
++      'type': 'executable',
++      'dependencies': ['mksnapshot_u'],
++      'actions': [
++        {
++          'action_name': 'paxmark_m_mksnapshot',
++          'inputs': [
++            '<(mksnapshot_u_exec)',
++          ],
++          'outputs': [
++            '<(mksnapshot_exec)',
++          ],
++          'action': [
++            'sh',
++            '-c',
++            'cp <(mksnapshot_u_exec) <(mksnapshot_exec) && paxctl -czexm <(mksnapshot_exec)',
++          ],
++        },
++      ],
++    },
+   ],
+ }


### PR DESCRIPTION
###### Motivation for this change

* Currently unable to build qtwebengine on a pax-enabled host
* Resulting `QtWebEngineProcess` (in `libexec`) crashes on a PaX-enabled kernel.

The two patches files are identical, using multiple copies to match current practice for 5.5/5.6/5.7.

FWIW this matches Gentoo's approach[1][2]

[1] https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-qt/qtwebengine/qtwebengine-5.6.2.ebuild?id=94088f2bf48d6d0cbaa17754e245ac731791ce36
[2] https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-qt/qtwebengine/qtwebengine-5.7.0.ebuild?id=94088f2bf48d6d0cbaa17754e245ac731791ce36

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


* paxmark QtWebEngineProcess so it executes on PaX kernels
* when building on host w/PaX apply patch to fix mksnapshot

Patch taken from Gentoo[1], slightly modified to use paxctl directly.

[1] https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-qt/qtwebengine/files/qtwebengine-paxmark-mksnapshot.patch