### PR TITLE
miredo: init at 1.2.6

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -392,6 +392,7 @@
   ./services/networking/minidlna.nix
   ./services/networking/miniupnpd.nix
   ./services/networking/mosquitto.nix
+  ./services/networking/miredo.nix
   ./services/networking/mstpd.nix
   ./services/networking/murmur.nix
   ./services/networking/namecoind.nix

--- a/nixos/modules/services/networking/miredo.nix
+++ b/nixos/modules/services/networking/miredo.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   cfg = config.services.miredo;
+  pidFile = "/run/miredo.pid";
   miredoConf = pkgs.writeText "miredo.conf" ''
     InterfaceName ${cfg.interfaceName}
     ServerAddress ${cfg.serverAddress}
@@ -81,8 +82,8 @@ in
       serviceConfig = {
         Restart = "always";
         RestartSec = "5s";
-        ExecStartpre = "${cfg.package}/bin/miredo-checkconf -f ${miredoConf}";
-        ExecStart = "${cfg.package}/bin/miredo -c ${miredoConf} -f";
+        ExecStartPre = "${cfg.package}/bin/miredo-checkconf -f ${miredoConf}";
+        ExecStart = "${cfg.package}/bin/miredo -c ${miredoConf} -p ${pidFile} -f";
         ExecReload = "/bin/kill -HUP $MAINPID";
       };
     };

--- a/nixos/modules/services/networking/miredo.nix
+++ b/nixos/modules/services/networking/miredo.nix
@@ -4,7 +4,6 @@ with lib;
 
 let
   cfg = config.services.miredo;
-  pidFile = "/run/miredo.pid";
   miredoConf = pkgs.writeText "miredo.conf" ''
     InterfaceName ${cfg.interfaceName}
     ServerAddress ${cfg.serverAddress}
@@ -63,8 +62,8 @@ in
         default = null;
         type = types.nullOr types.str;
         description = ''
-          The hostname or primary IPv4 address of the Teredo server.
-          This setting is required if Miredo runs as a Teredo client.
+          Depending on the local firewall/NAT rules, you might need to force
+          Miredo to use a fixed UDP port and or IPv4 address.
         '';
       };
     };
@@ -80,11 +79,11 @@ in
       after = [ "network.target" ];
       description = "Teredo IPv6 Tunneling Daemon";
       serviceConfig = {
-        PIDFile = pidFile;
-        Type = "forking";
         Restart = "always";
         RestartSec = "5s";
-        ExecStart = "${cfg.package}/bin/miredo -c ${miredoConf} -p ${pidFile}";
+        ExecStartpre = "${cfg.package}/bin/miredo-checkconf -f ${miredoConf}";
+        ExecStart = "${cfg.package}/bin/miredo -c ${miredoConf} -f";
+        ExecReload = "/bin/kill -HUP $MAINPID";
       };
     };
 

--- a/nixos/modules/services/networking/miredo.nix
+++ b/nixos/modules/services/networking/miredo.nix
@@ -1,0 +1,93 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.miredo;
+  pidFile = "/run/miredo.pid";
+  miredoConf = pkgs.writeText "miredo.conf" ''
+    InterfaceName ${cfg.interfaceName}
+    ServerAddress ${cfg.serverAddress}
+    ${optionalString (cfg.bindAddress != null) "BindAddress ${cfg.bindAddress}"}
+    ${optionalString (cfg.bindPort != null) "BindPort ${cfg.bindPort}"}
+  '';
+in
+{
+
+  ###### interface
+
+  options = {
+
+    services.miredo = {
+
+      enable = mkEnableOption "Whether miredo should be run on startup.";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.miredo;
+        defaultText = "pkgs.miredo";
+        description = ''
+          The package to use for the miredo daemon's binary.
+        '';
+      };
+
+      serverAddress = mkOption {
+        default = "teredo.remlab.net";
+        type = types.str;
+        description = ''
+          The hostname or primary IPv4 address of the Teredo server.
+          This setting is required if Miredo runs as a Teredo client.
+          "teredo.remlab.net" is an experimental service for testing only.
+          Please use another server for production and/or large scale deployments.
+        '';
+      };
+
+      interfaceName = mkOption {
+        default = "teredo";
+        type = types.str;
+        description = ''
+          Name of the network tunneling interface.
+        '';
+      };
+
+      bindAddress = mkOption {
+        default = null;
+        type = types.nullOr types.str;
+        description = ''
+          Depending on the local firewall/NAT rules, you might need to force
+          Miredo to use a fixed UDP port and or IPv4 address.
+        '';
+      };
+
+      bindPort = mkOption {
+        default = null;
+        type = types.nullOr types.str;
+        description = ''
+          The hostname or primary IPv4 address of the Teredo server.
+          This setting is required if Miredo runs as a Teredo client.
+        '';
+      };
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.services.miredo = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      description = "Teredo IPv6 Tunneling Daemon";
+      serviceConfig = {
+        PIDFile = pidFile;
+        Type = "forking";
+        Restart = "always";
+        RestartSec = "5s";
+        ExecStart = "${cfg.package}/bin/miredo -c ${miredoConf} -p ${pidFile}";
+      };
+    };
+
+  };
+
+}

--- a/pkgs/tools/networking/miredo/default.nix
+++ b/pkgs/tools/networking/miredo/default.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    substituteInPlace misc/client-hook.bsd --replace '/sbin/route' '${nettools}/bin/route' --replace '/sbin/ifconfig' '${nettools}/bin/ifconfig'
+    substituteInPlace misc/client-hook.bsd \
+      --replace '/sbin/route' '${nettools}/bin/route' \
+      --replace '/sbin/ifconfig' '${nettools}/bin/ifconfig'
     substituteInPlace misc/client-hook.iproute --replace '/sbin/ip' '${iproute}/bin/ip'
   '';
 

--- a/pkgs/tools/networking/miredo/default.nix
+++ b/pkgs/tools/networking/miredo/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, nettools, iproute, judy }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.6";
+  name = "miredo-${version}";
+
+  buildInputs = [ judy ];
+
+  src = fetchurl {
+    url = "http://www.remlab.net/files/miredo/miredo-${version}.tar.xz";
+    sha256 = "0j9ilig570snbmj48230hf7ms8kvcwi2wblycqrmhh85lksd49ps";
+  };
+
+  postPatch = ''
+    substituteInPlace misc/client-hook.bsd --replace '/sbin/route' '${nettools}/bin/route' --replace '/sbin/ifconfig' '${nettools}/bin/ifconfig'
+    substituteInPlace misc/client-hook.iproute --replace '/sbin/ip' '${iproute}/bin/ip'
+  '';
+
+  configureFlags = [ "--with-Judy" ];
+
+  postInstall = ''
+    rm -rf $out/lib/systemd $out/var $out/etc/miredo/miredo.conf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Teredo IPv6 Tunneling Daemon";
+    homepage = http://www.remlab.net/miredo/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2801,6 +2801,8 @@ in
 
   minixml = callPackage ../development/libraries/minixml { };
 
+  miredo = callPackage ../tools/networking/miredo { };
+
   mjpegtoolsFull = callPackage ../tools/video/mjpegtools { };
 
   mjpegtools = self.mjpegtoolsFull.override {


### PR DESCRIPTION
###### Motivation for this change

Provide IPv6 where it is not available natively, including machines behind NAT.

I did not created the "miredo" user and group as the daemon consists of two processes: one requires root privileges and another runs under user "nobody".

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

