### PR TITLE
libdwarf: version the shared object

### DIFF
--- a/pkgs/development/libraries/libdwarf/default.nix
+++ b/pkgs/development/libraries/libdwarf/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/lib $out/include
-    cp libdwarf.so $out/lib
+    cp libdwarf.so.1 $out/lib
+    ln -s libdwarf.so.1 $out/lib/libdwarf.so
     cp libdwarf.h dwarf.h $out/include
   '';
 


### PR DESCRIPTION
###### Motivation for this change

libdwarf sets its soname to libdwarf.so.1 so anything that links `-ldwarf` is built to actually link against libdwarf.so.1. Install the versioned shared object and symlink libdwarf.so to it so binaries that link against libdwarf can be loaded and run successfully.

Fixes #20994. Should be backported to 16.09.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).