### PR TITLE
styx-themes.agency: fix version typo

### DIFF
--- a/pkgs/applications/misc/styx/themes.nix
+++ b/pkgs/applications/misc/styx/themes.nix
@@ -28,7 +28,7 @@ in
 {
   agency = mkThemeDrv {
     themeName = "agency";
-    version   = "20167-01-17";
+    version   = "2017-01-17";
     src = {
       rev    = "3201f65841c9e7f97cc0ab0264cafb01b1620ed7";
       sha256 = "1b3547lzmhs1lmr9gln1yvh5xrsg92m8ngrjwf0ny91y81x04da6";


### PR DESCRIPTION
###### Motivation for this change

Fixing version name typo.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

