### PR TITLE
ranger 1.7.2 - 1.8.0

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pythonPackages, w3m, file, less }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "ranger-1.7.2";
+  name = "ranger-1.8.0";
 
   meta = {
     description = "File manager with minimalistic curses interface";
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
 
   src = fetchurl {
     url = "http://ranger.nongnu.org/${name}.tar.gz";
-    sha256 = "0yaviybviwdvfg2a0pf2kk28g10k245499xmbpqlai7fv91f7xll";
+    sha256 = "14j067n1azk6vc6cxlhi5w5bsn2wcz4hypvgxc0vjl9xp5n4f0nf";
   };
 
   propagatedBuildInputs = [ file ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

