### PR TITLE
ntp: make timesyncd the new default

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -84,6 +84,18 @@ in
       '';
     };
 
+    networking.timeServers = mkOption {
+      default = [
+        "0.nixos.pool.ntp.org"
+        "1.nixos.pool.ntp.org"
+        "2.nixos.pool.ntp.org"
+        "3.nixos.pool.ntp.org"
+      ];
+      description = ''
+        The set of NTP servers from which to synchronise.
+      '';
+    };
+
     networking.proxy = {
 
       default = lib.mkOption {

--- a/nixos/modules/services/networking/chrony.nix
+++ b/nixos/modules/services/networking/chrony.nix
@@ -31,7 +31,7 @@ in
       };
 
       servers = mkOption {
-        default = config.services.ntp.servers;
+        default = config.networking.timeServers;
         description = ''
           The set of NTP servers from which to synchronise.
         '';
@@ -102,7 +102,7 @@ in
         home = stateDir;
       };
 
-    systemd.services.ntpd.enable = mkForce false;
+    systemd.services.timesyncd.enable = mkForce false;
 
     systemd.services.chronyd =
       { description = "chrony NTP daemon";

--- a/nixos/modules/services/networking/ntpd.nix
+++ b/nixos/modules/services/networking/ntpd.nix
@@ -34,7 +34,7 @@ in
     services.ntp = {
 
       enable = mkOption {
-        default = !config.boot.isContainer;
+        default = false;
         description = ''
           Whether to synchronise your machine's time using the NTP
           protocol.
@@ -42,12 +42,7 @@ in
       };
 
       servers = mkOption {
-        default = [
-          "0.nixos.pool.ntp.org"
-          "1.nixos.pool.ntp.org"
-          "2.nixos.pool.ntp.org"
-          "3.nixos.pool.ntp.org"
-        ];
+        default = config.networking.timeServers;
         description = ''
           The set of NTP servers from which to synchronise.
         '';
@@ -70,6 +65,7 @@ in
 
     # Make tools such as ntpq available in the system path.
     environment.systemPackages = [ pkgs.ntp ];
+    services.timesyncd.enable = mkForce false;
 
     users.extraUsers = singleton
       { name = ntpUser;

--- a/nixos/modules/services/networking/openntpd.nix
+++ b/nixos/modules/services/networking/openntpd.nix
@@ -49,7 +49,7 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-    services.ntp.enable = mkForce false;
+    services.timesyncd.enable = mkForce false;
 
     # Add ntpctl to the environment for status checking
     environment.systemPackages = [ package ];

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -687,8 +687,5 @@ in
     };
 
     services.resolved.enable = mkDefault true;
-    services.timesyncd.enable = mkDefault config.services.ntp.enable;
-
   };
-
 }

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -6,14 +6,21 @@ with lib;
 
   options = {
 
-    services.timesyncd.enable = mkOption {
-      default = false;
-      type = types.bool;
-      description = ''
-        Enables the systemd NTP client daemon.
-      '';
+    services.timesyncd = {
+      enable = mkOption {
+        default = !config.boot.isContainer;
+        type = types.bool;
+        description = ''
+          Enables the systemd NTP client daemon.
+        '';
+      };
+      servers = mkOption {
+        default = config.networking.timeServers;
+        description = ''
+          The set of NTP servers from which to synchronise.
+        '';
+      };
     };
-
   };
 
   config = mkIf config.services.timesyncd.enable {
@@ -29,8 +36,6 @@ with lib;
       [Time]
       NTP=${concatStringsSep " " config.services.ntp.servers}
     '';
-
-    systemd.services.ntpd.enable = false;
 
     users.extraUsers.systemd-timesync.uid = config.ids.uids.systemd-timesync;
     users.extraGroups.systemd-timesync.gid = config.ids.gids.systemd-timesync;

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -125,7 +125,7 @@ in
     169.254.169.254 metadata.google.internal metadata
   '';
 
-  services.ntp.servers = [ "metadata.google.internal" ];
+  networking.timeServers = [ "metadata.google.internal" ];
 
   networking.usePredictableInterfaceNames = false;
 

--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -57,7 +57,7 @@ in
 
     boot.kernelModules = [ "prl_tg" "prl_eth" "prl_fs" "prl_fs_freeze" "acpi_memhotplug" ];
 
-    services.ntp.enable = false;
+    services.timesyncd.enable = false;
 
     systemd.services.prltoolsd = {
       description = "Parallels Tools' service";

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -470,7 +470,7 @@ in
     boot.initrd.luks.devices = mkVMOverride {};
 
     # Don't run ntpd in the guest.  It should get the correct time from KVM.
-    services.ntp.enable = false;
+    services.timesyncd.enable = false;
 
     system.build.vm = pkgs.runCommand "nixos-vm" { preferLocalBuild = true; }
       ''

--- a/nixos/modules/virtualisation/xen-domU.nix
+++ b/nixos/modules/virtualisation/xen-domU.nix
@@ -18,5 +18,5 @@
   services.syslogd.tty = "hvc0";
 
   # Don't run ntpd, since we should get the correct time from Dom0.
-  services.ntp.enable = false;
+  services.timesyncd.enable = false;
 }


### PR DESCRIPTION
###### Motivation for this change

- most nixos user only require time synchronisation,
  while ntpd implements a battery-included ntp server (1,215 LOCs of C-Code vs 64,302)
- timesyncd support ntp server per interface (if configured through dhcp for instance, fix https://github.com/NixOS/nixpkgs/issues/7542 if networkd is used)
- timesyncd is already included in the systemd package, switching to it would
  save a little disk space (1,5M)
- ntpd has a history of weird hang ups: https://github.com/NixOS/nixpkgs/issues/21136

What do you think? I would appreciate, if you would thumb up/down on this pull request.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


