### PR TITLE
Improve release-cross tests

### DIFF
--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -1,4 +1,4 @@
-with import ./release-lib.nix { supportedSystems = []; };
+with import ./release-lib.nix { supportedSystems = [ builtins.currentSystem ]; };
 let
   nativePlatforms = linux;
 

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -20,39 +20,34 @@ let
   basic = basicCrossDrv // basicNativeDrv;
 
 in
-(
 
-/* Test some cross builds to the Sheevaplug */
-let
-  crossSystem = {
-    config = "armv5tel-unknown-linux-gnueabi";
-    bigEndian = false;
-    arch = "arm";
-    float = "soft";
-    withTLS = true;
-    platform = pkgs.platforms.sheevaplug;
-    libc = "glibc";
-    openssl.system = "linux-generic32";
-  };
+{
+  /* Test some cross builds to the Sheevaplug */
+  crossSheevaplugLinux = let
+    crossSystem = {
+      config = "armv5tel-unknown-linux-gnueabi";
+      bigEndian = false;
+      arch = "arm";
+      float = "soft";
+      withTLS = true;
+      platform = pkgs.platforms.sheevaplug;
+      libc = "glibc";
+      openssl.system = "linux-generic32";
+    };
+  in mapTestOnCross crossSystem (basic // {
+    ubootSheevaplug.crossDrv = nativePlatforms;
+  });
 
-in {
-  crossSheevaplugLinux = mapTestOnCross crossSystem (
-    basic //
-    {
-      ubootSheevaplug.crossDrv = nativePlatforms;
-    });
-}) // (
 
