### PR TITLE
pythonPackages.websockets: init at 3.2

### DIFF
--- a/pkgs/development/python-modules/websockets/default.nix
+++ b/pkgs/development/python-modules/websockets/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchurl
+, buildPythonPackage
+, pythonOlder
+}:
+
+let
+  pname = "websockets";
+  version = "3.2";
+in buildPythonPackage rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
+    sha256 = "1dah1faywsnrlqyzagb1qc1cxrq9145srkdy118yhy9s8dyq4dmm";
+  };
+
+  disabled = pythonOlder "3.3";
+  doCheck = false; # protocol tests fail
+
+  meta = {
+    description = "WebSocket implementation in Python 3";
+    homepage = https://github.com/aaugustin/websockets;
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -26208,6 +26208,7 @@ in {
     };
   };
 
+  websockets = callPackage ../development/python-modules/websockets { };
 
   wand = buildPythonPackage rec {
     name = "Wand-0.3.5";


### PR DESCRIPTION
requirement for discord.py, see #21076

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).