### PR TITLE
python/pillow: Disable tests on Darwin

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18871,7 +18871,7 @@ in {
       sha256 = "0ee9975c05602e755ff5000232e0335ba30d507f6261922a658ee11b1cec36d1";
     };
 
-    doCheck = !isPyPy;
+    doCheck = !stdenv.isDarwin && !isPyPy;
 
     # Disable imagefont tests, because they don't work well with infinality:
     # https://github.com/python-pillow/Pillow/issues/1259


### PR DESCRIPTION
###### Motivation for this change
On Darwin, Pillow breaks when testing `ImageGrab` due to its inability to add `screencapture`. This prevents NixOps from being built on NixOS. Disable tests from running on Mac until `screencapture` can be included in the build inputs (currently, `screencapture` is not included directly into nixpkgs).

Removing the `ImageGrab` test does not alleviate all problems, as other problems arise; therefore, this seems to be the best path until the situation is alleviated. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
