### PR TITLE
darktable: 2.0.7 -> 2.2.0

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -11,12 +11,12 @@
 assert stdenv ? glibc;
 
 stdenv.mkDerivation rec {
-  version = "2.0.7";
+  version = "2.2.0";
   name = "darktable-${version}";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    sha256 = "1aqxiaw89xdx0s0h3gb9nvdzw4690y3kp7h794sihf2581bn28m9";
+    sha256 = "3eca193831faae58200bb1cb6ef29e658bce43a81706b54420953a7c33d79377";
   };
 
   buildInputs =
@@ -34,6 +34,16 @@ stdenv.mkDerivation rec {
     "-DBUILD_USERMANUAL=False"
   ];
 
+  # darktable changed its rpath handling in commit
+  # 83c70b876af6484506901e6b381304ae0d073d3c and as a result the
+  # binaries can't find libdarktable.so, so change LD_LIBRARY_PATH in
+  # the wrappers:
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH ":" "$out/lib/darktable"
+    )
+  '';
+  
   meta = with stdenv.lib; {
     description = "Virtual lighttable and darkroom for photographers";
     homepage = https://www.darktable.org;


### PR DESCRIPTION
###### Motivation for this change

A new release of darktable is available. Some change in the darktable build seems to have broken things (the binaries are unable to find `libdarktable.so`), but I've not yet identified the cause. The change below just patches the binaries - but for some reason, it must do so on the wrapped binaries (after `wrapGAppsHook`) rather than the pre-wrapped ones. Some more is noted in the comments in the commit.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

