### PR TITLE
tigervnc: fix missing Xvnc (xauth)

### DIFF
--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -39,9 +39,20 @@ stdenv.mkDerivation rec {
     tar xf ${xorg.xorgserver.src}
     cp -R xorg*/* unix/xserver
     pushd unix/xserver
+    version=$(echo ${xorg.xorgserver.name} | sed 's/.*-\([0-9]\+\).\([0-9]\+\).*/\1\2/g')
+    patch -p1 < ${src}/unix/xserver$version.patch
     autoreconf -vfi
-    ./configure $configureFlags --disable-devel-docs --disable-docs --disable-xinerama --disable-xvfb --disable-xnest \
-        --disable-xorg --disable-dmx --disable-dri --disable-dri2 --disable-glx \
+    ./configure $configureFlags  --disable-devel-docs --disable-docs \
+        --disable-xorg --disable-xnest --disable-xvfb --disable-dmx \
+        --disable-xwin --disable-xephyr --disable-kdrive --with-pic \
+        --disable-xorgcfg --disable-xprint --disable-static \
+        --disable-composite --disable-xtrap --enable-xcsecurity \
+        --disable-{a,c,m}fb \
+        --disable-xwayland \
+        --disable-config-dbus --disable-config-udev --disable-config-hal \
+        --disable-xevie \
+        --disable-dri --disable-dri2 --disable-dri3 --enable-glx \
+        --enable-install-libxf86config \
         --prefix="$out" --disable-unit-tests \
         --with-xkb-path=${xkeyboard_config}/share/X11/xkb \
         --with-xkb-bin-directory=${xorg.xkbcomp}/bin \
@@ -49,9 +60,9 @@ stdenv.mkDerivation rec {
     make TIGERVNC_SRCDIR=`pwd`/../..
     popd
   '';
-  
+
   postInstall = ''
-    pushd unix/xserver
+    pushd unix/xserver/hw/vnc
     make TIGERVNC_SRCDIR=`pwd`/../.. install
     popd
     rm -f $out/lib/xorg/protocol.txt


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


the xorg patch was not applied.
Also a different root for `make install` is needed.
In addition more unnessary option are disabled.