### PR TITLE
apacheHttpdPackages.mod_perl: init at 2.0.10

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_perl/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_perl/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, apacheHttpd, perl }:
+
+stdenv.mkDerivation rec {
+  name = "mod_perl-2.0.10";
+
+  src = fetchurl {
+    url = "mirror://apache/perl/${name}.tar.gz";
+    sha256 = "0r1bhzwl5gr0202r6448943hjxsickzn55kdmb7dzad39vnq7kyi";
+  };
+
+  buildInputs = [ apacheHttpd perl ];
+  buildPhase = ''
+    perl Makefile.PL \
+      MP_APXS=${apacheHttpd.dev}/bin/apxs
+    make
+  '';
+  installPhase = ''
+    mkdir -p $out
+    make install DESTDIR=$out
+    mv $out${apacheHttpd}/* $out
+    mv $out${apacheHttpd.dev}/* $out
+    mv $out${perl}/* $out
+    rm $out/nix -rf
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10005,6 +10005,8 @@ in
 
     mod_evasive = callPackage ../servers/http/apache-modules/mod_evasive { };
 
+    mod_perl = callPackage ../servers/http/apache-modules/mod_perl { };
+
     mod_fastcgi = callPackage ../servers/http/apache-modules/mod_fastcgi { };
 
     mod_python = callPackage ../servers/http/apache-modules/mod_python { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

