### PR TITLE
musl: 1.1.11 -> 1.1.15, add security patch.

### DIFF
--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name    = "musl-${version}";
-  version = "1.1.11";
+  version = "1.1.15";
 
   src = fetchurl {
     url    = "http://www.musl-libc.org/releases/${name}.tar.gz";
-    sha256 = "0grmmah3d9wajii26010plpinv3cbiq3kfqsblgn84kv3fjnv7mv";
+    sha256 = "1ymhxkskivzph0q34zadwfglc5gyahqajm7chqqn2zraxv3lgr4p";
   };
 
   enableParallelBuilding = true;
@@ -22,6 +22,15 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-shared"
     "--enable-static"
+    "--disable-gcc-wrapper"
+  ];
+
+  patches = [
+    # CVE-2016-8859: http://www.openwall.com/lists/oss-security/2016/10/19/1
+    (fetchpatch {
+      url = "https://git.musl-libc.org/cgit/musl/patch/?id=c3edc06d1e1360f3570db9155d6b318ae0d0f0f7";
+      sha256 = "15ih0aj27lz4sgq8r5jndc3qy5gz3ciraavrqpp0vw8h5wjcsb9v";
+    })
   ];
 
   dontDisableStatic = true;


### PR DESCRIPTION
###### Motivation for this change

Update to latest (Aug 2015 -> July 2016), and apply recommended upstream patch for security issue present in all versions.

(see http://www.openwall.com/lists/oss-security/2016/10/19/1 for more information)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


I did test using nox-review but it only built the musl package.  I'm not sure if there are more useful things to check that use musl.