### PR TITLE
add nix-prefetch-source

### DIFF
--- a/pkgs/tools/package-management/nix-update-source/default.nix
+++ b/pkgs/tools/package-management/nix-update-source/default.nix
@@ -1,0 +1,29 @@
+{ lib, pkgs, fetchFromGitHub, python3Packages, nix-prefetch-scripts }:
+python3Packages.buildPythonApplication rec {
+  version = "0.2.1";
+  name = "nix-update-source-${version}";
+  src = fetchFromGitHub {
+    owner = "timbertson";
+    repo = "nix-update-source";
+    rev = "version-${version}";
+    sha256 = "1w3aj0kjp8zhxkzqxnm5srrsqsvrmxhn4sqkr4kjffh61jg8jq8a";
+  };
+  propagatedBuildInputs = [ nix-prefetch-scripts ];
+  passthru = {
+    fetch = path:
+      let
+        fetchers = {
+          # whitelist of allowed fetchers
+          inherit (pkgs) fetchgit fetchurl fetchFromGitHub;
+        };
+        json = lib.importJSON path;
+        fetchFn = builtins.getAttr json.fetch.fn fetchers;
+        src = fetchFn json.fetch.args;
+      in
+      json // { inherit src; };
+  };
+  meta = {
+    description = "Utility to autimate updating of nix derivation sources";
+    maintainers = with lib.maintainers; [ timbertson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17484,6 +17484,8 @@ in
     nix-prefetch-zip
     nix-prefetch-scripts;
 
+  nix-update-source = callPackage ../tools/package-management/nix-update-source {};
+
   nix-template-rpm = callPackage ../build-support/templaterpm { inherit (pythonPackages) python toposort; };
 
   nix-repl = callPackage ../tools/package-management/nix-repl { };


### PR DESCRIPTION
### Motivation:

I've always found updating sources to be somewhat awkward. I don't know how others do it, but for me it's usually a matter of running `nix-prefetch-$whatever`, then copy-pasting the relevant fields into my nix expression.

But tediously, I need to keep the source information updated in multiple locations:
 - the upstream project (so developers can `nix-build` or `nix-shell` from a checkout)
 - any other repos which depend on specific versions of a dependency
 - my own collection of development dependencies (a collection of nixexprs so I can access my unpublished or in-development tools wherever I go)
 - nixpkgs itself

In fact, this friction has prevented me from bothering adding packages to `nixpkgs` in the past, because the other requirements are already inconvenient enough. Which is sad, and I want to fix that.

### Goals:

 - Make it painless (and automatable) to update a nix expression to build the latest upstream source code. I was particularly inspired by [Rok's recent blog post on automating updates](https://garbas.si/2016/updating-your-nix-sources.html), and by discovering the existing support in `maintainers/scripts/update.nix` for scripted updates.

 - Make it less tedious to keep upstream `.nix` expressions in sync with the nixpkgs repository

### Approach:

I've created a tool called `nix-prefetch-source`. It's a wrapper around the other `nix-prefetch-*` scripts, with the aim of making source updates as automatable as possible.

So for example currently you might:

 - run `nix-prefetch-git <repo> HEAD`
 - copy and paste bith `rev` and `sha265` into your nix expression

It's not hard, but it's not automatable. With nix-prefetch-source, you store what you want to fetch as JSON:

```
{
  "url": "https://example.org/foo.git",
  "rev": "HEAD",
  "type": "fetchgit"
}
```

(you can pass them directly as command line arguments if you don't want to store this as JSON)

Then you run `nix-prefetch-source -i src.in.json -o src.json`, and out pops the latest source for those inputs:

```
{
  "url": "https://example.org/foo.git",
  "rev": "HEAD",
  "type": "fetchgit",
  "fetchArgs": {
    "fetchSubmodules": true,
    "rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
    "sha256": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
    "url": "https://example.org/foo.git"
  }
}
```

This can be re-run at any time to get the latest sources. It contains whatever inputs were given, plus a set of attributes in `fetchArgs` suitable for passing directly to `fetchgit`.

And indeed my PR adds a convenience function, `importSource` which takes a path to this kind of file, and returns an object with all the same properties plus `src`, which is really just `(getAttribute input.type) input.fetchArgs`.

It's generic enough that it ought to be able to support every fetcher, by simply adding a handler to `nix-prefetch-source`, which knows how to perform the prefetch and then generate the arguments to give to the fetching function.


Here's how I've used to package a simple python package that I happened to be packaging today:

```
# nix/default.nix
{ pythonPackages, importSource, gnome3 }:
let source = (importSource ./src.json); in
pythonPackages.buildPythonPackage {
  inherit (source) src;
  name = "dconf-user-overrides-${source.version}";
  propagatedBuildInputs = with pythonPackages; [ pygobject3 ];
  postInstall = ''
    wrapProgram $out/bin/dconf-user-overrides \
      --suffix GIO_EXTRA_MODULES : ${gnome3.dconf}/lib/gio/modules \
      ;
  '';
}

# default.nix:
with import <nixpkgs> {} ; callPackage ./nix/default.nix {}
```

This separation conveniently means that `nix/default.nix` can be copied wholesale into `nixpkgs`, as long as `src.json` comes along with it. You can even use a different `src.json` while keeping the same `nix` expression, if for example you want to reference tagged releases in `nixpkgs` using `fetchFromGitHub` but need to reference a specific git commit via `fetchgit` in development.

### Next steps:

Any thoughts? objections? I believe the PR should be mergeable and useable as-is, although there's opportunity for a bit more integration if we want to include `nix-prefetch-source` in nix-prefetch-scripts. I haven't done this yet because I wanted to validate the approach first, and I'd need to invert a dependency (currently it depends on nix-prefetch-scripts)
