### PR TITLE
haskellPackages.lentil: override dep versions

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1153,4 +1153,11 @@ self: super: {
   turtle_1_3_0 = super.turtle_1_3_0.overrideScope (self: super: {
     optparse-applicative = self.optparse-applicative_0_13_0_0;
   });
+
+  lentil = super.lentil.overrideScope (self: super: {
+    pipes = self.pipes_4_3_2;
+    optparse-applicative = self.optparse-applicative_0_13_0_0;
+    # https://github.com/roelvandijk/terminal-progress-bar/issues/14
+    terminal-progress-bar = doJailbreak self.terminal-progress-bar_0_1_1;
+  });
 }


### PR DESCRIPTION
###### Motivation for this change

Getting [lentil](http://www.ariis.it/static/articles/lentil/page.html) to build.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
