### PR TITLE
enpass: bump to 5.4.0.post4 and fix application icon

### DIFF
--- a/pkgs/tools/security/enpass/data.json
+++ b/pkgs/tools/security/enpass/data.json
@@ -1,12 +1,12 @@
 {
   "amd64": {
-    "path": "pool/main/e/enpass/enpass_5.3.0_amd64.deb", 
-    "sha256": "d9da061c6456281da836bdd78bdb7baeced4b7f1805bb2495e4f1d15038cf86b", 
-    "version": "5.3.0"
+    "path": "pool/main/e/enpass/enpass_5.4.0-4_amd64.deb", 
+    "sha256": "6b460fed2d7d8473e2b5d069dbe60263195b916c8b79a8fc7c2e8cb953134579", 
+    "version": "5.4.0.post4"
   }, 
   "i386": {
-    "path": "pool/main/e/enpass/enpass_5.3.0_i386.deb", 
-    "sha256": "58d9f3b83c2da477c13976e1826d112236eabd46a389de7e8767ee99ac41f469", 
-    "version": "5.3.0"
+    "path": "pool/main/e/enpass/enpass_5.4.0-4_i386.deb", 
+    "sha256": "1ec8088d5c3b2906d6820f96e1868c473e78dbe882f04e74a7816d19d43e3692", 
+    "version": "5.4.0.post4"
   }
 }

--- a/pkgs/tools/security/enpass/default.nix
+++ b/pkgs/tools/security/enpass/default.nix
@@ -44,16 +44,6 @@ let
     inherit (data) version;
     name = "enpass-${version}";
 
-    desktopItem = makeDesktopItem {
-      name = "Enpass";
-      exec = "$out/bin/Enpass";
-      #icon = "Enpass";
-      desktopName = "Enpass";
-      genericName = "Password manager";
-      categories = "Application;Security;";
-    };
-
-
     src = fetchurl {
       inherit (data) sha256;
       url = "${baseUrl}/${data.path}";
@@ -74,11 +64,12 @@ let
     installPhase=''
       mkdir $out
       cp -r opt/Enpass/*  $out
+      cp -r usr/* $out
+      rm $out/bin/runenpass.sh
 
-      # Make desktop item
-      mkdir -p "$out"/share/applications
-      cp "$desktopItem"/share/applications/* "$out"/share/applications/
-      mkdir -p "$out"/share/icons
+      sed \
+      	-i s@/opt/Enpass/bin/runenpass.sh@$out/bin/Enpass@ \
+      	$out/share/applications/enpass.desktop 
 
       patchelf  \
         --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
@@ -88,7 +79,8 @@ let
         --set LD_LIBRARY_PATH "${libPath}:$out/lib:$out/plugins/sqldrivers" \
         --set QT_PLUGIN_PATH "$out/plugins" \
         --set QT_QPA_PLATFORM_PLUGIN_PATH "$out/plugins/platforms" \
-        --set QT_XKB_CONFIG_ROOT "${xkeyboardconfig}/share/X11/xkb"
+        --set QT_XKB_CONFIG_ROOT "${xkeyboardconfig}/share/X11/xkb" \
+        --set HIDE_TOOLBAR_LINE 0
     '';
   };
   updater = {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

