### PR TITLE
hydra: remove any patches from aws-sdk-cpp

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -92,6 +92,7 @@ in releaseTools.nixBuild rec {
           rev = "local";
           sha256 = "1vhgsxkhpai9a7dk38q4r239l6dsz2jvl8hii24c194lsga3g84h";
         };
+        patches = [];
       }))
     ];
 


### PR DESCRIPTION
###### Motivation for this change

215b1e519b added a patch to aws-sdk-cpp which does not
apply to the override in hydra's aws-sdk-cpp, since it
is an older version fetched from edolstra/aws-sdk-cpp
which does not contain `aws-cpp-sdk-s3-encryption/CMakeLists.txt`

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

