### PR TITLE
makerpm: init at 1.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -201,6 +201,7 @@
   ianwookim = "Ian-Woo Kim <ianwookim@gmail.com>";
   igsha = "Igor Sharonov <igor.sharonov@gmail.com>";
   ikervagyok = "Balázs Lengyel <ikervagyok@gmail.com>";
+  ivan-tkatchev = "Ivan Tkatchev <tkatchev@gmail.com>";
   j-keck = "Jürgen Keck <jhyphenkeck@gmail.com>";
   jagajaga = "Arseniy Seroka <ars.seroka@gmail.com>";
   javaguirre = "Javier Aguirre <contacto@javaguirre.net>";

--- a/pkgs/development/tools/makerpm/default.nix
+++ b/pkgs/development/tools/makerpm/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, zlib, libarchive, openssl }: 
+
+stdenv.mkDerivation rec { 
+  version = "1.0";
+  name = "makerpm-${version}";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp makerpm $out/bin
+  '';
+
+  buildInputs = [ zlib libarchive openssl ];
+
+  src = fetchFromGitHub {
+    owner = "ivan-tkatchev";
+    repo = "makerpm";
+    rev = "${version}";
+    sha256 = "089dkbh5705ppyi920rd0ksjc0143xmvnhm8qrx93rsgwc1ggi1y";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ivan-tkatchev/makerpm/;
+    description = "A clean, simple RPM packager reimplemented completely from scratch";
+    license = licenses.free;
+    platforms = platforms.all;
+    maintainers = [ maintainers.ivan-tkatchev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2712,6 +2712,8 @@ in
 
   makemkv = callPackage ../applications/video/makemkv { };
 
+  makerpm = callPackage ../development/tools/makerpm { };
+
   # See https://github.com/NixOS/nixpkgs/issues/15849. I'm switching on isLinux because
   # it looks like gnulib is broken on non-linux, so it seems likely that this would cause
   # trouble on bsd and/or cygwin as well.


### PR DESCRIPTION
###### Motivation for this change

Nix is frequently used for maintaining developer environments, and making RPM files is something that developers frequently have to do.

makerpm is a tool for making RPM's that doesn't pull in the complete RPM package manager as a dependency.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

