### PR TITLE
dvdplusrwtools: apply multiple fixes

### DIFF
--- a/pkgs/tools/cd-dvd/dvd+rw-tools/default.nix
+++ b/pkgs/tools/cd-dvd/dvd+rw-tools/default.nix
@@ -8,12 +8,24 @@ stdenv.mkDerivation {
     sha256 = "1jkjvvnjcyxpql97xjjx0kwvy70kxpiznr2zpjy2hhci5s10zmpq";
   };
 
+  # Patches from Gentoo / Fedora
+  # https://bugs.gentoo.org/257360
+  # https://bugzilla.redhat.com/show_bug.cgi?id=426068
+  # https://bugzilla.redhat.com/show_bug.cgi?id=243036
+  patches = [
+    ./dvd+rw-tools-7.0-dvddl.patch
+    ./dvd+rw-tools-7.0-glibc2.6.90.patch
+    ./dvd+rw-tools-7.0-wctomb.patch
+    ./dvd+rw-tools-7.0-wexit.patch
+    ./dvd+rw-tools-7.1-layerbreaksetup.patch
+  ];
+
   buildInputs = [cdrkit m4];
 
   preBuild = ''
     makeFlags="prefix=$out"
   '';
-  
+
   # Incompatibility with Linux 2.6.23 headers, see
   # http://www.mail-archive.com/cdwrite@other.debian.org/msg11464.html
   NIX_CFLAGS_COMPILE = "-DINT_MAX=__INT_MAX__";

--- a/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.0-dvddl.patch
+++ b/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.0-dvddl.patch
@@ -1,0 +1,13 @@
+--- ./growisofs_mmc.cpp.joe	2006-04-27 20:45:00.788446635 +0200
++++ ./growisofs_mmc.cpp	2006-04-27 20:46:01.666824300 +0200
+@@ -1412,9 +1412,7 @@
+     blocks += 15, blocks &= ~15;
+ 
+     if (blocks <= split)
+-	fprintf (stderr,":-( more than 50%% of space will be *wasted*!\n"
+-			"    use single layer media for this recording\n"),
+-	exit (FATAL_START(EMEDIUMTYPE));
++	fprintf (stderr,":-? more than 50%% of space will be *wasted*!\n");
+ 
+     blocks /= 16;
+     blocks += 1;

--- a/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.0-glibc2.6.90.patch
+++ b/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.0-glibc2.6.90.patch
@@ -1,0 +1,11 @@
+diff -up dvd+rw-tools-7.0/transport.hxx.glibc2.6.90 dvd+rw-tools-7.0/transport.hxx
+--- dvd+rw-tools-7.0/transport.hxx.glibc2.6.90	2007-08-15 12:56:17.000000000 +0200
++++ dvd+rw-tools-7.0/transport.hxx	2007-08-15 12:56:42.000000000 +0200
+@@ -11,6 +11,7 @@
+ #include <stdlib.h>
+ #include <unistd.h>
+ #include <string.h>
++#include <limits.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>

