### PR TITLE
fzf: 0.15.1 -> 0.15.9

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "fzf-${version}";
-  version = "0.15.1";
+  version = "0.15.9";
   rev = "${version}";
 
   goPackagePath = "github.com/junegunn/fzf";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "junegunn";
     repo = "fzf";
-    sha256 = "0wj5nhrrgx4nkiqwjp5wpfzdyikrjv4qr5x39s5094yc4p2k30b1";
+    sha256 = "0r099mk9r6f52qqhx0ifb1xa8f2isqvyza80z9mcpi5zkd96174l";
   };
 
   buildInputs = [ ncurses ];
@@ -41,5 +41,6 @@ buildGoPackage rec {
     description = "A command-line fuzzy finder written in Go";
     license = licenses.mit;
     platforms = platforms.unix;
+    maintainers = [ maintainers.mimadrid ];
   };
 }

--- a/pkgs/tools/misc/fzf/deps.nix
+++ b/pkgs/tools/misc/fzf/deps.nix
@@ -17,4 +17,13 @@
       sha256 = "08la0axabk9hiba9mm4ypp6a116qhvdlxa1jvkxhv3d4zpjsp4n7";
     };
   }
+  {
+    goPackagePath = "github.com/junegunn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/junegunn/go-isatty";
+      rev = "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8";
+      sha256 = "17lf13ndnai9a6dlmykqkdyzf1z04q7kffs0l7kvd78wpv3l6rm5";
+    };
+  }
 ]


### PR DESCRIPTION
###### Motivation for this change

Update fzf to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


