### PR TITLE
ding: 1.8 -> 1.8.1

### DIFF
--- a/pkgs/applications/misc/ding/default.nix
+++ b/pkgs/applications/misc/ding/default.nix
@@ -10,11 +10,11 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  name = "ding-1.8";
+  name = "ding-1.8.1";
 
   src = fetchurl {
     url = "http://ftp.tu-chemnitz.de/pub/Local/urz/ding/${name}.tar.gz";
-    sha256 = "00z97ndwmzsgig9q6y98y8nbxy76pyi9qyj5qfpbbck24gakpz5l";
+    sha256 = "0chjqs3z9zs1w3l7b5lsaj682rgnkf9kibcbzhggqqcn1pbvl5sq";
   };
 
   buildInputs = [ aspellEnv fortune gnugrep makeWrapper tk tre ];
@@ -36,11 +36,11 @@ stdenv.mkDerivation rec {
 
     sed -i "s@/usr/bin/ding@$out/bin/ding@g" ding.desktop
 
-    cp ding $out/bin/
-    cp de-en.txt $out/share/dict/
-    cp ding.1 $out/share/man/man1/
-    cp ding.png $out/share/pixmaps/
-    cp ding.desktop $out/share/applications/
+    cp -v ding $out/bin/
+    cp -v de-en.txt $out/share/dict/
+    cp -v ding.1 $out/share/man/man1/
+    cp -v ding.png $out/share/pixmaps/
+    cp -v ding.desktop $out/share/applications/
 
     wrapProgram $out/bin/ding --prefix PATH : ${stdenv.lib.makeBinPath [ gnugrep aspellEnv tk fortune ]} --prefix ASPELL_CONF : "\"prefix ${aspellEnv};\""
   '';


### PR DESCRIPTION
###### Motivation for this change
The actual tar did not change for some reason, but the version did
change.
Also make the install a bit more verbose.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

