### PR TITLE
profanity: 0.4.7 -> 0.5.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, automake, autoconf, pkgconfig, glib, openssl, expat
-, ncurses, libotr, curl, libstrophe, readline, libuuid
+{ stdenv, fetchurl, pkgconfig, glib, openssl, expat, libmesode
+, ncurses, libotr, curl, readline, libuuid
 
 , autoAwaySupport ? false, libXScrnSaver ? null, libX11 ? null
 , notifySupport ? false,   libnotify ? null, gdk_pixbuf ? null
@@ -12,20 +12,18 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "profanity-${version}";
-  version = "0.4.7";
+  version = "0.5.0";
 
   src = fetchurl {
     url = "http://www.profanity.im/profanity-${version}.tar.gz";
-    sha256 = "1p8ixvxacvf63r6lnf6iwlyz4pgiyp6widna1h2l2jg8kw14wb5h";
+    sha256 = "0s4njc4rcaii51qw1najxa0fa8bb2fnas00z47y94wdbdsmfhfvq";
   };
 
   buildInputs = [
-    automake autoconf pkgconfig readline libuuid
-    glib openssl expat ncurses libotr curl libstrophe
+    pkgconfig readline libuuid libmesode
+    glib openssl expat ncurses libotr curl
   ] ++ optionals autoAwaySupport [ libXScrnSaver libX11 ]
     ++ optionals notifySupport   [ libnotify gdk_pixbuf ];
-
-  preConfigure = "sh bootstrap.sh";
 
   meta = {
     description = "A console based XMPP client";


### PR DESCRIPTION
From the changelog:
- Plugins API supporting C and Python plugins
- SSL certificate verification (requires libmesode) (/tls)
- HTTP file upload (xep-0363) (/sendfile)
- Blocking command (xep-0191) (/blocked)
- Allow auto extended away (/autoaway)
- Include last acitvity in initial presence (xep-0256) (/lastactivity)
- Last Activity (xep-0012) (/lastactivity)
- Ability to run command scripts (/script)
- Account startscript property to execute a command script on connect (/account)
- Export roster to CSV file (/export)
- Support for GTK tray icons (/tray)
- User specified text triggers for chat room notifications (/notify)
- Per chat room notification options (/notify)
- Many new roster panel display options (/roster)
- Time format preferences per window type (/time)
- Edit, prepend and append to room subject (/subject)
- Autoping timeout preference (/autoping)
- Window navigation by window title (/win)
- Window closing by window title (/close)
- Account theme setting (/account)
- Allow sending XMPP stanzas in xmlconsole window (/xmlconsole)
- Configure level of room message notifications in console window (/console)
- Check ~/.config/profanity/inputrc for readline settings
- Custom readline functions for navigation key bindings
- Autocomplete command arguments when no characters entered

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

