### PR TITLE
pyroute2: init at 0.4.12

### DIFF
--- a/pkgs/development/python-modules/pyroute2/default.nix
+++ b/pkgs/development/python-modules/pyroute2/default.nix
@@ -1,0 +1,21 @@
+{stdenv, buildPythonPackage, fetchurl}:
+
+buildPythonPackage rec {
+  name = "pyroute2-0.4.12";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pyroute2/${name}.tar.gz";
+    sha256 = "0csp6y38pgswhn46rivdgrlqw99dpjzwa0g32h6iiaj12n2f9qlq";
+  };
+
+  # requires root priviledges
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python Netlink library";
+    homepage = https://github.com/svinota/pyroute2;
+    license = licenses.asl20;
+    maintainers = [maintainers.mic92];
+    platform = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9207,6 +9207,8 @@ in {
     propagatedBuildInputs = with self; [ pyramid hawkauthlib tokenlib webtest ];
   };
 
+  pyroute2 = callPackage ../development/python-modules/pyroute2 { };
+
   pyspf = buildPythonPackage rec {
     name = "pyspf-${version}";
     version = "2.0.12";
@@ -20064,8 +20066,8 @@ in {
 
     buildInputs = [ pkgs.libev ];
 
-    libEvSharedLibrary = 
-      if !stdenv.isDarwin  
+    libEvSharedLibrary =
+      if !stdenv.isDarwin
       then "${pkgs.libev}/lib/libev.so.4"
       else "${pkgs.libev}/lib/libev.4.dylib";
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

