### PR TITLE
Add overlays mechanism to Nixpkgs.

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -17,66 +17,6 @@
     derivations or even the whole package set.
   </para>
 
-  <section xml:id="sec-pkgs-overridePackages">
-    <title>pkgs.overridePackages</title>
-
-    <para>
-      This function inside the nixpkgs expression (<varname>pkgs</varname>)
-      can be used to override the set of packages itself.
-    </para>
-    <para>
-      Warning: this function is expensive and must not be used from within
-      the nixpkgs repository.
-    </para>
-    <para>
-      Example usage:
-
-      <programlisting>let
-    pkgs = import &lt;nixpkgs&gt; {};
-    newpkgs = pkgs.overridePackages (self: super: {
-      foo = super.foo.override { ... };
-    });
-  in ...</programlisting>
-    </para>
-
-    <para>
-      The resulting <varname>newpkgs</varname> will have the new <varname>foo</varname>
-      expression, and all other expressions depending on <varname>foo</varname> will also
-      use the new <varname>foo</varname> expression.
-    </para>
-
-    <para>
-      The behavior of this function is similar to <link 
-      linkend="sec-modify-via-packageOverrides">config.packageOverrides</link>.
-    </para>
-
-    <para>
-      The <varname>self</varname> parameter refers to the final package set with the
-      applied overrides. Using this parameter may lead to infinite recursion if not
-      used consciously.
-    </para>
-
-    <para>
-      The <varname>super</varname> parameter refers to the old package set.
-      It's equivalent to <varname>pkgs</varname> in the above example.
-    </para>
-
-    <para>
-      Note that in previous versions of nixpkgs, this method replaced any changes from <link 
-      linkend="sec-modify-via-packageOverrides">config.packageOverrides</link>,
-      along with that from previous calls if this function was called repeatedly.
-      Now those previous changes will be preserved so this function can be "chained" meaningfully.
-      To recover the old behavior, make sure <varname>config.packageOverrides</varname> is unset,
-      and call this only once off a "freshly" imported nixpkgs:
-
-      <programlisting>let
-    pkgs = import &lt;nixpkgs&gt; { config: {}; };
-    newpkgs = pkgs.overridePackages ...;
-  in ...</programlisting>
-    </para>
-
-  </section>
-
   <section xml:id="sec-pkg-override">
     <title>&lt;pkg&gt;.override</title>
 
@@ -91,9 +31,9 @@
       Example usages:
 
       <programlisting>pkgs.foo.override { arg1 = val1; arg2 = val2; ... }</programlisting>
-      <programlisting>pkgs.overridePackages (self: super: {
+      <programlisting>import pkgs.path { overlays = [ (self: super: {
     foo = super.foo.override { barSupport = true ; };
-  })</programlisting>
+  })]};</programlisting>
       <programlisting>mypkg = pkgs.callPackage ./mypkg.nix {
     mydep = pkgs.mydep.override { ... };
   }</programlisting>

