### PR TITLE
pidgin-osd: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "edanaher";
     repo = "pidgin-osd";
-    rev = "pidgin-osd-0.2.0";
+    rev = name;
     sha256 = "07wa9anz99hnv6kffpcph3fbq8mjbyq17ij977ggwgw37zb9fzb5";
   };
 

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchurl, pidgin, xosd
+{ stdenv, fetchFromGitHub, pidgin, xosd
 , autoreconfHook } :
 
 stdenv.mkDerivation rec {
   name = "pidgin-osd-0.2.0";
-  src = fetchurl {
-    url = https://github.com/edanaher/pidgin-osd/archive/pidgin-osd-0.2.0.tar.gz;
-    sha256 = "1dfb0957wwm5zly4w4g815svhkhvjbj3dgik1lbyac8adh9ks784";
+  src = fetchFromGitHub {
+    owner = "edanaher";
+    repo = "pidgin-osd";
+    rev = "pidgin-osd-0.2.0";
+    sha256 = "07wa9anz99hnv6kffpcph3fbq8mjbyq17ij977ggwgw37zb9fzb5";
   };
 
   # autoreconf is run such that it *really* wants all the files, and there's no

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-osd/default.nix
@@ -2,13 +2,11 @@
 , autoreconfHook } :
 
 stdenv.mkDerivation rec {
-  name = "pidgin-osd-0.1.0";
+  name = "pidgin-osd-0.2.0";
   src = fetchurl {
-    url = https://github.com/mbroemme/pidgin-osd/archive/pidgin-osd-0.1.0.tar.gz;
-    sha256 = "11hqfifhxa9gijbnp9kq85k37hvr36spdd79cj9bkkvw4kyrdp3j";
+    url = https://github.com/edanaher/pidgin-osd/archive/pidgin-osd-0.2.0.tar.gz;
+    sha256 = "1dfb0957wwm5zly4w4g815svhkhvjbj3dgik1lbyac8adh9ks784";
   };
-
-  makeFlags = "PIDGIN_LIBDIR=$(out)";
 
   # autoreconf is run such that it *really* wants all the files, and there's no
   # default ChangeLog.  So make it happy.
@@ -16,7 +14,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/lib/pidgin
-    ln -s $out/pidgin $out/lib/pidgin
+    mv $out/lib/pidgin-osd.{la,so} $out/lib/pidgin
   '';
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Also clean up the build a bit, and point to my fork, since the original appears
to be ignoring pull requests.

###### Motivation for this change

I added some features to pidgin-osd, and have been running it off of a local nixpkgs for a few months waiting for the PR to go through upstream.  I've finally given up and am just switching to my fork.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

