### PR TITLE
godot: init at 2.1.1-stable

### DIFF
--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, gcc, scons, pkgconfig, libX11, libXcursor
+, libXinerama, libXrandr, libXrender, freetype, openssl, alsaLib
+, libpulseaudio, mesa, mesa_glu, zlib }:
+
+stdenv.mkDerivation rec {
+  name    = "godot-${version}";
+  version = "2.1.1-stable";
+
+  src = fetchFromGitHub {
+    owner  = "godotengine";
+    repo   = "godot";
+    rev    = version;
+    sha256 = "071qkm1l6yn2s9ha67y15w2phvy5m5wl3wqvrslhfmnsir3q3k01";
+  };
+
+  buildInputs = [
+    gcc scons pkgconfig libX11 libXcursor libXinerama libXrandr libXrender
+    freetype openssl alsaLib libpulseaudio mesa mesa_glu zlib
+  ];
+
+  patches = [ ./pkg_config_additions.patch ];
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    scons platform=x11 prefix=$out -j $NIX_BUILD_CORES
+  '';
+
+  installPhase = ''
+    mkdir $out/bin -p
+    cp bin/godot.* $out/bin/
+  '';
+
+  meta = {
+    homepage    = "http://godotengine.org";
+    description = "Free and Open Source 2D and 3D game engine";
+    license     = stdenv.lib.licenses.mit;
+    platforms   = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/tools/godot/pkg_config_additions.patch
+++ b/pkgs/development/tools/godot/pkg_config_additions.patch
@@ -1,0 +1,12 @@
++++ build/platform/x11/detect.py
+@@ -132,6 +132,10 @@
+     env.ParseConfig('pkg-config xinerama --cflags --libs')
+     env.ParseConfig('pkg-config xcursor --cflags --libs')
+     env.ParseConfig('pkg-config xrandr --cflags --libs')
++    env.ParseConfig('pkg-config xrender --cflags --libs')
++    env.ParseConfig('pkg-config osmesa --cflags')
++    env.ParseConfig('pkg-config glu --cflags --libs')
++    env.ParseConfig('pkg-config zlib --cflags --libs')
+
+     if (env['builtin_openssl'] == 'no'):
+         env.ParseConfig('pkg-config openssl --cflags --libs')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1938,6 +1938,8 @@ in
 
   gocryptfs = callPackage ../tools/filesystems/gocrypfs { };
 
+  godot = callPackage ../development/tools/godot {};
+
   go-mtpfs = callPackage ../tools/filesystems/go-mtpfs { };
 
   go-pup = callPackage ../development/tools/pup { };


### PR DESCRIPTION
Adds the [godot engine](https://godotengine.org/) at the latest stable version.

This package builds the engine and the editor.

Since this is a fairly large C++ project I have added `enableParallelBuilding = true;` to speed up the build.

Using `nix.buildCores = 4;` on my computer that has a [i5 760](http://www.cpubenchmark.net/cpu.php?cpu=Intel%20Core%20i5-760%20%40%202.80GHz) the whole build took:

```
/nix/store/l0si3mbcacrhq9hz922qw2f8c9cr0y5g-godot-2.1.1-stable

real    7m41.175s
user    0m0.323s
sys     0m0.084s
```

Here's a short screencast of me opening the binary inside the `result/bin` dir after running `nix-build`:

![godot](https://cloud.githubusercontent.com/assets/766350/21697211/9a264264-d391-11e6-89ba-48f86107a8cc.gif)

In the screencast I open the example project Minesweeper that I downloaded via the interface earlier. I then run the project and fail at sweeping all the mines.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS unstable (17.03pre96677.7926e75) x86_64
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
