### PR TITLE
update rustBeta and rustNightly

### DIFF
--- a/pkgs/development/compilers/rust/beta.nix
+++ b/pkgs/development/compilers/rust/beta.nix
@@ -1,27 +1,56 @@
-{ stdenv, callPackage, rustPlatform,
+{ stdenv, callPackage, rustPlatform, cacert, gdb,
   targets ? [], targetToolchains ? [], targetPatches ? [] }:
 
 rec {
-  rustc = callPackage ./rustc.nix {
-    shortVersion = "beta-2016-11-16";
-    forceBundledLLVM = false;
+  rustc = stdenv.lib.overrideDerivation (callPackage ./rustc.nix {
+    shortVersion = "beta-2017-01-07";
+    forceBundledLLVM = true; # TODO: figure out why linking fails without this
     configureFlags = [ "--release-channel=beta" ];
-    srcRev = "e627a2e6edbc7b7fd205de8ca7c86cff76655f4d";
-    srcSha = "14sbhn6dp6rri1rpkspjlmy359zicwmyppdak52xj1kqhcjn71wa";
+    srcRev = "a035041ba450ce3061d78a2bdb9c446eb5321d0d";
+    srcSha = "12xsm0yp1y39fvf9j218gxv73j8hhahc53jyv3q58kiriyqvfc1s";
     patches = [
-      ./patches/disable-lockfile-check-beta.patch
+     ./patches/disable-lockfile-check-nightly.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
     inherit targets;
     inherit targetPatches;
     inherit targetToolchains;
     inherit rustPlatform;
-  };
+  }) (oldAttrs: {
+    nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ gdb rustPlatform.rust.cargo ];
+    postUnpack = ''
+      export CARGO_HOME="$(realpath deps)"
+      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+    '';
+    postPatch = ''
+      ${oldAttrs.postPatch}
+
+      # Remove failing debuginfo tests because of old gdb version: https://github.com/rust-lang/rust/issues/38948#issuecomment-271443596
+      rm -vr src/test/debuginfo/borrowed-enum.rs || true
+      rm -vr src/test/debuginfo/generic-struct-style-enum.rs || true
+      rm -vr src/test/debuginfo/generic-tuple-style-enum.rs || true
+      rm -vr src/test/debuginfo/packed-struct.rs || true
+      rm -vr src/test/debuginfo/recursive-struct.rs || true
+      rm -vr src/test/debuginfo/struct-in-enum.rs || true
+      rm -vr src/test/debuginfo/struct-style-enum.rs || true
+      rm -vr src/test/debuginfo/tuple-style-enum.rs || true
+      rm -vr src/test/debuginfo/union-smoke.rs || true
+      rm -vr src/test/debuginfo/unique-enum.rs || true
+
+      # make external cargo work until https://github.com/rust-lang/rust/issues/38950 is fixed
+      sed -i "s#    def cargo(self):#    def cargo(self):\n        return \"${rustPlatform.rust.cargo}/bin/cargo\"#g" src/bootstrap/bootstrap.py
+      substituteInPlace \
+        src/bootstrap/config.rs \
+        --replace \
+        'self.cargo = Some(push_exe_path(path, &["bin", "cargo"]));' \
+        ''$'self.cargo = Some(\n                        "${rustPlatform.rust.cargo}\\\n                        /bin/cargo".into());'
+    '';
+  });
 
   cargo = callPackage ./cargo.nix rec {
-    version = "0.14.0";
-    srcRev = "eca9e159b6b0d484788ac757cf23052eba75af55";
-    srcSha = "1zm5rzw1mvixnkzr4775pcxx6k235qqxbysyp179cbxsw3dm045s";
-    depsSha256 = "0gpn0cpwgpzwhc359qn6qplx371ag9pqbwayhqrsydk1zm5bm3zr";
+    version = "beta-2017-01-10";
+    srcRev = "6dd4ff0f5b59fff524762c4a7b65882adda713c0";
+    srcSha = "1x6d42qq2zhr1iaw0m0nslhv6c1w6x6schmd96max0p9xb47l9zj";
+    depsSha256 = "1sywnhzgambmqsjs2xlnzracfv7vjljha55hgf8wca2marafr5dp";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo

--- a/pkgs/development/compilers/rust/nightly.nix
+++ b/pkgs/development/compilers/rust/nightly.nix
@@ -1,13 +1,13 @@
-{ stdenv, callPackage, rustPlatform,
+{ stdenv, callPackage, rustPlatform, cacert, gdb,
   targets ? [], targetToolchains ? [], targetPatches ? [] }:
 
 rec {
-  rustc = callPackage ./rustc.nix {
-    shortVersion = "nightly-2016-11-23";
-    forceBundledLLVM = false;
+  rustc = stdenv.lib.overrideDerivation (callPackage ./rustc.nix {
+    shortVersion = "nightly-2017-01-10";
+    forceBundledLLVM = true; # TODO: figure out why linking fails without this
     configureFlags = [ "--release-channel=nightly" ];
-    srcRev = "d5814b03e652043be607f96e24709e06c2b55429";
-    srcSha = "0x2vr1mda0mr8q28h96zfpv0f26dyrg8jwxznlh6gk0y0mprgcbr";
+    srcRev = "7bffede97cf58f7159e261eac592f9cf88ce209d";
+    srcSha = "1784jvsf9g03cglwask1zhjmba4ghycbin3rw0hmhb41cz2y4q8v";
     patches = [
      ./patches/disable-lockfile-check-nightly.patch
     ] ++ stdenv.lib.optional stdenv.needsPax ./patches/grsec.patch;
@@ -15,13 +15,42 @@ rec {
     inherit targetPatches;
     inherit targetToolchains;
     inherit rustPlatform;
-  };
+  }) (oldAttrs: {
+    nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ gdb rustPlatform.rust.cargo ];
+    postUnpack = ''
+      export CARGO_HOME="$(realpath deps)"
+      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+    '';
+    postPatch = ''
+      ${oldAttrs.postPatch}
+
+      # Remove failing debuginfo tests because of old gdb version: https://github.com/rust-lang/rust/issues/38948#issuecomment-271443596
+      rm -vr src/test/debuginfo/borrowed-enum.rs || true
+      rm -vr src/test/debuginfo/generic-struct-style-enum.rs || true
+      rm -vr src/test/debuginfo/generic-tuple-style-enum.rs || true
+      rm -vr src/test/debuginfo/packed-struct.rs || true
+      rm -vr src/test/debuginfo/recursive-struct.rs || true
+      rm -vr src/test/debuginfo/struct-in-enum.rs || true
+      rm -vr src/test/debuginfo/struct-style-enum.rs || true
+      rm -vr src/test/debuginfo/tuple-style-enum.rs || true
+      rm -vr src/test/debuginfo/union-smoke.rs || true
+      rm -vr src/test/debuginfo/unique-enum.rs || true
+
+      # make external cargo work until https://github.com/rust-lang/rust/issues/38950 is fixed
+      sed -i "s#    def cargo(self):#    def cargo(self):\n        return \"${rustPlatform.rust.cargo}/bin/cargo\"#g" src/bootstrap/bootstrap.py
+      substituteInPlace \
+        src/bootstrap/config.rs \
+        --replace \
+        'self.cargo = Some(push_exe_path(path, &["bin", "cargo"]));' \
+        ''$'self.cargo = Some(\n                        "${rustPlatform.rust.cargo}\\\n                        /bin/cargo".into());'
+    '';
+  });
 
   cargo = callPackage ./cargo.nix rec {
-    version = "nightly-2016-07-25";
-    srcRev = "f09ef68cc47956ccc5f99212bdcdd15298c400a0";
-    srcSha = "1r6q9jd0fl6mzhwkvrrcv358q2784hg51dfpy28xgh4n61m7c155";
-    depsSha256 = "055ky0lkrcsi976kmvc4lqyv0sjdpcj3jv36kz9hkqq0gip3crjc";
+    version = "nightly-2017-01-10";
+    srcRev = "6dd4ff0f5b59fff524762c4a7b65882adda713c0";
+    srcSha = "1x6d42qq2zhr1iaw0m0nslhv6c1w6x6schmd96max0p9xb47l9zj";
+    depsSha256 = "1sywnhzgambmqsjs2xlnzracfv7vjljha55hgf8wca2marafr5dp";
 
     inherit rustc; # the rustc that will be wrapped by cargo
     inherit rustPlatform; # used to build cargo


### PR DESCRIPTION
###### Motivation for this change
rustBeta is out of date, cargo as well. Nightly fails to build currently.

As the rust code has changed quite a lot recently, i needed to add more workaround to make it compile.
Those should be merged up to rustc.nix once stable hits those issues.

@Ericson2314 