### PR TITLE
atlas: change platforms to unix

### DIFF
--- a/pkgs/development/libraries/science/math/atlas/default.nix
+++ b/pkgs/development/libraries/science/math/atlas/default.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation {
     homepage = "http://math-atlas.sourceforge.net/";
     description = "Automatically Tuned Linear Algebra Software (ATLAS)";
     license = stdenv.lib.licenses.bsd3;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
 
     longDescription = ''
       The ATLAS (Automatically Tuned Linear Algebra Software) project is an


### PR DESCRIPTION
The build succeeds on darwin and linux.

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

