### PR TITLE
pythonPackages.voltron: init at 0.1.7

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -370,6 +370,7 @@
   psibi = "Sibi <sibi@psibi.in>";
   pstn = "Philipp Steinpaß <philipp@xndr.de>";
   pSub = "Pascal Wittmann <mail@pascal-wittmann.de>";
+  psychomario = "Rory McNamara <rory@rorym.cnamara.com>";
   puffnfresh = "Brian McKenna <brian@brianmckenna.org>";
   pxc = "Patrick Callahan <patrick.callahan@latitudeengineering.com>";
   qknight = "Joachim Schiele <js@lastlog.de>";

--- a/pkgs/development/python-modules/Flask-RESTful/default.nix
+++ b/pkgs/development/python-modules/Flask-RESTful/default.nix
@@ -1,0 +1,23 @@
+{
+stdenv, pkgs, python, wrapPython, buildPythonPackage,
+flask, pytz, six, aniso8601, itsdangerous, click, jinja2, werkzeug, dateutil, nose
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-RESTful";
+  name = "${pname}-${version}";
+  version = "0.3.5";
+  src = pkgs.fetchurl {
+    url = "mirror://pypi/F/${pname}/${name}.tar.gz";
+    sha256 = "0hjcmdb56b7z4bkw848lxfkyrpnkwzmqn2dgnlv12mwvjpzsxr6c";
+  };
+  PYTHON_EGG_CACHE = "`pwd`/.egg-cache";
+  meta = with stdenv.lib; {
+    description = "Simple framework for creating REST APIs";
+    homepage    = "https://github.com/flask-restful/flask-restful/";
+    license     = licenses.bsd3;
+    platforms   = platforms.linux;
+  };
+  propagatedBuildInputs = [ flask pytz six aniso8601 itsdangerous click jinja2 werkzeug dateutil nose ];
+  maintainer = with stdenv.lib.maintainers; [ psychomario ];
+}

--- a/pkgs/development/python-modules/aniso8601/default.nix
+++ b/pkgs/development/python-modules/aniso8601/default.nix
@@ -1,0 +1,25 @@
+{
+stdenv, pkgs, python, wrapPython, buildPythonPackage,
+dateutil, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "aniso8601";
+  name = "${pname}-${version}";
+  version = "1.2.0";
+  src = pkgs.fetchurl {
+    url = "mirror://pypi/a/${pname}/${name}.tar.gz";
+    sha256 = "1m2d83rm684xdf54ynfd9lv3slv7bkqq6pcirh2aibvl4pw0092h";
+  };
+  checkPhase = ''
+    py.test
+  '';
+  meta = with stdenv.lib; {
+    description = "A library for parsing ISO 8601 strings";
+    homepage    = "https://bitbucket.org/nielsenb/aniso8601";
+    license     = licenses.bsd3;
+    platforms   = platforms.linux;
+  };
+  propagatedBuildInputs = [ dateutil pytest ];
+  maintainer = with stdenv.lib.maintainers; [ psychomario ];
+}

--- a/pkgs/development/python-modules/blessed/default.nix
+++ b/pkgs/development/python-modules/blessed/default.nix
@@ -1,0 +1,28 @@
+{
+stdenv, pkgs, python, wrapPython, buildPythonPackage,
+pytest, mock,
+wcwidth, six
+}:
+
+buildPythonPackage rec {
+  pname = "blessed";
+  name = "${pname}-${version}";
+  version = "1.14.1";
+  src = pkgs.fetchurl {
+    url = "mirror://pypi/b/${pname}/${name}.tar.gz";
+    sha256 = "0wy0na399swybp5bzys31pn57vg34bjsl0kv5zf496996gc8k8jq";
+  };
+  doCheck = false;
+  checkPhase = ''
+    py.test
+  '';
+  meta = with stdenv.lib; {
+    description = "A thin, practical wrapper around terminal styling, screen positioning, and keyboard input.";
+    homepage    = "https://github.com/jquast/blessed";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+  };
+  buildInputs = [ pytest mock ];
+  propagatedBuildInputs = [ wcwidth six ];
+  maintainer = with stdenv.lib.maintainers; [ psychomario ];
+}

