### PR TITLE
android-sdk: 25.2.2 -> 25.2.3

### DIFF
--- a/pkgs/development/mobile/androidenv/addon.xml
+++ b/pkgs/development/mobile/androidenv/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdk:sdk-addon xmlns:sdk="http://schemas.android.com/sdk/android/addon/7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2016-09-13 10:48:39.682447 with ADRT.-->
+	<!--Generated on 2016-11-23 16:51:44.011243 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -1262,18 +1262,18 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:libs/>
 	</sdk:add-on>
 	<sdk:extra>
-		<!--Generated from bid:3256427, branch:git_nyc-support-release-->
+		<!--Generated from bid:3453458, branch:git_nyc-support-release-->
 		<sdk:revision>
-			<sdk:major>37</sdk:major>
+			<sdk:major>40</sdk:major>
 			<sdk:minor>0</sdk:minor>
 			<sdk:micro>0</sdk:micro>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Sep 12 10:14:44 2016.-->
-				<sdk:size>281268000</sdk:size>
-				<sdk:checksum type="sha1">2f862a5d66d5526cd5b7655c3e9678f493e485f7</sdk:checksum>
-				<sdk:url>android_m2repository_r37.zip</sdk:url>
+				<!--Built on: Wed Nov  9 14:52:17 2016.-->
+				<sdk:size>305545706</sdk:size>
+				<sdk:checksum type="sha1">782e7233f18c890463e8602571d304e680ce354c</sdk:checksum>
+				<sdk:url>android_m2repository_r40.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -1308,16 +1308,16 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:old-paths>compatibility</sdk:old-paths>
 	</sdk:extra>
 	<sdk:extra>
-		<!--Generated from bid:128809501, branch:perforce-->
+		<!--Generated from bid:140037564, branch:perforce-->
 		<sdk:revision>
-			<sdk:major>32</sdk:major>
+			<sdk:major>40</sdk:major>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 29 09:01:13 2016.-->
-				<sdk:size>113922721</sdk:size>
-				<sdk:checksum type="sha1">ae24bde9c8f732f4d13b72e70802be8c97dcfddf</sdk:checksum>
-				<sdk:url>google_m2repository_r32.zip</sdk:url>
+				<!--Built on: Wed Nov 23 09:14:40 2016.-->
+				<sdk:size>152633821</sdk:size>
+				<sdk:checksum type="sha1">0f599f7f35fba49b9277ef9e1394c5c82d8bd369</sdk:checksum>
+				<sdk:url>google_m2repository_gms_v8_rc42_wear_2a3.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -1392,16 +1392,16 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:path>google_play_services_froyo</sdk:path>
 	</sdk:extra>
 	<sdk:extra>
-		<!--Generated from bid:128810771, branch:perforce-->
+		<!--Generated from bid:139489718, branch:perforce-->
 		<sdk:revision>
-			<sdk:major>32</sdk:major>
+			<sdk:major>38</sdk:major>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 29 09:01:17 2016.-->
-				<sdk:size>11820632</sdk:size>
-				<sdk:checksum type="sha1">bf0e7c1848371c7e6dd7a01e237dbd916e5cb04f</sdk:checksum>
-				<sdk:url>google_play_services_945200_r32.zip</sdk:url>
+				<!--Built on: Fri Nov 18 10:26:20 2016.-->
+				<sdk:size>12351978</sdk:size>
+				<sdk:checksum type="sha1">7a50dec81ba9c9b51d7778c19ca05002498209e8</sdk:checksum>
+				<sdk:url>google_play_services_v8_rc41.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>

--- a/pkgs/development/mobile/androidenv/addons.nix
+++ b/pkgs/development/mobile/androidenv/addons.nix
@@ -283,8 +283,8 @@ in
   google_play_services = buildGoogleApis {
     name = "google_play_services";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/google_play_services_945200_r32.zip;
-      sha1 = "bf0e7c1848371c7e6dd7a01e237dbd916e5cb04f";
+      url = https://dl.google.com/android/repository/google_play_services_v8_rc41.zip;
+      sha1 = "7a50dec81ba9c9b51d7778c19ca05002498209e8";
     };
     meta = {
       description = "Google Play services client library and sample code";

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -11,16 +11,16 @@ with { inherit (stdenv.lib) makeLibraryPath; };
 
 stdenv.mkDerivation rec {
   name = "android-sdk-${version}";
-  version = "25.2.2";
+  version = "25.2.3";
 
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "http://dl.google.com/android/repository/tools_r${version}-linux.zip";
-      sha256 = "0q53yq8fjc10kr4fz3rap5vsil3297w5nn4kw1z0ms7yz1d1im8h";
+      sha256 = "0q5m8lqhj07c6izhc0b0d73820ma0flvrj30ckznss4s9swvqd8v";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "http://dl.google.com/android/repository/tools_r${version}-macosx.zip";
-      sha256 = "1wq7xm0rhy0h6qylv7fq9mhf8hqihrr1nzf7d322rc3g0jfrdrcl";
+      sha256 = "1ihxd2a37ald3sdd04i4yk85prw81h6gnch0bmq65cbsrba48dar";
     }
     else throw "platform not ${stdenv.system} supported!";
 

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,16 +1,16 @@
 {stdenv, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses}:
 
 stdenv.mkDerivation rec {
-  version = "24.0.2";
+  version = "25.0.1";
   name = "android-build-tools-r${version}";
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/build-tools_r${version}-linux.zip";
-      sha256 = "15bxk03m1r1i74idydgqsrz1k7qczi8f9sj4kl8vvbw9l6w2jklj";
+      sha256 = "0kyrazmcckikn6jiz9hwy6nlqjssf95h5iq7alswg1mryl04w6v7";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "https://dl.google.com/android/repository/build-tools_r${version}-macosx.zip";
-      sha256 = "0h71bv8rdkssn7a17vj3r7jl5jwsxbwpg3sig0k9a7yfwyfc71s8";
+      sha256 = "116i5xxbwz229m9z98n6bfkjk2xf3kbhdnqhbbnaagjsjzqdirki";
     }
     else throw "System ${stdenv.system} not supported!";
 

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -1,16 +1,16 @@
 {stdenv, zlib, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "24.0.2";
+  version = "25.0.1";
   name = "android-platform-tools-r${version}";
   src = if (stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-linux.zip";
-      sha256 = "0y36mlwh4kb77d3vcpqxqwkxsadllap6g6jjylf3rb7blh5l4zw6";
+      sha256 = "0r8ix3jjqpk6wyxm8f6az9r4z5a1lnb3b9hzh8ay4ayidwhn8isx";
     }
     else if stdenv.system == "x86_64-darwin" then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-macosx.zip";
-      sha256 = "1whfhdwjir2sv2pfypagva813yn0fx8idi6c2mxhddv2mlws6zk4";
+      sha256 = "18pzwpr6fbxlw782j65clwz9kvdgvb04jpr2z12bbwyd8wqc4yln";
     }
     else throw "System ${stdenv.system} not supported!";
 

--- a/pkgs/development/mobile/androidenv/platforms-linux.nix
+++ b/pkgs/development/mobile/androidenv/platforms-linux.nix
@@ -292,4 +292,16 @@ in
     };
   };
 
