### PR TITLE
opendungeons: 0.6.0 -> 0.7.1

### DIFF
--- a/pkgs/games/opendungeons/default.nix
+++ b/pkgs/games/opendungeons/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchurl, ogre, cegui, boost, sfml, openal, cmake, ois }:
+{ stdenv, fetchFromGitHub, ogre, cegui, boost, sfml, openal, cmake, ois, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "opendungeons-${version}";
-  version = "0.6.0";
+  version = "0.7.1";
 
-  src = fetchurl {
-    url = "ftp://download.tuxfamily.org/opendungeons/${version}/${name}.tar.xz";
-    sha256 = "1g0sjh732794h26cbkr0p96i3c0avm0mx9ip5zbvb2y3sbpjcbib";
+  src = fetchFromGitHub {
+    owner = "OpenDungeons";
+    repo = "OpenDungeons";
+    rev = version;
+    sha256 = "0nipb2h0gn628yxlahjgnfhmpfqa19mjdbj3aqabimdfqds9pryh";
   };
 
   patches = [ ./cmakepaths.patch ];
 
-  buildInputs = [ cmake ogre cegui boost sfml openal ois ];
+  buildInputs = [ cmake ogre cegui boost sfml openal ois pkgconfig ];
 
   meta = with stdenv.lib; {
     description = "An open source, real time strategy game sharing game elements with the Dungeon Keeper series and Evil Genius.";


### PR DESCRIPTION
###### Motivation for this change

The old download link was giving corrupted file errors.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

