### PR TITLE
kde5: fix error message in "Add Printer" dialog

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/kde5.nix
+++ b/nixos/modules/services/x11/desktop-managers/kde5.nix
@@ -229,6 +229,8 @@ in
       # Enable helpful DBus services.
       services.udisks2.enable = true;
       services.upower.enable = config.powerManagement.enable;
+      services.dbus.packages =
+        mkIf config.services.printing.enable [ pkgs.system-config-printer ];
 
       # Extra UDEV rules used by Solid
       services.udev.packages = [

--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
     ];
 
   pythonPath = with pythonPackages;
-    [ pycups pycurl dbus-python pygobject3 requests2 ];
+    [ pycups pycurl dbus-python pygobject3 requests2 pycairo ];
 
   configureFlags =
     [ "--with-udev-rules"


### PR DESCRIPTION
###### Motivation for this change
By adding missing 'system-config-printer' dbus service, we fix the following error in "Add Printer" dialog:

Failed to group devices: 'The name org.fedoraproject.Config.Printing was not provided by any .service files'

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
