### PR TITLE
libupnp: 1.6.20 -> 1.6.21

### DIFF
--- a/pkgs/development/libraries/pupnp/default.nix
+++ b/pkgs/development/libraries/pupnp/default.nix
@@ -1,11 +1,12 @@
-{ fetchurl, stdenv }:
+{ fetchzip, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "libupnp-1.6.20";
+  name = "libupnp-1.6.21";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/pupnp/${name}.tar.bz2";
-    sha256 = "0qrsdsb1qm85hc4jy04qph895613d148f0x1mmk6z99y3q43fdgf";
+  # TODO: use proper source, but it's not available for now.
+  src = fetchzip {
+    url = "https://sourceforge.net/code-snapshots/git/p/pu/pupnp/code.git/pupnp-code-07c03def31d7d8fc6c04646a28432a580a3b2d85.zip";
+    sha256 = "07ksfhadinaa20542gblrxi9pqz0v6y70a836hp3qr4037id4nm9";
   };
 
   hardeningDisable = [ "fortify" ];


### PR DESCRIPTION
###### Motivation for this change

I'm not super familiar with sourceforge, I hope this is not a temporary url.


/cc @grahamc


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

