### PR TITLE
top-level: missing parentheses

### DIFF
--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -49,8 +49,8 @@ in let
   # reasonable default.
   platform =
     args.platform
-    or (config.platform
-    or (import ./platforms.nix).selectPlatformBySystem system);
+    or ( config.platform
+      or ((import ./platforms.nix).selectPlatformBySystem system) );
 
   # A few packages make a new package set to draw their dependencies from.
   # (Currently to get a cross tool chain, or forced-i686 package.) Rather than


### PR DESCRIPTION
###### Motivation for this change

Without this change, when `config.platform` is set, the evaluator tries to apply it as a function to `system`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

