### PR TITLE
Flatten nested kdeWrappers

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -31,204 +31,223 @@ in
         '';
       };
 
+      extraPackages = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = ''
+          KDE packages that need to be installed system-wide.
+        '';
+      };
+
     };
 
   };
 
 
-  config = mkIf (xcfg.enable && cfg.enable) {
+  config = mkMerge [
+    (mkIf (cfg.extraPackages != []) {
+      environment.systemPackages = [ (kde5.kdeWrapper cfg.extraPackages) ];
+    })
 
-    warnings = optional config.services.xserver.desktopManager.kde4.enable
-      "KDE 4 should not be enabled at the same time as KDE 5";
+    (mkIf (xcfg.enable && cfg.enable) {
 
-    services.xserver.desktopManager.session = singleton {
-      name = "kde5";
-      bgSupport = true;
-      start = ''
-        # Load PulseAudio module for routing support.
-        # See http://colin.guthr.ie/2009/10/so-how-does-the-kde-pulseaudio-support-work-anyway/
-        ${optionalString config.hardware.pulseaudio.enable ''
-          ${getBin config.hardware.pulseaudio.package}/bin/pactl load-module module-device-manager "do_routing=1"
-        ''}
+      warnings = optional config.services.xserver.desktopManager.kde4.enable
+        "KDE 4 should not be enabled at the same time as KDE 5";
 
-        exec "${kde5.startkde}"
+      services.xserver.desktopManager.session = singleton {
+        name = "kde5";
+        bgSupport = true;
+        start = ''
+          # Load PulseAudio module for routing support.
+          # See http://colin.guthr.ie/2009/10/so-how-does-the-kde-pulseaudio-support-work-anyway/
+          ${optionalString config.hardware.pulseaudio.enable ''
+            ${getBin config.hardware.pulseaudio.package}/bin/pactl load-module module-device-manager "do_routing=1"
+          ''}
 
-      '';
-    };
+          exec "${kde5.startkde}"
 
-    security.setuidOwners = [
-      {
-        program = "kcheckpass";
-        source = "${kde5.plasma-workspace.out}/lib/libexec/kcheckpass";
-        owner = "root";
-        setuid = true;
-      }
-      {
-        program = "start_kdeinit";
-        source = "${kde5.kinit.out}/lib/libexec/kf5/start_kdeinit";
-        owner = "root";
-        setuid = true;
-      }
-    ];
+        '';
+      };
 
-    environment.systemPackages =
-      [
-        kde5.frameworkintegration
-        kde5.kactivities
-        kde5.kauth
-        kde5.kcmutils
-        kde5.kconfig
-        kde5.kconfigwidgets
-        kde5.kcoreaddons
-        kde5.kdbusaddons
-        kde5.kdeclarative
-        kde5.kded
-        kde5.kdesu
-        kde5.kdnssd
-        kde5.kemoticons
-        kde5.kfilemetadata
-        kde5.kglobalaccel
-        kde5.kguiaddons
-        kde5.kiconthemes
-        kde5.kidletime
-        kde5.kimageformats
-        kde5.kinit
-        kde5.kio
-        kde5.kjobwidgets
-        kde5.knewstuff
-        kde5.knotifications
-        kde5.knotifyconfig
-        kde5.kpackage
-        kde5.kparts
-        kde5.kpeople
-        kde5.krunner
-        kde5.kservice
-        kde5.ktextwidgets
-        kde5.kwallet
-        kde5.kwayland
-        kde5.kwidgetsaddons
-        kde5.kxmlgui
-        kde5.kxmlrpcclient
-        kde5.plasma-framework
-        kde5.solid
-        kde5.sonnet
-        kde5.threadweaver
-
-        kde5.breeze-qt5
-        kde5.kactivitymanagerd
-        kde5.kde-cli-tools
-        kde5.kdecoration
-        kde5.kdeplasma-addons
-        kde5.kgamma5
-        kde5.khelpcenter
-        kde5.khotkeys
-        kde5.kinfocenter
-        kde5.kmenuedit
-        kde5.kscreen
-        kde5.kscreenlocker
-        kde5.ksysguard
-        kde5.kwayland
-        kde5.kwin
-        kde5.kwrited
-        kde5.libkscreen
-        kde5.libksysguard
-        kde5.milou
-        kde5.oxygen
-        kde5.plasma-integration
-        kde5.polkit-kde-agent
-        kde5.systemsettings
-
-        kde5.plasma-desktop
-        kde5.plasma-workspace
-        kde5.plasma-workspace-wallpapers
-
-        kde5.dolphin
-        kde5.dolphin-plugins
-        kde5.ffmpegthumbs
-        kde5.kdegraphics-thumbnailers
-        kde5.kio-extras
-        kde5.konsole
-        kde5.print-manager
-
-        # Install Breeze icons if available
-        (kde5.breeze-icons or kde5.oxygen-icons5 or kde5.oxygen-icons)
-        pkgs.hicolor_icon_theme
-
-        kde5.kde-gtk-config kde5.breeze-gtk
-
-        pkgs.qt5.phonon-backend-gstreamer
-      ]
-
-      # Plasma 5.5 and later has a Breeze GTK theme.
-      # If it is not available, Orion is very similar to Breeze.
-      ++ lib.optional (!(lib.hasAttr "breeze-gtk" kde5)) pkgs.orion
-
-      # Install activity manager if available
-      ++ lib.optional (lib.hasAttr "kactivitymanagerd" kde5) kde5.kactivitymanagerd
-
-      # frameworkintegration was split with plasma-integration in Plasma 5.6
-      ++ lib.optional (lib.hasAttr "plasma-integration" kde5) kde5.plasma-integration
-
-      ++ lib.optionals cfg.enableQt4Support [ kde5.breeze-qt4 pkgs.phonon-backend-gstreamer ]
-
-      # Optional hardware support features
-      ++ lib.optional config.hardware.bluetooth.enable kde5.bluedevil
-      ++ lib.optional config.networking.networkmanager.enable kde5.plasma-nm
-      ++ lib.optional config.hardware.pulseaudio.enable kde5.plasma-pa
-      ++ lib.optional config.powerManagement.enable kde5.powerdevil
-      ++ lib.optional config.services.colord.enable pkgs.colord-kde
-      ++ lib.optionals config.services.samba.enable [ kde5.kdenetwork-filesharing pkgs.samba ];
-
-    environment.pathsToLink = [ "/share" ];
-
-    environment.etc = singleton {
-      source = "${pkgs.xkeyboard_config}/etc/X11/xkb";
-      target = "X11/xkb";
-    };
-
-    # Enable GTK applications to load SVG icons
-    environment.variables =
-      {
-        GST_PLUGIN_SYSTEM_PATH_1_0 =
-          lib.makeSearchPath "/lib/gstreamer-1.0"
-          (builtins.map (pkg: pkg.out) (with pkgs.gst_all_1; [
-            gstreamer
-            gst-plugins-base
-            gst-plugins-good
-            gst-plugins-ugly
-            gst-plugins-bad
-            gst-libav # for mp3 playback
-          ]));
-      }
-      // (if (lib.hasAttr "breeze-icons" kde5)
-          then { GDK_PIXBUF_MODULE_FILE = "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"; }
-          else { });
-
-    fonts.fonts = [ (kde5.oxygen-fonts or pkgs.noto-fonts) ];
-
-    programs.ssh.askPassword = "${kde5.ksshaskpass.out}/bin/ksshaskpass";
-
-    # Enable helpful DBus services.
-    services.udisks2.enable = true;
-    services.upower.enable = config.powerManagement.enable;
-
-    # Extra UDEV rules used by Solid
-    services.udev.packages = [
-      pkgs.libmtp
-      pkgs.media-player-info
-    ];
-
-    services.xserver.displayManager.sddm = {
-      theme = "breeze";
-      themes = [
-        kde5.ecm # for the setup-hook
-        kde5.plasma-workspace
-        kde5.breeze-icons
+      security.setuidOwners = [
+        {
+          program = "kcheckpass";
+          source = "${kde5.plasma-workspace.out}/lib/libexec/kcheckpass";
+          owner = "root";
+          setuid = true;
+        }
+        {
+          program = "start_kdeinit";
+          source = "${kde5.kinit.out}/lib/libexec/kf5/start_kdeinit";
+          owner = "root";
+          setuid = true;
+        }
       ];
-    };
 
-    security.pam.services.kde = { allowNullPassword = true; };
+      environment.systemPackages =
+        [
+          kde5.frameworkintegration
+          kde5.kactivities
+          kde5.kauth
+          kde5.kcmutils
+          kde5.kconfig
+          kde5.kconfigwidgets
+          kde5.kcoreaddons
+          kde5.kdbusaddons
+          kde5.kdeclarative
+          kde5.kded
+          kde5.kdesu
+          kde5.kdnssd
+          kde5.kemoticons
+          kde5.kfilemetadata
+          kde5.kglobalaccel
+          kde5.kguiaddons
+          kde5.kiconthemes
+          kde5.kidletime
+          kde5.kimageformats
+          kde5.kinit
+          kde5.kio
+          kde5.kjobwidgets
+          kde5.knewstuff
+          kde5.knotifications
+          kde5.knotifyconfig
+          kde5.kpackage
+          kde5.kparts
+          kde5.kpeople
+          kde5.krunner
+          kde5.kservice
+          kde5.ktextwidgets
+          kde5.kwallet
+          kde5.kwayland
+          kde5.kwidgetsaddons
+          kde5.kxmlgui
+          kde5.kxmlrpcclient
+          kde5.plasma-framework
+          kde5.solid
+          kde5.sonnet
+          kde5.threadweaver
 
-  };
+          kde5.breeze-qt5
+          kde5.kactivitymanagerd
+          kde5.kde-cli-tools
+          kde5.kdecoration
+          kde5.kdeplasma-addons
+          kde5.kgamma5
+          kde5.khotkeys
+          kde5.kinfocenter
+          kde5.kmenuedit
+          kde5.kscreen
+          kde5.kscreenlocker
+          kde5.ksysguard
+          kde5.kwayland
+          kde5.kwin
+          kde5.kwrited
+          kde5.libkscreen
+          kde5.libksysguard
+          kde5.milou
+          kde5.plasma-integration
+          kde5.polkit-kde-agent
+          kde5.systemsettings
+
+          kde5.plasma-desktop
+          kde5.plasma-workspace
+          kde5.plasma-workspace-wallpapers
+
+          kde5.dolphin-plugins
+          kde5.ffmpegthumbs
+          kde5.kdegraphics-thumbnailers
+          kde5.kio-extras
+          kde5.print-manager
+
+          # Install Breeze icons if available
+          (kde5.breeze-icons or kde5.oxygen-icons5 or kde5.oxygen-icons)
+          pkgs.hicolor_icon_theme
+
+          kde5.kde-gtk-config kde5.breeze-gtk
+
+          pkgs.qt5.phonon-backend-gstreamer
+        ]
+
+        # Plasma 5.5 and later has a Breeze GTK theme.
+        # If it is not available, Orion is very similar to Breeze.
+        ++ lib.optional (!(lib.hasAttr "breeze-gtk" kde5)) pkgs.orion
+
+        # Install activity manager if available
+        ++ lib.optional (lib.hasAttr "kactivitymanagerd" kde5) kde5.kactivitymanagerd
+
+        # frameworkintegration was split with plasma-integration in Plasma 5.6
+        ++ lib.optional (lib.hasAttr "plasma-integration" kde5) kde5.plasma-integration
+
+        ++ lib.optionals cfg.enableQt4Support [ kde5.breeze-qt4 pkgs.phonon-backend-gstreamer ]
+
+        # Optional hardware support features
+        ++ lib.optional config.hardware.bluetooth.enable kde5.bluedevil
+        ++ lib.optional config.networking.networkmanager.enable kde5.plasma-nm
+        ++ lib.optional config.hardware.pulseaudio.enable kde5.plasma-pa
+        ++ lib.optional config.powerManagement.enable kde5.powerdevil
+        ++ lib.optional config.services.colord.enable pkgs.colord-kde
+        ++ lib.optionals config.services.samba.enable [ kde5.kdenetwork-filesharing pkgs.samba ];
+
+      services.xserver.desktopManager.kde5.extraPackages =
+        [
+          kde5.khelpcenter
+          kde5.oxygen
+
+          kde5.dolphin
+          kde5.konsole
+        ];
+
+      environment.pathsToLink = [ "/share" ];
+
+      environment.etc = singleton {
+        source = "${pkgs.xkeyboard_config}/etc/X11/xkb";
+        target = "X11/xkb";
+      };
+
+      environment.variables =
+        {
+          # Enable GTK applications to load SVG icons
+          GST_PLUGIN_SYSTEM_PATH_1_0 =
+            lib.makeSearchPath "/lib/gstreamer-1.0"
+            (builtins.map (pkg: pkg.out) (with pkgs.gst_all_1; [
+              gstreamer
+              gst-plugins-base
+              gst-plugins-good
+              gst-plugins-ugly
+              gst-plugins-bad
+              gst-libav # for mp3 playback
+            ]));
+        }
+        // (if (lib.hasAttr "breeze-icons" kde5)
+            then { GDK_PIXBUF_MODULE_FILE = "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"; }
+            else { });
+
+      fonts.fonts = [ (kde5.oxygen-fonts or pkgs.noto-fonts) ];
+
+      programs.ssh.askPassword = "${kde5.ksshaskpass.out}/bin/ksshaskpass";
+
+      # Enable helpful DBus services.
+      services.udisks2.enable = true;
+      services.upower.enable = config.powerManagement.enable;
+
+      # Extra UDEV rules used by Solid
+      services.udev.packages = [
+        pkgs.libmtp
+        pkgs.media-player-info
+      ];
+
+      services.xserver.displayManager.sddm = {
+        theme = "breeze";
+        themes = [
+          kde5.ecm # for the setup-hook
+          kde5.plasma-workspace
+          kde5.breeze-icons
+        ];
+      };
+
+      security.pam.services.kde = { allowNullPassword = true; };
+
+    })
+  ];
 
 }

