### PR TITLE
gup: 0.5.5 -> 0.6.0 and extract src into JSON

### DIFF
--- a/pkgs/development/tools/build-managers/gup/build.nix.gup
+++ b/pkgs/development/tools/build-managers/gup/build.nix.gup
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+if [ -n "${GUP_TARGET:-}" ]; then
+	gup --always
+fi
+curl -LSs -o "$1" https://raw.githubusercontent.com/timbertson/gup/master/nix/gup-python.nix

--- a/pkgs/development/tools/build-managers/gup/default.nix
+++ b/pkgs/development/tools/build-managers/gup/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, fetchFromGitHub, lib, python, which }:
-let
-  version = "0.5.5";
-  src = fetchFromGitHub {
-    sha256 = "12yv0j333z6jkaaal8my3jx3k4ml9hq8ldis5zfvr8179d4xah7q";
-    rev = "version-${version}";
-    repo = "gup";
-    owner = "timbertson";
-  };
-in
+{ stdenv, fetchFromGitHub, lib, pythonPackages, nix-update-source, curl }:
 import ./build.nix
-  { inherit stdenv lib python which; }
-  { inherit src version;
+  { inherit stdenv lib pythonPackages; }
+  { inherit (nix-update-source.fetch ./src.json) src version;
     meta = {
-      inherit (src.meta) homepage;
+      homepage = https://github.com/timbertson/gup/;
       description = "A better make, inspired by djb's redo";
       license = stdenv.lib.licenses.lgpl2Plus;
       maintainers = [ stdenv.lib.maintainers.timbertson ];
       platforms = stdenv.lib.platforms.all;
+    };
+    passthru = {
+      updateScript = ''
+        set -e
+        echo
+        cd ${toString ./.}
+        ${nix-update-source}/bin/nix-update-source --prompt version src.json
+        ./build.nix.gup build.nix
+      '';
     };
   }

--- a/pkgs/development/tools/build-managers/gup/src.json
+++ b/pkgs/development/tools/build-managers/gup/src.json
@@ -1,0 +1,17 @@
+{
+  "fetch": {
+    "args": {
+      "owner": "timbertson",
+      "repo": "gup",
+      "rev": "version-0.6.0",
+      "sha256": "053xnx39jh9kn9l572z4k0q7bbxjpisf1fm9aq27ybj2ha1rh6wr"
+    },
+    "fn": "fetchFromGitHub",
+    "rev": "version-0.6.0",
+    "version": "0.6.0"
+  },
+  "owner": "timbertson",
+  "repo": "gup",
+  "rev": "version-{version}",
+  "type": "fetchFromGitHub"
+}

--- a/pkgs/tools/package-management/nix-update-source/default.nix
+++ b/pkgs/tools/package-management/nix-update-source/default.nix
@@ -1,12 +1,12 @@
 { lib, pkgs, fetchFromGitHub, python3Packages, nix-prefetch-scripts }:
 python3Packages.buildPythonApplication rec {
-  version = "0.2.1";
+  version = "0.2.2";
   name = "nix-update-source-${version}";
   src = fetchFromGitHub {
     owner = "timbertson";
     repo = "nix-update-source";
     rev = "version-${version}";
-    sha256 = "1w3aj0kjp8zhxkzqxnm5srrsqsvrmxhn4sqkr4kjffh61jg8jq8a";
+    sha256 = "0liigkr37ib2xy269bcp53ivpir4mpg6lzwnfrsqc4kbkz3l16gg";
   };
   propagatedBuildInputs = [ nix-prefetch-scripts ];
   passthru = {
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
         fetchFn = builtins.getAttr json.fetch.fn fetchers;
         src = fetchFn json.fetch.args;
       in
-      json // { inherit src; };
+      json // json.fetch // { inherit src; };
   };
   meta = {
     description = "Utility to autimate updating of nix derivation sources";


### PR DESCRIPTION
###### Motivation for this change

 - update to latest version
 - extract `fetchFromGitHub` attributes into separate JSON file for scripted updates

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
