### PR TITLE
ior: init at 3.0.1

### DIFF
--- a/pkgs/tools/system/ior/default.nix
+++ b/pkgs/tools/system/ior/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, openmpi, automake, autoconf, perl }:
+
+let
+  version = "3.0.1";
+  sha256 = "039rh4z3lsj4vqjsqgakk0b7dkrdrkkzj0p1cjikpc9gn36zpghc";
+in
+
+stdenv.mkDerivation rec {
+  name = "ior-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/LLNL/ior/archive/${version}.tar.gz";
+    inherit sha256;
+  };
+
+  buildInputs = [ openmpi automake autoconf perl ];
+
+  enableParallelBuilding = true;
+
+  preConfigure = "./bootstrap";
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.nersc.gov/users/computational-systems/cori/nersc-8-procurement/trinity-nersc-8-rfp/nersc-8-trinity-benchmarks/ior/";
+    description = "Parallel file system I/O performance test";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ bzizou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2246,6 +2246,8 @@ in
   ioping = callPackage ../tools/system/ioping { };
 
   iops = callPackage ../tools/system/iops { };
+  
+  ior = callPackage ../tools/system/ior { };
 
   iodine = callPackage ../tools/networking/iodine { };
 


### PR DESCRIPTION
###### Motivation for this change
IOR is a benchmark tool for parallel file systems. It will be very useful for us as we are using NIX in an HPC environment.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