+  platform_25 = buildPlatform {
+    name = "android-platform-7.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/platform-25_r02.zip;
+      sha1 = "6057e54a04f1d141f36a2c8d20f2962b41a3183f";
+    };
+    meta = {
+      description = "Android SDK Platform 25";
+      url = http://developer.android.com/sdk/;
+    };
+  };
+
 }

--- a/pkgs/development/mobile/androidenv/platforms-macosx.nix
+++ b/pkgs/development/mobile/androidenv/platforms-macosx.nix
@@ -292,4 +292,16 @@ in
     };
   };
 
+  platform_25 = buildPlatform {
+    name = "android-platform-7.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/platform-25_r02.zip;
+      sha1 = "6057e54a04f1d141f36a2c8d20f2962b41a3183f";
+    };
+    meta = {
+      description = "Android SDK Platform 25";
+      url = http://developer.android.com/sdk/;
+    };
+  };
+
 }

--- a/pkgs/development/mobile/androidenv/repository-11.xml
+++ b/pkgs/development/mobile/androidenv/repository-11.xml
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 <sdk:sdk-repository xmlns:sdk="http://schemas.android.com/sdk/android/repository/11" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2016-09-13 11:44:58.246002 with ADRT.-->
+	<!--Generated on 2016-11-23 16:51:35.129300 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -296,85 +296,69 @@ This is the Android SDK Preview License Agreement (the &quot;License Agreement&q
 
 June 2014.</sdk:license>
 	<sdk:ndk>
-		<!--Generated from bid:2977051, branch:aosp-ndk-r12-release-->
+		<!--Generated from bid:3345770, branch:aosp-ndk-r13-release-->
 		<sdk:description>NDK</sdk:description>
-		<sdk:revision>12</sdk:revision>
+		<sdk:revision>13</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Wed Jun 15 13:55:11 2016.-->
-				<sdk:size>734135279</sdk:size>
-				<sdk:checksum type="sha1">e257fe12f8947be9f79c10c3fffe87fb9406118a</sdk:checksum>
-				<sdk:url>android-ndk-r12b-darwin-x86_64.zip</sdk:url>
+				<!--Built on: Wed Oct 12 22:27:26 2016.-->
+				<sdk:size>665967997</sdk:size>
+				<sdk:checksum type="sha1">71fe653a7bf5db08c3af154735b6ccbc12f0add5</sdk:checksum>
+				<sdk:url>android-ndk-r13b-darwin-x86_64.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 				<sdk:host-bits>64</sdk:host-bits>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Wed Jun 15 13:55:32 2016.-->
-				<sdk:size>755551010</sdk:size>
-				<sdk:checksum type="sha1">170a119bfa0f0ce5dc932405eaa3a7cc61b27694</sdk:checksum>
-				<sdk:url>android-ndk-r12b-linux-x86_64.zip</sdk:url>
+				<!--Built on: Wed Oct 12 22:27:48 2016.-->
+				<sdk:size>687311866</sdk:size>
+				<sdk:checksum type="sha1">0600157c4ddf50ec15b8a037cfc474143f718fd0</sdk:checksum>
+				<sdk:url>android-ndk-r13b-linux-x86_64.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 				<sdk:host-bits>64</sdk:host-bits>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Wed Jun 15 13:54:32 2016.-->
-				<sdk:size>706453972</sdk:size>
-				<sdk:checksum type="sha1">8e6eef0091dac2f3c7a1ecbb7070d4fa22212c04</sdk:checksum>
-				<sdk:url>android-ndk-r12b-windows-x86.zip</sdk:url>
+				<!--Built on: Wed Oct 12 22:26:38 2016.-->
+				<sdk:size>620461544</sdk:size>
+				<sdk:checksum type="sha1">4eb1288b1d4134a9d6474eb247f0448808d52408</sdk:checksum>
+				<sdk:url>android-ndk-r13b-windows-x86.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 				<sdk:host-bits>32</sdk:host-bits>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Wed Jun 15 13:54:50 2016.-->
-				<sdk:size>749567353</sdk:size>
-				<sdk:checksum type="sha1">337746d8579a1c65e8a69bf9cbdc9849bcacf7f5</sdk:checksum>
-				<sdk:url>android-ndk-r12b-windows-x86_64.zip</sdk:url>
+				<!--Built on: Wed Oct 12 22:27:04 2016.-->
+				<sdk:size>681320123</sdk:size>
+				<sdk:checksum type="sha1">649d306559435c244cec5881b880318bb3dee53a</sdk:checksum>
+				<sdk:url>android-ndk-r13b-windows-x86_64.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 				<sdk:host-bits>64</sdk:host-bits>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:ndk>
-	<sdk:ndk>
-		<!--Generated from bid:3214847, branch:aosp-ndk-r13-release-->
-		<sdk:description>NDK</sdk:description>
-		<sdk:revision>13</sdk:revision>
+	<sdk:platform>
+		<!--Generated from bid:3485210, branch:git_nyc-mr1-sdk-dev-->
+		<sdk:version>7.1.1</sdk:version>
+		<sdk:api-level>25</sdk:api-level>
+		<sdk:description>Android SDK Platform 25</sdk:description>
+		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Aug 23 15:40:55 2016.-->
-				<sdk:size>665405792</sdk:size>
-				<sdk:checksum type="sha1">0cbdb271b103a7e4237b34b73f0e56381e4632aa</sdk:checksum>
-				<sdk:url>android-ndk-r13-beta2-darwin-x86_64.zip</sdk:url>
-				<sdk:host-os>macosx</sdk:host-os>
-				<sdk:host-bits>64</sdk:host-bits>
-			</sdk:archive>
-			<sdk:archive>
-				<!--Built on: Tue Aug 23 15:41:13 2016.-->
-				<sdk:size>686843165</sdk:size>
-				<sdk:checksum type="sha1">ea1a76d9ebdc82fe742d32798aaee7c980afd2f6</sdk:checksum>
-				<sdk:url>android-ndk-r13-beta2-linux-x86_64.zip</sdk:url>
-				<sdk:host-os>linux</sdk:host-os>
-				<sdk:host-bits>64</sdk:host-bits>
-			</sdk:archive>
-			<sdk:archive>
-				<!--Built on: Tue Aug 23 15:40:19 2016.-->
-				<sdk:size>619981813</sdk:size>
-				<sdk:checksum type="sha1">a5f6edceb3afa4ecd47071822ea32ba6bd6ac002</sdk:checksum>
-				<sdk:url>android-ndk-r13-beta2-windows-x86.zip</sdk:url>
-				<sdk:host-os>windows</sdk:host-os>
-				<sdk:host-bits>32</sdk:host-bits>
-			</sdk:archive>
-			<sdk:archive>
-				<!--Built on: Tue Aug 23 15:40:37 2016.-->
-				<sdk:size>680836961</sdk:size>
-				<sdk:checksum type="sha1">a0b6a0ed271b0a99cdca28ce8fd405f89defc539</sdk:checksum>
-				<sdk:url>android-ndk-r13-beta2-windows-x86_64.zip</sdk:url>
-				<sdk:host-os>windows</sdk:host-os>
-				<sdk:host-bits>64</sdk:host-bits>
+				<!--Built on: Mon Nov 14 23:49:40 2016.-->
+				<sdk:size>85434042</sdk:size>
+				<sdk:checksum type="sha1">6057e54a04f1d141f36a2c8d20f2962b41a3183f</sdk:checksum>
+				<sdk:url>platform-25_r02.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-preview-license"/>
-	</sdk:ndk>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>22</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>16</sdk:api>
+			<sdk:revision>2</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
 	<sdk:platform>
 		<!--Generated from bid:3209611, branch:git_nyc-sdk-dev-->
 		<sdk:version>7.0</sdk:version>
@@ -1147,6 +1131,102 @@ June 2014.</sdk:license>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:source>
+	<sdk:build-tool>
+		<!--Generated from bid:3485210, branch:git_nyc-mr1-sdk-dev-->
+		<sdk:revision>
+			<sdk:major>25</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Nov 14 23:49:02 2016.-->
+				<sdk:size>49880178</sdk:size>
+				<sdk:checksum type="sha1">ff063d252ab750d339f5947d06ff782836f22bac</sdk:checksum>
+				<sdk:url>build-tools_r25.0.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Nov 14 23:49:00 2016.-->
+				<sdk:size>49667353</sdk:size>
+				<sdk:checksum type="sha1">7bf7f22d7d48ef20b6ab0e3d7a2912e5c088340f</sdk:checksum>
+				<sdk:url>build-tools_r25.0.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Nov 14 23:48:57 2016.-->
+				<sdk:size>50458759</sdk:size>
+				<sdk:checksum type="sha1">c6c61393565ccf46349e7f44511e5db7c1c6169d</sdk:checksum>
+				<sdk:url>build-tools_r25.0.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:3359293, branch:git_nyc-mr1-sdk-dev-->
+		<sdk:revision>
+			<sdk:major>25</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Oct 17 14:57:00 2016.-->
+				<sdk:size>49872921</sdk:size>
+				<sdk:checksum type="sha1">f2bbda60403e75cabd0f238598c3b4dfca56ea44</sdk:checksum>
+				<sdk:url>build-tools_r25-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Oct 17 14:56:58 2016.-->
+				<sdk:size>49659466</sdk:size>
+				<sdk:checksum type="sha1">273c5c29a65cbed00e44f3aa470bbd7dce556606</sdk:checksum>
+				<sdk:url>build-tools_r25-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Oct 17 14:56:56 2016.-->
+				<sdk:size>50451378</sdk:size>
+				<sdk:checksum type="sha1">f9258f2308ff8b62cfc4513d40cb961612d07b6a</sdk:checksum>
+				<sdk:url>build-tools_r25-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:3303571, branch:git_nyc-sdk-dev-->
+		<sdk:revision>
+			<sdk:major>24</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>3</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Sep 27 10:00:17 2016.-->
+				<sdk:size>49779151</sdk:size>
+				<sdk:checksum type="sha1">9e8cc49d66e03fa1a8ecc1ac3e58f1324f5da304</sdk:checksum>
+				<sdk:url>build-tools_r24.0.3-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Sep 27 10:00:14 2016.-->
+				<sdk:size>49568967</sdk:size>
+				<sdk:checksum type="sha1">a01c15f1b105c34595681075e1895d58b3fff48c</sdk:checksum>
+				<sdk:url>build-tools_r24.0.3-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Sep 27 10:00:12 2016.-->
+				<sdk:size>50354788</sdk:size>
+				<sdk:checksum type="sha1">8b960d693fd4163caeb8dc5f5f5f80b10987089c</sdk:checksum>
+				<sdk:url>build-tools_r24.0.3-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
 	<sdk:build-tool>
 		<!--Generated from bid:3209611, branch:git_nyc-sdk-dev-->
 		<sdk:revision>
@@ -1963,64 +2043,64 @@ June 2014.</sdk:license>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:build-tool>
 	<sdk:platform-tool>
-		<!--Generated from bid:3264814, branch:git_nyc-sdk-dev-->
+		<!--Generated from bid:3485210, branch:git_nyc-mr1-sdk-dev-->
 		<sdk:revision>
-			<sdk:major>24</sdk:major>
+			<sdk:major>25</sdk:major>
 			<sdk:minor>0</sdk:minor>
-			<sdk:micro>2</sdk:micro>
+			<sdk:micro>1</sdk:micro>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Sep 12 16:08:48 2016.-->
-				<sdk:size>3341647</sdk:size>
-				<sdk:checksum type="sha1">a268850d31973d32de5c1515853f81924a4068cf</sdk:checksum>
-				<sdk:url>platform-tools_r24.0.2-linux.zip</sdk:url>
+				<!--Built on: Mon Nov 14 23:49:26 2016.-->
+				<sdk:size>3916151</sdk:size>
+				<sdk:checksum type="sha1">8e461a2c76717824d1d8e91af68216c9f230a373</sdk:checksum>
+				<sdk:url>platform-tools_r25.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Sep 12 16:08:48 2016.-->
-				<sdk:size>3157182</sdk:size>
-				<sdk:checksum type="sha1">16053da716cbc6ef31c32a0d2f1437b22089c88c</sdk:checksum>
-				<sdk:url>platform-tools_r24.0.2-macosx.zip</sdk:url>
+				<!--Built on: Mon Nov 14 23:49:25 2016.-->
+				<sdk:size>3732924</sdk:size>
+				<sdk:checksum type="sha1">96abc8638bf9f65435bc0ab641cc4a3ff753eed5</sdk:checksum>
+				<sdk:url>platform-tools_r25.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Sep 12 16:08:47 2016.-->
-				<sdk:size>2997417</sdk:size>
-				<sdk:checksum type="sha1">ce09a7351d5c50865691554ed56325f6e5cd733c</sdk:checksum>
-				<sdk:url>platform-tools_r24.0.2-windows.zip</sdk:url>
+				<!--Built on: Mon Nov 14 23:49:25 2016.-->
+				<sdk:size>3573485</sdk:size>
+				<sdk:checksum type="sha1">75249224c12528329a151dfbc591509168ef6efd</sdk:checksum>
+				<sdk:url>platform-tools_r25.0.1-windows.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:platform-tool>
 	<sdk:tool>
-		<!--Generated from bid:3098464, branch:aosp-emu-2.2-release-->
+		<!--Generated from bid:3470232, branch:aosp-emu-2.2-release-->
 		<sdk:revision>
 			<sdk:major>25</sdk:major>
 			<sdk:minor>2</sdk:minor>
-			<sdk:micro>2</sdk:micro>
+			<sdk:micro>3</sdk:micro>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jul 29 11:26:26 2016.-->
-				<sdk:size>273491448</sdk:size>
-				<sdk:checksum type="sha1">99257925a3d8b46fee948a7520d7b7e3e3e1890e</sdk:checksum>
-				<sdk:url>tools_r25.2.2-linux.zip</sdk:url>
+				<!--Built on: Fri Nov 11 08:51:34 2016.-->
+				<sdk:size>277861433</sdk:size>
+				<sdk:checksum type="sha1">aafe7f28ac51549784efc2f3bdfc620be8a08213</sdk:checksum>
+				<sdk:url>tools_r25.2.3-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jul 29 11:26:16 2016.-->
-				<sdk:size>195856788</sdk:size>
-				<sdk:checksum type="sha1">bbaa3929696ce523ea62b58cc8032d7964a154c5</sdk:checksum>
-				<sdk:url>tools_r25.2.2-macosx.zip</sdk:url>
+				<!--Built on: Fri Nov 11 08:51:29 2016.-->
+				<sdk:size>200496727</sdk:size>
+				<sdk:checksum type="sha1">0e88c0bdb8f8ee85cce248580173e033a1bbc9cb</sdk:checksum>
+				<sdk:url>tools_r25.2.3-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jul 29 11:26:07 2016.-->
-				<sdk:size>301642481</sdk:size>
-				<sdk:checksum type="sha1">ef898dff805c4b9e39f6e77fd9ec397fb1b1f809</sdk:checksum>
-				<sdk:url>tools_r25.2.2-windows.zip</sdk:url>
+				<!--Built on: Fri Nov 11 08:51:26 2016.-->
+				<sdk:size>306745639</sdk:size>
+				<sdk:checksum type="sha1">b965decb234ed793eb9574bad8791c50ca574173</sdk:checksum>
+				<sdk:url>tools_r25.2.3-windows.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 			</sdk:archive>
 		</sdk:archives>

--- a/pkgs/development/mobile/androidenv/support-repository.nix
+++ b/pkgs/development/mobile/androidenv/support-repository.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, unzip}:
 
 stdenv.mkDerivation rec {
-  version = "35";
+  version = "40";
   name = "android-support-repository-r${version}";
   src = fetchurl {
     url = "http://dl.google.com/android/repository/android_m2repository_r${version}.zip";
-    sha1 = "2wi1b38n3dmnikpwbwcbyy2xfws1683s";
+    sha1 = "782e7233f18c890463e8602571d304e680ce354c";
   };
 
   buildCommand = ''

--- a/pkgs/development/mobile/androidenv/sys-img.xml
+++ b/pkgs/development/mobile/androidenv/sys-img.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdk:sdk-sys-img xmlns:sdk="http://schemas.android.com/sdk/android/sys-img/3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2016-09-12 21:35:04.795787 with ADRT.-->
+	<!--Generated on 2016-11-23 16:51:35.431708 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -405,6 +405,23 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 10.8 Open Source Software. In the event Open Source software is included with Evaluation Software, such Open Source software is licensed pursuant to the applicable Open Source software license agreement identified in the Open Source software comments in the applicable source code file(s) and/or file header as indicated in the Evaluation Software. Additional detail may be available (where applicable) in the accompanying on-line documentation. With respect to the Open Source software, nothing in this Agreement limits any rights under, or grants rights that supersede, the terms of any applicable Open Source software license agreement.
 </sdk:license>
 	<sdk:system-image>
+		<!--Generated from bid:3093079, branch:git_gb-emu-release-->
+		<sdk:api-level>10</sdk:api-level>
+		<sdk:description>ARM EABI v7a System Image</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Sep 16 16:38:16 2016.-->
+				<sdk:size>67918042</sdk:size>
+				<sdk:checksum type="sha1">54680383118eb5c95a11e1cc2a14aa572c86ee69</sdk:checksum>
+				<sdk:url>armv7-10_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>armeabi-v7a</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
 		<!--Generated from bid:229537, branch:git_ics-mr0-->
 		<sdk:api-level>14</sdk:api-level>
 		<sdk:description>ARM EABI v7a System Image</sdk:description>
@@ -422,16 +439,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:1741834, branch:git_ics-mr1-->
+		<!--Generated from bid:3462039, branch:git_ics-mr1-emu-release-->
 		<sdk:api-level>15</sdk:api-level>
 		<sdk:description>ARM EABI v7a System Image</sdk:description>
-		<sdk:revision>3</sdk:revision>
+		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:24:59 2016.-->
-				<sdk:size>96240395</sdk:size>
-				<sdk:checksum type="sha1">0a47f586e172b1cf3db2ada857a70c2bdec24ef8</sdk:checksum>
-				<sdk:url>sysimg_armv7a-15_r03.zip</sdk:url>
+				<!--Built on: Thu Nov 10 17:19:27 2016.-->
+				<sdk:size>102079727</sdk:size>
+				<sdk:checksum type="sha1">363223bd62f5afc0b2bd760b54ce9d26b31eacf1</sdk:checksum>
+				<sdk:url>armeabi-v7a-15_r04.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -456,16 +473,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:1742939, branch:git_jb-mr1.1-dev-->
+		<!--Generated from bid:3453820, branch:git_jb-mr1.1-emu-release-->
 		<sdk:api-level>17</sdk:api-level>
 		<sdk:description>ARM EABI v7a System Image</sdk:description>
-		<sdk:revision>3</sdk:revision>
+		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:00 2016.-->
-				<sdk:size>118663847</sdk:size>
-				<sdk:checksum type="sha1">97cfad22b51c8475e228b207dd36dbef1c18fa38</sdk:checksum>
-				<sdk:url>sysimg_armv7a-17_r03.zip</sdk:url>
+				<!--Built on: Thu Nov 10 17:19:54 2016.-->
+				<sdk:size>124238679</sdk:size>
+				<sdk:checksum type="sha1">7460e8110f4a87f9644f1bdb5511a66872d50fd9</sdk:checksum>
+				<sdk:url>armeabi-v7a-17_r05.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -473,16 +490,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:1743067, branch:git_jb-mr2-dev-->
+		<!--Generated from bid:3462034, branch:git_jb-mr2-emu-release-->
 		<sdk:api-level>18</sdk:api-level>
 		<sdk:description>ARM EABI v7a System Image</sdk:description>
-		<sdk:revision>3</sdk:revision>
+		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:01 2016.-->
-				<sdk:size>125503391</sdk:size>
-				<sdk:checksum type="sha1">2d7d51f4d2742744766511e5d6b491bd49161c51</sdk:checksum>
-				<sdk:url>sysimg_armv7a-18_r03.zip</sdk:url>
+				<!--Built on: Thu Nov 10 17:20:07 2016.-->
+				<sdk:size>130394401</sdk:size>
+				<sdk:checksum type="sha1">0bf34ecf4ddd53f6b1b7fe7dfa12f2887c17e642</sdk:checksum>
+				<sdk:url>armeabi-v7a-18_r04.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -490,16 +507,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:1743154, branch:git_klp-dev-->
+		<!--Generated from bid:3462041, branch:git_klp-emu-release-->
 		<sdk:api-level>19</sdk:api-level>
 		<sdk:description>ARM EABI v7a System Image</sdk:description>
-		<sdk:revision>3</sdk:revision>
+		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:02 2016.-->
-				<sdk:size>159399028</sdk:size>
-				<sdk:checksum type="sha1">5daf7718e3ab03d9bd8792b492dd305f386ef12f</sdk:checksum>
-				<sdk:url>sysimg_armv7a-19_r03.zip</sdk:url>
+				<!--Built on: Thu Nov 10 17:20:23 2016.-->
+				<sdk:size>159871567</sdk:size>
+				<sdk:checksum type="sha1">d1a5fd4f2e1c013c3d3d9bfe7e9db908c3ed56fa</sdk:checksum>
+				<sdk:url>armeabi-v7a-19_r05.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -507,16 +524,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:1772600, branch:git_lmp-sdk-release-->
+		<!--Generated from bid:3079185, branch:git_lmp-emu-release-->
 		<sdk:api-level>21</sdk:api-level>
 		<sdk:description>ARM EABI v7a System Image</sdk:description>
-		<sdk:revision>3</sdk:revision>
+		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:03 2016.-->
-				<sdk:size>186521381</sdk:size>
-				<sdk:checksum type="sha1">0b2e21421d29f48211b5289ca4addfa7f4c7ae5a</sdk:checksum>
-				<sdk:url>sysimg_arm-21_r03.zip</sdk:url>
+				<!--Built on: Fri Sep 16 16:35:34 2016.-->
+				<sdk:size>187163871</sdk:size>
+				<sdk:checksum type="sha1">8c606f81306564b65e41303d2603e4c42ded0d10</sdk:checksum>
+				<sdk:url>armeabi-v7a-21_r04.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -524,16 +541,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:1737576, branch:git_lmp-mr1-sdk-release-->
+		<!--Generated from bid:3079158, branch:git_lmp_mr1-emu-release-->
 		<sdk:api-level>22</sdk:api-level>
 		<sdk:description>ARM EABI v7a System Image</sdk:description>
-		<sdk:revision>1</sdk:revision>
+		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:24:58 2016.-->
-				<sdk:size>193687339</sdk:size>
-				<sdk:checksum type="sha1">2aa6a887ee75dcf3ac34627853d561997792fcb8</sdk:checksum>
-				<sdk:url>sysimg_arm-22_r01.zip</sdk:url>
+				<!--Built on: Fri Sep 16 16:35:50 2016.-->
+				<sdk:size>194596267</sdk:size>
+				<sdk:checksum type="sha1">2114ec015dbf3a16cbcb4f63e8a84a1b206a07a1</sdk:checksum>
+				<sdk:url>armeabi-v7a-22_r02.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -541,16 +558,17 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:2166767, branch:git_mnc-release-->
+		<!--Generated from bid:3079352, branch:git_mnc-emu-release-->
 		<sdk:api-level>23</sdk:api-level>
 		<sdk:description>ARM EABI v7a System Image</sdk:description>
-		<sdk:revision>3</sdk:revision>
+		<sdk:revision>6</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:04 2016.-->
-				<sdk:size>226879660</sdk:size>
-				<sdk:checksum type="sha1">7bb8768ec4333500192fd9627d4234f505fa98dc</sdk:checksum>
-				<sdk:url>sysimg_arm-23_r03.zip</sdk:url>
+				<!--Built on: Fri Sep 16 16:41:26 2016.-->
+				<sdk:size>238333358</sdk:size>
+				<sdk:checksum type="sha1">7cf2ad756e54a3acfd81064b63cb0cb9dff2798d</sdk:checksum>
+				<sdk:url>armeabi-v7a-23_r06.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -643,16 +661,67 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:1, branch:-->
+		<!--Generated from bid:3093079, branch:git_gb-emu-release-->
 		<sdk:api-level>10</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Sep 16 16:10:43 2016.-->
+				<sdk:size>75382637</sdk:size>
+				<sdk:checksum type="sha1">655ffc5cc89dd45a3aca154b254009016e473aeb</sdk:checksum>
+				<sdk:url>x86-10_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3462039, branch:git_ics-mr1-emu-release-->
+		<sdk:api-level>15</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Thu Nov 10 17:20:36 2016.-->
+				<sdk:size>115324561</sdk:size>
+				<sdk:checksum type="sha1">e45c728b64881c0e86529a8f7ea9c103a3cd14c1</sdk:checksum>
+				<sdk:url>x86-15_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3462064, branch:git_jb-emu-release-->
+		<sdk:api-level>16</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>5</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Thu Nov 10 17:20:52 2016.-->
+				<sdk:size>134339698</sdk:size>
+				<sdk:checksum type="sha1">7ea16da3a8fdb880b1b290190fcc1bde2821c1e0</sdk:checksum>
+				<sdk:url>x86-16_r05.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3453820, branch:git_jb-mr1.1-emu-release-->
+		<sdk:api-level>17</sdk:api-level>
 		<sdk:description>Intel x86 Atom System Image</sdk:description>
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:24:58 2016.-->
-				<sdk:size>66997702</sdk:size>
-				<sdk:checksum type="sha1">6b8539eaca9685d2d3289bf8e6d21d366d791326</sdk:checksum>
-				<sdk:url>sysimg_x86-10_r03.zip</sdk:url>
+				<!--Built on: Thu Nov 10 17:21:06 2016.-->
+				<sdk:size>142951842</sdk:size>
+				<sdk:checksum type="sha1">eb30274460ff0d61f3ed37862b567811bebd8270</sdk:checksum>
+				<sdk:url>x86-17_r03.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -660,67 +729,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:2, branch:-->
-		<sdk:api-level>15</sdk:api-level>
-		<sdk:description>Intel x86 Atom System Image</sdk:description>
-		<sdk:revision>2</sdk:revision>
-		<sdk:archives>
-			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:04 2016.-->
-				<sdk:size>109019058</sdk:size>
-				<sdk:checksum type="sha1">56b8d4b3d0f6a8876bc78d654da186f3b7b7c44f</sdk:checksum>
-				<sdk:url>sysimg_x86-15_r02.zip</sdk:url>
-			</sdk:archive>
-		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-license"/>
-		<sdk:abi>x86</sdk:abi>
-		<sdk:tag-id>default</sdk:tag-id>
-	</sdk:system-image>
-	<sdk:system-image>
-		<!--Generated from bid:3, branch:unknown-->
-		<sdk:api-level>16</sdk:api-level>
-		<sdk:description>Intel x86 Atom System Image</sdk:description>
-		<sdk:revision>2</sdk:revision>
-		<sdk:archives>
-			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:12 2016.-->
-				<sdk:size>135252264</sdk:size>
-				<sdk:checksum type="sha1">36c2a2e394bcb3290583ce09815eae7711d0b2c2</sdk:checksum>
-				<sdk:url>sysimg_x86-16_r02.zip</sdk:url>
-			</sdk:archive>
-		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-license"/>
-		<sdk:abi>x86</sdk:abi>
-		<sdk:tag-id>default</sdk:tag-id>
-	</sdk:system-image>
-	<sdk:system-image>
-		<!--Generated from bid:1742939, branch:git_jb-mr1.1-dev-->
-		<sdk:api-level>17</sdk:api-level>
-		<sdk:description>Intel x86 Atom System Image</sdk:description>
-		<sdk:revision>2</sdk:revision>
-		<sdk:archives>
-			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:01 2016.-->
-				<sdk:size>136075512</sdk:size>
-				<sdk:checksum type="sha1">bd8c7c5411431af7e051cbe961be430fc31e773d</sdk:checksum>
-				<sdk:url>sysimg_x86-17_r02.zip</sdk:url>
-			</sdk:archive>
-		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-license"/>
-		<sdk:abi>x86</sdk:abi>
-		<sdk:tag-id>default</sdk:tag-id>
-	</sdk:system-image>
-	<sdk:system-image>
-		<!--Generated from bid:1743067, branch:git_jb-mr2-dev-->
+		<!--Generated from bid:3462034, branch:git_jb-mr2-emu-release-->
 		<sdk:api-level>18</sdk:api-level>
 		<sdk:description>Intel x86 Atom System Image</sdk:description>
-		<sdk:revision>2</sdk:revision>
+		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:02 2016.-->
-				<sdk:size>143899902</sdk:size>
-				<sdk:checksum type="sha1">ab3de121a44fca43ac3aa83f7d68cc47fc643ee8</sdk:checksum>
-				<sdk:url>sysimg_x86-18_r02.zip</sdk:url>
+				<!--Built on: Thu Nov 10 17:21:19 2016.-->
+				<sdk:size>149657535</sdk:size>
+				<sdk:checksum type="sha1">03a0cb23465c3de15215934a1dbc9715b56e9458</sdk:checksum>
+				<sdk:url>x86-18_r03.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -728,16 +746,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:2872501, branch:git_klp-emu-release-->
+		<!--Generated from bid:3462041, branch:git_klp-emu-release-->
 		<sdk:api-level>19</sdk:api-level>
 		<sdk:description>Intel x86 Atom System Image</sdk:description>
 		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon May 16 16:26:22 2016.-->
-				<sdk:size>183946064</sdk:size>
-				<sdk:checksum type="sha1">c9298a8eafceed3b8fa11071ba63a3d18e17fd8e</sdk:checksum>
-				<sdk:url>sysimg_x86-19_r05.zip</sdk:url>
+				<!--Built on: Thu Nov 10 17:21:38 2016.-->
+				<sdk:size>183968605</sdk:size>
+				<sdk:checksum type="sha1">1d98426467580abfd03c724c5344450f5d0df379</sdk:checksum>
+				<sdk:url>x86-19_r05.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -745,16 +763,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:2781484, branch:git_lmp-emu-release-->
+		<!--Generated from bid:3079185, branch:git_lmp-emu-release-->
 		<sdk:api-level>21</sdk:api-level>
 		<sdk:description>Intel x86 Atom System Image</sdk:description>
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Apr 21 08:05:21 2016.-->
-				<sdk:size>206323409</sdk:size>
-				<sdk:checksum type="sha1">3b78ad294aa1cdefa4be663d4af6c80d920ec49e</sdk:checksum>
-				<sdk:url>sysimg_x86-21_r04.zip</sdk:url>
+				<!--Built on: Fri Sep 16 16:12:20 2016.-->
+				<sdk:size>206305926</sdk:size>
+				<sdk:checksum type="sha1">c7732f45c931c0eaa064e57e8c054bce86c30e54</sdk:checksum>
+				<sdk:url>x86-21_r04.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -762,16 +780,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:2780077, branch:git_lmp-mr1-emu-release-->
+		<!--Generated from bid:3079158, branch:git_lmp-mr1-emu-release-->
 		<sdk:api-level>22</sdk:api-level>
 		<sdk:description>Intel x86 Atom System Image</sdk:description>
 		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Wed Apr 20 08:41:31 2016.-->
-				<sdk:size>212301282</sdk:size>
-				<sdk:checksum type="sha1">909e0ad91ed43381597e82f65ec93d41f049dd53</sdk:checksum>
-				<sdk:url>sysimg_x86-22_r05.zip</sdk:url>
+				<!--Built on: Fri Sep 16 16:12:40 2016.-->
+				<sdk:size>212327460</sdk:size>
+				<sdk:checksum type="sha1">7e2c93891ea9efec07dccccf6b9ab051a014dbdf</sdk:checksum>
+				<sdk:url>x86-22_r05.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -779,16 +797,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:2780065, branch:git_mnc-emu-release-->
+		<!--Generated from bid:3079352, branch:git_mnc-emu-release-->
 		<sdk:api-level>23</sdk:api-level>
 		<sdk:description>Intel x86 Atom System Image</sdk:description>
 		<sdk:revision>9</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Wed Apr 20 08:41:52 2016.-->
-				<sdk:size>252059065</sdk:size>
-				<sdk:checksum type="sha1">0ce9229974818179833899dce93f228a895ec6a2</sdk:checksum>
-				<sdk:url>sysimg_x86-23_r09.zip</sdk:url>
+				<!--Built on: Fri Sep 16 16:13:52 2016.-->
+				<sdk:size>260241399</sdk:size>
+				<sdk:checksum type="sha1">d7ee1118a73eb5c3e803d4dd3b96a124ac909ee1</sdk:checksum>
+				<sdk:url>x86-23_r09.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -813,16 +831,34 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:2781484, branch:git_lmp-emu-release-->
+		<!--Generated from bid:3479480, branch:git_nyc-preview-release-->
+		<sdk:api-level>25</sdk:api-level>
+		<sdk:description>Google APIs Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Nov 14 16:41:48 2016.-->
+				<sdk:size>703131759</sdk:size>
+				<sdk:checksum type="sha1">7dd19cfee4e43a1f60e0f5f058404d92d9544b33</sdk:checksum>
+				<sdk:url>x86-25_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>google_apis</sdk:tag-id>
+		<sdk:tag-display>Google APIs</sdk:tag-display>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3079185, branch:git_lmp-emu-release-->
 		<sdk:api-level>21</sdk:api-level>
 		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Apr 21 08:05:44 2016.-->
-				<sdk:size>290590059</sdk:size>
-				<sdk:checksum type="sha1">eb14ba9c14615d5e5a21c854be29aa903d9bb63d</sdk:checksum>
-				<sdk:url>sysimg_x86_64-21_r04.zip</sdk:url>
+				<!--Built on: Fri Sep 16 16:08:22 2016.-->
+				<sdk:size>290608820</sdk:size>
+				<sdk:checksum type="sha1">9b2d64a69a72fa596c386899a742a404308f2c92</sdk:checksum>
+				<sdk:url>x86_64-21_r04.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -830,16 +866,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:2780077, branch:git_lmp_mr1-emu-release-->
+		<!--Generated from bid:3079158, branch:git_lmp_mr1-emu-release-->
 		<sdk:api-level>22</sdk:api-level>
 		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
 		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Wed Apr 20 08:44:05 2016.-->
-				<sdk:size>297851141</sdk:size>
-				<sdk:checksum type="sha1">8a04ff4fb30f70414e6ec7b3b06285f316e93d08</sdk:checksum>
-				<sdk:url>sysimg_x86_64-22_r05.zip</sdk:url>
+				<!--Built on: Fri Sep 16 16:08:46 2016.-->
+				<sdk:size>297850561</sdk:size>
+				<sdk:checksum type="sha1">99d1d6c77e92284b4210640edf6c81eceb28520d</sdk:checksum>
+				<sdk:url>x86_64-22_r05.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -847,16 +883,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:2780065, branch:git_mnc-emu-release-->
+		<!--Generated from bid:3079352, branch:git_mnc-emu-release-->
 		<sdk:api-level>23</sdk:api-level>
 		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
 		<sdk:revision>9</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Wed Apr 20 08:44:42 2016.-->
-				<sdk:size>349443901</sdk:size>
-				<sdk:checksum type="sha1">571f5078a3d337a9144e2af13bd23ca46845a979</sdk:checksum>
-				<sdk:url>sysimg_x86_64-23_r09.zip</sdk:url>
+				<!--Built on: Fri Sep 16 16:09:15 2016.-->
+				<sdk:size>363794271</sdk:size>
+				<sdk:checksum type="sha1">84cc076eacec043c8e88382c6ab391b0cd5c0695</sdk:checksum>
+				<sdk:url>x86_64-23_r09.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -879,5 +915,23 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:uses-license ref="android-sdk-license"/>
 		<sdk:abi>x86_64</sdk:abi>
 		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:3479480, branch:git_nyc-preview-release-->
+		<sdk:api-level>25</sdk:api-level>
+		<sdk:description>Google APIs Intel x86 Atom_64 System Image</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Nov 14 16:42:52 2016.-->
+				<sdk:size>912938750</sdk:size>
+				<sdk:checksum type="sha1">4593ee04811df21c339f3374fc5917843db06f8d</sdk:checksum>
+				<sdk:url>x86_64-25_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:abi>x86_64</sdk:abi>
+		<sdk:tag-id>google_apis</sdk:tag-id>
+		<sdk:tag-display>Google APIs</sdk:tag-display>
 	</sdk:system-image>
 </sdk:sdk-sys-img>

--- a/pkgs/development/mobile/androidenv/sysimages.nix
+++ b/pkgs/development/mobile/androidenv/sysimages.nix
@@ -15,11 +15,19 @@ let
 in
 {
 
+  sysimg_armeabi-v7a_10 = buildSystemImage {
+    name = "sysimg-armeabi-v7a-10";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armv7-10_r04.zip;
+      sha1 = "54680383118eb5c95a11e1cc2a14aa572c86ee69";
+    };
+  };
+
   sysimg_x86_10 = buildSystemImage {
     name = "sysimg-x86-10";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-10_r03.zip;
-      sha1 = "6b8539eaca9685d2d3289bf8e6d21d366d791326";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-10_r04.zip;
+      sha1 = "655ffc5cc89dd45a3aca154b254009016e473aeb";
     };
   };
 
