### PR TITLE
strongswan: enable charon-systemd

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, gmp, pkgconfig, python, autoreconfHook
 , curl, trousers, sqlite, iptables, libxml2, openresolv
-, ldns, unbound, pcsclite, openssl
+, ldns, unbound, pcsclite, openssl, systemd
 , enableTNC ? false }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
 
   buildInputs =
-    [ gmp pkgconfig python autoreconfHook iptables ldns unbound openssl pcsclite ]
+    [ gmp pkgconfig python autoreconfHook iptables ldns unbound openssl pcsclite systemd.dev ]
     ++ stdenv.lib.optionals enableTNC [ curl trousers sqlite libxml2 ];
 
   patches = [
@@ -26,10 +26,21 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/libcharon/plugins/resolve/resolve_handler.c --replace "/sbin/resolvconf" "${openresolv}/sbin/resolvconf"
+
+    # swanctl can be configured by files in SWANCTLDIR which defaults to
+    # $out/etc/swanctl. Since that directory is in the nix store users can't
+    # modify it. Ideally swanctl accepts a command line option for specifying
+    # the configuration files. In the absence of that we patch swanctl to look
+    # for configuration files in /etc/swanctl.
+    substituteInPlace src/swanctl/swanctl.h --replace "SWANCTLDIR" "\"/etc/swanctl\""
     '';
 
+  preConfigure = ''
+    configureFlagsArray+=("--with-systemdsystemunitdir=$out/etc/systemd/system")
+  '';
+
   configureFlags =
-    [ "--enable-swanctl" "--enable-cmd"
+    [ "--enable-swanctl" "--enable-cmd" "--enable-systemd"
       "--enable-farp" "--enable-dhcp"
       "--enable-eap-sim" "--enable-eap-sim-file" "--enable-eap-simaka-pseudonym"
       "--enable-eap-simaka-reauth" "--enable-eap-identity" "--enable-eap-md5"


### PR DESCRIPTION
I have trouble getting my StrongSwan VPN to start reliably. My issue is described in detail on the StrongSwan mailing list:

https://lists.strongswan.org/pipermail/users/2017-January/010359.html

The proposed solution is to switch from the `charon` daemon and the `ipsec` tool to `charon-systemd` and the `swanctl` tool. This patch adds support for `charon-systemd` and makes sure that `swanctl` reads its configuration files from `/etc/swanctl` instead of from `$out/etc/swanctl` which is in the unmodifiable nix store. 

I hope to add a subsequent patch with a corresponding NixOS module.

Also see: https://wiki.strongswan.org/projects/strongswan/wiki/Charon-systemd

It would be really ideal if this and the last two commits on `strongswan/default.nix` ( namely: https://github.com/NixOS/nixpkgs/commit/c38b4da9946b32267301ccf352731ed2d80cc2f6 and https://github.com/NixOS/nixpkgs/commit/9c61571f1a4119689d001bf1902869ca12f1c0b3) could be merged in `release-16.09`. 
