### PR TITLE
selenium-server-standalone: restore htmlunit-driver support

### DIFF
--- a/pkgs/development/tools/selenium/htmlunit-driver/default.nix
+++ b/pkgs/development/tools/selenium/htmlunit-driver/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "htmlunit-driver-standalone-${version}";
+  version = "2.21";
+
+  src = fetchurl {
+    url = "https://github.com/SeleniumHQ/htmlunit-driver/releases/download/${version}/htmlunit-driver-standalone-${version}.jar";
+    sha256 = "1wrbam0hb036717z3y73lsw4pwp5sdiw2i1818kg9pvc7i3fb3yn";
+  };
+
+  unpackPhase = "true";
+
+  installPhase = "install -D $src $out/share/lib/${name}/${name}.jar";
+
+  meta = {
+    homepage = https://github.com/SeleniumHQ/htmlunit-driver;
+    description = "A WebDriver server for running Selenium tests on the HtmlUnit headless browser";
+    maintainers = with maintainers; [ coconnor offline ];
+    platforms = platforms.all;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, makeWrapper, jre, jdk, gcc, xorg
-, chromedriver, chromeSupport ? true }:
+, htmlunit-driver, chromedriver, chromeSupport ? true }:
 
 with stdenv.lib;
 
@@ -25,8 +25,9 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/share/lib/${name}
     cp $src $out/share/lib/${name}/${name}.jar
     makeWrapper ${jre}/bin/java $out/bin/selenium-server \
-      --add-flags "-jar $out/share/lib/${name}/${name}.jar" \
-      --add-flags ${optionalString chromeSupport "-Dwebdriver.chrome.driver=${chromedriver}/bin/chromedriver"}
+      --add-flags "-cp ${htmlunit-driver}/share/lib/${htmlunit-driver.name}/${htmlunit-driver.name}.jar:$out/share/lib/${name}/${name}.jar" \
+      --add-flags ${optionalString chromeSupport "-Dwebdriver.chrome.driver=${chromedriver}/bin/chromedriver"} \
+      --add-flags "org.openqa.grid.selenium.GridLauncher"
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6356,6 +6356,8 @@ in
 
   heroku = callPackage ../development/tools/heroku { };
 
+  htmlunit-driver = callPackage ../development/tools/selenium/htmlunit-driver { };
+
   hyenae = callPackage ../tools/networking/hyenae { };
 
   icestorm = callPackage ../development/tools/icestorm { };


### PR DESCRIPTION
It was moved to a separate project between versions 2.45 and 2.53:
https://github.com/SeleniumHQ/selenium/commit/2d3150b

###### Motivation for this change

This restores the previous behaviour of selenium-server-standalone, namely having the HtmlUnit driver available. They've been split into separate projects upstream, but it still makes sense for end users to have the whole package. selenium-server-standalone already depended on chromedriver in a similar way.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

