### PR TITLE
rubocop: init at 0.47.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -245,6 +245,7 @@
   ldesgoui = "Lucas Desgouilles <ldesgoui@gmail.com>";
   league = "Christopher League <league@contrapunctus.net>";
   lebastr = "Alexander Lebedev <lebastr@gmail.com>";
+  leemachin = "Lee Machin <me@mrl.ee>";
   leenaars = "Michiel Leenaars <ml.software@leenaa.rs>";
   leonardoce = "Leonardo Cecchi <leonardo.cecchi@gmail.com>";
   lethalman = "Luca Bruno <lucabru@src.gnome.org>";

--- a/pkgs/development/tools/rubocop/Gemfile
+++ b/pkgs/development/tools/rubocop/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'rake'
+gem 'rubocop'

--- a/pkgs/development/tools/rubocop/Gemfile.lock
+++ b/pkgs/development/tools/rubocop/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.3.0)
+    parser (2.3.3.1)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    rainbow (2.2.1)
+    rake (12.0.0)
+    rubocop (0.47.0)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
+    unicode-display_width (1.1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  rubocop
+
+BUNDLED WITH
+   1.13.7

--- a/pkgs/development/tools/rubocop/default.nix
+++ b/pkgs/development/tools/rubocop/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, lib, bundlerEnv, ruby, makeWrapper }:
+
+bundlerEnv rec {
+  pname = "rubocop";
+
+  inherit ruby;
+
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "Automatic Ruby code style checking tool";
+    homepage = http://rubocop.readthedocs.io/en/latest/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ leemachin ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/rubocop/gemset.nix
+++ b/pkgs/development/tools/rubocop/gemset.nix
@@ -1,0 +1,69 @@
+{
+  ast = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pp82blr5fakdk27d1d21xq9zchzb6vmyb1zcsl520s3ygvprn8m";
+      type = "gem";
+    };
+    version = "2.3.0";
+  };
+  parser = {
+    dependencies = ["ast"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nply96nqrkgx8d3jay31sfy5p4q74dg8ymln0mdazxx5cz2n8bq";
+      type = "gem";
+    };
+    version = "2.3.3.1";
+  };
+  powerpack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fnn3fli5wkzyjl4ryh0k90316shqjfnhydmc7f8lqpi0q21va43";
+      type = "gem";
+    };
+    version = "0.1.1";
+  };
+  rainbow = {
+    dependencies = ["rake"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0frz90gyi5k26jx3ham1x661hpkxf82rkxb85nakcz70dna7i8ri";
+      type = "gem";
+    };
+    version = "2.2.1";
+  };
+  rake = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01j8fc9bqjnrsxbppncai05h43315vmz9fwg28qdsgcjw9ck1d7n";
+      type = "gem";
+    };
+    version = "12.0.0";
+  };
+  rubocop = {
+    dependencies = ["parser" "powerpack" "rainbow" "ruby-progressbar" "unicode-display_width"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lsv3zbjl14nqyqqvcwciz15nq76l7vg97nydrdsrxs2bc5jrlsm";
+      type = "gem";
+    };
+    version = "0.47.0";
+  };
+  ruby-progressbar = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1qzc7s7r21bd7ah06kskajc2bjzkr9y0v5q48y0xwh2l55axgplm";
+      type = "gem";
+    };
+    version = "1.8.1";
+  };
+  unicode-display_width = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1r28mxyi0zwby24wyn1szj5hcnv67066wkv14wyzsc94bf04fqhx";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3641,6 +3641,8 @@ in
   rtorrent = callPackage ../tools/networking/p2p/rtorrent { };
 
   rubber = callPackage ../tools/typesetting/rubber { };
+  
+  rubocop = callPackage ../development/tools/rubocop { };
 
   runningx = callPackage ../tools/X11/runningx { };
 


### PR DESCRIPTION
###### Motivation for this change
 
To add the rubocop linter as a global package (for support with text editors that don't know how to use bundler or docker or nix-shell)

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

