### PR TITLE
git-crecord: init at 20161216.0

### DIFF
--- a/pkgs/applications/version-management/git-crecord/default.nix
+++ b/pkgs/applications/version-management/git-crecord/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "git-crecord-${version}";
+  version = "20161216.0";
+
+  src = fetchFromGitHub {
+    owner = "andrewshadura";
+    repo = "git-crecord";
+    rev = version;
+    sha256 = "0v3y90zi43myyi4k7q3892dcrbyi9dn2q6xgk12nw9db9zil269i";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ docutils ];
+
+  meta = {
+    homepage = https://github.com/andrewshadura/git-crecord;
+    description = "Git subcommand to interactively select changes to commit or stage";
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1868,6 +1868,8 @@ in
 
   gifsicle = callPackage ../tools/graphics/gifsicle { };
 
+  git-crecord = callPackage ../applications/version-management/git-crecord { };
+
   git-lfs = callPackage ../applications/version-management/git-lfs { };
 
   git-up = callPackage ../applications/version-management/git-up { };


### PR DESCRIPTION
###### Motivation for this change

Would like to test this package and maybe use it myself.

I need help though, as I cannot get the `docutils` into scope while building...

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
