### PR TITLE
insync: init at 1.3.13.36129

### DIFF
--- a/pkgs/applications/networking/insync/default.nix
+++ b/pkgs/applications/networking/insync/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "insync-${version}";
+  version = "1.3.13.36129";
+  src = fetchurl {
+    url = "http://s.insynchq.com/builds/insync-portable_${version}_amd64.tar.bz2";
+    sha256 = "18d8ww529nvhwcl5k31qmkzb83k9753ics0dw64w202r8vwbm3cd";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" client/insync-portable
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a client $out/client
+    makeWrapper $out/client/insync-portable $out/bin/insync --set LC_TIME C
+  '';
+
+  meta = {
+    platforms = ["x86_64-linux"];
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.benley ];
+    homepage = https://www.insynchq.com;
+    description = "Google Drive sync and backup with multiple account support";
+    longDescription = ''
+     Insync is a commercial application that syncs your Drive files to your
+     computer.  It has more advanced features than Google's official client
+     such as multiple account support, Google Doc conversion, symlink support,
+     and built in sharing.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14892,6 +14892,8 @@ in
 
   dropbox-cli = callPackage ../applications/networking/dropbox-cli { };
 
+  insync = callPackage ../applications/networking/insync { };
+
   lightdm = qt5.callPackage ../applications/display-managers/lightdm {
     qt4 = null;
     withQt5 = false;


### PR DESCRIPTION
###### Motivation for this change

This is a thing that I use.  It's non-free, but there doesn't seem to be any free-software alternative that's even in the same ballpark as a Google Drive client.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

