### PR TITLE
SDL2: split derivation

### DIFF
--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     sha256 = "0jqp46mxxbh9lhpx1ih6sp93k752j2smhpc0ad0q4cb3px0famfs";
   };
 
+  outputs = [ "out" "dev" ];
+
   patches = [ ./find-headers.patch ];
 
   nativeBuildInputs = [ pkgconfig ];
@@ -61,6 +63,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     rm $out/lib/*.a
+    moveToOutput bin/sdl2-config "$dev"
   '';
 
   setupHook = ./setup-hook.sh;


### PR DESCRIPTION
###### Motivation for this change
Reduce closure size of dependent packages

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Definitely needs review of dependent packages building, will get around to it eventually — I don't have the space to test this on my laptop.