@@ -34,8 +42,8 @@ in
   sysimg_armeabi-v7a_15 = buildSystemImage {
     name = "sysimg-armeabi-v7a-15";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-15_r03.zip;
-      sha1 = "0a47f586e172b1cf3db2ada857a70c2bdec24ef8";
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-15_r04.zip;
+      sha1 = "363223bd62f5afc0b2bd760b54ce9d26b31eacf1";
     };
   };
 
@@ -50,8 +58,8 @@ in
   sysimg_x86_15 = buildSystemImage {
     name = "sysimg-x86-15";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-15_r02.zip;
-      sha1 = "56b8d4b3d0f6a8876bc78d654da186f3b7b7c44f";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-15_r04.zip;
+      sha1 = "e45c728b64881c0e86529a8f7ea9c103a3cd14c1";
     };
   };
 
@@ -74,16 +82,16 @@ in
   sysimg_x86_16 = buildSystemImage {
     name = "sysimg-x86-16";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-16_r02.zip;
-      sha1 = "36c2a2e394bcb3290583ce09815eae7711d0b2c2";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-16_r05.zip;
+      sha1 = "7ea16da3a8fdb880b1b290190fcc1bde2821c1e0";
     };
   };
 
   sysimg_armeabi-v7a_17 = buildSystemImage {
     name = "sysimg-armeabi-v7a-17";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-17_r03.zip;
-      sha1 = "97cfad22b51c8475e228b207dd36dbef1c18fa38";
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-17_r05.zip;
+      sha1 = "7460e8110f4a87f9644f1bdb5511a66872d50fd9";
     };
   };
 
