### PR TITLE
util-linux: 2.28.1 -> 2.29

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -4,12 +4,12 @@ stdenv.mkDerivation rec {
   name = "util-linux-${version}";
   version = lib.concatStringsSep "." ([ majorVersion ]
     ++ lib.optional (patchVersion != "") patchVersion);
-  majorVersion = "2.28";
-  patchVersion = "1";
+  majorVersion = "2.29";
+  patchVersion = "";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/util-linux/v${majorVersion}/${name}.tar.xz";
-    sha256 = "03xnaw3c7pavxvvh1vnimcr44hlhhf25whawiyv8dxsflfj4xkiy";
+    sha256 = "1rzrmdrz51p9sy7vlw5qmj8pmqazm7hgcch5yq242mkvrikyln9c";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/util-linux/rtcwake-search-PATH-for-shutdown.patch
+++ b/pkgs/os-specific/linux/util-linux/rtcwake-search-PATH-for-shutdown.patch
@@ -3,21 +3,17 @@ which isn't valid on NixOS (and a compatibility link on most other modern
 distros anyway).
 
   -- nckx <tobias.geerinckx.rice@gmail.com>
-diff --git a/include/pathnames.h b/include/pathnames.h
-index de6a13c..0c1aeb9 100644
 --- a/include/pathnames.h
 +++ b/include/pathnames.h
-@@ -50,7 +50,7 @@
- #define	_PATH_VAR_NOLOGIN	"/var/run/nologin"
- 
+@@ -53,7 +53,7 @@
+ #ifndef _PATH_LOGIN
  #define _PATH_LOGIN		"/bin/login"
+ #endif
 -#define _PATH_SHUTDOWN		"/sbin/shutdown"
-+#define _PATH_SHUTDOWN		"shutdown"
- 
++#define _PATH_SHUTDOWN   "shutdown"
+
  #define _PATH_TERMCOLORS_DIRNAME "terminal-colors.d"
  #define _PATH_TERMCOLORS_DIR	"/etc/" _PATH_TERMCOLORS_DIRNAME
-diff --git a/sys-utils/rtcwake.c b/sys-utils/rtcwake.c
-index 7c748dc..9a99a7c 100644
 --- a/sys-utils/rtcwake.c
 +++ b/sys-utils/rtcwake.c
 @@ -575,7 +575,7 @@ int main(int argc, char **argv)


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I believe this to be relevant to `stdenv`, so I am sending this PR against `staging`.