### PR TITLE
ppl-address-book: init at 2.4.0

### DIFF
--- a/pkgs/applications/office/ppl-address-book/Gemfile
+++ b/pkgs/applications/office/ppl-address-book/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'ppl'

--- a/pkgs/applications/office/ppl-address-book/Gemfile.lock
+++ b/pkgs/applications/office/ppl-address-book/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colored (1.2)
+    greencard (0.0.5)
+    i18n (0.7.0)
+    inifile (2.0.2)
+    mail (2.5.3)
+      i18n (>= 0.4.0)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mime-types (1.25.1)
+    morphine (0.1.1)
+    polyglot (0.3.5)
+    ppl (2.4.0)
+      colored (= 1.2)
+      greencard (= 0.0.5)
+      inifile (= 2.0.2)
+      mail (= 2.5.3)
+      morphine (= 0.1.1)
+      rugged (= 0.17.0.b6)
+    rugged (0.17.0.b6)
+    treetop (1.4.15)
+      polyglot
+      polyglot (>= 0.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ppl
+
+BUNDLED WITH
+   1.12.5

--- a/pkgs/applications/office/ppl-address-book/default.nix
+++ b/pkgs/applications/office/ppl-address-book/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, bundlerEnv, ruby, makeWrapper, which }:
+
+let
+  pname = "ppl-address-book";
+
+  version = (import ./gemset.nix).ppl.version;
+
+  env = bundlerEnv rec {
+    name = "${pname}-env-${version}";
+    inherit ruby;
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+
+    gemConfig.rugged = attrs: { buildInputs = [ which ]; };
+  };
+
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  phases = [ "installPhase" ];
+
+  buildInputs = [ env makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${env}/bin/ppl $out/bin/ppl
+  '';
+
+  meta = with lib; {
+    description = "Address book software for command-line users";
+    homepage    = http://ppladdressbook.org/;
+    license     = with licenses; mit;
+    maintainers = with maintainers; [ chris-martin ];
+    platforms   = platforms.unix;
+  };
+
+}

--- a/pkgs/applications/office/ppl-address-book/gemset.nix
+++ b/pkgs/applications/office/ppl-address-book/gemset.nix
@@ -1,0 +1,90 @@
+{
+  colored = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0b0x5jmsyi0z69bm6sij1k89z7h0laag3cb4mdn7zkl9qmxb90lx";
+      type = "gem";
+    };
+    version = "1.2";
+  };
+  greencard = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11pxrl1w8c7m7rmnnmdaplrv53qgylyvkv8bzsfyjna7k16hynvq";
+      type = "gem";
+    };
+    version = "0.0.5";
+  };
+  i18n = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1i5z1ykl8zhszsxcs8mzl8d0dxgs3ylz8qlzrw74jb0gplkx6758";
+      type = "gem";
+    };
+    version = "0.7.0";
+  };
+  inifile = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "03rpacxnrnisjhd2zhc7629ica958bkdbakicl5kipw1wbprck25";
+      type = "gem";
+    };
+    version = "2.0.2";
+  };
+  mail = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1afr3acz7vsvr4gp6wnrkw1iwbjhf14mh8g8mlm40r86wcwzr39k";
+      type = "gem";
+    };
+    version = "2.5.3";
+  };
+  mime-types = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mhzsanmnzdshaba7gmsjwnv168r1yj8y0flzw88frw1cickrvw8";
+      type = "gem";
+    };
+    version = "1.25.1";
+  };
+  morphine = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05aw93cijd1gq39ikw2dw3i2c79bjq05kvxrs81mqxqdlini5wwa";
+      type = "gem";
+    };
+    version = "0.1.1";
+  };
+  polyglot = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1bqnxwyip623d8pr29rg6m8r0hdg08fpr2yb74f46rn1wgsnxmjr";
+      type = "gem";
+    };
+    version = "0.3.5";
+  };
+  ppl = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vpp4s12ggbk5kpl9z1i7vi9vvghgxrc8my35yk8knckg5waxg47";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  rugged = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "025rj3rkj5yxf4pjj1s8x4yzshlyni3hgrjwhggg54nvw6b688qi";
+      type = "gem";
+    };
+    version = "0.17.0.b6";
+  };
+  treetop = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zqj5y0mvfvyz11nhsb4d5ch0i0rfcyj64qx19mw4qhg3hh8z9pz";
+      type = "gem";
+    };
+    version = "1.4.15";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14441,6 +14441,8 @@ in
 
   posterazor = callPackage ../applications/misc/posterazor { };
 
+  ppl-address-book = callPackage ../applications/office/ppl-address-book { };
+
   pqiv = callPackage ../applications/graphics/pqiv { };
 
   qiv = callPackage ../applications/graphics/qiv { };


### PR DESCRIPTION
###### Motivation for this change

Adds the "ppl" application.

We already have a package called "ppl", so I called it "ppl-address-book".

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

