### PR TITLE
Haskell generic builder: enable parallel builds for GHC 8.0.2

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -114,6 +114,7 @@ let
     (optionalString (isGhcjs || versionOlder "7" ghc.version) (enableFeature enableStaticLibraries "library-vanilla"))
     (optionalString (isGhcjs || versionOlder "7.4" ghc.version) (enableFeature enableSharedExecutables "executable-dynamic"))
     (optionalString (isGhcjs || versionOlder "7" ghc.version) (enableFeature doCheck "tests"))
+    (optionalString (versionOlder "8.0.1" ghc.version) "--ghc-option=-j$NIX_BUILD_CORES")
   ] ++ optionals isGhcjs [
     "--with-hsc2hs=${nativeGhc}/bin/hsc2hs"
     "--ghcjs"


### PR DESCRIPTION
According to https://ghc.haskell.org/trac/ghc/ticket/4012, this should/could work again. I think it's worthwhile enabling it and if errors appear, we report to upstream.