### PR TITLE
nix-prefetch-git: remove call to nonexistent print_metadata function

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -406,8 +406,7 @@ else
         finalPath=$(nix-store --add-fixed --recursive "$hashType" "$tmpFile")
 
         if test -n "$expHash" -a "$expHash" != "$hash"; then
-            print_metadata
-            echo "hash mismatch for URL \`$url'" >&2
+            echo "hash mismatch for URL \`$url'. Got \`$hash'; expected \`$expHash'." >&2
             exit 1
         fi
     fi


### PR DESCRIPTION
###### Motivation for this change

If we provide an incorrect expected hash to `nix-prefetch-git`, it fails with an unhelpful error message:

```
line 409: print_metadata: command not found
```

This commit simply removes the call to `print_metadata` and improves the error message:

```
hash mismatch for URL `https://github.com/awakenetworks/proto3-wire.git'. Got `128fcdwra3j1mcxnra4h8q79r671img5x2xph9pc8lf1wxr2hyi3'; expected `17mh23pdzv028gcvig1mc8llixscawqqv6zpy0i2zhcaxpnya1qz'.
```

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

