### PR TITLE
grib-api: 1.14.4 -> 1.19.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -231,6 +231,7 @@
   KibaFox = "Kiba Fox <kiba.fox@foxypossibilities.com>";
   kierdavis = "Kier Davis <kierdavis@gmail.com>";
   kkallio = "Karn Kallio <tierpluspluslists@gmail.com>";
+  knedlsepp = "Josef Kemetmüller <josef.kemetmueller@gmail.com>";
   koral = "Koral <koral@mailoo.org>";
   kovirobi = "Kovacsics Robert <kovirobi@gmail.com>";
   kragniz = "Louis Taylor <louis@kragniz.eu>";

--- a/pkgs/development/libraries/grib-api/default.nix
+++ b/pkgs/development/libraries/grib-api/default.nix
@@ -1,32 +1,60 @@
-{ fetchurl, stdenv, curl,
-  netcdf, jasper, openjpeg }:
+{ fetchurl, stdenv,
+  cmake, netcdf, gfortran, jasper, libpng,
+  enablePython ? false, pythonPackages }:
 
 stdenv.mkDerivation rec{
   name = "grib-api-${version}";
-  version = "1.14.4";
+  version = "1.19.0";
 
   src = fetchurl {
-    url = https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.14.4-Source.tar.gz;
-    sha256 = "1w8z9y79wakhwv1r4rb4dwlh9pbyw367klcm6laxz91hhvfrpfq8";
+    url = "https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-${version}-Source.tar.gz";
+    sha256 = "07cj9mw5bb249lxx1m9nmfdqb8b2a8cm7s6x62cdwca3sp16dv6a";
   };
 
-  buildInputs = [ netcdf
+  preConfigure = ''
+    # Fix "no member named 'inmem_' in 'jas_image_t'"
+    substituteInPlace "src/grib_jasper_encoding.c" --replace "image.inmem_    = 1;" ""
+  '';
+
+  buildInputs = [ cmake
+                  netcdf
+                  gfortran
                   jasper
-                  openjpeg
-                  curl     # Used for downloading during make test
+                  libpng
+                ] ++ stdenv.lib.optionals enablePython [
+                  pythonPackages.python
                 ];
+
+  cmakeFlags = [ "-DENABLE_PYTHON=${if enablePython then "ON" else "OFF"}"
+                 "-DENABLE_PNG=ON"
+                 "-DENABLE_FORTRAN=ON"
+               ];
+
+  enableParallelBuilding = true;
+
   doCheck = true;
+
+  # Only do tests that don't require downloading 120MB of testdata
+  # We fix the darwin checkPhase, which searches for libgrib_api.dylib
+  # in /nix/store by setting DYLD_LIBRARY_PATH
+  checkPhase = stdenv.lib.optionalString (stdenv.isDarwin) ''
+    substituteInPlace "tests/include.sh" --replace "set -ea" "set -ea; export DYLD_LIBRARY_PATH=$(pwd)/lib"
+  '' + ''
+    ctest -R "t_definitions|t_calendar|t_unit_tests" -VV
+  '';
+
 
   meta = with stdenv.lib; {
     homepage = "https://software.ecmwf.int/wiki/display/GRIB/Home";
     license = licenses.asl20;
+    platforms = with platforms; linux ++ darwin;
     description = "ECMWF Library for the GRIB file format";
     longDescription = ''
       The ECMWF GRIB API is an application program interface accessible from C,
       FORTRAN and Python programs developed for encoding and decoding WMO FM-92
       GRIB edition 1 and edition 2 messages.
     '';
-
+    maintainers = with maintainers; [ knedlsepp ];
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change
The hydra build for this package never worked, because the package tries to download data during the checkPhase.

###### Things done
- Remove downloading of testdata during checkPhase to
    - fix hydra build
    - remove impurity
    - reduce traffic
- Bump version
- Add myself as a maintainer

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

