### PR TITLE
pythonPackages.livereload: init at 2.5.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13825,6 +13825,28 @@ in {
     };
   };
 
+  livereload = buildPythonPackage rec {
+    name = "livereload-${version}";
+    version = "2.5.0";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "lepture";
+      repo = "python-livereload";
+      rev = "v${version}";
+      sha256 = "0ixsc7wibmkfk9fnyq0d1b5d9snxfpzzzgsxvq28rn54v6q8b7m2";
+    };
+
+    buildInputs = with self; [ nose django ];
+
+    propagatedBuildInputs = with self; [ tornado six ];
+
+    meta = {
+      description = "Runs a local server that reloads as you develop";
+      homepage = "https://github.com/lepture/python-livereload";
+      license = licenses.bsd3;
+    };
+  };
+
   llfuse = buildPythonPackage rec {
     name = "llfuse-1.0";
 


### PR DESCRIPTION
###### Motivation for this change

Livereload is a dependency of [statik](https://github.com/thanethomson/statik) static website generator, which I hope to include in nixpkgs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

