### PR TITLE
wineUnstable: 1.9.23 -> 2.0-rc2

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -30,9 +30,9 @@ in rec {
   };
 
   unstable = fetchurl rec {
-    version = "1.9.23";
-    url = "https://dl.winehq.org/wine/source/1.9/wine-${version}.tar.bz2";
-    sha256 = "131nqkwlss24r8la84s3v1qx376wq0016d2i2767bpxkyqkagvz3";
+    version = "2.0-rc2";
+    url = "https://dl.winehq.org/wine/source/2.0/wine-${version}.tar.bz2";
+    sha256 = "0pjkrvslfksx7m2w52pnd3dfxb82l082cz9dr57x58s9al2jpwb6";
     inherit (stable) mono;
     gecko32 = fetchurl rec {
       version = "2.47";
@@ -48,7 +48,7 @@ in rec {
 
   staging = fetchFromGitHub rec {
     inherit (unstable) version;
-    sha256 = "188svpmaba2x5a7g8rk68cl2mqrv1vhf1si2g5j5lps9r6pgq1c0";
+    sha256 = "1xx9bfirij12l278f5f7vpxxay1zacnrsaib6yfzrybm517ynfw3";
     owner = "wine-compholio";
     repo = "wine-staging";
     rev = "v${version}";


### PR DESCRIPTION
Update staging as well

###### Motivation for this change

Update unstable wine to last version.

PS Only 32bit version tested

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

