### PR TITLE
systemd-boot: allow setting editor security option

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -28,6 +28,8 @@ def write_loader_conf(generation):
         if "@timeout@" != "":
             f.write("timeout @timeout@\n")
         f.write("default nixos-generation-%d\n" % generation)
+        if not @editor@:
+            f.write("editor 0");
     os.rename("@efiSysMountPoint@/loader/loader.conf.tmp", "@efiSysMountPoint@/loader/loader.conf")
 
 def copy_from_profile(generation, name, dry_run=False):

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -20,6 +20,8 @@ let
 
     timeout = if config.boot.loader.timeout != null then config.boot.loader.timeout else "";
 
+    editor = if cfg.editor then "True" else "False";
+
     inherit (efi) efiSysMountPoint canTouchEfiVariables;
   };
 in {
@@ -35,6 +37,20 @@ in {
       type = types.bool;
 
       description = "Whether to enable the systemd-boot (formerly gummiboot) EFI boot manager";
+    };
+
+    editor = mkOption {
+      default = true;
+
+      type = types.bool;
+
+      description = ''
+        Whether to allow editing the kernel command-line before
+        boot. It is recommended to set this to false, as it allows
+        gaining root access by passing init=/bin/sh as a kernel
+        parameter. However, it is enabled by default for backwards
+        compatibility.
+      ''
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
Security. Currently anyone can easily gain root access on an unencrypted, powered off machine using systemd-boot from NixOS.
See also #21832 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note that I have NOT tested this yet!