### PR TITLE
ocaml-gettext: init at 0.3.5

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, ocaml, findlib, camlp4, ounit, gettext, fileutils, camomile }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml-gettext-${version}";
+  version = "0.3.5";
+
+  src = fetchurl {
+    url = "https://forge.ocamlcore.org/frs/download.php/1433/ocaml-gettext-${version}.tar.gz";
+    sha256 = "0s625h7y9xxqvzk4bnw45k4wvl4fn8gblv56bp47il0lgsx8956i";
+  };
+
+  propagatedBuildInputs = [ gettext fileutils camomile ];
+
+  buildInputs = [ ocaml findlib camlp4 ounit ];
+
+  configureFlags = [ "--disable-doc" ];
+
+  createFindlibDestdir = true;
+
+  meta = with stdenv.lib; {
+    description = "OCaml Bindings to gettext";
+    homepage = https://forge.ocamlcore.org/projects/ocaml-gettext;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -297,6 +297,8 @@ let
 
     ocamlfuse = callPackage ../development/ocaml-modules/ocamlfuse { };
 
+    ocaml_gettext = callPackage ../development/ocaml-modules/ocaml-gettext { };
+
     ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };
 
     ocaml_http = callPackage ../development/ocaml-modules/http { };


### PR DESCRIPTION
###### Motivation for this change

virt-top dependency

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

---

