### PR TITLE
Add networkd notify

### DIFF
--- a/nixos/modules/services/desktops/networkd-notify.nix
+++ b/nixos/modules/services/desktops/networkd-notify.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+
+  options = {
+
+    services.networkd-notify = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable the networkd-notify script.
+          Make sure to enable a desktop-notification service like dunst as well.
+        '';
+      };
+
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf config.services.networkd-notify.enable {
+
+    environment.systemPackages = [ pkgs.networkd-notify ];
+
+    systemd.services.networkd-notify = {
+      description = "networkd desktop notification";
+      wantedBy    = [ "multi-user.target" ];
+    };
+
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
+  };
+
+}
+

--- a/pkgs/applications/misc/networdk-notify/default.nix
+++ b/pkgs/applications/misc/networdk-notify/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, pythonPackages, fetchFromGitHub }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "networkd-notify-unstable-2016-05-17";
+  version = "690b848b8baf8a8254d8402a7e2d5168285f38f7";
+
+  src = fetchFromGitHub {
+    owner = "wavexx";
+    repo = "networkd-notify";
+    rev = version;
+    sha256 = "006d8qmmk0jg0a3fbl2q934wmmhx9n7c156i34i9zgzapdhhacq6";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ dbus-python ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    install -D -m755 networkd-notify $out/bin/networkd-notify
+  '';
+
+  meta = with stdenv.lib; {
+    description = "desktop notification integration for networkd";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2973,6 +2973,8 @@ in
 
   netselect = callPackage ../tools/networking/netselect { };
 
+  networkd-notify = callPackage ../applications/misc/networdk-notify { };
+
   # stripped down, needed by steam
   networkmanager098 = callPackage ../tools/networking/network-manager/0.9.8 { };
 


### PR DESCRIPTION
###### Motivation for this change

I want to have this... so I started to implement a package for it.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


This is one of the first services I write, so please tell me what to improve etc. It is not tested yet, though (as I do not know how to).