### PR TITLE
endless sky: init at 0.9.4

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -242,6 +242,7 @@
   leonardoce = "Leonardo Cecchi <leonardo.cecchi@gmail.com>";
   lethalman = "Luca Bruno <lucabru@src.gnome.org>";
   lewo = "Antoine Eiche <lewo@abesis.fr>";
+  lheckemann = "Linus Heckemann <git@sphalerite.org>";
   lhvwb = "Nathaniel Baxter <nathaniel.baxter@gmail.com>";
   lihop = "Leroy Hopson <nixos@leroy.geek.nz>";
   linquize = "Linquize <linquize@yahoo.com.hk>";

--- a/pkgs/games/endless-sky/default.nix
+++ b/pkgs/games/endless-sky/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub
+, SDL2, libpng, libjpeg, glew, openal, scons
+}:
+
+let
+  version = "0.9.4";
+
+in
+stdenv.mkDerivation rec {
+  name = "endless-sky-${version}";
+
+  src = fetchFromGitHub {
+    owner = "endless-sky";
+    repo = "endless-sky";
+    rev = "v${version}";
+    sha256 = "1mirdcpap0a280j472lhmhqg605b7glvdr4l93qcapk8an8d46m7";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    SDL2 libpng libjpeg glew openal scons
+  ];
+
+  patches = [
+    ./fixes.patch
+  ];
+
+  buildPhase = ''
+    scons -j$NIX_BUILD_CORES PREFIX="$out"
+  '';
+
+  installPhase = ''
+    scons -j$NIX_BUILD_CORES install PREFIX="$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A sandbox-style space exploration game similar to Elite, Escape Velocity, or Star Control";
+    homepage = "https://endless-sky.github.io/";
+    license = with licenses; [
+      gpl3Plus cc-by-sa-30 cc-by-sa-40 publicDomain
+    ];
+    maintainers = with maintainers; [ lheckemann ];
+    platforms = with platforms; allBut darwin;
+  };
+}

--- a/pkgs/games/endless-sky/fixes.patch
+++ b/pkgs/games/endless-sky/fixes.patch
@@ -1,0 +1,45 @@
+diff --git a/SConstruct b/SConstruct
+index 48fd080..419b40d 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -1,7 +1,7 @@
+ import os
+ 
+ # Load any environment variables that alter the build.
+-env = Environment()
++env = Environment(ENV = os.environ)
+ if 'CCFLAGS' in os.environ:
+ 	env.Append(CCFLAGS = os.environ['CCFLAGS'])
+ if 'CXXFLAGS' in os.environ:
+@@ -55,7 +55,7 @@ sky = env.Program("endless-sky", Glob("build/" + env["mode"] + "/*.cpp"))
+ 
+ 
+ # Install the binary:
+-env.Install("$DESTDIR$PREFIX/games", sky)
++env.Install("$DESTDIR$PREFIX/bin", sky)
+ 
+ # Install the desktop file:
+ env.Install("$DESTDIR$PREFIX/share/applications", "endless-sky.desktop")
+diff --git a/source/Files.cpp b/source/Files.cpp
+index c8c8957..d196459 100644
+--- a/source/Files.cpp
++++ b/source/Files.cpp
+@@ -114,15 +114,9 @@ void Files::Init(const char * const *argv)
+ 	if(resources.back() != '/')
+ 		resources += '/';
+ #if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
+-	// Special case, for Linux: the resource files are not in the same place as
+-	// the executable, but are under the same prefix (/usr or /usr/local).
+-	static const string LOCAL_PATH = "/usr/local/";
+-	static const string STANDARD_PATH = "/usr/";
+-	static const string RESOURCE_PATH = "share/games/endless-sky/";
+-	if(!resources.compare(0, LOCAL_PATH.length(), LOCAL_PATH))
+-		resources = LOCAL_PATH + RESOURCE_PATH;
+-	else if(!resources.compare(0, STANDARD_PATH.length(), STANDARD_PATH))
+-		resources = STANDARD_PATH + RESOURCE_PATH;
++	// Workaround for NixOS. Not sure how to proceed with other OSes, feedback
++	// is welcome.
++	resources += "../share/games/endless-sky/";
+ #elif defined __APPLE__
+ 	// Special case for Mac OS X: the resources are in ../Resources relative to
+ 	// the folder the binary is in.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1550,7 +1550,6 @@ in
 
   emscriptenStdenv = stdenv // { mkDerivation = buildEmscriptenPackage; };
 
-
   efibootmgr = callPackage ../tools/system/efibootmgr { };
 
   efivar = callPackage ../tools/system/efivar { };
@@ -15637,6 +15636,8 @@ in
   eduke32 = callPackage ../games/eduke32 { };
 
   egoboo = callPackage ../games/egoboo { };
+
+  endless-sky = callPackage ../games/endless-sky { };
 
   eternity = callPackage ../games/eternity-engine { };
 


### PR DESCRIPTION
###### Motivation for this change
It's a fun game!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS — probably won't work as is, but not sure if it's useful to have it available as a nix package considering it can be downloaded as a shiny natively packaged app or via Steam?
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` — not sure I fully understand this one, but seeing as it's a new application with no dependents it should be fine?
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).