### PR TITLE
discord: 0.0.11 -> 0.0.13

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -7,12 +7,12 @@
 stdenv.mkDerivation rec {
 
     pname = "discord";
-    version = "0.0.11";
+    version = "0.0.13";
     name = "${pname}-${version}";
 
     src = fetchurl {
         url = "https://cdn-canary.discordapp.com/apps/linux/${version}/${pname}-canary-${version}.tar.gz";
-        sha256 = "1lk53vm14vr5pb8xxcx6hinpc2mkdns2xxv0bfzxvlmhfr6d6y18";
+        sha256 = "1pwb8y80z1bmfln5wd1vrhras0xygd1j15sib0g9vaig4mc55cs6";
     };
 
     libPath = stdenv.lib.makeLibraryPath [


### PR DESCRIPTION
###### Motivation for this change

Discord 0.0.13 is required

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

