### PR TITLE
Make services.xserver.xkbDir conflict free when overriden.

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -64,10 +64,7 @@ in
 
     security.setuidPrograms = [ "e_freqset" ];
 
-    environment.etc = singleton
-      { source = "${pkgs.xkeyboard_config}/etc/X11/xkb";
-        target = "X11/xkb";
-      };
+    services.xserver.exportConfiguration = true;
 
     fonts.fonts = [ pkgs.dejavu_fonts pkgs.ubuntu_font_family ];
 

--- a/nixos/modules/services/x11/desktop-managers/kde4.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde4.nix
@@ -183,10 +183,7 @@ in
       GST_PLUGIN_SYSTEM_PATH = [ "/lib/gstreamer-0.10" ];
     };
 
-    environment.etc = singleton
-      { source = "${pkgs.xkeyboard_config}/etc/X11/xkb";
-        target = "X11/xkb";
-      };
+    services.xserver.exportConfiguration = true;
 
     # Enable helpful DBus services.
     services.udisks2.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -199,10 +199,7 @@ in
 
       environment.pathsToLink = [ "/share" ];
 
-      environment.etc = singleton {
-        source = "${pkgs.xkeyboard_config}/etc/X11/xkb";
-        target = "X11/xkb";
-      };
+      services.xserver.exportConfiguration = true;
 
       environment.variables =
         {

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -465,23 +465,15 @@ in
         }
       ];
 
-    environment.etc =
-      (optionals cfg.exportConfiguration
-        [ { source = "${configFile}";
-            target = "X11/xorg.conf";
-          }
-          # -xkbdir command line option does not seems to be passed to xkbcomp.
-          { source = "${cfg.xkbDir}";
-            target = "X11/xkb";
-          }
-        ])
+    environment.etc = mkMerge [
+      (mkIf cfg.exportConfiguration {
+        "X11/xorg.conf".source = configFile;
+        "X11/xkb".source = cfg.xkbDir;
+      })
       # Needed since 1.18; see https://bugs.freedesktop.org/show_bug.cgi?id=89023#c5
-      ++ (let cfgPath = "/X11/xorg.conf.d/10-evdev.conf"; in
-        [{
-          source = xorg.xf86inputevdev.out + "/share" + cfgPath;
-          target = cfgPath;
-        }]
-      );
+      (let cfgPath = "X11/xorg.conf.d/10-evdev.conf"; in
+        { "${cfgPath}".source = xorg.xf86inputevdev.out + "/share" + cfgPath; })
+    ];
 
     environment.systemPackages =
       [ xorg.xorgserver.out


### PR DESCRIPTION
###### Motivation for this change

I was looking into adding extra symbol maps to the xkb directory, and wanted to override the `services.xserver.xkbDir` option.  Unfortunately, the `enlightment`, `kde4` and `kde5` desktop manager are also defining `environment.etc.*.target = "X11/xkb"`.

Lists are not modular, which implies that one cannot prevent the error to happen unless the exact same source is used, which implies to override `xkbeyboard_config` to make it work.

###### Things done

- Built on platform(s)
   - [x] NixOS

