### PR TITLE
glusterfs: fix mount.glusterfs installation

### DIFF
--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, fuse, bison, flex_2_5_35, openssl, python, ncurses, readline,
  autoconf, automake, libtool, pkgconfig, zlib, libaio, libxml2, acl, sqlite
- , liburcu, attr
+ , liburcu, attr, makeWrapper, coreutils, gnused, gnugrep, which
 }:
 let 
   s = # Generated upstream information 
@@ -15,7 +15,7 @@ let
   buildInputs = [
     fuse bison flex_2_5_35 openssl python ncurses readline
     autoconf automake libtool pkgconfig zlib libaio libxml2
-    acl sqlite liburcu attr
+    acl sqlite liburcu attr makeWrapper
   ];
   # Some of the headers reference acl
   propagatedBuildInputs = [
@@ -32,7 +32,7 @@ rec {
     '';
 
   configureFlags = [
-    ''--with-mountutildir="$out/sbin" --localstatedir=/var''
+    ''--localstatedir=/var''
     ];
 
   makeFlags = "DESTDIR=$(out)";
@@ -48,6 +48,7 @@ rec {
   postInstall = ''
     cp -r $out/$out/* $out
     rm -r $out/nix
+    wrapProgram $out/sbin/mount.glusterfs --set PATH "${stdenv.lib.makeBinPath [ coreutils gnused attr gnugrep which]}"
     '';
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

Fix #21619 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` -> Failed, see below
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tried to build all pkgs that depend on this change but it fails. However I don't think it is related to my change:

> LD [M]  /tmp/nix-build-dpdk-16.04-4.6.3.drv-1/dpdk-16.04/x86_64-native-linuxapp-gcc/build/lib/librte_eal/linuxapp/kni/rte_kni.o
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/x86_64-native-linuxapp-gcc/build/lib/librte_eal/linuxapp/kni/kni_net.c: In function 'kni_net_tx':     
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/x86_64-native-linuxapp-gcc/build/lib/librte_eal/linuxapp/kni/kni_net.c:399:5: error: 'struct net_device' has no member named 'trans_start'
>   dev->trans_start = jiffies; /* save the timestamp */                           
>      ^                                                                           
> /nix/store/kqxj66xzi1dhjbp033yjx6h5nvn1kwm8-linux-4.7-rc6-dev/lib/modules/4.7.0-rc6/source/scripts/Makefile.build:289: recipe for target '/tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/x86_64-native-linuxapp-gcc/build/lib/librte_eal/linuxapp/kni/kni_net.o' failed
> make[11]: *** [/tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/x86_64-native-linuxapp-gcc/build/lib/librte_eal/linuxapp/kni/kni_net.o] Error 1
> /nix/store/kqxj66xzi1dhjbp033yjx6h5nvn1kwm8-linux-4.7-rc6-dev/lib/modules/4.7.0-rc6/source/Makefile:1457: recipe for target '_module_/tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/x86_64-native-linuxapp-gcc/build/lib/librte_eal/linuxapp/kni' failed
> make[10]: *** [_module_/tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/x86_64-native-linuxapp-gcc/build/lib/librte_eal/linuxapp/kni] Error 2
> Makefile:150: recipe for target 'sub-make' failed                                
> make[9]: *** [sub-make] Error 2                                                  
> Makefile:24: recipe for target '__sub-make' failed                               
> make[8]: *** [__sub-make] Error 2                                                
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/mk/rte.module.mk:79: recipe for target 'rte_kni.ko' failed
> make[7]: *** [rte_kni.ko] Error 2                                                
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/mk/rte.subdir.mk:61: recipe for target 'kni' failed
> make[6]: *** [kni] Error 2                                                       
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/mk/rte.subdir.mk:61: recipe for target 'linuxapp' failed
> make[5]: *** [linuxapp] Error 2                                                  
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/mk/rte.subdir.mk:61: recipe for target 'librte_eal' failed
> make[4]: *** [librte_eal] Error 2                                                
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/mk/rte.sdkbuild.mk:77: recipe for target 'lib' failed
> make[3]: *** [lib] Error 2                                                       
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/mk/rte.sdkroot.mk:123: recipe for target 'all' failed
> make[2]: *** [all] Error 2                                                       
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/mk/rte.sdkinstall.mk:84: recipe for target 'pre_install' failed
> make[1]: *** [pre_install] Error 2                                               
> /tmp/nix-build-dpdk-16.04-4.7-rc6.drv-0/dpdk-16.04/mk/rte.sdkroot.mk:98: recipe for target 'install' failed
> make: *** [install] Error 2                                                      
> builder for ‘/nix/store/1ffgi07hv2mqzpw8h8a94hg3aiwayx1v-dpdk-16.04-4.7-rc6.drv’ failed with exit code 2
> error: build of ‘/nix/store/1ffgi07hv2mqzpw8h8a94hg3aiwayx1v-dpdk-16.04-4.7-rc6.drv’ failed


