### PR TITLE
DarwinTools: init at 1

### DIFF
--- a/pkgs/os-specific/darwin/DarwinTools/default.nix
+++ b/pkgs/os-specific/darwin/DarwinTools/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "DarwinTools-1";
+
+  src = fetchurl {
+    url = "https://opensource.apple.com/tarballs/DarwinTools/${name}.tar.gz";
+    sha256 = "0hh4jl590jv3v830p77r3jcrnpndy7p2b8ajai3ldpnx2913jfhp";
+  };
+
+  patchPhase = ''
+    substituteInPlace Makefile \
+      --replace gcc cc
+  '';
+
+  configurePhase = ''
+    export SRCROOT=.
+    export SYMROOT=.
+    export DSTROOT=$out
+  '';
+
+  postInstall = ''
+    mv $out/usr/* $out
+    rmdir $out/usr
+  '';
+
+  meta = {
+    maintainers = [ stdenv.lib.maintainers.matthewbauer ];
+    platforms = stdenv.lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10724,6 +10724,8 @@ in
     stubs = callPackages ../os-specific/darwin/stubs {};
 
     usr-include = callPackage ../os-specific/darwin/usr-include {};
+
+    DarwinTools = callPackage ../os-specific/darwin/DarwinTools {};
   };
 
   devicemapper = lvm2;


### PR DESCRIPTION
###### Motivation for this change

This derivation provides binaries for sw_vers and startupfiletool. This is useful because some configure scripts expect sw_vers to be in $PATH to determine the OS X version. DarwinTools should be usable as a native build input in these cases.

see https://github.com/NixOS/nixpkgs/search?q=sw_vers

NOTE: while this should go in apple-source-releases, it doesn't look like this is listed for any specific macOS or Developer Tools release, so I can't use the usual "applePackage" functions.
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

