### PR TITLE
opencv 3.1.0: add patch fixing python use of FlannBasedMatcher.add

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -52,7 +52,11 @@ stdenv.mkDerivation rec {
         url = "https://github.com/opencv/opencv/commit/d76f258aebdf63f979a205cabe6d3e81700a7cd8.patch";
         sha256 = "00b3msfgrcw7laij6qafn4b18c1dl96xxpzwx05wxzrjldqb6kqg";
       })
-    ];
+    ]
+    ++ lib.optional enablePython (fetchpatch { # Patch to fix FlannBasedMatcher under python
+      url = "https://github.com/opencv/opencv/commit/05cfe28612fd8dc8fb0ccb876df945c7b435dd26.patch";
+      sha256 = "0niza5lybr1ljzdkyiapr16laa468168qinpy5qn00yimnaygpm6";
+    });
 
   preConfigure =
     let ippicvVersion = "20151201";


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Patch is from https://github.com/opencv/opencv/pull/6009, corresponding to
opencv commit 05cfe28612fd8dc8fb0ccb876df945c7b435dd26. Upstream doesn't seem
particularly enthusiastic about a 3.1.x point release, so who knows when
this fix would otherwise see the light of day.