### PR TITLE
xcbuild: add meta

### DIFF
--- a/pkgs/development/tools/xcbuild/default.nix
+++ b/pkgs/development/tools/xcbuild/default.nix
@@ -41,4 +41,11 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ cmake zlib libxml2 libpng ninja ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices CoreGraphics ImageIO ];
+
+  meta = with stdenv.lib; {
+    description = "Xcode-compatible build tool";
+    homepage = https://github.com/facebook/xcbuild;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ copumpkin matthewbauer ];
+  };
 }

--- a/pkgs/development/tools/xcbuild/platform.nix
+++ b/pkgs/development/tools/xcbuild/platform.nix
@@ -19,10 +19,10 @@ let
   # is removed because NixPkgs only supports darwin-x86_64.
   Architectures = [
     {
-		  Identifier = "Standard";
-	    Type = "Architecture";
-		  Name = "Standard Architectures (64-bit Intel)";
-		  RealArchitectures = [ "x86_64" ];
+      Identifier = "Standard";
+      Type = "Architecture";
+      Name = "Standard Architectures (64-bit Intel)";
+      RealArchitectures = [ "x86_64" ];
       ArchitectureSetting = "ARCHS_STANDARD";
     }
     {

--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -64,6 +64,8 @@ stdenv.mkDerivation {
       --set DEVELOPER_DIR "$out"
   '';
 
+  inherit (xcbuild) meta;
+
   passthru = {
     raw = xcbuild;
   };


### PR DESCRIPTION
###### Motivation for this change

This should make hydra build the darwin derivation.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


