### PR TITLE
Eliom 6 and various OCaml package updates

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0h7wdsic4v6ys130w61zvxm5s2vc7y574hn7zby12rq88lhhrjh7";
   };
 
+  patches = [ ./uchar.patch ];
+
   buildInputs = with ocamlPackages; [
                   ocaml ocamlbuild findlib topkg ppx_sexp_conv
                   erm_xmpp_0_3 tls nocrypto x509 ocaml_lwt otr astring

--- a/pkgs/applications/networking/instant-messengers/jackline/uchar.patch
+++ b/pkgs/applications/networking/instant-messengers/jackline/uchar.patch
@@ -1,0 +1,302 @@
+diff --git a/_tags b/_tags
+index 88318d9..b433ee8 100644
+--- a/_tags
++++ b/_tags
+@@ -7,9 +7,11 @@ true : package(sexplib astring)
+ 
+ <src/xconfig.ml>: package(otr ppx_sexp_conv)
+ <src/utils.ml>: package(uutf)
++<src/muc.ml>: package(uchar)
++<src/contact.mli>: package(uchar)
+ <src/persistency.ml>: package(lwt nocrypto)
+ <src/xjid.{ml,mli}>: package(ppx_sexp_conv erm_xmpp)
+-<src/user.{ml,mli}>: package(ppx_sexp_conv otr hex ptime ptime.clock.os)
++<src/user.{ml,mli}>: package(uchar ppx_sexp_conv otr hex ptime ptime.clock.os)
+ <src/xmpp_callbacks.ml>: package(erm_xmpp lwt tls tls.lwt ptime)
+ <src/xmpp_connection.ml>: package(erm_xmpp lwt tls tls.lwt)
+ 
+@@ -18,6 +20,6 @@ true : package(sexplib astring)
+ <cli/cli_input.ml>: package(notty lwt erm_xmpp otr)
+ <cli/cli_commands.ml>: package(lwt otr erm_xmpp)
+ <cli/cli_config.ml>: package(lwt nocrypto otr notty tls.lwt x509)
+-<cli/cli_state.ml>: package(hex lwt nocrypto erm_xmpp tls.lwt x509)
++<cli/cli_state.ml>: package(uchar hex lwt nocrypto erm_xmpp tls.lwt x509)
+ 
+ <bin/jackline.{ml,byte,native}>: package(erm_xmpp hex lwt notty notty.lwt nocrypto otr sexplib tls tls.lwt ptime ptime.clock.os)
+diff --git a/cli/cli_config.ml b/cli/cli_config.ml
+index 618d655..dac6e68 100644
+--- a/cli/cli_config.ml
++++ b/cli/cli_config.ml
+@@ -34,7 +34,7 @@ let rewrap term above below (prefix, inp, inp2) (width, _) =
+     let height = if col mod width = 0 then succ h else h in
+     (succ (col mod width), height)
+   in
+-  Notty_lwt.Term.cursor term (Some (col, row))
++  Notty_lwt.Term.cursor term (Some (col - 1, row - 1))
+ 
+ let read_line ?(above = []) ?(prefix = "") ?default ?(below = []) term =
+   let rec go (pre, post) =
+@@ -56,8 +56,8 @@ let read_line ?(above = []) ?(prefix = "") ?default ?(below = []) term =
+       | `Unhandled k ->
+         match k with
+         | `Key (`Enter, []) -> Lwt.return (char_list_to_str (pre @ post))
+-        | `Key (`Uchar 0x43, [`Ctrl]) -> Lwt.fail (Invalid_argument "Ctrl-c")
+-        | `Key (`Uchar 0x44, [`Ctrl]) -> Lwt.fail (Invalid_argument "Ctrl-d")
++        | `Key (`Uchar u, [`Ctrl]) when Uchar.to_int u = 0x43 -> Lwt.fail (Invalid_argument "Ctrl-c")
++        | `Key (`Uchar u, [`Ctrl]) when Uchar.to_int u = 0x44 -> Lwt.fail (Invalid_argument "Ctrl-d")
+         | _ -> go (pre, post)
+   in
+   let pre = Utils.option [] str_to_char_list default in
+@@ -180,7 +180,7 @@ let configure term () =
+     let pw = "Password: " in
+     let chars = match password with
+       | None -> I.string A.empty "will be asked at startup"
+-      | Some _ -> I.uchar A.empty 0x2605 5 1
++      | Some _ -> I.uchar A.empty (Uchar.of_int 0x2605) 5 1
+     in
+     above @ [I.(string A.empty pw <|> chars)]
+   in
+diff --git a/cli/cli_input.ml b/cli/cli_input.ml
+index 34b4288..07488f2 100644
+--- a/cli/cli_input.ml
++++ b/cli/cli_input.ml
+@@ -314,19 +314,19 @@ let read_terminal term mvar input_mvar () =
+           | `Key (`Arrow `Up, []) -> p (fun s -> ok (history s Up)) >>= fun () -> loop ()
+           | `Key (`Arrow `Down, []) -> p (fun s -> ok (history s Down)) >>= fun () -> loop ()
+ 
+-          | `Key (`Uchar 0x44, [`Ctrl]) (* C-d *) -> p (fun s -> Lwt.return (`Quit s))
++          | `Key (`Uchar u, [`Ctrl]) when Uchar.to_int u = 0x44 (* C-d *) -> p (fun s -> Lwt.return (`Quit s))
+ 
+           (* UI navigation and toggles *)
+           | `Key (`Page `Up, []) -> p (fun s -> ok (navigate_buddy_list s Up)) >>= fun () -> loop ()
+           | `Key (`Page `Down, []) -> p (fun s -> ok (navigate_buddy_list s Down)) >>= fun () -> loop ()
+ 
+           | `Key (`Page `Up, [`Ctrl]) -> p (fun s -> ok (navigate_message_buffer s Up)) >>= fun () -> loop ()
+-          | `Key (`Uchar 0x50, [`Ctrl]) (* C-p *) -> p (fun s -> ok (navigate_message_buffer s Up)) >>= fun () -> loop ()
++          | `Key (`Uchar u, [`Ctrl]) when Uchar.to_int u = 0x50 (* C-p *) -> p (fun s -> ok (navigate_message_buffer s Up)) >>= fun () -> loop ()
+           | `Key (`Page `Down, [`Ctrl]) -> p (fun s -> ok (navigate_message_buffer s Down)) >>= fun () -> loop ()
+-          | `Key (`Uchar 0x4E, [`Ctrl]) (* C-n *) -> p (fun s -> ok (navigate_message_buffer s Down)) >>= fun () -> loop ()
++          | `Key (`Uchar u, [`Ctrl]) when Uchar.to_int u = 0x4E (* C-n *) -> p (fun s -> ok (navigate_message_buffer s Down)) >>= fun () -> loop ()
+ 
+-          | `Key (`Uchar 0x58, [`Ctrl]) (* C-x *) -> p (fun s -> ok (activate_contact s s.last_active_contact)) >>= fun () -> loop ()
+-          | `Key (`Uchar 0x51, [`Ctrl]) (* C-q *) ->
++          | `Key (`Uchar u, [`Ctrl]) when Uchar.to_int u = 0x58 (* C-x *) -> p (fun s -> ok (activate_contact s s.last_active_contact)) >>= fun () -> loop ()
++          | `Key (`Uchar u, [`Ctrl]) when Uchar.to_int u = 0x51 (* C-q *) ->
+             let handle s =
+               let s = match List.rev s.notifications with
+                 | x::_ -> activate_contact s x
+diff --git a/cli/cli_state.ml b/cli/cli_state.ml
+index 5603cfe..ee320ce 100644
+--- a/cli/cli_state.ml
++++ b/cli/cli_state.ml
+@@ -24,7 +24,7 @@ type connect_v =
+   | Reconnect
+   | Presence of (User.presence * string option * int option)
+ 
+-type input = int list * int list
++type input = Uchar.t list * Uchar.t list
+ 
+ type state = {
+   (* set only initially *)
+diff --git a/cli/cli_support.ml b/cli/cli_support.ml
+index 1c54df6..8275c38 100644
+--- a/cli/cli_support.ml
++++ b/cli/cli_support.ml
+@@ -4,17 +4,17 @@ open Notty
+ module Char = struct
+   let hdash a w =
+     if !Utils.unicode then
+-      I.uchar a 0x2500 w 1
++      I.uchar a (Uchar.of_int 0x2500) w 1
+     else
+       I.char a '-' w 1
+   and vdash a h =
+     if !Utils.unicode then
+-      I.uchar a 0x2502 1 h
++      I.uchar a (Uchar.of_int 0x2502) 1 h
+     else
+       I.char a '|' 1 h
+   and star a w =
+     if !Utils.unicode then
+-      I.uchar a 0x2605 w 1
++      I.uchar a (Uchar.of_int 0x2605) w 1
+     else
+       I.char a '*' w 1
+ end
+@@ -186,8 +186,8 @@ let v_center left right width =
+   and rw = I.width right
+   in
+   match rw, lw >= width with
+-  | 0, true -> (I.hcrop (lw - width + 1) 0 left, width)
+-  | 0, false -> (left, succ lw)
++  | 0, true -> (I.hcrop (lw - width + 1) 0 left, width - 1)
++  | 0, false -> (left, lw)
+   | _, _ ->
+     if lw + rw >= width then
+       let leftw = min (max (width - rw) (width / 2)) lw in
+@@ -195,11 +195,11 @@ let v_center left right width =
+       let l = I.hcrop (lw - leftw) 0 left
+       and r = I.hcrop 0 (rw - rightw) right
+       in
+-      (I.(l <|> r), succ leftw)
++      (I.(l <|> r), leftw)
+     else
+-      (I.(left <|> right), succ lw)
++      (I.(left <|> right), lw)
+ 
+-let str_to_char_list str : int list =
++let str_to_char_list str : Uchar.t list =
+   let open Uutf in
+   List.rev (String.fold_utf_8 (fun acc _ -> function `Uchar i -> i :: acc | `Malformed _ -> acc) [] str)
+ 
+@@ -236,22 +236,26 @@ let readline_input = function
+   | k -> `Unhandled k
+ 
+ let emacs_bindings = function
+-  | `Key (`Uchar 0x41, [`Ctrl]) (* C-a *) -> `Ok (fun (pre, post) -> ([], pre @ post))
+-  | `Key (`Uchar 0x45, [`Ctrl]) (* C-e *) -> `Ok (fun (pre, post) -> (pre @ post, []))
++  | `Key (`Uchar u, [`Ctrl]) as k ->
++    begin match Uchar.to_int u with
++    | 0x41 (* C-a *) -> `Ok (fun (pre, post) -> ([], pre @ post))
++    | 0x45 (* C-e *) -> `Ok (fun (pre, post) -> (pre @ post, []))
+ 
+-  | `Key (`Uchar 0x4b, [`Ctrl]) (* C-k *) -> `Ok (fun (pre, _) -> (pre, []))
+-  | `Key (`Uchar 0x55, [`Ctrl]) (* C-u *) -> `Ok (fun (_, post) -> ([], post))
++    | 0x4b (* C-k *) -> `Ok (fun (pre, _) -> (pre, []))
++    | 0x55 (* C-u *) -> `Ok (fun (_, post) -> ([], post))
+ 
+-  | `Key (`Uchar 0x46, [`Ctrl]) (* C-f *) ->
++    | 0x46 (* C-f *) ->
+     `Ok (fun (pre, post) ->
+         match post with
+         | [] -> (pre, post)
+         | hd::tl -> (pre @ [hd], tl))
+-  | `Key (`Uchar 0x42, [`Ctrl]) (* C-b *) ->
++    | 0x42 (* C-b *) ->
+     `Ok (fun (pre, post) ->
+         match List.rev pre with
+         | [] -> ([], post)
+         | hd::tl -> (List.rev tl, hd :: post))
++    | _ -> `Unhandled k
++    end
+ 
+   | `Key (`Arrow `Left, [`Ctrl]) ->
+     `Ok (fun (pre, post) ->
+diff --git a/src/contact.mli b/src/contact.mli
+index 6926296..d6c795b 100644
+--- a/src/contact.mli
++++ b/src/contact.mli
+@@ -8,7 +8,7 @@ val bare : contact -> Xjid.bare_jid
+ val preserve_messages : contact -> bool
+ val expanded : contact -> bool
+ val messages : contact -> User.message list
+-val input_buffer : contact -> (int list * int list)
++val input_buffer : contact -> (Uchar.t list * Uchar.t list)
+ 
+ val readline_history : contact -> string list
+ val add_readline_history : contact -> string -> contact
+@@ -18,7 +18,7 @@ val set_history_position : contact -> int -> contact
+ val received : contact -> string -> contact
+ 
+ val expand : contact -> contact
+-val set_input_buffer : contact -> (int list * int list) -> contact
++val set_input_buffer : contact -> (Uchar.t list * Uchar.t list) -> contact
+ val set_preserve_messages : contact -> bool -> contact
+ 
+ val reset : contact -> contact
+diff --git a/src/muc.ml b/src/muc.ml
+index 1c98037..3293541 100644
+--- a/src/muc.ml
++++ b/src/muc.ml
+@@ -132,7 +132,7 @@ type groupchat = {
+   expand : bool ;
+   preserve_messages : bool ;
+   message_history : User.message list ; (* persistent if preserve_messages *)
+-  input_buffer : (int list * int list) ;
++  input_buffer : (Uchar.t list * Uchar.t list) ;
+   readline_history : string list ;
+   history_position : int ;
+   autojoin : bool ;
+diff --git a/src/user.ml b/src/user.ml
+index d039278..42a8c47 100644
+--- a/src/user.ml
++++ b/src/user.ml
+@@ -229,7 +229,7 @@ type user = {
+   properties        : property list ;
+   preserve_messages : bool ;
+   message_history   : message list ; (* persistent if preserve_messages is true *)
+-  input_buffer: (int list * int list) ; (* not persistent *)
++  input_buffer: (Uchar.t list * Uchar.t list) ; (* not persistent *)
+   readline_history  : string list ; (* not persistent *)
+   history_position  : int ; (* not persistent *)
+   otr_fingerprints  : fingerprint list ;
+diff --git a/src/user.mli b/src/user.mli
+index 52b503d..5ce41be 100644
+--- a/src/user.mli
++++ b/src/user.mli
+@@ -118,7 +118,7 @@ type user = {
+   properties        : property list ;
+   preserve_messages : bool ;
+   message_history   : message list ; (* persistent if preserve_messages is true *)
+-  input_buffer: (int list * int list) ; (* not persistent *)
++  input_buffer: (Uchar.t list * Uchar.t list) ; (* not persistent *)
+   readline_history  : string list ; (* not persistent *)
+   history_position  : int ;
+   otr_fingerprints  : fingerprint list ;
+diff --git a/src/utils.ml b/src/utils.ml
+index 0b4a3a7..cd9cb10 100644
+--- a/src/utils.ml
++++ b/src/utils.ml
+@@ -30,31 +30,33 @@ let validate_utf8 txt =
+   let rec loop d buf = match Uutf.decode d with
+     | `Await -> Buffer.contents buf
+     | `End -> Buffer.contents buf
+-    | `Malformed _ -> if !unicode then Uutf.Buffer.add_utf_8 buf 0xFFFD; loop d buf
+-    | `Uchar 0x000A -> (* newline *) Uutf.Buffer.add_utf_8 buf 0x000A ; loop d buf
+-    | `Uchar 0x0009 -> (* tab -> 4 spaces *) Uutf.Buffer.add_utf_8 buf 0x0020 ; Uutf.Buffer.add_utf_8 buf 0x0020 ; Uutf.Buffer.add_utf_8 buf 0x0020 ; Uutf.Buffer.add_utf_8 buf 0x0020 ; loop d buf
+-    | `Uchar 0x007F (* DEL *)
++    | `Malformed _ -> if !unicode then Uutf.Buffer.add_utf_8 buf (Uchar.of_int 0xFFFD); loop d buf
++    | `Uchar u ->
++      match Uchar.to_int u with
++      | 0x000A -> (* newline *) Uutf.Buffer.add_utf_8 buf (Uchar.of_int 0x000A) ; loop d buf
++      | 0x0009 -> (* tab -> 4 spaces *) Uutf.Buffer.add_utf_8 buf (Uchar.of_int 0x0020) ; Uutf.Buffer.add_utf_8 buf (Uchar.of_int 0x0020) ; Uutf.Buffer.add_utf_8 buf (Uchar.of_int 0x0020) ; Uutf.Buffer.add_utf_8 buf (Uchar.of_int 0x0020) ; loop d buf
++      | 0x007F (* DEL *)
+     (* See https://en.wikipedia.org/wiki/Unicode_control_characters / https://en.wikipedia.org/wiki/Bi-directional_text *)
+-    | `Uchar 0x200E | `Uchar 0x200F (* left-to-right / right-to-left *)
+-    | `Uchar 0x202A | `Uchar 0x202D (* left-to-right embedding / override *)
+-    | `Uchar 0x202B | `Uchar 0x202E (* right-to-left embedding / override *)
+-    | `Uchar 0x202C  (* pop directional format *)
+-    | `Uchar 0x2066 | `Uchar 0x2067 (* l-t-r isolate r-t-l isolate *)
+-    | `Uchar 0x2068 | `Uchar 0x2069 (* first strong isolate / pop directional isolate *)
+-    | `Uchar 0x2028 | `Uchar 0x2029 (* line separator / page separator *) ->
+-      if !unicode then Uutf.Buffer.add_utf_8 buf 0xFFFD ; loop d buf
+-    | `Uchar x when x < 0x20 ->
++      | 0x200E | 0x200F (* left-to-right / right-to-left *)
++      | 0x202A | 0x202D (* left-to-right embedding / override *)
++      | 0x202B | 0x202E (* right-to-left embedding / override *)
++      | 0x202C  (* pop directional format *)
++      | 0x2066 | 0x2067 (* l-t-r isolate r-t-l isolate *)
++      | 0x2068 | 0x2069 (* first strong isolate / pop directional isolate *)
++      | 0x2028 | 0x2029 (* line separator / page separator *) ->
++      if !unicode then Uutf.Buffer.add_utf_8 buf (Uchar.of_int 0xFFFD) ; loop d buf
++      | x when x < 0x20 ->
+       (* other control characters *)
+-      if !unicode then Uutf.Buffer.add_utf_8 buf 0xFFFD ; loop d buf
+-    | `Uchar x when x >= 0x0080 && x <= 0x009F ->
++      if !unicode then Uutf.Buffer.add_utf_8 buf (Uchar.of_int 0xFFFD) ; loop d buf
++      | x when x >= 0x0080 && x <= 0x009F ->
+       (* ctrl chars used in conjunction with ISO 8859 character sets (C0/C1) *)
+-      if !unicode then Uutf.Buffer.add_utf_8 buf 0xFFFD ; loop d buf
++      if !unicode then Uutf.Buffer.add_utf_8 buf (Uchar.of_int 0xFFFD) ; loop d buf
+ 
+-    | `Uchar x ->
++      | x ->
+       let c = if !unicode then x else if x > 0xff then 0x3f else x in
+-      Uutf.Buffer.add_utf_8 buf c ; loop d buf
++      Uutf.Buffer.add_utf_8 buf (Uchar.of_int c) ; loop d buf
+   in
+-  let nln = `Readline 0x000A in
++  let nln = `Readline (Uchar.of_int 0x000A) in
+   loop (Uutf.decoder ~nln ~encoding:`UTF_8 (`String txt)) (Buffer.create (String.length txt))
+ 
+ let version = "%%VERSION_NUM%%"

--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,37 +1,31 @@
-{ buildOcaml, stdenv, fetchurl, which, ocsigen_server, ocsigen_deriving, ocaml,
+{ stdenv, fetchurl, which, ocsigen_server, ocsigen_deriving, ocaml,
   js_of_ocaml, ocaml_react, ocaml_lwt, calendar, cryptokit, tyxml,
   ipaddr, ocamlnet, ocaml_ssl, ocaml_pcre, ocaml_optcomp,
-  reactivedata, opam, ppx_tools, ppx_deriving, camlp4}:
+  reactivedata, opam, ppx_tools, ppx_deriving, findlib
+}:
 
-let ocamlVersion = (stdenv.lib.getVersion ocaml); in
-buildOcaml rec
+assert stdenv.lib.versionAtLeast ocaml.version "4.02";
+
+stdenv.mkDerivation rec
 {
   pname = "eliom";
-  version = "5.0.0";
+  version = "6.0.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/eliom/archive/${version}.tar.gz";
-    sha256 = "1g9wq2qpn0sgzyb6iq0h9afq5p68il4h8pc7jppqsislk87m09k7";
+    sha256 = "1yaqi5fdzvi2ga412chw5rk3533a3xamwfmias1crk793d43cmpc";
   };
 
   patches = [ ./camlp4.patch ];
 
-  buildInputs = [ which ocaml_optcomp opam ppx_tools camlp4 ];
+  buildInputs = [ ocaml which findlib ocaml_optcomp opam ppx_tools ];
 
   propagatedBuildInputs = [ ocaml_lwt reactivedata tyxml ipaddr ocsigen_server ppx_deriving
                             ocsigen_deriving js_of_ocaml
                             calendar cryptokit ocamlnet ocaml_react ocaml_ssl ocaml_pcre ];
 
-  preConfigure = stdenv.lib.optionalString (!stdenv.lib.versionAtLeast ocamlVersion "4.02") ''
-      export PPX=false
-    '';
-
-  installPhase =
-  ''opam-installer --script --prefix=$out ${pname}.install > install.sh
-    sh install.sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocamlVersion}/site-lib/
-  '';
+  installPhase = "opam-installer -i --prefix=$out --libdir=$OCAMLFIND_DESTDIR";
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/jsonm/default.nix
+++ b/pkgs/development/ocaml-modules/jsonm/default.nix
@@ -1,24 +1,23 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, uutf }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, opam, uutf }:
 
-let version = "0.9.1"; in
+let version = "1.0.0"; in
 
 stdenv.mkDerivation {
-  name = "ocaml-jsonm-${version}";
+  name = "ocaml${ocaml.version}-jsonm-${version}";
 
   src = fetchurl {
     url = "http://erratique.ch/software/jsonm/releases/jsonm-${version}.tbz";
-    sha256 = "0wszqrmx8iqlwzvs76fjf4sqh15mv20yjrbyhkd348yq8nhdrm1z";
+    sha256 = "1v3ln6d965lplj28snjdqdqablpp1kx8bw2cfx0m6i157mqyln62";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ ocaml findlib ocamlbuild topkg opam ];
   propagatedBuildInputs = [ uutf ];
 
   unpackCmd = "tar xjf $src";
 
-  configurePhase = "ocaml setup.ml -configure --prefix $prefix";
-  buildPhase = "ocaml setup.ml -build";
   createFindlibDestdir = true;
-  installPhase = "ocaml setup.ml -install";
+
+  inherit (topkg) buildPhase installPhase;
 
   meta = {
     description = "An OCaml non-blocking streaming codec to decode and encode the JSON data format";

--- a/pkgs/development/ocaml-modules/markup/default.nix
+++ b/pkgs/development/ocaml-modules/markup/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, uutf, lwt }:
+{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, uutf, lwt }:
 
 stdenv.mkDerivation rec {
-  pname = "ocaml-markup";
-  version = "0.7.2";
-  name = "${pname}-${version}";
+  pname = "markup";
+  version = "0.7.3";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "http://github.com/aantron/markup.ml/archive/${version}.tar.gz";
-    sha256 = "0d3wi22v7h0iqzq8dgl0g4fj2wb67gvmbzdckacifghinrx762k3";
+    sha256 = "03vyv609a60azw8qs7v0kkmy4704hkzw7c3skpzax5krwgwcqfxj";
     };
 
   buildInputs = [ ocaml findlib ocamlbuild ];

--- a/pkgs/development/ocaml-modules/markup/default.nix
+++ b/pkgs/development/ocaml-modules/markup/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "markup";
-  version = "0.7.3";
+  version = "0.7.4";
   name = "ocaml${ocaml.version}-${pname}-${version}";
 
   src = fetchzip {
     url = "http://github.com/aantron/markup.ml/archive/${version}.tar.gz";
-    sha256 = "03vyv609a60azw8qs7v0kkmy4704hkzw7c3skpzax5krwgwcqfxj";
+    sha256 = "1hchlqzsy9pax91gcdmxzakfm22fbvhxzwyzpvz8fqkx4372zs37";
     };
 
   buildInputs = [ ocaml findlib ocamlbuild ];

--- a/pkgs/development/ocaml-modules/ocb-stubblr/default.nix
+++ b/pkgs/development/ocaml-modules/ocb-stubblr/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, opam, topkg, astring }:
+
+stdenv.mkDerivation {
+  name = "ocaml${ocaml.version}-ocb-stubblr-0.1.0";
+  src = fetchzip {
+    url = http://github.com/pqwy/ocb-stubblr/releases/download/v0.1.0/ocb-stubblr-0.1.0.tbz;
+    name = "src.tar.bz";
+    sha256 = "0hpds1lkq4j8wgslv7hnirgfrjmqi36h5rarpw9mwf24gfp5ays2";
+  };
+
+  patches = [ ./pkg-config.patch ];
+
+  buildInputs = [ ocaml findlib ocamlbuild opam topkg ];
+
+  propagatedBuildInputs = [ astring ];
+
+  inherit (topkg) buildPhase installPhase;
+
+  meta = {
+    description = "OCamlbuild plugin for C stubs";
+    homepage = https://github.com/pqwy/ocb-stubblr;
+    license = stdenv.lib.licenses.isc;
+    inherit (ocaml.meta) platforms;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ocb-stubblr/pkg-config.patch
+++ b/pkgs/development/ocaml-modules/ocb-stubblr/pkg-config.patch
@@ -1,0 +1,25 @@
+--- a/src/ocb_stubblr.ml	1970-01-01 00:00:01.000000000 +0000
++++ b/src/ocb_stubblr.ml	2016-12-04 11:10:10.000000000 +0000
+@@ -31,20 +31,9 @@
+ 
+   (* XXX Would be nice to move pkg-config results to a build artefact. *)
+ 
+-  let opam_prefix =
+-    let cmd = "opam config var prefix" in
+-    lazy ( try run_and_read cmd with Failure _ ->
+-            error_msgf "error running opam")
+-
+-  let var = "PKG_CONFIG_PATH"
+-
+-  let path () =
+-    Lazy.force opam_prefix / "lib" / "pkgconfig" ::
+-      (try [Sys.getenv var] with Not_found -> []) |> String.concat ~sep:":"
+-
+   let run ~flags package =
+-    let cmd = strf "%s=%s pkg-config %s %s 2>/dev/null"
+-              var (path ()) package (String.concat ~sep:" " flags) in
++    let cmd = strf "pkg-config %s %s 2>/dev/null"
++              package (String.concat ~sep:" " flags) in
+     try `Res (run_and_read cmd) with Failure _ -> `Nonexistent
+ end
+ 

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -9,11 +9,11 @@ let mkpath = p: n:
 in
 
 stdenv.mkDerivation {
-  name = "ocsigenserver-2.7";
+  name = "ocsigenserver-2.8";
 
   src = fetchurl {
-    url = https://github.com/ocsigen/ocsigenserver/archive/2.7.tar.gz;
-    sha256 = "0gv9nchsx9z74hh46gn7bd0053j4694fhxriannf13sqh2qpg901";
+    url = https://github.com/ocsigen/ocsigenserver/archive/2.8.tar.gz;
+    sha256 = "1v44qv2ixd7i1qinyhlzzqiffawsdl7xhhh6ysd7lf93kh46d5sy";
   };
 
   buildInputs = [ocaml which findlib ocaml_react ocaml_ssl ocaml_lwt

--- a/pkgs/development/ocaml-modules/otfm/default.nix
+++ b/pkgs/development/ocaml-modules/otfm/default.nix
@@ -1,14 +1,12 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, uutf }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, topkg, uutf, result }:
 
 let
-  inherit (stdenv.lib) getVersion versionAtLeast;
-
   pname = "otfm";
-  version = "0.2.0";
+  version = "0.3.0";
   webpage = "http://erratique.ch/software/${pname}";
 in
 
-assert versionAtLeast (getVersion ocaml) "4.01.0";
+assert stdenv.lib.versionAtLeast ocaml.version "4.01.0";
 
 stdenv.mkDerivation rec {
 
@@ -16,23 +14,18 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "1wgi9plf98gd7x3b7fzjxds089sivsap97bl1bw2lj73nxwnyb9c";
+    sha256 = "054s82539k3kc9na6s47g3scsl04icjahpas7pv5351jmsgqcq3k";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opam ];
+  buildInputs = [ ocaml findlib ocamlbuild opam topkg ];
 
-  propagatedBuildInputs = [ uutf ];
+  propagatedBuildInputs = [ uutf result ];
 
   createFindlibDestdir = true;
 
   unpackCmd = "tar xjf $src";
 
-  buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
-
-  installPhase = ''
-    opam-installer --script --prefix=$out ${pname}.install | sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${getVersion ocaml}/site-lib/${pname}
-  '';
+  inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {
     description = "OpenType font decoder for OCaml";

--- a/pkgs/development/ocaml-modules/reactivedata/default.nix
+++ b/pkgs/development/ocaml-modules/reactivedata/default.nix
@@ -1,28 +1,20 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, ocaml_react, camlp4, opam }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, ocaml_react, opam }:
 
-let
-  ocamlVersion = stdenv.lib.getVersion ocaml;
-in
-
-assert stdenv.lib.versionAtLeast ocamlVersion "3.11";
+assert stdenv.lib.versionAtLeast ocaml.version "3.11";
 
 stdenv.mkDerivation {
-  name = "ocaml-reactiveData-0.2";
+  name = "ocaml${ocaml.version}-reactiveData-0.2.1";
   src = fetchurl {
-    url = https://github.com/ocsigen/reactiveData/archive/0.2.tar.gz;
-    sha256 = "0rskcxnyjn8sxqnncdm6rh9wm99nha5m5sc83fywgzs64xfl43fq";
+    url = https://github.com/ocsigen/reactiveData/archive/0.2.1.tar.gz;
+    sha256 = "0wcs0z50nia1cpk8mh6i5qbc6sff9cc8x7s7q1q89d7m73bnv4vf";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opam camlp4 ];
+  buildInputs = [ ocaml findlib ocamlbuild opam ];
   propagatedBuildInputs = [ocaml_react];
 
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
 
-  installPhase = ''
-    opam-installer --script --prefix=$out reactiveData.install > install.sh
-    sed -i s!lib/reactiveData!lib/ocaml/${ocamlVersion}/site-lib/reactiveData! install.sh
-    sh install.sh
-  '';
+  installPhase = "opam-installer -i --prefix=$out --libdir=$OCAMLFIND_DESTDIR";
 
   meta = with stdenv.lib; {
     description = "An OCaml module for functional reactive programming (FRP) based on React";

--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-topkg-${version}";
-  version = "0.7.8";
+  version = "0.8.1";
 
   src = fetchurl {
     url = "http://erratique.ch/software/topkg/releases/topkg-${version}.tbz";
-    sha256 = "029lbmabczpmcgkj53mc20vmpcn3f7rf7xms4xf0nywswfzsash6";
+    sha256 = "18rrh6fmf708z7dd30amljmcgaypj3kk49jrmrj68r4wnw8004j8";
   };
 
   nativeBuildInputs = [ opam ];

--- a/pkgs/development/ocaml-modules/tyxml/default.nix
+++ b/pkgs/development/ocaml-modules/tyxml/default.nix
@@ -1,14 +1,22 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, ocaml_oasis, camlp4, uutf, markup, ppx_tools, re }:
+{ stdenv, fetchzip, fetchpatch, ocaml, findlib, ocamlbuild, ocaml_oasis, camlp4, uutf, markup, ppx_tools, re
+}:
+
+assert stdenv.lib.versionAtLeast ocaml.version "4.02";
 
 stdenv.mkDerivation rec {
   pname = "tyxml";
-  version = "3.6.0";
-  name = "${pname}-${version}";
+  version = "4.0.1";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "http://github.com/ocsigen/tyxml/archive/${version}.tar.gz";
-    sha256 = "1rz0f48x8p1m30723rn5v85pp7rd0spr04sd7gzryy99vn3ianga";
-    };
+    sha256 = "1mwkjvl78gvw7pvql5qp64cfjjca6aqsb04999qkllifyicaaq8y";
+  };
+
+  patches = [ (fetchpatch {
+    url = https://github.com/dbuenzli/tyxml/commit/a2bf5ccc0b6e684e7b81274ff19df8d72e2def8d.diff;
+    sha256 = "11sidgiwz3zqw815vlslbfzb456z0lndkh425mlmvnmck4d2v2i3";
+  })];
 
   buildInputs = [ ocaml findlib ocamlbuild camlp4 ];
 

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -1,36 +1,31 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, topkg, uchar }:
 
 let
-  inherit (stdenv.lib) getVersion versionAtLeast;
-
   pname = "uucp";
-  version = "1.1.0";
+  version = "2.0.0";
   webpage = "http://erratique.ch/software/${pname}";
 in
 
-assert versionAtLeast (getVersion ocaml) "4.00";
+assert stdenv.lib.versionAtLeast ocaml.version "4.01";
 
 stdenv.mkDerivation {
 
-  name = "ocaml-${pname}-${version}";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "1vm5f2ppdrnk19j0ppjiqz56qf5bzyk26gs0lz071s7iblk459jz";
+    sha256 = "07m7pfpcf03dqsbvqpq88y9hzic8fighlp4fgbav6n6xla35mk5k";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opam ];
+  buildInputs = [ ocaml findlib ocamlbuild opam topkg ];
+
+  propagatedBuildInputs = [ uchar ];
 
   createFindlibDestdir = true;
 
   unpackCmd = "tar xjf $src";
 
-  buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
-
-  installPhase = ''
-    opam-installer --script --prefix=$out ${pname}.install | sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${getVersion ocaml}/site-lib/${pname}
-  '';
+  inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {
     description = "An OCaml library providing efficient access to a selection of character properties of the Unicode character database";

--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -1,33 +1,29 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, topkg, uchar, uutf, cmdliner }:
 let
   pname = "uunf";
   webpage = "http://erratique.ch/software/${pname}";
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "3.12";
+assert stdenv.lib.versionAtLeast ocaml.version "4.01";
 
 stdenv.mkDerivation rec {
   name = "ocaml-${pname}-${version}";
-  version = "0.9.3";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "16cgjy1m0m61srv1pmlc3gr0y40kd4724clvpagdnz68raz4zmn0";
+    sha256 = "1i132168949vdc8magycgf9mdysf50vvr7zngnjl4vi3zdayq20c";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opam ];
+  buildInputs = [ ocaml findlib ocamlbuild opam topkg uutf cmdliner ];
+
+  propagatedBuildInputs = [ uchar ];
 
   createFindlibDestdir = true;
 
   unpackCmd = "tar xjf $src";
 
-  buildPhase = "./pkg/build true false";
-
-  installPhase = ''
-    opam-installer --script --prefix=$out ${pname}.install > install.sh
-    sh install.sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
-  '';
+  inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {
     description = "An OCaml module for normalizing Unicode text";

--- a/pkgs/development/ocaml-modules/uuseg/default.nix
+++ b/pkgs/development/ocaml-modules/uuseg/default.nix
@@ -1,39 +1,28 @@
-{ stdenv, buildOcaml, fetchurl, ocaml, findlib, ocamlbuild, opam, uucp, uutf, cmdliner }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, topkg, uchar, uucp, uutf, cmdliner }:
 
 let
   pname = "uuseg";
   webpage = "http://erratique.ch/software/${pname}";
 in
 
-buildOcaml rec {
+stdenv.mkDerivation rec {
 
-  minimumSupportedOcamlVersion = "4.01";
-
-  name = pname;
-  version = "0.9.0";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "00n4zi8dyw2yzi4nr2agcrr33b0q4dr9mgnkczipf4c0gm5cm50h";
+    sha256 = "0m5n0kn70w862g5dhfkfvrnmb98z1r02g21ap7l81hy8sn08cbsz";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opam cmdliner ];
-  propagatedBuildInputs = [ uucp uutf ];
+  buildInputs = [ ocaml findlib ocamlbuild opam cmdliner topkg uutf ];
+  propagatedBuildInputs = [ uucp uchar ];
 
   createFindlibDestdir = true;
 
   unpackCmd = "tar xjf $src";
 
-  buildPhase = ''
-    ocaml pkg/build.ml \
-      native=true native-dynlink=true \
-      uutf=true cmdliner=true
-  '';
-
-  installPhase = ''
-    opam-installer --script --prefix=$out ${pname}.install | sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/${pname}
-  '';
+  inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {
     description = "An OCaml library for segmenting Unicode text";

--- a/pkgs/development/ocaml-modules/uutf/default.nix
+++ b/pkgs/development/ocaml-modules/uutf/default.nix
@@ -1,37 +1,26 @@
-{ stdenv, buildOcaml, fetchurl, ocaml, findlib, ocamlbuild, opam, cmdliner}:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam, cmdliner , topkg, uchar }:
 let
   pname = "uutf";
   webpage = "http://erratique.ch/software/${pname}";
 in
 
-buildOcaml rec {
-  name = pname;
-  version = "0.9.4";
-
-  minimumSupportedOcamlVersion = "4.00.0";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "1f71fyawxal42x6g82539bv0ava2smlar6rmxxz1cyq3l0i6fw0k";
+    sha256 = "08i0cw02cxw4mi2rs01v9xi307qshs6fnd1dlqyb52kcxzblpp37";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opam cmdliner ];
+  buildInputs = [ ocaml findlib ocamlbuild topkg opam cmdliner ];
+  propagatedBuildInputs = [ uchar ];
 
   createFindlibDestdir = true;
 
   unpackCmd = "tar xjf $src";
 
-  buildPhase = ''
-    ocaml pkg/build.ml \
-      native=true \
-      native-dynlink=true \
-      cmdliner=true
-  '';
-
-  installPhase = ''
-    opam-installer --prefix=$out --script ${pname}.install | sh
-    ln -s $out/lib/uutf $out/lib/ocaml/${ocaml.version}/site-lib/
-  '';
+  inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {
     description = "Non-blocking streaming Unicode codec for OCaml";

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -1,16 +1,26 @@
-{ stdenv, fetchurl, ocaml, findlib, ocaml_lwt, menhir, ocsigen_deriving, ppx_deriving, camlp4,
- cmdliner, tyxml, reactivedata, cppo, which, base64}:
+{ stdenv, fetchurl, ocaml, findlib, ocaml_lwt, menhir, ocsigen_deriving, ppx_deriving, camlp4
+, cmdliner, tyxml, reactivedata, cppo, which, base64, uchar
+}:
+
+let version = if stdenv.lib.versionAtLeast ocaml.version "4.02"
+  then "2.8.3" else "2.7";
+in
 
 stdenv.mkDerivation {
-  name = "js_of_ocaml-2.7";
+  name = "js_of_ocaml-${version}";
   src = fetchurl {
-    url = https://github.com/ocsigen/js_of_ocaml/archive/2.7.tar.gz;
-    sha256 = "1dali1akyd4zmkwav0d957ynxq2jj6cc94r4xiaql7ca89ajz4jj";
-    };
+    url = "https://github.com/ocsigen/js_of_ocaml/archive/${version}.tar.gz";
+    sha256 = {
+      "2.7" = "1dali1akyd4zmkwav0d957ynxq2jj6cc94r4xiaql7ca89ajz4jj";
+      "2.8.3" = "0xrw215w5saqdcdd9ipjhvg8f982z63znsds9ih445s3jr49szm7";
+    }."${version}";
+  };
 
   buildInputs = [ ocaml findlib menhir ocsigen_deriving
-                 cmdliner tyxml reactivedata cppo which base64];
-  propagatedBuildInputs = [ ocaml_lwt camlp4 ppx_deriving ];
+                 cmdliner reactivedata cppo which base64 ]
+  ++ stdenv.lib.optional (stdenv.lib.versionAtLeast ocaml.version "4.02") tyxml;
+  propagatedBuildInputs = [ ocaml_lwt camlp4 ppx_deriving ]
+  ++ stdenv.lib.optional (version == "2.8.3") uchar;
 
   patches = [ ./Makefile.conf.diff ];
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -414,6 +414,8 @@ let
       minimal = false;
     };
 
+    ocb-stubblr = callPackage ../development/ocaml-modules/ocb-stubblr { };
+
     ocurl = callPackage ../development/ocaml-modules/ocurl { };
 
     pa_ounit = callPackage ../development/ocaml-modules/pa_ounit { };


### PR DESCRIPTION
###### Motivation for this change

All these packages sort of work together: updating one required to update them all.

In addition `txyml`, `notty` and `jackline` need patches. I had to update `notty` to the current development version to be able to apply said patch.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

