### PR TITLE
apparmor: support for lxc profiles

### DIFF
--- a/nixos/modules/security/apparmor.nix
+++ b/nixos/modules/security/apparmor.nix
@@ -18,22 +18,30 @@ in
          default = [];
          description = "List of files containing AppArmor profiles.";
        };
+       packages = mkOption {
+         type = types.listOf types.package;
+         default = [];
+         description = "List of packages to be added to apparmor's include path";
+       };
      };
    };
 
    config = mkIf cfg.enable {
      environment.systemPackages = [ pkgs.apparmor-utils ];
 
-     systemd.services.apparmor = {
+     systemd.services.apparmor = let
+       paths = concatMapStrings (s: " -I ${s}/etc/apparmor.d")
+         ([ pkgs.apparmor-profiles ] ++ cfg.packages);
+     in {
        wantedBy = [ "local-fs.target" ];
        serviceConfig = {
          Type = "oneshot";
          RemainAfterExit = "yes";
-         ExecStart = concatMapStrings (p:
-           ''${pkgs.apparmor-parser}/bin/apparmor_parser -rKv -I ${pkgs.apparmor-profiles}/etc/apparmor.d "${p}" ; ''
+         ExecStart = map (p:
+           ''${pkgs.apparmor-parser}/bin/apparmor_parser -rKv ${paths} "${p}"''
          ) cfg.profiles;
-         ExecStop = concatMapStrings (p:
-           ''${pkgs.apparmor-parser}/bin/apparmor_parser -Rv "${p}" ; ''
+         ExecStop = map (p:
+           ''${pkgs.apparmor-parser}/bin/apparmor_parser -Rv "${p}"''
          ) cfg.profiles;
        };
      };

--- a/nixos/modules/virtualisation/lxc.nix
+++ b/nixos/modules/virtualisation/lxc.nix
@@ -62,19 +62,17 @@ in
             </citerefentry>.
           '';
       };
-
   };
 
   ###### implementation
 
   config = mkIf cfg.enable {
-
     environment.systemPackages = [ pkgs.lxc ];
-
     environment.etc."lxc/lxc.conf".text = cfg.systemConfig;
     environment.etc."lxc/lxc-usernet".text = cfg.usernetConfig;
     environment.etc."lxc/default.conf".text = cfg.defaultConfig;
 
+    security.apparmor.packages = [ pkgs.lxc ];
+    security.apparmor.profiles = [ "${pkgs.lxc}/etc/apparmor.d/lxc-containers" ];
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

