### PR TITLE
bind: fix collision of binaries in outputs

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -155,7 +155,7 @@ in
         chown ${bindUser} /var/run/named
       '';
 
-      script = "${pkgs.bind.bin}/sbin/named -u ${bindUser} ${optionalString cfg.ipv4Only "-4"} -c ${cfg.configFile} -f";
+      script = "${pkgs.bind.out}/sbin/named -u ${bindUser} ${optionalString cfg.ipv4Only "-4"} -c ${cfg.configFile} -f";
       unitConfig.Documentation = "man:named(8)";
     };
   };

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "11lxkb7d79c75scrs28q4xmr0ii2li69zj1c650al3qxir8yf754";
   };
 
-  outputs = [ "bin" "lib" "dev" "out" "man" "dnsutils" "host" ];
+  outputs = [ "out" "lib" "dev" "man" "dnsutils" "host" ];
 
   patches = [ ./dont-keep-configure-flags.patch ./remove-mkdir-var.patch ] ++
     stdenv.lib.optional stdenv.isDarwin ./darwin-openssl-linking-fix.patch;
@@ -40,13 +40,10 @@ stdenv.mkDerivation rec {
     moveToOutput bin/isc-config.sh $dev
 
     moveToOutput bin/host $host
-    ln -sf $host/bin/host $bin/bin
 
     moveToOutput bin/dig $dnsutils
     moveToOutput bin/nslookup $dnsutils
     moveToOutput bin/nsupdate $dnsutils
-    ln -sf $dnsutils/bin/{dig,nslookup,nsupdate} $bin/bin
-    ln -sf $host/bin/host $dnsutils/bin
 
     for f in "$lib/lib/"*.la "$dev/bin/"{isc-config.sh,bind*-config}; do
       sed -i "$f" -e 's|-L${openssl.dev}|-L${openssl.out}|g'
@@ -60,5 +57,7 @@ stdenv.mkDerivation rec {
 
     maintainers = with stdenv.lib.maintainers; [viric peti];
     platforms = with stdenv.lib.platforms; unix;
+
+    outputsToInstall = [ "out" "dnsutils" "host" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Using outputsToInstall the intended behaviour of including host and dnsutils when bind is installed can be implemented instead of using symlinks to fix installing all outputs individually with nix-env.

Fixes #19761.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

