### PR TITLE
Fix simp_le certificate creation

### DIFF
--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -15,9 +15,13 @@ pythonPackages.buildPythonApplication rec {
       url = "https://github.com/kuba/simp_le/commit/4bc788fdd611c4118c3f86b5f546779723aca5a7.patch";
       sha256 = "0036p11qn3plydv5s5z6i28r6ihy1ipjl0y8la0izpkiq273byfc";
     })
+    (fetchpatch {
+      url = "https://github.com/kuba/simp_le/commit/9ec7efe593cadb46348dc6924c1e6a31f0f9e636.patch";
+      sha256 = "0n3m94n14y9c42185ly47d061g6awc8vb8xs9abffaigxv59k06j";
+    })
   ];
 
-  propagatedBuildInputs = with pythonPackages; [ acme_0_5_0 ];
+  propagatedBuildInputs = with pythonPackages; [ acme ];
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -412,26 +412,6 @@ in {
       maintainers = with maintainers; [ teh ];
     };
   };
-  acme_0_5_0 = buildPythonPackage rec {
-    version = "0.5.0";
-    name = "acme-${version}";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "letsencrypt";
-      repo = "letsencrypt";
-      rev = "v${version}";
-      sha256 = "0x098cdyfgqvh7x5d3sz56qjpjyg5b4fl82086sm43d8mbz0h5rm";
-    };
-
-    propagatedBuildInputs = with self; [
-      cryptography pyasn1 pyopenssl pyRFC3339 pytz requests2 six werkzeug mock
-      ndg-httpsclient
-    ];
-
-    buildInputs = with self; [ nose ];
-
-    sourceRoot = "letsencrypt-v${version}-src/acme";
-  };
 
   acme = buildPythonPackage rec {
     inherit (pkgs.certbot) src version;


### PR DESCRIPTION
###### Motivation for this change
Fixes simp_le which as of a few days ago can no longer create certificates for new domains


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

