### PR TITLE
stanchion: add Darwin support

### DIFF
--- a/pkgs/servers/nosql/riak-cs/stanchion.nix
+++ b/pkgs/servers/nosql/riak-cs/stanchion.nix
@@ -1,11 +1,13 @@
-{ stdenv, lib, fetchurl, unzip, erlang, git, wget, which, pam, coreutils, riak }:
+{ stdenv, lib, fetchurl, unzip, erlang, git, wget, which, pam, coreutils, riak 
+, Carbon ? null, Cocoa ? null }:
 
 stdenv.mkDerivation rec {
   name = "stanchion-2.1.1";
 
   buildInputs = [
-    which unzip erlang pam git wget
-  ];
+    which unzip erlang git wget
+  ] ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa ]
+    ++ lib.optional stdenv.isLinux [ pam ];
 
   src = fetchurl {
     url = "http://s3.amazonaws.com/downloads.basho.com/stanchion/2.1/2.1.1/stanchion-2.1.1.tar.gz";
@@ -57,7 +59,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     maintainers = with maintainers; [ mdaiter ];
     description = "Manager for Riak CS";
-    platforms   = [ "x86_64-linux" ];
+    platforms   = [ "x86_64-linux" "x86_64-darwin" ];
     license = licenses.asl20;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10293,6 +10293,7 @@ in
   };
 
   stanchion = callPackage ../servers/nosql/riak-cs/stanchion.nix {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
     erlang = erlang_basho_R16B02;
   };
 


### PR DESCRIPTION
###### Motivation for this change
We should get this package running on Darwin.
Previous build attempts resulted in failures from Stanchion's inability to find the Cocoa and Carbon frameworks. These changes should solve that.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
