### PR TITLE
ponyc: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation ( rec {
   name = "ponyc-${version}";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
     rev = version;
-    sha256 = "1g2i3x9k36h5rx7ifx0i6hn78xlj42i86x8apwzvkh0y84y88adi";
+    sha256 = "1v314abmhlqsj8iyab61cf8nb4kbddv1ycnw29z53mpbmivk4gn0";
   };
 
   buildInputs = [ llvm makeWrapper which ];


### PR DESCRIPTION
###### Motivation for this change

New Pony release https://github.com/ponylang/ponyc/releases/tag/0.10.0

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


