### PR TITLE
{lib}mediainfo{-gui},libzen: 0.7.87 -> 0.7.91, 0.4.33 -> 0.4.34

### DIFF
--- a/pkgs/applications/misc/mediainfo-gui/default.nix
+++ b/pkgs/applications/misc/mediainfo-gui/default.nix
@@ -2,11 +2,11 @@
 , desktop_file_utils, libSM, imagemagick }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.87";
+  version = "0.7.91";
   name = "mediainfo-gui-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "1ws4hyfcw289hax0bq8y3bbw5y321xmh0va1x4zv5rjwfzcd51pv";
+    sha256 = "15jrph9hjza4c87m739s7c9v27gji94ha7rpchb8li0rcdvy40dm";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/applications/misc/mediainfo/default.nix
+++ b/pkgs/applications/misc/mediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, libmediainfo, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.87";
+  version = "0.7.91";
   name = "mediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/mediainfo/${version}/mediainfo_${version}.tar.xz";
-    sha256 = "1ws4hyfcw289hax0bq8y3bbw5y321xmh0va1x4zv5rjwfzcd51pv";
+    sha256 = "15jrph9hjza4c87m739s7c9v27gji94ha7rpchb8li0rcdvy40dm";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/development/libraries/libmediainfo/default.nix
+++ b/pkgs/development/libraries/libmediainfo/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, libzen, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.7.87";
+  version = "0.7.91";
   name = "libmediainfo-${version}";
   src = fetchurl {
     url = "http://mediaarea.net/download/source/libmediainfo/${version}/libmediainfo_${version}.tar.xz";
-    sha256 = "1gvjvc809mrhpcqr62cihhc6jnwml197xjbgydnzvsghih8dq8s9";
+    sha256 = "1h39cwd85rgidr0hbwab9dwbjv25xhvjv8y2nv35p3fwrs48p098";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/development/libraries/libzen/default.nix
+++ b/pkgs/development/libraries/libzen/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.33";
+  version = "0.4.34";
   name = "libzen-${version}";
   src = fetchurl {
     url = "https://mediaarea.net/download/source/libzen/${version}/libzen_${version}.tar.bz2";
-    sha256 = "0py5iagajz6m5zh26svkjyy85k1dmyhi6cdbmc3cb56a4ix1k2d2";
+    sha256 = "02krmhl6dplidz6h251ajpzzdhzzm0hp0lwwv9rgn55xjgh4yxw3";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/tools/misc/profile-cleaner/default.nix
+++ b/pkgs/tools/misc/profile-cleaner/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, makeWrapper, parallel, sqlite }:
 
 stdenv.mkDerivation rec {
-  version = "2.35";
+  version = "2.36";
   name = "profile-cleaner-${version}";
 
   src = fetchFromGitHub {
     owner = "graysky2";
     repo = "profile-cleaner";
     rev = "v${version}";
-    sha256 = "0gashrzhpgcy98zsyc6b3awfp15j1x0nq82h60kvfjbs6xxzvszh";
+    sha256 = "0vm4ca99dyr6i0sfjsr0w06i0rbmqf40kp37h04bk4c8yassq1zq";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Unfortunately I've not been able to keep this updated on a regular basis
at the moment, therefore some versions have been skipped. I'm therefore
going to just add the link for the changelog:

https://mediaarea.net/MediaInfo/ChangeLog

###### Motivation for this change
Get it finally updated again.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

