### PR TITLE
skype: paxmark to fix execution on PaX-enabled kernels

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skype/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skype/default.nix
@@ -38,6 +38,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{libexec/skype/,bin}
     cp -r * $out/libexec/skype/
 
+    # Fix execution on PaX-enabled kernels
+    paxmark m $out/libexec/skype/skype
+
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "${lib.makeLibraryPath buildInputs}" $out/libexec/skype/skype
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Interestingly, my first attempt had 'paxmark' occurring after patchelf touched the binary but that
resulted in an error complaining that the file was not a valid executable:

```
file /nix/store/9ambl5f70zjmv8q3nckf48j1ii8dl7pl-skype-4.3.0.37/libexec/skype/skype is not a valid ELF executable (invalid SHT_ entry:1)
```

Is this a known problem? Anyway running paxmark first seems to work properly.