### PR TITLE
(r16.09 backport of) opencv 3.1.0: add patch fixing python use of FlannBasedMatcher.add

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig, unzip
+{ lib, stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig, unzip, fetchpatch
 , zlib
 , enableIpp ? false
 , enableContrib ? false
@@ -40,6 +40,11 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1l0w12czavgs0wzw1c594g358ilvfg2fn32cn8z7pv84zxj4g429";
   };
+
+  patches = lib.optional enablePython (fetchpatch { # Patch to fix FlannBasedMatcher under python
+      url = "https://github.com/opencv/opencv/commit/05cfe28612fd8dc8fb0ccb876df945c7b435dd26.patch";
+      sha256 = "0niza5lybr1ljzdkyiapr16laa468168qinpy5qn00yimnaygpm6";
+    });
 
   postPatch =
     let ippicvVersion = "20151201";


### PR DESCRIPTION
This is essentially a backport/cherrypick of #21086/bcb1cf0db40541f63f0e478b9b2dbc60ec8a43b7, while master will presumably be moving to 3.2.0 it would be good to have this fix in stable.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

