### PR TITLE
darwin.libunwind: fix source

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -220,7 +220,7 @@ let
     libresolv       = applePackage "libresolv"         "osx-10.11.6"     "09flfdi3dlzq0yap32sxidacpc4nn4va7z12a6viip21ix2xb2gf" {};
     Libsystem       = applePackage "Libsystem"         "osx-10.11.6"     "1nfkmbqml587v2s1d1y2s2v8nmr577jvk51y6vqrfvsrhdhc2w94" {};
     libutil         = applePackage "libutil"           "osx-10.11.6"     "1gmgmcyqdyc684ih7dimdmxdljnq7mzjy5iqbf589wc0pa8h5abm" {};
-    libunwind       = applePackage "libunwind"         "osx-10.11.6"     "16nhx2pahh9d62mvszc88q226q5lwjankij276fxwrm8wb50zzlx" {};
+    libunwind       = applePackage "libunwind"         "osx-10.11.6"     "0miffaa41cv0lzf8az5k1j1ng8jvqvxcr4qrlkf3xyj479arbk1b" {};
     mDNSResponder   = applePackage "mDNSResponder"     "osx-10.11.6"     "069incq28a78yh1bnr17h9cd5if5mwqpq8ahnkyxxx25fkaxgzcf" {};
     objc4           = applePackage "objc4"             "osx-10.11.6"     "00b7vbgxni8frrqyi69b4njjihlwydzjd9zj9x4z5dbx8jabkvrj" {};
     ppp             = applePackage "ppp"               "osx-10.11.6"     "1dql6r1v0vbcs04958nn2i6p31yfsxyy51jca63bm5mf0gxalk3f" {};

--- a/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libunwind/default.nix
@@ -1,15 +1,16 @@
 { stdenv, appleDerivation, dyld, osx_private_sdk }:
 
 appleDerivation {
-  phases = [ "unpackPhase" "installPhase" ];
+  buildPhase = ":";
 
+  # install headers only
   installPhase = ''
     mkdir -p $out/lib
     cp -R include $out/include
   '';
 
   meta = with stdenv.lib; {
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = with maintainers; [ copumpkin lnl7 ];
     platforms   = platforms.darwin;
     license     = licenses.apsl20;
   };


### PR DESCRIPTION
###### Motivation for this change

Unlike #21003 this fixes the julia build and doesn't break ruby.
Since this was the same sha as the linux package nix just used that instead. 🙁

Fixes #20977.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---