### PR TITLE
Add vim-markdown plugin

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1039,6 +1039,17 @@ rec {
 
   };
 
+  vim-markdown = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "vim-markdown-2016-05-19";
+    src = fetchgit {
+      url = "git://github.com/plasticboy/vim-markdown";
+      rev = "a3169545f330ec8080244c3ad755bb2211eca8a0";
+      sha256 = "1ycqx280xpc5gvfx8rrnmkqlv8q8g51hgiryx6yvd9a8ci805cx1";
+    };
+    dependencies = [];
+
+  };
+
   vim-racer = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "vim-racer-2016-10-18";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -79,6 +79,7 @@
 "github:neovimhaskell/haskell-vim"
 "github:osyo-manga/shabadou.vim"
 "github:osyo-manga/vim-watchdogs"
+"github:plasticboy/vim-markdown"
 "github:racer-rust/vim-racer"
 "github:raichoo/purescript-vim"
 "github:rhysd/vim-grammarous"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


