### PR TITLE
shell_cmds: init at 198

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -40,6 +40,7 @@ let
       basic_cmds    = "55";
       adv_cmds      = "163";
       file_cmds     = "264.1.1";
+      shell_cmds    = "187";
     };
     "osx-10.11.5" = {
       Libc          = "1082.50.1"; # 10.11.6 still unreleased :/
@@ -233,6 +234,7 @@ let
     developer_cmds  = applePackage "developer_cmds"    "osx-10.11.6"     "1r9c2b6dcl22diqf90x58psvz797d3lxh4r2wppr7lldgbgn24di" {};
     network_cmds    = applePackage "network_cmds"      "osx-10.11.6"     "0lhi9wz84qr1r2ab3fb4nvmdg9gxn817n5ldg7zw9gnf3wwn42kw" {};
     file_cmds       = applePackage "file_cmds"         "osx-10.11.6"     "1zfxbmasps529pnfdjvc13p7ws2cfx8pidkplypkswyff0nff4wp" {};
+    shell_cmds      = applePackage "shell_cmds"        "osx-10.11.6"     "0084k271v66h4jqp7q7rmjvv7w4mvhx3aq860qs8jbd30canm86n" {};
 
     libsecurity_apple_csp      = libsecPackage "libsecurity_apple_csp"      "osx-10.7.5" "1ngyn1ik27n4x981px3kfd1z1n8zx7r5w812b6qfjpy5nw4h746w" {};
     libsecurity_apple_cspdl    = libsecPackage "libsecurity_apple_cspdl"    "osx-10.7.5" "1svqa5fhw7p7njzf8bzg7zgc5776aqjhdbnlhpwmr5hmz5i0x8r7" {};

--- a/pkgs/os-specific/darwin/apple-source-releases/shell_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/shell_cmds/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, appleDerivation, xcbuild }:
+
+appleDerivation rec {
+  buildInputs = [ xcbuild ];
+
+  patchPhase = ''
+    # NOTE: these hashes must be recalculated for each version change
+
+    # disables:
+    # - su ('security/pam_appl.h' file not found)
+    # - find (Undefined symbol '_get_date')
+    # - w (Undefined symbol '_res_9_init')
+    substituteInPlace shell_cmds.xcodeproj/project.pbxproj \
+      --replace "FCBA168714A146D000AA698B /* PBXTargetDependency */," "" \
+      --replace "FCBA165914A146D000AA698B /* PBXTargetDependency */," "" \
+      --replace "FCBA169514A146D000AA698B /* PBXTargetDependency */," ""
+
+    # disable w, test install
+    # get rid of permission stuff
+    substituteInPlace xcodescripts/install-files.sh \
+      --replace 'ln -f "$BINDIR/w" "$BINDIR/uptime"' "" \
+      --replace 'ln -f "$DSTROOT/bin/test" "$DSTROOT/bin/["' "" \
+      --replace "-o root -g wheel -m 0755" "" \
+      --replace "-o root -g wheel -m 0644" ""
+  '';
+
+  # temporary install phase until xcodebuild has "install" support
+  installPhase = ''
+    mkdir -p $out/usr/bin
+    install shell_cmds-*/Build/Products/Release/* $out/usr/bin
+
+    export DSTROOT=$out
+    export SRCROOT=$PWD
+    . xcodescripts/install-files.sh
+
+    mv $out/usr/* $out
+    mv $out/private/etc $out
+    rmdir $out/usr $out/private
+  '';
+
+  meta = {
+    platforms = stdenv.lib.platforms.darwin;
+    maintainers = with stdenv.lib.maintainers; [ matthewbauer ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

This adds Apple's shell_cmds which contains the following binaries:
- alias
- apply
- basename
- bg
- cd
- chroot
- command
- date
- dirname
- echo
- env
- false
- fc
- fg
- getopt
- getopts
- groups
- hash
- hexdump
- hostname
- id
- jobs
- jot
- kill
- killall
- lastcomm
- locate
- locate.bigram
- locate.code
- logname
- mktemp
- nice
- nohup
- od
- path_helper
- printenv
- printf
- pwd
- read
- renice
- script
- seq
- shlock
- sleep
- systime
- tee
- time
- true
- type
- ulimit
- umask
- unalias
- uname
- users
- wait
- what
- whereis
- which
- who
- whoami
- xargs
- yes

These are **disabled** currently because they don't build:
- w
- find
- su

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


fixes #11707