### PR TITLE
db: disable dbm support by default

### DIFF
--- a/pkgs/development/libraries/db/clang-4.8.patch
+++ b/pkgs/development/libraries/db/clang-4.8.patch
@@ -38,19 +38,6 @@ index 0034dcc..160c8ea 100644
  #else
  #define atomic_inc(env, p)	__atomic_inc(env, p)
  #define atomic_dec(env, p)	__atomic_dec(env, p)
-diff --git a/dbinc/db.in b/dbinc/db.in
-index 9fc6712..7428e0a 100644
---- a/dbinc/db.in
-+++ b/dbinc/db.in
-@@ -2413,7 +2413,7 @@ typedef struct {
- #define	fetch(a)	__db_dbm_fetch@DB_VERSION_UNIQUE_NAME@(a)
- #define	firstkey	__db_dbm_firstkey@DB_VERSION_UNIQUE_NAME@
- #define	nextkey(a)	__db_dbm_nextkey@DB_VERSION_UNIQUE_NAME@(a)
--#define	store(a, b)	__db_dbm_store@DB_VERSION_UNIQUE_NAME@(a, b)
-+#define	store_db(a, b)	__db_dbm_store@DB_VERSION_UNIQUE_NAME@(a, b)
- 
- /*******************************************************
-  * Hsearch historic interface.
 diff --git a/mp/mp_fget.c b/mp/mp_fget.c
 index 5fdee5a..0b75f57 100644
 --- a/mp/mp_fget.c

--- a/pkgs/development/libraries/db/clang-5.3.patch
+++ b/pkgs/development/libraries/db/clang-5.3.patch
@@ -38,19 +38,6 @@ index 6a858f7..9f338dc 100644
  #else
  #define atomic_inc(env, p)	__atomic_inc(env, p)
  #define atomic_dec(env, p)	__atomic_dec(env, p)
-diff --git a/src/dbinc/db.in b/src/dbinc/db.in
-index 92ac822..f80428e 100644
---- a/src/dbinc/db.in
-+++ b/src/dbinc/db.in
-@@ -2782,7 +2782,7 @@ typedef struct {
- #define	fetch(a)	__db_dbm_fetch@DB_VERSION_UNIQUE_NAME@(a)
- #define	firstkey	__db_dbm_firstkey@DB_VERSION_UNIQUE_NAME@
- #define	nextkey(a)	__db_dbm_nextkey@DB_VERSION_UNIQUE_NAME@(a)
--#define	store(a, b)	__db_dbm_store@DB_VERSION_UNIQUE_NAME@(a, b)
-+#define	store_db(a, b)	__db_dbm_store@DB_VERSION_UNIQUE_NAME@(a, b)
- 
- /*******************************************************
-  * Hsearch historic interface.
 diff --git a/src/mp/mp_fget.c b/src/mp/mp_fget.c
 index 16de695..d0dcc29 100644
 --- a/src/mp/mp_fget.c

--- a/pkgs/development/libraries/db/clang-6.0.patch
+++ b/pkgs/development/libraries/db/clang-6.0.patch
@@ -20,19 +20,6 @@ index e4420aa..4799b5f 100644
  #else
  #define	atomic_inc(env, p)	__atomic_inc_int(env, p)
  #define	atomic_dec(env, p)	__atomic_dec_int(env, p)
-diff --git a/src/dbinc/db.in b/src/dbinc/db.in
-index 3c2ad9b..3e46f02 100644
---- a/src/dbinc/db.in
-+++ b/src/dbinc/db.in
-@@ -2999,7 +2999,7 @@ typedef struct {
- #define	fetch(a)	__db_dbm_fetch@DB_VERSION_UNIQUE_NAME@(a)
- #define	firstkey	__db_dbm_firstkey@DB_VERSION_UNIQUE_NAME@
- #define	nextkey(a)	__db_dbm_nextkey@DB_VERSION_UNIQUE_NAME@(a)
--#define	store(a, b)	__db_dbm_store@DB_VERSION_UNIQUE_NAME@(a, b)
-+#define	store_db(a, b)	__db_dbm_store@DB_VERSION_UNIQUE_NAME@(a, b)
- 
- /*******************************************************
-  * Hsearch historic interface.
 diff --git a/src/mp/mp_fget.c b/src/mp/mp_fget.c
 index 59fe9fe..fa4ced7 100644
 --- a/src/mp/mp_fget.c

--- a/pkgs/development/libraries/db/generic.nix
+++ b/pkgs/development/libraries/db/generic.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl
 , cxxSupport ? true
 , compat185 ? true
+, dbmSupport ? false
 
 # Options from inherited versions
 , version, sha256
@@ -19,12 +20,13 @@ stdenv.mkDerivation (rec {
 
   patches = extraPatches;
 
-  configureFlags = [
-    (if cxxSupport then "--enable-cxx" else "--disable-cxx")
-    (if compat185 then "--enable-compat185" else "--disable-compat185")
-    "--enable-dbm"
-    (stdenv.lib.optionalString stdenv.isFreeBSD "--with-pic")
-  ];
+  configureFlags =
+    [
+      (if cxxSupport then "--enable-cxx" else "--disable-cxx")
+      (if compat185 then "--enable-compat185" else "--disable-compat185")
+    ]
+    ++ stdenv.lib.optional dbmSupport "--enable-dbm"
+    ++ stdenv.lib.optional stdenv.isFreeBSD "--with-pic";
 
   preConfigure = ''
     cd build_unix


### PR DESCRIPTION
###### Motivation for this change

I think that the patch I added before to fix the build with clang-3.8 broke dbm support.
It looks like none of our packages actually depend on it.


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


