### PR TITLE
nvi: link against libncurses as there is no libcurses

### DIFF
--- a/pkgs/applications/editors/nvi/default.nix
+++ b/pkgs/applications/editors/nvi/default.nix
@@ -19,7 +19,8 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     sed -i build/configure \
       -e s@vi_cv_path_preserve=no@vi_cv_path_preserve=/tmp/vi.recover@ \
-      -e s@/var/tmp@@
+      -e s@/var/tmp@@ \
+      -e s@-lcurses@-lncurses@
   '';
 
   configurePhase = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

