### PR TITLE
rustc: enable codegen units and parallel building

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -20,27 +20,17 @@ let
     else
       "${shortVersion}-g${builtins.substring 0 7 srcRev}";
 
-  name = "rustc-${version}";
-
   procps = if stdenv.isDarwin then darwin.ps else args.procps;
 
   llvmShared = llvm.override { enableSharedLibraries = true; };
 
   target = builtins.replaceStrings [" "] [","] (builtins.toString targets);
 
-  meta = with stdenv.lib; {
-    homepage = http://www.rust-lang.org/;
-    description = "A safe, concurrent, practical language";
-    maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington retrry ];
-    license = [ licenses.mit licenses.asl20 ];
-    platforms = platforms.linux ++ platforms.darwin;
-  };
 in
 
 stdenv.mkDerivation {
-  inherit name;
+  name = "rustc-${version}";
   inherit version;
-  inherit meta;
 
   __impureHostDeps = [ "/usr/lib/libedit.3.dylib" ];
 
@@ -51,6 +41,9 @@ stdenv.mkDerivation {
   # This loosens the hard restrictions on bootstrapping-compiler
   # versions.
   RUSTC_BOOTSTRAP = "1";
+
+  # Increase codegen units to introduce parallelism within the compiler.
+  RUSTFLAGS = "-Ccodegen-units=10";
 
   src = fetchgit {
     url = https://github.com/rust-lang/rust;
@@ -130,13 +123,12 @@ stdenv.mkDerivation {
   buildInputs = [ ncurses ] ++ targetToolchains
     ++ optional (!forceBundledLLVM) llvmShared;
 
-  # https://github.com/rust-lang/rust/issues/30181
-  # enableParallelBuilding = false; # missing files during linking, occasionally
-
   outputs = [ "out" "doc" ];
   setOutputFlags = false;
 
+  # Disable codegen units for the tests.
   preCheck = ''
+    export RUSTFLAGS=
     export TZDIR=${tzdata}/share/zoneinfo
   '' +
   # Ensure TMPDIR is set, and disable a test that removing the HOME
@@ -147,7 +139,16 @@ stdenv.mkDerivation {
     sed -i '28s/home_dir().is_some()/true/' ./src/test/run-pass/env-home-dir.rs
   '';
 
-  # Disable doCheck on Darwin to work around upstream issue
   doCheck = true;
   dontSetConfigureCross = true;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.rust-lang.org/;
+    description = "A safe, concurrent, practical language";
+    maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington retrry ];
+    license = [ licenses.mit licenses.asl20 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

This makes `rustc` build in about ~30m compared to ~1h15m on my build machine.

I also noticed that patching the shebangs for the dev output is also very slow.
I'm pretty sure we don't have to do that, but I'm not sure how to disable it for a single output.


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@retrry Did you run into issues with parallel builds? I have built a bunch of times now before I figured out what was causing the tests to fail and I have not seen any issues with it.