### PR TITLE
latex2html: init at 2016

### DIFF
--- a/pkgs/tools/misc/latex2html/default.nix
+++ b/pkgs/tools/misc/latex2html/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchurl, makeWrapper
+, ghostscript, netpbm, perl }:
+# TODO: withTex
+
+# Ported from Homebrew.
+# https://github.com/Homebrew/homebrew-core/blob/21834573f690407d34b0bbf4250b82ec38dda4d6/Formula/latex2html.rb
+
+stdenv.mkDerivation rec {
+  name = "latex2html-${version}";
+  version = "2016";
+
+  src = fetchurl {
+    url = "http://mirrors.ctan.org/support/latex2html/latex2html-${version}.tar.gz";
+    sha256 = "028k0ypbq94mlhydf1sbqlphlfl2fhmlzhgqq5jjzihfmccbq7db";
+  };
+
+  buildInputs = [ ghostscript netpbm perl ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  configurePhase = ''
+    ./configure \
+      --prefix="$out" \
+      --without-mktexlsr \
+      --with-texpath=$out/share/texmf/tex/latex/html
+  '';
+
+  postInstall = ''
+    for p in $out/bin/{latex2html,pstoimg}; do \
+      wrapProgram $p --add-flags '--tmp="''${TMPDIR:-/tmp}"'
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "LaTeX-to-HTML translator";
+    longDescription = ''
+      A Perl program that translates LaTeX into HTML (HyperText Markup
+      Language), optionally creating separate HTML files corresponding to each
+      unit (e.g., section) of the document. LaTeX2HTML proceeds by interpreting
+      LaTeX (to the best of its abilities). It contains definitions from a wide
+      variety of classes and packages, and users may add further definitions by
+      writing Perl scripts that provide information about class/package
+      commands.
+    '';
+
+    homepage = "https://www.ctan.org/pkg/latex2html";
+
+    license = licenses.gpl2;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ yurrriq ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2646,6 +2646,8 @@ with pkgs;
 
   kindlegen = callPackage ../tools/typesetting/kindlegen { };
 
+  latex2html = callPackage ../tools/misc/latex2html { };
+
   ldapvi = callPackage ../tools/misc/ldapvi { };
 
   ldns = callPackage ../development/libraries/ldns {


### PR DESCRIPTION
###### Motivation for this change
 
Add [latex2html](https://www.ctan.org/pkg/latex2html).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
