### PR TITLE
Transmission: Darwin support

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, file, makeWrapper
 , openssl, curl, libevent, inotify-tools, systemd, zlib
 , enableGTK3 ? false, gtk3
+, enableSystemd ? stdenv.isLinux
 }:
 
 let
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pkgconfig intltool file openssl curl libevent inotify-tools zlib ]
     ++ optionals enableGTK3 [ gtk3 makeWrapper ]
-    ++ optional stdenv.isLinux systemd;
+    ++ optionals enableSystemd [ systemd ]
 
   postPatch = ''
     substituteInPlace ./configure \
@@ -27,8 +28,10 @@ stdenv.mkDerivation rec {
       --replace "/usr/bin/file"     "${file}/bin/file"
   '';
 
-  configureFlags = [ "--with-systemd-daemon" ]
-    ++ [ "--enable-cli" ]
+  configureFlags = [
+      "--enable-cli"
+    ]
+    ++ optional enableSystemd "--with-systemd-daemon"
     ++ optional enableGTK3 "--with-gtk";
 
   preFixup = optionalString enableGTK3 /* gsettings schemas for file dialogues */ ''

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -2,6 +2,7 @@
 , openssl, curl, libevent, inotify-tools, systemd, zlib
 , enableGTK3 ? false, gtk3
 , enableSystemd ? stdenv.isLinux
+, enableDaemon ? true
 , enableCli ? true
 }:
 
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
       ("--enable-cli=" + (if enableCli then "yes" else "no"))
+      ("--enable-daemon=" + (if enableDaemon then "yes" else "no"))
     ]
     ++ optional enableSystemd "--with-systemd-daemon"
     ++ optional enableGTK3 "--with-gtk";

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -2,6 +2,7 @@
 , openssl, curl, libevent, inotify-tools, systemd, zlib
 , enableGTK3 ? false, gtk3
 , enableSystemd ? stdenv.isLinux
+, enableCli ? true
 }:
 
 let
@@ -29,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-      "--enable-cli"
+      ("--enable-cli=" + (if enableCli then "yes" else "no"))
     ]
     ++ optional enableSystemd "--with-systemd-daemon"
     ++ optional enableGTK3 "--with-gtk";


### PR DESCRIPTION
###### Motivation for this change

This adds a Transmission support of Darwin. Like my other Darwin App PR #20658, it depends on #21382 to work correctly.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