--- a/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.0-wctomb.patch
+++ b/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.0-wctomb.patch
@@ -1,0 +1,11 @@
+--- ./transport.hxx~	2008-03-25 21:24:47.000000000 -0400
++++ ./transport.hxx	2008-03-25 21:25:36.000000000 -0400
+@@ -116,7 +116,7 @@
+ extern "C" char *plusminus_locale()
+ { static class __plusminus {
+     private:
+-	char str[4];
++	char str[MB_LEN_MAX];
+     public:
+ 	__plusminus()	{   setlocale(LC_CTYPE,ENV_LOCALE);
+ 			    int l = wctomb(str,(wchar_t)(unsigned char)'±');

--- a/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.0-wexit.patch
+++ b/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.0-wexit.patch
@@ -1,0 +1,11 @@
+--- dvd+rw-tools-7.0/dvd+rw-format.cpp.wexit	2007-06-21 12:42:30.000000000 +0200
++++ dvd+rw-tools-7.0/dvd+rw-format.cpp	2007-06-21 12:44:13.000000000 +0200
+@@ -245,7 +245,7 @@ int main (int argc, char *argv[])
+ 	alarm(1);
+ 	while ((waitpid(pid,&i,0) != pid) && !WIFEXITED(i)) ;
+ 	if (WEXITSTATUS(i) == 0) fprintf (stderr,"\n");
+-	exit (0);
++	exit (WEXITSTATUS(i));
+     }
+ #endif
+ 

--- a/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.1-layerbreaksetup.patch
+++ b/pkgs/tools/cd-dvd/dvd+rw-tools/dvd+rw-tools-7.1-layerbreaksetup.patch
@@ -1,0 +1,93 @@
+diff -ur dvd+rw-tools-7.1-orig/growisofs.c dvd+rw-tools-7.1/growisofs.c
+--- dvd+rw-tools-7.1-orig/growisofs.c	2008-03-04 10:15:03.000000000 +0100
++++ dvd+rw-tools-7.1/growisofs.c	2009-09-06 22:39:33.000000000 +0200
+@@ -535,7 +535,7 @@
+  */
+ int        get_mmc_profile	(void *fd);
+ int        plusminus_r_C_parm	(void *fd,char *C_parm);
+-pwrite64_t poor_mans_setup	(void *fd,off64_t leadout);
++pwrite64_t poor_mans_setup	(void *fd,off64_t leadout,unsigned int lbreak);
+ char      *plusminus_locale	();
+ int        __1x			();
+ /*
+@@ -2447,7 +2447,7 @@
+ 			    goto out;
+ 			}
+ 			if (!progress.final) progress.final = tracksize;
+-			tracksize = layer_break*CD_BLOCK*2;
++			//tracksize = layer_break*CD_BLOCK*2;
+ 		    }
+ 		}
+ 		else if (capacity > outoff)
+@@ -2648,7 +2648,7 @@
+ 	 * further details on poor_mans_setup
+ 	 */
+ 	pwrite64_method = poor_mans_setup (ioctl_handle,
+-					   outoff+tracksize);
++					   outoff+tracksize, (unsigned int)layer_break);
+     }
+ 
+     if (!progress.final)
+diff -ur dvd+rw-tools-7.1-orig/growisofs_mmc.cpp dvd+rw-tools-7.1/growisofs_mmc.cpp
+--- dvd+rw-tools-7.1-orig/growisofs_mmc.cpp	2008-03-04 18:47:49.000000000 +0100
++++ dvd+rw-tools-7.1/growisofs_mmc.cpp	2009-09-06 20:52:46.000000000 +0200
+@@ -1612,7 +1612,7 @@
+   return 0;
+ }
+ 
+-static void plus_r_dl_split (Scsi_Command &cmd,off64_t size)
++static void plus_r_dl_split (Scsi_Command &cmd,off64_t size,unsigned int lbreak)
+ { int           err;
+   unsigned int  blocks,split;
+   unsigned char dvd_20[4+8];
+@@ -1644,10 +1644,17 @@
+ 			"    use single layer media for this recording\n"),
+ 	exit (FATAL_START(EMEDIUMTYPE));
+ 
+-    blocks /= 16;
+-    blocks += 1;
+-    blocks /= 2;
+-    blocks *= 16;
++    if (lbreak)
++      {
++	blocks=lbreak;
++      }
++    else
++      {
++	blocks /= 16;
++	blocks += 1;
++	blocks /= 2;
++	blocks *= 16;
++      }
+ 
+     fprintf (stderr,"%s: splitting layers at %u blocks\n",
+ 		    ioctl_device,blocks);
+@@ -2010,7 +2017,7 @@
+ typedef ssize_t (*pwrite64_t)(int,const void *,size_t,off64_t);
+ 
+ extern "C"
+-pwrite64_t poor_mans_setup (void *fd,off64_t leadout)
++pwrite64_t poor_mans_setup (void *fd,off64_t leadout,unsigned int lbreak)
+ { Scsi_Command cmd(ioctl_handle=fd);
+   int err,profile=mmc_profile&0xFFFF;
+ 
+@@ -2059,7 +2066,7 @@
+ 	case 0x2B:	// DVD+R Double Layer
+ 	    plusminus_pages_setup(cmd,profile);
+ 	    if (profile==0x2B && next_track==1 && dvd_compat && leadout)
+-		plus_r_dl_split (cmd,leadout);
++	      plus_r_dl_split (cmd,leadout,lbreak);
+ 	    atexit (plus_r_finalize);
+ 	    if (next_wr_addr)
+ 	    {	atsignals (no_r_finalize);
+diff -ur dvd+rw-tools-7.1-orig/transport.hxx dvd+rw-tools-7.1/transport.hxx
+--- dvd+rw-tools-7.1-orig/transport.hxx	2008-03-01 11:34:43.000000000 +0100
++++ dvd+rw-tools-7.1/transport.hxx	2009-09-06 20:53:53.000000000 +0200
+@@ -9,6 +9,7 @@
+ #if defined(__unix) || defined(__unix__)
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <limits.h>
+ #include <unistd.h>
+ #include <string.h>
+ #include <sys/types.h>


### PR DESCRIPTION
###### Motivation for this change

Upstream version of dvd+rw-tools is quite old and many Linux
distributions apply multiple patches to keep it working on newer
systems. This commit includes those patches.

This closes #21024.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

