### PR TITLE
kubernetes module: fix default dns ip

### DIFF
--- a/nixos/modules/services/cluster/kubernetes.nix
+++ b/nixos/modules/services/cluster/kubernetes.nix
@@ -484,7 +484,7 @@ in {
 
       clusterDns = mkOption {
         description = "Use alternative dns.";
-        default = "10.10.1.1";
+        default = "10.10.0.1";
         type = types.str;
       };
 


### PR DESCRIPTION
Default dns ip is wrong, and needs to be changed.