### PR TITLE
zlib: Fix zlib.net URL.

### DIFF
--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     urls =
-      [ "http://www.zlib.net/${name}.tar.gz"  # old versions vanish from here
+      [ "http://www.zlib.net/fossils/${name}.tar.gz"  # stable archive path
         "mirror://sourceforge/libpng/zlib/${version}/${name}.tar.gz"
       ];
     sha256 = "039agw5rqvqny92cpkrfn243x2gd4xn13hs3xi6isk55d2vqqr9n";


### PR DESCRIPTION
Look for primary source file below
  http://zlib.net/fossils/ as opposed to
  http://zlib.net/
. zlib-1.2.8.tar.gz is still available at the former location, and will likely
remain there. In addition, it's important that the first URL work since zlib
is in the bootstrap path, and 16.09 (at least) bootstrap doesn't try to fetch
from later ones.

###### Motivation for this change
Bootstrap source tarball fetch is broken due the first URL going dark.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

