### PR TITLE
xorg.xserver: configure --with-xkb-path=

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -456,15 +456,14 @@ in
           "--with-default-font-path="   # there were only paths containing "${prefix}",
                                         # and there are no fonts in this package anyway
           "--with-xkb-bin-directory=${xorg.xkbcomp}/bin"
+          "--with-xkb-path=${xorg.xkeyboardconfig}/share/X11/xkb"
+          "--with-xkb-output=$out/share/X11/xkb/compiled"
           "--enable-glamor"
         ];
         postInstall = ''
           rm -fr $out/share/X11/xkb/compiled # otherwise X will try to write in it
-          wrapProgram $out/bin/Xephyr \
-            --add-flags "-xkbdir ${xorg.xkeyboardconfig}/share/X11/xkb"
           wrapProgram $out/bin/Xvfb \
-            --set XORG_DRI_DRIVER_PATH ${args.mesa}/lib/dri \
-            --add-flags "-xkbdir ${xorg.xkeyboardconfig}/share/X11/xkb"
+            --set XORG_DRI_DRIVER_PATH ${args.mesa}/lib/dri
           ( # assert() keeps runtime reference xorgserver-dev in xf86-video-intel and others
             cd "$dev"
             for f in include/xorg/*.h; do

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, buildEnv, makeFontsConf, gnused, writeScript, xorg, bashInteractive, substituteAll, xterm, makeWrapper, ruby
-, openssl, quartz-wm, fontconfig, xkeyboard_config, xlsfonts, xfontsel
+, openssl, quartz-wm, fontconfig, xlsfonts, xfontsel
 , ttf_bitstream_vera, freefont_ttf, liberation_ttf_binary
 , shell ? "${bashInteractive}/bin/bash"
 }:
@@ -126,7 +126,6 @@ in stdenv.mkDerivation {
       --replace "@DEFAULT_CLIENT@"    "${xterm}/bin/xterm" \
       --replace "@XINIT@"             "$out/bin/xinit" \
       --replace "@XINITRC@"           "$out/etc/X11/xinit/xinitrc" \
-      --replace "@XKEYBOARD_CONFIG@"  "${xkeyboard_config}/etc/X11/xkb" \
       --replace "@FONTCONFIG_FILE@"   "$fontsConfPath"
 
     wrapProgram $out/bin/Xquartz \

--- a/pkgs/servers/x11/xquartz/startx
+++ b/pkgs/servers/x11/xquartz/startx
@@ -217,7 +217,7 @@ EOF
     done
 fi
 
-eval @XINIT@ \"$client\" $clientargs -- \"$server\" $display $serverargs "-xkbdir" "@XKEYBOARD_CONFIG@"
+eval @XINIT@ \"$client\" $clientargs -- \"$server\" $display $serverargs
 retval=$?
 
 if [ x"$enable_xauth" = x1 ] ; then

--- a/pkgs/tools/X11/bumblebee/default.nix
+++ b/pkgs/tools/X11/bumblebee/default.nix
@@ -18,7 +18,7 @@
 
 { stdenv, lib, fetchurl, fetchpatch, pkgconfig, help2man, makeWrapper
 , glib, libbsd
-, libX11, libXext, xorgserver, xkbcomp, kmod, xkeyboard_config, xf86videonouveau
+, libX11, libXext, xorgserver, xkbcomp, kmod, xf86videonouveau
 , nvidia_x11, virtualgl, primusLib
 , automake111x, autoconf
 # The below should only be non-null in a x86_64 system. On a i686
@@ -125,7 +125,6 @@ in stdenv.mkDerivation rec {
 
   CFLAGS = [
     "-DX_MODULE_APPENDS=\\\"${xmodules}\\\""
-    "-DX_XKB_DIR=\\\"${xkeyboard_config}/etc/X11/xkb\\\""
   ];
 
   postInstall = ''

--- a/pkgs/tools/X11/bumblebee/nixos.patch
+++ b/pkgs/tools/X11/bumblebee/nixos.patch
@@ -49,12 +49,11 @@ index 71a6b73..a682d8a 100644
      char *x_argv[] = {
        XORG_BINARY,
        bb_config.x_display,
-@@ -153,24 +170,25 @@ bool start_secondary(bool need_secondary) {
+@@ -153,24 +170,24 @@ bool start_secondary(bool need_secondary) {
        "-sharevts",
        "-nolisten", "tcp",
        "-noreset",
 +      "-logfile", "/var/log/X.bumblebee.log",
-+      "-xkbdir", X_XKB_DIR,
        "-verbose", "3",
        "-isolateDevice", pci_id,
 -      "-modulepath", bb_config.mod_path, // keep last

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, python2Packages, pkgconfig
 , xorg, gtk2, glib, pango, cairo, gdk_pixbuf, atk
-, makeWrapper, xkbcomp, xorgserver, getopt, xauth, utillinux, which, fontsConf, xkeyboard_config
+, makeWrapper, xkbcomp, xorgserver, getopt, xauth, utillinux, which, fontsConf
 , ffmpeg, x264, libvpx, libwebp
 , libfakeXinerama
 , gst_all_1, pulseaudioLight, gobjectIntrospection }:

--- a/pkgs/tools/X11/xpra/gtk3.nix
+++ b/pkgs/tools/X11/xpra/gtk3.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, buildPythonApplication
 , python, cython, pkgconfig
 , xorg, gtk3, glib, pango, cairo, gdk_pixbuf, atk, pygobject3, pycairo, gobjectIntrospection
-, makeWrapper, xkbcomp, xorgserver, getopt, xauth, utillinux, which, fontsConf, xkeyboard_config
+, makeWrapper, xkbcomp, xorgserver, getopt, xauth, utillinux, which, fontsConf
 , ffmpeg, x264, libvpx, libwebp
 , libfakeXinerama }:
 

--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, xkbcomp, xorgserver, getopt, xkeyboard_config
+{ stdenv, fetchurl, makeWrapper, xkbcomp, xorgserver, getopt
 , xauth, utillinux, which, fontsConf, gawk, coreutils }:
 let
   xvfb_run = fetchurl {
@@ -12,7 +12,6 @@ stdenv.mkDerivation {
   buildCommand = ''
     mkdir -p $out/bin
     cp ${xvfb_run} $out/bin/xvfb-run
-    sed -i 's|XVFBARGS="|XVFBARGS="-xkbdir ${xkeyboard_config}/etc/X11/xkb |' $out/bin/xvfb-run
 
     chmod a+x $out/bin/xvfb-run
     wrapProgram $out/bin/xvfb-run \


### PR DESCRIPTION
###### Motivation for this change

Xorg binaries contain inside the wrong path ```${xorg.xserver}/share/X11/xkb``` instead of ```${xorg.xkeyboardconfig}/share/X11/xkb```.

This forces every program launching any of the ```Xorg``` binaries to take care on passing a command like parameter ```-xkbdir ${xkeyboard_config}/etc/X11/xkb``` overriding the wrong path compiled into binaries:[1](https://github.com/NixOS/nixpkgs/blob/68ab32fbf880787a6e7340d749483cdc743b4b96/pkgs/servers/x11/xquartz/startx#L220) [2](https://github.com/NixOS/nixpkgs/blob/68ab32fbf880787a6e7340d749483cdc743b4b96/pkgs/tools/misc/xvfb-run/default.nix#L15) [3](https://github.com/NixOS/nixpkgs/blob/68ab32fbf880787a6e7340d749483cdc743b4b96/pkgs/tools/X11/bumblebee/nixos.patch#L57) [4](https://github.com/NixOS/nixpkgs/blob/68ab32fbf880787a6e7340d749483cdc743b4b96/pkgs/tools/admin/tigervnc/default.nix#L23) [5](https://github.com/NixOS/nixpkgs/blob/68ab32fbf880787a6e7340d749483cdc743b4b96/nixos/modules/services/x11/xserver.nix#L569)

This patch proposes to fix the path in the binaries by passing ```${xorg.xkeyboardconfig}/share/X11/xkb``` as ```./configure``` parameter.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

