### PR TITLE
pktgen: fix runtime paths

### DIFF
--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [ "-march=core2" ];
 
+  postPatch = ''
+    substituteInPlace lib/lua/src/luaconf.h --replace /usr/local $out
+    substituteInPlace lib/common/lscpu.h --replace /usr/bin/lscpu ${utillinux}/bin/lscpu
+  '';
+
   installPhase = ''
     install -d $out/bin
     install -m 0755 app/app/${RTE_TARGET}/app/pktgen $out/bin


### PR DESCRIPTION
###### Motivation for this change

The Lua and lscpu path substitution got accidentally removed in
with commit 605b8095ca11a678af83364549d8fc72ba3f4219

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

