### PR TITLE
crystal: fix build in chroot environment

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -57,6 +57,9 @@ stdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
+    # patch the script which launches the prebuilt compiler
+    substituteInPlace $(pwd)/crystal-${version}-1/bin/crystal --replace \
+      "/usr/bin/env bash" "${stdenv.shell}"
     ${fixPrebuiltBinary}
 
     cd crystal-${version}


### PR DESCRIPTION
###### Motivation for this change

crystal package (pr #21339) build failed on hydra.
https://hydra.nixos.org/build/45498661

The reason is there is no /usr/bin/env in hydra's linux build environment.
So darwin build on hydra succeed but linux build on hydra failed.

I am sorry that I did not aware that before. This pr should fix the issue.

Thanks!

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

