### PR TITLE
kubernetes: generate docs, fix empty man files

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -28,16 +28,23 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ makeWrapper which go rsync go-bindata ];
 
-  outputs = ["out" "man""pause"];
+  outputs = ["out" "man" "pause"];
 
   postPatch = ''
     substituteInPlace "hack/lib/golang.sh" --replace "_cgo" ""
+    substituteInPlace "hack/generate-docs.sh" --replace "make" "make SHELL=${stdenv.shell}"
+    substituteInPlace "hack/update-munge-docs.sh" --replace "make" "make SHELL=${stdenv.shell}"
+    substituteInPlace "hack/update-munge-docs.sh" --replace "kube::util::git_upstream_remote_name" "echo origin"
+
     patchShebangs ./hack
   '';
 
   WHAT="--use_go_build ${concatStringsSep " " components}";
 
-  postBuild = "(cd build/pause && gcc pause.c -o pause)";
+  postBuild = ''
+    ./hack/generate-docs.sh
+    (cd build/pause && gcc pause.c -o pause)
+  '';
 
   installPhase = ''
     mkdir -p "$out/bin" "$man/share/man" "$pause/bin"


### PR DESCRIPTION
###### Motivation for this change

Kubernetes docs and man files are empty by default, and need to be generated explicitly. This pull request generates docs and man files for kubernetes.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


