### PR TITLE
stellar-core: init at 0.5.1

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -32,4 +32,6 @@ rec {
   primecoin  = callPackage ./primecoin.nix { withGui = true; };
   primecoind = callPackage ./primecoin.nix { withGui = false; };
 
+  stellar-core = callPackage ./stellar-core.nix { };
+
 }

--- a/pkgs/applications/altcoins/stellar-core-dirty-version.patch
+++ b/pkgs/applications/altcoins/stellar-core-dirty-version.patch
@@ -1,0 +1,15 @@
+Subject: Prevent "-dirty" from being erroneously added to the version
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index d36d1a3..00048fc 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -28,7 +28,7 @@ always:
+ # Always rebuild because .git/HEAD is a symbolic ref one can't depend on
+ StellarCoreVersion.h: always
+ 	@vers=$$(cd "$(srcdir)" \
+-		&& git describe --always --dirty --tags 2>/dev/null \
++		&& git describe --always --tags 2>/dev/null \
+ 		|| echo "$(PACKAGE) $(VERSION)"); \
+ 	    echo "#define STELLAR_CORE_VERSION \"$$vers\"" > $@~
+ 	@if cmp -s $@~ $@; then rm -f $@~; else \

--- a/pkgs/applications/altcoins/stellar-core.nix
+++ b/pkgs/applications/altcoins/stellar-core.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, fetchgit, autoconf, libtool, automake, pkgconfig, git
+, bison, flex, postgresql }:
+
+let
+  pname = "stellar-core";
+  version = "0.5.1";
+
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchgit {
+    url = "https://github.com/stellar/stellar-core.git";
+    rev = "refs/tags/v${version}";
+    sha256 = "0ldw3qr0sajgam38z2w2iym0214ial6iahbzx3b965cw92n8n88z";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+  };
+
+  buildInputs = [ autoconf automake libtool pkgconfig git ];
+
+  propagatedBuildInputs = [ bison flex postgresql ];
+
+  patches = [ ./stellar-core-dirty-version.patch ];
+
+  preConfigure = ''
+    # Everything needs to be staged in git because the build uses
+    # `git ls-files` to search for source files to compile.
+    git add .
+
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Implements the Stellar Consensus Protocol, a federated consensus protocol";
+    longDescription = ''
+      Stellar-core is the backbone of the Stellar network. It maintains a
+      local copy of the ledger, communicating and staying in sync with other
+      instances of stellar-core on the network. Optionally, stellar-core can
+      store historical records of the ledger and participate in consensus.
+    '';
+    homepage = https://www.stellar.org/;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ chris-martin ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12324,6 +12324,8 @@ in
   go-ethereum = self.altcoins.go-ethereum;
   ethabi = self.altcoins.ethabi;
 
+  stellar-core = self.altcoins.stellar-core;
+
   aumix = callPackage ../applications/audio/aumix {
     gtkGUI = false;
   };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

