### PR TITLE
crystal: init at 0.20.3

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -1,0 +1,96 @@
+{ stdenv, fetchurl, boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm_39, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  version = "0.20.3";
+  name = "crystal-${version}-1";
+  arch =
+    {
+      "x86_64-linux" = "linux-x86_64";
+      "i686-linux" = "linux-i686";
+      "x86_64-darwin" = "darwin-x86_64";
+    }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+
+  prebuiltBinary = fetchurl {
+    url = "https://github.com/crystal-lang/crystal/releases/download/${version}/crystal-${version}-1-${arch}.tar.gz";
+    sha256 =
+      {
+        "x86_64-linux" = "c656dc8092a6161262f527df441aaab4ea9dd9a836a013f7155c6378b26b8cd7";
+        "i686-linux" = "85edfa1dda5e712341869bab87f6de0f7c6860e2a04dec2f00e8dc6aa1418611";
+        "x86_64-darwin" = "0088972c5cad9543f262976ae6c8ee1dbcbefdee3a8bedae851998bfa7098637";
+      }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+  };
+
+  src = fetchurl {
+    url = "https://github.com/crystal-lang/crystal/archive/${version}.tar.gz";
+    sha256 = "5372ba2a35d885345207047a51b9389f9190fd12389847e7f7298618bcf59ad6";
+  };
+
+  # crystal on Darwin needs libiconv to build
+  buildInputs = [
+    boehmgc libatomic_ops pcre libevent llvm_39 makeWrapper
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    libiconv
+  ];
+
+  libPath = stdenv.lib.makeLibraryPath ([
+    boehmgc libatomic_ops pcre libevent
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    libiconv
+  ]);
+
+  unpackPhase = ''
+    tar zxf ${src}
+    tar zxf ${prebuiltBinary}
+  '';
+
+  sourceRoot = ".";
+
+  fixPrebuiltBinary = if stdenv.isDarwin then ''
+    wrapProgram $(pwd)/crystal-${version}-1/embedded/bin/crystal \
+        --suffix DYLD_LIBRARY_PATH : $libPath
+  ''
+  else ''
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      crystal-${version}-1/embedded/bin/crystal
+    patchelf --set-rpath ${ stdenv.lib.makeLibraryPath [ stdenv.cc.cc ] } \
+      crystal-${version}-1/embedded/bin/crystal
+  '';
+
+  buildPhase = ''
+    ${fixPrebuiltBinary}
+
+    cd crystal-${version}
+    make release=1 PATH="../crystal-${version}-1/bin:$PATH"
+    make doc
+  '';
+
+  installPhase = ''
+    install -Dm755 .build/crystal $out/bin/crystal
+    wrapProgram $out/bin/crystal \
+        --suffix CRYSTAL_PATH : $out/lib/crystal \
+        --suffix LIBRARY_PATH : $libPath
+
+    install -dm755 $out/lib/crystal
+    cp -r src/* $out/lib/crystal/
+
+    install -dm755 $out/share/doc/crystal/api
+    cp -r doc/* $out/share/doc/crystal/api/
+    cp -r samples $out/share/doc/crystal/
+
+    install -Dm644 etc/completion.bash $out/share/bash-completion/completions/crystal
+    install -Dm644 etc/completion.zsh $out/share/zsh/site-functions/_crystal
+
+    install -Dm644 LICENSE $out/share/licenses/crystal/LICENSE
+  '';
+
+  dontStrip = true;
+
+  meta = {
+    description = "A compiled language with Ruby like syntax and type inference";
+    homepage = "https://crystal-lang.org/";
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ mingchuan ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+  };
+}
+

--- a/pkgs/development/tools/build-managers/shards/default.nix
+++ b/pkgs/development/tools/build-managers/shards/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, crystal, libyaml, which }:
+
+stdenv.mkDerivation rec {
+  name = "shards-${version}";
+  version = "0.7.1";
+
+  src = fetchurl {
+    url = "https://github.com/crystal-lang/shards/archive/v${version}.tar.gz";
+    sha256 = "31de819c66518479682ec781a39ef42c157a1a8e6e865544194534e2567cb110";
+  };
+
+  buildInputs = [ crystal libyaml which ];
+
+  buildFlags = [ "CRFLAGS=" "release" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/shards $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://crystal-lang.org/";
+    license = licenses.asl20;
+    description = "Dependency manager for the Crystal language";
+    maintainers = with maintainers; [ mingchuan ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6495,6 +6495,8 @@ in
   sbt = callPackage ../development/tools/build-managers/sbt { };
   simpleBuildTool = sbt;
 
+  shards = callPackage ../development/tools/build-managers/shards { };
+
   shellcheck = self.haskellPackages.ShellCheck;
 
   shncpd = callPackage ../tools/networking/shncpd { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4643,6 +4643,8 @@ in
     '';
   });
 
+  crystal = callPackage ../development/compilers/crystal { };
+
   devpi-client = callPackage ../development/tools/devpi-client {};
 
   drumstick = callPackage ../development/libraries/drumstick { };


### PR DESCRIPTION
###### Motivation for this change
There is a package request requests the Crystal programming language #21247 .

This pr adds two packages:
crystal: the Crystal compiler
shards: dependency manager for Crystal language

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

All sample code provided by crystal is tested.
All sample code works except sdl related sample.
(~~I'm not sure if this is caused by my packaging~~
ok. It appears that it also do not work on archlinux, at least for me)
Edit: sdl issue for reference: crystal-lang/crystal#3678 

~~I will test these on other linux distro and i686 when I have time.~~ Done.
Tested on archlinux x86_64 and ubuntu 16.04 i386.

cc @mimadrid

All suggestions are welcomed.