--- a/pkgs/applications/editors/kile/frameworks.nix
+++ b/pkgs/applications/editors/kile/frameworks.nix
@@ -60,8 +60,9 @@ let
       };
     };
 in
-kdeWrapper unwrapped
+kdeWrapper
 {
+  inherit unwrapped;
   targets = [ "bin/kile" ];
   paths = [ konsole.unwrapped ];
 }

--- a/pkgs/applications/misc/yakuake/3.0.nix
+++ b/pkgs/applications/misc/yakuake/3.0.nix
@@ -55,9 +55,9 @@ let
 
 
 in
-kdeWrapper unwrapped
+kdeWrapper
 {
+  inherit unwrapped;
   targets = [ "bin/yakuake" ];
   paths = [ konsole.unwrapped ];
 }
-

--- a/pkgs/applications/networking/irc/konversation/1.6.nix
+++ b/pkgs/applications/networking/irc/konversation/1.6.nix
@@ -75,7 +75,8 @@ let
       homepage = https://konversation.kde.org;
     };
   };
-in kdeWrapper unwrapped {
+in kdeWrapper {
+  inherit unwrapped;
   targets = [ "bin/konversation" ];
 }
 

--- a/pkgs/desktops/kde-5/applications/ark/default.nix
+++ b/pkgs/desktops/kde-5/applications/ark/default.nix
@@ -36,7 +36,8 @@ let
       };
     };
 in
