### PR TITLE
mpv: 0.22.0 ->  0.23.0

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchFromGitHub, makeWrapper
-, docutils, perl, pkgconfig, python3, which, ffmpeg
+, docutils, perl, pkgconfig, python3, which, ffmpeg_3_2
 , freefont_ttf, freetype, libass, libpthreadstubs
 , lua, lua5_sockets, libuchardet, libiconv ? null, darwin
 
@@ -79,13 +79,13 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "mpv-${version}";
-  version = "0.22.0";
+  version = "0.23.0";
 
   src = fetchFromGitHub {
     owner = "mpv-player";
     repo  = "mpv";
     rev    = "v${version}";
-    sha256 = "0mv8fs2zxp6pvpi5xdrpvvqcaa5f0c83jdfi0pfqnwbpkz1kb9s6";
+    sha256 = "02k8p4z1mwxxlg9spwwrlcciia80kyrpp09hpl60g22h85jj1ng9";
   };
 
   patchPhase = ''
@@ -112,7 +112,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ docutils makeWrapper perl pkgconfig python3 which ];
 
   buildInputs = [
-    ffmpeg freetype libass libpthreadstubs
+    ffmpeg_3_2 freetype libass libpthreadstubs
     lua lua5_sockets libuchardet
   ] ++ optional alsaSupport        alsaLib
     ++ optional xvSupport          libXv

--- a/pkgs/development/libraries/ffmpeg/3.2.nix
+++ b/pkgs/development/libraries/ffmpeg/3.2.nix
@@ -1,0 +1,13 @@
+{ stdenv, callPackage
+# Darwin frameworks
+, Cocoa, CoreMedia
+, ...
+}@args:
+
+callPackage ./generic.nix (args // rec {
+  version = "${branch}.2";
+  branch = "3.2";
+  sha256 = "0srn788i4k5827sl8vmds6133vjy9ygsmgzwn40n3l5qs5b9l4hb";
+  darwinFrameworks = [ Cocoa CoreMedia ];
+  patches = stdenv.lib.optional stdenv.isDarwin ./sdk_detection.patch;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7091,6 +7091,9 @@ in
   ffmpeg_3_1 = callPackage ../development/libraries/ffmpeg/3.1.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreMedia;
   };
+  ffmpeg_3_2 = callPackage ../development/libraries/ffmpeg/3.2.nix {
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreMedia;
+  };
   # Aliases
   ffmpeg_0 = ffmpeg_0_10;
   ffmpeg_1 = ffmpeg_1_2;


### PR DESCRIPTION
###### Motivation for this change
new mpv version; mpv now requires at least Ffmpeg-3.2.2. Added ffmpeg-3.2.2 to satisfy this requirement.

for all changes see: [mpv-release-0.23.0](https://github.com/mpv-player/mpv/releases/tag/v0.23.0)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
