### PR TITLE
mmex: v1.2.7 -> v1.3.1

### DIFF
--- a/pkgs/applications/office/mmex/default.nix
+++ b/pkgs/applications/office/mmex/default.nix
@@ -2,7 +2,7 @@
 
 
 let
-  version = "1.2.7";
+  version = "1.3.1";
 in
   stdenv.mkDerivation {
     name = "money-manager-ex-${version}";
@@ -10,13 +10,8 @@ in
     src = fetchgit {
       url = "https://github.com/moneymanagerex/moneymanagerex.git";
       rev = "refs/tags/v${version}";
-      sha256 = "0d6jcsj3m3b9mj68vfwr7dn67dws11p0pdys3spyyiv1464vmywi";
+      sha256 = "1cmwmvlzg7r85qq23lbbmq2y91vhf9f5pblpja5ph98bsd218pc0";
     };
-
-    preConfigure = ''
-      export CFLAGS="-I`pwd`/include"
-      export CXXFLAGS="$CFLAGS"
-    '';
 
     buildInputs = [ sqlite wxGTK30 gettext ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

