### PR TITLE
pocketsphinx: 0.8 -> 5prealpha

### DIFF
--- a/pkgs/development/libraries/pocketsphinx/default.nix
+++ b/pkgs/development/libraries/pocketsphinx/default.nix
@@ -1,16 +1,22 @@
-{ stdenv, fetchurl, sphinxbase, pkgconfig }:
+{ stdenv
+, fetchurl
+, sphinxbase
+, pkgconfig
+, python27 # >= 2.6
+, swig2 # 2.0
+}:
 
 stdenv.mkDerivation rec {
-  name = "pocketsphinx-0.8";
+  name = "pocketsphinx-5prealpha";
 
   src = fetchurl {
     url = "mirror://sourceforge/cmusphinx/${name}.tar.gz";
-    sha256 = "0ynf5ik4ib2d3ha3r4i8ywpr2dz5i6v51hmfl8kgzj4i7l44qk47";
+    sha256 = "1n9yazzdgvpqgnfzsbl96ch9cirayh74jmpjf7svs4i7grabanzg";
   };
 
   propagatedBuildInputs = [ sphinxbase ];
 
-  buildInputs = [ pkgconfig ];
+  buildInputs = [ pkgconfig python27 swig2 ];
 
   meta = {
     description = "Voice recognition library written in C";
@@ -19,3 +25,22 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.linux;
   };
 }
+
+/* Example usage:
+
+
+1.
+
+$ cat << EOF > vocabulary.txt
+oh mighty computer /1e-40/
+hello world /1e-30/
+EOF
+
+2.
+
+$ pocketsphinx_continuous -inmic yes -kws vocabulary.txt 2> /dev/null
+# after you say "hello world":
+hello world
+...
+
+*/

--- a/pkgs/development/libraries/sphinxbase/default.nix
+++ b/pkgs/development/libraries/sphinxbase/default.nix
@@ -2,18 +2,20 @@
 , fetchurl
 , bison
 , pkgconfig
+, python27 # >= 2.6
+, swig2 # 2.0
 , multipleOutputs ? false #Uses incomplete features of nix!
 }:
 
 stdenv.mkDerivation (rec {
-  name = "sphinxbase-0.8";
+  name = "sphinxbase-5prealpha";
 
   src = fetchurl {
     url = "mirror://sourceforge/cmusphinx/${name}.tar.gz";
-    sha256 = "1a3c91g6rcfb2k8qyfhnd7s68ds6pxwv61xfp0ai1arbhx28jw2m";
+    sha256 = "0vr4k8pv5a8nvq9yja7kl13b5lh0f9vha8fc8znqnm8bwmcxnazp";
   };
 
-  buildInputs = [ pkgconfig bison ];
+  buildInputs = [ swig2 python27 pkgconfig bison ];
 
   meta = {
     description = "Support Library for Pocketsphinx";


### PR DESCRIPTION
###### Motivation for this change

Version was outdated, the old `pocketsphinx_continuous` lacked features. 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

(This is my first commit) `nix-shell -p nox --run "nox-review wip"` errored, but sphinxbase/pocketsphinx don't seem to have any reverse dependencies. 

cc @Fuuzetsu 