### PR TITLE
ruby: 2.4.0

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -113,6 +113,7 @@ let
 
         configureFlags = ["--enable-shared" "--enable-pthread"]
           ++ op useRailsExpress "--with-baseruby=${baseruby}/bin/ruby"
+          ++ op (!docSupport) "--disable-install-doc"
           ++ ops stdenv.isDarwin [
             # on darwin, we have /usr/include/tk.h -- so the configure script detects
             # that tk is installed
@@ -154,7 +155,7 @@ let
           license = stdenv.lib.licenses.ruby;
           homepage = http://www.ruby-lang.org/en/;
           description = "The Ruby language";
-          maintainers = [ stdenv.lib.maintainers.vrthra ];
+          maintainers = with stdenv.lib.maintainers; [ vrthra manveru ];
           platforms = stdenv.lib.platforms.all;
         };
 
@@ -216,6 +217,14 @@ in {
     sha256 = {
       src = "1dqmh42p6siv9aqzdjldsnhljj3f2h30m0v8cf25icjmqp40h514";
       git = "0cwjf0nrzaa5g81bw0qp65byyadhxvbnvprkshv3ckjl7yi46zf6";
+    };
+  };
+
+  ruby_2_4_0 = generic {
+    version = rubyVersion "2" "4" "0" "";
+    sha256 = {
+      src = "0gcyn9328w2vma882l71c9v9ygmmsj2z8j1l44c4l2x92nyx0bqm";
+      git = "1w9zyx8xmka8jdiha57snnbfls2r6dc9g03d8cjx0nxkmwf3r2l3";
     };
   };
 }

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -65,4 +65,9 @@ rec {
     "${patchSet}/patches/ruby/2.3/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.3/head/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
+  "2.4.0" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/2.4.0/railsexpress/01-skip-broken-tests.patch"
+    "${patchSet}/patches/ruby/2.4.0/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.4.0/railsexpress/03-display-more-detailed-stack-trace.patch"
+  ];
 }

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -1,8 +1,8 @@
 { fetchFromGitHub }:
 
 fetchFromGitHub {
-  owner  = "skaes";
+  owner  = "manveru";
   repo   = "rvm-patchsets";
-  rev    = "951e47ca1022cd1e41de9177fa87438cfb72d127";
-  sha256 = "18n2frwmn6lcnjywysyjam1zfzfad0r50141xs2h9kifsyak5xcf";
+  rev    = "46e04f230ce91a786f5e583389443efec0ecd594";
+  sha256 = "0ayh8zj8knyz3344an942qdf33pi42jmksqk34frb346zi1ag693";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5770,7 +5770,8 @@ in
     ruby_2_0_0
     ruby_2_1_10
     ruby_2_2_5
-    ruby_2_3_3;
+    ruby_2_3_3
+    ruby_2_4_0;
 
   # Ruby aliases
   ruby = ruby_2_3;
@@ -5779,6 +5780,7 @@ in
   ruby_2_1 = ruby_2_1_10;
   ruby_2_2 = ruby_2_2_5;
   ruby_2_3 = ruby_2_3_3;
+  ruby_2_4 = ruby_2_4_0;
 
   scsh = callPackage ../development/interpreters/scsh { };
 


### PR DESCRIPTION
###### Motivation for this change

* Made an updated rvm-patchsets fork until upstream is fixed.
* Fixed the `docSupport` option, so a build with `docSupport = false` is now 19MB instead of 85MB and builds faster.
* Added the 2.4.0 version, but it's not the default ruby yet, would recommend waiting a few days for stability.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

