### PR TITLE
subsurface: rev update for 4.5.97

### DIFF
--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -24,9 +24,9 @@ stdenv.mkDerivation rec {
   name = "subsurface-${version}";
 
   src = fetchgit {
-    sha256 = "0mbf8m5sbimbyvlh65sjlydrycr4ssfyfzdlqyl0wcpzw7h0qfp8";
+    sha256 = "035ywhicadmr9sh7zhfxsvpchwa9sywccacbspfam39n2hpyqnmm";
     url = "git://git.subsurface-divelog.org/subsurface";
-    rev = "5f15ad5a86ada3c5e574041a5f9d85235322dabb";
+    rev = "72bcb6481f3b935444d7868a74599dda133f9b43";
     branchName = "master";
   };
 


### PR DESCRIPTION
###### Motivation for this change

The build of subsurface fails in a non-deterministic way. The updated rev fixes that.

Ref: https://hydra.nixos.org/build/46165175
Ref: http://git.subsurface-divelog.org/index.cgi?p=subsurface.git;a=commit;h=72bcb6481f3b935444d7868a74599dda133f9b43

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