-kdeWrapper unwrapped
+kdeWrapper
 {
+  inherit unwrapped;
   targets = [ "bin/ark" ];
 }

--- a/pkgs/desktops/kde-5/applications/dolphin.nix
+++ b/pkgs/desktops/kde-5/applications/dolphin.nix
@@ -24,8 +24,9 @@ let
       ];
     };
 in
-kdeWrapper unwrapped
+kdeWrapper
 {
+  inherit unwrapped;
   targets = [ "bin/dolphin" ];
   paths = [ dolphin-plugins konsole.unwrapped ];
 }

--- a/pkgs/desktops/kde-5/applications/filelight.nix
+++ b/pkgs/desktops/kde-5/applications/filelight.nix
@@ -18,4 +18,7 @@ let
       ];
     };
 in
-kdeWrapper unwrapped { targets = [ "bin/filelight" ]; }
+kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/filelight" ];
+}

--- a/pkgs/desktops/kde-5/applications/gwenview.nix
+++ b/pkgs/desktops/kde-5/applications/gwenview.nix
@@ -20,7 +20,8 @@ let
       ];
     };
 in
-kdeWrapper unwrapped {
+kdeWrapper {
+  inherit unwrapped;
   targets = [ "bin/gwenview" ];
   paths = [ kipi-plugins ];
 }

--- a/pkgs/desktops/kde-5/applications/kate.nix
+++ b/pkgs/desktops/kde-5/applications/kate.nix
@@ -24,8 +24,9 @@ let
       ];
     };
 in
