### PR TITLE
oh-my-zsh: add share dir to pathsToLink

### DIFF
--- a/pkgs/shells/oh-my-zsh/default.nix
+++ b/pkgs/shells/oh-my-zsh/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1adgj0p4c8aq9rpkv33k8ra69922vfkjw63b666i66v6zr0s8znp";
   };
 
+  environment.pathsToLink = [ "/share/oh-my-zsh" ];
+
   phases = "installPhase";
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Some window/desktop managers do not add `share` directory or do it selectively.
Without it `oh-my-zsh` is not linked to `/run/current-system/sw/share`, which then makes it harder to set `$ZSH` variable in `.zshrc`

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

