### PR TITLE
amd-hybrid-graphics: fix race condition

### DIFF
--- a/nixos/modules/services/hardware/amd-hybrid-graphics.nix
+++ b/nixos/modules/services/hardware/amd-hybrid-graphics.nix
@@ -25,14 +25,21 @@
       path = [ pkgs.bash ];
       description = "Disable AMD Card";
       after = [ "sys-kernel-debug.mount" ];
-      requires = [ "sys-kernel-debug.mount" ];
-      wantedBy = [ "multi-user.target" ];
+      before = [ "systemd-vconsole-setup.service" "display-manager.service" ];
+      requires = [ "sys-kernel-debug.mount" "vgaswitcheroo.path" ];
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStart = "${pkgs.bash}/bin/sh -c 'echo -e \"IGD\\nOFF\" > /sys/kernel/debug/vgaswitcheroo/switch; exit 0'";
-        ExecStop = "${pkgs.bash}/bin/sh -c 'echo ON >/sys/kernel/debug/vgaswitcheroo/switch; exit 0'";
+        ExecStart = "${pkgs.bash}/bin/sh -c 'echo -e \"IGD\\nOFF\" > /sys/kernel/debug/vgaswitcheroo/switch'";
+        ExecStop = "${pkgs.bash}/bin/sh -c 'echo ON >/sys/kernel/debug/vgaswitcheroo/switch'";
       };
+    };
+    systemd.paths."vgaswitcheroo" = {
+      pathConfig = {
+        PathExists = "/sys/kernel/debug/vgaswitcheroo/switch";
+        Unit = "amd-hybrid-graphics.service";
+      };
+      wantedBy = ["multi-user.target"];
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
#19775 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm really not sure about the correctness of my implementation. Feedback is very welcome!