### PR TITLE
h2: init at 1.4.193

### DIFF
--- a/pkgs/servers/h2/default.nix
+++ b/pkgs/servers/h2/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchzip, jre, makeWrapper, unzip }:
+stdenv.mkDerivation rec {
+  name = "h2-${version}";
+
+  version = "1.4.193";
+
+  src = fetchzip {
+    url = "http://www.h2database.com/h2-2016-10-31.zip";
+    sha256 = "1da1qcfwi5gvh68i6w6y0qpcqp3rbgakizagkajmjxk2ryc4b3z9";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase =
+    let
+      h2ToolScript = ''
+        #!/usr/bin/env bash
+        dir=$(dirname "$0")
+
+        if [ -n "$1" ]; then
+          ${jre}/bin/java -cp "$dir/h2-${version}.jar:$H2DRIVERS:$CLASSPATH" $1 "''${@:2}"
+        else
+          echo "You have to provide the full java class path for the h2 tool you want to run. E.g. 'org.h2.tools.Server'"
+        fi
+      '';
+    in ''
+      mkdir -p $out
+      cp -R * $out
+
+      echo '${h2ToolScript}' > $out/bin/h2tool.sh
+
+      substituteInPlace $out/bin/h2.sh --replace "java" "${jre}/bin/java"
+
+      chmod +x $out/bin/*.sh
+    '';
+
+  meta = with stdenv.lib; {
+    description = "The Java SQL database";
+    homepage = http://www.h2database.com/html/main.html;
+    license = licenses.mpl20;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ mahe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2125,6 +2125,8 @@ in
 
   hans = callPackage ../tools/networking/hans { };
 
+  h2 = callPackage ../servers/h2 { };
+
   haproxy = callPackage ../tools/networking/haproxy { };
 
   haveged = callPackage ../tools/security/haveged { };


### PR DESCRIPTION
###### Motivation for this change
h2 is a often used database for jvm development

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

