### PR TITLE
Darwin gtk2/pygtk quartz backend

### DIFF
--- a/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
@@ -1,5 +1,8 @@
-{stdenv, fetchurl, pkgconfig, atk, cairo, glib, gtk, pango, 
-  libxml2Python, perl, intltool, gettext}:
+{stdenv, fetchpatch, fetchurl, autoreconfHook, pkgconfig, atk, cairo, glib
+, gnome_common, gtk, pango
+, libxml2Python, perl, intltool, gettext, gtk-mac-integration }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "gtksourceview-${version}";
@@ -9,6 +12,29 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/gtksourceview/2.10/${name}.tar.bz2";
     sha256 = "c585773743b1df8a04b1be7f7d90eecdf22681490d6810be54c81a7ae152191e";
   };
-  buildInputs = [pkgconfig atk cairo glib gtk pango libxml2Python perl intltool
-    gettext];
+
+  patches = optionals stdenv.isDarwin [
+    (fetchpatch {
+      name = "change-igemacintegration-to-gtkosxapplication.patch";
+      url = "https://git.gnome.org/browse/gtksourceview/patch/?id=e88357c5f210a8796104505c090fb6a04c213902";
+      sha256 = "0h5q79q9dqbg46zcyay71xn1pm4aji925gjd5j93v4wqn41wj5m7";
+    })
+    (fetchpatch {
+      name = "update-to-gtk-mac-integration-2.0-api.patch";
+      url = "https://git.gnome.org/browse/gtksourceview/patch/?id=ab46e552e1d0dae73f72adac8d578e40bdadaf95";
+      sha256 = "0qzrbv4hpa0v8qbmpi2vp575n13lkrvp3cgllwrd2pslw1v9q3aj";
+    })
+  ];
+
+  buildInputs = [
+    pkgconfig atk cairo glib gtk
+    pango libxml2Python perl intltool
+    gettext
+  ] ++ optionals stdenv.isDarwin [
+    autoreconfHook gnome_common gtk-mac-integration
+  ];
+
+  preConfigure = optionalString stdenv.isDarwin ''
+    intltoolize --force
+  '';
 }

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
     libiconv
   ] ++ libintlOrEmpty ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     CoreGraphics
+    CoreText
     ApplicationServices
     Carbon
   ]);

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation rec {
   ] ++ libintlOrEmpty ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     CoreGraphics
     CoreText
-    ApplicationServices
     Carbon
   ]);
 
@@ -57,6 +56,9 @@ stdenv.mkDerivation rec {
     ++ optionals xcbSupport [ libxcb xcbutil ]
     ++ optional gobjectSupport glib
     ++ optional glSupport mesa_noglu
+    ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+      ApplicationServices
+    ])
     ; # TODO: maybe liblzo but what would it be for here?
 
   configureFlags = if stdenv.isDarwin then [

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -2,10 +2,14 @@
 , gdk_pixbuf, libintlOrEmpty, xlibsWrapper
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? true, cups ? null
+, gdktarget ? "x11"
+, AppKit, Cocoa
 }:
 
 assert xineramaSupport -> xorg.libXinerama != null;
 assert cupsSupport -> cups != null;
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "gtk+-2.24.31";
@@ -20,7 +24,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString (libintlOrEmpty != []) "-lintl";
+  NIX_CFLAGS_COMPILE = optionalString (libintlOrEmpty != []) "-lintl";
 
   setupHook = ./setup-hook.sh;
 
@@ -28,7 +32,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./2.0-immodules.cache.patch ];
 
