### PR TITLE
mm: init at 2016.11.04

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mm/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mm/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildGoPackage, fetchFromGitLab }:
+
+buildGoPackage rec {
+  name = "mm-${version}";
+  version = "2016.11.04";
+
+  goPackagePath = "gitlab.com/meutraa/mm";
+
+  src = fetchFromGitLab {
+    owner = "meutraa";
+    repo = "mm";
+    rev = "473fdd97285168054b672dbad2ffc4047324c518";
+    sha256 = "1s8v5gxpw1sms1g3i8nq2x2mmmyz97qkmxs1fzlspfcd6i8vknkp";
+  };
+
+  meta = {
+    description = "A file system based matrix client";
+    homepage = https://gitlab.com/meutraa/mm;
+    license = stdenv.lib.licenses.isc;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13971,6 +13971,8 @@ in
 
   normalize = callPackage ../applications/audio/normalize { };
 
+  mm = callPackage ../applications/networking/instant-messengers/mm { };
+
   mplayer = callPackage ../applications/video/mplayer ({
     pulseSupport = config.pulseaudio or false;
     libdvdnav = libdvdnav_4_2_1;


### PR DESCRIPTION
###### Motivation for this change

Make mm package for chatting on matrix network available as part of nixpkgs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

