### PR TITLE
sauce-connect: 4.4.0 -> 4.4.2

### DIFF
--- a/pkgs/development/tools/sauce-connect/default.nix
+++ b/pkgs/development/tools/sauce-connect/default.nix
@@ -4,18 +4,18 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "sauce-connect-${version}";
-  version = "4.4.0";
+  version = "4.4.2";
 
   src = fetchurl (
     if stdenv.system == "x86_64-linux" then {
       url = "https://saucelabs.com/downloads/sc-${version}-linux.tar.gz";
-      sha256 = "19zgnw0qn5f775p581mq5ry086rhcnnhqc6x82hzmwfysbsyl7xs";
+      sha256 = "0n3c9ihrxqy4y4mzgchggqa2v7c0y9jw2yqnjdd7cf4nd24fixbq";
     } else if stdenv.system == "i686-linux" then {
       url = "https://saucelabs.com/downloads/sc-${version}-linux32.tar.gz";
-      sha256 = "1m4nf1yidwkmlwald0ycwzvnsp5p93nc4bs1xh67phw0b2db99x9";
+      sha256 = "1pdvx4apd4x1bsyl8lhzlpv3jp3xzyv7yrsl3wjrql17p2asaba6";
     } else {
       url = "https://saucelabs.com/downloads/sc-${version}-osx.zip";
-      sha256 = "1bpdpwqa9sw2n7vw2g8q4c1mzgh8wgwn4p7sbryc2ki90yz8ibga";
+      sha256 = "03kn7i0a6mpxfc6mz9h560wadhmw5qxn15is7cl9kgkz5j874xlz";
     }
   );
 


### PR DESCRIPTION
update sauce-connect 4.4.0 -> 4.4.2

- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
