### PR TITLE
clipster: use python3:

### DIFF
--- a/pkgs/tools/misc/clipster/default.nix
+++ b/pkgs/tools/misc/clipster/default.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub , stdenv, makeWrapper, python, gtk3,  libwnck3 }:
+{fetchFromGitHub , stdenv, makeWrapper, python3, gtk3, libwnck3 }:
 
 stdenv.mkDerivation  rec {
   name = "clipster-unstable-${version}";
@@ -11,11 +11,12 @@ stdenv.mkDerivation  rec {
     sha256 = "005akgk1wn3z5vxfjii202zzwz85zydimfgm69ml68imj5vbhkg1";
   };
 
-  pythonEnv = python.withPackages(ps: with ps; [ dbus-python pygtk pygobject3 ]);
+  pythonEnv = python3.withPackages(ps: with ps; [ pygobject3 ]);
 
   buildInputs =  [ pythonEnv gtk3 libwnck3 makeWrapper ];
 
   installPhase = ''
+    sed -i 's/python/python3/g' clipster
     mkdir -p $out/bin/
     cp clipster $out/bin/
     wrapProgram "$out/bin/clipster" \


### PR DESCRIPTION
###### Motivation for this change

to work around https://github.com/mrichar1/clipster/issues/32

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