--- a/doc/languages-frameworks/python.md
+++ b/doc/languages-frameworks/python.md
@@ -737,18 +737,18 @@ in (pkgs.python35.override {inherit packageOverrides;}).withPackages (ps: [ps.bl
 ```
 The requested package `blaze` depends on `pandas` which itself depends on `scipy`.
 
-If you want the whole of Nixpkgs to use your modifications, then you can use `pkgs.overridePackages`
+If you want the whole of Nixpkgs to use your modifications, then you can use `overlays`
 as explained in this manual. In the following example we build a `inkscape` using a different version of `numpy`.
 ```
 let
   pkgs = import <nixpkgs> {};
-  newpkgs = pkgs.overridePackages ( pkgsself: pkgssuper: {
+  newpkgs = import pkgs.path { overlays = [ (pkgsself: pkgssuper: {
     python27 = let
       packageOverrides = self: super: {
         numpy = super.numpy_1_10;
       };
     in pkgssuper.python27.override {inherit packageOverrides;};
-  } );
+  } ) ]; };
 in newpkgs.inkscape
 ```
 

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -18,6 +18,7 @@
   <xi:include href="meta.xml" />
   <xi:include href="languages-frameworks/index.xml" />
   <xi:include href="package-notes.xml" />
+  <xi:include href="overlays.xml" />
   <xi:include href="coding-conventions.xml" />
   <xi:include href="submitting-changes.xml" />
   <xi:include href="reviewing-contributions.xml" />

--- a/doc/overlays.xml
+++ b/doc/overlays.xml
@@ -4,56 +4,53 @@
 
 <title>Overlays</title>
 
-<para>This chapter describes how to extend and change Nixpkgs content using
-overlays.  Overlays are used to add layers in the fix-point used by Nixpkgs
-to bind the dependencies of all packages.</para>
+<para>This chapter describes how to extend and change Nixpkgs packages using
+overlays. Overlays are used to add layers in the fix-point used by Nixpkgs
+to compose the set of all packages.</para>
 
 <!--============================================================-->
 
 <section xml:id="sec-overlays-install">
 <title>Installing Overlays</title>
 
-<para>The set of overlays are looked for in the following order, only the
+<para>The set of overlays is looked for in the following places. The
 first one present is considered, and all the rest are ignored:
 
 <orderedlist>
 
   <listitem>
 
-    <para>As argument of the imported attribute set. When importing Nixpkgs,
+    <para>As an argument of the imported attribute set. When importing Nixpkgs,
     the <varname>overlays</varname> attribute argument can be set to a list of
-    functions, which would be describe in <xref linkend="sec-overlays-layout"/>.</para>
+    functions, which is described in <xref linkend="sec-overlays-layout"/>.</para>
 
   </listitem>
 
   <listitem>
 
-    <para>As a directory pointed by the environment variable named
-<varname>NIXPKGS_OVERLAYS</varname>. This directory can contain symbolic
-links to Nix expressions.
-
+    <para>In the directory pointed by the environment variable
+<varname>NIXPKGS_OVERLAYS</varname>.
   </listitem>
 
   <listitem>
 
-    <para>As the directory located at
-<filename>~/.nixpkgs/overlays/</filename>. This directory can contain
-symbolic links to Nix expressions.
-
+    <para>In the directory <filename>~/.nixpkgs/overlays/</filename>.
   </listitem>
 
 </orderedlist>
 </para>
 
-<para>For the second and third option, the directory contains either
-directories providing a default.nix expression, or files, or symbolic links
-to the entry Nix expression of the overlay.  These Nix expressions are
-following the syntax described in <xref
-linkend="sec-overlays-layout"/>.</para>
+<para>For the second and third option, the directory should contain Nix expressions defining the
+overlays. Each overlay can be a file, a directory containing a
+<filename>default.nix</filename>, or a symlink to one of those. The expressions should follow
+the syntax described in <xref linkend="sec-overlays-layout"/>.</para>
 
-<para>To install an overlay, using the last option.  Clone the repository of
-the overlay, and add a symbolic link to it in the
-<filename>~/.nixpkgs/overlays/</filename> directory.</para>
+<para>The order of the overlay layers can influence the recipe of packages if multiple layers override
+the same recipe. In the case where overlays are loaded from a directory, these are loaded in
+alphabetical order.</para>
+
+<para>To install an overlay using the last option, you can clone the overlay's repository and add
+a symbolic link to in the <filename>~/.nixpkgs/overlays/</filename> directory.</para>
 
 </section>
 
@@ -62,37 +59,40 @@ the overlay, and add a symbolic link to it in the
 <section xml:id="sec-overlays-layout">
 <title>Overlays Layout</title>
 
-<para>An overlay is a Nix expression, which is a function which accepts 2
-arguments.</para>
+<para>Overlays are expressed as Nix functions which accept 2 arguments and return a set of
+packages</para>
 
 <programlisting>
 self: super:
 
 {
-  foo = super.foo.override { ... };
-  bar = import ./pkgs/bar {
-    inherit (self) stdenv fetchurl;
-    inherit (self) ninja crawl dwarf-fortress;
+  boost = super.boost.override {
+    python = self.python3;
+  };
+  rr = super.callPackage ./pkgs/rr {
+    stdenv = self.stdenv_32bit;
   };
 }
 </programlisting>
 
-<para>The first argument, usualy named <varname>self</varname>, corresponds
-to the final package set. You should use this set to inherit all the
-dependencies needed by your package expression.</para>
+<para>The first argument, usually named <varname>self</varname>, corresponds to the final package
+set. You should use this set for the dependencies of all packages specified in your
+overlay. For example, all the dependencies of <varname>rr</varname> in the example above come
+from <varname>self</varname>, as well as the overriden dependencies used in the
+<varname>boost</varname> override.</para>
 
-<para>The second argument, usualy named <varname>super</varname>,
+<para>The second argument, usually named <varname>super</varname>,
 corresponds to the result of the evaluation of the previous stages of
-Nixpkgs, it does not contain any of the packages added by the current
-overlay nor any of the following overlays.  This set is used in to override
-existing packages, either by changing their dependencies or their
-recipes.</para>
+Nixpkgs. It does not contain any of the packages added by the current
+overlay nor any of the following overlays. This set should be used either
+to refer to packages you wish to override, or to access functions defined
+in Nixpkgs. For example, the original recipe of <varname>boost</varname>
+in the above example, comes from <varname>super</varname>, as well as the
+<varname>callPackage</varname> function.</para>
 
 <para>The value returned by this function should be a set similar to
-<filename>pkgs/top-level/all-packages.nix</filename>, which contains either
-extra packages defined by the overlay, or which overwrite Nixpkgs packages
-with other custom defaults. This is similar to <xref
-linkend="sec-modify-via-packageOverrides"/>.</para>
+<filename>pkgs/top-level/all-packages.nix</filename>, which contains
+overridden and/or new packages.</para>
 
 </section>
 

--- a/doc/overlays.xml
+++ b/doc/overlays.xml
@@ -5,7 +5,7 @@
 <title>Overlays</title>
 
 <para>This chapter describes how to extend and change Nixpkgs content using
-overlays.  Overlays are used to add phases in the fix-point used by Nixpkgs
+overlays.  Overlays are used to add layers in the fix-point used by Nixpkgs
 to bind the dependencies of all packages.</para>
 
 <!--============================================================-->

--- a/doc/overlays.xml
+++ b/doc/overlays.xml
@@ -13,8 +13,8 @@ to bind the dependencies of all packages.</para>
 <section xml:id="sec-overlays-install">
 <title>Installing Overlays</title>
 
-<para>Overlays are looked for in the following order, the first valid one is
-considered, and all the rest are ignored:
+<para>The set of overlays are looked for in the following order, only the
+first one present is considered, and all the rest are ignored:
 
 <orderedlist>
 

--- a/doc/overlays.xml
+++ b/doc/overlays.xml
@@ -40,17 +40,17 @@ first one present is considered, and all the rest are ignored:
 </orderedlist>
 </para>
 
-<para>For the second and third option, the directory should contain Nix expressions defining the
+<para>For the second and third options, the directory should contain Nix expressions defining the
 overlays. Each overlay can be a file, a directory containing a
 <filename>default.nix</filename>, or a symlink to one of those. The expressions should follow
 the syntax described in <xref linkend="sec-overlays-layout"/>.</para>
 
 <para>The order of the overlay layers can influence the recipe of packages if multiple layers override
-the same recipe. In the case where overlays are loaded from a directory, these are loaded in
+the same recipe. In the case where overlays are loaded from a directory, they are loaded in
 alphabetical order.</para>
 
 <para>To install an overlay using the last option, you can clone the overlay's repository and add
-a symbolic link to in the <filename>~/.nixpkgs/overlays/</filename> directory.</para>
+a symbolic link to it in <filename>~/.nixpkgs/overlays/</filename> directory.</para>
 
 </section>
 
@@ -60,7 +60,7 @@ a symbolic link to in the <filename>~/.nixpkgs/overlays/</filename> directory.</
 <title>Overlays Layout</title>
 
 <para>Overlays are expressed as Nix functions which accept 2 arguments and return a set of
-packages</para>
+packages.</para>
 
 <programlisting>
 self: super:

--- a/doc/overlays.xml
+++ b/doc/overlays.xml
@@ -29,12 +29,12 @@ first one present is considered, and all the rest are ignored:
   <listitem>
 
     <para>In the directory pointed by the environment variable
-<varname>NIXPKGS_OVERLAYS</varname>.
+    <varname>NIXPKGS_OVERLAYS</varname>.</para>
   </listitem>
 
   <listitem>
 
-    <para>In the directory <filename>~/.nixpkgs/overlays/</filename>.
+    <para>In the directory <filename>~/.nixpkgs/overlays/</filename>.</para>
   </listitem>
 
 </orderedlist>

--- a/doc/overlays.xml
+++ b/doc/overlays.xml
@@ -1,0 +1,99 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="chap-overlays">
+
+<title>Overlays</title>
+
+<para>This chapter describes how to extend and change Nixpkgs content using
+overlays.  Overlays are used to add phases in the fix-point used by Nixpkgs
+to bind the dependencies of all packages.</para>
+
+<!--============================================================-->
+
+<section xml:id="sec-overlays-install">
+<title>Installing Overlays</title>
+
+<para>Overlays are looked for in the following order, the first valid one is
+considered, and all the rest are ignored:
+
+<orderedlist>
+
+  <listitem>
+
+    <para>As argument of the imported attribute set. When importing Nixpkgs,
+    the <varname>overlays</varname> attribute argument can be set to a list of
+    functions, which would be describe in <xref linkend="sec-overlays-layout"/>.</para>
+
+  </listitem>
+
+  <listitem>
+
+    <para>As a directory pointed by the environment variable named
+<varname>NIXPKGS_OVERLAYS</varname>. This directory can contain symbolic
+links to Nix expressions.
+
+  </listitem>
+
+  <listitem>
+
+    <para>As the directory located at
+<filename>~/.nixpkgs/overlays/</filename>. This directory can contain
+symbolic links to Nix expressions.
+
+  </listitem>
+
+</orderedlist>
+</para>
+
+<para>For the second and third option, the directory contains either
+directories providing a default.nix expression, or files, or symbolic links
+to the entry Nix expression of the overlay.  These Nix expressions are
+following the syntax described in <xref
+linkend="sec-overlays-layout"/>.</para>
+
+<para>To install an overlay, using the last option.  Clone the repository of
+the overlay, and add a symbolic link to it in the
+<filename>~/.nixpkgs/overlays/</filename> directory.</para>
+
+</section>
+
+<!--============================================================-->
+
+<section xml:id="sec-overlays-layout">
+<title>Overlays Layout</title>
+
+<para>An overlay is a Nix expression, which is a function which accepts 2
+arguments.</para>
+
+<programlisting>
+self: super:
+
+{
+  foo = super.foo.override { ... };
+  bar = import ./pkgs/bar {
+    inherit (self) stdenv fetchurl;
+    inherit (self) ninja crawl dwarf-fortress;
+  };
+}
+</programlisting>
+
+<para>The first argument, usualy named <varname>self</varname>, corresponds
+to the final package set. You should use this set to inherit all the
+dependencies needed by your package expression.</para>
+
+<para>The second argument, usualy named <varname>super</varname>,
+corresponds to the result of the evaluation of the previous stages of
+Nixpkgs, it does not contain any of the packages added by the current
+overlay nor any of the following overlays.  This set is used in to override
+existing packages, either by changing their dependencies or their
+recipes.</para>
+
+<para>The value returned by this function should be a set similar to
+<filename>pkgs/top-level/all-packages.nix</filename>, which contains either
+extra packages defined by the overlay, or which overwrite Nixpkgs packages
+with other custom defaults. This is similar to <xref
+linkend="sec-modify-via-packageOverrides"/>.</para>
+
+</section>
+
+</chapter>

--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -108,7 +108,7 @@ following incompatible changes:</para>
 
 <programlisting>
   let
-    pkgs = import &lt;nixpkgs&gt {};
+    pkgs = import &lt;nixpkgs&gt; {};
   in
     pkgs.overridePackages (self: super: ...)
 </programlisting>
@@ -117,7 +117,7 @@ following incompatible changes:</para>
 
 <programlisting>
   let
-    pkgs = import &lt;nixpkgs&gt {}; in
+    pkgs = import &lt;nixpkgs&gt; {}; in
   in
     import pkgs.path { overlays = [(self: super: ...)] }
 </programlisting>

--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -100,7 +100,8 @@ following incompatible changes:</para>
   </listitem>
 
   <listitem>
-    <para><literal>pkgs.overridePackages</literal> function no longer exists.     Instead import Nixpkgs a second time using <literal>import pkgs.path {
+    <para><literal>pkgs.overridePackages</literal> function no longer exists.
+     Instead import Nixpkgs a second time using <literal>import pkgs.path {
     overlays = [ <replaceable>...</replaceable> ]; }</literal>.</para>
   </listitem>
 </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -113,7 +113,7 @@ following incompatible changes:</para>
     pkgs.overridePackages (self: super: ...)
 </programlisting>
 
-    Should be replaced by:
+    should be replaced by:
 
 <programlisting>
   let

--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -11,7 +11,9 @@ has the following highlights: </para>
 
 <itemizedlist>
   <listitem>
-    <para></para>
+    <para>Nixpkgs is now extensible through <link
+    xlink:href="https://github.com/NixOS/nixpkgs/pull/21243">overlays</link>.
+    See the Nixpkgs manual for more information.</para>
   </listitem>
 </itemizedlist>
 
@@ -95,6 +97,11 @@ following incompatible changes:</para>
      Upstream time servers for all NTP implementations are now configured using
      <literal>networking.timeServers</literal>.
    </para>
+  </listitem>
+
+  <listitem>
+    <para><literal>pkgs.overridePackages</literal> function no longer exists.     Instead import Nixpkgs a second time using <literal>import pkgs.path {
+    overlays = [ <replaceable>...</replaceable> ]; }</literal>.</para>
   </listitem>
 </itemizedlist>
 

--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -11,9 +11,9 @@ has the following highlights: </para>
 
 <itemizedlist>
   <listitem>
-    <para>Nixpkgs is now extensible through <link
-    xlink:href="https://github.com/NixOS/nixpkgs/pull/21243">overlays</link>.
-    See the Nixpkgs manual for more information.</para>
+    <para>Nixpkgs is now extensible through overlays. See the <link
+    xlink:href="https://nixos.org/nixpkgs/manual/#sec-overlays-install">Nixpkgs
+    manual</link> for more information.</para>
   </listitem>
 </itemizedlist>
 
@@ -100,9 +100,29 @@ following incompatible changes:</para>
   </listitem>
 
   <listitem>
-    <para><literal>pkgs.overridePackages</literal> function no longer exists.
-     Instead import Nixpkgs a second time using <literal>import pkgs.path {
-    overlays = [ <replaceable>...</replaceable> ]; }</literal>.</para>
+
+    <para><literal>overridePackages</literal> function no longer exists.
+    It is replaced by <link
+    xlink:href="https://nixos.org/nixpkgs/manual/#sec-overlays-install">
+    overlays</link>.  For example, the following code:
+
+<programlisting>
+  let
+    pkgs = import &lt;nixpkgs&gt {};
+  in
+    pkgs.overridePackages (self: super: ...)
+</programlisting>
+
+    Should be replaced by:
+
+<programlisting>
+  let
+    pkgs = import &lt;nixpkgs&gt {}; in
+  in
+    import pkgs.path { overlays = [(self: super: ...)] }
+</programlisting>
+
+    </para>
   </listitem>
 </itemizedlist>
 

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -30,7 +30,7 @@ let
 
   configType = mkOptionType {
     name = "nixpkgs-config";
-    description = "nixpkgs config"
+    description = "nixpkgs config";
     check = traceValIfNot isConfig;
     merge = args: fold (def: mergeConfig def.value) {};
   };

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -69,7 +69,7 @@ in
               openssh = super.openssh.override {
                 hpnSupport = true;
                 withKerberos = true;
-                kerberos = self.libkrb5
+                kerberos = self.libkrb5;
               };
             };
           ) ]

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -74,7 +74,7 @@ in
             };
           ) ]
         '';
-      type = lib.listOf overlayType;
+      type = types.listOf overlayType;
       description = ''
         List of overlays to use with the Nix Packages collection.
         (For details, see the Nixpkgs documentation.)  It allows

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -29,9 +29,17 @@ let
     };
 
   configType = mkOptionType {
-    name = "nixpkgs config";
+    name = "nixpkgs-config";
+    description = "nixpkgs config"
     check = traceValIfNot isConfig;
     merge = args: fold (def: mergeConfig def.value) {};
+  };
+
+  overlayType = mkOptionType {
+    name = "nixpkgs-overlay";
+    description = "nixpkgs overlay";
+    check = builtins.isFunction;
+    merge = lib.mergeOneOption;
   };
 
 in
@@ -43,23 +51,37 @@ in
       default = {};
       example = literalExample
         ''
-          { firefox.enableGeckoMediaPlayer = true;
-            packageOverrides = pkgs: {
-              firefox60Pkgs = pkgs.firefox60Pkgs.override {
-                enableOfficialBranding = true;
-              };
-            };
-          }
+          { firefox.enableGeckoMediaPlayer = true; }
         '';
       type = configType;
       description = ''
         The configuration of the Nix Packages collection.  (For
         details, see the Nixpkgs documentation.)  It allows you to set
-        package configuration options, and to override packages
-        globally through the <varname>packageOverrides</varname>
-        option.  The latter is a function that takes as an argument
-        the <emphasis>original</emphasis> Nixpkgs, and must evaluate
-        to a set of new or overridden packages.
+        package configuration options.
+      '';
+    };
+
+    nixpkgs.overlays = mkOption {
+      default = [];
+      example = literalExample
+        ''
+          [ (self: super: {
+              openssh = super.openssh.override {
+                hpnSupport = true;
+                withKerberos = true;
+                kerberos = self.libkrb5
+              };
+            };
+          ) ]
+        '';
+      type = lib.listOf overlayType;
+      description = ''
+        List of overlays to use with the Nix Packages collection.
+        (For details, see the Nixpkgs documentation.)  It allows
+        you to override packages globally. This is a function that
+        takes as an argument the <emphasis>original</emphasis> Nixpkgs.
+        The first argument should be used for finding dependencies, and
+        the second should be used for overriding recipes.
       '';
     };
 

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -1,10 +1,10 @@
 { lib
-, system, platform, crossSystem, config
+, system, platform, crossSystem, config, overlays
 }:
 
 let
   bootStages = import ../. {
-    inherit lib system platform;
+    inherit lib system platform overlays;
     crossSystem = null;
     # Ignore custom stdenvs when cross compiling for compatability
     config = builtins.removeAttrs config [ "replaceStdenv" ];
@@ -18,7 +18,7 @@ in bootStages ++ [
   # should be used to build compilers and other such tools targeting the cross
   # platform. Then, `forceNativeDrv` can be removed.
   (vanillaPackages: {
-    inherit system platform crossSystem config;
+    inherit system platform crossSystem config overlays;
     # It's OK to change the built-time dependencies
     allowCustomOverrides = true;
     stdenv = vanillaPackages.stdenv // {
@@ -30,7 +30,7 @@ in bootStages ++ [
 
   # Run packages
   (buildPackages: {
-    inherit system platform crossSystem config;
+    inherit system platform crossSystem config overlays;
     stdenv = if crossSystem.useiOSCross or false
       then let
           inherit (buildPackages.darwin.ios-cross {

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -1,12 +1,12 @@
 { lib
-, system, platform, crossSystem, config
+, system, platform, crossSystem, config, overlays
 }:
 
 assert crossSystem == null;
 
 let
   bootStages = import ../. {
-    inherit lib system platform crossSystem;
+    inherit lib system platform crossSystem overlays;
     # Remove config.replaceStdenv to ensure termination.
     config = builtins.removeAttrs config [ "replaceStdenv" ];
   };
@@ -15,7 +15,7 @@ in bootStages ++ [
 
   # Additional stage, built using custom stdenv
   (vanillaPackages: {
-    inherit system platform crossSystem config;
+    inherit system platform crossSystem config overlays;
     stdenv = config.replaceStdenv { pkgs = vanillaPackages; };
   })
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1,5 +1,5 @@
 { lib
-, system, platform, crossSystem, config
+, system, platform, crossSystem, config, overlays
 
 # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
 , bootstrapFiles ? let
@@ -98,7 +98,7 @@ in rec {
       };
 
     in {
-      inherit system platform crossSystem config;
+      inherit system platform crossSystem config overlays;
       stdenv = thisStdenv;
     };
 
@@ -316,7 +316,7 @@ in rec {
     stage3
     stage4
     (prevStage: {
-      inherit system crossSystem platform config;
+      inherit system crossSystem platform config overlays;
       stdenv = stdenvDarwin prevStage;
     })
   ];

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -7,7 +7,7 @@
 { # Args just for stdenvs' usage
   lib
   # Args to pass on to the pkgset builder, too
-, system, platform, crossSystem, config
+, system, platform, crossSystem, config, overlays
 } @ args:
 
 let

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -1,5 +1,5 @@
 { lib
-, system, platform, crossSystem, config
+, system, platform, crossSystem, config, overlays
 }:
 
 assert crossSystem == null;
@@ -58,7 +58,7 @@ assert crossSystem == null;
   })
 
   (prevStage: {
-    inherit system crossSystem platform config;
+    inherit system crossSystem platform config overlays;
     stdenv = import ../generic {
       name = "stdenv-freebsd-boot-3";
       inherit system config;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -246,7 +246,7 @@ in
   # dependency (`nix-store -qR') on bootstrapTools or the first
   # binutils built.
   (prevStage: {
-    inherit system crossSystem platform config;
+    inherit system crossSystem platform config overlays;
     stdenv = import ../generic rec {
       inherit system config;
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -4,7 +4,7 @@
 # compiler and linker that do not search in default locations,
 # ensuring purity of components produced by it.
 { lib
-, system, platform, crossSystem, config
+, system, platform, crossSystem, config, overlays
 
 , bootstrapFiles ?
     if system == "i686-linux" then import ./bootstrap-files/i686.nix
@@ -91,7 +91,7 @@ let
       };
 
     in {
-      inherit system platform crossSystem config;
+      inherit system platform crossSystem config overlays;
       stdenv = thisStdenv;
     };
 

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -1,5 +1,5 @@
 { lib
-, system, platform, crossSystem, config
+, system, platform, crossSystem, config, overlays
 }:
 
 assert crossSystem == null;
@@ -134,7 +134,7 @@ in
 
   # First build a stdenv based only on tools outside the store.
   (prevStage: {
-    inherit system crossSystem platform config;
+    inherit system crossSystem platform config overlays;
     stdenv = makeStdenv {
       inherit (prevStage) cc fetchurl;
     } // { inherit (prevStage) fetchurl; };
@@ -143,7 +143,7 @@ in
   # Using that, build a stdenv that adds the ‘xz’ command (which most systems
   # don't have, so we mustn't rely on the native environment providing it).
   (prevStage: {
-    inherit system crossSystem platform config;
+    inherit system crossSystem platform config overlays;
     stdenv = makeStdenv {
       inherit (prevStage.stdenv) cc fetchurl;
       extraPath = [ prevStage.xz ];

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -23,6 +23,9 @@
 , # Allow a configuration attribute set to be passed in as an argument.
   config ? {}
 
+, # List of overlays layers used to extend Nixpkgs.
+  overlays ? []
+
 , # A function booting the final package set for a specific standard
   # environment. See below for the arguments given to that function,
   # the type of list it returns.
@@ -80,7 +83,7 @@ in let
   boot = import ../stdenv/booter.nix { inherit lib allPackages; };
 
   stages = stdenvStages {
-    inherit lib system platform crossSystem config;
+    inherit lib system platform crossSystem config overlays;
   };
 
   pkgs = boot stages;

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -31,7 +31,9 @@
         let content = readDir dir; in
         map (n: import "${dir}/${n}") (sort lessThan (attrNames content));
     in
-      if dirCheck dirEnv then overlays dirEnv
+      if dirEnv != "" then
+        if dirCheck dirEnv then overlays dirEnv
+        else throw "The environment variable NIXPKGS_OVERLAYS does not name a valid directory."
       else if dirCheck dirHome then overlays dirHome
       else []
 

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -30,6 +30,8 @@
 , # The configuration attribute set
   config
 
+, overlays # List of overlays to use in the fix-point.
+
 , crossSystem
 , platform
 , lib
@@ -79,7 +81,7 @@ let
       ((config.packageOverrides or (super: {})) super);
 
   # The complete chain of package set builders, applied from top to bottom
-  toFix = lib.foldl' (lib.flip lib.extends) (self: {}) [
+  toFix = lib.foldl' (lib.flip lib.extends) (self: {}) ([
     stdenvBootstappingAndPlatforms
     stdenvAdapters
     trivialBuilders
@@ -87,20 +89,8 @@ let
     aliases
     stdenvOverrides
     configOverrides
-  ];
+  ] ++ overlays);
 
-  # Use `overridePackages` to easily override this package set.
-  # Warning: this function is very expensive and must not be used
-  # from within the nixpkgs repository.
-  #
-  # Example:
-  #  pkgs.overridePackages (self: super: {
-  #    foo = super.foo.override { ... };
-  #  }
-  #
-  # The result is `pkgs' where all the derivations depending on `foo'
-  # will use the new version.
-
-  # Return the complete set of packages. Warning: this function is very
-  # expensive!
-in lib.makeExtensibleWithCustomName "overridePackages" toFix
+in
+  # Return the complete set of packages.
+  lib.fix toFix


### PR DESCRIPTION
This patch add a new argument to Nixpkgs default expression named "overlays".

By default, the value of the argument is either taken from the environment variable `NIXPKGS_OVERLAYS`,
or from the directory `~/.nixpkgs/overlays/`.  If the environment variable does not name a valid directory
then this mechanism would fallback on the home directory.  If the home directory does not exists it will
fallback on an empty list of overlays.

The overlays directory should contain the list of extra Nixpkgs stages which would be used to extend the
content of Nixpkgs, with additional set of packages.  The overlays, i-e directory, files, symbolic links
are used in alphabetical order.

The simplest overlay which extends Nixpkgs with nothing looks like:

```nix
self: super: {
}
```

More refined overlays can use `super` as the basis for building new packages, and `self` as a way to query
the final result of the fix-point.

An example of overlay which extends Nixpkgs with a small set of packages can be found at:
  https://github.com/nbp/nixpkgs-mozilla/blob/nixpkgs-overlay/moz-overlay.nix

To use this file, checkout the repository and add a symbolic link to
the `moz-overlay.nix` file in `~/.nixpkgs/overlays` directory.

###### Motivation

The goal of this patch is to provide an alternative to the `pkgs.overridePackages` function (#20927), which re-execute Nixpkgs fix-point with new inputs.  Instead, the alternative would be use Nixpkgs top-level function, with an `overlays` attribute which would be a list with the same argument as what is today the argument given to `pkgs.overridePackages`.

Thus, in addition to provide a useful extensible layer to Nixpkgs third parties, such as Mozilla, or any other company.  This would remove the existing leakage of Nixpkgs fix-point out of Nixpkgs.  This feature would also be nicer for the `security-updates` branch (#10851), as the overlays would be under the fix-point on which the patching mechanism works on.

###### Things done

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

---

