### PR TITLE
shfmt: 0.2.0 -> 1.1.0

### DIFF
--- a/pkgs/tools/text/shfmt/default.nix
+++ b/pkgs/tools/text/shfmt/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "shfmt-${version}";
-  version = "0.2.0";
+  version = "1.1.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/mvdan/sh";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "mvdan";
     repo = "sh";
     inherit rev;
-    sha256 = "07jf9v6583vvmk07fp7xdlnh7rvgl6f06ib2588g3xf1wk9vrq3d";
+    sha256 = "0h1qy27z6j1cgkk3hkvl7w3wjqc5flgn92r3j6frn8k2wzwj7zhz";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Requested by author:
https://github.com/mvdan/sh/issues/13#issuecomment-270738232

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

