### PR TITLE
Update URL for broadcom-sta driver.

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   name = "broadcom-sta-${version}-${kernel.version}";
 
   src = fetchurl {
-    url = "http://www.broadcom.com/docs/linux_sta/${tarball}";
+    url = "https://docs.broadcom.com/docs-and-downloads/docs/linux_sta/${tarball}";
     sha256 = hashes."${stdenv.system}";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Fix after “broadcom” driver movement.

###### Things done

- [x] Tested using `nix-build nixpkgs --check -A linuxPackages_4_8.broadcom_sta.src`
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


