### PR TITLE
pythonPackages.parsedatetime: update

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17989,11 +17989,19 @@ in {
 
   parsedatetime = buildPythonPackage rec {
     name = "parsedatetime-${version}";
-    version = "1.5";
+    version = "2.1";
+
+    meta = {
+      description = "Parse human-readable date/time text";
+      homepage = "https://github.com/bear/parsedatetime";
+      license = licenses.asl20;
+    };
+
+    buildInputs = with self; [ PyICU nose ];
 
     src = pkgs.fetchurl {
         url = "mirror://pypi/p/parsedatetime/${name}.tar.gz";
-        sha256 = "1as0mm4ql3z0324nc9bys2s1ngh507i317p16b79rx86wlmvx9ix";
+        sha256 = "0bdgyw6y3v7bcxlx0p50s8drxsh5bb5cy2afccqr3j90amvpii8p";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
Added metadata, disabled tests so parsedatetime builds again

---

Building the parsedatetime python module failed at the tests with the error
```
======================================================================
FAIL: testEndOfPhrases (parsedatetime.tests.TestStartTimeFromSourceTime.test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/timo/nix-build-python3.5-parsedatetime-1.5.drv-0/parsedatetime-1.5/parsedatetime/tests/TestStartTimeFromSourceTime.py", line 41, in testEndOfPhrases
    self.assertExpectedResult(self.cal.parse('eom',         start), (target, 2))
  File "/tmp/timo/nix-build-python3.5-parsedatetime-1.5.drv-0/parsedatetime-1.5/parsedatetime/tests/__init__.py", line 40, in decoratedComparator
    self.fail(failureMessage % (result, check))
AssertionError: Result does not match target value

        Result:
        ((2017, 12, 31, 13, 14, 15, 3, 348, -1), 2)

        Expected:
        (time.struct_time(tm_year=2016, tm_mon=12, tm_mday=31, tm_hour=13, tm_min=14, tm_sec=15, tm_wday=5, tm_yday=366, tm_isdst=-1), 2)
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).