### PR TITLE
zsh-autosuggestions: init at 0.3.3

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -91,6 +91,13 @@ in
         '';
         type = types.bool;
       };
+      
+      enableAutosuggestions = mkOption {
+        default = false;
+        description = ''
+          Enable zsh-autosuggestions
+        '';
+      };
 
     };
 
@@ -130,6 +137,10 @@ in
 
         ${optionalString (cfg.enableSyntaxHighlighting)
           "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+        }
+
+        ${optionalString (cfg.enableAutosuggestions)
+          "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
         }
 
         HELPDIR="${pkgs.zsh}/share/zsh/$ZSH_VERSION/help"

--- a/pkgs/shells/zsh-autosuggestions/default.nix
+++ b/pkgs/shells/zsh-autosuggestions/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, zsh }:
+
+# To make use of this derivation, use the `programs.zsh.enableAutoSuggestions` option
+
+stdenv.mkDerivation rec {
+  name = "zsh-autosuggestions-${version}";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    repo = "zsh-autosuggestions";
+    owner = "zsh-users";
+    rev = "v${version}";
+    sha256 = "0mnwyz4byvckrslzqfng5c0cx8ka0y12zcy52kb7amg3l07jrls4";
+  };
+
+  buildInputs = [ zsh ];
+
+  buildPhases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    install -D zsh-autosuggestions.zsh \
+      $out/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Fish shell autosuggestions for Zsh";
+    homepage = "https://github.com/zsh-users/zsh-autosuggestions";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.loskutov ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4534,6 +4534,8 @@ in
 
   zsh-syntax-highlighting = callPackage ../shells/zsh-syntax-highlighting { };
 
+  zsh-autosuggestions = callPackage ../shells/zsh-autosuggestions { };
+
   zstd = callPackage ../tools/compression/zstd { };
 
   zsync = callPackage ../tools/compression/zsync { };


### PR DESCRIPTION
###### Motivation for this change

PR #19179 added zsh-syntax-highlighting. I needed zsh-autosuggestions, which is a plugin often paired with it as they both provide a fish-like experience.

###### Things done

Added the zsh-autosuggestions package.
Added also a related `programs.zsh.enableAutosuggestions` option, as advised in #19179

@loskutov, I left you as a maintainer given your work on packaging zsh-syntax-highlighting.
Let me know if it's ok for you or if you want me to change that.

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

