### PR TITLE
nginx: add PageSpeed module (Linux only)

### DIFF
--- a/pkgs/development/libraries/psol/default.nix
+++ b/pkgs/development/libraries/psol/default.nix
@@ -1,0 +1,5 @@
+{ callPackage }:
+callPackage ./generic.nix {} {
+  version = "1.11.33.4";
+  sha256  = "1jq2llp0i4666rwqnx1hs4pjlpblxivvs1jkkjzlmdbsv28jzjq8";
+}

--- a/pkgs/development/libraries/psol/generic.nix
+++ b/pkgs/development/libraries/psol/generic.nix
@@ -1,0 +1,16 @@
+{ fetchzip, stdenv }:
+{ version, sha256 }:
+{ inherit version; } // fetchzip {
+  inherit sha256;
+  name   = "psol-${version}";
+  url    = "https://dl.google.com/dl/page-speed/psol/${version}.tar.gz";
+
+  meta = {
+    description = "PageSpeed Optimization Libraries";
+    homepage    = "https://developers.google.com/speed/pagespeed/psol";
+    license     = stdenv.lib.licenses.asl20;
+    # WARNING: This only works with Linux because the pre-built PSOL binary is only supplied for Linux.
+    # TODO: Build PSOL from source to support more platforms.
+    platforms   = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -146,4 +146,33 @@
       sha256 = "0ib2jrbjwrhvmihhnzkp4w87fxssbbmmmj6lfdwpm6ni8p9g60dw";
     };
   };
+
+  pagespeed =
+    let
+      version = pkgs.psol.version;
+
+      moduleSrc = fetchFromGitHub {
+        owner  = "pagespeed";
+        repo   = "ngx_pagespeed";
+        rev    = "v${version}-beta";
+        sha256 = "03dvzf1lgsjxcs1jjxq95n2rhgq0wy0f9ahvgascy0fak7qx4xj9";
+      };
+
+      ngx_pagespeed = pkgs.runCommand
+        "ngx_pagespeed"
+        {
+          meta = {
+            description = "PageSpeed module for Nginx";
+            homepage    = "https://developers.google.com/speed/pagespeed/module/";
+            license     = pkgs.stdenv.lib.licenses.asl20;
+          };
+        }
+        ''
+          cp -r "${moduleSrc}" "$out"
+          chmod -R +w "$out"
+          ln -s "${pkgs.psol}" "$out/psol"
+        '';
+    in {
+      src = ngx_pagespeed;
+    };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8395,7 +8395,7 @@ in
 
   libpfm = callPackage ../development/libraries/libpfm { };
 
-  libpqxx = callPackage ../development/libraries/libpqxx { 
+  libpqxx = callPackage ../development/libraries/libpqxx {
     gnused = gnused_422;
   };
 
@@ -14588,6 +14588,8 @@ in
     notifySupport   = config.profanity.notifySupport   or true;
     autoAwaySupport = config.profanity.autoAwaySupport or true;
   };
+
+  psol = callPackage ../development/libraries/psol/default.nix { };
 
   pstree = callPackage ../applications/misc/pstree { };
 


### PR DESCRIPTION
###### Motivation for this change

Ref #14277
Fixes #9420

Adds the PageSpeed module for nginx. Currently only Linux is supported because we use the prebuilt PSOL binaries.


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

