### PR TITLE
zim: fix #21270 (double call of wrapPythonPrograms)

### DIFF
--- a/pkgs/applications/office/zim/default.nix
+++ b/pkgs/applications/office/zim/default.nix
@@ -31,7 +31,6 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   postFixup = ''
-    wrapPythonPrograms
     substituteInPlace $out/bin/.zim-wrapped \
     --replace "sys.argv[0] = 'zim'" "sys.argv[0] = '$out/bin/zim'"
   '';


### PR DESCRIPTION
Fixes #21270

###### Motivation for this change

Comment by @FRidh on the linked issue

###### Things done

- [] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

