### PR TITLE
openjdk-darwin: Fix libfreetype path

### DIFF
--- a/pkgs/development/compilers/openjdk-darwin/8.nix
+++ b/pkgs/development/compilers/openjdk-darwin/8.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, setJavaClassPath }:
+{ stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
 let
   jdk = stdenv.mkDerivation {
     name = "zulu1.8.0_66-8.11.0.1";
@@ -9,7 +9,7 @@ let
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
     };
 
-    buildInputs = [ unzip ];
+    buildInputs = [ unzip freetype ];
 
     installPhase = ''
       mkdir -p $out
@@ -25,6 +25,8 @@ let
       # properly.
       mkdir -p $out/nix-support
       echo -n "${setJavaClassPath}" > $out/nix-support/propagated-native-build-inputs
+
+      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/jre/lib/libfontmanager.dylib
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook

--- a/pkgs/development/compilers/openjdk-darwin/default.nix
+++ b/pkgs/development/compilers/openjdk-darwin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, setJavaClassPath }:
+{ stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
 let
   jdk = stdenv.mkDerivation {
     name = "openjdk-7u60b30";
@@ -9,7 +9,7 @@ let
       sha256 = "af510a4d566712d82c17054bb39f91d98c69a85586e244c6123669a0bd4b7401";
     };
 
-    buildInputs = [ unzip ];
+    buildInputs = [ unzip freetype ];
 
     installPhase = ''
       mv */Contents/Home $out
@@ -24,6 +24,8 @@ let
       # properly.
       mkdir -p $out/nix-support
       echo -n "${setJavaClassPath}" > $out/nix-support/propagated-native-build-inputs
+
+      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/jre/lib/libfontmanager.dylib
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook


### PR DESCRIPTION
###### Motivation for this change

OpenJDK gives these errors when you don't have Xquartz installed on macOS:

```
Exception in thread "main" java.lang.UnsatisfiedLinkError: /nix/store/dfmh7qh5hc21wx4v5rxq6as5xjfcj2pq-openjdk-7u60b30/jre/lib/libfontmanager.dylib: dlopen(/nix/store/dfmh7qh5hc21wx4v5rxq6as5xjfcj2pq-openjdk-7u60b30/jre/lib/libfontmanager.dylib, 1): Library not loaded: /usr/X11/lib/libfreetype.6.dylib
  Referenced from: /nix/store/dfmh7qh5hc21wx4v5rxq6as5xjfcj2pq-openjdk-7u60b30/jre/lib/libfontmanager.dylib
  Reason: image not found
```

This patches openjdk to resolve to nixpkgs' freetype.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


The freetype path was not working. This fixes it to use the nix
freetype version with install_name_tool.