### PR TITLE
mendeley: 1.16.3 -> 1.17.7 - WIP

### DIFF
--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -1,6 +1,8 @@
 { fetchurl, stdenv, dpkg, makeWrapper, which
-, gcc, orc, xorg, qt4, zlib
-, ...}:
+, alsaLib, dbus, expat, fontconfig, freetype, gcc, glib, libcap
+, orc, libxml2, libxslt, nss, nspr, sqlite, xorg, zlib
+, libxkbcommon
+}:
 
 assert stdenv.system == "i686-linux" || stdenv.system == "x86_64-linux";
 
@@ -12,26 +14,53 @@ let
     then "i386"
     else "amd64";
 
-  shortVersion = "1.16.3-stable";
+  shortVersion = "1.17.7-stable";
 
   version = "${shortVersion}_${arch}";
 
   url = "http://desktop-download.mendeley.com/download/apt/pool/main/m/mendeleydesktop/mendeleydesktop_${version}.deb";
   sha256 = if stdenv.system == arch32
-    then "14cxysn1l6s6z8awmqj1glm4146jif0852wiyhjg1dhhh25cvpbv"
-    else "1hdvawj8g4hpj36xy5ys27h1fa76xcdx8apsxa6hpg5xmxvcamqz";
+    then "1frzp5glnxmcad21ilnd5ghs6n1x21w888xi1wbm6dqbfna71p9h"
+    else "0nsfrx3blap3n3q7pn1l69h9v8naqhlmds2vqfxijx54y396xy1x";
 
   deps = [
+    alsaLib
+    dbus
+    expat
+    fontconfig
+    freetype
     gcc.cc
+    glib
+    libcap
+    libxml2
+    libxslt
     orc
-    qt4
+    nspr
+    nss
+    sqlite
     xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    libxkbcommon
+    xorg.libxcb
+    xorg.libICE
+    xorg.libSM
+
     zlib
+#     qt55.qtbase
+#     qt55.qtdeclarative
+#     qt55.qtsvg
+#     qt55.qtwebkit
   ];
 
-in
-
-stdenv.mkDerivation {
+in stdenv.mkDerivation {
   name = "mendeley-${version}";
 
   src = fetchurl {
@@ -51,7 +80,15 @@ stdenv.mkDerivation {
     patchelf --set-interpreter $interpreter $out/bin/mendeleydesktop
 
     librarypath="${stdenv.lib.makeLibraryPath deps}:$out/lib:$out/lib/qt"
-    wrapProgram $out/bin/mendeleydesktop --prefix LD_LIBRARY_PATH : "$librarypath"
+    wrapProgram $out/bin/mendeleydesktop \
+      --prefix LD_LIBRARY_PATH : "$librarypath" \
+      --set QT_PLUGIN_PATH : "$out/plugins/qt/plugins" \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH "$out/plugins/qt/plugins/platforms" \
+      --set QT_XKB_CONFIG_ROOT= "${libxkbcommon}/share/X11/xkb";
+
+    # Remove vendored libraries
+#     rm -rf $out/lib/qt
+
   '';
 
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Since 1.17 Mendeley uses Qt5. And its become massive, growing from 33 MB to 130 MB.


