### PR TITLE
rust: make rust beta and nightly be build by hydra

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5329,16 +5329,16 @@ in
 
   rust = rustStable;
   rustStable = callPackage ../development/compilers/rust {};
-  rustBeta = callPackage ../development/compilers/rust/beta.nix {};
-  rustNightly = callPackage ../development/compilers/rust/nightly.nix {
+  rustBeta = lowPrio (recurseIntoAttrs (callPackage ../development/compilers/rust/beta.nix {}));
+  rustNightly = lowPrio (recurseIntoAttrs (callPackage ../development/compilers/rust/nightly.nix {
     rustPlatform = recurseIntoAttrs (makeRustPlatform rustBeta);
-  };
-  rustNightlyBin = callPackage ../development/compilers/rust/nightlyBin.nix {
+  }));
+  rustNightlyBin = lowPrio (callPackage ../development/compilers/rust/nightlyBin.nix {
      buildRustPackage = callPackage ../build-support/rust {
        rust = rustNightlyBin;
        rustRegistry = callPackage ./rust-packages.nix { };
      };
-  };
+  });
 
   cargo = rust.cargo;
   rustc = rust.rustc;


### PR DESCRIPTION
###### Motivation for this change
Building rust nightly requires rustBeta.
Both of which take 1.5 hours to compile.
This includes them into hydra builds so we don't waste peoples time too much.

