### PR TITLE
flashplayer: 24.0.0.186 -> 24.0.0.194

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -94,12 +94,12 @@ let
 
   flash = stdenv.mkDerivation rec {
     name = "flashplayer-ppapi-${version}";
-    version = "24.0.0.186";
+    version = "24.0.0.194";
 
     src = fetchzip {
       url = "https://fpdownload.adobe.com/pub/flashplayer/pdc/"
           + "${version}/flash_player_ppapi_linux.x86_64.tar.gz";
-      sha256 = "1pwayhnfjvb6gal5msw0k8rv4h6jvl0mpfsi0jqlka00cnyfjqpd";
+      sha256 = "1l9gz81mwb4p1yj9n8s7hrkxdyw0amcpcc3295dq7zhsr35dm76z";
       stripRoot = false;
     };
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/commit/ce11097b712c9415952a5bd6fce6184c7b923c20 missed one file  with old vulnerable flash version
