### PR TITLE
crystal: fix build in chroot environment, again

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -60,6 +60,9 @@ stdenv.mkDerivation rec {
     # patch the script which launches the prebuilt compiler
     substituteInPlace $(pwd)/crystal-${version}-1/bin/crystal --replace \
       "/usr/bin/env bash" "${stdenv.shell}"
+    substituteInPlace $(pwd)/crystal-${version}/bin/crystal --replace \
+      "/usr/bin/env bash" "${stdenv.shell}"
+
     ${fixPrebuiltBinary}
 
     cd crystal-${version}


### PR DESCRIPTION
###### Motivation for this change

After last pr (#21428) being merged into master, hydra still failed to build crystal,
then I realized that forgot to patch another script used by Makefile.
(I test last pr with nix.useSandbox = true, it succeed to build locally, strange..)

This time I'm sure it can be build without /usr/bin/env,
but to make sure everything works after this pr,
@mimadrid I would be very appreciated if you can also test this pr to ensure everything works with nix.useSandbox = true, and to avoid I made any silly mistake again, thank you!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

