### PR TITLE
stdenv: bootstrap cmake and python on darwin

### DIFF
--- a/pkgs/development/compilers/llvm/3.7/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/default.nix
@@ -1,6 +1,6 @@
-{ newScope, stdenv, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun }:
+{ newScope, stdenv, cmake, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun }:
 let
-  callPackage = newScope (self // { inherit stdenv isl version fetch; });
+  callPackage = newScope (self // { inherit stdenv cmake libxml2 python2 isl version fetch; });
 
   version = "3.7.1";
 

--- a/pkgs/development/interpreters/python/cpython/2.7/boot.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/boot.nix
@@ -1,0 +1,94 @@
+{ stdenv, fetchurl, CF, configd, coreutils }:
+
+with stdenv.lib;
+
+let
+
+  mkPaths = paths: {
+    C_INCLUDE_PATH = makeSearchPathOutput "dev" "include" paths;
+    LIBRARY_PATH = makeLibraryPath paths;
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  name = "python-boot-${version}";
+  version = "2.7.12";
+  libPrefix = "python2.7";
+
+  src = fetchurl {
+    url = "https://www.python.org/ftp/python/2.7.12/Python-${version}.tar.xz";
+    sha256 = "0y7rl603vmwlxm6ilkhc51rx2mfj14ckcz40xxgs0ljnvlhp30yp";
+  };
+
+  inherit (mkPaths buildInputs) C_INCLUDE_PATH LIBRARY_PATH;
+
+  LDFLAGS = optionalString (!stdenv.isDarwin) "-lgcc_s";
+  NIX_CFLAGS_COMPILE = optionalString stdenv.isDarwin "-msse2";
+
+  buildInputs = optionals stdenv.isDarwin [ CF configd ];
+
+  patches =
+    [ # Look in C_INCLUDE_PATH and LIBRARY_PATH for stuff.
+      ./search-path.patch
+
+      # Python recompiles a Python if the mtime stored *in* the
+      # pyc/pyo file differs from the mtime of the source file.  This
+      # doesn't work in Nix because Nix changes the mtime of files in
+      # the Nix store to 1.  So treat that as a special case.
+      ./nix-store-mtime.patch
+
+      # patch python to put zero timestamp into pyc
+      # if DETERMINISTIC_BUILD env var is set
+      ./deterministic-build.patch
+    ];
+
+  DETERMINISTIC_BUILD = 1;
+
+  preConfigure = ''
+      # Purity.
+      for i in /usr /sw /opt /pkg; do
+        substituteInPlace ./setup.py --replace $i /no-such-path
+      done
+    '' + optionalString (stdenv ? cc && stdenv.cc.libc != null) ''
+      for i in Lib/plat-*/regen; do
+        substituteInPlace $i --replace /usr/include/ ${stdenv.cc.libc}/include/
+      done
+    '' + optionalString stdenv.isDarwin ''
+      substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
+      substituteInPlace Lib/multiprocessing/__init__.py \
+        --replace 'os.popen(comm)' 'os.popen("${coreutils}/bin/nproc")'
+    '';
+
+  configureFlags = [ "--enable-shared" "--with-threads" "--enable-unicode=ucs4" ]
+    ++ optionals stdenv.isCygwin [ "ac_cv_func_bind_textdomain_codeset=yes" ]
+    ++ optionals stdenv.isDarwin [ "--disable-toolbox-glue" ];
+
+  postInstall =
+    ''
+      ln -s $out/share/man/man1/{python2.7.1.gz,python.1.gz}
+
+      paxmark E $out/bin/python2.7
+
+      rm "$out"/lib/python*/plat-*/regen # refers to glibc.dev
+    '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "http://python.org";
+    description = "A high-level dynamically-typed programming language";
+    longDescription = ''
+      Python is a remarkably powerful dynamic programming language that
+      is used in a wide variety of application domains. Some of its key
+      distinguishing features include: clear, readable syntax; strong
+      introspection capabilities; intuitive object orientation; natural
+      expression of procedural code; full modularity, supporting
+      hierarchical packages; exception-based error handling; and very
+      high level dynamic data types.
+    '';
+    license = stdenv.lib.licenses.psfl;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ lnl7 chaoflow domenkozar ];
+  };
+}

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, pkgconfig
 , bzip2, curl, expat, libarchive, xz, zlib, libuv
