### PR TITLE
pommed service: Replace broken pommed package with pommed-light

### DIFF
--- a/nixos/modules/services/hardware/pommed.nix
+++ b/nixos/modules/services/hardware/pommed.nix
@@ -2,7 +2,9 @@
 
 with lib;
 
-{
+let cfg = config.services.hardware.pommed;
+    defaultConf = "${pkgs.pommed_light}/etc/pommed.conf.mactel";
+in {
 
   options = {
 
@@ -12,37 +14,37 @@ with lib;
         type = types.bool;
         default = false;
         description = ''
-          Whether to use the pommed tool to handle Apple laptop keyboard hotkeys.
+          Whether to use the pommed tool to handle Apple laptop
+          keyboard hotkeys.
         '';
       };
 
       configFile = mkOption {
-        type = types.path;
+        type = types.nullOr types.path;
+        default = null;
         description = ''
-          The path to the <filename>pommed.conf</filename> file.
+          The path to the <filename>pommed.conf</filename> file. Leave
+          to null to use the default config file
+          (<filename>/etc/pommed.conf.mactel</filename>). See the
+          files <filename>/etc/pommed.conf.mactel</filename> and
+          <filename>/etc/pommed.conf.pmac</filename> for examples to
+          build on.
         '';
       };
     };
 
   };
 
-  config = mkIf config.services.hardware.pommed.enable {
-    environment.systemPackages = [ pkgs.polkit ];
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.polkit pkgs.pommed_light ];
 
-    environment.etc."pommed.conf".source = config.services.hardware.pommed.configFile;
-
-    services.hardware.pommed.configFile = "${pkgs.pommed}/etc/pommed.conf";
-
-    services.dbus.packages = [ pkgs.pommed ];
+    environment.etc."pommed.conf".source =
+      if cfg.configFile == null then defaultConf else cfg.configFile;
 
     systemd.services.pommed = {
-      description = "Pommed hotkey management";
+      description = "Pommed Apple Hotkeys Daemon";
       wantedBy = [ "multi-user.target" ];
-      after = [ "dbus.service" ];
-      postStop = "rm -f /var/run/pommed.pid";
-      script = "${pkgs.pommed}/bin/pommed";
-      serviceConfig.Type = "forking";
-      path = [ pkgs.eject ];
+      script = "${pkgs.pommed_light}/bin/pommed -f";
     };
   };
 }

--- a/pkgs/os-specific/linux/pommed-light/default.nix
+++ b/pkgs/os-specific/linux/pommed-light/default.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation rec {
       and the like.
     '';
     homepage = https://github.com/bytbox/pommed-light;
+    platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2;
   };
 }

--- a/pkgs/os-specific/linux/pommed-light/default.nix
+++ b/pkgs/os-specific/linux/pommed-light/default.nix
@@ -1,0 +1,64 @@
+{
+  stdenv
+, fetchurl
+, pciutils
+, confuse
+, alsaLib
+, audiofile
+, pkgconfig
+, zlib
+, eject
+}:
+
+stdenv.mkDerivation rec {
+  pkgname = "pommed-light";
+  version = "1.50lw";
+  name = "${pkgname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/bytbox/${pkgname}/archive/v${version}.tar.gz";
+
+    sha256 = "1r2f28zqmyvzgymd0ng53hscbrq8vcqhxdnkq5dppjf9yrzn018b";
+  };
+
+  postPatch = ''
+    substituteInPlace pommed.conf.mactel --replace /usr $out
+    substituteInPlace pommed.conf.pmac --replace /usr $out
+    substituteInPlace pommed/beep.h --replace /usr $out
+    substituteInPlace pommed/cd_eject.c --replace /usr/bin/eject ${eject}/bin/eject
+  '';
+
+  buildInputs = [
+    pciutils
+    confuse
+    alsaLib
+    audiofile
+    pkgconfig
+    zlib
+    eject
+  ];
+
+  installPhase = ''
+    install -Dm755 pommed/pommed $out/bin/pommed
+    install -Dm644 pommed.conf.mactel $out/etc/pommed.conf.mactel
+    install -Dm644 pommed.conf.pmac $out/etc/pommed.conf.pmac
+
+    # Man page
+    install -Dm644 pommed.1 $out/share/man/man1/pommed.1
+
+    # Sounds
+    install -Dm644 pommed/data/goutte.wav $out/share/pommed/goutte.wav
+    install -Dm644 pommed/data/click.wav $out/share/pommed/click.wav
+  '';
+
+  meta = {
+    description = "A trimmed version of the pommed hotkey handler for MacBooks";
+    longDescription = ''
+      This is a stripped-down version of pommed with client, dbus, and
+      ambient light sensor support removed, optimized for use with dwm
+      and the like.
+    '';
+    homepage = https://github.com/bytbox/pommed-light;
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14347,6 +14347,8 @@ in
 
   pommed = callPackage ../os-specific/linux/pommed {};
 
+  pommed_light = callPackage ../os-specific/linux/pommed-light {};
+
   pond = callPackage ../applications/networking/instant-messengers/pond { };
 
   ponymix = callPackage ../applications/audio/ponymix { };


### PR DESCRIPTION
###### Motivation for this change

The pommed package was marked as broken. It is also severely unmaintained. I therefore chose to replace it entirely with `pommed-light`, for now.

There are some forks of the original pommed to be found (in fact, `pommed-light` seems to be one) which aren't unmaintained. For example, Arch's AUR has a package [`pommed-jalaziz`](https://aur.archlinux.org/packages/pommed-jalaziz/) which seems to be maintained well.

So we could maybe follow the same example, and add two versions of pommed in our package tree: `pommed-jalaziz` and `pommed-light`. And then we could extend the service with an option (e.g. `services.hardware.pommed.package`) to allow the user to select a package.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

