### PR TITLE
libmemcached: update sha256 hash

### DIFF
--- a/pkgs/development/libraries/libmemcached/default.nix
+++ b/pkgs/development/libraries/libmemcached/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   patches = stdenv.lib.optional stdenv.isLinux ./libmemcached-fix-linking-with-libpthread.patch
     ++ stdenv.lib.optional stdenv.isDarwin (fetchpatch {
       url = "https://raw.githubusercontent.com/Homebrew/homebrew/bfd4a0a4626b61c2511fdf573bcbbc6bbe86340e/Library/Formula/libmemcached.rb";
-      sha256 = "1nvxwdkxj2a2g39z0g8byxjwnw4pa5xlvsmdk081q63vmfywh7zb";
+      sha256 = "1gjf3vd7hiyzxjvlg2zfc3y2j0lyr6nhbws4xb5dmin3csyp8qb8";
     });
 
   buildInputs = [ libevent ];


### PR DESCRIPTION
###### Motivation for this change
`libmemcached` was not building on darwin, because the sha256 hash was wrong. When I was trying to build, I got the following error:

```
these derivations will be built:
  /nix/store/dpvlhr4c277035bqp45y84hjh3zwfhmh-libmemcached.rb.drv
  /nix/store/ag0250cphl1spa41v23cnb4h7rrifrxp-libmemcached-1.0.18.drv
  /nix/store/6bxlkjxnkcnxrs0myhddsvncc1fhww26-zengrc-dev.drv
  /nix/store/fvg04q666rr4fibkvagb9db92flx8br8-pylibmc-libs.drv
building path(s) '/nix/store/851i9vscxj478yl6vv93hv8r6k3pyk5c-libmemcached.rb'

trying https://raw.githubusercontent.com/Homebrew/homebrew/bfd4a0a4626b61c2511fdf573bcbbc6bbe86340e/Library/Formula/libmemcached.rb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      100  6907  100  6907    0     0  37987      0 --:--:-- --:--:-- --:--:-- 52725
output path '/nix/store/851i9vscxj478yl6vv93hv8r6k3pyk5c-libmemcached.rb' has sha256 hash '1gjf3vd7hiyzxjvlg2zfc3y2j0lyr6nhbws4xb5dmin3csyp8qb8' when '1nvxwdkxj2a2g39z0g8byxjwnw4pa5xlvsmdk081q63vmfywh7zb' was expected
cannot build derivation '/nix/store/ag0250cphl1spa41v23cnb4h7rrifrxp-libmemcached-1.0.18.drv': 1 dependencies couldn't be built
error: build of '/nix/store/ag0250cphl1spa41v23cnb4h7rrifrxp-libmemcached-1.0.18.drv' failed
```

This is one of the failing packages listed in #18067.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

