### PR TITLE
monero: 0.9.4 -> 0.10.1

### DIFF
--- a/pkgs/applications/misc/monero/default.nix
+++ b/pkgs/applications/misc/monero/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchFromGitHub, cmake, boost, miniupnpc, pkgconfig, unbound }:
 
 let
-  version = "0.9.4";
+  version = "0.10.1";
 in
 stdenv.mkDerivation {
   name = "monero-${version}";
 
   src = fetchFromGitHub {
     owner = "monero-project";
-    repo = "bitmonero";
+    repo = "monero";
     rev = "v${version}";
-    sha256 = "1qzpy1mxz0ky6hfk1gf67ybbr9xy6p6irh6zwri35h1gb97sbc3c";
+    sha256 = "1zngskpgxz3vqq348h0mab2kv95z6g9ckvqkr77mx15m5z3qi6aw";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
@@ -27,19 +27,17 @@ stdenv.mkDerivation {
 
   installPhase = ''
     install -Dt "$out/bin/" \
-        bin/bitmonerod \
-        bin/blockchain_converter \
-        bin/blockchain_dump \
-        bin/blockchain_export \
-        bin/blockchain_import \
-        bin/cn_deserialize \
-        bin/simpleminer \
-        bin/simplewallet
+        bin/monerod \
+        bin/monero-blockchain-export \
+        bin/monero-blockchain-import \
+        bin/monero-utils-deserialize \
+        bin/monero-wallet-cli \
+        bin/monero-wallet-rpc
   '';
 
   meta = with stdenv.lib; {
     description = "Private, secure, untraceable currency";
-    homepage = http://monero.cc/;
+    homepage = https://getmonero.org/;
     license = licenses.bsd3;
     maintainers = [ maintainers.ehmry ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
###### Motivation for this change
 
there was a recent hard-fork in monero and 0.9.4 can no longer sync the new chain properly. will need to backport this to stable.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).