### PR TITLE
erlang_basho_R16: add explicit Carbon and Cocoa support

### DIFF
--- a/pkgs/development/interpreters/erlang/R16B02-8-basho.nix
+++ b/pkgs/development/interpreters/erlang/R16B02-8-basho.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ perl gnum4 ncurses openssl makeWrapper autoconf264 gcc 
     ] ++ optional wxSupport [ mesa wxGTK xorg.libX11 ]
-      ++ optional odbcSupport [ unixODBC ];
+      ++ optional odbcSupport [ unixODBC ]
+      ++ optionals stdenv.isDarwin [ Carbon Cocoa ];
 
   patchPhase = '' sed -i "s@/bin/rm@rm@" lib/odbc/configure.in erts/configure.in '';
 


### PR DESCRIPTION
###### Motivation for this change
erlang_basho_R16 currently inherits Carbon and Cocoa but doesn't explicitly state their compile flags when building the Mac OS X version of the package. This should be amended to include these flags.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

