### PR TITLE
kexec-tools: 2.0.12 -> 2.0.13 (fix broken cflags)

### DIFF
--- a/pkgs/os-specific/linux/kexectools/default.nix
+++ b/pkgs/os-specific/linux/kexectools/default.nix
@@ -2,17 +2,17 @@
 
 stdenv.mkDerivation rec {
   name = "kexec-tools-${version}";
-  version = "2.0.12";
+  version = "2.0.13";
 
   src = fetchurl {
     urls = [
       "mirror://kernel/linux/utils/kernel/kexec/${name}.tar.xz"
       "http://horms.net/projects/kexec/kexec-tools/${name}.tar.xz"
     ];
-    sha256 = "03cj7w2l5fqn72xfhl4q6z0zbziwkp9bfn0gs7gaf9i44jv6gkhl";
+    sha256 = "1k75p9h29xx57l1c69ravm4pg9pmriqxmwja12hgrnvi251ayjw7";
   };
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pic" "relro" ];
 
   buildInputs = [ zlib ];
 


### PR DESCRIPTION
###### Motivation for this change

also fix kexec by removing faulty hardeningFlags.
this is probably also broken in stable.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


