### PR TITLE
mu: allow gtk-free builds

### DIFF
--- a/pkgs/tools/networking/mu/default.nix
+++ b/pkgs/tools/networking/mu/default.nix
@@ -1,6 +1,7 @@
 { fetchurl, stdenv, sqlite, pkgconfig, autoreconfHook
 , xapian, glib, gmime, texinfo , emacs, guile
-, gtk3, webkitgtk24x, libsoup, icu }:
+, gtk3, webkitgtk24x, libsoup, icu
+, withMug ? stdenv.isLinux }:
 
 stdenv.mkDerivation rec {
   version = "0.9.18";
@@ -13,8 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     sqlite pkgconfig xapian glib gmime texinfo emacs guile libsoup icu
-    autoreconfHook
-    gtk3 webkitgtk24x ];
+    autoreconfHook ] ++ stdenv.lib.optionals withMug [ gtk3 webkitgtk24x ];
 
   preBuild = ''
     # Fix mu4e-builddir (set it to $out)
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   # Install mug and msg2pdf
-  postInstall = ''
+  postInstall = stdenv.lib.optionalString withMug ''
     cp -v toys/msg2pdf/msg2pdf $out/bin/
     cp -v toys/mug/mug $out/bin/
   '';


### PR DESCRIPTION
The `postInstall` step needs to be more careful to support successful
builds that do not produce `msg2pdf` and `mug` executables.

###### Motivation for this change

`mu` should not have `gtk3` and `webkit` as hard dependencies. Perhaps defining a `mu-no-gtk` variant in `all-packages.nix` is warranted, but this change at least lets you put,

```
mu = pkgs.mu.override {
      gtk3 = null;
      webkitgtk24x = null;
    };
```

in your `config.nix` to get things working again if you are on `darwin` or just don't want those extra components.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
