### PR TITLE
clblas-cuda: use system gtest library

### DIFF
--- a/pkgs/development/libraries/science/math/clblas/cuda/default.nix
+++ b/pkgs/development/libraries/science/math/clblas/cuda/default.nix
@@ -7,6 +7,7 @@
 , python
 , cudatoolkit
 , nvidia_x11
+, gtest
 }:
 
 stdenv.mkDerivation rec {
@@ -40,6 +41,7 @@ stdenv.mkDerivation rec {
     cmake ../src -DCMAKE_INSTALL_PREFIX=$out \
                  -DCMAKE_BUILD_TYPE=Release \
                  -DOPENCL_ROOT=${cudatoolkit} \
+                 -DUSE_SYSTEM_GTEST=ON
   '';
 
   dontStrip = true; 
@@ -51,6 +53,7 @@ stdenv.mkDerivation rec {
     python
     cudatoolkit
     nvidia_x11
+    gtest
   ]; 
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Without this change the build fails with
```
…
[ 59%] Linking CXX executable ../../../staging/make-ktest
[ 59%] Built target make-ktest
Scanning dependencies of target gtest-external
[ 59%] Creating directories for 'gtest-external'
[ 59%] Performing download step (download, verify and extract) for 'gtest-external'
-- Downloading...
   dst='/tmp/nix-build-clblas-cuda-git-20160505.drv-0/clBLAS-d20977ec4389c6b3751e318779410007c5e272f8-src/Build/tests/gtest-external-prefix/src/release-1.7.0.zip'
   timeout='none'
-- Using src='https://github.com/google/googletest/archive/release-1.7.0.zip'
-- Retrying...
-- Using src='https://github.com/google/googletest/archive/release-1.7.0.zip'
-- Retry after 5 seconds (attempt #2) ...
-- Using src='https://github.com/google/googletest/archive/release-1.7.0.zip'
-- Retry after 5 seconds (attempt #3) ...
-- Using src='https://github.com/google/googletest/archive/release-1.7.0.zip'
-- Retry after 15 seconds (attempt #4) ...
-- Using src='https://github.com/google/googletest/archive/release-1.7.0.zip'
-- Retry after 60 seconds (attempt #5) ...
-- Using src='https://github.com/google/googletest/archive/release-1.7.0.zip'
CMake Error at gtest-external-stamp/download-gtest-external.cmake:157 (message):
  Each download failed!

    error: downloading 'https://github.com/google/googletest/archive/release-1.7.0.zip' failed
         status_code: 6
         status_string: "Couldn't resolve host name"
         log:
         --- LOG BEGIN ---
         getaddrinfo(3) failed for github.com:443

  Couldn't resolve host 'github.com'

  Closing connection 0
…
```

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).