### PR TITLE
pangomm: Add ApplicationServices on darwin

### DIFF
--- a/pkgs/development/libraries/pangomm/default.nix
+++ b/pkgs/development/libraries/pangomm/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, pango, glibmm, cairomm }:
+{ stdenv, fetchurl, pkgconfig, pango, glibmm, cairomm
+, ApplicationServices }:
 
 let
   ver_maj = "2.40";
@@ -14,7 +15,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ] ++ stdenv.lib.optional stdenv.isDarwin [
+    ApplicationServices
+  ];
   propagatedBuildInputs = [ pango glibmm cairomm ];
 
   doCheck = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7492,7 +7492,9 @@ in
   cairomm = callPackage ../development/libraries/cairomm { };
 
   pango = callPackage ../development/libraries/pango { };
-  pangomm = callPackage ../development/libraries/pangomm { };
+  pangomm = callPackage ../development/libraries/pangomm {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices;
+  };
 
   pangox_compat = callPackage ../development/libraries/pangox-compat { };
 


### PR DESCRIPTION
###### Motivation for this change

Noticed that ApplicationServices is missing for pangomm, http://hydra.nixos.org/build/46397710

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

