### PR TITLE
Backport: gnupg: build with sqlite to enable TOFU

### DIFF
--- a/pkgs/tools/security/gnupg/21.nix
+++ b/pkgs/tools/security/gnupg/21.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, libgcrypt, libassuan, libksba, libiconv, npth
-, gettext, texinfo, pcsclite
+, gettext, texinfo, pcsclite, sqlite
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pkgconfig libgcrypt libassuan libksba libiconv npth gettext texinfo
-    readline libusb gnutls adns openldap zlib bzip2
+    readline libusb gnutls adns openldap zlib bzip2 sqlite
   ];
 
   patches = [ ./fix-libusb-include-path.patch ];


### PR DESCRIPTION
See https://lists.gnupg.org/pipermail/gnupg-users/2015-October/054608.html.

(cherry-picked from 3c104ca71c37b664b4bb62d32c6ffa398e716b18)

fixes #21923

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

