### PR TITLE
locate: extend module

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -4,10 +4,12 @@ with lib;
 
 let
   cfg = config.services.locate;
+  isMLocate = hasPrefix "mlocate" cfg.locate.name;
+  isFindutils = hasPrefix "findutils" cfg.locate.name;
 in {
-  options.services.locate = {
+  options.services.locate = with types; {
     enable = mkOption {
-      type = types.bool;
+      type = bool;
       default = false;
       description = ''
         If enabled, NixOS will periodically update the database of
@@ -16,7 +18,7 @@ in {
     };
 
     locate = mkOption {
-      type = types.package;
+      type = package;
       default = pkgs.findutils;
       defaultText = "pkgs.findutils";
       example = "pkgs.mlocate";
@@ -26,7 +28,7 @@ in {
     };
 
     interval = mkOption {
-      type = types.str;
+      type = str;
       default = "02:15";
       example = "hourly";
       description = ''
@@ -40,7 +42,7 @@ in {
     };
 
     extraFlags = mkOption {
-      type = types.listOf types.str;
+      type = listOf str;
       default = [ ];
       description = ''
         Extra flags to pass to <command>updatedb</command>.
@@ -48,7 +50,7 @@ in {
     };
 
     output = mkOption {
-      type = types.path;
+      type = path;
       default = "/var/cache/locatedb";
       description = ''
         The database file to build.
@@ -56,7 +58,7 @@ in {
     };
 
     localuser = mkOption {
-      type = types.nullOr types.str;
+      type = nullOr str;
       default = "nobody";
       description = ''
         The user to search non-network directories as, using
@@ -64,27 +66,75 @@ in {
       '';
     };
 
-    includeStore = mkOption {
-      type = types.bool;
-      default = false;
+    pruneFS = mkOption {
+      type = listOf str;
+      default = ["afs" "anon_inodefs" "auto" "autofs" "bdev" "binfmt" "binfmt_misc" "cgroup" "cifs" "coda" "configfs" "cramfs" "cpuset" "debugfs" "devfs" "devpts" "devtmpfs" "ecryptfs" "eventpollfs" "exofs" "futexfs" "ftpfs" "fuse" "fusectl" "gfs" "gfs2" "hostfs" "hugetlbfs" "inotifyfs" "iso9660" "jffs2" "lustre" "misc" "mqueue" "ncpfs" "nnpfs" "ocfs" "ocfs2" "pipefs" "proc" "ramfs" "rpc_pipefs" "securityfs" "selinuxfs" "sfs" "shfs" "smbfs" "sockfs" "spufs" "nfs" "NFS" "nfs4" "nfsd" "sshfs" "subfs" "supermount" "sysfs" "tmpfs" "ubifs" "udf" "usbfs" "vboxsf" "vperfctrfs" ];
       description = ''
-        Whether to include <filename>/nix/store</filename> in the locate database.
+        Which filesystem types to exclude from indexing
       '';
     };
+
+    prunePaths = mkOption {
+      type = listOf path;
+      default = ["/tmp" "/var/tmp" "/var/cache" "/var/lock" "/var/run" "/var/spool" "/nix/store"];
+      description = ''
+        Which paths to exclude from indexing
+      '';
+    };
+
+    pruneNames = mkOption {
+      type = listOf str;
+      default = [];
+      description = ''
+        Directory components which should exclude paths containing them from indexing
+      '';
+    };
+
+    pruneBindMounts = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Whether not to index bind mounts
+      '';
+    };
+    
   };
 
-  config = {
+  config = mkIf cfg.enable {
+    users.extraGroups = mkIf isMLocate { mlocate = {}; };
+
+    security.setuidOwners = mkIf isMLocate
+      [ { group = "mlocate";
+          owner = "root";
+          permissions = "u+rx,g+x,o+x";
+          setgid = true;
+          setuid = false;
+          program = "locate";
+        }
+      ];
+
+    environment.systemPackages = [ cfg.locate ];
+
+    warnings = optional (isMLocate && cfg.localuser != null) "mlocate does not support searching as user other than root"
+            ++ optional (isFindutils && cfg.pruneNames != []) "findutils locate does not support pruning by directory component"
+            ++ optional (isFindutils && cfg.pruneBindMounts) "findutils locate does not support skipping bind mounts";
+  
     systemd.services.update-locatedb =
       { description = "Update Locate Database";
-        path  = [ pkgs.su ];
+        path = mkIf (!isMLocate) [ pkgs.su ];
         script =
           ''
-            mkdir -m 0755 -p $(dirname ${toString cfg.output})
+            install -m ${if isMLocate then "0750" else "0755"} -o root -g ${if isMLocate then "mlocate" else "root"} -d $(dirname ${cfg.output})
             exec ${cfg.locate}/bin/updatedb \
               ${optionalString (cfg.localuser != null) ''--localuser=${cfg.localuser}''} \
-              ${optionalString (!cfg.includeStore) "--prunepaths='/nix/store'"} \
               --output=${toString cfg.output} ${concatStringsSep " " cfg.extraFlags}
           '';
+        environment = {
+          PRUNEFS = concatStringsSep " " cfg.pruneFS;
+          PRUNEPATHS = concatStringsSep " " cfg.prunePaths;
+          PRUNENAMES = concatStringsSep " " cfg.pruneNames;
+          PRUNE_BIND_MOUNTS = if cfg.pruneBindMounts then "yes" else "no";
+        };
         serviceConfig.Nice = 19;
         serviceConfig.IOSchedulingClass = "idle";
         serviceConfig.PrivateTmp = "yes";
@@ -94,7 +144,7 @@ in {
         serviceConfig.ReadWriteDirectories = dirOf cfg.output;
       };
 
-    systemd.timers.update-locatedb = mkIf cfg.enable
+    systemd.timers.update-locatedb =
       { description = "Update timer for locate database";
         partOf      = [ "update-locatedb.service" ];
         wantedBy    = [ "timers.target" ];

--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -113,7 +113,13 @@ in {
         }
       ];
 
+    nixpkgs.config = { locate.dbfile = cfg.output; };
+
     environment.systemPackages = [ cfg.locate ];
+
+    environment.variables = mkIf (!isMLocate)
+      { LOCATE_PATH = cfg.output;
+      };
 
     warnings = optional (isMLocate && cfg.localuser != null) "mlocate does not support searching as user other than root"
             ++ optional (isFindutils && cfg.pruneNames != []) "findutils locate does not support pruning by directory component"

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -17,8 +17,7 @@ in
   config = {
 
     environment.variables =
-      { LOCATE_PATH = "/var/cache/locatedb";
-        NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
+      { NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
         PAGER = mkDefault "less -R";
         EDITOR = mkDefault "nano";
       };

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -170,6 +170,7 @@ with lib;
 
     # locate
     (mkRenamedOptionModule [ "services" "locate" "period" ] [ "services" "locate" "interval" ])
+    (mkRemovedOptionModule [ "services" "locate" "includeStore" ] "Use services.locate.prunePaths" )
 
     # Options that are obsolete and have no replacement.
     (mkRemovedOptionModule [ "boot" "initrd" "luks" "enable" ] "")

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -168,6 +168,9 @@ with lib;
     # dhcpd
     (mkRenamedOptionModule [ "services" "dhcpd" ] [ "services" "dhcpd4" ])
 
+    # locate
+    (mkRenamedOptionModule [ "services" "locate" "period" ] [ "services" "locate" "interval" ])
+
     # Options that are obsolete and have no replacement.
     (mkRemovedOptionModule [ "boot" "initrd" "luks" "enable" ] "")
     (mkRemovedOptionModule [ "programs" "bash" "enable" ] "")

--- a/pkgs/tools/misc/mlocate/default.nix
+++ b/pkgs/tools/misc/mlocate/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, config }:
 
-stdenv.mkDerivation rec {
+let
+  dbfile = stdenv.lib.attrByPath [ "locate" "dbfile" ] "/var/cache/locatedb" config;
+in stdenv.mkDerivation rec {
   name = "mlocate-${version}";
   version = "0.26";
 
@@ -10,6 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ ];
+  makeFlags = [ "dbfile=${dbfile}" ];
 
   meta = with stdenv.lib; {
     description = "Merging locate is an utility to index and quickly search for files";


### PR DESCRIPTION
###### Motivation for this change
Support for `mlocate` looked significantly more complete than it turned out to be

###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I couldn't find a way to properly handle `includeStore` in `rename.nix` so I´m just echoing a warning for now. I think a reasonable approach would be to remove `/nix/store` from `prunePaths` when `includeStore` is set (and print a warning). I could not, however, find a way to do so without running into infinite recursion – any ideas?
