### PR TITLE
emscriptenfastcomp: build using cmake and use cc-wrapper

### DIFF
--- a/pkgs/development/compilers/emscripten-fastcomp/default.nix
+++ b/pkgs/development/compilers/emscripten-fastcomp/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, python, ... }:
 
 let
-  rev = "1.36.4";
+  rev = "1.37.1";
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in
 stdenv.mkDerivation rec {
@@ -10,14 +10,14 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten-fastcomp";
-    sha256 = "0838rl0n9hyq5dd0gmj5rvigbmk5mhrhzyjk0zd8mjs2mk8z510l";
+    sha256 = "08jci6h73j4pcd6iq5r4zn8c6qpd6qxc7xivxh3iama9hghmxyk9";
     inherit rev;
   };
 
   srcFL = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten-fastcomp-clang";
-    sha256 = "169hfabamv3jmf88flhl4scwaxdh24196gwpz3sdb26lzcns519q";
+    sha256 = "053svm8vnsma61jzzr8n1224brmjw4pzvklh572bm1p7yg32chaw";
     inherit rev;
   };
 

--- a/pkgs/development/compilers/emscripten-fastcomp/default.nix
+++ b/pkgs/development/compilers/emscripten-fastcomp/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchFromGitHub, python }:
+{ stdenv, fetchFromGitHub, cmake, python, ... }:
 
 let
   rev = "1.36.4";
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in
-
 stdenv.mkDerivation rec {
   name = "emscripten-fastcomp-${rev}";
 
-  srcFC = fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten-fastcomp";
     sha256 = "0838rl0n9hyq5dd0gmj5rvigbmk5mhrhzyjk0zd8mjs2mk8z510l";
@@ -21,24 +21,32 @@ stdenv.mkDerivation rec {
     inherit rev;
   };
 
-  buildInputs = [ python ];
-  buildCommand = ''
-    cp -as ${srcFC} $TMPDIR/src
-    chmod +w $TMPDIR/src/tools
-    cp -as ${srcFL} $TMPDIR/src/tools/clang
-
-    chmod +w $TMPDIR/src
-    mkdir $TMPDIR/src/build
-    cd $TMPDIR/src/build
-
-    ../configure --enable-optimized --disable-assertions --enable-targets=host,js
-    make
-    cp -a Release/bin $out
+  nativeBuildInputs = [ cmake python ];
+  preConfigure = ''
+    cp -Lr ${srcFL} tools/clang
+    chmod +w -R tools/clang
   '';
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DLLVM_TARGETS_TO_BUILD='X86;JSBackend'"
+    "-DLLVM_INCLUDE_EXAMPLES=OFF"
+    "-DLLVM_INCLUDE_TESTS=OFF"
+    # "-DCLANG_INCLUDE_EXAMPLES=OFF"
+    "-DCLANG_INCLUDE_TESTS=OFF"
+  ] ++ (stdenv.lib.optional stdenv.isLinux
+    # necessary for clang to find crtend.o
+    "-DGCC_INSTALL_PREFIX=${gcc}"
+  );
+  enableParallelBuilding = true;
+
+  passthru = {
+    isClang = true;
+    inherit gcc;
+  };
 
   meta = with stdenv.lib; {
     homepage = https://github.com/kripken/emscripten-fastcomp;
-    description = "Emscripten llvm";
+    description = "Emscripten LLVM";
     platforms = platforms.all;
     maintainers = with maintainers; [ qknight matthewbauer ];
     license = stdenv.lib.licenses.ncsa;

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     ln -s $out/${appdir}/{em++,em-config,emar,embuilder.py,emcc,emcmake,emconfigure,emlink.py,emmake,emranlib,emrun,emscons} $out/bin
 
     echo "EMSCRIPTEN_ROOT = '$out/${appdir}'" > $out/${appdir}/config
-    echo "LLVM_ROOT = '${emscriptenfastcomp}'" >> $out/${appdir}/config
+    echo "LLVM_ROOT = '${emscriptenfastcomp}/bin'" >> $out/${appdir}/config
     echo "PYTHON = '${python}/bin/python'" >> $out/${appdir}/config
     echo "NODE_JS = '${nodejs}/bin/node'" >> $out/${appdir}/config
     echo "JS_ENGINES = [NODE_JS]" >> $out/${appdir}/config

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, emscriptenfastcomp, python, nodejs, closurecompiler, jre }:
 
 let
