### PR TITLE
thunderbird: 45.5.1 -> 45.6.0 [Critical security fix]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -13,7 +13,7 @@
   enableOfficialBranding ? false
 }:
 
-let version = "45.5.1"; in
+let version = "45.6.0"; in
 let verName = "${version}"; in
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${verName}/source/thunderbird-${verName}.source.tar.xz";
-    sha512 = "f6dc5f526e50facb9947627fcbc8db222cc20438fa62c552090dcabeabcc31dba2c66c20345090deaf5b58fd42b54938935eb1b3904528dce5949fd4cfc1ceb7";
+    sha512 = "1f4579ac37b8ab98c91fe2e3e6742ba1b005ca9346d23f467d19e6af45eb457cab749bf91ed2a79f2058bd66f54da661da3ea5d5786f8c4b472d8a2a6c34db4b";
   };
 
   buildInputs = # from firefox30Pkgs.xulrunner, without gstreamer and libvpx


### PR DESCRIPTION
###### Motivation for this change

- Critical security fix
- Other bug fix

https://www.mozilla.org/en-US/security/advisories/mfsa2016-96/
https://www.mozilla.org/en-US/thunderbird/45.6.0/releasenotes/

See also #21487

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not tested yet. Now building.