### PR TITLE
darwin.stdenv: use minimal python to bootstrap clang

### DIFF
--- a/pkgs/development/compilers/llvm/3.7/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/default.nix
@@ -1,6 +1,6 @@
-{ newScope, stdenv, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun }:
+{ newScope, stdenv, cmake, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun }:
 let
-  callPackage = newScope (self // { inherit stdenv isl version fetch; });
+  callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl version fetch; });
 
   version = "3.7.1";
 

--- a/pkgs/development/interpreters/python/cpython/2.7/boot.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/boot.nix
@@ -1,0 +1,94 @@
+{ stdenv, fetchurl, CF, configd, coreutils, self }:
+
+with stdenv.lib;
+
+let
+
+  mkPaths = paths: {
+    C_INCLUDE_PATH = makeSearchPathOutput "dev" "include" paths;
+    LIBRARY_PATH = makeLibraryPath paths;
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  name = "bootstrap-python-${version}";
+  version = "2.7.12";
+  libPrefix = "python2.7";
+
+  src = fetchurl {
+    url = "https://www.python.org/ftp/python/2.7.12/Python-${version}.tar.xz";
+    sha256 = "0y7rl603vmwlxm6ilkhc51rx2mfj14ckcz40xxgs0ljnvlhp30yp";
+  };
+
+  inherit (mkPaths buildInputs) C_INCLUDE_PATH LIBRARY_PATH;
+
+  LDFLAGS = optionalString (!stdenv.isDarwin) "-lgcc_s";
+  NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin "-msse2";
+
+  buildInputs = optionals stdenv.isDarwin [ CF configd ];
+
+  patches =
+    [ # Look in C_INCLUDE_PATH and LIBRARY_PATH for stuff.
+      ./search-path.patch
+
+      # Python recompiles a Python if the mtime stored *in* the
+      # pyc/pyo file differs from the mtime of the source file.  This
+      # doesn't work in Nix because Nix changes the mtime of files in
+      # the Nix store to 1.  So treat that as a special case.
+      ./nix-store-mtime.patch
+
+      # patch python to put zero timestamp into pyc
+      # if DETERMINISTIC_BUILD env var is set
+      ./deterministic-build.patch
+    ];
+
+  DETERMINISTIC_BUILD = 1;
+
+  preConfigure = ''
+      # Purity.
+      for i in /usr /sw /opt /pkg; do
+        substituteInPlace ./setup.py --replace $i /no-such-path
+      done
+    '' + optionalString (stdenv ? cc && stdenv.cc.libc != null) ''
+      for i in Lib/plat-*/regen; do
+        substituteInPlace $i --replace /usr/include/ ${stdenv.cc.libc}/include/
+      done
+    '' + optionalString stdenv.isDarwin ''
+      substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
+      substituteInPlace Lib/multiprocessing/__init__.py \
+        --replace 'os.popen(comm)' 'os.popen("${coreutils}/bin/nproc")'
+    '';
+
+  configureFlags = [ "--enable-shared" "--with-threads" "--enable-unicode=ucs4" ]
+    ++ optionals stdenv.isCygwin [ "ac_cv_func_bind_textdomain_codeset=yes" ]
+    ++ optionals stdenv.isDarwin [ "--disable-toolbox-glue" ];
+
+  postInstall =
+    ''
+      ln -s $out/share/man/man1/{python2.7.1.gz,python.1.gz}
+
+      paxmark E $out/bin/python2.7
+
+      rm "$out"/lib/python*/plat-*/regen # refers to glibc.dev
+    '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "http://python.org";
+    description = "A high-level dynamically-typed programming language";
+    longDescription = ''
+      Python is a remarkably powerful dynamic programming language that
+      is used in a wide variety of application domains. Some of its key
+      distinguishing features include: clear, readable syntax; strong
+      introspection capabilities; intuitive object orientation; natural
+      expression of procedural code; full modularity, supporting
+      hierarchical packages; exception-based error handling; and very
+      high level dynamic data types.
+    '';
+    license = stdenv.lib.licenses.psfl;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ lnl7 chaoflow domenkozar ];
+  };
+}

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -1,9 +1,8 @@
-{
-  fetchurl, stdenv, pkgconfig,
-  acl, attr, bzip2, e2fsprogs, libxml2, lzo, openssl, sharutils, xz, zlib,
+{ fetchurl, stdenv, pkgconfig
+, acl, attr, bzip2, e2fsprogs, lzo, openssl, sharutils, xz, zlib
 
   # Optional but increases closure only negligibly.
-  xarSupport ? true,
+, xarSupport ? true, libxml2 ? null
 }:
 
 assert xarSupport -> libxml2 != null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5127,9 +5127,34 @@ in
     inherit (stdenvAdapters) overrideCC;
   };
 
