### PR TITLE
Add yubioath-desktop application and required pyscard module to suppo…

### DIFF
--- a/pkgs/applications/misc/yubioath-desktop/default.nix
+++ b/pkgs/applications/misc/yubioath-desktop/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl,  python27Packages, swig, gettext, pcsclite, qt48Full, yubikey-personalization }:
+
+python27Packages.buildPythonApplication rec {
+    namePrefix = "";
+    name = "yubioath-desktop-${version}";
+    version = "3.1.0";
+
+    src = fetchurl {
+      url = "http://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-${version}.tar.gz";
+      sha256 = "0jfvllgh88g2vwd8sg6willlnn2hq05nd9d3xmv98lhl7gyy1akw";
+    };
+
+    doCheck = false;
+
+    buildInputs = [ stdenv ];
+
+    propagatedBuildInputs = [ python27Packages.pycrypto python27Packages.click python27Packages.pyscard python27Packages.pyside ];
+
+    # Need LD_PRELOAD for libykpers as the Nix cpython disables ctypes.cdll.LoadLibrary
+    # support that the yubicommon library uses to load libykpers
+    makeWrapperArgs = ''--prefix LD_LIBRARY_PATH : "${pcsclite}/lib:${yubikey-personalization}/lib" --prefix LD_PRELOAD : "${yubikey-personalization}/lib/libykpers-1.so"'';
+
+    postInstall = ''
+      mkdir -p $out/share/applications
+      cp resources/yubioath.desktop $out/share/applications/yubioath.desktop
+      mkdir -p $out/share/yubioath/icons
+      cp resources/yubioath*.{icns,ico,png,xpm} $out/share/yubioath/icons
+      substituteInPlace $out/share/applications/yubioath.desktop \
+        --replace 'Exec=yubioath-gui' "Exec=$out/bin/yubioath-gui" \
+        --replace 'Icon=yubioath' "Icon=$out/share/yubioath/icons"
+
+    '';
+
+    meta = {
+      description = "Yubikey Desktop Authenticator";
+
+      homepage = https://www.yubico.com/support/knowledge-base/categories/articles/yubico-authenticator-download/;
+
+      license = stdenv.lib.licenses.gpl3;
+    };
+}

--- a/pkgs/development/python-modules/pyscard/default.nix
+++ b/pkgs/development/python-modules/pyscard/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, fetchpatch, python, buildPythonPackage, swig, pcsclite }:
+
+buildPythonPackage rec {
+  name = "pyscard-1.9.4";
+  namePrefix = "";
+
+  src = fetchurl {
+    url = "mirror://pypi/p/pyscard/${name}.tar.gz";
+    sha256 = "0gn0p4p8dhk99g8vald0dcnh45jbf82bj72n4djyr8b4hawkck4v";
+  };
+
+  configurePhase = "";
+
+
+  LDFLAGS="-L${pcsclite}/lib";
+  CFLAGS="-I${pcsclite}/include/PCSC";
+
+  propagatedBuildInputs = [ swig pcsclite ];
+
+  #doCheck = !(python.isPypy or stdenv.isDarwin); # error: AF_UNIX path too long
+
+  meta = {
+    homepage = "https://pyscard.sourceforge.io/";
+    description = "Smartcard library for python";
+    license = stdenv.lib.licenses.lgpl21;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9879,6 +9879,8 @@ in
 
   yajl = callPackage ../development/libraries/yajl { };
 
+  yubioath-desktop = callPackage ../applications/misc/yubioath-desktop { };
+
   yubico-piv-tool = callPackage ../tools/misc/yubico-piv-tool { };
 
   yubikey-neo-manager = callPackage ../tools/misc/yubikey-neo-manager { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -281,6 +281,8 @@ in {
     pythonPackages = self;
   };
 
+  pyscard = callPackage ../development/python-modules/pyscard { };
+
   pyside = callPackage ../development/python-modules/pyside { };
 
   pysideApiextractor = callPackage ../development/python-modules/pyside/apiextractor.nix { };


### PR DESCRIPTION
…rt it

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

