### PR TITLE
rustNightlyBin: 2016-12-05 -> 2016-12-29

### DIFF
--- a/pkgs/development/compilers/rust/nightlyBin.nix
+++ b/pkgs/development/compilers/rust/nightlyBin.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, makeWrapper, cacert, zlib }:
+{ stdenv, fetchurl, makeWrapper, cacert, zlib, buildRustPackage }:
 
 let
   inherit (stdenv.lib) optionalString;
 
-  platform = if stdenv.system == "x86_64-linux" 
+  platform = if stdenv.system == "x86_64-linux"
     then "x86_64-unknown-linux-gnu"
     else abort "missing boostrap url for platform ${stdenv.system}";
 
@@ -19,10 +19,12 @@ let
      sha256 = bootstrapHash;
   };
 
-  version = "2016-12-05";
+  version = "2016-12-29";
 in
 
 rec {
+  inherit buildRustPackage;
+
   rustc = stdenv.mkDerivation rec {
     name = "rustc-nightly-${version}";
 
@@ -47,6 +49,34 @@ rec {
         patchelf \
           --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
           "$out/bin/rustc"
+      ''}
+    '';
+
+  };
+  cargo = stdenv.mkDerivation rec {
+    name = "cargo-nightly-${version}";
+
+    inherit version;
+    inherit src;
+
+    meta = with stdenv.lib; {
+      homepage = http://www.rust-lang.org/;
+      description = "A safe, concurrent, practical language";
+      maintainers = with maintainers; [ qknight ];
+      license = [ licenses.mit licenses.asl20 ];
+    };
+
+    buildInputs = [ makeWrapper ];
+    phases = ["unpackPhase" "installPhase"];
+
+    installPhase = ''
+      ./install.sh --prefix=$out \
+        --components=cargo
+
+      ${optionalString needsPatchelf ''
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/cargo"
       ''}
     '';
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5279,11 +5279,16 @@ in
   };
 
   rust = rustStable;
-  rustcNightlyBin = lowPrio (callPackage ../development/compilers/rust/nightlyBin.nix {});
   rustStable = callPackage ../development/compilers/rust {};
   rustBeta = callPackage ../development/compilers/rust/beta.nix {};
   rustNightly = callPackage ../development/compilers/rust/nightly.nix {
     rustPlatform = recurseIntoAttrs (makeRustPlatform rustBeta);
+  };
+  rustNightlyBin = callPackage ../development/compilers/rust/nightlyBin.nix {
+     buildRustPackage = callPackage ../build-support/rust {
+       rust = rustNightlyBin;
+       rustRegistry = callPackage ./rust-packages.nix { };
+     };
   };
 
   cargo = rust.cargo;


### PR DESCRIPTION
- add cargo (hence the renaming)
- also allow to built nix packages

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

