### PR TITLE
fix 2 xml errors in the description of efiInstallAsRemovable

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -361,7 +361,7 @@ in
         example = true;
         type = types.bool;
         description = ''
-          Whether to invoke <literal>grub-install</literal> with
+          <para>Whether to invoke <literal>grub-install</literal> with
           <literal>--removable</literal>.</para>
 
           <para>Unless you turn this on, GRUB will install itself somewhere in
@@ -391,6 +391,7 @@ in
             <listitem><para>You simply dislike the idea of depending on NVRAM
             state to make your drive bootable</para></listitem>
           </itemizedlist>
+          </para>
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
