### PR TITLE
netbpm: tell config.mk where to find JPEGLIB and JPEGHDR_DIR or jpegtopnm and friends will not be built

### DIFF
--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -24,7 +24,9 @@ stdenv.mkDerivation rec {
     echo "STATICLIB_TOO = n" >> config.mk
     substituteInPlace "config.mk" \
         --replace "TIFFLIB = NONE" "TIFFLIB = ${libtiff.out}/lib/libtiff.so" \
-        --replace "TIFFHDR_DIR =" "TIFFHDR_DIR = ${libtiff.dev}/include"
+        --replace "TIFFHDR_DIR =" "TIFFHDR_DIR = ${libtiff.dev}/include" \
+        --replace "JPEGLIB = NONE" "JPEGLIB = ${libjpeg.out}/lib/libjpeg.so" \
+        --replace "JPEGHDR_DIR =" "JPEGHDR_DIR = ${libjpeg.dev}/include"
    '' + stdenv.lib.optionalString stdenv.isDarwin ''
     echo "LDSHLIB=-dynamiclib -install_name $out/lib/libnetpbm.\$(MAJ).dylib" >> config.mk
     echo "NETPBMLIBTYPE = dylib" >> config.mk


### PR DESCRIPTION
I noticed that `netpbm` was not providing tools like `jpegtopnm`. I copied the existing hack for `libtiff` and modified it for `libjpeg` and the missing tools are now being built.
