### PR TITLE
gphoto2: nixos programs module to configure udev

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -240,6 +240,7 @@
   lassulus = "Lassulus <lassulus@gmail.com>";
   layus = "Guillaume Maudoux <layus.on@gmail.com>";
   ldesgoui = "Lucas Desgouilles <ldesgoui@gmail.com>";
+  league = "Christopher League <league@contrapunctus.net>";
   lebastr = "Alexander Lebedev <lebastr@gmail.com>";
   leenaars = "Michiel Leenaars <ml.software@leenaa.rs>";
   leonardoce = "Leonardo Cecchi <leonardo.cecchi@gmail.com>";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -71,6 +71,7 @@
   ./programs/environment.nix
   ./programs/fish.nix
   ./programs/freetds.nix
+  ./programs/gphoto2.nix
   ./programs/info.nix
   ./programs/java.nix
   ./programs/kbdlight.nix

--- a/nixos/modules/programs/gphoto2.nix
+++ b/nixos/modules/programs/gphoto2.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta.maintainers = [ maintainers.league ];
+
+  ###### interface
+  options = {
+    programs.gphoto2 = {
+      enable = mkOption {
+        default = false;
+        example = true;
+        type = types.bool;
+        description = ''
+          Whether to configure system to use gphoto2.
+          To grant digital camera access to a user, the user must
+          be part of the camera group:
+          <code>users.extraUsers.alice.extraGroups = ["camera"];</code>
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+  config = mkIf config.programs.gphoto2.enable {
+    services.udev.packages = [ pkgs.libgphoto2 ];
+    environment.systemPackages = [ pkgs.gphoto2 ];
+    users.extraGroups.camera = {};
+  };
+}

--- a/pkgs/development/libraries/libgphoto2/default.nix
+++ b/pkgs/development/libraries/libgphoto2/default.nix
@@ -25,6 +25,11 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  postInstall = ''
+    mkdir -p $out/lib/udev/rules.d
+    $out/lib/libgphoto2/print-camera-list udev-rules version 175 group camera >$out/lib/udev/rules.d/40-gphoto2.rules
+  '';
+
   meta = {
     homepage = http://www.gphoto.org/proj/libgphoto2/;
     description = "A library for accessing digital cameras";
@@ -41,4 +46,3 @@ stdenv.mkDerivation rec {
     maintainers = with stdenv.lib.maintainers; [ jcumming ];
   };
 }
-


### PR DESCRIPTION
Closes #21420.

###### Motivation for this change

See #21420: I plugged in my digital camera and could not run `gphoto2` to download images as regular user due to insufficient permissions. This adds a NixOS option `programs.gphoto2.enable` that installs not just `gphoto2`, but also a file of udev rules for setting the group ownership of a plugged-in camera to `camera`.

Tested on my NixOS 16.09.git.9db36f2 and then applied changes to master.

First contribution, happy to learn and fix anything to follow standards better.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] (N/A) macOS
   - [X] Linux
- [ ] (N/A) Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] (N/A) Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

