### PR TITLE
tdesktop: 0.10.19 -> 1.0.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -19,14 +19,14 @@ let
 
 in stdenv.mkDerivation rec {
   name = "telegram-desktop-${version}";
-  version = "0.10.19";
+  version = "1.0.0";
   qtVersion = lib.replaceStrings ["."] ["_"] packagedQt;
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "tdesktop";
     rev = "v${version}";
-    sha256 = "1p07kxfmcd90sx9bq046x03h1h807vs0pn64lfghr6m6ln8z44s3";
+    sha256 = "1qxzi82cgd8klk6rn83rzrmik0s76alarfaknknww5iw5px7gi8b";
   };
 
   tgaur = fetchgit {

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -31,8 +31,8 @@ in stdenv.mkDerivation rec {
 
   tgaur = fetchgit {
     url = "https://aur.archlinux.org/telegram-desktop.git";
-    rev = "99bb0519f14e23fafb6884fe296d34b6f8bed5c3";
-    sha256 = "0z5m3binbl06kk34plmfblhqz6hlnkbnjb93sam0c6c995k3sz82";
+    rev = "957a76f9fb691486341bcf4781ad0ef3d16f6b69";
+    sha256 = "01nrvvq0mrdyvamjgqr4z5aahyd1wrf28jyddpfsnixp2w5kxqj8";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Update tdesktop to the stable 1.0.0 version

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

