### PR TITLE
remmina: add icon packages as soft deps

### DIFF
--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -4,7 +4,10 @@
 , pcre, webkitgtk, libdbusmenu-gtk3, libappindicator-gtk3
 , libvncserver, libpthreadstubs, libXdmcp, libxkbcommon
 , libsecret, spice_protocol, spice_gtk, epoxy, at_spi2_core
-, openssl }:
+, openssl
+# The themes here are soft dependencies; only icons are missing without them.
+, hicolor_icon_theme, adwaita-icon-theme
+}:
 
 let
   version = "1.2.0-rcgit.15";
@@ -51,7 +54,7 @@ stdenv.mkDerivation {
                   pcre webkitgtk libdbusmenu-gtk3 libappindicator-gtk3
                   libvncserver libpthreadstubs libXdmcp libxkbcommon
                   libsecret spice_protocol spice_gtk epoxy at_spi2_core
-                  openssl ];
+                  openssl hicolor_icon_theme adwaita-icon-theme ];
 
   cmakeFlags = "-DWITH_VTE=OFF -DWITH_TELEPATHY=OFF -DWITH_AVAHI=OFF -DWINPR_INCLUDE_DIR=${freerdp_git}/include/winpr2";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3531,7 +3531,7 @@ in
 
   remind = callPackage ../tools/misc/remind { };
 
-  remmina = callPackage ../applications/networking/remote/remmina {};
+  remmina = callPackage ../applications/networking/remote/remmina { adwaita-icon-theme = gnome3.adwaita-icon-theme; };
 
   renameutils = callPackage ../tools/misc/renameutils { };
 


### PR DESCRIPTION
###### Motivation for this change

My remmina client had broken icons until I added these theme packages to my environment. I've added them as buildInputs. Is it appropriate to pull in themes directly like this in a derivation? I don't think relying on gnome3 being in the env is too good either, as many users like me will be using xmonad or another XDE.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

