### PR TITLE
flat-plat-gtk-theme: remove build dependency on gnome-shell

### DIFF
--- a/pkgs/misc/themes/flat-plat/default.nix
+++ b/pkgs/misc/themes/flat-plat/default.nix
@@ -11,14 +11,16 @@ stdenv.mkDerivation rec {
     sha256 = "1w4b16cp2yv5rpijcqywlzrs3xjkvg8ppp2rfls1kvxq12rz4jkb";
   };
 
-  nativeBuildInputs = [ gnome3.gnome_shell libxml2 ];
+  nativeBuildInputs = [ gnome3.glib libxml2 ];
 
   buildInputs = [ gnome3.gnome_themes_standard gtk-engine-murrine ];
 
   dontBuild = true;
 
   installPhase = ''
-    substituteInPlace install.sh --replace /usr ""
+    sed -i install.sh \
+      -e "s|^gnomever=.*$|gnomever=${gnome3.version}|" \
+      -e "s|/usr||"
     destdir="$out" ./install.sh
     rm $out/share/themes/*/COPYING
   '';


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).