### PR TITLE
r-modules: Fix `png` package

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -288,7 +288,7 @@ let
     pbdNCDF4 = [ pkgs.netcdf ];
     pbdPROF = [ pkgs.openmpi ];
     PKI = [ pkgs.openssl ];
-    png = [ pkgs.libpng ];
+    png = [ pkgs.libpng.dev ];
     PopGenome = [ pkgs.zlib ];
     proj4 = [ pkgs.proj ];
     qtbase = [ pkgs.qt4 ];


### PR DESCRIPTION
###### Motivation for this change

The R module `png` was broken.

CC: @peti 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


The package requires the `dev` output of `libpng`.