### PR TITLE
openbabel: 2.3.2 -> 2.4.1

### DIFF
--- a/pkgs/development/libraries/openbabel/default.nix
+++ b/pkgs/development/libraries/openbabel/default.nix
@@ -1,23 +1,23 @@
-{stdenv, fetchurl, cmake, zlib, libxml2, eigen, python, cairo, pkgconfig }:
+{stdenv, fetchurl, cmake, zlib, libxml2, eigen, python, cairo, pcre, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "openbabel-2.3.2";
+  name = "openbabel-${version}";
+  version = "2.4.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/openbabel/${name}.tar.gz";
-    sha256 = "122if0jkm71ngd1b0dic8k567b3j2hcikbwnpxgchv5ag5ka5b2f";
+    url = "https://github.com/openbabel/openbabel/archive/openbabel-${stdenv.lib.replaceStrings ["."] ["-"] version}.tar.gz";
+    sha256 = "0xm7y859ivq2cp0q08mwshfxm0jq31xkyr4x8s0j6l7khf57yk2r";
   };
 
   # TODO : perl & python bindings;
   # TODO : wxGTK: I have no time to compile
   # TODO : separate lib and apps
-  buildInputs = [ zlib libxml2 eigen python cairo ];
+  buildInputs = [ zlib libxml2 eigen python cairo pcre ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
   meta = {
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.urkud ];
-    broken = true; # doesn't build with GCC 5; fix in GitHub
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update openbabel to the last version

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

