### PR TITLE
transcrypt: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/transcrypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/transcrypt/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "transcrypt-${version}";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "elasticdog";
     repo = "transcrypt";
     rev = "v${version}";
-    sha256 = "195hi8lq1i9rfcwj3raw4pa7fhvv3ghznxp4crmbjm7c0sqilcpd";
+    sha256 = "12n8714my9i93lysqa3dj1z5xgi10iv5y1mnsqki9zn5av3lgqkq";
   };
 
   buildInputs = [ git makeWrapper openssl ];


### PR DESCRIPTION
###### Motivation for this change

Bump to the latest upstream release version.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---