### PR TITLE
ignition-math: 2.3.0 -> 2.6.0

### DIFF
--- a/pkgs/development/libraries/ignition-math/default.nix
+++ b/pkgs/development/libraries/ignition-math/default.nix
@@ -1,17 +1,20 @@
 { stdenv, fetchurl, cmake }:
 
 let
-  version = "2.3.0";
+  version = "2.6.0";
 in
 stdenv.mkDerivation rec {
   name = "ign-math2-${version}";
 
   src = fetchurl {
     url = "http://gazebosim.org/distributions/ign-math/releases/ignition-math2-${version}.tar.bz2";
-    sha256 = "1a2jgq6allcxg62y0r61iv4hgxkfr1whpsxy75hg7k85s7da8dpl";
+    sha256 = "1d4naq0zp704c7ckj2wwmhplxmwkvcs1jib8bklnnd09lhg9j92j";
   };
 
   buildInputs = [ cmake ];
+  preConfigure = ''
+    cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_INCLUDEDIR=include -DCMAKE_INSTALL_LIBDIR=lib"
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://ignitionrobotics.org/libraries/math;


### PR DESCRIPTION
###### Motivation for this change

Needed for working with Gazebo7

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


