### PR TITLE
puddletag: get rid of pypkgs variable

### DIFF
--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -1,10 +1,9 @@
 { stdenv, fetchFromGitHub, python2Packages, makeWrapper, chromaprint }:
 
 let
-  pypkgs = python2Packages;
   pname = "puddletag";
 
-in pypkgs.buildPythonApplication rec {
+in python2Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   version = "1.2.0";
 
@@ -17,11 +16,9 @@ in pypkgs.buildPythonApplication rec {
 
   sourceRoot = "${pname}-v${version}-src/source";
 
-  disabled = pypkgs.isPy3k; # work to support python 3 has not begun
+  disabled = python2Packages.isPy3k; # work to support python 3 has not begun
 
-  outputs = [ "out" ];
-
-  propagatedBuildInputs = [ chromaprint ] ++ (with pypkgs; [
+  propagatedBuildInputs = [ chromaprint ] ++ (with python2Packages; [
     configobj
     mutagen
     pyparsing
@@ -35,7 +32,7 @@ in pypkgs.buildPythonApplication rec {
     siteDir=$(toPythonPath $out)
     mkdir -p $siteDir
     PYTHONPATH=$PYTHONPATH:$siteDir
-    ${pypkgs.python.interpreter} setup.py install --prefix $out
+    ${python2Packages.python.interpreter} setup.py install --prefix $out
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Ref #21565, we do not use ```pypkgs``` as a shorthand for pythonPackages.

Cc: @FRidh 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

