### PR TITLE
tora: init at 3.1

### DIFF
--- a/pkgs/development/libraries/loki/default.nix
+++ b/pkgs/development/libraries/loki/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "loki-${version}";
+  version = "0.1.7";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/loki-lib/Loki/Loki%20${version}/loki-${version}.tar.gz";
+    sha256 = "1xhwna961fl4298ac5cc629x5030zlw31vx4h8zws290amw5860g";
+  };
+
+  buildPhase = ''
+    substituteInPlace Makefile.common --replace /usr $out
+    make build-shared
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A C++ library of designs, containing flexible implementations of common design patterns and idioms";
+    homepage = http://loki-lib.sourceforge.net;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/tools/tora/default.nix
+++ b/pkgs/development/tools/tora/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, lib, fetchFromGitHub, cmake, ecm, makeQtWrapper
+, boost, doxygen, openssl, mysql, postgresql, graphviz, loki, qscintilla, qtbase }:
+
+let
+  qscintillaLib = (qscintilla.override { withQt5 = true; });
+
+in stdenv.mkDerivation rec {
+  name = "tora-${version}";
+  version = "3.1";
+
+  src = fetchFromGitHub {
+    owner  = "tora-tool";
+    repo   = "tora";
+    rev    = "v${version}";
+    sha256 = "0wninl10bcgiljf6wnhn2rv8kmzryw78x5qvbw8s2zfjlnxjsbn7";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    cmake ecm makeQtWrapper
+    boost doxygen graphviz loki mysql openssl postgresql qscintillaLib qtbase
+  ];
+
+  preConfigure = ''
+    sed -i \
+      's|defaultGvHome = "/usr/bin"|defaultGvHome = "${lib.getBin graphviz}/bin"|' \
+      src/widgets/toglobalsetting.cpp
+
+    sed -i \
+      's|/usr/bin/dot|${lib.getBin graphviz}/bin/dot|' \
+      extlibs/libermodel/dotgraph.cpp
+  '';
+
+  cmakeFlags = [
+    "-DWANT_INTERNAL_LOKI=0"
+    "-DWANT_INTERNAL_QSCINTILLA=0"
+    # cmake/modules/FindQScintilla.cmake looks in qtbase and for the wrong library name
+    "-DQSCINTILLA_INCLUDE_DIR=${qscintillaLib}/include"
+    "-DQSCINTILLA_LIBRARY=${qscintillaLib}/lib/libqscintilla2.so"
+    "-DENABLE_DB2=0"
+    "-DENABLE_ORACLE=0"
+    "-DENABLE_TERADATA=0"
+    "-DQT5_BUILD=1"
+    "-Wno-dev"
+  ];
+
+  # these libraries are only searched for at runtime so we need to force-link them
+  NIX_LDFLAGS = [
+    "-lgvc"
+    "-lmysqlclient"
+    "-lecpg"
+    "-lssl"
+  ];
+
+  postFixup = ''
+    wrapQtProgram $out/bin/tora \
+      --prefix PATH : ${lib.getBin graphviz}/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tora SQL tool";
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.linux;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2669,6 +2669,8 @@ in
 
   logstalgia = callPackage ../tools/graphics/logstalgia {};
 
+  loki = callPackage ../development/libraries/loki { };
+
   longview = callPackage ../servers/monitoring/longview { };
 
   lout = callPackage ../tools/typesetting/lout { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17932,6 +17932,8 @@ in
 
   zoom-us = qt55.callPackage ../applications/networking/instant-messengers/zoom-us {};
 
+  tora = qt5.callPackage ../development/tools/tora {};
+
   xulrunner = firefox-unwrapped;
 
   nitrokey-app = callPackage ../tools/security/nitrokey-app { };


### PR DESCRIPTION
It depends on the "loki" library so I'm including that here.

Requires #21634 (for the qt5 support) before it can compile.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

