### PR TITLE
Make cross-compiling with the crossSystem argument work (v2)

### DIFF
--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -62,6 +62,10 @@ with builtins;
 let version = "5.4.0";
     sha256 = "0fihlcy5hnksdxk0sn6bvgnyq8gfrgs8m794b1jxwd1dxinzg3b0";
 
+    # Rename the libcCross argument so we can redefine libcCross to
+    # null for the native compiler.
+    libcCrossArg = libcCross;
+
     # Whether building a cross-compiler for GNU/Hurd.
     crossGNU = cross != null && cross.config == "i586-pc-gnu";
 
@@ -210,7 +214,12 @@ in
 # We need all these X libraries when building AWT with GTK+.
 assert x11Support -> (filter (x: x == null) ([ gtk2 libart_lgpl ] ++ xlibs)) == [];
 
-stdenv.mkDerivation ({
+stdenv.mkDerivationWithCrossArg ( hostCrossSystem:
+  let
+    targetCrossSystem = if cross != null then cross else hostCrossSystem;
+    libcCross = if targetCrossSystem != null then libcCrossArg else null;
+  in {
+
   name = "${name}${if stripped then "" else "-debug"}-${version}" + crossNameAddon;
 
   builder = ../builder.sh;

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -17,8 +17,11 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv ? cross;
+  # This is just here because it was present in previous commits and
+  # we want to avoid a meaningless mass rebuild.
+  dontStrip = false;
+
+  crossAttrs.dontStrip = true; # Don't run the native `strip' when cross-compiling.
 
   postInstall =
     ''

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -21,7 +21,11 @@ stdenv.mkDerivation rec {
 
   inherit doCheck;
 
-  dontStrip = stdenv ? cross; # Don't run the native `strip' when cross-compiling.
+  # This is just here because it was present in previous commits and
+  # we want to avoid a meaningless mass rebuild.
+  dontStrip = false;
+
+  crossAttrs.dontStrip = true; # Don't run the native `strip' when cross-compiling.
 
   # Install headers and libs in the right places.
   postFixup = ''

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -28,8 +28,12 @@ stdenv.mkDerivation rec {
      in
        import ./readline-6.3-patches.nix patch);
 
-  # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv ? cross;
+  # This is just here because it was present in previous commits and
+  # we want to avoid a meaningless mass rebuild.
+  dontStrip = false;
+
+  crossAttrs.dontStrip = true; # Don't run the native `strip' when cross-compiling.
+
   bash_cv_func_sigsetjmp = if stdenv.isCygwin then "missing" else null;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -21,9 +21,13 @@ stdenv.mkDerivation rec {
   # leads to the failure of a number of tests.
   doCheck = false;
 
+  # This is just here because it was present in previous commits and
+  # we want to avoid a meaningless mass-rebuild.
+  dontStrip = false;
+
   # Don't run the native `strip' when cross-compiling.  This breaks at least
   # with `.a' files for MinGW.
-  dontStrip = stdenv ? cross;
+  crossAttrs.dontStrip = true;
 
   meta = {
     description = "GNU Libtool, a generic library support script";

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -264,6 +264,9 @@ let
       # derivation (e.g., in assertions).
       passthru);
 
+  # This gets overridden in makeStdvenvCross to do something more useful.
+  mkDerivationWithCrossArg = attrFunc: mkDerivation (attrFunc null);
+
   # The stdenv that we are producing.
   result =
     derivation (
@@ -342,6 +345,8 @@ let
       needsPax = isLinux;
 
       inherit mkDerivation;
+
+      inherit mkDerivationWithCrossArg;
 
       # For convenience, bring in the library functions in lib/ so
       # packages don't have to do that themselves.

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -278,12 +278,10 @@ rec {
       ];
       */
 
-    overrides = pkgs: {
-      gcc = cc;
-
+    overrides = lib.overrideNativeDrvs {
       inherit (stage4.pkgs)
         gzip bzip2 xz bash binutils coreutils diffutils findutils gawk
-        glibc gnumake gnused gnutar gnugrep gnupatch patchelf
+        gcc glibc gnumake gnused gnutar gnugrep gnupatch patchelf
         attr acl paxctl zlib pcre;
     };
   };

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -71,7 +71,7 @@ let
   gnumake = pkgs.gnumake.crossDrv;
   patch = pkgs.patch.crossDrv;
   patchelf = pkgs.patchelf.crossDrv;
-  gcc = pkgs.gcc.cc.crossDrv;
+  gcc = pkgs.gcc.crossDrv.cc;
   gmpxx = pkgs.gmpxx.crossDrv;
   mpfr = pkgs.mpfr.crossDrv;
   zlib = pkgs.zlib.crossDrv;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4674,18 +4674,18 @@ in
 
   gccApple = throw "gccApple is no longer supported";
 
-  gccCrossStageStatic = let
-    libcCross1 =
-      if stdenv.cross.libc == "msvcrt" then windows.mingw_w64_headers
-      else if stdenv.cross.libc == "libSystem" then darwin.xcode
-      else null;
-    in wrapGCCCross {
-      gcc = forceNativeDrv (gcc.cc.override {
+  gccCrossStageStatic =
+    wrapGCCCross {
+      gcc = forceNativeDrv (callPackage ../development/compilers/gcc/5 {
         cross = crossSystem;
         crossStageStatic = true;
-        langCC = false;
+        noSysDirs = true;
+        isl = isl_0_14;
         libcCross = libcCross1;
         enableShared = false;
+        langCC = false;
+        langObjC = false;
+        langObjCpp = false;
       });
       libc = libcCross1;
       binutils = binutilsCross;
@@ -4701,13 +4701,19 @@ in
   };
 
   gccCrossStageFinal = wrapGCCCross {
-    gcc = forceNativeDrv (gcc.cc.override {
+    gcc = forceNativeDrv (callPackage ../development/compilers/gcc/5 {
       cross = crossSystem;
       crossStageStatic = false;
+      noSysDirs = true;
+      isl = isl_0_14;
+      libcCross = libcCross;
 
       # XXX: We have troubles cross-compiling libstdc++ on MinGW (see
       # <http://hydra.nixos.org/build/4268232>), so don't even try.
       langCC = crossSystem.config != "i686-pc-mingw32";
+
+      langObjC = false;
+      langObjCpp = false;
     });
     libc = libcCross;
     binutils = binutilsCross;
@@ -7184,8 +7190,13 @@ in
     linuxHeaders = linuxHeadersCross;
   });
 
-  # We can choose:
-  libcCrossChooser = name: if name == "glibc" then glibcCross
+  libcCross1 =
+    if stdenv.cross.libc == "msvcrt" then windows.mingw_w64_headers
+    else if stdenv.cross.libc == "libSystem" then darwin.xcode
+    else null;
+
+  libcCrossChooser = name:
+    if name == "glibc" then glibcCross
     else if name == "uclibc" then uclibcCross
     else if name == "msvcrt" then windows.mingw_w64
     else if name == "libSystem" then darwin.xcode
@@ -8081,14 +8092,17 @@ in
 
   # glibc provides libiconv so systems with glibc don't need to build libiconv
   # separately, but we also provide libiconvReal, which will always be a
-  # standalone libiconv, just in case you want it
-  libiconv = if crossSystem != null then
-    (if crossSystem.libc == "glibc" then libcCross
-      else if crossSystem.libc == "libSystem" then darwin.libiconv
-      else libiconvReal)
-    else if stdenv.isGlibc then glibcIconv stdenv.cc.libc
-    else if stdenv.isDarwin then darwin.libiconv
-    else libiconvReal;
+  # standalone libiconv, just in case you want it.
+  libiconv =
+    let
+      nativeDrv = if stdenv.isGlibc then stdenv.cc.libc
+        else if stdenv.isDarwin then darwin.libiconv
+        else libiconvReal;
+      crossDrv =
+        if crossSystem.libc == "glibc" then libcCross
+        else if crossSystem.libc == "libSystem" then darwin.libiconv
+        else libiconvReal.crossDrv;
+    in nativeDrv // { inherit crossDrv nativeDrv; };
 
   glibcIconv = libc: let
     inherit (builtins.parseDrvName libc.name) name version;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -58,15 +58,11 @@ let
 
   aliases = self: super: import ./aliases.nix super;
 
-  # stdenvOverrides is used to avoid circular dependencies for building
-  # the standard build environment. This mechanism uses the override
-  # mechanism to implement some staged compilation of the stdenv.
-  #
-  # We don't want stdenv overrides in the case of cross-building, or
-  # otherwise the basic overridden packages will not be built with the
-  # crossStdenv adapter.
+  # stdenvOverrides is used to avoid having multiple of versions
+  # of certain dependencies that were used in bootstrapping the
+  # standard environment.
   stdenvOverrides = self: super:
-    lib.optionalAttrs (crossSystem == null && super.stdenv ? overrides)
+    lib.optionalAttrs (super.stdenv ? overrides)
       (super.stdenv.overrides super);
 
   # Allow packages to be overridden globally via the `packageOverrides'


### PR DESCRIPTION
This is version 2 of my previous pull request (https://github.com/NixOS/nixpkgs/pull/18386).  Compared to my previous pull request, this has a bit of a smaller scope: it does not add a `test` directory and it does not try to fix the deprecated `--with-headers` option used to compile GCC cross-compilers.  Also, it does not do as much fixing of the top-level logic, thanks to the merged pull request https://github.com/NixOS/nixpkgs/pull/19940 by @Ericson2314 which cleaned up a lot of the problems in that area.

This pull request fixes several things about cross-compiling with the `crossSystem` argument:

- It fixes the expressions for several derivations (gcc5, boehmgc, libffi, libxml2, readline, libtool, libiconv) so that their native derivations do not change when the top-level crossSystem argument is provided.
- It avoids using bootstrap tools to compile the cross-compilers; it uses the normal stdenv.

To accomplish these goals, some new things were added:

- stdenv.mkDerivationWithCrossArg
- lib.overrideNativeDrv
- lib.overrideNativeDrvs

###### Motivation for this change

For motivation information, see my comment on the old pull request: https://github.com/NixOS/nixpkgs/pull/18386#issuecomment-245522662

###### Things done to test

This pull request was tested using the expression here:

https://gist.github.com/DavidEGrayson/8f962b3ec6edf06365ecb0c70a88029f

The tests passed, all the derivations were successfully built, and the rpiHello derivation was successfully run on a Raspberry Pi.  This pull request should not cause a mass rebuild of native derivations.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

######  Future work

Here are some similar things that could be done in the future:

- Search for more improper uses of `stdenv.cross`, possibly remove `stdenv.cross` to prevent future errors.
- Stop using the deprecated --with-headers option to configure GCC cross-compilers.
- Apply these GCC fixes to the GCC 6 expression.
- Get cross-compiling working on Darwin too; this pull request is mainly about getting it to work on Linux.
- Add automated tests to make sure the problems fixed by this PR do not reoccur.
