### PR TITLE
kdeWrapper: Fix XDG_DATA_DIRS/XDG_CONFIG_DIRS mixup.

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kde-wrapper.nix
+++ b/pkgs/development/libraries/kde-frameworks/kde-wrapper.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation {
                 makeWrapper "$drv/$t" "$out/$t" \
                     --argv0 '"$0"' \
                     --suffix PATH : "$env/bin" \
-                    --prefix XDG_CONFIG_DIRS : "$env/share" \
-                    --prefix XDG_DATA_DIRS : "$env/etc/xdg" \
+                    --prefix XDG_CONFIG_DIRS : "$env/etc/xdg" \
+                    --prefix XDG_DATA_DIRS : "$env/share" \
                     --set QML_IMPORT_PATH "$env/lib/qt5/imports" \
                     --set QML2_IMPORT_PATH "$env/lib/qt5/qml" \
                     --set QT_PLUGIN_PATH "$env/lib/qt5/plugins"


### PR DESCRIPTION
`share` directories go with `XDG_DATA_DIRS`, and `etc/xdg` directories go with `XDG_CONFIG_DIRS`. These were accidentally reversed.

See [this KDE wiki page](https://userbase.kde.org/KDE_System_Administration/Environment_Variables#freedesktop.org_Compliance) for example.

###### Motivation for this change

This solves my problem with Spectacle not having any items in the `Export Image... > More Online Services` menu, such as the Imgur uploader. I had previously mentioned this [here](https://github.com/NixOS/nixpkgs/issues/9680#issuecomment-253714454) but I don't think there's a dedicated issue.

I figured out that the plugin loader relied on a `kservices5` directory and by `strace`ing Spectacle, I noticed that it was looking in the `kdeWrapper` "env" package for `etc/xdg/kservices5` but I knew the real path was `share/kservices5`, and then the accidental reversal became clear.

Since the problem was actually in `kdeWrapper`, this has a good chance of fixing issues in other KDE5 packages that I'm not aware of.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).