### PR TITLE
capstone: fix pkgconfig file generation

### DIFF
--- a/pkgs/development/libraries/capstone/default.nix
+++ b/pkgs/development/libraries/capstone/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildPhase = '' ./make.sh '';
   installPhase = '' env PREFIX=$out ./make.sh install '';
   
-  buildInputs = [
+  nativeBuildInputs = [
     pkgconfig
   ];
 

--- a/pkgs/development/libraries/capstone/default.nix
+++ b/pkgs/development/libraries/capstone/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bash }:
+{ stdenv, fetchurl, bash, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name    = "capstone-${version}";
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
   configurePhase = '' patchShebangs make.sh '';
   buildPhase = '' ./make.sh '';
   installPhase = '' env PREFIX=$out ./make.sh install '';
+  
+  buildInputs = [
+    pkgconfig
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

The generation of pkgconfig `.pc` files is currently broken, because `pkgconfig` isn't being passed to the expression as a dependency. This leads to failures when attempting to build other software that relies on capstone through pkgconfig (eg. `edb`).

This PR fixes that by adding `pkgconfig` as a dependency. The buildscript picks it up automatically and correctly generates a `.pc` file (which is correctly picked up by other expressions).

Note that while I've tested this patch locally, I've tested it differently (namely, by copying the expression to a custom repository and modifying it). I see no reason why it wouldn't work as submitted in this PR, but figured I'd make note of this anyway.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

