### PR TITLE
boinc service: optionally use a FHS environment

### DIFF
--- a/nixos/modules/services/computing/boinc/client.nix
+++ b/nixos/modules/services/computing/boinc/client.nix
@@ -6,6 +6,18 @@ let
   cfg = config.services.boinc;
   allowRemoteGuiRpcFlag = optionalString cfg.allowRemoteGuiRpc "--allow_remote_gui_rpc";
 
+  # A package providing the boinc_client that will actually be executed.
+  execPkg = if cfg.useFHSEnv then
+    pkgs.buildFHSUserEnv {
+      name = "boinc_client";
+      targetPkgs = p: [ cfg.package ]
+                   ++ optional cfg.virtualbox.enable cfg.virtualbox.package;
+      multiPkgs  = p: optional cfg.gpu.enable cfg.gpu.package
+                   ++ optional cfg.gpu.nvidia.enable cfg.gpu.nvidia.package;
+      runScript = "/bin/boinc";
+    }
+  else cfg.package;
+
 in
   {
     options.services.boinc = {
@@ -51,6 +63,85 @@ in
           See also: <link xlink:href="http://boinc.berkeley.edu/wiki/Controlling_BOINC_remotely#Remote_access"/>
         '';
       };
+
+      useFHSEnv = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          If set to true, run the BOINC software inside an FHS-compatible
+          environment. This allows BOINC project apps to find libraries that
+          wouldn't be otherwise found, due to apps using hardcoded paths for
+          these libraries.
+
+          If BOINC tasks appear to be failing with the message "Computation
+          Error", try enabling this option.
+        '';
+      };
+
+      virtualbox.enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          If set to true, make Virtualbox available to BOINC project apps that
+          require it, such as ATLAS@Home. This only works if useFHSEnv is
+          enabled.
+        '';
+      };
+
+      virtualbox.package = mkOption {
+        type = types.package;
+        default = pkgs.virtualbox;
+        defaultText = "pkgs.virtualbox";
+        description = ''
+          Which Virtualbox package to use.
+        '';
+      };
+
+      gpu.enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          If set to true, make OpenCL libraries available to BOINC project apps
+          that can use them, such as GPUGRID and Moo! Wrapper. This only works
+          if useFHSEnv.
+
+          Note that for support for NVIDIA GPUs to work, you may also need to
+          set <varname>gpu.nvidia.enable</varname> to true in order to make
+          CUDA libraries available as well.
+        '';
+      };
+
+      gpu.package = mkOption {
+        type = types.package;
+        default = pkgs.ocl-icd;
+        defaultText = "pkgs.ocl-icd";
+        description = ''
+          Which ocl-icd package to use.
+        '';
+      };
+
+      gpu.nvidia.enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          If set to true, make the NVIDIA CUDA libraries available to BOINC
+          project apps that can use them, such as GPUGRID and Moo! Wrapper.
+          This only works if useFHSEnv is enabled.
+        '';
+      };
+
+      gpu.nvidia.package = mkOption {
+        type = types.package;
+        default = pkgs.linuxPackages.nvidia_x11.override { libsOnly = true; };
+        defaultText = "pkgs.linuxPackages.nvidia_x11.override { libsOnly = true; }";
+        description = ''
+          Which nvidia_x11 package to use.
+        '';
+      };
     };
 
     config = mkIf cfg.enable {
@@ -72,7 +163,7 @@ in
           chown boinc ${cfg.dataDir}
         '';
         script = ''
-          ${cfg.package}/bin/boinc_client --dir ${cfg.dataDir} --redirectio ${allowRemoteGuiRpcFlag}
+          ${execPkg}/bin/boinc_client --dir ${cfg.dataDir} --redirectio ${allowRemoteGuiRpcFlag}
         '';
         serviceConfig = {
           PermissionsStartOnly = true; # preStart must be run as root


### PR DESCRIPTION
This ensures that the BOINC project applications (immutable blobs) can
find the libraries they need to run, since many contain hardcoded paths.

Additionally, an option to install Virtualbox into the environment
and an option to install NVIDIA OpenCL/CUDA libraries into the
environment were added. Other OpenCL libraries could probably be
added similarly, but I don't have the hardware to test it on.

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

