### PR TITLE
fetchBower: fold arg in all-packages into the nix file

### DIFF
--- a/pkgs/build-support/fetchbower/default.nix
+++ b/pkgs/build-support/fetchbower/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, lib, bower2nix, cacert }:
+{ stdenvNoCC, lib, nodePackages, cacert }:
 let
   bowerVersion = version:
     let
@@ -21,8 +21,9 @@ let
     '';
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
+    inherit (nodePackages) bower2nix;
     inherit outputHash;
-    nativeBuildInputs = [ bower2nix cacert ];
+    nativeBuildInputs = [ nodePackages.bower2nix cacert ];
   };
 
 in fetchbower

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -177,9 +177,7 @@ in
 
   etBook = callPackage ../data/fonts/et-book { };
 
-  fetchbower = callPackage ../build-support/fetchbower {
-    inherit (nodePackages) bower2nix;
-  };
+  fetchbower = callPackage ../build-support/fetchbower { };
 
   fetchbzr = callPackage ../build-support/fetchbzr { };
 


### PR DESCRIPTION
###### Motivation for this change

Would this be better?
If such, I'm thinking of doing the same to the rest of the packages, so that `all-packages.nix` (or a major subset of it) can be automatically-generated through a fs walk.
The PR is made minimal in order to avoid merge conflicts w/ other existing PRs and occasional rebase (which has staled some feats e.g. attempt at deterministic build #2281).

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

