### PR TITLE
cargo: Do not make install in cargo

### DIFF
--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -23,17 +23,6 @@ rustPlatform.buildRustPackage rec {
 
   LIBGIT2_SYS_USE_PKG_CONFIG=1;
 
-  configurePhase = ''
-    ./configure --enable-optimize --prefix=$out
-  '';
-
-  buildPhase = "make";
-
-  installPhase = ''
-    make install
-    ${postInstall}
-  '';
-
   postInstall = ''
     rm "$out/lib/rustlib/components" \
        "$out/lib/rustlib/install.log" \


### PR DESCRIPTION
cargo is already a cargo package, so why not build it with cargo
and safe us the special cases.