### PR TITLE
ed: Add fedoraproject mirror.

### DIFF
--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -2,6 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "ed-1.13";
+  file_md5 = "fb8ffc8d8072e13dd5799131e889bfa5"; # for fedora mirror
 
   src = fetchurl {
     # gnu only provides *.lz tarball, which is unfriendly for stdenv bootstrapping
@@ -9,7 +10,10 @@ stdenv.mkDerivation rec {
     # When updating, please make sure the sources pulled match those upstream by
     # Unpacking both tarballs and running `find . -type f -exec sha256sum \{\} \; | sha256sum`
     # in the resulting directory
-    url = "http://fossies.org/linux/privat/${name}.tar.bz2";
+    urls = [
+      "http://pkgs.fedoraproject.org/repo/extras/ed/${name}.tar.bz2/${file_md5}/${name}.tar.bz2"
+      "http://fossies.org/linux/privat/${name}.tar.bz2"
+    ];
     sha256 = "1iym2fsamxr886l3sz8lqzgf00bip5cr0aly8jp04f89kf5mvl0j";
   };
 


### PR DESCRIPTION
The existing URL has gone dark; this commit adds one from fedoraproject.org
that still works. We put the new mirror first since ed is in the bootstrap
path, and 16.09 bootstrap doesn't try later URLs.

###### Motivation for this change
Bootstrap source tarball fetch is broken because the existing source URL went dark.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

