### PR TITLE
nginx: Allow GD to be optional.

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation {
     "--with-http_realip_module"
     "--with-http_addition_module"
     "--with-http_xslt_module"
-    "--with-http_image_filter_module"
     "--with-http_geoip_module"
     "--with-http_sub_module"
     "--with-http_dav_module"
@@ -44,6 +43,7 @@ stdenv.mkDerivation {
     # Install destination problems
     # "--with-http_perl_module"
   ] ++ optional withStream "--with-stream"
+    ++ optional (gd != null) "--with-http_image_filter_module"
     ++ optional (elem stdenv.system (with platforms; linux ++ freebsd)) "--with-file-aio"
     ++ map (mod: "--add-module=${mod.src}") modules;
 


### PR DESCRIPTION
This commit permits incantations like `pkgs.nginx.override { gd = null; }` to
produce a slimmed-down nginx.

When used, this functionality removes a pile of stuff from nginx's closure.
The resulting nginx's closure:

    $ nix-store -q -R /nix/store/wk3h0a4dmdmjmxkbd0q09iw0wfq0yzpz-nginx-1.10.2 | wc -l
    12
    $ nix-store -q -R /nix/store/gpcx77anqrj05qz0mrwm7hf4wgxry5py-nginx-1.10.2 | wc -l
    24

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

