### PR TITLE
light-locker: use systemd/logind instead of UPower

### DIFF
--- a/pkgs/misc/screensavers/light-locker/default.nix
+++ b/pkgs/misc/screensavers/light-locker/default.nix
@@ -5,6 +5,8 @@
 , glib
 , pkgconfig
 , libX11
+, libXScrnSaver
+, libXxf86misc
 , gtk3
 , dbus_glib
 , systemd
@@ -23,18 +25,32 @@ stdenv.mkDerivation rec {
     sha256 = "0ygkp5vgkx2nfhfql6j2jsfay394gda23ir3sx4f72j4agsirjvj";
   };
 
-  buildInputs = [ which xfce.xfce4_dev_tools glib pkgconfig libX11 gtk3 dbus_glib systemd wrapGAppsHook ];
+  # Patch so that systemd is "found" when configuring.
+  patches = [ ./systemd.patch ];
+
+  buildInputs = [ which xfce.xfce4_dev_tools glib systemd pkgconfig
+                  libX11 libXScrnSaver libXxf86misc gtk3 dbus_glib wrapGAppsHook ];
 
   preConfigure = ''
     ./autogen.sh
   '';
 
+  configureFlags = [ "--with-xf86gamma-ext" "--with-mit-ext"
+                     "--with-dpms-ext" "--with-systemd"
+                     # ConsoleKit and UPower were dropped in favor
+                     # of systemd replacements
+                     "--without-console-kit" "--without-upower" ];
+
   meta = with stdenv.lib; {
     homepage = https://github.com/the-cavalry/light-locker;
     description = "Light-locker is a simple locker";
     longDescription = ''
-      light-locker is a simple locker (forked from gnome-screensaver) that aims to have simple, sane, secure defaults and be well integrated with the desktop while not carrying any desktop-specific dependencies.
-      It relies on lightdm for locking and unlocking your session via ConsoleKit/UPower or logind/systemd.
+      light-locker is a simple locker (forked from gnome-screensaver)
+      that aims to have simple, sane, secure defaults and be well
+      integrated with the desktop while not carrying any
+      desktop-specific dependencies. It relies on lightdm for locking
+      and unlocking your session via ConsoleKit/UPower or
+      logind/systemd.
     '';
     license = licenses.gpl2;
     maintainers = with maintainers; [ obadz ];

--- a/pkgs/misc/screensavers/light-locker/default.nix
+++ b/pkgs/misc/screensavers/light-locker/default.nix
@@ -43,14 +43,15 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://github.com/the-cavalry/light-locker;
-    description = "Light-locker is a simple locker";
+    description = "A simple session-locker for LightDM";
     longDescription = ''
-      light-locker is a simple locker (forked from gnome-screensaver)
-      that aims to have simple, sane, secure defaults and be well
-      integrated with the desktop while not carrying any
-      desktop-specific dependencies. It relies on lightdm for locking
-      and unlocking your session via ConsoleKit/UPower or
-      logind/systemd.
+      A simple locker (forked from gnome-screensaver) that aims to
+      have simple, sane, secure defaults and be well integrated with
+      the desktop while not carrying any desktop-specific
+      dependencies.
+
+      It relies on LightDM for locking and unlocking your session via
+      ConsoleKit/UPower or logind/systemd.
     '';
     license = licenses.gpl2;
     maintainers = with maintainers; [ obadz ];

--- a/pkgs/misc/screensavers/light-locker/systemd.patch
+++ b/pkgs/misc/screensavers/light-locker/systemd.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac.in b/configure.ac.in
+index f7d5f5d..341bc83 100644
+--- a/configure.ac.in
++++ b/configure.ac.in
+@@ -424,7 +424,7 @@ AC_ARG_WITH(systemd,
+             [with_systemd=$withval], [with_systemd=auto])
+ 
+ PKG_CHECK_MODULES(SYSTEMD,
+-                  [libsystemd-login],
++                  [libsystemd],
+                   [have_systemd=yes], [have_systemd=no])
+ 
+ if test "x$with_systemd" = "xauto" ; then


### PR DESCRIPTION
###### Motivation for this change
Since systemd has been adopted for a while now, we should switch to using it for light-locker as well. So I disabled ConsoleKit/UPower support in favor of using systemd with logind. This fixed many issues for me, and made light-locker working again.

I followed the PKGBUILD of Arch's package in determining the right configure flags (see [here](https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/light-locker)).

This may fix #19535, pinging @siddharthist to try out this change.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

