### PR TITLE
ocaml-curses: init at 1.0.3

### DIFF
--- a/pkgs/development/ocaml-modules/curses/default.nix
+++ b/pkgs/development/ocaml-modules/curses/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, ocaml, findlib, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml-curses-${version}";
+  version = "1.0.3";
+
+  src = fetchurl {
+    url = "http://ocaml.phauna.org/distfiles/ocaml-curses-${version}.ogunden1.tar.gz";
+    sha256 = "0fxya4blx4zcp9hy8gxxm2z7aas7hfvwnjdlj9pmh0s5gijpwsll";
+  };
+
+  propagatedBuildInputs = [ ncurses ];
+
+  buildInputs = [ ocaml findlib ];
+
+  createFindlibDestdir = true;
+
+  buildPhase = "make all opt";
+
+  meta = with stdenv.lib; {
+    description = "OCaml Bindings to curses/ncurses";
+    homepage = https://opam.ocaml.org/packages/curses/curses.1.0.3/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/development/ocaml-modules/curses/default.nix
+++ b/pkgs/development/ocaml-modules/curses/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
+  postPatch = ''
+    substituteInPlace curses.ml --replace "pp gcc" "pp $CC"
+  '';
+
   buildPhase = "make all opt";
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -140,6 +140,8 @@ let
 
     csv = callPackage ../development/ocaml-modules/csv { };
 
+    curses = callPackage ../development/ocaml-modules/curses { };
+
     custom_printf = callPackage ../development/ocaml-modules/custom_printf { };
 
     ctypes = callPackage ../development/ocaml-modules/ctypes { };


### PR DESCRIPTION
###### Motivation for this change

virt-top dependency

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

