### PR TITLE
procmail: unbreak "make install"

### DIFF
--- a/pkgs/applications/misc/procmail/default.nix
+++ b/pkgs/applications/misc/procmail/default.nix
@@ -6,11 +6,15 @@ stdenv.mkDerivation {
   patches = [ ./CVE-2014-3618.patch ];
 
   # getline is defined differently in glibc now. So rename it.
+  # Without the .PHONY target "make install" won't install anything on Darwin.
   postPatch = ''
     sed -e "s%^RM.*$%#%" -i Makefile
     sed -e "s%^BASENAME.*%\BASENAME=$out%" -i Makefile
     sed -e "s%^LIBS=.*%LIBS=-lm%" -i Makefile
     sed -e "s%getline%thisgetline%g" -i src/*.c src/*.h
+    sed -e "3i\
+.PHONY: install
+" -i Makefile
   '';
 
   src = fetchurl {


### PR DESCRIPTION
procmail's Makefile lacks a ".PHONY: install" line, which turns "make
install" into a no-op, at least on macOS.  Insert one.

###### Motivation for this change

nix-env -i procmail would not install anything into the store.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

