### PR TITLE
mbedtls: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
-  name = "mbedtls-2.3.0";
+  name = "mbedtls-2.4.0";
 
   src = fetchurl {
     url = "https://tls.mbed.org/download/${name}-gpl.tgz";
-    sha256 = "0jfb20crlcp67shp9p8cy6vmwdjkxb0rqfbi5l5yggbrywa708r1";
+    sha256 = "0gwyxsz7av8fyzrz4zxhcy9jmszlvg9zskz3srar75lg0bhg1vw0";
   };
 
   nativeBuildInputs = [ perl ];


### PR DESCRIPTION
###### Motivation for this change

There is a bug in mbedtls 2.3.0: https://github.com/ARMmbed/mbedtls/issues/522

This bug prohibits me from building Neko 2.1.0. With an upgraded mbedtls I can build both Neko 2.1.0 and Haxe 3.1.3 on both Linux and Darwin (which is currently unsupported).

Next steps:
- https://github.com/boronine/nixpkgs/tree/neko-2.1.0
- https://github.com/boronine/nixpkgs/tree/haxe-enable-darwin

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


