### PR TITLE
flashplayer: 11.2.202.644 -> 24.0.0.186 [Critical security fix]

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
@@ -1,0 +1,135 @@
+{ stdenv
+, lib
+, fetchurl
+, alsaLib
+, atk
+, bzip2
+, cairo
+, curl
+, expat
+, fontconfig
+, freetype
+, gdk_pixbuf
+, glib
+, glibc
+, graphite2
+, gtk2
+, harfbuzz
+, libICE
+, libSM
+, libX11
+, libXau
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXdmcp
+, libXext
+, libXfixes
+, libXi
+, libXinerama
+, libXrandr
+, libXrender
+, libXt
+, libXxf86vm
+, libdrm
+, libffi
+, libpng
+, libvdpau
+, libxcb
+, libxshmfence
+, nspr
+, nss
+, pango
+, pcre
+, pixman
+, zlib
+, unzip
+
+/* you have to add ~/mm.cfg :
+
+    TraceOutputFileEnable=1
+    ErrorReportingEnable=1
+    MaxWarnings=1
+
+  in order to read the flash trace at ~/.macromedia/Flash_Player/Logs/flashlog.txt
+  Then FlashBug (a FireFox plugin) shows the log as well
+*/
+
+}:
+
+let
+  arch =
+    if      stdenv.system == "x86_64-linux" then
+      "x86_64"
+    else if stdenv.system == "i686-linux"   then
+      "i386"
+    else throw "Flash Player is not supported on this platform";
+  lib_suffix =
+      if stdenv.system == "x86_64-linux" then
+      "64"
+    else
+      "";
+in
+stdenv.mkDerivation rec {
+  name = "flashplayer-${version}";
+  version = "24.0.0.186";
+
+  src = fetchurl {
+    url = "  https://fpdownload.adobe.com/get/flashplayer/pdc/${version}/flash_player_npapi_linux.${arch}.tar.gz";
+    sha256 =
+      if arch == "x86_64" then
+        "0qs6hx31p1q2zqsr8jcf7niwsp6nncpqs3igb6l9f9fi0a8va8f7"
+      else
+        "1zcinq7629bgbashx25krby8r91sag2v8382q620951iiww06n1v";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  preferLocalBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/lib/mozilla/plugins
+    cp -pv libflashplayer.so $out/lib/mozilla/plugins
+
+    mkdir -p $out/bin
+    cp -pv usr/bin/flash-player-properties $out/bin
+
+    mkdir -p $out/lib${lib_suffix}/kde4
+    cp -pv usr/lib${lib_suffix}/kde4/kcm_adobe_flash_player.so $out/lib${lib_suffix}/kde4
+
+    patchelf --set-rpath "$rpath" \
+      $out/lib/mozilla/plugins/libflashplayer.so \
+      $out/lib${lib_suffix}/kde4/kcm_adobe_flash_player.so
+
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      --set-rpath "$rpath" \
+      $out/bin/flash-player-properties
+  '';
+
+  passthru = {
+    mozillaPlugin = "/lib/mozilla/plugins";
+  };
+
+  rpath = lib.makeLibraryPath
+    [ stdenv.cc.cc
+      alsaLib atk bzip2 cairo curl expat fontconfig freetype gdk_pixbuf glib
+      glibc graphite2 gtk2 harfbuzz libICE libSM libX11 libXau libXcomposite
+      libXcursor libXdamage libXdmcp libXext libXfixes libXi libXinerama
+      libXrandr libXrender libXt libXxf86vm libdrm libffi libpng libvdpau
+      libxcb libxshmfence nspr nss pango pcre pixman zlib
+    ];
+
+  meta = {
+    description = "Adobe Flash Player browser plugin";
+    homepage = http://www.adobe.com/products/flashplayer/;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
@@ -44,6 +44,7 @@
 , pixman
 , zlib
 , unzip
+, debug ? false
 
 /* you have to add ~/mm.cfg :
 
@@ -75,12 +76,22 @@ stdenv.mkDerivation rec {
   version = "24.0.0.186";
 
   src = fetchurl {
-    url = "  https://fpdownload.adobe.com/get/flashplayer/pdc/${version}/flash_player_npapi_linux.${arch}.tar.gz";
-    sha256 =
-      if arch == "x86_64" then
-        "0qs6hx31p1q2zqsr8jcf7niwsp6nncpqs3igb6l9f9fi0a8va8f7"
+    url =
+      if debug then
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/24/flash_player_npapi_linux_debug.${arch}.tar.gz"
       else
-        "1zcinq7629bgbashx25krby8r91sag2v8382q620951iiww06n1v";
+        "https://fpdownload.adobe.com/get/flashplayer/pdc/${version}/flash_player_npapi_linux.${arch}.tar.gz";
+    sha256 =
+      if debug then
+        if arch == "x86_64" then
+          "0i7c861n42vb2zd9hnp26lxjakkv0fxp53smcwzc9xhdbjr14ail"
+        else
+          "0gj59iinh8gbjm5bn24qi3niyvi8x6byyc1sa6qvqkvjwh1ckdi3"
+      else
+        if arch == "x86_64" then
+          "0qs6hx31p1q2zqsr8jcf7niwsp6nncpqs3igb6l9f9fi0a8va8f7"
+        else
+          "1zcinq7629bgbashx25krby8r91sag2v8382q620951iiww06n1v";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
@@ -1,0 +1,110 @@
+{ stdenv
+, lib
+, fetchurl
+, alsaLib
+, atk
+, bzip2
+, cairo
+, curl
+, expat
+, fontconfig
+, freetype
+, gdk_pixbuf
+, glib
+, glibc
+, graphite2
+, gtk2
+, harfbuzz
+, libICE
+, libSM
+, libX11
+, libXau
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXdmcp
+, libXext
+, libXfixes
+, libXi
+, libXinerama
+, libXrandr
+, libXrender
+, libXt
+, libXxf86vm
+, libdrm
+, libffi
+, libpng
+, libvdpau
+, libxcb
+, libxshmfence
+, nspr
+, nss
+, pango
+, pcre
+, pixman
+, zlib
+, unzip
+, debug ? false
+}:
+
+let
+  arch =
+    if      stdenv.system == "x86_64-linux" then
+      "x86_64"
+    else if stdenv.system == "i686-linux"   then
+      "i386"
+    else throw "Flash Player is not supported on this platform";
+in
+stdenv.mkDerivation rec {
+  name = "flashplayer-standalone-${version}";
+  version = "24.0.0.186";
+
+  src = fetchurl {
+    url =
+      if debug then
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/24/flash_player_sa_linux_debug.x86_64.tar.gz"
+      else
+        "https://fpdownload.macromedia.com/pub/flashplayer/updaters/24/flash_player_sa_linux.x86_64.tar.gz";
+    sha256 =
+      if debug then
+        "09653jphzijk3w3dcd05f4pya1ciaymna31qqrmcwhxa0ginxhz2"
+      else
+        "0q0wc2lgjzi1v4lpcr5x5nszigli3vsryfq2zk4qq4pqy3i6aq7q";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  preferLocalBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -pv flashplayer${lib.optionalString debug "debugger"} $out/bin
+
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      --set-rpath "$rpath" \
+      $out/bin/flashplayer${lib.optionalString debug "debugger"}
+  '';
+
+  rpath = lib.makeLibraryPath
+    [ stdenv.cc.cc
+      alsaLib atk bzip2 cairo curl expat fontconfig freetype gdk_pixbuf glib
+      glibc graphite2 gtk2 harfbuzz libICE libSM libX11 libXau libXcomposite
+      libXcursor libXdamage libXdmcp libXext libXfixes libXi libXinerama
+      libXrandr libXrender libXt libXxf86vm libdrm libffi libpng libvdpau
+      libxcb libxshmfence nspr nss pango pcre pixman zlib
+    ];
+
+  meta = {
+    description = "Adobe Flash Player standalone executable";
+    homepage = https://www.adobe.com/support/flashplayer/debug_downloads.html;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13131,13 +13131,16 @@ in
 
   flac = callPackage ../applications/audio/flac { };
 
-  flashplayer = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer-11 {
+  flashplayer = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer {
+  };
+
+  flashplayer_11 = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer-11 {
     debug = config.flashplayer.debug or false;
   };
 
-  flashplayer-standalone = pkgsi686Linux.flashplayer.sa;
+  flashplayer-standalone = pkgsi686Linux.flashplayer_11.sa;
 
-  flashplayer-standalone-debugger = (pkgsi686Linux.flashplayer.override { debug = true; }).sa;
+  flashplayer-standalone-debugger = (pkgsi686Linux.flashplayer_11.override { debug = true; }).sa;
 
   fluxbox = callPackage ../applications/window-managers/fluxbox { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13132,6 +13132,7 @@ in
   flac = callPackage ../applications/audio/flac { };
 
   flashplayer = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer {
+      debug = config.flashplayer.debug or false;
   };
 
   flashplayer_11 = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer-11 {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13135,13 +13135,13 @@ in
       debug = config.flashplayer.debug or false;
   };
 
-  flashplayer_11 = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer-11 {
-    debug = config.flashplayer.debug or false;
+  flashplayer-standalone = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix {
+      debug = config.flashplayer.debug or false;
   };
 
-  flashplayer-standalone = pkgsi686Linux.flashplayer_11.sa;
-
-  flashplayer-standalone-debugger = (pkgsi686Linux.flashplayer_11.override { debug = true; }).sa;
+  flashplayer-standalone-debugger = flashplayer-standalone.override {
+      debug = true;
+  };
 
   fluxbox = callPackage ../applications/window-managers/fluxbox { };
 


### PR DESCRIPTION
###### Motivation for this change

Critical security fix:
https://helpx.adobe.com/security/products/flash-player/apsb16-39.html

The version leaped from 11 to 24.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested x86_64 version:
- http://www.adobe.com/software/flash/about/ shows `24,0,0,186 installed`
- Plays sounds
- Plays movie

Issues:

- Should we keep the version 11?
- Is `mm.cfg` still effective?
- How to use `kcm_adobe_flash_player.so`?