### PR TITLE
nix-zsh-completions: 0.2 -> 0.3

### DIFF
--- a/pkgs/shells/nix-zsh-completions/default.nix
+++ b/pkgs/shells/nix-zsh-completions/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "spwhitt";
     repo = "nix-zsh-completions";
-    rev = "0.2";
-    sha256 = "0wimjdxnkw1lzhjn28zm4pgbij86ym0z17ayivpzz27g0sacimga";
+    rev = "0.3";
+    sha256 = "1vwkd4nppjrvy6xb0vx4z73awrhaah1433dp6h4ghi3cdrrjn7ri";
   };
 
   installPhase = ''
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = "ZSH completions for Nix, NixOS, and NixOps";
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.spwhitt ];
+    maintainers = [ stdenv.lib.maintainers.spwhitt stdenv.lib.maintainers.olejorgenb ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Bump version. [Version 0.3](https://github.com/spwhitt/nix-zsh-completions/releases/tag/0.3) provide attribute path completion.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (not relevant I think?)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

