### PR TITLE
git-bz: add pycrypto dependency

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-bz/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bz/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/git-bz \
+      --prefix PYTHONPATH : "$(toPythonPath "${pythonPackages.pycrypto}")" \
       --prefix PYTHONPATH : "$(toPythonPath "${pythonPackages.pysqlite}")"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Fixes git-bz (#21013)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


