### PR TITLE
vultr: init at 1.12.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -507,6 +507,7 @@
   yurrriq = "Eric Bailey <eric@ericb.me>";
   z77z = "Marco Maggesi <maggesi@math.unifi.it>";
   zagy = "Christian Zagrodnick <cz@flyingcircus.io>";
+  zauberpony = "Elmar Athmer <elmar@athmer.org>";
   zef = "Zef Hemel <zef@zef.me>";
   zimbatm = "zimbatm <zimbatm@zimbatm.com>";
   zohl = "Al Zohali <zohl@fmap.me>";

--- a/pkgs/development/tools/vultr/default.nix
+++ b/pkgs/development/tools/vultr/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "vultr-${version}";
+  version = "1.12.0";
+  goPackagePath = "github.com/JamesClonk/vultr";
+
+  src = fetchFromGitHub {
+    owner = "JamesClonk";
+    repo = "vultr";
+    rev = "${version}";
+    sha256 = "0fzwzp0vhf3cgl9ij5zpdyn29w9rwwxghr50jjfbagpkfpy4g686";
+  };
+
+  meta = {
+    description = "A command line tool for Vultr services, a provider for cloud virtual private servers";
+    homepage = "https://github.com/JamesClonk/vultr";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.zauberpony ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6638,6 +6638,8 @@ in
 
   visualvm = callPackage ../development/tools/java/visualvm { };
 
+  vultr = callPackage ../development/tools/vultr { };
+
   xc3sprog = callPackage ../development/tools/misc/xc3sprog { };
 
   xcbuild  = callPackage ../development/tools/xcbuild/wrapper.nix {


### PR DESCRIPTION
###### Motivation for this change

vultr is a cli client for the vultr api, i.e. to start/stop VPS instances.

It's the analog to 'doctl'.

This PR adds the 'vultr' to nixpkgs.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

