### PR TITLE
nghttp2: 1.16.1 -> 1.17.0

### DIFF
--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation rec {
   name = "nghttp2-${version}";
-  version = "1.16.1";
+  version = "1.17.0";
 
   # Don't use fetchFromGitHub since this needs a bootstrap curl
   src = fetchurl {
     url = "https://github.com/nghttp2/nghttp2/releases/download/v${version}/nghttp2-${version}.tar.bz2";
-    sha256 = "069pw84f8gg21npapn7y1sizwn6w35692zaq5g45gy8hdbmcl8yc";
+    sha256 = "7685b6717d205d3a251b7dd5e73a7ca5e643bc5c01f928b82bfeed30c243f28a";
   };
 
   # Configure script searches for a symbol which does not exist in jemalloc on Darwin

--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -1,9 +1,17 @@
 { stdenv, fetchurl, pkgconfig
 
 # Optional Dependencies
-, openssl ? null, libev ? null, zlib ? null, jansson ? null, boost ? null
-, libxml2 ? null, jemalloc ? null
+, openssl ? null, libev ? null, zlib ? null
+, enableHpack ? false, jansson ? null
+, enableAsioLib ? false, boost ? null
+, enableGetAssets ? false, libxml2 ? null
+, enableJemalloc ? false, jemalloc ? null
 }:
+
+assert enableHpack -> jansson != null;
+assert enableAsioLib -> boost != null;
+assert enableGetAssets -> libxml2 != null;
+assert enableJemalloc -> jemalloc != null;
 
 stdenv.mkDerivation rec {
   name = "nghttp2-${version}";
@@ -15,16 +23,14 @@ stdenv.mkDerivation rec {
     sha256 = "7685b6717d205d3a251b7dd5e73a7ca5e643bc5c01f928b82bfeed30c243f28a";
   };
 
-  # Configure script searches for a symbol which does not exist in jemalloc on Darwin
-  # Reported upstream in https://github.com/tatsuhiro-t/nghttp2/issues/233
-  postPatch = if stdenv.isDarwin && jemalloc != null then ''
-    substituteInPlace configure --replace "malloc_stats_print" "je_malloc_stats_print"
-  '' else null;
-
   outputs = [ "out" "dev" "lib" ];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl libev zlib ];
+  buildInputs = [ openssl libev zlib ]
+    ++ stdenv.lib.optional enableHpack jansson
+    ++ stdenv.lib.optional enableAsioLib boost
+    ++ stdenv.lib.optional enableGetAssets libxml2
+    ++ stdenv.lib.optional enableJemalloc jemalloc;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
v1.17.0 fixes crashes, issue with memcpy and compilation with BoringSSL

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


See release notes :
https://github.com/nghttp2/nghttp2/releases/tag/v1.17.0