### PR TITLE
google-talk-plugin: 5.41.0.0 -> 5.41.3.0

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/google-talk-plugin/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/google-talk-plugin/default.nix
@@ -51,18 +51,18 @@ stdenv.mkDerivation rec {
   # You can get the upstream version and SHA-1 hash from the following URLs:
   # curl -s http://dl.google.com/linux/talkplugin/deb/dists/stable/main/binary-amd64/Packages | grep -E 'Version|SHA1'
   # curl -s http://dl.google.com/linux/talkplugin/deb/dists/stable/main/binary-i386/Packages | grep -E 'Version|SHA1'
-  version = "5.41.0.0";
+  version = "5.41.3.0";
 
   src =
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "${baseURL}/google-talkplugin_${version}-1_amd64.deb";
-        sha1 = "1c3cc0411444587b56178de4868eb5d0ff742ec0";
+        sha1 = "0bbc3d6997ba22ce712d93e5bc336c894b54fc81";
       }
     else if stdenv.system == "i686-linux" then
       fetchurl {
         url = "${baseURL}/google-talkplugin_${version}-1_i386.deb";
-        sha1 = "0d31d726c5e9a49917e2749e73386b1c0fdcb376";
+        sha1 = "6eae0544858f85c68b0cc46d7786e990bd94f139";
       }
     else throw "Google Talk does not support your platform.";
 


### PR DESCRIPTION
###### Motivation for this change

To bump to the latest version.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).