### PR TITLE
yarn: init at 0.18.1

### DIFF
--- a/pkgs/development/tools/yarn/default.nix
+++ b/pkgs/development/tools/yarn/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, nodejs, fetchzip, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "yarn-${version}";
+  version = "0.18.1";
+
+  src = fetchzip {
+    url = "https://github.com/yarnpkg/yarn/releases/download/v${version}/yarn-v${version}.tar.gz";
+    sha256 = "1jkgd2d0n78jw66a0v3cgawcc9qvzjy1zp8c1wzfqf0hl5wrcv9q";
+  };
+
+  buildInputs = [makeWrapper nodejs];
+
+  installPhase = ''
+    mkdir -p $out/{bin,libexec/yarn/}
+    cp -R . $out/libexec/yarn
+    makeWrapper $out/libexec/yarn/bin/yarn.js $out/bin/yarn
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://yarnpkg.com/;
+    description = "Fast, reliable, and secure dependency management for javascript";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.offline ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4462,6 +4462,8 @@ in
 
   xwinmosaic = callPackage ../tools/X11/xwinmosaic {};
 
+  yarn = callPackage ../development/tools/yarn  { };
+
   yank = callPackage ../tools/misc/yank { };
 
   yaml-merge = callPackage ../tools/text/yaml-merge { };


### PR DESCRIPTION
###### Motivation for this change

Currently yarn is packaged as npm package, but i don't want to use npm, no really. So i packaged it as standalone package, from builds that yarn already provides. This allows to install with any npm residuals, amen.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

