### PR TITLE
ncurses: Create libtinfo symlink

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -102,6 +102,9 @@ stdenv.mkDerivation rec {
       done
     done
 
+    # create libtinfo symlink
+    ln -svf $out/lib/libncurses.$dylibtype $out/libtinfo.$dylibtype
+        
     # move some utilities to $bin
     # these programs are used at runtime and don't really belong in $dev
     moveToOutput "bin/clear" "$out"


### PR DESCRIPTION
Some applications expect libtinfo to be a separate library to libncurses; this fixes that.

Fedora's workaround which does the same thing: https://github.com/commercialhaskell/stack/issues/1012#issuecomment-259675831

Arch's: https://aur.archlinux.org/packages/ncurses5-compat-libs/

Gentoo example: https://forums.gentoo.org/viewtopic-t-996220-start-0.html

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

