### PR TITLE
sakura: fixed GLib-GIO-ERROR #21698

### DIFF
--- a/pkgs/applications/misc/sakura/default.nix
+++ b/pkgs/applications/misc/sakura/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, gtk3, perl, vte, pcre, glib }:
+{ stdenv, fetchurl, cmake, pkgconfig, gtk3, perl, vte, pcre, glib , makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "sakura-${version}";
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake perl pkgconfig ];
 
-  buildInputs = [ gtk3 vte pcre glib ];
+  buildInputs = [ makeWrapper gtk3 vte pcre glib ];
+
+  # Wrapper sets path to gsettings-schemata so sakura knows where to find colorchooser, fontchooser ...
+  postInstall = "wrapProgram $out/bin/sakura --suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}/";
 
   meta = with stdenv.lib; {
     description = "A terminal emulator based on GTK and VTE";

--- a/pkgs/tools/system/chase/default.nix
+++ b/pkgs/tools/system/chase/default.nix
@@ -14,14 +14,14 @@ stdenv.mkDerivation rec {
   makeFlags = [ "-e" ];
   makeFlagsArray="LIBS=-lgc";
 
-  meta = {
+  meta = with stdenv.lib ; {
     description = "Follow a symlink and print out its target file";
     longDescription = ''
     A commandline program that chases symbolic filesystems links to the original file
     '';
     homepage = "https://qa.debian.org/developer.php?login=rotty%40debian.org";
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [ stdenv.lib.maintainers.polyrod ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.polyrod ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Bug Fix for issue; GLib-GIO-ERROR #21698

###### Things done
added wrapper to sakura binary wich sets path to gtk3-gsettings-schemata which provide
colorchooser fontchooser gui descriptions.

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

