### PR TITLE
Newsbeuter: fix darwin build and podbeuter download

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsbeuter/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsbeuter/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "DESTDIR=$(out)" "prefix=" ];
 
-  installPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     for prog in $out/bin/*; do
       wrapProgram "$prog" --prefix DYLD_LIBRARY_PATH : "${stfl}/lib"
     done
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     description = "An open-source RSS/Atom feed reader for text terminals";
     maintainers = with stdenv.lib.maintainers; [ lovek323 ];
     license     = stdenv.lib.licenses.mit;
-    platforms   = stdenv.lib.platforms.linux;
+    platforms   = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/networking/feedreaders/newsbeuter/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsbeuter/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
       url = "https://github.com/akrennmair/newsbeuter/commit/cdacfbde9fe3ae2489fc96d35dfb7d263ab03f50.patch";
       sha256 = "1lhvn63cqjpikwsr6zzndb1p5y140vvphlg85fazwx4xpzd856d9";
     })
+    (fetchpatch {
+      url = "https://github.com/akrennmair/newsbeuter/commit/33577f842d9b74c119f3cebda95ef8652304db81.patch";
+      sha256 = "1kwhp6k14gk1hclgsr9w47qg7hs60p23zsl6f6vw13mczp2naqlb";
+    })
   ];
 
   installFlags = [ "DESTDIR=$(out)" "prefix=" ];


### PR DESCRIPTION
###### Motivation for this change

I've been installing newsbeuter with homebrew, but I noticed that whenever I tried to download anything in podbeuter, it would segfault.  That got me off my butt to get the whole thing working via nix instead.

I'm willing to add myself as a maintainer.

###### Things done

- ~~[ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)~~
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] Linux
- ~~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

