### PR TITLE
vim plugins: added vim-speeddating

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1322,6 +1322,17 @@ rec {
 
   };
 
+  vim-speeddating = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "vim-speeddating-2015-01-24";
+    src = fetchgit {
+      url = "git://github.com/tpope/vim-speeddating";
+      rev = "426c792e479f6e1650a6996c683943a09344c21e";
+      sha256 = "1i8pndds1lk5afxl6nwsnl4vzszh0qxgqx7x11fp3vqw27c5bwn8";
+    };
+    dependencies = [];
+
+  };
+
   hasksyn = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "hasksyn-2014-09-03";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -100,6 +100,7 @@
 "github:tomasr/molokai"
 "github:tpope/vim-eunuch"
 "github:tpope/vim-repeat"
+"github:tpope/vim-speeddating"
 "github:travitch/hasksyn"
 "github:twinside/vim-haskellconceal"
 "github:valloric/youcompleteme"


### PR DESCRIPTION
###### Motivation for this change

vim-orgmode likes this

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

