### PR TITLE
isl: add 0.17.1

### DIFF
--- a/pkgs/development/libraries/isl/0.17.1.nix
+++ b/pkgs/development/libraries/isl/0.17.1.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, gmp }:
+
+stdenv.mkDerivation rec {
+  name = "isl-0.17.1";
+
+  src = fetchurl {
+    url = "http://isl.gforge.inria.fr/${name}.tar.xz";
+    sha256 = "be152e5c816b477594f4c6194b5666d8129f3a27702756ae9ff60346a8731647";
+  };
+
+  buildInputs = [ gmp ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = http://www.kotnet.org/~skimo/isl/;
+    license = stdenv.lib.licenses.lgpl21;
+    description = "A library for manipulating sets and relations of integer points bounded by linear constraints";
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2271,11 +2271,12 @@ in
 
   ised = callPackage ../tools/misc/ised {};
 
-  isl = isl_0_15;
+  isl = isl_0_17;
   isl_0_11 = callPackage ../development/libraries/isl/0.11.1.nix { };
   isl_0_12 = callPackage ../development/libraries/isl/0.12.2.nix { };
   isl_0_14 = callPackage ../development/libraries/isl/0.14.1.nix { };
   isl_0_15 = callPackage ../development/libraries/isl/0.15.0.nix { };
+  isl_0_17 = callPackage ../development/libraries/isl/0.17.1.nix { };
 
   ispike = callPackage ../development/libraries/science/robotics/ispike { };
 


### PR DESCRIPTION
###### Motivation for this change

Upgrade isl to the latest version.

@wkennington @globin @fpletz (Not sure whom to ping, here...)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---