@@ -98,112 +106,112 @@ in
   sysimg_x86_17 = buildSystemImage {
     name = "sysimg-x86-17";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-17_r02.zip;
-      sha1 = "bd8c7c5411431af7e051cbe961be430fc31e773d";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-17_r03.zip;
+      sha1 = "eb30274460ff0d61f3ed37862b567811bebd8270";
     };
   };
 
   sysimg_armeabi-v7a_18 = buildSystemImage {
     name = "sysimg-armeabi-v7a-18";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-18_r03.zip;
-      sha1 = "2d7d51f4d2742744766511e5d6b491bd49161c51";
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-18_r04.zip;
+      sha1 = "0bf34ecf4ddd53f6b1b7fe7dfa12f2887c17e642";
     };
   };
 
   sysimg_x86_18 = buildSystemImage {
     name = "sysimg-x86-18";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-18_r02.zip;
-      sha1 = "ab3de121a44fca43ac3aa83f7d68cc47fc643ee8";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-18_r03.zip;
+      sha1 = "03a0cb23465c3de15215934a1dbc9715b56e9458";
     };
   };
 
   sysimg_armeabi-v7a_19 = buildSystemImage {
     name = "sysimg-armeabi-v7a-19";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-19_r03.zip;
-      sha1 = "5daf7718e3ab03d9bd8792b492dd305f386ef12f";
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-19_r05.zip;
+      sha1 = "d1a5fd4f2e1c013c3d3d9bfe7e9db908c3ed56fa";
     };
   };
 
   sysimg_x86_19 = buildSystemImage {
     name = "sysimg-x86-19";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-19_r05.zip;
-      sha1 = "c9298a8eafceed3b8fa11071ba63a3d18e17fd8e";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-19_r05.zip;
+      sha1 = "1d98426467580abfd03c724c5344450f5d0df379";
     };
   };
 
   sysimg_armeabi-v7a_21 = buildSystemImage {
     name = "sysimg-armeabi-v7a-21";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_arm-21_r03.zip;
-      sha1 = "0b2e21421d29f48211b5289ca4addfa7f4c7ae5a";
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-21_r04.zip;
+      sha1 = "8c606f81306564b65e41303d2603e4c42ded0d10";
     };
   };
 
   sysimg_x86_21 = buildSystemImage {
     name = "sysimg-x86-21";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-21_r04.zip;
-      sha1 = "3b78ad294aa1cdefa4be663d4af6c80d920ec49e";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-21_r04.zip;
+      sha1 = "c7732f45c931c0eaa064e57e8c054bce86c30e54";
     };
   };
 
   sysimg_x86_64_21 = buildSystemImage {
     name = "sysimg-x86_64-21";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-21_r04.zip;
-      sha1 = "eb14ba9c14615d5e5a21c854be29aa903d9bb63d";
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-21_r04.zip;
+      sha1 = "9b2d64a69a72fa596c386899a742a404308f2c92";
     };
   };
 
   sysimg_armeabi-v7a_22 = buildSystemImage {
     name = "sysimg-armeabi-v7a-22";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_arm-22_r01.zip;
-      sha1 = "2aa6a887ee75dcf3ac34627853d561997792fcb8";
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-22_r02.zip;
+      sha1 = "2114ec015dbf3a16cbcb4f63e8a84a1b206a07a1";
     };
   };
 
   sysimg_x86_22 = buildSystemImage {
     name = "sysimg-x86-22";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-22_r05.zip;
-      sha1 = "909e0ad91ed43381597e82f65ec93d41f049dd53";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-22_r05.zip;
+      sha1 = "7e2c93891ea9efec07dccccf6b9ab051a014dbdf";
     };
   };
 
   sysimg_x86_64_22 = buildSystemImage {
     name = "sysimg-x86_64-22";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-22_r05.zip;
-      sha1 = "8a04ff4fb30f70414e6ec7b3b06285f316e93d08";
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-22_r05.zip;
+      sha1 = "99d1d6c77e92284b4210640edf6c81eceb28520d";
     };
   };
 
   sysimg_armeabi-v7a_23 = buildSystemImage {
     name = "sysimg-armeabi-v7a-23";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_arm-23_r03.zip;
-      sha1 = "7bb8768ec4333500192fd9627d4234f505fa98dc";
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-23_r06.zip;
+      sha1 = "7cf2ad756e54a3acfd81064b63cb0cb9dff2798d";
     };
   };
 
   sysimg_x86_23 = buildSystemImage {
     name = "sysimg-x86-23";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86-23_r09.zip;
-      sha1 = "0ce9229974818179833899dce93f228a895ec6a2";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-23_r09.zip;
+      sha1 = "d7ee1118a73eb5c3e803d4dd3b96a124ac909ee1";
     };
   };
 
   sysimg_x86_64_23 = buildSystemImage {
     name = "sysimg-x86_64-23";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_x86_64-23_r09.zip;
-      sha1 = "571f5078a3d337a9144e2af13bd23ca46845a979";
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-23_r09.zip;
+      sha1 = "84cc076eacec043c8e88382c6ab391b0cd5c0695";
     };
   };
 
@@ -238,4 +246,21 @@ in
       sha1 = "a379932395ced0a8f572b39c396d86e08827a9ba";
     };
   };
+
+  sysimg_x86_25 = buildSystemImage {
+    name = "sysimg-x86-25";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-25_r03.zip;
+      sha1 = "7dd19cfee4e43a1f60e0f5f058404d92d9544b33";
+    };
+  };
+
+  sysimg_x86_64_25 = buildSystemImage {
+    name = "sysimg-x86_64-25";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-25_r03.zip;
+      sha1 = "4593ee04811df21c339f3374fc5917843db06f8d";
+    };
+  };
 }
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -551,9 +551,9 @@ in
 
   inherit (androidenv) androidsdk_4_4 androidndk;
 
-  androidsdk = androidenv.androidsdk_6_0;
+  androidsdk = androidenv.androidsdk_7_0;
 
-  androidsdk_extras = self.androidenv.androidsdk_6_0_extras;
+  androidsdk_extras = self.androidenv.androidsdk_7_0_extras;
 
   arc-theme = callPackage ../misc/themes/arc { };
 


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
