### PR TITLE
tryton: init 4.2.1

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -221,6 +221,7 @@
   joamaki = "Jussi Maki <joamaki@gmail.com>";
   joelmo = "Joel Moberg <joel.moberg@gmail.com>";
   joelteon = "Joel Taylor <me@joelt.io>";
+  johbo = "Johannes Bornhold <johannes@bornhold.name>";
   joko = "Ioannis Koutras <ioannis.koutras@gmail.com>";
   jonafato = "Jon Banafato <jon@jonafato.com>";
   jpbernardy = "Jean-Philippe Bernardy <jeanphilippe.bernardy@gmail.com>";

--- a/pkgs/applications/office/tryton/default.nix
+++ b/pkgs/applications/office/tryton/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, python2Packages, librsvg }:
+
+with stdenv.lib;
+
+python2Packages.buildPythonApplication rec {
+  name = "tryton-${version}";
+  version = "4.2.1";
+  src = fetchurl {
+    url = "mirror://pypi/t/tryton/${name}.tar.gz";
+    sha256 = "1ry3kvbk769m8rwqa90pplfvmmgsv4jj9w1aqhv892smia8f0ybm";
+  };
+  propagatedBuildInputs = with python2Packages; [
+    chardet
+    dateutil
+    pygtk
+    librsvg
+  ];
+  makeWrapperArgs = [
+    ''--set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"''
+  ];
+  meta = {
+    description = "The client of the Tryton application platform";
+    longDescription = ''
+      The client for Tryton, a three-tier high-level general purpose
+      application platform under the license GPL-3 written in Python and using
+      PostgreSQL as database engine.
+
+      It is the core base of a complete business solution providing
+      modularity, scalability and security.
+    '';
+    homepage = http://www.tryton.org/;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.johbo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4066,6 +4066,8 @@ in
 
   trousers = callPackage ../tools/security/trousers { };
 
+  tryton = callPackage ../applications/office/tryton { };
+
   omapd = callPackage ../tools/security/omapd { };
 
   ttf2pt1 = callPackage ../tools/misc/ttf2pt1 { };


### PR DESCRIPTION
###### Motivation for this change

Add a new package Tryton to make the client of the Tryton application platform available via Nix.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

