### PR TITLE
Sane cross-compiling through bootstrapping

### DIFF
--- a/doc/cross-compilation.xml
+++ b/doc/cross-compilation.xml
@@ -124,6 +124,11 @@
       Because of this, a best-of-both-worlds solution is in the works with no splicing or explicit access of <varname>buildPackages</varname> needed.
       For now, feel free to use either method.
     </para>
+    <note><para>
+      There is also a "backlink" <varname>__targetPackages</varname>, yielding a package set which whose <varname>buildPackages<varname> is the current package set.
+      This is a hack, though, to accommodate compilers with lousy build systems.
+      Please do not use this unless you are absolutely sure you are packaging such a compiler and there is no other way.
+    </para></note>
   </section>
 
 </section>

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -60,6 +60,38 @@ rec {
   */
   foldl' = builtins.foldl' or foldl;
 
+  /* "Fold" a ternary function `op' between successive elements of `list' as if
+     it was a doubly-linked list with `lnul' and `rnul` base cases at either
+     end. In precise terms, `fold op lnul rnul [x_0 x_1 x_2 ... x_n-1]` is the
+     same as
+
+       let
+         f_-1  = lnul;
+         f_0   = op f_-1   x_0  f_1;
+         f_1   = op f_0    x_1  f_2;
+         f_2   = op f_1    x_2  f_3;
+         ...
+         f_n   = op f_n-1  x_n  f_n+1;
+         f_n+1 = rnul;
+       in
+         f_0
+
+     New in 17.03 --- Until that release is cut, feel free to modify this
+     function (and update its uses accordingly).
+  */
+  dfold = op: lnul: rnul: list:
+    let
+      len = length list;
+      go = pred: n:
+        if n == len
+        then rnul
+        else let
+          # Note the cycle -- call-by-need ensures finite fold.
+          cur  = op pred (elemAt list n) succ;
+          succ = go cur (n + 1);
+        in cur;
+    in go lnul 0;
+
   /* Map with index
 
      FIXME(zimbatm): why does this start to count at 1?

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -37,13 +37,13 @@ let
   # base packages of the chroot
   # these match the host's architecture, glibc_multi is used for multilib
   # builds.
-  basePkgs = with pkgs;
+  basePkgs = with (pkgs.buildPackages // pkgs);
     [ (if isMultiBuild then glibc_multi else glibc)
       (toString gcc.cc.lib) bashInteractive coreutils less shadow su
       gawk diffutils findutils gnused gnugrep
       gnutar gzip bzip2 xz glibcLocales
     ];
-  baseMultiPkgs = with pkgsi686Linux;
+  baseMultiPkgs = with (pkgsi686Linux.buildPackages // pkgsi686Linux);
     [ (toString gcc.cc.lib)
     ];
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -280,8 +280,8 @@ stdenv.mkDerivation {
     else "";
 
   crossAttrs = {
-    shell = shell.crossDrv + shell.crossDrv.shellPath;
-    libc = stdenv.ccCross.libc;
+    #shell = shell.crossDrv + shell.crossDrv.shellPath;
+    #libc = stdenv.ccCross.libc;
     #
     # This is not the best way to do this. I think the reference should be
     # the style in the gcc-cross-wrapper, but to keep a stable stdenv now I

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -1,11 +1,7 @@
-{ stdenv, lib, fetchurl, tzdata, iana_etc, libcCross
+{ stdenv, lib, fetchurl, tzdata, iana_etc, libc
 , pkgconfig
 , pcre
 , Security }:
-
-let
-  libc = if stdenv ? "cross" then libcCross else stdenv.cc.libc;
-in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -78,7 +78,8 @@ let
       };
 
     in
-      import ./hackage-packages.nix { inherit pkgs stdenv callPackage; } self // {
+      # TODO(@Ericson2314) think harder about build-time dependencies
+      import ./hackage-packages.nix { inherit stdenv callPackage; pkgs = pkgs.buildPackages // pkgs;  } self // {
 
         inherit mkDerivation callPackage;
 

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -58,6 +58,10 @@ rec {
   # builds.
   makeStdenvCross = stdenv: cross: binutilsCross: gccCross: stdenv // {
 
+    # Overrides are surely not valid as packages built with this run on a
+    # different platform.
+    overrides = _: _: {};
+
     mkDerivation =
       { name ? "", buildInputs ? [], nativeBuildInputs ? []
       , propagatedBuildInputs ? [], propagatedNativeBuildInputs ? []

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -21,9 +21,7 @@ in bootStages ++ [
     selfBuild = false;
     # It's OK to change the built-time dependencies
     allowCustomOverrides = true;
-    stdenv = vanillaPackages.stdenv // {
-      overrides = _: _: {};
-    };
+    inherit (vanillaPackages) stdenv;
   })
 
   # Run Packages

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -253,7 +253,7 @@ in rec {
     inherit
       gnumake gzip gnused bzip2 gawk ed xz patch bash
       libcxxabi libcxx ncurses libffi zlib icu llvm gmp pcre gnugrep
-      coreutils findutils diffutils patchutils binutils binutils-raw;
+      coreutils findutils diffutils patchutils;
 
     llvmPackages = super.llvmPackages // {
       inherit (llvmPackages) llvm clang-unwrapped;
@@ -262,6 +262,9 @@ in rec {
     darwin = super.darwin // {
       inherit (darwin) dyld Libsystem cctools libiconv;
     };
+  } // lib.optionalAttrs (super.targetPlatform == localSystem) {
+    # Need to get rid of these when cross-compiling.
+    inherit binutils binutils-raw;
   };
 
   stdenvDarwin = prevStage: let pkgs = prevStage; in import ../generic rec {

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -300,10 +300,12 @@ in
 
       overrides = self: super: {
         inherit (prevStage)
-          gcc-unwrapped
-          gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
+          gzip bzip2 xz bash coreutils diffutils findutils gawk
           glibc gnumake gnused gnutar gnugrep gnupatch patchelf
           attr acl paxctl zlib pcre;
+      } // lib.optionalAttrs (super.targetPlatform == localSystem) {
+        # Need to get rid of these when cross-compiling.
+        inherit (prevStage) binutils gcc-unwrapped;
       };
     };
   })

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -232,7 +232,8 @@ in
       # other purposes (binutils and top-level pkgs) too.
       inherit (prevStage) gettext gnum4 bison gmp perl glibc zlib linuxHeaders;
 
-      gcc = lib.makeOverridable (import ../../build-support/cc-wrapper) {
+      # Can't be called plain `gcc` or will be clobbered by build wrappers
+      gcc' = lib.makeOverridable (import ../../build-support/cc-wrapper) {
         nativeTools = false;
         nativeLibc = false;
         isGNU = true;
@@ -277,7 +278,7 @@ in
         # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
         lib.optional (system == "aarch64-linux") prevStage.updateAutotoolsGnuConfigScriptsHook;
 
-      cc = prevStage.gcc;
+      cc = prevStage.gcc';
 
       shell = cc.shell;
 
@@ -298,9 +299,8 @@ in
         */
 
       overrides = self: super: {
-        gcc = cc;
-
         inherit (prevStage)
+          gcc-unwrapped
           gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
           glibc gnumake gnused gnutar gnugrep gnupatch patchelf
           attr acl paxctl zlib pcre;

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -94,12 +94,12 @@ rec {
         cp -d ${gnugrep.pcre.out}/lib/libpcre*.so* $out/lib # needed by grep
 
         # Copy what we need of GCC.
-        cp -d ${gcc.cc.out}/bin/gcc $out/bin
-        cp -d ${gcc.cc.out}/bin/cpp $out/bin
-        cp -d ${gcc.cc.out}/bin/g++ $out/bin
-        cp -d ${gcc.cc.lib}/lib*/libgcc_s.so* $out/lib
-        cp -d ${gcc.cc.lib}/lib*/libstdc++.so* $out/lib
-        cp -rd ${gcc.cc.out}/lib/gcc $out/lib
+        cp -d ${gcc-unwrapped.out}/bin/gcc $out/bin
+        cp -d ${gcc-unwrapped.out}/bin/cpp $out/bin
+        cp -d ${gcc-unwrapped.out}/bin/g++ $out/bin
+        cp -d ${gcc-unwrapped.lib}/lib*/libgcc_s.so* $out/lib
+        cp -d ${gcc-unwrapped.lib}/lib*/libstdc++.so* $out/lib
+        cp -rd ${gcc-unwrapped.out}/lib/gcc $out/lib
         chmod -R u+w $out/lib
         rm -f $out/lib/gcc/*/*/include*/linux
         rm -f $out/lib/gcc/*/*/include*/sound
@@ -107,11 +107,11 @@ rec {
         rm -f $out/lib/gcc/*/*/include-fixed/asm
         rm -rf $out/lib/gcc/*/*/plugin
         #rm -f $out/lib/gcc/*/*/*.a
-        cp -rd ${gcc.cc.out}/libexec/* $out/libexec
+        cp -rd ${gcc-unwrapped.out}/libexec/* $out/libexec
         chmod -R u+w $out/libexec
         rm -rf $out/libexec/gcc/*/*/plugin
         mkdir $out/include
-        cp -rd ${gcc.cc.out}/include/c++ $out/include
+        cp -rd ${gcc-unwrapped.out}/include/c++ $out/include
         chmod -R u+w $out/include
         rm -rf $out/include/c++/*/ext/pb_ds
         rm -rf $out/include/c++/*/ext/parallel

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -43,10 +43,12 @@ bootStages ++ [
 
       overrides = self: super: {
         inherit cc;
-        inherit (cc) binutils;
         inherit (prevStage)
           gzip bzip2 xz bash coreutils diffutils findutils gawk
           gnumake gnused gnutar gnugrep gnupatch perl;
+      } // lib.optionalAttrs (super.targetPlatform == localSystem) {
+        # Need to get rid of these when cross-compiling.
+        inherit (prevStage) binutils;
       };
     };
   })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8270,9 +8270,9 @@ with pkgs;
   # glibc provides libiconv so systems with glibc don't need to build libiconv
   # separately, but we also provide libiconvReal, which will always be a
   # standalone libiconv, just in case you want it
-  libiconv = if stdenv ? cross then
-    (if stdenv.cross.libc == "glibc" then libcCross
-      else if stdenv.cross.libc == "libSystem" then darwin.libiconv
+  libiconv = if hostPlatform != buildPlatform then
+    (if hostPlatform.libc == "glibc" then libcCross
+      else if hostPlatform.libc == "libSystem" then darwin.libiconv
       else libiconvReal)
     else if stdenv.isGlibc then glibcIconv stdenv.cc.libc
     else if stdenv.isDarwin then darwin.libiconv

--- a/pkgs/top-level/build-wrappers.nix
+++ b/pkgs/top-level/build-wrappers.nix
@@ -1,0 +1,113 @@
+# Build-time wrapers referencing run-time packages
+#
+# There are a few simple rules on deps that apply to the vast majority of
+# packages: packages used at build-time are native, packages used at run-time
+# are foreign, a run-time dep of a build-time dep is a transative build-time
+# dep. The overal principle here is a run-time dep is a same phase/stage dep,
+# while a build-time dep is a previous phase/stage dep; a package should never
+# depend on a future phase/stage.
+#
+# The glaring exception to this is certain wrappers around build tools
+# (especially compilers) that inject run-time dependencies into the artifacts
+# these tools create. The inject dependencies belong in a future stage than the
+# wrapped tool or the wrapper script, as they are run-time with respect to the
+# artifacts built by the tool, not the tool itself.
+#
+# Where possible, its best to avoid the need for such wrappers, but this cannot
+# always be readily accomplished, hence the purpose of this package
+# index. `__targetPackages` is the future stage from which to drawn these
+# downstream dependencies. Care must be taken to avoid cycles--i.e. use
+# unwrapped or less-wrapped version of the tools when building the packages that
+# are then injected here.
+#
+# As an added bonus, since these wrappers are only available as part of
+# `buidlPackages`, it will be slightly harder to accidently depend on compilers
+# at runtime, which is usually a mistake.
+self: super:
+
+with self;
+
+{
+  wrapCCWith = ccWrapper: libc: extraBuildCommands: baseCC: ccWrapper {
+    nativeTools = stdenv.cc.nativeTools or false;
+    nativeLibc = stdenv.cc.nativeLibc or false;
+    nativePrefix = stdenv.cc.nativePrefix or "";
+    cc = baseCC;
+    dyld = if stdenv.isDarwin then darwin.dyld else null;
+    isGNU = baseCC.isGNU or false;
+    isClang = baseCC.isClang or false;
+    inherit libc extraBuildCommands;
+  };
+
+  ccWrapperFun = callPackage ../build-support/cc-wrapper;
+
+  wrapCC = wrapCCWith ccWrapperFun __targetPackages.libc "";
+  # legacy version, used for gnat bootstrapping
+  wrapGCC-old = baseGCC: callPackage ../build-support/gcc-wrapper-old {
+    nativeTools = stdenv.cc.nativeTools or false;
+    nativeLibc = stdenv.cc.nativeLibc or false;
+    nativePrefix = stdenv.cc.nativePrefix or "";
+    gcc = baseGCC;
+    libc = glibc;
+  };
+
+  wrapGCCCross =
+    {gcc, libc, binutils, cross, shell ? "", name ? "gcc-cross-wrapper"}:
+
+    callPackage ../build-support/gcc-cross-wrapper {
+      nativeTools = false;
+      nativeLibc = false;
+      noLibc = (libc == null);
+      inherit gcc binutils libc shell name cross;
+    };
+
+  gccCrossStageStatic = assert stdenv ? cross; wrapGCCCross {
+    gcc = gccCrossStageStatic-unwrapped;
+    libc = libcTarget;
+    inherit binutils;
+    inherit (stdenv) cross;
+  };
+
+  # Only needed for mingw bootstrapping
+  gccCrossMingw2 = assert stdenv ? cross; wrapGCCCross {
+    gcc = gccCrossStageStatic-unwrapped;
+    libc = windows.mingw_headers2;
+    inherit binutils;
+    inherit (stdenv) cross;
+  };
+
+  gccCrossStageFinal = assert stdenv ? cross; wrapGCCCross {
+    gcc = gccCrossStageFinal-unwrapped;
+    inherit (__targetPackages) libc;
+    inherit binutils;
+    inherit (stdenv) cross;
+  };
+
+  gcc45 = wrapCC gcc45-unwrapped;
+  gcc48 = wrapCC gcc48-unwrapped;
+  gcc49 = wrapCC gcc49-unwrapped;
+  gcc5 = wrapCC gcc5-unwrapped;
+  gcc6 = wrapCC gcc6-unwrapped;
+  gcc = wrapCC gcc-unwrapped;
+
+  gcc_debug = wrapCC gcc_debug-unwrapped;
+
+  gfortran48 = wrapCC gfortran48-unwrapped;
+  gfortran49 = wrapCC gfortran49-unwrapped;
+  gfortran5 = wrapCC gfortran5-unwrapped;
+  gfortran6 = wrapCC gfortran6-unwrapped;
+
+  gcj49 = wrapCC gcj49-unwrapped;
+  gcj = wrapCC gcj-unwrapped;
+
+  gnat45 = wrapCC gnat45-unwrapped;
+  gnat = wrapCC gnat-unwrapped;
+
+  gnatboot = wrapGCC-old  gnatboot-unwrapped;
+
+  gccgo49 = wrapCC gccgo49-unwrapped;
+  gccgo = wrapCC gccgo-unwrapped;
+
+  clang_35 = wrapCC llvmPackages_35.clang;
+  clang_34 = wrapCC llvmPackages_34.clang;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1945,7 +1945,7 @@ in {
       sha256 = "1ajmflvvlkflrcmqmkrx0zaira84z8kv4ssb2jprfwvjh8vfkysb";
     };
 
-    buildInputs = [ pkgs.gcc ];
+    buildInputs = [ pkgs.buildPackages.gcc ];
     propagatedBuildInputs = [ pkgs.wirelesstools ];
 
     meta = {
@@ -7201,7 +7201,7 @@ in {
     };
 
     buildInputs = [
-      pkgs.gcc
+      pkgs.buildPackages.gcc
       pkgs.gmp
     ];
 
@@ -7221,7 +7221,7 @@ in {
     };
 
     buildInputs = [
-      pkgs.gcc
+      pkgs.buildPackages.gcc
       pkgs.gmp
       pkgs.mpfr
       pkgs.libmpc
@@ -22174,7 +22174,7 @@ in {
     propagatedBuildInputs = with self; [ numpy scipy matplotlib pyqt4
       cython ];
 
-    buildInputs = [ pkgs.gcc pkgs.qt4 pkgs.blas self.nose ];
+    buildInputs = [ pkgs.buildPackages.gcc pkgs.qt4 pkgs.blas self.nose ];
 
     meta = {
       description = "QuTiP - Quantum Toolbox in Python";
@@ -31035,7 +31035,7 @@ EOF
     propagatedBuildInputs = with self; [ numpy six protobuf3_0_0b2 pkgs.swig mock];
 
     preFixup = ''
-      RPATH="${stdenv.lib.makeLibraryPath [ pkgs.gcc.cc.lib pkgs.zlib ]}"
+      RPATH="${stdenv.lib.makeLibraryPath [ pkgs.buildPackages.gcc.cc.lib pkgs.zlib ]}"
       find $out -name '*.so' -exec patchelf --set-rpath "$RPATH" {} \;
     '';
 
@@ -31060,13 +31060,13 @@ EOF
     };
 
     buildInputs = with self; [ pkgs.swig ];
-    propagatedBuildInputs = with self; [ numpy six protobuf3_0 pkgs.cudatoolkit75 pkgs.cudnn5_cudatoolkit75 pkgs.gcc49 self.mock ];
+    propagatedBuildInputs = with self; [ numpy six protobuf3_0 pkgs.cudatoolkit75 pkgs.cudnn5_cudatoolkit75 pkgs.buildPackages.gcc49 self.mock ];
 
     # Note that we need to run *after* the fixup phase because the
     # libraries are loaded at runtime. If we run in preFixup then
     # patchelf --shrink-rpath will remove the cuda libraries.
     postFixup = let rpath = stdenv.lib.makeLibraryPath [
-      pkgs.gcc49.cc.lib
+      pkgs.buildPackages.gcc49.cc.lib
       pkgs.zlib pkgs.cudatoolkit75
       pkgs.cudnn5_cudatoolkit75
       pkgs.linuxPackages.nvidia_x11

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -65,7 +65,7 @@ let
   splicedPackages =
     if actuallySplice
     then splicer defaultBuildScope defaultRunScope
-    else pkgs // pkgs.xorg;
+    else import ./build-wrappers.nix pkgs // pkgs.xorg;
 
 in
 

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -49,6 +49,13 @@
   # be defined internally as the produced package set as itself.
   buildPackages
 
+, # The package set used in the next stage. If null, `__targetPackages` will be
+  # defined internally as the produced package set as itself.
+  #
+  # THIS IS A HACK for compilers that don't think critically about cross-
+  # compilation. Please do *not* use unless you really know what you are doing.
+  __targetPackages
+
 , # The standard environment to use for building packages.
   stdenv
 
@@ -86,6 +93,8 @@ let
 
   stdenvBootstappingAndPlatforms = self: super: {
     buildPackages = (if buildPackages == null then self else buildPackages)
+      // { recurseForDerivations = false; };
+    __targetPackages = (if __targetPackages == null then self else __targetPackages)
       // { recurseForDerivations = false; };
     inherit stdenv
       buildPlatform hostPlatform targetPlatform;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -122,6 +122,18 @@ let
       res self;
     in res;
 
+  # Build wrappers are added in anticipation of there being a successor stage
+  # using this stage as its `buildPackages` (or this stage being built against
+  # itself. As such, it is the only semi-acceptable use of `__targetPackages`.
+  #
+  # Note that if `__targetPackages` is `{}`, then we know there is no successor
+  # stage, so we don't need to apply this. This is a small half-measure to help
+  # catch improperly *using* wrappers from `pkgs` instead of `buildPackages`.
+  buildWrappers = self: super:
+    if targetPackages == {}
+    then {};
+    else import ./splice.nix self
+
   aliases = self: super: import ./aliases.nix super;
 
   # stdenvOverrides is used to avoid having multiple of versions
@@ -149,6 +161,7 @@ let
     trivialBuilders
     splice
     allPackages
+    buildWrappers
     aliases
     stdenvOverrides
     configOverrides


### PR DESCRIPTION
Ok, this is it, my final and biggest top-level refactor for 2016!

I've factored things into separate PRs, so this builds on https://github.com/NixOS/nixpkgs/pull/21415 to provide a consistent idiom for bootstrapping which I extend and further utilize for cross compiling, and https://github.com/NixOS/nixpkgs/pull/21414 which cleans up the cross-compiling tests.

It should also eventually subsume https://github.com/NixOS/nixpkgs/pull/21388, but I am still getting things unbroken.

This isn't ready to merge (need to unbreak cross compiling completely) but is ready to review---only uninteresting bug fixes should be left.

----

OP

The first commit introduces a new abstraction for dealing with stdenv bootstrapping. It doesn't really make anything shorter, but at least it enforces a consistent ideom across all of them. This commit  works, but I'd love advice on how to make linux and darwin better utilize it. @copumpkin I'm especially curious about your feedback, and whether this will help with your goal of automatically solving for bootstrapping stages (I hope it will! but not sure).

The second commit is just the bare-bones of what I want cross-compiling to look like. The big ideas are

- To finally take advantage of bootstrapping rather than have all these `*Cross` packages and other hacks: "native dependencies" are actually stage n-1 dependencies  
- Properly distinguish between `host` and `target` in the autotools sense.

I'll probably end up splitting this into two PRs to get the first part merged sooner, but wanted to include the second part for now in order to better motivate the first.

---

Probably closes https://github.com/NixOS/nixpkgs/issues/14965
Takes a big stab at closing https://github.com/NixOS/nixpkgs/issues/10874
I shamelessly stole things from https://github.com/NixOS/nixpkgs/pull/18386 and will steal more!

CC @DavidEGrayson @nbp @shlevy @copumpkin @vcunat 