### PR TITLE
picard: use lower mutagen version

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -3,6 +3,7 @@
 }:
 
 let
+  # ON UPDATE: remove mutagen_1_23 and update
   version = "1.3.2";
   pythonPackages = python2Packages;
 in pythonPackages.buildPythonApplication {
@@ -23,7 +24,7 @@ in pythonPackages.buildPythonApplication {
 
   propagatedBuildInputs = with pythonPackages; [
     pyqt4
-    mutagen
+    mutagen_1_23
     discid
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15001,6 +15001,28 @@ in {
     };
   });
 
+  # needed by picard
+  mutagen_1_23 = buildPythonPackage (rec {
+    name = "mutagen-1.23";
+
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/m/mutagen/${name}.tar.gz";
+      sha256 = "12f70aaf5ggdzll76bhhkn64b27xy9s1acx417dbsaqnnbis8s76";
+    };
+
+    # Needed for tests only
+    buildInputs = [ pkgs.faad2 pkgs.flac pkgs.vorbis-tools pkgs.liboggz
+      pkgs.glibcLocales
+    ];
+    LC_ALL = "en_US.UTF-8";
+
+    meta = {
+      description = "Python multimedia tagging library";
+      homepage = http://code.google.com/p/mutagen;
+      license = licenses.lgpl2;
+    };
+  });
+
 
   muttils = buildPythonPackage (rec {
     name = "muttils-1.3";


### PR DESCRIPTION
Picard failed with missing symbols with the newer version.

executes again.