### PR TITLE
pachyderm: init at 1.3.0

### DIFF
--- a/pkgs/applications/networking/cluster/pachyderm/default.nix
+++ b/pkgs/applications/networking/cluster/pachyderm/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  name = "pachyderm-${version}";
+  version = "1.3.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/pachyderm/pachyderm";
+  subPackages = [ "src/server/cmd/pachctl" ];
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "pachyderm";
+    repo = "pachyderm";
+    sha256 = "0y25xh6h7p8hg0bzrjlschmz62r6dwh5mrvbnni1hb1pm0w9jb6g";
+  };
+
+  meta = with lib; {
+    description = "Containerized Data Analytics";
+    homepage = https://github.com/pachyderm/pachyderm;
+    license = licenses.asl20;
+    maintainers = with maintainers; [offline];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5601,6 +5601,8 @@ in
 
   inherit (callPackages ../development/interpreters/perl {}) perl perl520 perl522;
 
+  pachyderm = callPackage ../applications/networking/cluster/pachyderm { };
+
   php = php70;
 
   phpPackages = php70Packages;


### PR DESCRIPTION
###### Notes

This only builds `pachctl` tool, which is capable of provisioning on kubernetes clusters using `pachctl deploy`. Server binaries can be added later if needed.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


