### PR TITLE
neovim: Inherit meta into neovim-configured

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -167,7 +167,7 @@ let
 
 in if (vimAlias == false && configure == null) then neovim else stdenv.mkDerivation {
   name = "neovim-${neovim.version}-configured";
-  inherit (neovim) version;
+  inherit (neovim) version meta;
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
When adding neovim's configure option to config.nix, builds fail with

  error: attribute ‘platforms’ missing, at
  /nix/store/*/nixos/pkgs/applications/editors/neovim/qt.nix:41:28

Inheriting meta into neovim-configured fixes this, and seems reasonable.

###### Motivation for this change
To fix the error described in the commit message as simply as possible.  No testing performed, since this should be a trivial change.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

