### PR TITLE
ocaml-pcre: fix name

### DIFF
--- a/pkgs/development/ocaml-modules/pcre/default.nix
+++ b/pkgs/development/ocaml-modules/pcre/default.nix
@@ -1,7 +1,7 @@
 {stdenv, buildOcaml, fetchurl, pcre, ocaml, findlib}:
 
 buildOcaml {
-  name = "ocaml-pcre";
+  name = "pcre";
   version = "7.1.1";
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

the package name for ocaml-pcre is ocaml-ocaml-pcre. This changes that name to ocaml-pcre so that other packages can find the pcre dll stub.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

