### PR TITLE
unclutter: add missing licence (publicDomain)

### DIFF
--- a/pkgs/tools/misc/unclutter/default.nix
+++ b/pkgs/tools/misc/unclutter/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation {
     '';
     maintainers = with maintainers; [ domenkozar ];
     platforms = platforms.unix;
+    license = stdenv.lib.licenses.publicDomain;
   };
 }


### PR DESCRIPTION
Licence defined in the readme of the downloaded tar.gz