### PR TITLE
zoom-us: 2.052458.0531 -> 2.0.707090.1031, paxmark

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -10,7 +10,7 @@
 , libxml2
 , libxslt
 , makeQtWrapper
-, qt55
+, qt56
 , sqlite
 , stdenv
 , xlibs
@@ -27,15 +27,15 @@ stdenv.mkDerivation rec {
       platforms = stdenv.lib.platforms.linux;
     };
 
-    version = "2.0.52458.0531";
+    version = "2.0.70790.1031";
     src = fetchurl {
-      url = "https://zoom.us/client/${version}/zoom_${version}_x86_64.tar.xz";
-      sha256 = "16d64pn9j27v3fnh4c9i32vpkr10q1yr26w14964n0af1mv5jf7a";
+      url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
+      sha256 = "0kkg3bqv8zwhpxgrssa7ds00dxhdimnq2vfklgrdqn5qzbij31hd";
     };
 
     phases = [ "unpackPhase" "installPhase" ];
     nativeBuildInputs = [ makeQtWrapper ];
-    libPath = stdenv.lib.makeLibraryPath [
+    buildInputs = [
       alsaLib
       gcc.cc
       glib
@@ -46,10 +46,12 @@ stdenv.mkDerivation rec {
       libuuid
       libxml2
       libxslt
-      qt55.qtbase
-      qt55.qtdeclarative
-      qt55.qtscript
-      qt55.qtwebkit
+      qt56.qtbase
+      qt56.qtdeclarative
+      qt56.qtlocation
+      qt56.qtscript
+      qt56.qtwebchannel
+      qt56.qtwebengine
       sqlite
       xlibs.xcbutilkeysyms
       xorg.libX11
@@ -61,13 +63,15 @@ stdenv.mkDerivation rec {
       xorg.xcbutilimage
       zlib
     ];
+
+    libPath = stdenv.lib.makeLibraryPath buildInputs;
+
     installPhase = ''
       mkdir -p $out/share
       cp -r \
          application-x-zoom.png \
          audio \
          imageformats \
-         chrome.bmp \
          config-dump.sh \
          dingdong1.pcm \
          dingdong.pcm \
@@ -77,13 +81,7 @@ stdenv.mkDerivation rec {
          platforminputcontexts \
          platforms \
          platformthemes \
-         Qt \
-         QtMultimedia \
-         QtQml \
-         QtQuick \
-         QtQuick.2 \
-         QtWebKit \
-         QtWebProcess \
+         leave.pcm \
          ring.pcm \
          ring.wav \
          version.txt \
@@ -98,6 +96,7 @@ stdenv.mkDerivation rec {
         --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
         --set-rpath ${libPath} \
         $out/share/zoom
+      paxmark m $out/share/zoom
       wrapQtProgram "$out/share/zoom"
       mkdir -p $out/bin
       ln -s $out/share/zoom $out/bin/zoom-us


### PR DESCRIPTION
###### Motivation for this change

Updates to latest zoom, fixes execution on PaX-enabled kernel, cleans up some Qt bits.

cc @savannidgerinel 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


* paxmark zoom to fix execution on PaX-enabled kernels[1]
* Requires moving from qt55 to qt56
* Put libs as buildInputs so that wrapQtProgram sees their paths!
* Don't use bundled Qt libs.
  (if these should be used, we shouldn't put our own on rpath, etc.)

[1] Without this, program fails to start (but doesn't exit),
and the following exception is logged a few times:

Dec 07 12:24:26 hostname kernel: grsec: denied RWX mmap of <anonymous mapping> by /nix/store/v1i2bff9fs7w1vycv0y615phhs7hky87-zoom-us/share/.zoom-wrapped[.zoom-wrapped:23812] uid/euid:1000/1

zoom still won't run unless using a pax-fixed version of qtwebengine.
( see: https://github.com/NixOS/nixpkgs/pull/20991 )