### PR TITLE
i3blocks: search for config in correct system directory

### DIFF
--- a/pkgs/applications/window-managers/i3/blocks.nix
+++ b/pkgs/applications/window-managers/i3/blocks.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "c64720057e22cc7cac5e8fcd58fd37e75be3a7d5a3cb8995841a7f18d30c0536";
   };
 
-  makeFlags = "all";
+  buildFlags = "SYSCONFDIR=/etc all";
   installFlags = "PREFIX=\${out} VERSION=${version}";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
The `SYSCONFDIR` variable used in the Makefile servers two purposes:

1) During buildPhase, it is hardcoded into the executable as one of
   the locations that will be searched for the `i3blocks.conf` config
   file. We want this set to `/etc`, so that `/etc/i3blocks.conf`
   will be automatically loaded if it exists, as specified in the
   manpage.

2) During installPhase, it specifies the location that the sample
   `i3blocks.conf` should be installed to. We want this to be `$out/etc`.

Case 2 was already handled correctly, but case 1 was not. This resulted
in i3blocks instead searching for `i3blocks.conf` in the default value of
`SYSCONFDIR`, which is `/usr/local/etc`, a directory which generally does
not exist on NixOS. This commit remedies this problem by setting
`SYSCONFDIR=/etc` during buildPhase.

A minor stylistic fix (correcting a usage of `makeFlags` to `buildFlags`) has also been applied in this commit.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

