### PR TITLE
bundleEnv: Used gemdir for most applications now

### DIFF
--- a/doc/languages-frameworks/ruby.xml
+++ b/doc/languages-frameworks/ruby.xml
@@ -26,9 +26,8 @@ bundlerEnv rec {
 
   version = (import gemset).sensu.version;
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  # expects Gemfile, Gemfile.lock and gemset.nix in the same directory
+  gemdir = ./.;
 
   meta = with lib; {
     description = "A monitoring framework that aims to be simple, malleable, and scalable";

--- a/pkgs/applications/misc/gollum/default.nix
+++ b/pkgs/applications/misc/gollum/default.nix
@@ -5,9 +5,7 @@ bundlerEnv rec {
   version = "4.0.1";
 
   ruby = ruby_2_2;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = with lib; {
     description = "A simple, Git-powered wiki";

--- a/pkgs/applications/misc/jekyll/default.nix
+++ b/pkgs/applications/misc/jekyll/default.nix
@@ -5,9 +5,7 @@ bundlerEnv rec {
   version = "3.0.1";
 
   ruby = ruby_2_2;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = with lib; {
     description = "Simple, blog aware, static site generator";

--- a/pkgs/applications/misc/pt/default.nix
+++ b/pkgs/applications/misc/pt/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   name = "pt-0.7.3";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = with lib; {
     description = "Minimalist command-line Pivotal Tracker client";

--- a/pkgs/applications/misc/taskjuggler/3.x/default.nix
+++ b/pkgs/applications/misc/taskjuggler/3.x/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   name = "taskjuggler-3.5.0";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = {
     description = "A modern and powerful project management tool";

--- a/pkgs/applications/networking/cluster/panamax/api/default.nix
+++ b/pkgs/applications/networking/cluster/panamax/api/default.nix
@@ -11,9 +11,7 @@ stdenv.mkDerivation rec {
   env = bundlerEnv {
     name = "panamax-api-gems-${version}";
     inherit ruby;
-    gemset = ./gemset.nix;
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
+    gemdir = ./.;
   };
 
   bundler = args.bundler.override { inherit ruby; };

--- a/pkgs/applications/networking/cluster/panamax/ui/default.nix
+++ b/pkgs/applications/networking/cluster/panamax/ui/default.nix
@@ -10,9 +10,7 @@ stdenv.mkDerivation rec {
   env = bundlerEnv {
     name = "panamax-ui-gems-${version}";
     inherit ruby;
-    gemset = ./gemset.nix;
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
+    gemdir = ./.;
   };
 
   bundler = args.bundler.override { inherit ruby; };

--- a/pkgs/applications/office/ledger-web/default.nix
+++ b/pkgs/applications/office/ledger-web/default.nix
@@ -6,11 +6,9 @@
 bundlerEnv rec {
   name = "ledger-web-${version}";
 
-  version = (import gemset).ledger_web.version;
+  version = (import ./gemset.nix).ledger_web.version;
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   buildInputs =    lib.optional withPostgresql postgresql
                 ++ lib.optional withSqlite sqlite;

--- a/pkgs/applications/office/ppl-address-book/default.nix
+++ b/pkgs/applications/office/ppl-address-book/default.nix
@@ -8,9 +8,7 @@ let
   env = bundlerEnv rec {
     name = "${pname}-env-${version}";
     inherit ruby;
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
 
     gemConfig.rugged = attrs: { buildInputs = [ which ]; };
   };

--- a/pkgs/applications/office/timetrap/default.nix
+++ b/pkgs/applications/office/timetrap/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   name = "timetrap-1.10.0";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = {
     description = "A simple command line time tracker written in ruby";

--- a/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/default.nix
@@ -3,11 +3,9 @@
 bundlerEnv rec {
   name = "bitbucket-server-cli-${version}";
 
-  version = (import gemset).atlassian-stash.version;
+  version = (import ./gemset.nix).atlassian-stash.version;
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   pname = "atlassian-stash";
 

--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -9,9 +9,7 @@ let
   env = bundlerEnv {
     name = "gitlab";
     inherit ruby;
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
     meta = with lib; {
       homepage = http://www.gitlab.com/;
       platforms = platforms.linux;

--- a/pkgs/development/compilers/matter-compiler/default.nix
+++ b/pkgs/development/compilers/matter-compiler/default.nix
@@ -5,9 +5,7 @@ bundlerEnv {
   name = "matter_compiler-0.5.1";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = with lib; {
     description = ''

--- a/pkgs/development/tools/build-managers/rake/default.nix
+++ b/pkgs/development/tools/build-managers/rake/default.nix
@@ -4,10 +4,8 @@ bundlerEnv {
   name = "rake-11.1.1";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
-  
+  gemdir = ./.;
+
   meta = with lib; {
     description = "A software task management and build automation tool";
     homepage = https://github.com/ruby/rake;

--- a/pkgs/development/tools/chefdk/default.nix
+++ b/pkgs/development/tools/chefdk/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   name = "chefdk-0.11.2";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   buildInputs = [ perl autoconf ];
 

--- a/pkgs/development/tools/compass/default.nix
+++ b/pkgs/development/tools/compass/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   name = "compass-1.0.3";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = with lib; {
     description = "Stylesheet Authoring Environment that makes your website design simpler to implement and easier to maintain";

--- a/pkgs/development/tools/continuous-integration/cide/default.nix
+++ b/pkgs/development/tools/continuous-integration/cide/default.nix
@@ -7,9 +7,7 @@ stdenv.mkDerivation rec {
   env = bundlerEnv {
     name = "${name}-gems";
 
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
   };
 
   phases = ["installPhase"];

--- a/pkgs/development/tools/redis-dump/default.nix
+++ b/pkgs/development/tools/redis-dump/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   name = "redis-dump-0.3.5";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   buildInputs = [ perl autoconf ];
 

--- a/pkgs/development/tools/rhc/default.nix
+++ b/pkgs/development/tools/rhc/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   name = "rhc-1.36.4";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = with lib; {
     homepage = https://github.com/openshift/rhc;

--- a/pkgs/development/tools/ronn/default.nix
+++ b/pkgs/development/tools/ronn/default.nix
@@ -6,9 +6,7 @@ stdenv.mkDerivation rec {
 
   env = bundlerEnv rec {
     name = "ronn-gems";
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
   };
 
   phases = ["installPhase"];

--- a/pkgs/development/tools/sass/default.nix
+++ b/pkgs/development/tools/sass/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   name = "sass-3.4.22";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = with lib; {
     description = "Tools and Ruby libraries for the CSS3 extension languages: Sass and SCSS";

--- a/pkgs/servers/consul/ui.nix
+++ b/pkgs/servers/consul/ui.nix
@@ -4,9 +4,7 @@ let
   # `sass` et al
   gems = bundlerEnv {
     name = "consul-ui-deps";
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
   };
 in
 

--- a/pkgs/servers/monitoring/sensu/default.nix
+++ b/pkgs/servers/monitoring/sensu/default.nix
@@ -4,9 +4,7 @@
     name = "sensu-0.17.1";
 
     inherit ruby;
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
 
     meta = with lib; {
       description = "A monitoring framework that aims to be simple, malleable, and scalable";

--- a/pkgs/tools/audio/mpdcron/default.nix
+++ b/pkgs/tools/audio/mpdcron/default.nix
@@ -4,9 +4,7 @@
 let
   gemEnv = bundlerEnv {
     name = "mpdcron-bundle";
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
   };
 in stdenv.mkDerivation rec {
   version = "20130809";

--- a/pkgs/tools/backup/backup/default.nix
+++ b/pkgs/tools/backup/backup/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   name = "backup_v4";
 
   ruby = ruby_2_1;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   buildInputs = [ curl ];
 

--- a/pkgs/tools/misc/homesick/default.nix
+++ b/pkgs/tools/misc/homesick/default.nix
@@ -2,9 +2,7 @@
 bundlerEnv {
   name = "homesick-1.1.3";
 
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   # Cannot use `wrapProgram` because the the help is aware of the file name.
   postInstall = ''

--- a/pkgs/tools/misc/pws/default.nix
+++ b/pkgs/tools/misc/pws/default.nix
@@ -8,9 +8,7 @@ stdenv.mkDerivation rec {
 
     inherit ruby;
 
-    gemfile  = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset   = ./gemset.nix;
+    gemdir = ./.;
   };
 
   buildInputs = [ makeWrapper ];

--- a/pkgs/tools/networking/maphosts/default.nix
+++ b/pkgs/tools/networking/maphosts/default.nix
@@ -6,9 +6,7 @@ stdenv.mkDerivation rec {
   env = bundlerEnv {
     name = "maphosts-gems";
     inherit ruby;
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
   };
 
   phases = ["installPhase"];

--- a/pkgs/tools/system/r10k/default.nix
+++ b/pkgs/tools/system/r10k/default.nix
@@ -8,9 +8,7 @@ stdenv.mkDerivation rec {
   env = bundlerEnv {
     name = "${name}-gems";
 
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
     inherit ruby;
   };
 

--- a/pkgs/tools/text/reckon/default.nix
+++ b/pkgs/tools/text/reckon/default.nix
@@ -7,9 +7,7 @@ stdenv.mkDerivation rec {
   env = bundlerEnv {
     name = "${name}-gems";
 
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
+    gemdir = ./.;
   };
 
   phases = [ "installPhase" ];

--- a/pkgs/tools/text/ruby-zoom/default.nix
+++ b/pkgs/tools/text/ruby-zoom/default.nix
@@ -4,9 +4,7 @@ bundlerEnv {
   pname = "ruby-zoom";
 
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
 
   meta = with lib; {
     description = "Quickly open CLI search results in your favorite editor!";


### PR DESCRIPTION
###### Motivation for this change

I replaced in every healthy package `gemfile`, `lockfile`, `gemset` with `gemdir`.
@zimbatm

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

