### PR TITLE
pg_similarity: init at 1.0

### DIFF
--- a/pkgs/servers/sql/postgresql/pg_similarity/default.nix
+++ b/pkgs/servers/sql/postgresql/pg_similarity/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, gcc, postgresql }:
+
+stdenv.mkDerivation {
+
+  name = "pg_similarity-1.0";
+  src = fetchFromGitHub {
+    owner = "eulerto";
+    repo = "pg_similarity";
+    rev = "be1a8b08c8716e59b89982557da9ea68cdf868c5";
+    sha256 = "1z4v4r2yccdr8kz3935fnk1bc5vj0qj0apscldyap4wxlyi89xim";
+  };
+
+  buildInputs = [ postgresql gcc ];
+  buildPhase = "USE_PGXS=1 make";
+  installPhase = ''
+    mkdir -p $out/bin   # for buildEnv to setup proper symlinks
+    install -D pg_similarity.so -t $out/lib/
+    install -D ./{pg_similarity--unpackaged--1.0.sql,pg_similarity--1.0.sql,pg_similarity.control} -t $out/share/extension
+  '';
+
+  meta = {
+    description = ''
+       pg_similarity is an extension to support similarity queries on PostgreSQL. The implementation
+       is tightly integrated in the RDBMS in the sense that it defines operators so instead of the traditional
+       operators (= and <>) you can use ~~~ and ~!~ (any of these operators represents a similarity function).
+    '';
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ danbst ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8892,6 +8892,8 @@ in
 
   pg_repack = callPackage ../servers/sql/postgresql/pg_repack {};
 
+  pg_similarity = callPackage ../servers/sql/postgresql/pg_similarity {};
+
   phonon = callPackage ../development/libraries/phonon {};
 
   phonon-backend-gstreamer = callPackage ../development/libraries/phonon/backends/gstreamer.nix {};


### PR DESCRIPTION
###### Motivation for this change
Fullfills request at https://github.com/NixOS/nixpkgs/issues/13410

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Here is an automated test to check that `CREATE EXTENSION pg_similarity` works:

```
import <nixpkgs/nixos/tests/make-test.nix> {

  machine = { pkgs, ...}: { 
    services.postgresql.enable = true;
    services.postgresql.package = pkgs.postgresql95;
    services.postgresql.extraPlugins = [
      (pkgs.pg_similarity.override { postgresql = pkgs.postgresql95; })
    ];
    systemd.services.test-postgresql.wantedBy = [ "multi-user.target" ];
    systemd.services.test-postgresql.after = [ "postgresql.service" ];
    systemd.services.test-postgresql.script = ''
      ${pkgs.postgresql95}/bin/psql -c "CREATE EXTENSION pg_similarity" -d postgres
      sleep 100
    '';
  };

  testScript =
    ''
      $machine->start;
      $machine->waitForUnit("test-postgresql.service");
    '';
}
```