### PR TITLE
rustc, cargo, rustRegistry updates

### DIFF
--- a/pkgs/applications/networking/dyndns/cfdyndns/default.nix
+++ b/pkgs/applications/networking/dyndns/cfdyndns/default.nix
@@ -27,5 +27,6 @@ buildRustPackage rec {
     license = stdenv.lib.licenses.mit;
     maintainers = with maintainers; [ colemickens ];
     platforms = with platforms; linux;
+    broken = true;
   };
 }

--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -33,5 +33,6 @@ buildRustPackage rec {
     license = licenses.gpl3;
     platforms = stdenv.lib.platforms.x86_64;  # i686 builds fail due to lmdb
     maintainers = with maintainers; [ puffnfresh ];
+    broken = true;
   };
 }

--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -14,16 +14,16 @@ let
     then "x86_64-apple-darwin"
     else abort "missing boostrap url for platform ${stdenv.system}";
 
-  # fetch hashes by running `print-hashes.sh 1.12.1`
+  # fetch hashes by running `print-hashes.sh 1.13.0`
   bootstrapHash =
     if stdenv.system == "i686-linux"
-    then "ede9b9d14d1ddbc29975d1ead73fcf2758719b4b371363afe1c32eb8d6e96bb3"
+    then "239734113f6750d31085c7a08c260d492991cc1ef10817b6d44154515f3f9439"
     else if stdenv.system == "x86_64-linux"
-    then "9e546aec13e389429ba2d86c8f4e67eba5af146c979e4faa16ffb40ddaf9984c"
+    then "95f4c372b1b81ac1038161e87e932dd7ab875d25c167a861c3949b0f6a65516d"
     else if stdenv.system == "i686-darwin"
-    then "2648645c4fe1ecf36beb7de63501dd99e9547a7a6d5683acf2693b919a550b69"
+    then "f6e01cab3bf8d0a6fe9cc2447aa10ce894569daaa72d44063c229da918b96023"
     else if stdenv.system == "x86_64-darwin"
-    then "0ac5e58dba3d24bf09dcc90eaac02d2df053122b0def945ec4cfe36ac6d4d011"
+    then "f538ca5732b844cf7f00fc4aaaf200a49a845b58b4ec8aef38da0b00e2cf6efe"
     else throw "missing boostrap hash for platform ${stdenv.system}";
 
   needsPatchelf = stdenv.isLinux;
@@ -33,7 +33,7 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "1.12.1";
+  version = "1.13.0";
 in
 
 rec {

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
   LIBGIT2_SYS_USE_PKG_CONFIG=1;
 
   configurePhase = ''
-    ./configure --enable-optimize --prefix=$out --local-cargo=${rustPlatform.rust.cargo}/bin/cargo
+    ./configure --enable-optimize --prefix=$out
   '';
 
   buildPhase = "make";
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage rec {
     cargo test
   '';
 
-  # Disable check phase as there are failures (author_prefers_cargo test fails)
+  # Disable check phase as there are failures (4 tests fail)
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -7,12 +7,12 @@ in
 
 rec {
   rustc = callPackage ./rustc.nix {
-    shortVersion = "1.13";
+    shortVersion = "1.14";
     isRelease = true;
     forceBundledLLVM = false;
     configureFlags = [ "--release-channel=stable" ];
-    srcRev = "2c6933acc05c61e041be764cb1331f6281993f3f";
-    srcSha = "1w0alyyc29cy2lczrqvg1kfycjxy0xg8fpzdac80m88fxpv23glp";
+    srcRev = "e8a0123241f0d397d39cd18fcc4e5e7edde22730";
+    srcSha = "1sla3gnx9dqvivnyhvwz299mc3jmdy805q2y5xpmpi1vhfk0bafx";
 
     patches = [
       ./patches/disable-lockfile-check-stable.patch
@@ -25,10 +25,10 @@ rec {
   };
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.14.0";
-    srcRev = "eca9e159b6b0d484788ac757cf23052eba75af55";
-    srcSha = "1zm5rzw1mvixnkzr4775pcxx6k235qqxbysyp179cbxsw3dm045s";
-    depsSha256 = "0gpn0cpwgpzwhc359qn6qplx371ag9pqbwayhqrsydk1zm5bm3zr";
+    version = "0.15.0";
+    srcRev = "298a0127f703d4c2500bb06d309488b92ef84ae1";
+    srcSha = "0v74r18vszapw2rfk7w72czkp9gbq4s1sggphm5vx0kyh058dxc5";
+    depsSha256 = "0ksiywli8r4lkprfknm0yz1w27060psi3db6wblqmi8sckzdm44h";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo

--- a/pkgs/development/compilers/rust/patches/disable-lockfile-check-stable.patch
+++ b/pkgs/development/compilers/rust/patches/disable-lockfile-check-stable.patch
@@ -11,12 +11,13 @@ diff --git a/src/tools/tidy/src/main.rs b/src/tools/tidy/src/main.rs
 index 2839bbd..50142ff 100644
 --- a/src/tools/tidy/src/main.rs
 +++ b/src/tools/tidy/src/main.rs
-@@ -47,7 +47,7 @@ fn main() {
+@@ -48,7 +48,7 @@ fn main() {
      errors::check(&path, &mut bad);
      cargo::check(&path, &mut bad);
      features::check(&path, &mut bad);
 -    cargo_lock::check(&path, &mut bad);
 +    //cargo_lock::check(&path, &mut bad);
+     pal::check(&path, &mut bad);
  
      if bad {
          panic!("some tidy checks failed");

--- a/pkgs/top-level/rust-packages.nix
+++ b/pkgs/top-level/rust-packages.nix
@@ -7,9 +7,9 @@
 { runCommand, fetchFromGitHub, git }:
 
 let
-  version = "2016-12-16";
-  rev = "1da5a7d0cd31d72324481760067bde5cf2e07be5";
-  sha256 = "0kbh3aq738sqns8w6yfia17fwrk98g6m763wqsqwhnrg2ndqrp8d";
+  version = "2016-12-28";
+  rev = "3399254d4a021d07736944b339a8794eddcda517";
+  sha256 = "1vbixbgzv21anqayz8ya0x1qlzndb7fpdf9dyh4yyscl1kaibvg9";
 
   src = fetchFromGitHub {
       inherit rev;


### PR DESCRIPTION
###### Motivation for this change
Updating compiler to newest version. Couple packages are broken and I didn't find newer released versions so I marked them as broken. Pinging maintainers @colemickens (cfdyndns) and @puffnfresh (pijul).

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

