### PR TITLE
rr: 4.3.0 -> 4.4.0

### DIFF
--- a/pkgs/development/tools/analysis/rr/default.nix
+++ b/pkgs/development/tools/analysis/rr/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, libpfm, zlib, pkgconfig, python2Packages, which, procps, gdb }:
 
 stdenv.mkDerivation rec {
-  version = "4.3.0";
+  version = "4.4.0";
   name = "rr-${version}";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "rr";
     rev = version;
-    sha256 = "0hl59g6252zi1j9zng5x5gqlmdwa4gz7mbvz8h3b7z4gnn2q5l6c";
+    sha256 = "1ijzs5lwscg0k5ch1bljiqqh35rzai75xcgghgkjbz86ynmf62rd";
   };
 
   postPatch = ''
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  buildInputs = [ cmake libpfm zlib python2Packages.python pkgconfig python2Packages.pexpect which procps gdb ];
+  buildInputs = [
+    cmake libpfm zlib python2Packages.python pkgconfig python2Packages.pexpect which procps gdb
+  ];
   cmakeFlags = [
     "-DCMAKE_C_FLAGS_RELEASE:STRING="
     "-DCMAKE_CXX_FLAGS_RELEASE:STRING="


### PR DESCRIPTION
###### Motivation for this change

[New release](https://github.com/mozilla/rr/releases/tag/4.4.0) came out in October 2016.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc maintainers @nbp @thoughtpolice 