### PR TITLE
[WIP, don't merge] make-disk-image: change to be less VM-centric

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -36,73 +36,143 @@
 
 with lib;
 
-pkgs.vmTools.runInLinuxVM (
-  pkgs.runCommand name
-    { preVM =
-        ''
-          mkdir $out
-          diskImage=$out/nixos.${if format == "qcow2" then "qcow2" else "img"}
-          ${pkgs.vmTools.qemu}/bin/qemu-img create -f ${format} $diskImage "${toString diskSize}M"
-          mv closure xchg/
-        '';
-      buildInputs = [ pkgs.utillinux pkgs.perl pkgs.e2fsprogs pkgs.parted ];
-      exportReferencesGraph =
-        [ "closure" config.system.build.toplevel ];
-      inherit postVM;
-      memSize = 1024;
-    }
-    ''
-      ${if partitioned then ''
-        # Create a single / partition.
-        parted /dev/vda mklabel msdos
-        parted /dev/vda -- mkpart primary ext2 1M -1s
-        . /sys/class/block/vda1/uevent
-        mknod /dev/vda1 b $MAJOR $MINOR
-        rootDisk=/dev/vda1
-      '' else ''
-        rootDisk=/dev/vda
-      ''}
+let
+  # Copied from https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/cd-dvd/channel.nix
+  channelSources = pkgs.runCommand "nixos-${config.system.nixosVersion}" {} ''
+    mkdir -p $out
+    cp -prd ${pkgs.path} $out/nixos
+    chmod -R u+w $out/nixos
+    if [ ! -e $out/nixos/nixpkgs ]; then
+      ln -s . $out/nixos/nixpkgs
+    fi
+    rm -rf $out/nixos/.git
+    echo -n ${config.system.nixosVersionSuffix} > $out/nixos/.version-suffix
+  '';
 
-      # Create an empty filesystem and mount it.
-      mkfs.${fsType} -L nixos $rootDisk
-      mkdir /mnt
-      mount $rootDisk /mnt
+  metaClosure = pkgs.writeText "meta" ''
+    ${config.system.build.toplevel}
+    ${config.nix.package.out}
+    ${channelSources}
+  '';
 
-      # Register the paths in the Nix database.
-      printRegistration=1 perl ${pkgs.pathsFromGraph} /tmp/xchg/closure | \
-          ${config.nix.package.out}/bin/nix-store --load-db --option build-users-group ""
+  prepareImageInputs = with pkgs; [ utillinux parted e2fsprogs rsync fakeroot fakechroot perl lkl config.nix.package ];
 
-      ${if fixValidity then ''
-        # Add missing size/hash fields to the database. FIXME:
-        # exportReferencesGraph should provide these directly.
-        ${config.nix.package.out}/bin/nix-store --verify --check-contents --option build-users-group ""
-      '' else ""}
+  prepareImage = ''
+    export PATH=${pkgs.lib.makeSearchPathOutput "bin" "bin" (prepareImageInputs ++ pkgs.stdenv.initialPath)}
+    mkdir $out
+    diskImage=$out/nixos.img
+    truncate -s ${toString diskSize}M $diskImage
+  
+    ${if partitioned then ''
+      parted $diskImage -- mklabel msdos mkpart primary ext4 1M -1s
+      offset=$((2048*512))
+    '' else ''
+      offset=0
+    ''}
+  
+    mkfs.${fsType} -F -L nixos -E offset=$offset $diskImage
+  
+    umask 0022
+  
+    root="$PWD/root"
 
-      # In case the bootloader tries to write to /dev/sda…
-      ln -s vda /dev/xvda
-      ln -s vda /dev/sda
+    # A big chunk of this code was stolen from https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/tools/nixos-install.sh
+    # which we can't use directly because it assumes it owns the machine. TODO: refactor the code so we can share the relevant parts with it. 
+    mkdir -m 0755 -p $root/{dev,proc,sys,etc,run,home}
+    mkdir -m 01777 -p $root/tmp
+    mkdir -m 0755 -p $root/tmp/root
+    mkdir -m 0755 -p $root/var
+    mkdir -m 0700 -p $root/root
+    ln -s /run $root/var/run
+  
+    ln -s /nix/var/nix/profiles/system $root/run/current-system
+  
+    mkdir -m 0755 -p \
+      $root/nix/var/nix/gcroots \
+      $root/nix/var/nix/temproots \
+      $root/nix/var/nix/userpool \
+      $root/nix/var/nix/profiles \
+      $root/nix/var/nix/db \
+      $root/nix/var/log/nix/drvs
+  
+    mkdir -m 1755 -p $root/nix/store
+  
+    echo "copying system closure to staging area..."
+    for i in $(perl ${pkgs.pathsFromGraph} closure); do
+      chattr -R -i $root/$i 2> /dev/null || true # clear immutable bit
+      ${pkgs.rsync}/bin/rsync -a $i $root/nix/store
+    done
 
-      # Install the closure onto the image
-      USER=root ${config.system.build.nixos-install}/bin/nixos-install \
-        --closure ${config.system.build.toplevel} \
-        --no-channel-copy \
-        --no-root-passwd \
-        ${optionalString (!installBootLoader) "--no-bootloader"}
+    mkdir -m 0755 -p "$root/bin/"
+    ln -sf ${pkgs.stdenv.shell} "$root/bin/sh"
+  
+    mkdir -m 0755 -p "$root/nix/var/nix/profiles"
+    mkdir -m 1777 -p "$root/nix/var/nix/profiles/per-user"
+    mkdir -m 0755 -p "$root/nix/var/nix/profiles/per-user/root"
+  
+    mkdir -m 0700 -p $root/root/.nix-defexpr
+    ln -sfn /nix/var/nix/profiles/per-user/root/channels $root/root/.nix-defexpr/channels
+  
+    ln -sfn /proc/mounts $root/etc/mtab
+  
+    touch $root/etc/NIXOS
 
-      # Install a configuration.nix.
-      mkdir -p /mnt/etc/nixos
-      ${optionalString (configFile != null) ''
-        cp ${configFile} /mnt/etc/nixos/configuration.nix
-      ''}
+    echo "faking stuff..."
+    fakechroot -- chroot $root nix-store --option build-users-group "" --register-validity < closure
 
-      # Remove /etc/machine-id so that each machine cloning this image will get its own id
-      rm -f /mnt/etc/machine-id
+    # XXX: do I need to do these with nix-env? Not sure if it does anything except create two symlinks, which I then need to fix up...
+    fakechroot -- chroot $root nix-env --option build-users-group "" --option build-use-substitutes false -p /nix/var/nix/profiles/per-user/root/channels --set ${channelSources}
+    fakechroot -- chroot $root nix-env --option build-users-group "" --option build-use-substitutes false -p /nix/var/nix/profiles/system --set ${config.system.build.toplevel}
+    
+    # Fix up the bad symlinks we get as a result of fakechroot above... :(
+    ln -snf ${channelSources} $root/nix/var/nix/profiles/per-user/root/$(readlink $root/nix/var/nix/profiles/per-user/root/channels)
+    ln -snf ${config.system.build.toplevel} $root/nix/var/nix/profiles/$(readlink $root/nix/var/nix/profiles/system)
 
-      umount /mnt
+    ${pkgs.lib.optionalString fixValidity ''
+      echo "fixing validity..."
+      fakechroot -- chroot $root nix-store --verify --check-contents --option build-users-group ""
+    ''}
 
-      # Make sure resize2fs works
-      ${optionalString (fsType == "ext4") ''
-        tune2fs -c 0 -i 0 $rootDisk
-      ''}
-    ''
+    echo "copying staging root to image..."
+    cptofs ${pkgs.lib.optionalString partitioned "-P 1"} -t ${fsType} -i $diskImage $root/* /
+  '';
+in pkgs.vmTools.runInLinuxVM (
+  pkgs.runCommand name {
+    preVM = prepareImage;
+    buildInputs = with pkgs; [ utillinux config.nix.package ];
+    exportReferencesGraph = [ "closure" metaClosure ];
+    inherit postVM;
+    memSize = 1024;
+  }
+  # This entire VM block exists because the activation and switch-to-configuration scripts assume global things, and currently need to be run
+  # inside a real chroot (unlike the fakechroots we have above). If we can kill those parts, we can kill the VM stuff altogether, which takes
+  # the majority of the build time on EC2, even with a ~1G store.
+  ''
+    ${if partitioned then ''
+      . /sys/class/block/vda1/uevent
+      mknod /dev/vda1 b $MAJOR $MINOR
+      rootDisk=/dev/vda1
+    '' else ''
+      rootDisk=/dev/vda
+    ''}
+
+    ln -s vda /dev/xvda
+    ln -s vda /dev/sda
+
+    mountPoint=/mnt
+
+    mkdir $mountPoint
+    mount $rootDisk $mountPoint
+
+    mount --rbind /dev $mountPoint/dev
+    mount --rbind /proc $mountPoint/proc
+    mount --rbind /sys $mountPoint/sys
+
+    NIXOS_INSTALL_BOOTLOADER=1 chroot $mountPoint /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+
+    chroot $mountPoint /nix/var/nix/profiles/system/activate
+
+    rm -f $mountPoint/etc/machine-id
+  ''
 )
+


### PR DESCRIPTION
This changes much of the make-disk-image.nix logic (and thus most NixOS image building) to use LKL to set up the target directory structure rather than a Linux VM. The only work we still do in a VM is less IO-heavy stuff that while still time-consuming, is less of the overall load. The goal is to kill more of that stuff, but that will require deeper changes to NixOS activation scripts and switch-to-configuration.pl, and I don't want to bite off too much at once.

On my test EC2 instance, the old image building code took about 25 minutes (see #20471), and this takes a little less than a minute. I've been testing it as follows:

```shell
time nix-build nixos/ --no-out-link -A config.system.build.amazonImage --arg configuration "{ imports = [ ./nixos/maintainers/scripts/ec2/amazon-image.nix ]; ec2.hvm = true; }"
```

Things I'm unsure about and would appreciate comments on:

1. Whether this actually produces an image that doesn't have subtle issues. I'm not so much concerned about the filesystem (since I'm using the Linux filesystem drivers) but I did hack up nixos-install.sh and might have missed something.
2. Whether I can kill the last two uses of the VM
3. Whether the `fakechroot` + `nix-env` is actually necessary. If I'm just doing `--set` with no previous generations, is `nix-env` doing anything beyond making two symlinks? Not doing it myself future-proofs this code a bit if the link scheme changes someday, but that also seems unlikely.

Things I still need to do before I take the WIP marker off:

1. More testing
2. Add back support for `qcow2`, which I'd probably do as a post-VM conversion with `qemu-img` now that I touch image files directly and LKL doesn't understand anything but a flat image
3. Possibly refactor the `nixos-install.sh` logic to share the core bits and pieces with this work, so we don't risk getting out of sync. I'd however rather do that as a follow-up PR to keep moving parts to a minimum.