### PR TITLE
libsecret: add dev output

### DIFF
--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1cychxc3ff8fp857iikw0n2s13s2mhw2dn1mr632f7w3sn6vvrww";
   };
 
+  outputs = [ "out" "dev" ];
+
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-lintl";
 
   propagatedBuildInputs = [ glib ];


### PR DESCRIPTION
###### Motivation for this change

To reduce the closure size of the secret-tool binary. On my install the closure size reduces from 178 MiB to 38 MiB:

```
rycee@beta:~/devel/nixpkgs$ du -hcs $(nix-store -qR result.single-output)
22M	/nix/store/m71hw9kw0z74w93lq44l1xdcy2nq155f-glibc-2.24
368K	/nix/store/171w2nhr1l1iqwm31vqx7qwj11y1cb27-libelf-0.8.13
100K	/nix/store/h4xqrnm3w23ifwkm04jj72b5ik3mg1kl-attr-2.4.47
140K	/nix/store/rnp2l7n2qbbaj5ybw7iywpr3ppyn4pqy-acl-2.2.52
11M	/nix/store/1j0ykqz2q2r76nyl9gzsmcpii6plipld-coreutils-8.26
1.3M	/nix/store/1xpviqpv0bdmgyjg67v11zqp25z33qmd-util-linux-2.28.1
2.7M	/nix/store/gr8nfygbswfrxl4qhfs43fc6cry95wzj-glibc-2.24-bin
5.6M	/nix/store/i70ls3v8q574gd4xadbb9mkcc7hcygdk-linux-headers-4.4.10
3.2M	/nix/store/57ll6yym0wfrw1dnc4fb5p3q55113s0d-glibc-2.24-dev
4.0K	/nix/store/44jdy5pkibwb4mzv8l5659is8pxk7paq-glibc-iconv-2.24
48K	/nix/store/7a4mln4zcckyixqabih080d8szmdcc6v-libffi-3.2.1
32K	/nix/store/5nj1kmwmbdjs4piwlazhx5qbw3j4h6ff-libffi-3.2.1-dev
104K	/nix/store/dns4zbhnkkmgcfnsf2i35p731lrlfr5d-zlib-1.2.8
500K	/nix/store/rcm2h5d9r1xyi2yhw5mf9hwk82hfkpxx-pcre-8.39
12M	/nix/store/5p80wz7fzkgk7nsn5jfrk00bspm13v9x-glib-2.50.2
11M	/nix/store/5pxhnfh9863j2fnx9fxnmdir9l77agv9-ncurses-6.0
1.1M	/nix/store/611iiv3iglwfbcixfwhff3imr09z7dz0-sqlite-3.15.2
47M	/nix/store/gb7sw3wq4q0l8jwkgb65k992g5dc1k38-perl-5.22.2
112K	/nix/store/gsvbs5pda689w8f8kn7kwq9yiinrhcsc-zlib-1.2.8-dev
1.2M	/nix/store/hgbbz9kv3m7583rmb339595xrvaiw8bg-bash-4.4-p5
576K	/nix/store/93khdji42rmxwsf0wm1y1x1x9wq80vvv-gdbm-1.12
3.4M	/nix/store/ccr0a19cahjqmp3373z7yypi88nbklkx-openssl-1.0.2j
4.7M	/nix/store/hw3rgzn5zz7ins6j2fzsy2nkqw8ifydw-gcc-5.4.0-lib
4.4M	/nix/store/phshdcpdzz9xcls9y3i5kp6g8cm5nkmq-db-5.3.28
80K	/nix/store/w4rljvlvwvffvgdh2y957bl9yxjcyyhm-bzip2-1.0.6.0.1
400K	/nix/store/ywj93src8m2adc44knp9bpml0j6c9nkj-readline-6.3p08
42M	/nix/store/hx3x2h2d3ww5jghvik7wmxnwvl49v6ml-python-2.7.13
3.4M	/nix/store/68gwi53qj9y6x9b022pnasq2q9j7810f-glib-2.50.2-dev
584K	/nix/store/mrb281radx9vwxaij3lfcmhvl50875si-libgpg-error-1.24
1.2M	/nix/store/k5qhg8hw2zsriii3xnsfscch10qsbhal-libgcrypt-1.7.5
1.2M	/nix/store/q6r5lkqhpfrjxm6cwp4cb40q3aj5idis-libsecret-0.18.5
178M	total

rycee@beta:~/devel/nixpkgs$ du -hcs $(nix-store -qR result.multiple-output)
22M	/nix/store/m71hw9kw0z74w93lq44l1xdcy2nq155f-glibc-2.24
1.3M	/nix/store/1xpviqpv0bdmgyjg67v11zqp25z33qmd-util-linux-2.28.1
48K	/nix/store/7a4mln4zcckyixqabih080d8szmdcc6v-libffi-3.2.1
104K	/nix/store/dns4zbhnkkmgcfnsf2i35p731lrlfr5d-zlib-1.2.8
500K	/nix/store/rcm2h5d9r1xyi2yhw5mf9hwk82hfkpxx-pcre-8.39
12M	/nix/store/5p80wz7fzkgk7nsn5jfrk00bspm13v9x-glib-2.50.2
584K	/nix/store/mrb281radx9vwxaij3lfcmhvl50875si-libgpg-error-1.24
1.2M	/nix/store/k5qhg8hw2zsriii3xnsfscch10qsbhal-libgcrypt-1.7.5
688K	/nix/store/qscqh451yvr4vham8zv3mgr4j2n0vidp-libsecret-0.18.5
38M	total
```

I have not been able to to a full nox-review since a fair amount of heavy packages are touched (my laptop wouldn't cope) but have successfully tried a few random packages.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).