### PR TITLE
Couchpotato: init at 3.0.1 + couchpotato module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -282,6 +282,7 @@
       infinoted = 264;
       keystone = 265;
       glance = 266;
+      couchpotato = 267;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -534,6 +535,7 @@
       infinoted = 264;
       keystone = 265;
       glance = 266;
+      couchpotato = 267;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -242,6 +242,7 @@
   ./services/misc/cpuminer-cryptonight.nix
   ./services/misc/cgminer.nix
   ./services/misc/confd.nix
+  ./services/misc/couchpotato.nix
   ./services/misc/devmon.nix
   ./services/misc/dictd.nix
   ./services/misc/dysnomia.nix

--- a/nixos/modules/services/misc/couchpotato.nix
+++ b/nixos/modules/services/misc/couchpotato.nix
@@ -1,0 +1,50 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.couchpotato;
+
+in
+{
+  options = {
+    services.couchpotato = {
+      enable = mkEnableOption "CouchPotato Server";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.couchpotato = {
+      description = "CouchPotato Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = ''
+        mkdir -p /var/lib/couchpotato
+        chown -R couchpotato:couchpotato /var/lib/couchpotato
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        User = "couchpotato";
+        Group = "couchpotato";
+        PermissionsStartOnly = "true";
+        ExecStart = "${pkgs.couchpotato}/bin/couchpotato";
+        Restart = "on-failure";
+      };
+    };
+
+    users.extraUsers = singleton
+      { name = "couchpotato";
+        group = "couchpotato";
+        home = "/var/lib/couchpotato/";
+        description = "CouchPotato daemon user";
+        uid = config.ids.uids.couchpotato;
+      };
+
+    users.extraGroups = singleton
+      { name = "couchpotato";
+        gid = config.ids.gids.couchpotato;
+      };
+  };
+}

--- a/pkgs/servers/couchpotato/default.nix
+++ b/pkgs/servers/couchpotato/default.nix
@@ -1,0 +1,43 @@
+{ fetchurl, pythonPackages, lib }:
+
+with pythonPackages;
+
+buildPythonApplication rec {
+  name = "couchpotato-${version}";
+  version = "3.0.1";
+  disabled = isPy3k;
+
+  src = fetchurl {
+    url = "https://github.com/CouchPotato/CouchPotatoServer/archive/build/${version}.tar.gz";
+    sha256 = "1xwjis3ijh1rff32mpdsphmsclf0lkpd3phpgxkccrigq1m9r3zh";
+  };
+
+  format = "other";
+
+  postPatch = ''
+    substituteInPlace CouchPotato.py --replace "dirname(os.path.abspath(__file__))" "os.path.join(dirname(os.path.abspath(__file__)), '../${python.sitePackages}')"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    mkdir -p $out/${python.sitePackages}/
+
+    cp -r libs/* $out/${python.sitePackages}/
+    cp -r couchpotato $out/${python.sitePackages}/
+
+    cp CouchPotato.py $out/bin/couchpotato
+    chmod +x $out/bin/*
+  '';
+
+  fixupPhase = ''
+    wrapProgram "$out/bin/couchpotato" --set PYTHONPATH "$PYTHONPATH:$out/${python.sitePackages}" \
+                                       --set PATH ${python}/bin
+  '';
+
+  meta = {
+    description = "Automatic movie downloading via NZBs and torrents";
+    license     = lib.licenses.gpl3;
+    homepage    = https://couchpota.to/;
+    maintainers = with lib.maintainers; [ fadenb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10220,6 +10220,8 @@ in
     erlang = erlangR16;
   };
 
+  couchpotato = callPackage ../servers/couchpotato {};
+
   dico = callPackage ../servers/dico { };
 
   dict = callPackage ../servers/dict {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