-, useNcurses ? false, ncurses, useQt4 ? false, qt4
-, wantPS ? false, ps ? null
+# darwin attributes
+, ps
+, isBootstrap ? false
+, useSharedLibraries ? !stdenv.isCygwin
+, useNcurses ? false, ncurses
+, useQt4 ? false, qt4
 }:
 
 with stdenv.lib;
-
-assert wantPS -> (ps != null);
-assert stdenv ? cc;
-assert stdenv.cc ? libc;
 
 let
   os = stdenv.lib.optionalString;
@@ -18,7 +18,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "cmake-${os useNcurses "cursesUI-"}${os useQt4 "qt4UI-"}${version}";
+  name = "cmake-${os isBootstrap "boot-"}${os useNcurses "cursesUI-"}${os useQt4 "qt4UI-"}${version}";
 
   inherit majorVersion;
 
@@ -27,6 +27,11 @@ stdenv.mkDerivation rec {
     # from https://cmake.org/files/v3.7/cmake-3.7.1-SHA-256.txt
     sha256 = "449a5bce64dbd4d5b9517ebd1a1248ed197add6ad27934478976fd5f1f9330e1";
   };
+
+  prePatch = optionalString (!useSharedLibraries) ''
+    substituteInPlace Utilities/cmlibarchive/CMakeLists.txt \
+      --replace '"-framework CoreServices"' '""'
+  '';
 
   # Don't search in non-Nix locations such as /usr, but do search in our libc.
   patches = [ ./search-path-3.2.patch ]
@@ -38,39 +43,36 @@ stdenv.mkDerivation rec {
   setupHook = ./setup-hook.sh;
 
   buildInputs =
-    [ setupHook pkgconfig bzip2 curl expat libarchive xz zlib libuv ]
+    [ setupHook pkgconfig ]
+    ++ optionals useSharedLibraries [ bzip2 curl expat libarchive xz zlib libuv ]
     ++ optional useNcurses ncurses
     ++ optional useQt4 qt4;
 
-  propagatedBuildInputs = optional wantPS ps;
+  propagatedBuildInputs = optional stdenv.isDarwin ps;
 
-  preConfigure = with stdenv; ''
-      fixCmakeFiles .
-      substituteInPlace Modules/Platform/UnixPaths.cmake \
-        --subst-var-by libc_bin ${getBin cc.libc} \
-        --subst-var-by libc_dev ${getDev cc.libc} \
-        --subst-var-by libc_lib ${getLib cc.libc}
-      substituteInPlace Modules/FindCxxTest.cmake \
-        --replace "$""{PYTHON_EXECUTABLE}" ${stdenv.shell}
-      configureFlags="--parallel=''${NIX_BUILD_CORES:-1} $configureFlags"
-    '';
-  configureFlags =
-    [ "--docdir=share/doc/${name}"
-      "--no-system-jsoncpp"
-    ]
-    ++ optional (!stdenv.isCygwin) "--system-libs"
+  preConfigure = ''
+    fixCmakeFiles .
+    substituteInPlace Modules/Platform/UnixPaths.cmake \
+      --subst-var-by libc_bin ${getBin stdenv.cc.libc} \
+      --subst-var-by libc_dev ${getDev stdenv.cc.libc} \
+      --subst-var-by libc_lib ${getLib stdenv.cc.libc}
+    substituteInPlace Modules/FindCxxTest.cmake \
+      --replace "$""{PYTHON_EXECUTABLE}" ${stdenv.shell}
+    configureFlags="--parallel=''${NIX_BUILD_CORES:-1} $configureFlags"
+  '';
+
+  configureFlags = [ "--docdir=share/doc/${name}" ]
+    ++ (if useSharedLibraries then [ "--no-system-jsoncpp" "--system-libs" ] else [ "--no-system-libs" ]) # FIXME: cleanup
     ++ optional useQt4 "--qt-gui"
-    ++ ["--"]
-    ++ optional (!useNcurses) "-DBUILD_CursesDialog=OFF";
+    ++ optionals (!useNcurses) [ "--" "-DBUILD_CursesDialog=OFF" ];
 
   dontUseCmakeConfigure = true;
-
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = http://www.cmake.org/;
     description = "Cross-Platform Makefile Generator";
     platforms = if useQt4 then qt4.meta.platforms else platforms.all;
-    maintainers = with maintainers; [ urkud mornfall ttuegel ];
+    maintainers = with maintainers; [ urkud mornfall ttuegel lnl7 ];
   };
 }

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool_2
-, llvm, libcxx, libcxxabi, clang, openssl, libuuid
+, llvm, libcxx, libcxxabi, clang, libuuid
 , libobjc ? null
 }:
 
