### PR TITLE
transcrypt: 0.9.9 -> 1.0.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/transcrypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/transcrypt/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "transcrypt-${version}";
-  version = "0.9.9";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "elasticdog";
     repo = "transcrypt";
     rev = "v${version}";
-    sha256 = "0brsgj3qmvkgxzqqamk8krwyarwff1dlb3jjd09snnbfl0kdq1a5";
+    sha256 = "195hi8lq1i9rfcwj3raw4pa7fhvv3ghznxp4crmbjm7c0sqilcpd";
   };
 
   buildInputs = [ git makeWrapper openssl ];


### PR DESCRIPTION
###### Motivation for this change

Bump to the latest upstream release version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

