### PR TITLE
xfce4-windowck-plugin: init at 0.4.4

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -95,6 +95,7 @@ xfce_self = rec { # the lines are very long but it seems better than the even-od
   xfce4_xkb_plugin              = callPackage ./panel-plugins/xfce4-xkb-plugin.nix              { };
   xfce4_weather_plugin          = callPackage ./panel-plugins/xfce4-weather-plugin.nix          { };
   xfce4_whiskermenu_plugin      = callPackage ./panel-plugins/xfce4-whiskermenu-plugin.nix      { };
+  xfce4_windowck_plugin         = callPackage ./panel-plugins/xfce4-windowck-plugin.nix         { };
   xfce4_pulseaudio_plugin       = callPackage ./panel-plugins/xfce4-pulseaudio-plugin.nix       { };
 
 }; # xfce_self

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, pkgconfig, intltool, python3, imagemagick, libwnck, gtk2
+, exo, libxfce4ui, libxfce4util, xfce4panel, xfconf, xfce4_dev_tools }:
+
+stdenv.mkDerivation rec {
+  p_name  = "xfce4-windowck-plugin";
+  version = "0.4.4";
+
+  src = fetchFromGitHub {
+    owner = "cedl38";
+    repo = "xfce4-windowck-plugin";
+    rev = "v${version}";
+    sha256 = "0c6a1ibh39dpq9x0dha5lsg0vzmgaf051fgwz0nlky0s94nwzvgv";
+  };
+  name = "${p_name}-${version}";
+
+  buildInputs = [ pkgconfig intltool python3 imagemagick libwnck gtk2
+    exo libxfce4ui libxfce4util xfce4panel xfconf xfce4_dev_tools ];
+
+  preConfigure = "./autogen.sh";
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
+    description = "Set of two plugins which allows you to put the maximized window title and windows buttons on the panel";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.volth ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Set of two plugins which allows you to put the maximized window title and windows buttons on the panel

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