--- a/pkgs/development/python-modules/pysigset/default.nix
+++ b/pkgs/development/python-modules/pysigset/default.nix
@@ -1,0 +1,20 @@
+{
+stdenv, pkgs, python, wrapPython, buildPythonPackage
+}:
+
+buildPythonPackage rec {
+  pname = "pysigset";
+  name = "${pname}-${version}";
+  version = "0.2.1";
+  src = pkgs.fetchurl {
+    url = "mirror://pypi/p/${pname}/${name}.tar.gz";
+    sha256 = "0f3g705r2zb09xvz81kmci4iza7ph2gqydmmv0nxqfs50msn3pw1";
+  };
+  meta = with stdenv.lib; {
+    description = "Python blocking/suspending signals under Linux/OSX using ctypes sigprocmask access";
+    homepage    = "https://github.com/ossobv/pysigset";
+    license     = licenses.gpl3Plus;
+    platforms   = platforms.linux;
+  };
+  maintainer = with stdenv.lib.maintainers; [ psychomario ];
+}

--- a/pkgs/development/python-modules/requests-unixsocket/default.nix
+++ b/pkgs/development/python-modules/requests-unixsocket/default.nix
@@ -1,0 +1,26 @@
+{
+stdenv, pkgs, python, wrapPython, buildPythonPackage, isPy3k,
+urllib3, pytest, pytestpep8, waitress, requests, requests2
+}:
+
+buildPythonPackage rec {
+  pname = "requests-unixsocket";
+  name = "${pname}-${version}";
+  version = "0.1.5";
+  src = pkgs.fetchurl {
+    url = "mirror://pypi/r/${pname}/${name}.tar.gz";
+    sha256 = "0k19knydh0fzd7w12lfy18arl1ndwa0zln33vsb37yv1iw9w06x9";
+  };
+  doCheck = false;
+  checkPhase = ''
+    py.test
+  '';
+  meta = with stdenv.lib; {
+    description = "Use requests to talk HTTP via a UNIX domain socket";
+    homepage    = "https://github.com/msabramo/requests-unixsocket";
+    license     = licenses.asl20;
+    platforms   = platforms.linux;
+  };
+  propagatedBuildInputs = [ urllib3 pytest pytestpep8 waitress ] ++ (if isPy3k then [requests2] else [requests]);
+  maintainer = with stdenv.lib.maintainers; [ psychomario ];
+}

--- a/pkgs/development/python-modules/scruffington/default.nix
+++ b/pkgs/development/python-modules/scruffington/default.nix
@@ -1,0 +1,29 @@
+{
+stdenv, pkgs, python, wrapPython, buildPythonPackage,
+pyyaml, six, nose
+}:
+
+buildPythonPackage rec {
+  pname = "scruffington";
+  name = "${pname}-${version}";
+  version = "0.3.7";
+  src = pkgs.fetchurl {
+    # github release not PyPI so we have tests
+    url = "https://github.com/snare/scruffy/archive/v${version}.tar.gz";
+    sha256 = "1585xpvdyz85nmxhdgfvb8hdv8jlbv2yx41lfxl3wlr8ck61yrs3";
+  };
+  # fails when run multiple times as different users
+  # https://github.com/snare/scruffy/issues/15
+  doCheck = false;
+  checkPhase = ''
+    nosetests
+  '';
+  meta = with stdenv.lib; {
+    description = "Scruffy. The janitor";
+    homepage    = "https://github.com/snare/scruffy";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+  };
+  propagatedBuildInputs = [ pyyaml six nose ];
+  maintainer = with stdenv.lib.maintainers; [ psychomario ];
+}

