### PR TITLE
ImageMagick: Add additional mirror.

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
       "mirror://imagemagick/releases/ImageMagick-${version}.tar.xz"
       # the original source above removes tarballs quickly
       "http://distfiles.macports.org/ImageMagick/ImageMagick-${version}.tar.xz"
+      "https://bintray.com/homebrew/mirror/download_file?file_path=imagemagick-${version}.tar.xz"
     ];
     inherit (cfg) sha256;
   };


### PR DESCRIPTION
###### Motivation for this change
Cherrypick additional source tarball mirror from master, since all the existing mirrors are inoperable.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


The 16.09-nixpkgs source tarball Imagemagick-6.9.6-7.tar.xz source tarball is
not available on any of the existing mirrors. We here add one that has it.

(cherry picked from commit e314e5b9304b5a9be811145bf5275163912192ba)