### PR TITLE
dictd-db: Add deu2eng / eng2deu

### DIFF
--- a/pkgs/servers/dict/dictd-db.nix
+++ b/pkgs/servers/dict/dictd-db.nix
@@ -28,6 +28,14 @@ let
      };
    };
 in rec {
+  deu2eng = makeDictdDBFreedict (fetchurl {
+    url = http://prdownloads.sourceforge.net/freedict/deu-eng.tar.gz;
+    sha256 = "0dqrhv04g4f5s84nbgisgcfwk5x0rpincif0yfhfh4sc1bsvzsrb";
+  }) "deu-eng" "de_DE";
+  eng2deu = makeDictdDBFreedict (fetchurl {
+    url = http://prdownloads.sourceforge.net/freedict/eng-deu.tar.gz;
+    sha256 = "01x12p72sa3071iff3jhzga8588440f07zr56r3x98bspvdlz73r";
+  }) "eng-deu" "en_EN";
   nld2eng = makeDictdDBFreedict (fetchurl {
     url = http://prdownloads.sourceforge.net/freedict/nld-eng.tar.gz;
     sha256 = "1vhw81pphb64fzsjvpzsnnyr34ka2fxizfwilnxyjcmpn9360h07";


### PR DESCRIPTION
###### Motivation for this change

Was missing by now.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I just build these packages, I did not try whether they work with the `dictd` server.