### PR TITLE
xrectsel: init at 0.3.2

### DIFF
--- a/pkgs/tools/X11/ffcast/default.nix
+++ b/pkgs/tools/X11/ffcast/default.nix
@@ -1,22 +1,19 @@
-{ stdenv, fetchgit, autoconf, automake, perl, libX11 }:
+{ stdenv, fetchFromGitHub, autoreconfHook, automake, perl, libX11 }:
 
 stdenv.mkDerivation rec {
   name = "ffcast-${version}";
   version = "2.5.0";
-  rev = "7c3bf681e7ca9b242e55dbf0c07856ed994d94e9";
 
-  src = fetchgit {
-    url = https://github.com/lolilolicon/FFcast;
-    sha256 = "1s1y6rqjq126jvdzc75wz20szisbz8h8fkphlwxcxzl9xll17akj";
+  src = fetchFromGitHub {
+    owner = "lolilolicon";
+    repo = "FFcast";
+    rev = "${version}";
+    sha256 = "047y32bixhc8ksr98vwpgd0k1xxgsv2vs0n3kc2xdac4krc9454h";
   };
 
-  buildInputs = [ autoconf automake perl libX11 ];
+  buildInputs = [ autoreconfHook automake perl libX11 ];
 
-  preConfigure = ''
-    ./bootstrap
-  '';
-
-  configureFlags = [ "--enable-xrectsel" ];
+  configureFlags = [ "--disable-xrectsel" ];
 
   postBuild = ''
     make DESTDIR="$out" install

--- a/pkgs/tools/X11/ffcast/default.nix
+++ b/pkgs/tools/X11/ffcast/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, automake, perl, libX11 }:
+{ stdenv, fetchFromGitHub, autoreconfHook, perl, libX11 }:
 
 stdenv.mkDerivation rec {
   name = "ffcast-${version}";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "047y32bixhc8ksr98vwpgd0k1xxgsv2vs0n3kc2xdac4krc9454h";
   };
 
-  buildInputs = [ autoreconfHook automake perl libX11 ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ perl libX11 ];
 
   configureFlags = [ "--disable-xrectsel" ];
 

--- a/pkgs/tools/X11/xrectsel/default.nix
+++ b/pkgs/tools/X11/xrectsel/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, automake, libX11 }:
+
+stdenv.mkDerivation rec {
+  name = "xrectsel-${version}";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "lolilolicon";
+    repo = "xrectsel";
+    rev = "${version}";
+    sha256 = "0prl4ky3xzch6xcb673mcixk998d40ngim5dqc5374b1ls2r6n7l";
+  };
+
+  buildInputs = [ autoreconfHook automake libX11 ];
+
+  postBuild = ''
+    make DESTDIR="$out" install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Print the geometry of a rectangular screen region";
+    homepage = https://github.com/lolilolicon/xrectsel;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.guyonvarch ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/X11/xrectsel/default.nix
+++ b/pkgs/tools/X11/xrectsel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, automake, libX11 }:
+{ stdenv, fetchFromGitHub, autoreconfHook, libX11 }:
 
 stdenv.mkDerivation rec {
   name = "xrectsel-${version}";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0prl4ky3xzch6xcb673mcixk998d40ngim5dqc5374b1ls2r6n7l";
   };
 
-  buildInputs = [ autoreconfHook automake libX11 ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ libX11 ];
 
   postBuild = ''
     make DESTDIR="$out" install

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15480,6 +15480,8 @@ in
   #TODO: 'pil' is not available for python3, yet
   xpraGtk3 = callPackage ../tools/X11/xpra/gtk3.nix { inherit (texFunctions) fontsConf; inherit (python3Packages) buildPythonApplication python cython pygobject3 pycairo; };
 
+  xrectsel = callPackage ../tools/X11/xrectsel { };
+
   xrestop = callPackage ../tools/X11/xrestop { };
 
   xsd = callPackage ../development/libraries/xsd { };


### PR DESCRIPTION
###### Motivation for this change

- Separate xrectsel from ffcast
- Modify ffcast so that it does not expose xrectsel anymore

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


