### PR TITLE
eval-config.nix: Clarify (`configuration`) comment

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -1,4 +1,4 @@
-# From an end-user configuration file (`configuration'), build a NixOS
+# From an end-user configuration file (`configuration.nix'), build a NixOS
 # configuration object (`config') from which we can retrieve option
 # values.
 


### PR DESCRIPTION
`configuration` seems to be a reference to an argument that was removed seven years ago in commit 2892aed7.
