### PR TITLE
xournal: Support gtk with quartz or x11 backend

### DIFF
--- a/pkgs/applications/graphics/xournal/default.nix
+++ b/pkgs/applications/graphics/xournal/default.nix
@@ -3,6 +3,11 @@
 , libgnomecanvas, libgnomeprint, libgnomeprintui
 , pango, libX11, xproto, zlib, poppler
 , autoconf, automake, libtool, pkgconfig}:
+
+let
+  isGdkQuartzBackend = (gtk2.gdktarget == "quartz");
+in
+
 stdenv.mkDerivation rec {
   version = "0.4.8";
   name = "xournal-" + version;
@@ -21,7 +26,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
 
-  NIX_LDFLAGS = [ "-lX11" "-lz" ];
+  patches = stdenv.lib.optionals isGdkQuartzBackend [
+    ./gdk-quartz-backend.patch
+  ];
+
+  NIX_LDFLAGS = [ "-lz" ]
+    ++ stdenv.lib.optionals (!isGdkQuartzBackend) [ "-lX11" ];
 
   desktopItem = makeDesktopItem {
     name = name;

--- a/pkgs/applications/graphics/xournal/gdk-quartz-backend.patch
+++ b/pkgs/applications/graphics/xournal/gdk-quartz-backend.patch
@@ -1,0 +1,90 @@
+diff -rup xournal-0.4.8-orig/src/Makefile.am xournal-0.4.8/src/Makefile.am
+--- xournal-0.4.8-orig/src/Makefile.am	2012-07-04 23:12:47.000000000 +0200
++++ xournal-0.4.8/src/Makefile.am	2016-12-25 03:04:00.000000000 +0100
+@@ -31,6 +31,5 @@ if WIN32
+   xournal_LDFLAGS = -mwindows
+   xournal_LDADD = win32/xournal.res ttsubset/libttsubset.a @PACKAGE_LIBS@ $(INTLLIBS) -lz
+ else
+-  xournal_LDADD = ttsubset/libttsubset.a @PACKAGE_LIBS@ $(INTLLIBS) -lX11 -lz -lm
++  xournal_LDADD = ttsubset/libttsubset.a @PACKAGE_LIBS@ $(INTLLIBS) -lz -lm
+ endif
+-
+diff -rup xournal-0.4.8-orig/src/xo-file.c xournal-0.4.8/src/xo-file.c
+--- xournal-0.4.8-orig/src/xo-file.c	2014-06-28 21:52:25.000000000 +0200
++++ xournal-0.4.8/src/xo-file.c	2016-12-25 03:07:19.000000000 +0100
+@@ -31,11 +31,6 @@
+ #include <glib/gstdio.h>
+ #include <poppler/glib/poppler.h>
+ 
+-#ifndef WIN32
+- #include <gdk/gdkx.h>
+- #include <X11/Xlib.h>
+-#endif
+-
+ #include "xournal.h"
+ #include "xo-interface.h"
+ #include "xo-support.h"
+@@ -1275,50 +1270,8 @@ GList *attempt_load_gv_bg(char *filename
+ 
+ struct Background *attempt_screenshot_bg(void)
+ {
+-#ifndef WIN32
+-  struct Background *bg;
+-  GdkPixbuf *pix;
+-  XEvent x_event;
+-  GdkWindow *window;
+-  GdkColormap *cmap;
+-  int x,y,w,h;
+-  Window x_root, x_win;
+-
+-  x_root = gdk_x11_get_default_root_xwindow();
+-  
+-  if (!XGrabButton(GDK_DISPLAY(), AnyButton, AnyModifier, x_root, 
+-      False, ButtonReleaseMask, GrabModeAsync, GrabModeSync, None, None))
+-    return NULL;
+-
+-  XWindowEvent (GDK_DISPLAY(), x_root, ButtonReleaseMask, &x_event);
+-  XUngrabButton(GDK_DISPLAY(), AnyButton, AnyModifier, x_root);
+-
+-  x_win = x_event.xbutton.subwindow;
+-  if (x_win == None) x_win = x_root;
+-
+-  window = gdk_window_foreign_new_for_display(gdk_display_get_default(), x_win);
+-    
+-  gdk_window_get_geometry(window, &x, &y, &w, &h, NULL);
+-  cmap = gdk_drawable_get_colormap(window);
+-  if (cmap == NULL) cmap = gdk_colormap_get_system();
+-  
+-  pix = gdk_pixbuf_get_from_drawable(NULL, window,
+-     cmap, 0, 0, 0, 0, w, h);
+-    
+-  if (pix == NULL) return NULL;
+-  
+-  bg = g_new(struct Background, 1);
+-  bg->type = BG_PIXMAP;
+-  bg->canvas_item = NULL;
+-  bg->pixbuf = pix;
+-  bg->pixbuf_scale = DEFAULT_ZOOM;
+-  bg->filename = new_refstring(NULL);
+-  bg->file_domain = DOMAIN_ATTACH;
+-  return bg;
+-#else
+   // not implemented under WIN32
+   return FALSE;
+-#endif
+ }
+ 
+ /************** pdf annotation ***************/
+diff -rup xournal-0.4.8-orig/src/xo-misc.c xournal-0.4.8/src/xo-misc.c
+--- xournal-0.4.8-orig/src/xo-misc.c	2014-06-28 15:17:44.000000000 +0200
++++ xournal-0.4.8/src/xo-misc.c	2016-12-25 03:05:50.000000000 +0100
+@@ -2288,9 +2288,7 @@ void hide_unimplemented(void)
+   }  
+   
+   /* screenshot feature doesn't work yet in Win32 */
+-#ifdef WIN32
+   gtk_widget_hide(GET_COMPONENT("journalScreenshot"));
+-#endif
+ }  
+ 
+ // toggle fullscreen mode


### PR DESCRIPTION
###### Motivation for this change

Allows to use gtk2 with either quartz or x11 backend to build xournal on darwin.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

