### PR TITLE
darwin.libunwind: fix install phase

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
@@ -1,15 +1,16 @@
 { stdenv, appleDerivation, dyld, osx_private_sdk }:
 
 appleDerivation {
-  phases = [ "unpackPhase" "installPhase" ];
+  buildPhase = ":";
 
+  # install headers only
   installPhase = ''
     mkdir -p $out/lib
-    cp -R include $out/include
+    make install-data-am
   '';
 
   meta = with stdenv.lib; {
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = with maintainers; [ copumpkin lnl7 ];
     platforms   = platforms.darwin;
     license     = licenses.apsl20;
   };


### PR DESCRIPTION
###### Motivation for this change

Fixes #20977 


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] macOS
   - [x] No changes for other platforms
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

