### PR TITLE
darwin.stdenv: remove openssl

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -1,11 +1,16 @@
-{
-  fetchurl, stdenv, pkgconfig,
-  acl, attr, bzip2, e2fsprogs, libxml2, lzo, openssl, sharutils, xz, zlib,
+{ fetchurl, stdenv, pkgconfig
+, acl, attr, bzip2, e2fsprogs, sharutils, xz, zlib
 
   # Optional but increases closure only negligibly.
-  xarSupport ? true,
+, withLzo ? true, lzo ? null
+, withOpenssl ? true, openssl ? null
+, xarSupport ? true, libxml2 ? null
 }:
 
+with stdenv.lib;
+
+assert withLzo -> lzo != null;
+assert withOpenssl -> openssl != null;
 assert xarSupport -> libxml2 != null;
 
 stdenv.mkDerivation rec {
@@ -20,23 +25,32 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "lib" "dev" ];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ sharutils zlib bzip2 openssl xz lzo ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ e2fsprogs attr acl ]
-    ++ stdenv.lib.optional xarSupport libxml2;
+
+  buildInputs = [ sharutils zlib bzip2 xz ]
+    ++ optionals stdenv.isLinux [ e2fsprogs attr acl ]
+    ++ optional withLzo lzo
+    ++ optional withOpenssl openssl
+    ++ optional xarSupport libxml2;
 
   # Without this, pkgconfig-based dependencies are unhappy
   propagatedBuildInputs = stdenv.lib.optionals stdenv.isLinux [ attr acl ];
 
-  configureFlags = stdenv.lib.optional (!xarSupport) "--without-xml2";
+  configureFlags = []
+    ++ optional (!withLzo) "--without-lzo"
+    ++ optional (!withOpenssl) "--without-openssl"
+    ++ optional (!xarSupport) "--without-xml2";
 
-  preBuild = if stdenv.isCygwin then ''
+  preBuild = optionalString stdenv.isCygwin ''
     echo "#include <windows.h>" >> config.h
-  '' else null;
+  '';
 
   preFixup = ''
+  '' + optionalString withLzo ''
     sed -i $lib/lib/libarchive.la \
-      -e 's|-lcrypto|-L${openssl.out}/lib -lcrypto|' \
       -e 's|-llzo2|-L${lzo}/lib -llzo2|'
+  '' + optionalString withOpenssl ''
+    sed -i $lib/lib/libarchive.la \
+      -e 's|-lcrypto|-L${openssl.out}/lib -lcrypto|
   '';
 
   meta = {
@@ -47,8 +61,8 @@ stdenv.mkDerivation rec {
       compressed with gzip, bzip2, lzma, xz, ...
     '';
     homepage = http://libarchive.org;
-    license = stdenv.lib.licenses.bsd3;
-    platforms = with stdenv.lib.platforms; all;
-    maintainers = with stdenv.lib.maintainers; [ jcumming ];
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jcumming lnl7 ];
   };
 }

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -15,7 +15,7 @@ let
       sha256 = "0bzyabzr5dvbxglr74d0kbrk2ij5x7s5qcamqi1v546q1had1wz1";
     };
 
-    buildInputs = [ autoconf automake libtool_2 openssl libuuid ] ++
+    buildInputs = [ autoconf automake libtool_2 libuuid ] ++
       # Only need llvm and clang if the stdenv isn't already clang-based (TODO: just make a stdenv.cc.isClang)
       stdenv.lib.optionals (!stdenv.isDarwin) [ llvm clang ] ++
       stdenv.lib.optionals stdenv.isDarwin [ libcxxabi libobjc ];
@@ -73,12 +73,14 @@ let
       popd
     '';
 
-    meta = {
+    meta = with stdenv.lib; {
       homepage = "http://www.opensource.apple.com/source/cctools/";
       description = "Mac OS X Compiler Tools (cross-platform port)";
-      license = stdenv.lib.licenses.apsl20;
+      license = licenses.apsl20;
+      maintainers = with maintainers; [ copumpkin lnl7 ];
     };
   };
+
 in {
   native = stdenv.mkDerivation (baseParams // {
     # A hack for now...

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5127,9 +5127,39 @@ in
     inherit (stdenvAdapters) overrideCC;
   };
 
-  llvmPackages_37 = callPackage ../development/compilers/llvm/3.7 {
-    inherit (stdenvAdapters) overrideCC;
-  };
+  llvmPackages_37 =
+    let
+
+      libxml2Boot = callPackage ../development/libraries/libxml2 { pythonSupport = false; };
+
+      libarchiveBoot = callPackage ../development/libraries/libarchive {
+        withLzo = false;
+        withOpenssl = false;
+        xarSupport = false;
+      };
+
+      cmakeBoot = callPackage ../development/tools/build-managers/cmake {
+        libarchive = libarchiveBoot;
+        useCurl = false;
+        wantPS = stdenv.isDarwin;
+        inherit (darwin) ps;
+      };
+
+      # This is used to bootstrap clang, don't use this as a runtime dependency.
+      python27Boot = callPackage ../development/interpreters/python/cpython/2.7/boot.nix {
+        self = python27Boot;
+        inherit (darwin) CF configd;
+      };
+
+      llvmPackages = callPackage ../development/compilers/llvm/3.7 {
+        cmake = cmakeBoot;
+        libxml2 = libxml2Boot;
+        python2 = python27Boot;
+        inherit (stdenvAdapters) overrideCC;
+      };
+
+    in
+      llvmPackages;
 
   llvmPackages_38 = callPackage ../development/compilers/llvm/3.8 {
     inherit (stdenvAdapters) overrideCC;


### PR DESCRIPTION
###### Motivation for this change

Together with #21078 this will get rid of `openssl` and `lzo` in the darwin stdenv.

I'm testing a branch [WIP](https://github.com/LnL7/nixpkgs/commits/lnl7-wip) with #21078, #21099 and #21101.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```diff
+bootstrap-python-2.7.12.drv
+bzip2-1.0.6.0.1.drv
-bzip2-1.0.6.0.1.drv
-clang-5.3.patch
+cmake-3.6.2.drv
-cmake-3.6.2.drv
-curl-7.51.0.drv
-curl-7.51.0.tar.bz2.drv
-db-5.3.28.drv
-db-5.3.28.tar.gz.drv
-e0ec3471cb09.drv
-gdbm-1.12.drv
-gdbm-1.12.drv
-gdbm-1.12.tar.gz.drv
-hook.drv
+libarchive-3.2.2.drv
-libarchive-3.2.2.drv
-libssh2-1.7.0.drv
-libssh2-1.7.0.tar.gz.drv
-libxml2-2.9.4.drv
-link-against-ncurses.patch
+lzo-2.09.drv
-lzo-2.09.drv
-no-arch_only-6.3.patch
-openssl-1.0.2j.drv
-openssl-1.0.2j.drv
-openssl-1.0.2j.tar.gz.drv
+pkg-config-0.29.drv
-pkg-config-0.29.drv
-properly-detect-curses.patch
-python-2.7-distutils-C++.patch
-python-2.7.12.drv
-python-2.7.12.drv
-readline-6.3.tar.gz.drv
-readline-6.3p08.drv
-readline-6.3p08.drv
-readline63-001.drv
-readline63-002.drv
-readline63-003.drv
-readline63-004.drv
-readline63-005.drv
-readline63-006.drv
-readline63-007.drv
-readline63-008.drv
-setup-hook.sh
-sqlite-3.15.0.drv
-sqlite-autoconf-3150000.tar.gz.drv
-use-etc-ssl-certs.patch
```