### PR TITLE
firefox-bin: fix updateScript

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -223,7 +223,7 @@ stdenv.mkDerivation {
                        tr " " ":"`; do
             # create an entry for every locale
             cat >> $tmpfile <<EOF
-            { url = "$url$version/$arch/`echo $line | cut -d":" -f3`";
+            { url = "$url$version/`echo $line | cut -d":" -f3`";
               locale = "`echo $line | cut -d":" -f3 | sed "s/$arch\///" | sed "s/\/.*//"`";
               arch = "$arch";
               sha512 = "`echo $line | cut -d":" -f1`";

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -223,7 +223,7 @@ stdenv.mkDerivation {
                        tr " " ":"`; do
             # create an entry for every locale
             cat >> $tmpfile <<EOF
-            { url = "$url$version/$arch/`echo $line | cut -d":" -f3`";"
+            { url = "$url$version/$arch/`echo $line | cut -d":" -f3`";
               locale = "`echo $line | cut -d":" -f3 | sed "s/$arch\///" | sed "s/\/.*//"`";
               arch = "$arch";
               sha512 = "`echo $line | cut -d":" -f1`";

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -236,7 +236,7 @@ stdenv.mkDerivation {
         }
         EOF
 
-        cat $tmpfile > ${if isBeta then "beta_" else ""}sources.nix
+        mv $tmpfile ${if isBeta then "beta_" else ""}sources.nix
 
         popd
       '';


### PR DESCRIPTION
###### Motivation for this change

Extra double quotes in generated codes.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc: @garbas
