### PR TITLE
minikube: 0.13.1 -> 0.15.0

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -30,9 +30,6 @@ stdenv.mkDerivation rec {
   installPhase = ''
     cp $src $out/bin/${pname}
     chmod +x $out/bin/${pname}
-
-    mkdir -p $out/share/bash-completion/completions/
-    HOME=$(pwd) $out/bin/minikube completion bash > $out/share/bash-completion/completions/minikube
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -4,12 +4,12 @@ let
          then "linux-amd64"
          else "darwin-amd64";
   checksum = if stdenv.isLinux
-             then "17r8w4lvj7fhh7qppi9z5i2fpqqry4s61zjr9zmsbybc5flnsw2j"
-             else "0jf0kd1mm35qcf0ydr5yyzfq6qi8ifxchvpjsydb1gm1kikp5g3p";
+             then "1g6k3va84nm2h9z2ywbbkc8jabgkarqlf8wv1sp2p6s6hw7hi5h3"
+             else "0jpwyvgpl34n07chcyd7ldvk3jq3rx72cp8yf0bh7gnzr5lcnxnc";
 in
 stdenv.mkDerivation rec {
   pname = "minikube";
-  version = "0.13.1";
+  version = "0.15.0";
   name = "${pname}-${version}";
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

