### PR TITLE
geary: 0.11.2 -> 0.11.3

### DIFF
--- a/pkgs/desktops/gnome-3/3.22/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/3.22/misc/geary/default.nix
@@ -8,11 +8,11 @@ let
   majorVersion = "0.11";
 in
 stdenv.mkDerivation rec {
-  name = "geary-${majorVersion}.2";
+  name = "geary-${majorVersion}.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/geary/${majorVersion}/${name}.tar.xz";
-    sha256 = "0ca6kdprhm8w990n6wgpvn0vzsdrnv9vjdm448pa8winspn217jw";
+    sha256 = "1r42ijxafach5lv8ibs6y0l5k4nacjg427dnma8fj00xr1sri7j1";
   };
 
   propagatedUserEnvPkgs = [ gnome3.gnome_themes_standard ];


### PR DESCRIPTION
###### Motivation for this change

`0.11.3` is the most recent release of Geary.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

