### PR TITLE
Update GHC 8.0.2 to RC 2

### DIFF
--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -13,21 +13,15 @@ let
   });
 in
 stdenv.mkDerivation rec {
-  version = "8.0.1.20161117";
+  version = "8.0.1.20161213";
   name = "ghc-${version}";
 
   src = fetchurl {
-    url = "https://downloads.haskell.org/~ghc/8.0.2-rc1/${name}-src.tar.xz";
-    sha256 = "08hpzvg059ha0knmlngd0winfkplkkb7dk88zfz3s177z38kd874";
+    url = "https://downloads.haskell.org/~ghc/8.0.2-rc2/${name}-src.tar.xz";
+    sha256 = "0l1arhbh3rbs011f0y4pgc35yn07x3hz6lfqlvqbwn96f8ff5529";
   };
 
-  patches = [
-    # Already applied?
-    # ./relocation.patch
-    # Fix https://ghc.haskell.org/trac/ghc/ticket/12130
-    # (fetchFilteredPatch { url = https://git.haskell.org/ghc.git/patch/4d71cc89b4e9648f3fbb29c8fcd25d725616e265; sha256 = "0syaxb4y4s2dc440qmrggb4vagvqqhb55m6mx12rip4i9qhxl8k0"; })
-    (fetchFilteredPatch { url = https://git.haskell.org/ghc.git/patch/2f8cd14fe909a377b3e084a4f2ded83a0e6d44dd; sha256 = "06zvlgcf50ab58bw6yw3krn45dsmhg4cmlz4nqff8k4z1f1bj01v"; })
-  ] ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch;
+  patches = [] ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch;
 
   buildInputs = [ ghc perl hscolour ];
 


### PR DESCRIPTION
###### Motivation for this change

I updated the derivation for the new release candidate and removed some patches that are already in the release. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

