### PR TITLE
qscintilla: 2.9 -> 2.9.4 and support for qt5

### DIFF
--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, unzip
 , qt4 ? null, qmake4Hook ? null
 , withQt5 ? false, qtbase ? null, qmakeHook ? null
 }:
 
 stdenv.mkDerivation rec {
   pname = "qscintilla";
-  version = "2.9";
+  version = "2.9.4";
 
   name = "${pname}-${if withQt5 then "qt5" else "qt4"}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/pyqt/QScintilla2/QScintilla-${version}/QScintilla-gpl-${version}.tar.gz";
-    sha256 = "d7c32e32582f93779de861006d87467b38b9ebc06e3d0b32e981cb24369fa417";
+    url = "mirror://sourceforge/pyqt/QScintilla2/QScintilla-${version}/QScintilla_gpl-${version}.zip";
+    sha256 = "04678skipydx68zf52vznsfmll2v9aahr66g50lcqbr6xsmgr1yi";
   };
 
   buildInputs = if withQt5 then [ qtbase ] else [ qt4 ];
-  nativeBuildInputs = if withQt5 then [ qmakeHook ] else [ qmake4Hook ];
+  nativeBuildInputs = [ unzip ] ++ (if withQt5 then [ qmakeHook ] else [ qmake4Hook ]);
 
   enableParallelBuilding = true;
 
@@ -47,5 +47,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.riverbankcomputing.com/software/qscintilla/intro;
     license = with licenses; [ gpl2 gpl3 ]; # and commercial
     platforms = platforms.unix;
+    maintainers = with maintainers; [ peterhoeg ];
   };
 }

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -1,18 +1,23 @@
-{ stdenv, fetchurl, qt4, qmake4Hook }:
+{ stdenv, fetchurl
+, qt4 ? null, qmake4Hook ? null
+, withQt5 ? false, qtbase ? null, qmakeHook ? null
+}:
 
 stdenv.mkDerivation rec {
   pname = "qscintilla";
   version = "2.9";
 
-  name = "${pname}-${version}";
+  name = "${pname}-${if withQt5 then "qt5" else "qt4"}-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/QScintilla2/QScintilla-${version}/QScintilla-gpl-${version}.tar.gz";
     sha256 = "d7c32e32582f93779de861006d87467b38b9ebc06e3d0b32e981cb24369fa417";
   };
 
-  buildInputs = [ qt4 ];
-  nativeBuildInputs = [ qmake4Hook ];
+  buildInputs = if withQt5 then [ qtbase ] else [ qt4 ];
+  nativeBuildInputs = if withQt5 then [ qmakeHook ] else [ qmake4Hook ];
+
+  enableParallelBuilding = true;
 
   preConfigure = ''
     cd Qt4Qt5
@@ -23,7 +28,7 @@ stdenv.mkDerivation rec {
            qscintilla.pro
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A Qt port of the Scintilla text editing library";
     longDescription = ''
       QScintilla is a port to Qt of Neil Hodgson's Scintilla C++ editor
@@ -40,7 +45,7 @@ stdenv.mkDerivation rec {
       background colours and multiple fonts.
     '';
     homepage = http://www.riverbankcomputing.com/software/qscintilla/intro;
-    license = stdenv.lib.licenses.gpl2; # and gpl3 and commercial
-    platforms = stdenv.lib.platforms.unix;
+    license = with licenses; [ gpl2 gpl3 ]; # and commercial
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9125,6 +9125,10 @@ in
 
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
+    qscintilla = callPackage ../development/libraries/qscintilla {
+      withQt5 = true;
+    };
+
     qtkeychain = callPackage ../development/libraries/qtkeychain {
       withQt5 = true;
     };
@@ -14516,7 +14520,7 @@ in
   qscreenshot = callPackage ../applications/graphics/qscreenshot {
     qt = qt4;
   };
-  
+
   qsyncthingtray = qt5.callPackage ../applications/misc/qsyncthingtray { };
 
   qsynth = callPackage ../applications/audio/qsynth { };


### PR DESCRIPTION
###### Motivation for this change

Regular minor upgrade + add support for qt5.

The qt5 version is for tora (separate PR).

~~I have not run ```nox-review``` yet as I need to do that when I'm on a faster machine.~~ ```nox-review``` is happy.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

