### PR TITLE
Python: script names now include full path

### DIFF
--- a/pkgs/development/interpreters/python/wrap-python.nix
+++ b/pkgs/development/interpreters/python/wrap-python.nix
@@ -35,7 +35,7 @@ makeSetupHook {
           import sys
           import site
           import functools
-          sys.argv[0] = '"'$(basename "$f")'"'
+          sys.argv[0] = '"'$(readlink -f "$f")'"'
           functools.reduce(lambda k, p: site.addsitedir(p, k), ['"$([ -n "$program_PYTHONPATH" ] && (echo "'$program_PYTHONPATH'" | sed "s|:|','|g") || true)"'], site._init_pathinfo())
         '';
 


### PR DESCRIPTION
Certain programs, like zim, calibre and now also apparently mercurial,
rely on sys.argv[0] providing not just the script name but the full
path.

The Python docs [1] state the following on the matter:

> argv[0] is the script name (it is operating system dependent whether
this is a full pathname or not).

Therefore, scripts should not expect to receive a full path.
Unfortunately some do. While this can be considered a bug, there doesn't
seem any reason not to provide the full path. Therefore we now provide
the full path.

[1]
https://docs.python.org/3.5/library/sys.html?highlight=sys.argv#sys.argv

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

