### PR TITLE
openblas: Fix build issue when inside VM and CPU is undetected

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -18,6 +18,7 @@ let local = config.openblas.preferLocalBuild or false;
     genericFlags =
       [ "DYNAMIC_ARCH=${if stdenv.system == "armv7l-linux" then "0" else "1"}"
         "NUM_THREADS=64"
+        "TARGET=NEHALEM" # To fix undetected CPU problem when compiling inside VM
       ];
     localFlags = config.openblas.flags or
       optionals (hasAttr "target" config.openblas) [ "TARGET=${config.openblas.target}" ];


### PR DESCRIPTION
###### Motivation for this change
Trying to build openblas inside a virtual machine leads an undetected CPU and a build failure.
I circumvent this the same way it is done in the OpenBLAS .travis.yml: https://github.com/xianyi/OpenBLAS/blob/master/.travis.yml and set the TARGET flag to NEHALEM. It is odd that we have to do this even though DYNAMIC_ARCH is set. That is why I opened an issue upstream:
https://github.com/xianyi/OpenBLAS/issues/1027

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
