### PR TITLE
hugo: 0.17 -> 0.18.1

### DIFF
--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "hugo-${version}";
-  version = "0.17";
+  version = "0.18.1";
 
   goPackagePath = "github.com/spf13/hugo";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "spf13";
     repo = "hugo";
     rev = "v${version}";
-    sha256 = "1h5d7m019r4zhk7xlcdbn4z3w6x7jq2lcdgq7w377688rk58wbgp";
+    sha256 = "1nmabcrq96b339in2yr2zwcd41nadr4bha3rlpyaxlzbyyhz2f81";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/misc/hugo/deps.nix
+++ b/pkgs/applications/misc/hugo/deps.nix
@@ -229,8 +229,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/spf13/fsync";
-      rev = "eefee59ad7de621617d4ff085cf768aab4b919b1";
-      sha256 = "0d56xdczawikyczc12i661qc79dbv4q8ihlj4p20zsjkyxxym59p";
+      rev = "cb2da332d00cbc04e4f3f677520dc3e7cc11874b";
+      sha256 = "03ib2xj80cbz77hx2baanyi50qr40akrybg49fzdvdm3lv9x100z";
     };
   }
   {
@@ -339,6 +339,15 @@
       url = "https://github.com/pelletier/go-buffruneio";
       rev = "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d";
       sha256 = "0jwn2g4jfdb3wvpqisd8h055099pwx6c5i3bb4zxk5l9vybg1c5f";
+    };
+  }
+  {
+    goPackagePath = "github.com/bep/gitmap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bep/gitmap";
+      rev = "a1a71abe12823e27ae7507189fe2e914ba9626ac";
+      sha256 = "0qfhb72y6wbypaqv6dkl42syifnhps3qcy1karpd6ziw4pxak18g";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change
updated hugo to latest release

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).