### PR TITLE
rename sound.enableMediaKeys to sound.mediaKeys.enable and add sound.mediaKeys.volumeStep

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -150,6 +150,9 @@ with lib;
     # tarsnap
     (mkRemovedOptionModule [ "services" "tarsnap" "cachedir" ] "Use services.tarsnap.archives.<name>.cachedir")
 
+    # alsa
+    (mkRenamedOptionModule [ "sound" "enableMediaKeys" ] [ "sound" "mediaKeys" "enable" ])
+
     # Options that are obsolete and have no replacement.
     (mkRemovedOptionModule [ "boot" "initrd" "luks" "enable" ] "")
     (mkRemovedOptionModule [ "programs" "bash" "enable" ] "")

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -33,16 +33,6 @@ in
         '';
       };
 
-      enableMediaKeys = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable volume and capture control with keyboard media keys.
-
-          Enabling this will turn on <option>services.actkbd</option>.
-        '';
-      };
-
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -52,6 +42,31 @@ in
         description = ''
           Set addition configuration for system-wide alsa.
         '';
+      };
+
+      mediaKeys = {
+
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to enable volume and capture control with keyboard media keys.
+
+            Enabling this will turn on <option>services.actkbd</option>.
+          '';
+        };
+
+        volumeStep = mkOption {
+          type = types.string;
+          default = "1";
+          example = "1%";
+          description = ''
+            The value by which to increment/decrement volume on media keys.
+
+            See amixer(1) for allowed values.
+          '';
+        };
+
       };
 
     };
@@ -90,17 +105,17 @@ in
         };
       };
 
-    services.actkbd = mkIf config.sound.enableMediaKeys {
+    services.actkbd = mkIf config.sound.mediaKeys.enable {
       enable = true;
       bindings = [
         # "Mute" media key
         { keys = [ 113 ]; events = [ "key" ];       command = "${alsaUtils}/bin/amixer -q set Master toggle"; }
 
         # "Lower Volume" media key
-        { keys = [ 114 ]; events = [ "key" "rep" ]; command = "${alsaUtils}/bin/amixer -q set Master 1- unmute"; }
+        { keys = [ 114 ]; events = [ "key" "rep" ]; command = "${alsaUtils}/bin/amixer -q set Master ${config.sound.mediaKeys.volumeStep}- unmute"; }
 
         # "Raise Volume" media key
-        { keys = [ 115 ]; events = [ "key" "rep" ]; command = "${alsaUtils}/bin/amixer -q set Master 1+ unmute"; }
+        { keys = [ 115 ]; events = [ "key" "rep" ]; command = "${alsaUtils}/bin/amixer -q set Master ${config.sound.mediaKeys.volumeStep}+ unmute"; }
 
         # "Mic Mute" media key
         { keys = [ 190 ]; events = [ "key" ];       command = "${alsaUtils}/bin/amixer -q set Capture toggle"; }

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -76,7 +76,7 @@ in
 
   ###### implementation
 
-  config = mkIf config.sound.mediaKeys.enable {
+  config = mkIf config.sound.enable {
 
     environment.systemPackages = [ alsaUtils ];
 

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -33,16 +33,6 @@ in
         '';
       };
 
-      enableMediaKeys = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable volume and capture control with keyboard media keys.
-
-          Enabling this will turn on <option>services.actkbd</option>.
-        '';
-      };
-
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -54,6 +44,31 @@ in
         '';
       };
 
+      mediaKeys = {
+
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to enable volume and capture control with keyboard media keys.
+
+            Enabling this will turn on <option>services.actkbd</option>.
+          '';
+        };
+
+        volumeStep = mkOption {
+          type = types.string;
+          default = "1";
+          example = "1%";
+          description = ''
+            The value by which to increment/decrement volume on media keys.
+
+            See amixer(1) for allowed values.
+          '';
+        };
+
+      };
+
     };
 
   };
@@ -61,7 +76,7 @@ in
 
   ###### implementation
 
-  config = mkIf config.sound.enable {
+  config = mkIf config.sound.mediaKeys.enable {
 
     environment.systemPackages = [ alsaUtils ];
 
@@ -90,17 +105,17 @@ in
         };
       };
 
-    services.actkbd = mkIf config.sound.enableMediaKeys {
+    services.actkbd = mkIf config.sound.mediaKeys.enable {
       enable = true;
       bindings = [
         # "Mute" media key
         { keys = [ 113 ]; events = [ "key" ];       command = "${alsaUtils}/bin/amixer -q set Master toggle"; }
 
         # "Lower Volume" media key
-        { keys = [ 114 ]; events = [ "key" "rep" ]; command = "${alsaUtils}/bin/amixer -q set Master 1- unmute"; }
+        { keys = [ 114 ]; events = [ "key" "rep" ]; command = "${alsaUtils}/bin/amixer -q set Master ${config.sound.mediaKeys.volumeStep}- unmute"; }
 
         # "Raise Volume" media key
-        { keys = [ 115 ]; events = [ "key" "rep" ]; command = "${alsaUtils}/bin/amixer -q set Master 1+ unmute"; }
+        { keys = [ 115 ]; events = [ "key" "rep" ]; command = "${alsaUtils}/bin/amixer -q set Master ${config.sound.mediaKeys.volumeStep}+ unmute"; }
 
         # "Mic Mute" media key
         { keys = [ 190 ]; events = [ "key" ];       command = "${alsaUtils}/bin/amixer -q set Capture toggle"; }


### PR DESCRIPTION
Slightly different than what I proposed in https://github.com/NixOS/nixpkgs/pull/20020#issuecomment-265461518 but backwards compatible.

###### Motivation for this change

#20020, #17068

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

