### PR TITLE
coreutils: Build with xattr support

### DIFF
--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -87,8 +87,9 @@ rec {
 
 
   coreutilsMinimal = (pkgs.coreutils.override (args: {
-    # We want coreutils without ACL support.
+    # We want coreutils without ACL/attr support.
     aclSupport = false;
+    attrSupport = false;
     # Our tooling currently can't handle scripts in bin/, only ELFs and symlinks.
     singleBinary = "symlinks";
   })).crossDrv;

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -6,8 +6,9 @@ rec {
 
 
   coreutilsMinimal = coreutils.override (args: {
-    # We want coreutils without ACL support.
+    # We want coreutils without ACL/attr support.
     aclSupport = false;
+    attrSupport = false;
     # Our tooling currently can't handle scripts in bin/, only ELFs and symlinks.
     singleBinary = "symlinks";
   });

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, perl, xz, gmp ? null
 , aclSupport ? false, acl ? null
+, attrSupport ? false, attr ? null
 , selinuxSupport? false, libselinux ? null, libsepol ? null
 , autoconf, automake114x, texinfo
 , withPrefix ? false
@@ -44,12 +45,14 @@ let
 
     buildInputs = [ gmp ]
       ++ optional aclSupport acl
+      ++ optional attrSupport attr
       ++ optionals stdenv.isCygwin [ autoconf automake114x texinfo ]   # due to patch
       ++ optionals selinuxSupport [ libselinux libsepol ];
 
     crossAttrs = {
       buildInputs = [ gmp.crossDrv ]
         ++ optional aclSupport acl.crossDrv
+        ++ optional attrSupport attr.crossDrv
         ++ optionals selinuxSupport [ libselinux.crossDrv libsepol.crossDrv ]
         ++ optional (stdenv.ccCross.libc ? libiconv)
           stdenv.ccCross.libc.libiconv.crossDrv;
@@ -89,8 +92,6 @@ let
     FORCE_UNSAFE_CONFIGURE = optionalString stdenv.isSunOS "1";
 
     makeFlags = optionalString stdenv.isDarwin "CFLAGS=-D_FORTIFY_SOURCE=0";
-
-    postFixup = ""; # FIXME: remove on next mass rebuild
 
     meta = {
       homepage = http://www.gnu.org/software/coreutils/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1287,6 +1287,7 @@ in
 
   coreutils = callPackage ../tools/misc/coreutils {
     aclSupport = stdenv.isLinux;
+    attrSupport = stdenv.isLinux;
   };
 
   coreutils-prefixed = coreutils.override { withPrefix = true; singleBinary = false; };


### PR DESCRIPTION
#21649 claims coreutils used to support them previously. I didn't check but obviously it's still useful to have them supported.