### PR TITLE
xfce.mousepad: use keyfile instead of gconf

### DIFF
--- a/pkgs/desktops/xfce/applications/mousepad.nix
+++ b/pkgs/desktops/xfce/applications/mousepad.nix
@@ -19,9 +19,7 @@ stdenv.mkDerivation rec {
       dconf
     ];
 
-  preConfigure = ''
-    substituteInPlace mousepad/mousepad-settings-store.c --replace '#ifdef MOUSEPAD_SETTINGS_KEYFILE_BACKEND' '#if 1'
-  '';
+  configureFlags = [ "--enable-keyfile-settings" ];
 
   preFixup = ''
     wrapProgram "$out/bin/mousepad" \

--- a/pkgs/desktops/xfce/applications/mousepad.nix
+++ b/pkgs/desktops/xfce/applications/mousepad.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation rec {
       dconf
     ];
 
+  preConfigure = ''
+    substituteInPlace mousepad/mousepad-settings-store.c --replace '#ifdef MOUSEPAD_SETTINGS_KEYFILE_BACKEND' '#if 1'
+  '';
+
   preFixup = ''
     wrapProgram "$out/bin/mousepad" \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:${gtksourceview}/share" \


### PR DESCRIPTION
###### Motivation for this change

Let ```xfce.mousepad``` use configuration in ```~/.config/Mousepad``` instead of ```gconf```
Fixes #12016 #14862 #21725

The error message about absence of 'none' color scheme in GtkSourceView is still here (it would require a bigger [patch](https://bugzilla.xfce.org/show_bug.cgi?id=11663)). but now it does result in the CPU-consuming infinite loop.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

