### PR TITLE
planner: making Gantt and Resource Usage views usable

### DIFF
--- a/pkgs/applications/office/planner/default.nix
+++ b/pkgs/applications/office/planner/default.nix
@@ -35,6 +35,9 @@ in stdenv.mkDerivation {
     python
   ];
 
+  patches = [ ./planner-gantt-background.c.patch
+              ./planner-gantt-row.c.patch ];
+
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
@@ -42,6 +45,6 @@ in stdenv.mkDerivation {
     description = "Project management application for GNOME";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.rasendubi ];
+    maintainers = with maintainers; [ rasendubi amiloradovsky ];
   };
 }

--- a/pkgs/applications/office/planner/planner-gantt-background.c.patch
+++ b/pkgs/applications/office/planner/planner-gantt-background.c.patch
@@ -1,22 +1,40 @@
 diff --git a/src/planner-gantt-background.c b/src/planner-gantt-background.c
-index ed21de9..1fde7d9 100644
+index ed21de9..9e3b4d8 100644
 --- a/src/planner-gantt-background.c
 +++ b/src/planner-gantt-background.c
-@@ -390,7 +390,7 @@ gantt_background_realize (GnomeCanvasItem *item)
+@@ -380,7 +380,7 @@ gantt_background_realize (GnomeCanvasItem *item)
+ 	priv->border_gc = gdk_gc_new (item->canvas->layout.bin_window);
+ 	gdk_gc_set_foreground (priv->border_gc, &color);
+ 	gdk_gc_set_line_attributes (priv->border_gc,
+-				    0,
++				    0, /* why 0? */
+ 				    GDK_LINE_SOLID,
+ 				    GDK_CAP_BUTT,
+ 				    GDK_JOIN_MITER);
+@@ -389,7 +389,7 @@ gantt_background_realize (GnomeCanvasItem *item)
+ 	priv->timeline_gc = gdk_gc_new (item->canvas->layout.bin_window);
  	gdk_gc_set_foreground (priv->timeline_gc, &color);
  	gdk_gc_set_line_attributes (priv->timeline_gc,
- 				    0,
--				    GDK_LINE_ON_OFF_DASH,
-+				    GDK_LINE_SOLID /*GDK_LINE_ON_OFF_DASH*/,
+-				    0,
++				    1,
+ 				    GDK_LINE_ON_OFF_DASH,
  				    GDK_CAP_BUTT,
  				    GDK_JOIN_MITER);
- 
-@@ -399,7 +399,7 @@ gantt_background_realize (GnomeCanvasItem *item)
+@@ -398,7 +398,7 @@ gantt_background_realize (GnomeCanvasItem *item)
+ 	priv->start_gc = gdk_gc_new (item->canvas->layout.bin_window);
  	gdk_gc_set_foreground (priv->start_gc, &color);
  	gdk_gc_set_line_attributes (priv->start_gc,
- 				    0,
--				    GDK_LINE_ON_OFF_DASH,
-+				    GDK_LINE_SOLID /*GDK_LINE_ON_OFF_DASH*/,
+-				    0,
++				    1,
+ 				    GDK_LINE_ON_OFF_DASH,
  				    GDK_CAP_BUTT,
  				    GDK_JOIN_MITER);
- 
+@@ -407,7 +407,7 @@ gantt_background_realize (GnomeCanvasItem *item)
+ 	priv->guidelines_gc = gdk_gc_new (item->canvas->layout.bin_window);
+ 	gdk_gc_set_foreground (priv->guidelines_gc, &color);
+ 	gdk_gc_set_line_attributes (priv->guidelines_gc,
+-				    0,
++				    0, /* why 0? */
+ 				    GDK_LINE_SOLID,
+ 				    GDK_CAP_BUTT,
+ 				    GDK_JOIN_MITER);

--- a/pkgs/applications/office/planner/planner-gantt-background.c.patch
+++ b/pkgs/applications/office/planner/planner-gantt-background.c.patch
@@ -1,0 +1,22 @@
+diff --git a/src/planner-gantt-background.c b/src/planner-gantt-background.c
+index ed21de9..1fde7d9 100644
+--- a/src/planner-gantt-background.c
++++ b/src/planner-gantt-background.c
+@@ -390,7 +390,7 @@ gantt_background_realize (GnomeCanvasItem *item)
+ 	gdk_gc_set_foreground (priv->timeline_gc, &color);
+ 	gdk_gc_set_line_attributes (priv->timeline_gc,
+ 				    0,
+-				    GDK_LINE_ON_OFF_DASH,
++				    GDK_LINE_SOLID /*GDK_LINE_ON_OFF_DASH*/,
+ 				    GDK_CAP_BUTT,
+ 				    GDK_JOIN_MITER);
+ 
+@@ -399,7 +399,7 @@ gantt_background_realize (GnomeCanvasItem *item)
+ 	gdk_gc_set_foreground (priv->start_gc, &color);
+ 	gdk_gc_set_line_attributes (priv->start_gc,
+ 				    0,
+-				    GDK_LINE_ON_OFF_DASH,
++				    GDK_LINE_SOLID /*GDK_LINE_ON_OFF_DASH*/,
+ 				    GDK_CAP_BUTT,
+ 				    GDK_JOIN_MITER);
+ 

