### PR TITLE
freebayes: init at 1.1.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -206,6 +206,7 @@
   jb55 = "William Casarin <bill@casarin.me>";
   jbedo = "Justin Bedő <cu@cua0.org>";
   jcumming = "Jack Cummings <jack@mudshark.org>";
+  jdagilliland = "Jason Gilliland <jdagilliland@gmail.com>";
   jefdaj = "Jeffrey David Johnson <jefdaj@gmail.com>";
   jerith666 = "Matt McHenry <github@matt.mchenryfamily.org>";
   jfb = "James Felix Black <james@yamtime.com>";

--- a/pkgs/applications/science/biology/freebayes/builder.sh
+++ b/pkgs/applications/science/biology/freebayes/builder.sh
@@ -1,0 +1,11 @@
+source $stdenv/setup
+
+unpackPhase
+
+cd freebayes-*
+
+make
+
+mkdir -p $out/bin
+cp bin/freebayes bin/bamleftalign $out/bin
+cp scripts/* $out/bin

--- a/pkgs/applications/science/biology/freebayes/default.nix
+++ b/pkgs/applications/science/biology/freebayes/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, gcc, zlib}:
+
+stdenv.mkDerivation rec {
+  name    = "freebayes-${version}";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner  = "ekg";
+    repo   = "freebayes";
+    # rev    = "v${version}";
+    # rev    = "refs/tags/v${version}";
+    rev = "39e5e4bcb801556141f2da36aba1df5c5c60701f";
+    sha256 = "0xb8aicb36w9mfs1gq1x7mcp3p82kl7i61d162hfncqzg2npg8rr";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ cmake gcc zlib ];
+
+  builder = ./builder.sh;
+
+  meta = with stdenv.lib; {
+    description = "Bayesian haplotype-based polymorphism discovery and genotyping";
+    license     = licenses.mit;
+    homepage    = https://github.com/ekg/freebayes;
+    maintainers = with maintainers; [ jdagilliland ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12970,6 +12970,8 @@ in
 
   fossil = callPackage ../applications/version-management/fossil { };
 
+  freebayes = callPackage ../applications/science/biology/freebayes { };
+
   freewheeling = callPackage ../applications/audio/freewheeling { };
 
   fribid = callPackage ../applications/networking/browsers/mozilla-plugins/fribid { };


### PR DESCRIPTION
###### Motivation for this change

I wanted to make this variant calling package available for Nix users (recently including myself).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

