### PR TITLE
docker: update service units from upstream

### DIFF
--- a/nixos/modules/services/web-servers/lighttpd/inginious.nix
+++ b/nixos/modules/services/web-servers/lighttpd/inginious.nix
@@ -191,9 +191,8 @@ in
         virtualisation.docker = {
           enable = true;
           # We need docker to listen on port 2375.
-          extraOptions = "-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock";
+          listenOptions = ["127.0.0.1:2375" "/var/run/docker.sock"];
           storageDriver = mkDefault "overlay";
-          socketActivation = false;
         };
 
         users.extraUsers."lighttpd".extraGroups = [ "docker" ];

--- a/nixos/tests/docker-registry.nix
+++ b/nixos/tests/docker-registry.nix
@@ -16,13 +16,11 @@ import ./make-test.nix ({ pkgs, ...} : {
 
     client1 = { config, pkgs, ...}: {
       virtualisation.docker.enable = true;
-      virtualisation.docker.socketActivation = false;
       virtualisation.docker.extraOptions = "--insecure-registry registry:8080";
     };
 
     client2 = { config, pkgs, ...}: {
       virtualisation.docker.enable = true;
-      virtualisation.docker.socketActivation = false;
       virtualisation.docker.extraOptions = "--insecure-registry registry:8080";
     };
   };


### PR DESCRIPTION
All the new options in detail:

Enable docker in multi-user.target make container created with restart=always
to start. We still want socket activation as it decouples dependencies between
the existing of /var/run/docker.sock and the docker daemon. This means that
services can rely on the availability of this socket. Fixes #11478 #21303

  wantedBy = ["multi-user.target"];

This allows us to remove the postStart hack, as docker reports on its own when
it is ready.

  Type=notify

The following will set unset some limits because overhead in kernel's ressource
accounting was observed. Note that these limit only apply to containerd.
Containers will have their own limit set.

  LimitNPROC=infinity
  LimitCORE=infinity
  TasksMax=infinity

Upgrades may require schema migrations. This can delay the startup of dockerd.

  TimeoutStartSec=0

Allows docker to create its own cgroup subhierarchy to apply ressource limits on
containers.

  Delegate=true

When dockerd is killed, container should be not affected to allow
`live restore` to work.

  KillMode=process

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

