### PR TITLE
unigine-valley: refactor

### DIFF
--- a/pkgs/applications/graphics/unigine-valley/default.nix
+++ b/pkgs/applications/graphics/unigine-valley/default.nix
@@ -93,6 +93,8 @@ in
         --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:$instdir/bin:$libPath
     '';
 
+    stripDebugList = ["lib/unigine/valley/bin"];
+
     meta = {
       description = "The Unigine Valley GPU benchmarking tool";
       homepage = "http://unigine.com/products/benchmarks/valley/";

--- a/pkgs/applications/graphics/unigine-valley/default.nix
+++ b/pkgs/applications/graphics/unigine-valley/default.nix
@@ -16,7 +16,6 @@
 
 let
   version = "1.0";
-  pkgversion = "1";
 
   arch = if stdenv.system == "x86_64-linux" then
     "x64"
@@ -27,7 +26,7 @@ let
 
 in
   stdenv.mkDerivation {
-    name = "unigine-valley-${version}-${pkgversion}";
+    name = "unigine-valley-${version}";
 
     src = fetchurl {
       url = "http://assets.unigine.com/d/Unigine_Valley-${version}.run";

--- a/pkgs/applications/graphics/unigine-valley/default.nix
+++ b/pkgs/applications/graphics/unigine-valley/default.nix
@@ -70,7 +70,7 @@ in
     buildPhase = "";
 
     installPhase = ''
-      instdir=$out/opt/unigine/valley
+      instdir=$out/lib/unigine/valley
 
       # Install executables and libraries
       mkdir -p $instdir/bin
@@ -96,7 +96,7 @@ in
     meta = {
       description = "The Unigine Valley GPU benchmarking tool";
       homepage = "http://unigine.com/products/benchmarks/valley/";
-      license = stdenv.lib.licenses.unfree; # see also: /nix/store/*-unigine-valley-1.0/opt/unigine/valley/documentation/License.pdf
+      license = stdenv.lib.licenses.unfree; # see also: /nix/store/*-unigine-valley-1.0/lib/unigine/valley/documentation/License.pdf
       maintainers = [ stdenv.lib.maintainers.kierdavis ];
       platforms = ["x86_64-linux" "i686-linux"];
     };


### PR DESCRIPTION
###### Motivation for this change

I was quite inexperienced with Nix/NixOS when I wrote this expression a couple of months ago. This PR cleans up the expression to be more consistent with other Nix expressions.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Changes:

* Remove unnecessary and un-Nix-y "release version".
* Only run strip over the directory containing binaries and shared libraries, rather than the entire installation directory.
* Change install location from `$out/opt/unigine/valley` to `$out/lib/unigine/valley`.
* Define the above install location in a derivation variable, so that it doesn't have to copy-pasted everywhere.
* Remove debug messages from ELF patching phase.
* Clean up some comments.

There are a few other things that I'd like to fix in the near future, but need some more input:

* The upstream package should work on 32-bit and 64-bit x86 systems; however I think this expression will only work on 64-bit systems, since I've hardcoded the ELF interpreter path to `${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2`. Do I need to use a different ELF interpreter for 32-bit ELFs? If so, what path can it be found at? Alternatively, is choosing an appropriate ELF interpreter already handled somewhere else in nixpkgs, so I can just use something along the lines of `${stdenv.elfInterpreter}` instead?
* This expression only works on NixOS at the moment. Getting it to work on Linux+Nix or macOS+Nix systems would require locating `libGL.so.1` on that system. Is there a built in way to pick the right directory to add to `LD_LIBRARY_PATH` for this, or does this expression need to do the logic itself?
* As requested in #20547, I think it should be straightforward to package Unigine's other graphics benchmarks. Perhaps a single generic expression could be used for all of them.