### PR TITLE
ckb: init at 0.2.6

### DIFF
--- a/nixos/modules/hardware/ckb.nix
+++ b/nixos/modules/hardware/ckb.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.ckb;
+
+in
+  {
+    options.hardware.ckb = {
+      enable = mkEnableOption "the Corsair keyboard/mouse driver";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.ckb;
+        defaultText = "pkgs.ckb";
+        description = ''
+          The package implementing the Corsair keyboard/mouse driver.
+        '';
+      };
+    };
+
+    config = mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+
+      systemd.services.ckb = {
+        description = "Corsair Keyboard Daemon";
+        wantedBy = ["multi-user.target"];
+        script = "${cfg.package}/bin/ckb-daemon";
+        serviceConfig = {
+          Restart = "always";
+          StandardOutput = "syslog";
+        };
+      };
+    };
+
+    meta = {
+      maintainers = with lib.maintainers; [ kierdavis ];
+    };
+  }

--- a/pkgs/tools/misc/ckb/ckb-animations-location.patch
+++ b/pkgs/tools/misc/ckb/ckb-animations-location.patch
@@ -1,0 +1,12 @@
+diff --git a/src/ckb/animscript.cpp b/src/ckb/animscript.cpp
+index d0b7f46..d7a3459 100644
+--- a/src/ckb/animscript.cpp
++++ b/src/ckb/animscript.cpp
+@@ -30,7 +30,7 @@ QString AnimScript::path(){
+ #ifdef __APPLE__
+     return QDir(QApplication::applicationDirPath() + "/../Resources").absoluteFilePath("ckb-animations");
+ #else
+-    return QDir(QApplication::applicationDirPath()).absoluteFilePath("ckb-animations");
++    return QDir(QApplication::applicationDirPath() + "/../libexec").absoluteFilePath("ckb-animations");
+ #endif
+ }

--- a/pkgs/tools/misc/ckb/default.nix
+++ b/pkgs/tools/misc/ckb/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, libudev, pkgconfig, qtbase, qmakeHook, zlib }:
+
+stdenv.mkDerivation rec {
+  version = "0.2.6";
+  name = "ckb-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ccMSC";
+    repo = "ckb";
+    rev = "v${version}";
+    sha256 = "04h50qdzsbi77mj62jghr52i35vxvmhnvsb7pdfdq95ryry8bnwm";
+  };
+
+  buildInputs = [
+    libudev
+    qtbase
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmakeHook
+  ];
+
+  patches = [
+    ./ckb-animations-location.patch
+  ];
+
+  doCheck = false;
+
+  installPhase = ''
+    install -D --mode 0755 --target-directory $out/bin bin/ckb-daemon bin/ckb
+    install -D --mode 0755 --target-directory $out/libexec/ckb-animations bin/ckb-animations/*
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Driver and configuration tool for Corsair keyboards and mice";
+    homepage = https://github.com/ccMSC/ckb;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kierdavis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1267,6 +1267,8 @@ in
 
   cloud-utils = callPackage ../tools/misc/cloud-utils { };
 
+  ckb = qt5.callPackage ../tools/misc/ckb { };
+
   compass = callPackage ../development/tools/compass { };
 
   convmv = callPackage ../tools/misc/convmv { };


### PR DESCRIPTION
ckb is a driver for Corsair keyboards/mice. It also contains a graphical tool for configuring their LED backlight settings.

The driver is implemented as a userland daemon. A NixOS module is included that runs this as a systemd service.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