-  llvmPackages_37 = callPackage ../development/compilers/llvm/3.7 {
-    inherit (stdenvAdapters) overrideCC;
-  };
+  llvmPackages_37 =
+    let
+
+      libarchiveBoot = callPackage ../development/libraries/libarchive { xarSupport = false; };
+
+      libxml2Boot = callPackage ../development/libraries/libxml2 { pythonSupport = false; };
+
+      cmakeBoot = callPackage ../development/tools/build-managers/cmake {
+        libarchive = libarchiveBoot;
+        wantPS = stdenv.isDarwin;
+        inherit (darwin) ps;
+      };
+
+      # This is used to bootstrap clang, don't use this as a runtime dependency.
+      python27Boot = callPackage ../development/interpreters/python/cpython/2.7/boot.nix {
+        self = python27Boot;
+        inherit (darwin) CF configd;
+      };
+
+      llvmPackages = callPackage ../development/compilers/llvm/3.7 {
+        cmake = cmakeBoot;
+        libxml2 = libxml2Boot;
+        python2 = python27Boot;
+        inherit (stdenvAdapters) overrideCC;
+      };
+
+    in
+      llvmPackages;
 
   llvmPackages_38 = callPackage ../development/compilers/llvm/3.8 {
     inherit (stdenvAdapters) overrideCC;
@@ -8469,8 +8494,8 @@ in
 
   libxmi = callPackage ../development/libraries/libxmi { };
 
-  libxml2 = callPackage ../development/libraries/libxml2 {
-  };
+  libxml2 = callPackage ../development/libraries/libxml2 { };
+
   libxml2Python = pkgs.buildEnv { # slightly hacky
     name = "libxml2+py-${self.libxml2.version}";
     paths = with libxml2; [ dev bin py ];


### PR DESCRIPTION
###### Motivation for this change

By using a minimal version of python in the stdenv we can remove a bunch of dependencies like `db`, `readline` and `sqlite`.

I'm testing a branch [WIP](https://github.com/LnL7/nixpkgs/commits/lnl7-wip) with #21078, #21099 and #21101.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```diff
+bootstrap-python-2.7.12.drv
+bzip2-1.0.6.0.1.drv
-bzip2-1.0.6.0.1.drv
-clang-5.3.patch
+cmake-3.6.2.drv
-cmake-3.6.2.drv
-curl-7.51.0.drv
-curl-7.51.0.tar.bz2.drv
-db-5.3.28.drv
-db-5.3.28.tar.gz.drv
-e0ec3471cb09.drv
-gdbm-1.12.drv
-gdbm-1.12.drv
-gdbm-1.12.tar.gz.drv
-hook.drv
+libarchive-3.2.2.drv
-libarchive-3.2.2.drv
-libssh2-1.7.0.drv
-libssh2-1.7.0.tar.gz.drv
-libxml2-2.9.4.drv
-link-against-ncurses.patch
+lzo-2.09.drv
-lzo-2.09.drv
-no-arch_only-6.3.patch
-openssl-1.0.2j.drv
-openssl-1.0.2j.drv
-openssl-1.0.2j.tar.gz.drv
+pkg-config-0.29.drv
-pkg-config-0.29.drv
-properly-detect-curses.patch
-python-2.7-distutils-C++.patch
-python-2.7.12.drv
-python-2.7.12.drv
-readline-6.3.tar.gz.drv
-readline-6.3p08.drv
-readline-6.3p08.drv
-readline63-001.drv
-readline63-002.drv
-readline63-003.drv
-readline63-004.drv
-readline63-005.drv
-readline63-006.drv
-readline63-007.drv
-readline63-008.drv
-setup-hook.sh
-sqlite-3.15.0.drv
-sqlite-autoconf-3150000.tar.gz.drv
-use-etc-ssl-certs.patch
```