### PR TITLE
git-up: not a python package

### DIFF
--- a/pkgs/applications/version-management/git-up/default.nix
+++ b/pkgs/applications/version-management/git-up/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, python2Packages, git }:
+
+python2Packages.buildPythonApplication rec {
+  version = "1.4.2";
+  name = "git-up-${version}";
+
+  src = fetchurl {
+    url = "mirror://pypi/g/git-up/${name}.zip";
+    sha256 = "121ia5gyjy7js6fbsx9z98j2qpq7rzwpsj8gnfvsbz2d69g0vl7q";
+  };
+
+  buildInputs = [ git ] ++ (with python2Packages; [ nose ]);
+  propagatedBuildInputs = with python2Packages; [ click colorama docopt GitPython six termcolor ];
+
+  # 1. git fails to run as it cannot detect the email address, so we set it
+  # 2. $HOME is by default not a valid dir, so we have to set that too
+  # https://github.com/NixOS/nixpkgs/issues/12591
+  preCheck = ''
+      export HOME=$TMPDIR
+      git config --global user.email "nobody@example.com"
+      git config --global user.name "Nobody"
+    '';
+
+  postInstall = ''
+    rm -r $out/${python2Packages.python.sitePackages}/PyGitUp/tests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/msiemens/PyGitUp;
+    description = "A git pull replacement that rebases all local branches when pulling.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1863,6 +1863,8 @@ in
 
   git-lfs = callPackage ../applications/version-management/git-lfs { };
 
+  git-up = callPackage ../applications/version-management/git-up { };
+
   gitfs = callPackage ../tools/filesystems/gitfs { };
 
   gitinspector = callPackage ../applications/version-management/gitinspector { };
@@ -14516,7 +14518,7 @@ in
   qscreenshot = callPackage ../applications/graphics/qscreenshot {
     qt = qt4;
   };
-  
+
   qsyncthingtray = qt5.callPackage ../applications/misc/qsyncthingtray { };
 
   qsynth = callPackage ../applications/audio/qsynth { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7334,35 +7334,6 @@ in {
 
   };
 
-  git-up = buildPythonPackage rec {
-    version = "1.4.2";
-    name = "git-up-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/g/git-up/${name}.zip";
-      sha256 = "121ia5gyjy7js6fbsx9z98j2qpq7rzwpsj8gnfvsbz2d69g0vl7q";
-    };
-
-    buildInputs = with self; [ pkgs.git nose ];
-    propagatedBuildInputs = with self; [ click colorama docopt GitPython six termcolor ];
-
-    # git fails to run as it cannot detect the email address, so we set it
-    # $HOME is by default not a valid dir, so we have to set that too
-    # https://github.com/NixOS/nixpkgs/issues/12591
-    preCheck = ''
-      export HOME=$TMPDIR
-      git config --global user.email "nobody@example.com"
-      git config --global user.name "Nobody"
-    '';
-
-    meta = {
-      homepage = http://github.com/msiemens/PyGitUp;
-      description = "A git pull replacement that rebases all local branches when pulling.";
-      license = licenses.mit;
-      maintainers = with maintainers; [ peterhoeg ];
-    };
-  };
-
   GitPython = buildPythonPackage rec {
     version = "2.0.8";
     name = "GitPython-${version}";


### PR DESCRIPTION
###### Motivation for this change

1. git-up is *not* a python package as such but an application, so move it out of python-packages.nix
2. get rid of the tests (we've already run the tests)

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
