### PR TITLE
kcov: 29 -> 32

### DIFF
--- a/pkgs/development/tools/analysis/kcov/default.nix
+++ b/pkgs/development/tools/analysis/kcov/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "kcov-${version}";
-  version = "29";
+  version = "32";
 
   src = fetchurl {
     url = "https://github.com/SimonKagstrom/kcov/archive/v${version}.tar.gz";
-    sha256 = "0nspf1bfq8zv7zmcmvkbgg3c90k10qcd56gyg8ln5z64nadvha9d";
+    sha256 = "0ic5w6r3cpwb32iky1jmyvfclgkqr0rnfyim7j2r6im21846sa85";
   };
 
   preConfigure = "patchShebangs src/bin-to-c-source.py";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

