### PR TITLE
Normalize bootstrapping

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -30,6 +30,14 @@ following incompatible changes:</para>
 <itemizedlist>
   <listitem>
     <para>
+      <literal>stdenv.overrides</literal> is now expected to take <literal>self</literal>
+      and <literal>super</literal> arguments. See <literal>lib.trivial.extends</literal>
+      for what those parameters represent.
+    </para>
+  </listitem>
+
+  <listitem>
+    <para>
       <literal>gnome</literal> alias has been removed along with
       <literal>gtk</literal>, <literal>gtkmm</literal> and several others.
       Now you need to use versioned attributes, like <literal>gnome3</literal>.

--- a/pkgs/stdenv/booter.nix
+++ b/pkgs/stdenv/booter.nix
@@ -1,0 +1,65 @@
+# This file defines a single function for booting a package set from a list of
+# stages. The exact mechanics of that function are defined below; here I
+# (@Ericson2314) wish to describe the purpose of the abstraction.
+#
+# The first goal is consistency across stdenvs. Regardless of what this function
+# does, by making every stdenv use it for bootstrapping we ensure that they all
+# work in a similar way. [Before this abstraction, each stdenv was its own
+# special snowflake due to different authors writing in different times.]
+#
+# The second goal is consistency across each stdenv's stage functions. By
+# writing each stage it terms of the previous stage, commonalities between them
+# are more easily observable. [Before, there usually was a big attribute set
+# with each stage, and stages would access the previous stage by name.]
+#
+# The third goal is composition. Because each stage is written in terms of the
+# previous, the list can be reordered or, more practically, extended with new
+# stages. The latter is used for cross compiling and custom
+# stdenvs. Additionally, certain options should by default apply only to the
+# last stage, whatever it may be. By delaying the creation of stage package sets
+# until the final fold, we prevent these options from inhibiting composition.
+#
+# The fourth and final goal is debugging. Normal packages should only source
+# their dependencies from the current stage. But for the sake of debugging, it
+# is nice that all packages still remain accessible. We make sure previous
+# stages are kept around with a `stdenv.__bootPackges` attribute referring the
+# previous stage. It is idiomatic that attributes prefixed with `__` come with
+# special restrictions and should not be used under normal circumstances.
+{ lib, allPackages }:
+
+# Type:
+#   [ pkgset -> (args to stage/default.nix) or ({ __raw = true; } // pkgs) ]
+#   -> pkgset
+#
+# In english: This takes a list of function from the previous stage pkgset and
+# returns the final pkgset. Each of those functions returns, if `__raw` is
+# undefined or false, args for this stage's pkgset (the most complex and
+# important arg is the stdenv), or, if `__raw = true`, simply this stage's
+# pkgset itself.
+#
+# The list takes stages in order, so the final stage is last in the list. In
+# other words, this does a foldr not foldl.
+stageFuns: let
+
+  # Take the list and disallow custom overrides in all but the final stage,
+  # and allow it in the final flag. Only defaults this boolean field if it
+  # isn't already set.
+  withAllowCustomOverrides = lib.lists.imap
+    (index: stageFun: prevStage:
+      { allowCustomOverrides = index == 1; } # first element, 1-indexed
+      // (stageFun prevStage))
+    (lib.lists.reverseList stageFuns);
+
+  # Adds the stdenv to the arguments, and sticks in it the previous stage for
+  # debugging purposes.
+  folder = stageFun: finalSoFar: let
+    args = stageFun finalSoFar;
+    stdenv = args.stdenv // {
+      # For debugging
+      __bootPackages = finalSoFar;
+    };
+    args' = args // { inherit stdenv; };
+  in
+    (if args.__raw or false then lib.id else allPackages) args';
+
+in lib.lists.fold folder {} withAllowCustomOverrides

