### PR TITLE
libmesode: init at 0.9.1

### DIFF
--- a/pkgs/development/libraries/libmesode/default.nix
+++ b/pkgs/development/libraries/libmesode/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, libtool, openssl, expat, pkgconfig, check }:
+
+stdenv.mkDerivation rec {
+  name = "libmesode-${version}";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "boothj5";
+    repo = "libmesode";
+    rev = version;
+    sha256 = "1zb1x422zkpnxrz9d2b7pmi8ms60lbw49yh78mydqfypsmj2iyfh";
+  };
+
+  buildInputs = [ autoreconfHook openssl expat libtool pkgconfig check ];
+
+  dontDisableStatic = true;
+
+  doCheck = true;
+
+  meta = {
+    description = "Fork of libstrophe (https://github.com/strophe/libstrophe) for use with Profanity XMPP Client";
+    longDescription = ''
+      Reasons for forking:
+
+      - Remove Windows support
+      - Support only one XML Parser implementation (expat)
+      - Support only one SSL implementation (OpenSSL)
+
+      This simplifies maintenance of the library when used in Profanity.
+      Whilst Profanity will run against libstrophe, libmesode provides extra
+      TLS functionality such as manual SSL certificate verification.
+    '';
+    homepage = http://github.com/boothj5/libmesode/;
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.devhell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2596,6 +2596,8 @@ in
   libmbim = callPackage ../development/libraries/libmbim { };
 
   libmongo-client = callPackage ../development/libraries/libmongo-client { };
+  
+  libmesode = callPackage ../development/libraries/libmesode { };
 
   libnabo = callPackage ../development/libraries/libnabo { };
 


### PR DESCRIPTION
This library is a fork of ``libstrophe`` and is needed if the
``profanity`` XMPP client is to have TLS support. TLS support has been
added to ``profanity`` since version 5.0.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

