### PR TITLE
scala: fix versions and $PATH

### DIFF
--- a/pkgs/development/compilers/scala/2.10.nix
+++ b/pkgs/development/compilers/scala/2.10.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ stdenv, fetchurl, makeWrapper, jre, gnugrep, coreutils }:
 
 stdenv.mkDerivation rec {
-  name = "scala-2.10.5";
+  name = "scala-2.10.6";
 
   src = fetchurl {
     url = "http://www.scala-lang.org/files/archive/${name}.tgz";
-    sha256 = "1ckyz31gmf2pgdl51h1raa669mkl7sqfdl3vqkrmyc46w5ysz3ci";
+    sha256 = "0rrdrndnxy8m76gppqh7yr68qfx0kxns5bwc69k4swz6va1zbbal";
   };
 
   propagatedBuildInputs = [ jre ] ;
@@ -17,7 +17,11 @@ stdenv.mkDerivation rec {
     mv * $out
 
     for p in $(ls $out/bin/) ; do
-      wrapProgram $out/bin/$p --prefix PATH ":" ${jre}/bin ;
+      wrapProgram $out/bin/$p \
+        --prefix PATH ":" ${coreutils}/bin \
+        --prefix PATH ":" ${gnugrep}/bin \
+        --prefix PATH ":" ${jre}/bin \
+        --set JAVA_HOME ${jre}
     done
   '';
 

--- a/pkgs/development/compilers/scala/2.11.nix
+++ b/pkgs/development/compilers/scala/2.11.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, makeWrapper, jre, gnugrep, coreutils }:
 
 stdenv.mkDerivation rec {
-  name = "scala-2.12.1";
+  name = "scala-2.11.8";
 
   src = fetchurl {
     url = "http://www.scala-lang.org/files/archive/${name}.tgz";
-    sha256 = "0nf37ix3rrm50s7dacwlyr8fl1hgrbxbw5yz21qf58rj8n46ic2d";
+    sha256 = "1khs7673wca7gnxz2rxphv6v5k94jkpcarlqznsys9cpknhqdz47";
   };
 
   propagatedBuildInputs = [ jre ] ;
@@ -38,5 +38,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.scala-lang.org/;
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.all;
+    branch = "2.11";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5379,8 +5379,9 @@ in
 
   scala_2_9 = callPackage ../development/compilers/scala/2.9.nix { };
   scala_2_10 = callPackage ../development/compilers/scala/2.10.nix { };
-  scala_2_11 = callPackage ../development/compilers/scala { };
-  scala = scala_2_11;
+  scala_2_11 = callPackage ../development/compilers/scala/2.11.nix { };
+  scala_2_12 = callPackage ../development/compilers/scala { };
+  scala = scala_2_12;
 
   scalafmt = callPackage ../development/tools/scalafmt { };
 


### PR DESCRIPTION
###### Motivation for this change

1. ```pkgs.scala_2_11``` pointed to scala 2.12
2. scala 2.11 was not in nixpkgs at all. there were 2.9, 2.10, 2.12
3. bash scripts (such as ```scalac```) rely on ```coreutils```, ```gnugrep``` and environment variable ```JAVA_HOME``` 
4. minor version updated from 2.10.5 to 2.10.6 in 2.10 branch 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

