### PR TITLE
haskell: export `haskellBuildInputs`

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -292,6 +292,7 @@ stdenv.mkDerivation ({
 
     inherit pname version;
 
+    inherit haskellBuildInputs;
     isHaskellLibrary = hasActiveLibrary;
 
     env = stdenv.mkDerivation {


### PR DESCRIPTION
In certain cases one needs the buildInputs of a package to be available, e.g.
for constructing a hoogle database (of which the provided ghc.withHoogle is a
special case).

Example:

`hoogleLocal { packages = haskellPackage.somePkg.haskellBuildInputs; }`