### PR TITLE
Fontconfig for Android Studio

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -9,7 +9,6 @@
 , gnugrep
 , gnutar
 , gzip
-, jdk
 , fontconfig
 , freetype
 , libpulseaudio
@@ -50,7 +49,6 @@ let
         coreutils
         findutils
         gnugrep
-        jdk
         which
 
         # For Android emulator

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -43,52 +43,56 @@ let
     ];
     installPhase = ''
       cp -r . $out
-      wrapProgram $out/bin/studio.sh --set PATH "${stdenv.lib.makeBinPath [
+      wrapProgram $out/bin/studio.sh \
+        --set PATH "${stdenv.lib.makeBinPath [
 
-        # Checked in studio.sh
-        coreutils
-        findutils
-        gnugrep
-        which
+          # Checked in studio.sh
+          coreutils
+          findutils
+          gnugrep
+          which
 
-        # For Android emulator
-        file
-        glxinfo
-        pciutils
-        setxkbmap
+          # For Android emulator
+          file
+          glxinfo
+          pciutils
+          setxkbmap
 
-        # Used during setup wizard
-        gnutar
-        gzip
+          # Used during setup wizard
+          gnutar
+          gzip
 
-        # Runtime stuff
-        git
+          # Runtime stuff
+          git
 
-      ]}" --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
+        ]}" \
+        --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
 
-        # Crash at startup without these
-        fontconfig
-        freetype
-        libXext
-        libXi
-        libXrender
-        libXtst
+          # Crash at startup without these
+          fontconfig
+          freetype
+          libXext
+          libXi
+          libXrender
+          libXtst
 
-        # Gradle wants libstdc++.so.6
-        stdenv.cc.cc.lib
-        # mksdcard wants 32 bit libstdc++.so.6
-        pkgsi686Linux.stdenv.cc.cc.lib
+          # Gradle wants libstdc++.so.6
+          stdenv.cc.cc.lib
+          # mksdcard wants 32 bit libstdc++.so.6
+          pkgsi686Linux.stdenv.cc.cc.lib
 
-        # aapt wants libz.so.1
-        zlib
-        pkgsi686Linux.zlib
-        # Support multiple monitors
-        libXrandr
+          # aapt wants libz.so.1
+          zlib
+          pkgsi686Linux.zlib
+          # Support multiple monitors
+          libXrandr
 
-        # For Android emulator
-        libpulseaudio
-        libX11
-      ]}" --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb"
+          # For Android emulator
+          libpulseaudio
+          libX11
+
+        ]}" \
+        --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb"
     '';
     src = fetchurl {
       url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -28,6 +28,7 @@
 , writeTextFile
 , xkeyboard_config
 , zlib
+, fontsConf
 }:
 
 let
@@ -92,7 +93,8 @@ let
           libX11
 
         ]}" \
-        --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb"
+        --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb" \
+        --set FONTCONFIG_FILE ${fontsConf}
     '';
     src = fetchurl {
       url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";

--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -65,6 +65,15 @@ let
         git
 
       ]}" --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
+
+        # Crash at startup without these
+        fontconfig
+        freetype
+        libXext
+        libXi
+        libXrender
+        libXtst
+
         # Gradle wants libstdc++.so.6
         stdenv.cc.cc.lib
         # mksdcard wants 32 bit libstdc++.so.6
@@ -79,12 +88,6 @@ let
         # For Android emulator
         libpulseaudio
         libX11
-        libXext
-        libXrender
-        libXtst
-        libXi
-        freetype
-        fontconfig
       ]}" --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb"
     '';
     src = fetchurl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12323,6 +12323,9 @@ in
   amsn = callPackage ../applications/networking/instant-messengers/amsn { };
 
   android-studio = callPackage ../applications/editors/android-studio {
+    fontsConf = makeFontsConf {
+      fontDirectories = [];
+    };
   };
 
   antimony = qt5.callPackage ../applications/graphics/antimony {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12322,17 +12322,6 @@ in
 
   amsn = callPackage ../applications/networking/instant-messengers/amsn { };
 
-  # Oracle JDK is recommended upstream, but unfree and requires a manual
-  # download. OpenJDK is straightforward, but may suffer from compatibility
-  # problems e.g. https://code.google.com/p/android/issues/detail?id=174496.
-  # To use Oracle JDK add an override to ~/.nixpkgs/config.nix:
-  # {
-  #   packageOverrides = pkgs: {
-  #     android-studio = pkgs.android-studio.override {
-  #       jdk = pkgs.oraclejdk8;
-  #     };
-  #   };
-  # }
   android-studio = callPackage ../applications/editors/android-studio {
       inherit (xorg) libX11 libXext libXi libXrandr libXrender libXtst;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12323,7 +12323,6 @@ in
   amsn = callPackage ../applications/networking/instant-messengers/amsn { };
 
   android-studio = callPackage ../applications/editors/android-studio {
-      inherit (xorg) libX11 libXext libXi libXrandr libXrender libXtst;
   };
 
   antimony = qt5.callPackage ../applications/graphics/antimony {};


### PR DESCRIPTION
###### Motivation for this change

With the fonts.conf by Ubuntu (I use Nix instead of Apt on Ubuntu), Android Studio crashes during startup because it [fails to do some font stuff](https://gist.github.com/phunehehe/f3389bc79b4428a03b20053377ebdd5a). With a config file built with `makeFontsConf` (even an empty one!?), it works fine. The workaround is found via https://github.com/docker-library/openjdk/issues/73.

On the one side, it could be argued that I should fix my fonts.conf, but then it means the package isn't really usable out of NixOS.

On the other side, overriding FONTCONFIG_FILE probably means the package can't use all the installed fonts, but then I also see other packages doing the same.

Thoughts?

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

