### PR TITLE
webkitgtk: make 2.14 the default

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.14.nix
+++ b/pkgs/development/libraries/webkitgtk/2.14.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, perl, python2, ruby, bison, gperf, cmake
 , pkgconfig, gettext, gobjectIntrospection, libnotify, gnutls
 , gtk2, gtk3, wayland, libwebp, enchant, xlibs, libxkbcommon, epoxy, at_spi2_core
-, libxml2, libsoup, libsecret, libxslt, harfbuzz, libpthreadstubs
+, libxml2, libsoup, libsecret, libxslt, harfbuzz, libpthreadstubs, pcre, nettle, libtasn1, p11_kit
+, libidn
 , enableGeoLocation ? true, geoclue2, sqlite
 , gst-plugins-base
 }:
@@ -11,7 +12,7 @@ assert enableGeoLocation -> geoclue2 != null;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "webkitgtk-${version}";
-  version = "2.14.1";
+  version = "2.14.2";
 
   meta = {
     description = "Web content rendering engine, GTK+ port";
@@ -26,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://webkitgtk.org/releases/${name}.tar.xz";
-    sha256 = "1dffnz20psgc604azhbzn9a6cdhafar9dw74w3bbwrfy531pcb9f";
+    sha256 = "0mjmcxhafh6l6j062z2nwfqbbvfyx16iqrzrbajswijh23awpnrf";
   };
 
   # see if we can clean this up....
@@ -49,8 +50,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk2 wayland libwebp enchant libnotify gnutls
-    libxml2 libsecret libxslt harfbuzz libpthreadstubs
+    gtk2 wayland libwebp enchant libnotify gnutls pcre nettle libidn
+    libxml2 libsecret libxslt harfbuzz libpthreadstubs libtasn1 p11_kit
     gst-plugins-base libxkbcommon epoxy at_spi2_core
   ] ++ optional enableGeoLocation geoclue2
     ++ (with xlibs; [ libXdmcp libXt libXtst ]);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9646,7 +9646,7 @@ in
 
   wcslib = callPackage ../development/libraries/wcslib { };
 
-  webkitgtk = webkitgtk212x;
+  webkitgtk = webkitgtk214x;
 
   webkitgtk24x = callPackage ../development/libraries/webkitgtk/2.4.nix {
     harfbuzz = harfbuzz-icu;


### PR DESCRIPTION
###### Motivation for this change

I've been running 2.14 as a default for some time now, no apparent problems (none expected either, since the API should be stable)

Not sure if this needs to go to staging ...

###### Things done

There is also a security update for 2.14, if we decide not to update the default version, I'll create a new PR for that.

- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

