### PR TITLE
android-studio: 2.1.3 -> 2.2.3

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -10,9 +10,15 @@
 , gnutar
 , gzip
 , jdk
+, fontconfig
+, freetype
 , libpulseaudio
 , libX11
+, libXext
+, libXi
 , libXrandr
+, libXrender
+, libXtst
 , makeWrapper
 , pciutils
 , pkgsi686Linux
@@ -27,8 +33,8 @@
 
 let
 
-  version = "2.1.3.0";
-  build = "143.3101438";
+  version = "2.2.3.0";
+  build = "145.3537739";
 
   androidStudio = stdenv.mkDerivation {
     name = "android-studio";
@@ -75,11 +81,17 @@ let
         # For Android emulator
         libpulseaudio
         libX11
+        libXext
+        libXrender
+        libXtst
+        libXi
+        freetype
+        fontconfig
       ]}" --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb"
     '';
     src = fetchurl {
       url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
-      sha256 = "1xlz3ibqrm4ckw4lgbkzbxvpgg0y8hips9b54p4d15f34i0r8bvj";
+      sha256 = "10fmffkvvbnmgjxb4rq7rjwnn16jp5phw6div4n7hh2ad6spf8wq";
     };
   };
 

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -93,6 +93,12 @@ let
       url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
       sha256 = "10fmffkvvbnmgjxb4rq7rjwnn16jp5phw6div4n7hh2ad6spf8wq";
     };
+    meta = {
+      description = "The Official IDE for Android";
+      homepage = https://developer.android.com/studio/index.html;
+      license = stdenv.lib.licenses.asl20;
+      platforms = [ "x86_64-linux" ];
+    };
   };
 
   # Android Studio downloads prebuilt binaries as part of the SDK. These tools

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12143,7 +12143,9 @@ in
   #     };
   #   };
   # }
-  android-studio = callPackage ../applications/editors/android-studio { };
+  android-studio = callPackage ../applications/editors/android-studio {
+      inherit (xorg) libX11 libXext libXi libXrandr libXrender libXtst;
+  };
 
   antimony = qt5.callPackage ../applications/graphics/antimony {};
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

It now requires libraries for X.
