### PR TITLE
dmd: Fix build for Darwin

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -20,10 +20,6 @@ stdenv.mkDerivation rec {
       substituteInPlace src/dmd/posix.mak \
           --replace g++ clang++ \
           --replace MACOSX_DEPLOYMENT_TARGET MACOSX_DEPLOYMENT_TARGET_
-
-      # Was not able to compile on darwin due to "__inline_isnanl"
-      # being undefined.
-      substituteInPlace src/dmd/root/port.c --replace __inline_isnanl __inline_isnan
   '';
 
   # Buid and install are based on http://wiki.dlang.org/Building_DMD


### PR DESCRIPTION
###### Motivation for this change

Noticed that the dmd build was broken on Hydra: http://hydra.nixos.org/build/45029212/nixlog/1

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

