### PR TITLE
urlscan: replace input 'isPy35' with 'pythonOlder'

### DIFF
--- a/pkgs/applications/misc/urlscan/default.nix
+++ b/pkgs/applications/misc/urlscan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, isPy35, fetchFromGitHub, urwid, pythonOlder }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, urwid, pythonOlder }:
 
 buildPythonPackage rec {
   name = "urlscan-${version}";


### PR DESCRIPTION
###### Motivation for this change
fix build inputs

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

