### PR TITLE
qemu: fix CVE-2016-9911, CVE 2016-9921 and 2016-9922

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -143,6 +143,11 @@ stdenv.mkDerivation rec {
       url = "http://git.qemu.org/?p=qemu.git;a=patch;h=791f97758e223de3290592d169f8e6339c281714";
       sha256 = "0952mpc81h42k5kqsw42prnw5vw86r3j88wk5z4sr1xd1sg428d6";
     })
+    (fetchpatch {
+      name = "qemu-CVE-2016-9921_9922.patch";
+      url = "http://git.qemu.org/?p=qemu.git;a=commit;h=4299b90e9ba9ce5ca9024572804ba751aa1a7e70";
+      sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
+    })
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch;
   hardeningDisable = [ "stackprotector" ];
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -137,6 +137,12 @@ stdenv.mkDerivation rec {
 
     # from http://git.qemu.org/?p=qemu.git;a=patch;h=ff55e94d23ae94c8628b0115320157c763eb3e06
     ./CVE-2016-9102.patch
+
+    (fetchpatch {
+      name = "qemu-CVE-2016-9911.patch";
+      url = "http://git.qemu.org/?p=qemu.git;a=patch;h=791f97758e223de3290592d169f8e6339c281714";
+      sha256 = "0952mpc81h42k5kqsw42prnw5vw86r3j88wk5z4sr1xd1sg428d6";
+    })
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch;
   hardeningDisable = [ "stackprotector" ];
 


### PR DESCRIPTION
###### Motivation for this change
fix CVE-2016-9911

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

