### PR TITLE
qt5.6: darwin compatibility

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -112,13 +112,12 @@ let
       makeQtWrapper =
         makeSetupHook
         { deps = [ makeWrapper ]; }
-        ../make-qt-wrapper.sh;
+        (if stdenv.isDarwin then ../make-qt-wrapper-darwin.sh else ../make-qt-wrapper.sh);
 
       qmakeHook =
         makeSetupHook
         { deps = [ self.qtbase.dev ]; }
-        ../qmake-hook.sh;
-
+        (if stdenv.isDarwin then ../qmake-hook-darwin.sh else ../qmake-hook.sh);
     };
 
    self = makeScope pkgs.newScope addPackages;

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/cmake-paths-darwin.patch
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/cmake-paths-darwin.patch
@@ -1,0 +1,384 @@
+Index: qtbase-opensource-src-5.6.1/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.6.1.orig/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
++++ qtbase-opensource-src-5.6.1/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+@@ -9,30 +9,6 @@ if (CMAKE_VERSION VERSION_LESS 3.0.0)
+ endif()
+ !!ENDIF
+ 
+-!!IF !isEmpty(CMAKE_USR_MOVE_WORKAROUND)
+-!!IF !isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-set(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"$$[QT_INSTALL_PREFIX]\")
+-!!ELSE
+-get_filename_component(_IMPORT_PREFIX \"${CMAKE_CURRENT_LIST_FILE}\" PATH)
+-# Use original install prefix when loaded through a
+-# cross-prefix symbolic link such as /lib -> /usr/lib.
+-get_filename_component(_realCurr \"${_IMPORT_PREFIX}\" REALPATH)
+-get_filename_component(_realOrig \"$$CMAKE_INSTALL_LIBS_DIR/cmake/Qt5$${CMAKE_MODULE_NAME}\" REALPATH)
+-if(_realCurr STREQUAL _realOrig)
+-    get_filename_component(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"$$CMAKE_INSTALL_LIBS_DIR/$${CMAKE_RELATIVE_INSTALL_LIBS_DIR}\" ABSOLUTE)
+-else()
+-    get_filename_component(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"${CMAKE_CURRENT_LIST_DIR}/$${CMAKE_RELATIVE_INSTALL_DIR}\" ABSOLUTE)
+-endif()
+-unset(_realOrig)
+-unset(_realCurr)
+-unset(_IMPORT_PREFIX)
+-!!ENDIF
+-!!ELIF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-get_filename_component(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"${CMAKE_CURRENT_LIST_DIR}/$${CMAKE_RELATIVE_INSTALL_DIR}\" ABSOLUTE)
+-!!ELSE
+-set(_qt5$${CMAKE_MODULE_NAME}_install_prefix \"$$[QT_INSTALL_PREFIX]\")
+-!!ENDIF
+-
+ !!IF !equals(TEMPLATE, aux)
+ # For backwards compatibility only. Use Qt5$${CMAKE_MODULE_NAME}_VERSION instead.
+ set(Qt5$${CMAKE_MODULE_NAME}_VERSION_STRING "$$eval(QT.$${MODULE}.MAJOR_VERSION).$$eval(QT.$${MODULE}.MINOR_VERSION).$$eval(QT.$${MODULE}.PATCH_VERSION)")
+@@ -59,7 +35,10 @@ macro(_populate_$${CMAKE_MODULE_NAME}_ta
+     set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+ 
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    set(imported_location \"@NIX_OUT@/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    if(NOT EXISTS \"${imported_location}\")
++        set(imported_location \"@NIX_DEV@/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    endif()
+ !!ELSE
+     set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
+ !!ENDIF
+@@ -74,45 +53,17 @@ macro(_populate_$${CMAKE_MODULE_NAME}_ta
+         \"IMPORTED_LINK_INTERFACE_LIBRARIES_${Configuration}\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}\"
+     )
+ 
+-!!IF !isEmpty(CMAKE_WINDOWS_BUILD)
+-!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_implib \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+-!!ELSE
+-    set(imported_implib \"IMPORTED_IMPLIB_${Configuration}\" \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+-!!ENDIF
+-    _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_implib})
+-    if(NOT \"${IMPLIB_LOCATION}\" STREQUAL \"\")
+-        set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
+-        \"IMPORTED_IMPLIB_${Configuration}\" ${imported_implib}
+-        )
+-    endif()
+-!!ENDIF
+ endmacro()
+ !!ENDIF
+ 
+ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+ 
+ !!IF !no_module_headers
+-!!IF !isEmpty(CMAKE_BUILD_IS_FRAMEWORK)
+-    set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS
+-      \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework\"
+-      \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework/Headers\"
+-    )
+-!!IF isEmpty(CMAKE_NO_PRIVATE_INCLUDES)
+-    set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework/Versions/$$section(VERSION, ., 0, 0)/Headers/$$VERSION/\"
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}Qt$${CMAKE_MODULE_NAME}.framework/Versions/$$section(VERSION, ., 0, 0)/Headers/$$VERSION/$${MODULE_INCNAME}\"
+-    )
+-!!ELSE
+-    set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
+-!!ENDIF
+-!!ELSE
+ !!IF isEmpty(CMAKE_INCLUDE_DIR_IS_ABSOLUTE)
+-    set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$$CMAKE_INCLUDE_DIR\" \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}\")
++    set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS \"@NIX_OUT@/lib\" \"@NIX_OUT@/lib/$${MODULE_INCNAME}.framework/Headers\")
+ !!IF isEmpty(CMAKE_NO_PRIVATE_INCLUDES)
+     set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION\"
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_INCLUDE_DIR}$${MODULE_INCNAME}/$$VERSION/$${MODULE_INCNAME}\"
++        \"\"
+     )
+ !!ELSE
+     set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
+@@ -128,7 +80,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+     set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
+ !!ENDIF
+ !!ENDIF
+-!!ENDIF
++
+ !!IF !isEmpty(CMAKE_ADD_SOURCE_INCLUDE_DIRS)
+     include(\"${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake\" OPTIONAL)
+ !!ENDIF
+@@ -253,28 +205,19 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+ 
+ !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
+ !!IF isEmpty(CMAKE_DEBUG_TYPE)
+-!!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
+-!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    if (EXISTS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ELSE // CMAKE_LIB_DIR_IS_ABSOLUTE
+-    if (EXISTS \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ENDIF // CMAKE_LIB_DIR_IS_ABSOLUTE
+-        _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" \"\" )
+-!!ELSE // CMAKE_STATIC_WINDOWS_BUILD
+     if (EXISTS
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_DEBUG}\"
++        \"@NIX_OUT@/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_DEBUG}\"
+ !!ELSE
+         \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\"
+ !!ENDIF
+       AND EXISTS
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
++        \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+ !!ELSE
+         \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+ !!ENDIF
+         _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
+     endif()
+ !!ENDIF // CMAKE_DEBUG_TYPE
+ !!ENDIF // CMAKE_FIND_OTHER_LIBRARY_BUILD
+@@ -282,36 +225,23 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+ !!ENDIF // CMAKE_RELEASE_TYPE
+ 
+ !!IF !isEmpty(CMAKE_DEBUG_TYPE)
+-!!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
+-    _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" \"\" )
+-!!ELSE
+     _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
+-!!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
+ 
+ !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
+ !!IF isEmpty(CMAKE_RELEASE_TYPE)
+-!!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
+-!!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    if (EXISTS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+-!!ELSE // CMAKE_LIB_DIR_IS_ABSOLUTE
+-    if (EXISTS \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+-!!ENDIF // CMAKE_LIB_DIR_IS_ABSOLUTE
+-        _populate_$${CMAKE_MODULE_NAME}_target_properties(RELEASE \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" \"\" )
+-!!ELSE // CMAKE_STATIC_WINDOWS_BUILD
+     if (EXISTS
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_RELEASE}\"
++        \"@NIX_OUT@/$${CMAKE_DLL_DIR}$${CMAKE_LIB_FILE_LOCATION_RELEASE}\"
+ !!ELSE
+         \"$${CMAKE_LIB_FILE_LOCATION_RELEASE}\"
+ !!ENDIF
+       AND EXISTS
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-        \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
++        \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+ !!ELSE
+         \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+ !!ENDIF
+         _populate_$${CMAKE_MODULE_NAME}_target_properties(RELEASE \"$${CMAKE_LIB_FILE_LOCATION_RELEASE}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
+-!!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
+     endif()
+ !!ENDIF // CMAKE_RELEASE_TYPE
+ !!ENDIF // CMAKE_FIND_OTHER_LIBRARY_BUILD
+@@ -328,11 +258,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME
+     macro(_populate_$${CMAKE_MODULE_NAME}_plugin_properties Plugin Configuration PLUGIN_LOCATION)
+         set_property(TARGET Qt5::${Plugin} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+ 
+-!!IF isEmpty(CMAKE_PLUGIN_DIR_IS_ABSOLUTE)
+-        set(imported_location \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$${CMAKE_PLUGIN_DIR}${PLUGIN_LOCATION}\")
+-!!ELSE
+-        set(imported_location \"$${CMAKE_PLUGIN_DIR}${PLUGIN_LOCATION}\")
+-!!ENDIF
++        set(imported_location \"${PLUGIN_LOCATION}\")
+         _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
+         set_target_properties(Qt5::${Plugin} PROPERTIES
+             \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
+Index: qtbase-opensource-src-5.6.1/src/gui/Qt5GuiConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.6.1.orig/src/gui/Qt5GuiConfigExtras.cmake.in
++++ qtbase-opensource-src-5.6.1/src/gui/Qt5GuiConfigExtras.cmake.in
+@@ -2,7 +2,7 @@
+ !!IF !isEmpty(CMAKE_ANGLE_EGL_DLL_RELEASE)
+ 
+ !!IF isEmpty(CMAKE_INCLUDE_DIR_IS_ABSOLUTE)
+-set(Qt5Gui_EGL_INCLUDE_DIRS \"${_qt5$${CMAKE_MODULE_NAME}_install_prefix}/$$CMAKE_INCLUDE_DIR/QtANGLE\")
++set(Qt5Gui_EGL_INCLUDE_DIRS \"@NIX_DEV@/$$CMAKE_INCLUDE_DIR/QtANGLE\")
+ !!ELSE
+ set(Qt5Gui_EGL_INCLUDE_DIRS \"$$CMAKE_INCLUDE_DIR/QtANGLE\")
+ !!ENDIF
+@@ -17,13 +17,13 @@ macro(_populate_qt5gui_gl_target_propert
+     set_property(TARGET Qt5::${TargetName} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
+ 
+ !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Gui_install_prefix}/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
++    set(imported_location \"@NIX_OUT@/$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
+ !!ENDIF
+ 
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_implib \"${_qt5Gui_install_prefix}/$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
++    set(imported_implib \"@NIX_DEV@/$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+ !!ELSE
+     set(imported_implib \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.6.1/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.6.1.orig/src/widgets/Qt5WidgetsConfigExtras.cmake.in
++++ qtbase-opensource-src-5.6.1/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::uic)
+     add_executable(Qt5::uic IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Widgets_install_prefix}/$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.6.1/src/corelib/Qt5CoreConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.6.1.orig/src/corelib/Qt5CoreConfigExtras.cmake.in
++++ qtbase-opensource-src-5.6.1/src/corelib/Qt5CoreConfigExtras.cmake.in
+@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qmake)
+     add_executable(Qt5::qmake IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -18,7 +18,7 @@ if (NOT TARGET Qt5::moc)
+     add_executable(Qt5::moc IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -35,7 +35,7 @@ if (NOT TARGET Qt5::rcc)
+     add_executable(Qt5::rcc IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -131,7 +131,7 @@ if (NOT TARGET Qt5::WinMain)
+ !!IF !isEmpty(CMAKE_RELEASE_TYPE)
+     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
+ !!ENDIF
+@@ -145,7 +145,7 @@ if (NOT TARGET Qt5::WinMain)
+     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+ 
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.6.1/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.6.1.orig/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
++++ qtbase-opensource-src-5.6.1/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
+@@ -1,6 +1,6 @@
+ 
+ !!IF isEmpty(CMAKE_INSTALL_DATA_DIR_IS_ABSOLUTE)
+-set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
++set(_qt5_corelib_extra_includes \"@NIX_DEV@/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
+ !!ELSE
+ set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.6.1/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.6.1.orig/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
++++ qtbase-opensource-src-5.6.1/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
+@@ -1,6 +1,6 @@
+ 
+ !!IF isEmpty(CMAKE_HOST_DATA_DIR_IS_ABSOLUTE)
+-set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
++set(_qt5_corelib_extra_includes \"@NIX_DEV@/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
+ !!ELSE
+ set(_qt5_corelib_extra_includes \"$${CMAKE_HOST_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.6.1/src/dbus/Qt5DBusConfigExtras.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.6.1.orig/src/dbus/Qt5DBusConfigExtras.cmake.in
++++ qtbase-opensource-src-5.6.1/src/dbus/Qt5DBusConfigExtras.cmake.in
+@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qdbuscpp2xml)
+     add_executable(Qt5::qdbuscpp2xml IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5DBus_install_prefix}/$${CMAKE_BIN_DIR}qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qdbuscpp2xml$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -18,7 +18,7 @@ if (NOT TARGET Qt5::qdbusxml2cpp)
+     add_executable(Qt5::qdbusxml2cpp IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5DBus_install_prefix}/$${CMAKE_BIN_DIR}qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"@NIX_DEV@/$${CMAKE_BIN_DIR}qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qdbusxml2cpp$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+Index: qtbase-opensource-src-5.6.1/mkspecs/features/create_cmake.prf
+===================================================================
+--- qtbase-opensource-src-5.6.1.orig/mkspecs/features/create_cmake.prf
++++ qtbase-opensource-src-5.6.1/mkspecs/features/create_cmake.prf
+@@ -136,28 +136,28 @@ contains(CONFIG, plugin) {
+ 
+     win32 {
+         isEmpty(CMAKE_STATIC_TYPE) {
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/$${TARGET}.dll
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/$${TARGET}d.dll
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}.dll
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}d.dll
+         } else:mingw {
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/lib$${TARGET}.a
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/lib$${TARGET}d.a
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}/$$PLUGIN_TYPE/lib$${TARGET}.a
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}d.a
+         } else {                         # MSVC static
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/$${TARGET}.lib
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/$${TARGET}d.lib
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}.lib
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/$${TARGET}d.lib
+         }
+     } else {
+         mac {
+             isEmpty(CMAKE_STATIC_TYPE): CMAKE_PlUGIN_EXT = .dylib
+             else: CMAKE_PlUGIN_EXT = .a
+ 
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+         } else {
+             isEmpty(CMAKE_STATIC_TYPE): CMAKE_PlUGIN_EXT = .so
+             else: CMAKE_PlUGIN_EXT = .a
+ 
+-            CMAKE_PLUGIN_LOCATION_RELEASE = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+-            CMAKE_PLUGIN_LOCATION_DEBUG = $$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_RELEASE = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
++            CMAKE_PLUGIN_LOCATION_DEBUG = $${CMAKE_PLUGIN_DIR}$$PLUGIN_TYPE/lib$${TARGET}$${CMAKE_PlUGIN_EXT}
+         }
+     }
+     cmake_target_file.input = $$PWD/data/cmake/Qt5PluginTarget.cmake.in
+Index: qtbase-opensource-src-5.6.1/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
+===================================================================
+--- qtbase-opensource-src-5.6.1.orig/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
++++ qtbase-opensource-src-5.6.1/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
+@@ -2,10 +2,10 @@
+ add_library(Qt5::$$CMAKE_PLUGIN_NAME MODULE IMPORTED)
+ 
+ !!IF !isEmpty(CMAKE_RELEASE_TYPE)
+-_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME RELEASE \"$${CMAKE_PLUGIN_LOCATION_RELEASE}\")
++_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME RELEASE \"@NIX_OUT@/$${CMAKE_PLUGIN_LOCATION_RELEASE}\")
+ !!ENDIF
+ !!IF !isEmpty(CMAKE_DEBUG_TYPE)
+-_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME DEBUG \"$${CMAKE_PLUGIN_LOCATION_DEBUG}\")
++_populate_$${CMAKE_MODULE_NAME}_plugin_properties($$CMAKE_PLUGIN_NAME DEBUG \"@NIX_OUT@/$${CMAKE_PLUGIN_LOCATION_DEBUG}\")
+ !!ENDIF
+ 
+ list(APPEND Qt5$${CMAKE_MODULE_NAME}_PLUGINS Qt5::$$CMAKE_PLUGIN_NAME)

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
@@ -9,13 +9,15 @@
 
 , coreutils, bison, flex, gdb, gperf, lndir
 , patchelf, perl, pkgconfig, python2
+, darwin, libiconv
 
 # optional dependencies
 , cups ? null
 , mysql ? null, postgresql ? null
 
 # options
-, mesaSupported, mesa
+, mesaSupported ? (!stdenv.isDarwin)
+, mesa
 , buildExamples ? false
 , buildTests ? false
 , developerBuild ? false
@@ -35,6 +37,7 @@ stdenv.mkDerivation {
 
   patches =
     copyPathsToStore (lib.readPathsFromFile ./. ./series)
+    ++ [(if stdenv.isDarwin then ./cmake-paths-darwin.patch else ./cmake-paths.patch)]
     ++ lib.optional decryptSslTraffic ./decrypt-ssl-traffic.patch
     ++ lib.optional mesaSupported [ ./dlopen-gl.patch ./mkspecs-libgl.patch ];
 
@@ -54,11 +57,11 @@ stdenv.mkDerivation {
       substituteInPlace src/network/kernel/qhostinfo_unix.cpp \
         --replace "@glibc@" "${stdenv.cc.libc.out}"
 
-      substituteInPlace src/plugins/platforms/xcb/qxcbcursor.cpp \
-        --replace "@libXcursor@" "${libXcursor.out}"
-
       substituteInPlace src/network/ssl/qsslsocket_openssl_symbols.cpp \
         --replace "@openssl@" "${openssl.out}"
+    '' + lib.optionalString stdenv.isLinux ''
+      substituteInPlace src/plugins/platforms/xcb/qxcbcursor.cpp \
+        --replace "@libXcursor@" "${libXcursor.out}"
 
       substituteInPlace src/dbus/qdbus_symbols.cpp \
         --replace "@dbus_libs@" "${dbus.lib}"
@@ -66,16 +69,30 @@ stdenv.mkDerivation {
       substituteInPlace \
         src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp \
         --replace "@libX11@" "${libX11.out}"
-    ''
-    + lib.optionalString mesaSupported ''
+    '' + lib.optionalString mesaSupported ''
       substituteInPlace \
         src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp \
         --replace "@mesa_lib@" "${mesa.out}"
       substituteInPlace mkspecs/common/linux.conf \
         --replace "@mesa_lib@" "${mesa.out}" \
         --replace "@mesa_inc@" "${mesa.dev or mesa}"
+    '' + lib.optionalString stdenv.isDarwin ''
+      sed -i \
+          -e 's|! /usr/bin/xcode-select --print-path >/dev/null 2>&1;|false;|' \
+          -e 's|! /usr/bin/xcrun -find xcodebuild >/dev/null 2>&1;|false;|' \
+          -e 's|sysroot=$(/usr/bin/xcodebuild -sdk $sdk -version Path 2>/dev/null)|sysroot="${darwin.apple_sdk.sdk}"|' \
+          -e 's|QMAKE_CONF_COMPILER=`getXQMakeConf QMAKE_CXX`|QMAKE_CXX="clang++"\nQMAKE_CONF_COMPILER="clang++"|' \
+          -e 's|XCRUN=`/usr/bin/xcrun -sdk macosx clang -v 2>&1`|XCRUN="clang -v 2>&1"|' \
+          -e 's#sdk_val=$(/usr/bin/xcrun -sdk $sdk -find $(echo $val | cut -d \x27 \x27 -f 1))##' \
+          -e 's#val=$(echo $sdk_val $(echo $val | cut -s -d \x27 \x27 -f 2-))##' \
+          ./configure
+      sed -i '3,$d' ./mkspecs/features/mac/default_pre.prf
+      sed -i '26,$d' ./mkspecs/features/mac/default_post.prf
+      sed -i '1,$d' ./mkspecs/features/mac/sdk.prf
+      sed 's/QMAKE_LFLAGS_RPATH      = -Wl,-rpath,/QMAKE_LFLAGS_RPATH      =/' -i ./mkspecs/common/mac.conf
     '';
-
+    # Note on the above: \x27 is a way if including a single-quote
+    # character in the sed string arguments.
 
   setOutputFlags = false;
   preConfigure = ''
@@ -104,7 +121,6 @@ stdenv.mkDerivation {
     ${lib.optionalString developerBuild "-developer-build"}
     -largefile
     -accessibility
-    -rpath
     -optimized-qmake
     -strip
     -no-reduce-relocations
@@ -118,15 +134,6 @@ stdenv.mkDerivation {
     -iconv
     -icu
     -pch
-    -glib
-    -xcb
-    -qpa xcb
-    -${lib.optionalString (cups == null) "no-"}cups
-
-    -no-eglfs
-    -no-directfb
-    -no-linuxfb
-    -no-kms
 
     ${lib.optionalString (!system-x86_64) "-no-sse2"}
     -no-sse3
@@ -142,11 +149,8 @@ stdenv.mkDerivation {
     -system-libpng
     -system-libjpeg
     -system-harfbuzz
-    -system-xcb
-    -system-xkbcommon
     -system-pcre
     -openssl-linked
-    -dbus-linked
 
     -system-sqlite
     -${if mysql != null then "plugin" else "no"}-sql-mysql
@@ -156,6 +160,27 @@ stdenv.mkDerivation {
     -make tools
     -${lib.optionalString (buildExamples == false) "no"}make examples
     -${lib.optionalString (buildTests == false) "no"}make tests
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    -no-rpath
+    -glib
+    -xcb
+    -qpa xcb
+
+    -${lib.optionalString (cups == null) "no-"}cups
+
+    -no-eglfs
+    -no-directfb
+    -no-linuxfb
+    -no-kms
+
+    -system-xcb
+    -system-xkbcommon
+    -dbus-linked
+  '' + lib.optionalString stdenv.isDarwin ''
+    -platform macx-clang
+    -no-use-gold-linker
+    -no-fontconfig
+    -qt-freetype
   '';
 
   # PostgreSQL autodetection fails sporadically because Qt omits the "-lpq" flag
@@ -164,19 +189,27 @@ stdenv.mkDerivation {
   PSQL_LIBS = lib.optionalString (postgresql != null) "-L${postgresql.lib}/lib -lpq";
 
   propagatedBuildInputs = [
-    dbus glib libxml2 libxslt openssl pcre16 sqlite udev zlib
+    libxml2 libxslt openssl pcre16 sqlite zlib
+
+    # Text rendering
+    harfbuzz icu
 
     # Image formats
     libjpeg libpng libtiff
+  ]
+  ++ lib.optional mesaSupported mesa
+  ++ lib.optionals (!stdenv.isDarwin) [
+    dbus glib udev
 
     # Text rendering
-    fontconfig freetype harfbuzz icu
-
+    fontconfig freetype
     # X11 libs
     xlibs.libXcomposite libX11 libxcb libXext libXrender libXi
     xcbutil xcbutilimage xcbutilkeysyms xcbutilwm libxkbcommon
-  ]
-  ++ lib.optional mesaSupported mesa;
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    ApplicationServices CoreServices AppKit Carbon OpenGL AGL Cocoa
+    DiskArbitration darwin.cf-private libiconv darwin.apple_sdk.sdk
+  ]);
 
   buildInputs =
     [ bison flex gperf ]
@@ -185,10 +218,14 @@ stdenv.mkDerivation {
     ++ lib.optional (mysql != null) mysql.lib
     ++ lib.optional (postgresql != null) postgresql;
 
-  nativeBuildInputs = [ lndir patchelf perl pkgconfig python2 ];
+  nativeBuildInputs = [ lndir perl pkgconfig python2 ] ++ lib.optional (!stdenv.isDarwin) patchelf;
 
   # freetype-2.5.4 changed signedness of some struct fields
-  NIX_CFLAGS_COMPILE = "-Wno-error=sign-compare";
+  NIX_CFLAGS_COMPILE = "-Wno-error=sign-compare"
+    + lib.optionalString stdenv.isDarwin " -D__MAC_OS_X_VERSION_MAX_ALLOWED=1090 -D__AVAILABILITY_INTERNAL__MAC_10_10=__attribute__((availability(macosx,introduced=10.10)))";
+  # Note that nixpkgs's objc4 is from macOS 10.11 while the SDK is
+  # 10.9 which necessitates the above macro definition that mentions
+  # 10.10
 
   postInstall = ''
     find "$out" -name "*.cmake" | while read file; do
@@ -210,6 +247,11 @@ stdenv.mkDerivation {
     moveToOutput "share/doc" "$dev"
   '';
 
+  # Don't move .prl files on darwin because they end up in
+  # "dev/lib/Foo.framework/Foo.prl" which interferes with subsequent
+  # use of lndir in the qtbase setup-hook. On Linux, the .prl files
+  # are in lib, and so do not cause a subsequent recreation of deep
+  # framework directory trees.
   postFixup =
     ''
       # Don't retain build-time dependencies like gdb.
@@ -218,17 +260,33 @@ stdenv.mkDerivation {
       # Move libtool archives and qmake projects
       if [ "z''${!outputLib}" != "z''${!outputDev}" ]; then
           pushd "''${!outputLib}"
-          find lib -name '*.a' -o -name '*.la' -o -name '*.prl' | \
+          find lib -name '*.a' -o -name '*.la'${if stdenv.isDarwin then "" else "-o -name '*.prl'"} | \
               while read -r file; do
                   mkdir -p "''${!outputDev}/$(dirname "$file")"
                   mv "''${!outputLib}/$file" "''${!outputDev}/$file"
               done
           popd
       fi
+    '' + lib.optionalString stdenv.isDarwin ''
+      fixDarwinDylibNames_rpath() {
+        local flags=()
+
+        for fn in "$@"; do
+          flags+=(-change "@rpath/$fn.framework/Versions/5/$fn" "$out/lib/$fn.framework/Versions/5/$fn")
+        done
+
+        for fn in "$@"; do
+          echo "$fn: fixing dylib"
+          install_name_tool -id "$out/lib/$fn.framework/Versions/5/$fn" "''${flags[@]}" "$out/lib/$fn.framework/Versions/5/$fn"
+        done
+      }
+      fixDarwinDylibNames_rpath "QtConcurrent" "QtPrintSupport" "QtCore" "QtSql" "QtDBus" "QtTest" "QtGui" "QtWidgets" "QtNetwork" "QtXml" "QtOpenGL"
     '';
 
   inherit lndir;
-  setupHook = ../../qtbase-setup-hook.sh;
+  setupHook = if stdenv.isDarwin
+              then ../../qtbase-setup-hook-darwin.sh
+              else ../../qtbase-setup-hook.sh;
 
   enableParallelBuilding = true;
 
@@ -237,7 +295,6 @@ stdenv.mkDerivation {
     description = "A cross-platform application framework for C++";
     license = with licenses; [ fdl13 gpl2 lgpl21 lgpl3 ];
     maintainers = with maintainers; [ bbenoist qknight ttuegel ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
-
 }

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/series
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/series
@@ -7,4 +7,3 @@ xdg-config-dirs.patch
 nix-profiles-library-paths.patch
 compose-search-path.patch
 libressl.patch
-cmake-paths.patch

--- a/pkgs/development/libraries/qt-5/make-qt-wrapper-darwin.sh
+++ b/pkgs/development/libraries/qt-5/make-qt-wrapper-darwin.sh
@@ -1,0 +1,38 @@
+wrapQtProgram() {
+    local prog="$1"
+    shift
+    wrapProgram "$prog" \
+        --set QT_PLUGIN_PATH "$QT_PLUGIN_PATH" \
+        --set QML_IMPORT_PATH "$QML_IMPORT_PATH" \
+        --set QML2_IMPORT_PATH "$QML2_IMPORT_PATH" \
+        --set DYLD_FRAMEWORK_PATH "/System/Library/Frameworks" \
+        --prefix XDG_DATA_DIRS : "$RUNTIME_XDG_DATA_DIRS" \
+        --prefix XDG_CONFIG_DIRS : "$RUNTIME_XDG_CONFIG_DIRS" \
+        "$@"
+}
+
+makeQtWrapper() {
+    local old="$1"
+    local new="$2"
+    shift
+    shift
+    makeWrapper "$old" "$new" \
+        --set QT_PLUGIN_PATH "$QT_PLUGIN_PATH" \
+        --set QML_IMPORT_PATH "$QML_IMPORT_PATH" \
+        --set QML2_IMPORT_PATH "$QML2_IMPORT_PATH" \
+        --set DYLD_FRAMEWORK_PATH "/System/Library/Frameworks" \
+        --prefix XDG_DATA_DIRS : "$RUNTIME_XDG_DATA_DIRS" \
+        --prefix XDG_CONFIG_DIRS : "$RUNTIME_XDG_CONFIG_DIRS" \
+        "$@"
+}
+
+_makeQtWrapperSetup() {
+    # cannot use addToSearchPath because these directories may not exist yet
+    export QT_PLUGIN_PATH="$QT_PLUGIN_PATH${QT_PLUGIN_PATH:+:}${!outputLib}/lib/qt5/plugins"
+    export QML_IMPORT_PATH="$QML_IMPORT_PATH${QML_IMPORT_PATH:+:}${!outputLib}/lib/qt5/imports"
+    export QML2_IMPORT_PATH="$QML2_IMPORT_PATH${QML2_IMPORT_PATH:+:}${!outputLib}/lib/qt5/qml"
+    export RUNTIME_XDG_DATA_DIRS="$XDG_DATA_DIRS${XDG_DATA_DIRS:+:}${!outputBin}/share"
+    export RUNTIME_XDG_CONFIG_DIRS="$XDG_CONFIG_DIRS${XDG_CONFIG_DIRS:+:}${!outputBin}/etc/xdg"
+}
+
+prePhases+=(_makeQtWrapperSetup)

--- a/pkgs/development/libraries/qt-5/qmake-hook-darwin.sh
+++ b/pkgs/development/libraries/qt-5/qmake-hook-darwin.sh
@@ -1,0 +1,42 @@
+qmakeConfigurePhase() {
+    runHook preConfigure
+
+    qmake PREFIX=$out $qmakeFlags
+
+    runHook postConfigure
+}
+
+if [ -z "$dontUseQmakeConfigure" -a -z "$configurePhase" ]; then
+    configurePhase=qmakeConfigurePhase
+fi
+
+_qtModuleMultioutDevsPre() {
+    # We cannot simply set these paths in configureFlags because libQtCore retains
+    # references to the paths it was built with.
+    moveToOutput "bin" "${!outputDev}"
+    moveToOutput "include" "${!outputDev}"
+
+    # The destination directory must exist or moveToOutput will do nothing
+    mkdir -p "${!outputDev}/share"
+    moveToOutput "share/doc" "${!outputDev}"
+}
+
+_qtModuleMultioutDevsPost() {
+    # Move libtool archives and qmake project files to $dev/lib
+    if [ "z${!outputLib}" != "z${!outputDev}" ]; then
+        pushd "${!outputLib}"
+        if [ -d "lib" ]; then
+            find lib \( -name '*.a' -o -name '*.la' \) -print0 | \
+                while read -r -d $'\0' file; do
+                    mkdir -p "${!outputDev}/$(dirname "$file")"
+                    mv "${!outputLib}/$file" "${!outputDev}/$file"
+                done
+        fi
+        popd
+    fi
+}
+
+if [ -n "$NIX_QT_SUBMODULE" ]; then
+    preFixupHooks+=(_qtModuleMultioutDevsPre)
+    postFixupHooks+=(_qtModuleMultioutDevsPost)
+fi

--- a/pkgs/development/libraries/qt-5/qtbase-setup-hook-darwin.sh
+++ b/pkgs/development/libraries/qt-5/qtbase-setup-hook-darwin.sh
@@ -1,0 +1,181 @@
+addToSearchPathOnceWithCustomDelimiter() {
+    local delim="$1"
+    local search="$2"
+    local target="$3"
+    local dirs
+    local exported
+    IFS="$delim" read -a dirs <<< "${!search}"
+    local canonical
+    if canonical=$(readlink -e "$target"); then
+        for dir in ${dirs[@]}; do
+            if [ "z$dir" == "z$canonical" ]; then exported=1; fi
+        done
+        if [ -z $exported ]; then
+            eval "export ${search}=\"${!search}${!search:+$delim}$canonical\""
+        fi
+    fi
+}
+
+addToSearchPathOnce() {
+    addToSearchPathOnceWithCustomDelimiter ':' "$@"
+}
+
+propagateOnce() {
+    addToSearchPathOnceWithCustomDelimiter ' ' "$@"
+}
+
+_qtPropagate() {
+    for dir in "lib/qt5/plugins" "lib/qt5/qml" "lib/qt5/imports"; do
+        if [ -d "$1/$dir" ]; then
+            propagateOnce propagatedBuildInputs "$1"
+            break
+        fi
+    done
+    addToSearchPathOnce QT_PLUGIN_PATH "$1/lib/qt5/plugins"
+    addToSearchPathOnce QML_IMPORT_PATH "$1/lib/qt5/imports"
+    addToSearchPathOnce QML2_IMPORT_PATH "$1/lib/qt5/qml"
+}
+
+crossEnvHooks+=(_qtPropagate)
+
+_qtPropagateNative() {
+    for dir in "lib/qt5/plugins" "lib/qt5/qml" "lib/qt5/imports"; do
+        if [ -d "$1/$dir" ]; then
+            propagateOnce propagatedNativeBuildInputs "$1"
+            break
+        fi
+    done
+    if [ -z "$crossConfig" ]; then
+        addToSearchPathOnce QT_PLUGIN_PATH "$1/lib/qt5/plugins"
+        addToSearchPathOnce QML_IMPORT_PATH "$1/lib/qt5/imports"
+        addToSearchPathOnce QML2_IMPORT_PATH "$1/lib/qt5/qml"
+    fi
+}
+
+envHooks+=(_qtPropagateNative)
+
+_qtMultioutDevs() {
+    # This is necessary whether the package is a Qt module or not
+    moveToOutput "mkspecs" "${!outputDev}"
+}
+
+preFixupHooks+=(_qtMultioutDevs)
+
+_qtSetCMakePrefix() {
+    export CMAKE_PREFIX_PATH="$NIX_QT5_TMP${CMAKE_PREFIX_PATH:+:}${CMAKE_PREFIX_PATH}"
+}
+
+_qtRmTmp() {
+    if [ -z "$NIX_QT_SUBMODULE" ]; then
+        rm -fr "$NIX_QT5_TMP"
+    else
+        cat "$NIX_QT5_TMP/nix-support/qt-inputs" | while read file; do
+            if [ ! -d "$NIX_QT5_TMP/$file" ]; then
+                rm -f "$NIX_QT5_TMP/$file"
+            fi
+        done
+
+        cat "$NIX_QT5_TMP/nix-support/qt-inputs" | while read dir; do
+            if [ -d "$NIX_QT5_TMP/$dir" ]; then
+                rmdir --ignore-fail-on-non-empty -p "$NIX_QT5_TMP/$dir"
+            fi
+        done
+
+        rm "$NIX_QT5_TMP/nix-support/qt-inputs"
+    fi
+}
+
+_qtSetQmakePath() {
+    export PATH="$NIX_QT5_TMP/bin${PATH:+:}$PATH"
+}
+
+if [ -z "$NIX_QT5_TMP" ]; then
+    if [ -z "$NIX_QT_SUBMODULE" ]; then
+        NIX_QT5_TMP=$(pwd)/.nix_qt5
+    else
+        NIX_QT5_TMP=$out
+    fi
+    postInstallHooks+=(_qtRmTmp)
+
+    mkdir -p "$NIX_QT5_TMP/nix-support"
+    for subdir in bin include mkspecs share; do
+        mkdir -p "$NIX_QT5_TMP/$subdir"
+        echo "$subdir/" >> "$NIX_QT5_TMP/nix-support/qt-inputs"
+    done
+    mkdir -p "$NIX_QT5_TMP/lib"
+
+    postHooks+=(_qtSetCMakePrefix)
+
+    ln -sf "@dev@/bin/qmake" "$NIX_QT5_TMP/bin"
+    echo "bin/qmake" >> "$NIX_QT5_TMP/nix-support/qt-inputs"
+
+    cat >"$NIX_QT5_TMP/bin/qt.conf" <<EOF
+[Paths]
+Prefix = $NIX_QT5_TMP
+Plugins = lib/qt5/plugins
+Imports = lib/qt5/imports
+Qml2Imports = lib/qt5/qml
+Documentation = share/doc/qt5
+EOF
+    echo "bin/qt.conf" >> "$NIX_QT5_TMP/nix-support/qt-inputs"
+
+    export QMAKE="$NIX_QT5_TMP/bin/qmake"
+
+    # Set PATH to find qmake first in a preConfigure hook
+    # It must run after all the envHooks!
+    preConfigureHooks+=(_qtSetQmakePath)
+fi
+
+qt5LinkModuleDir() {
+    if [ -d "$1/$2" ]; then
+        @lndir@/bin/lndir -silent "$1/$2" "$NIX_QT5_TMP/$2"
+        find "$1/$2" -printf "$2/%P\n" >> "$NIX_QT5_TMP/nix-support/qt-inputs"
+    fi
+}
+
+qt5LinkDarwinModuleLibDir() {
+  for fw in $(find "$1"/lib -maxdepth 1 -name '*.framework'); do
+      ln -s "$fw" "$NIX_QT5_TMP"/lib
+  done
+  for file in $(find "$1"/lib -maxdepth 1 -type f); do
+      ln -s "$file" "$NIX_QT5_TMP"/lib
+  done
+  for dir in $(find "$1"/lib -maxdepth 1 -mindepth 1 -type d ! -name '*.framework'); do
+      mkdir -p "$NIX_QT5_TMP"/lib/$(basename "$dir")
+      @lndir@/bin/lndir -silent "$dir" "$NIX_QT5_TMP"/lib/$(basename "$dir")
+  done
+}
+
+NIX_QT5_MODULES="${NIX_QT5_MODULES}${NIX_QT5_MODULES:+:}@out@"
+NIX_QT5_MODULES_DEV="${NIX_QT5_MODULES_DEV}${NIX_QT5_MODULES_DEV:+:}@dev@"
+
+_qtLinkAllModules() {
+    IFS=: read -a modules <<< $NIX_QT5_MODULES
+    for module in ${modules[@]}; do
+        qt5LinkDarwinModuleLibDir "$module"
+    done
+
+    IFS=: read -a modules <<< $NIX_QT5_MODULES_DEV
+    for module in ${modules[@]}; do
+        qt5LinkModuleDir "$module" "bin"
+        qt5LinkModuleDir "$module" "include"
+        qt5LinkDarwinModuleLibDir "$module"
+        qt5LinkModuleDir "$module" "mkspecs"
+        qt5LinkModuleDir "$module" "share"
+    done
+}
+
+preConfigureHooks+=(_qtLinkAllModules)
+
+_qtFixCMakePaths() {
+    find "${!outputLib}" -name "*.cmake" | while read file; do
+        substituteInPlace "$file" \
+            --subst-var-by NIX_OUT "${!outputLib}" \
+            --subst-var-by NIX_DEV "${!outputDev}"
+    done
+}
+
+if [ -n "$NIX_QT_SUBMODULE" ]; then
+    postInstallHooks+=(_qtFixCMakePaths)
+fi
+


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This extends the [prior attempt at adding darwin support](https://github.com/NixOS/nixpkgs/pull/20455) to support `qtbase-5.6.2` and updates hooks to reflect changes in how `qmake` supported on nixpkgs. @ttuegel @periklis and @matthewbauer all chimed in on the last version, I hope they can take another look to ensure things still look okay.

- qtbase builds on darwin
- Downstream qmake and cmake build configurations supported

Darwin-specific changes:

Prevent `qmake -project` from adding build support files in the temp
directory to the project.

Shrink the temp directory used for building with qmake.

The issue here is that `lndir` recreates the entire directory structure
of the module we are merging (e.g. the `out` and `dev` build outputs) into the temporary build environment. On
darwin, the framework directory structures mean that this shadow
directory tree is 17MB even though the file contents are all symlinks
into the store.

To address this, we symlink the `qmake` executable and the framework directories explicitly, and
use `lndir` for everything else. This brings the temp directory size down to 3.2MB.