### PR TITLE
openldap: load configuration files from global sysconfdir /etc

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -19,9 +19,12 @@ stdenv.mkDerivation rec {
     [ "--enable-overlays"
       "--disable-dependency-tracking"   # speeds up one-time build
       "--enable-modules"
+      "--sysconfdir=/etc"
     ] ++ stdenv.lib.optional (openssl == null) "--without-tls"
       ++ stdenv.lib.optional (cyrus_sasl == null) "--without-cyrus-sasl"
       ++ stdenv.lib.optional stdenv.isFreeBSD "--with-pic";
+
+  installFlags = [ "sysconfdir=$(out)/etc" ];
 
   # 1. Fixup broken libtool
   # 2. Libraries left in the build location confuse `patchelf --shrink-rpath`


### PR DESCRIPTION
###### Motivation for this change

openldap is currently built so that the client programs only ever read the sample configuration file in `$out/etc/openldap/ldap.conf`. The path is fixed and can't be changed via runtime parameters, while some options can only be set through that file. This simple change solves the problem by separating the install and runtime sysconfdirs so that `environment.etc."openldap/ldap.conf"` can be used to configure openldap.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

