### PR TITLE
emacs-packages:  init haskell-unicode-input-method at 20110905

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -238,6 +238,22 @@ let
     };
   };
 
+  haskell-unicode-input-method = melpaBuild rec {
+    pname = "emacs-haskell-unicode-input-method";
+    version = "20110905.2307";
+    src = fetchFromGitHub {
+      owner = "roelvandijk";
+      repo = "emacs-haskell-unicode-input-method";
+      rev = "d8d168148c187ed19350bb7a1a190217c2915a63";
+      sha256 = "09b7bg2s9aa4s8f2kdqs4xps3jxkq5wsvbi87ih8b6id38blhf78";
+    };
+    packageRequires = [];
+    meta = {
+      homepage = "https://melpa.org/#haskell-unicode-input-method/";
+      license = lib.licenses.free;
+    };
+  };
+
   hindent = melpaBuild rec {
     pname = "hindent";
     version = external.hindent.version;


### PR DESCRIPTION
###### Motivation for this change
emacs-haskell-unicode-input-method isn't packaged, since it's not in Melpa, which is a terrible shame.

###### Things done

- [x] Submitted a MELPA packaging plea to upstream: https://github.com/roelvandijk/emacs-haskell-unicode-input-method/issues/1
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

