### PR TITLE
wireguard: 0.0.20161230 -> 0.0.20170105

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, libmnl, kernel ? null }:
 
-# module requires Linux >= 4.1 https://www.wireguard.io/install/#kernel-requirements
-assert kernel != null -> stdenv.lib.versionAtLeast kernel.version "4.1";
+# module requires Linux >= 3.18 https://www.wireguard.io/install/#kernel-requirements
+assert kernel != null -> stdenv.lib.versionAtLeast kernel.version "3.18";
 
 let
   name = "wireguard-${version}";
 
-  version = "0.0.20161230";
+  version = "0.0.20170105";
 
   src = fetchurl {
     url    = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "15p3k8msk3agr0i96k12y5h4fxv0gc8zqjk15mizd3wwmw6pgjb9";
+    sha256 = "1bd990eeae6fbf599ccddde81caa92770f58623ad9705f875bcfab8254583896";
   };
 
   meta = with stdenv.lib; {
@@ -46,6 +46,9 @@ let
     buildInputs = [ libmnl ];
 
     makeFlags = [
+      "WITH_BASHCOMPLETION=yes"
+      "WITH_WGQUICK=yes"
+      "WITH_SYSTEMDUNITS=yes"
       "DESTDIR=$(out)"
       "PREFIX=/"
       "-C" "tools"


### PR DESCRIPTION
Version bump that contains some new tools. From `src/tools/INSTALL`:

```
Installation Makefile Target
============================

    # make install

This command takes into account several environment variables:

  * PREFIX               default: /usr
  * DESTDIR              default:
  * BINDIR               default: $(PREFIX)/bin
  * LIBDIR               default: $(PREFIX)/lib
  * MANDIR               default: $(PREFIX)/share/man
  * BASHCOMPDIR          default: $(PREFIX)/share/bash-completion/completions
  * RUNSTATEDIR          default: /var/run
  * PKG_CONFIG           default: pkg-config

  * WITH_BASHCOMPLETION  default: [auto-detect]
  * WITH_WGQUICK         default: [auto-detect]
  * WITH_SYSTEMDUNITS    default: [auto-detect]

The first section is rather standard. The second section is not:

  * WITH_BASHCOMPLETION decides whether or not bash completion files for the
    tools are installed. This is just a nice thing for people who have bash.
    If you don't have bash, or don't want this, set the environment variable
    to `no'. If you'd like to force its use, even if bash-completion isn't
    detected in DESTDIR, then set it to `yes'.

  * WITH_WGQUICK decides whether or not the wg-quick(8) script is installed.
    This is a very quick and dirty bash script for reading a few extra
    variables from wg(8)-style configuration files, and automatically
    configures the interface. If you don't have bash, you probably don't want
    this at all. Likewise, if you already have a working network management
    tool or configuration, you probably want to integrate wg(8) or the direct
    WireGuard API into your network manager, rather than using wg-quick(8).
    But for folks who like simple quick&dirty scripts, this is nice. If you'd
    like to force its use, even if bash isn't detected in DESTDIR, then set it
    to `yes'.

  * WITH_SYSTEMDUNITS decides whether or not systemd units are installed for
    wg-quick(8). If you don't use systemd, you certainly don't want this, and
    should set it to `no'. If systemd isn't auto-detected, but you still would
    like to install it, set this to `yes'.
```