### PR TITLE
Fiddle LD_LIBRARY_PATH to include GDAL

### DIFF
--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation {
     wrapProgram $out/bin/grass70 \
     --set PYTHONPATH $PYTHONPATH \
     --set GRASS_PYTHON ${python2Packages.python}/bin/${python2Packages.python.executable}
+    --suffix LD_LIBRARY_PATH ':' '${gdal}/lib'
     ln -s $out/grass-*/lib $out/lib
   '';
 


### PR DESCRIPTION
###### Motivation for this change
GRASS commands like `r.sun` that use GDAL don't work because they can't `dlopen` one or more GDAL libraries.
If I `export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/nix/store/"*gdal*(:d)/lib` after starting grass then it works (using the zsh fancy glob).
This seems like the consistent way of doing that change.

There may be a better equivalent change which touches the source so that it refers to the absolute library path in `dlopen` instead?
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).