### PR TITLE
ripgrep: 0.2.1 -> 0.3.2

### DIFF
--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "ripgrep-${version}";
-  version = "0.2.1";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = "ripgrep";
     rev = "${version}";
-    sha256 = "0whw6hqjkf6sysrfv931jaia2hqhy8m9aa5rxax1kygm4snz4j85";
+    sha256 = "15j68bkkxpbh9c05f8l7j0y33da01y28kpg781lc0234h45535f3";
   };
 
-  depsSha256 = "10f7pkgaxwizl7kzhkry7wx1rgm9wsybwkk92myc29s7sqir2mx4";
+  depsSha256 = "142h6pcf2mr4i7dg7di4299c18aqn0yvk9nr1mxnkb7wjcmrvcfg";
 
   meta = with stdenv.lib; {
     description = "An untility that combines the usability of The Silver Searcher with the raw speed of grep";

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2016-12-03";
-  rev = "94e482dd6667aa239e5b3b8590fc9bfa0c1fd376";
-  sha256 = "0k300vhc0m8a0165pikl6rvyz0w20dnlacpb9b4jjl7gfixynlmz";
+  version = "2016-12-16";
+  rev = "1da5a7d0cd31d72324481760067bde5cf2e07be5";
+  sha256 = "0kbh3aq738sqns8w6yfia17fwrk98g6m763wqsqwhnrg2ndqrp8d";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change

Update first rustRegistry and then ripgrep to the last versions

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

