### PR TITLE
openntpd: v6+ requires libressl for constraints

### DIFF
--- a/pkgs/tools/networking/openntpd/default.nix
+++ b/pkgs/tools/networking/openntpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl
+{ stdenv, fetchurl, libressl
 , privsepPath ? "/var/empty"
 , privsepUser ? "ntp"
 }:
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
   ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [ libressl ];
 
   installFlags = [
     "sysconfdir=\${out}/etc"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

