### PR TITLE
rmilter: Fix a couple of bugs

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1703.xml
+++ b/nixos/doc/manual/release-notes/rl-1703.xml
@@ -237,6 +237,18 @@ following incompatible changes:</para>
     </para>
   </listitem>
 
+  <listitem>
+    <para>
+      The socket handling of the <literal>services.rmilter</literal> module
+      has been fixed and refactored. As rmilter doesn't support binding to
+      more than one socket, the options <literal>bindUnixSockets</literal>
+      and <literal>bindInetSockets</literal> have been replaced by
+      <literal>services.rmilter.bindSocket.*</literal>. The default is still
+      a unix socket in <literal>/run/rmilter/rmilter.sock</literal>. Refer to
+      the options documentation for more information.
+    </para>
+  </listitem>
+
 </itemizedlist>
 
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -35,6 +35,9 @@ with lib;
     (mkRemovedOptionModule [ "security" "setuidOwners" ] "Use security.wrappers instead")
     (mkRemovedOptionModule [ "security" "setuidPrograms" ] "Use security.wrappers instead")
 
+    (mkRemovedOptionModule [ "services" "rmilter" "bindInetSockets" ] "Use services.rmilter.bindSocket.* instead")
+    (mkRemovedOptionModule [ "services" "rmilter" "bindUnixSockets" ] "Use services.rmilter.bindSocket.* instead")
+
     # Old Grub-related options.
     (mkRenamedOptionModule [ "boot" "initrd" "extraKernelModules" ] [ "boot" "initrd" "kernelModules" ])
     (mkRenamedOptionModule [ "boot" "extraKernelParams" ] [ "boot" "kernelParams" ])

--- a/nixos/modules/services/mail/rmilter.nix
+++ b/nixos/modules/services/mail/rmilter.nix
@@ -7,14 +7,17 @@ let
   rspamdCfg = config.services.rspamd;
   cfg = config.services.rmilter;
 
-  inetSockets = map (sock: let s = splitString ":" sock; in "inet:${last s}@${head s}") cfg.bindInetSockets;
-  unixSockets = map (sock: "unix:${sock}") cfg.bindUnixSockets;
+  inetSocket = addr: port: "inet:[${toString port}@${addr}]";
+  unixSocket = sock: "unix:${sock}";
 
-  allSockets = unixSockets ++ inetSockets;
+  systemdSocket = if cfg.bindSocket.type == "unix" then cfg.bindSocket.path
+    else "${cfg.bindSocket.address}:${toString cfg.bindSocket.port}";
+  rmilterSocket = if cfg.bindSocket.type == "unix" then unixSocket cfg.bindSocket.path
+    else inetSocket cfg.bindSocket.address cfg.bindSocket.port;
 
   rmilterConf = ''
     pidfile = /run/rmilter/rmilter.pid;
-    bind_socket = ${if cfg.socketActivation then "fd:3" else last inetSockets};
+    bind_socket = ${if cfg.socketActivation then "fd:3" else rmilterSocket};
     tempdir = /tmp;
   '' + (with cfg.rspamd; if enable then ''
     spamd {
@@ -32,7 +35,7 @@ let
       rspamd_metric = "default";
       ${extraConfig}
     };
-    '' else "") + cfg.extraConfig;
+  '' else "") + cfg.extraConfig;
 
   rmilterConfigFile = pkgs.writeText "rmilter.conf" rmilterConf;
 
@@ -47,11 +50,13 @@ in
     services.rmilter = {
 
       enable = mkOption {
+        type = types.bool;
         default = cfg.rspamd.enable;
         description = "Whether to run the rmilter daemon.";
       };
 
       debug = mkOption {
+        type = types.bool;
         default = false;
         description = "Whether to run the rmilter daemon in debug mode.";
       };
@@ -72,25 +77,37 @@ in
         '';
        };
 
-      bindUnixSockets =  mkOption {
-        type = types.listOf types.str;
-        default = ["/run/rmilter/rmilter.sock"];
+      bindSocket.type = mkOption {
+        type = types.enum [ "unix" "inet" ];
+        default = "unix";
         description = ''
-          Unix domain sockets to listen for MTA requests.
-        '';
-        example = ''
-            [ "/run/rmilter.sock"]
+          What kind of socket rmilter should listen on. Either "unix"
+          for an Unix domain socket or "inet" for a TCP socket.
         '';
       };
 
-      bindInetSockets = mkOption {
-        type = types.listOf types.str;
-        default = [];
-        description = ''
-          Inet addresses to listen (in format accepted by systemd.socket)
+      bindSocket.path = mkOption {
+       type = types.str;
+       default = "/run/rmilter/rmilter.sock";
+       description = ''
+          Path to Unix domain socket to listen on.
         '';
-        example = ''
-            ["127.0.0.1:11990"]
+      };
+
+      bindSocket.address = mkOption {
+        type = types.str;
+        default = "::1";
+        example = "0.0.0.0";
+        description = ''
+          Inet address to listen on.
+        '';
+      };
+
+      bindSocket.port = mkOption {
+        type = types.int;
+        default = 11990;
+        description = ''
+          Inet port to listen on.
         '';
       };
 
@@ -102,13 +119,13 @@ in
 
           Disabling socket activation is not recommended when a Unix
           domain socket is used and could lead to incorrect
-          permissions.  Therefore, setting this to false will
-          configure rmilter to use an inet socket only.
+          permissions.
         '';
       };
 
       rspamd = {
         enable = mkOption {
+          type = types.bool;
           default = rspamdCfg.enable;
           description = "Whether to use rspamd to filter mails";
         };
@@ -158,13 +175,9 @@ in
           type = types.str;
           description = "Addon to postfix configuration";
           default = ''
-smtpd_milters = ${head allSockets}
-# or for TCP socket
-# # smtpd_milters = inet:localhost:9900
-milter_protocol = 6
-milter_mail_macros = i {mail_addr} {client_addr} {client_name} {auth_authen}
-# skip mail without checks if milter will die
-milter_default_action = accept
+            smtpd_milters = ${rmilterSocket}
+            milter_protocol = 6
+            milter_mail_macros = i {mail_addr} {client_addr} {client_name} {auth_authen}
           '';
         };
       };
