### PR TITLE
Xournal: Darwin support

### DIFF
--- a/pkgs/applications/graphics/xournal/default.nix
+++ b/pkgs/applications/graphics/xournal/default.nix
@@ -13,8 +13,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     ghostscript atk gtk2 glib fontconfig freetype
-    libgnomecanvas libgnomeprint libgnomeprintui
+    libgnomecanvas
     pango libX11 xproto zlib poppler
+  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
+    libgnomeprint libgnomeprintui
   ];
 
   nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
@@ -47,11 +49,11 @@ stdenv.mkDerivation rec {
       cp $out/share/xournal/pixmaps/xournal.png $out/share/icons
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://xournal.sourceforge.net/;
     description = "Note-taking application (supposes stylus)";
-    maintainers = [ stdenv.lib.maintainers.guibert ];
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ maintainers.guibert ];
+    license = licenses.gpl2;
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -38,9 +38,13 @@ stdenv.mkDerivation rec {
     ++ optional xineramaSupport libXinerama
     ++ optionals cupsSupport [ cups ];
 
-  configureFlags = if stdenv.isDarwin
-    then "--disable-glibtest --disable-introspection --disable-visibility"
-    else "--with-xinput=yes";
+  configureFlags = [
+    "--with-xinput=yes"
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    "--disable-glibtest"
+    "--disable-introspection"
+    "--disable-visibility"
+  ];
 
   postInstall = ''
     moveToOutput share/gtk-2.0/demo "$devdoc"


### PR DESCRIPTION
###### Motivation for this change

This PR has two small changes:

1. It allows to build Xournal on Darwin.
2. In enables xinput also on Darwin, so that e.g. pressure sensitivity works in Xournal.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