-kdeWrapper unwrapped
+kdeWrapper
 {
+  inherit unwrapped;
   targets = [ "bin/kate" "bin/kwrite" ];
   paths = [ konsole.unwrapped ];
 }

--- a/pkgs/desktops/kde-5/applications/kcalc.nix
+++ b/pkgs/desktops/kde-5/applications/kcalc.nix
@@ -18,4 +18,7 @@ let
       ];
     };
 in
-kdeWrapper unwrapped { targets = [ "bin/kcalc" ]; }
+kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/kcalc" ];
+}

--- a/pkgs/desktops/kde-5/applications/kcolorchooser.nix
+++ b/pkgs/desktops/kde-5/applications/kcolorchooser.nix
@@ -15,4 +15,7 @@ let
       propagatedBuildInputs = [ ki18n kwidgetsaddons kxmlgui ];
     };
 in
-kdeWrapper unwrapped { targets = [ "bin/kcolorchooser" ]; }
+kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/kcolorchooser" ];
+}

--- a/pkgs/desktops/kde-5/applications/kdenlive.nix
+++ b/pkgs/desktops/kde-5/applications/kdenlive.nix
@@ -74,8 +74,9 @@ unwrapped = kdeApp {
   };
 };
 in
-kdeWrapper unwrapped
+kdeWrapper
 {
+  inherit unwrapped;
   targets = [ "bin/kdenlive" ];
   paths = [ kinit ];
 }

