### PR TITLE
update os-release manpage link

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -99,7 +99,7 @@ in
     };
 
     # Generate /etc/os-release.  See
-    # http://0pointer.de/public/systemd-man/os-release.html for the
+    # https://www.freedesktop.org/software/systemd/man/os-release.html for the
     # format.
     environment.etc."os-release".text =
       ''


### PR DESCRIPTION
the old manpage at 0pointer is still there, but does not seem to get updated.

###### Motivation for this change
Link was not pointing to the official systemd docs.

###### Things done

- Compared the version number of the generated manpages to see that the ones at 0pointer are out of date.

---

