### PR TITLE
utillinux: undo seccomp sandbox and improve purity

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchurl, pkgconfig, zlib, libseccomp, fetchpatch, autoreconfHook, ncurses ? null, perl ? null, pam, systemd, minimal ? false }:
+{ lib, stdenv, fetchurl, pkgconfig, zlib, fetchpatch
+, ncurses ? null, perl ? null, pam, systemd, minimal ? false }:
 
 stdenv.mkDerivation rec {
   name = "util-linux-${version}";
@@ -12,13 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "1rzrmdrz51p9sy7vlw5qmj8pmqazm7hgcch5yq242mkvrikyln9c";
   };
 
-  patches = [
-    ./rtcwake-search-PATH-for-shutdown.patch
-    (fetchpatch {
-      name = "CVE-2016-2779.diff";
-      url = https://github.com/karelzak/util-linux/commit/8e4925016875c6a4f2ab4f833ba66f0fc57396a2.patch;
-      sha256 = "0kmigkq4s1b1ijrq8vcg2a5cw4qnm065m7cb1jn1q1f4x99ycy60";
-  })];
+  patches = [ ./rtcwake-search-PATH-for-shutdown.patch ];
 
   outputs = [ "bin" "dev" "out" "man" ];
 
@@ -54,11 +49,9 @@ stdenv.mkDerivation rec {
 
   makeFlags = "usrbin_execdir=$(bin)/bin usrsbin_execdir=$(bin)/sbin";
 
-  # autoreconfHook is required for CVE-2016-2779
-  nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  # libseccomp is required for CVE-2016-2779
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs =
-    [ zlib pam libseccomp ]
+    [ zlib pam ]
     ++ lib.optional (ncurses != null) ncurses
     ++ lib.optional (systemd != null) systemd
     ++ lib.optional (perl != null) perl;

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkgconfig, zlib, fetchpatch
+{ lib, stdenv, fetchurl, pkgconfig, zlib, fetchpatch, shadow
 , ncurses ? null, perl ? null, pam, systemd, minimal ? false }:
 
 stdenv.mkDerivation rec {
@@ -17,12 +17,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "man" ];
 
-  #FIXME: make it also work on non-nixos?
   postPatch = ''
-    # Substituting store paths would create a circular dependency on systemd
     substituteInPlace include/pathnames.h \
-      --replace "/bin/login" "/run/current-system/sw/bin/login" \
-      --replace "/sbin/shutdown" "/run/current-system/sw/bin/shutdown"
+      --replace "/bin/login" "${shadow}/bin/login"
   '';
 
   crossAttrs = {


### PR DESCRIPTION
###### Motivation for this change

 the patch for CVE-2016-2779 was reverted by upstream and was not adopted
 by any other downstream distributions. Upstream waits for a better fix
 in the kernel: https://www.kernel.org/pub/linux/utils/util-linux/v2.28/v2.28-ReleaseNotes

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

