### PR TITLE
kdeWrapper: postpone /share linking till final buildEnv

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kde-wrapper.nix
+++ b/pkgs/development/libraries/kde-frameworks/kde-wrapper.nix
@@ -61,13 +61,9 @@ stdenv.mkDerivation {
         fi
     done
 
-    ln -s "$env/share" "$out"
-
+    mkdir -p "$out/nix-support"
     for drv in $unwrapped; do
-        if [ -a "$drv/nix-support/propagated-user-env-packages" ]; then
-            mkdir -p "$out/nix-support"
-            cat "$drv/nix-support/propagated-user-env-packages" >> "$out/nix-support/propagated-user-env-packages"
-        fi
+        echo "$drv" >> "$out/nix-support/propagated-user-env-packages"
     done
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/21763. The idea is that now `/share` doesn't get linked to wrapped package. Instead we list unwrapped packages in `propagated-user-env-pkgs`, so that final `buildEnv` builds `/share` for us.

I'm not sure this is the right way to fix the problem -- review appreciated!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
