### PR TITLE
pythonPackages.discordpy: 0.15.1 -> 0.16

### DIFF
--- a/pkgs/development/python-modules/discordpy/default.nix
+++ b/pkgs/development/python-modules/discordpy/default.nix
@@ -11,13 +11,13 @@
 
 let
   pname = "discord.py";
-  version = "0.15.1";
+  version = "0.16.0";
 in buildPythonPackage rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
-    sha256 = "01lgidvnwwva1i65853gaplamllym2nsk0jis2r6f1rzbamgk1yj";
+    sha256 = "0r3qqvx36vywjyjk1nh11ymmr8y81sb45nk63665kcjagx8qnmfx";
   };
 
   propagatedBuildInputs = [ asyncio aiohttp websockets pynacl ];


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).