### PR TITLE
dropbox: 16.4.30 -> 17.4.33

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -23,11 +23,11 @@
 let
   # NOTE: When updating, please also update in current stable,
   # as older versions stop working
-  version = "16.4.30";
+  version = "17.4.33";
   sha256 =
     {
-      "x86_64-linux" = "0inwc12d14i6gyfllxbhizb434a7vy0l5nvc07kz0bca7c4665wb";
-      "i686-linux"   = "0pdn8558ll317k3jrrjir90pn6abwbm99y9wzdq39wxj4dmrlh6w";
+      "x86_64-linux" = "0q3afwzd48mdv4mj4zbm6bvafj4hv18ianzhwjxz5dj6njv7s47y";
+      "i686-linux"   = "0wgq94if8wx08kqzsj6n20aia29h1qfn448ww63yn8dvkp6nlpya";
     }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   arch =


### PR DESCRIPTION
###### Motivation for this change

Dropbox on NixOS is a royal pain in the rear due to:

1. Forced upgrades where anything but the latest version will simply stop working
2. No changelog when new versions are released

This user hostile approach by Dropbox means that dropbox stops working on NixOS from the time a new version is released and until the nixpkgs repository is updated.

There are several free and open source self-hosted alternatives to the Dropbox service. Please consider using one (or more) of these instead:

 - [Librevault](https://librevault.com)
 - [Nextcloud](https://nextcloud.com)
 - [ownCloud](https://owncloud.org)
 - [Syncthing](https://syncthing.net)

Note: This is not in any way an endorsement of any of the projects mentioned above.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
