### PR TITLE
ndiswrapper: mark as broken

### DIFF
--- a/pkgs/os-specific/linux/ndiswrapper/default.nix
+++ b/pkgs/os-specific/linux/ndiswrapper/default.nix
@@ -38,5 +38,6 @@ stdenv.mkDerivation {
     description = "Ndis driver wrapper for the Linux kernel";
     homepage = http://sourceforge.net/projects/ndiswrapper;
     license = "GPL";
+    broken = true;
   };
 }


### PR DESCRIPTION
Build fails across all our kernels.  There is a new version 1.60, but it, too, fails to build.  Until somebody comes along to patch around it, we might as well mark this as broken.