### PR TITLE
unbound 1.5.10 -> 1.6.0

### DIFF
--- a/pkgs/development/libraries/libpaper/default.nix
+++ b/pkgs/development/libraries/libpaper/default.nix
@@ -9,6 +9,25 @@ stdenv.mkDerivation rec {
     sha256 = "0zhcx67afb6b5r936w5jmaydj3ks8zh83n9rm5sv3m3k8q8jib1q";
   };
 
+  # The configure script of libpaper is buggy: it uses AC_SUBST on a headerfile
+  # to compile sysconfdir into the library. Autoconf however defines sysconfdir
+  # as "${prefix}/etc", which is not expanded by AC_SUBST so libpaper will look
+  # for config files in (literally, without expansion) '${prefix}/etc'. Manually
+  # setting sysconfdir fixes this issue.
+  preConfigure = ''
+    configureFlagsArray+=(
+      "--sysconfdir=$out/etc"
+    )
+  '';
+
+  # Set the default paper to letter (this is what libpaper uses as default as well,
+  # if you call getdefaultpapername()).
+  # The user can still override this with the PAPERCONF environment variable.
+  postInstall = ''
+    mkdir -p $out/etc
+    echo letter > $out/etc/papersize
+  '';
+
   meta = {
     description = "Library for handling paper characteristics";
     homepage = "http://packages.debian.org/unstable/source/libpaper";

--- a/pkgs/tools/misc/man-db/default.nix
+++ b/pkgs/tools/misc/man-db/default.nix
@@ -29,8 +29,11 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    for i in "$out/bin/"*; do
-      wrapProgram "$i" --prefix PATH : "${groff}/bin"
+    # apropos/whatis uses program name to decide whether to act like apropos or whatis
+    # (multi-call binary). `apropos` is actually just a symlink to whatis. So we need to
+    # make sure that we don't wrap symlinks (since that changes argv[0] to the -wrapped name)
+    find "$out/bin" -type f | while read file; do
+      wrapProgram "$file" --prefix PATH : "${groff}/bin"
     done
   '';
 

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "unbound-${version}";
-  version = "1.5.10";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "http://unbound.net/downloads/${name}.tar.gz";
-    sha256 = "11lli8jgq4n917gcx6nw728g1hqc2lszwlxa5mdb78m2ri7qp6x3";
+    sha256 = "1dzsxyp34ianp08wk4vf13qzl5ss5rr9v1p8zr1aggfywrsbhzbb";
   };
 
   outputs = [ "out" "lib" "man" ]; # "dev" would only split ~20 kB

--- a/pkgs/tools/networking/unbound/python.nix
+++ b/pkgs/tools/networking/unbound/python.nix
@@ -5,11 +5,11 @@ let
 in stdenv.mkDerivation rec {
   pname = "pyunbound";
   name = "${pname}-${version}";
-  version = "1.5.9";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "http://unbound.net/downloads/unbound-${version}.tar.gz";
-    sha256 = "01328cfac99ab5b8c47115151896a244979e442e284eb962c0ea84b7782b6990";
+    sha256 = "1dzsxyp34ianp08wk4vf13qzl5ss5rr9v1p8zr1aggfywrsbhzbb";
   };
 
   buildInputs = [ openssl expat libevent swig python ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -24571,6 +24571,22 @@ in {
     };
   });
 
+  sphinxcontrib_newsfeed = buildPythonPackage (rec {
+    name = "sphinxcontrib-newsfeed-${version}";
+    version = "0.1.4";
+    src = pkgs.fetchurl {
+      url = "mirror://pypi/s/sphinxcontrib-newsfeed/${name}.tar.gz";
+      sha256 = "1d7gam3mn8v4in4p16yn3v10vps7nnaz6ilw99j4klij39dqd37p";
+    };
+
+    propagatedBuildInputs = with self; [sphinx];
+
+    meta = {
+      description = "Extension for adding a simple Blog, News or Announcements section to a Sphinx website";
+      homepage = http://bitbucket.org/prometheus/sphinxcontrib-newsfeed;
+      license = licenses.bsd2;
+    };
+  });
 
   sphinxcontrib_plantuml = buildPythonPackage (rec {
     name = "sphinxcontrib-plantuml-0.7";


### PR DESCRIPTION
###### Motivation for this change
New release

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

