### PR TITLE
whisper: upgrade to the same version as the other graphite components

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -36,6 +36,8 @@ let
     tkinter = null;
   };
 
+  graphiteVersion = "0.9.15";
+
 in modules // {
 
   inherit python bootstrapped-pip isPy26 isPy27 isPy33 isPy34 isPy35 isPy36 isPyPy isPy3k mkPythonDerivation buildPythonPackage buildPythonApplication;
@@ -26413,11 +26415,11 @@ in modules // {
 
   whisper = buildPythonPackage rec {
     name = "whisper-${version}";
-    version = "0.9.12";
+    version = graphiteVersion;
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/w/whisper/${name}.tar.gz";
-      sha256 = "0eca66449d6ceb29e2ab5457b01618e0fe525710dd130a286a18282d849ae5b2";
+      sha256 = "1chkphxwnwvy2cs7jc2h2i0lqqvi9jx6vqj3ly88lwk7m35r4ss2";
     };
 
     # error: invalid command 'test'
@@ -26432,7 +26434,7 @@ in modules // {
 
   carbon = buildPythonPackage rec {
     name = "carbon-${version}";
-    version = "0.9.15";
+    version = graphiteVersion;
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/c/carbon/${name}.tar.gz";
@@ -26665,7 +26667,7 @@ in modules // {
   graphite_web = buildPythonPackage rec {
     name = "graphite-web-${version}";
     disabled = isPy3k;
-    version = "0.9.15";
+    version = graphiteVersion;
 
     src = pkgs.fetchurl rec {
       url = "mirror://pypi/g/graphite-web/${name}.tar.gz";


### PR DESCRIPTION
Without this patch (based on `release-16.09`) we get the following Python exception when trying to fetch a graph in the graphite web app:

```
...
File "/nix/store/nj62jqk2xmp5c3h93pfnlqn66qj1kkvs-python-2.7.12-env/lib/python2.7/site-packages/opt/graphite/webapp/graphite/storage.py", line 335, in fetch
    return whisper.fetch(self.fs_path, startTime, endTime, now)
TypeError: fetch() takes at most 3 arguments (4 given)
```

@fpletz I also abstracted the graphite version behind a variable so this mistake won't happen again.

This probably also has to be cherry picked on `master`.