@@ -176,52 +189,58 @@ milter_default_action = accept
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = mkMerge [
 
-    users.extraUsers = singleton {
-      name = cfg.user;
-      description = "rspamd daemon";
-      uid = config.ids.uids.rmilter;
-      group = cfg.group;
-    };
+    (mkIf cfg.enable {
 
-    users.extraGroups = singleton {
-      name = cfg.group;
-      gid = config.ids.gids.rmilter;
-    };
-
-    systemd.services.rmilter = {
-      description = "Rmilter Service";
-
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
-
-      serviceConfig = {
-        ExecStart = "${pkgs.rmilter}/bin/rmilter ${optionalString cfg.debug "-d"} -n -c ${rmilterConfigFile}";
-        ExecReload = "${pkgs.coreutils}/bin/kill -USR1 $MAINPID";
-        User = cfg.user;
-        Group = cfg.group;
-        PermissionsStartOnly = true;
-        Restart = "always";
-        RuntimeDirectory = "rmilter";
-        RuntimeDirectoryMode = "0755";
+      users.extraUsers = singleton {
+        name = cfg.user;
+        description = "rmilter daemon";
+        uid = config.ids.uids.rmilter;
+        group = cfg.group;
       };
 
-    };
-
-    systemd.sockets.rmilter = mkIf cfg.socketActivation {
-      description = "Rmilter service socket";
-      wantedBy = [ "sockets.target" ];
-      socketConfig = {
-        ListenStream = cfg.bindUnixSockets ++ cfg.bindInetSockets;
-        SocketUser = cfg.user;
-        SocketGroup = cfg.group;
-        SocketMode = "0666";
+      users.extraGroups = singleton {
+        name = cfg.group;
+        gid = config.ids.gids.rmilter;
       };
-    };
 
-    services.postfix.extraConfig = optionalString cfg.postfix.enable cfg.postfix.configFragment;
-    users.users.postfix.extraGroups = [ cfg.group ];
-  };
+      systemd.services.rmilter = {
+        description = "Rmilter Service";
 
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        serviceConfig = {
+          ExecStart = "${pkgs.rmilter}/bin/rmilter ${optionalString cfg.debug "-d"} -n -c ${rmilterConfigFile}";
+          ExecReload = "${pkgs.coreutils}/bin/kill -USR1 $MAINPID";
+          User = cfg.user;
+          Group = cfg.group;
+          PermissionsStartOnly = true;
+          Restart = "always";
+          RuntimeDirectory = "rmilter";
+          RuntimeDirectoryMode = "0755";
+        };
+
+      };
+
+      systemd.sockets.rmilter = mkIf cfg.socketActivation {
+        description = "Rmilter service socket";
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = systemdSocket;
+          SocketUser = cfg.user;
+          SocketGroup = cfg.group;
+          SocketMode = "0666";
+        };
+      };
+    })
+
+    (mkIf (cfg.enable && cfg.postfix.enable) {
+
+      services.postfix.extraConfig = cfg.postfix.configFragment;
+      users.users.postfix.extraGroups = [ cfg.group ];
+
+    })
+  ];
 }

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -53,8 +53,11 @@ in
       bindSocket = mkOption {
         type = types.listOf types.str;
         default = [
-          "/run/rspamd/rspamd.sock mode=0666 owner=${cfg.user}"
+          "/run/rspamd/rspamd.sock mode=0660 owner=${cfg.user} group=${cfg.group}"
         ];
+        defaultText = ''[
+          "/run/rspamd/rspamd.sock mode=0660 owner=${cfg.user} group=${cfg.group}"
+        ]'';
         description = ''
           List of sockets to listen, in format acceptable by rspamd
         '';


### PR DESCRIPTION
###### Motivation for this change

  * The module uses `stringSplit` but it should be `splitString`

  * `rmilter` doesn't actually support binding to multiple sockets.
    Therefore, bind to the last one specified if `socketActivation` is
    `false`.

I also believe there is a bug in this module related to systemd
`ListenStream`.  If `socketActivation` is true, Postfix gets
connection timeouts trying to connect to one of the `ListenStream`
inet addresses.  I don't know enough about `ListenStream` passing
connections on to `fd:3` to understand what's going on.

These changes are in production (with `socketActivation = false`) via NixOps.



###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

