### PR TITLE
gopher: init at 3.0.11

### DIFF
--- a/pkgs/applications/networking/gopher/gopher/default.nix
+++ b/pkgs/applications/networking/gopher/gopher/default.nix
@@ -1,0 +1,23 @@
+{stdenv, fetchurl, ncurses}:
+
+stdenv.mkDerivation rec {
+  name = "gopher-${version}";
+  version = "3.0.11";
+
+  src = fetchurl {
+    url = "http://gopher.quux.org:70/devel/gopher/Downloads/gopher_${version}.tar.gz";
+    sha256 = "15r7x518wlpfqpd6z0hbdwm8rw8ll8hbpskdqgxxhrmy00aa7w9c";
+  };
+
+  buildInputs = [ ncurses ];
+
+  preConfigure = "export LIBS=-lncurses";
+
+  meta = {
+    homepage = http://gopher.quux.org:70/devel/gopher;
+    description = "A ncurses gopher client";
+    platforms = stdenv.lib.platforms.unix;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12962,6 +12962,8 @@ in
 
   google-musicmanager = callPackage ../applications/audio/google-musicmanager { };
 
+  gopher = callPackage ../applications/networking/gopher/gopher { };
+
   gpa = callPackage ../applications/misc/gpa { };
 
   gpicview = callPackage ../applications/graphics/gpicview { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


