### PR TITLE
coq_HEAD: Update to the latest commit

### DIFF
--- a/pkgs/applications/science/logic/coq/HEAD.nix
+++ b/pkgs/applications/science/logic/coq/HEAD.nix
@@ -1,26 +1,29 @@
-# - coqide compilation can be disabled by setting lablgtk to null;
+# - coqide compilation can be disabled by setting buildIde to false;
 # - The csdp program used for the Micromega tactic is statically referenced.
 #   However, coq can build without csdp by setting it to null.
 #   In this case some Micromega tactics will search the user's path for the csdp program and will fail if it is not found.
 
-{stdenv, fetchgit, writeText, pkgconfig, ocaml, findlib, camlp5, ncurses, lablgtk ? null, csdp ? null}:
+{stdenv, fetchgit, writeText, pkgconfig, ocamlPackages_4_02, ncurses, buildIde ? true, csdp ? null}:
 
 let
   version = "2017-01-22";
   coq-version = "8.6";
-  buildIde = lablgtk != null;
-  ideFlags = if buildIde then "-lablgtkdir ${lablgtk}/lib/ocaml/*/site-lib/lablgtk2 -coqide opt" else "";
+  ideFlags = if buildIde then "-lablgtkdir ${ocamlPackages_4_02.lablgtk}/lib/ocaml/*/site-lib/lablgtk2 -coqide opt" else "";
   csdpPatch = if csdp != null then ''
     substituteInPlace plugins/micromega/sos.ml --replace "; csdp" "; ${csdp}/bin/csdp"
     substituteInPlace plugins/micromega/coq_micromega.ml --replace "System.is_in_system_path \"csdp\"" "true"
   '' else "";
+  ocaml = ocamlPackages_4_02.ocaml;
+  findlib = ocamlPackages_4_02.findlib;
+  lablgtk = ocamlPackages_4_02.lablgtk;
+  camlp5 = ocamlPackages_4_02.camlp5_transitional;
 in
 
 stdenv.mkDerivation {
   name = "coq-unstable-${version}";
 
   inherit coq-version;
-  inherit ocaml camlp5;
+  inherit ocaml camlp5 findlib;
 
   src = fetchgit {
     url = git://scm.gforge.inria.fr/coq/coq.git;

--- a/pkgs/applications/science/logic/coq/HEAD.nix
+++ b/pkgs/applications/science/logic/coq/HEAD.nix
@@ -6,7 +6,7 @@
 {stdenv, fetchgit, writeText, pkgconfig, ocamlPackages_4_02, ncurses, buildIde ? true, csdp ? null}:
 
 let
-  version = "2017-01-22";
+  version = "2017-02-03";
   coq-version = "8.6";
   ideFlags = if buildIde then "-lablgtkdir ${ocamlPackages_4_02.lablgtk}/lib/ocaml/*/site-lib/lablgtk2 -coqide opt" else "";
   csdpPatch = if csdp != null then ''
@@ -27,8 +27,8 @@ stdenv.mkDerivation {
 
   src = fetchgit {
     url = git://scm.gforge.inria.fr/coq/coq.git;
-    rev = "d6bcc6ebe4f65d0555414851f7e4fb6fa1fb22a4";
-    sha256 = "1k5wkwlis836iwy1s8hfjw9gwdk8vp405hp09s6d44ijb2ihr356";
+    rev = "078598d029792a3d9a54fae9b9ac189b75bc3b06";
+    sha256 = "0sflrpp6x0ada0bjh67q1x65g88d179n3cawpwkp1pm4kw76g8x7";
   };
 
   buildInputs = [ pkgconfig ocaml findlib camlp5 ncurses lablgtk ];

--- a/pkgs/applications/science/logic/coq/HEAD.nix
+++ b/pkgs/applications/science/logic/coq/HEAD.nix
@@ -6,7 +6,7 @@
 {stdenv, fetchgit, writeText, pkgconfig, ocaml, findlib, camlp5, ncurses, lablgtk ? null, csdp ? null}:
 
 let
-  version = "8.6pre-0c999f02";
+  version = "2017-01-22";
   coq-version = "8.6";
   buildIde = lablgtk != null;
   ideFlags = if buildIde then "-lablgtkdir ${lablgtk}/lib/ocaml/*/site-lib/lablgtk2 -coqide opt" else "";
@@ -17,15 +17,15 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "coq-${version}";
+  name = "coq-unstable-${version}";
 
   inherit coq-version;
   inherit ocaml camlp5;
 
   src = fetchgit {
     url = git://scm.gforge.inria.fr/coq/coq.git;
-    rev = "ad768e435a736ca51ac79a575967b388b34918c7";
-    sha256 = "05s7sk1l3mvdjag3idnhkpj707y4bv56da7kpffw862f2qgfr77j";
+    rev = "d6bcc6ebe4f65d0555414851f7e4fb6fa1fb22a4";
+    sha256 = "1k5wkwlis836iwy1s8hfjw9gwdk8vp405hp09s6d44ijb2ihr356";
   };
 
   buildInputs = [ pkgconfig ocaml findlib camlp5 ncurses lablgtk ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17222,8 +17222,8 @@ with pkgs;
   };
   coq_8_6 = callPackage ../applications/science/logic/coq {};
   coq_HEAD = callPackage ../applications/science/logic/coq/HEAD.nix {
-    inherit (ocamlPackages) ocaml findlib lablgtk;
-    camlp5 = ocamlPackages.camlp5_transitional;
+    inherit (ocamlPackages_4_02) ocaml findlib lablgtk;
+    camlp5 = ocamlPackages_4_02.camlp5_transitional;
   };
   coq = coq_8_6;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17221,10 +17221,7 @@ with pkgs;
     version = "8.5pl3";
   };
   coq_8_6 = callPackage ../applications/science/logic/coq {};
-  coq_HEAD = callPackage ../applications/science/logic/coq/HEAD.nix {
-    inherit (ocamlPackages_4_02) ocaml findlib lablgtk;
-    camlp5 = ocamlPackages_4_02.camlp5_transitional;
-  };
+  coq_HEAD = callPackage ../applications/science/logic/coq/HEAD.nix {};
   coq = coq_8_6;
 
   mkCoqPackages_8_4 = self: let callPackage = newScope self; in {


### PR DESCRIPTION
###### Motivation for this change
Testing an automatically generated nix file update, through https://github.com/rht/nixpkg-git-fetch-head/blob/master/nixpkg-git-fetch-head.sh.
With tiny modification (e.g. replace the ls-remote HEAD tag with release tags), this could be used for other packages that mainly use `fetchgit`.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

