### PR TITLE
helm (kubernetes): init at v2.0.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -384,6 +384,7 @@
   retrry = "Tadas Barzdžius <retrry@gmail.com>";
   rick68 = "Wei-Ming Yang <rick68@gmail.com>";
   rickynils = "Rickard Nilsson <rickynils@gmail.com>";
+  rlupton20 = "Richard Lupton <richard.lupton@gmail.com>";
   rnhmjoj = "Michele Guerini Rocco <micheleguerinirocco@me.com>";
   rob = "Rob Vermaas <rob.vermaas@gmail.com>";
   robberer = "Longrin Wischnewski <robberer@freakmail.de>";

--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "${checksum}";
   };
 
+  preferLocalBuild = true;
+
   buildInputs = [ ];
 
   propagatedBuildInputs = [ kubernetes ];
@@ -37,6 +39,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/kubernetes/helm;
     description = "A package manager for kubernetes";
     license = licenses.asl20;
+    maintainers = [ maintainers.rlupton20 ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, kubernetes }:
+let
+  arch = if stdenv.isLinux
+         then "linux-amd64"
+         else "darwin-amd64";
+  checksum = if stdenv.isLinux
+             then "dad3791fb07e6cf34f4cf611728cb8ae109a75234498a888529a68ac6923f200"
+             else "d27bd7e40e12c0a5f08782a8a883166008565b28e0b82126d2089300ff3f8465";
+in
+stdenv.mkDerivation rec {
+  pname = "helm";
+  version = "2.0.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://kubernetes-helm.storage.googleapis.com/helm-v${version}-${arch}.tar.gz";
+    sha256 = "${checksum}";
+  };
+
+  buildInputs = [ ];
+
+  propagatedBuildInputs = [ kubernetes ];
+
+  phases = [ "buildPhase" "installPhase" ];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+  '';
+
+  installPhase = ''
+    tar -xvzf $src
+    cp ${arch}/helm $out/bin/${pname}
+    chmod +x $out/bin/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/kubernetes/helm;
+    description = "A package manager for kubernetes";
+    license = licenses.asl20;
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -22,6 +22,6 @@ buildGoPackage rec {
     homepage = https://www.vaultproject.io;
     description = "A tool for managing secrets";
     license = licenses.mpl20;
-    maintainers = [ maintainers.rushmorem ];
+    maintainers = with maintainers; [ rushmorem offline ];
   };
 }

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "vault-${version}";
-  version = "0.6.1";
+  version = "0.6.3";
 
   goPackagePath = "github.com/hashicorp/vault";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "06xf2dpn0q398qb6wbh9j1wjl5smqq9nrrn2039g48haqm8853jx";
+    sha256 = "0cbaws106v5dxqjii1s9rmk55pm6y34jls35iggpx0pp1dd433xy";
   };
 
   buildFlagsArray = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13341,7 +13341,7 @@ in
 
   hello = callPackage ../applications/misc/hello { };
 
-  kubernetes_helm = callPackage ../applications/networking/cluster/helm { };
+  kubernetes-helm = callPackage ../applications/networking/cluster/helm { };
 
   helmholtz = callPackage ../applications/audio/pd-plugins/helmholtz { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13341,6 +13341,8 @@ in
 
   hello = callPackage ../applications/misc/hello { };
 
+  kubernetes_helm = callPackage ../applications/networking/cluster/helm { };
+
   helmholtz = callPackage ../applications/audio/pd-plugins/helmholtz { };
 
   heme = callPackage ../applications/editors/heme { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9114,6 +9114,29 @@ in {
 
   };
 
+  pytun = buildPythonPackage rec {
+    name = "pytun-${version}";
+    version = "2.2.1";
+    rev = "v${version}";
+
+    src = pkgs.fetchFromGitHub {
+      inherit rev;
+      owner = "montag451";
+      repo = "pytun";
+      sha256 = "1bxk0z0v8m0b01xg94f039j3bsclkshb7girvjqfzk5whbd2nryh";
+    };
+
+    doCheck = false;
+
+    meta = {
+      homepage = https://github.com/montag451/pytun;
+      description = "Linux TUN/TAP wrapper for Python";
+      license = licenses.mit;
+      maintainers = with maintainers; [ montag451 ];
+      platforms = platforms.linux;
+    };
+  };
+
   raven = buildPythonPackage rec {
     name = "raven-3.4.1";
 


### PR DESCRIPTION
###### Motivation for this change

helm is a neat tool for installing packages in kubernetes. It would be useful to have it in nix.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Added a nix expression to download and install helm; added it to top
level packages as kubernetes_helm.