### PR TITLE
gplates: init at 2.0.0

### DIFF
--- a/pkgs/applications/science/misc/gplates/boostfix.patch
+++ b/pkgs/applications/science/misc/gplates/boostfix.patch
@@ -1,0 +1,612 @@
+--- a/src/app-logic/ApplicationState.h
++++ b/src/app-logic/ApplicationState.h
+@@ -33,6 +33,7 @@
+ #include <boost/shared_ptr.hpp>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "FeatureCollectionFileState.h"
+ #include "Layer.h"
+ #include "LayerTaskRegistry.h"
+@@ -48,6 +49,7 @@
+ #include "model/ModelInterface.h"
+ #include "model/types.h"
+ #include "model/WeakReferenceCallback.h"
++#endif
+ 
+ ////////////////////////////////////////////////////////////////////////////////////////////////
+ // NOTE: Please use forward declarations (and boost::scoped_ptr) instead of including headers
+--- a/src/app-logic/CoRegistrationLayerTask.h
++++ b/src/app-logic/CoRegistrationLayerTask.h
+@@ -32,11 +32,13 @@
+ #include <QObject>
+ #include <QString>
+ 
++#ifndef Q_MOC_RUN
+ #include "CoRegistrationLayerParams.h"
+ #include "CoRegistrationLayerProxy.h"
+ #include "LayerTask.h"
+ 
+ #include "model/FeatureCollectionHandle.h"
++#endif
+ 
+ namespace GPlatesAppLogic
+ {
+--- a/src/app-logic/RasterLayerTask.h
++++ b/src/app-logic/RasterLayerTask.h
+@@ -32,11 +32,13 @@
+ #include <QObject>
+ #include <QString>
+ 
++#ifndef Q_MOC_RUN
+ #include "LayerTask.h"
+ #include "RasterLayerParams.h"
+ #include "RasterLayerProxy.h"
+ 
+ #include "model/FeatureCollectionHandle.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/app-logic/ReconstructGraph.h
++++ b/src/app-logic/ReconstructGraph.h
+@@ -46,6 +46,7 @@
+ #include <boost/lambda/construct.hpp>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "FeatureCollectionFileState.h"
+ #include "Layer.h"
+ #include "Reconstruction.h"
+@@ -53,6 +54,7 @@
+ 
+ #include "model/FeatureCollectionHandle.h"
+ #include "model/WeakReferenceCallback.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/app-logic/ReconstructLayerTask.h
++++ b/src/app-logic/ReconstructLayerTask.h
+@@ -33,6 +33,7 @@
+ #include <QObject>
+ #include <QString>
+ 
++#ifndef Q_MOC_RUN
+ #include "LayerTask.h"
+ #include "ReconstructLayerProxy.h"
+ #include "ReconstructLayerParams.h"
+@@ -42,6 +43,7 @@
+ #include "maths/types.h"
+ 
+ #include "model/FeatureCollectionHandle.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/app-logic/ReconstructScalarCoverageLayerParams.h
++++ b/src/app-logic/ReconstructScalarCoverageLayerParams.h
+@@ -30,6 +30,7 @@
+ #include <boost/optional.hpp>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "LayerParams.h"
+ #include "ReconstructScalarCoverageLayerProxy.h"
+ #include "ReconstructScalarCoverageParams.h"
+@@ -38,6 +39,7 @@
+ #include "property-values/ValueObjectType.h"
+ 
+ #include "utils/SubjectObserverToken.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/app-logic/ReconstructScalarCoverageLayerTask.h
++++ b/src/app-logic/ReconstructScalarCoverageLayerTask.h
+@@ -30,12 +30,14 @@
+ #include <boost/shared_ptr.hpp>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "LayerTask.h"
+ #include "ReconstructScalarCoverageLayerParams.h"
+ #include "ReconstructScalarCoverageLayerProxy.h"
+ #include "ScalarCoverageFeatureProperties.h"
+ 
+ #include "model/FeatureCollectionHandle.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/app-logic/TopologyNetworkResolverLayerTask.h
++++ b/src/app-logic/TopologyNetworkResolverLayerTask.h
+@@ -33,6 +33,7 @@
+ #include <QObject>
+ #include <QString>
+ 
++#ifndef Q_MOC_RUN
+ #include "LayerParams.h"
+ #include "LayerTask.h"
+ #include "ReconstructLayerProxy.h"
+@@ -41,6 +42,7 @@
+ #include "TopologyNetworkResolverLayerProxy.h"
+ 
+ #include "model/FeatureCollectionHandle.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/app-logic/VelocityFieldCalculatorLayerTask.h
++++ b/src/app-logic/VelocityFieldCalculatorLayerTask.h
+@@ -32,9 +32,11 @@
+ #include <QObject>
+ #include <QString>
+ 
++#ifndef Q_MOC_RUN
+ #include "LayerTask.h"
+ #include "VelocityFieldCalculatorLayerParams.h"
+ #include "VelocityFieldCalculatorLayerProxy.h"
++#endif
+ 
+ #include "model/FeatureCollectionHandle.h"
+ 
+--- a/src/data-mining/CoRegConfigurationTable.h
++++ b/src/data-mining/CoRegConfigurationTable.h
+@@ -28,6 +28,7 @@
+ 
+ #include <vector>
+ #include <map>
++#ifndef Q_MOC_RUN
+ #include <boost/operators.hpp>
+ 
+ #include "CoRegFilter.h"
+@@ -44,6 +45,7 @@
+ #include "scribe/Transcribe.h"
+ #include "scribe/TranscribeContext.h"
+ 
++#endif
+ 
+ namespace GPlatesDataMining
+ {
+--- a/src/gui/CommandServer.h
++++ b/src/gui/CommandServer.h
+@@ -38,9 +38,11 @@
+ #include <QRegExp>
+ #include <QtXml/QXmlStreamReader>
+ 
++#ifndef Q_MOC_RUN
+ #include "app-logic/ApplicationState.h"
+ 
+ #include "presentation/ViewState.h"
++#endif
+ 
+ namespace GPlatesGui
+ {
+--- a/src/gui/FeatureTableModel.h
++++ b/src/gui/FeatureTableModel.h
+@@ -32,8 +32,10 @@
+ #include <QItemSelection>
+ #include <QHeaderView>
+ 
++#ifndef Q_MOC_RUN
+ #include "app-logic/Layer.h"
+ #include "app-logic/ReconstructionGeometry.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/gui/TopologyTools.h
++++ b/src/gui/TopologyTools.h
+@@ -35,6 +35,7 @@
+ #include <QDebug>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "TopologySectionsContainer.h"
+ 
+ #include "app-logic/Layer.h"
+@@ -64,6 +65,7 @@
+ #include "utils/UnicodeStringUtils.h"
+ 
+ #include "view-operations/RenderedGeometryCollection.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/opengl/GLVisualLayers.h
++++ b/src/opengl/GLVisualLayers.h
+@@ -35,6 +35,7 @@
+ #include <boost/shared_ptr.hpp>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "GLAgeGridMaskSource.h"
+ #include "GLContext.h"
+ #include "GLLight.h"
+@@ -79,6 +80,7 @@
+ 
+ #include "view-operations/RenderedGeometry.h"
+ #include "view-operations/ScalarField3DRenderParameters.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/presentation/VisualLayer.h
++++ b/src/presentation/VisualLayer.h
+@@ -32,6 +32,7 @@
+ #include <QString>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "VisualLayerParams.h"
+ #include "VisualLayerType.h"
+ 
+@@ -42,6 +43,7 @@
+ #include "model/FeatureCollectionHandle.h"
+ 
+ #include "view-operations/RenderedGeometryCollection.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/presentation/VisualLayers.h
++++ b/src/presentation/VisualLayers.h
+@@ -34,6 +34,7 @@
+ #include <boost/weak_ptr.hpp>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "VisualLayer.h"
+ 
+ #include "app-logic/FeatureCollectionFileState.h"
+@@ -42,6 +43,7 @@
+ #include "gui/Symbol.h"
+ 
+ #include "view-operations/RenderedGeometryCollection.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/qt-widgets/AssignReconstructionPlateIdsDialog.h
++++ b/src/qt-widgets/AssignReconstructionPlateIdsDialog.h
+@@ -39,6 +39,7 @@
+ #include "GPlatesDialog.h"
+ #include "InformationDialog.h"
+ 
++#ifndef Q_MOC_RUN
+ #include "app-logic/AssignPlateIds.h"
+ 
+ #include "file-io/File.h"
+@@ -47,6 +48,7 @@
+ #include "model/ModelInterface.h"
+ 
+ #include "presentation/VisualLayer.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/qt-widgets/CoRegistrationLayerConfigurationDialog.h
++++ b/src/qt-widgets/CoRegistrationLayerConfigurationDialog.h
+@@ -38,6 +38,7 @@
+ 
+ #include "OpenDirectoryDialog.h"
+ 
++#ifndef Q_MOC_RUN
+ #include "app-logic/ApplicationState.h"
+ #include "app-logic/Layer.h"
+ #include "app-logic/LayerInputChannelName.h"
+@@ -45,6 +46,7 @@
+ 
+ #include "data-mining/CheckAttrTypeVisitor.h"
+ #include "data-mining/CoRegConfigurationTable.h"
++#endif
+ 
+ #include "global/PointerTraits.h"
+ 
+--- a/src/qt-widgets/CoRegistrationOptionsWidget.h
++++ b/src/qt-widgets/CoRegistrationOptionsWidget.h
+@@ -31,6 +31,7 @@
+ #include "CoRegistrationLayerConfigurationDialog.h"
+ #include "CoRegistrationOptionsWidgetUi.h"
+ #include "LayerOptionsWidget.h"
++#ifndef Q_MOC_RUN
+ #include "CoRegistrationResultTableDialog.h"
+ 
+ #include "app-logic/CoRegistrationLayerTask.h"
+@@ -41,7 +42,7 @@
+ #include "file-io/File.h"
+ 
+ #include "presentation/VisualLayer.h"
+-
++#endif
+ 
+ namespace GPlatesAppLogic
+ {
+--- a/src/qt-widgets/CoRegistrationResultTableDialog.h
++++ b/src/qt-widgets/CoRegistrationResultTableDialog.h
+@@ -36,6 +36,7 @@
+ #include <QEvent>
+ #include <qevent.h>
+ 
++#ifndef Q_MOC_RUN
+ #include "CoRegistrationResultTableDialogUi.h"
+ #include "SaveFileDialog.h"
+ 
+@@ -43,6 +44,7 @@
+ #include "data-mining/OpaqueDataToQString.h"
+ 
+ #include "presentation/VisualLayer.h"
++#endif
+ 
+ namespace GPlatesPresentation
+ {
+--- a/src/qt-widgets/DrawStyleDialog.h
++++ b/src/qt-widgets/DrawStyleDialog.h
+@@ -33,6 +33,7 @@
+ #include <QMutex>
+ #include <QMutexLocker>
+ 
++#ifndef Q_MOC_RUN
+ #include "DrawStyleDialogUi.h"
+ #include "GPlatesDialog.h"
+ #include "PythonArgumentWidget.h"
+@@ -41,6 +42,7 @@
+ #include "gui/PythonConfiguration.h"
+ 
+ #include "presentation/Application.h"
++#endif
+ 
+ namespace GPlatesAppLogic
+ {
+--- a/src/qt-widgets/EditTableActionWidget.h
++++ b/src/qt-widgets/EditTableActionWidget.h
+@@ -27,8 +27,11 @@
+ #define GPLATES_QTWIDGETS_EDITTABLEACTIONWIDGET_H
+ 
+ #include <QWidget>
++
++#ifndef Q_MOC_RUN
+ #include "app-logic/ApplicationState.h"
+ #include "EditTableActionWidgetUi.h"
++#endif
+ 
+ namespace GPlatesQtWidgets
+ {
+--- a/src/qt-widgets/GlobeCanvas.h
++++ b/src/qt-widgets/GlobeCanvas.h
+@@ -41,6 +41,7 @@
+ #include <QPainter>
+ #include <QtOpenGL/qgl.h>
+ 
++#ifndef Q_MOC_RUN
+ #include "gui/ColourScheme.h"
+ #include "gui/Globe.h"
+ #include "gui/ViewportZoom.h"
+@@ -58,6 +59,7 @@
+ #include "qt-widgets/SceneView.h"
+ 
+ #include "view-operations/RenderedGeometryFactory.h"
++#endif
+ 
+ 
+ namespace GPlatesGui
+--- a/src/qt-widgets/LogDialog.h
++++ b/src/qt-widgets/LogDialog.h
+@@ -34,7 +34,9 @@
+ #include "GPlatesDialog.h"
+ #include "LogDialogUi.h"
+ 
++#ifndef Q_MOC_RUN
+ #include "app-logic/ApplicationState.h"
++#endif
+ 
+ 
+ namespace GPlatesGui
+--- a/src/qt-widgets/MapCanvas.h
++++ b/src/qt-widgets/MapCanvas.h
+@@ -39,6 +39,7 @@
+ #include <QSize>
+ #include <QTransform>
+ 
++#ifndef Q_MOC_RUN
+ #include "gui/ColourScheme.h"
+ #include "gui/Map.h"
+ #include "gui/TextOverlay.h"
+@@ -47,6 +48,7 @@
+ #include "opengl/GLMatrix.h"
+ #include "opengl/GLOffScreenContext.h"
+ #include "opengl/GLVisualLayers.h"
++#endif
+ 
+ 
+ namespace GPlatesGui
+--- a/src/qt-widgets/MapView.h
++++ b/src/qt-widgets/MapView.h
+@@ -36,6 +36,7 @@
+ #include <QGLWidget>
+ #include <QMouseEvent>
+ 
++#ifndef Q_MOC_RUN
+ #include "gui/ColourScheme.h"
+ 
+ #include "maths/LatLonPoint.h"
+@@ -44,6 +45,7 @@
+ #include "opengl/GLVisualLayers.h"
+ 
+ #include "qt-widgets/SceneView.h"
++#endif
+ 
+ 
+ namespace GPlatesGui
+--- a/src/qt-widgets/MergeReconstructionLayersDialog.h
++++ b/src/qt-widgets/MergeReconstructionLayersDialog.h
+@@ -33,7 +33,9 @@
+ 
+ #include "MergeReconstructionLayersDialogUi.h"
+ 
++#ifndef Q_MOC_RUN
+ #include "app-logic/Layer.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/qt-widgets/RasterLayerOptionsWidget.h
++++ b/src/qt-widgets/RasterLayerOptionsWidget.h
+@@ -31,6 +31,7 @@
+ #include <QString>
+ #include <QToolButton>
+ 
++#ifndef Q_MOC_RUN
+ #include "RasterLayerOptionsWidgetUi.h"
+ 
+ #include "LayerOptionsWidget.h"
+@@ -40,6 +41,7 @@
+ 
+ #include "gui/BuiltinColourPaletteType.h"
+ #include "gui/RasterColourPalette.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/qt-widgets/ReconstructScalarCoverageLayerOptionsWidget.h
++++ b/src/qt-widgets/ReconstructScalarCoverageLayerOptionsWidget.h
+@@ -28,6 +28,7 @@
+ 
+ #include <utility>
+ 
++#ifndef Q_MOC_RUN
+ #include "ReconstructScalarCoverageLayerOptionsWidgetUi.h"
+ 
+ #include "LayerOptionsWidget.h"
+@@ -37,6 +38,7 @@
+ 
+ #include "gui/BuiltinColourPaletteType.h"
+ #include "gui/RasterColourPalette.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/qt-widgets/ScalarField3DLayerOptionsWidget.h
++++ b/src/qt-widgets/ScalarField3DLayerOptionsWidget.h
+@@ -30,6 +30,7 @@
+ #include <vector>
+ #include <QSlider>
+ 
++#ifndef Q_MOC_RUN
+ #include "ScalarField3DLayerOptionsWidgetUi.h"
+ 
+ #include "LayerOptionsWidget.h"
+@@ -41,6 +42,7 @@
+ #include "gui/RasterColourPalette.h"
+ 
+ #include "view-operations/ScalarField3DRenderParameters.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/qt-widgets/TotalReconstructionPolesDialog.h
++++ b/src/qt-widgets/TotalReconstructionPolesDialog.h
+@@ -32,12 +32,14 @@
+ #include <boost/weak_ptr.hpp>
+ #include <QDialog>
+ 
++#ifndef Q_MOC_RUN
+ #include "TotalReconstructionPolesDialogUi.h"
+ 
+ #include "GPlatesDialog.h"
+ #include "SaveFileDialog.h"
+ 
+ #include "presentation/VisualLayer.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/qt-widgets/VisualLayersComboBox.h
++++ b/src/qt-widgets/VisualLayersComboBox.h
+@@ -32,8 +32,10 @@
+ #include <QComboBox>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "presentation/VisualLayer.h"
+ #include "presentation/VisualLayerType.h"
++#endif
+ 
+ 
+ namespace GPlatesPresentation
+--- a/src/qt-widgets/VisualLayerWidget.h
++++ b/src/qt-widgets/VisualLayerWidget.h
+@@ -36,11 +36,13 @@
+ #include <QMenu>
+ #include <QStackedWidget>
+ 
++#ifndef Q_MOC_RUN
+ #include "VisualLayerWidgetUi.h"
+ 
+ #include "app-logic/Layer.h"
+ 
+ #include "gui/Colour.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/view-operations/InternalGeometryBuilder.h
++++ b/src/view-operations/InternalGeometryBuilder.h
+@@ -30,9 +30,11 @@
+ #include <vector>
+ #include <boost/optional.hpp>
+ 
++#ifndef Q_MOC_RUN
+ #include "maths/GeometryOnSphere.h"
+ #include "maths/GeometryType.h"
+ #include "maths/PointOnSphere.h"
++#endif
+ 
+ namespace GPlatesViewOperations
+ {
+--- a/src/view-operations/RenderedGeometryCollection.h
++++ b/src/view-operations/RenderedGeometryCollection.h
+@@ -39,7 +39,9 @@
+ #include <boost/foreach.hpp>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "RenderedGeometryLayer.h"
++#endif
+ 
+ namespace GPlatesViewOperations
+ {
+--- a/src/view-operations/RenderedGeometryFactory.h
++++ b/src/view-operations/RenderedGeometryFactory.h
+@@ -33,6 +33,7 @@
+ #include <QString>
+ #include <QFont>
+ 
++#ifndef Q_MOC_RUN
+ #include "RenderedGeometry.h"
+ #include "RenderedColouredEdgeSurfaceMesh.h"
+ #include "RenderedColouredTriangleSurfaceMesh.h"
+@@ -62,6 +63,7 @@
+ #include "property-values/TextContent.h"
+ 
+ #include "view-operations/ScalarField3DRenderParameters.h"
++#endif
+ 
+ 
+ namespace GPlatesAppLogic
+--- a/src/view-operations/RenderedGeometryLayer.h
++++ b/src/view-operations/RenderedGeometryLayer.h
+@@ -35,10 +35,12 @@
+ #include <boost/optional.hpp>
+ #include <QObject>
+ 
++#ifndef Q_MOC_RUN
+ #include "RenderedGeometry.h"
+ 
+ #include "maths/CubeQuadTreeLocation.h"
+ 
++#endif
+ 
+ namespace GPlatesMaths
+ {

--- a/pkgs/applications/science/misc/gplates/default.nix
+++ b/pkgs/applications/science/misc/gplates/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, qt4, qwt6_qt4, mesa, glew, gdal_1_11, cgal, proj, boost, cmake, python2, doxygen, graphviz, gmp }:
+
+stdenv.mkDerivation rec {
+  name = "gplates-${version}";
+  version = "2.0.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/gplates/${name}-unixsrc.tar.bz2";
+    sha256 = "02scnjj5nlc2d2c8lbx0xvj8gg1bgkjliv3wxsx564c55a9x69qw";
+  };
+
+  patches = [
+    ./boostfix.patch
+  ];
+
+  buildInputs = [ qt4 qwt6_qt4 mesa glew gdal_1_11 cgal proj boost cmake python2 doxygen graphviz gmp ];
+
+  meta = with stdenv.lib; {
+    description = "Desktop software for the interactive visualisation of plate-tectonics";
+    homepage = https://www.gplates.org;
+    license = licenses.gpl2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/qwt/6_qt4.nix
+++ b/pkgs/development/libraries/qwt/6_qt4.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, qt4, qmake4Hook }:
+
+stdenv.mkDerivation rec {
+  name = "qwt-6.1.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/qwt/${name}.tar.bz2";
+    sha256 = "031x4hz1jpbirv9k35rqb52bb9mf2w7qav89qv1yfw1r3n6z221b";
+  };
+
+  buildInputs = [ qt4 ];
+  nativeBuildInputs = [ qmake4Hook ];
+
+  postPatch = ''
+    sed -e "s|QWT_INSTALL_PREFIX.*=.*|QWT_INSTALL_PREFIX = $out|g" -i qwtconfig.pri
+  '';
+
+  qmakeFlags = [ "-after doc.path=$out/share/doc/${name}" ];
+
+  meta = with stdenv.lib; {
+    description = "Qt widgets for technical applications";
+    homepage = http://qwt.sourceforge.net/;
+    # LGPL 2.1 plus a few exceptions (more liberal)
+    license = stdenv.lib.licenses.qwt;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bjornfor ];
+    branch = "6";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9061,6 +9061,8 @@ in
 
   qwt = callPackage ../development/libraries/qwt {};
 
+  qwt6_qt4 = callPackage ../development/libraries/qwt/6_qt4.nix { };
+
   qxt = callPackage ../development/libraries/qxt {};
 
   rabbitmq-c = callPackage ../development/libraries/rabbitmq-c {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16894,6 +16894,8 @@ in
 
   fityk = callPackage ../applications/science/misc/fityk { };
 
+  gplates = callPackage ../applications/science/misc/gplates { };
+
   gravit = callPackage ../applications/science/astronomy/gravit { };
 
   golly = callPackage ../applications/science/misc/golly { };


### PR DESCRIPTION
###### Motivation for this change

the boostfix.patch is because qt4's precompiler doesn't like BOOST_JOIN 

qwt6_qt4 is because this requires qwt6 on qt4. Not sure if it's better to modify qwt6 so it takes a parameter somehow.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