--- a/pkgs/applications/office/planner/planner-gantt-row.c.patch
+++ b/pkgs/applications/office/planner/planner-gantt-row.c.patch
@@ -1,31 +1,33 @@
 diff --git a/src/planner-gantt-row.c b/src/planner-gantt-row.c
-index a981d10..c881736 100644
+index a981d10..888c2fb 100644
 --- a/src/planner-gantt-row.c
 +++ b/src/planner-gantt-row.c
-@@ -943,7 +943,7 @@ gantt_row_setup_frame_gc (PlannerGanttRow *row, gboolean highlight)
+@@ -942,7 +942,7 @@ static void
+ gantt_row_setup_frame_gc (PlannerGanttRow *row, gboolean highlight)
  {
  	gdk_gc_set_line_attributes (row->priv->frame_gc,
- 				    0,
--				    highlight ? GDK_LINE_ON_OFF_DASH : GDK_LINE_SOLID,
-+				    /*highlight ? GDK_LINE_ON_OFF_DASH :*/ GDK_LINE_SOLID,
+-				    0,
++				    1,
+ 				    highlight ? GDK_LINE_ON_OFF_DASH : GDK_LINE_SOLID,
  				    GDK_CAP_BUTT,
  				    GDK_JOIN_MITER);
- }
-@@ -1789,7 +1789,7 @@ gantt_row_draw (GnomeCanvasItem *item,
+@@ -1788,8 +1788,8 @@ gantt_row_draw (GnomeCanvasItem *item,
+  				gdk_gc_set_foreground (priv->frame_gc, &color);
  
   				gdk_gc_set_line_attributes (priv->frame_gc,
-  								0,
+- 								0,
 - 								GDK_LINE_ON_OFF_DASH,
-+								GDK_LINE_SOLID /*GDK_LINE_ON_OFF_DASH*/,
++								1,
++								GDK_LINE_ON_OFF_DASH,
   								GDK_CAP_BUTT,
   								GDK_JOIN_MITER);
   				draw_cut_line (drawable, priv->frame_gc, cx1, cy1, cx2, cy1);
-@@ -1858,7 +1858,7 @@ gantt_row_draw (GnomeCanvasItem *item,
+@@ -1857,7 +1857,7 @@ gantt_row_draw (GnomeCanvasItem *item,
+ 				gdk_gc_set_foreground (priv->frame_gc, &color);
  
  				gdk_gc_set_line_attributes (priv->frame_gc,
- 								0,
--								GDK_LINE_ON_OFF_DASH,
-+								GDK_LINE_SOLID /*GDK_LINE_ON_OFF_DASH*/,
+-								0,
++								1,
+ 								GDK_LINE_ON_OFF_DASH,
  								GDK_CAP_BUTT,
  								GDK_JOIN_MITER);
- 			}

--- a/pkgs/applications/office/planner/planner-gantt-row.c.patch
+++ b/pkgs/applications/office/planner/planner-gantt-row.c.patch
@@ -1,0 +1,31 @@
+diff --git a/src/planner-gantt-row.c b/src/planner-gantt-row.c
+index a981d10..c881736 100644
+--- a/src/planner-gantt-row.c
++++ b/src/planner-gantt-row.c
+@@ -943,7 +943,7 @@ gantt_row_setup_frame_gc (PlannerGanttRow *row, gboolean highlight)
+ {
+ 	gdk_gc_set_line_attributes (row->priv->frame_gc,
+ 				    0,
+-				    highlight ? GDK_LINE_ON_OFF_DASH : GDK_LINE_SOLID,
++				    /*highlight ? GDK_LINE_ON_OFF_DASH :*/ GDK_LINE_SOLID,
+ 				    GDK_CAP_BUTT,
+ 				    GDK_JOIN_MITER);
+ }
+@@ -1789,7 +1789,7 @@ gantt_row_draw (GnomeCanvasItem *item,
+ 
+  				gdk_gc_set_line_attributes (priv->frame_gc,
+  								0,
+- 								GDK_LINE_ON_OFF_DASH,
++								GDK_LINE_SOLID /*GDK_LINE_ON_OFF_DASH*/,
+  								GDK_CAP_BUTT,
+  								GDK_JOIN_MITER);
+  				draw_cut_line (drawable, priv->frame_gc, cx1, cy1, cx2, cy1);
+@@ -1858,7 +1858,7 @@ gantt_row_draw (GnomeCanvasItem *item,
+ 
+ 				gdk_gc_set_line_attributes (priv->frame_gc,
+ 								0,
+-								GDK_LINE_ON_OFF_DASH,
++								GDK_LINE_SOLID /*GDK_LINE_ON_OFF_DASH*/,
+ 								GDK_CAP_BUTT,
+ 								GDK_JOIN_MITER);
+ 			}


### PR DESCRIPTION
###### Motivation for this change

Gnome Planner couldn't be used to edit the diagrams, now it can.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There was an issue, at least on my (stable) system, with the background in Gantt and Resource Usage views.
Due to apparently a bug with some drawing primitives, the background of the views was totally black -- unusable.
Solved by setting the dashed lines' width to 1 (from 0).
Now at least the grid is shown properly -- diagrams are visible.