### PR TITLE
httpie: 0.9.6 -> 0.9.8

### DIFF
--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "httpie-0.9.6";
+  name = "httpie-0.9.8";
   namePrefix = "";
 
   src = fetchurl {
     url = "mirror://pypi/h/httpie/${name}.tar.gz";
-    sha256 = "1cch5y0hr9qpfn9m4nw5796c2x7v3m1ni4psjm26ajsl8pw90jx6";
+    sha256 = "1qgn1mpkk8wxxhvgxw3fnscqg3klh42ijr11zrb0ylriaaqp0n2i";
   };
 
   propagatedBuildInputs = with pythonPackages; [ pygments requests2 ];
@@ -17,6 +17,6 @@ pythonPackages.buildPythonApplication rec {
     description = "A command line HTTP client whose goal is to make CLI human-friendly";
     homepage = http://httpie.org/;
     license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ antono relrod ];
+    maintainers = with stdenv.lib.maintainers; [ antono relrod schneefux ];
   };
 }


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).