### PR TITLE
hhpc: init at 0.3.1

### DIFF
--- a/pkgs/tools/misc/hhpc/default.nix
+++ b/pkgs/tools/misc/hhpc/default.nix
@@ -1,0 +1,28 @@
+{stdenv, fetchFromGitHub, xorg, pkgconfig}:
+
+stdenv.mkDerivation rec {
+  name = "hhpc-${version}";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "aktau";
+    repo = "hhpc";
+    rev = "v${version}";
+    sha256 = "1djsw1r38mh6zx0rbyn2cfa931hyddib4fl3i27c4z7xinl709ss";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ xorg.libX11 ];
+
+  installPhase = ''
+      mkdir -p $out/bin
+      cp hhpc $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Hides the mouse pointer in X11";
+    maintainers = with maintainers; [ nico202 ];
+    platforms = platforms.unix;
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2146,6 +2146,8 @@ in
 
   hevea = callPackage ../tools/typesetting/hevea { };
 
+  hhpc = callPackage ../tools/misc/hhpc { };
+
   hiera-eyaml = callPackage ../tools/system/hiera-eyaml { };
 
   hfsprogs = callPackage ../tools/filesystems/hfsprogs { };


### PR DESCRIPTION
###### Motivation for this change
unclutter does not work well for me (see https://wiki.archlinux.org/index.php/unclutter "known bugs").
hhpc is lightweight and does its job.

