### PR TITLE
firefox, thunderbird: add updateScript

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/default.nix
@@ -5,6 +5,7 @@
 , hunspell, libevent, libstartup_notification, libvpx
 , cairo, gstreamer, gst_plugins_base, icu, libpng, jemalloc, libpulseaudio
 , autoconf213, which
+, writeScript, xidel, coreutils, gnused, gnugrep, curl, ed
 , enableGTK3 ? false
 , debugBuild ? false
 , # If you want the resulting program to call itself "Firefox" instead
@@ -19,7 +20,7 @@ assert stdenv.cc ? libc && stdenv.cc.libc != null;
 
 let
 
-common = { pname, version, sha512 }: stdenv.mkDerivation rec {
+common = { pname, version, sha512, updateScript }: stdenv.mkDerivation rec {
   name = "${pname}-unwrapped-${version}";
 
   src = fetchurl {
@@ -135,7 +136,7 @@ common = { pname, version, sha512 }: stdenv.mkDerivation rec {
   };
 
   passthru = {
-    inherit nspr version;
+    inherit nspr version updateScript;
     gtk = gtk2;
     isFirefox3Like = true;
     browserName = "firefox";
@@ -148,13 +149,22 @@ in {
   firefox-unwrapped = common {
     pname = "firefox";
     version = "50.1.0";
-    sha512 = "2jwpk3aymkcq9f4xhzc31sb1c90vy3dvyqq2hvw97vk9dw7rgvv2cki10ns5cshbc4k57yd3j8nm7ppy2kw6na6771mj6sbijdjw39p";
+    sha512 = "370d2e9b8c4b1b59c3394659c3a7f0f79e6a911ccd9f32095b50b3a22d087132b1f7cb87b734f7497c4381b1df6df80d120b4b87c13eecc425cc66f56acccba5";
+    updateScript = import ./update.nix {
+        name = "firefox";
+        inherit writeScript xidel coreutils gnused gnugrep curl ed;
+    };
   };
 
   firefox-esr-unwrapped = common {
     pname = "firefox-esr";
     version = "45.6.0esr";
-    sha512 = "086ci461hmz6kdn0ly9dlc723gc117si4a11a1c51gh79hczhahdaxg5s4r3k59rb43gpwxrlvm4wx1aka36bsihnh8a4caxnp72v5r";
+    sha512 = "b96c71aeed8a1185a085512f33d454a1735237cd9ddf37c8caa9cc91892eafab0615fc0ca6035f282ca8101489fa84c0de1087d1963c05b64df32b0c86446610";
+    updateScript = import ./update.nix {
+        name = "firefox-esr";
+        versionSuffix = "esr";
+        inherit writeScript xidel coreutils gnused gnugrep curl ed;
+    };
   };
 
 }

--- a/pkgs/applications/networking/browsers/firefox/update.nix
+++ b/pkgs/applications/networking/browsers/firefox/update.nix
@@ -1,0 +1,54 @@
+{ name
+, writeScript
+, xidel
+, coreutils
+, gnused
+, gnugrep
+, curl
+, ed
+, sourceSectionRegex ? "${name}-unwrapped = common"
+, basePath ? "pkgs/applications/networking/browsers/firefox"
+, baseUrl ? "http://archive.mozilla.org/pub/firefox/releases/"
+, versionSuffix ? ""
+}:
+
+let
+  version = (builtins.parseDrvName name).version;
+in writeScript "update-${name}" ''
+  PATH=${coreutils}/bin:${gnused}/bin:${gnugrep}/bin:${xidel}/bin:${curl}/bin:${ed}/bin
+
+  pushd ${basePath}
+
+  url=${baseUrl}
+
+  # retriving latest released version
+  #  - extracts all links from the $url
+  #  - extracts lines only with number and dots followed by a slash
+  #  - removes trailing slash
+  #  - sorts everything with semver in mind
+  #  - picks up latest release
+  version=`xidel -q $url --extract "//a" | \
+           grep "^[0-9.]*${versionSuffix}/$" | \
+           sed s/[/]$// | \
+           sort --version-sort | \
+           tail -n 1`
+
+  shasum=`curl --silent $url$version/SHA512SUMS | grep 'source\.tar\.xz' | cut -d ' ' -f 1`
+
+  ed default.nix <<COMMANDS
+  # search line
+    /${sourceSectionRegex}/
+  # search version number line
+    /version/
+  # update the version
+    s/".*"/"$version"/
+  # search hash line
+    /sha512/
+  # update the hash
+    s/".*"/"$shasum"/
+  # write then quit
+    wq
+  COMMANDS
+
+  popd
+''

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -4,6 +4,7 @@
 , yasm, mesa, sqlite, unzip, makeWrapper
 , hunspell, libevent, libstartup_notification, libvpx
 , cairo, gstreamer, gst_plugins_base, icu
+, writeScript, xidel, coreutils, gnused, gnugrep, curl, ed
 , debugBuild ? false
 , # If you want the resulting program to call itself "Thunderbird"
   # instead of "Earlybird", enable this option.  However, those
@@ -127,5 +128,13 @@ stdenv.mkDerivation rec {
       if enableOfficialBranding then licenses.proprietary else licenses.mpl11;
     maintainers = [ maintainers.pierron maintainers.eelco ];
     platforms = platforms.linux;
+  };
+
+  passthru.updateScript = import ./../../browsers/firefox/update.nix {
+    name = "thunderbird";
+    sourceSectionRegex = ".";
+    basePath = "pkgs/applications/networking/mailreaders/thunderbird";
+    baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
+    inherit writeScript xidel coreutils gnused gnugrep curl ed;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Automating updating packages (#20844).

```
nix-shell maintainers/scripts/update.nix --argstr package firefox-unwrapped
nix-shell maintainers/scripts/update.nix --argstr package firefox-esr-unwrapped
nix-shell maintainers/scripts/update.nix --argstr package thunderbird
```

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc: @garbas