### PR TITLE
cataract: init at 1.1.0 and HEAD

### DIFF
--- a/pkgs/applications/misc/cataract/build.nix
+++ b/pkgs/applications/misc/cataract/build.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchgit
+, autoreconfHook
+, glib
+, pkgconfig
+, libxml2
+, exiv2
+, imagemagick
+, version
+, sha256
+, rev }:
+
+stdenv.mkDerivation rec {
+  inherit version;
+  name = "cataract-${version}";
+
+  src = fetchgit {
+    url = "git://git.bzatek.net/cataract";
+    inherit sha256 rev;
+  };
+
+  buildInputs = [ autoreconfHook glib pkgconfig libxml2 exiv2 imagemagick ];
+
+  installPhase = ''
+    mkdir $out/{bin,share} -p
+    cp src/cgg{,-dirgen} $out/bin/
+  '';
+
+  meta = {
+    homepage = "http://cgg.bzatek.net/";
+    description = "a simple static web photo gallery, designed to be clean and easily usable";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
+    platforms = with stdenv.lib.platforms; [ linux darwin ];
+  };
+}
+
+

--- a/pkgs/applications/misc/cataract/default.nix
+++ b/pkgs/applications/misc/cataract/default.nix
@@ -1,0 +1,17 @@
+{ callPackage
+, stdenv
+, fetchgit
+, autoconf
+, automake
+, glib
+, pkgconfig
+, libxml2
+, exiv2
+, imagemagick }:
+
+callPackage ./build.nix {
+  version = "1.1.0";
+  rev = "675e647dc8ae918d29f520a29be9201ae85a94dd";
+  sha256 = "13b9rvcy9k2ay8w36j28kc7f4lnxp4jc0494ck3xsmwgqsawmzdj";
+}
+

--- a/pkgs/applications/misc/cataract/unstable.nix
+++ b/pkgs/applications/misc/cataract/unstable.nix
@@ -1,0 +1,17 @@
+{ callPackage
+, stdenv
+, fetchgit
+, autoconf
+, automake
+, glib
+, pkgconfig
+, libxml2
+, exiv2
+, imagemagick }:
+
+callPackage ./build.nix {
+  version = "unstable-2016-10-18";
+  rev = "db3d992febbe703931840e9bdad95c43081694a5";
+  sha256 = "04f85piy675lq36w1mw6mw66n8911mmn4ifj8h9x47z8z806h3rf";
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -696,6 +696,9 @@ with pkgs;
 
   capstone = callPackage ../development/libraries/capstone { };
 
+  cataract          = callPackage ../applications/misc/cataract { };
+  cataract-unstable = callPackage ../applications/misc/cataract/unstable.nix { };
+
   catch = callPackage ../development/libraries/catch { };
 
   catdoc = callPackage ../tools/text/catdoc { };


### PR DESCRIPTION
###### Motivation for this change

Cataract 1.1.0 and the latest HEAD from the repository (as there was no release in ... 6 years, though there were commits in the repository)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

