### PR TITLE
gperf: 3.0.4 -> 3.1

### DIFF
--- a/pkgs/development/tools/misc/gperf/default.nix
+++ b/pkgs/development/tools/misc/gperf/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "gperf-3.0.4";
+  name = "gperf-3.1";
 
   src = fetchurl {
     url = "mirror://gnu/gperf/${name}.tar.gz";
-    sha256 = "0gnnm8iqcl52m8iha3sxrzrl9mcyhg7lfrhhqgdn4zj00ji14wbn";
+    sha256 = "1qispg6i508rq8pkajh26cznwimbnj06wq9sd85vg95v8nwld1aq";
   };
 
   meta = {


### PR DESCRIPTION
This PR is against `staging`.

See https://lists.gnu.org/archive/html/info-gnu/2017-01/msg00005.html
for full release announcement.

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

