### PR TITLE
bazaar: enable sftp transport

### DIFF
--- a/pkgs/applications/version-management/bazaar/default.nix
+++ b/pkgs/applications/version-management/bazaar/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, python2Packages }:
+{ stdenv, fetchurl, python2Packages
+, withSFTP ? true
+ }:
 
 python2Packages.buildPythonApplication rec {
   version = "2.7";
@@ -11,6 +13,9 @@ python2Packages.buildPythonApplication rec {
   };
 
   doCheck = false;
+
+  propagatedBuildInputs = []
+  ++ stdenv.lib.optionals withSFTP [ python2Packages.paramiko ];
 
   # Bazaar can't find the certificates alone
   patches = [ ./add_certificates.patch ];


### PR DESCRIPTION
###### Motivation for this change

SFTP transport needs python paramiko package, which is now an optional
input

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


