### PR TITLE
rubygems: 2.6.6 -> 2.6.8

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems-src.nix
+++ b/pkgs/development/interpreters/ruby/rubygems-src.nix
@@ -1,6 +1,6 @@
 { fetchurl
-, version ? "2.6.6"
-, sha256 ? "0x0ldlwr627d0brw96jdbscib6d2nk19izvnh8lzsasszi1k5rkq"
+, version ? "2.6.8"
+, sha256 ? "1v6n6s8cq5l0xyf1fbm1w4752b9vdk3p130ar59ig72p9vqvkbl1"
 }:
 fetchurl {
   url = "http://production.cf.rubygems.org/rubygems/rubygems-${version}.tgz";


### PR DESCRIPTION
###### Motivation for this change

Update rubygems to latest version. This is the version of rubygems that comes with the official ruby 2.3.3 docker image.

(This version includes https://github.com/rubygems/rubygems/pull/1683 which fixes `gem install --user`.)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


