### PR TITLE
test-driver: support punctuation in sendChars

### DIFF
--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -611,16 +611,6 @@ sub copyFileFromHost {
 }
 
 
-sub sendKeys {
-    my ($self, @keys) = @_;
-    foreach my $key (@keys) {
-        $key = "spc" if $key eq " ";
-        $key = "ret" if $key eq "\n";
-        $self->sendMonitorCommand("sendkey $key");
-    }
-}
-
-
 my %charToKey = (
     '!' => "shift-0x02",
     '@' => "shift-0x03",
@@ -643,13 +633,24 @@ my %charToKey = (
     ',' => "0x33", '<' => "shift-0x33",
     '.' => "0x34", '>' => "shift-0x34",
     '/' => "0x35", '?' => "shift-0x35",
+    ' ' => "spc",
+   "\n" => "ret",
 );
+
+
+sub sendKeys {
+    my ($self, @keys) = @_;
+    foreach my $key (@keys) {
+        $key = $charToKey{$key} if exists $charToKey{$key};
+        $self->sendMonitorCommand("sendkey $key");
+    }
+}
 
 
 sub sendChars {
     my ($self, $chars) = @_;
     $self->nest("sending keys ‘$chars’", sub {
-        $self->sendKeys(map { exists $charToKey{$_} ? $charToKey{$_} : $_ } split //, $chars);
+        $self->sendKeys(split //, $chars);
     });
 }
 

--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -621,10 +621,35 @@ sub sendKeys {
 }
 
 
+my %charToKey = (
+    '!' => "shift-0x02",
+    '@' => "shift-0x03",
+    '#' => "shift-0x04",
+    '$' => "shift-0x05",
+    '%' => "shift-0x06",
+    '^' => "shift-0x07",
+    '&' => "shift-0x08",
+    '*' => "shift-0x09",
+    '(' => "shift-0x0A",
+    ')' => "shift-0x0B",
+    '-' => "0x0C", '_' => "shift-0x0C",
+    '=' => "0x0D", '+' => "shift-0x0D",
+    '[' => "0x1A", '{' => "shift-0x1A",
+    ']' => "0x1B", '}' => "shift-0x1B",
+    ';' => "0x27", ':' => "shift-0x27",
+   '\'' => "0x28", '"' => "shift-0x28",
+    '`' => "0x29", '~' => "shift-0x29",
+   '\\' => "0x2B", '|' => "shift-0x2B",
+    ',' => "0x33", '<' => "shift-0x33",
+    '.' => "0x34", '>' => "shift-0x34",
+    '/' => "0x35", '?' => "shift-0x35",
+);
+
+
 sub sendChars {
     my ($self, $chars) = @_;
     $self->nest("sending keys ‘$chars’", sub {
-        $self->sendKeys(split //, $chars);
+        $self->sendKeys(map { exists $charToKey{$_} ? $charToKey{$_} : $_ } split //, $chars);
     });
 }
 


### PR DESCRIPTION
###### Motivation for this change

```sendChars``` sends only alphanumeric keys.
```$machine->sendChars("a:b/c");``` is the same as ```$machine->sendChars("abc");``` 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

