### PR TITLE
minecraft-server: 1.11 -> 1.11.1

### DIFF
--- a/pkgs/games/minecraft-server/default.nix
+++ b/pkgs/games/minecraft-server/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name    = "minecraft-server-${version}";
-  version = "1.11";
+  version = "1.11.1";
 
   src  = fetchurl {
     url    = "http://s3.amazonaws.com/Minecraft.Download/versions/${version}/minecraft_server.${version}.jar";
-    sha256 = "10vgvkklv3l66cvin2ikva2nj86gjl6p9ffizd6r89ixv1grcxrj";
+    sha256 = "161cwwcv73zisac1biz9arrby8y8n0j4bn9hz9rvy8dszlrbq0l0";
   };
 
   preferLocalBuild = true;


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

