### PR TITLE
virtualbox: 5.1.8 -> 5.1.10

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/update.py
+++ b/pkgs/applications/virtualization/virtualbox/update.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python3
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3
+
 import os
 import re
 import json

--- a/pkgs/applications/virtualization/virtualbox/upstream-info.json
+++ b/pkgs/applications/virtualization/virtualbox/upstream-info.json
@@ -1,8 +1,8 @@
 {
   "__NOTE": "Generated using update.py from the same directory.",
-  "extpack": "d28bcd01c14eb07eedd2b964d1abe4876f0a7e0e89530e7ba285a5d6267bf322",
-  "extpackRev": "111374",
-  "guest": "347fd39df6ddee8079ad41fbc038e2fb64952a40255d75292e8e49a0a0cbf657",
-  "main": "e447031de468aee746529b2cf60768922f9beff22a13c54284aa430f5e925933",
-  "version": "5.1.8"
+  "extpack": "3982657fd4853bcbc79b9162e618545a479b65aca08e9ced43a904aeeba3ffa5",
+  "extpackRev": "112026",
+  "guest": "29fa0af66a3dd273b0c383c4adee31a52061d52f57d176b67f444698300b8c41",
+  "main": "98073b1b2adee4e6553df73cb5bb6ea8ed7c3a41a475757716fd9400393bea40",
+  "version": "5.1.10"
 }


### PR DESCRIPTION
###### Motivation for this change

Works fine here. Additionally, I changed the ```update.py``` script to run via nix-shell so we can express the python3 dependency.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


