### PR TITLE
haskellPackages: add hoogleLocal

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -18,6 +18,11 @@ self: super: {
   # Apply NixOS-specific patches.
   ghc-paths = appendPatch super.ghc-paths ./patches/ghc-paths-nix.patch;
 
+  # enable using a local hoogle with extra packagages in the database
+  # nix-shell -p "haskellPackages.hoogleLocal (with haskellPackages; [ mtl lens ])"
+  # $ hoogle server
+  hoogleLocal = { packages ? [] }: self.callPackage ./hoogle.nix { inherit packages; };
+
   # Break infinite recursions.
   clock = dontCheck super.clock;
   Dust-crypto = dontCheck super.Dust-crypto;


### PR DESCRIPTION
The docs in `hoogle.nix` intend for it to be in the packageset as `hoogleLocal`
and that also makes a lot of sense from a user perspective.

`packages` is not a function `HaskellPackages -> [Package]`, but that is good,
because that way it can be used e.g. to merge package databases from other
versions of the packageset.

Another way to do it would be: make it a function

```nix
let hoogleWith = packages: callPackage ./hoogle.nix { inherit packages; };
```

@peti, what do you think?