### PR TITLE
googleAuthenticator: 1.0 -> 1.03

### DIFF
--- a/pkgs/os-specific/linux/google-authenticator/default.nix
+++ b/pkgs/os-specific/linux/google-authenticator/default.nix
@@ -1,27 +1,28 @@
-{ stdenv, lib, fetchurl, pam, qrencode }:
+{ stdenv, lib, fetchurl, autoreconfHook, pam, qrencode }:
 
 stdenv.mkDerivation rec {
-  name = "google-authenticator-1.0";
+  name = "google-authenticator-libpam-${version}";
+  version = "1.03";
 
   src = fetchurl {
-    url = "https://google-authenticator.googlecode.com/files/libpam-${name}-source.tar.bz2";
-    sha1 = "017b7d89989f1624e360abe02d6b27a6298d285d";
+    url = "https://github.com/google/google-authenticator-libpam/archive/${version}.tar.gz";
+    sha256 = "0wb95z5v1w4sk0p7y9pbn4v95w9hrbf80vw9k2z2sgs0156ljkb7";
   };
 
-  buildInputs = [ pam ];
+  buildInputs = [ autoreconfHook pam ];
 
   preConfigure = ''
-    sed -i 's|libqrencode.so.3|${qrencode}/lib/libqrencode.so.3|' google-authenticator.c
+    sed -i "s|libqrencode.so.3|${qrencode}/lib/libqrencode.so.3|" src/google-authenticator.c
   '';
 
   installPhase = ''
     mkdir -p $out/bin $out/lib/security
-    cp pam_google_authenticator.so $out/lib/security
+    cp ./.libs/pam_google_authenticator.so $out/lib/security
     cp google-authenticator $out/bin
   '';
 
   meta = with lib; {
-    homepage = https://code.google.com/p/google-authenticator/;
+    homepage = https://github.com/google/google-authenticator-libpam;
     description = "Two-step verification, with pam module";
     license = licenses.asl20;
     maintainers = with maintainers; [ aneeshusa ];


### PR DESCRIPTION
###### Motivation for this change

A new release (version 1.03) of google-authenticator-libpam has been cut; this is a follow up from #19603.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).