### PR TITLE
httpd module: don't create documentRoot directory if it doesn't exist

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -709,13 +709,6 @@ in
             ''}
             mkdir -m 0700 -p ${mainCfg.logDir}
 
-            ${optionalString (mainCfg.documentRoot != null)
-            ''
-              # Create the document root directory if does not exists yet
-              mkdir -p ${mainCfg.documentRoot}
-            ''
-            }
-
             # Get rid of old semaphores.  These tend to accumulate across
             # server restarts, eventually preventing it from restarting
             # successfully.


### PR DESCRIPTION
It hides bugs and do you ever actually want to serve up an empty directory? It was pretty confusing to me when it tried to write into a read-only store path because I accidentally pointed it to the wrong store path.

See #21684 for more discussion.