### PR TITLE
[WIP] openjdk : add version 6

### DIFF
--- a/pkgs/development/compilers/openjdk/6.nix
+++ b/pkgs/development/compilers/openjdk/6.nix
@@ -1,0 +1,201 @@
+{ stdenv, fetchurl, unzip, zip, procps, coreutils, alsaLib, ant, freetype
+, which, bootjdk, nettools, xorg, file, cups
+, fontconfig, cpio, cacert, perl, setJavaClassPath
+, minimal ? false
+}:
+
+let
+
+
+  build = "40";
+
+  # On x86 for heap sizes over 700MB disable SEGMEXEC and PAGEEXEC as well.
+  paxflags = if stdenv.isi686 then "msp" else "m";
+
+  baseurl = "http://hg.openjdk.java.net/jdk6/jdk6";
+  repover = "jdk6-b${build}";
+  jdk6 = fetchurl {
+    url = "${baseurl}/archive/${repover}.tar.gz";
+    sha256 = "00d365dc1806c678255d13d6788c807d09d08737670b43da26b78b6d50eab0ef";
+  };
+  langtools = fetchurl {
+    url = "${baseurl}/langtools/archive/${repover}.tar.gz";
+    sha256 = "d523b41b7f33f186c4873089c9e0e30a88a91155bf697ebf07c318f9b58b5662";
+  };
+  hotspot = fetchurl {
+    url = "${baseurl}/hotspot/archive/${repover}.tar.gz";
+    sha256 = "7c9fbec8c6c367303c0fd8b228ad56d89cea3ef2963aab0bb85a4df17050d2f2";
+  };
+  corba = fetchurl {
+    url = "${baseurl}/corba/archive/${repover}.tar.gz";
+    sha256 = "a356743bd699aa0545decded11085826569468dd5d6af4e24e0b9462f2a60bce";
+  };
+  jdk = fetchurl {
+    url = "${baseurl}/jdk/archive/${repover}.tar.gz";
+    sha256 = "18deb06d4f996f37c45610422b344b46e03fb2e4b3b9d135e8bd7032c9bd5b26";
+  };
+  jaxws = fetchurl {
+    url = "${baseurl}/jaxws/archive/${repover}.tar.gz";
+    sha256 = "6f7251a5d39a3e9f2b103b31b8752ff14333cef24a92649cb4ee4ae366182a9d";
+  };
+  jaxp = fetchurl {
+    url = "${baseurl}/jaxp/archive/${repover}.tar.gz";
+    sha256 = "e71c6ea820adb6d0b35aa89a7b2d41411beefbe94eeb2afdf1016d6e8fed7750";
+  };
+  openjdk = stdenv.mkDerivation rec {
+    name = "openjdk-6b${build}";
+
+    srcs = [ jdk6 langtools hotspot corba jdk jaxws jaxp ];
+    sourceRoot = ".";
+
+    outputs = [ "out" "jre" ];
+
+    buildInputs =
+      [ unzip procps ant which zip cpio nettools alsaLib
+        xorg.libX11 xorg.libXt xorg.libXext xorg.libXrender xorg.libXtst
+        xorg.libXi xorg.libXinerama xorg.libXcursor xorg.lndir
+        fontconfig perl file bootjdk
+      ];
+
+    NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+
+    NIX_LDFLAGS = if minimal then null else "-lfontconfig -lXcursor -lXinerama";
+
+    NIX_NO_SELF_RPATH = true;
+
+    makeFlags = [
+      "SORT=${coreutils}/bin/sort"
+      "ALSA_INCLUDE=${alsaLib.dev}/include/alsa/version.h"
+      "FREETYPE_HEADERS_PATH=${freetype.dev}/include"
+      "FREETYPE_LIB_PATH=${freetype.out}/lib"
+      "BUILD_NUMBER=b${build}"
+      "USRBIN_PATH="
+      "COMPILER_PATH="
+      "DEVTOOLS_PATH="
+      "UNIXCOMMAND_PATH="
+      "BOOTDIR=${bootjdk.home}"
+      "STATIC_CXX=false"
+      "UNLIMITED_CRYPTO=1"
+      "FULL_DEBUG_SYMBOLS=0"
+    ] ++ stdenv.lib.optional minimal "BUILD_HEADLESS=1";
+
+    configurePhase = "true";
+
+    preBuild = ''
+      # We also need to PaX-mark in the middle of the build
+      substituteInPlace hotspot*/make/linux/makefiles/launcher.make \
+         --replace XXX_PAXFLAGS_XXX ${paxflags}
+      substituteInPlace jdk-${repover}/make/common/Program.gmk  \
+         --replace XXX_PAXFLAGS_XXX ${paxflags}
+    '';
+
+    installPhase = ''
+      mkdir -p $out/lib/openjdk $out/share $jre/lib/openjdk
+
+      cp -av build/*/j2sdk-image/* $out/lib/openjdk
+
+      # Move some stuff to top-level.
+      mv $out/lib/openjdk/include $out/include
+      mv $out/lib/openjdk/man $out/share/man
+
+      # jni.h expects jni_md.h to be in the header search path.
+      ln -s $out/include/linux/*_md.h $out/include/
+
+      # Remove some broken manpages.
+      rm -rf $out/share/man/ja*
+
+      # Remove crap from the installation.
+      rm -rf $out/lib/openjdk/demo $out/lib/openjdk/sample
+
+      # Move the JRE to a separate output.
+      mv $out/lib/openjdk/jre $jre/lib/openjdk/
+      mkdir $out/lib/openjdk/jre
+      lndir $jre/lib/openjdk/jre $out/lib/openjdk/jre
+
+      rm -rf $out/lib/openjdk/jre/bin
+      ln -s $out/lib/openjdk/bin $out/lib/openjdk/jre/bin
+
+      # Set PaX markings
+      exes=$(file $out/lib/openjdk/bin/* $jre/lib/openjdk/jre/bin/* 2> /dev/null | grep -E 'ELF.*(executable|shared object)' | sed -e 's/: .*$//')
+      echo "to mark: *$exes*"
+      for file in $exes; do
+        echo "marking *$file*"
+        paxmark ${paxflags} "$file"
+      done
+
+      # Remove duplicate binaries.
+      for i in $(cd $out/lib/openjdk/bin && echo *); do
+        if [ "$i" = java ]; then continue; fi
+        if cmp -s $out/lib/openjdk/bin/$i $jre/lib/openjdk/jre/bin/$i; then
+          ln -sfn $jre/lib/openjdk/jre/bin/$i $out/lib/openjdk/bin/$i
+        fi
+      done
+
+      # Generate certificates.
+      pushd $jre/lib/openjdk/jre/lib/security
+      rm cacerts
+      perl ${./generate-cacerts.pl} $jre/lib/openjdk/jre/bin/keytool ${cacert}/etc/ssl/certs/ca-bundle.crt
+      popd
+
+      ln -s $out/lib/openjdk/bin $out/bin
+      ln -s $jre/lib/openjdk/jre/bin $jre/bin
+    ''; # */
+
+    # FIXME: this is unnecessary once the multiple-outputs branch is merged.
+    preFixup = ''
+      prefix=$jre stripDirs "$stripDebugList" "''${stripDebugFlags:--S}"
+      patchELF $jre
+      propagatedNativeBuildInputs+=" $jre"
+
+      # Propagate the setJavaClassPath setup hook from the JRE so that
+      # any package that depends on the JRE has $CLASSPATH set up
+      # properly.
+      mkdir -p $jre/nix-support
+      echo -n "${setJavaClassPath}" > $jre/nix-support/propagated-native-build-inputs
+
+      # Set JAVA_HOME automatically.
+      mkdir -p $out/nix-support
+      cat <<EOF > $out/nix-support/setup-hook
+      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      EOF
+    '';
+
+    postFixup = ''
+      # Build the set of output library directories to rpath against
+      LIBDIRS=""
+      for output in $outputs; do
+        LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \; | sort | uniq | tr '\n' ':'):$LIBDIRS"
+      done
+
+      # Add the local library paths to remove dependencies on the bootstrap
+      for output in $outputs; do
+        OUTPUTDIR="$(eval echo \$$output)"
+        BINLIBS="$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)"
+        echo "$BINLIBS" | while read i; do
+          patchelf --set-rpath "$LIBDIRS:$(patchelf --print-rpath "$i")" "$i" || true
+          patchelf --shrink-rpath "$i" || true
+        done
+      done
+
+      # Test to make sure that we don't depend on the bootstrap
+      for output in $outputs; do
+        if grep -q -r '${bootjdk}' $(eval echo \$$output); then
+          echo "Extraneous references to ${bootjdk} detected"
+          exit 1
+        fi
+      done
+    '';
+
+    meta = {
+      homepage = http://openjdk.java.net/;
+      license = stdenv.lib.licenses.gpl2;
+      description = "The open-source Java Development Kit";
+      maintainers = [ stdenv.lib.maintainers.eelco ];
+      platforms = stdenv.lib.platforms.linux;
+    };
+
+    passthru = {
+      home = "${openjdk}/lib/openjdk";
+    };
+  };
+in openjdk

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5050,6 +5050,14 @@ in
 
   hugs = callPackage ../development/interpreters/hugs { };
 
+  openjdk6 =
+    if stdenv.isDarwin then
+      callPackage ../development/compilers/openjdk-darwin/6.nix { }
+    else
+      callPackage ../development/compilers/openjdk/6.nix {
+        bootjdk = callPackage ../development/compilers/openjdk/bootstrap.nix { version = "7"; };
+      };
+
   openjdk7 =
     if stdenv.isDarwin then
       callPackage ../development/compilers/openjdk-darwin { }


### PR DESCRIPTION
###### Motivation for this change

A lot of companies are still using JDK6 and developers have to work with it.
Furthermore, some project are Java 6 retro-compatible (for example the language kotlin) and have to be tested under that specific JDK.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

