### PR TITLE
chase: init at 0.5.2

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -285,6 +285,7 @@
   mboes = "Mathieu Boespflug <mboes@tweag.net>";
   mcmtroffaes = "Matthias C. M. Troffaes <matthias.troffaes@gmail.com>";
   mdaiter = "Matthew S. Daiter <mdaiter8121@gmail.com>";
+  mdipietro = "Maurizio Di Pietro <dc1mdp@gmail.com>";
   meditans = "Carlo Nucera <meditans@gmail.com>";
   meisternu = "Matt Miemiec <meister@krutt.org>";
   mguentner = "Maximilian Güntner <code@klandest.in>";

--- a/pkgs/tools/system/chase/default.nix
+++ b/pkgs/tools/system/chase/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl ,pkgconfig, libatomic_ops , boehmgc , ... }:
+
+stdenv.mkDerivation rec {
+  name = "chase_0.5.2.orig";
+
+  buildInputs = [ pkgconfig libatomic_ops boehmgc ] ;
+  src = fetchurl {
+    url = "http://ftp.stw-bonn.de/debian/pool/main/c/chase/${name}.tar.gz";
+    sha256 = "68d95c2d4dc45553b75790fcea4413b7204a2618dff148116ca9bdb0310d737f";
+  };
+
+  doCheck = true;
+  makeFlags = [ "-e" ];
+  makeFlagsArray="LIBS=-lgc";
+
+  meta = {
+    description = "Follow a symlink and print out its target file";
+    longDescription = ''
+      A commandline program that chases symbolic filesystems links to the original file
+    '';
+    homepage = "https://qa.debian.org/developer.php?login=rotty%40debian.org";
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [ "Maurizio Di Pietro" ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/tools/system/chase/default.nix
+++ b/pkgs/tools/system/chase/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl ,pkgconfig, libatomic_ops , boehmgc , ... }:
+{ stdenv, fetchurl ,pkgconfig, libatomic_ops , boehmgc }:
 
 stdenv.mkDerivation rec {
-  name = "chase_0.5.2.orig";
+  name = "chase_0.5.2";
 
   buildInputs = [ pkgconfig libatomic_ops boehmgc ] ;
   src = fetchurl {
-    url = "http://ftp.stw-bonn.de/debian/pool/main/c/chase/${name}.tar.gz";
+    url = "mirror://debian/pool/main/c/chase/${name}.orig.tar.gz";
     sha256 = "68d95c2d4dc45553b75790fcea4413b7204a2618dff148116ca9bdb0310d737f";
   };
 
@@ -16,11 +16,11 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Follow a symlink and print out its target file";
     longDescription = ''
-      A commandline program that chases symbolic filesystems links to the original file
+    A commandline program that chases symbolic filesystems links to the original file
     '';
     homepage = "https://qa.debian.org/developer.php?login=rotty%40debian.org";
     license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [ "Maurizio Di Pietro" ];
+    maintainers = [ stdenv.lib.maintainers.mdipietro ];
     platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4359,6 +4359,10 @@ in
 
   which = callPackage ../tools/system/which { };
 
+  chase = callPackage ../tools/system/chase {
+    inherit boehmgc;
+  };
+
   wicd = callPackage ../tools/networking/wicd { };
 
   wipe = callPackage ../tools/security/wipe { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4359,9 +4359,7 @@ in
 
   which = callPackage ../tools/system/which { };
 
-  chase = callPackage ../tools/system/chase {
-    inherit boehmgc;
-  };
+  chase = callPackage ../tools/system/chase { };
 
   wicd = callPackage ../tools/networking/wicd { };
 


### PR DESCRIPTION
###### Motivation for this change
NixOs handles different versions of software contemporary installed on a NixOs installation.
Dispatching is done via symlinks.
"Chase" automatically resolves  to the last target of a chain of symlinks avoiding looping.
I think its a valuable tool for any NixOs admin and is good company for "which".


###### Things done

Added chase under pkgs/tools/system/chase
Its empowers "which" that is installed in the same pkgs path

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

