### PR TITLE
darwin.stdenv: use cmake without curl to bootstrap clang

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -1,14 +1,17 @@
 { stdenv, fetchurl, pkgconfig
-, bzip2, curl, expat, libarchive, xz, zlib
-, useNcurses ? false, ncurses, useQt4 ? false, qt4
+, bzip2, expat, libarchive, xz, zlib
+
+, useCurl ? true, curl ? null
+, useNcurses ? false, ncurses ? null
+, useQt4 ? false, qt4 ? null
 , wantPS ? false, ps ? null
 }:
 
 with stdenv.lib;
 
-assert wantPS -> (ps != null);
-assert stdenv ? cc;
-assert stdenv.cc ? libc;
+assert useNcurses -> ncurses != null;
+assert useQt4 -> qt4 != null;
+assert wantPS -> ps != null;
 
 let
   os = stdenv.lib.optionalString;
@@ -36,8 +39,8 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
-  buildInputs =
-    [ setupHook pkgconfig bzip2 curl expat libarchive xz zlib ]
+  buildInputs = [ setupHook pkgconfig bzip2 expat libarchive xz zlib ]
+    ++ optional useCurl curl
     ++ optional useNcurses ncurses
     ++ optional useQt4 qt4;
 
@@ -58,6 +61,7 @@ stdenv.mkDerivation rec {
       "--no-system-jsoncpp"
     ]
     ++ optional (!stdenv.isCygwin) "--system-libs"
+    ++ optional (!useCurl) "--no-system-curl"
     ++ optional useQt4 "--qt-gui"
     ++ ["--"]
     ++ optional (!useNcurses) "-DBUILD_CursesDialog=OFF";
@@ -70,6 +74,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.cmake.org/;
     description = "Cross-Platform Makefile Generator";
     platforms = if useQt4 then qt4.meta.platforms else platforms.all;
-    maintainers = with maintainers; [ urkud mornfall ttuegel ];
+    maintainers = with maintainers; [ urkud mornfall ttuegel lnl7 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5127,9 +5127,35 @@ in
     inherit (stdenvAdapters) overrideCC;
   };
 
-  llvmPackages_37 = callPackage ../development/compilers/llvm/3.7 {
-    inherit (stdenvAdapters) overrideCC;
-  };
+  llvmPackages_37 =
+    let
+
+      libarchiveBoot = callPackage ../development/libraries/libarchive { xarSupport = false; };
+
+      libxml2Boot = callPackage ../development/libraries/libxml2 { pythonSupport = false; };
+
+      cmakeBoot = callPackage ../development/tools/build-managers/cmake {
+        libarchive = libarchiveBoot;
+        useCurl = false;
+        wantPS = stdenv.isDarwin;
+        inherit (darwin) ps;
+      };
+
+      # This is used to bootstrap clang, don't use this as a runtime dependency.
+      python27Boot = callPackage ../development/interpreters/python/cpython/2.7/boot.nix {
+        self = python27Boot;
+        inherit (darwin) CF configd;
+      };
+
+      llvmPackages = callPackage ../development/compilers/llvm/3.7 {
+        cmake = cmakeBoot;
+        libxml2 = libxml2Boot;
+        python2 = python27Boot;
+        inherit (stdenvAdapters) overrideCC;
+      };
+
+    in
+      llvmPackages;
 
   llvmPackages_38 = callPackage ../development/compilers/llvm/3.8 {
     inherit (stdenvAdapters) overrideCC;


### PR DESCRIPTION
###### Motivation for this change

This gets rid of `curl` by using a version of cmake that does not have it as a system library.

I'm testing a branch [WIP](https://github.com/LnL7/nixpkgs/commits/lnl7-wip) with #21078, #21099 and #21101.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```diff
+bootstrap-python-2.7.12.drv
+bzip2-1.0.6.0.1.drv
-bzip2-1.0.6.0.1.drv
-clang-5.3.patch
+cmake-3.6.2.drv
-cmake-3.6.2.drv
-curl-7.51.0.drv
-curl-7.51.0.tar.bz2.drv
-db-5.3.28.drv
-db-5.3.28.tar.gz.drv
-e0ec3471cb09.drv
-gdbm-1.12.drv
-gdbm-1.12.drv
-gdbm-1.12.tar.gz.drv
-hook.drv
+libarchive-3.2.2.drv
-libarchive-3.2.2.drv
-libssh2-1.7.0.drv
-libssh2-1.7.0.tar.gz.drv
-libxml2-2.9.4.drv
-link-against-ncurses.patch
+lzo-2.09.drv
-lzo-2.09.drv
-no-arch_only-6.3.patch
-openssl-1.0.2j.drv
-openssl-1.0.2j.drv
-openssl-1.0.2j.tar.gz.drv
+pkg-config-0.29.drv
-pkg-config-0.29.drv
-properly-detect-curses.patch
-python-2.7-distutils-C++.patch
-python-2.7.12.drv
-python-2.7.12.drv
-readline-6.3.tar.gz.drv
-readline-6.3p08.drv
-readline-6.3p08.drv
-readline63-001.drv
-readline63-002.drv
-readline63-003.drv
-readline63-004.drv
-readline63-005.drv
-readline63-006.drv
-readline63-007.drv
-readline63-008.drv
-setup-hook.sh
-sqlite-3.15.0.drv
-sqlite-autoconf-3150000.tar.gz.drv
-use-etc-ssl-certs.patch
```