--- a/pkgs/desktops/kde-5/applications/kdf.nix
+++ b/pkgs/desktops/kde-5/applications/kdf.nix
@@ -18,4 +18,7 @@ let
       ];
     };
 in
-kdeWrapper unwrapped { targets = [ "bin/kdf" ]; }
+kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/kdf" ];
+}

--- a/pkgs/desktops/kde-5/applications/khelpcenter.nix
+++ b/pkgs/desktops/kde-5/applications/khelpcenter.nix
@@ -16,4 +16,7 @@ let
       ];
     };
 in
-kdeWrapper unwrapped { targets = [ "bin/khelpcenter" ]; }
+kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/khelpcenter" ];
+}

--- a/pkgs/desktops/kde-5/applications/kompare.nix
+++ b/pkgs/desktops/kde-5/applications/kompare.nix
@@ -15,4 +15,7 @@ let
       ];
     };
 in
-kdeWrapper unwrapped { targets = [ "bin/kompare" ]; }
+kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/kompare" ];
+}

--- a/pkgs/desktops/kde-5/applications/konsole.nix
+++ b/pkgs/desktops/kde-5/applications/konsole.nix
@@ -24,4 +24,7 @@ let
       ];
     };
 in
-kdeWrapper unwrapped { targets = [ "bin/konsole" ]; }
+kdeWrapper {
+  inherit unwrapped;
+  targets = [ "bin/konsole" ];
+}

