### PR TITLE
shotwell: 0.23.5 -> 0.25.2

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   version = "${major}.${minor}";
-  major = "0.23";
-  minor = "5";
+  major = "0.25";
+  minor = "2";
   name = "shotwell-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/shotwell/${major}/${name}.tar.xz";
-    sha256 = "0fgs1rgvkmy79bmpxrsvm5w8rvqml4l1vnwma0xqx5zzm02p8a07";
+    sha256 = "1bih5hr3pvpkx3fck55bnhngn4fl92ryjizc34wb8pwigbkxnaj1";
   };
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/glib-2.0 -I${glib.out}/lib/glib-2.0/include";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
                   pkgconfig gst_all_1.gstreamer gst_all_1.gst-plugins-base gnome3.libgee
                   which udev libgudev gnome3.gexiv2 hicolor_icon_theme
                   libraw json_glib gettext desktop_file_utils glib lcms2 gdk_pixbuf librsvg
-                  wrapGAppsHook gnome_doc_utils gnome3.rest
+                  wrapGAppsHook gnome_doc_utils gnome3.rest gnome3.gcr
                   gnome3.defaultIconTheme itstool ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/3.22/misc/gexiv2/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/misc/gexiv2/default.nix
@@ -5,11 +5,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "gexiv2-${version}";
-  version = "${majorVersion}.3";
+  version = "${majorVersion}.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gexiv2/${majorVersion}/${name}.tar.xz";
-    sha256 = "390cfb966197fa9f3f32200bc578d7c7f3560358c235e6419657206a362d3988";
+    sha256 = "190www3b61spfgwx42jw8h5hsz2996jcxky48k63468avjpk33dd";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

Update shotwell to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

