### PR TITLE
astroid: init at 0.6

### DIFF
--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, fetchurl, scons, pkgconfig, gnome3, gmime, webkitgtk24x, libsass
-  , notmuch, boost, makeWrapper }:
+{ stdenv, fetchFromGitHub, scons, pkgconfig, gnome3, gmime, webkitgtk24x
+  , libsass, notmuch, boost, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "astroid-${version}";
   version = "0.6";
 
-  src = fetchurl {
-    url = "https://github.com/astroidmail/astroid/archive/v${version}.tar.gz";
-    sha256 = "1d1ivn3vaddlz6bxcgifw4n5jaf7d8y35kk1a457gdq9n1mq87mr";
+  src = fetchFromGitHub {
+    owner = "astroidmail";
+    repo = "astroid";
+    rev = "v${version}";
+    sha256 = "0zashjmqv8ips9q8ckyhgm9hfyf01wpgs6g21cwl05q5iklc5x7r";
   };
 
   patches = [ ./propagate-environment.patch ];

--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, scons, pkgconfig, gnome3, gmime, webkitgtk24x, libsass
+  , notmuch, boost, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "astroid-${version}";
+  version = "0.6";
+
+  src = fetchurl {
+    url = "https://github.com/astroidmail/astroid/archive/v${version}.tar.gz";
+    sha256 = "1d1ivn3vaddlz6bxcgifw4n5jaf7d8y35kk1a457gdq9n1mq87mr";
+  };
+
+  patches = [ ./propagate-environment.patch ];
+
+  buildInputs = [ scons pkgconfig gnome3.gtkmm gmime webkitgtk24x libsass
+                  gnome3.libpeas notmuch boost gnome3.gsettings_desktop_schemas
+                  makeWrapper ];
+
+  buildPhase = "scons --prefix=$out build";
+  installPhase = "scons --prefix=$out install";
+
+  preFixup = ''
+    wrapProgram "$out/bin/astroid" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+  '';
+
+  meta = {
+    homepage = "https://astroidmail.github.io/";
+    description = "GTK+ frontend to the notmuch mail system";
+    maintainers = [ stdenv.lib.maintainers.bdimcheff ];
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/mailreaders/astroid/propagate-environment.patch
+++ b/pkgs/applications/networking/mailreaders/astroid/propagate-environment.patch
@@ -1,0 +1,13 @@
+diff --git a/SConstruct b/SConstruct
+index a80bca3..ed2cd6d 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -5,7 +5,7 @@ from subprocess import *
+ def getGitDesc():
+   return Popen('git describe --abbrev=8 --tags --always', stdout=PIPE, shell=True).stdout.read ().strip ()
+ 
+-env = Environment ()
++env = Environment(ENV = os.environ)
+ 
+ AddOption ("--release", action="store", dest="release", default="git", help="Make a release (default: git describe output)")
+ AddOption ("--enable-debug", action="store", dest="debug", default=None, help="Enable the -g flag for debugging (default: true when release is git)")

--- a/pkgs/development/libraries/gmime/default.nix
+++ b/pkgs/development/libraries/gmime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, zlib, libgpgerror }:
+{ stdenv, fetchurl, pkgconfig, glib, zlib, libgpgerror, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
   name = "gmime-2.6.20";
@@ -10,8 +10,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
   propagatedBuildInputs = [ glib zlib libgpgerror ];
+  configureFlags = [ "--enable-introspection=yes" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12297,6 +12297,8 @@ in
     giflib = giflib_4_1;
   };
 
+  astroid = callPackage ../applications/networking/mailreaders/astroid { };
+
   audacious = callPackage ../applications/audio/audacious { };
   audaciousQt5 = qt5.callPackage ../applications/audio/audacious/qt-5.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
Added astroid, a gtk+ interface for the notmuch mail system.  Note that I had to compile gmime with introspection as well.  I could parameterize this if necessary, but it seemed like it might be useful to be enabled generally.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

