### PR TITLE
opencv3: pull patches only if necessary

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -42,16 +42,17 @@ stdenv.mkDerivation rec {
     sha256 = "1l0w12czavgs0wzw1c594g358ilvfg2fn32cn8z7pv84zxj4g429";
   };
 
-  patches = [
-    (fetchpatch { # Patch for CUDA 8 compatibility
-      url = "https://github.com/opencv/opencv/commit/10896129b39655e19e4e7c529153cb5c2191a1db.patch";
-      sha256 = "0jka3kxxywgs3prqqgym5kav6p73rrblwj50k1nf3fvfpk194ah1";
-    })
-    (fetchpatch { # Patch to add CUDA Compute Capability compilation targets up to 6.0
-      url = "https://github.com/opencv/opencv/commit/d76f258aebdf63f979a205cabe6d3e81700a7cd8.patch";
-      sha256 = "00b3msfgrcw7laij6qafn4b18c1dl96xxpzwx05wxzrjldqb6kqg";
-    })
-  ];
+  patches =
+    lib.optionals enableCuda [
+      (fetchpatch { # Patch for CUDA 8 compatibility
+        url = "https://github.com/opencv/opencv/commit/10896129b39655e19e4e7c529153cb5c2191a1db.patch";
+        sha256 = "0jka3kxxywgs3prqqgym5kav6p73rrblwj50k1nf3fvfpk194ah1";
+      })
+      (fetchpatch { # Patch to add CUDA Compute Capability compilation targets up to 6.0
+        url = "https://github.com/opencv/opencv/commit/d76f258aebdf63f979a205cabe6d3e81700a7cd8.patch";
+        sha256 = "00b3msfgrcw7laij6qafn4b18c1dl96xxpzwx05wxzrjldqb6kqg";
+      })
+    ];
 
   preConfigure =
     let ippicvVersion = "20151201";


### PR DESCRIPTION
###### Motivation for this change
Only pull patches for fixing specific functionalities in OpenCV 3 iff
1. The end user requires it in order for the functionality requested to work properly
2. The source code MUST be amended to work as intended

This also implies a specific context for each patch applied; for example, the CUDA patches are wrapped in a `lib.optionals enableCUDA` if-block, which tells the reader that the patches are meant for CUDA.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

