### PR TITLE
Modular OpenLDAP

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -16,9 +16,14 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl cyrus_sasl db groff libtool ];
 
   configureFlags =
-    [ "--enable-overlays"
+    [
       "--disable-dependency-tracking"   # speeds up one-time build
+      "--disable-ndb"
+      "--disable-perl"
+      "--disable-sql"
+      "--enable-backends=mod"
       "--enable-modules"
+      "--enable-overlays=mod"
     ] ++ stdenv.lib.optional (openssl == null) "--without-tls"
       ++ stdenv.lib.optional (cyrus_sasl == null) "--without-cyrus-sasl"
       ++ stdenv.lib.optional stdenv.isFreeBSD "--with-pic";


### PR DESCRIPTION
Turn on all overlays and all modules except perl, ndb, sql.
Those modules aren't built by default anyway.

This change does not add new dependencies, but will require
additional configuration to load modules, including `back_mdb`.

This is how OpenLDAP is built in Debian.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

