### PR TITLE
chromium, google-chrome: add commandLineArgs

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -12,6 +12,7 @@
 , enableWideVine ? false
 , cupsSupport ? true
 , pulseSupport ? false
+, commandLineArgs ? ""
 }:
 
 let
@@ -76,6 +77,7 @@ in stdenv.mkDerivation {
     mkdir -p "$out/bin"
 
     eval makeWrapper "${browserBinary}" "$out/bin/chromium" \
+      ${commandLineArgs} \
       ${concatMapStringsSep " " getWrapperFlags chromium.plugins.enabled}
 
     ed -v -s "$out/bin/chromium" << EOF

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -6,6 +6,9 @@
 , alsaLib, libXdamage, libXtst, libXrandr, expat, cups
 , dbus_libs, gtk2, gdk_pixbuf, gcc
 
+# command line arguments which are always set e.g "--disable-gpu"
+, commandLineArgs ? ""
+
 # Will crash without.
 , systemd
 
@@ -106,7 +109,7 @@ in stdenv.mkDerivation rec {
     #!${bash}/bin/sh
     export LD_LIBRARY_PATH=$rpath\''${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}
     export PATH=$binpath\''${PATH:+:\$PATH}
-    $out/share/google/$appname/google-$appname "\$@"
+    $out/share/google/$appname/google-$appname ${commandLineArgs} "\$@"
     EOF
     chmod +x $exe
 


### PR DESCRIPTION
###### Motivation for this change

It is convenient to be able to ```.override``` chromium package in a way so it is always start with given [command line arguments](http://peter.sh/experiments/chromium-command-line-switches/), e.g ```--disable-gpu``` irregardless of how chromium is launched: by clicking on a toolbar icon, via ```xdg-open```, or from a some shell script.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

