### PR TITLE
rst2html5: init at 1.9.3

### DIFF
--- a/pkgs/tools/text/rst2html5/default.nix
+++ b/pkgs/tools/text/rst2html5/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonPackage rec {
+
+  name = "${pname}-${version}";
+  pname = "rst2html5";
+  version = "1.9.3";
+
+  src = fetchurl {
+    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+    sha256 = "1js90asy7s0278b4p28inkkp0r7ajr5fk5pcdgcdw628a30vl3i6";
+  };
+
+  propagatedBuildInputs = with pythonPackages;
+  [ docutils genshi pygments beautifulsoup4 ];
+
+  meta = with stdenv.lib;{
+    homepage = "https://bitbucket.org/andre_felipe_dias/rst2html5";
+    description = "Converts ReSTructuredText to (X)HTML5";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3724,6 +3724,8 @@ with pkgs;
 
   redsocks = callPackage ../tools/networking/redsocks { };
 
+  rst2html5 = callPackage ../tools/text/rst2html5 { };
+
   rt = callPackage ../servers/rt { };
 
   rtmpdump = callPackage ../tools/video/rtmpdump { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22637,30 +22637,7 @@ in {
       homepage = "https://github.com/goinnn/django-multiselectfield";
     };
   };
-
-
-  rst2html5 = buildPythonPackage rec {
-    name = "${pname}-${version}";
-    pname = "rst2html5";
-    version = "1.9.3";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
-      sha256 = "1js90asy7s0278b4p28inkkp0r7ajr5fk5pcdgcdw628a30vl3i6";
-    };
-
-    propagatedBuildInputs = with self;
-      [ docutils genshi pygments beautifulsoup4 ];
-
-    meta = {
-      homepage = "https://bitbucket.org/andre_felipe_dias/rst2html5";
-      description = "Converts ReSTructuredText to (X)HTML5";
-      license = licenses.mit;
-      maintainers = with maintainers; [ AndersonTorres ];
-    };
-    # TODO: treat rst2html5 as an ordinary package
-  };
-
+  
   reviewboard = buildPythonPackage rec {
     name = "ReviewBoard-2.5.1.1";
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22639,6 +22639,28 @@ in {
   };
 
 
+  rst2html5 = buildPythonPackage rec {
+    name = "${pname}-${version}";
+    pname = "rst2html5";
+    version = "1.9.3";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+      sha256 = "1js90asy7s0278b4p28inkkp0r7ajr5fk5pcdgcdw628a30vl3i6";
+    };
+
+    propagatedBuildInputs = with self;
+      [ docutils genshi pygments beautifulsoup4 ];
+
+    meta = {
+      homepage = "https://bitbucket.org/andre_felipe_dias/rst2html5";
+      description = "Converts ReSTructuredText to (X)HTML5";
+      license = licenses.mit;
+      maintainers = with maintainers; [ AndersonTorres ];
+    };
+    # TODO: treat rst2html5 as an ordinary package
+  };
+
   reviewboard = buildPythonPackage rec {
     name = "ReviewBoard-2.5.1.1";
 


### PR DESCRIPTION
###### Motivation for this change

Adds rst2html5
Converts ReSTructuredtext to (X)HTML5

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

