### PR TITLE
qualia: init at 1.0.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -444,6 +444,7 @@
   spinus = "Tomasz Czyż <tomasz.czyz@gmail.com>";
   sprock = "Roger Mason <rmason@mun.ca>";
   spwhitt = "Spencer Whitt <sw@swhitt.me>";
+  srhb = "Sarah Brofeldt <sbrofeldt@gmail.com>";
   SShrike = "Severen Redwood <severen@shrike.me>";
   stephenmw = "Stephen Weinberg <stephen@q5comm.com>";
   sternenseemann = "Lukas Epple <post@lukasepple.de>";

--- a/pkgs/tools/text/mir-qualia/default.nix
+++ b/pkgs/tools/text/mir-qualia/default.nix
@@ -1,0 +1,21 @@
+{ lib, pythonPackages, fetchurl }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "mir.qualia-${version}";
+  version = "1.0.0";
+  doCheck = false; # 1.0.0-released pytests are broken
+
+  buildInputs = with pythonPackages; [ pytest ];
+
+  src = fetchurl {
+    url = "mirror://pypi/m/mir.qualia/mir.qualia-${version}.tar.gz";
+    sha256 = "1g0nwncwk4nq7b7zszqi1q4d2bdga1q50g9nkxigdaq647wqdf7x";
+  };
+
+  meta = {
+    description = "Dynamically enable sections of config files";
+    homepage = https://github.com/darkfeline/mir.qualia;
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.srhb ] ;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2818,6 +2818,10 @@ in
 
   minixml = callPackage ../development/libraries/minixml { };
 
+  mir-qualia = callPackage ../tools/text/mir-qualia {
+    pythonPackages = python3Packages;
+  };
+
   miredo = callPackage ../tools/networking/miredo { };
 
   mitmproxy = callPackage ../tools/networking/mitmproxy { };


### PR DESCRIPTION
###### Motivation for this change
New package

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