--- a/pkgs/desktops/kde-5/applications/kwalletmanager.nix
+++ b/pkgs/desktops/kde-5/applications/kwalletmanager.nix
@@ -30,6 +30,7 @@ let
       kxmlgui
     ];
   };
-in kdeWrapper unwrapped {
+in kdeWrapper {
+  inherit unwrapped;
   targets = ["bin/kwalletmanager5"];
 }

--- a/pkgs/desktops/kde-5/applications/marble.nix
+++ b/pkgs/desktops/kde-5/applications/marble.nix
@@ -18,7 +18,8 @@ let
       enableParallelBuilding = true;
     };
 in
-kdeWrapper unwrapped {
+kdeWrapper {
+  inherit unwrapped;
   targets = [ "bin/marble-qt" ];
   paths = [ unwrapped ];
 }

--- a/pkgs/desktops/kde-5/applications/okular.nix
+++ b/pkgs/desktops/kde-5/applications/okular.nix
@@ -25,6 +25,7 @@ let
     };
   };
 in
-kdeWrapper unwrapped {
+kdeWrapper {
+  inherit unwrapped;
   targets = [ "bin/okular" ];
 }

--- a/pkgs/desktops/kde-5/applications/spectacle.nix
+++ b/pkgs/desktops/kde-5/applications/spectacle.nix
@@ -18,7 +18,8 @@ let
       ];
     };
 in
-kdeWrapper unwrapped {
+kdeWrapper {
+  inherit unwrapped;
   targets = [ "bin/spectacle" ];
   paths = [ kipi-plugins ];
 }

--- a/pkgs/desktops/kde-5/plasma/oxygen.nix
+++ b/pkgs/desktops/kde-5/plasma/oxygen.nix
@@ -15,6 +15,7 @@ let
     ];
   };
 in
