### PR TITLE
cpp-ipfs-api: 2016-11-09 -> 2017-01-04

### DIFF
--- a/pkgs/development/libraries/cpp-ipfs-api/default.nix
+++ b/pkgs/development/libraries/cpp-ipfs-api/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "cpp-ipfs-api-${version}";
-  version = "2016-11-09";
+  version = "2017-01-04";
 
   src = fetchFromGitHub {
     owner = "vasild";
     repo = "cpp-ipfs-api";
-    rev = "46e473e49ede4fd829235f1d4930754d5356a747";
-    sha256 = "10c5hmg9857zb0fp262ca4a42gq9iqdyqz7f975cp3qs70x12q08";
+    rev = "96a890f4518665a56581a2a52311eaa65928eac8";
+    sha256 = "1z6gbd7npg4pd9wmdyzcp9h12sg84d7a43c69pp4lzqkyqg8pz1g";
   };
 
   buildInputs = [ cmake curl ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