-  rev = "1.36.4";
+  rev = "1.37.1";
   appdir = "share/emscripten";
 in
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten";
-    sha256 = "1c9592i891z1v9rp4a4lnsp14nwiqfxnh37g6xwwjd1bqx7x4hn7";
+    sha256 = "0xl8lv0ihxsnwnhma3i34pkbz0v1yyc93ac6mdqmzv6fx2wczm04";
     inherit rev;
   };
 
@@ -23,6 +23,8 @@ stdenv.mkDerivation {
     sed -i -e "s,EM_CONFIG = '~/.emscripten',EM_CONFIG = '$out/${appdir}/config'," $out/${appdir}/tools/shared.py
     sed -i -e 's,^.*did not see a source tree above the LLVM.*$,      return True,' $out/${appdir}/tools/shared.py
     sed -i -e 's,def check_sanity(force=False):,def check_sanity(force=False):\n  return,' $out/${appdir}/tools/shared.py
+    # fixes cmake support
+    sed -i -e "s/print \('emcc (Emscript.*\)/sys.stderr.write(\1); sys.stderr.flush()/g" $out/${appdir}/emcc.py
     mkdir $out/bin
     ln -s $out/${appdir}/{em++,em-config,emar,embuilder.py,emcc,emcmake,emconfigure,emlink.py,emmake,emranlib,emrun,emscons} $out/bin
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1555,7 +1555,18 @@ in
 
   emscripten = callPackage ../development/compilers/emscripten { };
 
-  emscriptenfastcomp = callPackage ../development/compilers/emscripten-fastcomp { };
+  emscriptenfastcomp-unwrapped = callPackage ../development/compilers/emscripten-fastcomp { };
+  emscriptenfastcomp-wrapped = wrapCC emscriptenfastcomp-unwrapped;
+  emscriptenfastcomp = symlinkJoin {
+    name = "emscriptenfastcomp";
+    paths = [ emscriptenfastcomp-wrapped emscriptenfastcomp-unwrapped ];
+    preferLocalBuild = false;
+    allowSubstitutes = true;
+    postBuild = ''
+      # replace unwrapped clang-3.9 binary by wrapper
+      ln -sf $out/bin/clang $out/bin/clang-[0-9]*
+    '';
+  };
 
   emscriptenPackages = recurseIntoAttrs (callPackage ./emscripten-packages.nix { });
 


### PR DESCRIPTION
###### Motivation for this change

The current emscripten package does not support building without `EMCONFIGURE_JS=2`: emscripten then builds conftest executables using the native x86 compiler, and that fails with `crtend.o not found`.
This PR fixes the issue, at least if you use `pkgsi686Linux.emscripten`.

cc maintainers @qknight @matthewbauer: I have tried to test the `emscriptenPackages` derivation, but `libxml2` fails even on master.

The reason it only works on 32-bit is that neither clang nor emscriptenfastcomp support `-m32`:
```
> $(nix-build -A clang)/bin/clang -m32 test.c
In file included from test.c:1:
In file included from /nix/store/1igqwf6zhpc3p8vlfb10pw400xy0d1xy-glibc-2.24-dev/include/stdio.h:27:
In file included from /nix/store/1igqwf6zhpc3p8vlfb10pw400xy0d1xy-glibc-2.24-dev/include/features.h:392:
/nix/store/1igqwf6zhpc3p8vlfb10pw400xy0d1xy-glibc-2.24-dev/include/gnu/stubs.h:7:11: fatal error: 'gnu/stubs-32.h' file
      not found
# include <gnu/stubs-32.h>
          ^
1 error generated.
```
@shlevy @vcunat @copumpkin Is there an easy way to have a multilib-capable clang?  I tried `wrapCCMulti (wrapCC ...)`, but that builds clang twice and then still fails with `-m32`.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).