### PR TITLE
linux_{4_8,grsec_nixos}: patch to fix build failure

### DIFF
--- a/pkgs/os-specific/linux/kernel/multithreaded-rsapubkey-asn1.patch
+++ b/pkgs/os-specific/linux/kernel/multithreaded-rsapubkey-asn1.patch
@@ -1,0 +1,45 @@
+
+From	Yang Shi <>
+Subject	[PATCH] crypto: rsa - fix a potential race condition in build
+Date	Fri, 2 Dec 2016 15:41:04 -0800
+
+
+When building kernel with RSA enabled with multithreaded, the below
+compile failure might be caught:
+
+| /buildarea/kernel-source/crypto/rsa_helper.c:18:28: fatal error: rsapubkey-asn1.h: No such file or directory
+| #include "rsapubkey-asn1.h"
+| ^
+| compilation terminated.
+| CC crypto/rsa-pkcs1pad.o
+| CC crypto/algboss.o
+| CC crypto/testmgr.o
+| make[3]: *** [/buildarea/kernel-source/scripts/Makefile.build:289: crypto/rsa_helper.o] Error 1
+| make[3]: *** Waiting for unfinished jobs....
+| make[2]: *** [/buildarea/kernel-source/Makefile:969: crypto] Error 2
+| make[1]: *** [Makefile:150: sub-make] Error 2
+| make: *** [Makefile:24: __sub-make] Error 2
+
+The header file is not generated before rsa_helper is compiled, so
+adding dependency to avoid such issue.
+
+Signed-off-by: Yang Shi <yang.shi@windriver.com>
+
+---
+ crypto/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/crypto/Makefile b/crypto/Makefile
+index 99cc64a..8db39f9 100644
+--- a/crypto/Makefile
++++ b/crypto/Makefile
+@@ -40,6 +40,7 @@ obj-$(CONFIG_CRYPTO_ECDH) += ecdh_generic.o
+
+ $(obj)/rsapubkey-asn1.o: $(obj)/rsapubkey-asn1.c $(obj)/rsapubkey-asn1.h
+ $(obj)/rsaprivkey-asn1.o: $(obj)/rsaprivkey-asn1.c $(obj)/rsaprivkey-asn1.h
++$(obj)/rsa_helper.o: $(obj)/rsa_helper.c $(obj)/rsaprivkey-asn1.h
+ clean-files += rsapubkey-asn1.c rsapubkey-asn1.h
+ clean-files += rsaprivkey-asn1.c rsaprivkey-asn1.h
+
+--
+2.0.2

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -38,6 +38,12 @@ in
 
 rec {
 
+  multithreaded_rsapubkey =
+    {
+      name = "multithreaded-rsapubkey-asn1.patch";
+      patch = ./multithreaded-rsapubkey-asn1.patch;
+    };
+
   bridge_stp_helper =
     { name = "bridge-stp-helper";
       patch = ./bridge-stp-helper.patch;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10985,6 +10985,7 @@ in
   linux_4_8 = callPackage ../os-specific/linux/kernel/linux-4.8.nix {
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
+        kernelPatches.multithreaded_rsapubkey
         # See pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
         # when adding a new linux version
         # !!! 4.7 patch doesn't apply, 4.8 patch not up yet, will keep checking
@@ -11191,6 +11192,7 @@ in
     inherit (lib) overrideDerivation;
     kernel = callPackage ../os-specific/linux/kernel/linux-grsecurity.nix {
       kernelPatches = with self.kernelPatches; [
+        kernelPatches.multithreaded_rsapubkey
         bridge_stp_helper
         modinst_arg_list_too_long
       ] ++ lib.optionals ((platform.kernelArch or null) == "mips")


### PR DESCRIPTION
###### Motivation for this change
Frequent kernel build failures have plagued the release branch since upgrading from 4.8.12. My understanding is this issue as fixed a long time ago, but it appears to have opened up since. This patch should hopefully fix the issue.

Example problem: https://hydra.nixos.org/build/44743895/nixlog/1

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


crypto/rsa_helper.c:18:28: fatal error: rsapubkey-asn1.h: No such file or directory

cc @joachifm (grsec)
cc @fpletz (kernel)
cc @NeQuissimus (kernel)

I'd like to get this done before tomorrow so we can have prompt releases.