### PR TITLE
terragrunt: 0.8.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/networking/cluster/terragrunt/default.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/default.nix
@@ -2,16 +2,15 @@
 
 buildGoPackage rec {
   name = "terragrunt-${version}";
-  version = "0.8.0";
-  rev = "v${version}";
+  version = "0.9.1";
 
   goPackagePath = "github.com/gruntwork-io/terragrunt";
 
   src = fetchFromGitHub {
-    inherit rev;
+    rev    = "v${version}";
     owner  = "gruntwork-io";
     repo   = "terragrunt";
-    sha256 = "1d035p2r6d8c1crxvpi5ayb9jx6f2pdgzw2197zhllavyi8n8dw1";
+    sha256 = "19im4sazw09854lnzalljwx22qswly8ffyys3yrjkd2l9vfxfly3";
   };
 
   goDeps = ./deps.nix;
@@ -20,7 +19,7 @@ buildGoPackage rec {
 
   postInstall = ''
     wrapProgram $bin/bin/terragrunt \
-      --suffix PATH : ${lib.makeBinPath [ terraform ]}
+      --set TERRAGRUNT_TFPATH {lib.getBin terraform}/bin/terraform
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/cluster/terragrunt/deps.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/deps.nix
@@ -5,8 +5,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/aws/aws-sdk-go";
-      rev = "8649d278323ebf6bd20c9cd56ecb152b1c617375";
-      sha256 = "0m2nxdlvi90vw68ds9qby291skc5d0dgqi3pkalr8ma3kd9r9khv";
+      rev = "5e1afe1c0a077fb2da9b5f74232b790d99397ce8";
+      sha256 = "073yx5acqybw0h2zshg209wmldm0g5h5x9bhbn6h08ak0r4i80al";
     };
   }
   {
@@ -32,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/mattn/go-zglob";
-      rev = "0b24567ec079616e9897f635f542e3bf56abb3d0";
-      sha256 = "0380dqsy0qdjranl5qfmmcr6a4g7sw4z26g1bld9y1s66madl03l";
+      rev = "1783ae1a9f7ff3a79240e8c249d8b575d70a6528";
+      sha256 = "0g4ih6swqpq0bqwsv5mv8ymicgr92xh9i6sm1793lqwb63x8ga1x";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change

Update.

###### Things done

- [X ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

