### PR TITLE
[don't merge] qt55.qtbase: fix patch sha with fetchpatch instead of fetchurl

### DIFF
--- a/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.5/qtbase/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, copyPathsToStore
+{ stdenv, lib, fetchpatch, copyPathsToStore
 , srcs
 
 , xlibs, libX11, libxcb, libXcursor, libXext, libXrender, libXi
@@ -30,10 +30,10 @@ let
   # Search path for Gtk plugin
   gtkLibPath = lib.makeLibraryPath [ gtk2 gnome_vfs libgnomeui GConf ];
 
-  dontInvalidateBacking = fetchurl {
+  dontInvalidateBacking = fetchpatch {
     url = "https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=patch;h=0f68f8920573cdce1729a285a92ac8582df32841;hp=24c50f8dcf7fa61ac3c3d4d6295c259a104a2b8c";
     name = "qtbug-48321-dont-invalidate-backing-store.patch";
-    sha256 = "07vnndmvri73psz0nrs2hg0zw2i4b1k1igy2al6kwjbp7d5xpglr";
+    sha256 = "1wynm2hhbhpvzvsz4vpzzkl0ss5skac6934bva8brcpi5xq68h1q";
   };
 in
 


### PR DESCRIPTION
###### Motivation for this change
this patch seemed to change sha, so change to fetchpatch which should have a more stable patch.


Please don't merge yet.

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

