### PR TITLE
ofp: init at 2.0.0

### DIFF
--- a/pkgs/os-specific/linux/ofp/default.nix
+++ b/pkgs/os-specific/linux/ofp/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook
+, openssl, libpcap, odp-dpdk, dpdk
+}:
+
+stdenv.mkDerivation rec {
+  name = "ofp-${version}";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenFastPath";
+    repo = "ofp";
+    rev = "${version}";
+    sha256 = "05902593fycgkwzk5g7wzgk0k40nrrgybplkdka3rqnlj6aydhqf";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ openssl libpcap odp-dpdk dpdk ];
+
+  dontDisableStatic = true;
+
+  postPatch = ''
+    substituteInPlace configure.ac --replace m4_esyscmd m4_esyscmd_s
+    substituteInPlace scripts/git_hash.sh --replace /bin/bash /bin/sh
+    echo ${version} > .scmversion
+  '';
+
+  configureFlags = [
+    "--with-odp=${odp-dpdk}"
+    "--with-odp-lib=odp-dpdk"
+    "--disable-shared"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "High performance TCP/IP stack";
+    homepage = http://www.openfastpath.org;
+    license = licenses.bsd3;
+    platforms =  [ "x86_64-linux" ];
+    maintainers = [ maintainers.abuibrahim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11197,6 +11197,8 @@ in
 
     odp-dpdk = callPackage ../os-specific/linux/odp-dpdk { };
 
+    ofp = callPackage ../os-specific/linux/ofp { };
+
     e1000e = callPackage ../os-specific/linux/e1000e {};
 
     ixgbevf = callPackage ../os-specific/linux/ixgbevf {};


### PR DESCRIPTION
###### Motivation for this change

Package OpenFastPath library (http://www.openfastpath.org)

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

