### PR TITLE
roboto: 2.134 -> 2.135

### DIFF
--- a/pkgs/data/fonts/roboto/default.nix
+++ b/pkgs/data/fonts/roboto/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "roboto-${version}";
-  version = "2.134";
+  version = "2.135";
 
   src = fetchurl {
     url = "https://github.com/google/roboto/releases/download/v${version}/roboto-unhinted.zip";
-    sha256 = "1l033xc2n4754gwakxshh5235cnrnzy7q6zsp5zghn8ib0gdp5rb";
+    sha256 = "1ndlh36bcx4mhi58sxfx6ywbib586brh6s5sk3jyji78h1i7j8zr";
   };
 
   nativeBuildInputs = [ unzip ];
 
   installPhase = ''
     mkdir -p $out/share/fonts/truetype
-    cp -a * $out/share/fonts/truetype/
+    cp -a *.ttf $out/share/fonts/truetype/
   '';
 
   meta = {
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       Material Design.
     '';
     license = stdenv.lib.licenses.asl20;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
     platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).