### PR TITLE
xcbuild: 0ab861ab -> 0.1.1

### DIFF
--- a/pkgs/development/tools/xcbuild/default.nix
+++ b/pkgs/development/tools/xcbuild/default.nix
@@ -15,14 +15,14 @@ let
     sha256 = "0wasql7ph5g473zxhc2z47z3pjp42q0dsn4gpijwzbxawid71b4w";
   };
 in stdenv.mkDerivation rec {
-  name    = "xcbuild-${stdenv.lib.substring 0 8 version}";
-  version = "0ab861abcc11185a17d59608f96a015752a6fadc";
+  name    = "xcbuild-${version}";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner  = "facebook";
     repo   = "xcbuild";
     rev    = version;
-    sha256 = "12h0rn8v0js2vph2pwp5wvcrfkj12nz365i5qxw9miyfn4msnz26";
+    sha256 = "0i98c6lii8r3bgs5gj7div12pxyzjvm4qqzmmzgr7dyhj00qa8r5";
   };
 
   prePatch = ''
@@ -38,6 +38,8 @@ in stdenv.mkDerivation rec {
     mv $out/usr/* $out
     rmdir $out/usr
   '';
+
+  NIX_CFLAGS_COMPILE = "-Wno-error=strict-aliasing";
 
   buildInputs = [ cmake zlib libxml2 libpng ninja ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices CoreGraphics ImageIO ];

--- a/pkgs/development/tools/xcbuild/wrapper.nix
+++ b/pkgs/development/tools/xcbuild/wrapper.nix
@@ -60,7 +60,8 @@ stdenv.mkDerivation {
       --add-flags "DERIVED_DATA_DIR=." \
       --set DEVELOPER_DIR "$out"
     wrapProgram $out/bin/xcrun \
-      --add-flags "-sdk ${sdkName}" \
+      --set DEVELOPER_DIR "$out"
+    wrapProgram $out/bin/xcode-select \
       --set DEVELOPER_DIR "$out"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

These changes fix an issue with building under i686-linux (http://hydra.nixos.org/job/nixpkgs/trunk/xcbuild.i686-linux). I've also added a wrapper for xcode-select so that it detects the pure SDK instead of looking in /Applications/Xcode.app.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
