### PR TITLE
Shellinabox 2.19 -> 2.20

### DIFF
--- a/pkgs/servers/shellinabox/default.nix
+++ b/pkgs/servers/shellinabox/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pam, openssl, openssh, shadow, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "2.19";
+  version = "2.20";
   name = "shellinabox-${version}";
 
   src = fetchFromGitHub {
     owner = "shellinabox";
     repo = "shellinabox";
-    rev = "1a8010f2c94a62e7398c4fa130dfe9e099dc55cd";
-    sha256 = "16cr7gbnh6vzsxlhg9j9avqrxbhbkqhsbvh197b0ccdwbb04ysan";
+    rev = "v${version}";
+    sha256 = "1hmfayh21cks2lyj572944ll0mmgsxbnj981b3hq3nhdg8ywzjfr";
   };
 
   patches = [ ./shellinabox-minus.patch ];


### PR DESCRIPTION
should fix shellinabox vulnerabilities in https://github.com/NixOS/nixpkgs/issues/21457

###### Motivation for this change
New release.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

