### PR TITLE
openshift: 1.3.1 -> 1.3.2

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,9 +1,11 @@
 { stdenv, fetchFromGitHub, go, which }:
 
 let
-  version = "1.3.1";
-  versionMajor = "1";
-  versionMinor = "3";
+  version = "1.3.2";
+  ver = stdenv.lib.elemAt (stdenv.lib.splitString "." version);
+  versionMajor = ver 0;
+  versionMinor = ver 1;
+  versionPatch = ver 2;
 in
 stdenv.mkDerivation rec {
   name = "openshift-origin-${version}";
@@ -13,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "openshift";
     repo = "origin";
     rev = "v${version}";
-    sha256 = "1kxa1k38hvi1vg52p82mmkmp9k4bbbm2pryzapsxwga7d8x4bnbh";
+    sha256 = "0zw8zb9c6icigcq6y47ppnjnqyghk2kril07bapbddvgnvbbfp6m";
   };
 
   buildInputs = [ go which ];
@@ -43,7 +45,7 @@ stdenv.mkDerivation rec {
     description = "Build, deploy, and manage your applications with Docker and Kubernetes";
     license = licenses.asl20;
     homepage = http://www.openshift.org;
-    maintainers = with maintainers; [offline];
+    maintainers = with maintainers; [offline bachp];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update OpenShift to latest version including security fixes.

Further remove some redundancy in version specification.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


