### PR TITLE
linux_4_9: enable support for amdgpu on older chipsets

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -186,6 +186,10 @@ with stdenv.lib;
   ${optionalString (versionAtLeast version "4.5" && (versionOlder version "4.9")) ''
     DRM_AMD_POWERPLAY y # necessary for amdgpu polaris support
   ''}
+  ${optionalString (versionAtLeast version "4.9") ''
+    DRM_AMDGPU_SI y # (experimental) amdgpu support for verde and newer chipsets
+    DRM_AMDGPU_CIK y # (stable) amdgpu support for bonaire and newer chipsets
+  ''}
 
   # Sound.
   SND_DYNAMIC_MINORS y


### PR DESCRIPTION
Linux 4.9 includes experimental amdgpu support for AMD Southern Islands
chipsets. (By default, only Sea Islands and newer chipsets are supported.)
Southern Islands chips will still use radeon by default, but daring users may
set `services.xserver.videoDrivers = [ "amdgpu" ];` to try the experimental
driver.

###### Motivation for this change

The amdgpu-based driver is awesome!

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
 - ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
  (This does not really apply.)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  (I am using the driver right now.)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

