### PR TITLE
miredo: do not run miredo-checkconf

### DIFF
--- a/nixos/modules/services/networking/miredo.nix
+++ b/nixos/modules/services/networking/miredo.nix
@@ -82,7 +82,6 @@ in
       serviceConfig = {
         Restart = "always";
         RestartSec = "5s";
-        ExecStartPre = "${cfg.package}/bin/miredo-checkconf -f ${miredoConf}";
         ExecStart = "${cfg.package}/bin/miredo -c ${miredoConf} -p ${pidFile} -f";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };


### PR DESCRIPTION
###### Motivation for this change

Network is down when ```nixos-rebuild``` restarts ```miredo``` service.
It results in ```miredo-checkconf``` failure.
The failure to restart ```miredo``` aborts ```nixos-rebuild```.

```
Jan 12 14:10:59 nixos miredo-checkconf[13432]: Invalid host name “teredo.remlab.net” at line 2: Temporary failure in name resolution
Jan 12 14:10:59 nixos miredo-checkconf[13432]: Server address not specified
Jan 12 14:10:59 nixos miredo-checkconf[13432]: Fatal configuration error
```


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

