### PR TITLE
digikam: Add patch to fix compilation against Lensfun 0.3.2

### DIFF
--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, automoc4, boost, shared_desktop_ontologies, cmake
-, eigen, lcms, gettext, jasper, kdelibs, kdepimlibs, lensfun
+{ stdenv, fetchurl, fetchpatch, automoc4, boost, shared_desktop_ontologies
+, cmake, eigen, lcms, gettext, jasper, kdelibs, kdepimlibs, lensfun
 , libgphoto2, libjpeg, libkdcraw, libkexiv2, libkipi, libpgf, libtiff
 , libusb1, liblqr1, marble, mysql, opencv, perl, phonon, pkgconfig
 , qca2, qimageblitz, qjson, qt4, soprano
@@ -35,6 +35,16 @@ let
       url = "http://download.kde.org/stable/digikam/${pName}.tar.bz2";
       sha256 = "081ldsaf3frf5khznjd3sxkjmi4dyp6w6nqnc2a0agkk0kxkl10m";
     };
+
+    patches = [
+      (fetchpatch {
+        # Fix compilation against Lensfun 0.3.2
+        url = "http://cgit.kde.org/digikam.git/patch/?id=0f159981176faa6da701f112bfe557b79804d468";
+        sha256 = "1c8bg7s84vg4v620gbs16cjcbpml749018gy5dpvfacx5vl24wza";
+      })
+    ];
+
+    patchFlags = ["-p1" "-dcore"];
 
     nativeBuildInputs = [ 
       automoc4 cmake gettext perl pkgconfig


### PR DESCRIPTION
###### Motivation for this change
Digikam4 compilation was broken by updating Lensfun to 0.3.2. This adds a patch from upstream to fix it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

