### PR TITLE
garbage lines in mercurial.nix

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -38,10 +38,6 @@ in python2Packages.mkPythonDerivation {
                 --prefix PATH : \"${tk}/bin\" "
     '') +
     ''
-      for i in $(cd $out/bin && ls); do
-        wrapProgram $out/bin/$i \
-          $WRAP_TK
-      done
 
       mkdir -p $out/etc/mercurial
       cat >> $out/etc/mercurial/hgrc << EOF


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

double wrapping of python application after https://github.com/NixOS/nixpkgs/commit/a01d7d131edb31513123eaa0def8fb8abca60430.
The second wrapper brings no value, so these lines is just garpage.

see also discussion in https://github.com/NixOS/nixpkgs/issues/21563