### PR TITLE
ssrc: init at 1.33

### DIFF
--- a/pkgs/applications/audio/ssrc/default.nix
+++ b/pkgs/applications/audio/ssrc/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "ssrc";
+  name = "${pname}-${version}";
+  version = "1.33";
+
+  src = fetchFromGitHub {
+    owner = "shibatch";
+    repo = "SSRC";
+    rev = "4adf75116dfc0ef709fef74a0e2f3360bd15007f";
+    sha256 = "0hgma66v7sszkpz5jkyscj0q6lmjfqdwf1hw57535c012pa2vdrh";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ssrc ssrc_hp $out/bin
+    '';
+
+  meta = with stdenv.lib; {
+    description = "A high quality audio sampling rate converter";
+    longDescription = ''
+      This program converts sampling rates of PCM wav files. This
+      program also has a function to apply dither to its output and
+      extend perceived dynamic range.
+
+      Sampling rates of 44.1kHz and 48kHz are popularly used, but the
+      ratio between these two frequencies is 147:160, which are not
+      small numbers. As a result, sampling rate conversion without
+      degradation of sound quality requires filter with very large
+      order, and it is difficult to have both quality and speed. This
+      program quickly converts between these sampling frequencies
+      without audible degradation.
+    '';
+
+    version = "${version}";
+    homepage = "http://shibatch.sourceforge.net/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ leenaars];
+    platforms = with platforms; [ linux ] ;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14810,6 +14810,8 @@ in
 
   ssr = callPackage ../applications/audio/soundscape-renderer {};
 
+  ssrc = callPackage ../applications/audio/ssrc { };
+
   stalonetray = callPackage ../applications/window-managers/stalonetray {};
 
   stp = callPackage ../applications/science/logic/stp {};


### PR DESCRIPTION
###### Motivation for this change

It is a useful program not currently available in Nixpkgs. It converts the sampling rate of a PCM wav file. 44.1kHz sampling rate is used for a CD, and 48kHz is used for a DVD. Converting between these frequencies is hard, because the ratio beteen these two frequencies is 147:160, which are not small numbers. Accordingly, it uses a very long FIR filter in order not to degrade the sound quality during conversion. It utilizes FFTs to apply the FIR filter in order to reduce the amount of computation. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

