### PR TITLE
ffcast: init at 2.5.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -188,6 +188,7 @@
   gridaphobe = "Eric Seidel <eric@seidel.io>";
   guibert = "David Guibert <david.guibert@gmail.com>";
   guillaumekoenig = "Guillaume Koenig <guillaume.edward.koenig@gmail.com>";
+  guyonvarch = "Joris Guyonvarch <joris@guyonvarch.me>";
   hakuch = "Jesse Haber-Kucharsky <hakuch@gmail.com>";
   havvy = "Ryan Scheel <ryan.havvy@gmail.com>";
   hbunke = "Hendrik Bunke <bunke.hendrik@gmail.com>";

--- a/pkgs/tools/X11/ffcast/default.nix
+++ b/pkgs/tools/X11/ffcast/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit, autoconf, automake, perl, libX11 }:
+
+stdenv.mkDerivation rec {
+  name = "ffcast-${version}";
+  version = "2.5.0";
+  rev = "7c3bf681e7ca9b242e55dbf0c07856ed994d94e9";
+
+  src = fetchgit {
+    url = https://github.com/lolilolicon/FFcast;
+    sha256 = "1s1y6rqjq126jvdzc75wz20szisbz8h8fkphlwxcxzl9xll17akj";
+  };
+
+  buildInputs = [ autoconf automake perl libX11 ];
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  configureFlags = [ "--enable-xrectsel" ];
+
+  postBuild = ''
+    make DESTDIR="$out" install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Run commands on rectangular screen regions";
+    homepage = https://github.com/lolilolicon/FFcast;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.guyonvarch ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6958,6 +6958,8 @@ in
 
   fcgi = callPackage ../development/libraries/fcgi { };
 
+  ffcast = callPackage ../tools/X11/ffcast { };
+
   fflas-ffpack = callPackage ../development/libraries/fflas-ffpack {};
   fflas-ffpack_1 = callPackage ../development/libraries/fflas-ffpack/1.nix {};
 


### PR DESCRIPTION
###### Motivation for this change

Add ffcast package

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


