### PR TITLE
Python tix module

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -6,7 +6,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, xlibsWrapper ? null, libX11 ? null, x11Support ? false
+, tcl ? null, tk ? null, tix ? null, xlibsWrapper ? null, libX11 ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -149,6 +149,10 @@ in stdenv.mkDerivation {
     DETERMINISTIC_BUILD = 1;
 
     setupHook = ./setup-hook.sh;
+
+    postPatch = optionalString (x11Support && (tix != null)) ''
+          substituteInPlace "Lib/lib-tk/Tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
+    '';
 
     postInstall =
       ''

--- a/pkgs/development/interpreters/python/cpython/3.3/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.3/default.nix
@@ -6,7 +6,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? false
+, tcl ? null, tk ? null, tix ? null, libX11 ? null, xproto ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -49,6 +49,10 @@ in stdenv.mkDerivation {
   };
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
+
+  postPatch = optionalString (x11Support && (tix != null)) ''
+    substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
+  '';
 
   preConfigure = ''
     for i in /usr /sw /opt /pkg; do	# improve purity

--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -6,7 +6,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? false
+, tcl ? null, tk ? null, tix ? null, libX11 ? null, xproto ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -53,6 +53,10 @@ in stdenv.mkDerivation {
   prePatch = optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
     substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
+  '';
+
+  postPatch = optionalString (x11Support && (tix != null)) ''
+    substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
   '';
 
   preConfigure = ''

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -6,7 +6,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? false
+, tcl ? null, tk ? null, tix ? null, libX11 ? null, xproto ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -53,6 +53,10 @@ in stdenv.mkDerivation {
   prePatch = optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
     substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
+  '';
+
+  postPatch = optionalString (x11Support && (tix != null)) ''
+    substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
   '';
 
   preConfigure = ''

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -7,7 +7,7 @@
 , openssl
 , readline
 , sqlite
-, tcl ? null, tk ? null, libX11 ? null, xproto ? null, x11Support ? false
+, tcl ? null, tk ? null, tix ? null, libX11 ? null, xproto ? null, x11Support ? false
 , zlib
 , callPackage
 , self
@@ -53,6 +53,10 @@ in stdenv.mkDerivation {
   prePatch = optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
     substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
+  '';
+
+  postPatch = optionalString (x11Support && (tix != null)) ''
+    substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
   '';
 
   preConfigure = ''

--- a/pkgs/development/interpreters/python/pypy/2.7/default.nix
+++ b/pkgs/development/interpreters/python/pypy/2.7/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, zlib ? null, zlibSupport ? true, bzip2, pkgconfig, libffi
-, sqlite, openssl, ncurses, python, expat, tcl, tk, xlibsWrapper, libX11
+, sqlite, openssl, ncurses, python, expat, tcl, tk, tix, xlibsWrapper, libX11
 , makeWrapper, callPackage, self, gdbm, db
 # For the Python package set
 , pkgs, packageOverrides ? (self: super: {})
@@ -35,6 +35,7 @@ let
       };
       in ''
       patch lib-python/2.7/test/test_pyexpat.py < '${expatch}'
+      substituteInPlace "lib-python/2.7/lib-tk/Tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
     '';
 
     buildInputs = [ bzip2 openssl pkgconfig python libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 makeWrapper gdbm db ]

--- a/pkgs/development/libraries/tix/default.nix
+++ b/pkgs/development/libraries/tix/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, tcl, tk, fetchpatch } :
+
+stdenv.mkDerivation rec {
+  version = "8.4.3";
+  name = "tix-${version}";
+  src = fetchurl {
+     url = "mirror://sourceforge/tix/tix/8.4.3/Tix8.4.3-src.tar.gz";
+     sha256 = "1jq3dkyk9mqkj4cg7mdk5r0cclqsby9l2b7wrysi0zk5yw7h8bsn";
+  };
+  patches = [ 
+  (fetchpatch {
+    name = "tix-8.4.3-tcl8.5.patch";
+    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-tcltk/tix/files/tix-8.4.3-tcl8.5.patch?id=56bd759df1d0c750a065b8c845e93d5dfa6b549d";
+    sha256 = "0wzqmcxxq0rqpnjgxz10spw92yhfygnlwv0h8pcx2ycnqiljz6vj";
+    })
+  ] ++ stdenv.lib.optional (tcl.release == "8.6")
+  (fetchpatch {
+    name = "tix-8.4.3-tcl8.6.patch";
+    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-tcltk/tix/files/tix-8.4.3-tcl8.6.patch?id=56bd759df1d0c750a065b8c845e93d5dfa6b549d";
+    sha256 = "1jaz0l22xj7x1k4rb9ia6i1psnbwk4pblgq4gfvya7gg7fbb7r36";
+    })
+  ;
+  buildInputs = [ tcl tk ];
+  # the configure script expects to find the location of the sources of
+  # tcl and tk in {tcl,tk}Config.sh
+  # In fact, it only needs some private headers. We copy them in 
+  # the private_headers folders and trick the configure script into believing
+  # the sources are here.
+  preConfigure = ''
+    mkdir -p private_headers/generic
+    < ${tcl}/lib/tclConfig.sh sed "s@TCL_SRC_DIR=.*@TCL_SRC_DIR=private_headers@" > tclConfig.sh
+    < ${tk}/lib/tkConfig.sh sed "s@TK_SRC_DIR=.*@TK_SRC_DIR=private_headers@" > tkConfig.sh
+    for i in ${tcl}/include/* ${tk.dev}/include/*; do
+      ln -s $i private_headers/generic;
+    done;
+    '';
+  configureFlags = ''
+      --with-tclinclude=${tcl}/include
+      --with-tclconfig=.
+      --with-tkinclude=${tk.dev}/include
+      --with-tkconfig=.
+      --libdir=''${prefix}/lib
+    '';
+
+  meta = with stdenv.lib; {
+    description = "A widget library for Tcl/Tk";
+    homepage    = http://tix.sourceforge.net/;
+    platforms   = platforms.all;
+    license     = with licenses; [
+      bsd2 # tix
+      gpl2 # patches from portage
+    ];
+  };
+}
+

--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation {
 
   postInstall = ''
     ln -s $out/bin/wish* $out/bin/wish
+    cp ../{unix,generic}/*.h $out/include
   '';
 
   configureFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9477,6 +9477,8 @@ in
 
   tivodecode = callPackage ../applications/video/tivodecode { };
 
+  tix = callPackage ../development/libraries/tix { };
+
   tk = tk-8_6;
 
   tk-8_6 = callPackage ../development/libraries/tk/8.6.nix { };


### PR DESCRIPTION
###### Motivation for this change
 Being able to use the [tkinter.tix](https://docs.python.org/3.5/library/tkinter.tix.html) python module (which is in the standard library).
This is done in three parts:
* adding tk private headers to the dev output of the derivation (tcl private headers are already there) which are needed to build tix
* adding a tix package
* wrapping python to set the correct [TIX_LIBRARY](https://docs.python.org/3.5/library/tkinter.tix.html#using-tix) environment variable

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Regarding testing : I rebuilt my whole system with those versions of cpython (my laptop has not enough ram to build pypy) and it has been working fine since then. I could not test extensively all the packages impacted by those changes. And of course I checked that the tkinter.tix module works.

