### PR TITLE
Not only linux

### DIFF
--- a/pkgs/development/tools/misc/cscope/default.nix
+++ b/pkgs/development/tools/misc/cscope/default.nix
@@ -53,6 +53,6 @@ stdenv.mkDerivation rec {
 
     maintainers = with stdenv.lib.maintainers; [viric];
 
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -32,6 +32,6 @@ in python2Packages.buildPythonApplication {
     homepage = "http://www.nongnu.org/duplicity";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [viric peti];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/backup/duply/default.nix
+++ b/pkgs/tools/backup/duply/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation {
     homepage = http://duply.net/;
     license = licenses.gpl2;
     maintainers = [ maintainers.bjornfor ];
-    platforms = platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/compression/pigz/default.nix
+++ b/pkgs/tools/compression/pigz/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://www.zlib.net/pigz/";
     description = "A parallel implementation of gzip for multi-core machines";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/compression/pixz/default.nix
+++ b/pkgs/tools/compression/pixz/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     description = ''A parallel compressor/decompressor for xz format'';
     license = stdenv.lib.licenses.bsd2;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/networking/wakelan/default.nix
+++ b/pkgs/tools/networking/wakelan/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
 
     maintainers = [ stdenv.lib.maintainers.viric ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Stores, retrieves, generates, and synchronizes passwords securely";
     homepage    = "https://github.com/lastpass/lastpass-cli";
     license     = licenses.gpl2Plus;
-    platforms   = platforms.linux;
+    platforms   = stdenv.lib.platforms.unix;
     maintainers = with maintainers; [ cstrahan ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I wanted to use these packages on OS X without local changes in my fork, note, that for most of the packages its unlikely they are linux specific. Adjusted all platforms to build on any unix platform.

I've been running with these changes on osx for about 2-3 months successfully as a note, with cscope being the most problematic on OS X.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
