### PR TITLE
bitbucket-server-cli: init at 0.7.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -214,6 +214,7 @@
   jerith666 = "Matt McHenry <github@matt.mchenryfamily.org>";
   jfb = "James Felix Black <james@yamtime.com>";
   jgeerds = "Jascha Geerds <jascha@jgeerds.name>";
+  jgertm = "Tim Jaeger <jger.tm@gmail.com>";
   jgillich = "Jakob Gillich <jakob@gillich.me>";
   jirkamarsik = "Jirka Marsik <jiri.marsik89@gmail.com>";
   joachifm = "Joachim Fasting <joachifm@fastmail.fm>";

--- a/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/Gemfile
+++ b/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'atlassian-stash'

--- a/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/Gemfile.lock
+++ b/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    atlassian-stash (0.7.0)
+      commander (~> 4.1.2)
+      git (>= 1.2.5)
+      json (>= 1.7.5)
+      launchy (~> 2.4.2)
+    commander (4.1.6)
+      highline (~> 1.6.11)
+    git (1.3.0)
+    highline (1.6.21)
+    json (2.0.2)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    public_suffix (2.0.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  atlassian-stash
+
+BUNDLED WITH
+   1.13.6

--- a/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/default.nix
@@ -1,0 +1,19 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv rec {
+  name = "bitbucket-server-cli-${version}";
+
+  version = (import gemset).atlassian-stash.version;
+  inherit ruby;
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+  gemset = ./gemset.nix;
+
+  meta = with lib; {
+    description = "A command line interface to interact with BitBucket Server (formerly Atlassian Stash)";
+    homepage    = https://bitbucket.org/atlassian/bitbucket-server-cli;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ jgertm ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/default.nix
@@ -9,6 +9,8 @@ bundlerEnv rec {
   lockfile = ./Gemfile.lock;
   gemset = ./gemset.nix;
 
+  pname = "atlassian-stash";
+
   meta = with lib; {
     description = "A command line interface to interact with BitBucket Server (formerly Atlassian Stash)";
     homepage    = https://bitbucket.org/atlassian/bitbucket-server-cli;

--- a/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/gemset.nix
+++ b/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/gemset.nix
@@ -1,0 +1,66 @@
+{
+  addressable = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1j5r0anj8m4qlf2psnldip4b8ha2bsscv11lpdgnfh4nnchzjnxw";
+      type = "gem";
+    };
+    version = "2.5.0";
+  };
+  atlassian-stash = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rsf9h5w5wiglwv0fqwp45fq06fxbg68cqkc3bpqvps1i1qm0p6i";
+      type = "gem";
+    };
+    version = "0.7.0";
+  };
+  commander = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0x9i8hf083wjlgj09nl1p9j8sr5g7amq0fdmxjqs4cxdbg3wpmsb";
+      type = "gem";
+    };
+    version = "4.1.6";
+  };
+  git = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1waikaggw7a1d24nw0sh8fd419gbf7awh000qhsf411valycj6q3";
+      type = "gem";
+    };
+    version = "1.3.0";
+  };
+  highline = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06bml1fjsnrhd956wqq5k3w8cyd09rv1vixdpa3zzkl6xs72jdn1";
+      type = "gem";
+    };
+    version = "1.6.21";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lhinj9vj7mw59jqid0bjn2hlfcnq02bnvsx9iv81nl2han603s0";
+      type = "gem";
+    };
+    version = "2.0.2";
+  };
+  launchy = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "190lfbiy1vwxhbgn4nl4dcbzxvm049jwc158r2x7kq3g5khjrxa2";
+      type = "gem";
+    };
+    version = "2.4.3";
+  };
+  public_suffix = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "040jf98jpp6w140ghkhw2hvc1qx41zvywx5gj7r2ylr1148qnj7q";
+      type = "gem";
+    };
+    version = "2.0.5";
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -22,6 +22,8 @@ in
 rec {
   # Try to keep this generally alphabetized
 
+  bitbucket-server-cli = callPackage ./bitbucket-server-cli { };
+
   darcsToGit = callPackage ./darcs-to-git { };
 
   diff-so-fancy = callPackage ./diff-so-fancy { };


### PR DESCRIPTION
###### Motivation for this change
This commit introduces the ```stash``` command which allows users to interact Atlassian's enterprise BitBucket (BitBucket Server/ formerly Atlassian Stash).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
