### PR TITLE
yuicompressor: add bin wrapper for jar

### DIFF
--- a/pkgs/development/tools/yuicompressor/default.nix
+++ b/pkgs/development/tools/yuicompressor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
   name = "yuicompressor";
@@ -7,6 +7,8 @@ stdenv.mkDerivation rec {
     url = "http://github.com/yui/yuicompressor/releases/download/v${version}/${name}-${version}.jar";
     sha256 = "1qjxlak9hbl9zd3dl5ks0w4zx5z64wjsbk7ic73r1r45fasisdrh";
   };
+
+  buildInputs = [makeWrapper jre];
 
   meta = {
     description = "A JavaScript and CSS minifier";
@@ -17,7 +19,9 @@ stdenv.mkDerivation rec {
   };
 
   buildCommand = ''
-    mkdir -p $out/lib
+    mkdir -p $out/{bin,lib}
     ln -s $src $out/lib/yuicompressor.jar
+    makeWrapper ${jre}/bin/java $out/bin/${name} --add-flags \
+     "-cp $out/lib/yuicompressor.jar com.yahoo.platform.yui.compressor.YUICompressor"
   '';
 }


### PR DESCRIPTION
yuicompressor is a JavaScript and CSS minifier, distributed as a jar
file. This change uses `makeWrapper` to create a corresponding bin
script, adding `jre` as a dependency.

###### Motivation for this change

I want to be able to call yuicompressor easily from a Makefile.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

