### PR TITLE
remarshal: 0.3.0 -> 0.6.0

### DIFF
--- a/pkgs/development/tools/remarshal/default.nix
+++ b/pkgs/development/tools/remarshal/default.nix
@@ -1,20 +1,23 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ stdenv, pythonPackages, fetchFromGitHub }:
 
-buildGoPackage rec {
-  name = "remarshal-${rev}";
-  rev = "0.3.0";
-  goPackagePath = "github.com/dbohdan/remarshal";
+pythonPackages.buildPythonApplication rec {
+  name = "remarshal-${version}";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
-    rev = "v${rev}";
     owner  = "dbohdan";
     repo   = "remarshal";
-    sha256 = "0lhsqca3lq3xvdwsmrngv4p6b7k2lkbfnxnk5qj6jdd5y7f4b496";
+    rev    = "v${version}";
+    sha256 = "0jslawpzghv3chamrfddnyn5p5068kjxy8d38fxvi5h06qgfb4wp";
   };
 
-  goDeps = ./deps.nix;
+  propagatedBuildInputs = with pythonPackages; [
+    dateutil
+    pytoml
+    pyyaml
+  ];
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Convert between TOML, YAML and JSON";
     license = licenses.mit;
     homepage = https://github.com/dbohdan/remarshal;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -31653,6 +31653,28 @@ EOF
     };
   };
 
+  pytoml = buildPythonPackage rec {
+    name = "pytoml-${version}";
+    version = "0.1.11";
+
+    checkPhase = "${python.interpreter} test/test.py";
+
+    # fetchgit used to ensure test submodule is available
+    src = pkgs.fetchgit {
+      url = "${meta.homepage}.git";
+      rev = "refs/tags/v${version}";
+      sha256 = "1jiw04zk9ccynr8kb1vqh9r1p2kh0al7g7b1f94911iazg7dgs9j";
+    };
+
+    meta = {
+      description = "A TOML parser/writer for Python";
+      homepage    = https://github.com/avakar/pytoml;
+      license     = licenses.mit;
+      maintainers = with maintainers; [ peterhoeg ];
+    };
+
+  };
+
   ROPGadget = buildPythonPackage rec {
     name = "ROPGadget-5.4";
     src = pkgs.fetchurl {


### PR DESCRIPTION
###### Motivation for this change

remarshal: 0.3.0 -> 0.6.0

upstream rewrote the application in python.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
