### PR TITLE
idrisPackages.httpclient: init

### DIFF
--- a/pkgs/development/idris-modules/httpclient.nix
+++ b/pkgs/development/idris-modules/httpclient.nix
@@ -1,0 +1,30 @@
+{ pkgs
+, build-idris-package
+, fetchFromGitHub
+, lightyear
+, contrib
+, lib
+, idris
+}:
+
+let
+  date = "2016-12-20";
+in
+build-idris-package {
+  name = "httpclient-${date}";
+
+  src = fetchFromGitHub {
+    owner = "justjoheinz";
+    repo = "idris-httpclient";
+    rev = "4a7296d572d7f7fde87d27da07d5c9566dc4ff14";
+    sha256 = "0sy0q7gri9lwbqdmx9720pby3w1470w7wzn62bf2rir532219hhl";
+  };
+
+  propagatedBuildInputs = [ pkgs.curl lightyear contrib ];
+
+  meta = {
+    description = "HTTP Client for Idris";
+    homepage = https://github.com/justjoheinz/idris-httpclient;
+    inherit (idris.meta) platforms;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Add Idris HTTP Client Library.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

