### PR TITLE
gwrap: remove unnecessary checks

### DIFF
--- a/pkgs/development/tools/guile/g-wrap/default.nix
+++ b/pkgs/development/tools/guile/g-wrap/default.nix
@@ -9,12 +9,11 @@ stdenv.mkDerivation rec {
 
   # Note: Glib support is optional, but it's quite useful (e.g., it's
   # used by Guile-GNOME).
-  buildInputs = [ guile pkgconfig glib ]
-    ++ stdenv.lib.optional doCheck guile_lib;
+  buildInputs = [ guile pkgconfig glib guile_lib ];
 
   propagatedBuildInputs = [ libffi ];
 
-  doCheck = !stdenv.isFreeBSD; # XXX: 00-socket.test hangs
+  doCheck = true;
 
   meta = {
     description = "G-Wrap, a wrapper generator for Guile";


### PR DESCRIPTION
###### Motivation for this change

Within gwrap, an OS check is performed to see if the system is using FreeBSD to include a package. However, the gwrap package is set to only build for Linux. Even if the package is set to build for Linux and FreeBSD, a dependency (guile_lib) only builds on GNU platforms, which is currently set to only Linux.

We should remove this unnecessary check, or we should get this package and all dependencies to build (if able) on Linux and FreeBSD.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
