### PR TITLE
libmd: init at 0.0.0

### DIFF
--- a/pkgs/development/libraries/libmd/default.nix
+++ b/pkgs/development/libraries/libmd/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "libmd";
+  version = "0.0.0";
+
+  src = fetchurl {
+    url = "https://archive.hadrons.org/software/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "121s73pgbqsnmy6xblbrkj9y44c5zzzpf2hcmh6zvcvg4dk26gzx";
+  };
+
+  buildInputs = [ autoreconfHook ];
+
+  # Writing the version to a .dist-version file is required for the get-version
+  # shell script because fetchgit removes the .git directory.
+  prePatch = ''
+    echo '${version}' > .dist-version;
+  '';
+
+  autoreconfPhase = "./autogen";
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.hadrons.org/software/${pname}/";
+    description = "Message Digest functions from BSD systems";
+    license = with licenses; [ bsd3 bsd2 isc beerware publicDomain ];
+    maintainers = with maintainers; [ primeos ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8199,6 +8199,8 @@ in
 
   libmcs = callPackage ../development/libraries/libmcs { };
 
+  libmd = callPackage ../development/libraries/libmd { };
+
   libmemcached = callPackage ../development/libraries/libmemcached { };
 
   libmicrohttpd = callPackage ../development/libraries/libmicrohttpd { };


### PR DESCRIPTION
###### Motivation for this change

I'll update the `signing-party` package from version 2.2 to 2.5 which requires this library as a build dependency.

The licenses are a bit messy... I'm not entirely sure if I added them correctly, please have a close look - thx :) - All licenses are specified in [COPYING](https://git.hadrons.org/cgit/libmd.git/tree/COPYING?id=0.0.0).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux (Gentoo+Nix)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

