### PR TITLE
lnav: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/tools/misc/lnav/default.nix
+++ b/pkgs/tools/misc/lnav/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "tstack";
     repo = "lnav";
     rev = "v${meta.version}";
-    sha256 = "06h0hy8k0w692df2490dshxf2x8qcnw5myyp0k5jkc63ai2ra6aq";
+    sha256 = "0pag2rl7b6s2xfl80c629vhwsdvvlhcdy6732yvpgfv94w0zyjp9";
     inherit name;
   };
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     '';
     downloadPage = "https://github.com/tstack/lnav/releases";
     license = licenses.bsd2;
-    version = "0.8.0";
+    version = "0.8.1";
     maintainers = [ maintainers.dochang ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

Bump version.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

