### PR TITLE
aptly: add bash completion

### DIFF
--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -1,16 +1,30 @@
 { stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, gnupg1compat, bzip2, xz, graphviz }:
 
-buildGoPackage rec {
-  name = "aptly-${version}";
+let
+
   version = "0.9.7";
   rev = "v${version}";
 
-  src = fetchFromGitHub {
+  aptlySrc = fetchFromGitHub {
     inherit rev;
     owner = "smira";
     repo = "aptly";
     sha256 = "0j1bmqdah4i83r2cf8zcq87aif1qg90yasgf82yygk3hj0gw1h00";
   };
+
+  aptlyCompletionSrc = fetchFromGitHub {
+    rev = version;
+    owner = "aptly-dev";
+    repo = "aptly-bash-completion";
+    sha256 = "1yz3pr2jfczqv81as2q3cizwywj5ksw76vi15xlbx5njkjp4rbm4";
+  };
+
+in
+
+buildGoPackage {
+  name = "aptly-${version}";
+
+  src = aptlySrc;
 
   goPackagePath = "github.com/smira/aptly";
   goDeps = ./deps.nix;
@@ -19,6 +33,8 @@ buildGoPackage rec {
 
   postInstall = ''
     rm $bin/bin/man
+    mkdir -p $bin/share/bash-completion/completions
+    ln -s ${aptlyCompletionSrc}/aptly $bin/share/bash-completion/completions
     wrapProgram "$bin/bin/aptly" \
       --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg1compat bzip2 xz graphviz ]}"
   '';


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


