### PR TITLE
wine: 1.8.4 -> 1.8.6

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -6,9 +6,9 @@ let fetchurl = args@{url, sha256, ...}:
 in rec {
 
   stable = fetchurl rec {
-    version = "1.8.4";
+    version = "1.8.6";
     url = "https://dl.winehq.org/wine/source/1.8/wine-${version}.tar.bz2";
-    sha256 = "0yahh1n3s3y0bp1a1sr3zpna56749jdgr85hwmpq393pjx1i0pai";
+    sha256 = "1lq6770pkv3342ss2ih18s2hw6i1srbcfg3mljwalqrvxfb7hydi";
 
     ## see http://wiki.winehq.org/Gecko
     gecko32 = fetchurl rec {
@@ -30,9 +30,9 @@ in rec {
   };
 
   unstable = fetchurl rec {
-    version = "2.0-rc2";
+    version = "2.0-rc3";
     url = "https://dl.winehq.org/wine/source/2.0/wine-${version}.tar.bz2";
-    sha256 = "0pjkrvslfksx7m2w52pnd3dfxb82l082cz9dr57x58s9al2jpwb6";
+    sha256 = "0sq8li7p30h2a5bbpv27vxpzihr8h890qm78nq21fnh0zflg8x8y";
     inherit (stable) mono;
     gecko32 = fetchurl rec {
       version = "2.47";
@@ -48,15 +48,15 @@ in rec {
 
   staging = fetchFromGitHub rec {
     inherit (unstable) version;
-    sha256 = "1xx9bfirij12l278f5f7vpxxay1zacnrsaib6yfzrybm517ynfw3";
+    sha256 = "1nk8s54nrlws0d8wpyj1vv2z0l2jansn990xw73v15wzwc3j9p6l";
     owner = "wine-compholio";
     repo = "wine-staging";
     rev = "v${version}";
   };
 
   winetricks = fetchFromGitHub rec {
-    version = "20160724";
-    sha256 = "0nl8gnmsqwwrc8773q8py64kv3r5836xjxsnxjv91n4hhmvgyrzs";
+    version = "20170101";
+    sha256 = "0c2aam68x3nlvc6f4r6rnfw6y3a86644zb0qirwkmh3p04mpdl39";
     owner = "Winetricks";
     repo = "winetricks";
     rev = version;


### PR DESCRIPTION
wine: 2.0-rc2 -> 2.0-rc3
winetricks: 20160724 -> 20170101

###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

