### PR TITLE
pulseaudio nixos: do not force start pulseaudio.service and use upstream units

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -212,6 +212,7 @@ in {
       # Allow PulseAudio to get realtime priority using rtkit.
       security.rtkit.enable = true;
 
+      systemd.packages = [ cfg.package ];
     })
 
     (mkIf hasZeroconf {
@@ -227,30 +228,13 @@ in {
         target = "pulse/default.pa";
         source = myConfigFile;
       };
-
       systemd.user = {
         services.pulseaudio = {
-          description = "PulseAudio Server";
-          # NixOS doesn't support "Also" so we bring it in manually
-          wantedBy = [ "default.target" ];
           serviceConfig = {
-            Type = "notify";
-            ExecStart = binaryNoDaemon;
-            Restart = "on-failure";
             RestartSec = "500ms";
           };
           environment = { DISPLAY = ":${toString config.services.xserver.display}"; };
           restartIfChanged = true;
-        };
-
-        sockets.pulseaudio = {
-          description = "PulseAudio Socket";
-          wantedBy = [ "sockets.target" ];
-          socketConfig = {
-            Priority = 6;
-            Backlog = 5;
-            ListenStream = "%t/pulse/native";
-          };
         };
       };
     })


### PR DESCRIPTION
###### Motivation for this change

Currently, systemd will spawn a ```pulseaudio.service``` for each user when the user logs on interactively because we are unconditionally starting it.

This is bad.

"each user" above also means "root".

This is very bad.

What we should do instead is to socket activate it so it is only started when needed.

The PR does the following:
  1. Removes the loading of the service by ```default.target```.
  2. Uses the unit files from upstream instead of defining our own.

I have left in 2 NixOS custom config directives, so the configuration should be the same as when we were providing our own.

I don't know what the purpose is of setting DISPLAY in the service environment, but I left it in to avoid changing too many things at the same time.

This PR works perfectly fine under KDE5, but I am yet to test it out with XFCE.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
