### PR TITLE
nixos/graphite: fix beacon config parameter

### DIFF
--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -585,7 +585,7 @@ in {
         serviceConfig = {
           ExecStart = ''
             ${pkgs.pythonPackages.graphite_beacon}/bin/graphite-beacon \
-              --config ${pkgs.writeText "graphite-beacon.json" (builtins.toJSON cfg.beacon.config)}
+              --config=${pkgs.writeText "graphite-beacon.json" (builtins.toJSON cfg.beacon.config)}
           '';
           User = "graphite";
           Group = "graphite";


### PR DESCRIPTION
###### Motivation for this change

services.graphite.beacon currently doesn't work.

Following error occurs during launch:
```
Traceback (most recent call last):
  File "/nix/store/5f2xayl4dirw80svbmn0gzishrm0a6xz-python2.7-graphite_beacon-0.22.1/bin/.graphite-beacon-wrapped", line 12, in <module>
    sys.exit(run())
  File "/nix/store/5f2xayl4dirw80svbmn0gzishrm0a6xz-python2.7-graphite_beacon-0.22.1/lib/python2.7/site-packages/graphite_beacon/app.py", line 14, in run
    options.parse_command_line()
  File "/nix/store/f81aar4gipmync6jnbs967zcan0nw2lw-python2.7-tornado-4.4.2/lib/python2.7/site-packages/tornado/options.py", line 293, in parse_command_line
    raise Error('Option %r requires a value' % name)
tornado.options.Error: Option 'config' requires a value

```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

