### PR TITLE
dropbox: 16.4.29 -> 16.4.30

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -23,11 +23,11 @@
 let
   # NOTE: When updating, please also update in current stable,
   # as older versions stop working
-  version = "16.4.29";
+  version = "16.4.30";
   sha256 =
     {
-      "x86_64-linux" = "0zng19qisbr3c9d312ar43p1b44xidabj4x2l3g3q85i300vj661";
-      "i686-linux"   = "0hc5fs0akc437valbxwlymk7ncjkdnhc51pja5bbiy48gqmd42bb";
+      "x86_64-linux" = "0inwc12d14i6gyfllxbhizb434a7vy0l5nvc07kz0bca7c4665wb";
+      "i686-linux"   = "0pdn8558ll317k3jrrjir90pn6abwbm99y9wzdq39wxj4dmrlh6w";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
###### Motivation for this change

dropbox: 16.4.29 -> 16.4.30

Apologies in advance if this is seen as politicizing something which shouldn't be (or if this is not the right platform for doing so) - I will naturally edit the text here if it is not in line with what the project wants, but otherwise I'll simply copy paste in this text every time I do a new PR for dropbox.

---

Dropbox on NixOS is a royal pain in the rear due to:

1. Forced upgrades where anything but the latest version will simply stop working
2. No changelog when new versions are released

This user hostile approach by Dropbox means that dropbox stops working on NixOS from the time a new version is released and until the nixpkgs repository is updated.

Please consider using one (or more) of these free and open source alternatives:

 - [Librevault](https://librevault.com)
 - [Nextcloud](https://nextcloud.org)
 - [ownCloud](https://owncloud.org)
 - [Syncthing](https://syncthing.net)

Note: This is not in any way an endorsement of any of the projects mentioned above.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Cc: @ttuegel @aristidb @domenkozar @edolstra 