### PR TITLE
wireguard: 0.0.20161209 -> 0.0.20161218

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -14,6 +14,13 @@ let
 
     options = {
 
+      package = mkOption {
+        type = types.path;
+        default = pkgs.wireguard;
+        defaultText = "pkgs.wireguard";
+        description = "Used wireguard package";
+      };
+
       ips = mkOption {
         example = [ "192.168.2.1/24" ];
         default = [];
@@ -150,7 +157,7 @@ let
   '';
 
   ipCommand = "${pkgs.iproute}/bin/ip";
-  wgCommand = "${pkgs.wireguard}/bin/wg";
+  wgCommand = "${cfg.package}/bin/wg";
 
   generateUnit = name: values:
     nameValuePair "wireguard-${name}"

--- a/pkgs/os-specific/linux/wireguard/0.0.20161209.nix
+++ b/pkgs/os-specific/linux/wireguard/0.0.20161209.nix
@@ -1,0 +1,9 @@
+{ stdenv, fetchurl, libmnl, iproute, kernel ? null }:
+
+# 0.0.20161216 introduced a non-backwards protocol change.
+# this version is kept around to have a version compatible with nixos stable.
+import ./generic.nix {
+  version = "0.0.20161209";
+  sha256  = "caabb9bb471a262e178162c30b8b8524cc3a05e0e9daf23a921870a4106ec886";
+  inherit stdenv fetchurl libmnl iproute kernel;
+}

--- a/pkgs/os-specific/linux/wireguard/latest.nix
+++ b/pkgs/os-specific/linux/wireguard/latest.nix
@@ -1,0 +1,7 @@
+{ stdenv, fetchurl, libmnl, iproute, kernel ? null }:
+
+import ./generic.nix {
+  version = "0.0.20161218";
+  sha256  = "d805035d3e99768e69d8cdeb8fb5250a59b994ce127fceb71a078582c30f5597";
+  inherit stdenv fetchurl libmnl iproute kernel;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11213,7 +11213,9 @@ in
       virtualbox = pkgs.virtualboxHardened;
     };
 
-    wireguard = callPackage ../os-specific/linux/wireguard { };
+    # kept for backwards compatibility with nixos 16.03
+    wireguard_0_0_20161209 = callPackage ../os-specific/linux/wireguard/0.0.20161209.nix { };
+    wireguard = callPackage ../os-specific/linux/wireguard/latest.nix { };
 
     x86_energy_perf_policy = callPackage ../os-specific/linux/x86_energy_perf_policy { };
 
@@ -15261,7 +15263,9 @@ in
 
   wings = callPackage ../applications/graphics/wings { };
 
-  wireguard = callPackage ../os-specific/linux/wireguard { };
+  # kept for backwards compatibility with nixos 16.03
+  wireguard_0_0_20161209 = callPackage ../os-specific/linux/wireguard/0.0.20161209.nix { };
+  wireguard = callPackage ../os-specific/linux/wireguard/latest.nix { };
 
   wmname = callPackage ../applications/misc/wmname { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

