### PR TITLE
fping: enable IPv6 (provides fping6 binary)

### DIFF
--- a/pkgs/tools/networking/fping/default.nix
+++ b/pkgs/tools/networking/fping/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "082pis2c2ad6kkj35zmsf6xb2lm8v8hdrnjiwl529ldk3kyqxcjb";
   };
 
+  configureFlags = [ "--enable-ipv6" "--enable-ipv4" ];
+
   meta = {
     homepage = "http://fping.org/";
     description = "Send ICMP echo probes to network hosts";


### PR DESCRIPTION
###### Motivation for this change
In order to allow my smokeping to monitor IPv6 hosts I require fping6.
This change builds `fping` as well as `fping6` binaries so nothing should break.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

