### PR TITLE
gnuapl: add Darwin support

### DIFF
--- a/pkgs/development/interpreters/gnu-apl/default.nix
+++ b/pkgs/development/interpreters/gnu-apl/default.nix
@@ -11,6 +11,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ readline gettext ncurses ];
 
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace src/LApack.cc --replace "malloc.h" "malloc/malloc.h"
+  '';
+
+  configureFlags = stdenv.lib.optionals stdenv.isDarwin [
+    "--disable-dependency-tracking"
+    "--disable-silent-rules"
+  ];
+
   postInstall = ''
     cp -r support-files/ $out/share/doc/
     find $out/share/doc/support-files -name 'Makefile*' -delete
@@ -21,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage    = http://www.gnu.org/software/apl/;
     license     = licenses.gpl3Plus;
     maintainers = [ maintainers.kovirobi ];
-    platforms   = stdenv.lib.platforms.linux;
+    platforms   = with stdenv.lib.platforms; linux ++ darwin;
     inherit version;
 
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change
Adding Darwin support for GNU APL.
Implementation of GNU APL support taken from here: https://github.com/Homebrew/homebrew-core/blob/master/Formula/gnu-apl.rb

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
