### PR TITLE
GHC add man pages

### DIFF
--- a/pkgs/development/compilers/ghc/8.0.1.nix
+++ b/pkgs/development/compilers/ghc/8.0.1.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, bootPkgs, perl, gmp, ncurses, libiconv, binutils, coreutils
-, hscolour, patchutils
+, hscolour, patchutils, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42
 }:
 
 let
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     (fetchFilteredPatch { url = https://git.haskell.org/ghc.git/patch/2f8cd14fe909a377b3e084a4f2ded83a0e6d44dd; sha256 = "06zvlgcf50ab58bw6yw3krn45dsmhg4cmlz4nqff8k4z1f1bj01v"; })
   ] ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch;
 
-  buildInputs = [ ghc perl hscolour ];
+  buildInputs = [ ghc perl libxml2 libxslt docbook_xsl docbook_xml_dtd_45 docbook_xml_dtd_42 hscolour ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/ghc/8.0.1.nix
+++ b/pkgs/development/compilers/ghc/8.0.1.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, bootPkgs, perl, gmp, ncurses, libiconv, binutils, coreutils
-, hscolour, patchutils, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42
+, hscolour, patchutils, sphinx
 }:
 
 let
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     (fetchFilteredPatch { url = https://git.haskell.org/ghc.git/patch/2f8cd14fe909a377b3e084a4f2ded83a0e6d44dd; sha256 = "06zvlgcf50ab58bw6yw3krn45dsmhg4cmlz4nqff8k4z1f1bj01v"; })
   ] ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch;
 
-  buildInputs = [ ghc perl libxml2 libxslt docbook_xsl docbook_xml_dtd_45 docbook_xml_dtd_42 hscolour ];
+  buildInputs = [ ghc perl hscolour sphinx];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, bootPkgs, perl, gmp, ncurses, libiconv, binutils, coreutils
-, hscolour, patchutils
+, hscolour, patchutils, sphinx
 }:
 
 let
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   patches = [] ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch;
 
-  buildInputs = [ ghc perl hscolour ];
+  buildInputs = [ ghc perl hscolour sphinx ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -50,6 +50,7 @@ rec {
     ghc802 = callPackage ../development/compilers/ghc/8.0.2.nix rec {
       bootPkgs = packages.ghc7103;
       inherit (bootPkgs) hscolour;
+      sphinx = pkgs.python27Packages.sphinx;
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix rec {
       bootPkgs = packages.ghc7103;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -45,6 +45,7 @@ rec {
     ghc801 = callPackage ../development/compilers/ghc/8.0.1.nix rec {
       bootPkgs = packages.ghc7103;
       inherit (bootPkgs) hscolour;
+      sphinx = pkgs.python27Packages.sphinx;
     };
     ghc802 = callPackage ../development/compilers/ghc/8.0.2.nix rec {
       bootPkgs = packages.ghc7103;


### PR DESCRIPTION
###### Motivation for this change

Adds man pages for `ghc` versions 8.0.1 and 8.0.2 to resolve issue  #20281. Also makes the section titled "The User's Guide" build in the html documentation. Note that `man ghci` still finds no man pages, but Fedora 24 behaves the same way so that is an upstream issue.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

