### PR TITLE
Plex: update, open ports

### DIFF
--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -127,7 +127,7 @@ in
         User = cfg.user;
         Group = cfg.group;
         PermissionsStartOnly = "true";
-        ExecStart = "/bin/sh -c '${cfg.package}/usr/lib/plexmediaserver/Plex\\ Media\\ Server'";
+        ExecStart = "/bin/sh -c ${cfg.package}/usr/lib/plexmediaserver/Plex\\ Media\\ Server";
         Restart = "on-failure";
       };
       environment = {

--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -141,6 +141,11 @@ in
       };
     };
 
+    networking.firewall = {
+      allowedTCPPorts = [ 32400 3005 8324 32469 ];
+      allowedUDPPorts = [ 1900 5353 32410 32412 32413 32414 ];
+    };
+
     users.extraUsers = mkIf (cfg.user == "plex") {
       plex = {
         group = cfg.group;

--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -6,9 +6,9 @@
 let
   plexPass = throw "Plex pass has been removed at upstream's request; please unset nixpkgs.config.plex.pass";
   plexpkg = if enablePlexPass then plexPass else {
-    version = "1.2.7.2987";
-    vsnHash = "1bef33a";
-    sha256 = "17d1yisbikcp25mgn71rf8w76zhy015f33hxjj93swfm1qrq55hq";
+    version = "1.3.3.3148";
+    vsnHash = "b38628e";
+    sha256 = "1dx8z27l1dwigr3ipcdzn25hnj0206255ihxh9rnh2qchrcqmb5y";
   };
 
 in stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm not sure if it's standard practice for network services to open up firewall ports on their own like this, or if it instead needs to be made into an option or put in the documentation.