### PR TITLE
libtermkey: from 0.18 to 0.19

### DIFF
--- a/pkgs/development/libraries/libtermkey/default.nix
+++ b/pkgs/development/libraries/libtermkey/default.nix
@@ -3,11 +3,11 @@
 stdenv.mkDerivation rec {
   name = "libtermkey-${version}";
 
-  version = "0.18";
+  version = "0.19";
 
   src = fetchzip {
     url = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-${version}.tar.gz";
-    sha256 = "0a0ih1a114phzmyq6jzgbp03x97463fwvrp1cgnl26awqw3f8sbf";
+    sha256 = "0v85h0zacd5lqwkykl2ms4009x8mfidzb6jr4dsq4gh7kwm54w56";
   };
 
   makeFlags = [ "PREFIX=$(out)" ]


### PR DESCRIPTION
###### Motivation for this change

neovim/neovim#5322

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

