### PR TITLE
packagekit: add 'enableNixBackend' as an option 

### DIFF
--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-systemd"
-    "--enable-nix"
+# TODO: enable nix-backend again
+#   "--enable-nix"
     "--disable-dummy"
     "--disable-cron"
     "--disable-introspection"

--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, lib
 , intltool, glib, pkgconfig, polkit, python, sqlite, systemd
 , gobjectIntrospection, vala_0_23, gtk_doc, autoreconfHook, autoconf-archive
-, nix, boost
+# TODO: set enableNixBackend to true, as soon as it builds
+, nix, enableNixBackend ? false, boost
 , enableCommandNotFound ? false
 , enableBashCompletion ? false, bash-completion ? null }:
 
@@ -28,8 +29,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-systemd"
-# TODO: enable nix-backend again
-#   "--enable-nix"
     "--disable-dummy"
     "--disable-cron"
     "--disable-introspection"
@@ -39,6 +38,7 @@ stdenv.mkDerivation rec {
     "--with-dbus-sys=$(out)/etc/dbus-1/system.d"
     "--with-systemdsystemunitdir=$(out)/lib/systemd/system/"
   ]
+  ++ lib.optional enableNixBackend "--enable-nix"
   ++ lib.optional (!enableBashCompletion) "--disable-bash-completion"
   ++ lib.optional (!enableCommandNotFound) "--disable-command-not-found";
 


### PR DESCRIPTION
###### Motivation for this change packagekit: add 'enableNixBackend' as an option 
packagekit doesn't compile on my computers because of a broken nix-backend.
i am not good at fixing cpp, so i cant really analyse the source. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

