### PR TITLE
multimc: update to Java 8

### DIFF
--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, qt5Full, jdk7, zlib, file, makeWrapper, xorg, libpulseaudio, qt5 }:
+{ stdenv, fetchFromGitHub, cmake, qt5Full, jdk, zlib, file, makeWrapper, xorg, libpulseaudio, qt5 }:
 
 let
   libnbt = fetchFromGitHub {
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     rev = "895d8ab4699f1b50bf03532c967a91f5ecb62a50";
     sha256 = "179vc1iv57fx4g4h1wy8yvyvdm671jnvp6zi8pcr1n6azqhwklds";
   };
-  buildInputs = [ cmake qt5Full jdk7 zlib file makeWrapper ];
+  buildInputs = [ cmake qt5Full jdk zlib file makeWrapper ];
 
   libpath = with xorg; [ libX11 libXext libXcursor libXrandr libXxf86vm libpulseaudio ];
   postUnpack = ''
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
     cp -v MultiMC $out/bin/
     cp -v jars/*.jar $out/bin/jars/ #*/
     cp -v librainbow.so libnbt++.so libMultiMC_logic.so $out/lib
-    wrapProgram $out/bin/MultiMC --add-flags "-d \$HOME/.multimc/" --set GAME_LIBRARY_PATH $RESULT --prefix PATH : ${jdk7}/bin/
+    wrapProgram $out/bin/MultiMC --add-flags "-d \$HOME/.multimc/" --set GAME_LIBRARY_PATH $RESULT --prefix PATH : ${jdk}/bin/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Technically, this changes the version of Java depended on from 7 to
the default, which is currently 7 on darwin and 8 on all other
systems.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