-kdeWrapper unwrapped {
+kdeWrapper {
+  inherit unwrapped;
   targets = [ "bin/oxygen-demo5" "bin/oxygen-settings5" ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kde-wrapper.nix
+++ b/pkgs/development/libraries/kde-frameworks/kde-wrapper.nix
@@ -1,53 +1,73 @@
 { stdenv, lib, makeWrapper, buildEnv }:
 
-drv:
-
-{ targets, paths ? [] }:
+packages:
 
 let
+  packages_ = if builtins.isList packages then packages else [packages];
+
+  unwrapped = lib.concatMap (p: if builtins.isList p.unwrapped then p.unwrapped else [p.unwrapped]) packages_;
+  targets = lib.concatMap (p: p.targets) packages_;
+  paths = lib.concatMap (p: p.paths or []) packages_;
+
+  name =
+    if builtins.length unwrapped == 1
+    then (lib.head unwrapped).name
+    else "kde-application";
+  meta =
+    if builtins.length unwrapped == 1
+    then (lib.head unwrapped).meta
+    else {};
+
   env = buildEnv {
-    inherit (drv) name meta;
-    paths = builtins.map lib.getBin ([drv] ++ paths);
+    inherit name meta;
+    paths = builtins.map lib.getBin (unwrapped ++ paths);
     pathsToLink = [ "/bin" "/share" "/lib/qt5" "/etc/xdg" ];
   };
 in
 
 stdenv.mkDerivation {
-  inherit (drv) name meta;
+  inherit name meta;
   preferLocalBuild = true;
 
-  paths = builtins.map lib.getBin ([drv] ++ paths);
-  inherit drv env targets;
-  passthru = { unwrapped = drv; };
+  inherit unwrapped env targets;
+
+  passthru = {
+    inherit targets paths;
+    unwrapped = if builtins.length unwrapped == 1 then lib.head unwrapped else unwrapped;
+  };
 
   nativeBuildInputs = [ makeWrapper ];
 
-  builder = builtins.toFile "builder.sh" ''
-    . $stdenv/setup
-
+  buildCommand = ''
     for t in $targets; do
-        if [ -a "$drv/$t" ]; then
-            makeWrapper "$drv/$t" "$out/$t" \
-                --argv0 '"$0"' \
-                --suffix PATH : "$env/bin" \
-                --prefix XDG_CONFIG_DIRS : "$env/share" \
-                --prefix XDG_DATA_DIRS : "$env/etc/xdg" \
-                --set QML_IMPORT_PATH "$env/lib/qt5/imports" \
-                --set QML2_IMPORT_PATH "$env/lib/qt5/qml" \
-                --set QT_PLUGIN_PATH "$env/lib/qt5/plugins"
-        else
-            echo "no such file or directory: $drv/$t"
+        good=""
+        for drv in $unwrapped; do
+            if [ -a "$drv/$t" ]; then
+                makeWrapper "$drv/$t" "$out/$t" \
+                    --argv0 '"$0"' \
+                    --suffix PATH : "$env/bin" \
+                    --prefix XDG_CONFIG_DIRS : "$env/share" \
+                    --prefix XDG_DATA_DIRS : "$env/etc/xdg" \
+                    --set QML_IMPORT_PATH "$env/lib/qt5/imports" \
+                    --set QML2_IMPORT_PATH "$env/lib/qt5/qml" \
+                    --set QT_PLUGIN_PATH "$env/lib/qt5/plugins"
+                good="1"
+                break
+            fi
+        done
+        if [ -z "$good" ]; then
+            echo "file or directory not found in derivations: $t"
             exit 1
         fi
     done
 
-    if [ -a "$drv/share" ]; then
-        ln -s "$drv/share" "$out"
-    fi
+    ln -s "$env/share" "$out"
 
-    if [ -a "$drv/nix-support/propagated-user-env-packages" ]; then
-        mkdir -p "$out/nix-support"
-        ln -s "$drv/nix-support/propagated-user-env-packages" "$out/nix-support/"
-    fi
+    for drv in $unwrapped; do
+        if [ -a "$drv/nix-support/propagated-user-env-packages" ]; then
+            mkdir -p "$out/nix-support"
+            cat "$drv/nix-support/propagated-user-env-packages" >> "$out/nix-support/propagated-user-env-packages"
+        fi
+    done
   '';
 }

--- a/pkgs/tools/misc/kronometer/default.nix
+++ b/pkgs/tools/misc/kronometer/default.nix
@@ -23,6 +23,7 @@ let
     propagatedBuildInputs = [ kconfig kinit ];
   };
 in
-kdeWrapper unwrapped {
+kdeWrapper {
+  inherit unwrapped;
   targets = [ "bin/kronometer" ];
 }

--- a/pkgs/tools/misc/peruse/default.nix
+++ b/pkgs/tools/misc/peruse/default.nix
@@ -37,6 +37,7 @@ let
 
   };
 
-in kdeWrapper unwrapped {
+in kdeWrapper {
+  inherit unwrapped;
   targets = [ "bin/peruse" ];
 }


### PR DESCRIPTION
###### Motivation for this change

Takes a stab at https://github.com/NixOS/nixpkgs/issues/21345. With this nested `kdeWrapper`ed packages are flattened into one symlink tree, saving disk space.

As @FRidh suggested we now use this in KDE5 service with a new option `extraPackages`. I've moved all the wrapped packages from the big list (there are not too many of them; is this right?).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested with this configuration:
```
{
  services.xserver.enable = true;
  services.xserver.desktopManager.kde5.enable = true;
  services.xserver.desktopManager.kde5.enableQt4Support = true;
  hardware.bluetooth.enable = true;
  hardware.pulseaudio.enable = true;
  powerManagement.enable = true;
  networking.networkmanager.enable = true;
  services.colord.enable = true;
  services.samba.enable = true;

  users.extraUsers.root.password = "";
}
```