### PR TITLE
Freeciv

### DIFF
--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -10,14 +10,14 @@ let
   gtkName = if gtkClient then "-gtk" else "";
 
   name = "freeciv";
-  version = "2.5.3";
+  version = "2.5.6";
 in
 stdenv.mkDerivation {
   name = "${name}${sdlName}${gtkName}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/freeciv/${name}-${version}.tar.bz2";
-    sha256 = "0p40bpkhbldsnlqdvfn3qd2vzadxfrfsf1r57x1akwabqs0h62s8";
+    sha256 = "16wrnsx5rmbz6rjs03bhy0vn20i6n6g73lx7fjpai98ixhzc5bfg";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, zlib, bzip2, pkgconfig, curl, lzma, gettext
 , sdlClient ? true, SDL, SDL_mixer, SDL_image, SDL_ttf, SDL_gfx, freetype, fluidsynth
 , gtkClient ? false, gtk2
-, server ? true, readline }:
+, server ? true, enable_sqlite ? true, readline, sqlite }:
 
 let
   inherit (stdenv.lib) optional optionals;
@@ -25,10 +25,12 @@ stdenv.mkDerivation {
   buildInputs = [ zlib bzip2 curl lzma gettext ]
     ++ optionals sdlClient [ SDL SDL_mixer SDL_image SDL_ttf SDL_gfx freetype fluidsynth ]
     ++ optionals gtkClient [ gtk2 ]
-    ++ optional server readline;
+    ++ optional server readline
+    ++ optional enable_sqlite sqlite;
 
   configureFlags = []
     ++ optional sdlClient "--enable-client=sdl"
+    ++ optional enable_sqlite "--enable-fcdb=sqlite3"
     ++ optional (!gtkClient) "--enable-fcmp=cli"
     ++ optional (!server) "--disable-server";
 


### PR DESCRIPTION
###### Motivation for this change

update and added a flag for using sqlite3 as the server database. I thought it was nice to add at least one database engine, and sqlite should be small enough to not increase closure size too much?

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

