### PR TITLE
debianutils: init at 4.8.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -449,6 +449,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Sleepycat License";
   };
 
+  smail = {
+    shortName = "smail";
+    fullName = "SMAIL General Public License";
+    url = http://metadata.ftp-master.debian.org/changelogs/main/d/debianutils/debianutils_4.8.1_copyright;
+  };
+
   tcltk = spdx {
     spdxId = "TCL";
     fullName = "TCL/TK License";

--- a/pkgs/tools/misc/debianutils/default.nix
+++ b/pkgs/tools/misc/debianutils/default.nix
@@ -4,11 +4,6 @@ let
   checksums = {
     "4.8.1" = "09phylg8ih1crgxjadkdb8idbpj9ap62a7cbh8qdx2gyvh5mqf9c";
   };
-  smail = {
-    shortName = "smail";
-    fullName = "SMAIL General Public License";
-    url = http://metadata.ftp-master.debian.org/changelogs/main/d/debianutils/debianutils_4.8.1_copyright;
-  };
 in stdenv.mkDerivation rec {
   version = "4.8.1";
   name = "debianutils-${version}";

--- a/pkgs/tools/misc/debianutils/default.nix
+++ b/pkgs/tools/misc/debianutils/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl }:
+
+let
+  checksums = {
+    "4.8.1" = "09phylg8ih1crgxjadkdb8idbpj9ap62a7cbh8qdx2gyvh5mqf9c";
+  };
+  smail = {
+    shortName = "smail";
+    fullName = "SMAIL General Public License";
+    url = http://metadata.ftp-master.debian.org/changelogs/main/d/debianutils/debianutils_4.8.1_copyright;
+  };
+in stdenv.mkDerivation rec {
+  version = "4.8.1";
+  name = "debianutils-${version}";
+
+  src = fetchurl {
+    url = "mirror://debian/pool/main/d/debianutils/debianutils_${version}.tar.xz";
+    sha256 = checksums."${version}";
+  };
+
+  meta = {
+    description = "Miscellaneous utilities specific to Debian";
+    longDescription = ''
+       This package provides a number of small utilities which are used primarily by the installation scripts of Debian packages, although you may use them directly.
+
+       The specific utilities included are: add-shell installkernel ischroot remove-shell run-parts savelog tempfile which 
+    '';
+    downloadPage = https://packages.debian.org/sid/debianutils;
+    license = with stdenv.lib.license; [ gpl2Plus publicDomain smail ];
+    maintainers = [];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/tools/misc/debianutils/default.nix
+++ b/pkgs/tools/misc/debianutils/default.nix
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
        The specific utilities included are: add-shell installkernel ischroot remove-shell run-parts savelog tempfile which 
     '';
     downloadPage = https://packages.debian.org/sid/debianutils;
-    license = with stdenv.lib.license; [ gpl2Plus publicDomain smail ];
+    license = with stdenv.lib.licenses; [ gpl2Plus publicDomain smail ];
     maintainers = [];
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1369,6 +1369,8 @@ in
 
   dcfldd = callPackage ../tools/system/dcfldd { };
 
+  debianutils = callPackage ../tools/misc/debianutils { };
+
   debian-devscripts = callPackage ../tools/misc/debian-devscripts {
     inherit (perlPackages) CryptSSLeay LWP TimeDate DBFile FileDesktopEntry;
   };


### PR DESCRIPTION
###### Motivation for this change
I needed `run-parts`

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
   - [X] `run-parts`
   - [ ] `add-shell`
   - [ ] `installkernel`
   - [ ] `ischroot`
   - [ ] `remove-shell`
   - [ ] `savelog`
   - [ ] `tempfile`
   - [ ] `which`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

