### PR TITLE
nim: wrap binary so it can find gcc

### DIFF
--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -1,26 +1,32 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, lib, fetchurl, makeWrapper, gcc }:
 
 stdenv.mkDerivation rec {
-  name = "nim-0.15.2";
+  name = "nim-${version}";
+  version = "0.15.2";
 
   src = fetchurl {
     url = "http://nim-lang.org/download/${name}.tar.xz";
     sha256 = "12pyzjx7x4hclzrf3zf6r1qjlp60bzsaqrz0rax2rak2c8qz4pch";
   };
 
+  buildInputs  = [ makeWrapper ];
+
   buildPhase   = "sh build.sh";
+
   installPhase =
     ''
       install -Dt "$out/bin" bin/nim
       substituteInPlace install.sh --replace '$1/nim' "$out"
       sh install.sh $out
+      wrapProgram $out/bin/nim \
+        --suffix PATH : ${lib.makeBinPath [ gcc ]}
     '';
 
   meta = with stdenv.lib;
     { description = "Statically typed, imperative programming language";
       homepage = http://nim-lang.org/;
       license = licenses.mit;
-      maintainers = with maintainers; [ ehmry ];
+      maintainers = with maintainers; [ ehmry peterhoeg ];
       platforms = platforms.linux ++ platforms.darwin; # arbitrary
     };
 }


### PR DESCRIPTION
###### Motivation for this change

nim currently requires gcc on the global path.

This PR wraps the binary properly so it works without gcc on the global path.

@ehmry 

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
