### PR TITLE
xca: qt4 -> qt5

### DIFF
--- a/pkgs/applications/misc/xca/default.nix
+++ b/pkgs/applications/misc/xca/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, pkgconfig, which, openssl, qt4, libtool, gcc, makeWrapper }:
+{ stdenv, fetchurl, pkgconfig, which, makeQtWrapper,
+  libtool, openssl, qtbase, qttools }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "xca-${version}";
@@ -9,19 +12,28 @@ stdenv.mkDerivation rec {
     sha256 = "1r2w9gpahjv221j963bd4vn0gj4cxmb9j42f3cd9qdn890hizw84";
   };
 
-  postInstall = ''
-    wrapProgram "$out/bin/xca" \
-      --prefix LD_LIBRARY_PATH : \
-        "${gcc.cc.lib}/lib64:${stdenv.lib.makeLibraryPath [ qt4 gcc.cc openssl libtool ]}"
+  enableParallelBuilding = false;
+
+  buildInputs = [ libtool openssl qtbase qttools ];
+
+  nativeBuildInputs = [ makeQtWrapper pkgconfig which ];
+
+  preBuild = ''
+    substituteInPlace Local.mak \
+      --replace ${qtbase}/bin/moc ${qtbase.dev}/bin/moc \
+      --replace ${qtbase}/bin/uic ${qtbase.dev}/bin/uic
   '';
 
-  buildInputs = [ openssl qt4 libtool gcc makeWrapper ];
-  nativeBuildInputs = [ pkgconfig ];
+  postInstall = ''
+    wrapQtProgram "$out/bin/xca"
+    wrapQtProgram "$out/bin/xca_db_stat"
+  '';
 
   meta = with stdenv.lib; {
     description = "Interface for managing asymetric keys like RSA or DSA";
     homepage = http://xca.sourceforge.net/;
     platforms = platforms.all;
     license = licenses.bsd3;
+    maintainers = with maintainers; [ offline peterhoeg ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15476,7 +15476,7 @@ in
   };
   xbmc-retroarch-advanced-launchers = kodi-retroarch-advanced-launchers;
 
-  xca = callPackage ../applications/misc/xca { };
+  xca = qt5.callPackage ../applications/misc/xca { };
 
   xcalib = callPackage ../tools/X11/xcalib { };
 


### PR DESCRIPTION
###### Motivation for this change

v1.3.2 gained support for being compiled against qt5, so let's do that!

Cc: @offlinehacker - I added you as maintainer based on ```git blame``` info.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

