### PR TITLE
AgdaStdlib: v0.12 -> v0.13

### DIFF
--- a/pkgs/development/libraries/agda/agda-stdlib/default.nix
+++ b/pkgs/development/libraries/agda/agda-stdlib/default.nix
@@ -1,14 +1,14 @@
 { stdenv, agda, fetchFromGitHub, ghcWithPackages }:
 
 agda.mkDerivation (self: rec {
-  version = "0.12";
+  version = "0.13";
   name = "agda-stdlib-${version}";
 
   src = fetchFromGitHub {
     repo = "agda-stdlib";
     owner = "agda";
     rev = "v${version}";
-    sha256 = "1n5hn3xa0bqyq8rjvfsfmh6z3l8rr4z3s7gyfmf3kiv9f235bnd2";
+    sha256 = "156xbqvqjck9izz613v52ppwk8s1y0kv7xkjpcm16vys2c3bh0x5";
   };
 
   nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];


### PR DESCRIPTION
###### Motivation for this change
Agda will soon be updated to version 2.5.2. This is the version of stdlib to go with it. Other than the timing, this is a standard version bump.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @peti. Agda is a Haskell package. I'm not familiar with how Haskell packages are put on nixpkgs, but they seem to be tied to LTS Haskell, which doesn't have Agda 2.5.2 yet. When it does, this commit should be applied simultaneously.