### PR TITLE
exim: corrected implementation of services.exim.config

### DIFF
--- a/nixos/modules/services/mail/exim.nix
+++ b/nixos/modules/services/mail/exim.nix
@@ -72,7 +72,7 @@ in
         exim_group = ${cfg.group}
         exim_path = /var/setuid-wrappers/exim
         spool_directory = ${cfg.spoolDir}
-        ${cfg.config}
+        .include ${cfg.config}
       '';
       systemPackages = [ exim ];
     };


### PR DESCRIPTION
###### Motivation for this change
The exim configuration specification allows you to include other configuration files and that is the purpose of the service.exim.config declaration.

The syntax for including a file is:
.include filename

This PR fixes the bug where .include is omitted causing a syntax error.

Documentation reference: http://www.exim.org/exim-html-current/doc/html/spec_html/ch-the_exim_run_time_configuration_file.html  Item 3.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

