### PR TITLE
stdenv setup: disallow references to the build directory

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1009,6 +1009,15 @@ installcheck</command>.</para>
   </varlistentry>
 
   <varlistentry>
+    <term><varname>noErrorBuildTop</varname></term>
+    <listitem><para>Allow outputs to capture references to the build
+    directory.  Normally, all outputs are scanned for references to
+    the build directory and the build aborted if any are found.  Such
+    references are most likely accidental and may make the build
+    non-reproducible.</para></listitem>
+  </varlistentry>
+
+  <varlistentry>
     <term><varname>preInstallCheck</varname></term>
     <listitem><para>Hook executed at the start of the installCheck
     phase.</para></listitem>

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -794,15 +794,15 @@ installCheckPhase() {
         $makeFlags "${makeFlagsArray[@]}" \
         $installCheckFlags "${installCheckFlagsArray[@]}" ${installCheckTarget:-installcheck}
 
-
     if [ -z "$noErrorBuildTop" -a "$NIX_ENFORCE_PURITY" = "1" -a -n "$NIX_BUILD_TOP" ]; then
-        if grep -qr $NIX_BUILD_TOP $out; then
-            echo "ERROR: The following files include the build path: $NIX_BUILD_TOP"
-            echo "ERROR: Either fix the nix expression or set noErrorBuildTop"
-            grep -lr $NIX_BUILD_TOP $out
-            exit 1
-        fi
-    fi
+        for output in $outputs; do
+            if grep -qr $NIX_BUILD_TOP ${!output} ; then
+                echo "ERROR: found reference to build path $NIX_BUILD_TOP in the following files"
+                grep -lr $NIX_BUILD_TOP ${!output}
+                exit 1
+            fi
+        done
+    done
 
     runHook postInstallCheck
 }

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -794,6 +794,16 @@ installCheckPhase() {
         $makeFlags "${makeFlagsArray[@]}" \
         $installCheckFlags "${installCheckFlagsArray[@]}" ${installCheckTarget:-installcheck}
 
+
+    if [ -z "$noErrorBuildTop" -a "$NIX_ENFORCE_PURITY" = "1" -a -n "$NIX_BUILD_TOP" ]; then
+        if grep -qr $NIX_BUILD_TOP $out; then
+            echo "ERROR: The following files include the build path: $NIX_BUILD_TOP"
+            echo "ERROR: Either fix the nix expression or set noErrorBuildTop"
+            grep -lr $NIX_BUILD_TOP $out
+            exit 1
+        fi
+    fi
+
     runHook postInstallCheck
 }
 


### PR DESCRIPTION
Extracted from https://github.com/NixOS/nixpkgs/pull/2281

Unfortunately, I lack the capacity for testing this, hopefully somebody is able and willing to do so in my stead (if this is something we want to do).