-/* Test some cross builds on 32 bit mingw-w64 */
-let
-  crossSystem = {
+  /* Test some cross builds on 32 bit mingw-w64 */
+  crossMingw32 = let
+    crossSystem = {
       config = "i686-w64-mingw32";
       arch = "x86"; # Irrelevant
       libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
       platform = {};
-  };
-in {
-  crossMingw32 = mapTestOnCross crossSystem {
+    };
+  in mapTestOnCross crossSystem {
     coreutils.crossDrv = nativePlatforms;
     boehmgc.crossDrv = nativePlatforms;
     gmp.crossDrv = nativePlatforms;
@@ -62,19 +57,18 @@ in {
     libunistring.crossDrv = nativePlatforms;
     windows.wxMSW.crossDrv = nativePlatforms;
   };
-}) // (
 
-/* Test some cross builds on 64 bit mingw-w64 */
-let
-  crossSystem = {
+
+  /* Test some cross builds on 64 bit mingw-w64 */
+  crossMingwW64 = let
+    crossSystem = {
       # That's the triplet they use in the mingw-w64 docs.
       config = "x86_64-w64-mingw32";
       arch = "x86_64"; # Irrelevant
       libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
       platform = {};
-  };
-in {
-  crossMingwW64 = mapTestOnCross crossSystem {
+    };
+  in mapTestOnCross crossSystem {
     coreutils.crossDrv = nativePlatforms;
     boehmgc.crossDrv = nativePlatforms;
     gmp.crossDrv = nativePlatforms;
@@ -84,63 +78,60 @@ in {
     libunistring.crossDrv = nativePlatforms;
     windows.wxMSW.crossDrv = nativePlatforms;
   };
-}) // (
 
-/* Linux on the fuloong */
-let
-  crossSystem = {
-    config = "mips64el-unknown-linux";
-    bigEndian = false;
-    arch = "mips";
-    float = "hard";
-    withTLS = true;
-    libc = "glibc";
-    platform = {
-      name = "fuloong-minipc";
-      kernelMajor = "2.6";
-      kernelBaseConfig = "lemote2f_defconfig";
-      kernelHeadersBaseConfig = "fuloong2e_defconfig";
-      uboot = null;
-      kernelArch = "mips";
-      kernelAutoModules = false;
-      kernelTarget = "vmlinux";
-    };
-    openssl.system = "linux-generic32";
-    gcc = {
-      arch = "loongson2f";
-      abi = "n32";
-    };
-  };
-in {
-  fuloongminipc = mapTestOnCross crossSystem {
 
+  /* Linux on the fuloong */
+  fuloongminipc = let
+    crossSystem = {
+      config = "mips64el-unknown-linux";
+      bigEndian = false;
+      arch = "mips";
+      float = "hard";
+      withTLS = true;
+      libc = "glibc";
+      platform = {
+        name = "fuloong-minipc";
+        kernelMajor = "2.6";
+        kernelBaseConfig = "lemote2f_defconfig";
+        kernelHeadersBaseConfig = "fuloong2e_defconfig";
+        uboot = null;
+        kernelArch = "mips";
+        kernelAutoModules = false;
+        kernelTarget = "vmlinux";
+      };
+      openssl.system = "linux-generic32";
+      gcc = {
+        arch = "loongson2f";
+        abi = "n32";
+      };
+    };
+  in mapTestOnCross crossSystem {
     coreutils.crossDrv = nativePlatforms;
     ed.crossDrv = nativePlatforms;
     patch.crossDrv = nativePlatforms;
   };
-}) // (
 
-/* Linux on Raspberrypi */
-let
-  crossSystem = {
-    config = "armv6l-unknown-linux-gnueabi";
-    bigEndian = false;
-    arch = "arm";
-    float = "hard";
-    fpu = "vfp";
-    withTLS = true;
-    libc = "glibc";
-    platform = pkgs.platforms.raspberrypi;
-    openssl.system = "linux-generic32";
-    gcc = {
-      arch = "armv6";
+
+  /* Linux on Raspberrypi */
+  rpi = let
+    crossSystem = {
+      config = "armv6l-unknown-linux-gnueabi";
+      bigEndian = false;
+      arch = "arm";
+      float = "hard";
       fpu = "vfp";
-      float = "softfp";
-      abi = "aapcs-linux";
+      withTLS = true;
+      libc = "glibc";
+      platform = pkgs.platforms.raspberrypi;
+      openssl.system = "linux-generic32";
+      gcc = {
+        arch = "armv6";
+        fpu = "vfp";
+        float = "softfp";
+        abi = "aapcs-linux";
+      };
     };
-  };
-in {
-  rpi = mapTestOnCross crossSystem {
+  in mapTestOnCross crossSystem {
     coreutils.crossDrv = nativePlatforms;
     ed.crossDrv = nativePlatforms;
     patch.crossDrv = nativePlatforms;
@@ -152,13 +143,12 @@ in {
     binutils.crossDrv = nativePlatforms;
     mpg123.crossDrv = nativePlatforms;
   };
-}) // (
 
-/* Cross-built bootstrap tools for every supported platform */
-let
-  tools = import ../stdenv/linux/make-bootstrap-tools-cross.nix { system = "x86_64-linux"; };
-  maintainers = [ pkgs.lib.maintainers.dezgeg ];
-  mkBootstrapToolsJob = bt: hydraJob' (pkgs.lib.addMetaAttrs { inherit maintainers; } bt.dist);
-in {
-  bootstrapTools = pkgs.lib.mapAttrs (name: mkBootstrapToolsJob) tools;
-})
+
+  /* Cross-built bootstrap tools for every supported platform */
+  bootstrapTools = let
+    tools = import ../stdenv/linux/make-bootstrap-tools-cross.nix { system = "x86_64-linux"; };
+    maintainers = [ pkgs.lib.maintainers.dezgeg ];
+    mkBootstrapToolsJob = bt: hydraJob' (pkgs.lib.addMetaAttrs { inherit maintainers; } bt.dist);
+  in pkgs.lib.mapAttrs (name: mkBootstrapToolsJob) tools;
+}

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -46,21 +46,22 @@ rec {
      interested in the result of cross building a package. */
   crossMaintainers = [ maintainers.viric ];
 
+  forAllSupportedSystems = systems: f:
+    genAttrs (filter (x: elem x supportedSystems) systems) f;
 
   /* Build a package on the given set of platforms.  The function `f'
      is called for each supported platform with Nixpkgs for that
      platform as an argument .  We return an attribute set containing
      a derivation for each supported platform, i.e. ‘{ x86_64-linux =
      f pkgs_x86_64_linux; i686-linux = f pkgs_i686_linux; ... }’. */
-  testOn = systems: f: genAttrs
-    (filter (x: elem x supportedSystems) systems) (system: hydraJob' (f (pkgsFor system)));
+  testOn = systems: f: forAllSupportedSystems systems
+    (system: hydraJob' (f (pkgsFor system)));
 
 
   /* Similar to the testOn function, but with an additional
      'crossSystem' parameter for allPackages, defining the target
      platform for cross builds. */
-  testOnCross = crossSystem: systems: f: genAttrs
-    (filter (x: elem x supportedSystems) systems)
+  testOnCross = crossSystem: systems: f: forAllSupportedSystems systems
     (system: hydraJob' (f (allPackages { inherit system crossSystem; })));
 
 

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -59,10 +59,9 @@ rec {
   /* Similar to the testOn function, but with an additional
      'crossSystem' parameter for allPackages, defining the target
      platform for cross builds. */
-  testOnCross = crossSystem: systems: f: {system ? builtins.currentSystem}:
-    if elem system systems
-    then f (allPackages { inherit system crossSystem; })
-    else {};
+  testOnCross = crossSystem: systems: f: genAttrs
+    (filter (x: elem x supportedSystems) systems)
+    (system: hydraJob' (f (allPackages { inherit system crossSystem; })));
 
 
   /* Given a nested set where the leaf nodes are lists of platforms,


### PR DESCRIPTION
Ahead of https://github.com/NixOS/nixpkgs/pull/21388 or https://github.com/NixOS/nixpkgs/pull/21268, it would be nice to test cross-compiling better. This PR cleans up the existing tests, and adds some new ones. Those new ones fail, but that's OK: they won't hold up any channel, and they'll remind us to merge one of the two PRs above, which fixes the new tests.

@DavidEGrayson What do you think? I'd add you as a reviewer on the side panel, but It won't let me. If you like this I'll go ahead and merge it.