### PR TITLE
Do not trim trailing whitespace in patch files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,7 @@ indent_size = 2
 [*.{sh,py,pl}]
 indent_style = space
 indent_size = 4
+
+# Match diffs, avoid to trim trailing whitespace
+[*.{diff,patch}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
###### Motivation for this change

The automatic removal of trailing whitespace can cause trouble when working on a patch file. It can lead to hunks not being applied anymore.

This change switches it off for files ending in `.diff` and `.patch`.
