### PR TITLE
ipfs: Set IPFS_PATH globally when daemon is enabled

### DIFF
--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -79,6 +79,7 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.ipfs ];
+    environment.variables.IPFS_PATH = cfg.dataDir + "/.ipfs";
 
     users.extraUsers = mkIf (cfg.user == "ipfs") {
       ipfs = {


### PR DESCRIPTION
###### Motivation for this change

There's little point to running a system-wide daemon which can't be accessed.

Setting IPFS_PATH allows users other than `ipfs` to use the ipfs commands.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