--- a/pkgs/stdenv/booter.nix
+++ b/pkgs/stdenv/booter.nix
@@ -46,7 +46,10 @@ stageFuns: let
   # isn't already set.
   withAllowCustomOverrides = lib.lists.imap
     (index: stageFun: prevStage:
-      { allowCustomOverrides = index == 1; } # first element, 1-indexed
+      # So true by default for only the first element because one
+      # 1-indexing. Since we reverse the list, this means this is true
+      # for the final stage.
+      { allowCustomOverrides = index == 1; }
       // (stageFun prevStage))
     (lib.lists.reverseList stageFuns);
 

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -1,35 +1,48 @@
-{ lib, allPackages
+{ lib
 , system, platform, crossSystem, config
 }:
 
-rec {
-  vanillaStdenv = (import ../. {
-    inherit lib allPackages system platform;
+let
+  bootStages = import ../. {
+    inherit lib system platform;
     crossSystem = null;
     # Ignore custom stdenvs when cross compiling for compatability
     config = builtins.removeAttrs config [ "replaceStdenv" ];
-  }) // {
-    # Needed elsewhere as a hacky way to pass the target
-    cross = crossSystem;
   };
 
-  # For now, this is just used to build the native stdenv. Eventually, it should
-  # be used to build compilers and other such tools targeting the cross
+in bootStages ++ [
+
+  # Build Packages.
+  #
+  # For now, this is just used to build the native stdenv. Eventually, it
+  # should be used to build compilers and other such tools targeting the cross
   # platform. Then, `forceNativeDrv` can be removed.
-  buildPackages = allPackages {
+  (vanillaPackages: {
     inherit system platform crossSystem config;
     # It's OK to change the built-time dependencies
     allowCustomOverrides = true;
-    stdenv = vanillaStdenv;
-  };
+    stdenv = vanillaPackages.stdenv // {
+      # Needed elsewhere as a hacky way to pass the target
+      cross = crossSystem;
+    };
+  })
 
-  stdenvCross = buildPackages.makeStdenvCross
-    buildPackages.stdenv crossSystem
-    buildPackages.binutilsCross buildPackages.gccCrossStageFinal;
+  # Run packages
+  (buildPackages: {
+    inherit system platform crossSystem config;
+    stdenv = if crossSystem.useiOSCross or false
+      then let
+          inherit (buildPackages.darwin.ios-cross {
+              prefix = crossSystem.config;
+              inherit (crossSystem) arch;
+              simulator = crossSystem.isiPhoneSimulator or false; })
+            cc binutils;
+        in buildPackages.makeStdenvCross
+          buildPackages.stdenv crossSystem
+          binutils cc
+      else buildPackages.makeStdenvCross
+        buildPackages.stdenv crossSystem
+        buildPackages.binutilsCross buildPackages.gccCrossStageFinal;
+  })
 
-  stdenvCrossiOS = let
-    inherit (buildPackages.darwin.ios-cross { prefix = crossSystem.config; inherit (crossSystem) arch; simulator = crossSystem.isiPhoneSimulator or false; }) cc binutils;
-  in buildPackages.makeStdenvCross
-    buildPackages.stdenv crossSystem
-    binutils cc;
-}
+]

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -24,6 +24,7 @@ in bootStages ++ [
     stdenv = vanillaPackages.stdenv // {
       # Needed elsewhere as a hacky way to pass the target
       cross = crossSystem;
+      overrides = _: _: {};
     };
   })
 

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -1,22 +1,22 @@
-{ lib, allPackages
+{ lib
 , system, platform, crossSystem, config
 }:
 
 assert crossSystem == null;
 
-rec {
-  vanillaStdenv = import ../. {
-    inherit lib allPackages system platform crossSystem;
+let
+  bootStages = import ../. {
+    inherit lib system platform crossSystem;
     # Remove config.replaceStdenv to ensure termination.
     config = builtins.removeAttrs config [ "replaceStdenv" ];
   };
 
-  buildPackages = allPackages {
-    inherit system platform crossSystem config;
-    # It's OK to change the built-time dependencies
-    allowCustomOverrides = true;
-    stdenv = vanillaStdenv;
-  };
+in bootStages ++ [
 
-  stdenvCustom = config.replaceStdenv { pkgs = buildPackages; };
-}
+  # Additional stage, built using custom stdenv
+  (vanillaPackages: {
+    inherit system platform crossSystem config;
+    stdenv = config.replaceStdenv { pkgs = vanillaPackages; };
+  })
+
+]

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -334,8 +334,8 @@ in rec {
   # The ultimate test: bootstrap a whole stdenv from the tools specified above and get a package set out of it
   test-pkgs = import test-pkgspath {
     inherit system;
-    stdenvFunc = args: let
+    stdenvStages = args: let
         args' = args // { inherit bootstrapFiles; };
-      in (import (test-pkgspath + "/pkgs/stdenv/darwin") args').stdenvDarwin;
+      in (import (test-pkgspath + "/pkgs/stdenv/darwin") args').stagesDarwin;
   };
 }

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -1,13 +1,12 @@
-# This file defines the various standard build environments.
+# This file chooses a sane default stdenv given the system, platform, etc.
 #
-# On Linux systems, the standard build environment consists of
-# Nix-built instances glibc and the `standard' Unix tools, i.e., the
-# Posix utilities, the GNU C compiler, and so on.  On other systems,
-# we use the native C library.
+# Rather than returning a stdenv, this returns a list of functions---one per
+# each bootstrapping stage. See `./booter.nix` for exactly what this list should
+# contain.
 
 { # Args just for stdenvs' usage
-  lib, allPackages
-  # Args to pass on to `allPacakges` too
+  lib
+  # Args to pass on to the pkgset builder, too
 , system, platform, crossSystem, config
 } @ args:
 
@@ -17,50 +16,39 @@ let
   # i.e., the stuff in /bin, /usr/bin, etc.  This environment should
   # be used with care, since many Nix packages will not build properly
   # with it (e.g., because they require GNU Make).
-  inherit (import ./native args) stdenvNative;
-
-  stdenvNativePkgs = allPackages {
-    inherit system platform crossSystem config;
-    allowCustomOverrides = false;
-    stdenv = stdenvNative;
-    noSysDirs = false;
-  };
-
+  stagesNative = import ./native args;
 
   # The Nix build environment.
-  stdenvNix = assert crossSystem == null; import ./nix {
-    inherit config lib;
-    stdenv = stdenvNative;
-    pkgs = stdenvNativePkgs;
-  };
+  stagesNix = import ./nix (args // { bootStages = stagesNative; });
 
-  inherit (import ./freebsd args) stdenvFreeBSD;
+  stagesFreeBSD = import ./freebsd args;
 
-  # Linux standard environment.
-  inherit (import ./linux args) stdenvLinux;
+  # On Linux systems, the standard build environment consists of Nix-built
+  # instances glibc and the `standard' Unix tools, i.e., the Posix utilities,
+  # the GNU C compiler, and so on.
+  inherit (import ./linux args) stagesLinux;
 
-  inherit (import ./darwin args) stdenvDarwin;
+  inherit (import ./darwin args) stagesDarwin;
 
-  inherit (import ./cross args) stdenvCross stdenvCrossiOS;
+  stagesCross = import ./cross args;
 
-  inherit (import ./custom args) stdenvCustom;
+  stagesCustom = import ./custom args;
 
-  # Select the appropriate stdenv for the platform `system'.
+  # Select the appropriate stages for the platform `system'.
 in
-    if crossSystem != null then
-      if crossSystem.useiOSCross or false then stdenvCrossiOS
-      else stdenvCross else
-    if config ? replaceStdenv then stdenvCustom else
-    if system == "i686-linux" then stdenvLinux else
-    if system == "x86_64-linux" then stdenvLinux else
-    if system == "armv5tel-linux" then stdenvLinux else
-    if system == "armv6l-linux" then stdenvLinux else
-    if system == "armv7l-linux" then stdenvLinux else
-    if system == "mips64el-linux" then stdenvLinux else
-    if system == "powerpc-linux" then /* stdenvLinux */ stdenvNative else
-    if system == "x86_64-darwin" then stdenvDarwin else
-    if system == "x86_64-solaris" then stdenvNix else
-    if system == "i686-cygwin" then stdenvNative else
-    if system == "x86_64-cygwin" then stdenvNative else
-    if system == "x86_64-freebsd" then stdenvFreeBSD else
-    stdenvNative
+  if crossSystem != null then stagesCross
+  else if config ? replaceStdenv then stagesCustom
+  else { # switch
+    "i686-linux" = stagesLinux;
+    "x86_64-linux" = stagesLinux;
+    "armv5tel-linux" = stagesLinux;
+    "armv6l-linux" = stagesLinux;
+    "armv7l-linux" = stagesLinux;
+    "mips64el-linux" = stagesLinux;
+    "powerpc-linux" = /* stagesLinux */ stagesNative;
+    "x86_64-darwin" = stagesDarwin;
+    "x86_64-solaris" = stagesNix;
+    "i686-cygwin" = stagesNative;
+    "x86_64-cygwin" = stagesNative;
+    "x86_64-freebsd" = stagesFreeBSD;
+  }.${system} or stagesNative

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -26,7 +26,7 @@ let
   # On Linux systems, the standard build environment consists of Nix-built
   # instances glibc and the `standard' Unix tools, i.e., the Posix utilities,
   # the GNU C compiler, and so on.
-  inherit (import ./linux args) stagesLinux;
+  stagesLinux = import ./linux args;
 
   inherit (import ./darwin args) stagesDarwin;
 

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -1,65 +1,86 @@
-{ lib, allPackages
+{ lib
 , system, platform, crossSystem, config
 }:
 
 assert crossSystem == null;
 
-rec {
-  inherit allPackages;
 
-  bootstrapTools = derivation {
-    inherit system;
+[
 
-    name    = "trivial-bootstrap-tools";
-    builder = "/usr/local/bin/bash";
-    args    = [ ./trivial-bootstrap.sh ];
+  ({}: {
+    __raw = true;
 
-    mkdir   = "/bin/mkdir";
-    ln      = "/bin/ln";
-  };
+    bootstrapTools = derivation {
+      inherit system;
 
-  fetchurl = import ../../build-support/fetchurl {
+      name = "trivial-bootstrap-tools";
+      builder = "/usr/local/bin/bash";
+      args = [ ./trivial-bootstrap.sh ];
+
+      mkdir = "/bin/mkdir";
+      ln = "/bin/ln";
+    };
+  })
+
+  ({ bootstrapTools, ... }: rec {
+    __raw = true;
+
+    inherit bootstrapTools;
+
+    fetchurl = import ../../build-support/fetchurl {
+      inherit stdenv;
+      curl = bootstrapTools;
+    };
+
     stdenv = import ../generic {
       name = "stdenv-freebsd-boot-1";
       inherit system config;
-
-      initialPath  = [ "/" "/usr" ];
-      shell        = "${bootstrapTools}/bin/bash";
+      initialPath = [ "/" "/usr" ];
+      shell = "${bootstrapTools}/bin/bash";
       fetchurlBoot = null;
       cc = null;
-    };
-    curl = bootstrapTools;
-  };
-
-  stdenvFreeBSD = import ../generic {
-    name = "stdenv-freebsd-boot-3";
-
-    inherit system config;
-
-    initialPath  = [ bootstrapTools ];
-    shell        = "${bootstrapTools}/bin/bash";
-    fetchurlBoot = fetchurl;
-
-    cc = import ../../build-support/cc-wrapper {
-      nativeTools  = true;
-      nativePrefix = "/usr";
-      nativeLibc   = true;
-      stdenv = import ../generic {
-        inherit system config;
-        name         = "stdenv-freebsd-boot-0";
-        initialPath  = [ bootstrapTools ];
-        shell = stdenvFreeBSD.shell;
-        fetchurlBoot = fetchurl;
-        cc           = null;
+      overrides = self: super: {
       };
-      cc           = {
-        name    = "clang-9.9.9";
-        cc      = "/usr";
-        outPath = "/usr";
-      };
-      isClang      = true;
     };
+  })
 
-    preHook = ''export NIX_NO_SELF_RPATH=1'';
-  };
-}
+  (prevStage: {
+    __raw = true;
+
+    stdenv = import ../generic {
+      name = "stdenv-freebsd-boot-0";
+      inherit system config;
+      initialPath = [ prevStage.bootstrapTools ];
+      inherit (prevStage.stdenv) shell;
+      fetchurlBoot = prevStage.fetchurl;
+      cc = null;
+    };
+  })
+
+  (prevStage: {
+    inherit system crossSystem platform config;
+    stdenv = import ../generic {
+      name = "stdenv-freebsd-boot-3";
+      inherit system config;
+
+      inherit (prevStage.stdenv)
+        initialPath shell fetchurlBoot;
+
+      cc = import ../../build-support/cc-wrapper {
+        nativeTools  = true;
+        nativePrefix = "/usr";
+        nativeLibc   = true;
+        inherit (prevStage) stdenv;
+        cc           = {
+          name    = "clang-9.9.9";
+          cc      = "/usr";
+          outPath = "/usr";
+        };
+        isClang      = true;
+      };
+
+      preHook = ''export NIX_NO_SELF_RPATH=1'';
+    };
+  })
+
+]

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -1,7 +1,7 @@
 let lib = import ../../../lib; in lib.makeOverridable (
 
 { system, name ? "stdenv", preHook ? "", initialPath, cc, shell
-, allowedRequisites ? null, extraAttrs ? {}, overrides ? (pkgs: {}), config
+, allowedRequisites ? null, extraAttrs ? {}, overrides ? (self: super: {}), config
 
 , # The `fetchurl' to use for downloading curl and its dependencies
   # (see all-packages.nix).

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -77,7 +77,7 @@ rec {
   # A function that builds a "native" stdenv (one that uses tools in
   # /usr etc.).
   makeStdenv =
-    { cc, fetchurl, extraPath ? [], overrides ? (pkgs: { }) }:
+    { cc, fetchurl, extraPath ? [], overrides ? (self: super: { }) }:
 
     import ../generic {
       preHook =
@@ -142,7 +142,7 @@ rec {
   stdenvBoot2 = makeStdenv {
     inherit cc fetchurl;
     extraPath = [ stdenvBoot1Pkgs.xz ];
-    overrides = pkgs: { inherit (stdenvBoot1Pkgs) xz; };
+    overrides = self: super: { inherit (stdenvBoot1Pkgs) xz; };
   };
 
 

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -1,10 +1,10 @@
-{ lib, allPackages
+{ lib
 , system, platform, crossSystem, config
 }:
 
 assert crossSystem == null;
 
-rec {
+let
 
   shell =
     if system == "i686-freebsd" || system == "x86_64-freebsd" then "/usr/local/bin/bash"
@@ -101,50 +101,54 @@ rec {
       inherit system shell cc overrides config;
     };
 
+in
 
-  stdenvBoot0 = makeStdenv {
-    cc = null;
-    fetchurl = null;
-  };
+[
 
+  ({}: rec {
+    __raw = true;
 
-  cc = import ../../build-support/cc-wrapper {
-    name = "cc-native";
-    nativeTools = true;
-    nativeLibc = true;
-    nativePrefix = if system == "i686-solaris" then "/usr/gnu" else if system == "x86_64-solaris" then "/opt/local/gcc47" else "/usr";
-    stdenv = stdenvBoot0;
-  };
+    stdenv = makeStdenv {
+      cc = null;
+      fetchurl = null;
+    };
 
+    cc = import ../../build-support/cc-wrapper {
+      name = "cc-native";
+      nativeTools = true;
+      nativeLibc = true;
+      nativePrefix = { # switch
+        "i686-solaris" = "/usr/gnu";
+        "x86_64-solaris" = "/opt/local/gcc47";
+      }.${system} or "/usr";
+      inherit stdenv;
+    };
 
-  fetchurl = import ../../build-support/fetchurl {
-    stdenv = stdenvBoot0;
-    # Curl should be in /usr/bin or so.
-    curl = null;
-  };
+    fetchurl = import ../../build-support/fetchurl {
+      inherit stdenv;
+      # Curl should be in /usr/bin or so.
+      curl = null;
+    };
 
+  })
 
   # First build a stdenv based only on tools outside the store.
-  stdenvBoot1 = makeStdenv {
-    inherit cc fetchurl;
-  } // {inherit fetchurl;};
+  (prevStage: {
+    inherit system crossSystem platform config;
+    stdenv = makeStdenv {
+      inherit (prevStage) cc fetchurl;
+    } // { inherit (prevStage) fetchurl; };
+  })
 
-  stdenvBoot1Pkgs = allPackages {
-    inherit system platform crossSystem config;
-    allowCustomOverrides = false;
-    stdenv = stdenvBoot1;
-  };
+  # Using that, build a stdenv that adds the ‘xz’ command (which most systems
+  # don't have, so we mustn't rely on the native environment providing it).
+  (prevStage: {
+    inherit system crossSystem platform config;
+    stdenv = makeStdenv {
+      inherit (prevStage.stdenv) cc fetchurl;
+      extraPath = [ prevStage.xz ];
+      overrides = self: super: { inherit (prevStage) xz; };
+    };
+  })
 
-
-  # Using that, build a stdenv that adds the ‘xz’ command (which most
-  # systems don't have, so we mustn't rely on the native environment
-  # providing it).
-  stdenvBoot2 = makeStdenv {
-    inherit cc fetchurl;
-    extraPath = [ stdenvBoot1Pkgs.xz ];
-    overrides = self: super: { inherit (stdenvBoot1Pkgs) xz; };
-  };
-
-
-  stdenvNative = stdenvBoot2;
-}
+]

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -29,7 +29,7 @@ import ../generic rec {
 
   fetchurlBoot = stdenv.fetchurlBoot;
 
-  overrides = pkgs_: {
+  overrides = self: super: {
     inherit cc;
     inherit (cc) binutils;
     inherit (pkgs)

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -1,39 +1,53 @@
-{ stdenv, pkgs, config, lib }:
+{ lib
+, crossSystem, config
+, bootStages
+, ...
+}:
 
-import ../generic rec {
-  inherit config;
+assert crossSystem == null;
 
-  preHook =
-    ''
-      export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
-      export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
-      export NIX_IGNORE_LD_THROUGH_GCC=1
-    '';
+bootStages ++ [
+  (prevStage: let
+    inherit (prevStage) stdenv;
+    inherit (stdenv) system platform;
+  in {
+    inherit system platform crossSystem config;
 
-  initialPath = (import ../common-path.nix) {pkgs = pkgs;};
+    stdenv = import ../generic rec {
+      inherit config;
 
-  system = stdenv.system;
+      preHook = ''
+        export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
+        export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
+        export NIX_IGNORE_LD_THROUGH_GCC=1
+      '';
 
-  cc = import ../../build-support/cc-wrapper {
-    nativeTools = false;
-    nativePrefix = stdenv.lib.optionalString stdenv.isSunOS "/usr";
-    nativeLibc = true;
-    inherit stdenv;
-    inherit (pkgs) binutils coreutils gnugrep;
-    cc = pkgs.gcc.cc;
-    isGNU = true;
-    shell = pkgs.bash + "/bin/sh";
-  };
+      initialPath = (import ../common-path.nix) { pkgs = prevStage; };
 
-  shell = pkgs.bash + "/bin/sh";
+      system = stdenv.system;
 
-  fetchurlBoot = stdenv.fetchurlBoot;
+      cc = import ../../build-support/cc-wrapper {
+        nativeTools = false;
+        nativePrefix = stdenv.lib.optionalString stdenv.isSunOS "/usr";
+        nativeLibc = true;
+        inherit stdenv;
+        inherit (prevStage) binutils coreutils gnugrep;
+        cc = prevStage.gcc.cc;
+        isGNU = true;
+        shell = prevStage.bash + "/bin/sh";
+      };
 
-  overrides = self: super: {
-    inherit cc;
-    inherit (cc) binutils;
-    inherit (pkgs)
-      gzip bzip2 xz bash coreutils diffutils findutils gawk
-      gnumake gnused gnutar gnugrep gnupatch perl;
-  };
-}
+      shell = prevStage.bash + "/bin/sh";
+
+      fetchurlBoot = stdenv.fetchurlBoot;
+
+      overrides = self: super: {
+        inherit cc;
+        inherit (cc) binutils;
+        inherit (prevStage)
+          gzip bzip2 xz bash coreutils diffutils findutils gawk
+          gnumake gnused gnutar gnugrep gnupatch perl;
+      };
+    };
+  })
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5,9 +5,7 @@
  * to merges. Please use the full-text search of your editor. ;)
  * Hint: ### starts category names.
  */
-{ system, noSysDirs, config, crossSystem, platform, lib
-, nixpkgsFun
-}:
+{ lib, nixpkgsFun, noSysDirs, config}:
 self: pkgs:
 
 with pkgs;
@@ -17,9 +15,6 @@ let
 in
 
 {
-
-  # Make some arguments passed to all-packages.nix available
-  inherit system platform;
 
   # Allow callPackage to fill in the pkgs argument
   inherit pkgs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4721,6 +4721,7 @@ in
   gambit = callPackage ../development/compilers/gambit { };
 
   gcc = gcc5;
+  gcc-unwrapped = gcc.cc;
 
   wrapCCMulti = cc:
     if system == "x86_64-linux" then lowPrio (

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -7,11 +7,11 @@
 
      3. Defaults to no non-standard config and no cross-compilation target
 
-     4. Uses the above to infer the default standard environment (stdenv) if
-        none is provided
+     4. Uses the above to infer the default standard environment's (stdenv's)
+        stages if no stdenv's are provided
 
-     5. Builds the final stage --- a fully booted package set with the chosen
-        stdenv
+     5. Folds the stages to yield the final fully booted package set for the
+        chosen stdenv
 
    Use `impure.nix` to also infer the `system` based on the one on which
    evaluation is taking place, and the configuration from environment variables
@@ -23,9 +23,10 @@
 , # Allow a configuration attribute set to be passed in as an argument.
   config ? {}
 
-, # The standard environment for building packages, or rather a function
-  # providing it. See below for the arguments given to that function.
-  stdenvFunc ? import ../stdenv
+, # A function booting the final package set for a specific standard
+  # environment. See below for the arguments given to that function,
+  # the type of list it returns.
+  stdenvStages ? import ../stdenv
 
 , crossSystem ? null
 , platform ? assert false; null
@@ -76,10 +77,12 @@ in let
     inherit lib nixpkgsFun;
   } // newArgs);
 
-  stdenv = stdenvFunc {
-    inherit lib allPackages system platform crossSystem config;
+  boot = import ../stdenv/booter.nix { inherit lib allPackages; };
+
+  stages = stdenvStages {
+    inherit lib system platform crossSystem config;
   };
 
-  pkgs = allPackages { inherit system stdenv config crossSystem platform; };
+  pkgs = boot stages;
 
 in pkgs

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -67,7 +67,7 @@ let
   # crossStdenv adapter.
   stdenvOverrides = self: super:
     lib.optionalAttrs (crossSystem == null && super.stdenv ? overrides)
-      (super.stdenv.overrides super);
+      (super.stdenv.overrides self super);
 
   # Allow packages to be overridden globally via the `packageOverrides'
   # configuration option, which must be a function that takes `pkgs'

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -18,7 +18,7 @@
 , # This is used because stdenv replacement and the stdenvCross do benefit from
   # the overridden configuration provided by the user, as opposed to the normal
   # bootstrapping stdenvs.
-  allowCustomOverrides ? true
+  allowCustomOverrides
 
 , # Non-GNU/Linux OSes are currently "impure" platforms, with their libc
   # outside of the store.  Thus, GCC, GFortran, & co. must always look for

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -47,12 +47,15 @@ let
       inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.xorg) lndir;
     };
 
-  stdenvDefault = self: super:
-    { stdenv = stdenv // { inherit platform; }; };
+  stdenvBootstappingAndPlatforms = self: super: {
+    stdenv = stdenv // { inherit platform; };
+    inherit
+      system platform crossSystem;
+  };
 
   allPackages = self: super:
     let res = import ./all-packages.nix
-      { inherit system noSysDirs config crossSystem platform lib nixpkgsFun; }
+      { inherit lib nixpkgsFun noSysDirs config; }
       res self;
     in res;
 
@@ -77,7 +80,7 @@ let
 
   # The complete chain of package set builders, applied from top to bottom
   toFix = lib.foldl' (lib.flip lib.extends) (self: {}) [
-    stdenvDefault
+    stdenvBootstappingAndPlatforms
     stdenvAdapters
     trivialBuilders
     allPackages

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -58,16 +58,11 @@ let
 
   aliases = self: super: import ./aliases.nix super;
 
-  # stdenvOverrides is used to avoid circular dependencies for building
-  # the standard build environment. This mechanism uses the override
-  # mechanism to implement some staged compilation of the stdenv.
-  #
-  # We don't want stdenv overrides in the case of cross-building, or
-  # otherwise the basic overridden packages will not be built with the
-  # crossStdenv adapter.
+  # stdenvOverrides is used to avoid having multiple of versions
+  # of certain dependencies that were used in bootstrapping the
+  # standard environment.
   stdenvOverrides = self: super:
-    lib.optionalAttrs (crossSystem == null && super.stdenv ? overrides)
-      (super.stdenv.overrides self super);
+    (super.stdenv.overrides or (_: _: {})) self super;
 
   # Allow packages to be overridden globally via the `packageOverrides'
   # configuration option, which must be a function that takes `pkgs'


### PR DESCRIPTION
Split out from https://github.com/NixOS/nixpkgs/pull/21268

This PR introduces a new abstraction for dealing with stdenv bootstrapping. It doesn't really make anything shorter, but at least it enforces a consistent ideom across all of them. I've made all the stdenvs but darwin really embrace the new abstraction. Darwin is a bit bigger, and so I made minimal changes to make it use it, but I'll refactor it to make it embrace the new abstraction too if wanted.

https://github.com/NixOS/nixpkgs/pull/21268 builds on this to make cross compiling not a dirty hack.