### PR TITLE
syncthing: remove runtime dependency on go

### DIFF
--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -1,4 +1,10 @@
 { stdenv, lib, fetchFromGitHub, go, pkgs }:
+let
+  removeExpr = ref: ''
+    sed -i "s,${ref},$(echo "${ref}" | sed "s,$NIX_STORE/[^-]*,$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee,"),g" \
+  '';
+
+in
 
 stdenv.mkDerivation rec {
   version = "0.14.18";
@@ -40,6 +46,10 @@ stdenv.mkDerivation rec {
     substitute etc/linux-systemd/user/syncthing.service \
                $out/etc/systemd/user/syncthing.service \
                --replace /usr/bin/syncthing $out/bin/syncthing
+  '';
+
+  preFixup = ''
+    find $out/bin -type f -exec ${removeExpr go} '{}' '+'
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
The hack used here is shamelessly stolen from buildGoPackage. If it is
going to be applied to more expressions, it may make sense to factor it
out so it can be shared.

###### Motivation for this change
#21397 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).