### PR TITLE
discord: 0.0.11 -> 0.0.13, PaX fix.

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
                  --set-rpath "$out:$libPath"                                   \
                  $out/DiscordCanary
 
+        paxmark m $out/DiscordCanary
+
         ln -s $out/DiscordCanary $out/bin/
         ln -s $out/discord.png $out/share/pixmaps
 

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -7,12 +7,12 @@
 stdenv.mkDerivation rec {
 
     pname = "discord";
-    version = "0.0.11";
+    version = "0.0.13";
     name = "${pname}-${version}";
 
     src = fetchurl {
         url = "https://cdn-canary.discordapp.com/apps/linux/${version}/${pname}-canary-${version}.tar.gz";
-        sha256 = "1lk53vm14vr5pb8xxcx6hinpc2mkdns2xxv0bfzxvlmhfr6d6y18";
+        sha256 = "1pwb8y80z1bmfln5wd1vrhras0xygd1j15sib0g9vaig4mc55cs6";
     };
 
     libPath = stdenv.lib.makeLibraryPath [


### PR DESCRIPTION
###### Motivation for this change

Update to latest (application apparently refuses to run if not on latest!),
paxmark to allow RWX mapping required for execution.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

grsec warning:

```
... denied RWX mmap of <anonymous mapping> by /nix/store/sil4wixsg8cig38xbnd0yr82kkpjp41d-discord-0.0.11/DiscordCanary[DiscordCanary:63121]
```