### PR TITLE
oraclejdk: 8u111, 8u112 -> 8u121 [Critical security fix]

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "111";
+  patchVersion = "121";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "07wyyds52c3fp4ha1fnzp6mbxwq0rs3vx59167b57gkggg7qz3ls";
-  sha256_x86_64 = "0x4937c3307v78wx1jf227b89cf5lsd5yarmbjrxs4pq6lidlzhq";
+  sha256_i686 = "0k1xyg000qmd96c2r2m8l84ygn6dmjf1ih5yjzq1zry5d0aczmpp";
+  sha256_x86_64 = "1g0hh9ccmsrdfa9493k31v2vd6yiymwd1nclgjh29wxfy41h5qwp";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,9 +1,9 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "112";
+  patchVersion = "121";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256_i686 = "19b9vwb7bd17s9p04y47zzjkccazzmpy4dqx4rgxd79k1fw2yz0y";
-  sha256_x86_64 = "19blsx81x5p2f6d9vig89z7cc8778cp6qdjy9ylsa2444vaxfyvp";
+  sha256_i686 = "0k1xyg000qmd96c2r2m8l84ygn6dmjf1ih5yjzq1zry5d0aczmpp";
+  sha256_x86_64 = "1g0hh9ccmsrdfa9493k31v2vd6yiymwd1nclgjh29wxfy41h5qwp";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Motivation for this change

- Critical security fix
- Other updates

http://www.oracle.com/technetwork/security-advisory/cpujan2017-2881727.html#AppendixJAVA
http://www.oracle.com/technetwork/java/javase/8u121-relnotes-3315208.html

Note that PSU (8u122) is not released. It is identical to CPU version.

###### Things done

- [X] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

