### PR TITLE
Systemd: enable systemd-importd

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -155,12 +155,15 @@ let
       "dbus-org.freedesktop.timedate1.service"
       "dbus-org.freedesktop.locale1.service"
       "dbus-org.freedesktop.hostname1.service"
+      "dbus-org.freedesktop.import1.service"
       "org.freedesktop.timedate1.busname"
       "org.freedesktop.locale1.busname"
       "org.freedesktop.hostname1.busname"
+      "org.freedesktop.import1.busname"
       "systemd-timedated.service"
       "systemd-localed.service"
       "systemd-hostnamed.service"
+      "systemd-importd.service"
       "systemd-binfmt.service"
     ]
     ++ cfg.additionalUpstreamSystemUnits;
@@ -830,6 +833,7 @@ in
     systemd.targets.local-fs.unitConfig.X-StopOnReconfiguration = true;
     systemd.targets.remote-fs.unitConfig.X-StopOnReconfiguration = true;
     systemd.services.systemd-binfmt.wants = [ "proc-sys-fs-binfmt_misc.automount" ];
+    systemd.services.systemd-importd.path = [ pkgs.gnutar pkgs.btrfs-progs pkgs.gnupg-minimal ];
 
     # Don't bother with certain units in containers.
     systemd.services.systemd-remount-fs.unitConfig.ConditionVirtualization = "!container";

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch, pkgconfig, intltool, gperf, libcap, kmod
-, zlib, xz, pam, acl, cryptsetup, libuuid, m4, utillinux, libffi
+, zlib, xz, pam, acl, cryptsetup, libuuid, m4, utillinux, libffi, curl, bzip2
 , glib, kbd, libxslt, coreutils, libgcrypt, libgpgerror, libapparmor, audit, lz4
 , kexectools, libmicrohttpd, linuxHeaders ? stdenv.cc.libc.linuxHeaders, libseccomp
 , iptables, gnu-efi
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "lib" "man" "dev" ];
 
   buildInputs =
-    [ linuxHeaders pkgconfig intltool gperf libcap kmod xz pam acl
+    [ linuxHeaders pkgconfig intltool gperf libcap kmod xz pam acl curl bzip2
       /* cryptsetup */ libuuid m4 glib libxslt libgcrypt libgpgerror
       libmicrohttpd kexectools libseccomp libffi audit lz4 libapparmor
       iptables gnu-efi
@@ -66,7 +66,9 @@ stdenv.mkDerivation rec {
       "--enable-localed"
       "--enable-resolved"
       "--disable-split-usr"
-      "--disable-libcurl"
+      "--enable-importd"
+      "--enable-libcurl"
+      "--enable-bzip2"
       "--disable-libidn"
       "--disable-quotacheck"
       "--disable-ldconfig"
@@ -172,6 +174,11 @@ stdenv.mkDerivation rec {
       # Keep only libudev and libsystemd in the lib output.
       mkdir -p $out/lib
       mv $lib/lib/security $lib/lib/libnss* $out/lib/
+
+      # Allow importd to mount. fixed in systemd-232: https://github.com/systemd/systemd/issues/3996
+      substituteInPlace $out/example/systemd/system/systemd-importd.service --replace \
+        "SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @raw-io" \
+        "SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @obsolete @raw-io"
     ''; # */
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1919,6 +1919,16 @@ in
     pinentry = if stdenv.isDarwin then pinentry_mac else pinentry;
   };
   gnupg = gnupg21;
+  # suitable to verify signatures non-interactively
+  gnupg-minimal = callPackage ../tools/security/gnupg/21.nix {
+    guiSupport = false;
+    pinentry = null;
+    adns = null;
+    gnutls = null;
+    libusb = null;
+    openldap = null;
+    readline = null;
+  };
 
   gnuplot = callPackage ../tools/graphics/gnuplot { qt = qt4; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1920,7 +1920,7 @@ in
   };
   gnupg = gnupg21;
   # suitable to verify signatures non-interactively
-  gnupg-minimal = callPackage ../tools/security/gnupg/21.nix {
+  gnupg-minimal = gnupg.override {
     guiSupport = false;
     pinentry = null;
     adns = null;


### PR DESCRIPTION
###### Motivation for this change

Bring ```systemd-importd``` to work. Fixes #12347

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

