### PR TITLE
uxrvtd: Fix clipboard

### DIFF
--- a/nixos/modules/services/x11/urxvtd.nix
+++ b/nixos/modules/services/x11/urxvtd.nix
@@ -32,6 +32,7 @@ in {
 
       services.urxvtd = {
         description = "urxvt terminal daemon";
+        path = [ pkgs.xsel ];
         serviceConfig = {
           ExecStart = "${pkgs.rxvt_unicode-with-plugins}/bin/urxvtd -o";
           Environment = "RXVT_SOCKET=%t/urxvtd-socket";


### PR DESCRIPTION
###### Motivation for this change
Without either xsel (called by default) or xclip in the path the urxvt daemon can't access the primary selection/clipboard.

###### Things done

- [x] Tested
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
