### PR TITLE
dstat: python2.72: bad interpreter: No such file

### DIFF
--- a/pkgs/os-specific/linux/dstat/default.nix
+++ b/pkgs/os-specific/linux/dstat/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   pythonPath = with python2Packages; [ python-wifi ];
 
   patchPhase = ''
-    sed -i -e 's|/usr/bin/env python|${python2Packages.python.interpreter}|' \
+    sed -i -e 's|/usr/bin/env python2|${python2Packages.python.interpreter}|' \
            -e "s|/usr/share/dstat|$out/share/dstat|" dstat
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Fix python2.72: bad interpreter: No such file or directory

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


