### PR TITLE
Strongswan: enable rdrand and aes-ni only on X86

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -37,8 +37,9 @@ stdenv.mkDerivation rec {
       "--enable-eap-mschapv2" "--enable-xauth-eap" "--enable-ext-auth"
       "--enable-forecast" "--enable-connmark" "--enable-acert"
       "--enable-pkcs11" "--enable-eap-sim-pcsc" "--enable-dnscert" "--enable-unbound"
-      "--enable-aesni" "--enable-af-alg" "--enable-rdrand" ]
-    ++ stdenv.lib.optional (stdenv.system == "i686-linux") "--enable-padlock" 
+      "--enable-af-alg" ]
+    ++ stdenv.lib.optional stdenv.isx86_64 [ "--enable-aesni" "--enable-rdrand" ]
+    ++ stdenv.lib.optional (stdenv.system == "i686-linux") "--enable-padlock"
     ++ stdenv.lib.optionals enableTNC [
          "--disable-gmp" "--disable-aes" "--disable-md5" "--disable-sha1" "--disable-sha2" "--disable-fips-prf"
          "--enable-curl" "--enable-openssl"


### PR DESCRIPTION
###### Motivation for this change

Strongswan fails to compile on armv7l-linux with `--enable-aesni` and  `--enable-rdrand` enabled. Errors are thrown about impossible constraints in asm (`--enable-rdrand`) or about gcc getting unknown command line parameters about aes (`--enable-aesni`). The options only makes sense on X86_64 processors.

The rdrand plugin is designed for Ivy Bridge processors:

> High quality / high performance random source using the Intel rdrand instruction found on Ivy Bridge processors

The aes-ni plugin also only exists on X86 processors (which have the AES instruction set)

Tested with a local override. The change triggers a (successful) rebuild on my X86_64 system (purely because of the changed order of options). On armv7-linux this change fixes build errors.

See for a similar issue: 
https://wiki.strongswan.org/issues/337