### PR TITLE
matrix-synapse: 0.18.4 -> 0.18.5

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -9,15 +9,28 @@ let
       sha256 = "0gmx4y5kqqphnq3m7xk2vpzb0w2a4palicw7wfdr1q2schl9fhz2";
     };
   };
+  matrix-synapse-ldap3 = pythonPackages.buildPythonApplication rec {
+    name = "matrix-synapse-ldap3-${version}";
+    version = "0.1.1";
+
+    src = fetchFromGitHub {
+      owner = "matrix-org";
+      repo = "matrix-synapse-ldap3";
+      rev = "564eb3f109ce7f1082c47d5f8efaa792d90467f1";
+      sha256 = "1mkjlvy7a3rq405m59ihkh1wq7pa4l03fp8hgwwyjnbmz25bqmbk";
+    };
+
+    propagatedBuildInputs = with pythonPackages; [ service-identity ldap3 twisted ];
+  };
 in pythonPackages.buildPythonApplication rec {
   name = "matrix-synapse-${version}";
-  version = "0.18.4";
+  version = "0.18.5";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "synapse";
     rev = "v${version}";
-    sha256 = "0hcag9a4wd6a9q0ln5l949xr1bhmk1zrnf9vf3qi3lzxgi0rbm98";
+    sha256 = "1l9vfx08alf71323jrfjjvcb7pww613dwxskdgc1bplnva4khj4f";
   };
 
   patches = [ ./matrix-synapse.patch ];
@@ -25,9 +38,9 @@ in pythonPackages.buildPythonApplication rec {
   propagatedBuildInputs = with pythonPackages; [
     blist canonicaljson daemonize dateutil frozendict pillow pybcrypt pyasn1
     pydenticon pymacaroons-pynacl pynacl pyopenssl pysaml2 pytz requests2
-    service-identity signedjson systemd twisted ujson unpaddedbase64 pyyaml
+    signedjson systemd twisted ujson unpaddedbase64 pyyaml
     matrix-angular-sdk bleach netaddr jinja2 psycopg2
-    ldap3 psutil msgpack lxml
+    psutil msgpack lxml matrix-synapse-ldap3
   ];
 
   # Checks fail because of Tox.

--- a/pkgs/servers/matrix-synapse/matrix-synapse.patch
+++ b/pkgs/servers/matrix-synapse/matrix-synapse.patch
@@ -3,18 +3,18 @@ new file mode 120000
 index 0000000..2f1d413
 --- /dev/null
 +++ b/homeserver
-@@ -0,0 +1 @@
+@@ -0,0 +1,1 @@
 +synapse/app/homeserver.py
 \ No newline at end of file
 diff --git a/setup.py b/setup.py
-index 9d24761..f3e6a00 100755
+index b00c2af..c7f6e0a 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -85,6 +85,6 @@ setup(
+@@ -92,6 +92,6 @@ setup(
      include_package_data=True,
      zip_safe=False,
      long_description=long_description,
 -    scripts=["synctl"] + glob.glob("scripts/*"),
 +    scripts=["synctl", "homeserver"] + glob.glob("scripts/*"),
-     cmdclass={'test': Tox},
+     cmdclass={'test': TestCommand},
  )


### PR DESCRIPTION
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

