### PR TITLE
erlangR19: 19.1.6 -> 19.2

### DIFF
--- a/pkgs/development/interpreters/erlang/R19.nix
+++ b/pkgs/development/interpreters/erlang/R19.nix
@@ -21,7 +21,7 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "erlang-" + version + "${optionalString odbcSupport "-odbc"}"
   + "${optionalString javacSupport "-javac"}";
-  version = "19.1.6";
+  version = "19.2";
 
   # Minor OTP releases are not always released as tarbals at
   # http://erlang.org/download/ So we have to download from
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "erlang";
     repo = "otp";
     rev = "OTP-${version}";
-    sha256 = "120dqi8h2fwqfmh9g2nmkf153zlglzw9kkddz57xqvqq5arcs72y";
+    sha256 = "06pr4ydrqpp1skx85zjb1an4kvzv6vacb771vy71k54j7w6lh9hk";
   };
 
   buildInputs =
@@ -42,6 +42,11 @@ stdenv.mkDerivation rec {
       ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
 
   debugInfo = enableDebugInfo;
+
+  prePatch = ''
+    substituteInPlace configure.in \
+      --replace '`sw_vers -productVersion`' '10.10'
+  '';
 
   preConfigure = ''
     ./otp_build autoconf


### PR DESCRIPTION
###### Motivation for this change

Update `erlangR19` from 19.1.6 to 19.2.

N.B. I've added a `sw_vers` substitution for `darwin`.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
