### PR TITLE
auctex: 11.89 -> 11.90

### DIFF
--- a/pkgs/tools/typesetting/tex/auctex/default.nix
+++ b/pkgs/tools/typesetting/tex/auctex/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, emacs, texlive, ghostscript }:
  
 let auctex = stdenv.mkDerivation ( rec {
-  version = "11.89";
+  version = "11.90";
   name = "${pname}-${version}";
 
   # Make this a valid tex(live-new) package;
@@ -14,7 +14,7 @@ let auctex = stdenv.mkDerivation ( rec {
 
   src = fetchurl {
     url = "mirror://gnu/${pname}/${name}.tar.gz";
-    sha256 = "1cf9fkkmzjxa4jvk6c01zgxdikr4zzb5pcx8i4r0hwdk0xljkbwq";
+    sha256 = "13zimbyar3159arrcklmnmjxjvibrjpkac6d53mfv03pwpc2y8rw";
   };
 
   buildInputs = [ emacs texlive.combined.scheme-basic ghostscript ];


### PR DESCRIPTION
See http://lists.gnu.org/archive/html/info-gnu/2017-01/msg00003.html
for release announcement

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

