### PR TITLE
fte: init at 0.50.02

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -483,6 +483,7 @@
   vlstill = "Vladimír Štill <xstill@fi.muni.cz>";
   vmandela = "Venkateswara Rao Mandela <venkat.mandela@gmail.com>";
   volhovm = "Mikhail Volkhov <volhovm.cs@gmail.com>";
+  volth = "Jaroslavas Pocepko <jaroslavas@volth.com>";
   vozz = "Oliver Hunt <oliver.huntuk@gmail.com>";
   vrthra = "Rahul Gopinath <rahul@gopinath.org>";
   wedens = "wedens <kirill.wedens@gmail.com>";

--- a/pkgs/applications/editors/fte/default.nix
+++ b/pkgs/applications/editors/fte/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, unzip, perl, libX11, libXpm, gpm, ncurses, slang }:
+
+stdenv.mkDerivation rec {
+  name = "fte-0.50.02";
+
+  buildInputs = [ unzip perl libX11 libXpm gpm ncurses slang ];
+
+  ftesrc = fetchurl {
+    url = "mirror://sourceforge/fte/fte-20110708-src.zip";
+    sha256 = "17j9akr19w19myglw5mljjw2g3i2cwxiqrjaln82h3rz5ma1qcfn";
+  };
+  ftecommon = fetchurl {
+    url = "mirror://sourceforge/fte/fte-20110708-common.zip";
+    sha256 = "1xva4kh0674sj2b9rhf2amlr37yxmsvjkgyj89gpcn0rndw1ahaq";
+  };
+  src = [ ftesrc ftecommon ];
+
+  buildFlags = "PREFIX=$(out)";
+
+  installFlags = "PREFIX=$(out) INSTALL_NONROOT=1";
+
+  meta = with stdenv.lib; {
+    description = "A free text editor for developers";
+    homepage = http://fte.sourceforge.net/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13167,6 +13167,8 @@ in
     boost = boost155;
   };
 
+  fte = callPackage ../applications/editors/fte { };
+
   game-music-emu = callPackage ../applications/audio/game-music-emu { };
 
   gcolor2 = callPackage ../applications/graphics/gcolor2 { };


### PR DESCRIPTION
###### Motivation for this change

Package FTE (straightforward translation from [Arch Linux](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fte))

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

