### PR TITLE
kirigami: add pre-release v2

### DIFF
--- a/pkgs/development/libraries/kirigami/v2.nix
+++ b/pkgs/development/libraries/kirigami/v2.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, cmake, ecm, pkgconfig, plasma-framework, qtbase, qtquickcontrols2 }:
+
+stdenv.mkDerivation rec {
+  pname = "kirigami";
+  version = "1.90.0";
+  name = "${pname}2-${version}";
+
+  src = fetchurl {
+    url = "mirror://kde/unstable/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "a5ca094a60d1cc48116cbed07bbe68be016773d2488a91e278859c90f59e64a8";
+  };
+
+  buildInputs = [ qtbase qtquickcontrols2 plasma-framework ];
+
+  nativeBuildInputs = [ cmake pkgconfig ecm ];
+
+  meta = with stdenv.lib; {
+    license = licenses.lgpl2;
+    homepage = http://www.kde.org;
+    maintainers = with maintainers; [ ttuegel peterhoeg ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/qt-5/5.7/default.nix
+++ b/pkgs/development/libraries/qt-5/5.7/default.nix
@@ -82,6 +82,7 @@ let
         inherit (pkgs.gst_all_1) gstreamer gst-plugins-base;
       };
       qtquickcontrols = callPackage ./qtquickcontrols.nix {};
+      qtquickcontrols2 = callPackage ./qtquickcontrols2.nix {};
       qtscript = callPackage ./qtscript {};
       qtsensors = callPackage ./qtsensors.nix {};
       qtserialport = callPackage ./qtserialport {};

--- a/pkgs/development/libraries/qt-5/5.7/qtquickcontrols2.nix
+++ b/pkgs/development/libraries/qt-5/5.7/qtquickcontrols2.nix
@@ -1,0 +1,6 @@
+{ qtSubmodule, qtdeclarative }:
+
+qtSubmodule {
+  name = "qtquickcontrols2";
+  qtInputs = [ qtdeclarative ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9082,7 +9082,14 @@ in
 
     grantlee = callPackage ../development/libraries/grantlee/5.x.nix { };
 
-    kirigami = callPackage ../development/libraries/kirigami { };
+    kirigami_1 = callPackage ../development/libraries/kirigami { };
+
+    kirigami_2 = callPackage ../development/libraries/kirigami/v2.nix {
+      # kirigami v2 requires qt 5.7 and above
+      inherit (qt57) qtbase qtquickcontrols2;
+    };
+
+    kirigami = kirigami_1;
 
     libcommuni = callPackage ../development/libraries/libcommuni { };
 


### PR DESCRIPTION
###### Motivation for this change

kirigami: add version 2 pre-release to get ready for applications needing kirigami 2

As both version 1 and 2 will co-exist for some time, we keep them as kirigami_1 and kirigami_2 with 1 as the default.

@ttuegel, couple of questions:

1. do you want this split into 2 different PRs as we are both adding qtquickcontrols2 and kirigami2? They are both minor changes...
2. kirigami2 requires qt 5.7 - how do we express this dependency?


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