@@ -15,7 +15,7 @@ let
       sha256 = "0bzyabzr5dvbxglr74d0kbrk2ij5x7s5qcamqi1v546q1had1wz1";
     };
 
-    buildInputs = [ autoconf automake libtool_2 openssl libuuid ] ++
+    buildInputs = [ autoconf automake libtool_2 libuuid ] ++
       # Only need llvm and clang if the stdenv isn't already clang-based (TODO: just make a stdenv.cc.isClang)
       stdenv.lib.optionals (!stdenv.isDarwin) [ llvm clang ] ++
       stdenv.lib.optionals stdenv.isDarwin [ libcxxabi libobjc ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5186,9 +5186,13 @@ in
     inherit (stdenvAdapters) overrideCC;
   };
 
-  llvmPackages_37 = callPackage ../development/compilers/llvm/3.7 {
+  llvmPackages_37 = callPackage ../development/compilers/llvm/3.7 ({
     inherit (stdenvAdapters) overrideCC;
-  };
+  } // stdenv.lib.optionalAttrs stdenv.isDarwin {
+    cmake = cmake.override { isBootstrap = true; useSharedLibraries = false; };
+    libxml2 = libxml2.override { pythonSupport = false; };
+    python2 = callPackage ../development/interpreters/python/cpython/2.7/boot.nix { inherit (darwin) CF configd; };
+  });
 
   llvmPackages_38 = callPackage ../development/compilers/llvm/3.8 {
     inherit (stdenvAdapters) overrideCC;
@@ -6110,7 +6114,6 @@ in
   };
 
   cmake = callPackage ../development/tools/build-managers/cmake {
-    wantPS = stdenv.isDarwin;
     inherit (darwin) ps;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Use bootstrap versions of cmake and python to get some dependencies like curl, libarchive and sqlite out of the stdenv.

/cc @copumpkin 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change: [lnl7-wip](http://hydra.nixos.org/eval/1318255?compare=trunk)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```diff
-CF-osx-10.9.5-private.drv
-DevSDK_OSX109.pkg.drv
-MacOS_SDK-10.9.drv
-OSXPrivateSDK-f4d52b60e86b496abfaffa119a7d299562d99783-src.drv
-apple-framework-Accelerate.drv
-apple-framework-ApplicationServices.drv
-apple-framework-CFNetwork.drv
-apple-framework-CoreAudio.drv
-apple-framework-CoreData.drv
-apple-framework-CoreGraphics.drv
-apple-framework-CoreServices.drv
-apple-framework-CoreText.drv
-apple-framework-CoreWLAN.drv
-apple-framework-DiskArbitration.drv
-apple-framework-IOBluetooth.drv
-apple-framework-IOKit.drv
-apple-framework-IOSurface.drv
-apple-framework-ImageIO.drv
-apple-framework-NetFS.drv
-apple-framework-OpenDirectory.drv
-apple-framework-Security.drv
-apple-framework-SecurityFoundation.drv
-apple-framework-ServiceManagement.drv
-apple-framework-SystemConfiguration.drv
-apple-lib-xpc.drv
-cmake-3.7.1.drv
+cmake-boot-3.7.1.drv
-curl-7.51.0.drv
-db-5.3.28.drv
-expat-2.2.0.drv
-gdbm-1.12.drv
-gdbm-1.12.drv
-libarchive-3.2.2.drv
-libssh2-1.8.0.drv
-libuv-1.10.1.drv
-libuv-v1.10.1-src.drv
-lzo-2.09.drv
-openssl-1.0.2j.drv
-openssl-1.0.2j.drv
-python-2.7.13.drv
+python-boot-2.7.12.drv
-readline-6.3p08.drv
-sharutils-4.11.1.drv
-sqlite-3.15.2.drv
-xar-1.5.2.drv
```