--- a/pkgs/development/python-modules/voltron/default.nix
+++ b/pkgs/development/python-modules/voltron/default.nix
@@ -1,0 +1,38 @@
+{
+stdenv, pkgs, python, wrapPython, buildPythonPackage, isPy3k,
+nose, mock, pexpect,
+requests-unixsocket, pysigset, blessed, Flask-RESTful, scruffington, pygments, requests, requests2
+}:
+
+buildPythonPackage rec {
+    name = "voltron-${version}";
+    version = "0.1.7";
+    src = pkgs.fetchurl {
+        # github release not PyPI so we have tests
+        url = "https://github.com/snare/voltron/archive/v${version}.tar.gz";
+        sha256 = "0qvznkrr2m90x96ac246kwxqrkpvwda0fh6zrqnnf1dwbszdl699";
+    };
+    # fails in tests.gdb_cli_tests.test_disassemble
+    # and because of wrong lldb version, mitigated in sed below
+    doCheck = false;
+    # $HOME is by default not a valid dir, so we have to set that too
+    # https://github.com/NixOS/nixpkgs/issues/12591
+    # taken from the voltron .travis.yml
+    checkPhase = ''
+      export HOME=$TMPDIR
+      mkdir ~/.voltron/
+      echo '{"general":{"debug_logging":true}}' >~/.voltron/config
+      sed -i "s|p = pexpect.spawn('lldb-3.4')|p = pexpect.spawn('lldb')|" tests/lldb_cli_tests.py
+      nosetests
+    '';
+    meta = with stdenv.lib; {
+        description = "A hacky debugger UI for hackers";
+        homepage    = "https://github.com/snare/voltron";
+        license     = licenses.mit;
+        platforms   = platforms.all;
+    };
+    buildInputs = [ nose mock pexpect ];
+    propagatedBuildInputs = [ requests-unixsocket pysigset blessed Flask-RESTful scruffington pygments pkgs.llvmPackages.lldb pkgs.gdb ]
+        ++ (if isPy3k then [requests2] else [requests]);
+    maintainer = with stdenv.lib.maintainers; [ psychomario ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31769,6 +31769,8 @@ EOF
 
   blessed = callPackage ../development/python-modules/blessed { };
 
+  Flask-RESTful = callPackage ../development/python-modules/Flask-RESTful { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31763,6 +31763,8 @@ EOF
     };
   };
 
+  requests-unixsocket = callPackage ../development/python-modules/requests-unixsocket { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31767,6 +31767,8 @@ EOF
 
   pysigset = callPackage ../development/python-modules/pysigset { };
 
+  blessed = callPackage ../development/python-modules/blessed { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31775,6 +31775,8 @@ EOF
 
   scruffington = callPackage ../development/python-modules/scruffington { };
 
+  voltron = callPackage ../development/python-modules/voltron { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31765,6 +31765,8 @@ EOF
 
   requests-unixsocket = callPackage ../development/python-modules/requests-unixsocket { };
 
+  pysigset = callPackage ../development/python-modules/pysigset { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31773,6 +31773,8 @@ EOF
 
   aniso8601 = callPackage ../development/python-modules/aniso8601 { };
 
+  scruffington = callPackage ../development/python-modules/scruffington { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31771,6 +31771,8 @@ EOF
 
   Flask-RESTful = callPackage ../development/python-modules/Flask-RESTful { };
 
+  aniso8601 = callPackage ../development/python-modules/aniso8601 { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

Add the [voltron](https://github.com/snare/voltron) package and required dependencies:

 - requests-unixsocket
 - pysigset
 - blessed
 - Flask-RESTful
 - aniso8601
 - scruffington
 - voltron

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Note that for testing purposes I had to recompile my gdb to use the full version of python27 due to the curses library not being there. This is likely due to my own stupidity.

Python27, Python3{3,4,5,6} all compile, fully tested with Python27.

Apologies if I've done this completely wrong, I'm very new to this packaging format.
