### PR TITLE
bird: refactor module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -211,7 +211,6 @@
       lambdabot = 191;
       asterisk = 192;
       plex = 193;
-      bird = 195;
       grafana = 196;
       skydns = 197;
       ripple-rest = 198;
@@ -470,7 +469,6 @@
       #asterisk = 192; # unused
       plex = 193;
       sabnzbd = 194;
-      bird = 195;
       #grafana = 196; #unused
       #skydns = 197; #unused
       #ripple-rest = 198; #unused

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -1,76 +1,68 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkEnableOption mkIf mkOption singleton types;
-  inherit (pkgs) bird;
-  cfg = config.services.bird;
+  inherit (lib) mkEnableOption mkIf mkOption types;
 
-  configFile = pkgs.writeText "bird.conf" ''
-    ${cfg.config}
-  '';
-in
-
-{
-
-  ###### interface
-
-  options = {
-
-    services.bird = {
-
-      enable = mkEnableOption "BIRD Internet Routing Daemon";
-
-      config = mkOption {
-        type = types.string;
-        description = ''
-          BIRD Internet Routing Daemon configuration file.
-          <link xlink:href='http://bird.network.cz/'/>
+  generic = variant:
+    let
+      cfg = config.services.${variant};
+      pkg = pkgs.${variant};
+      birdc = if variant == "bird6" then "birdc6" else "birdc";
+      configFile = pkgs.stdenv.mkDerivation {
+        name = "${variant}.conf";
+        text = cfg.config;
+        preferLocalBuild = true;
+        buildCommand = ''
+          echo -n "$text" > $out
+          ${pkg}/bin/${variant} -d -p -c $out
         '';
       };
-
-      user = mkOption {
-        type = types.string;
-        default = "bird";
-        description = ''
-          BIRD Internet Routing Daemon user.
-        '';
+    in {
+      ###### interface
+      options = {
+        services.${variant} = {
+          enable = mkEnableOption "BIRD Internet Routing Daemon";
+          config = mkOption {
+            type = types.lines;
+            description = ''
+              BIRD Internet Routing Daemon configuration file.
+              <link xlink:href='http://bird.network.cz/'/>
+            '';
+          };
+        };
       };
 
-      group = mkOption {
-        type = types.string;
-        default = "bird";
-        description = ''
-          BIRD Internet Routing Daemon group.
-        '';
-      };
-
-    };
-
-  };
-
-
-  ###### implementation
-
-  config = mkIf cfg.enable {
-
-    users.extraUsers = singleton {
-      name = cfg.user;
-      description = "BIRD Internet Routing Daemon user";
-      uid = config.ids.uids.bird;
-      group = cfg.group;
-    };
-
-    users.extraGroups = singleton {
-      name = cfg.group;
-      gid = config.ids.gids.bird;
-    };
-
-    systemd.services.bird = {
-      description = "BIRD Internet Routing Daemon";
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        ExecStart   = "${bird}/bin/bird -d -c ${configFile} -s /var/run/bird.ctl -u ${cfg.user} -g ${cfg.group}";
+      ###### implementation
+      config = mkIf cfg.enable {
+        systemd.services.${variant} = {
+          description = "BIRD Internet Routing Daemon";
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "forking";
+            Restart = "on-failure";
+            ExecStart = "${pkg}/bin/${variant} -c ${configFile} -u ${variant} -g ${variant}";
+            ExecReload = "${pkg}/bin/${birdc} configure";
+            ExecStop = "${pkg}/bin/${birdc} down";
+            CapabilityBoundingSet = [ "CAP_CHOWN" "CAP_FOWNER" "CAP_DAC_OVERRIDE" "CAP_SETUID" "CAP_SETGID"
+                                      # see bird/sysdep/linux/syspriv.h
+                                      "CAP_NET_BIND_SERVICE" "CAP_NET_BROADCAST" "CAP_NET_ADMIN" "CAP_NET_RAW" ];
+            ProtectSystem = "full";
+            ProtectHome = "yes";
+            SystemCallFilter="~@cpu-emulation @debug @keyring @module @mount @obsolete @raw-io";
+            MemoryDenyWriteExecute = "yes";
+          };
+        };
+        users = {
+          extraUsers.${variant} = {
+            description = "BIRD Internet Routing Daemon user";
+            group = "${variant}";
+          };
+          extraGroups.${variant} = {};
+        };
       };
     };
-  };
+
+  inherit (config.services) bird bird6;
+in {
+  imports = [(generic "bird") (generic "bird6")];
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- proper bird6 support

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


- syntax check before deploying configuration
- remove static unnessary static uid/gid (configuration is opened as root)
- add service hardening