### PR TITLE
vscode: 1.6.1 -> 1.7.2

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -2,20 +2,21 @@
   makeWrapper, libXScrnSaver }:
 
 let
-  version = "1.6.1";
-  rev = "9e4e44c19e393803e2b05fe2323cf4ed7e36880e";
+  version = "1.7.2";
+  rev = "7ba55c5860b152d999dda59393ca3ebeb1b5c85f";
 
-  sha256 = if stdenv.system == "i686-linux"    then "1aks84siflpjbd2s9y1f0vvvf3nas4f50cimjf25lijxzjxrlivy"
-      else if stdenv.system == "x86_64-linux"  then "05kbi081ih64fadj4k74grkk9ca3wga6ybwgs5ld0bal4ilw1q6i"
-      else if stdenv.system == "x86_64-darwin" then "00p2m8b0l3pkf5k74szw6kcql3j1fjnv3rwnhy24wfkg4b4ah2x9"
+  sha256 = if stdenv.system == "i686-linux"    then "0cjjqs40f81h2j3n7sd2g0jj8gfji1kzhbdmdibk2dkr243bs87p"
+      else if stdenv.system == "x86_64-linux"  then "0l3n20rvgrxk2j9962wqmprjz7lnvldkp0yw26yfxl99yvrph68f"
+      else if stdenv.system == "x86_64-darwin" then "1a1mxmvai2yz0gzmac6nrm5mqrxa2ypwrhf0k8qjim4cbv1cj5h2"
       else throw "Unsupported system: ${stdenv.system}";
 
   urlBase = "https://az764295.vo.msecnd.net/stable/${rev}/";
 
   urlStr = if stdenv.system == "i686-linux" then
-        urlBase + "code-stable-code_${version}-1476372351_i386.tar.gz"
+        urlBase + "code-stable-code_${version}-1479767514_i386.tar.gz"
       else if stdenv.system == "x86_64-linux" then
-        urlBase + "code-stable-code_${version}-1476373175_amd64.tar.gz"
+        urlBase + "code-stable-code_${version}-1479766213_amd64.tar.gz"
+
       else if stdenv.system == "x86_64-darwin" then
         urlBase + "VSCode-darwin-stable.zip"
       else throw "Unsupported system: ${stdenv.system}";

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -5,9 +5,9 @@ let
   version = "1.7.2";
   rev = "7ba55c5860b152d999dda59393ca3ebeb1b5c85f";
 
-  sha256 = if stdenv.system == "i686-linux"    then "0cjjqs40f81h2j3n7sd2g0jj8gfji1kzhbdmdibk2dkr243bs87p"
+  sha256 = if stdenv.system == "i686-linux"    then "0n49c6m53vbmhvrb8q0lxqa77r7kivn4n542k8y62bii8hi19ixc"
       else if stdenv.system == "x86_64-linux"  then "0l3n20rvgrxk2j9962wqmprjz7lnvldkp0yw26yfxl99yvrph68f"
-      else if stdenv.system == "x86_64-darwin" then "1a1mxmvai2yz0gzmac6nrm5mqrxa2ypwrhf0k8qjim4cbv1cj5h2"
+      else if stdenv.system == "x86_64-darwin" then "1chl84scngpxdmcmzbciiz50j459xdcjbpcv4vpm5061gfp5qnh9"
       else throw "Unsupported system: ${stdenv.system}";
 
   urlBase = "https://az764295.vo.msecnd.net/stable/${rev}/";

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -16,7 +16,6 @@ let
         urlBase + "code-stable-code_${version}-1479767514_i386.tar.gz"
       else if stdenv.system == "x86_64-linux" then
         urlBase + "code-stable-code_${version}-1479766213_amd64.tar.gz"
-
       else if stdenv.system == "x86_64-darwin" then
         urlBase + "VSCode-darwin-stable.zip"
       else throw "Unsupported system: ${stdenv.system}";


### PR DESCRIPTION
###### Motivation for this change

Update vscode to the latest stable version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


