### PR TITLE
ricochet: 1.1.2 -> 1.1.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/ricochet/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ricochet/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "ricochet-${version}";
-  version = "1.1.2";
+  version = "1.1.4";
 
   src = fetchurl {
     url = "https://github.com/ricochet-im/ricochet/archive/v${version}.tar.gz";
-    sha256 = "1szb5vmlqal0vhan87kgbks184f7xbfay1hr3d3vm8r1lvcjjfkr";
+    sha256 = "1kfj42ksvj7axc809lb8siqzj5hck2pib427b63a3ipnqc5h1faf";
   };
 
   desktopItem = makeDesktopItem {
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     description = "Anonymous peer-to-peer instant messaging";
     homepage = "https://ricochet.im";
     license = licenses.bsd3;
-    maintainers = [ maintainers.codsl maintainers.jgillich ];
+    maintainers = [ maintainers.codsl maintainers.jgillich maintainers.np ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Try the latest version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
