### PR TITLE
virt-top: init at 1.0.8

### DIFF
--- a/pkgs/applications/virtualization/virt-top/default.nix
+++ b/pkgs/applications/virtualization/virt-top/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, ocamlPackages }:
+{ stdenv, fetchurl, ocamlPackages }:
 
 stdenv.mkDerivation rec {
   name = "virt-top-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "04i1sf2d3ghilmzvr2vh74qcy009iifyc2ymj9kxnbkp97lrz13w";
   };
 
-  buildInputs = [ ocaml ] ++ (with ocamlPackages; [ findlib ocaml_extlib ocaml_libvirt ocaml_gettext curses csv xml-light ]);
+  buildInputs = with ocamlPackages; [ ocaml findlib ocaml_extlib ocaml_libvirt ocaml_gettext curses csv xml-light ];
 
   buildPhase = "make opt";
 

--- a/pkgs/applications/virtualization/virt-top/default.nix
+++ b/pkgs/applications/virtualization/virt-top/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, ocaml, ocamlPackages }:
+
+stdenv.mkDerivation rec {
+  name = "virt-top-${version}";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "https://people.redhat.com/~rjones/virt-top/files/virt-top-${version}.tar.gz";
+    sha256 = "04i1sf2d3ghilmzvr2vh74qcy009iifyc2ymj9kxnbkp97lrz13w";
+  };
+
+  buildInputs = [ ocaml ] ++ (with ocamlPackages; [ findlib ocaml_extlib ocaml_libvirt ocaml_gettext curses csv xml-light ]);
+
+  buildPhase = "make opt";
+
+  meta = with stdenv.lib; {
+    description = "A top-like utility for showing stats of virtualized domains";
+    homepage = https://people.redhat.com/~rjones/virt-top/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/ocaml-modules/curses/default.nix
+++ b/pkgs/development/ocaml-modules/curses/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, ocaml, findlib, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml-curses-${version}";
+  version = "1.0.3";
+
+  src = fetchurl {
+    url = "http://ocaml.phauna.org/distfiles/ocaml-curses-${version}.ogunden1.tar.gz";
+    sha256 = "0fxya4blx4zcp9hy8gxxm2z7aas7hfvwnjdlj9pmh0s5gijpwsll";
+  };
+
+  propagatedBuildInputs = [ ncurses ];
+
+  buildInputs = [ ocaml findlib ];
+
+  createFindlibDestdir = true;
+
+  postPatch = ''
+    substituteInPlace curses.ml --replace "pp gcc" "pp $CC"
+  '';
+
+  buildPhase = "make all opt";
+
+  meta = with stdenv.lib; {
+    description = "OCaml Bindings to curses/ncurses";
+    homepage = https://opam.ocaml.org/packages/curses/curses.1.0.3/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, ocaml, findlib, camlp4, ounit, gettext, fileutils, camomile }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml-gettext-${version}";
+  version = "0.3.5";
+
+  src = fetchurl {
+    url = "https://forge.ocamlcore.org/frs/download.php/1433/ocaml-gettext-${version}.tar.gz";
+    sha256 = "0s625h7y9xxqvzk4bnw45k4wvl4fn8gblv56bp47il0lgsx8956i";
+  };
+
+  propagatedBuildInputs = [ gettext fileutils camomile ];
+
+  buildInputs = [ ocaml findlib camlp4 ounit ];
+
+  configureFlags = [ "--disable-doc" ];
+
+  createFindlibDestdir = true;
+
+  meta = with stdenv.lib; {
+    description = "OCaml Bindings to gettext";
+    homepage = https://forge.ocamlcore.org/projects/ocaml-gettext;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
@@ -13,6 +13,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib camlp4 ounit ];
 
+  postPatch = stdenv.lib.optionalString (camlp4 != null) ''
+    substituteInPlace test/test.ml                  --replace "+camlp4" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib/camlp4"
+    substituteInPlace ocaml-gettext/OCamlGettext.ml --replace "+camlp4" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib/camlp4"
+    substituteInPlace ocaml-gettext/Makefile        --replace "+camlp4" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib/camlp4"
+    substituteInPlace ocaml-gettext/Makefile        --replace "unix.cma" ""
+    substituteInPlace libgettext-ocaml/Makefile     --replace "+camlp4" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib/camlp4"
+    substituteInPlace libgettext-ocaml/Makefile     --replace "\$(shell ocamlc -where)" "${camlp4}/lib/ocaml/${ocaml.version}/site-lib"
+  '';
+
   configureFlags = [ "--disable-doc" ];
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, libvirt, ocaml, findlib }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml-libvirt-${version}";
+  version = "0.6.1.4";
+
+  src = fetchurl {
+    url = "http://libvirt.org/sources/ocaml/ocaml-libvirt-${version}.tar.gz";
+    sha256 = "06q2y36ckb34n179bwczxkl82y3wrba65xb2acg8i04jpiyxadjd";
+  };
+
+  propagatedBuildInputs = [ libvirt ];
+
+  buildInputs = [ ocaml findlib ];
+
+  createFindlibDestdir = true;
+
+  buildPhase = if stdenv.cc.isClang then "make all opt CPPFLAGS=-Wno-error" else "make all opt";
+
+  installPhase = "make install-opt";
+
+  meta = with stdenv.lib; {
+    description = "OCaml bindings for libvirt";
+    homepage = https://libvirt.org/ocaml/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15218,6 +15218,8 @@ in
     spice_gtk = spice_gtk;
   };
 
+  virt-top = callPackage ../applications/virtualization/virt-top { };
+
   virtmanager = callPackage ../applications/virtualization/virt-manager {
     inherit (gnome2) gnome_python;
     vte = gnome3.vte;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -140,6 +140,8 @@ let
 
     csv = callPackage ../development/ocaml-modules/csv { };
 
+    curses = callPackage ../development/ocaml-modules/curses { };
+
     custom_printf = callPackage ../development/ocaml-modules/custom_printf { };
 
     ctypes = callPackage ../development/ocaml-modules/ctypes { };
@@ -297,9 +299,13 @@ let
 
     ocamlfuse = callPackage ../development/ocaml-modules/ocamlfuse { };
 
+    ocaml_gettext = callPackage ../development/ocaml-modules/ocaml-gettext { };
+
     ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };
 
     ocaml_http = callPackage ../development/ocaml-modules/http { };
+
+    ocaml_libvirt = callPackage ../development/ocaml-modules/ocaml-libvirt { };
 
     ocamlify = callPackage ../development/tools/ocaml/ocamlify { };
 


### PR DESCRIPTION
###### Motivation for this change

A top-like utility for showing stats of virtualized domains

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

