### PR TITLE
Anki: Darwin support

### DIFF
--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -199,6 +199,6 @@ stdenv.mkDerivation rec {
     homepage = "http://mplayerhq.hu";
     license = "GPL";
     maintainers = [ stdenv.lib.maintainers.eelco stdenv.lib.maintainers.urkud ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/portaudio/default.nix
+++ b/pkgs/development/libraries/portaudio/default.nix
@@ -16,16 +16,12 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin [ AudioUnit AudioToolbox CoreAudio CoreServices Carbon ];
 
-  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i '50 i\
       #include <CoreAudio/AudioHardware.h>\
       #include <CoreAudio/AudioHardwareBase.h>\
       #include <CoreAudio/AudioHardwareDeprecated.h>' \
       include/pa_mac_core.h
-
-    # disable two tests that don't compile
-    sed -i -e 105d Makefile
-    sed -i -e 107d Makefile
   '';
 
   # not sure why, but all the headers seem to be installed by the make install

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -4,7 +4,7 @@
 , libmng, which, mesaSupported, mesa, mesa_glu, openssl, dbus, cups, pkgconfig
 , libtiff, glib, icu, mysql, postgresql, sqlite, perl, coreutils, libXi
 , buildMultimedia ? stdenv.isLinux, alsaLib, gstreamer, gst_plugins_base
-, buildWebkit ? stdenv.isLinux
+, buildWebkit ? (stdenv.isLinux || stdenv.isDarwin)
 , flashplayerFix ? false, gdk_pixbuf
 , gtkStyle ? false, libgnomeui, gtk2, GConf, gnome_vfs
 , developerBuild ? false

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkgconfig, intltool, autoreconfHook
+{ lib, stdenv, fetchurl, fetchpatch, pkgconfig, intltool, autoreconfHook
 , json_c, libsndfile, libtool
 , xorg, libcap, alsaLib, glib
 , avahi, libjack2, libasyncns, lirc, dbus
@@ -30,6 +30,8 @@
 
 , # Whether to build only the library.
   libOnly ? false
+
+, CoreServices, AudioUnit, Cocoa
 }:
 
 stdenv.mkDerivation rec {
@@ -41,7 +43,11 @@ stdenv.mkDerivation rec {
     sha256 = "11j682g2mn723sz3bh4i44ggq29z053zcggy0glzn63zh9mxdly3";
   };
 
-  patches = [ ./caps-fix.patch ];
+  patches = [ ./caps-fix.patch ]
+            ++ stdenv.lib.optional stdenv.isDarwin (fetchpatch {
+              url = "https://bugs.freedesktop.org/attachment.cgi?id=127889";
+              sha256 = "063h5vmh4ykgxjbxyxjlj6qhyyxhazbh3p18p1ik69kq24nkny9m";
+            });
 
   outputs = [ "out" "dev" ];
 
@@ -53,6 +59,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ json_c libsndfile speexdsp fftwFloat ]
     ++ lib.optionals stdenv.isLinux [ glib dbus ]
+    ++ lib.optionals stdenv.isDarwin [ CoreServices AudioUnit Cocoa ]
     ++ lib.optionals (!libOnly) (
       [ libasyncns webrtc-audio-processing ]
       ++ lib.optional jackaudioSupport libjack2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8987,7 +8987,9 @@ in
 
   popt = callPackage ../development/libraries/popt { };
 
-  portaudio = callPackage ../development/libraries/portaudio { };
+  portaudio = callPackage ../development/libraries/portaudio {
+    inherit (darwin.apple_sdk.frameworks) AudioToolbox AudioUnit CoreAudio CoreServices Carbon;
+  };
 
   portmidi = callPackage ../development/libraries/portmidi {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10315,11 +10315,16 @@ in
 
   pshs = callPackage ../servers/http/pshs { };
 
-  libpulseaudio = callPackage ../servers/pulseaudio { libOnly = true; };
+  libpulseaudio = callPackage ../servers/pulseaudio {
+    libOnly = true;
+    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
+  };
 
   # Name is changed to prevent use in packages;
   # please use libpulseaudio instead.
-  pulseaudioLight = callPackage ../servers/pulseaudio { };
+  pulseaudioLight = callPackage ../servers/pulseaudio {
+    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
+  };
 
   pulseaudioFull = callPackage ../servers/pulseaudio {
     gconf = gnome3.gconf;
@@ -10330,6 +10335,7 @@ in
     bluetoothSupport = true;
     remoteControlSupport = true;
     zeroconfSupport = true;
+    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };
 
   tomcat_connectors = callPackage ../servers/http/apache-modules/tomcat-connectors { };


### PR DESCRIPTION
###### Motivation for this change

These are all changes needed to get Anki working on macOS. No changes to the Anki derivation are necessary. However, to run Anki correctly you must set DYLD_FRAMEWORK_PATH correctly until #20484 is fixed:

```
DYLD_FRAMEWORK_PATH=/System/Library/Frameworks `nix-build '<nixpkgs>' -A anki --no-out-link`/bin/anki
```

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

