### PR TITLE
gzip: `xz.bin` should be native input---accidentally worked because `bin`

### DIFF
--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ xz.bin ];
+  nativeBuildInputs = [ xz.bin ];
 
   preConfigure = if stdenv.isCygwin then ''
     sed -i lib/fpending.h -e 's,include <stdio_ext.h>,,'


### PR DESCRIPTION

Otherwise http://hydra.nixos.org/build/46501984/nixlog/2

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

