### PR TITLE
remove xorg.intelgputools in favor of intel-gpu-tools

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -602,17 +602,6 @@ let
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit ;};
 
-  intelgputools = (mkDerivation "intelgputools" {
-    name = "intel-gpu-tools-1.15";
-    builder = ./builder.sh;
-    src = fetchurl {
-      url = mirror://xorg/individual/app/intel-gpu-tools-1.15.tar.bz2;
-      sha256 = "1gb22hvj4gdjj92iqbwcp44kf2znk2l1fvbcrr4sm4i65l8mdwnw";
-    };
-    buildInputs = [pkgconfig dri2proto libdrm udev libpciaccess python libX11 libXext libXrandr libXv ];
-    meta.platforms = stdenv.lib.platforms.unix;
-  }) // {inherit dri2proto libdrm udev libpciaccess python libX11 libXext libXrandr libXv ;};
-
   kbproto = (mkDerivation "kbproto" {
     name = "kbproto-1.0.7";
     builder = ./builder.sh;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -57,10 +57,6 @@ in
     tradcpp = if stdenv.isDarwin then args.tradcpp else null;
   };
 
-  intelgputools = attrs: attrs // {
-    buildInputs = attrs.buildInputs ++ [ args.cairo args.libunwind ];
-  };
-
   mkfontdir = attrs: attrs // {
     preBuild = "substituteInPlace mkfontdir.in --replace @bindir@ ${xorg.mkfontscale}/bin";
   };


### PR DESCRIPTION
###### Motivation for this change
There is no reason in having both and the latter is a
separate derivation and thus easier to maintain.

Closes #21976 

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

