### PR TITLE
/bin/sh -> ${stdenv.shell}

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -82,7 +82,7 @@ rec {
     export PATH=${shadow}/bin:$PATH
     mkdir -p /etc/pam.d
     if [[ ! -f /etc/passwd ]]; then
-      echo "root:x:0:0::/root:/bin/sh" > /etc/passwd
+      echo "root:x:0:0::/root:${stdenv.shell}" > /etc/passwd
       echo "root:!x:::::::" > /etc/shadow
     fi
     if [[ ! -f /etc/group ]]; then

--- a/pkgs/build-support/kdewrapper/default.nix
+++ b/pkgs/build-support/kdewrapper/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     for a in ${program}/bin/*; do 
       PROG=$out/bin/`basename $a` 
     cat > $PROG << END
-    #!/bin/sh
+    #!${stdenv.shell}
     export KDEDIRS=$KDEDIRS\''${KDEDIRS:+:}\$KDEDIRS
     export QT_PLUGIN_PATH=$QT_PLUGIN_PATH\''${QT_PLUGIN_PATH:+:}\$QT_PLUGIN_PATH
     exec $a "\$@"

--- a/pkgs/build-support/release/ant-build.nix
+++ b/pkgs/build-support/release/ant-build.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (
 
       mkdir -p $out/bin
       cat >> $out/bin/${w.name} <<EOF
-      #! /bin/sh
+      #!${stdenv.shell}
       export JAVA_HOME=$jre
       $jre/bin/java ${cp w} ${if w ? mainClass then w.mainClass else "-jar ${w.jar}"} \$@
       EOF

--- a/pkgs/build-support/vm/windows/default.nix
+++ b/pkgs/build-support/vm/windows/default.nix
@@ -1,3 +1,4 @@
+#note: the hardcoded /bin/sh is required for the VM's cygwin shell
 pkgs:
 
 let

--- a/pkgs/servers/nosql/eventstore/default.nix
+++ b/pkgs/servers/nosql/eventstore/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,lib/eventstore/clusternode}
     cp -r bin/clusternode/* $out/lib/eventstore/clusternode/
     cat > $out/bin/clusternode << EOF
-    #!/bin/sh
+    #!${stdenv.shell}
     exec ${mono}/bin/mono $out/lib/eventstore/clusternode/EventStore.ClusterNode.exe "\$@"
     EOF
     chmod +x $out/bin/clusternode

--- a/pkgs/servers/xmpp/pyIRCt/default.nix
+++ b/pkgs/servers/xmpp/pyIRCt/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     sed -e '/configFiles/iimport os' -i config.py
     cp * $out/share/${name}
     cat > $out/bin/pyIRCt <<EOF
-      #! /bin/sh
+      #!${stdenv.shell}
       cd $out/share/${name}
       ./irc.py \"$@\"
     EOF

--- a/pkgs/servers/xmpp/pyMAILt/default.nix
+++ b/pkgs/servers/xmpp/pyMAILt/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     sed -e '/configFiles/iimport os' -i config.py
     cp * $out/share/$name
     cat > $out/bin/pyMAILt <<EOF
-      #! /bin/sh
+      #!${stdenv.shell}
       cd $out/share/${name}
       ./mail.py \"$@\"
     EOF


### PR DESCRIPTION
###### Motivation for this change

Use `${stdenv.shell}` in `pkgs/build-support` and `pkgs/servers`.

Address a subset of https://github.com/NixOS/nixpkgs/issues/183, #1424.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

