### PR TITLE
pythonPackages.discordpy: init at 0.15.1

### DIFF
--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchurl
+, buildPythonPackage
+, pythonOlder
+, withVoice ? true, libopus
+, asyncio
+, aiohttp
+, websockets
+, pynacl
+}:
+
+let
+  pname = "discord.py";
+  version = "0.15.1";
+in buildPythonPackage rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+    sha256 = "01lgidvnwwva1i65853gaplamllym2nsk0jis2r6f1rzbamgk1yj";
+  };
+
+  propagatedBuildInputs = [ asyncio aiohttp websockets pynacl ];
+  patchPhase = ''
+    substituteInPlace "requirements.txt" \
+      --replace "aiohttp>=1.0.0,<1.1.0" "aiohttp"
+  '' + lib.optionalString withVoice ''
+    substituteInPlace "discord/opus.py" \
+      --replace "ctypes.util.find_library('opus')" "'${libopus}/lib/libopus.so.0'"
+  '';
+
+  disabled = pythonOlder "3.5";
+
+  meta = {
+    description = "A python wrapper for the Discord API";
+    homepage    = "https://discordpy.rtfd.org/";
+    license     = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -212,6 +212,8 @@ in {
     '';
   };
 
+  discordpy = callPackage ../development/python-modules/discordpy { };
+
   h5py = callPackage ../development/python-modules/h5py {
     hdf5 = pkgs.hdf5;
   };


### PR DESCRIPTION
###### Motivation for this change
Added the [discordpy](https://discordpy.readthedocs.io/en/latest/) python library with dependencies.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

