### PR TITLE
ocaml-libvirt: init at 0.6.1.4

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, libvirt, ocaml, findlib }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml-libvirt-${version}";
+  version = "0.6.1.4";
+
+  src = fetchurl {
+    url = "http://libvirt.org/sources/ocaml/ocaml-libvirt-${version}.tar.gz";
+    sha256 = "06q2y36ckb34n179bwczxkl82y3wrba65xb2acg8i04jpiyxadjd";
+  };
+
+  propagatedBuildInputs = [ libvirt ];
+
+  buildInputs = [ ocaml findlib ];
+
+  createFindlibDestdir = true;
+
+  buildPhase = if stdenv.cc.isClang then "make all opt CPPFLAGS=-Wno-error" else "make all opt";
+
+  installPhase = "make install-opt";
+
+  meta = with stdenv.lib; {
+    description = "OCaml bindings for libvirt";
+    homepage = https://libvirt.org/ocaml/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.volth ];
+    platforms = ocaml.meta.platforms or [];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -301,6 +301,8 @@ let
 
     ocaml_http = callPackage ../development/ocaml-modules/http { };
 
+    ocaml_libvirt = callPackage ../development/ocaml-modules/ocaml-libvirt { };
+
     ocamlify = callPackage ../development/tools/ocaml/ocamlify { };
 
     ocaml_lwt = callPackage ../development/ocaml-modules/lwt { };


### PR DESCRIPTION
###### Motivation for this change

virt-top dependency

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

