### PR TITLE
stdenv: add runPhase function

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -832,6 +832,34 @@ showPhaseHeader() {
 }
 
 
+runPhase() {
+    local phase="$1"
+
+    if [ -n "$tracePhases" ]; then
+        echo
+        echo "@ phase-started $out $phase"
+    fi
+
+    showPhaseHeader "$phase"
+    dumpVars
+
+    # Evaluate the variable named $phase if it exists, otherwise the
+    # function named $phase.
+    eval "${!phase:-$phase}"
+
+    if [ "$phase" = unpackPhase ]; then
+        cd "${sourceRoot:-.}"
+    fi
+
+    if [ -n "$tracePhases" ]; then
+        echo
+        echo "@ phase-succeeded $out $phase"
+    fi
+
+    stopNest
+}
+
+
 genericBuild() {
     if [ -f "$buildCommandPath" ]; then
         . "$buildCommandPath"
@@ -857,28 +885,7 @@ genericBuild() {
         if [ "$curPhase" = installCheckPhase -a -z "$doInstallCheck" ]; then continue; fi
         if [ "$curPhase" = distPhase -a -z "$doDist" ]; then continue; fi
 
-        if [ -n "$tracePhases" ]; then
-            echo
-            echo "@ phase-started $out $curPhase"
-        fi
-
-        showPhaseHeader "$curPhase"
-        dumpVars
-
-        # Evaluate the variable named $curPhase if it exists, otherwise the
-        # function named $curPhase.
-        eval "${!curPhase:-$curPhase}"
-
-        if [ "$curPhase" = unpackPhase ]; then
-            cd "${sourceRoot:-.}"
-        fi
-
-        if [ -n "$tracePhases" ]; then
-            echo
-            echo "@ phase-succeeded $out $curPhase"
-        fi
-
-        stopNest
+        runPhase "$curPhase"
     done
 }
 


### PR DESCRIPTION
###### Motivation for this change

This is useful for running phases inside a nix-shell, using `buildPhase` for example will always execute make even when a derivation has a custom buildPhase.


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested `stdenv.mkDerivation`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---