### PR TITLE
nox: 0.0.4 -> 0.0.5

### DIFF
--- a/pkgs/tools/package-management/nox/default.nix
+++ b/pkgs/tools/package-management/nox/default.nix
@@ -2,12 +2,12 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "nox-${version}";
-  version = "0.0.4";
+  version = "0.0.5";
   namePrefix = "";
 
   src = fetchurl {
     url = "mirror://pypi/n/nix-nox/nix-nox-${version}.tar.gz";
-    sha256 = "11f6css8rnh7qz55z7i81cnb5h9ys98fqxq3fps3hsh64zlydj52";
+    sha256 = "1kwrkp7njxn2sqmmzy5d33d07gawbw2ab2bmfjz0y1r23z9iadf2";
   };
 
   buildInputs = [ pythonPackages.pbr git ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

