### PR TITLE
stellarium: 0.14.3 -> 0.15.0

### DIFF
--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -1,20 +1,22 @@
 { stdenv, fetchurl, cmake, freetype, libpng, mesa, gettext, openssl, perl, libiconv
 , qtscript, qtserialport, qttools, makeQtWrapper
+, qtmultimedia
 }:
 
 stdenv.mkDerivation rec {
-  name = "stellarium-0.14.3";
+  name = "stellarium";
+  version = "0.15.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/stellarium/${name}.tar.gz";
-    sha256 = "1919wzlvhfxdxficbwhp31xlhm0571grgcmsfdp5y36z9yqwahfy";
+    url = "mirror://sourceforge/stellarium/${name}-${version}.tar.gz";
+    sha256 = "0il751lgnfkx35h1m8fzwwnrygpxjx2a80gng1i1rbybkykf7l3l";
   };
 
   nativeBuildInputs = [ makeQtWrapper ];
 
   buildInputs = [
     cmake freetype libpng mesa gettext openssl perl libiconv qtscript
-    qtserialport qttools
+    qtserialport qttools qtmultimedia
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@peti 