### PR TITLE
wxMac: fixed main compile on 10.6

### DIFF
--- a/pkgs/development/libraries/wxGTK-2.8/default.nix
+++ b/pkgs/development/libraries/wxGTK-2.8/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xf86vidmodeproto
 , gstreamer, gst_plugins_base, GConf, libX11, cairo
-, withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true,
+, withMesa ? true, mesa ? null, compat24 ? false, compat26 ? true, unicode ? true
+, Carbon ? null, Cocoa ? null, CoreServices ? null
 }:
 
 assert withMesa -> mesa != null;
@@ -17,7 +18,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ gtk2 libXinerama libSM libXxf86vm xf86vidmodeproto gstreamer gst_plugins_base GConf libX11 cairo ]
-    ++ optional withMesa mesa;
+    ++ optional withMesa mesa
+    ++ optionals stdenv.isDarwin [ Carbon Cocoa CoreServices ];
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -42,6 +44,8 @@ stdenv.mkDerivation rec {
 
   # Work around a bug in configure.
   NIX_CFLAGS_COMPILE = [ "-DHAVE_X11_XLIB_H=1" "-lX11" "-lcairo" ];
+
+  NIX_LDFLAGS = optionalString stdenv.isDarwin "-framework CoreServices";
 
   preConfigure = "
     substituteInPlace configure --replace 'SEARCH_INCLUDE=' 'DUMMY_SEARCH_INCLUDE='

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9655,6 +9655,7 @@ in
 
   wxGTK28 = callPackage ../development/libraries/wxGTK-2.8 {
     inherit (gnome2) GConf;
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa CoreServices;
     withMesa = lib.elem system lib.platforms.mesaPlatforms;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Need to link appropriate services when compiling wxMac 2.8 on Darwin.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

