### PR TITLE
skrooge: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/applications/office/skrooge/2.nix
+++ b/pkgs/applications/office/skrooge/2.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "skrooge-${version}";
-  version = "2.5.0";
+  version = "2.6.0";
 
   src = fetchurl {
     url = "http://download.kde.org/stable/skrooge/${name}.tar.xz";
-    sha256 = "03ayrrr7rrj1jl1qh3sgn56hbi44wn4ldgcj08b93mqw7wdvpglp";
+    sha256 = "13sd669rx66fpk9pm72nr2y69k2h4mcs4b904i9xm41i0fiy6szp";
   };
 
   nativeBuildInputs = [ cmake ecm makeQtWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Recommended update from upstream.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