-  propagatedBuildInputs = with xorg; with stdenv.lib;
+  propagatedBuildInputs = with xorg;
     [ glib cairo pango gdk_pixbuf atk ]
     ++ optionals (stdenv.isLinux || stdenv.isDarwin) [
          libXrandr libXrender libXcomposite libXi libXcursor
@@ -36,11 +40,13 @@ stdenv.mkDerivation rec {
     ++ optionals stdenv.isDarwin [ xlibsWrapper libXdamage ]
     ++ libintlOrEmpty
     ++ optional xineramaSupport libXinerama
-    ++ optionals cupsSupport [ cups ];
+    ++ optionals cupsSupport [ cups ]
+    ++ optionals (gdktarget == "quartz") [ AppKit Cocoa ];
 
   configureFlags = [
+    "--with-gdktarget=${gdktarget}"
     "--with-xinput=yes"
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+  ] ++ optionals stdenv.isDarwin [
     "--disable-glibtest"
     "--disable-introspection"
     "--disable-visibility"
@@ -57,9 +63,10 @@ stdenv.mkDerivation rec {
       rm $out/lib/gtk-2.0/2.10.0/immodules.cache
       $out/bin/gtk-query-immodules-2.0 $out/lib/gtk-2.0/2.10.0/immodules/*.so > $out/lib/gtk-2.0/2.10.0/immodules.cache
     ''; # workaround for bug of nix-mode for Emacs */ '';
+    inherit gdktarget;
   };
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "A multi-platform toolkit for creating graphical user interfaces";
     homepage    = http://www.gtk.org/;
     license     = licenses.lgpl2Plus;

--- a/pkgs/development/libraries/gtk-mac-integration/default.nix
+++ b/pkgs/development/libraries/gtk-mac-integration/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig, glib, gtk_doc, gtk }:
+
+stdenv.mkDerivation rec {
+  name = "gtk-mac-integration-2.0.8";
+
+  src = fetchFromGitHub {
+    owner = "GNOME";
+    repo = "gtk-mac-integration";
+    rev = "79e708870cdeea24ecdb036c77b4630104ae1776";
+    sha256 = "1fbhnvj0rqc3089ypvgnpkp6ad2rr37v5qk38008dgamb9h7f3qs";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig gtk_doc ];
+  buildInputs = [ glib gtk ];
+
+  preAutoreconf = ''
+    gtkdocize
+  '';
+
+  meta = with lib; {
+    description = "Provides integration for Gtk+ applications into the Mac desktop";
+
+    license = licenses.lgpl21;
+
+    homepage = https://wiki.gnome.org/Projects/GTK+/OSX/Integration;
+
+    maintainers = [ maintainers.matthewbauer ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkgconfig, glib, gdk_pixbuf, pango, cairo, libxml2, libgsf
-, bzip2, libcroco, libintlOrEmpty
+, bzip2, libcroco, libintlOrEmpty, darwin
 , withGTK ? false, gtk3 ? null
 , gobjectIntrospection ? null, enableIntrospection ? false }:
 
@@ -22,7 +22,10 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib gdk_pixbuf cairo ] ++ lib.optional withGTK gtk3;
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+      ApplicationServices
+    ]);
 
   configureFlags = [ "--enable-introspection=auto" ]
     ++ stdenv.lib.optional stdenv.isDarwin "--disable-Bsymbolic";

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkgconfig, glib, gdk_pixbuf, pango, cairo, libxml2, libgsf
-, bzip2, libcroco, libintlOrEmpty, darwin
+, bzip2, libcroco, libintlOrEmpty
 , withGTK ? false, gtk3 ? null
 , gobjectIntrospection ? null, enableIntrospection ? false }:
 
@@ -22,10 +22,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib gdk_pixbuf cairo ] ++ lib.optional withGTK gtk3;
 
-  nativeBuildInputs = [ pkgconfig ]
-    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-      ApplicationServices
-    ]);
+  nativeBuildInputs = [ pkgconfig ];
 
   configureFlags = [ "--enable-introspection=auto" ]
     ++ stdenv.lib.optional stdenv.isDarwin "--disable-Bsymbolic";

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libXft, cairo, harfbuzz
-, libintlOrEmpty, gobjectIntrospection
+, libintlOrEmpty, gobjectIntrospection, darwin
 }:
 
 with stdenv.lib;
@@ -19,7 +19,12 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "devdoc" ];
 
   buildInputs = [ gobjectIntrospection ];
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ]
+    ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+       Carbon
+       CoreGraphics
+       CoreText
+    ]);
   propagatedBuildInputs = [ cairo harfbuzz libXft ] ++ libintlOrEmpty;
 
   enableParallelBuilding = true;
@@ -48,6 +53,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
 
     maintainers = with maintainers; [ raskin urkud ];
-    platforms = with platforms; linux ++ darwin;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/python-modules/pygtk/default.nix
+++ b/pkgs/development/python-modules/pygtk/default.nix
@@ -3,7 +3,7 @@
 
 buildPythonPackage rec {
   name = "pygtk-2.24.0";
-  
+
   disabled = isPy3k;
 
   src = fetchurl {
@@ -19,6 +19,8 @@ buildPythonPackage rec {
   configurePhase = "configurePhase";
 
   buildPhase = "buildPhase";
+
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-ObjC";
 
   installPhase = "installPhase";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7515,6 +7515,10 @@ in
 
   gtk-sharp-beans = callPackage ../development/libraries/gtk-sharp-beans { };
 
+  gtk-mac-integration = callPackage ../development/libraries/gtk-mac-integration {
+    gtk = gtk2;
+  };
+
   gtkspell2 = callPackage ../development/libraries/gtkspell { };
 
   gtkspell3 = callPackage ../development/libraries/gtkspell/3.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7488,6 +7488,8 @@ in
 
   gtk2 = callPackage ../development/libraries/gtk+/2.x.nix {
     cupsSupport = config.gtk2.cups or stdenv.isLinux;
+    gdktarget = if stdenv.isDarwin then "quartz" else "x11";
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
   };
 
   gtk3 = callPackage ../development/libraries/gtk+/3.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

I wanted to use a pygtk based application on darwin and noticed that it relied on the X11 backend of gtk which leads to trouble in multi screen setups (lost windows out of screen). Using the quartz backend also leads to a nicer display of the applications.

This Pull Request adjust GTK2 based on the work from #20658. I aimed to keep the changes to the GTK2 Derivation as close as possible to the other PR. The main change is that I added the CoreText dependencies to cairo and pango, so that fonts are actually visible.

Due to #12346 starting the applications still needs a twist by using something like `DYLD_FRAMEWORK_PATH=/System/Library/Frameworks`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

