### PR TITLE
haskell: workaround for bug with dynamic libraries on darwin

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -245,9 +245,41 @@ stdenv.mkDerivation ({
     runHook postConfigure
   '';
 
+  # The darwin pre/post build sections are a workaround https://github.com/haskell/cabal/issues/4183
+  # It seems like --extra-lib-dirs from the previous steps is not detected properly,
+  # to work around this we build using a DYLD_LIBRARY_PATH and fixup the build afterwards.
   buildPhase = ''
     runHook preBuild
+    ${optionalString stdenv.isDarwin ''
+      local inputClosure=""
+      for i in $propagatedNativeBuildInputs $nativeBuildInputs; do
+        findInputs $i inputClosure propagated-native-build-inputs
+      done
+      local -a inputLibs=()
+      for p in $inputClosure; do
+        if [ -d "$p/lib/${ghc.name}/package.conf.d" ]; then
+          continue
+        fi
+        if [ -d "$p/lib" ]; then
+          inputLibs+="$p/lib"
+        fi
+      done
+
+      for lib in $inputLibs; do
+        export DYLD_LIBRARY_PATH="$lib:''${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+      done
+    ''}
     ${setupCommand} build ${buildTarget}${crossCabalFlagsString}
+    ${optionalString stdenv.isDarwin ''
+      unset DYLD_LIBRARY_PATH
+
+      local outputLib=dist/build/*-ghc${ghc.version}.dylib
+      for lib in $inputLib/*.dylib; do
+        for name in $(otool -L $outputLib | awk '$1 ~ /^'$(basename lib)'/ {print $1}' | cat); do
+          install_name_tool -change $name $lib $outputLib
+        done
+      done
+    ''}
     runHook postBuild
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Workaround for https://github.com/haskell/cabal/issues/4183
It seems like --extra-lib-dirs from the previous steps is not detected properly,
to work around this we build using a DYLD_LIBRARY_PATH and fixup the build afterwards.

/cc @domenkozar

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
