### PR TITLE
bspwm: 1.9.1 -> 1.9.2

### DIFF
--- a/pkgs/applications/window-managers/bspwm/default.nix
+++ b/pkgs/applications/window-managers/bspwm/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "bspwm-${version}";
-  version = "0.9.1";
+  version = "0.9.2";
 
 
   src = fetchurl {
     url = "https://github.com/baskerville/bspwm/archive/${version}.tar.gz";
-    sha256 = "11dvfcvr8bc116yb3pvl0k1h2gfm9rv652jbxd1c5pmc0yimifq2";
+    sha256 = "1w6wxwgyb14w664xafp3b2ps6zzf9yw7cfhbh9229x2hil9rss1k";
   };
 
   buildInputs = [ libxcb libXinerama xcbutil xcbutilkeysyms xcbutilwm ];


### PR DESCRIPTION
###### Motivation for this change

[changelog](https://github.com/baskerville/bspwm/blob/master/doc/CHANGELOG.md#from-091-to-092)

0.9.1 was released in March, 0.9.2 in October.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Apologies if I've done anything wrong, I've only been using NixOS for a few hours. I've built and installed this update on my local system with no issues. To do so I rolled back my clone of this repo to my `nixos-version` commit, and used `sudo nixos-rebuild -I nixpkgs=/home/rory/nixpkgs switch --fast`. The correct version seems to be running based on features, the output of `bspwm -v`, and the path present in the output of `ps`.


