### PR TITLE
ncurses: Create ABI-version'd libtinfo

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -91,6 +91,9 @@ stdenv.mkDerivation rec {
           if [ -e "$out/lib/lib''${library}$suffix.$dylibtype" ]; then
             ln -svf lib''${library}$suffix.$dylibtype $out/lib/lib$library$newsuffix.$dylibtype
             ln -svf lib''${library}$suffix.$dylibtype.${abiVersion} $out/lib/lib$library$newsuffix.$dylibtype.${abiVersion}
+            # make libtinfo symlinks
+            ln -svf lib''${library}$suffix.$dylibtype $out/lib/libtinfo$newsuffix.$dylibtype
+            ln -svf lib''${library}$suffix.$dylibtype.${abiVersion} $out/lib/libtinfo$newsuffix.$dylibtype.${abiVersion}
           fi
         done
         for statictype in a dll.a la; do
@@ -102,10 +105,6 @@ stdenv.mkDerivation rec {
       done
     done
 
-    # create libtinfo symlink
-    ln -svf $out/lib/libncurses.$dylibtype $out/libtinfo.$dylibtype
-    ln -svf $out/lib/libncurses.$dylibtype.${abiVersion} $out/libtinfo.$dylibtype.${abiVersion}
-        
     # move some utilities to $bin
     # these programs are used at runtime and don't really belong in $dev
     moveToOutput "bin/clear" "$out"

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -104,6 +104,7 @@ stdenv.mkDerivation rec {
 
     # create libtinfo symlink
     ln -svf $out/lib/libncurses.$dylibtype $out/libtinfo.$dylibtype
+    ln -svf $out/lib/libncurses.$dylibtype.${abiVersion} $out/libtinfo.$dylibtype.${abiVersion}
         
     # move some utilities to $bin
     # these programs are used at runtime and don't really belong in $dev


### PR DESCRIPTION
###### Motivation for this change
Making sure versioned library loads work correctly. Also, the PR works, just travis log length error.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

